### PR TITLE
Spec: one-person company runtime

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,9 @@
 # Roadmap
 
+This file tracks engineering now/next/later for the current code surface.
+The product roadmap — stages, phases, and non-goals for the one-person
+company runtime — lives in [docs/spec/roadmap.md](docs/spec/roadmap.md).
+
 ## Now
 
 - Keep the Rust/Axum surface small and compile-tested.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,41 +1,116 @@
 # OpenCompany System Specification
 
-OpenCompany is a Rust host for company-aware agent systems built around Axum,
-vendored OpenHuman, and vendored TinyAgents.
+OpenCompany is the open-source runtime that turns one person into a whole
+company. A single human operator brings capital, taste, and judgment; a roster
+of AI teammates does every functional job. The runtime keeps each company's
+**brain** — its charter, roster, memory, ledger, and pending approvals —
+durable and consistent, drives it with **Medulla** (TinyHumans' hosted
+orchestrator-first model), and makes every company a first-class, discoverable
+citizen of the **tiny.place** agent economy.
 
-The goal is to make it easy to start an OpenHuman-backed company runtime,
-inspect the inherited runtime modules, and grow company-specific behavior
-without duplicating the lower-level OpenHuman and TinyAgents surfaces.
+Two personas are served by the same crate:
 
-## Detailed Module Docs
+- **Prosumer operator** — a non-technical person running a one-person
+  business. Installs one binary, pastes one key (`TINYHUMANS_API_KEY`), picks
+  a template, and goes live.
+- **Platform operator** — a builder embedding the crate or hosting fleets of
+  one-person companies behind a provisioning API.
 
-- [App module](../modules/app/README.md)
-- [Server module](../modules/server/README.md)
-- [OpenHuman module](../modules/openhuman/README.md)
-- [Tiny module](../modules/tiny/README.md)
+One invariant binds everything: **the only mandatory external dependency is
+the TinyHumans API key.** Storage is DB-agnostic behind ports, tiny.place is
+opt-in, and every integration degrades gracefully.
 
-Docs should follow the package layout. Do not place standalone specification
-files directly in `docs/` or `docs/modules/`; each high-level topic should have
-its own directory with a `README.md` entrypoint and any supporting files beside
-it.
+## Layered Architecture
 
-## Package Layout
+Dependencies point strictly downward. OpenCompany owns the kernel; every
+neighbor sits behind a Rust trait ("port") and is swappable.
 
 ```text
-src/app/         process configuration and shared state
-src/server/      Axum router and HTTP handlers
-src/openhuman/   OpenHuman launcher seams
-src/tiny/        TinyHumans module feature/status surface
-src/bin/         CLI entrypoints
-vendor/openhuman/   OpenHuman git submodule
-vendor/tinyagents/  TinyAgents git submodule
+L4  Surfaces        Axum HTTP (operator API, A2A, webhooks), CLI, future UI
+L3  Company Brain   cycle loop, approvals, effect routing, feedback loop
+L2  Kernel ports    Brain, CompanyStore, EventLog, MemoryStore, ContextStore,
+                    ChannelAdapter, ToolProvider, AgentEconomy, ApprovalGate
+L1  Adapters        hosted-medulla | openhuman-rpc | tinyagents | tinycortex |
+                    tinyplace | fs (default)
+L0  Substrate       api.tinyhumans.ai, openhuman-core, tiny.place, filesystem
 ```
+
+| Concern | Owner | OpenCompany's role |
+| --- | --- | --- |
+| Cognition (orchestrate / delegate / dispatch) | Medulla | called via the `Brain` port; never reimplemented |
+| Model access, tier→SKU mapping, billing | TinyHumans backend | sends tier names + credential; never sees SKUs |
+| Tools, channels, credentials, policy tiers | OpenHuman | consumed via JSON-RPC; gaps go upstream as PRs |
+| In-process LLM sub-work | TinyAgents | embedded library behind `ToolProvider` |
+| Long-term memory | TinyCortex (candidate) | behind `MemoryStore`; default is file-based |
+| Identity, discovery, payments, A2A | tiny.place | behind `AgentEconomy` |
+| Company definition, brain state, lifecycle, approvals, HTTP surface | **OpenCompany** | owned outright |
+
+## Reading Paths
+
+- **Product / UX**: [product/](product/README.md) →
+  [company-as-agent/](company-as-agent/README.md) →
+  [feedback-loop/](feedback-loop/README.md)
+- **Runtime engineering**: [runtime/](runtime/README.md) →
+  [company-brain/](company-brain/README.md) →
+  [integrations/](integrations/README.md)
+- **Where this is going**: [roadmap.md](roadmap.md) →
+  [vision/](vision/README.md)
+
+## Index
+
+| Doc | Purpose |
+| --- | --- |
+| [glossary.md](glossary.md) | Authoritative vocabulary and term bridges |
+| [roadmap.md](roadmap.md) | Stages 0–4, phase mapping, non-goals |
+| [product/README.md](product/README.md) | Product thesis, personas, surfaces, one-key promise |
+| [product/prosumer.md](product/prosumer.md) | Non-technical operator journey end to end |
+| [product/platform.md](product/platform.md) | Embed mode and hosted multi-tenant mode |
+| [product/templates.md](product/templates.md) | Templates: the productized company manifests |
+| [company-brain/README.md](company-brain/README.md) | What the company brain is; the cycle |
+| [company-brain/charter.md](company-brain/charter.md) | The company constitution |
+| [company-brain/approvals.md](company-brain/approvals.md) | Checkpoints and the approval model |
+| [company-brain/memory.md](company-brain/memory.md) | Long-term memory and retention |
+| [runtime/README.md](runtime/README.md) | Kernel architecture and crate layout |
+| [runtime/ports.md](runtime/ports.md) | Port trait contracts (normative) |
+| [runtime/manifest.md](runtime/manifest.md) | `company.toml` schema, `agents.toml` compatibility |
+| [runtime/lifecycle.md](runtime/lifecycle.md) | Company state machine and durability |
+| [runtime/api.md](runtime/api.md) | HTTP surface and auth model |
+| [runtime/config.md](runtime/config.md) | Configuration and the one-key story |
+| [company-as-agent/README.md](company-as-agent/README.md) | Companies as economy citizens |
+| [company-as-agent/identity.md](company-as-agent/identity.md) | Wallet, handle, Agent Card |
+| [company-as-agent/commerce.md](company-as-agent/commerce.md) | Selling, hiring, delegated signers, ledger |
+| [integrations/README.md](integrations/README.md) | Reuse-first rule, dependency matrix |
+| [integrations/medulla.md](integrations/medulla.md) | Brain contract and the hosted wire protocol |
+| [integrations/openhuman.md](integrations/openhuman.md) | OpenHuman seams and upstream PR list |
+| [integrations/tinyagents.md](integrations/tinyagents.md) | TinyAgents harness usage |
+| [integrations/tinycortex.md](integrations/tinycortex.md) | TinyCortex expectations behind the memory port |
+| [integrations/tinyplace.md](integrations/tinyplace.md) | tiny.place protocol integration |
+| [feedback-loop/README.md](feedback-loop/README.md) | Feedback capture → GitHub issue → release loop |
+| [feedback-loop/privacy.md](feedback-loop/privacy.md) | Redaction rules (normative) |
+| [feedback-loop/triage.md](feedback-loop/triage.md) | Labels, triage, closing the loop |
+| [vision/README.md](vision/README.md) | The AVI north star (aspirational) |
+
+Module docs under [`docs/modules/`](../modules/) describe the code as it
+exists today; this spec describes the target design. When they disagree, the
+spec wins for new work.
+
+## Conventions
+
+- Every Markdown file stays at 500 lines or fewer; topics that outgrow a file
+  split into a directory with a `README.md` entrypoint.
+- MUST / SHOULD / MAY carry their RFC 2119 meanings in normative sections.
+- [glossary.md](glossary.md) is authoritative for vocabulary; docs link terms
+  on first use rather than redefining them.
+- Prosumer-facing language rules in the glossary are normative: product docs
+  and UI text never expose runtime internals ("agent graph", "tier",
+  "dispatch", "cycle").
 
 ## Design Goals
 
-- Make simple company workflows concise.
-- Make complex workflows explicit, inspectable, and testable.
-- Reuse OpenHuman and TinyAgents instead of reimplementing their runtime layers.
-- Keep the default build small while making deeper inheritance feature-gated.
-- Use Axum for the HTTP surface.
+- Make simple company workflows concise; make complex workflows explicit,
+  inspectable, and testable.
+- Reuse Medulla, OpenHuman, TinyAgents, TinyCortex, and tiny.place instead of
+  reimplementing them; changes those layers need go upstream as PRs.
+- Keep the default build small; deeper integrations are feature-gated.
+- One required credential; everything else optional and gracefully degrading.
 - Keep docs, examples, and public APIs aligned.

--- a/docs/spec/company-as-agent/README.md
+++ b/docs/spec/company-as-agent/README.md
@@ -1,0 +1,62 @@
+# Company as Agent
+
+Every OpenCompany company can be a first-class citizen of the agent economy:
+discoverable, hireable, and paying — not just a consumer of models. This
+directory specifies what that means; the protocol details live in
+[integrations/tinyplace.md](../integrations/tinyplace.md).
+
+Supporting docs: [identity.md](identity.md), [commerce.md](commerce.md).
+
+## Why public
+
+A private company does work for its operator. A **public** company also
+earns: it appears in the tiny.place directory with a services card, other
+agents (and other one-person companies) discover it by skill and hire it
+over A2A, and revenue lands in its wallet and ledger. Discoverability is the
+growth loop for the whole network — every public company makes every other
+company more capable, because "hire a specialist" becomes a tool call.
+
+Public is **opt-in and reversible** (`[place].discoverable`); a company runs
+forever private if the operator never flips the switch.
+
+## The going-public flow
+
+One switch in Settings ("List my company so other companies can hire it"),
+expanding to human-approved steps:
+
+1. **Identity** — generate/confirm the company keypair
+   ([identity.md](identity.md)). *Checkpoint: identity.*
+2. **Fund** — the handle claim costs real USDC; the operator sees the exact
+   amount and funds the wallet. *Checkpoint: spend.*
+3. **Handle** — claim `@handle` on the registry. *Checkpoint: identity.*
+4. **Card** — publish the Agent Card generated from the Charter's service
+   catalog; the operator previews exactly what becomes public.
+   *Checkpoint: publish.*
+5. **Open for business** — the `/a2a/{handle}` endpoint and `skill.md` go
+   live ([runtime/api.md](../runtime/api.md)).
+
+Each step degrades gracefully: an unfunded wallet parks the flow with a
+plain prompt, and failures never affect private operation.
+
+## Trust model
+
+- **The wallet attests continuity, not virtue**: the same keypair signed
+  every past engagement, payment, and card update. Reputation accrues to the
+  handle through tiny.place's own reputation surface over settled
+  engagements.
+- **Counterparties are untrusted by default**: first-time counterparties are
+  a checkpoint ([approvals](../company-brain/approvals.md)); inbound text is
+  promptguard-sanitized before the brain sees it; payment precedes work for
+  priced skills (x402 verify-then-dispatch).
+- **The operator's exposure is bounded** by construction: delegated signers
+  cap spend, budgets cap everything, and the master key never leaves the
+  bundle ([commerce.md](commerce.md)).
+
+## One company, one agent
+
+The company is the citizen: **one keypair, one @handle, one card, one
+voice** — the roster stays internal, consistent with the
+[one-voice invariant](../company-brain/README.md). Roster teammates MAY
+later get scoped identities via tiny.place subnames and delegated signers
+(e.g. `support.acme` with a narrow budget) — spec'd in
+[identity.md](identity.md) as optional, never default.

--- a/docs/spec/company-as-agent/commerce.md
+++ b/docs/spec/company-as-agent/commerce.md
@@ -1,0 +1,74 @@
+# Commerce
+
+How a company sells, hires, and moves money — with the operator's exposure
+bounded by construction.
+
+## Inbound engagements (selling)
+
+1. A counterparty discovers the company (directory / skill search / resolve)
+   and calls `POST /a2a/{handle}` with `tasks/send`.
+2. The runtime verifies the SIWX signature; for priced skills it answers
+   `402` with the x402 challenge, then verifies the payment through the
+   facilitator before anything reaches the brain
+   (**payment precedes work**).
+3. The paid task becomes an `A2aTaskReceived` event → an **Engagement** in
+   the world state; the brain works it like any other job, with the same
+   approval gates (a customer paying does not bypass the operator's fence).
+4. Deliverables return over A2A; settlement and the engagement link are
+   journaled to the ledger.
+5. **Refunds** follow charter policy: within-policy refunds are a Spend
+   effect under the standing rules; beyond-policy refunds are always a
+   checkpoint.
+
+## Outbound hiring (buying)
+
+When the brain decides work should be outsourced ("we need a logo;
+`@pixel-forge` sells that for $4"):
+
+1. **Discover** — directory search by skill; candidates ranked with
+   reputation visible.
+2. **Checkpoint** — first-time counterparties or above-threshold amounts
+   park for approval ([approvals](../company-brain/approvals.md), Hire).
+3. **Engage** — negotiate over tiny.place messaging where needed, then
+   `send_a2a_task` with the x402 payment built under a `BudgetScope`.
+4. **Receive and verify** — the deliverable enters the cycle as an event;
+   acceptance (and any dispute) is the brain's job, eskalating to the
+   operator per policy.
+
+Everything is journaled: who was hired, for what, under which signer, at
+what price, linked to the engagement.
+
+## Delegated signers (bounded spend authority)
+
+The master key never signs day-to-day spend. The runtime mints **delegated
+signers** — tiny.place session keys authorized by an x402 `upto` grant:
+
+- **Caps**: hard spend ceiling, expiry, optional counterparty allowlist.
+- **Scope**: per-engagement or per-period (e.g. "this month's procurement,
+  $50"); per-agent daily budgets from the manifest map to per-teammate
+  signers.
+- **Lifecycle**: minting or expanding a signer is an Identity checkpoint;
+  revocation is immediate and unilateral; every signer's spend is
+  attributable in the ledger.
+- Sub-agent identities spend **only** through their signer
+  ([identity.md](identity.md)).
+
+The layered bound: signer cap ≤ charter spend caps ≤ `[budget].monthly_usd`
+(the kernel's hard ceiling — breach pauses the company, notifying the
+operator).
+
+## The ledger
+
+Append-only money-and-usage journal (`CompanyStore::append_ledger`,
+`ledger.jsonl` in the fs bundle):
+
+| Entry | Recorded |
+| --- | --- |
+| x402 payment in/out | amount, asset, counterparty, engagement link, signer used, receipt |
+| Inference usage | per-cycle token usage against the TinyHumans credential |
+| Handle/subname fees | registry receipts |
+| Budget events | caps approached, breached, company paused |
+
+The ledger is the source for the Earnings surface, budget enforcement,
+platform billing pass-through, and export. It never rewrites; corrections
+are compensating entries.

--- a/docs/spec/company-as-agent/identity.md
+++ b/docs/spec/company-as-agent/identity.md
@@ -1,0 +1,66 @@
+# Identity
+
+## Wallet and keys
+
+- The company identity is an **Ed25519 keypair**; its `agentId` on
+  tiny.place is the base58 Solana address of the public key. The wallet *is*
+  the identity — it owns the handle, signs every action (SIWX), and anchors
+  payments.
+- The seed lives in the company bundle (`keys/agent.ed25519`, `0600`,
+  excluded from exports unless `--include-secrets`). Custody is the
+  **Operator's**: the runtime holds the key to act, but minting spend
+  authority for agents always goes through delegated signers, never the
+  master key ([commerce.md](commerce.md)).
+- **Rotation**: tiny.place identity is key-anchored, so rotation means
+  claiming continuity — re-signing the card and handle records with the new
+  key per the registry's claim flow. Rotation is an Identity checkpoint and
+  journaled. Loss of the seed without a backup loses the handle; the export
+  flow exists precisely so this is recoverable operator error, not fate.
+
+## Handle
+
+- Claimed via `POST /registry/names` — **paid** (annual, priced by label
+  length, USDC). Registration, renewal, and any subname operations are
+  Identity checkpoints; renewal surfaces well before expiry and an expired
+  handle degrades to "not discoverable", never to data loss.
+- The manifest suggests the handle (`[company].handle`); availability is
+  checked during the going-public flow with alternatives offered in plain
+  language.
+- **Who pays**: the operator funds the wallet today (exact amount shown at
+  the checkpoint). A TinyHumans-sponsored delegated signer bundled with the
+  account — so a fresh company's first handle is free to the operator — is
+  an open product question tracked in [roadmap.md](../roadmap.md).
+
+## Agent Card
+
+The public directory record, published with `PUT /directory/agents/{id}` and
+**deterministically generated from the Charter** — the card is a projection,
+never hand-edited:
+
+| Card field | Source |
+| --- | --- |
+| `name`, `description` | Charter `name`, `output`/`mission` |
+| `skills[]`, `paymentRequirements` | Charter services / `[place].skills` (id, description, price) |
+| `capabilities[]`, `tags[]` | template metadata + charter services |
+| `endpoint`, `supportedInterfaces` | this host's `/a2a/{handle}` route |
+| `actorType` | `agent` (the company; the human is not the actor) |
+
+`GET /a2a/{handle}/skill.md` renders the same catalog as capability docs for
+other agents. Any change that would alter the public card (service added,
+price changed) is a Publish checkpoint with a preview; the card version
+history is journaled.
+
+## Optional sub-agent identities
+
+Default: roster stays internal (one company, one agent). When a teammate
+needs an addressable public presence — a support inbox, a procurement bot —
+it MAY get:
+
+- a **subname** under the company handle (e.g. `support.acme`), claimed
+  through the registry's subname surface, and
+- a **delegated signer** as its spending identity, capped and expiring
+  ([commerce.md](commerce.md)).
+
+Sub-identities never hold the master key, inherit the company's policy
+gates, and are listed on the company card as facets, not as independent
+citizens. Creating one is an Identity checkpoint.

--- a/docs/spec/company-brain/README.md
+++ b/docs/spec/company-brain/README.md
@@ -1,0 +1,77 @@
+# The Company Brain
+
+"The core maintains the company brain" means two things: the runtime keeps a
+Company's durable cognitive state consistent, and it drives cognition over
+that state through the `Brain` port. Cognition itself is
+[Medulla](../integrations/medulla.md)'s job; the runtime never reimplements
+it.
+
+Supporting docs: [charter.md](charter.md), [approvals.md](approvals.md),
+[memory.md](memory.md).
+
+## Definition
+
+```text
+CompanyBrain
+├── identity   CompanyId (ULID), Ed25519 keypair, tiny.place @handle, Agent Card
+├── charter    name, output, mission, human_role, policies (mutable at runtime)
+├── roster     teammates: id, role, description, tier hint, tool grants, budgets
+├── memory     compressed cycle traces (~20:1 working memory) + task results
+├── context    addressable chunks (the RLM environment: put/list/peek/search)
+├── world      event log (append-only), ledger, open tasks, approval queue
+└── feedback   inbox of feedback items + links to filed GitHub issues
+```
+
+Each family maps to a storage port ([runtime/ports.md](../runtime/ports.md)):
+identity/charter/roster/world → `CompanyStore` + `EventLog`, memory →
+`MemoryStore`, context → `ContextStore`. All of it exports as one bundle
+([runtime/lifecycle.md](../runtime/lifecycle.md)).
+
+## The cycle
+
+One `CycleRunner::run(company, events) -> CycleReport`, in Medulla
+vocabulary (glossary: Cycle, Pass, Dispatch):
+
+1. **Drain** pending events (batched — a burst of webhooks becomes one
+   cycle).
+2. **Load** working memory: recent compressed traces, the context index,
+   roster and charter.
+3. **Think**: `Brain::run_cycle`. The orchestrator tier reviews everything
+   and loops refine → delegate → dispatch. Mid-cycle callbacks come back to
+   the host: tool calls (grant-checked against the manifest), context ops,
+   and effects.
+4. **Gate**: every effect that crosses the trust boundary — send an external
+   message, spend money, publish, file — passes the
+   [`ApprovalGate`](approvals.md). Allowed effects execute; gated ones park
+   and the cycle result records "awaiting approval".
+5. **Persist**: compressed trace → memory, events and effect outcomes →
+   event log, spend/usage → ledger.
+
+Inherited from Medulla: termination by construction (pass ceiling, budget
+exhaustion, forced final turn) and at least one channel response per cycle.
+Added by the kernel: a wall-clock timeout and a per-cycle budget cap.
+
+## One voice
+
+The Operator chats with **the company**, not with teammates. The brain
+compresses inward (everything the roster did becomes working memory) and
+compiles outward (one coherent reply per surface, produced by dispatch).
+This is a product invariant, not just an implementation detail: exposing
+per-agent chat would leak roster mechanics that the
+[prosumer language rules](../glossary.md) forbid, and it would break the
+single-approval-queue model.
+
+## State ownership boundaries
+
+| State | System of record | Notes |
+| --- | --- | --- |
+| Charter, roster, ledger, approvals | OpenCompany (`CompanyStore`/`EventLog`) | never delegated |
+| Working memory (compressed traces) | `MemoryStore` — fs default, TinyCortex target | hosted Medulla also keeps server-side compressed state per session; the local copy is authoritative for export |
+| Context chunks | `ContextStore` | ditto |
+| Conversation history with the hosted brain | TinyHumans backend (per-session messages) | mirrored locally via the read surface when needed |
+| Channel credentials, tool state | OpenHuman domains | reached through ports, never copied |
+| Reputation, payments record | tiny.place ledger (on-chain / directory) | the local ledger journals our view |
+
+The rule: **anything needed to move a company between hosts lives behind the
+four storage ports**; everything else is reconstructible or belongs to a
+neighbor system.

--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -1,0 +1,71 @@
+# Checkpoints and Approvals
+
+The trust core of the product: agents act freely inside the fence; anything
+irreversible waits for the Operator. This doc is normative.
+
+## Checkpoint taxonomy
+
+Effect kinds that MAY require sign-off, grouped by what they risk:
+
+| Group | Effect kinds (examples) | Default in `supervised` mode |
+| --- | --- | --- |
+| **Spend** | `payment.send`, `subscription.start`, x402 outbound above cap | approval above `auto_approve_under_usd` |
+| **Send** | `email.send`, `dm.external`, any first message to a new counterparty | approval for new counterparties; allowed for established threads |
+| **Sign** | `filing.submit`, `contract.accept` | always approval |
+| **Publish** | `external.publish`, Agent Card / price changes, website deploys | always approval |
+| **Hire** | outbound A2A engagement with a new company; firing a vendor | approval above threshold or first-time counterparty |
+| **Identity** | handle registration/renewal, key rotation, delegated signer mint/expand | always approval |
+
+`readonly` mode gates *every* effect; `full` mode auto-allows everything
+except `[policy].always_approve` entries. Modes mirror OpenHuman's security
+tiers so an OpenHuman-backed `ApprovalGate` maps 1:1.
+
+## Approval lifecycle
+
+```text
+effect emitted ─▶ evaluate ─▶ Allow ─▶ execute, journal
+                      │
+                      ├─▶ Deny ─▶ returned to brain as refusal (it replans)
+                      │
+                      └─▶ RequireApproval ─▶ park (ApprovalId)
+                                              │  surfaces in approvals inbox + chat
+                                              ▼
+                            operator resolves: approve │ deny │ edit
+                                              │
+                                              ▼
+                            ApprovalResolved event ─▶ follow-up cycle
+```
+
+- **Default-deny on silence**: parked approvals expire (default 7 days,
+  configurable) to `deny`. Nothing irreversible ever happens because the
+  Operator was on vacation.
+- **Edit** lets the Operator amend the effect payload (fix the email, lower
+  the amount) and approve the amended version; the brain sees both the
+  original and the edit.
+- Resolution requires operator auth ([runtime/api.md](../runtime/api.md));
+  the resolving `Actor` is journaled.
+- Approve executes the parked effect exactly once
+  (journal-before-execute, [runtime/lifecycle.md](../runtime/lifecycle.md));
+  deny feeds the refusal back so the brain replans rather than retries.
+
+## Delegation levels (standing rules)
+
+Prosumers adjust the fence in plain language, which compiles to policy:
+
+- "Auto-approve spending under $5" → `auto_approve_under_usd = 5.0`
+- "Never contact my customers directly" → `never_do` → `Deny` on
+  `dm.external` matching the customer list
+- "You can post to the blog without asking" → remove `external.publish`
+  from `always_approve` for that channel
+
+Standing-rule changes are themselves Charter edits with provenance and audit
+([charter.md](charter.md)); loosening a rule takes effect for *future*
+effects only.
+
+## Audit
+
+The approval log is immutable: every evaluate decision, park, resolution
+(with actor and timestamp), expiry, and execution outcome is an `EventLog`
+entry, and money-touching effects additionally journal to the ledger. The
+operator surface renders this as plain history ("you approved sending the
+Acme invoice on June 2").

--- a/docs/spec/company-brain/charter.md
+++ b/docs/spec/company-brain/charter.md
@@ -1,0 +1,57 @@
+# Charter
+
+The Charter is the company's constitution: what it is, what it sells, how it
+speaks, and what it must never do without asking. It seeds from the manifest
+`[company]` table, fills in during the onboarding interview, and stays
+editable by the Operator for the company's whole life.
+
+## Schema
+
+Stored in `CompanyStore` as part of the `CompanyRecord`; the manifest is the
+seed layer, not the live record ([runtime/manifest.md](../runtime/manifest.md)).
+
+| Field | Source | Purpose |
+| --- | --- | --- |
+| `name` | manifest `[company].name` | display + Agent Card |
+| `output` | manifest `[company].output` | one-line what-we-make |
+| `mission` | interview | longer articulation the brain quotes when reasoning |
+| `human_role` | manifest `[company].human_role` | what the Operator keeps |
+| `services` | interview / `[place].skills` | the catalog: id, description, price — source of truth for the Agent Card |
+| `tone` | interview | voice rules for outbound copy |
+| `never_do` | interview | hard prohibitions, enforced as `Deny` in the ApprovalGate |
+| `spend_caps` | `[policy]`, `[budget]` | standing limits |
+| `checkpoint_overrides` | `[policy]` + runtime edits | per-effect-kind approval rules |
+
+## Provenance
+
+Every field records which layer set it: template default ⟵ manifest ⟵
+interview answer ⟵ operator edit (later wins). The operator-facing settings
+surface shows this provenance ("you changed this on May 3; the template
+default was …") and every change lands in the `EventLog` as an auditable
+event.
+
+## The onboarding interview
+
+When a company enters `onboarding`
+([runtime/lifecycle.md](../runtime/lifecycle.md)), the brain runs a short
+plain-language interview: *Who are your customers? What do you charge? What
+should I never do without asking you?* Answers populate `mission`,
+`services`, `tone`, and `never_do`. The interview is skippable; skipped
+fields keep template defaults. Non-AI-savvy phrasing is a requirement, not a
+nicety — the interview is most prosumers' first contact with the product.
+
+## Enforcement points
+
+The Charter is consulted, not decorative:
+
+- **Dispatch guardrails** — `tone` and `never_do` are injected into the
+  brain's prompt variables every cycle.
+- **ApprovalGate** — `never_do` compiles to `Deny` rules;
+  `checkpoint_overrides` and `spend_caps` drive
+  Allow/RequireApproval/Deny decisions ([approvals.md](approvals.md)).
+- **Agent Card generation** — `services` deterministically generates the
+  card and `skill.md`
+  ([company-as-agent/identity.md](../company-as-agent/identity.md));
+  publishing a changed card is itself a checkpoint.
+- **Delegated signer caps** — `spend_caps` bound every signer minted
+  ([company-as-agent/commerce.md](../company-as-agent/commerce.md)).

--- a/docs/spec/company-brain/memory.md
+++ b/docs/spec/company-brain/memory.md
@@ -1,0 +1,54 @@
+# Memory
+
+What a company remembers, where it lives, and the Operator's rights over it.
+
+## What is remembered
+
+| Kind | Written by | Retention |
+| --- | --- | --- |
+| Compressed cycle traces (~20:1 working memory) | every cycle | rolling window feeds cycles; older traces retained until evicted |
+| Task results (delegated work products) | cycles | durable |
+| Context chunks (documents, research, transcripts the brain filed) | cycles, imports | durable, content-addressed |
+| Customers, engagements, decisions, outcomes | cycles (as structured task results / context) | durable |
+| Feedback items and their issue links | feedback flow | durable |
+
+Conversation history with the hosted brain also exists server-side per
+session ([integrations/medulla.md](../integrations/medulla.md)); the local
+stores remain authoritative for export and migration.
+
+## Port boundary
+
+Memory is two ports, not a database
+([runtime/ports.md](../runtime/ports.md)):
+
+- **`MemoryStore`** — traces and task results; the shape of Medulla's
+  `CyclePersistence` (`save_trace`, `recent_traces`, `save_task_result`,
+  `evict`).
+- **`ContextStore`** — the RLM environment (`put`/`list`/`peek`/`search`)
+  the brain queries lazily instead of stuffing context windows.
+
+**TinyCortex is the intended backend for both**
+([integrations/tinycortex.md](../integrations/tinycortex.md)) but is a
+choice, not a dependency: the fs default preserves the one-key promise, and
+DB-agnosticism applies to memory exactly as to every other store.
+
+## Compounding
+
+Each cycle loads recent traces, so decisions and outcomes bias future work —
+this is the mechanism behind "memory compounds" in the
+[vision](../vision/README.md). Eviction (`evict` with an `EvictionPolicy`)
+keeps the working window bounded; evicted traces are archived, not deleted,
+until retention policy or the Operator says otherwise.
+
+## Operator rights (normative)
+
+- **Inspect**: `GET /api/v1/companies/{id}/memory/traces` and the exported
+  bundle expose everything remembered, human-readably.
+- **Delete**: the Operator MAY delete any memory item or context chunk;
+  deletion propagates to the backing store and is journaled (that a deletion
+  happened is auditable; the content is gone).
+- **Redact**: customer-content redaction requests are honored across traces
+  and chunks — required for the privacy stance in
+  [feedback-loop/privacy.md](../feedback-loop/privacy.md).
+- **Export**: memory travels with the bundle; no store may hold memory
+  hostage ([runtime/lifecycle.md](../runtime/lifecycle.md), export).

--- a/docs/spec/feedback-loop/README.md
+++ b/docs/spec/feedback-loop/README.md
@@ -1,0 +1,66 @@
+# Feedback Loop
+
+The product improves through its users: feedback captured in-product becomes
+**public GitHub issues** on `tinyhumansai/opencompany`, triage clusters them
+into roadmap items, and releases tell the users who spoke up that they were
+heard. This is the [vision's](../vision/README.md) learning loop, made
+concrete.
+
+Supporting docs: [privacy.md](privacy.md) (normative scrubbing rules),
+[triage.md](triage.md) (labels and closure).
+
+## The loop
+
+```text
+operator reaction ─▶ Feedback Item ─▶ scrub ─▶ preview ─▶ GitHub issue
+        ▲                                                     │
+        │                                              triage / cluster
+        │                                                     │
+"2 things you flagged were fixed in v0.4" ◀── release ◀── roadmap item
+```
+
+## Capture
+
+Every brain reply, deliverable, and approval request carries a lightweight
+reaction affordance: thumbs-down, "this was wrong", or free text. Capture
+also works via `POST /api/v1/companies/{id}/feedback`
+([runtime/api.md](../runtime/api.md)), an operator-chat intent ("that
+invoice was wrong — flag it"), and a built-in `feedback` tool the brain
+itself can invoke when the operator complains mid-conversation.
+
+A **Feedback Item** snapshots: category, the operator's words, the work item
+it concerns, template name + version, runtime version, and a *redacted*
+context excerpt. Items persist in the company's feedback family
+([company-brain](../company-brain/README.md)) whether or not they are ever
+filed.
+
+## Consent modes
+
+| Mode | Behavior | Default |
+| --- | --- | --- |
+| **manual** | Operator files via a prefilled issue link; nothing leaves the machine otherwise | ✔ default |
+| **assisted** | The company drafts the issue; the operator taps approve on the exact final body | opt-in |
+| **auto** | Standing consent per category ("file template gaps without asking"); revocable anytime; still journaled | opt-in |
+
+In every mode the **scrub-then-preview** gate of
+[privacy.md](privacy.md) applies: the operator (or their standing consent)
+sees exactly what becomes public. Filing without `GITHUB_TOKEN` degrades to
+the manual prefilled link ([runtime/config.md](../runtime/config.md)).
+
+## Agent-filed issues
+
+Assisted/auto filings are posted by a shared bot account and **signed with
+the company's @handle** in the issue body for provenance (verifiable against
+the tiny.place directory). Obligations: dedupe against existing issues
+before filing (search first, comment instead of duplicating), rate-limit per
+company, and label `source/agent-filed` so triage can weight accordingly.
+
+## Closing the loop
+
+- Filed issues' URLs land back in the Feedback Item; a scheduled poll tracks
+  status changes into company memory.
+- Release notes map fixes → originating issues
+  ([triage.md](triage.md)); the runtime surfaces this in-product: *"2 things
+  you flagged were fixed in v0.4"*, and the bot comments on the issues.
+- The loop is measured: time-to-triage, cluster-to-roadmap rate, and
+  fixed-feedback-per-release are the health metrics of the product itself.

--- a/docs/spec/feedback-loop/privacy.md
+++ b/docs/spec/feedback-loop/privacy.md
@@ -1,0 +1,42 @@
+# Privacy Scrubbing
+
+Feedback goes to a **public** issue tracker; the scrubber is the
+non-negotiable gate between a company's private context and the internet.
+This document is normative.
+
+## Redaction classes
+
+Before anything leaves the machine, the scrubber MUST remove or mask:
+
+| Class | Examples | Strategy |
+| --- | --- | --- |
+| **Secrets** | TinyHumans credential, GitHub tokens, channel HMACs, anything from `SecretStore` | exact + entropy-pattern match; a `SecretStore` value appearing anywhere aborts filing outright |
+| **Wallet material** | seeds, private keys, delegated-signer grants; wallet addresses | keys abort; addresses masked (`sol:…abcd`) |
+| **Personal data** | emails, phone numbers, personal names, physical addresses | pattern + roster/contact-list match → `⟨redacted:email⟩` placeholders |
+| **Customer content** | message bodies, documents, deliverables belonging to the company's customers | never included; excerpts come only from runtime/brain output, not customer input |
+| **Charter specifics** | prices, client lists, never-do rules, mission text | replaced by structural descriptions ("a priced skill", "a standing deny rule") |
+
+What remains — and is all a useful issue needs: the category, the operator's
+own words (scrubbed), template name + version, runtime version, the effect
+kind or route involved, and error codes.
+
+## The preview gate (normative)
+
+- The operator MUST be shown the **exact final issue body** — post-scrub,
+  byte-for-byte what will be posted.
+- Nothing is transmitted without explicit confirmation or a standing
+  per-category auto-consent ([README.md](README.md)); auto-consent filings
+  are journaled and the operator can review every filed body after the fact.
+- Scrubbing failures fail **closed**: if a redaction class can't be
+  evaluated (e.g. secrets store unreadable), filing is blocked, not risked.
+
+## Data minimization
+
+- Issues carry the minimum to reproduce: prefer structural description over
+  raw excerpt; excerpts are capped and always scrubbed.
+- The unscrubbed original stays **local** in the feedback family — the
+  maintainers can ask for more via the issue thread, and the operator
+  decides again.
+- Deletion rights ([company-brain/memory.md](../company-brain/memory.md))
+  cover feedback items; deleting one does not delete the public issue (the
+  operator is told this at preview time).

--- a/docs/spec/feedback-loop/triage.md
+++ b/docs/spec/feedback-loop/triage.md
@@ -1,0 +1,52 @@
+# Triage
+
+How filed feedback becomes shipped improvement, and how the loop closes.
+
+## Label taxonomy
+
+Every feedback issue gets `feedback` plus one from each axis:
+
+| Axis | Values | Meaning |
+| --- | --- | --- |
+| `type/` | `wrong-output` | the company produced incorrect/bad work |
+| | `bug` | runtime misbehavior (crash, lost event, broken route) |
+| | `missing-capability` | "it can't do X" |
+| | `approval-friction` | the fence is wrong: over- or under-asking |
+| | `template-gap` | a template's roster/charter/defaults fall short |
+| | `docs` | docs wrong or missing |
+| `area/` | `brain`, `runtime`, `product`, `template:<name>`, `integration:<name>` | owning surface |
+| `sev/` | `annoyance`, `blocked`, `money-lost` | operator impact |
+| `source/` | `operator`, `agent-filed`, `platform` | who filed |
+
+`sev/money-lost` issues page maintainers; `area/brain` issues that reproduce
+upstream get mirrored to the owning repo (medulla/backend) with a link, per
+the [reuse-first rule](../integrations/README.md).
+
+## Triage flow
+
+1. **Dedupe/cluster** — a triage agent (itself an OpenCompany-style roster
+   job, Phase 6) searches existing issues, merges duplicates by commenting
+   and closing, and maintains cluster issues ("12 reports: email drafts too
+   formal — template:marketing_agency").
+2. **Human triage** — maintainers confirm labels, set severity, and answer
+   the operator in the thread.
+3. **Promotion** — clusters crossing a threshold (count × severity) become
+   roadmap items with the cluster issue linked; the threshold and the
+   current promotions are public in the tracker, so users can see the
+   pipeline they feed.
+
+Agent-filed issues (`source/agent-filed`) carry the filing company's
+@handle; repeated low-quality filings from a handle throttle that company's
+auto-consent mode.
+
+## Release-notes contract (normative)
+
+- Every release's notes include a **"You said, we did"** section mapping
+  fixed issues → the feedback that caused them (issue links, not private
+  data).
+- On release, the bot comments on each fixed issue; the runtime's update
+  check surfaces the in-product notice — *"2 things you flagged were fixed
+  in v0.4"* — to the specific operators whose feedback items link those
+  issues ([README.md](README.md)).
+- A fix without a linked issue is fine; a `feedback`-labeled issue closed by
+  a release without appearing in the notes is a process bug.

--- a/docs/spec/glossary.md
+++ b/docs/spec/glossary.md
@@ -1,0 +1,87 @@
+# Glossary
+
+This file is the authoritative vocabulary for every document under
+`docs/spec/`. Other docs link here on first use instead of redefining terms.
+
+## Core nouns
+
+| Term | Definition |
+| --- | --- |
+| **Company** | One running instance of a one-person business: Charter + Roster + Brain + Memory + Ledger, hosted by the OpenCompany runtime. |
+| **Operator** | The one human who owns a Company. Provides capital, taste, and irreversible decisions. Exactly one per Company. |
+| **Platform Operator** | The persona that embeds the `opencompany` crate or hosts many Companies behind a provisioning API. |
+| **Brain** | A Company's cognition and the durable state it runs over. Cognition is provided by Medulla through the `Brain` port; the runtime's core job is keeping the brain state consistent and durable. |
+| **Company Brain state** | The seven state families: identity, charter, roster, memory, context, world (event log + ledger + approvals), and feedback inbox. |
+| **Cycle** | One brain iteration over a batch of events: orchestrate → refine / delegate / dispatch → responses out, memory written back. Medulla term, adopted as-is. Internal-only; never shown to prosumers. |
+| **Pass** | One orchestrate↔execute round trip inside a Cycle (Medulla caps at 12). Internal-only. |
+| **Dispatch** | The orchestrator's instruction to compile output for one surface. Internal-only. |
+| **Teammate** | A Roster member with a mandate (internally: an agent). *Teammate* is the prosumer-facing word. |
+| **Roster** | The set of Teammates a Company employs, declared in the manifest (`[[agent]]` entries). |
+| **Charter** | The Company's constitution: name, mission, output, services and prices, tone, never-do policies, spend caps, checkpoint overrides. Extends the manifest's `[company]` table. |
+| **Template** | A packaged company definition ready to launch — the productized form of the 18 `examples/*` manifests. |
+| **Manifest** | The on-disk company definition (`company.toml`, with `agents.toml` accepted for compatibility). |
+| **Checkpoint** | A moment that requires human sign-off before an effect executes (spend, send, sign, publish, hire, identity change). |
+| **Approval** | The Operator's decision at a Checkpoint: approve, deny, or edit. |
+| **Effect** | Any action that touches the world (send a message, call a paid API, spend money, publish). Effects pass the `ApprovalGate` before execution. |
+| **Event** | A normalized stimulus entering a Company: operator message, webhook, schedule firing, A2A task, approval resolution, feedback filing. |
+| **Engagement** | A paid job between Companies delivered over A2A. |
+| **Feedback Item** | A captured "this was wrong" (or thumbs-down) with scrubbed context, optionally filed as a public GitHub issue. |
+| **Work Feed** | The prosumer surface listing what the team did, in plain language. |
+
+## Brain and cycle terms (Medulla mapping)
+
+Medulla vocabulary is adopted unchanged where it appears; see
+[integrations/medulla.md](integrations/medulla.md) for the wire contract.
+
+| Medulla term | Meaning here |
+| --- | --- |
+| **Tier** | A named cognition class (`orchestrator`, `reasoning`, `frontend`, `compress`, `subconscious`). The client only names a tier; the TinyHumans backend maps tier → model SKU. OpenCompany never selects models. |
+| **Compressed history** | ~20:1 summaries of cycle traces — the Company's working memory, persisted through `MemoryStore`. |
+| **World-state diff** | Append-only notes about the world uploaded between cycles (`POST /orchestration/v1/world-diff`). |
+| **Steering** | A directive synthesized by the subconscious tick that biases future cycles. |
+| **Device tool** | A tool the client registers over Socket.IO that the hosted brain calls back into (`orch:tool_call` → `orch:tool_result`). |
+| **ContextStore** | The RLM environment: addressable chunks the brain queries lazily (`put`/`list`/`peek`/`search`). |
+
+## Economy terms (tiny.place mapping)
+
+| Term | Meaning here |
+| --- | --- |
+| **Handle** | The Company's paid `@name` on tiny.place, claimed via `POST /registry/names`. |
+| **Wallet** | The Company's Ed25519 keypair; the base58 Solana address of its public key is its `agentId`. The wallet *is* the identity — there are no API keys on tiny.place. |
+| **Agent Card** | The public directory listing (skills, capabilities, endpoint, payment requirements) published with `PUT /directory/agents/{id}`. Generated from the Charter's service catalog. |
+| **Skill** | A sellable capability priced in x402 USDC on the Agent Card. |
+| **A2A** | Agent-to-agent JSON-RPC task delegation (`POST /a2a/{id}`, discovery via `GET /a2a/{id}/skill.md`). |
+| **x402** | The HTTP-402 micropayment protocol (USDC on Solana) used to price and settle Skills. |
+| **Delegated Signer** | A budget-capped, expiring session key minted from the master wallet so agents can spend without holding the master key. |
+| **Ledger** | The Company's money and usage journal: every payment in/out, token spend, signer used, engagement link. Append-only. |
+| **SIWX** | Per-action wallet-signature authentication used by tiny.place (no bearer tokens). |
+
+## Legacy / AVI term bridge
+
+The [vision doc](vision/README.md) predates this spec. Its terms map as:
+
+| AVI term | Current term |
+| --- | --- |
+| Venture | Company |
+| Assigned humans | Operator |
+| Agent team | Roster of Teammates |
+| Venture Orchestrator | Brain (Medulla) |
+| Governance / approvals | Checkpoints and Approvals |
+| Learning loop | Feedback Loop |
+| Knowledge Graph | Memory (future evolution) |
+| Signal / Opportunity | Reserved for Stage 3+ features; defined now, unused in the kernel |
+
+## Prosumer translation table (normative)
+
+Prosumer-facing docs and UI text MUST use the right-hand column and MUST NOT
+use the left-hand column:
+
+| Internal term | What the Operator sees |
+| --- | --- |
+| agent, agent graph | your team / a teammate |
+| dispatch, pass, cycle | (never shown; describe the work itself) |
+| tier, SKU, model routing | (never shown) |
+| checkpoint raised | "needs your approval" |
+| A2A engagement | "a job from/for another company" |
+| effect denied by policy | "blocked by your rules" |
+| event log replay | (never shown) |

--- a/docs/spec/integrations/README.md
+++ b/docs/spec/integrations/README.md
@@ -1,0 +1,40 @@
+# Integrations
+
+How OpenCompany composes its neighbor systems, and the rules that keep it a
+thin kernel instead of a fork farm.
+
+## The reuse-first rule (normative)
+
+OpenCompany MUST NOT reimplement what a neighbor already provides. When a
+neighbor lacks something the runtime needs, the fix is a PR against that
+neighbor's repo — never a local fork or a parallel implementation. Candidate
+upstream workstreams are tracked in [roadmap.md](../roadmap.md) and in each
+integration doc.
+
+The corollary: every neighbor sits behind a kernel port
+([runtime/ports.md](../runtime/ports.md)), so being *preferred* never means
+being *required*.
+
+## Dependency matrix
+
+| System | Doc | Class | Without it |
+| --- | --- | --- | --- |
+| Medulla via TinyHumans backend | [medulla.md](medulla.md) | **required for cycles** | build/inspect/explore only |
+| OpenHuman | [openhuman.md](openhuman.md) | default tools/channels | built-in tools; extra channels disabled |
+| TinyAgents | [tinyagents.md](tinyagents.md) | default harness (feature `tiny`) | stub brain and local workers unavailable |
+| TinyCortex | [tinycortex.md](tinycortex.md) | optional memory backend | fs memory bundle |
+| tiny.place | [tinyplace.md](tinyplace.md) | optional economy (feature `tinyplace`) | company runs privately |
+
+## Vendoring and versioning
+
+- `vendor/openhuman` and `vendor/tinyagents` are git submodules
+  (`git submodule update --init --recursive`); OpenHuman nests its own
+  submodules including TinyCortex and the tiny.place SDK.
+- Published crates are preferred where they exist: `tinyagents = "1.8"`
+  (path-patched to the submodule via `[patch.crates-io]`), `tinyplace =
+  "2.0"`.
+- OpenHuman is **never compiled into** the host: it is launched
+  (`opencompany open-human`) or attached to (`OPENCOMPANY_OPENHUMAN_URL`)
+  and spoken to over JSON-RPC.
+- Submodule bumps are ordinary PRs with a changelog note; integration docs
+  state which version they were written against and get re-verified on bump.

--- a/docs/spec/integrations/medulla.md
+++ b/docs/spec/integrations/medulla.md
@@ -1,0 +1,159 @@
+# Medulla (the hosted brain)
+
+Medulla is TinyHumans' orchestrator-first cognitive model: a closed-loop
+cycle (orchestrate → refine / delegate / dispatch) with guaranteed
+termination and at least one response per cycle. The library itself is
+TypeScript and import-only; OpenCompany consumes it **as a hosted service**
+through the TinyHumans backend, which mounts it at `/orchestration/v1/*` on
+`api.tinyhumans.ai`. The Rust runtime plays the same role the OpenHuman
+desktop app plays today: the **device client** that ingests events, receives
+effects, and services device-tool callbacks.
+
+`HostedMedullaBrain` (`src/brain/hosted.rs`) implements the
+[`Brain` port](../runtime/ports.md) over this contract.
+
+## Cognition contract (what the brain guarantees)
+
+- One cycle per wake: orchestrator tier reviews everything, loops
+  refine/delegate/dispatch, pass ceiling 12.
+- Tiers name cognition classes only — `orchestrator`, `reasoning`,
+  `frontend`, `compress`, `subconscious`. The **server** maps tier → SKU
+  (today: frontend→`chat-v1`, reasoning→`agentic-v1`, compress→`burst-v1`,
+  subconscious→`reasoning-v1`; billed against the opaque `orchestrator-v1`
+  SKU). The client can never select a model: any request body containing a
+  `model` field is rejected with `400 ORCH_MODEL_NOT_ALLOWED`.
+- Working memory is compressed ~20:1 server-side per session; steering
+  directives from the subconscious tick bias future wakes.
+
+## Wire contract, v1 (as implemented today)
+
+### Envelope
+
+- Every request body carries `"protocol": 1` (server supports range [1,1];
+  mismatch → `409 ORCH_PROTOCOL_MISMATCH` with `{min,max}`).
+- Success: `{ "success": true, "data": … }`. Error:
+  `{ "success": false, "error", "errorCode"?, "details"? }`.
+- Error codes: `ORCH_PROTOCOL_MISMATCH`, `ORCH_MODEL_NOT_ALLOWED`,
+  `ORCH_VALIDATION_ERROR`, `ORCH_INSUFFICIENT_BALANCE`, `ORCH_RATE_LIMITED`,
+  `ORCH_UPSTREAM_MODEL_ERROR`, `ORCH_INVALID_STATE`, `ORCH_DEVICE_OFFLINE`,
+  `ORCH_EXECUTE_TIMEOUT`.
+- Auth: `Authorization: Bearer <credential>` on HTTP; the same credential as
+  the Socket.IO handshake `auth.token`
+  ([runtime/config.md](../runtime/config.md) — session JWT today, API key
+  as the contract).
+
+### HTTP endpoints
+
+**`POST /orchestration/v1/events`** — ingest an event; the wake trigger.
+
+```json
+{
+  "protocol": 1,
+  "counterpartAgentId": "string(1..256)",
+  "sessionId": "string(1..256)",
+  "event": {
+    "seq": 0,
+    "role": "user|assistant|system",
+    "sender": "string(1..256)",
+    "body": "string(≤200000, plaintext)",
+    "ts": 0,
+    "kind": "string(1..64)"
+  }
+}
+```
+
+→ `202 { "data": { "accepted": true, "cycleId": "cyc:<counterpart>:<session>:<seq>" } }`.
+Idempotent on `(user, counterpartAgentId, sessionId, seq)`. The reply is
+**not** in the HTTP response — the wake fires out-of-band and results arrive
+over Socket.IO.
+
+**`POST /orchestration/v1/world-diff`** — upload world-state notes (feeds
+the subconscious tick):
+`{ protocol, sessionId, entries: [{seq, note(≤8000), ts}] (1..500) }` →
+`202 { accepted, duplicates, tickScheduled }`.
+
+**Read surface** (all `{ success, data }`):
+
+```text
+GET /orchestration/v1/sessions                      SessionSummary[]
+GET /orchestration/v1/sessions/:id/messages?after=  MessageView[] (seq asc, page 200)
+GET /orchestration/v1/sessions/:id/state            { sessionId, status, lastSeq, lastCycleId? }
+GET /orchestration/v1/steering                      { active|null, history }
+GET /orchestration/v1/world-diff?session=<id>       WorldDiffView[]
+```
+
+### Socket.IO channel (effects + device tools)
+
+Default namespace, credential in handshake `auth.token`.
+
+- **Effects out**: events named `orch:effect:<kind>` (e.g.
+  `orch:effect:send_dm`), frame `{ cycleId, callId, …payload }`. Delivery is
+  **at-least-once** — pending effects replay on reconnect; the client MUST
+  dedupe on `callId` (deterministic `{cycleId}:{kind}:{index}`).
+- **Acks**: client emits `orch:effect:result`
+  `{ callId, ok, error?, result? }`.
+- **Device tools** (client-provided tools the brain can call):
+  1. On connect, register the manifest: `orch:register_tools`
+     `{ tools: [{ name, description?, inputSchema? }] }`.
+  2. Mid-cycle the server emits `orch:tool_call`
+     `{ cycleId, callId, name, args, timeoutMs }` (~30 s timeout).
+  3. Client answers `orch:tool_result` `{ callId, ok, result?, error? }`.
+  Cloud tools (server-side) win over device tools on name collision; unknown
+  tools are rejected.
+
+## How `HostedMedullaBrain` maps the kernel onto v1
+
+| Kernel concept | v1 mapping |
+| --- | --- |
+| `CompanyId` | one session per company: `sessionId = company ULID`, `counterpartAgentId = "opencompany:<slug>"`. One TinyHumans account may host many companies as many sessions. |
+| `CycleRequest.events` | one `POST /v1/events` per normalized event, seq from the `EventLog` sequence |
+| `CycleResult` channel responses | `orch:effect:send_dm` frames, acked then routed to `ChannelAdapter`s |
+| `CycleHost::call_tool` | device-tool round-trip: the runtime registers the company's granted tool catalog via `orch:register_tools`; `orch:tool_call` → `ToolProvider::invoke` → `orch:tool_result` |
+| `CycleHost::context_op` | exposed as device tools (`context_put`, `context_search`, …) until v2 adds first-class context ops |
+| `CycleHost::emit_effect` | every effect frame passes the `ApprovalGate` **before** acking `ok`; parked effects ack `ok: false` with a "pending approval" error so the brain hears the gate |
+| `MemoryStore` | mirrors the read surface (`/sessions/:id/messages`) plus locally-journaled cycle summaries; server keeps its own compressed state |
+| World state | `POST /v1/world-diff` after notable local effects (approvals resolved, payments, feedback) |
+
+Constraints inherited from v1: the 30 s device-tool timeout means long tools
+must return a handle and complete asynchronously (result uploaded as a
+follow-up event); effect delivery requires a live socket, so the runtime
+maintains a persistent reconnecting connection per account and marks the
+company `paused` with an operator notice if the backend is unreachable for
+long periods.
+
+## Proposed v2 (candidate backend workstream)
+
+v1 is per-user and chat-session-shaped. A company-scoped v2 would add — as
+PRs against the backend, tracked in [roadmap.md](../roadmap.md):
+
+1. **API-key auth** for headless hosts (issuance + scoping), fulfilling the
+   `TINYHUMANS_API_KEY` contract.
+2. **Company-scoped routing**: first-class `companyId` on events, sessions,
+   and effect frames; server-side multiplexing of many companies over one
+   socket with per-company ordering.
+3. **Richer effect vocabulary**: beyond `send_dm` — typed effects for
+   publish, payment intents, and approval-aware dispositions so the gate
+   result is a first-class protocol state rather than an error-shaped ack.
+4. **First-class context ops**: `context_put/list/peek/search` as protocol
+   frames instead of device tools, aligning the wire with Medulla's
+   `ContextStore` port.
+5. **Tool namespacing + long-running tools**: per-company tool manifests,
+   call handles that outlive the 30 s window.
+6. **Orchestrator-tier events**: expose pass/dispatch telemetry so the work
+   feed can narrate progress without scraping messages.
+
+## Modes other than hosted
+
+- **`SidecarBrain`** (feature `sidecar`): a thin Node process embedding
+  `@tinyhumansai/medulla-v1` directly, speaking the same frames over local
+  HTTP/stdio; its `InferenceClient` calls back into the Rust host, which
+  proxies to any provider through the TinyAgents harness. For self-hosters
+  who bring their own inference.
+- **`NativeBrain`** (far future): a TinyAgents graph port of `runCycle`.
+  Interface only; no commitment.
+
+## Degraded mode
+
+Without a TinyHumans credential the brain is unavailable; the runtime still
+builds, validates, inspects, and serves read-only routes
+([runtime/config.md](../runtime/config.md)).

--- a/docs/spec/integrations/openhuman.md
+++ b/docs/spec/integrations/openhuman.md
@@ -1,0 +1,62 @@
+# OpenHuman
+
+OpenHuman (vendored at `vendor/openhuman`, written against v0.58.x) is the
+local-first personal-AI product: a Rust core with a Tauri/React shell. For
+OpenCompany it is the **preferred backend for tools, channels, credentials,
+and policy** — roughly 60 mature domains (memory, threads, channels,
+subconscious, routing, providers, tools, skills, cron, workflows, wallet,
+security, people, embeddings, …) that the kernel should consume, not copy.
+
+## Integration seams
+
+- **Process**: the existing launcher (`opencompany open-human [--dry-run]`)
+  shells out through Cargo to `openhuman-core` (Core) or the Tauri app
+  (Desktop); alternatively `OPENCOMPANY_OPENHUMAN_URL` attaches to an
+  already-running `openhuman-core serve`.
+- **Wire**: JSON-RPC at `http://127.0.0.1:<port>/rpc` (methods
+  `openhuman.<namespace>_<function>`, per-launch bearer) plus REST
+  `GET /health`, `GET /schema`, `GET /events`.
+- **Ports backed by OpenHuman**:
+  - `ToolProvider` → the tools/skills domains (`OpenHumanToolProvider`),
+    catalog filtered by the company's manifest grants.
+  - `ChannelAdapter` → the channels domain (email and the other messaging
+    surfaces) as `OpenHumanChannelAdapter`s.
+  - `ApprovalGate` → mapped onto OpenHuman's security tiers
+    (readonly/supervised/full), which is why the manifest `[policy].mode`
+    uses the same three words.
+  - `SecretStore` (optional) → the credentials domain.
+
+All of these degrade: OpenHuman unreachable means built-in tools and the
+operator channel only, with a boot warning
+([runtime/config.md](../runtime/config.md)).
+
+## Desktop story
+
+The Tauri app is a natural prosumer install path: OpenHuman as the shell,
+OpenCompany as the company runtime behind it. Whether the prosumer UI ships
+as an OpenHuman mode or a separate frontend is an open product question
+([product/prosumer.md](../product/prosumer.md)); the runtime API is the same
+either way.
+
+## Upstreaming policy
+
+Glue that adapts OpenHuman's RPC to kernel ports lives in OpenCompany.
+Anything that changes OpenHuman behavior goes upstream. Candidate PRs
+identified so far:
+
+1. **Headless multi-workspace mode** — `openhuman-core serve` today serves
+   one local persona; a `--workspace <id>` scope (or workspace param on RPC
+   methods) would let one daemon serve N companies.
+2. **Library-crate split** — expose the tool/channel/credential/policy
+   domains as an embeddable crate so co-located hosts can link instead of
+   RPC.
+3. **External approval hook** — policy tiers currently resolve in-app; a
+   webhook/RPC callback would let OpenCompany's `ApprovalGate` be the
+   resolver of record.
+4. **Namespaced credentials** — per-workspace credential scoping so company
+   A's secrets are invisible to company B.
+5. **Documented `/events` schema** — the REST event stream exists but has no
+   stable documented schema for external consumers.
+6. **Brain-protocol port** — make OpenHuman's own orchestration loop
+   pluggable so an OpenHuman instance could delegate cognition to a hosted
+   Medulla brain (the inverse of our integration).

--- a/docs/spec/integrations/tinyagents.md
+++ b/docs/spec/integrations/tinyagents.md
@@ -1,0 +1,49 @@
+# TinyAgents
+
+TinyAgents (vendored at `vendor/tinyagents`, crate `tinyagents = "1.8"`,
+Rust 2024) is the recursive language-model harness: durable typed state
+graphs (checkpoints, interrupts, `Send` fan-out, subgraphs), a
+provider-neutral model harness (typed tools, middleware, structured output,
+streaming, usage/cost), a capability registry, the `.rag`/`.ragsh` surfaces,
+and an RLM runtime. It is embedded as a library behind the existing `tiny`
+feature — it is **not** a server.
+
+## What OpenCompany uses it for
+
+- **`StubBrain`** — the Phase 1 offline brain: a single harness call so the
+  whole kernel pipeline is testable without the hosted backend (the mock
+  provider makes this work in CI with no network).
+- **Local worker execution** — when the brain delegates sub-work that should
+  run host-side (long tools, local file work), workers run as TinyAgents
+  sub-agents under `ToolProvider`, with usage/cost rolled into the ledger.
+- **Built-in tools** — the fallback `ToolProvider` when OpenHuman is absent.
+- **`SidecarBrain` inference proxy** — the sidecar's `InferenceClient` calls
+  back into the host, which fulfils it through the TinyAgents harness.
+- **Observability** — the embedded Langfuse exporter, proxied through the
+  TinyHumans backend with the same credential
+  ([runtime/config.md](../runtime/config.md)).
+- **`NativeBrain` (far future)** — a graph port of Medulla's `runCycle`;
+  interface reserved, no commitment
+  ([medulla.md](medulla.md)).
+
+## Roster → execution mapping (internal detail)
+
+A manifest `[[agent]]` entry does **not** become a standing process. The
+Roster is charter data the brain reasons over; when a cycle delegates,
+host-side workers are ephemeral TinyAgents sub-agents parameterized by the
+teammate's role/description/grants, with recursion depth and budget caps
+enforced by the harness (`SubAgentDepth`, usage rollup). This mapping is
+never surfaced to prosumers ([glossary](../glossary.md), translation table).
+
+## Registry use
+
+The TinyAgents registry gives names to capabilities (models/tools/agents/
+graphs) inside a company runtime; the kernel registers the granted tool
+catalog and worker archetypes there so `.ragsh` debugging and future `.rag`
+blueprints see the same catalog the brain does.
+
+## Boundary
+
+TinyAgents never talks to the network on its own in OpenCompany: model
+access goes through the TinyHumans credential; provider keys beyond that are
+out of scope ([roadmap.md](../roadmap.md), non-goals — not a model host).

--- a/docs/spec/integrations/tinycortex.md
+++ b/docs/spec/integrations/tinycortex.md
@@ -1,0 +1,45 @@
+# TinyCortex
+
+TinyCortex is the TinyHumans memory layer — the intended durable backend for
+the company brain's memory. It is registered as an OpenHuman submodule
+(`vendor/openhuman/vendor/tinycortex`) but is not checked out in this repo's
+default state, so this document specifies **expectations against the kernel
+ports**, not TinyCortex internals. When the adapter is written (feature
+`tinycortex`, Phase 6), this doc gets re-verified against the real API.
+
+## Role
+
+Implement the two memory ports
+([runtime/ports.md](../runtime/ports.md)) for companies that outgrow the fs
+bundle:
+
+- **`MemoryStore`** — compressed cycle traces and task results. Requirements
+  the backend must satisfy: append traces keyed by company + cycle, return
+  the N most recent efficiently (this is on the hot path of every cycle),
+  count-or-age-based eviction that archives rather than destroys, and honor
+  hard deletes ([company-brain/memory.md](../company-brain/memory.md),
+  operator rights).
+- **`ContextStore`** — the RLM environment: content-addressed `put`,
+  prefix `list`, ranged `peek`, and relevance `search` over chunks. Search
+  quality is the value proposition — embeddings/semantic recall is exactly
+  what a real memory layer adds over the fs default's lexical search.
+
+## Contract requirements (normative for the adapter)
+
+- **Company isolation**: every operation is scoped by `CompanyId`; the
+  adapter MUST NOT allow cross-company reads regardless of how TinyCortex
+  namespaces internally.
+- **Export completeness**: everything written MUST be readable back out so
+  bundle export stays total
+  ([runtime/lifecycle.md](../runtime/lifecycle.md)).
+- **Deletion and redaction propagate** to the backing store, not just an
+  index.
+- **No new required credentials**: if TinyCortex runs as part of an
+  OpenHuman deployment, it is reached through that seam; the one-key promise
+  is unaffected.
+
+## Fallback
+
+The fs implementation (JSONL traces + content-addressed chunks with a
+lexical index) is always compiled and remains the default. TinyCortex is a
+quality upgrade, not a dependency.

--- a/docs/spec/integrations/tinyplace.md
+++ b/docs/spec/integrations/tinyplace.md
@@ -1,0 +1,88 @@
+# tiny.place
+
+tiny.place is the social economy for AI agents: wallet-keyed identities,
+paid `@handles`, an open directory of Agent Cards, Signal-encrypted
+messaging, A2A JSON-RPC task delegation, and x402 USDC micropayments settled
+on Solana. It is how a Company becomes discoverable and hireable
+([company-as-agent/](../company-as-agent/README.md)).
+
+The `TinyplaceEconomy` adapter (feature `tinyplace`, `src/economy/`)
+implements the [`AgentEconomy` port](../runtime/ports.md) on the official
+Rust SDK, crate **`tinyplace = "2.0"`**.
+
+## Protocol essentials
+
+- **Identity is a keypair.** No API keys or accounts: an agent is an Ed25519
+  keypair; its `agentId` is the base58 Solana address of the public key.
+- **Auth is per-action SIWX.** Every mutating call carries
+  `Authorization: tiny.place <agentId>:<signature>:<timestamp>` over a
+  canonical payload with nonce + ±5 min skew replay protection.
+- **Payments are x402.** Paid endpoints return `402` with a challenge
+  (amount/recipient/asset/network); the caller signs an x402 authorization
+  with the same key; the facilitator verifies and settles (Solana USDC).
+
+## Surfaces used
+
+| Purpose | Endpoint |
+| --- | --- |
+| Claim `@handle` (paid, annual) | `POST /registry/names`; renew via `/registry/names/{id}/renew` |
+| Publish/replace Agent Card | `PUT /directory/agents/{id}` |
+| Discover | `GET /directory/agents`, `GET /directory/skills`, `GET /directory/resolve/{name}` |
+| Delegate work | `POST /a2a/{id}` (JSON-RPC `tasks/send`), `GET /a2a/{id}/skill.md` |
+| Messaging (relay) | key-bundle + opaque-envelope endpoints |
+| Payments | `POST /payments/verify`, `POST /payments/settle` |
+| Budget-capped keys | delegated signers via x402 `upto` authorizations |
+
+## Company onboarding flow
+
+Mirrors the canonical `ensureRegistered → ensureCard → ensureEncryption`
+lifecycle from tiny.place's reference bots:
+
+1. Generate or load the company keypair (`LocalSigner`; seed persisted in
+   the bundle `keys/`, `0600`).
+2. Fund the wallet (handle claims are real USDC). Boot never blocks on this:
+   unfunded wallets skip registration with a clear operator prompt
+   ([runtime/config.md](../runtime/config.md)).
+3. `registry.register(...)` — catch the `402`, check `[budget]` caps and the
+   Identity checkpoint ([approvals](../company-brain/approvals.md)), then
+   complete the paid registration.
+4. `directory.upsert_agent(agent_id, &AgentCard { .. })` — the card is
+   generated from the Charter's service catalog and points `endpoint` /
+   `supportedInterfaces` at our `/a2a/{handle}` route with
+   `paymentRequirements` from `[place].skills`.
+5. Serve the A2A endpoint and `skill.md`
+   ([runtime/api.md](../runtime/api.md)).
+
+## Host responsibilities
+
+- Serve inbound `/a2a/{handle}` with SIWX verification and x402 challenge/
+  verify for priced skills; sanitize counterparty text (promptguard) before
+  it reaches the brain.
+- Outbound hiring: directory search → checkpoint for new counterparties →
+  `send_a2a_task` with x402 payment under `BudgetScope`
+  ([commerce](../company-as-agent/commerce.md)).
+- Journal every payment in/out to the ledger with the engagement link.
+- Renewals: handle expiry surfaces as an Identity checkpoint well before the
+  deadline.
+
+## Rust SDK gaps (plan around these)
+
+The Rust SDK is a fully-typed REST wrapper with signing and x402
+auth-building, but:
+
+- **No Signal E2E crypto** — the SDK moves opaque relay envelopes only.
+  Until Rust E2E exists, company DMs over the encrypted relay are limited to
+  plaintext-free coordination or delegated to a TS-side helper; A2A + HTTP
+  remain the primary work channel.
+- **No on-chain transaction submission** — funding and native settlement
+  happen via the TS SDK/CLI or an external Solana signer; the Rust side
+  verifies receipts.
+
+Both are candidate upstream contributions to the SDK rather than local
+workarounds ([reuse-first rule](README.md)).
+
+## Offline behavior
+
+tiny.place unreachable ⇒ the company keeps working privately: outbound
+economy actions queue in an outbox, the card simply goes stale, and inbound
+A2A returns 503. Discoverability is additive, never load-bearing.

--- a/docs/spec/product/README.md
+++ b/docs/spec/product/README.md
@@ -1,0 +1,48 @@
+# Product
+
+OpenCompany is the open-source runtime that turns one person into a whole
+company: a durable host where the [Brain](../glossary.md) runs a roster of AI
+teammates that do the work, sell services to other agents on tiny.place, and
+ask the human only for the decisions that matter.
+
+Supporting docs: [prosumer.md](prosumer.md), [platform.md](platform.md),
+[templates.md](templates.md).
+
+## Thesis
+
+A single operator brings capital, taste, and irreversible decisions;
+everything else — production, marketing, sales, support, books — is a
+functional job an agent can hold around the clock. "Done" means:
+
+- **For the prosumer**: their business runs while they sleep, nothing
+  irreversible happens without them, and they never needed to learn what an
+  agent graph is.
+- **For the platform operator**: provisioning a working company is one API
+  call, storage is theirs, and upgrades never strand tenant data.
+
+## Personas
+
+| | Prosumer Operator | Platform Operator |
+| --- | --- | --- |
+| Who | A non-AI-savvy person running a one-person business | A builder embedding or hosting fleets of companies |
+| Buys | "OpenCompany is my staff" | "OpenCompany is my company runtime" |
+| Touches | Chat, Work Feed, Approvals Inbox, Earnings, Settings | the crate, the provisioning API, storage ports, webhooks |
+| Never sees | agent graphs, tiers, cycles, dispatch ([glossary](../glossary.md), normative translation table) | prosumer UI (they build their own) |
+
+## Surfaces
+
+| Surface | Core? | What it is |
+| --- | --- | --- |
+| **Chat** | core | One conversation with the company as a single entity — the Brain speaks for the whole org |
+| **Work Feed** | core | What the team did, in plain language, with artifacts attached |
+| **Approvals Inbox** | core | Checkpoints awaiting sign-off: spend, send, sign, publish |
+| **Earnings / Ledger** | with tiny.place | Money in/out, jobs sold and bought |
+| **Settings** | core | Charter edits, standing approval rules, going public, feedback consent |
+
+## The one-key promise (normative)
+
+`TINYHUMANS_API_KEY` is the only required credential
+([runtime/config.md](../runtime/config.md)). Every other integration is
+optional and degrades gracefully; no flow may hard-require a database, a
+funded wallet, a GitHub token, or an OpenHuman install. A violation of this
+promise is a release blocker.

--- a/docs/spec/product/platform.md
+++ b/docs/spec/product/platform.md
@@ -1,0 +1,70 @@
+# Platform Operators
+
+Two consumption modes, one invariant: storage and surfaces belong to the
+platform; the kernel and its guarantees come from the crate.
+
+## Embed mode
+
+Depend on the `opencompany` crate and construct companies programmatically:
+
+```rust
+let runtime = RuntimeBuilder::new(manifest)
+    .company_store(my_postgres_store)   // any impl of the port traits
+    .event_log(my_postgres_log)
+    .memory_store(my_s3_memory)
+    .context_store(my_vector_store)
+    .build()?;
+```
+
+- **Bring your own persistence.** The four storage ports
+  ([runtime/ports.md](../runtime/ports.md)) are the entire storage contract;
+  DB-agnosticism means the kernel never names an engine. A conformance test
+  suite (Phase 5) validates operator-supplied stores: isolation by
+  `CompanyId`, append-only event/ledger semantics, export totality.
+- **Bring your own surfaces.** The platform builds its own UI against the
+  operator API or embeds `CompanyRuntime` directly and skips HTTP.
+
+## Hosted multi-tenant mode
+
+Run `opencompany serve` with a `CompanyRegistry` of many companies:
+
+- **Provision** via `POST /api/v1/companies` with a manifest; per-company
+  lifecycle controls (`pause`, suspend, archive) —
+  [runtime/api.md](../runtime/api.md).
+- **Auth**: platform-issued JWTs per tenant; platform-scope claims for
+  provisioning and suspension. The prosumer-style operator token never
+  crosses tenants.
+- **Webhooks** instead of polling: `approval.requested`, `work.completed`,
+  `feedback.created`, `budget.exhausted`, delivered at-least-once with
+  signature headers.
+- **Ledger read** per company for billing pass-through
+  (`GET /api/v1/companies/{id}` includes budget burn; the ledger itself
+  exports with the bundle).
+
+## Tenancy and isolation (normative)
+
+- Every storage port call carries `CompanyId`; stores MUST enforce isolation
+  at that boundary — shared-table implementations must prove it in the
+  conformance suite.
+- Secrets are per-company (`SecretStore`); tool grants never cross
+  companies.
+- One hosted-brain session per company
+  ([integrations/medulla.md](../integrations/medulla.md)); the proposed v2
+  backend adds first-class multi-company multiplexing.
+- Budgets are per-company hard caps; a tenant exhausting its budget pauses
+  only itself.
+
+## Operational concerns
+
+- **Quotas**: max companies per tenant, per-company event-rate limits —
+  enforced at the API layer, configurable by the platform.
+- **Upgrades/migration**: export/import is total by construction
+  ([runtime/lifecycle.md](../runtime/lifecycle.md)), so moving a company
+  between hosts, stores, or versions is tar-out/tar-in; the manifest schema
+  is versioned with compatibility guarantees
+  ([templates.md](templates.md)).
+- **Observability**: tracing via the TinyAgents Langfuse exporter (proxied
+  through the TinyHumans backend), plus the SSE event stream per company;
+  platforms attach their own log/metrics stack around the process.
+- **Who holds the TinyHumans credential**: the platform, one per deployment
+  or per tenant — both work; billing granularity follows the credential.

--- a/docs/spec/product/prosumer.md
+++ b/docs/spec/product/prosumer.md
@@ -1,0 +1,81 @@
+# The Prosumer Journey
+
+The golden path for a non-technical operator, install to earnings. Every
+screen and error message on this path follows the
+[prosumer translation table](../glossary.md) — this doc deliberately uses
+the words the operator will see.
+
+## 1. Install
+
+One download: the desktop app (the Tauri shell — whether it ships as an
+OpenHuman mode or a dedicated frontend is an open question; the runtime API
+is identical) or the `opencompany` binary for the terminal-comfortable.
+Nothing to provision: storage is a folder
+([runtime/lifecycle.md](../runtime/lifecycle.md), fs bundle).
+
+## 2. Connect
+
+Paste the TinyHumans key — framed as *"your company's brain subscription."*
+Validation happens immediately with plain-language failures ("that key
+didn't work — check for a missing character" / "your subscription is out of
+credit"). Without a key the app still opens in explore mode: browse
+templates, read what each company would do.
+
+## 3. Pick a template
+
+The 18 example companies presented as a **Template Gallery** — Marketing
+Agency, Law Firm, Design Studio, … ([templates.md](templates.md)). Each card
+shows: what the company produces, the team it comes with (roles in plain
+words), and **what you keep** (the human role — sign-offs, taste, client
+relationships).
+
+## 4. Name it and interview
+
+The operator names the company; the brain runs a five-minute onboarding
+interview ([charter](../company-brain/charter.md)): who your customers are,
+what you charge, what it must never do without asking. Every question is
+skippable; skipped answers keep sensible template defaults.
+
+## 5. Go live
+
+The company starts working. Daily life happens on three surfaces:
+
+- **Chat** — talk to the company like a cofounder. One voice; asking "who
+  did this?" gets a plain answer ("our copywriter draft, reviewed by the
+  brand lead") without exposing machinery.
+- **Work Feed** — a running plain-language log: "Drafted the May newsletter
+  (attached). Scheduled 3 posts. Two invoices went out."
+- **Approvals Inbox** — anything irreversible waits here with the full
+  context and an approve / deny / edit control
+  ([approvals](../company-brain/approvals.md)). Unanswered requests expire
+  to "no" — silence never spends money.
+
+Notifications: approvals and money events notify immediately; everything
+else digests daily by default.
+
+## 6. Growth moments
+
+Each is a single plain-language decision in Settings:
+
+- **Go public** — "List my company on tiny.place so other companies can
+  hire it." Triggers the [going-public flow](../company-as-agent/README.md):
+  claiming the paid @handle, publishing the services card, opening the jobs
+  endpoint — each step its own approval, including funding the wallet with a
+  clear dollar amount.
+- **Add a channel** — "Let the company answer its own email." (Delegates to
+  OpenHuman channels; degrades with a plain warning if unavailable.)
+- **Loosen the fence** — "Stop asking me about spending under $5."
+  Compiles to a standing rule with visible history
+  ([approvals](../company-brain/approvals.md)).
+- **Say something was wrong** — thumbs-down on any piece of work opens the
+  [feedback flow](../feedback-loop/README.md): the operator previews the
+  exact scrubbed text before anything is filed publicly.
+
+## Failure states, in plain words
+
+| Condition | What the operator sees |
+| --- | --- |
+| Brain unreachable | "The company can't think right now — we're reconnecting. Nothing is lost." |
+| Budget cap hit | "Your company paused itself: it reached the $200 monthly limit you set." |
+| tiny.place down | "Jobs from other companies are paused; your own work continues." |
+| Tool unavailable | "Email isn't connected yet — here's the draft to send yourself." |

--- a/docs/spec/product/templates.md
+++ b/docs/spec/product/templates.md
@@ -1,0 +1,54 @@
+# Templates
+
+A Template is a packaged company definition ready to launch — the productized
+form of today's `examples/*` manifests. The Template Gallery is the
+prosumer's step 3 ([prosumer.md](prosumer.md)).
+
+## Anatomy
+
+A template is a directory containing:
+
+| Part | File | Content |
+| --- | --- | --- |
+| Manifest | `company.toml` | company metadata, roster, default policy/budget/place tables ([runtime/manifest.md](../runtime/manifest.md)) |
+| Story | `README.md` | what the company produces, the team, **what you keep** (human role) |
+| Charter defaults | in-manifest | mission/tone/never-do seeds the interview can override |
+| Skill catalog | `[place].skills` | what the company could sell if taken public (ships `discoverable = false`) |
+| Checkpoint list | `[policy]` | which effects always require the operator |
+
+Templates contain **no code**. The example crates shrink to a manifest plus
+a two-line `main` calling `opencompany::run_company(...)`, so `examples/`
+and the gallery are the same artifact.
+
+## The 18 launch templates
+
+From `examples/`: venture studio, software company, startup accelerator,
+venture capital, consultation firm, marketing agency, design studio, media
+company, influencer business, game studio, game business, recruiting
+company, enterprise sales, customer support, real-estate company, accounting
+firm, law firm, pharma startup. Each README states the human role — e.g. the
+marketing agency keeps *campaign review and sign-off*; the law firm keeps
+*filings and client counsel*.
+
+## Authoring and validation
+
+- New templates are PRs adding a directory under `examples/`; CI runs
+  `opencompany check` on every template manifest.
+- Lint rules: unique agent ids; every `[place].skills` entry priced and
+  described; `[policy]` present (a template without checkpoints is
+  rejected); README states the human role; prosumer-language rules apply to
+  README and descriptions.
+- **Schema versioning**: the manifest carries an implicit schema version;
+  additive keys are minor, semantic changes require a migration note and a
+  `opencompany check --fix` path. Old templates keep working
+  (compatibility rule in [runtime/manifest.md](../runtime/manifest.md)).
+
+## Customization without forking
+
+An operator's changes (interview answers, charter edits, standing rules)
+layer **over** the template with provenance
+([charter.md](../company-brain/charter.md)) — the template underneath stays
+pristine, so a template update can be offered as a diff ("the Marketing
+Agency template improved its SEO teammate — apply?") instead of a merge
+conflict. Applying a template update is an explicit operator action, never
+automatic.

--- a/docs/spec/roadmap.md
+++ b/docs/spec/roadmap.md
@@ -1,0 +1,93 @@
+# Roadmap
+
+Product stages (what a user can do) map onto engineering phases (what ships in
+the crate). Each phase is independently shippable and leaves `main` releasable.
+Terms: [glossary.md](glossary.md).
+
+## Stage 0 — Host (today)
+
+The current state: a thin Axum host (`/healthz`, `/spec`, `/tiny`), a clap CLI,
+a cargo shell-out launcher for OpenHuman, and 18 example companies whose
+`agents.toml` manifests are printed but not executed.
+
+## Stage 1 — Company of One
+
+An Operator boots a real company from a manifest and works with it daily.
+
+- **Phase 0 — Spec + manifest.** This spec; `src/company/manifest.rs` parses
+  `company.toml`/`agents.toml` with validation; `opencompany check <dir>`
+  lints manifests. Examples stop merely printing TOML.
+- **Phase 1 — Kernel + fs store + stub brain.** `src/ports/` traits, file-based
+  default stores, `CompanyRuntime`/`CycleRunner`, event log, operator chat
+  route backed by a single-call stub `Brain` (via TinyAgents) so the plumbing
+  ships and is testable offline.
+- **Phase 2 — Hosted Medulla brain.** `HostedMedullaBrain` speaking the
+  [/orchestration/v1 wire contract](integrations/medulla.md): HTTP event
+  ingestion plus the Socket.IO effect/device-tool channel. Compressed traces
+  land in `MemoryStore`; budget ledger starts. Requires a TinyHumans
+  credential ([runtime/config.md](runtime/config.md)).
+- **Phase 3 — Tools, channels, approvals via OpenHuman.** `ToolProvider` and
+  `ChannelAdapter` over JSON-RPC to `openhuman-core serve`; `ApprovalGate`
+  mapped to OpenHuman policy tiers; cron schedules; the
+  [feedback loop](feedback-loop/README.md) files its first GitHub issues.
+
+## Stage 2 — Public Company
+
+The company earns: it is discoverable and hireable on tiny.place.
+
+- **Phase 4 — tiny.place economy.** `TinyplaceEconomy` adapter (crate
+  `tinyplace`): keypair identity, handle claim, Agent Card publish, inbound
+  `/a2a/{handle}` with SIWX verification and x402-priced skills, outbound
+  hiring under `[budget]` caps, delegated signers.
+
+## Stage 3 — Learning Company
+
+The product improves itself and companies remember.
+
+- **Phase 5 — Platform mode.** Multi-company registry, `POST
+  /api/v1/companies` provisioning, per-company auth, sqlite store, the
+  operator-pluggable store guide, export/import migration between local and
+  hosted.
+- **Phase 6 — Memory maturity + alternate brains.** TinyCortex `MemoryStore` /
+  `ContextStore` implementations; `SidecarBrain`; feedback triage agent;
+  Signals and the Opportunity Engine arrive as a venture-studio Template, not
+  kernel code.
+
+## Stage 4 — Venture Factory
+
+The [AVI vision](vision/README.md): autonomous opportunity discovery, venture
+spawning, compounding knowledge graph. Horizon, not commitment.
+
+## Candidate upstream workstreams
+
+Documented here, executed as PRs against the owning repos — never forked
+locally:
+
+- **TinyHumans backend**: API-key authentication for headless hosts (today:
+  session JWT only); company-scoped orchestration v2 (multi-company routing,
+  richer effects, tool namespacing) — see
+  [integrations/medulla.md](integrations/medulla.md).
+- **OpenHuman**: headless multi-workspace mode; library-crate split of the
+  tool/channel/credential domains; external approval hook; namespaced
+  credentials; documented `/events` schema — see
+  [integrations/openhuman.md](integrations/openhuman.md).
+
+## Non-goals
+
+- **Not a model host.** Medulla and all model routing are hosted by
+  TinyHumans; no local-LLM or BYO-model support.
+- **Not a general agent framework.** TinyAgents is the harness; OpenCompany
+  grows no graph engine of its own.
+- **Not a fork of OpenHuman.** Gaps go upstream as PRs.
+- **Not multi-human companies.** Exactly one Operator per Company.
+- **Not the AVI venture factory (yet).** No autonomous opportunity discovery
+  or venture spawning; `vision/` only.
+- **Not custodial finance.** No fiat, no custody beyond the delegated-signer
+  model; x402 USDC only.
+- **Not a legal-entity service.** Incorporation, tax, and compliance stay
+  with the human.
+- **No private feedback backend.** Feedback goes to public GitHub issues or
+  stays local; there is no telemetry side channel.
+- **No prosumer-visible runtime internals.** UI or product text exposing
+  "agent graph", tiers, or dispatch is a spec violation
+  ([glossary](glossary.md), translation table).

--- a/docs/spec/runtime/README.md
+++ b/docs/spec/runtime/README.md
@@ -1,0 +1,78 @@
+# Runtime
+
+The runtime is the part of OpenCompany that is owned outright: the kernel
+that keeps each [Company](../glossary.md)'s brain state durable, runs cycles
+against the [Brain](../integrations/medulla.md), gates effects through
+approvals, and serves the HTTP surface. Everything that touches a neighbor
+system sits behind a port trait.
+
+Supporting docs:
+
+- [ports.md](ports.md) — the port trait contracts (normative)
+- [manifest.md](manifest.md) — `company.toml` schema
+- [lifecycle.md](lifecycle.md) — company state machine and durability
+- [api.md](api.md) — HTTP routes and auth
+- [config.md](config.md) — configuration and the one-key story
+
+## Responsibilities
+
+The kernel owns:
+
+- **Manifest parsing and validation** with prosumer-friendly errors.
+- **The cycle loop**: normalize stimuli into events, batch them per company,
+  invoke the `Brain`, service its callbacks (tools, context ops), route its
+  effects through the `ApprovalGate`, persist the results.
+- **Durability**: append-only event log, replay on boot, checkpointed
+  drain on shutdown, tar export/import of the whole company bundle.
+- **Multi-company hosting**: a registry of running `CompanyRuntime`s with
+  per-company isolation (one serial cycle queue each; companies run
+  concurrently).
+- **The HTTP surface**: operator API, agent-facing A2A endpoint, webhooks.
+
+The kernel explicitly does **not** own cognition (Medulla), model routing
+(TinyHumans backend), tool implementations (OpenHuman / TinyAgents), memory
+internals (TinyCortex or any store), or the agent economy (tiny.place).
+
+## Crate layout (target)
+
+Today's modules (`src/app`, `src/server`, `src/openhuman`, `src/tiny` — see
+[docs/modules/](../../modules/)) remain; the spec adds:
+
+```text
+src/ports/      one file per port trait (brain, store, events, memory,
+                context, channel, tools, economy, approvals, secrets)
+src/company/    manifest.rs, runtime.rs (CompanyRuntime, RuntimeBuilder),
+                cycle.rs (CycleRunner), registry.rs (CompanyRegistry)
+src/brain/      hosted.rs (HostedMedullaBrain), stub.rs, sidecar.rs (gated)
+src/economy/    tinyplace adapter, card generation, signer management
+src/store/      fs (default), sqlite (gated)
+src/feedback/   capture, scrubber, github filing
+```
+
+`AppState` grows a `CompanyRegistry`; `src/error.rs` grows variants
+(`Manifest`, `Store`, `Brain`, `Economy`, `PolicyDenied`, `Http`) so every
+port returns the crate `Result<T>`.
+
+## Feature flags
+
+| Feature | Adds |
+| --- | --- |
+| *(default)* | kernel, fs store, hosted brain client, operator API |
+| `tiny` | TinyAgents embedding (existing flag; used by stub brain and local workers) |
+| `sqlite` | SQLite store implementations |
+| `tinycortex` | TinyCortex `MemoryStore`/`ContextStore` adapters |
+| `tinyplace` | tiny.place economy adapter and A2A routes |
+| `sidecar` | Node sidecar brain for self-hosters |
+
+The default build MUST stay small and compile offline; every feature degrades
+to a stub or a clear "not enabled" error, never a panic.
+
+## DB-agnosticism
+
+No storage engine appears in the kernel. The four storage ports
+(`CompanyStore`, `EventLog`, `MemoryStore`, `ContextStore`) each ship a
+file-based default (a human-inspectable bundle under
+`~/.opencompany/companies/<slug>/` — see [lifecycle.md](lifecycle.md)), and a
+platform operator implements the same traits over Postgres, S3, or anything
+else. Export is defined as "read everything through the ports"; import is the
+inverse — so migration between backends is total by construction.

--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -1,0 +1,93 @@
+# HTTP API
+
+The Axum surface the runtime exposes. Existing routes (`GET /healthz`, `GET
+/spec`, `GET /tiny`) are kept unchanged. Routes are grouped by audience;
+handlers live as focused groups under `src/server/`, never in the binary.
+
+## Operator API
+
+Auth: local operator token in single-user mode; platform-issued JWT in
+platform mode (see below).
+
+```text
+GET    /api/v1/companies                       list running companies
+POST   /api/v1/companies                       boot from an uploaded manifest (platform)
+GET    /api/v1/companies/{id}                  status: charter, roster, budget burn,
+                                               lifecycle state, tiny.place state
+POST   /api/v1/companies/{id}/chat             operator message → event; SSE reply stream
+GET    /api/v1/companies/{id}/events?since=SEQ SSE stream of events/effects (work feed)
+GET    /api/v1/companies/{id}/approvals        pending approvals
+POST   /api/v1/companies/{id}/approvals/{aid}  { "verdict": "approve"|"deny", "note": "…" }
+POST   /api/v1/companies/{id}/feedback         file feedback (see feedback-loop/)
+GET    /api/v1/companies/{id}/memory/traces    inspect working memory (debug)
+POST   /api/v1/companies/{id}/export           export bundle (tar)
+POST   /api/v1/companies/{id}/pause            pause / resume lifecycle transitions
+```
+
+Single-company (prosumer) mode aliases everything under `/api/v1/company/...`
+with no `{id}`.
+
+- **`/chat`** enqueues an `OperatorMessage` event and streams the resulting
+  cycle's channel responses over SSE. One conversational surface, one voice:
+  the operator talks to the company, not to individual teammates.
+- **`/events`** is the work feed's backend: each frame is a plain-language
+  rendering of an event or executed effect plus the raw payload for
+  programmatic consumers. Resumable via `since` (event sequence number).
+
+## Agent-facing (tiny.place-compatible)
+
+Enabled per company by `[place].discoverable`; served only with the
+`tinyplace` feature.
+
+```text
+POST   /a2a/{handle}                        A2A JSON-RPC (tasks/send …), SIWX-verified
+GET    /a2a/{handle}/skill.md               capability discovery doc
+GET    /.well-known/agent-card.json         single-company mode
+GET    /companies/{handle}/.well-known/agent-card.json   platform mode
+```
+
+- Inbound requests carry tiny.place per-action signatures
+  (`Authorization: tiny.place <agentId>:<signature>:<timestamp>`); the
+  runtime verifies via the `tinyplace` SDK before anything reaches the brain.
+- **x402-priced skills**: if the requested skill has a price on the Agent
+  Card, the route responds `402 Payment Required` with the x402 challenge;
+  on resubmission the payment is verified through
+  `AgentEconomy`/the facilitator, receipted to the ledger, and the task
+  enters the event queue as `A2aTaskReceived`.
+- Untrusted counterparty text is prompt-guard sanitized before it reaches the
+  brain (mirroring tiny.place's own promptguard practice).
+
+## Inbound integrations
+
+```text
+POST   /hooks/{companyId}/{channel}         webhooks → CompanyEvent
+```
+
+HMAC-verified per channel secret from the `SecretStore`; unverifiable
+payloads are dropped with a 401 and never become events.
+
+## Auth model
+
+| Caller | Mechanism |
+| --- | --- |
+| Prosumer operator (local) | Operator token minted at first run, stored in the OS keychain / config dir; the desktop UI holds it. |
+| Platform | Platform-issued JWT per tenant; `POST /api/v1/companies` and suspend/archive require a platform-scope claim. |
+| Peer agents (A2A) | tiny.place SIWX signatures + optional x402 payment; no accounts. |
+| Webhook senders | Per-channel HMAC secrets. |
+
+The runtime's own upstream credential (`TINYHUMANS_API_KEY` / JWT) is never
+accepted inbound; it is outbound-only ([config.md](config.md)).
+
+## Errors
+
+JSON error envelope `{ "error": string, "code": string }` with stable `code`
+values; 4xx for caller mistakes, 402 reserved for x402 challenges, 409 for
+lifecycle-state conflicts (e.g. chatting with an archived company).
+
+## Platform webhooks (Phase 5)
+
+Platform mode can register outbound webhooks per tenant for
+`approval.requested`, `work.completed`, `feedback.created`, and
+`budget.exhausted` so hosts can build their own surfaces without polling
+SSE. Delivery is at-least-once with signature headers; see
+[product/platform.md](../product/platform.md) for the requirements source.

--- a/docs/spec/runtime/config.md
+++ b/docs/spec/runtime/config.md
@@ -1,0 +1,75 @@
+# Configuration
+
+## The one-key promise
+
+`TINYHUMANS_API_KEY` is the **only required secret**. It authenticates the
+runtime to the TinyHumans backend (api.tinyhumans.ai) and from it derive:
+
+- the hosted Medulla brain (the `/orchestration/v1` surface —
+  [integrations/medulla.md](../integrations/medulla.md)),
+- access to the model catalog for TinyAgents-backed fallbacks (tiers map to
+  SKUs server-side; the runtime never names models),
+- observability: TinyAgents' Langfuse exporter can proxy traces through the
+  backend's telemetry ingestion using the same credential.
+
+**Credential reality vs contract.** Today the backend authenticates
+`/orchestration/v1` with a session JWT (magic-link / OAuth / login-token
+exchange); a literal API key does not exist yet. The config slot is therefore
+an opaque *TinyHumans credential*: the runtime accepts either a session JWT
+(now) or an API key (once the backend ships an API-key path for headless
+hosts — a tracked upstream workstream, [roadmap.md](../roadmap.md)). The env
+var name `TINYHUMANS_API_KEY` is the stable product contract either way.
+
+Without a credential the runtime still builds, validates manifests, runs
+`opencompany check`/`spec`, and serves the inspection routes — matching the
+README promise that you can build/inspect/explore keyless. Cycles require the
+credential.
+
+## Precedence
+
+```text
+env (OPENCOMPANY_*, TINYHUMANS_API_KEY)
+  ⟵ ~/.opencompany/config.toml
+  ⟵ company manifest
+  ⟵ built-in defaults
+```
+
+Earlier layers win. `opencompany doctor` prints every effective value, which
+layer set it, and what is missing for each optional capability.
+
+## Reference
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `TINYHUMANS_API_KEY` | — (required for cycles) | TinyHumans credential (JWT or API key) |
+| `TINYHUMANS_API_URL` | `https://api.tinyhumans.ai` | Backend base URL |
+| `OPENCOMPANY_BIND` | `127.0.0.1:8080` | HTTP bind address |
+| `OPENCOMPANY_DATA_DIR` | `~/.opencompany` | Bundle root for fs stores |
+| `OPENCOMPANY_BRAIN_MODE` | `hosted` | `hosted` \| `sidecar` (overrides `[brain].mode`) |
+| `OPENCOMPANY_OPENHUMAN_URL` | — | Attach to a running `openhuman-core serve` instead of launching |
+| `TINYPLACE_API_URL` | `https://api.tiny.place` | tiny.place base (staging/local override) |
+| `GITHUB_TOKEN` | — | Only for the feedback→issue flow; without it, feedback is stored locally and a prefilled "file it yourself" link is shown |
+
+## Optional capabilities and their degradation
+
+| Capability | Needs | Without it |
+| --- | --- | --- |
+| Cycles (the brain) | TinyHumans credential | build/inspect only |
+| Tools/channels beyond built-ins | OpenHuman reachable | built-in tools; non-operator channels warn and disable |
+| tiny.place presence | `tinyplace` feature + funded wallet for the paid handle claim | company runs privately; going-public prompts for funding |
+| Feedback auto-filing | `GITHUB_TOKEN` + consent | local capture + manual prefilled link |
+| SQLite / TinyCortex stores | respective features | fs bundle |
+
+tiny.place deliberately needs **no key**: identity is a locally generated
+Ed25519 keypair in the company bundle. Paid actions (the handle claim) wait
+until the wallet is funded, with a clear operator prompt. Whether TinyHumans
+sponsors handle claims via a delegated signer bundled with the account is an
+open product question ([company-as-agent/identity.md](../company-as-agent/identity.md)).
+
+## Secrets handling
+
+The TinyHumans credential and all per-company secrets live in the
+`SecretStore` (fs default: encrypted at rest, `0600`). Secrets MUST never
+appear in logs, cycle traces, exports (bundles exclude `secrets/` unless
+`--include-secrets`), or feedback issues
+([feedback-loop/privacy.md](../feedback-loop/privacy.md)).

--- a/docs/spec/runtime/lifecycle.md
+++ b/docs/spec/runtime/lifecycle.md
@@ -1,0 +1,126 @@
+# Company Lifecycle
+
+The state machine every [Company](../glossary.md) moves through, and the
+durability guarantees the runtime makes at each step.
+
+## States
+
+```text
+drafted ──▶ onboarding ──▶ live ◀──▶ paused
+                            │
+                            ├──▶ suspended (platform-initiated)
+                            └──▶ archived  (terminal; export retained)
+```
+
+| State | Meaning | Who triggers transitions |
+| --- | --- | --- |
+| `drafted` | Manifest exists and validates; nothing runs. | Operator/platform creates |
+| `onboarding` | The brain runs the interview; Charter filling in. | Operator completes or skips |
+| `live` | Events flow, cycles run, effects execute. | — |
+| `paused` | Intake stopped by the Operator or a tripped budget cap; state preserved. | Operator, or kernel on `[budget]` breach |
+| `suspended` | Platform-forced pause (quota, billing, abuse). | Platform operator only |
+| `archived` | Terminal. Bundle exported and retained; handle renewal stops. | Operator/platform |
+
+All transitions are recorded as events in the `EventLog` with the acting
+`Actor`.
+
+## Boot sequence (`opencompany serve --company <dir>`)
+
+1. **Parse + validate** the manifest; materialize or refresh the
+   `CompanyRecord` in `CompanyStore`. The manifest is the source of truth for
+   charter/roster seeds; runtime state layers on top
+   ([manifest.md](manifest.md), provenance).
+2. **Open stores** (fs defaults unless the builder swapped them); **replay
+   the `EventLog` tail** to rebuild in-flight tasks and the approval queue.
+3. **Economy (optional)**: if `[place].discoverable`, load or generate the
+   Ed25519 keypair, then `AgentEconomy::ensure_registered` and
+   `publish_card`. Failures degrade to "not discoverable" with a warning —
+   they MUST NOT block boot.
+4. **Start** channel adapters, the cron scheduler, the feedback poller; mount
+   routes ([api.md](api.md)).
+
+Platform mode (`--companies-root <dir>` or provisioning API) runs this
+sequence per company under the `CompanyRegistry`.
+
+## Event → cycle loop
+
+All stimuli normalize to `CompanyEvent { source, kind, payload, correlation }`
+(variants in [ports.md](ports.md)). Per company there is **one serial cycle
+queue** — one cycle at a time, events batched/debounced between cycles;
+distinct companies run concurrently. A cycle
+([company-brain/README.md](../company-brain/README.md)):
+
+1. Drain pending events for the company.
+2. Load working memory (`MemoryStore::recent_traces`), context index, roster
+   + charter.
+3. `Brain::run_cycle`, servicing callbacks: tool calls → `ToolProvider`
+   (grant-checked), context ops → `ContextStore`, effects →
+   `ApprovalGate::evaluate`.
+4. Effects: `Allow` executes; `RequireApproval` parks
+   (`EffectDisposition::PendingApproval`) and surfaces in the operator's
+   approvals inbox; `Deny` returns to the brain as a refusal it can plan
+   around.
+5. Persist: compressed traces → `MemoryStore`, events/effects → `EventLog`,
+   ledger deltas → `CompanyStore`. Cycle results stream to API subscribers
+   over SSE.
+
+Resolving an approval emits `ApprovalResolved`, which schedules a follow-up
+cycle so the brain learns the verdict — approve executes the parked effect,
+deny makes the brain replan.
+
+## Durability guarantees
+
+Must survive a crash/restart with no operator-visible loss:
+
+- Charter and roster (CompanyStore)
+- The event log and everything derivable from replaying it (in-flight tasks,
+  approval queue)
+- The ledger (append-only; never rewritten)
+- Compressed memory traces and context chunks
+- The company keypair and secrets
+
+In-flight cycle work is **not** guaranteed: a crash mid-cycle loses that
+cycle's partial passes; the unhandled events remain queued and the next boot
+re-runs them. Effects are executed at-most-once by the kernel — an effect is
+journaled *before* execution and marked after, so replay never re-fires a
+completed effect.
+
+## The fs bundle (default store)
+
+```text
+~/.opencompany/companies/<slug>/
+├── company.toml        # materialized charter + roster (with provenance)
+├── events.jsonl        # append-only event log
+├── ledger.jsonl        # append-only money/usage journal
+├── memory/             # compressed traces, task results
+├── context/            # content-addressed chunks + index
+├── keys/agent.ed25519  # company identity (0600)
+└── secrets/            # encrypted at rest
+```
+
+Human-inspectable and git-friendly by design.
+
+## Export / import
+
+`opencompany export <company>` produces a tar of the bundle. For non-fs
+stores, export is defined as *read everything through the four storage ports
+and write the fs layout*; import is the inverse. This makes migration between
+an end user's laptop and a platform host (or between two platform backends)
+total by construction.
+
+## Shutdown
+
+On SIGINT/SIGTERM: stop intake, drain the in-flight cycle with a bounded
+timeout, checkpoint stores, exit. The tiny.place Agent Card stays published
+(the endpoint simply goes offline); liveness is a directory concern, not a
+registration concern.
+
+## Multi-company isolation
+
+- Separate store namespaces per `CompanyId` (separate bundle dirs in fs mode;
+  key-prefixing is NOT sufficient for operator-supplied stores — the traits
+  take `CompanyId` explicitly so implementations can enforce isolation).
+- Separate secrets (`SecretStore` scoping is per-company by signature).
+- Separate budgets and ledgers; no cross-company tool grants.
+- One brain session per company against the hosted backend
+  ([integrations/medulla.md](../integrations/medulla.md), session mapping).

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -1,0 +1,112 @@
+# Company Manifest
+
+The manifest is the on-disk definition of a [Company](../glossary.md). The
+preferred filename is `company.toml`; `agents.toml` (the current examples
+format) is accepted unchanged with a deprecation note from `opencompany
+check`.
+
+**Compatibility rule:** every key in today's `agents.toml` keeps its exact
+meaning, and a bare `agents.toml` (just `[company]` + `[[agent]]`) remains a
+complete, valid company. **Prosumer rule:** every new table is optional with
+a safe default; the defaults produce a working company with only
+`TINYHUMANS_API_KEY` set.
+
+Parsing lives in `src/company/manifest.rs` (`CompanyManifest::from_path`,
+serde + validation). Validation errors MUST be actionable in prosumer
+language ("`[policy].mode` must be one of readonly, supervised, full — you
+wrote `supervized`"), never serde traces.
+
+## Full schema
+
+```toml
+# ── existing keys (unchanged from agents.toml) ─────────────────────────
+[company]
+name = "Agentic Marketing Agency"
+output = "Campaigns across every channel"
+human_role = "Campaign review and sign-off"
+handle = "acme-marketing"          # NEW, optional: tiny.place @handle
+
+[[agent]]
+id = "copywriter"                  # snake_case, unique
+role = "Copywriter"
+description = "Write ads, pages, and campaign copy."
+# NEW optional per-agent keys:
+tier = "reasoning"                 # cognition tier hint (see glossary)
+tools = ["docs.*", "email.send"]   # tool grant globs
+budget_usd_daily = 5.0             # per-agent daily spend cap
+
+# ── new tables (all optional) ──────────────────────────────────────────
+[brain]
+mode = "hosted"                    # hosted (default) | sidecar
+max_passes = 12                    # passed through to Medulla
+
+[channels.operator]
+enabled = true                     # built-in chat; default true
+
+[channels.email]
+provider = "openhuman"             # delegate to an OpenHuman channel
+
+[tools]
+provider = "openhuman"             # openhuman (default) | builtin
+allow = ["web.*", "docs.*"]        # company-wide grant; agents intersect
+
+[policy]                           # see company-brain/approvals.md
+mode = "supervised"                # readonly | supervised (default) | full
+always_approve = ["payment.send", "filing.submit", "external.publish"]
+auto_approve_under_usd = 1.0
+
+[place]                            # see company-as-agent/
+discoverable = false               # default false: going public is opt-in
+skills = [
+  { id = "seo.audit", price_usd = "25.00", description = "Full SEO audit" },
+]
+
+[budget]
+monthly_usd = 200.0                # hard cap: inference + x402 combined
+
+[[schedule]]
+cron = "0 9 * * MON"
+prompt = "Weekly review and operator digest"
+```
+
+## Semantics
+
+- **`[company]`** becomes the seed of the [Charter](../company-brain/charter.md).
+  `handle` is only used when `[place].discoverable = true`.
+- **`[[agent]]`** entries define the Roster. `tier` is a hint the brain may
+  use when delegating; it never selects a model (the backend maps tiers to
+  SKUs). `tools` and `budget_usd_daily` intersect with the company-wide
+  `[tools].allow` and `[budget]` — the most restrictive wins.
+- **`[brain]`** selects the `Brain` implementation. `hosted` requires a
+  TinyHumans credential at runtime; `sidecar` requires the `sidecar` feature.
+- **`[channels.*]`** enables `ChannelAdapter`s. Unknown channels are a
+  validation error; disabled OpenHuman means non-operator channels degrade
+  with a boot warning, never a failure.
+- **`[policy]`** configures the default `ApprovalGate`. `mode` mirrors
+  OpenHuman's security tiers. `always_approve` lists effect kinds that park
+  for approval regardless of amount; `auto_approve_under_usd` lets small
+  spends through. Defaults are conservative: `supervised`, with all
+  money/publish/filing effects gated.
+- **`[place]`** drives the [going-public flow](../company-as-agent/README.md).
+  `skills` feed Agent Card generation; prices are decimal strings (USDC).
+- **`[budget].monthly_usd`** is a hard ceiling enforced by the kernel across
+  inference usage and x402 spend; reaching it pauses the company with an
+  operator notification rather than silently degrading.
+- **`[[schedule]]`** entries become `ScheduleFired` events; cron syntax is
+  standard 5-field.
+
+## Layering and provenance
+
+Effective configuration = template defaults ⟵ manifest ⟵ onboarding-interview
+answers ⟵ operator runtime edits. Later layers win; the runtime records which
+layer set each value so the Charter can show provenance
+([charter.md](../company-brain/charter.md)). Operator edits at runtime are
+persisted to the `CompanyStore`, not written back into the manifest file.
+
+## Tooling
+
+- `opencompany check <dir>` — validate a manifest, print effective config,
+  lint deprecations (e.g. `agents.toml` filename).
+- The 18 `examples/*` crates shrink to a manifest plus a two-line `main`
+  calling `opencompany::run_company(manifest_path)`; they double as the
+  [Template Gallery](../product/templates.md) source.

--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -1,0 +1,225 @@
+# Port Contracts
+
+Normative trait sketches for the kernel's seams. Signatures are Rust 2024
+(`async fn` in traits), all returning the crate `Result<T>` from
+`src/error.rs`. Names are binding; exact field lists on the payload types may
+evolve during Phase 1 without a spec change, methods may not.
+
+Ports live one-per-file under `src/ports/`.
+
+## Brain
+
+The cognition seam. The kernel never reimplements the cycle; it hands events
+to a `Brain` and services the brain's callbacks through a `CycleHost`.
+
+```rust
+// src/ports/brain.rs
+pub trait Brain: Send + Sync {
+    async fn run_cycle(&self, req: CycleRequest, host: &dyn CycleHost)
+        -> Result<CycleResult>;
+}
+
+/// Callbacks the brain makes into the host mid-cycle.
+pub trait CycleHost: Send + Sync {
+    async fn call_tool(&self, call: ToolCall) -> Result<ToolResult>;
+    async fn context_op(&self, op: ContextOp) -> Result<ContextOpResult>;
+    async fn emit_effect(&self, effect: Effect) -> Result<EffectDisposition>;
+}
+
+pub enum EffectDisposition {
+    Executed,
+    PendingApproval(ApprovalId),
+    Denied { reason: String },
+}
+```
+
+`CycleRequest` carries `{cycle_id, company_id, events, compressed_history,
+roster, context_index}`; `CycleResult` carries channel responses, new
+compressed traces, ledger deltas, and token usage. Implementations:
+`HostedMedullaBrain` (default — see
+[integrations/medulla.md](../integrations/medulla.md)), `StubBrain`
+(single TinyAgents call, offline tests), `SidecarBrain` (feature `sidecar`),
+and a far-future `NativeBrain` (TinyAgents graph port; interface only).
+
+Kernel-side backstops regardless of implementation: a wall-clock timeout and
+a per-cycle budget cap. Medulla's own guarantees (termination by
+construction, ≥1 response per cycle) are inherited, not re-verified.
+
+## CompanyStore
+
+Durable company records: charter, roster, ledger, approval queue.
+
+```rust
+// src/ports/store.rs
+pub trait CompanyStore: Send + Sync {
+    async fn load(&self, id: &CompanyId) -> Result<Option<CompanyRecord>>;
+    async fn save(&self, record: &CompanyRecord) -> Result<()>;
+    async fn list(&self) -> Result<Vec<CompanySummary>>;
+    async fn append_ledger(&self, id: &CompanyId, entry: LedgerEntry) -> Result<()>;
+}
+```
+
+## EventLog
+
+Append-only, replayable. Boot replays the tail to rebuild in-flight state.
+
+```rust
+// src/ports/events.rs
+pub trait EventLog: Send + Sync {
+    async fn append(&self, id: &CompanyId, event: CompanyEvent) -> Result<EventSeq>;
+    async fn read_from(&self, id: &CompanyId, seq: EventSeq, limit: usize)
+        -> Result<Vec<StoredEvent>>;
+    fn subscribe(&self, id: &CompanyId) -> BoxStream<'static, StoredEvent>;
+}
+```
+
+`CompanyEvent` variants: `OperatorMessage`, `WebhookReceived`,
+`ScheduleFired`, `A2aTaskReceived`, `ApprovalResolved`, `FeedbackFiled`,
+`PaymentReceived`.
+
+## MemoryStore
+
+The equivalent of Medulla's `CyclePersistence`; TinyCortex is the target
+backend ([integrations/tinycortex.md](../integrations/tinycortex.md)).
+
+```rust
+// src/ports/memory.rs
+pub trait MemoryStore: Send + Sync {
+    async fn save_trace(&self, id: &CompanyId, trace: CompressedTrace) -> Result<()>;
+    async fn recent_traces(&self, id: &CompanyId, limit: usize)
+        -> Result<Vec<CompressedTrace>>;
+    async fn save_task_result(&self, id: &CompanyId, result: TaskResult) -> Result<()>;
+    async fn evict(&self, id: &CompanyId, policy: EvictionPolicy) -> Result<u64>;
+}
+```
+
+## ContextStore
+
+The RLM environment: addressable chunks the brain queries lazily. Mirrors
+Medulla's `ContextStore` port.
+
+```rust
+// src/ports/context.rs
+pub trait ContextStore: Send + Sync {
+    async fn put(&self, id: &CompanyId, chunk: ContextChunk) -> Result<ChunkAddr>;
+    async fn list(&self, id: &CompanyId, prefix: &str) -> Result<Vec<ChunkMeta>>;
+    async fn peek(&self, id: &CompanyId, addr: &ChunkAddr, range: Option<Range<usize>>)
+        -> Result<String>;
+    async fn search(&self, id: &CompanyId, query: &str, limit: usize)
+        -> Result<Vec<ChunkHit>>;
+}
+```
+
+## ChannelAdapter
+
+Inbound/outbound conversation surfaces. The built-in `"operator"` channel is
+always present; others (email, tinyplace-dm, …) usually delegate to OpenHuman.
+
+```rust
+// src/ports/channel.rs
+pub trait ChannelAdapter: Send + Sync {
+    fn channel_id(&self) -> &str; // "operator", "email", "tinyplace-dm", ...
+    fn inbound(&self) -> BoxStream<'static, InboundMessage>;
+    async fn send(&self, msg: OutboundMessage) -> Result<()>;
+}
+```
+
+## ToolProvider
+
+Tool catalog + invocation, scoped per company. Backed by OpenHuman JSON-RPC
+by default, TinyAgents built-ins as fallback.
+
+```rust
+// src/ports/tools.rs
+pub trait ToolProvider: Send + Sync {
+    async fn catalog(&self, company: &CompanyId) -> Result<Vec<ToolSpec>>;
+    async fn invoke(&self, company: &CompanyId, call: ToolCall) -> Result<ToolResult>;
+}
+```
+
+Tool grants come from the manifest (`[tools].allow`, per-agent `tools`);
+`invoke` MUST reject calls outside the grant before any side effect.
+
+## AgentEconomy
+
+The tiny.place seam ([integrations/tinyplace.md](../integrations/tinyplace.md)).
+
+```rust
+// src/ports/economy.rs
+pub trait AgentEconomy: Send + Sync {
+    async fn ensure_registered(&self, identity: &CompanyIdentity)
+        -> Result<RegistrationState>;
+    async fn publish_card(&self, identity: &CompanyIdentity, card: &AgentCard)
+        -> Result<()>;
+    async fn send_a2a_task(&self, to: &AgentAddr, task: A2aTask)
+        -> Result<A2aTaskHandle>;
+    async fn quote(&self, requirement: &PaymentRequirement) -> Result<Quote>;
+    async fn pay(&self, quote: &Quote, budget: &BudgetScope) -> Result<PaymentReceipt>;
+}
+```
+
+`pay` MUST fail if the `BudgetScope` (derived from `[budget]` and delegated
+signer caps) would be exceeded; the ledger records every receipt.
+
+## ApprovalGate
+
+Policy evaluation and the approval queue
+([company-brain/approvals.md](../company-brain/approvals.md)).
+
+```rust
+// src/ports/approvals.rs
+pub trait ApprovalGate: Send + Sync {
+    async fn evaluate(&self, company: &CompanyId, effect: &Effect)
+        -> Result<PolicyDecision>; // Allow | RequireApproval | Deny
+    async fn park(&self, company: &CompanyId, effect: Effect) -> Result<ApprovalId>;
+    async fn resolve(&self, id: &ApprovalId, verdict: Verdict, by: Actor)
+        -> Result<Option<Effect>>;
+}
+```
+
+## SecretStore
+
+Per-company secrets (channel credentials, GitHub token). Company A's secrets
+MUST be invisible to company B.
+
+```rust
+pub trait SecretStore: Send + Sync {
+    async fn get(&self, company: &CompanyId, key: &str) -> Result<Option<SecretValue>>;
+    async fn set(&self, company: &CompanyId, key: &str, value: SecretValue) -> Result<()>;
+}
+```
+
+## Assembly
+
+```rust
+// src/company/runtime.rs
+pub struct CompanyRuntime {
+    brain: Arc<dyn Brain>,
+    store: Arc<dyn CompanyStore>,
+    events: Arc<dyn EventLog>,
+    memory: Arc<dyn MemoryStore>,
+    context: Arc<dyn ContextStore>,
+    tools: Arc<dyn ToolProvider>,
+    channels: Vec<Arc<dyn ChannelAdapter>>,
+    economy: Option<Arc<dyn AgentEconomy>>,
+    approvals: Arc<dyn ApprovalGate>,
+}
+```
+
+Built by a `RuntimeBuilder` with fs/hosted defaults; a platform operator
+swaps any port. `AppState` holds a `CompanyRegistry` mapping `CompanyId` →
+running `CompanyRuntime`, serving both the single-company prosumer case and
+the multi-tenant platform case with the same type.
+
+## Default implementations
+
+| Port | Default (`src/store/fs.rs` unless noted) | Alternates |
+| --- | --- | --- |
+| `Brain` | `HostedMedullaBrain` (`src/brain/hosted.rs`) | stub, sidecar, native |
+| `CompanyStore`, `EventLog` | fs bundle (TOML + JSONL) | sqlite, operator-supplied |
+| `MemoryStore`, `ContextStore` | fs (JSONL + content-addressed blobs) | tinycortex, operator-supplied |
+| `ToolProvider` | OpenHuman RPC, built-ins fallback | TinyAgents-native |
+| `ChannelAdapter` | built-in operator chat | OpenHuman channels |
+| `AgentEconomy` | none (companies work offline) | tinyplace |
+| `ApprovalGate` | manifest `[policy]` evaluator | OpenHuman policy hook |
+| `SecretStore` | fs (encrypted at rest) | OS keychain, operator-supplied |

--- a/docs/spec/vision/README.md
+++ b/docs/spec/vision/README.md
@@ -1,4 +1,28 @@
-# Agentic Venture Incubator (AVI)
+# Vision: the Agentic Venture Incubator (AVI)
+
+> **Status: aspirational north star.** This document predates the
+> one-person-company specification and describes where OpenCompany is
+> headed, not what it builds today. The normative specs live in the
+> sibling directories under [`docs/spec/`](../README.md).
+>
+> **Terminology bridge** (AVI term → current spec term, defined in
+> [`glossary.md`](../glossary.md)):
+>
+> | AVI term | Current term |
+> | --- | --- |
+> | Venture | Company |
+> | Assigned humans | Operator |
+> | Agent team | Roster of Teammates |
+> | Venture Orchestrator | Brain (Medulla) |
+> | Governance / approvals | Checkpoints and Approvals |
+> | Learning loop | Feedback Loop |
+> | Knowledge Graph | Memory (future evolution) |
+>
+> **Path from here:** the [roadmap](../roadmap.md) maps AVI components to
+> stages — Signals and the Opportunity Engine arrive as a *venture-studio
+> company template* in Stage 3+ (Learning Company), and the full venture
+> factory is Stage 4. Nothing in this document overrides the normative
+> specs.
 
 ## Vision
 


### PR DESCRIPTION
## Summary

Replaces the docs/spec stub with a full specification for the one-person-company runtime: 29 focused docs across seven topic directories, plus an authoritative glossary and a staged roadmap.

- **Product**: two personas (prosumer operator, platform operator), the golden-path journey, templates as productized `agents.toml`, and a normative one-key promise (`TINYHUMANS_API_KEY` is the only required credential).
- **Company brain**: the seven state families the core maintains (identity, charter, roster, memory, context, world, feedback), the cycle loop, charter provenance, checkpoint/approval model (default-deny), and memory with operator deletion rights.
- **Runtime**: kernel port traits (`Brain`/`CycleHost`, four DB-agnostic storage ports, `ToolProvider`, `ChannelAdapter`, `AgentEconomy`, `ApprovalGate`), backward-compatible `company.toml` schema, lifecycle state machine + fs bundle + total export/import, HTTP surface, config precedence.
- **Integrations**: Medulla as the hosted brain with the real `/orchestration/v1` wire contract (HTTP events + Socket.IO effects/device-tools) and a proposed company-scoped v2; OpenHuman (with candidate upstream PRs), TinyAgents, TinyCortex (behind ports), tiny.place (identity, Agent Card, A2A, x402, delegated signers).
- **Feedback loop**: in-product capture → normative privacy scrubbing with preview gate → public GitHub issues → label taxonomy/triage → "you said, we did" release-notes contract.
- The old AVI spec moves to `docs/spec/vision/README.md` with a status preface and terminology bridge.

## Commands run locally

- `cargo build --all-targets` (passes; docs-only change)
- Link check across `docs/spec` (0 broken relative links)
- `find docs/spec -name '*.md' | xargs wc -l` (all files ≤500 lines; every directory has a README.md)

## API or behavior changes

None — documentation only. The spec defines target design; `docs/modules/` continues to describe current code.

https://claude.ai/code/session_01NrUeF6CPgbNsDpvNaUQvsr