### PR TITLE
Implement runtime spec: kernel, hosted brain, OpenHuman, tiny.place, platform mode, memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,6 +1874,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "signals-opportunity-studio"
+version = "0.1.0"
+dependencies = [
+ "opencompany",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,10 +281,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -293,6 +308,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -336,8 +360,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "rand_core",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -411,6 +435,12 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -443,6 +473,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -458,6 +497,16 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
@@ -466,14 +515,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -492,6 +588,30 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "equivalent"
@@ -526,6 +646,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -637,6 +763,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,7 +807,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -1121,8 +1257,11 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
+ "bs58",
  "clap",
+ "ed25519-dalek",
  "futures",
+ "rand_core 0.6.4",
  "reqwest",
  "serde",
  "serde_json",
@@ -1165,6 +1304,16 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1281,7 +1430,16 @@ checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1296,7 +1454,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1432,6 +1590,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +1657,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1568,13 +1741,24 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1600,6 +1784,15 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1646,6 +1839,16 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "sqlite-wasm-rs"
@@ -1793,7 +1996,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,6 +552,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +565,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -652,6 +659,16 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -843,6 +860,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "http"
@@ -1125,6 +1151,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1269,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,10 +1327,15 @@ dependencies = [
  "clap",
  "ed25519-dalek",
  "futures",
+ "hmac",
+ "jsonwebtoken",
  "rand_core 0.6.4",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
+ "tar",
  "tempfile",
  "thiserror",
  "tinyagents",
@@ -1273,6 +1344,16 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -1335,6 +1416,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -1796,6 +1883,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,6 +2024,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,6 +2080,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2571,6 +2711,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,6 +1123,7 @@ dependencies = [
  "axum",
  "clap",
  "futures",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,14 @@ tinyagents = { path = "vendor/tinyagents", optional = true, features = ["sqlite"
 # default build links no network crates.
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
 
+# Offline crypto for the tiny.place economy identity. All three are optional and
+# only link under the `tinyplace` feature; the default build pulls none of them.
+# `rand_core`'s `getrandom` feature provides `OsRng` for seed generation; we call
+# `SigningKey::from_bytes` so dalek's own `rand_core` feature stays off.
+ed25519-dalek = { version = "2", default-features = false, features = ["std"], optional = true }
+bs58 = { version = "0.5", default-features = false, features = ["std"], optional = true }
+rand_core = { version = "0.6", default-features = false, features = ["getrandom"], optional = true }
+
 [features]
 default = []
 tiny = ["tinyagents"]
@@ -62,6 +70,10 @@ github = ["dep:reqwest"]
 # Real HTTP/Socket.IO transport to hosted Medulla. The wire types + offline
 # MockTransport compile without this; only the networked transport is gated.
 medulla = ["dep:reqwest"]
+# tiny.place economy: Ed25519 identity, SIWX auth, x402 payment authorization,
+# and (in later batches) the HTTP transport. Card projection + wire types stay
+# in the default build; only crypto and the networked client are gated here.
+tinyplace = ["dep:reqwest", "dep:ed25519-dalek", "dep:bs58", "dep:rand_core"]
 
 [patch.crates-io]
 tinyagents = { path = "vendor/tinyagents" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,24 @@ tinyagents = { path = "vendor/tinyagents", optional = true, features = ["sqlite"
 # default build links no network crates.
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
 
+# Real HMAC-SHA256 webhook signing. Pure-Rust, no system libs, no network beyond
+# the shared `reqwest` client used by `HttpWebhookSink`.
+hmac = { version = "0.12", optional = true }
+sha2 = { version = "0.10", optional = true }
+
+# Real signed per-tenant JWT verification for platform auth.
+jsonwebtoken = { version = "9", optional = true }
+
+# SQLite-backed implementations of the storage ports. The `bundled` feature
+# vendors SQLite into the build, so no system libsqlite3 is required and the
+# compile stays fully offline. Only links under the `sqlite` feature.
+rusqlite = { version = "0.40", features = ["bundled"], optional = true }
+
+# Single-file `.tar` packing/unpacking for `opencompany export`/`import`. Pure
+# Rust, no system libs, no network. Only links under the `export` feature; the
+# port-driven bundle core works on an unpacked directory without it.
+tar = { version = "0.4", optional = true }
+
 # Offline crypto for the tiny.place economy identity. All three are optional and
 # only link under the `tinyplace` feature; the default build pulls none of them.
 # `rand_core`'s `getrandom` feature provides `OsRng` for seed generation; we call
@@ -74,6 +92,22 @@ medulla = ["dep:reqwest"]
 # and (in later batches) the HTTP transport. Card projection + wire types stay
 # in the default build; only crypto and the networked client are gated here.
 tinyplace = ["dep:reqwest", "dep:ed25519-dalek", "dep:bs58", "dep:rand_core"]
+# Real HTTP POST webhook delivery + HMAC-SHA256 signing. The `WebhookSink` trait,
+# the offline `RecordingWebhookSink`, and the deterministic default signer
+# compile without this; only `HttpWebhookSink`/`HmacSha256Signer` are gated here.
+webhooks = ["dep:reqwest", "dep:hmac", "dep:sha2"]
+# Real signed per-tenant JWT verification. The `PlatformVerifier` trait and the
+# offline `StaticPlatformVerifier` compile without this; only the JWT verifier is
+# gated behind it.
+platform-jwt = ["dep:jsonwebtoken"]
+# SQLite-backed storage ports (CompanyStore/EventLog/MemoryStore/ContextStore
+# plus SecretStore) sharing one bundled connection. The fs stores and the
+# port-conformance suite compile without this; only `SqliteStore` is gated here.
+sqlite = ["dep:rusqlite"]
+# Single-file `.tar` bundle packing for `opencompany export`/`import`. The
+# port-driven export/import core (unpacked bundle directory) compiles without
+# this; only `pack_tar`/`unpack_tar` are gated here.
+export = ["dep:tar"]
 
 [patch.crates-io]
 tinyagents = { path = "vendor/tinyagents" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,21 @@ platform-jwt = ["dep:jsonwebtoken"]
 # plus SecretStore) sharing one bundled connection. The fs stores and the
 # port-conformance suite compile without this; only `SqliteStore` is gated here.
 sqlite = ["dep:rusqlite"]
+# TinyCortex-backed MemoryStore + ContextStore over a mockable CortexClient.
+# TinyCortex itself is not vendored, so this feature adds no dependency: the
+# compiled backend is an offline in-memory client and the real HTTP client is
+# inert until the service is reachable through the OpenHuman seam. The fs stores
+# and the port-conformance suite compile without this.
+tinycortex = []
+# Node sidecar brain for self-hosters (bring-your-own-inference). Adds
+# `SidecarBrain`, which speaks the same `/orchestration/v1` wire frames as the
+# hosted brain but against a local sidecar process, with inference routed back
+# into the Rust host through an `InferenceClient`. Process launch uses the
+# already-enabled tokio `process` feature and real inference rides the existing
+# `tiny` feature, so this flag adds no dependency. The whole brain, its mocks,
+# and the offline end-to-end test are gated here; the default build links none
+# of it and the builder routes `sidecar` mode to the echo brain.
+sidecar = []
 # Single-file `.tar` bundle packing for `opencompany export`/`import`. The
 # port-driven export/import core (unpacked bundle directory) compiles without
 # this; only `pack_tar`/`unpack_tar` are gated here.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 tinyagents = { path = "vendor/tinyagents", optional = true, features = ["sqlite", "repl"] }
+
+# Optional network client shared by the feature-gated integrations below; the
+# default build links no network crates.
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
 
 [features]
@@ -56,6 +59,9 @@ openhuman-rpc = ["dep:reqwest"]
 # mock + the whole filing flow compile without this; only `HttpGitHubClient` is
 # gated behind it.
 github = ["dep:reqwest"]
+# Real HTTP/Socket.IO transport to hosted Medulla. The wire types + offline
+# MockTransport compile without this; only the networked transport is gated.
+medulla = ["dep:reqwest"]
 
 [patch.crates-io]
 tinyagents = { path = "vendor/tinyagents" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,18 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 tinyagents = { path = "vendor/tinyagents", optional = true, features = ["sqlite", "repl"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
 
 [features]
 default = []
 tiny = ["tinyagents"]
+# Real HTTP transport to openhuman-core. The trait + offline mock + providers
+# compile without this; only `HttpOpenHumanRpc` is gated behind it.
+openhuman-rpc = ["dep:reqwest"]
+# Real GitHub REST filer for feedback issues. The `GitHubClient` trait + offline
+# mock + the whole filing flow compile without this; only `HttpGitHubClient` is
+# gated behind it.
+github = ["dep:reqwest"]
 
 [patch.crates-io]
 tinyagents = { path = "vendor/tinyagents" }

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ src/ports/              Kernel port traits and shared types
 src/store/              File-based CompanyStore/EventLog/Memory/Context/Secrets
 src/policy/             Manifest-driven ApprovalGate
 src/brain/              Offline EchoBrain (the default cognition seam)
-src/runtime/            CompanyRuntime, CycleRunner, and the company registry
+src/feedback/           Feedback items, privacy scrubber, GitHub issue filing
+src/runtime/            CompanyRuntime, CycleRunner, cron scheduler, registry
 src/server/             Axum HTTP router and handlers
 src/openhuman/          OpenHuman launcher seams
 src/tiny/               TinyAgents/OpenHuman status surface

--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ Without a key you can still build, inspect, and explore every company in
 `examples/`. Add the key when you're ready to put Medulla in the driver's seat
 and let the agents run for real.
 
+To let companies trade with other agents on tiny.place, build with the
+`tinyplace` feature and pass `serve --discoverable` to opt every loaded company
+into going public (register a `@handle`, publish an Agent Card, and answer
+inbound A2A `tasks/send` over SIWX + x402). See
+[`docs/modules/server/README.md`](docs/modules/server/README.md) for the full
+discovery flow and the `TINYPLACE_API_URL` / `OPENCOMPANY_PUBLIC_URL` settings.
+
 Each example loads its manifest, validates it, and prints the company's
 effective configuration. Open its `README.md` to see what it does and
 `agents.toml` to see (or edit) the team; `opencompany check` reports any

--- a/README.md
+++ b/README.md
@@ -68,8 +68,14 @@ where a human signs off:
 | **[Accounting Firm](examples/agentic_accounting_firm/)** | Bookkeeping, tax, payroll, forecasting, audit prep | Signing the filings |
 | **[Law Firm](examples/agentic_law_firm/)** | Research, drafting, litigation support, discovery, compliance | Approving filings |
 | **[Pharma Startup](examples/agentic_pharma_startup/)** | Literature, molecule discovery, simulation, trial planning | The lab work |
+| **[Signals + Opportunity Studio](examples/signals_opportunity_studio/)** | Scouting signals, clustering pains, ranking opportunities into a weekly brief | Which opportunities to fund |
 
-Eighteen companies. One operator. Pick one and run it — or run several at once.
+Nineteen companies. One operator. Pick one and run it — or run several at once.
+
+**Signals and the Opportunity Engine are a template, not kernel code.** The
+[Signals + Opportunity Studio](examples/signals_opportunity_studio/) realizes
+them as a roster, a charter, and a weekly `[[schedule]]` over the existing
+channel, memory, and brain ports — nothing new in the runtime.
 
 ## Why it works
 

--- a/docs/modules/brain/README.md
+++ b/docs/modules/brain/README.md
@@ -11,3 +11,25 @@ TinyAgents-backed `StubBrain` (feature `tiny`); see
 [`docs/spec/integrations/medulla.md`](../../spec/integrations/medulla.md).
 Anything that needs the model backend must not land here — this module stays
 dependency-light so `cargo test` runs offline.
+
+## `medulla` submodule (the hosted `/orchestration/v1` wire)
+
+`brain::medulla` holds the hosted-Medulla contract, all in the default build
+with no network dependency:
+
+- `medulla::wire` — typed serde for the protocol-1 envelope, the nine `ORCH_*`
+  error codes, `POST /events` (`cycleId` = `cyc:<counterpart>:<session>:<seq>`,
+  idempotent on `(user, counterpart, session, seq)`), `POST /world-diff`, the
+  read-surface views, and the Socket.IO frames (`orch:register_tools`,
+  `orch:effect:<kind>` with deterministic `callId` = `{cycleId}:{kind}:{index}`,
+  `orch:effect:result`, `orch:tool_call`, `orch:tool_result`).
+  `wire::assert_no_model` rejects any request body carrying a `model` field.
+- `medulla::transport` — the `MedullaTransport` seam abstracting the HTTP posts,
+  the per-cycle effect/tool-call stream, and the acks/answers, so the brain
+  never depends on a concrete network client.
+- `medulla::mock` — an in-memory `MockTransport` that scripts cycle frames and
+  records brain calls, driving the seam offline in tests.
+
+The networked `HttpSocketTransport` and `HostedMedullaBrain` itself land in a
+later batch behind an optional feature; nothing in this submodule pulls a
+network crate.

--- a/docs/modules/feedback/README.md
+++ b/docs/modules/feedback/README.md
@@ -1,0 +1,24 @@
+# Feedback Module
+
+The feedback module implements the [feedback loop](../../spec/feedback-loop/README.md):
+in-product feedback becomes public GitHub issues, with a non-negotiable privacy
+gate in between.
+
+- `types.rs` — the `FeedbackItem` (category, operator words, work item, template
+  + runtime version, capped/redacted excerpt) and consent modes
+  (`manual` default, `assisted`, `auto`).
+- the **scrubber** — enforces the normative redaction classes from
+  [privacy.md](../../spec/feedback-loop/privacy.md): any `SecretStore` value or
+  key material **aborts** filing; personal data and charter specifics are
+  masked; customer content is never included. Scrubbing fails **closed** — if a
+  class can't be evaluated, filing is blocked.
+- the **filer** — a mockable `GitHubClient` (real REST client behind the
+  optional `github` feature); dedupes by searching existing issues first,
+  rate-limits per company, signs the body with the company `@handle`, and labels
+  `source/agent-filed`. Without `GITHUB_TOKEN` it degrades to a prefilled manual
+  issue link.
+
+The scrub-then-preview gate returns the exact, byte-for-byte final issue body;
+nothing is transmitted without confirmation or standing per-category consent.
+Capture routes: `POST /api/v1/companies/{id}/feedback`, a built-in `feedback`
+tool, and an operator-chat intent.

--- a/docs/modules/openhuman/README.md
+++ b/docs/modules/openhuman/README.md
@@ -7,3 +7,16 @@ heavy default dependency of the OpenCompany library.
 
 Use `opencompany open-human --dry-run` to inspect the generated command before
 running the vendored checkout.
+
+## JSON-RPC backing (Phase 3)
+
+Beyond the launcher, this module adapts OpenHuman's JSON-RPC surface to kernel
+ports. `rpc.rs` defines the `OpenHumanRpc` transport trait (methods
+`openhuman.<namespace>_<function>`, `GET /health`) with an in-memory
+`MockOpenHumanRpc` so the providers are testable offline; `http_client.rs`
+holds the real `reqwest` client behind the optional `openhuman-rpc` feature.
+`tools.rs` (`OpenHumanToolProvider`) filters the RPC tool catalog by the
+company's manifest grants and rejects ungranted calls before any side effect;
+`channel.rs` (`OpenHumanChannelAdapter`) sends over the channels domain. All of
+it degrades to built-in tools and the operator channel with a boot warning when
+OpenHuman is unreachable — never a boot failure.

--- a/docs/modules/policy/README.md
+++ b/docs/modules/policy/README.md
@@ -9,3 +9,10 @@ against the manifest `[policy]` block into `Allow`, `RequireApproval`, or
 
 The gate is consulted by the `CycleRunner` before any effect crosses the trust
 boundary; parked effects surface in the operator's approvals inbox.
+
+Effects are classified into the checkpoint groups (Spend / Send / Sign /
+Publish / Hire / Identity) with per-group supervised defaults. Parked approvals
+**default-deny on silence**: they expire to `deny` after a configurable window
+(default 7 days) measured against an injectable clock. The operator may **edit**
+a parked effect's payload and approve the amended version; the follow-up cycle
+shows the brain both the original and the edit.

--- a/docs/modules/runtime/README.md
+++ b/docs/modules/runtime/README.md
@@ -12,3 +12,9 @@ re-fires a completed effect (at-most-once). `CompanyRegistry` maps `CompanyId`
 to a running runtime, serving both the single-company and multi-tenant cases
 with one type. Approval resolution schedules a follow-up cycle so the brain
 learns the verdict.
+
+`cron.rs` + `scheduler.rs` implement the cron scheduler: each manifest
+`[[schedule]]` 5-field expression is matched against an injectable clock, and a
+`ScheduleFired` event is enqueued into the company's serial cycle queue when
+due. The clock is injectable so schedule firing is tested deterministically
+without wall-clock waits.

--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -1,10 +1,81 @@
 # Server Module
 
-The server module owns the Axum HTTP surface. The initial routes are:
+The server module owns the Axum HTTP surface. The base routes are:
 
 - `GET /healthz`
 - `GET /spec`
 - `GET /tiny`
 
-Add future API routes as focused handler groups rather than wiring behavior
-directly in the binary entrypoint.
+Operator chat and approvals live under `/api/v1/...` (see `server::operator`),
+and feedback under `server::feedback`. Add future API routes as focused handler
+groups rather than wiring behavior directly in the binary entrypoint.
+
+## tiny.place A2A inbound + discovery (`tinyplace` feature)
+
+Behind the `tinyplace` feature the server mounts the agent-to-agent surface
+(`server::a2a`). With the feature off, none of these routes exist and the
+default build links no crypto.
+
+| Route | Purpose |
+| --- | --- |
+| `POST /a2a/{handle}` | JSON-RPC `tasks/send` from a counterparty agent |
+| `GET  /a2a/{handle}` | the company's Agent Card (directory record) |
+| `GET  /a2a/{handle}/skill.md` | human/agent-readable priced-skill catalog |
+| `GET  /.well-known/agent-card.json` | the sole company's card (prosumer) |
+| `GET  /companies/{handle}/.well-known/agent-card.json` | a named company's card |
+
+`POST /a2a/{handle}` enforces the trust boundary in a fixed order before any
+work reaches cognition:
+
+1. Resolve a **discoverable** company (`[place].discoverable = true` with a
+   matching `[company].handle`); a miss is `404`.
+2. Verify the SIWX `Authorization` header (skew window + single-use replay
+   protection via a host-global nonce cache). A bad/missing header is `401`.
+3. For a skill priced above `0.00`, require a valid x402 authorization; without
+   one the response is a `402` challenge naming the amount and the company's
+   own tiny.place address.
+4. Sanitize the counterparty payload (a minimal promptguard pass — control
+   characters are stripped) before it becomes an `A2aTaskReceived` event and
+   drives exactly one cycle. Paying customers run under the same approval gates
+   as any other stimulus.
+
+An unreachable tiny.place backend maps to `503`; any other transport failure is
+`502`.
+
+## Enable discovery for all companies
+
+Every company declares its own discoverability in its manifest:
+
+```toml
+[company]
+name = "Acme SEO"
+handle = "acme"
+
+[place]
+discoverable = true
+skills = [{ id = "seo.audit", price_usd = "25.00", description = "Full audit" }]
+```
+
+To opt **every** loaded company into going public regardless of its manifest,
+pass `serve --discoverable`. It marks each company discoverable and synthesizes
+a `@handle` (a slug of the company name) when one is missing, so Agent Card
+generation and validation succeed:
+
+```bash
+cargo run --features tinyplace --bin opencompany -- \
+  serve --discoverable \
+  --company examples/agentic_law_firm \
+  --company examples/agentic_marketing_agency
+```
+
+At boot each discoverable company runs the going-public flow (lifecycle step 3):
+load-or-generate the Ed25519 keypair, `ensure_registered`, then publish the
+Agent Card — all best-effort. An unreachable tiny.place degrades the company to
+"private" with a warning and never blocks or fails boot.
+
+Relevant configuration:
+
+- `TINYPLACE_API_URL` — tiny.place economy base URL (default
+  `https://api.tiny.place`).
+- `OPENCOMPANY_PUBLIC_URL` — public host base embedded in published Agent Card
+  endpoints. When unset, the endpoint falls back to `http://{bind}`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,6 +41,13 @@ configuration.
 | [`agentic_accounting_firm`](agentic_accounting_firm/) | Books, taxes, forecasts | Sign-off on filings |
 | [`agentic_law_firm`](agentic_law_firm/) | Drafts, research, discovery | Approving filings |
 | [`agentic_pharma_startup`](agentic_pharma_startup/) | Candidate molecules & trial plans | Laboratory work |
+| [`signals_opportunity_studio`](signals_opportunity_studio/) | A ranked weekly opportunity brief | Which opportunities to fund |
+
+Signals and the Opportunity Engine ship as the
+[`signals_opportunity_studio`](signals_opportunity_studio/) **template, not
+kernel code**: a roster, a charter, and a weekly `[[schedule]]` over the
+existing channels, memory/context, and brain ports. There is no Signals
+subsystem in `src/`.
 
 ## Running a harness
 

--- a/examples/signals_opportunity_studio/Cargo.toml
+++ b/examples/signals_opportunity_studio/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "signals-opportunity-studio"
+description = "A venture studio that scouts signals and ranks opportunities for the operator."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+# Inherit the host crate from the parent workspace.
+opencompany.workspace = true

--- a/examples/signals_opportunity_studio/README.md
+++ b/examples/signals_opportunity_studio/README.md
@@ -1,0 +1,71 @@
+# Signals + Opportunity Studio
+
+> A studio that never stops listening: it gathers market signals, turns them into ranked opportunities, and hands you a weekly brief — you decide what to fund.
+
+## What it can do
+
+- Continuously gather raw signals from the web, forums, and anything piped into
+  its channels.
+- Cluster the noise into real, recurring pains — not one-off complaints.
+- Rank the resulting opportunities by evidence and size.
+- Deep-dive the top few and compile a weekly brief you can act on.
+- Keep everything it learns, so next week starts smarter than this one.
+
+## Agent roster
+
+| Agent | Responsibility |
+| --- | --- |
+| Signal Scout | Continuously gather raw market signals from web, forums, and inbound channels. |
+| Opportunity Analyst | Cluster signals into pains and rank opportunities by evidence and size. |
+| Research Agent | Deep-dive the top opportunities and compile the weekly brief. |
+
+## The weekly loop
+
+A single schedule drives the studio. Every Monday morning it scans the week's
+signals, clusters them into pains, ranks the opportunities, and sends you a
+ranked brief:
+
+```toml
+[[schedule]]
+cron = "0 6 * * 1"
+prompt = "Scan this week's signals, cluster them into pains, rank the top opportunities, and send the operator a ranked brief."
+```
+
+Signals arrive the same way any other work does: through the studio's channels
+(operator and email) and the company's inbound webhook path,
+`POST /hooks/{company}/{channel}`. Nothing new is bolted onto the runtime.
+
+## Human in the loop
+
+You keep **deciding which opportunities to fund and pursue**. The studio does
+the listening, clustering, ranking, and writing; you make the call. Spending is
+supervised — anything over $1 waits for your approval, and payments, filings,
+and anything published externally always ask first. The output of this harness
+is **a ranked weekly opportunity brief**.
+
+## Signals and the Opportunity Engine are a template, not kernel code
+
+There is no "Signals subsystem" or "Opportunity Engine" inside OpenCompany.
+This studio *is* the Opportunity Engine, expressed entirely over the existing
+host:
+
+- **Ingress** — channels and the inbound webhook path carry raw signals in.
+- **Memory** — the runtime's memory and context stores hold the signal corpus
+  across weeks.
+- **Reasoning** — the brain does the clustering, ranking, and drafting.
+- **Cadence** — the `[[schedule]]` entry runs the loop on its own.
+
+Anyone can fork this manifest, point it at their market, and have their own
+opportunity studio — no changes to the kernel required.
+
+## Run it
+
+```sh
+cargo run -p signals-opportunity-studio
+```
+
+Or validate the manifest without booting:
+
+```sh
+cargo run --bin opencompany -- check examples/signals_opportunity_studio/agents.toml
+```

--- a/examples/signals_opportunity_studio/agents.toml
+++ b/examples/signals_opportunity_studio/agents.toml
@@ -1,0 +1,77 @@
+# Agent roster for the Signals + Opportunity Engine harness.
+#
+# Signals and the Opportunity Engine are NOT kernel code. They are realized
+# here — over the existing OpenCompany ports — as a roster plus a charter plus
+# schedules:
+#
+#   * ingress  → channels (operator/email) and the POST /hooks/{company}/{channel}
+#                webhook path carry raw signals into the company
+#   * memory   → the runtime's MemoryStore/ContextStore hold the signal corpus
+#   * reasoning → the brain clusters pain, ranks opportunities, drafts the digest
+#   * cadence  → [[schedule]] entries drive the weekly scan/rank/report loop
+#
+# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# the vendored OpenHuman / TinyAgents modules.
+
+[company]
+name = "Signals + Opportunity Studio"
+output = "A ranked weekly opportunity brief the operator can act on"
+human_role = "Deciding which opportunities to fund and pursue"
+handle = "signalstudio"
+
+[[agent]]
+id = "signal_scout"
+role = "Signal Scout"
+description = "Continuously gather raw market signals from web, forums, and inbound channels."
+tier = "subconscious"
+tools = ["web.*"]
+budget_usd_daily = 5.0
+
+[[agent]]
+id = "opportunity_analyst"
+role = "Opportunity Analyst"
+description = "Cluster signals into pains and rank the resulting opportunities by evidence and size."
+tier = "reasoning"
+tools = ["web.*", "docs.*"]
+budget_usd_daily = 8.0
+
+[[agent]]
+id = "research_agent"
+role = "Research Agent"
+description = "Deep-dive the top opportunities and compile the operator's weekly brief."
+tier = "reasoning"
+tools = ["web.*", "docs.*"]
+budget_usd_daily = 8.0
+
+[brain]
+mode = "hosted"
+max_passes = 12
+
+[tools]
+allow = ["web.*", "docs.*"]
+
+[channels.operator]
+enabled = true
+
+[channels.email]
+enabled = true
+
+[policy]
+mode = "supervised"
+always_approve = ["payment.send", "filing.submit", "external.publish"]
+auto_approve_under_usd = 1.0
+
+[place]
+discoverable = false
+skills = [
+  { id = "opportunity.brief", price_usd = "49.00", description = "A ranked, evidence-backed weekly opportunity brief for a chosen market." },
+]
+
+[budget]
+monthly_usd = 200.0
+
+# Weekly loop: scan fresh signals, cluster them into pains, rank opportunities,
+# and deliver the digest to the operator. Monday 06:00.
+[[schedule]]
+cron = "0 6 * * 1"
+prompt = "Scan this week's signals, cluster them into pains, rank the top opportunities, and send the operator a ranked brief."

--- a/examples/signals_opportunity_studio/src/main.rs
+++ b/examples/signals_opportunity_studio/src/main.rs
@@ -1,0 +1,9 @@
+//! Example harness entrypoint.
+//!
+//! Boots the company declared in `agents.toml` on the shared `opencompany`
+//! host crate. See `README.md` for what this harness does and `agents.toml`
+//! for the full roster, schedules, and policy.
+
+fn main() -> opencompany::Result<()> {
+    opencompany::run_company(concat!(env!("CARGO_MANIFEST_DIR"), "/agents.toml"))
+}

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -1,0 +1,611 @@
+//! Precedence-resolved runtime configuration.
+//!
+//! [`RuntimeConfig`] is assembled from four layers, earlier winning over later:
+//!
+//! 1. Environment variables (`OPENCOMPANY_*`, `TINYHUMANS_*`, `TINYPLACE_*`,
+//!    `GITHUB_TOKEN`).
+//! 2. `~/.opencompany/config.toml`.
+//! 3. The company manifest (`[brain].mode`).
+//! 4. Built-in defaults.
+//!
+//! [`resolve`] returns the effective config together with a
+//! [`ConfigProvenance`] recording *which* layer set each value, so
+//! [`crate::app::doctor`] can explain the configuration back to the operator.
+//! Resolution never touches the process environment directly: it reads through
+//! the [`EnvSource`] seam, which tests satisfy with an in-memory map (no
+//! `std::env::set_var` races).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use serde::Deserialize;
+
+use crate::error::{OpenCompanyError, Result};
+use crate::ports::types::SecretValue;
+
+/// Default TinyHumans orchestration API base URL.
+pub const DEFAULT_API_URL: &str = "https://api.tinyhumans.ai";
+
+/// Default tiny.place economy API base URL.
+pub const DEFAULT_TINYPLACE_API_URL: &str = "https://api.tiny.place";
+
+/// Default HTTP bind address for the local host.
+pub const DEFAULT_BIND: &str = "127.0.0.1:8080";
+
+/// The config file name looked up under the data directory.
+pub const CONFIG_FILE: &str = "config.toml";
+
+// ---------------------------------------------------------------------------
+// Brain mode
+// ---------------------------------------------------------------------------
+
+/// Which brain the runtime drives.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BrainMode {
+    /// Cognition is served by hosted Medulla over `/orchestration/v1`.
+    Hosted,
+    /// Cognition is served by a local sidecar process (a later phase).
+    Sidecar,
+}
+
+impl BrainMode {
+    /// The manifest/env spelling of this mode.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Hosted => "hosted",
+            Self::Sidecar => "sidecar",
+        }
+    }
+}
+
+impl std::fmt::Display for BrainMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for BrainMode {
+    type Err = OpenCompanyError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s.trim() {
+            "hosted" => Ok(Self::Hosted),
+            "sidecar" => Ok(Self::Sidecar),
+            other => Err(OpenCompanyError::Config(format!(
+                "brain mode must be one of hosted, sidecar — you wrote `{other}`"
+            ))),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Provenance
+// ---------------------------------------------------------------------------
+
+/// The layer that supplied a resolved value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConfigLayer {
+    /// Set by an environment variable.
+    Env,
+    /// Set by `config.toml`.
+    ConfigToml,
+    /// Set by the company manifest.
+    Manifest,
+    /// Fell back to a built-in default.
+    Default,
+}
+
+impl ConfigLayer {
+    /// A short human label for doctor output.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Env => "env",
+            Self::ConfigToml => "config.toml",
+            Self::Manifest => "manifest",
+            Self::Default => "default",
+        }
+    }
+}
+
+/// Records which [`ConfigLayer`] set each effective config field.
+#[derive(Clone, Debug, Default)]
+pub struct ConfigProvenance(BTreeMap<&'static str, ConfigLayer>);
+
+impl ConfigProvenance {
+    /// Records that `field` was set by `layer`.
+    fn set(&mut self, field: &'static str, layer: ConfigLayer) {
+        self.0.insert(field, layer);
+    }
+
+    /// The layer that set `field`, if resolved.
+    pub fn layer(&self, field: &str) -> Option<ConfigLayer> {
+        self.0.get(field).copied()
+    }
+
+    /// Iterates `(field, layer)` pairs in stable field order.
+    pub fn iter(&self) -> impl Iterator<Item = (&'static str, ConfigLayer)> + '_ {
+        self.0.iter().map(|(k, v)| (*k, *v))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Env seam
+// ---------------------------------------------------------------------------
+
+/// A read-only source of environment values. The `std::env`-backed
+/// [`ProcessEnv`] is used at runtime; tests use a [`MapEnv`].
+pub trait EnvSource {
+    /// Returns the value for `key`, or `None` when unset or empty.
+    fn get(&self, key: &str) -> Option<String>;
+}
+
+/// Reads from the real process environment.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ProcessEnv;
+
+impl EnvSource for ProcessEnv {
+    fn get(&self, key: &str) -> Option<String> {
+        match std::env::var(key) {
+            Ok(value) if !value.is_empty() => Some(value),
+            _ => None,
+        }
+    }
+}
+
+/// An in-memory [`EnvSource`] for deterministic tests.
+#[derive(Clone, Debug, Default)]
+pub struct MapEnv(std::collections::HashMap<String, String>);
+
+impl MapEnv {
+    /// Builds a map env from `(key, value)` pairs.
+    pub fn new<I, K, V>(pairs: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        Self(
+            pairs
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        )
+    }
+}
+
+impl EnvSource for MapEnv {
+    fn get(&self, key: &str) -> Option<String> {
+        self.0.get(key).filter(|value| !value.is_empty()).cloned()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// config.toml mirror
+// ---------------------------------------------------------------------------
+
+/// A deserialized `~/.opencompany/config.toml`. Every field is optional so a
+/// partial file only overrides what it names.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct ConfigFile {
+    /// TinyHumans API credential (the hosted-brain bearer token).
+    pub tinyhumans_api_key: Option<String>,
+    /// TinyHumans orchestration API base URL.
+    pub api_url: Option<String>,
+    /// Brain mode (`hosted` | `sidecar`).
+    pub brain_mode: Option<String>,
+    /// HTTP bind address.
+    pub bind: Option<String>,
+    /// Data directory holding company bundles and this file.
+    pub data_dir: Option<String>,
+    /// OpenHuman sidecar base URL.
+    pub openhuman_url: Option<String>,
+    /// tiny.place economy API base URL.
+    pub tinyplace_api_url: Option<String>,
+    /// GitHub token used by GitHub-backed tools.
+    pub github_token: Option<String>,
+}
+
+impl ConfigFile {
+    /// Loads `config.toml` from `dir`, returning `None` when the file is
+    /// absent. A malformed file is a hard [`OpenCompanyError::Config`] error.
+    pub fn load(dir: &Path) -> Result<Option<Self>> {
+        let path = dir.join(CONFIG_FILE);
+        let text = match std::fs::read_to_string(&path) {
+            Ok(text) => text,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => {
+                return Err(OpenCompanyError::Config(format!(
+                    "could not read {}: {e}",
+                    path.display()
+                )));
+            }
+        };
+        let parsed = toml::from_str(&text).map_err(|e| {
+            OpenCompanyError::Config(format!("{} is not valid TOML: {}", path.display(), e))
+        })?;
+        Ok(Some(parsed))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resolved config
+// ---------------------------------------------------------------------------
+
+/// The effective runtime configuration after precedence resolution.
+#[derive(Clone)]
+pub struct RuntimeConfig {
+    /// HTTP bind address for the local host.
+    pub bind: String,
+    /// Data directory holding company bundles and `config.toml`.
+    pub data_dir: PathBuf,
+    /// TinyHumans orchestration API base URL.
+    pub api_url: String,
+    /// Which brain the runtime drives.
+    pub brain_mode: BrainMode,
+    /// OpenHuman sidecar base URL, if configured.
+    pub openhuman_url: Option<String>,
+    /// tiny.place economy API base URL.
+    pub tinyplace_api_url: String,
+    /// GitHub token, if configured. Redacted in `Debug`.
+    pub github_token: Option<SecretValue>,
+    /// TinyHumans hosted-brain credential, if configured. Redacted in `Debug`.
+    pub tinyhumans_credential: Option<SecretValue>,
+}
+
+impl RuntimeConfig {
+    /// True when hosted cognition can run: hosted mode plus a credential.
+    pub fn cycles_available(&self) -> bool {
+        self.brain_mode == BrainMode::Hosted && self.tinyhumans_credential.is_some()
+    }
+}
+
+/// A manual `Debug` that redacts both secret handles so a credential can never
+/// reach a log line or panic message.
+impl std::fmt::Debug for RuntimeConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RuntimeConfig")
+            .field("bind", &self.bind)
+            .field("data_dir", &self.data_dir)
+            .field("api_url", &self.api_url)
+            .field("brain_mode", &self.brain_mode)
+            .field("openhuman_url", &self.openhuman_url)
+            .field("tinyplace_api_url", &self.tinyplace_api_url)
+            .field("github_token", &redacted(&self.github_token))
+            .field(
+                "tinyhumans_credential",
+                &redacted(&self.tinyhumans_credential),
+            )
+            .finish()
+    }
+}
+
+/// Renders a secret handle as `set`/`missing`, never its bytes.
+pub(crate) fn redacted(value: &Option<SecretValue>) -> &'static str {
+    if value.is_some() { "set" } else { "missing" }
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+/// Resolves the effective [`RuntimeConfig`] and its [`ConfigProvenance`].
+///
+/// `env` supplies environment values, `config_toml` an optional parsed
+/// `config.toml`, and `manifest` the company manifest whose `[brain].mode`
+/// participates in `brain_mode` resolution.
+pub fn resolve(
+    env: &dyn EnvSource,
+    config_toml: Option<&ConfigFile>,
+    manifest: &crate::company::CompanyManifest,
+) -> Result<(RuntimeConfig, ConfigProvenance)> {
+    let mut prov = ConfigProvenance::default();
+
+    let bind = resolve_str(
+        &mut prov,
+        "bind",
+        env.get("OPENCOMPANY_BIND"),
+        config_toml.and_then(|c| c.bind.clone()),
+        None,
+        DEFAULT_BIND.to_string(),
+    );
+
+    let data_dir = resolve_str(
+        &mut prov,
+        "data_dir",
+        env.get("OPENCOMPANY_DATA_DIR"),
+        config_toml.and_then(|c| c.data_dir.clone()),
+        None,
+        default_data_dir_str(env),
+    );
+
+    let api_url = resolve_str(
+        &mut prov,
+        "api_url",
+        env.get("TINYHUMANS_API_URL"),
+        config_toml.and_then(|c| c.api_url.clone()),
+        None,
+        DEFAULT_API_URL.to_string(),
+    );
+
+    let tinyplace_api_url = resolve_str(
+        &mut prov,
+        "tinyplace_api_url",
+        env.get("TINYPLACE_API_URL"),
+        config_toml.and_then(|c| c.tinyplace_api_url.clone()),
+        None,
+        DEFAULT_TINYPLACE_API_URL.to_string(),
+    );
+
+    // brain_mode: env <- config.toml <- manifest (always present) <- default.
+    let brain_raw = resolve_str(
+        &mut prov,
+        "brain_mode",
+        env.get("OPENCOMPANY_BRAIN_MODE"),
+        config_toml.and_then(|c| c.brain_mode.clone()),
+        Some(manifest.brain.mode.clone()),
+        BrainMode::Hosted.as_str().to_string(),
+    );
+    let brain_mode = BrainMode::from_str(&brain_raw)?;
+
+    let openhuman_url = resolve_opt(
+        &mut prov,
+        "openhuman_url",
+        env.get("OPENCOMPANY_OPENHUMAN_URL"),
+        config_toml.and_then(|c| c.openhuman_url.clone()),
+    );
+
+    let github_token = resolve_opt(
+        &mut prov,
+        "github_token",
+        env.get("GITHUB_TOKEN"),
+        config_toml.and_then(|c| c.github_token.clone()),
+    )
+    .map(SecretValue);
+
+    let tinyhumans_credential = resolve_opt(
+        &mut prov,
+        "tinyhumans_credential",
+        env.get("TINYHUMANS_API_KEY"),
+        config_toml.and_then(|c| c.tinyhumans_api_key.clone()),
+    )
+    .map(SecretValue);
+
+    let config = RuntimeConfig {
+        bind,
+        data_dir: PathBuf::from(data_dir),
+        api_url,
+        brain_mode,
+        openhuman_url,
+        tinyplace_api_url,
+        github_token,
+        tinyhumans_credential,
+    };
+    Ok((config, prov))
+}
+
+/// Resolves a required string field, recording its winning layer.
+fn resolve_str(
+    prov: &mut ConfigProvenance,
+    field: &'static str,
+    env_val: Option<String>,
+    toml_val: Option<String>,
+    manifest_val: Option<String>,
+    default_val: String,
+) -> String {
+    if let Some(value) = env_val {
+        prov.set(field, ConfigLayer::Env);
+        value
+    } else if let Some(value) = toml_val {
+        prov.set(field, ConfigLayer::ConfigToml);
+        value
+    } else if let Some(value) = manifest_val {
+        prov.set(field, ConfigLayer::Manifest);
+        value
+    } else {
+        prov.set(field, ConfigLayer::Default);
+        default_val
+    }
+}
+
+/// Resolves an optional string field, recording its winning layer (`Default`
+/// when unset by every source).
+fn resolve_opt(
+    prov: &mut ConfigProvenance,
+    field: &'static str,
+    env_val: Option<String>,
+    toml_val: Option<String>,
+) -> Option<String> {
+    if let Some(value) = env_val {
+        prov.set(field, ConfigLayer::Env);
+        Some(value)
+    } else if let Some(value) = toml_val {
+        prov.set(field, ConfigLayer::ConfigToml);
+        Some(value)
+    } else {
+        prov.set(field, ConfigLayer::Default);
+        None
+    }
+}
+
+/// The default data directory: `$HOME/.opencompany`, falling back to a relative
+/// path when `$HOME` is unset.
+fn default_data_dir_str(env: &dyn EnvSource) -> String {
+    match env.get("HOME") {
+        Some(home) => PathBuf::from(home)
+            .join(".opencompany")
+            .to_string_lossy()
+            .into_owned(),
+        None => PathBuf::from(".opencompany").to_string_lossy().into_owned(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::company::CompanyManifest;
+
+    fn manifest_with_brain(mode: &str) -> CompanyManifest {
+        let toml_src = format!("[company]\nname = \"X\"\n[brain]\nmode = \"{mode}\"\n");
+        toml::from_str(&toml_src).expect("valid manifest")
+    }
+
+    fn default_manifest() -> CompanyManifest {
+        toml::from_str("[company]\nname = \"X\"\n").expect("valid manifest")
+    }
+
+    #[test]
+    fn defaults_fill_in_when_nothing_set() {
+        let env = MapEnv::default();
+        let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
+
+        assert_eq!(cfg.api_url, DEFAULT_API_URL);
+        assert_eq!(cfg.tinyplace_api_url, DEFAULT_TINYPLACE_API_URL);
+        assert_eq!(cfg.bind, DEFAULT_BIND);
+        assert_eq!(cfg.brain_mode, BrainMode::Hosted);
+        assert!(cfg.tinyhumans_credential.is_none());
+        assert!(cfg.github_token.is_none());
+        assert!(!cfg.cycles_available());
+
+        // The manifest always supplies a brain mode, so its layer is Manifest.
+        assert_eq!(prov.layer("brain_mode"), Some(ConfigLayer::Manifest));
+        assert_eq!(prov.layer("api_url"), Some(ConfigLayer::Default));
+        assert_eq!(prov.layer("bind"), Some(ConfigLayer::Default));
+    }
+
+    #[test]
+    fn env_beats_config_toml_beats_manifest_beats_default() {
+        // brain_mode: env wins over everything.
+        let env = MapEnv::new([
+            ("OPENCOMPANY_BRAIN_MODE", "sidecar"),
+            ("OPENCOMPANY_BIND", "0.0.0.0:9000"),
+        ]);
+        let file = ConfigFile {
+            brain_mode: Some("hosted".into()),
+            bind: Some("127.0.0.1:1111".into()),
+            api_url: Some("https://toml.example".into()),
+            ..ConfigFile::default()
+        };
+        let (cfg, prov) = resolve(&env, Some(&file), &manifest_with_brain("hosted")).unwrap();
+
+        assert_eq!(cfg.brain_mode, BrainMode::Sidecar);
+        assert_eq!(prov.layer("brain_mode"), Some(ConfigLayer::Env));
+        assert_eq!(cfg.bind, "0.0.0.0:9000");
+        assert_eq!(prov.layer("bind"), Some(ConfigLayer::Env));
+
+        // api_url only in config.toml, so config.toml wins over the default.
+        assert_eq!(cfg.api_url, "https://toml.example");
+        assert_eq!(prov.layer("api_url"), Some(ConfigLayer::ConfigToml));
+    }
+
+    #[test]
+    fn config_toml_beats_manifest_for_brain_mode() {
+        let env = MapEnv::default();
+        let file = ConfigFile {
+            brain_mode: Some("sidecar".into()),
+            ..ConfigFile::default()
+        };
+        let (cfg, prov) = resolve(&env, Some(&file), &manifest_with_brain("hosted")).unwrap();
+        assert_eq!(cfg.brain_mode, BrainMode::Sidecar);
+        assert_eq!(prov.layer("brain_mode"), Some(ConfigLayer::ConfigToml));
+    }
+
+    #[test]
+    fn manifest_supplies_brain_mode_when_env_and_toml_absent() {
+        let env = MapEnv::default();
+        let (cfg, prov) = resolve(&env, None, &manifest_with_brain("sidecar")).unwrap();
+        assert_eq!(cfg.brain_mode, BrainMode::Sidecar);
+        assert_eq!(prov.layer("brain_mode"), Some(ConfigLayer::Manifest));
+    }
+
+    #[test]
+    fn credential_from_env_enables_cycles() {
+        let env = MapEnv::new([("TINYHUMANS_API_KEY", "th_live_abc123")]);
+        let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
+
+        assert!(cfg.tinyhumans_credential.is_some());
+        assert!(cfg.cycles_available());
+        assert_eq!(prov.layer("tinyhumans_credential"), Some(ConfigLayer::Env));
+    }
+
+    #[test]
+    fn credential_from_config_toml_when_env_absent() {
+        let env = MapEnv::default();
+        let file = ConfigFile {
+            tinyhumans_api_key: Some("th_from_toml".into()),
+            ..ConfigFile::default()
+        };
+        let (cfg, prov) = resolve(&env, Some(&file), &default_manifest()).unwrap();
+        assert_eq!(
+            cfg.tinyhumans_credential.as_ref().unwrap().expose(),
+            "th_from_toml"
+        );
+        assert_eq!(
+            prov.layer("tinyhumans_credential"),
+            Some(ConfigLayer::ConfigToml)
+        );
+    }
+
+    #[test]
+    fn debug_redacts_secrets() {
+        let env = MapEnv::new([
+            ("TINYHUMANS_API_KEY", "th_super_secret_value"),
+            ("GITHUB_TOKEN", "ghp_secret_token"),
+        ]);
+        let (cfg, _) = resolve(&env, None, &default_manifest()).unwrap();
+        let rendered = format!("{cfg:?}");
+        assert!(!rendered.contains("th_super_secret_value"));
+        assert!(!rendered.contains("ghp_secret_token"));
+        assert!(rendered.contains("set"));
+    }
+
+    #[test]
+    fn invalid_brain_mode_is_a_config_error() {
+        let env = MapEnv::new([("OPENCOMPANY_BRAIN_MODE", "quantum")]);
+        let err = resolve(&env, None, &default_manifest()).unwrap_err();
+        assert_eq!(err.code(), "config_error");
+        assert!(err.to_string().contains("quantum"));
+    }
+
+    #[test]
+    fn empty_env_value_is_ignored() {
+        let env = MapEnv::new([("OPENCOMPANY_BIND", "")]);
+        let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
+        assert_eq!(cfg.bind, DEFAULT_BIND);
+        assert_eq!(prov.layer("bind"), Some(ConfigLayer::Default));
+    }
+
+    #[test]
+    fn config_file_load_returns_none_when_absent() {
+        let dir = std::env::temp_dir().join(format!("oc-cfg-none-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(ConfigFile::load(&dir).unwrap().is_none());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn config_file_load_parses_toml() {
+        let dir = std::env::temp_dir().join(format!("oc-cfg-load-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join(CONFIG_FILE),
+            "brain_mode = \"sidecar\"\napi_url = \"https://x\"\n",
+        )
+        .unwrap();
+        let file = ConfigFile::load(&dir).unwrap().unwrap();
+        assert_eq!(file.brain_mode.as_deref(), Some("sidecar"));
+        assert_eq!(file.api_url.as_deref(), Some("https://x"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn malformed_config_file_is_a_config_error() {
+        let dir = std::env::temp_dir().join(format!("oc-cfg-bad-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(CONFIG_FILE), "not = = valid").unwrap();
+        let err = ConfigFile::load(&dir).unwrap_err();
+        assert_eq!(err.code(), "config_error");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -203,6 +203,8 @@ pub struct ConfigFile {
     pub openhuman_url: Option<String>,
     /// tiny.place economy API base URL.
     pub tinyplace_api_url: Option<String>,
+    /// Public host base URL advertised in published Agent Cards.
+    pub public_url: Option<String>,
     /// GitHub token used by GitHub-backed tools.
     pub github_token: Option<String>,
 }
@@ -248,6 +250,9 @@ pub struct RuntimeConfig {
     pub openhuman_url: Option<String>,
     /// tiny.place economy API base URL.
     pub tinyplace_api_url: String,
+    /// Public host base URL advertised in published Agent Cards, if configured.
+    /// When unset, the card endpoint falls back to `http://{bind}`.
+    pub public_url: Option<String>,
     /// GitHub token, if configured. Redacted in `Debug`.
     pub github_token: Option<SecretValue>,
     /// TinyHumans hosted-brain credential, if configured. Redacted in `Debug`.
@@ -272,6 +277,7 @@ impl std::fmt::Debug for RuntimeConfig {
             .field("brain_mode", &self.brain_mode)
             .field("openhuman_url", &self.openhuman_url)
             .field("tinyplace_api_url", &self.tinyplace_api_url)
+            .field("public_url", &self.public_url)
             .field("github_token", &redacted(&self.github_token))
             .field(
                 "tinyhumans_credential",
@@ -356,6 +362,13 @@ pub fn resolve(
         config_toml.and_then(|c| c.openhuman_url.clone()),
     );
 
+    let public_url = resolve_opt(
+        &mut prov,
+        "public_url",
+        env.get("OPENCOMPANY_PUBLIC_URL"),
+        config_toml.and_then(|c| c.public_url.clone()),
+    );
+
     let github_token = resolve_opt(
         &mut prov,
         "github_token",
@@ -379,6 +392,7 @@ pub fn resolve(
         brain_mode,
         openhuman_url,
         tinyplace_api_url,
+        public_url,
         github_token,
         tinyhumans_credential,
     };
@@ -527,6 +541,34 @@ mod test {
         assert!(cfg.tinyhumans_credential.is_some());
         assert!(cfg.cycles_available());
         assert_eq!(prov.layer("tinyhumans_credential"), Some(ConfigLayer::Env));
+    }
+
+    #[test]
+    fn public_url_and_tinyplace_url_resolve_by_precedence() {
+        // public_url: env wins; tinyplace_api_url only in config.toml.
+        let env = MapEnv::new([("OPENCOMPANY_PUBLIC_URL", "https://public.example")]);
+        let file = ConfigFile {
+            public_url: Some("https://toml.example".into()),
+            tinyplace_api_url: Some("https://tp.toml".into()),
+            ..ConfigFile::default()
+        };
+        let (cfg, prov) = resolve(&env, Some(&file), &default_manifest()).unwrap();
+
+        assert_eq!(cfg.public_url.as_deref(), Some("https://public.example"));
+        assert_eq!(prov.layer("public_url"), Some(ConfigLayer::Env));
+        assert_eq!(cfg.tinyplace_api_url, "https://tp.toml");
+        assert_eq!(
+            prov.layer("tinyplace_api_url"),
+            Some(ConfigLayer::ConfigToml)
+        );
+    }
+
+    #[test]
+    fn public_url_defaults_to_none() {
+        let env = MapEnv::default();
+        let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
+        assert!(cfg.public_url.is_none());
+        assert_eq!(prov.layer("public_url"), Some(ConfigLayer::Default));
     }
 
     #[test]

--- a/src/app/doctor.rs
+++ b/src/app/doctor.rs
@@ -1,0 +1,256 @@
+//! `opencompany doctor` — explain the effective configuration.
+//!
+//! [`report`] turns a resolved [`RuntimeConfig`] and its [`ConfigProvenance`]
+//! into a serializable [`DoctorReport`]: every effective value with the layer
+//! that set it, plus a per-capability section stating what is available and
+//! what is missing. Secrets are only ever surfaced as `set`/`missing`; the
+//! report never carries credential bytes.
+
+use serde::Serialize;
+
+use crate::app::config::{ConfigLayer, ConfigProvenance, RuntimeConfig, redacted};
+
+/// One effective configuration value with the layer that set it.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct DoctorValue {
+    /// The config field name (e.g. `api_url`).
+    pub name: &'static str,
+    /// The rendered value. Secrets render as `set`/`missing`.
+    pub value: String,
+    /// The layer that set this value (`env`, `config.toml`, `manifest`,
+    /// `default`).
+    pub layer: &'static str,
+}
+
+/// A capability and whether it is currently available.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct DoctorCapability {
+    /// Capability name (e.g. `cycles`).
+    pub name: &'static str,
+    /// Whether the capability can run with the current configuration.
+    pub available: bool,
+    /// When unavailable, what the operator must set; empty when available.
+    pub needs: String,
+}
+
+/// The full doctor report: effective values plus capability readiness.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct DoctorReport {
+    /// Effective configuration values, in stable field order.
+    pub values: Vec<DoctorValue>,
+    /// Per-capability readiness.
+    pub capabilities: Vec<DoctorCapability>,
+}
+
+impl DoctorReport {
+    /// Renders the report as a human-readable, aligned text block.
+    pub fn to_text(&self) -> String {
+        use std::fmt::Write as _;
+        let mut out = String::new();
+        out.push_str("Configuration\n");
+        let width = self.values.iter().map(|v| v.name.len()).max().unwrap_or(0);
+        for value in &self.values {
+            let _ = writeln!(
+                out,
+                "  {:<width$}  {}  [{}]",
+                value.name,
+                value.value,
+                value.layer,
+                width = width
+            );
+        }
+        out.push_str("\nCapabilities\n");
+        for cap in &self.capabilities {
+            if cap.available {
+                let _ = writeln!(out, "  {:<12} available", cap.name);
+            } else {
+                let _ = writeln!(out, "  {:<12} unavailable: {}", cap.name, cap.needs);
+            }
+        }
+        out
+    }
+}
+
+/// The value string for a config field, resolving secrets to `set`/`missing`.
+fn value_of(cfg: &RuntimeConfig, field: &str) -> String {
+    match field {
+        "bind" => cfg.bind.clone(),
+        "data_dir" => cfg.data_dir.display().to_string(),
+        "api_url" => cfg.api_url.clone(),
+        "brain_mode" => cfg.brain_mode.to_string(),
+        "openhuman_url" => cfg.openhuman_url.clone().unwrap_or_else(|| "unset".into()),
+        "tinyplace_api_url" => cfg.tinyplace_api_url.clone(),
+        "github_token" => redacted(&cfg.github_token).to_string(),
+        "tinyhumans_credential" => redacted(&cfg.tinyhumans_credential).to_string(),
+        other => format!("<unknown field {other}>"),
+    }
+}
+
+/// The stable field order shown by the doctor.
+const FIELDS: &[&str] = &[
+    "bind",
+    "data_dir",
+    "api_url",
+    "brain_mode",
+    "openhuman_url",
+    "tinyplace_api_url",
+    "github_token",
+    "tinyhumans_credential",
+];
+
+/// Builds a [`DoctorReport`] from resolved config and its provenance.
+pub fn report(cfg: &RuntimeConfig, prov: &ConfigProvenance) -> DoctorReport {
+    let values = FIELDS
+        .iter()
+        .map(|&field| DoctorValue {
+            name: field,
+            value: value_of(cfg, field),
+            layer: prov.layer(field).unwrap_or(ConfigLayer::Default).label(),
+        })
+        .collect();
+
+    let cycles = DoctorCapability {
+        name: "cycles",
+        available: cfg.cycles_available(),
+        needs: if cfg.cycles_available() {
+            String::new()
+        } else if cfg.tinyhumans_credential.is_none() {
+            "needs TINYHUMANS_API_KEY".into()
+        } else {
+            format!("needs brain_mode = hosted (currently {})", cfg.brain_mode)
+        },
+    };
+
+    let openhuman = DoctorCapability {
+        name: "openhuman",
+        available: cfg.openhuman_url.is_some(),
+        needs: if cfg.openhuman_url.is_some() {
+            String::new()
+        } else {
+            "needs OPENCOMPANY_OPENHUMAN_URL".into()
+        },
+    };
+
+    let tinyplace = DoctorCapability {
+        name: "tinyplace",
+        available: true,
+        needs: String::new(),
+    };
+
+    let github = DoctorCapability {
+        name: "github",
+        available: cfg.github_token.is_some(),
+        needs: if cfg.github_token.is_some() {
+            String::new()
+        } else {
+            "needs GITHUB_TOKEN".into()
+        },
+    };
+
+    DoctorReport {
+        values,
+        capabilities: vec![cycles, openhuman, tinyplace, github],
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::app::config::{MapEnv, resolve};
+    use crate::company::CompanyManifest;
+
+    fn default_manifest() -> CompanyManifest {
+        toml::from_str("[company]\nname = \"X\"\n").expect("valid manifest")
+    }
+
+    fn cap<'a>(report: &'a DoctorReport, name: &str) -> &'a DoctorCapability {
+        report
+            .capabilities
+            .iter()
+            .find(|c| c.name == name)
+            .expect("capability present")
+    }
+
+    #[test]
+    fn cycles_unavailable_without_credential() {
+        let env = MapEnv::default();
+        let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
+        let report = report(&cfg, &prov);
+
+        let cycles = cap(&report, "cycles");
+        assert!(!cycles.available);
+        assert_eq!(cycles.needs, "needs TINYHUMANS_API_KEY");
+    }
+
+    #[test]
+    fn cycles_available_with_hosted_credential() {
+        let env = MapEnv::new([("TINYHUMANS_API_KEY", "th_secret")]);
+        let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
+        let report = report(&cfg, &prov);
+
+        let cycles = cap(&report, "cycles");
+        assert!(cycles.available);
+        assert!(cycles.needs.is_empty());
+    }
+
+    #[test]
+    fn cycles_needs_hosted_when_credential_set_but_sidecar() {
+        let env = MapEnv::new([
+            ("TINYHUMANS_API_KEY", "th_secret"),
+            ("OPENCOMPANY_BRAIN_MODE", "sidecar"),
+        ]);
+        let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
+        let report = report(&cfg, &prov);
+
+        let cycles = cap(&report, "cycles");
+        assert!(!cycles.available);
+        assert!(cycles.needs.contains("brain_mode = hosted"));
+    }
+
+    #[test]
+    fn report_never_leaks_secret_bytes() {
+        let env = MapEnv::new([
+            ("TINYHUMANS_API_KEY", "th_super_secret_value"),
+            ("GITHUB_TOKEN", "ghp_super_secret_token"),
+        ]);
+        let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
+        let report = report(&cfg, &prov);
+
+        let text = report.to_text();
+        let json = serde_json::to_string(&report).unwrap();
+        for rendered in [&text, &json] {
+            assert!(!rendered.contains("th_super_secret_value"));
+            assert!(!rendered.contains("ghp_super_secret_token"));
+        }
+        // The credential is present, so it renders as `set`.
+        assert!(text.contains("set"));
+    }
+
+    #[test]
+    fn values_report_layer_labels() {
+        let env = MapEnv::new([("OPENCOMPANY_BIND", "0.0.0.0:9000")]);
+        let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
+        let report = report(&cfg, &prov);
+
+        let bind = report.values.iter().find(|v| v.name == "bind").unwrap();
+        assert_eq!(bind.value, "0.0.0.0:9000");
+        assert_eq!(bind.layer, "env");
+
+        let api = report.values.iter().find(|v| v.name == "api_url").unwrap();
+        assert_eq!(api.layer, "default");
+    }
+
+    #[test]
+    fn openhuman_and_github_capabilities_track_config() {
+        let env = MapEnv::new([
+            ("OPENCOMPANY_OPENHUMAN_URL", "http://127.0.0.1:7777"),
+            ("GITHUB_TOKEN", "ghp_x"),
+        ]);
+        let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
+        let report = report(&cfg, &prov);
+
+        assert!(cap(&report, "openhuman").available);
+        assert!(cap(&report, "github").available);
+        assert!(cap(&report, "tinyplace").available);
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,7 @@
+pub mod config;
+pub mod doctor;
 mod types;
 
+pub use config::{BrainMode, ConfigProvenance, RuntimeConfig, resolve};
+pub use doctor::{DoctorReport, report as doctor_report};
 pub use types::{AppConfig, AppSpec, AppState};

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -24,6 +24,11 @@ pub struct AppConfig {
     pub api_url: String,
     /// Which brain the runtime drives.
     pub brain_mode: BrainMode,
+    /// tiny.place economy API base URL.
+    pub tinyplace_api_url: String,
+    /// Public host base URL advertised in published Agent Cards. When `None`,
+    /// the card endpoint falls back to `http://{bind}`.
+    pub public_url: Option<String>,
     /// TinyHumans hosted-brain credential, if configured. Redacted in `Debug`.
     pub tinyhumans_credential: Option<SecretValue>,
 }
@@ -36,6 +41,8 @@ impl Default for AppConfig {
             operator_token: None,
             api_url: crate::app::config::DEFAULT_API_URL.to_string(),
             brain_mode: BrainMode::Hosted,
+            tinyplace_api_url: crate::app::config::DEFAULT_TINYPLACE_API_URL.to_string(),
+            public_url: None,
             tinyhumans_credential: None,
         }
     }
@@ -45,6 +52,15 @@ impl AppConfig {
     /// True when hosted cognition can run: hosted mode plus a credential.
     pub fn cycles_available(&self) -> bool {
         self.brain_mode == BrainMode::Hosted && self.tinyhumans_credential.is_some()
+    }
+
+    /// The host base URL to embed in published Agent Card endpoints: the
+    /// configured [`Self::public_url`] when set, otherwise `http://{bind}`.
+    pub fn host_base_url(&self) -> String {
+        match &self.public_url {
+            Some(url) => url.clone(),
+            None => format!("http://{}", self.bind),
+        }
     }
 }
 
@@ -59,6 +75,8 @@ impl std::fmt::Debug for AppConfig {
             )
             .field("api_url", &self.api_url)
             .field("brain_mode", &self.brain_mode)
+            .field("tinyplace_api_url", &self.tinyplace_api_url)
+            .field("public_url", &self.public_url)
             .field(
                 "tinyhumans_credential",
                 &redacted(&self.tinyhumans_credential),
@@ -72,6 +90,13 @@ impl std::fmt::Debug for AppConfig {
 pub struct AppState {
     config: AppConfig,
     registry: CompanyRegistry,
+    /// OpenCompany home root holding company bundles. Used by the tiny.place
+    /// A2A inbound routes to resolve a company's Ed25519 identity.
+    home: std::path::PathBuf,
+    /// Host-global replay-protection cache shared across every inbound A2A
+    /// request. Gated behind `tinyplace` so the default build links no crypto.
+    #[cfg(feature = "tinyplace")]
+    nonce: std::sync::Arc<crate::economy::NonceCache>,
 }
 
 impl AppState {
@@ -80,7 +105,16 @@ impl AppState {
         Self {
             config,
             registry: CompanyRegistry::new(),
+            home: std::path::PathBuf::from("."),
+            #[cfg(feature = "tinyplace")]
+            nonce: std::sync::Arc::new(crate::economy::NonceCache::new()),
         }
+    }
+
+    /// Sets the OpenCompany home root used to resolve company identities.
+    pub fn with_home(mut self, home: impl Into<std::path::PathBuf>) -> Self {
+        self.home = home.into();
+        self
     }
 
     /// Returns runtime configuration.
@@ -88,9 +122,20 @@ impl AppState {
         &self.config
     }
 
+    /// The OpenCompany home root holding company bundles.
+    pub fn home(&self) -> &std::path::Path {
+        &self.home
+    }
+
     /// The registry of running companies served by this host.
     pub fn registry(&self) -> &CompanyRegistry {
         &self.registry
+    }
+
+    /// The host-global A2A replay-protection nonce cache.
+    #[cfg(feature = "tinyplace")]
+    pub fn nonce(&self) -> &std::sync::Arc<crate::economy::NonceCache> {
+        &self.nonce
     }
 
     /// Returns a serializable system specification snapshot.
@@ -160,6 +205,18 @@ mod tests {
 
         assert_eq!(spec.framework, "axum");
         assert!(spec.modules.contains(&"server"));
+    }
+
+    #[test]
+    fn host_base_url_falls_back_to_bind() {
+        let config = AppConfig::default();
+        assert_eq!(config.host_base_url(), "http://127.0.0.1:8080");
+
+        let public = AppConfig {
+            public_url: Some("https://acme.example".into()),
+            ..AppConfig::default()
+        };
+        assert_eq!(public.host_base_url(), "https://acme.example");
     }
 
     #[test]

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -1,10 +1,14 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
 
 use serde::Serialize;
 
 use crate::app::config::{BrainMode, redacted};
-use crate::ports::types::SecretValue;
+use crate::ports::types::{CompanyId, SecretValue};
 use crate::runtime::CompanyRegistry;
+use crate::server::platform_auth::PlatformAuthConfig;
+use crate::server::webhook::WebhookConfig;
 use crate::{VERSION, tiny::RuntimeModuleStatus};
 
 /// Runtime configuration for OpenCompany.
@@ -31,6 +35,16 @@ pub struct AppConfig {
     pub public_url: Option<String>,
     /// TinyHumans hosted-brain credential, if configured. Redacted in `Debug`.
     pub tinyhumans_credential: Option<SecretValue>,
+    /// Platform (multi-tenant) auth. When set, `{id}` routes honor tenant scopes
+    /// and provisioning/suspension require the `platform` scope. When `None`, the
+    /// prosumer `operator_token` path is used.
+    pub platform_auth: Option<PlatformAuthConfig>,
+    /// Global cap on the number of provisioned companies. `None` = unlimited.
+    pub max_companies: Option<usize>,
+    /// Per-tenant cap on provisioned companies. `None` = unlimited.
+    pub max_companies_per_tenant: Option<usize>,
+    /// Outbound webhook delivery configuration. `None` disables webhooks.
+    pub webhook: Option<WebhookConfig>,
 }
 
 impl Default for AppConfig {
@@ -44,6 +58,10 @@ impl Default for AppConfig {
             tinyplace_api_url: crate::app::config::DEFAULT_TINYPLACE_API_URL.to_string(),
             public_url: None,
             tinyhumans_credential: None,
+            platform_auth: None,
+            max_companies: None,
+            max_companies_per_tenant: None,
+            webhook: None,
         }
     }
 }
@@ -81,6 +99,10 @@ impl std::fmt::Debug for AppConfig {
                 "tinyhumans_credential",
                 &redacted(&self.tinyhumans_credential),
             )
+            .field("platform_auth", &self.platform_auth)
+            .field("max_companies", &self.max_companies)
+            .field("max_companies_per_tenant", &self.max_companies_per_tenant)
+            .field("webhook", &self.webhook)
             .finish()
     }
 }
@@ -93,6 +115,12 @@ pub struct AppState {
     /// OpenCompany home root holding company bundles. Used by the tiny.place
     /// A2A inbound routes to resolve a company's Ed25519 identity.
     home: std::path::PathBuf,
+    /// Company → owning-tenant map, populated when a company is provisioned in
+    /// platform mode. Drives per-tenant quotas and cross-tenant isolation.
+    ///
+    /// Batch-1 durability is a documented stub: this map is in-memory and resets
+    /// on restart until a durable `tenant_id` slot exists on the company record.
+    ownership: Arc<RwLock<HashMap<CompanyId, String>>>,
     /// Host-global replay-protection cache shared across every inbound A2A
     /// request. Gated behind `tinyplace` so the default build links no crypto.
     #[cfg(feature = "tinyplace")]
@@ -106,6 +134,7 @@ impl AppState {
             config,
             registry: CompanyRegistry::new(),
             home: std::path::PathBuf::from("."),
+            ownership: Arc::new(RwLock::new(HashMap::new())),
             #[cfg(feature = "tinyplace")]
             nonce: std::sync::Arc::new(crate::economy::NonceCache::new()),
         }
@@ -115,6 +144,69 @@ impl AppState {
     pub fn with_home(mut self, home: impl Into<std::path::PathBuf>) -> Self {
         self.home = home.into();
         self
+    }
+
+    /// Installs platform (multi-tenant) auth. Mirrors [`Self::with_home`].
+    pub fn with_platform_auth(mut self, platform_auth: PlatformAuthConfig) -> Self {
+        self.config.platform_auth = Some(platform_auth);
+        self
+    }
+
+    /// Installs an outbound webhook sink configuration.
+    pub fn with_webhook(mut self, webhook: WebhookConfig) -> Self {
+        self.config.webhook = Some(webhook);
+        self
+    }
+
+    /// Sets provisioning quotas: a global cap and a per-tenant cap.
+    pub fn with_quota(
+        mut self,
+        max_companies: Option<usize>,
+        max_companies_per_tenant: Option<usize>,
+    ) -> Self {
+        self.config.max_companies = max_companies;
+        self.config.max_companies_per_tenant = max_companies_per_tenant;
+        self
+    }
+
+    /// The tenant that owns `id`, if it was provisioned in platform mode.
+    pub fn owner_of(&self, id: &CompanyId) -> Option<String> {
+        self.ownership
+            .read()
+            .expect("ownership poisoned")
+            .get(id)
+            .cloned()
+    }
+
+    /// Records that `tenant` owns `id`.
+    pub fn set_owner(&self, id: CompanyId, tenant: impl Into<String>) {
+        self.ownership
+            .write()
+            .expect("ownership poisoned")
+            .insert(id, tenant.into());
+    }
+
+    /// Forgets the ownership record for `id` (used by archive).
+    pub fn remove_owner(&self, id: &CompanyId) {
+        self.ownership
+            .write()
+            .expect("ownership poisoned")
+            .remove(id);
+    }
+
+    /// The number of companies owned by `tenant`.
+    pub fn tenant_company_count(&self, tenant: &str) -> usize {
+        self.ownership
+            .read()
+            .expect("ownership poisoned")
+            .values()
+            .filter(|owner| owner.as_str() == tenant)
+            .count()
+    }
+
+    /// The configured webhook delivery, if any.
+    pub fn webhook(&self) -> Option<&WebhookConfig> {
+        self.config.webhook.as_ref()
     }
 
     /// Returns runtime configuration.

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -2,11 +2,16 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
+use crate::app::config::{BrainMode, redacted};
+use crate::ports::types::SecretValue;
 use crate::runtime::CompanyRegistry;
 use crate::{VERSION, tiny::RuntimeModuleStatus};
 
 /// Runtime configuration for OpenCompany.
-#[derive(Clone, Debug)]
+///
+/// `Debug` is implemented by hand so the TinyHumans credential is redacted to
+/// `set`/`missing` and can never reach a log line or panic message.
+#[derive(Clone)]
 pub struct AppConfig {
     /// Address for the Axum HTTP server.
     pub bind: String,
@@ -15,6 +20,12 @@ pub struct AppConfig {
     /// Bearer token required on operator routes. When `None`, Phase-1 dev mode
     /// allows local operator calls without authentication.
     pub operator_token: Option<String>,
+    /// TinyHumans orchestration API base URL.
+    pub api_url: String,
+    /// Which brain the runtime drives.
+    pub brain_mode: BrainMode,
+    /// TinyHumans hosted-brain credential, if configured. Redacted in `Debug`.
+    pub tinyhumans_credential: Option<SecretValue>,
 }
 
 impl Default for AppConfig {
@@ -23,7 +34,36 @@ impl Default for AppConfig {
             bind: "127.0.0.1:8080".to_string(),
             openhuman_root: None,
             operator_token: None,
+            api_url: crate::app::config::DEFAULT_API_URL.to_string(),
+            brain_mode: BrainMode::Hosted,
+            tinyhumans_credential: None,
         }
+    }
+}
+
+impl AppConfig {
+    /// True when hosted cognition can run: hosted mode plus a credential.
+    pub fn cycles_available(&self) -> bool {
+        self.brain_mode == BrainMode::Hosted && self.tinyhumans_credential.is_some()
+    }
+}
+
+impl std::fmt::Debug for AppConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppConfig")
+            .field("bind", &self.bind)
+            .field("openhuman_root", &self.openhuman_root)
+            .field(
+                "operator_token",
+                &self.operator_token.as_ref().map(|_| "set"),
+            )
+            .field("api_url", &self.api_url)
+            .field("brain_mode", &self.brain_mode)
+            .field(
+                "tinyhumans_credential",
+                &redacted(&self.tinyhumans_credential),
+            )
+            .finish()
     }
 }
 
@@ -77,6 +117,8 @@ impl AppState {
                 .openhuman_root
                 .as_ref()
                 .map(|path| path.display().to_string()),
+            api_url: self.config.api_url.clone(),
+            cycles_available: self.config.cycles_available(),
         }
     }
 }
@@ -96,6 +138,11 @@ pub struct AppSpec {
     pub runtime_modules: Vec<RuntimeModuleStatus>,
     /// Configured OpenHuman checkout path, if any.
     pub openhuman_root: Option<String>,
+    /// TinyHumans orchestration API base URL.
+    pub api_url: String,
+    /// Whether hosted cognition can run (hosted brain plus a credential). No
+    /// secret bytes are surfaced.
+    pub cycles_available: bool,
 }
 
 #[cfg(test)]
@@ -113,5 +160,31 @@ mod tests {
 
         assert_eq!(spec.framework, "axum");
         assert!(spec.modules.contains(&"server"));
+    }
+
+    #[test]
+    fn debug_redacts_the_credential() {
+        let config = AppConfig {
+            tinyhumans_credential: Some(SecretValue("th_super_secret_value".into())),
+            ..AppConfig::default()
+        };
+        let rendered = format!("{config:?}");
+        assert!(!rendered.contains("th_super_secret_value"));
+        assert!(rendered.contains("set"));
+    }
+
+    #[test]
+    fn default_config_cannot_run_cycles() {
+        assert!(!AppConfig::default().cycles_available());
+    }
+
+    #[test]
+    fn hosted_with_credential_can_run_cycles() {
+        let config = AppConfig {
+            tinyhumans_credential: Some(SecretValue("th_secret".into())),
+            ..AppConfig::default()
+        };
+        assert!(config.cycles_available());
+        assert!(AppState::new(config).spec().cycles_available);
     }
 }

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -69,6 +69,35 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Export a company's bundle: read everything through the storage ports and
+    /// write the canonical filesystem layout. With `--features export` the output
+    /// is a single `.tar`; otherwise an unpacked bundle directory. Secrets and
+    /// keys are excluded unless `--include-secrets` is set.
+    Export {
+        /// Company id (slug) to export.
+        company: String,
+        /// Output path (`<slug>.tar` under `--features export`, else a bundle
+        /// directory). Defaults to the current directory.
+        #[arg(long)]
+        out: Option<PathBuf>,
+        /// Include the fs-only `secrets/` and `keys/` directories.
+        #[arg(long)]
+        include_secrets: bool,
+        /// OpenCompany home holding company bundles. Defaults to
+        /// `$HOME/.opencompany/companies`.
+        #[arg(long)]
+        home: Option<PathBuf>,
+    },
+    /// Import a company bundle (a `.tar` under `--features export`, else an
+    /// unpacked bundle directory) into a home through the storage ports.
+    Import {
+        /// Bundle `.tar` or unpacked bundle directory to import.
+        path: PathBuf,
+        /// OpenCompany home to import into. Defaults to
+        /// `$HOME/.opencompany/companies`.
+        #[arg(long)]
+        home: Option<PathBuf>,
+    },
     /// Launch a sibling OpenHuman checkout through cargo.
     OpenHuman {
         /// OpenHuman checkout path.
@@ -199,6 +228,179 @@ fn attach_openhuman(builder: RuntimeBuilder) -> RuntimeBuilder {
     }
 }
 
+/// Parses a non-empty `usize` environment variable, ignoring unset/empty/invalid
+/// values (an invalid value logs a warning and is treated as unset).
+fn env_usize(key: &str) -> Option<usize> {
+    match std::env::var(key) {
+        Ok(value) if !value.trim().is_empty() => match value.trim().parse::<usize>() {
+            Ok(parsed) => Some(parsed),
+            Err(_) => {
+                eprintln!("ignoring {key}=`{value}`: expected a non-negative integer");
+                None
+            }
+        },
+        _ => None,
+    }
+}
+
+/// Default build: outbound webhooks require the `webhooks` feature; without it a
+/// configured URL is warned and dropped.
+#[cfg(not(feature = "webhooks"))]
+fn webhook_config(_url: String) -> Option<opencompany::server::webhook::WebhookConfig> {
+    eprintln!(
+        "OPENCOMPANY_WEBHOOK_URL is set but the `webhooks` feature is not built; webhooks disabled"
+    );
+    None
+}
+
+/// Feature build: post to the configured URL with an HMAC-SHA256 signature.
+#[cfg(feature = "webhooks")]
+fn webhook_config(url: String) -> Option<opencompany::server::webhook::WebhookConfig> {
+    use opencompany::server::webhook::{HmacSha256Signer, HttpWebhookSink, WebhookConfig};
+    let secret = std::env::var("OPENCOMPANY_WEBHOOK_SECRET").unwrap_or_default();
+    Some(WebhookConfig {
+        sink: Arc::new(HttpWebhookSink::new(url)),
+        signer: Arc::new(HmacSha256Signer),
+        secret,
+    })
+}
+
+/// Builds the four fs storage ports over `home` as trait objects.
+fn fs_ports(home: &std::path::Path) -> opencompany::store::export::Ports {
+    use opencompany::store::{FsCompanyStore, FsContextStore, FsEventLog, FsMemoryStore};
+    (
+        Arc::new(FsCompanyStore::new(home.to_path_buf())),
+        Arc::new(FsEventLog::new(home.to_path_buf())),
+        Arc::new(FsMemoryStore::new(home.to_path_buf())),
+        Arc::new(FsContextStore::new(home.to_path_buf())),
+    )
+}
+
+/// A process-unique temporary path under the system temp dir. Used only by the
+/// `.tar` staging paths, which are compiled under the `export` feature.
+#[cfg(feature = "export")]
+fn unique_temp(tag: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    std::env::temp_dir().join(format!("opencompany-{tag}-{}-{nanos}", std::process::id()))
+}
+
+/// Exports `id`'s bundle over the fs ports into the directory `dest`.
+async fn export_to_dir(
+    home: &std::path::Path,
+    id: &CompanyId,
+    include_secrets: bool,
+    dest: &std::path::Path,
+) -> Result<()> {
+    use opencompany::store::export::{ExportOpts, export_bundle};
+    use opencompany::store::paths::Bundle;
+
+    let (store, events, memory, context) = fs_ports(home);
+    let opts = ExportOpts {
+        include_secrets,
+        fs_bundle: Some(Bundle::new(home.to_path_buf(), id).dir().to_path_buf()),
+    };
+    export_bundle(id, dest, store, events, memory, context, opts).await
+}
+
+/// Default build: export writes an unpacked bundle directory (no `.tar` support
+/// without the `export` feature).
+#[cfg(not(feature = "export"))]
+async fn run_export(
+    company: String,
+    out: Option<PathBuf>,
+    include_secrets: bool,
+    home: Option<PathBuf>,
+) -> Result<()> {
+    let home = home.unwrap_or_else(default_home);
+    let id = CompanyId::new(company);
+    let dest = out.unwrap_or_else(|| PathBuf::from(format!("{}-bundle", id.as_ref())));
+    export_to_dir(&home, &id, include_secrets, &dest).await?;
+    println!(
+        "exported bundle for `{id}` to {} (build with --features export to produce a .tar)",
+        dest.display()
+    );
+    Ok(())
+}
+
+/// Feature build: export writes a single-file `.tar`.
+#[cfg(feature = "export")]
+async fn run_export(
+    company: String,
+    out: Option<PathBuf>,
+    include_secrets: bool,
+    home: Option<PathBuf>,
+) -> Result<()> {
+    use opencompany::store::export::pack_tar;
+
+    let home = home.unwrap_or_else(default_home);
+    let id = CompanyId::new(company);
+    let out = out.unwrap_or_else(|| PathBuf::from(format!("{}.tar", id.as_ref())));
+
+    // Stage the unpacked bundle under a slug-named dir so the tar nests cleanly.
+    let staging = unique_temp("export");
+    let bundle_dir = staging.join(id.as_ref());
+    let result = async {
+        export_to_dir(&home, &id, include_secrets, &bundle_dir).await?;
+        pack_tar(&bundle_dir, &out)
+    }
+    .await;
+    tokio::fs::remove_dir_all(&staging).await.ok();
+    result?;
+    println!("exported bundle for `{id}` to {}", out.display());
+    Ok(())
+}
+
+/// Default build: import reads an unpacked bundle directory (no `.tar` support
+/// without the `export` feature).
+#[cfg(not(feature = "export"))]
+async fn run_import(path: PathBuf, home: Option<PathBuf>) -> Result<()> {
+    use opencompany::OpenCompanyError;
+
+    if !path.is_dir() {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "{} is not a directory; rebuild with --features export to import a .tar",
+            path.display()
+        )));
+    }
+    import_from_dir(&path, home).await
+}
+
+/// Feature build: import a `.tar` (unpacked to a temp dir first) or a directory.
+#[cfg(feature = "export")]
+async fn run_import(path: PathBuf, home: Option<PathBuf>) -> Result<()> {
+    use opencompany::store::export::unpack_tar;
+
+    if path.is_dir() {
+        return import_from_dir(&path, home).await;
+    }
+    let staging = unique_temp("import");
+    let result = async {
+        unpack_tar(&path, &staging)?;
+        import_from_dir(&staging, home.clone()).await
+    }
+    .await;
+    tokio::fs::remove_dir_all(&staging).await.ok();
+    result
+}
+
+/// Imports the bundle rooted under `dir` into `home` through the fs ports,
+/// restoring any fs-only secrets/keys the bundle carried.
+async fn import_from_dir(dir: &std::path::Path, home: Option<PathBuf>) -> Result<()> {
+    use opencompany::store::export::{find_bundle_root, import_bundle, restore_fs_artifacts};
+    use opencompany::store::paths::Bundle;
+
+    let home = home.unwrap_or_else(default_home);
+    let root = find_bundle_root(dir)?;
+    let (store, events, memory, context) = fs_ports(&home);
+    let id = import_bundle(&root, store, events, memory, context).await?;
+    restore_fs_artifacts(&root, Bundle::new(home.clone(), &id).dir()).await?;
+    println!("imported company `{id}` into {}", home.display());
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -224,14 +426,41 @@ async fn main() -> Result<()> {
             let public_url = std::env::var("OPENCOMPANY_PUBLIC_URL")
                 .ok()
                 .filter(|value| !value.trim().is_empty());
-            let state = AppState::new(AppConfig {
+            let mut state = AppState::new(AppConfig {
                 bind,
                 openhuman_root,
                 tinyplace_api_url,
                 public_url,
                 ..AppConfig::default()
             })
-            .with_home(home.clone());
+            .with_home(home.clone())
+            .with_quota(
+                env_usize("OPENCOMPANY_MAX_COMPANIES"),
+                env_usize("OPENCOMPANY_MAX_COMPANIES_PER_TENANT"),
+            );
+            // Platform (multi-tenant) auth: a shared platform token enables the
+            // provisioning/lifecycle surface. Without it the prosumer operator
+            // path stays in force. Real signed JWT is `platform-jwt`.
+            if let Some(token) = std::env::var("OPENCOMPANY_PLATFORM_TOKEN")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+            {
+                use opencompany::server::platform_auth::{
+                    PlatformAuthConfig, StaticPlatformVerifier,
+                };
+                state = state.with_platform_auth(PlatformAuthConfig::new(Arc::new(
+                    StaticPlatformVerifier::new(token),
+                )));
+            }
+            // Outbound webhooks: a URL wires the HTTP sink under `webhooks`;
+            // without the feature the request is warned and dropped.
+            if let Some(url) = std::env::var("OPENCOMPANY_WEBHOOK_URL")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+                && let Some(webhook) = webhook_config(url)
+            {
+                state = state.with_webhook(webhook);
+            }
             // Schedulers stop cleanly when this is notified (Ctrl-C below).
             let shutdown = Arc::new(Notify::new());
             let mut scheduler_handles = Vec::new();
@@ -315,6 +544,13 @@ async fn main() -> Result<()> {
             }
             Ok(())
         }
+        Some(Command::Export {
+            company,
+            out,
+            include_secrets,
+            home,
+        }) => run_export(company, out, include_secrets, home).await,
+        Some(Command::Import { path, home }) => run_import(path, home).await,
         Some(Command::OpenHuman {
             root,
             mode,

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -3,11 +3,14 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use clap::{Parser, Subcommand, ValueEnum};
+use opencompany::company::Schedule;
+use opencompany::runtime::{CompanyScheduler, SystemClock};
 use opencompany::{
-    AppConfig, AppState, CompanyManifest, Result,
+    AppConfig, AppState, CompanyId, CompanyManifest, Result,
     openhuman::{LaunchMode, OpenHumanLaunch},
     runtime::RuntimeBuilder,
 };
+use tokio::sync::Notify;
 
 #[derive(Debug, Parser)]
 #[command(author, version, about)]
@@ -94,17 +97,69 @@ async fn register_company(
     state: &AppState,
     home: &std::path::Path,
     dir: &std::path::Path,
-) -> Result<(String, String)> {
+) -> Result<(String, String, Vec<Schedule>)> {
     let manifest = CompanyManifest::from_path(dir)?;
     let name = manifest.company.name.clone();
-    let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
-        .build()
-        .await?;
+    // Capture the schedules before the manifest is moved into the builder; boot
+    // uses them to start this company's cron scheduler (lifecycle step 4).
+    let schedules = manifest.schedules.clone();
+    let builder = attach_openhuman(RuntimeBuilder::new(home.to_path_buf(), manifest));
+    let runtime = builder.build().await?;
     let id = runtime.id().as_ref().to_string();
     state
         .registry()
         .insert(runtime.id().clone(), Arc::new(runtime));
-    Ok((id, name))
+    Ok((id, name, schedules))
+}
+
+/// Starts a company's cron scheduler as a background task, if it has schedules.
+///
+/// A schedule whose cron fails to parse (which `opencompany check` does not
+/// catch beyond field count) logs a warning and is skipped rather than aborting
+/// boot. The returned handle is held by the caller and stops when `shutdown`
+/// fires.
+fn spawn_scheduler(
+    state: &AppState,
+    id: &str,
+    schedules: &[Schedule],
+    shutdown: &Arc<Notify>,
+) -> Option<tokio::task::JoinHandle<()>> {
+    if schedules.is_empty() {
+        return None;
+    }
+    let runtime = state.registry().get(&CompanyId::new(id))?;
+    match CompanyScheduler::new(runtime, schedules, Arc::new(SystemClock)) {
+        Ok(scheduler) => Some(scheduler.spawn(shutdown.clone())),
+        Err(err) => {
+            eprintln!("skipping scheduler for `{id}`: {err}");
+            None
+        }
+    }
+}
+
+/// Attaches an OpenHuman JSON-RPC transport when the `openhuman-rpc` feature is
+/// enabled and `OPENCOMPANY_OPENHUMAN_URL` is set (the attach path).
+///
+/// Without the feature this is the identity function, so the default build
+/// stays network-free and degrades to built-in tools and the operator channel.
+#[cfg(not(feature = "openhuman-rpc"))]
+fn attach_openhuman(builder: RuntimeBuilder) -> RuntimeBuilder {
+    builder
+}
+
+#[cfg(feature = "openhuman-rpc")]
+fn attach_openhuman(builder: RuntimeBuilder) -> RuntimeBuilder {
+    use opencompany::openhuman::HttpOpenHumanRpc;
+    use opencompany::ports::SecretValue;
+
+    match std::env::var("OPENCOMPANY_OPENHUMAN_URL") {
+        Ok(url) if !url.trim().is_empty() => {
+            let bearer =
+                SecretValue(std::env::var("OPENCOMPANY_OPENHUMAN_TOKEN").unwrap_or_default());
+            builder.with_openhuman_rpc(Arc::new(HttpOpenHumanRpc::attach(url, bearer)))
+        }
+        _ => builder,
+    }
 }
 
 #[tokio::main]
@@ -126,13 +181,37 @@ async fn main() -> Result<()> {
                 ..AppConfig::default()
             });
             let home = home.unwrap_or_else(default_home);
+            // Schedulers stop cleanly when this is notified (Ctrl-C below).
+            let shutdown = Arc::new(Notify::new());
+            let mut scheduler_handles = Vec::new();
             for dir in &companies {
-                let (id, name) = register_company(&state, &home, dir).await?;
-                println!("registered company `{id}` ({name}) from {}", dir.display());
+                let (id, name, schedules) = register_company(&state, &home, dir).await?;
+                if let Some(handle) = spawn_scheduler(&state, &id, &schedules, &shutdown) {
+                    scheduler_handles.push(handle);
+                    println!(
+                        "registered company `{id}` ({name}) from {} with {} schedule(s)",
+                        dir.display(),
+                        schedules.len()
+                    );
+                } else {
+                    println!("registered company `{id}` ({name}) from {}", dir.display());
+                }
             }
             if companies.is_empty() {
                 println!("serving with no companies; pass --company <dir> to load one");
             }
+
+            // Stop the schedulers on Ctrl-C so background cycle work halts with
+            // the process (lifecycle shutdown).
+            {
+                let shutdown = shutdown.clone();
+                tokio::spawn(async move {
+                    if tokio::signal::ctrl_c().await.is_ok() {
+                        shutdown.notify_waiters();
+                    }
+                });
+            }
+
             opencompany::server::serve(state).await
         }
         Some(Command::Spec { openhuman_root }) => {
@@ -194,7 +273,7 @@ mod test {
         let state = AppState::new(AppConfig::default());
         let dir = std::path::Path::new("examples/agentic_law_firm");
 
-        let (id, name) = register_company(&state, &home, dir).await.unwrap();
+        let (id, name, _schedules) = register_company(&state, &home, dir).await.unwrap();
 
         assert_eq!(name, "Agentic Law Firm");
         assert_eq!(id, "agentic-law-firm");

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -39,6 +39,12 @@ enum Command {
         /// `$HOME/.opencompany/companies`.
         #[arg(long)]
         home: Option<PathBuf>,
+        /// Opt every loaded company into going public on tiny.place, regardless
+        /// of each manifest's `[place].discoverable`. Requires the `tinyplace`
+        /// feature to actually reach the network; without it the flag only marks
+        /// companies discoverable for the local A2A routes.
+        #[arg(long)]
+        discoverable: bool,
     },
     /// Print a JSON runtime specification.
     Spec {
@@ -110,13 +116,31 @@ async fn register_company(
     state: &AppState,
     home: &std::path::Path,
     dir: &std::path::Path,
+    discoverable: bool,
 ) -> Result<(String, String, Vec<Schedule>)> {
-    let manifest = CompanyManifest::from_path(dir)?;
+    let mut manifest = CompanyManifest::from_path(dir)?;
+    // `serve --discoverable` opts this company into going public regardless of
+    // its manifest: mark it discoverable and synthesize a @handle when absent so
+    // Agent Card generation and validation succeed.
+    if discoverable {
+        manifest.place.discoverable = true;
+        if manifest.company.handle.is_none() {
+            let handle = opencompany::runtime::company_id_from_name(&manifest.company.name)
+                .as_ref()
+                .to_string();
+            manifest.company.handle = Some(handle);
+        }
+    }
     let name = manifest.company.name.clone();
     // Capture the schedules before the manifest is moved into the builder; boot
     // uses them to start this company's cron scheduler (lifecycle step 4).
     let schedules = manifest.schedules.clone();
-    let builder = attach_openhuman(RuntimeBuilder::new(home.to_path_buf(), manifest));
+    let mut builder = attach_openhuman(RuntimeBuilder::new(home.to_path_buf(), manifest))
+        .with_tinyplace_api_url(state.config().tinyplace_api_url.clone())
+        .with_host_base_url(state.config().host_base_url());
+    if discoverable {
+        builder = builder.with_discoverable(true);
+    }
     let runtime = builder.build().await?;
     let id = runtime.id().as_ref().to_string();
     state
@@ -187,27 +211,50 @@ async fn main() -> Result<()> {
             openhuman_root,
             companies,
             home,
+            discoverable,
         }) => {
+            let home = home.unwrap_or_else(default_home);
+            // tiny.place economy + public-card configuration resolved from the
+            // environment (with built-in defaults); the a2a routes and boot
+            // going-public flow read these off `AppConfig`.
+            let tinyplace_api_url = std::env::var("TINYPLACE_API_URL")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| opencompany::app::config::DEFAULT_TINYPLACE_API_URL.to_string());
+            let public_url = std::env::var("OPENCOMPANY_PUBLIC_URL")
+                .ok()
+                .filter(|value| !value.trim().is_empty());
             let state = AppState::new(AppConfig {
                 bind,
                 openhuman_root,
+                tinyplace_api_url,
+                public_url,
                 ..AppConfig::default()
-            });
-            let home = home.unwrap_or_else(default_home);
+            })
+            .with_home(home.clone());
             // Schedulers stop cleanly when this is notified (Ctrl-C below).
             let shutdown = Arc::new(Notify::new());
             let mut scheduler_handles = Vec::new();
             for dir in &companies {
-                let (id, name, schedules) = register_company(&state, &home, dir).await?;
+                let (id, name, schedules) =
+                    register_company(&state, &home, dir, discoverable).await?;
+                let visibility = if discoverable {
+                    " [discoverable: public]"
+                } else {
+                    ""
+                };
                 if let Some(handle) = spawn_scheduler(&state, &id, &schedules, &shutdown) {
                     scheduler_handles.push(handle);
                     println!(
-                        "registered company `{id}` ({name}) from {} with {} schedule(s)",
+                        "registered company `{id}` ({name}) from {} with {} schedule(s){visibility}",
                         dir.display(),
                         schedules.len()
                     );
                 } else {
-                    println!("registered company `{id}` ({name}) from {}", dir.display());
+                    println!(
+                        "registered company `{id}` ({name}) from {}{visibility}",
+                        dir.display()
+                    );
                 }
             }
             if companies.is_empty() {
@@ -312,7 +359,7 @@ mod test {
         let state = AppState::new(AppConfig::default());
         let dir = std::path::Path::new("examples/agentic_law_firm");
 
-        let (id, name, _schedules) = register_company(&state, &home, dir).await.unwrap();
+        let (id, name, _schedules) = register_company(&state, &home, dir, false).await.unwrap();
 
         assert_eq!(name, "Agentic Law Firm");
         assert_eq!(id, "agentic-law-firm");

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -7,6 +7,8 @@ use opencompany::company::Schedule;
 use opencompany::runtime::{CompanyScheduler, SystemClock};
 use opencompany::{
     AppConfig, AppState, CompanyId, CompanyManifest, Result,
+    app::config::{ConfigFile, ProcessEnv, resolve},
+    app::doctor,
     openhuman::{LaunchMode, OpenHumanLaunch},
     runtime::RuntimeBuilder,
 };
@@ -49,6 +51,17 @@ enum Command {
         /// Manifest file or a directory containing `company.toml`/`agents.toml`.
         #[arg(default_value = ".")]
         path: PathBuf,
+    },
+    /// Report the effective runtime configuration, which layer set each value,
+    /// and what is missing per optional capability.
+    Doctor {
+        /// Optional company manifest whose `[brain].mode` participates in
+        /// resolution. Defaults to a synthetic manifest when omitted.
+        #[arg(long = "company", value_name = "DIR")]
+        company: Option<PathBuf>,
+        /// Print the report as JSON instead of aligned text.
+        #[arg(long)]
+        json: bool,
     },
     /// Launch a sibling OpenHuman checkout through cargo.
     OpenHuman {
@@ -228,6 +241,32 @@ async fn main() -> Result<()> {
             } else {
                 std::process::exit(1);
             }
+        }
+        Some(Command::Doctor { company, json }) => {
+            let env = ProcessEnv;
+            // Locate config.toml under the resolved data dir (env override or
+            // the default `$HOME/.opencompany`).
+            let config_dir = match std::env::var_os("OPENCOMPANY_DATA_DIR") {
+                Some(dir) => PathBuf::from(dir),
+                None => match std::env::var_os("HOME") {
+                    Some(home) => PathBuf::from(home).join(".opencompany"),
+                    None => PathBuf::from(".opencompany"),
+                },
+            };
+            let config_toml = ConfigFile::load(&config_dir)?;
+            let manifest = match &company {
+                Some(dir) => CompanyManifest::from_path(dir)?,
+                None => toml::from_str("[company]\nname = \"opencompany\"\n")
+                    .expect("synthetic manifest is valid"),
+            };
+            let (cfg, prov) = resolve(&env, config_toml.as_ref(), &manifest)?;
+            let report = doctor::report(&cfg, &prov);
+            if json {
+                println!("{}", serde_json::to_string_pretty(&report).unwrap());
+            } else {
+                print!("{}", report.to_text());
+            }
+            Ok(())
         }
         Some(Command::OpenHuman {
             root,

--- a/src/brain/echo.rs
+++ b/src/brain/echo.rs
@@ -112,6 +112,7 @@ mod test {
             cycle_id: "cycle-1".to_string(),
             company_id: CompanyId::new("acme"),
             events,
+            event_seqs: Vec::new(),
             compressed_history: Vec::new(),
             roster: Vec::new(),
             context_index: Vec::new(),

--- a/src/brain/hosted.rs
+++ b/src/brain/hosted.rs
@@ -1,0 +1,524 @@
+//! [`HostedMedullaBrain`]: the [`Brain`] that drives hosted Medulla cognition
+//! over a [`MedullaTransport`].
+//!
+//! One company is one Medulla session: the `sessionId` is the [`CompanyId`] and
+//! the `counterpartAgentId` is `opencompany:<slug>`. Each [`CycleRequest`] event
+//! is posted as its own `POST /events` keyed on the durable
+//! [`EventLog`](crate::ports::EventLog) sequence, and the returned cycle's frames
+//! are drained:
+//!
+//! - Every **effect** frame passes through [`CycleHost::emit_effect`] — the
+//!   approval gate — *before* it is acked. An executed effect acks `ok:true`; a
+//!   parked or denied effect acks `ok:false` with the reason, so Medulla hears
+//!   the gate's verdict rather than a silent success.
+//! - Every **tool_call** frame is serviced through [`CycleHost::call_tool`]
+//!   (or [`CycleHost::context_op`] for the context device-tools) and answered.
+//! - Frames are deduped on `callId`, matching the at-least-once delivery
+//!   contract, so a replay is handled exactly once.
+//!
+//! Cycle summaries are journaled as [`CompressedTrace`]s, spend effects become
+//! ledger deltas, and notable effects trigger a `POST /world-diff`. The brain
+//! never fabricates a channel response: the ones it returns are the `send_dm`
+//! effects Medulla executed.
+//!
+//! The transport is abstracted, so the brain and its whole test surface live in
+//! the default build against [`MockTransport`](super::medulla::MockTransport);
+//! the networked `HttpSocketTransport` lands behind the `medulla` feature.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use serde_json::{Value, json};
+
+use crate::Result;
+use crate::ports::brain::{Brain, CycleHost};
+use crate::ports::now_millis;
+use crate::ports::types::{
+    ChunkAddr, CompanyEvent, CompanyId, CompressedTrace, ContextChunk, ContextOp, ContextOpResult,
+    CycleRequest, CycleResult, Effect, EffectDisposition, EffectGroup, LedgerEntry,
+    OutboundMessage, SecretValue, TokenUsage, ToolCall, Verdict,
+};
+
+use super::medulla::transport::{InboundFrame, MedullaTransport};
+use super::medulla::wire::{
+    EffectFrame, EffectResult, EventsRequest, Role, ToolCallFrame, ToolManifestEntry,
+    ToolResultFrame, WireEvent, WorldDiffEntry, WorldDiffRequest,
+};
+
+/// The device-tool name prefix that routes a tool call to the context store.
+const CONTEXT_TOOL_PREFIX: &str = "context_";
+
+/// The hosted Medulla brain: one company's cognition over a transport.
+pub struct HostedMedullaBrain {
+    transport: Arc<dyn MedullaTransport>,
+    session_id: String,
+    counterpart: String,
+    /// The hosted-brain bearer credential. Held for parity with the transport
+    /// and redacted in [`std::fmt::Debug`]; never logged or serialized.
+    credential: SecretValue,
+    tool_catalog: Vec<ToolManifestEntry>,
+    registered: AtomicBool,
+}
+
+impl HostedMedullaBrain {
+    /// Builds a hosted brain for `company` addressed as `opencompany:<slug>`.
+    ///
+    /// `slug` is the company's manifest-derived slug (typically the same string
+    /// as the [`CompanyId`]); `credential` is the TinyHumans bearer token and is
+    /// never logged. `tool_catalog` is the device-tool manifest registered with
+    /// Medulla on the first cycle.
+    pub fn new(
+        transport: Arc<dyn MedullaTransport>,
+        company: &CompanyId,
+        slug: &str,
+        credential: SecretValue,
+        tool_catalog: Vec<ToolManifestEntry>,
+    ) -> Self {
+        Self {
+            transport,
+            session_id: company.as_ref().to_string(),
+            counterpart: format!("opencompany:{slug}"),
+            credential,
+            tool_catalog,
+            registered: AtomicBool::new(false),
+        }
+    }
+
+    /// The Medulla session id (the company id).
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// The counterpart agent id (`opencompany:<slug>`).
+    pub fn counterpart(&self) -> &str {
+        &self.counterpart
+    }
+
+    /// Registers the device-tool manifest exactly once (on the first cycle).
+    ///
+    /// A no-op when the catalog is empty. The `registered` flag is flipped with
+    /// `compare_exchange` so concurrent first cycles register at most once.
+    async fn ensure_registered(&self) -> Result<()> {
+        if self.tool_catalog.is_empty() {
+            return Ok(());
+        }
+        if self
+            .registered
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            self.transport
+                .register_tools(self.tool_catalog.clone())
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Services one `orch:tool_call` frame and builds its answer.
+    ///
+    /// Context device-tools (`context_*`) route to [`CycleHost::context_op`];
+    /// everything else routes to [`CycleHost::call_tool`], which enforces the
+    /// manifest grant. A host error (e.g. an ungranted tool) becomes an
+    /// `ok:false` answer rather than aborting the cycle.
+    async fn service_tool_call(
+        &self,
+        host: &dyn CycleHost,
+        call: &ToolCallFrame,
+    ) -> Result<ToolResultFrame> {
+        if let Some(op) = context_op_from_call(&call.name, &call.args) {
+            return Ok(match host.context_op(op).await {
+                Ok(result) => ToolResultFrame {
+                    call_id: call.call_id.clone(),
+                    ok: true,
+                    result: Some(context_result_to_value(result)),
+                    error: None,
+                },
+                Err(err) => ToolResultFrame {
+                    call_id: call.call_id.clone(),
+                    ok: false,
+                    result: None,
+                    error: Some(err.to_string()),
+                },
+            });
+        }
+
+        let tool_call = ToolCall {
+            tool: call.name.clone(),
+            args: call.args.clone(),
+        };
+        Ok(match host.call_tool(tool_call).await {
+            Ok(result) => ToolResultFrame {
+                call_id: call.call_id.clone(),
+                ok: result.ok,
+                result: Some(result.output),
+                error: None,
+            },
+            Err(err) => ToolResultFrame {
+                call_id: call.call_id.clone(),
+                ok: false,
+                result: None,
+                error: Some(err.to_string()),
+            },
+        })
+    }
+
+    /// Passes an effect frame through the gate, acks it, and returns the channel
+    /// response and ledger delta it produced (if any).
+    async fn service_effect(
+        &self,
+        host: &dyn CycleHost,
+        frame: &EffectFrame,
+    ) -> Result<EffectOutcome> {
+        let effect = effect_from_frame(frame);
+        // The gate runs BEFORE the ack, so a parked effect acks `ok:false` and
+        // Medulla learns it must wait rather than seeing a false success.
+        let disposition = host.emit_effect(effect.clone()).await?;
+
+        let mut outcome = EffectOutcome::default();
+        let ack = match &disposition {
+            EffectDisposition::Executed => {
+                outcome.channel_response = channel_message_from_effect(&effect);
+                outcome.ledger_delta = ledger_delta_from_effect(&effect);
+                outcome.notable = is_notable(&effect);
+                EffectResult {
+                    call_id: frame.call_id.clone(),
+                    ok: true,
+                    error: None,
+                    result: None,
+                }
+            }
+            EffectDisposition::PendingApproval(id) => EffectResult {
+                call_id: frame.call_id.clone(),
+                ok: false,
+                error: Some(format!("pending approval ({id})")),
+                result: None,
+            },
+            EffectDisposition::Denied { reason } => EffectResult {
+                call_id: frame.call_id.clone(),
+                ok: false,
+                error: Some(reason.clone()),
+                result: None,
+            },
+        };
+        self.transport.ack_effect(ack).await?;
+        Ok(outcome)
+    }
+}
+
+/// What one executed effect contributed to the cycle result.
+#[derive(Default)]
+struct EffectOutcome {
+    channel_response: Option<OutboundMessage>,
+    ledger_delta: Option<LedgerEntry>,
+    notable: bool,
+}
+
+#[async_trait]
+impl Brain for HostedMedullaBrain {
+    async fn run_cycle(&self, req: CycleRequest, host: &dyn CycleHost) -> Result<CycleResult> {
+        self.ensure_registered().await?;
+
+        let mut channel_responses = Vec::new();
+        let mut new_traces = Vec::new();
+        let mut ledger_deltas = Vec::new();
+        let mut world_notes: Vec<WorldDiffEntry> = Vec::new();
+
+        for (index, event) in req.events.iter().enumerate() {
+            // Prefer the durable EventLog seq; fall back to the position when a
+            // caller did not thread seqs (idempotency then holds within a cycle).
+            let seq = req
+                .event_seqs
+                .get(index)
+                .map(|s| s.value())
+                .unwrap_or(index as u64);
+
+            let request = EventsRequest {
+                counterpart_agent_id: self.counterpart.clone(),
+                session_id: self.session_id.clone(),
+                event: wire_event(seq, event),
+            };
+            let accepted = self.transport.post_events(request).await?;
+            let cycle_id = accepted.cycle_id;
+
+            // Drain the cycle's frames, deduping on callId (at-least-once).
+            let mut seen: HashSet<String> = HashSet::new();
+            let mut frames = self.transport.cycle_frames(&cycle_id);
+            while let Some(frame) = frames.next().await {
+                match frame? {
+                    InboundFrame::CycleComplete => break,
+                    InboundFrame::Effect(effect_frame) => {
+                        if !seen.insert(effect_frame.call_id.clone()) {
+                            continue;
+                        }
+                        let outcome = self.service_effect(host, &effect_frame).await?;
+                        if let Some(message) = outcome.channel_response {
+                            channel_responses.push(message);
+                        }
+                        if let Some(delta) = outcome.ledger_delta {
+                            ledger_deltas.push(delta);
+                        }
+                        if outcome.notable {
+                            world_notes.push(WorldDiffEntry {
+                                seq,
+                                note: format!("executed {}", effect_frame.kind),
+                                ts: now_millis() as i64,
+                            });
+                        }
+                    }
+                    InboundFrame::ToolCall(call) => {
+                        if !seen.insert(call.call_id.clone()) {
+                            continue;
+                        }
+                        let answer = self.service_tool_call(host, &call).await?;
+                        self.transport.answer_tool_call(answer).await?;
+                    }
+                }
+            }
+
+            new_traces.push(CompressedTrace::now(
+                &cycle_id,
+                format!("medulla cycle for `{}` (seq {seq})", self.session_id),
+            ));
+        }
+
+        // Upload a world-diff after notable effects (payments, filings, etc.).
+        if !world_notes.is_empty() {
+            self.transport
+                .post_world_diff(WorldDiffRequest {
+                    session_id: self.session_id.clone(),
+                    entries: world_notes,
+                })
+                .await?;
+        }
+
+        Ok(CycleResult {
+            channel_responses,
+            new_traces,
+            ledger_deltas,
+            token_usage: TokenUsage::default(),
+        })
+    }
+}
+
+/// A hand-written `Debug` that redacts the credential so it can never reach a
+/// log line or panic message.
+impl std::fmt::Debug for HostedMedullaBrain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Borrow the credential so it counts as held/used, but never render its
+        // bytes — only the redaction marker reaches the formatter.
+        let _held = &self.credential;
+        f.debug_struct("HostedMedullaBrain")
+            .field("session_id", &self.session_id)
+            .field("counterpart", &self.counterpart)
+            .field("credential", &"<redacted>")
+            .field("tools", &self.tool_catalog.len())
+            .field("registered", &self.registered.load(Ordering::Acquire))
+            .finish()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Event, effect, and context mapping helpers
+// ---------------------------------------------------------------------------
+
+/// Normalizes a [`CompanyEvent`] into the [`WireEvent`] `POST /events` carries.
+fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
+    let (role, sender, body, kind) = match event {
+        CompanyEvent::OperatorMessage { text } => (
+            Role::User,
+            "operator".to_string(),
+            text.clone(),
+            "operator.message",
+        ),
+        CompanyEvent::WebhookReceived { channel, body } => (
+            Role::User,
+            channel.clone(),
+            body.to_string(),
+            "webhook.received",
+        ),
+        CompanyEvent::ScheduleFired { cron, prompt } => (
+            Role::System,
+            "scheduler".to_string(),
+            format!("[{cron}] {prompt}"),
+            "schedule.fired",
+        ),
+        CompanyEvent::A2aTaskReceived { from, task } => (
+            Role::User,
+            from.clone(),
+            task.to_string(),
+            "a2a.task_received",
+        ),
+        CompanyEvent::ApprovalResolved {
+            approval_id,
+            verdict,
+            by,
+        } => (
+            Role::System,
+            by.id.clone(),
+            format!("{} approval {approval_id}", verdict_word(*verdict)),
+            "approval.resolved",
+        ),
+        CompanyEvent::FeedbackFiled { note } => (
+            Role::User,
+            "operator".to_string(),
+            note.clone(),
+            "feedback.filed",
+        ),
+        CompanyEvent::PaymentReceived { amount_usd, memo } => (
+            Role::System,
+            "ledger".to_string(),
+            format!("received ${amount_usd}: {memo}"),
+            "payment.received",
+        ),
+    };
+    WireEvent {
+        seq,
+        role,
+        sender,
+        body,
+        ts: now_millis() as i64,
+        kind: kind.to_string(),
+    }
+}
+
+/// The lowercase wire word for an operator verdict.
+fn verdict_word(verdict: Verdict) -> &'static str {
+    match verdict {
+        Verdict::Approve => "approved",
+        Verdict::Deny => "denied",
+    }
+}
+
+/// Builds an [`Effect`] from an effect frame, classifying its supervised group
+/// and lifting `amountUsd` / thread flags out of the payload for the gate.
+fn effect_from_frame(frame: &EffectFrame) -> Effect {
+    let payload = &frame.payload;
+    Effect {
+        kind: frame.kind.clone(),
+        group: effect_group_for(&frame.kind),
+        amount_usd: payload_f64(payload, "amountUsd")
+            .or_else(|| payload_f64(payload, "amount_usd")),
+        established_thread: payload_bool(payload, "establishedThread")
+            .or_else(|| payload_bool(payload, "established_thread"))
+            .unwrap_or(false),
+        first_time_counterparty: payload_bool(payload, "firstTimeCounterparty")
+            .or_else(|| payload_bool(payload, "first_time_counterparty"))
+            .unwrap_or(false),
+        payload: frame.payload.clone(),
+    }
+}
+
+/// Maps a dotted effect kind to its supervised-policy [`EffectGroup`].
+fn effect_group_for(kind: &str) -> EffectGroup {
+    let k = kind.to_ascii_lowercase();
+    if k.contains("send_dm") || k.contains("message") || k.contains("email") || k.contains("reply")
+    {
+        EffectGroup::Send
+    } else if k.contains("payment")
+        || k.contains("spend")
+        || k.contains("x402")
+        || k.contains("pay")
+    {
+        EffectGroup::Spend
+    } else if k.contains("sign") || k.contains("filing") || k.contains("contract") {
+        EffectGroup::Sign
+    } else if k.contains("publish") {
+        EffectGroup::Publish
+    } else if k.contains("hire") || k.contains("engage") {
+        EffectGroup::Hire
+    } else if k.contains("identity") || k.contains("register") {
+        EffectGroup::Identity
+    } else {
+        EffectGroup::Other
+    }
+}
+
+/// Extracts a channel response from an executed `Send`-group effect.
+///
+/// Returns `None` for non-send effects. The channel is read from `channel`/`to`
+/// and the text from `text`/`body`/`message`, so the runtime's own effect
+/// executor (which only routes a `{channel,text}` pair) does not double-send
+/// when the payload uses the `{to,body}` shape.
+fn channel_message_from_effect(effect: &Effect) -> Option<OutboundMessage> {
+    if effect.group != EffectGroup::Send {
+        return None;
+    }
+    let payload = &effect.payload;
+    let channel = payload_str(payload, "channel")
+        .or_else(|| payload_str(payload, "to"))
+        .unwrap_or("operator")
+        .to_string();
+    let text = payload_str(payload, "text")
+        .or_else(|| payload_str(payload, "body"))
+        .or_else(|| payload_str(payload, "message"))?
+        .to_string();
+    Some(OutboundMessage { channel, text })
+}
+
+/// Records a ledger delta for an executed effect that moved money.
+fn ledger_delta_from_effect(effect: &Effect) -> Option<LedgerEntry> {
+    let amount = effect.amount_usd?;
+    Some(LedgerEntry {
+        at_millis: now_millis(),
+        kind: effect.kind.clone(),
+        amount_usd: amount,
+        memo: format!("medulla effect {}", effect.kind),
+    })
+}
+
+/// Whether an executed effect warrants a world-diff upload.
+fn is_notable(effect: &Effect) -> bool {
+    !matches!(effect.group, EffectGroup::Other | EffectGroup::Send)
+}
+
+/// Maps a `context_*` device tool call into a [`ContextOp`], or `None` when the
+/// tool is not a context tool.
+fn context_op_from_call(name: &str, args: &Value) -> Option<ContextOp> {
+    let op = name.strip_prefix(CONTEXT_TOOL_PREFIX)?;
+    match op {
+        "put" => Some(ContextOp::Put(ContextChunk {
+            label: payload_str(args, "label").unwrap_or("").to_string(),
+            body: payload_str(args, "body").unwrap_or("").to_string(),
+        })),
+        "list" => Some(ContextOp::List {
+            prefix: payload_str(args, "prefix").unwrap_or("").to_string(),
+        }),
+        "peek" => Some(ContextOp::Peek {
+            addr: ChunkAddr::new(payload_str(args, "addr").unwrap_or("")),
+            range: None,
+        }),
+        "search" => Some(ContextOp::Search {
+            query: payload_str(args, "query").unwrap_or("").to_string(),
+            limit: payload_f64(args, "limit").map(|n| n as usize).unwrap_or(10),
+        }),
+        _ => None,
+    }
+}
+
+/// Renders a [`ContextOpResult`] as the JSON a `tool_result` frame carries.
+fn context_result_to_value(result: ContextOpResult) -> Value {
+    match result {
+        ContextOpResult::Addr(addr) => json!({ "addr": addr.as_ref() }),
+        ContextOpResult::Metas(metas) => serde_json::to_value(metas).unwrap_or(Value::Null),
+        ContextOpResult::Text(text) => json!({ "text": text }),
+        ContextOpResult::Hits(hits) => serde_json::to_value(hits).unwrap_or(Value::Null),
+    }
+}
+
+fn payload_str<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
+    value.get(key).and_then(Value::as_str)
+}
+
+fn payload_f64(value: &Value, key: &str) -> Option<f64> {
+    value.get(key).and_then(Value::as_f64)
+}
+
+fn payload_bool(value: &Value, key: &str) -> Option<bool> {
+    value.get(key).and_then(Value::as_bool)
+}
+
+#[cfg(test)]
+mod test;

--- a/src/brain/hosted.rs
+++ b/src/brain/hosted.rs
@@ -373,6 +373,12 @@ fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("received ${amount_usd}: {memo}"),
             "payment.received",
         ),
+        CompanyEvent::LifecycleChanged { from, to, by } => (
+            Role::System,
+            by.id.clone(),
+            format!("Lifecycle changed from {from} to {to}"),
+            "lifecycle.changed",
+        ),
     };
     WireEvent {
         seq,

--- a/src/brain/hosted/test.rs
+++ b/src/brain/hosted/test.rs
@@ -1,0 +1,487 @@
+//! Offline tests for [`HostedMedullaBrain`] over the in-memory
+//! [`MockTransport`], plus end-to-end tests that drive a real
+//! [`CompanyRuntime`](crate::company::runtime::CompanyRuntime) with the brain
+//! wired in through the builder.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use super::*;
+use crate::brain::medulla::MockTransport;
+use crate::brain::medulla::wire::{self, OrchErrorCode};
+use crate::ports::types::{ApprovalId, ChunkHit, ToolResult};
+
+// ---------------------------------------------------------------------------
+// Test host
+// ---------------------------------------------------------------------------
+
+/// A [`CycleHost`] that records callbacks and returns canned dispositions.
+struct RecordingHost {
+    disposition: EffectDisposition,
+    tool_result: ToolResult,
+    effects: Mutex<Vec<Effect>>,
+    tool_calls: Mutex<Vec<ToolCall>>,
+    context_ops: Mutex<Vec<ContextOp>>,
+}
+
+impl RecordingHost {
+    fn executing() -> Self {
+        Self {
+            disposition: EffectDisposition::Executed,
+            tool_result: ToolResult {
+                ok: true,
+                output: json!({ "ran": true }),
+            },
+            effects: Mutex::new(Vec::new()),
+            tool_calls: Mutex::new(Vec::new()),
+            context_ops: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn parking() -> Self {
+        Self {
+            disposition: EffectDisposition::PendingApproval(ApprovalId::new("appr-1")),
+            ..Self::executing()
+        }
+    }
+}
+
+#[async_trait]
+impl CycleHost for RecordingHost {
+    async fn call_tool(&self, call: ToolCall) -> Result<ToolResult> {
+        self.tool_calls.lock().unwrap().push(call);
+        Ok(self.tool_result.clone())
+    }
+
+    async fn context_op(&self, op: ContextOp) -> Result<ContextOpResult> {
+        self.context_ops.lock().unwrap().push(op);
+        Ok(ContextOpResult::Hits(vec![ChunkHit {
+            addr: ChunkAddr::new("c1"),
+            snippet: "hit".into(),
+            score: 1.0,
+        }]))
+    }
+
+    async fn emit_effect(&self, effect: Effect) -> Result<EffectDisposition> {
+        self.effects.lock().unwrap().push(effect);
+        Ok(self.disposition.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+fn brain(transport: Arc<MockTransport>) -> HostedMedullaBrain {
+    HostedMedullaBrain::new(
+        transport,
+        &CompanyId::new("acme"),
+        "acme",
+        SecretValue("th_super_secret".into()),
+        vec![ToolManifestEntry {
+            name: "noop".into(),
+            description: None,
+            input_schema: None,
+        }],
+    )
+}
+
+/// The deterministic cycle id for a first operator event on company `acme`.
+fn cid() -> String {
+    wire::cycle_id("opencompany:acme", "acme", 0)
+}
+
+fn operator_request() -> CycleRequest {
+    CycleRequest {
+        cycle_id: "unused".into(),
+        company_id: CompanyId::new("acme"),
+        events: vec![CompanyEvent::OperatorMessage { text: "hi".into() }],
+        event_seqs: Vec::new(),
+        compressed_history: Vec::new(),
+        roster: Vec::new(),
+        context_index: Vec::new(),
+    }
+}
+
+fn effect_frame(kind: &str, index: usize, payload: Value) -> InboundFrame {
+    InboundFrame::Effect(EffectFrame {
+        kind: kind.into(),
+        cycle_id: cid(),
+        call_id: wire::call_id(&cid(), kind, index),
+        payload,
+    })
+}
+
+fn tool_call_frame(name: &str, index: usize, args: Value) -> InboundFrame {
+    InboundFrame::ToolCall(ToolCallFrame {
+        cycle_id: cid(),
+        call_id: wire::call_id(&cid(), "tool", index),
+        name: name.into(),
+        args,
+        timeout_ms: wire::DEFAULT_TOOL_TIMEOUT_MS,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn posts_one_normalized_event_without_a_model_field() {
+    let transport = Arc::new(MockTransport::new());
+    let brain = brain(transport.clone());
+    let host = RecordingHost::executing();
+
+    brain.run_cycle(operator_request(), &host).await.unwrap();
+
+    let posted = transport.posted_events();
+    assert_eq!(posted.len(), 1);
+    let event = &posted[0].event;
+    assert_eq!(event.seq, 0);
+    assert_eq!(event.role, Role::User);
+    assert_eq!(event.sender, "operator");
+    assert_eq!(event.body, "hi");
+    assert_eq!(event.kind, "operator.message");
+    assert_eq!(posted[0].counterpart_agent_id, "opencompany:acme");
+    assert_eq!(posted[0].session_id, "acme");
+
+    // The serialized wire body must never carry a `model` field.
+    let body = serde_json::to_value(wire::Envelope::v1(posted[0].clone())).unwrap();
+    assert!(wire::assert_no_model(&body).is_ok());
+
+    // The device-tool manifest was registered exactly once.
+    assert_eq!(transport.registered_tools().len(), 1);
+}
+
+#[tokio::test]
+async fn register_tools_fires_only_on_the_first_cycle() {
+    let transport = Arc::new(MockTransport::new());
+    let brain = brain(transport.clone());
+    let host = RecordingHost::executing();
+
+    brain.run_cycle(operator_request(), &host).await.unwrap();
+    brain.run_cycle(operator_request(), &host).await.unwrap();
+
+    assert_eq!(transport.registered_tools().len(), 1);
+}
+
+#[tokio::test]
+async fn executed_send_dm_becomes_a_channel_response_and_acks_ok() {
+    let transport = Arc::new(MockTransport::new());
+    transport.script_cycle(
+        cid(),
+        vec![effect_frame(
+            "send_dm",
+            0,
+            json!({ "to": "operator", "body": "hello from medulla" }),
+        )],
+    );
+    let brain = brain(transport.clone());
+    let host = RecordingHost::executing();
+
+    let result = brain.run_cycle(operator_request(), &host).await.unwrap();
+
+    assert_eq!(result.channel_responses.len(), 1);
+    assert_eq!(result.channel_responses[0].channel, "operator");
+    assert_eq!(result.channel_responses[0].text, "hello from medulla");
+
+    let acks = transport.acks();
+    assert_eq!(acks.len(), 1);
+    assert!(acks[0].ok);
+    // The effect passed through the gate before the ack.
+    assert_eq!(host.effects.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn duplicate_effect_frame_is_handled_once() {
+    let transport = Arc::new(MockTransport::new());
+    // Two frames sharing a callId: the replay must be ignored.
+    let payload = json!({ "to": "operator", "body": "dup" });
+    transport.script_cycle(
+        cid(),
+        vec![
+            effect_frame("send_dm", 0, payload.clone()),
+            effect_frame("send_dm", 0, payload),
+        ],
+    );
+    let brain = brain(transport.clone());
+    let host = RecordingHost::executing();
+
+    let result = brain.run_cycle(operator_request(), &host).await.unwrap();
+
+    assert_eq!(host.effects.lock().unwrap().len(), 1);
+    assert_eq!(transport.acks().len(), 1);
+    assert_eq!(result.channel_responses.len(), 1);
+}
+
+#[tokio::test]
+async fn tool_call_frame_routes_to_call_tool_and_answers() {
+    let transport = Arc::new(MockTransport::new());
+    transport.script_cycle(cid(), vec![tool_call_frame("noop", 0, json!({ "q": 1 }))]);
+    let brain = brain(transport.clone());
+    let host = RecordingHost::executing();
+
+    brain.run_cycle(operator_request(), &host).await.unwrap();
+
+    let calls = host.tool_calls.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].tool, "noop");
+
+    let answers = transport.tool_answers();
+    assert_eq!(answers.len(), 1);
+    assert!(answers[0].ok);
+    assert!(answers[0].result.is_some());
+}
+
+#[tokio::test]
+async fn context_device_tool_routes_to_context_op() {
+    let transport = Arc::new(MockTransport::new());
+    transport.script_cycle(
+        cid(),
+        vec![tool_call_frame(
+            "context_search",
+            0,
+            json!({ "query": "roadmap", "limit": 3 }),
+        )],
+    );
+    let brain = brain(transport.clone());
+    let host = RecordingHost::executing();
+
+    brain.run_cycle(operator_request(), &host).await.unwrap();
+
+    let ops = host.context_ops.lock().unwrap();
+    assert_eq!(ops.len(), 1);
+    match &ops[0] {
+        ContextOp::Search { query, limit } => {
+            assert_eq!(query, "roadmap");
+            assert_eq!(*limit, 3);
+        }
+        other => panic!("expected a context search, got {other:?}"),
+    }
+    // The tool_call was not forwarded to the tool provider.
+    assert!(host.tool_calls.lock().unwrap().is_empty());
+    assert_eq!(transport.tool_answers().len(), 1);
+}
+
+#[tokio::test]
+async fn parked_effect_acks_not_ok_with_pending_approval() {
+    let transport = Arc::new(MockTransport::new());
+    transport.script_cycle(cid(), vec![effect_frame("filing.submit", 0, Value::Null)]);
+    let brain = brain(transport.clone());
+    let host = RecordingHost::parking();
+
+    let result = brain.run_cycle(operator_request(), &host).await.unwrap();
+
+    let acks = transport.acks();
+    assert_eq!(acks.len(), 1);
+    assert!(!acks[0].ok);
+    assert!(
+        acks[0]
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("pending approval")
+    );
+    // A parked effect yields no channel response and no world-diff.
+    assert!(result.channel_responses.is_empty());
+    assert!(transport.posted_world_diffs().is_empty());
+}
+
+#[tokio::test]
+async fn orchestration_error_on_post_events_propagates_with_code() {
+    let transport = Arc::new(MockTransport::new());
+    transport.fail_post_events(OrchErrorCode::InsufficientBalance);
+    let brain = brain(transport.clone());
+    let host = RecordingHost::executing();
+
+    let err = brain
+        .run_cycle(operator_request(), &host)
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), "ORCH_INSUFFICIENT_BALANCE");
+}
+
+#[tokio::test]
+async fn spend_effect_records_ledger_delta_and_posts_world_diff() {
+    let transport = Arc::new(MockTransport::new());
+    transport.script_cycle(
+        cid(),
+        vec![effect_frame(
+            "x402.spend",
+            0,
+            json!({ "amountUsd": 4.25, "memo": "api call" }),
+        )],
+    );
+    let brain = brain(transport.clone());
+    let host = RecordingHost::executing();
+
+    let result = brain.run_cycle(operator_request(), &host).await.unwrap();
+
+    assert_eq!(result.ledger_deltas.len(), 1);
+    assert_eq!(result.ledger_deltas[0].amount_usd, 4.25);
+    assert_eq!(result.ledger_deltas[0].kind, "x402.spend");
+    // Spend is notable, so a world-diff was uploaded.
+    let diffs = transport.posted_world_diffs();
+    assert_eq!(diffs.len(), 1);
+    assert_eq!(diffs[0].entries.len(), 1);
+    assert_eq!(diffs[0].session_id, "acme");
+}
+
+#[test]
+fn debug_redacts_the_credential() {
+    let transport = Arc::new(MockTransport::new());
+    let brain = brain(transport);
+    let rendered = format!("{brain:?}");
+    assert!(!rendered.contains("th_super_secret"));
+    assert!(rendered.contains("redacted"));
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end tests through a real CompanyRuntime
+// ---------------------------------------------------------------------------
+
+use crate::app::config::BrainMode;
+use crate::company::CompanyManifest;
+use crate::ports::types::{Actor, ActorKind};
+use crate::runtime::RuntimeBuilder;
+
+fn tmp_home() -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "opencompany-hosted-{}",
+        crate::ports::generate_id()
+    ))
+}
+
+fn manifest(policy_mode: &str) -> CompanyManifest {
+    let toml_src = format!(
+        r#"
+        [company]
+        name = "Acme"
+
+        [brain]
+        mode = "hosted"
+
+        [tools]
+        allow = ["noop"]
+
+        [policy]
+        mode = "{policy_mode}"
+        "#
+    );
+    toml::from_str(&toml_src).expect("valid manifest")
+}
+
+/// The deterministic first-cycle id a real runtime for `Acme` produces: the
+/// company id slugs to `acme`, the first event lands at seq 0.
+fn runtime_cid() -> String {
+    wire::cycle_id("opencompany:acme", "acme", 0)
+}
+
+#[tokio::test]
+async fn e2e_operator_message_drives_tool_call_and_gated_send_dm() {
+    let home = tmp_home();
+    let transport = Arc::new(MockTransport::new());
+    transport.script_cycle(
+        runtime_cid(),
+        vec![
+            tool_call_frame("noop", 0, json!({ "q": "status" })),
+            effect_frame("send_dm", 0, json!({ "to": "operator", "body": "on it" })),
+        ],
+    );
+
+    let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
+        .with_brain_mode(BrainMode::Hosted)
+        .with_credential(SecretValue("th_live".into()))
+        .with_transport(transport.clone())
+        .build()
+        .await
+        .unwrap();
+
+    let report = rt
+        .run_cycle(vec![CompanyEvent::OperatorMessage {
+            text: "how are we doing".into(),
+        }])
+        .await
+        .unwrap();
+
+    // The gated send_dm produced a channel response routed to the operator.
+    assert_eq!(report.responses.len(), 1);
+    assert_eq!(report.responses[0].channel, "operator");
+    assert_eq!(report.responses[0].text, "on it");
+
+    // The effect flowed through the gate and acked ok:true.
+    let acks = transport.acks();
+    assert_eq!(acks.len(), 1);
+    assert!(acks[0].ok);
+
+    // The device tool was serviced and answered.
+    assert_eq!(transport.tool_answers().len(), 1);
+
+    // Exactly one event was posted for the operator message.
+    assert_eq!(transport.posted_events().len(), 1);
+
+    // A compressed trace was persisted to the fs-backed MemoryStore.
+    let traces = rt.memory.recent_traces(rt.id(), 10).await.unwrap();
+    assert!(!traces.is_empty());
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+#[tokio::test]
+async fn e2e_supervised_effect_parks_and_acks_not_ok() {
+    let home = tmp_home();
+    let transport = Arc::new(MockTransport::new());
+    transport.script_cycle(
+        runtime_cid(),
+        // A Sign-group effect always parks under supervised policy.
+        vec![effect_frame("filing.submit", 0, Value::Null)],
+    );
+
+    let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
+        .with_brain_mode(BrainMode::Hosted)
+        .with_credential(SecretValue("th_live".into()))
+        .with_transport(transport.clone())
+        .build()
+        .await
+        .unwrap();
+
+    let report = rt
+        .run_cycle(vec![CompanyEvent::OperatorMessage {
+            text: "file it".into(),
+        }])
+        .await
+        .unwrap();
+
+    // The effect parked: an approval is queued and no channel response emitted.
+    assert_eq!(report.parked.len(), 1);
+    assert_eq!(rt.pending_approvals().len(), 1);
+    assert!(report.responses.is_empty());
+
+    // Medulla was told the effect is pending, not that it succeeded.
+    let acks = transport.acks();
+    assert_eq!(acks.len(), 1);
+    assert!(!acks[0].ok);
+    assert!(
+        acks[0]
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("pending approval")
+    );
+
+    // Resolving the approval executes the parked effect and drains the queue.
+    let approval_id = report.parked[0].clone();
+    rt.resolve_approval(
+        &approval_id,
+        Verdict::Approve,
+        Actor {
+            kind: ActorKind::Operator,
+            id: "owner".into(),
+        },
+    )
+    .await
+    .unwrap();
+    assert!(rt.pending_approvals().is_empty());
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -1,0 +1,234 @@
+//! Shared wire→kernel mapping for the Medulla-family brains.
+//!
+//! [`HostedMedullaBrain`](crate::brain::HostedMedullaBrain) and the
+//! feature-gated [`SidecarBrain`](crate::brain::sidecar::SidecarBrain) drain the
+//! *same* `/orchestration/v1` frames, so the translation from a wire frame into
+//! a kernel [`Effect`], [`ContextOp`], channel response, or ledger delta lives
+//! here once. Both brains import these `pub(crate)` helpers rather than keeping
+//! two copies of the mapping.
+
+use serde_json::{Value, json};
+
+use crate::ports::now_millis;
+use crate::ports::types::{
+    ChunkAddr, CompanyEvent, ContextChunk, ContextOp, ContextOpResult, Effect, EffectGroup,
+    LedgerEntry, OutboundMessage, Verdict,
+};
+
+use super::wire::{EffectFrame, Role, WireEvent};
+
+/// The device-tool name prefix that routes a tool call to the context store.
+pub(crate) const CONTEXT_TOOL_PREFIX: &str = "context_";
+
+/// What one executed effect contributed to the cycle result.
+#[derive(Default)]
+pub(crate) struct EffectOutcome {
+    /// A channel response produced by an executed `Send`-group effect.
+    pub(crate) channel_response: Option<OutboundMessage>,
+    /// A ledger delta produced by an executed money-moving effect.
+    pub(crate) ledger_delta: Option<LedgerEntry>,
+    /// Whether the effect warrants a world-diff upload.
+    pub(crate) notable: bool,
+}
+
+/// Normalizes a [`CompanyEvent`] into the [`WireEvent`] `POST /events` carries.
+pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
+    let (role, sender, body, kind) = match event {
+        CompanyEvent::OperatorMessage { text } => (
+            Role::User,
+            "operator".to_string(),
+            text.clone(),
+            "operator.message",
+        ),
+        CompanyEvent::WebhookReceived { channel, body } => (
+            Role::User,
+            channel.clone(),
+            body.to_string(),
+            "webhook.received",
+        ),
+        CompanyEvent::ScheduleFired { cron, prompt } => (
+            Role::System,
+            "scheduler".to_string(),
+            format!("[{cron}] {prompt}"),
+            "schedule.fired",
+        ),
+        CompanyEvent::A2aTaskReceived { from, task } => (
+            Role::User,
+            from.clone(),
+            task.to_string(),
+            "a2a.task_received",
+        ),
+        CompanyEvent::ApprovalResolved {
+            approval_id,
+            verdict,
+            by,
+        } => (
+            Role::System,
+            by.id.clone(),
+            format!("{} approval {approval_id}", verdict_word(*verdict)),
+            "approval.resolved",
+        ),
+        CompanyEvent::FeedbackFiled { note } => (
+            Role::User,
+            "operator".to_string(),
+            note.clone(),
+            "feedback.filed",
+        ),
+        CompanyEvent::PaymentReceived { amount_usd, memo } => (
+            Role::System,
+            "ledger".to_string(),
+            format!("received ${amount_usd}: {memo}"),
+            "payment.received",
+        ),
+        CompanyEvent::LifecycleChanged { from, to, by } => (
+            Role::System,
+            by.id.clone(),
+            format!("Lifecycle changed from {from} to {to}"),
+            "lifecycle.changed",
+        ),
+    };
+    WireEvent {
+        seq,
+        role,
+        sender,
+        body,
+        ts: now_millis() as i64,
+        kind: kind.to_string(),
+    }
+}
+
+/// The lowercase wire word for an operator verdict.
+pub(crate) fn verdict_word(verdict: Verdict) -> &'static str {
+    match verdict {
+        Verdict::Approve => "approved",
+        Verdict::Deny => "denied",
+    }
+}
+
+/// Builds an [`Effect`] from an effect frame, classifying its supervised group
+/// and lifting `amountUsd` / thread flags out of the payload for the gate.
+pub(crate) fn effect_from_frame(frame: &EffectFrame) -> Effect {
+    let payload = &frame.payload;
+    Effect {
+        kind: frame.kind.clone(),
+        group: effect_group_for(&frame.kind),
+        amount_usd: payload_f64(payload, "amountUsd")
+            .or_else(|| payload_f64(payload, "amount_usd")),
+        established_thread: payload_bool(payload, "establishedThread")
+            .or_else(|| payload_bool(payload, "established_thread"))
+            .unwrap_or(false),
+        first_time_counterparty: payload_bool(payload, "firstTimeCounterparty")
+            .or_else(|| payload_bool(payload, "first_time_counterparty"))
+            .unwrap_or(false),
+        payload: frame.payload.clone(),
+    }
+}
+
+/// Maps a dotted effect kind to its supervised-policy [`EffectGroup`].
+pub(crate) fn effect_group_for(kind: &str) -> EffectGroup {
+    let k = kind.to_ascii_lowercase();
+    if k.contains("send_dm") || k.contains("message") || k.contains("email") || k.contains("reply")
+    {
+        EffectGroup::Send
+    } else if k.contains("payment")
+        || k.contains("spend")
+        || k.contains("x402")
+        || k.contains("pay")
+    {
+        EffectGroup::Spend
+    } else if k.contains("sign") || k.contains("filing") || k.contains("contract") {
+        EffectGroup::Sign
+    } else if k.contains("publish") {
+        EffectGroup::Publish
+    } else if k.contains("hire") || k.contains("engage") {
+        EffectGroup::Hire
+    } else if k.contains("identity") || k.contains("register") {
+        EffectGroup::Identity
+    } else {
+        EffectGroup::Other
+    }
+}
+
+/// Extracts a channel response from an executed `Send`-group effect.
+///
+/// Returns `None` for non-send effects. The channel is read from `channel`/`to`
+/// and the text from `text`/`body`/`message`, so the runtime's own effect
+/// executor (which only routes a `{channel,text}` pair) does not double-send
+/// when the payload uses the `{to,body}` shape.
+pub(crate) fn channel_message_from_effect(effect: &Effect) -> Option<OutboundMessage> {
+    if effect.group != EffectGroup::Send {
+        return None;
+    }
+    let payload = &effect.payload;
+    let channel = payload_str(payload, "channel")
+        .or_else(|| payload_str(payload, "to"))
+        .unwrap_or("operator")
+        .to_string();
+    let text = payload_str(payload, "text")
+        .or_else(|| payload_str(payload, "body"))
+        .or_else(|| payload_str(payload, "message"))?
+        .to_string();
+    Some(OutboundMessage { channel, text })
+}
+
+/// Records a ledger delta for an executed effect that moved money.
+pub(crate) fn ledger_delta_from_effect(effect: &Effect) -> Option<LedgerEntry> {
+    let amount = effect.amount_usd?;
+    Some(LedgerEntry {
+        at_millis: now_millis(),
+        kind: effect.kind.clone(),
+        amount_usd: amount,
+        memo: format!("medulla effect {}", effect.kind),
+    })
+}
+
+/// Whether an executed effect warrants a world-diff upload.
+pub(crate) fn is_notable(effect: &Effect) -> bool {
+    !matches!(effect.group, EffectGroup::Other | EffectGroup::Send)
+}
+
+/// Maps a `context_*` device tool call into a [`ContextOp`], or `None` when the
+/// tool is not a context tool.
+pub(crate) fn context_op_from_call(name: &str, args: &Value) -> Option<ContextOp> {
+    let op = name.strip_prefix(CONTEXT_TOOL_PREFIX)?;
+    match op {
+        "put" => Some(ContextOp::Put(ContextChunk {
+            label: payload_str(args, "label").unwrap_or("").to_string(),
+            body: payload_str(args, "body").unwrap_or("").to_string(),
+        })),
+        "list" => Some(ContextOp::List {
+            prefix: payload_str(args, "prefix").unwrap_or("").to_string(),
+        }),
+        "peek" => Some(ContextOp::Peek {
+            addr: ChunkAddr::new(payload_str(args, "addr").unwrap_or("")),
+            range: None,
+        }),
+        "search" => Some(ContextOp::Search {
+            query: payload_str(args, "query").unwrap_or("").to_string(),
+            limit: payload_f64(args, "limit").map(|n| n as usize).unwrap_or(10),
+        }),
+        _ => None,
+    }
+}
+
+/// Renders a [`ContextOpResult`] as the JSON a `tool_result` frame carries.
+pub(crate) fn context_result_to_value(result: ContextOpResult) -> Value {
+    match result {
+        ContextOpResult::Addr(addr) => json!({ "addr": addr.as_ref() }),
+        ContextOpResult::Metas(metas) => serde_json::to_value(metas).unwrap_or(Value::Null),
+        ContextOpResult::Text(text) => json!({ "text": text }),
+        ContextOpResult::Hits(hits) => serde_json::to_value(hits).unwrap_or(Value::Null),
+    }
+}
+
+pub(crate) fn payload_str<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
+    value.get(key).and_then(Value::as_str)
+}
+
+pub(crate) fn payload_f64(value: &Value, key: &str) -> Option<f64> {
+    value.get(key).and_then(Value::as_f64)
+}
+
+pub(crate) fn payload_bool(value: &Value, key: &str) -> Option<bool> {
+    value.get(key).and_then(Value::as_bool)
+}

--- a/src/brain/medulla/http.rs
+++ b/src/brain/medulla/http.rs
@@ -1,0 +1,128 @@
+//! [`HttpSocketTransport`]: the networked [`MedullaTransport`], gated behind the
+//! optional `medulla` feature.
+//!
+//! The two `POST` endpoints (`/orchestration/v1/events`, `/world-diff`) are
+//! implemented over [`reqwest`] with a protocol-1 envelope and `Bearer`
+//! credential; error envelopes decode to
+//! [`OpenCompanyError::Orchestration`](crate::error::OpenCompanyError::Orchestration)
+//! preserving the `ORCH_*` code. Every request body is scanned for a `model`
+//! field before it is sent.
+//!
+//! The Socket.IO half — the effect/tool-call frame stream and the acks/answers
+//! the client emits — is **stubbed** in this phase: [`Self::cycle_frames`]
+//! reports an empty cycle and the emit-side methods are no-ops, so a networked
+//! build is a compilable scaffold rather than a live client. All behavioral
+//! coverage runs against
+//! [`MockTransport`](super::mock::MockTransport) in the default build. Wiring a
+//! real Socket.IO client is deferred; the [`MedullaTransport`] seam isolates the
+//! choice so only this file changes.
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use futures::stream::{self, BoxStream};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::Result;
+use crate::ports::types::SecretValue;
+
+use super::transport::{InboundFrame, MedullaTransport};
+use super::wire::{
+    self, ApiResponse, EffectResult, Envelope, EventsAccepted, EventsRequest, OrchErrorCode,
+    ToolManifestEntry, ToolResultFrame, WorldDiffAccepted, WorldDiffRequest,
+};
+
+/// The networked transport speaking `/orchestration/v1` over HTTP + Socket.IO.
+pub struct HttpSocketTransport {
+    client: reqwest::Client,
+    base_url: String,
+    credential: SecretValue,
+}
+
+impl HttpSocketTransport {
+    /// Builds a transport against `base_url` (e.g. `https://api.tinyhumans.ai`)
+    /// authenticating with `credential`.
+    pub fn new(base_url: impl Into<String>, credential: SecretValue) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            base_url: base_url.into(),
+            credential,
+        }
+    }
+
+    /// Builds a full endpoint URL under `/orchestration/v1`.
+    fn endpoint(&self, path: &str) -> String {
+        format!(
+            "{}/orchestration/v1/{}",
+            self.base_url.trim_end_matches('/'),
+            path
+        )
+    }
+
+    /// Posts a protocol-1 envelope and decodes the `ApiResponse<T>` reply.
+    async fn post_json<T: DeserializeOwned>(&self, path: &str, envelope: Value) -> Result<T> {
+        // Belt-and-suspenders: never send a body carrying a `model` field.
+        wire::assert_no_model(&envelope)?;
+
+        let response = self
+            .client
+            .post(self.endpoint(path))
+            .bearer_auth(self.credential.expose())
+            .json(&envelope)
+            .send()
+            .await
+            .map_err(|err| {
+                OrchErrorCode::DeviceOffline.to_error(format!("POST {path} failed: {err}"))
+            })?;
+
+        let api: ApiResponse<T> = response.json().await.map_err(|err| {
+            OrchErrorCode::ValidationError.to_error(format!("decode {path} response failed: {err}"))
+        })?;
+        api.into_result()
+    }
+}
+
+impl std::fmt::Debug for HttpSocketTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpSocketTransport")
+            .field("base_url", &self.base_url)
+            .field("credential", &"<redacted>")
+            .finish()
+    }
+}
+
+#[async_trait]
+impl MedullaTransport for HttpSocketTransport {
+    async fn post_events(&self, req: EventsRequest) -> Result<EventsAccepted> {
+        let body = serde_json::to_value(Envelope::v1(req))?;
+        self.post_json("events", body).await
+    }
+
+    async fn post_world_diff(&self, req: WorldDiffRequest) -> Result<WorldDiffAccepted> {
+        req.validate()?;
+        let body = serde_json::to_value(Envelope::v1(req))?;
+        self.post_json("world-diff", body).await
+    }
+
+    async fn register_tools(&self, _tools: Vec<ToolManifestEntry>) -> Result<()> {
+        // TODO(medulla): emit `orch:register_tools` over the Socket.IO client.
+        Ok(())
+    }
+
+    fn cycle_frames(&self, _cycle_id: &str) -> BoxStream<'static, Result<InboundFrame>> {
+        // TODO(medulla): bridge the `orch:effect:*` / `orch:tool_call` stream.
+        // Until the socket client is wired, report an empty cycle so a networked
+        // build is a compilable scaffold rather than a hang.
+        stream::once(async { Ok(InboundFrame::CycleComplete) }).boxed()
+    }
+
+    async fn ack_effect(&self, _ack: EffectResult) -> Result<()> {
+        // TODO(medulla): emit `orch:effect:result` over the Socket.IO client.
+        Ok(())
+    }
+
+    async fn answer_tool_call(&self, _ans: ToolResultFrame) -> Result<()> {
+        // TODO(medulla): emit `orch:tool_result` over the Socket.IO client.
+        Ok(())
+    }
+}

--- a/src/brain/medulla/mock.rs
+++ b/src/brain/medulla/mock.rs
@@ -1,0 +1,153 @@
+//! [`MockTransport`]: an in-memory [`MedullaTransport`] for offline tests.
+//!
+//! It records every call the brain makes (posts, tool registrations, acks, tool
+//! answers) for later assertion, replays a scripted frame plan per cycle, and
+//! can inject an orchestration error to exercise the error-mapping path. No
+//! network, no async runtime assumptions beyond the trait's `async` methods.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use futures::stream::{self, BoxStream};
+
+use crate::Result;
+
+use super::transport::{InboundFrame, MedullaTransport};
+use super::wire::{
+    self, EffectResult, EventsAccepted, EventsRequest, OrchErrorCode, ToolManifestEntry,
+    ToolResultFrame, WorldDiffAccepted, WorldDiffRequest,
+};
+
+/// Everything the mock recorded, for test assertions.
+#[derive(Default)]
+struct Recorded {
+    posted_events: Vec<EventsRequest>,
+    posted_world_diffs: Vec<WorldDiffRequest>,
+    registered_tools: Vec<Vec<ToolManifestEntry>>,
+    acks: Vec<EffectResult>,
+    tool_answers: Vec<ToolResultFrame>,
+}
+
+/// An in-memory transport that scripts cycle frames and records brain calls.
+#[derive(Default)]
+pub struct MockTransport {
+    /// Scripted frames keyed by cycle id.
+    plans: Mutex<HashMap<String, Vec<InboundFrame>>>,
+    /// An error to return from the next (and every) `post_events`.
+    post_events_error: Mutex<Option<OrchErrorCode>>,
+    /// Recorded calls.
+    recorded: Mutex<Recorded>,
+}
+
+impl MockTransport {
+    /// Creates an empty mock with no scripted cycles.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Scripts the frames [`Self::cycle_frames`] will yield for `cycle_id`.
+    ///
+    /// A trailing [`InboundFrame::CycleComplete`] is appended automatically if
+    /// the plan does not already end with one, so the brain's drain loop always
+    /// terminates.
+    pub fn script_cycle(&self, cycle_id: impl Into<String>, mut frames: Vec<InboundFrame>) {
+        if !matches!(frames.last(), Some(InboundFrame::CycleComplete)) {
+            frames.push(InboundFrame::CycleComplete);
+        }
+        self.plans.lock().unwrap().insert(cycle_id.into(), frames);
+    }
+
+    /// Makes every subsequent `post_events` fail with `code`.
+    pub fn fail_post_events(&self, code: OrchErrorCode) {
+        *self.post_events_error.lock().unwrap() = Some(code);
+    }
+
+    /// The `EventsRequest`s the brain posted, in order.
+    pub fn posted_events(&self) -> Vec<EventsRequest> {
+        self.recorded.lock().unwrap().posted_events.clone()
+    }
+
+    /// The `WorldDiffRequest`s the brain posted, in order.
+    pub fn posted_world_diffs(&self) -> Vec<WorldDiffRequest> {
+        self.recorded.lock().unwrap().posted_world_diffs.clone()
+    }
+
+    /// The tool manifests the brain registered, in order.
+    pub fn registered_tools(&self) -> Vec<Vec<ToolManifestEntry>> {
+        self.recorded.lock().unwrap().registered_tools.clone()
+    }
+
+    /// The effect acks the brain emitted, in order.
+    pub fn acks(&self) -> Vec<EffectResult> {
+        self.recorded.lock().unwrap().acks.clone()
+    }
+
+    /// The tool answers the brain emitted, in order.
+    pub fn tool_answers(&self) -> Vec<ToolResultFrame> {
+        self.recorded.lock().unwrap().tool_answers.clone()
+    }
+}
+
+#[async_trait]
+impl MedullaTransport for MockTransport {
+    async fn post_events(&self, req: EventsRequest) -> Result<EventsAccepted> {
+        // Fidelity: real transports reject a smuggled `model` field before the
+        // POST. The typed body never has one, so this always passes here.
+        let body = serde_json::to_value(wire::Envelope::v1(req.clone()))?;
+        wire::assert_no_model(&body)?;
+
+        if let Some(code) = self.post_events_error.lock().unwrap().clone() {
+            return Err(code.to_error("mock post_events failure"));
+        }
+
+        let cycle_id = wire::cycle_id(&req.counterpart_agent_id, &req.session_id, req.event.seq);
+        self.recorded.lock().unwrap().posted_events.push(req);
+        Ok(EventsAccepted {
+            accepted: true,
+            cycle_id,
+        })
+    }
+
+    async fn post_world_diff(&self, req: WorldDiffRequest) -> Result<WorldDiffAccepted> {
+        req.validate()?;
+        let body = serde_json::to_value(wire::Envelope::v1(req.clone()))?;
+        wire::assert_no_model(&body)?;
+        self.recorded.lock().unwrap().posted_world_diffs.push(req);
+        Ok(WorldDiffAccepted {
+            accepted: true,
+            duplicates: 0,
+            tick_scheduled: true,
+        })
+    }
+
+    async fn register_tools(&self, tools: Vec<ToolManifestEntry>) -> Result<()> {
+        self.recorded.lock().unwrap().registered_tools.push(tools);
+        Ok(())
+    }
+
+    fn cycle_frames(&self, cycle_id: &str) -> BoxStream<'static, Result<InboundFrame>> {
+        let frames = self
+            .plans
+            .lock()
+            .unwrap()
+            .get(cycle_id)
+            .cloned()
+            .unwrap_or_else(|| vec![InboundFrame::CycleComplete]);
+        stream::iter(frames.into_iter().map(Ok)).boxed()
+    }
+
+    async fn ack_effect(&self, ack: EffectResult) -> Result<()> {
+        self.recorded.lock().unwrap().acks.push(ack);
+        Ok(())
+    }
+
+    async fn answer_tool_call(&self, ans: ToolResultFrame) -> Result<()> {
+        self.recorded.lock().unwrap().tool_answers.push(ans);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/src/brain/medulla/mock/test.rs
+++ b/src/brain/medulla/mock/test.rs
@@ -1,0 +1,157 @@
+//! Tests driving [`MockTransport`] through the [`MedullaTransport`] seam.
+
+use super::*;
+use crate::brain::medulla::wire::{
+    EffectFrame, Role, ToolCallFrame, WireEvent, WorldDiffEntry, call_id,
+};
+
+fn events_request(seq: u64) -> EventsRequest {
+    EventsRequest {
+        counterpart_agent_id: "opencompany:acme".to_string(),
+        session_id: "01SESSION".to_string(),
+        event: WireEvent {
+            seq,
+            role: Role::User,
+            sender: "operator".to_string(),
+            body: "hi".to_string(),
+            ts: 0,
+            kind: "operator.message".to_string(),
+        },
+    }
+}
+
+#[tokio::test]
+async fn post_events_computes_cycle_id_and_records() {
+    let mock = MockTransport::new();
+    let accepted = mock.post_events(events_request(7)).await.unwrap();
+    assert!(accepted.accepted);
+    assert_eq!(accepted.cycle_id, "cyc:opencompany:acme:01SESSION:7");
+
+    let posted = mock.posted_events();
+    assert_eq!(posted.len(), 1);
+    assert_eq!(posted[0].event.seq, 7);
+}
+
+#[tokio::test]
+async fn post_events_error_injection_maps_to_orchestration() {
+    let mock = MockTransport::new();
+    mock.fail_post_events(OrchErrorCode::InsufficientBalance);
+    let err = mock.post_events(events_request(1)).await.unwrap_err();
+    assert_eq!(err.code(), "ORCH_INSUFFICIENT_BALANCE");
+    // The failed post is not recorded as accepted.
+    assert!(mock.posted_events().is_empty());
+}
+
+#[tokio::test]
+async fn cycle_frames_replays_plan_then_completes() {
+    let mock = MockTransport::new();
+    let cycle = "cyc:opencompany:acme:01SESSION:1";
+    let effect = EffectFrame {
+        kind: "send_dm".to_string(),
+        cycle_id: cycle.to_string(),
+        call_id: call_id(cycle, "send_dm", 0),
+        payload: serde_json::json!({"channel": "operator", "text": "hi"}),
+    };
+    let tool = ToolCallFrame {
+        cycle_id: cycle.to_string(),
+        call_id: call_id(cycle, "tool", 0),
+        name: "context_search".to_string(),
+        args: serde_json::json!({"query": "x"}),
+        timeout_ms: 30_000,
+    };
+    // No trailing CycleComplete: the mock appends one.
+    mock.script_cycle(
+        cycle,
+        vec![
+            InboundFrame::Effect(effect.clone()),
+            InboundFrame::ToolCall(tool.clone()),
+        ],
+    );
+
+    let frames: Vec<_> = mock.cycle_frames(cycle).map(|f| f.unwrap()).collect().await;
+    assert_eq!(
+        frames,
+        vec![
+            InboundFrame::Effect(effect),
+            InboundFrame::ToolCall(tool),
+            InboundFrame::CycleComplete,
+        ]
+    );
+}
+
+#[tokio::test]
+async fn unscripted_cycle_yields_only_completion() {
+    let mock = MockTransport::new();
+    let frames: Vec<_> = mock
+        .cycle_frames("cyc:unknown")
+        .map(|f| f.unwrap())
+        .collect()
+        .await;
+    assert_eq!(frames, vec![InboundFrame::CycleComplete]);
+}
+
+#[tokio::test]
+async fn records_acks_answers_and_registrations() {
+    let mock = MockTransport::new();
+
+    mock.register_tools(vec![ToolManifestEntry {
+        name: "context_search".to_string(),
+        description: None,
+        input_schema: None,
+    }])
+    .await
+    .unwrap();
+
+    mock.ack_effect(EffectResult {
+        call_id: "cyc:a:s:1:send_dm:0".to_string(),
+        ok: true,
+        error: None,
+        result: None,
+    })
+    .await
+    .unwrap();
+
+    mock.answer_tool_call(ToolResultFrame {
+        call_id: "cyc:a:s:1:tool:0".to_string(),
+        ok: true,
+        result: Some(serde_json::json!({"hits": []})),
+        error: None,
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(mock.registered_tools().len(), 1);
+    assert_eq!(mock.registered_tools()[0][0].name, "context_search");
+    assert_eq!(mock.acks().len(), 1);
+    assert!(mock.acks()[0].ok);
+    assert_eq!(mock.tool_answers().len(), 1);
+    assert_eq!(mock.tool_answers()[0].call_id, "cyc:a:s:1:tool:0");
+}
+
+#[tokio::test]
+async fn world_diff_is_validated_and_recorded() {
+    let mock = MockTransport::new();
+    let req = WorldDiffRequest {
+        session_id: "01SESSION".to_string(),
+        entries: vec![WorldDiffEntry {
+            seq: 1,
+            note: "shipped".to_string(),
+            ts: 0,
+        }],
+    };
+    let accepted = mock.post_world_diff(req).await.unwrap();
+    assert!(accepted.accepted);
+    assert!(accepted.tick_scheduled);
+    assert_eq!(mock.posted_world_diffs().len(), 1);
+
+    // An invalid batch is rejected before recording.
+    let empty = WorldDiffRequest {
+        session_id: "s".to_string(),
+        entries: vec![],
+    };
+    assert_eq!(
+        mock.post_world_diff(empty).await.unwrap_err().code(),
+        "ORCH_VALIDATION_ERROR"
+    );
+    assert_eq!(mock.posted_world_diffs().len(), 1);
+}

--- a/src/brain/medulla/mod.rs
+++ b/src/brain/medulla/mod.rs
@@ -1,0 +1,27 @@
+//! The hosted Medulla brain and its `/orchestration/v1` wire contract.
+//!
+//! Medulla is TinyHumans' orchestrator-first cognitive model, consumed by
+//! OpenCompany as a hosted service mounted at `/orchestration/v1/*` on
+//! `api.tinyhumans.ai`. This module holds, entirely in the default build:
+//!
+//! - [`wire`]: the typed serde surface — envelope, error codes, HTTP request
+//!   and response bodies, read-surface views, and Socket.IO frames.
+//! - [`transport`]: the [`MedullaTransport`](transport::MedullaTransport) seam
+//!   abstracting the HTTP posts, the effect stream, and device-tool round-trips
+//!   so the brain never depends on a concrete network client.
+//! - [`mock`]: an in-memory [`MockTransport`](mock::MockTransport) that drives
+//!   the seam offline, for tests.
+//!
+//! The networked `HttpSocketTransport` lands in a later batch behind an
+//! optional feature; nothing here pulls a network dependency.
+
+#[cfg(feature = "medulla")]
+pub mod http;
+pub mod mock;
+pub mod transport;
+pub mod wire;
+
+#[cfg(feature = "medulla")]
+pub use http::HttpSocketTransport;
+pub use mock::MockTransport;
+pub use transport::{InboundFrame, MedullaTransport};

--- a/src/brain/medulla/mod.rs
+++ b/src/brain/medulla/mod.rs
@@ -15,6 +15,7 @@
 //! The networked `HttpSocketTransport` lands in a later batch behind an
 //! optional feature; nothing here pulls a network dependency.
 
+pub(crate) mod effects;
 #[cfg(feature = "medulla")]
 pub mod http;
 pub mod mock;

--- a/src/brain/medulla/transport.rs
+++ b/src/brain/medulla/transport.rs
@@ -1,0 +1,62 @@
+//! The [`MedullaTransport`] seam: the abstraction the hosted brain drives.
+//!
+//! `HostedMedullaBrain` never depends on a concrete network client. It talks to
+//! a `MedullaTransport`, which abstracts the two `POST` endpoints, the outbound
+//! effect/tool-call stream, and the acks/answers the client sends back. The
+//! default build ships the in-memory [`MockTransport`](super::mock::MockTransport);
+//! the networked `HttpSocketTransport` lands behind a feature in a later batch.
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+
+use crate::Result;
+
+use super::wire::{
+    EffectFrame, EffectResult, EventsAccepted, EventsRequest, ToolCallFrame, ToolManifestEntry,
+    ToolResultFrame, WorldDiffAccepted, WorldDiffRequest,
+};
+
+/// A frame arriving out-of-band for an in-flight cycle.
+///
+/// The brain consumes [`MedullaTransport::cycle_frames`] until it sees
+/// [`InboundFrame::CycleComplete`], routing effects through the approval gate
+/// and tool calls through the host in between.
+#[derive(Clone, Debug, PartialEq)]
+pub enum InboundFrame {
+    /// An effect to run then ack (`orch:effect:<kind>`).
+    Effect(EffectFrame),
+    /// A device tool to invoke then answer (`orch:tool_call`).
+    ToolCall(ToolCallFrame),
+    /// The cycle has finished; stop consuming the stream.
+    CycleComplete,
+}
+
+/// The transport the hosted brain speaks `/orchestration/v1` through.
+///
+/// Implementations bridge the synchronous [`Brain`](crate::ports::Brain) port to
+/// the asynchronous wire: the brain posts events, then drains
+/// [`Self::cycle_frames`] for the returned cycle, acking effects and answering
+/// tool calls as frames arrive.
+#[async_trait]
+pub trait MedullaTransport: Send + Sync {
+    /// Ingests one event (`POST /events`) and returns the wake acknowledgement.
+    async fn post_events(&self, req: EventsRequest) -> Result<EventsAccepted>;
+
+    /// Uploads world-state notes (`POST /world-diff`).
+    async fn post_world_diff(&self, req: WorldDiffRequest) -> Result<WorldDiffAccepted>;
+
+    /// Registers the device tool manifest (`orch:register_tools`).
+    async fn register_tools(&self, tools: Vec<ToolManifestEntry>) -> Result<()>;
+
+    /// The out-of-band frame stream for `cycle_id`.
+    ///
+    /// Yields effects and tool calls as they arrive, terminated by
+    /// [`InboundFrame::CycleComplete`] when the cycle finishes.
+    fn cycle_frames(&self, cycle_id: &str) -> BoxStream<'static, Result<InboundFrame>>;
+
+    /// Acks an effect (`orch:effect:result`).
+    async fn ack_effect(&self, ack: EffectResult) -> Result<()>;
+
+    /// Answers a device tool call (`orch:tool_result`).
+    async fn answer_tool_call(&self, ans: ToolResultFrame) -> Result<()>;
+}

--- a/src/brain/medulla/wire.rs
+++ b/src/brain/medulla/wire.rs
@@ -1,0 +1,612 @@
+//! The `/orchestration/v1` wire contract as typed serde.
+//!
+//! Every request body carries `"protocol": 1` (see [`Envelope`]); responses are
+//! `{ success, data }` or `{ success, error, errorCode?, details? }` (see
+//! [`ApiResponse`]). Field names on the wire are camelCase; the Rust structs use
+//! `snake_case` with `#[serde(rename_all = "camelCase")]`.
+//!
+//! The shapes here are pinned by the round-trip tests at the bottom of the file:
+//! if the live backend disagrees on a shape, only this module changes.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::Result;
+use crate::error::OpenCompanyError;
+
+// ---------------------------------------------------------------------------
+// Protocol + envelope
+// ---------------------------------------------------------------------------
+
+/// The wire protocol version every request declares.
+pub const PROTOCOL: u8 = 1;
+
+/// The minimum protocol the server accepts today.
+pub const PROTOCOL_MIN: u8 = 1;
+
+/// The maximum protocol the server accepts today.
+pub const PROTOCOL_MAX: u8 = 1;
+
+/// A request body wrapped with its `"protocol"` version.
+///
+/// The inner `body` is flattened, so `Envelope::v1(EventsRequest { … })`
+/// serializes to `{ "protocol": 1, "counterpartAgentId": …, … }`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Envelope<T> {
+    /// The wire protocol version. Always [`PROTOCOL`] for requests we send.
+    pub protocol: u8,
+    /// The wrapped request body.
+    #[serde(flatten)]
+    pub body: T,
+}
+
+impl<T> Envelope<T> {
+    /// Wraps `body` at protocol version 1.
+    pub fn v1(body: T) -> Self {
+        Self {
+            protocol: PROTOCOL,
+            body,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Response envelope + error codes
+// ---------------------------------------------------------------------------
+
+/// A decoded `{ success, data | error }` response envelope.
+///
+/// The `success` boolean discriminates: a `true` envelope carries `data`, a
+/// `false` envelope carries `error`/`errorCode`/`details`. Use
+/// [`ApiResponse::into_result`] to collapse it into a crate [`Result`].
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiResponse<T> {
+    /// Whether the call succeeded.
+    pub success: bool,
+    /// The success payload, present when `success` is `true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<T>,
+    /// The human-readable error message, present when `success` is `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// The `ORCH_*` error code, present on most error envelopes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+    /// Structured error detail (e.g. `{min,max}` for a protocol mismatch).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<Value>,
+}
+
+impl<T> ApiResponse<T> {
+    /// Wraps a success payload.
+    pub fn ok(data: T) -> Self {
+        Self {
+            success: true,
+            data: Some(data),
+            error: None,
+            error_code: None,
+            details: None,
+        }
+    }
+
+    /// Collapses the envelope into a crate [`Result`].
+    ///
+    /// A `success: false` envelope maps to
+    /// [`OpenCompanyError::Orchestration`], preserving the verbatim `ORCH_*`
+    /// code and folding any `details` into the message so `{min,max}` and
+    /// friends survive. A `success: true` envelope with no `data` is treated as
+    /// a validation error from the server.
+    pub fn into_result(self) -> Result<T> {
+        if self.success {
+            return self.data.ok_or_else(|| {
+                OrchErrorCode::ValidationError.to_error("success envelope had no data")
+            });
+        }
+        let code = self
+            .error_code
+            .as_deref()
+            .map(OrchErrorCode::from_wire)
+            .unwrap_or(OrchErrorCode::Unknown(String::new()));
+        let mut message = self
+            .error
+            .unwrap_or_else(|| "orchestration error".to_string());
+        if let Some(details) = &self.details {
+            message = format!("{message} ({details})");
+        }
+        Err(code.to_error(message))
+    }
+}
+
+/// The nine `ORCH_*` error codes the v1 orchestrator can return, plus a
+/// forward-compatible [`OrchErrorCode::Unknown`] carrying any future code.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum OrchErrorCode {
+    /// `ORCH_PROTOCOL_MISMATCH` — the request protocol is out of range.
+    ProtocolMismatch,
+    /// `ORCH_MODEL_NOT_ALLOWED` — the request tried to select a model.
+    ModelNotAllowed,
+    /// `ORCH_VALIDATION_ERROR` — the request body failed validation.
+    ValidationError,
+    /// `ORCH_INSUFFICIENT_BALANCE` — the account cannot fund the cycle.
+    InsufficientBalance,
+    /// `ORCH_RATE_LIMITED` — the account is being throttled.
+    RateLimited,
+    /// `ORCH_UPSTREAM_MODEL_ERROR` — a backing model provider failed.
+    UpstreamModelError,
+    /// `ORCH_INVALID_STATE` — the session is in a state that rejects the call.
+    InvalidState,
+    /// `ORCH_DEVICE_OFFLINE` — the device socket is not connected.
+    DeviceOffline,
+    /// `ORCH_EXECUTE_TIMEOUT` — a device tool exceeded its budget.
+    ExecuteTimeout,
+    /// Any code the client does not recognize, stored verbatim.
+    Unknown(String),
+}
+
+impl OrchErrorCode {
+    /// The verbatim `ORCH_*` wire string for this code.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::ProtocolMismatch => "ORCH_PROTOCOL_MISMATCH",
+            Self::ModelNotAllowed => "ORCH_MODEL_NOT_ALLOWED",
+            Self::ValidationError => "ORCH_VALIDATION_ERROR",
+            Self::InsufficientBalance => "ORCH_INSUFFICIENT_BALANCE",
+            Self::RateLimited => "ORCH_RATE_LIMITED",
+            Self::UpstreamModelError => "ORCH_UPSTREAM_MODEL_ERROR",
+            Self::InvalidState => "ORCH_INVALID_STATE",
+            Self::DeviceOffline => "ORCH_DEVICE_OFFLINE",
+            Self::ExecuteTimeout => "ORCH_EXECUTE_TIMEOUT",
+            Self::Unknown(code) => code,
+        }
+    }
+
+    /// Parses a wire `ORCH_*` string, mapping unknown codes to
+    /// [`OrchErrorCode::Unknown`].
+    pub fn from_wire(code: &str) -> Self {
+        match code {
+            "ORCH_PROTOCOL_MISMATCH" => Self::ProtocolMismatch,
+            "ORCH_MODEL_NOT_ALLOWED" => Self::ModelNotAllowed,
+            "ORCH_VALIDATION_ERROR" => Self::ValidationError,
+            "ORCH_INSUFFICIENT_BALANCE" => Self::InsufficientBalance,
+            "ORCH_RATE_LIMITED" => Self::RateLimited,
+            "ORCH_UPSTREAM_MODEL_ERROR" => Self::UpstreamModelError,
+            "ORCH_INVALID_STATE" => Self::InvalidState,
+            "ORCH_DEVICE_OFFLINE" => Self::DeviceOffline,
+            "ORCH_EXECUTE_TIMEOUT" => Self::ExecuteTimeout,
+            other => Self::Unknown(other.to_string()),
+        }
+    }
+
+    /// Builds an [`OpenCompanyError::Orchestration`] carrying this code.
+    pub fn to_error(&self, message: impl Into<String>) -> OpenCompanyError {
+        OpenCompanyError::orchestration(self.as_str(), message)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// POST /events
+// ---------------------------------------------------------------------------
+
+/// The role of an event's author, as the orchestrator sees it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Role {
+    /// The human operator or an inbound counterparty.
+    User,
+    /// The company/agent itself.
+    Assistant,
+    /// The runtime (timers, boot replay, system notices).
+    System,
+}
+
+/// A single normalized event delivered to `POST /events`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WireEvent {
+    /// The event's monotonic sequence within the session (the `EventLog` seq).
+    pub seq: u64,
+    /// Who authored the event.
+    pub role: Role,
+    /// A stable id for the sender (1..256 chars).
+    pub sender: String,
+    /// The plaintext event body (≤200000 chars).
+    pub body: String,
+    /// Epoch-millis timestamp.
+    pub ts: i64,
+    /// The dotted event kind (1..64 chars).
+    pub kind: String,
+}
+
+/// The `POST /events` request body (wrap in [`Envelope::v1`] to send).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventsRequest {
+    /// The counterpart agent id, e.g. `opencompany:<slug>` (1..256 chars).
+    pub counterpart_agent_id: String,
+    /// The session id — one session per company (1..256 chars).
+    pub session_id: String,
+    /// The event that triggers the wake.
+    pub event: WireEvent,
+}
+
+/// The `202` acknowledgement returned by `POST /events`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventsAccepted {
+    /// Whether the event was accepted for processing.
+    pub accepted: bool,
+    /// The deterministic cycle id the wake fires under.
+    pub cycle_id: String,
+}
+
+/// Builds the deterministic cycle id `cyc:<counterpart>:<session>:<seq>`.
+///
+/// Ingest is idempotent on `(user, counterpart, session, seq)`; this id is the
+/// stable key derived from those coordinates.
+pub fn cycle_id(counterpart: &str, session: &str, seq: u64) -> String {
+    format!("cyc:{counterpart}:{session}:{seq}")
+}
+
+// ---------------------------------------------------------------------------
+// POST /world-diff
+// ---------------------------------------------------------------------------
+
+/// The maximum number of world-diff entries a single request may carry.
+pub const WORLD_DIFF_MAX_ENTRIES: usize = 500;
+
+/// The maximum length of a single world-diff note, in characters.
+pub const WORLD_DIFF_MAX_NOTE: usize = 8000;
+
+/// One world-state note uploaded via `POST /world-diff`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct WorldDiffEntry {
+    /// The sequence the note is anchored to.
+    pub seq: u64,
+    /// The world-state note (≤8000 chars).
+    pub note: String,
+    /// Epoch-millis timestamp.
+    pub ts: i64,
+}
+
+/// The `POST /world-diff` request body (wrap in [`Envelope::v1`] to send).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorldDiffRequest {
+    /// The session the notes belong to.
+    pub session_id: String,
+    /// The notes to upload (1..=500 entries).
+    pub entries: Vec<WorldDiffEntry>,
+}
+
+impl WorldDiffRequest {
+    /// Validates the entry-count and note-length bounds the server enforces.
+    ///
+    /// Returns [`OrchErrorCode::ValidationError`] on a violation so the caller
+    /// fails fast without a round-trip.
+    pub fn validate(&self) -> Result<()> {
+        if self.entries.is_empty() {
+            return Err(
+                OrchErrorCode::ValidationError.to_error("world-diff requires at least one entry")
+            );
+        }
+        if self.entries.len() > WORLD_DIFF_MAX_ENTRIES {
+            return Err(OrchErrorCode::ValidationError.to_error(format!(
+                "world-diff exceeds {WORLD_DIFF_MAX_ENTRIES} entries"
+            )));
+        }
+        for entry in &self.entries {
+            if entry.note.chars().count() > WORLD_DIFF_MAX_NOTE {
+                return Err(OrchErrorCode::ValidationError.to_error(format!(
+                    "world-diff note exceeds {WORLD_DIFF_MAX_NOTE} chars"
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The `202` acknowledgement returned by `POST /world-diff`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorldDiffAccepted {
+    /// Whether the batch was accepted.
+    pub accepted: bool,
+    /// How many entries were duplicates of already-seen seqs.
+    pub duplicates: u32,
+    /// Whether a subconscious tick was scheduled as a result.
+    pub tick_scheduled: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Read surface
+// ---------------------------------------------------------------------------
+
+/// A row from `GET /sessions`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionSummary {
+    /// The session id.
+    pub session_id: String,
+    /// The session's lifecycle status.
+    pub status: String,
+    /// The last sequence the server has ingested for this session.
+    pub last_seq: u64,
+}
+
+/// A row from `GET /sessions/:id/messages`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageView {
+    /// The message sequence.
+    pub seq: u64,
+    /// Who authored the message.
+    pub role: Role,
+    /// The sender id.
+    pub sender: String,
+    /// The message body.
+    pub body: String,
+    /// Epoch-millis timestamp.
+    pub ts: i64,
+    /// The dotted message kind.
+    pub kind: String,
+}
+
+/// The body of `GET /sessions/:id/state`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionState {
+    /// The session id.
+    pub session_id: String,
+    /// The session's lifecycle status.
+    pub status: String,
+    /// The last ingested sequence.
+    pub last_seq: u64,
+    /// The last cycle id that fired, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_cycle_id: Option<String>,
+}
+
+/// A single steering directive from the subconscious tick.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SteeringDirective {
+    /// The steering text biasing future wakes.
+    pub directive: String,
+    /// Epoch-millis timestamp the directive was minted.
+    pub ts: i64,
+}
+
+/// The body of `GET /steering`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SteeringView {
+    /// The currently active directive, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active: Option<SteeringDirective>,
+    /// Prior directives, newest last.
+    pub history: Vec<SteeringDirective>,
+}
+
+/// A row from `GET /world-diff?session=<id>`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct WorldDiffView {
+    /// The sequence the note is anchored to.
+    pub seq: u64,
+    /// The stored world-state note.
+    pub note: String,
+    /// Epoch-millis timestamp.
+    pub ts: i64,
+}
+
+// ---------------------------------------------------------------------------
+// Socket.IO frames
+// ---------------------------------------------------------------------------
+
+/// The Socket.IO event that registers the device tool manifest.
+pub const REGISTER_TOOLS: &str = "orch:register_tools";
+
+/// The Socket.IO event the client emits to ack an effect.
+pub const EFFECT_RESULT: &str = "orch:effect:result";
+
+/// The Socket.IO event the server emits to invoke a device tool.
+pub const TOOL_CALL: &str = "orch:tool_call";
+
+/// The Socket.IO event the client emits to answer a device tool call.
+pub const TOOL_RESULT: &str = "orch:tool_result";
+
+/// The default device-tool timeout budget the server enforces (~30 s).
+pub const DEFAULT_TOOL_TIMEOUT_MS: u64 = 30_000;
+
+/// The Socket.IO event name for an effect of the given `kind`.
+///
+/// e.g. `effect_event_name("send_dm") == "orch:effect:send_dm"`.
+pub fn effect_event_name(kind: &str) -> String {
+    format!("orch:effect:{kind}")
+}
+
+/// Builds the deterministic dedupe key `{cycleId}:{kind}:{index}`.
+///
+/// Effect delivery is at-least-once; the client dedupes on this id so a replayed
+/// frame with the same `(cycle_id, kind, index)` is handled exactly once.
+pub fn call_id(cycle_id: &str, kind: &str, index: usize) -> String {
+    format!("{cycle_id}:{kind}:{index}")
+}
+
+/// One entry in the [`RegisterToolsFrame`] manifest.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolManifestEntry {
+    /// The tool name.
+    pub name: String,
+    /// A human description of the tool.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// JSON schema for the tool's arguments.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_schema: Option<Value>,
+}
+
+/// The `orch:register_tools` frame: the device tool catalog.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RegisterToolsFrame {
+    /// The registered tools.
+    pub tools: Vec<ToolManifestEntry>,
+}
+
+/// An effect the server pushes over `orch:effect:<kind>`.
+///
+/// On the wire the frame body is `{ cycleId, callId, …payload }` and the `kind`
+/// travels in the Socket.IO event name. This struct carries `kind` alongside for
+/// routing; [`EffectFrame::to_wire_body`] / [`EffectFrame::from_wire_body`]
+/// translate to and from the spread wire shape.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EffectFrame {
+    /// The effect kind, taken from the `orch:effect:<kind>` event name.
+    pub kind: String,
+    /// The cycle this effect belongs to.
+    pub cycle_id: String,
+    /// The deterministic dedupe id, `{cycleId}:{kind}:{index}`.
+    pub call_id: String,
+    /// The effect-specific payload (the remaining frame fields).
+    pub payload: Value,
+}
+
+impl EffectFrame {
+    /// The `orch:effect:<kind>` event name this frame is delivered on.
+    pub fn event_name(&self) -> String {
+        effect_event_name(&self.kind)
+    }
+
+    /// Renders the spread wire body `{ cycleId, callId, …payload }`.
+    ///
+    /// The payload object's keys are merged alongside `cycleId`/`callId`; a
+    /// non-object payload is placed under a `payload` key so nothing is lost.
+    pub fn to_wire_body(&self) -> Value {
+        let mut map = serde_json::Map::new();
+        map.insert("cycleId".to_string(), Value::String(self.cycle_id.clone()));
+        map.insert("callId".to_string(), Value::String(self.call_id.clone()));
+        match &self.payload {
+            Value::Object(fields) => {
+                for (key, value) in fields {
+                    map.insert(key.clone(), value.clone());
+                }
+            }
+            Value::Null => {}
+            other => {
+                map.insert("payload".to_string(), other.clone());
+            }
+        }
+        Value::Object(map)
+    }
+
+    /// Parses a spread wire body for the given effect `kind`.
+    ///
+    /// `cycleId` and `callId` are lifted out; everything else becomes the
+    /// [`EffectFrame::payload`].
+    pub fn from_wire_body(kind: impl Into<String>, mut body: Value) -> Result<Self> {
+        let obj = body.as_object_mut().ok_or_else(|| {
+            OrchErrorCode::ValidationError.to_error("effect frame body was not an object")
+        })?;
+        let cycle_id = take_string(obj, "cycleId")?;
+        let call_id = take_string(obj, "callId")?;
+        let payload = if let Some(payload) = obj.remove("payload") {
+            payload
+        } else {
+            Value::Object(std::mem::take(obj))
+        };
+        Ok(Self {
+            kind: kind.into(),
+            cycle_id,
+            call_id,
+            payload,
+        })
+    }
+}
+
+/// The `orch:effect:result` frame the client emits to ack an effect.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EffectResult {
+    /// The `callId` of the effect being acked.
+    pub call_id: String,
+    /// Whether the effect was executed.
+    pub ok: bool,
+    /// An error message when `ok` is `false` (e.g. `"pending approval"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// A structured result when the effect produced one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+}
+
+/// The `orch:tool_call` frame: a mid-cycle device-tool invocation.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolCallFrame {
+    /// The cycle the call belongs to.
+    pub cycle_id: String,
+    /// The dedupe/correlation id for the call.
+    pub call_id: String,
+    /// The tool name to invoke.
+    pub name: String,
+    /// The tool arguments.
+    pub args: Value,
+    /// The budget the client must answer within (~30 s).
+    pub timeout_ms: u64,
+}
+
+/// The `orch:tool_result` frame the client emits to answer a tool call.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolResultFrame {
+    /// The `callId` being answered.
+    pub call_id: String,
+    /// Whether the tool succeeded.
+    pub ok: bool,
+    /// The tool output, when it succeeded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    /// An error message, when it failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// model-field guard
+// ---------------------------------------------------------------------------
+
+/// Rejects any request body that carries a `model` field.
+///
+/// The client can never select a model; the server enforces this with
+/// `400 ORCH_MODEL_NOT_ALLOWED`. The typed request structs above have no such
+/// field, so this is defense-in-depth for [`Value`] passthroughs. The scan is
+/// recursive so a nested `model` key is caught too.
+pub fn assert_no_model(body: &Value) -> Result<()> {
+    if contains_model_key(body) {
+        return Err(
+            OrchErrorCode::ModelNotAllowed.to_error("request body must not contain a model field")
+        );
+    }
+    Ok(())
+}
+
+fn contains_model_key(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => map.contains_key("model") || map.values().any(contains_model_key),
+        Value::Array(items) => items.iter().any(contains_model_key),
+        _ => false,
+    }
+}
+
+fn take_string(obj: &mut serde_json::Map<String, Value>, key: &str) -> Result<String> {
+    match obj.remove(key) {
+        Some(Value::String(value)) => Ok(value),
+        _ => Err(OpenCompanyError::orchestration(
+            OrchErrorCode::ValidationError.as_str(),
+            format!("effect frame missing string field `{key}`"),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/src/brain/medulla/wire/test.rs
+++ b/src/brain/medulla/wire/test.rs
@@ -1,0 +1,463 @@
+//! Round-trip and mapping tests for the `/orchestration/v1` wire types.
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use serde_json::json;
+
+use super::*;
+use crate::error::OpenCompanyError;
+
+fn round_trip<T>(value: &T) -> T
+where
+    T: Serialize + DeserializeOwned,
+{
+    let json = serde_json::to_string(value).expect("serialize");
+    serde_json::from_str(&json).expect("deserialize")
+}
+
+// ---------------------------------------------------------------------------
+// Envelope + events
+// ---------------------------------------------------------------------------
+
+fn sample_events_request() -> EventsRequest {
+    EventsRequest {
+        counterpart_agent_id: "opencompany:acme".to_string(),
+        session_id: "01SESSION".to_string(),
+        event: WireEvent {
+            seq: 7,
+            role: Role::User,
+            sender: "operator".to_string(),
+            body: "ship it".to_string(),
+            ts: 1_700_000_000,
+            kind: "operator.message".to_string(),
+        },
+    }
+}
+
+#[test]
+fn events_request_round_trips_with_protocol_one() {
+    let req = sample_events_request();
+    let envelope = Envelope::v1(req.clone());
+    let json = serde_json::to_value(&envelope).unwrap();
+
+    // protocol:1 is present and the camelCase fields are flattened alongside it.
+    assert_eq!(json["protocol"], 1);
+    assert_eq!(json["counterpartAgentId"], "opencompany:acme");
+    assert_eq!(json["sessionId"], "01SESSION");
+    assert_eq!(json["event"]["role"], "user");
+
+    let back: Envelope<EventsRequest> = serde_json::from_value(json).unwrap();
+    assert_eq!(back.protocol, PROTOCOL);
+    assert_eq!(back.body, req);
+}
+
+#[test]
+fn wire_event_role_serializes_lowercase() {
+    for (role, wire) in [
+        (Role::User, "user"),
+        (Role::Assistant, "assistant"),
+        (Role::System, "system"),
+    ] {
+        assert_eq!(serde_json::to_value(role).unwrap(), json!(wire));
+        assert_eq!(round_trip(&role), role);
+    }
+}
+
+#[test]
+fn events_accepted_round_trips_camel_case() {
+    let accepted = EventsAccepted {
+        accepted: true,
+        cycle_id: "cyc:opencompany:acme:01SESSION:7".to_string(),
+    };
+    let json = serde_json::to_value(&accepted).unwrap();
+    assert_eq!(json["cycleId"], "cyc:opencompany:acme:01SESSION:7");
+    assert_eq!(round_trip(&accepted), accepted);
+}
+
+#[test]
+fn cycle_id_matches_spec_format_and_is_idempotent() {
+    let id = cycle_id("opencompany:acme", "01SESSION", 7);
+    assert_eq!(id, "cyc:opencompany:acme:01SESSION:7");
+    // Same coordinates → same id (the idempotency key).
+    assert_eq!(id, cycle_id("opencompany:acme", "01SESSION", 7));
+    // A different seq yields a different id.
+    assert_ne!(id, cycle_id("opencompany:acme", "01SESSION", 8));
+}
+
+// ---------------------------------------------------------------------------
+// world-diff
+// ---------------------------------------------------------------------------
+
+#[test]
+fn world_diff_round_trips_and_validates_bounds() {
+    let req = WorldDiffRequest {
+        session_id: "01SESSION".to_string(),
+        entries: vec![WorldDiffEntry {
+            seq: 1,
+            note: "closed a deal".to_string(),
+            ts: 42,
+        }],
+    };
+    let json = serde_json::to_value(Envelope::v1(req.clone())).unwrap();
+    assert_eq!(json["protocol"], 1);
+    assert_eq!(json["sessionId"], "01SESSION");
+    assert_eq!(round_trip(&req), req);
+    assert!(req.validate().is_ok());
+
+    let accepted = WorldDiffAccepted {
+        accepted: true,
+        duplicates: 2,
+        tick_scheduled: true,
+    };
+    let acc_json = serde_json::to_value(&accepted).unwrap();
+    assert_eq!(acc_json["tickScheduled"], true);
+    assert_eq!(round_trip(&accepted), accepted);
+}
+
+#[test]
+fn world_diff_rejects_empty_and_oversized() {
+    let empty = WorldDiffRequest {
+        session_id: "s".to_string(),
+        entries: vec![],
+    };
+    assert_orch_code(&empty.validate().unwrap_err(), "ORCH_VALIDATION_ERROR");
+
+    let too_many = WorldDiffRequest {
+        session_id: "s".to_string(),
+        entries: (0..(WORLD_DIFF_MAX_ENTRIES as u64 + 1))
+            .map(|seq| WorldDiffEntry {
+                seq,
+                note: "n".to_string(),
+                ts: 0,
+            })
+            .collect(),
+    };
+    assert_orch_code(&too_many.validate().unwrap_err(), "ORCH_VALIDATION_ERROR");
+
+    let long_note = WorldDiffRequest {
+        session_id: "s".to_string(),
+        entries: vec![WorldDiffEntry {
+            seq: 0,
+            note: "x".repeat(WORLD_DIFF_MAX_NOTE + 1),
+            ts: 0,
+        }],
+    };
+    assert_orch_code(&long_note.validate().unwrap_err(), "ORCH_VALIDATION_ERROR");
+}
+
+// ---------------------------------------------------------------------------
+// Read surface
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_surface_views_round_trip() {
+    let summary = SessionSummary {
+        session_id: "s".to_string(),
+        status: "running".to_string(),
+        last_seq: 12,
+    };
+    assert_eq!(
+        serde_json::to_value(&summary).unwrap()["lastSeq"],
+        json!(12)
+    );
+    assert_eq!(round_trip(&summary), summary);
+
+    let message = MessageView {
+        seq: 3,
+        role: Role::Assistant,
+        sender: "acme".to_string(),
+        body: "done".to_string(),
+        ts: 1,
+        kind: "chat".to_string(),
+    };
+    assert_eq!(round_trip(&message), message);
+
+    let state = SessionState {
+        session_id: "s".to_string(),
+        status: "running".to_string(),
+        last_seq: 9,
+        last_cycle_id: Some("cyc:a:s:9".to_string()),
+    };
+    assert_eq!(
+        serde_json::to_value(&state).unwrap()["lastCycleId"],
+        json!("cyc:a:s:9")
+    );
+    assert_eq!(round_trip(&state), state);
+
+    let steering = SteeringView {
+        active: Some(SteeringDirective {
+            directive: "prioritize refunds".to_string(),
+            ts: 5,
+        }),
+        history: vec![SteeringDirective {
+            directive: "be terse".to_string(),
+            ts: 1,
+        }],
+    };
+    assert_eq!(round_trip(&steering), steering);
+
+    let diff = WorldDiffView {
+        seq: 2,
+        note: "paid vendor".to_string(),
+        ts: 3,
+    };
+    assert_eq!(round_trip(&diff), diff);
+}
+
+#[test]
+fn session_state_omits_absent_last_cycle_id() {
+    let state = SessionState {
+        session_id: "s".to_string(),
+        status: "idle".to_string(),
+        last_seq: 0,
+        last_cycle_id: None,
+    };
+    let json = serde_json::to_value(&state).unwrap();
+    assert!(json.get("lastCycleId").is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Socket frames
+// ---------------------------------------------------------------------------
+
+#[test]
+fn register_tools_frame_round_trips_with_input_schema() {
+    let frame = RegisterToolsFrame {
+        tools: vec![
+            ToolManifestEntry {
+                name: "context_search".to_string(),
+                description: Some("search context".to_string()),
+                input_schema: Some(json!({"type": "object"})),
+            },
+            ToolManifestEntry {
+                name: "bare".to_string(),
+                description: None,
+                input_schema: None,
+            },
+        ],
+    };
+    let json = serde_json::to_value(&frame).unwrap();
+    assert_eq!(json["tools"][0]["inputSchema"], json!({"type": "object"}));
+    // Absent optionals are omitted, not null.
+    assert!(json["tools"][1].get("description").is_none());
+    assert!(json["tools"][1].get("inputSchema").is_none());
+    assert_eq!(round_trip(&frame), frame);
+}
+
+#[test]
+fn effect_frame_round_trips_through_spread_wire_body() {
+    let frame = EffectFrame {
+        kind: "send_dm".to_string(),
+        cycle_id: "cyc:a:s:1".to_string(),
+        call_id: call_id("cyc:a:s:1", "send_dm", 0),
+        payload: json!({"channel": "operator", "text": "hi"}),
+    };
+    assert_eq!(frame.event_name(), "orch:effect:send_dm");
+
+    // The wire body spreads the payload alongside cycleId/callId.
+    let body = frame.to_wire_body();
+    assert_eq!(body["cycleId"], "cyc:a:s:1");
+    assert_eq!(body["callId"], "cyc:a:s:1:send_dm:0");
+    assert_eq!(body["channel"], "operator");
+    assert_eq!(body["text"], "hi");
+
+    let back = EffectFrame::from_wire_body("send_dm", body).unwrap();
+    assert_eq!(back, frame);
+}
+
+#[test]
+fn effect_frame_preserves_non_object_payload() {
+    let frame = EffectFrame {
+        kind: "noop".to_string(),
+        cycle_id: "cyc:a:s:2".to_string(),
+        call_id: call_id("cyc:a:s:2", "noop", 0),
+        payload: json!("scalar-payload"),
+    };
+    let back = EffectFrame::from_wire_body("noop", frame.to_wire_body()).unwrap();
+    assert_eq!(back, frame);
+}
+
+#[test]
+fn call_id_matches_spec_and_dedupes_by_index() {
+    let id = call_id("cyc:a:s:1", "send_dm", 0);
+    assert_eq!(id, "cyc:a:s:1:send_dm:0");
+    // Same (cycle, kind, index) → identical id (dedupe key).
+    assert_eq!(id, call_id("cyc:a:s:1", "send_dm", 0));
+    // A different index → a different id.
+    assert_ne!(id, call_id("cyc:a:s:1", "send_dm", 1));
+    // A different kind → a different id.
+    assert_ne!(id, call_id("cyc:a:s:1", "publish", 0));
+}
+
+#[test]
+fn effect_and_tool_frames_round_trip() {
+    let result = EffectResult {
+        call_id: "cyc:a:s:1:send_dm:0".to_string(),
+        ok: false,
+        error: Some("pending approval".to_string()),
+        result: None,
+    };
+    assert_eq!(
+        serde_json::to_value(&result).unwrap()["callId"],
+        json!("cyc:a:s:1:send_dm:0")
+    );
+    assert_eq!(round_trip(&result), result);
+
+    let call = ToolCallFrame {
+        cycle_id: "cyc:a:s:1".to_string(),
+        call_id: "cyc:a:s:1:tool:0".to_string(),
+        name: "context_search".to_string(),
+        args: json!({"query": "invoices"}),
+        timeout_ms: DEFAULT_TOOL_TIMEOUT_MS,
+    };
+    assert_eq!(
+        serde_json::to_value(&call).unwrap()["timeoutMs"],
+        json!(30_000)
+    );
+    assert_eq!(round_trip(&call), call);
+
+    let answer = ToolResultFrame {
+        call_id: "cyc:a:s:1:tool:0".to_string(),
+        ok: true,
+        result: Some(json!({"hits": []})),
+        error: None,
+    };
+    assert_eq!(round_trip(&answer), answer);
+}
+
+#[test]
+fn socket_event_name_constants_and_helper() {
+    assert_eq!(REGISTER_TOOLS, "orch:register_tools");
+    assert_eq!(EFFECT_RESULT, "orch:effect:result");
+    assert_eq!(TOOL_CALL, "orch:tool_call");
+    assert_eq!(TOOL_RESULT, "orch:tool_result");
+    assert_eq!(effect_event_name("send_dm"), "orch:effect:send_dm");
+    assert_eq!(effect_event_name("publish"), "orch:effect:publish");
+}
+
+// ---------------------------------------------------------------------------
+// Response envelope + error codes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn success_envelope_decodes_to_data() {
+    let body = json!({
+        "success": true,
+        "data": { "accepted": true, "cycleId": "cyc:a:s:1" }
+    });
+    let resp: ApiResponse<EventsAccepted> = serde_json::from_value(body).unwrap();
+    let accepted = resp.into_result().unwrap();
+    assert_eq!(accepted.cycle_id, "cyc:a:s:1");
+}
+
+#[test]
+fn error_envelope_maps_all_nine_codes() {
+    let codes = [
+        ("ORCH_PROTOCOL_MISMATCH", OrchErrorCode::ProtocolMismatch),
+        ("ORCH_MODEL_NOT_ALLOWED", OrchErrorCode::ModelNotAllowed),
+        ("ORCH_VALIDATION_ERROR", OrchErrorCode::ValidationError),
+        (
+            "ORCH_INSUFFICIENT_BALANCE",
+            OrchErrorCode::InsufficientBalance,
+        ),
+        ("ORCH_RATE_LIMITED", OrchErrorCode::RateLimited),
+        (
+            "ORCH_UPSTREAM_MODEL_ERROR",
+            OrchErrorCode::UpstreamModelError,
+        ),
+        ("ORCH_INVALID_STATE", OrchErrorCode::InvalidState),
+        ("ORCH_DEVICE_OFFLINE", OrchErrorCode::DeviceOffline),
+        ("ORCH_EXECUTE_TIMEOUT", OrchErrorCode::ExecuteTimeout),
+    ];
+    for (wire, expected) in codes {
+        assert_eq!(OrchErrorCode::from_wire(wire), expected);
+        assert_eq!(expected.as_str(), wire);
+
+        let body = json!({ "success": false, "error": "boom", "errorCode": wire });
+        let resp: ApiResponse<EventsAccepted> = serde_json::from_value(body).unwrap();
+        let err = resp.into_result().unwrap_err();
+        assert_orch_code(&err, wire);
+    }
+}
+
+#[test]
+fn unknown_error_code_is_preserved() {
+    assert_eq!(
+        OrchErrorCode::from_wire("ORCH_FUTURE"),
+        OrchErrorCode::Unknown("ORCH_FUTURE".to_string())
+    );
+    let body = json!({ "success": false, "error": "boom", "errorCode": "ORCH_FUTURE" });
+    let resp: ApiResponse<EventsAccepted> = serde_json::from_value(body).unwrap();
+    assert_orch_code(&resp.into_result().unwrap_err(), "ORCH_FUTURE");
+}
+
+#[test]
+fn protocol_mismatch_surfaces_min_max_details() {
+    let body = json!({
+        "success": false,
+        "error": "protocol out of range",
+        "errorCode": "ORCH_PROTOCOL_MISMATCH",
+        "details": { "min": 1, "max": 1 }
+    });
+    let resp: ApiResponse<EventsAccepted> = serde_json::from_value(body).unwrap();
+
+    // The structured detail is available on the decoded envelope.
+    let details = resp.details.clone().unwrap();
+    assert_eq!(details["min"], 1);
+    assert_eq!(details["max"], 1);
+
+    // And the mapped error carries the code with the details folded in.
+    let err = resp.into_result().unwrap_err();
+    assert_orch_code(&err, "ORCH_PROTOCOL_MISMATCH");
+    let OpenCompanyError::Orchestration { message, .. } = &err else {
+        panic!("expected orchestration error");
+    };
+    assert!(message.contains("\"min\":1"), "message was {message}");
+    assert!(message.contains("\"max\":1"), "message was {message}");
+
+    // Advertised protocol range constants line up with the spec.
+    assert_eq!((PROTOCOL_MIN, PROTOCOL_MAX), (1, 1));
+}
+
+// ---------------------------------------------------------------------------
+// model-field guard
+// ---------------------------------------------------------------------------
+
+#[test]
+fn assert_no_model_flags_top_level_and_nested() {
+    assert_orch_code(
+        &assert_no_model(&json!({ "model": "gpt" })).unwrap_err(),
+        "ORCH_MODEL_NOT_ALLOWED",
+    );
+    assert_orch_code(
+        &assert_no_model(&json!({ "event": { "model": "claude" } })).unwrap_err(),
+        "ORCH_MODEL_NOT_ALLOWED",
+    );
+    assert_orch_code(
+        &assert_no_model(&json!({ "list": [ { "model": "x" } ] })).unwrap_err(),
+        "ORCH_MODEL_NOT_ALLOWED",
+    );
+}
+
+#[test]
+fn assert_no_model_passes_clean_bodies() {
+    let body = serde_json::to_value(Envelope::v1(sample_events_request())).unwrap();
+    assert!(assert_no_model(&body).is_ok());
+    // The typed events body never serializes a `model` key.
+    assert!(!body.to_string().contains("\"model\""));
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+fn assert_orch_code(err: &OpenCompanyError, expected: &str) {
+    match err {
+        OpenCompanyError::Orchestration { code, .. } => {
+            assert_eq!(code, expected, "unexpected orchestration code");
+            // The HTTP envelope surfaces the verbatim ORCH_* code.
+            assert_eq!(err.code(), expected);
+        }
+        other => panic!("expected orchestration error, got {other:?}"),
+    }
+}

--- a/src/brain/mod.rs
+++ b/src/brain/mod.rs
@@ -2,9 +2,15 @@
 //! seams.
 //!
 //! Phase 1 ships the offline [`EchoBrain`], which has no TinyAgents dependency
-//! and is the default. TinyAgents-backed and hosted brains land behind the
-//! `tiny` feature and in later phases.
+//! and is the default. Phase 2 adds the [`HostedMedullaBrain`], which drives
+//! hosted Medulla cognition over a [`MedullaTransport`](medulla::MedullaTransport);
+//! the brain and its whole test surface live in the default build against the
+//! in-memory mock transport. TinyAgents-backed and sidecar brains land behind
+//! the `tiny` feature and in later phases.
 
 pub mod echo;
+pub mod hosted;
+pub mod medulla;
 
 pub use echo::EchoBrain;
+pub use hosted::HostedMedullaBrain;

--- a/src/brain/mod.rs
+++ b/src/brain/mod.rs
@@ -5,12 +5,19 @@
 //! and is the default. Phase 2 adds the [`HostedMedullaBrain`], which drives
 //! hosted Medulla cognition over a [`MedullaTransport`](medulla::MedullaTransport);
 //! the brain and its whole test surface live in the default build against the
-//! in-memory mock transport. TinyAgents-backed and sidecar brains land behind
-//! the `tiny` feature and in later phases.
+//! in-memory mock transport. The [`sidecar`] brain, behind the `sidecar`
+//! feature, drives a local sidecar process over the same wire frames but routes
+//! each model pass back into the Rust host through an
+//! [`InferenceClient`](sidecar::InferenceClient); it too is fully offline-testable
+//! against its mock transport and mock inference client.
 
 pub mod echo;
 pub mod hosted;
 pub mod medulla;
+#[cfg(feature = "sidecar")]
+pub mod sidecar;
 
 pub use echo::EchoBrain;
 pub use hosted::HostedMedullaBrain;
+#[cfg(feature = "sidecar")]
+pub use sidecar::{InferenceClient, SidecarBrain, SidecarTransport};

--- a/src/brain/sidecar/mock.rs
+++ b/src/brain/sidecar/mock.rs
@@ -1,0 +1,209 @@
+//! Offline mocks for the sidecar seams.
+//!
+//! [`MockSidecarTransport`] scripts a [`SidecarFrame`] plan per cycle and records
+//! every call the brain makes (posts, tool registrations, acks, tool answers,
+//! inference answers). [`MockInferenceClient`] returns a canned completion and
+//! records the requests it received. Together they drive the whole sidecar brain
+//! offline — no network, no Node process.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use futures::stream::{self, BoxStream};
+
+use crate::Result;
+use crate::ports::types::TokenUsage;
+
+use crate::brain::medulla::wire::{
+    self, EffectResult, EventsAccepted, EventsRequest, OrchErrorCode, ToolManifestEntry,
+    ToolResultFrame,
+};
+
+use super::transport::{InferenceClient, SidecarTransport};
+use super::types::{InferenceRequest, InferenceResponse, SidecarFrame};
+
+/// An inference answer the mock transport recorded.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RecordedInference {
+    /// The correlation id answered.
+    pub call_id: String,
+    /// The completion returned.
+    pub response: InferenceResponse,
+}
+
+/// Everything the mock transport recorded, for test assertions.
+#[derive(Default)]
+struct Recorded {
+    posted_events: Vec<EventsRequest>,
+    registered_tools: Vec<Vec<ToolManifestEntry>>,
+    acks: Vec<EffectResult>,
+    tool_answers: Vec<ToolResultFrame>,
+    inference_answers: Vec<RecordedInference>,
+}
+
+/// An in-memory [`SidecarTransport`] that scripts cycle frames and records calls.
+#[derive(Default)]
+pub struct MockSidecarTransport {
+    /// Scripted frames keyed by cycle id.
+    plans: Mutex<HashMap<String, Vec<SidecarFrame>>>,
+    /// An error to return from every `post_events`.
+    post_events_error: Mutex<Option<OrchErrorCode>>,
+    /// Recorded calls.
+    recorded: Mutex<Recorded>,
+}
+
+impl MockSidecarTransport {
+    /// Creates an empty mock with no scripted cycles.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Scripts the frames [`Self::cycle_frames`] yields for `cycle_id`.
+    ///
+    /// A trailing [`SidecarFrame::CycleComplete`] is appended automatically so
+    /// the brain's drain loop always terminates.
+    pub fn script_cycle(&self, cycle_id: impl Into<String>, mut frames: Vec<SidecarFrame>) {
+        if !matches!(frames.last(), Some(SidecarFrame::CycleComplete)) {
+            frames.push(SidecarFrame::CycleComplete);
+        }
+        self.plans.lock().unwrap().insert(cycle_id.into(), frames);
+    }
+
+    /// Makes every subsequent `post_events` fail with `code`.
+    pub fn fail_post_events(&self, code: OrchErrorCode) {
+        *self.post_events_error.lock().unwrap() = Some(code);
+    }
+
+    /// The `EventsRequest`s the brain posted, in order.
+    pub fn posted_events(&self) -> Vec<EventsRequest> {
+        self.recorded.lock().unwrap().posted_events.clone()
+    }
+
+    /// The tool manifests the brain registered, in order.
+    pub fn registered_tools(&self) -> Vec<Vec<ToolManifestEntry>> {
+        self.recorded.lock().unwrap().registered_tools.clone()
+    }
+
+    /// The effect acks the brain emitted, in order.
+    pub fn acks(&self) -> Vec<EffectResult> {
+        self.recorded.lock().unwrap().acks.clone()
+    }
+
+    /// The tool answers the brain emitted, in order.
+    pub fn tool_answers(&self) -> Vec<ToolResultFrame> {
+        self.recorded.lock().unwrap().tool_answers.clone()
+    }
+
+    /// The inference answers the brain emitted, in order.
+    pub fn inference_answers(&self) -> Vec<RecordedInference> {
+        self.recorded.lock().unwrap().inference_answers.clone()
+    }
+}
+
+#[async_trait]
+impl SidecarTransport for MockSidecarTransport {
+    async fn post_events(&self, req: EventsRequest) -> Result<EventsAccepted> {
+        if let Some(code) = self.post_events_error.lock().unwrap().clone() {
+            return Err(code.to_error("mock post_events failure"));
+        }
+        let cycle_id = wire::cycle_id(&req.counterpart_agent_id, &req.session_id, req.event.seq);
+        self.recorded.lock().unwrap().posted_events.push(req);
+        Ok(EventsAccepted {
+            accepted: true,
+            cycle_id,
+        })
+    }
+
+    async fn register_tools(&self, tools: Vec<ToolManifestEntry>) -> Result<()> {
+        self.recorded.lock().unwrap().registered_tools.push(tools);
+        Ok(())
+    }
+
+    fn cycle_frames(&self, cycle_id: &str) -> BoxStream<'static, Result<SidecarFrame>> {
+        let frames = self
+            .plans
+            .lock()
+            .unwrap()
+            .get(cycle_id)
+            .cloned()
+            .unwrap_or_else(|| vec![SidecarFrame::CycleComplete]);
+        stream::iter(frames.into_iter().map(Ok)).boxed()
+    }
+
+    async fn ack_effect(&self, ack: EffectResult) -> Result<()> {
+        self.recorded.lock().unwrap().acks.push(ack);
+        Ok(())
+    }
+
+    async fn answer_tool_call(&self, ans: ToolResultFrame) -> Result<()> {
+        self.recorded.lock().unwrap().tool_answers.push(ans);
+        Ok(())
+    }
+
+    async fn answer_inference(&self, call_id: &str, resp: InferenceResponse) -> Result<()> {
+        self.recorded
+            .lock()
+            .unwrap()
+            .inference_answers
+            .push(RecordedInference {
+                call_id: call_id.to_string(),
+                response: resp,
+            });
+        Ok(())
+    }
+}
+
+/// An offline [`InferenceClient`] that returns a canned completion and records
+/// every request it received.
+pub struct MockInferenceClient {
+    text: String,
+    token_usage: TokenUsage,
+    requests: Mutex<Vec<InferenceRequest>>,
+}
+
+impl Default for MockInferenceClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MockInferenceClient {
+    /// Builds a client that always answers with an empty completion.
+    pub fn new() -> Self {
+        Self {
+            text: String::new(),
+            token_usage: TokenUsage::default(),
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Sets the canned completion text.
+    pub fn with_text(mut self, text: impl Into<String>) -> Self {
+        self.text = text.into();
+        self
+    }
+
+    /// Sets the token usage each completion reports.
+    pub fn with_tokens(mut self, input: u64, output: u64) -> Self {
+        self.token_usage = TokenUsage { input, output };
+        self
+    }
+
+    /// The inference requests this client received, in order.
+    pub fn requests(&self) -> Vec<InferenceRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl InferenceClient for MockInferenceClient {
+    async fn infer(&self, req: InferenceRequest) -> Result<InferenceResponse> {
+        self.requests.lock().unwrap().push(req);
+        Ok(InferenceResponse {
+            text: self.text.clone(),
+            token_usage: self.token_usage,
+        })
+    }
+}

--- a/src/brain/sidecar/mod.rs
+++ b/src/brain/sidecar/mod.rs
@@ -1,29 +1,26 @@
-//! [`HostedMedullaBrain`]: the [`Brain`] that drives hosted Medulla cognition
-//! over a [`MedullaTransport`].
+//! [`SidecarBrain`]: a [`Brain`] that drives a local sidecar process.
 //!
-//! One company is one Medulla session: the `sessionId` is the [`CompanyId`] and
-//! the `counterpartAgentId` is `opencompany:<slug>`. Each [`CycleRequest`] event
-//! is posted as its own `POST /events` keyed on the durable
-//! [`EventLog`](crate::ports::EventLog) sequence, and the returned cycle's frames
-//! are drained:
+//! The sidecar brain speaks the *same* `/orchestration/v1` wire frames as
+//! [`HostedMedullaBrain`](crate::brain::HostedMedullaBrain) — it reuses
+//! [`wire`](crate::brain::medulla::wire) verbatim and the shared wire→kernel
+//! mapping in [`effects`](crate::brain::medulla::effects) — but talks to a local
+//! sidecar process over stdio/HTTP instead of the hosted orchestrator. Its one
+//! distinctive addition is the **inference inversion**: the sidecar runs the
+//! cognitive loop but has no model access, so it calls *back* into the Rust host
+//! through an [`InferenceClient`] to run each model pass (offline in tests; under
+//! the `tiny` feature, into the TinyAgents harness).
 //!
-//! - Every **effect** frame passes through [`CycleHost::emit_effect`] — the
-//!   approval gate — *before* it is acked. An executed effect acks `ok:true`; a
-//!   parked or denied effect acks `ok:false` with the reason, so Medulla hears
-//!   the gate's verdict rather than a silent success.
-//! - Every **tool_call** frame is serviced through [`CycleHost::call_tool`]
-//!   (or [`CycleHost::context_op`] for the context device-tools) and answered.
-//! - Frames are deduped on `callId`, matching the at-least-once delivery
-//!   contract, so a replay is handled exactly once.
+//! Cycle drain shape, deduplication on `callId`, the effect→gate→ack flow, and
+//! the tool/context routing are identical to the hosted brain, so a supervised
+//! `Sign`/`Spend` effect parks an approval through the real kernel gate exactly
+//! as it does under hosted cognition.
 //!
-//! Cycle summaries are journaled as [`CompressedTrace`]s, spend effects become
-//! ledger deltas, and notable effects trigger a `POST /world-diff`. The brain
-//! never fabricates a channel response: the ones it returns are the `send_dm`
-//! effects Medulla executed.
-//!
-//! The transport is abstracted, so the brain and its whole test surface live in
-//! the default build against [`MockTransport`](super::medulla::MockTransport);
-//! the networked `HttpSocketTransport` lands behind the `medulla` feature.
+//! The whole module is gated behind the `sidecar` feature; the default build
+//! links none of it and the builder routes `sidecar` mode to the echo brain.
+
+mod mock;
+mod transport;
+mod types;
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -34,59 +31,72 @@ use futures::StreamExt;
 
 use crate::Result;
 use crate::ports::brain::{Brain, CycleHost};
-use crate::ports::now_millis;
 use crate::ports::types::{
-    CompanyId, CompressedTrace, CycleRequest, CycleResult, EffectDisposition, SecretValue,
-    TokenUsage, ToolCall,
+    CompanyId, CompressedTrace, CycleRequest, CycleResult, EffectDisposition, LedgerEntry,
+    OutboundMessage, TokenUsage, ToolCall,
 };
 
-use super::medulla::effects::{
+use crate::brain::medulla::effects::{
     EffectOutcome, channel_message_from_effect, context_op_from_call, context_result_to_value,
-    effect_from_frame, is_notable, ledger_delta_from_effect, wire_event,
+    effect_from_frame, ledger_delta_from_effect, wire_event,
 };
-use super::medulla::transport::{InboundFrame, MedullaTransport};
-use super::medulla::wire::{
+use crate::brain::medulla::wire::{
     EffectFrame, EffectResult, EventsRequest, ToolCallFrame, ToolManifestEntry, ToolResultFrame,
-    WorldDiffEntry, WorldDiffRequest,
 };
 
-/// The hosted Medulla brain: one company's cognition over a transport.
-pub struct HostedMedullaBrain {
-    transport: Arc<dyn MedullaTransport>,
+pub use mock::{MockInferenceClient, MockSidecarTransport, RecordedInference};
+pub use transport::{
+    InferenceClient, SidecarTransport, StdioSidecarTransport, TinyAgentsInferenceClient,
+};
+pub use types::{InferenceMessage, InferenceRequest, InferenceResponse, SidecarFrame};
+
+/// The default cap on inference passes the brain will run within one cycle.
+pub const DEFAULT_MAX_PASSES: usize = 12;
+
+/// The local-sidecar brain: one company's cognition over a sidecar process, with
+/// inference routed back into the host.
+pub struct SidecarBrain {
+    transport: Arc<dyn SidecarTransport>,
+    inference: Arc<dyn InferenceClient>,
     session_id: String,
     counterpart: String,
-    /// The hosted-brain bearer credential. Held for parity with the transport
-    /// and redacted in [`std::fmt::Debug`]; never logged or serialized.
-    credential: SecretValue,
     tool_catalog: Vec<ToolManifestEntry>,
+    max_passes: usize,
     registered: AtomicBool,
 }
 
-impl HostedMedullaBrain {
-    /// Builds a hosted brain for `company` addressed as `opencompany:<slug>`.
+impl SidecarBrain {
+    /// Builds a sidecar brain for `company` addressed as `opencompany:<slug>`.
     ///
-    /// `slug` is the company's manifest-derived slug (typically the same string
-    /// as the [`CompanyId`]); `credential` is the TinyHumans bearer token and is
-    /// never logged. `tool_catalog` is the device-tool manifest registered with
-    /// Medulla on the first cycle.
+    /// `inference` is the host-fulfilled callback the sidecar reaches back
+    /// through; `tool_catalog` is the device-tool manifest registered on the
+    /// first cycle. The pass cap defaults to [`DEFAULT_MAX_PASSES`]; override it
+    /// with [`with_max_passes`](Self::with_max_passes).
     pub fn new(
-        transport: Arc<dyn MedullaTransport>,
+        transport: Arc<dyn SidecarTransport>,
+        inference: Arc<dyn InferenceClient>,
         company: &CompanyId,
         slug: &str,
-        credential: SecretValue,
         tool_catalog: Vec<ToolManifestEntry>,
     ) -> Self {
         Self {
             transport,
+            inference,
             session_id: company.as_ref().to_string(),
             counterpart: format!("opencompany:{slug}"),
-            credential,
             tool_catalog,
+            max_passes: DEFAULT_MAX_PASSES,
             registered: AtomicBool::new(false),
         }
     }
 
-    /// The Medulla session id (the company id).
+    /// Overrides the inference-pass cap enforced per cycle.
+    pub fn with_max_passes(mut self, max_passes: usize) -> Self {
+        self.max_passes = max_passes.max(1);
+        self
+    }
+
+    /// The sidecar session id (the company id).
     pub fn session_id(&self) -> &str {
         &self.session_id
     }
@@ -97,9 +107,6 @@ impl HostedMedullaBrain {
     }
 
     /// Registers the device-tool manifest exactly once (on the first cycle).
-    ///
-    /// A no-op when the catalog is empty. The `registered` flag is flipped with
-    /// `compare_exchange` so concurrent first cycles register at most once.
     async fn ensure_registered(&self) -> Result<()> {
         if self.tool_catalog.is_empty() {
             return Ok(());
@@ -116,12 +123,8 @@ impl HostedMedullaBrain {
         Ok(())
     }
 
-    /// Services one `orch:tool_call` frame and builds its answer.
-    ///
-    /// Context device-tools (`context_*`) route to [`CycleHost::context_op`];
-    /// everything else routes to [`CycleHost::call_tool`], which enforces the
-    /// manifest grant. A host error (e.g. an ungranted tool) becomes an
-    /// `ok:false` answer rather than aborting the cycle.
+    /// Services one tool-call frame, routing `context_*` tools to the context
+    /// store and everything else to the manifest-enforcing tool provider.
     async fn service_tool_call(
         &self,
         host: &dyn CycleHost,
@@ -164,16 +167,15 @@ impl HostedMedullaBrain {
         })
     }
 
-    /// Passes an effect frame through the gate, acks it, and returns the channel
-    /// response and ledger delta it produced (if any).
+    /// Passes an effect frame through the gate, acks it, and returns what it
+    /// contributed. The gate runs *before* the ack, so a parked effect acks
+    /// `ok:false` and the sidecar learns it must wait.
     async fn service_effect(
         &self,
         host: &dyn CycleHost,
         frame: &EffectFrame,
     ) -> Result<EffectOutcome> {
         let effect = effect_from_frame(frame);
-        // The gate runs BEFORE the ack, so a parked effect acks `ok:false` and
-        // Medulla learns it must wait rather than seeing a false success.
         let disposition = host.emit_effect(effect.clone()).await?;
 
         let mut outcome = EffectOutcome::default();
@@ -181,7 +183,6 @@ impl HostedMedullaBrain {
             EffectDisposition::Executed => {
                 outcome.channel_response = channel_message_from_effect(&effect);
                 outcome.ledger_delta = ledger_delta_from_effect(&effect);
-                outcome.notable = is_notable(&effect);
                 EffectResult {
                     call_id: frame.call_id.clone(),
                     ok: true,
@@ -208,18 +209,16 @@ impl HostedMedullaBrain {
 }
 
 #[async_trait]
-impl Brain for HostedMedullaBrain {
+impl Brain for SidecarBrain {
     async fn run_cycle(&self, req: CycleRequest, host: &dyn CycleHost) -> Result<CycleResult> {
         self.ensure_registered().await?;
 
-        let mut channel_responses = Vec::new();
+        let mut channel_responses: Vec<OutboundMessage> = Vec::new();
         let mut new_traces = Vec::new();
-        let mut ledger_deltas = Vec::new();
-        let mut world_notes: Vec<WorldDiffEntry> = Vec::new();
+        let mut ledger_deltas: Vec<LedgerEntry> = Vec::new();
+        let mut token_usage = TokenUsage::default();
 
         for (index, event) in req.events.iter().enumerate() {
-            // Prefer the durable EventLog seq; fall back to the position when a
-            // caller did not thread seqs (idempotency then holds within a cycle).
             let seq = req
                 .event_seqs
                 .get(index)
@@ -236,11 +235,12 @@ impl Brain for HostedMedullaBrain {
 
             // Drain the cycle's frames, deduping on callId (at-least-once).
             let mut seen: HashSet<String> = HashSet::new();
+            let mut passes = 0usize;
             let mut frames = self.transport.cycle_frames(&cycle_id);
             while let Some(frame) = frames.next().await {
                 match frame? {
-                    InboundFrame::CycleComplete => break,
-                    InboundFrame::Effect(effect_frame) => {
+                    SidecarFrame::CycleComplete => break,
+                    SidecarFrame::Effect(effect_frame) => {
                         if !seen.insert(effect_frame.call_id.clone()) {
                             continue;
                         }
@@ -251,61 +251,55 @@ impl Brain for HostedMedullaBrain {
                         if let Some(delta) = outcome.ledger_delta {
                             ledger_deltas.push(delta);
                         }
-                        if outcome.notable {
-                            world_notes.push(WorldDiffEntry {
-                                seq,
-                                note: format!("executed {}", effect_frame.kind),
-                                ts: now_millis() as i64,
-                            });
-                        }
                     }
-                    InboundFrame::ToolCall(call) => {
+                    SidecarFrame::ToolCall(call) => {
                         if !seen.insert(call.call_id.clone()) {
                             continue;
                         }
                         let answer = self.service_tool_call(host, &call).await?;
                         self.transport.answer_tool_call(answer).await?;
                     }
+                    SidecarFrame::Inference { call_id, request } => {
+                        if !seen.insert(call_id.clone()) {
+                            continue;
+                        }
+                        // Honor the pass cap: stop draining once the sidecar has
+                        // asked for more inference passes than the budget allows.
+                        if passes >= self.max_passes {
+                            break;
+                        }
+                        passes += 1;
+                        // The inference inversion: the host runs the model pass.
+                        let response = self.inference.infer(request).await?;
+                        token_usage.input += response.token_usage.input;
+                        token_usage.output += response.token_usage.output;
+                        self.transport.answer_inference(&call_id, response).await?;
+                    }
                 }
             }
 
             new_traces.push(CompressedTrace::now(
                 &cycle_id,
-                format!("medulla cycle for `{}` (seq {seq})", self.session_id),
+                format!("sidecar cycle for `{}` (seq {seq})", self.session_id),
             ));
-        }
-
-        // Upload a world-diff after notable effects (payments, filings, etc.).
-        if !world_notes.is_empty() {
-            self.transport
-                .post_world_diff(WorldDiffRequest {
-                    session_id: self.session_id.clone(),
-                    entries: world_notes,
-                })
-                .await?;
         }
 
         Ok(CycleResult {
             channel_responses,
             new_traces,
             ledger_deltas,
-            token_usage: TokenUsage::default(),
+            token_usage,
         })
     }
 }
 
-/// A hand-written `Debug` that redacts the credential so it can never reach a
-/// log line or panic message.
-impl std::fmt::Debug for HostedMedullaBrain {
+impl std::fmt::Debug for SidecarBrain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Borrow the credential so it counts as held/used, but never render its
-        // bytes — only the redaction marker reaches the formatter.
-        let _held = &self.credential;
-        f.debug_struct("HostedMedullaBrain")
+        f.debug_struct("SidecarBrain")
             .field("session_id", &self.session_id)
             .field("counterpart", &self.counterpart)
-            .field("credential", &"<redacted>")
             .field("tools", &self.tool_catalog.len())
+            .field("max_passes", &self.max_passes)
             .field("registered", &self.registered.load(Ordering::Acquire))
             .finish()
     }

--- a/src/brain/sidecar/test.rs
+++ b/src/brain/sidecar/test.rs
@@ -1,7 +1,7 @@
-//! Offline tests for [`HostedMedullaBrain`] over the in-memory
-//! [`MockTransport`], plus end-to-end tests that drive a real
+//! Offline tests for [`SidecarBrain`] over the mock sidecar transport and mock
+//! inference client, plus an end-to-end test that drives a real
 //! [`CompanyRuntime`](crate::company::runtime::CompanyRuntime) with the brain
-//! wired in through the builder.
+//! injected through the builder. No test touches the network or a Node process.
 
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -9,11 +9,10 @@ use std::sync::Mutex;
 use serde_json::{Value, json};
 
 use super::*;
-use crate::brain::medulla::MockTransport;
-use crate::brain::medulla::wire::{self, EffectFrame, OrchErrorCode, Role, ToolCallFrame};
+use crate::brain::medulla::wire::{self, EffectFrame, OrchErrorCode, ToolCallFrame};
 use crate::ports::types::{
     ApprovalId, ChunkAddr, ChunkHit, CompanyEvent, ContextOp, ContextOpResult, Effect,
-    EffectDisposition, ToolResult, Verdict,
+    EffectDisposition, ToolResult,
 };
 
 // ---------------------------------------------------------------------------
@@ -77,12 +76,15 @@ impl CycleHost for RecordingHost {
 // Fixtures
 // ---------------------------------------------------------------------------
 
-fn brain(transport: Arc<MockTransport>) -> HostedMedullaBrain {
-    HostedMedullaBrain::new(
+fn brain(
+    transport: Arc<MockSidecarTransport>,
+    inference: Arc<MockInferenceClient>,
+) -> SidecarBrain {
+    SidecarBrain::new(
         transport,
+        inference,
         &CompanyId::new("acme"),
         "acme",
-        SecretValue("th_super_secret".into()),
         vec![ToolManifestEntry {
             name: "noop".into(),
             description: None,
@@ -91,7 +93,6 @@ fn brain(transport: Arc<MockTransport>) -> HostedMedullaBrain {
     )
 }
 
-/// The deterministic cycle id for a first operator event on company `acme`.
 fn cid() -> String {
     wire::cycle_id("opencompany:acme", "acme", 0)
 }
@@ -108,8 +109,8 @@ fn operator_request() -> CycleRequest {
     }
 }
 
-fn effect_frame(kind: &str, index: usize, payload: Value) -> InboundFrame {
-    InboundFrame::Effect(EffectFrame {
+fn effect_frame(kind: &str, index: usize, payload: Value) -> SidecarFrame {
+    SidecarFrame::Effect(EffectFrame {
         kind: kind.into(),
         cycle_id: cid(),
         call_id: wire::call_id(&cid(), kind, index),
@@ -117,8 +118,8 @@ fn effect_frame(kind: &str, index: usize, payload: Value) -> InboundFrame {
     })
 }
 
-fn tool_call_frame(name: &str, index: usize, args: Value) -> InboundFrame {
-    InboundFrame::ToolCall(ToolCallFrame {
+fn tool_call_frame(name: &str, index: usize, args: Value) -> SidecarFrame {
+    SidecarFrame::ToolCall(ToolCallFrame {
         cycle_id: cid(),
         call_id: wire::call_id(&cid(), "tool", index),
         name: name.into(),
@@ -127,68 +128,90 @@ fn tool_call_frame(name: &str, index: usize, args: Value) -> InboundFrame {
     })
 }
 
+fn inference_frame(index: usize, prompt: &str) -> SidecarFrame {
+    SidecarFrame::Inference {
+        call_id: wire::call_id(&cid(), "infer", index),
+        request: InferenceRequest {
+            messages: vec![InferenceMessage {
+                role: "user".into(),
+                content: prompt.into(),
+            }],
+            session_id: "acme".into(),
+        },
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Unit tests
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn posts_one_normalized_event_without_a_model_field() {
-    let transport = Arc::new(MockTransport::new());
-    let brain = brain(transport.clone());
+async fn posts_event_and_registers_tools_once() {
+    let transport = Arc::new(MockSidecarTransport::new());
+    let inference = Arc::new(MockInferenceClient::new());
+    let brain = brain(transport.clone(), inference);
     let host = RecordingHost::executing();
 
     brain.run_cycle(operator_request(), &host).await.unwrap();
+    brain.run_cycle(operator_request(), &host).await.unwrap();
 
     let posted = transport.posted_events();
-    assert_eq!(posted.len(), 1);
-    let event = &posted[0].event;
-    assert_eq!(event.seq, 0);
-    assert_eq!(event.role, Role::User);
-    assert_eq!(event.sender, "operator");
-    assert_eq!(event.body, "hi");
-    assert_eq!(event.kind, "operator.message");
+    assert_eq!(posted.len(), 2);
     assert_eq!(posted[0].counterpart_agent_id, "opencompany:acme");
     assert_eq!(posted[0].session_id, "acme");
-
-    // The serialized wire body must never carry a `model` field.
-    let body = serde_json::to_value(wire::Envelope::v1(posted[0].clone())).unwrap();
-    assert!(wire::assert_no_model(&body).is_ok());
-
+    assert_eq!(posted[0].event.kind, "operator.message");
     // The device-tool manifest was registered exactly once.
     assert_eq!(transport.registered_tools().len(), 1);
 }
 
 #[tokio::test]
-async fn register_tools_fires_only_on_the_first_cycle() {
-    let transport = Arc::new(MockTransport::new());
-    let brain = brain(transport.clone());
+async fn inference_frame_invokes_host_callback_and_answers() {
+    let transport = Arc::new(MockSidecarTransport::new());
+    transport.script_cycle(cid(), vec![inference_frame(0, "what next?")]);
+    let inference = Arc::new(
+        MockInferenceClient::new()
+            .with_text("do the thing")
+            .with_tokens(11, 7),
+    );
+    let brain = brain(transport.clone(), inference.clone());
     let host = RecordingHost::executing();
 
-    brain.run_cycle(operator_request(), &host).await.unwrap();
-    brain.run_cycle(operator_request(), &host).await.unwrap();
+    let result = brain.run_cycle(operator_request(), &host).await.unwrap();
 
-    assert_eq!(transport.registered_tools().len(), 1);
+    // The host-bound inference callback fired with the sidecar's prompt.
+    let requests = inference.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].messages[0].content, "what next?");
+
+    // The completion was answered back to the sidecar, keyed on its call id.
+    let answers = transport.inference_answers();
+    assert_eq!(answers.len(), 1);
+    assert_eq!(answers[0].response.text, "do the thing");
+
+    // Token usage accumulated into the cycle result.
+    assert_eq!(result.token_usage.input, 11);
+    assert_eq!(result.token_usage.output, 7);
 }
 
 #[tokio::test]
 async fn executed_send_dm_becomes_a_channel_response_and_acks_ok() {
-    let transport = Arc::new(MockTransport::new());
+    let transport = Arc::new(MockSidecarTransport::new());
     transport.script_cycle(
         cid(),
         vec![effect_frame(
             "send_dm",
             0,
-            json!({ "to": "operator", "body": "hello from medulla" }),
+            json!({ "to": "operator", "body": "hello from the sidecar" }),
         )],
     );
-    let brain = brain(transport.clone());
+    let brain = brain(transport.clone(), Arc::new(MockInferenceClient::new()));
     let host = RecordingHost::executing();
 
     let result = brain.run_cycle(operator_request(), &host).await.unwrap();
 
     assert_eq!(result.channel_responses.len(), 1);
     assert_eq!(result.channel_responses[0].channel, "operator");
-    assert_eq!(result.channel_responses[0].text, "hello from medulla");
+    assert_eq!(result.channel_responses[0].text, "hello from the sidecar");
 
     let acks = transport.acks();
     assert_eq!(acks.len(), 1);
@@ -198,81 +221,10 @@ async fn executed_send_dm_becomes_a_channel_response_and_acks_ok() {
 }
 
 #[tokio::test]
-async fn duplicate_effect_frame_is_handled_once() {
-    let transport = Arc::new(MockTransport::new());
-    // Two frames sharing a callId: the replay must be ignored.
-    let payload = json!({ "to": "operator", "body": "dup" });
-    transport.script_cycle(
-        cid(),
-        vec![
-            effect_frame("send_dm", 0, payload.clone()),
-            effect_frame("send_dm", 0, payload),
-        ],
-    );
-    let brain = brain(transport.clone());
-    let host = RecordingHost::executing();
-
-    let result = brain.run_cycle(operator_request(), &host).await.unwrap();
-
-    assert_eq!(host.effects.lock().unwrap().len(), 1);
-    assert_eq!(transport.acks().len(), 1);
-    assert_eq!(result.channel_responses.len(), 1);
-}
-
-#[tokio::test]
-async fn tool_call_frame_routes_to_call_tool_and_answers() {
-    let transport = Arc::new(MockTransport::new());
-    transport.script_cycle(cid(), vec![tool_call_frame("noop", 0, json!({ "q": 1 }))]);
-    let brain = brain(transport.clone());
-    let host = RecordingHost::executing();
-
-    brain.run_cycle(operator_request(), &host).await.unwrap();
-
-    let calls = host.tool_calls.lock().unwrap();
-    assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].tool, "noop");
-
-    let answers = transport.tool_answers();
-    assert_eq!(answers.len(), 1);
-    assert!(answers[0].ok);
-    assert!(answers[0].result.is_some());
-}
-
-#[tokio::test]
-async fn context_device_tool_routes_to_context_op() {
-    let transport = Arc::new(MockTransport::new());
-    transport.script_cycle(
-        cid(),
-        vec![tool_call_frame(
-            "context_search",
-            0,
-            json!({ "query": "roadmap", "limit": 3 }),
-        )],
-    );
-    let brain = brain(transport.clone());
-    let host = RecordingHost::executing();
-
-    brain.run_cycle(operator_request(), &host).await.unwrap();
-
-    let ops = host.context_ops.lock().unwrap();
-    assert_eq!(ops.len(), 1);
-    match &ops[0] {
-        ContextOp::Search { query, limit } => {
-            assert_eq!(query, "roadmap");
-            assert_eq!(*limit, 3);
-        }
-        other => panic!("expected a context search, got {other:?}"),
-    }
-    // The tool_call was not forwarded to the tool provider.
-    assert!(host.tool_calls.lock().unwrap().is_empty());
-    assert_eq!(transport.tool_answers().len(), 1);
-}
-
-#[tokio::test]
 async fn parked_effect_acks_not_ok_with_pending_approval() {
-    let transport = Arc::new(MockTransport::new());
+    let transport = Arc::new(MockSidecarTransport::new());
     transport.script_cycle(cid(), vec![effect_frame("filing.submit", 0, Value::Null)]);
-    let brain = brain(transport.clone());
+    let brain = brain(transport.clone(), Arc::new(MockInferenceClient::new()));
     let host = RecordingHost::parking();
 
     let result = brain.run_cycle(operator_request(), &host).await.unwrap();
@@ -287,72 +239,135 @@ async fn parked_effect_acks_not_ok_with_pending_approval() {
             .unwrap()
             .contains("pending approval")
     );
-    // A parked effect yields no channel response and no world-diff.
     assert!(result.channel_responses.is_empty());
-    assert!(transport.posted_world_diffs().is_empty());
+}
+
+#[tokio::test]
+async fn tool_call_frame_routes_to_call_tool_and_answers() {
+    let transport = Arc::new(MockSidecarTransport::new());
+    transport.script_cycle(cid(), vec![tool_call_frame("noop", 0, json!({ "q": 1 }))]);
+    let brain = brain(transport.clone(), Arc::new(MockInferenceClient::new()));
+    let host = RecordingHost::executing();
+
+    brain.run_cycle(operator_request(), &host).await.unwrap();
+
+    let calls = host.tool_calls.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].tool, "noop");
+
+    let answers = transport.tool_answers();
+    assert_eq!(answers.len(), 1);
+    assert!(answers[0].ok);
+}
+
+#[tokio::test]
+async fn context_device_tool_routes_to_context_op() {
+    let transport = Arc::new(MockSidecarTransport::new());
+    transport.script_cycle(
+        cid(),
+        vec![tool_call_frame(
+            "context_search",
+            0,
+            json!({ "query": "roadmap", "limit": 3 }),
+        )],
+    );
+    let brain = brain(transport.clone(), Arc::new(MockInferenceClient::new()));
+    let host = RecordingHost::executing();
+
+    brain.run_cycle(operator_request(), &host).await.unwrap();
+
+    let ops = host.context_ops.lock().unwrap();
+    assert_eq!(ops.len(), 1);
+    match &ops[0] {
+        ContextOp::Search { query, limit } => {
+            assert_eq!(query, "roadmap");
+            assert_eq!(*limit, 3);
+        }
+        other => panic!("expected a context search, got {other:?}"),
+    }
+    assert!(host.tool_calls.lock().unwrap().is_empty());
+    assert_eq!(transport.tool_answers().len(), 1);
+}
+
+#[tokio::test]
+async fn duplicate_frame_is_handled_once() {
+    let transport = Arc::new(MockSidecarTransport::new());
+    let payload = json!({ "to": "operator", "body": "dup" });
+    transport.script_cycle(
+        cid(),
+        vec![
+            effect_frame("send_dm", 0, payload.clone()),
+            effect_frame("send_dm", 0, payload),
+        ],
+    );
+    let brain = brain(transport.clone(), Arc::new(MockInferenceClient::new()));
+    let host = RecordingHost::executing();
+
+    let result = brain.run_cycle(operator_request(), &host).await.unwrap();
+
+    assert_eq!(host.effects.lock().unwrap().len(), 1);
+    assert_eq!(transport.acks().len(), 1);
+    assert_eq!(result.channel_responses.len(), 1);
+}
+
+#[tokio::test]
+async fn max_passes_caps_inference_frames() {
+    let transport = Arc::new(MockSidecarTransport::new());
+    transport.script_cycle(
+        cid(),
+        vec![
+            inference_frame(0, "one"),
+            inference_frame(1, "two"),
+            inference_frame(2, "three"),
+        ],
+    );
+    let inference = Arc::new(MockInferenceClient::new());
+    let brain = brain(transport.clone(), inference.clone()).with_max_passes(2);
+    let host = RecordingHost::executing();
+
+    brain.run_cycle(operator_request(), &host).await.unwrap();
+
+    // Only two inference passes ran before the cap stopped the drain.
+    assert_eq!(inference.requests().len(), 2);
+    assert_eq!(transport.inference_answers().len(), 2);
 }
 
 #[tokio::test]
 async fn orchestration_error_on_post_events_propagates_with_code() {
-    let transport = Arc::new(MockTransport::new());
-    transport.fail_post_events(OrchErrorCode::InsufficientBalance);
-    let brain = brain(transport.clone());
+    let transport = Arc::new(MockSidecarTransport::new());
+    transport.fail_post_events(OrchErrorCode::DeviceOffline);
+    let brain = brain(transport.clone(), Arc::new(MockInferenceClient::new()));
     let host = RecordingHost::executing();
 
     let err = brain
         .run_cycle(operator_request(), &host)
         .await
         .unwrap_err();
-    assert_eq!(err.code(), "ORCH_INSUFFICIENT_BALANCE");
-}
-
-#[tokio::test]
-async fn spend_effect_records_ledger_delta_and_posts_world_diff() {
-    let transport = Arc::new(MockTransport::new());
-    transport.script_cycle(
-        cid(),
-        vec![effect_frame(
-            "x402.spend",
-            0,
-            json!({ "amountUsd": 4.25, "memo": "api call" }),
-        )],
-    );
-    let brain = brain(transport.clone());
-    let host = RecordingHost::executing();
-
-    let result = brain.run_cycle(operator_request(), &host).await.unwrap();
-
-    assert_eq!(result.ledger_deltas.len(), 1);
-    assert_eq!(result.ledger_deltas[0].amount_usd, 4.25);
-    assert_eq!(result.ledger_deltas[0].kind, "x402.spend");
-    // Spend is notable, so a world-diff was uploaded.
-    let diffs = transport.posted_world_diffs();
-    assert_eq!(diffs.len(), 1);
-    assert_eq!(diffs[0].entries.len(), 1);
-    assert_eq!(diffs[0].session_id, "acme");
+    assert_eq!(err.code(), "ORCH_DEVICE_OFFLINE");
 }
 
 #[test]
-fn debug_redacts_the_credential() {
-    let transport = Arc::new(MockTransport::new());
-    let brain = brain(transport);
+fn debug_does_not_expose_internals_beyond_labels() {
+    let brain = brain(
+        Arc::new(MockSidecarTransport::new()),
+        Arc::new(MockInferenceClient::new()),
+    );
     let rendered = format!("{brain:?}");
-    assert!(!rendered.contains("th_super_secret"));
-    assert!(rendered.contains("redacted"));
+    assert!(rendered.contains("SidecarBrain"));
+    assert!(rendered.contains("acme"));
 }
 
 // ---------------------------------------------------------------------------
-// End-to-end tests through a real CompanyRuntime
+// End-to-end test through a real CompanyRuntime
 // ---------------------------------------------------------------------------
 
-use crate::app::config::BrainMode;
 use crate::company::CompanyManifest;
-use crate::ports::types::{Actor, ActorKind};
+use crate::ports::types::{Actor, ActorKind, Verdict};
 use crate::runtime::RuntimeBuilder;
 
 fn tmp_home() -> std::path::PathBuf {
     std::env::temp_dir().join(format!(
-        "opencompany-hosted-{}",
+        "opencompany-sidecar-{}",
         crate::ports::generate_id()
     ))
 }
@@ -364,7 +379,7 @@ fn manifest(policy_mode: &str) -> CompanyManifest {
         name = "Acme"
 
         [brain]
-        mode = "hosted"
+        mode = "sidecar"
 
         [tools]
         allow = ["noop"]
@@ -376,28 +391,46 @@ fn manifest(policy_mode: &str) -> CompanyManifest {
     toml::from_str(&toml_src).expect("valid manifest")
 }
 
-/// The deterministic first-cycle id a real runtime for `Acme` produces: the
-/// company id slugs to `acme`, the first event lands at seq 0.
 fn runtime_cid() -> String {
     wire::cycle_id("opencompany:acme", "acme", 0)
 }
 
+fn sidecar_brain_for(
+    transport: Arc<MockSidecarTransport>,
+    inference: Arc<MockInferenceClient>,
+) -> Arc<dyn Brain> {
+    Arc::new(SidecarBrain::new(
+        transport,
+        inference,
+        &CompanyId::new("acme"),
+        "acme",
+        vec![ToolManifestEntry {
+            name: "noop".into(),
+            description: None,
+            input_schema: None,
+        }],
+    ))
+}
+
 #[tokio::test]
-async fn e2e_operator_message_drives_tool_call_and_gated_send_dm() {
+async fn e2e_inference_then_gated_send_dm_drives_a_channel_response() {
     let home = tmp_home();
-    let transport = Arc::new(MockTransport::new());
+    let transport = Arc::new(MockSidecarTransport::new());
     transport.script_cycle(
         runtime_cid(),
         vec![
-            tool_call_frame("noop", 0, json!({ "q": "status" })),
+            inference_frame(0, "how are we doing?"),
             effect_frame("send_dm", 0, json!({ "to": "operator", "body": "on it" })),
         ],
     );
+    let inference = Arc::new(
+        MockInferenceClient::new()
+            .with_text("plan ready")
+            .with_tokens(5, 3),
+    );
 
     let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
-        .with_brain_mode(BrainMode::Hosted)
-        .with_credential(SecretValue("th_live".into()))
-        .with_transport(transport.clone())
+        .with_brain(sidecar_brain_for(transport.clone(), inference.clone()))
         .build()
         .await
         .unwrap();
@@ -409,7 +442,11 @@ async fn e2e_operator_message_drives_tool_call_and_gated_send_dm() {
         .await
         .unwrap();
 
-    // The gated send_dm produced a channel response routed to the operator.
+    // The inference callback fired through the real runtime.
+    assert_eq!(inference.requests().len(), 1);
+    assert_eq!(transport.inference_answers().len(), 1);
+
+    // The gated send_dm produced an operator channel response.
     assert_eq!(report.responses.len(), 1);
     assert_eq!(report.responses[0].channel, "operator");
     assert_eq!(report.responses[0].text, "on it");
@@ -419,12 +456,6 @@ async fn e2e_operator_message_drives_tool_call_and_gated_send_dm() {
     assert_eq!(acks.len(), 1);
     assert!(acks[0].ok);
 
-    // The device tool was serviced and answered.
-    assert_eq!(transport.tool_answers().len(), 1);
-
-    // Exactly one event was posted for the operator message.
-    assert_eq!(transport.posted_events().len(), 1);
-
     // A compressed trace was persisted to the fs-backed MemoryStore.
     let traces = rt.memory.recent_traces(rt.id(), 10).await.unwrap();
     assert!(!traces.is_empty());
@@ -433,19 +464,17 @@ async fn e2e_operator_message_drives_tool_call_and_gated_send_dm() {
 }
 
 #[tokio::test]
-async fn e2e_supervised_effect_parks_and_acks_not_ok() {
+async fn e2e_supervised_effect_parks_through_the_real_gate() {
     let home = tmp_home();
-    let transport = Arc::new(MockTransport::new());
+    let transport = Arc::new(MockSidecarTransport::new());
     transport.script_cycle(
         runtime_cid(),
-        // A Sign-group effect always parks under supervised policy.
         vec![effect_frame("filing.submit", 0, Value::Null)],
     );
+    let inference = Arc::new(MockInferenceClient::new());
 
     let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
-        .with_brain_mode(BrainMode::Hosted)
-        .with_credential(SecretValue("th_live".into()))
-        .with_transport(transport.clone())
+        .with_brain(sidecar_brain_for(transport.clone(), inference))
         .build()
         .await
         .unwrap();
@@ -457,24 +486,18 @@ async fn e2e_supervised_effect_parks_and_acks_not_ok() {
         .await
         .unwrap();
 
-    // The effect parked: an approval is queued and no channel response emitted.
+    // The Sign-group effect parked under supervised policy: an approval is
+    // queued and no channel response emitted.
     assert_eq!(report.parked.len(), 1);
     assert_eq!(rt.pending_approvals().len(), 1);
     assert!(report.responses.is_empty());
 
-    // Medulla was told the effect is pending, not that it succeeded.
+    // The sidecar was told the effect is pending, not that it succeeded.
     let acks = transport.acks();
     assert_eq!(acks.len(), 1);
     assert!(!acks[0].ok);
-    assert!(
-        acks[0]
-            .error
-            .as_deref()
-            .unwrap()
-            .contains("pending approval")
-    );
 
-    // Resolving the approval executes the parked effect and drains the queue.
+    // Resolving the approval drains the queue.
     let approval_id = report.parked[0].clone();
     rt.resolve_approval(
         &approval_id,

--- a/src/brain/sidecar/transport.rs
+++ b/src/brain/sidecar/transport.rs
@@ -1,0 +1,170 @@
+//! The sidecar transport and inference seams.
+//!
+//! [`SidecarTransport`] models the local sidecar process the same way
+//! [`MedullaTransport`](crate::brain::medulla::transport::MedullaTransport)
+//! models the hosted orchestrator: the brain posts events, drains a frame
+//! stream, and answers effects/tool-calls. The distinctive addition is
+//! [`InferenceClient`], the callback the *host* fulfils so the sidecar can run a
+//! model pass without owning credentials — the "inference inversion".
+//!
+//! Both traits ship with offline mocks (see [`mock`](super::mock)); the real
+//! stdio transport and the TinyAgents-backed inference client are documented
+//! stubs that compile but return [`Unimplemented`](crate::OpenCompanyError::Unimplemented)
+//! until the Node sidecar package and the `tiny` harness are wired.
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+
+use crate::Result;
+
+use crate::brain::medulla::wire::{
+    EffectResult, EventsAccepted, EventsRequest, ToolManifestEntry, ToolResultFrame,
+};
+
+use super::types::{InferenceRequest, InferenceResponse, SidecarFrame};
+
+/// The callback the host fulfils to run one inference pass for the sidecar.
+///
+/// The sidecar has no model access; when it needs a completion it emits a
+/// [`SidecarFrame::Inference`](super::types::SidecarFrame::Inference) and the
+/// brain routes it here. A mock returns a canned completion offline; under the
+/// `tiny` feature the production client routes to the TinyAgents harness.
+#[async_trait]
+pub trait InferenceClient: Send + Sync {
+    /// Runs one inference pass and returns its completion.
+    async fn infer(&self, req: InferenceRequest) -> Result<InferenceResponse>;
+}
+
+/// The transport the sidecar brain speaks to the local sidecar process.
+///
+/// Mirrors [`MedullaTransport`](crate::brain::medulla::transport::MedullaTransport)
+/// for events, effects, and tool calls, and adds
+/// [`answer_inference`](Self::answer_inference) for the host-bound callback.
+#[async_trait]
+pub trait SidecarTransport: Send + Sync {
+    /// Ingests one event and returns the wake acknowledgement.
+    async fn post_events(&self, req: EventsRequest) -> Result<EventsAccepted>;
+
+    /// Registers the device tool manifest with the sidecar.
+    async fn register_tools(&self, tools: Vec<ToolManifestEntry>) -> Result<()>;
+
+    /// The out-of-band frame stream for `cycle_id`.
+    ///
+    /// Yields effects, tool calls, and inference requests as they arrive,
+    /// terminated by [`SidecarFrame::CycleComplete`].
+    fn cycle_frames(&self, cycle_id: &str) -> BoxStream<'static, Result<SidecarFrame>>;
+
+    /// Acks an effect after the gate has ruled on it.
+    async fn ack_effect(&self, ack: EffectResult) -> Result<()>;
+
+    /// Answers a device tool call.
+    async fn answer_tool_call(&self, ans: ToolResultFrame) -> Result<()>;
+
+    /// Answers a host-bound inference request, unblocking the cycle.
+    async fn answer_inference(&self, call_id: &str, resp: InferenceResponse) -> Result<()>;
+}
+
+// ---------------------------------------------------------------------------
+// Real (stubbed) implementations
+// ---------------------------------------------------------------------------
+
+/// The stdio/local-HTTP transport to a running Node sidecar process.
+///
+/// The Rust-side protocol, brain loop, and inference inversion are complete and
+/// tested against [`MockSidecarTransport`](super::mock::MockSidecarTransport).
+/// The process launch itself waits on the `@tinyhumansai/medulla-v1` Node
+/// package: every method returns
+/// [`Unimplemented`](crate::OpenCompanyError::Unimplemented) until that package
+/// lands, so the feature graph is real without shipping a half-working launcher.
+#[derive(Debug, Default)]
+pub struct StdioSidecarTransport {
+    _private: (),
+}
+
+impl StdioSidecarTransport {
+    /// Builds a stdio transport. Inert until the Node sidecar package exists.
+    pub fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+#[async_trait]
+impl SidecarTransport for StdioSidecarTransport {
+    async fn post_events(&self, _req: EventsRequest) -> Result<EventsAccepted> {
+        Err(crate::OpenCompanyError::Unimplemented(
+            "stdio sidecar transport",
+        ))
+    }
+
+    async fn register_tools(&self, _tools: Vec<ToolManifestEntry>) -> Result<()> {
+        Err(crate::OpenCompanyError::Unimplemented(
+            "stdio sidecar transport",
+        ))
+    }
+
+    fn cycle_frames(&self, _cycle_id: &str) -> BoxStream<'static, Result<SidecarFrame>> {
+        Box::pin(futures::stream::once(async {
+            Err(crate::OpenCompanyError::Unimplemented(
+                "stdio sidecar transport",
+            ))
+        }))
+    }
+
+    async fn ack_effect(&self, _ack: EffectResult) -> Result<()> {
+        Err(crate::OpenCompanyError::Unimplemented(
+            "stdio sidecar transport",
+        ))
+    }
+
+    async fn answer_tool_call(&self, _ans: ToolResultFrame) -> Result<()> {
+        Err(crate::OpenCompanyError::Unimplemented(
+            "stdio sidecar transport",
+        ))
+    }
+
+    async fn answer_inference(&self, _call_id: &str, _resp: InferenceResponse) -> Result<()> {
+        Err(crate::OpenCompanyError::Unimplemented(
+            "stdio sidecar transport",
+        ))
+    }
+}
+
+/// The production inference client that routes back into the TinyAgents harness.
+///
+/// Under the `tiny` feature this reaches the vendored harness; without it the
+/// client returns a clear "enable the `tiny` feature" error rather than
+/// panicking, so a `sidecar`-only build still links and fails loudly.
+#[derive(Debug, Default)]
+pub struct TinyAgentsInferenceClient {
+    _private: (),
+}
+
+impl TinyAgentsInferenceClient {
+    /// Builds the harness-backed inference client.
+    pub fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+#[cfg(feature = "tiny")]
+#[async_trait]
+impl InferenceClient for TinyAgentsInferenceClient {
+    async fn infer(&self, _req: InferenceRequest) -> Result<InferenceResponse> {
+        // The real routing into the vendored TinyAgents harness lands with the
+        // harness integration; the seam is in place so nothing else changes.
+        Err(crate::OpenCompanyError::Unimplemented(
+            "tinyagents inference client",
+        ))
+    }
+}
+
+#[cfg(not(feature = "tiny"))]
+#[async_trait]
+impl InferenceClient for TinyAgentsInferenceClient {
+    async fn infer(&self, _req: InferenceRequest) -> Result<InferenceResponse> {
+        Err(crate::OpenCompanyError::Config(
+            "sidecar inference requires the `tiny` feature to route to the TinyAgents harness"
+                .to_string(),
+        ))
+    }
+}

--- a/src/brain/sidecar/types.rs
+++ b/src/brain/sidecar/types.rs
@@ -1,0 +1,67 @@
+//! The sidecar protocol types.
+//!
+//! The sidecar brain reuses the hosted Medulla wire frames verbatim (see
+//! [`wire`](crate::brain::medulla::wire)) for effects and tool calls, and adds
+//! one direction the hosted contract does not have: **host-bound inference**.
+//! The sidecar runs the cognitive loop locally but has no model access of its
+//! own, so it calls *back* into the Rust host to run inference. These types
+//! describe that inversion.
+
+use serde::{Deserialize, Serialize};
+
+use crate::ports::types::TokenUsage;
+
+use crate::brain::medulla::wire::{EffectFrame, ToolCallFrame};
+
+/// One message in an inference request, in the provider-neutral `role`/`content`
+/// shape the host's harness expects.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InferenceMessage {
+    /// The message author role (`system`/`user`/`assistant`).
+    pub role: String,
+    /// The message text.
+    pub content: String,
+}
+
+/// A request the sidecar sends back to the host to run one inference pass.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InferenceRequest {
+    /// The conversation the host should complete.
+    pub messages: Vec<InferenceMessage>,
+    /// The sidecar session the request belongs to (the company id).
+    pub session_id: String,
+}
+
+/// The host's answer to an [`InferenceRequest`].
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InferenceResponse {
+    /// The completion text.
+    pub text: String,
+    /// The tokens the pass consumed, folded into the cycle's usage total.
+    pub token_usage: TokenUsage,
+}
+
+/// A frame the sidecar pushes to the host during an in-flight cycle.
+///
+/// Mirrors [`InboundFrame`](crate::brain::medulla::transport::InboundFrame) but
+/// adds the [`SidecarFrame::Inference`] direction: the sidecar asks the host to
+/// run a model pass and continues once the host answers.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SidecarFrame {
+    /// An effect to gate then ack (`orch:effect:<kind>`).
+    Effect(EffectFrame),
+    /// A device tool to invoke then answer (`orch:tool_call`).
+    ToolCall(ToolCallFrame),
+    /// A host-bound inference request the host must answer to unblock the cycle.
+    Inference {
+        /// The correlation id the answer is keyed on.
+        call_id: String,
+        /// The conversation to complete.
+        request: InferenceRequest,
+    },
+    /// The cycle has finished; stop consuming the stream.
+    CycleComplete,
+}

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -435,6 +435,50 @@ mod tests {
     }
 
     #[test]
+    fn signals_opportunity_studio_template_passes_lint() {
+        // The Signals + Opportunity Engine ship as a venture-studio template,
+        // not kernel code. This guards that the shipped manifest keeps passing
+        // the same lint `opencompany check` runs — unique agent ids, priced +
+        // described `[place].skills`, a `[policy]`, and a stated `human_role`.
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("examples/signals_opportunity_studio/agents.toml");
+        let manifest = CompanyManifest::from_file(&path).expect("template manifest is valid");
+
+        assert!(manifest.validate().is_empty(), "{:?}", manifest.validate());
+        assert!(
+            manifest.company.human_role.is_some(),
+            "the template must name what the human keeps"
+        );
+        // Unique agent ids.
+        let mut ids: Vec<&str> = manifest.agents.iter().map(|a| a.id.as_str()).collect();
+        ids.sort_unstable();
+        let unique = ids.len();
+        ids.dedup();
+        assert_eq!(ids.len(), unique, "agent ids must be unique");
+        // Every advertised skill is priced and described.
+        assert!(!manifest.place.skills.is_empty());
+        for skill in &manifest.place.skills {
+            assert!(
+                parse_usd(&skill.price_usd).is_some(),
+                "skill must be priced"
+            );
+            assert!(
+                skill
+                    .description
+                    .as_deref()
+                    .is_some_and(|d| !d.trim().is_empty()),
+                "skill `{}` must be described",
+                skill.id
+            );
+        }
+        // A supervised policy with a defined always-approve fence.
+        assert_eq!(manifest.policy.mode, "supervised");
+        assert!(!manifest.policy.always_approve.is_empty());
+        // The weekly opportunity loop is a schedule.
+        assert!(!manifest.schedules.is_empty());
+    }
+
+    #[test]
     fn discover_prefers_company_toml() {
         let dir = std::env::temp_dir().join(format!("oc-discover-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -210,6 +210,10 @@ impl CompanyRuntime {
             &self.id,
             manifest.as_ref(),
             &item,
+            // The `POST .../feedback` route is operator-driven; default to an
+            // annoyance-severity operator filing.
+            crate::feedback::Severity::Annoyance,
+            crate::feedback::FeedbackSource::Operator,
             preview,
         )
         .await

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -16,10 +16,15 @@ use tokio::sync::Mutex as TokioMutex;
 
 use crate::Result;
 use crate::error::OpenCompanyError;
+use crate::feedback::service::{FeedbackFiler, FeedbackResponse};
+use crate::feedback::store::FeedbackStore;
+use crate::feedback::types::{FeedbackInput, FeedbackItem};
+use crate::policy::ManifestApprovalGate;
+use crate::ports::now_millis;
 use crate::ports::types::{Actor, ApprovalId, CompanyEvent, CompanyId, Verdict};
 use crate::ports::{
     AgentEconomy, ApprovalGate, Brain, ChannelAdapter, CompanyStore, ContextStore, EventLog,
-    MemoryStore, ToolProvider,
+    MemoryStore, SecretStore, ToolProvider,
 };
 use crate::runtime::CycleRunner;
 use crate::runtime::journal::RuntimeJournal;
@@ -38,7 +43,18 @@ pub struct CompanyRuntime {
     pub(crate) channels: Vec<Arc<dyn ChannelAdapter>>,
     pub(crate) economy: Option<Arc<dyn AgentEconomy>>,
     pub(crate) approvals: Arc<dyn ApprovalGate>,
+    /// The concrete gate, kept alongside the `dyn` port so the runtime can reach
+    /// the amend and expiry-sweep methods that live outside the trait without a
+    /// downcast.
+    pub(crate) approval_gate: Arc<ManifestApprovalGate>,
     pub(crate) journal: Arc<RuntimeJournal>,
+    /// Per-company secrets, read by the feedback scrubber (and webhook HMAC
+    /// verification, later).
+    pub(crate) secrets: Arc<dyn SecretStore>,
+    /// Durable store of feedback items (the "feedback family").
+    pub(crate) feedback: Arc<FeedbackStore>,
+    /// Filing configuration: the GitHub client, target repo, consent, limiter.
+    pub(crate) filer: Arc<FeedbackFiler>,
     /// Held for the duration of a cycle so cycles never interleave per company.
     pub(crate) serial: TokioMutex<()>,
 }
@@ -57,9 +73,13 @@ impl CompanyRuntime {
         tools: Arc<dyn ToolProvider>,
         channels: Vec<Arc<dyn ChannelAdapter>>,
         economy: Option<Arc<dyn AgentEconomy>>,
-        approvals: Arc<dyn ApprovalGate>,
+        approval_gate: Arc<ManifestApprovalGate>,
         journal: Arc<RuntimeJournal>,
+        secrets: Arc<dyn SecretStore>,
+        feedback: Arc<FeedbackStore>,
+        filer: Arc<FeedbackFiler>,
     ) -> Self {
+        let approvals: Arc<dyn ApprovalGate> = approval_gate.clone();
         Self {
             id,
             brain,
@@ -71,7 +91,11 @@ impl CompanyRuntime {
             channels,
             economy,
             approvals,
+            approval_gate,
             journal,
+            secrets,
+            feedback,
+            filer,
             serial: TokioMutex::new(()),
         }
     }
@@ -104,6 +128,34 @@ impl CompanyRuntime {
             .await
     }
 
+    /// Resolves a parked approval to an operator-amended effect
+    /// (approve-with-edit): the operator's `amended_payload` is overlaid onto
+    /// the parked effect, which is then executed. Runs a follow-up cycle so the
+    /// brain learns the resolution; the immutable journal records both the
+    /// original (parked) and amended effects.
+    pub async fn resolve_approval_amended(
+        &self,
+        id: &ApprovalId,
+        amended_payload: serde_json::Value,
+        by: Actor,
+    ) -> Result<CycleReport> {
+        CycleRunner::new(self)
+            .resolve_approval_amended(id, amended_payload, by)
+            .await
+    }
+
+    /// Sweeps every parked approval past its TTL, resolving each to a
+    /// default-deny and writing an `ApprovalExpired` audit entry to the journal.
+    /// Returns the ids that expired. Driven by the runtime's maintenance timer.
+    pub async fn sweep_expired_approvals(&self) -> Result<Vec<ApprovalId>> {
+        let now = now_millis();
+        let expired = self.approval_gate.sweep_expired(now);
+        for id in &expired {
+            self.journal.record_expired(id, now).await?;
+        }
+        Ok(expired)
+    }
+
     /// Replays the journal to rebuild the executed-key set and approval queue.
     pub async fn recover(&self) -> Result<()> {
         self.journal.load().await
@@ -121,6 +173,46 @@ impl CompanyRuntime {
                 at_millis: p.at_millis,
             })
             .collect()
+    }
+
+    /// Captures a feedback item: persists it to the feedback family and logs a
+    /// `FeedbackFiled` event. Nothing is filed — capture is always safe and
+    /// local. Used by the built-in `feedback` tool and operator-chat intent.
+    pub async fn capture_feedback(&self, input: FeedbackInput) -> Result<FeedbackItem> {
+        let item = FeedbackItem::capture(input, crate::VERSION, self.filer.consent);
+        self.feedback.append(&item).await?;
+        self.events
+            .append(
+                &self.id,
+                CompanyEvent::FeedbackFiled {
+                    note: item.operator_words.clone(),
+                },
+            )
+            .await?;
+        Ok(item)
+    }
+
+    /// Captures feedback, then runs the scrub-then-preview gate and either
+    /// previews the exact final issue body or files it (per consent). The
+    /// scrubber fails closed, so a report that cannot be safely scrubbed is
+    /// blocked rather than risked.
+    pub async fn submit_feedback(
+        &self,
+        input: FeedbackInput,
+        preview: bool,
+    ) -> Result<FeedbackResponse> {
+        let item = self.capture_feedback(input).await?;
+        let manifest = self.store.load(&self.id).await?.map(|r| r.manifest);
+        crate::feedback::service::finalize(
+            &self.feedback,
+            self.secrets.as_ref(),
+            &self.filer,
+            &self.id,
+            manifest.as_ref(),
+            &item,
+            preview,
+        )
+        .await
     }
 
     /// A status snapshot, loading the company record for name and lifecycle.

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -230,6 +230,35 @@ impl CompanyRuntime {
         })
     }
 
+    /// Transitions the company's lifecycle to `to`, persisting the new state and
+    /// appending a [`CompanyEvent::LifecycleChanged`] audit event stamped with
+    /// the acting `by` actor. Returns the previous lifecycle string.
+    ///
+    /// Powers the platform pause/resume/suspend/archive controls. A company with
+    /// no durable record yet is a [`OpenCompanyError::CompanyNotFound`].
+    pub async fn set_lifecycle(&self, to: impl Into<String>, by: Actor) -> Result<String> {
+        let to = to.into();
+        let mut record = self
+            .store
+            .load(&self.id)
+            .await?
+            .ok_or_else(|| OpenCompanyError::CompanyNotFound(self.id.to_string()))?;
+        let from = record.lifecycle.clone();
+        record.lifecycle = to.clone();
+        self.store.save(&record).await?;
+        self.events
+            .append(
+                &self.id,
+                CompanyEvent::LifecycleChanged {
+                    from: from.clone(),
+                    to,
+                    by,
+                },
+            )
+            .await?;
+        Ok(from)
+    }
+
     /// Rejects operation on a company that is not accepting work.
     ///
     /// Returns [`OpenCompanyError::LifecycleConflict`] when the loaded record's

--- a/src/economy/adapter.rs
+++ b/src/economy/adapter.rs
@@ -1,0 +1,673 @@
+//! [`TinyplaceEconomy`]: the [`AgentEconomy`] adapter over a [`TinyplaceClient`].
+//!
+//! This is the commerce brain of the tiny.place seam. It:
+//!
+//! - claims a `@handle` only after the operator opts in (the `going_public`
+//!   flag standing in for the Identity approval checkpoint) and funding covers
+//!   the registry fee — catching the `402` challenge, budget-checking, then
+//!   completing the paid registration;
+//! - publishes the Agent Card, queuing it to the [`Outbox`] (never erroring)
+//!   when tiny.place is unreachable;
+//! - sends outbound A2A tasks, paying an x402 challenge under budget and
+//!   journaling the spend, or queuing the task when offline;
+//! - quotes and pays firm requirements, **failing closed** the instant a
+//!   payment would exceed either the caller's [`BudgetScope`] or the company's
+//!   monthly ceiling, and journaling every in/out movement to the ledger.
+//!
+//! Every spend path is budget-fail-closed and ledger-journaled, so budget and
+//! audit are self-contained and unit-testable offline against
+//! [`MockTinyplaceClient`](super::client::MockTinyplaceClient).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::Result;
+use crate::economy::client::{JsonRpcRequest, PaidOutcome, TinyplaceClient, now_secs};
+use crate::economy::outbox::{Outbox, OutboxAction};
+use crate::economy::signer::LocalSigner;
+use crate::economy::x402::{self, X402Challenge};
+use crate::error::OpenCompanyError;
+use crate::ports::AgentEconomy;
+use crate::ports::store::CompanyStore;
+use crate::ports::types::{
+    A2aTask, A2aTaskHandle, AgentAddr, AgentCard, BudgetScope, CompanyId, CompanyIdentity,
+    LedgerEntry, PaymentReceipt, PaymentRequirement, Quote, RegistrationState,
+};
+use crate::ports::{generate_id, now_millis};
+
+/// The settlement asset used when a firm quote is paid.
+const PAY_ASSET: &str = "USDC";
+/// The settlement network used when a firm quote is paid.
+const PAY_NETWORK: &str = "solana";
+
+/// The [`AgentEconomy`] over a [`TinyplaceClient`].
+pub struct TinyplaceEconomy {
+    client: Arc<dyn TinyplaceClient>,
+    signer: Arc<LocalSigner>,
+    store: Arc<dyn CompanyStore>,
+    company: CompanyId,
+    monthly_cap: Option<f64>,
+    going_public: bool,
+    outbox: Arc<Outbox>,
+}
+
+impl TinyplaceEconomy {
+    /// Builds an economy for `company`. `going_public` starts `false`: the
+    /// adapter never spends the master key on registration until the operator
+    /// opts in via [`Self::going_public`].
+    pub fn new(
+        client: Arc<dyn TinyplaceClient>,
+        signer: Arc<LocalSigner>,
+        store: Arc<dyn CompanyStore>,
+        company: CompanyId,
+        monthly_cap: Option<f64>,
+    ) -> Self {
+        Self {
+            client,
+            signer,
+            store,
+            company,
+            monthly_cap,
+            going_public: false,
+            outbox: Arc::new(Outbox::new()),
+        }
+    }
+
+    /// Sets the going-public flag. `true` encodes the Identity approval
+    /// checkpoint plus funding: only then will [`Self::ensure_registered`]
+    /// claim (and pay for) the `@handle`.
+    pub fn going_public(mut self, approved: bool) -> Self {
+        self.going_public = approved;
+        self
+    }
+
+    /// The outbox holding actions deferred while tiny.place was unreachable.
+    pub fn outbox(&self) -> &Arc<Outbox> {
+        &self.outbox
+    }
+
+    /// Journals a negative (outflow) ledger movement.
+    async fn ledger_out(&self, kind: &str, amount: f64, memo: String) -> Result<()> {
+        self.store
+            .append_ledger(
+                &self.company,
+                LedgerEntry {
+                    at_millis: now_millis(),
+                    kind: kind.to_string(),
+                    amount_usd: -amount,
+                    memo,
+                },
+            )
+            .await
+    }
+
+    /// The remaining monthly budget: the cap minus the sum of ledger outflows.
+    /// Fails open to `+∞` when no cap is set or no record exists yet.
+    async fn remaining_budget(&self) -> Result<f64> {
+        let Some(cap) = self.monthly_cap else {
+            return Ok(f64::INFINITY);
+        };
+        let spent: f64 = match self.store.load(&self.company).await? {
+            Some(record) => record
+                .ledger
+                .iter()
+                .filter(|entry| entry.amount_usd < 0.0)
+                .map(|entry| -entry.amount_usd)
+                .sum(),
+            None => 0.0,
+        };
+        Ok(cap - spent)
+    }
+
+    /// Parses a decimal challenge amount, rejecting a malformed string.
+    fn parse_amount(raw: &str) -> Result<f64> {
+        raw.trim().parse::<f64>().map_err(|_| {
+            OpenCompanyError::tinyplace(
+                "bad_amount",
+                format!("challenge amount `{raw}` is not a number"),
+            )
+        })
+    }
+
+    /// Enforces both the monthly ceiling for `amount`, returning
+    /// [`OpenCompanyError::BudgetExceeded`] when it would be crossed.
+    async fn enforce_monthly(&self, amount: f64, what: &str) -> Result<()> {
+        let remaining = self.remaining_budget().await?;
+        if amount > remaining {
+            return Err(OpenCompanyError::BudgetExceeded(format!(
+                "{what} needs ${amount:.2} but only ${remaining:.2} remains this month"
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for TinyplaceEconomy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TinyplaceEconomy")
+            .field("company", &self.company)
+            .field("agent_id", &self.signer.agent_id())
+            .field("monthly_cap", &self.monthly_cap)
+            .field("going_public", &self.going_public)
+            .field("outbox_len", &self.outbox.len())
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl AgentEconomy for TinyplaceEconomy {
+    async fn ensure_registered(&self, identity: &CompanyIdentity) -> Result<RegistrationState> {
+        // If the handle already resolves to us, we are done.
+        if let Ok(addr) = self.client.resolve(&identity.handle).await
+            && addr.0 == self.signer.agent_id()
+        {
+            return Ok(RegistrationState::Registered { addr });
+        }
+
+        // A private company never spends its master key at boot.
+        if !self.going_public {
+            return Ok(RegistrationState::Unregistered);
+        }
+
+        match self.client.register_name(&identity.handle).await? {
+            PaidOutcome::Done(receipt) => Ok(RegistrationState::Registered { addr: receipt.addr }),
+            PaidOutcome::PaymentRequired(challenge) => {
+                let fee = Self::parse_amount(&challenge.amount)?;
+                self.enforce_monthly(fee, "registering a handle").await?;
+                let auth = x402::authorize(&self.signer, &challenge, now_secs());
+                let receipt = self
+                    .client
+                    .register_name_paid(&identity.handle, &auth)
+                    .await?;
+                self.ledger_out(
+                    "registry.fee",
+                    fee,
+                    format!(
+                        "claimed @{} (signer {})",
+                        identity.handle,
+                        self.signer.agent_id()
+                    ),
+                )
+                .await?;
+                Ok(RegistrationState::Registered { addr: receipt.addr })
+            }
+        }
+    }
+
+    async fn publish_card(&self, _identity: &CompanyIdentity, card: &AgentCard) -> Result<()> {
+        match self.client.put_agent(&self.signer.agent_id(), card).await {
+            Ok(()) => Ok(()),
+            Err(OpenCompanyError::Tinyplace { code, .. }) if code == "unreachable" => {
+                // Offline: queue the card so it goes stale rather than erroring.
+                self.outbox.enqueue(OutboxAction::PublishCard(card.clone()));
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn send_a2a_task(&self, to: &AgentAddr, task: A2aTask) -> Result<A2aTaskHandle> {
+        let params = serde_json::json!({
+            "id": generate_id(),
+            "skill": task.skill,
+            "input": task.input,
+        });
+        let rpc = JsonRpcRequest::new("tasks/send", params);
+
+        match self.client.send_task(&to.0, rpc.clone()).await {
+            Ok(PaidOutcome::Done(response)) => Ok(handle_from_response(&response, &rpc.id)),
+            Ok(PaidOutcome::PaymentRequired(challenge)) => {
+                let amount = Self::parse_amount(&challenge.amount)?;
+                self.enforce_monthly(amount, "hiring").await?;
+                let auth = x402::authorize(&self.signer, &challenge, now_secs());
+                let response = self
+                    .client
+                    .send_task_paid(&to.0, rpc.clone(), &auth)
+                    .await?;
+                self.ledger_out(
+                    "x402.out",
+                    amount,
+                    format!(
+                        "a2a tasks/send to {} for `{}` (signer {})",
+                        to.0,
+                        task.skill,
+                        self.signer.agent_id()
+                    ),
+                )
+                .await?;
+                Ok(handle_from_response(&response, &rpc.id))
+            }
+            Err(OpenCompanyError::Tinyplace { code, message }) if code == "unreachable" => {
+                // Offline: queue the task and surface the error so the caller
+                // decides whether to retry.
+                self.outbox.enqueue(OutboxAction::SendTask {
+                    to: to.clone(),
+                    task,
+                });
+                Err(OpenCompanyError::tinyplace("unreachable", message))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn quote(&self, requirement: &PaymentRequirement) -> Result<Quote> {
+        // A firm quote equal to the requirement; no wire round-trip needed.
+        Ok(Quote {
+            quote_id: generate_id(),
+            to: requirement.to.clone(),
+            amount_usd: requirement.amount_usd,
+        })
+    }
+
+    async fn pay(&self, quote: &Quote, budget: &BudgetScope) -> Result<PaymentReceipt> {
+        // Fail closed against the caller's scope first — before any wire call.
+        if quote.amount_usd > budget.remaining_usd {
+            return Err(OpenCompanyError::BudgetExceeded(format!(
+                "paying ${:.2} exceeds the {} scope's ${:.2}",
+                quote.amount_usd, budget.label, budget.remaining_usd
+            )));
+        }
+        // Then clamp against the monthly ceiling.
+        self.enforce_monthly(quote.amount_usd, "paying").await?;
+
+        let challenge = X402Challenge {
+            amount: format!("{:.2}", quote.amount_usd),
+            recipient: quote.to.0.clone(),
+            asset: PAY_ASSET.to_string(),
+            network: PAY_NETWORK.to_string(),
+        };
+        let auth = x402::authorize(&self.signer, &challenge, now_secs());
+
+        let verified = self.client.payments_verify(&auth).await?;
+        if !verified.ok {
+            return Err(OpenCompanyError::tinyplace(
+                "verify_failed",
+                verified
+                    .reason
+                    .unwrap_or_else(|| "payment authorization did not verify".to_string()),
+            ));
+        }
+        self.client.payments_settle(&auth).await?;
+
+        self.ledger_out(
+            "x402.out",
+            quote.amount_usd,
+            format!("paid quote {} to {}", quote.quote_id, quote.to.0),
+        )
+        .await?;
+
+        Ok(PaymentReceipt {
+            quote_id: quote.quote_id.clone(),
+            amount_usd: quote.amount_usd,
+            at_millis: now_millis(),
+        })
+    }
+}
+
+/// Extracts an [`A2aTaskHandle`] from a response, falling back to the request id.
+fn handle_from_response(
+    response: &crate::economy::client::JsonRpcResponse,
+    fallback_id: &str,
+) -> A2aTaskHandle {
+    let id = response
+        .result
+        .as_ref()
+        .and_then(|r| r.get("id").or_else(|| r.get("taskId")))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| fallback_id.to_string());
+    A2aTaskHandle(id)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::economy::client::{JsonRpcResponse, MockTinyplaceClient, RegistryReceipt};
+    use crate::ports::types::CompanyRecord;
+    use crate::store::FsCompanyStore;
+
+    fn signer() -> Arc<LocalSigner> {
+        Arc::new(LocalSigner::generate())
+    }
+
+    /// A store rooted at a fresh tempdir, seeded with an empty-ledger record so
+    /// `remaining_budget` can read it back.
+    async fn seeded_store(company: &CompanyId) -> (tempfile::TempDir, Arc<dyn CompanyStore>) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = FsCompanyStore::new(dir.path().to_path_buf());
+        let manifest =
+            toml::from_str("[company]\nname = \"Acme\"\nhandle = \"acme\"\n").expect("manifest");
+        store
+            .save(&CompanyRecord {
+                id: company.clone(),
+                manifest,
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+            })
+            .await
+            .expect("save");
+        (dir, Arc::new(store))
+    }
+
+    fn challenge(amount: &str) -> X402Challenge {
+        X402Challenge {
+            amount: amount.to_string(),
+            recipient: "Recipient".into(),
+            asset: "USDC".into(),
+            network: "solana".into(),
+        }
+    }
+
+    fn identity(company: &CompanyId) -> CompanyIdentity {
+        CompanyIdentity {
+            company: company.clone(),
+            handle: "acme".to_string(),
+        }
+    }
+
+    async fn ledger_of(store: &Arc<dyn CompanyStore>, company: &CompanyId) -> Vec<LedgerEntry> {
+        store.load(company).await.unwrap().unwrap().ledger
+    }
+
+    #[tokio::test]
+    async fn registration_402_then_budget_check_then_complete() {
+        let company = CompanyId::new("acme");
+        let (_dir, store) = seeded_store(&company).await;
+        let sk = signer();
+        let mock = Arc::new(
+            MockTinyplaceClient::new()
+                .with_register_name(PaidOutcome::PaymentRequired(challenge("25.00")))
+                .with_register_paid(RegistryReceipt {
+                    id: "reg-1".into(),
+                    addr: AgentAddr("acme.addr".into()),
+                    fee_usd: 25.0,
+                }),
+        );
+        let economy = TinyplaceEconomy::new(
+            mock.clone(),
+            sk,
+            store.clone(),
+            company.clone(),
+            Some(200.0),
+        )
+        .going_public(true);
+
+        let state = economy
+            .ensure_registered(&identity(&company))
+            .await
+            .unwrap();
+        assert_eq!(
+            state,
+            RegistrationState::Registered {
+                addr: AgentAddr("acme.addr".into())
+            }
+        );
+
+        let ledger = ledger_of(&store, &company).await;
+        assert_eq!(ledger.len(), 1, "one registry.fee row");
+        assert_eq!(ledger[0].kind, "registry.fee");
+        assert_eq!(ledger[0].amount_usd, -25.0);
+        assert_eq!(mock.count("register_name_paid"), 1);
+    }
+
+    #[tokio::test]
+    async fn registration_over_budget_rejected() {
+        let company = CompanyId::new("acme");
+        let (_dir, store) = seeded_store(&company).await;
+        let mock = Arc::new(
+            MockTinyplaceClient::new()
+                .with_register_name(PaidOutcome::PaymentRequired(challenge("25.00"))),
+        );
+        let economy = TinyplaceEconomy::new(
+            mock.clone(),
+            signer(),
+            store.clone(),
+            company.clone(),
+            Some(10.0),
+        )
+        .going_public(true);
+
+        let err = economy
+            .ensure_registered(&identity(&company))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), "budget_exceeded");
+        assert!(
+            ledger_of(&store, &company).await.is_empty(),
+            "ledger untouched"
+        );
+        assert_eq!(
+            mock.count("register_name_paid"),
+            0,
+            "never completed the paid call"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_registered_private_returns_unregistered() {
+        let company = CompanyId::new("acme");
+        let (_dir, store) = seeded_store(&company).await;
+        // resolve returns not_found; going_public is left false.
+        let mock = Arc::new(MockTinyplaceClient::new());
+        let economy =
+            TinyplaceEconomy::new(mock.clone(), signer(), store, company.clone(), Some(200.0));
+
+        let state = economy
+            .ensure_registered(&identity(&company))
+            .await
+            .unwrap();
+        assert_eq!(state, RegistrationState::Unregistered);
+        assert_eq!(
+            mock.count("register_name"),
+            0,
+            "private company never claims"
+        );
+    }
+
+    #[tokio::test]
+    async fn pay_fails_closed_when_over_scope() {
+        let company = CompanyId::new("acme");
+        let (_dir, store) = seeded_store(&company).await;
+        let mock = Arc::new(MockTinyplaceClient::new());
+        let economy = TinyplaceEconomy::new(mock.clone(), signer(), store, company, None);
+
+        let quote = Quote {
+            quote_id: "q1".into(),
+            to: AgentAddr("Vendor".into()),
+            amount_usd: 30.0,
+        };
+        let budget = BudgetScope {
+            remaining_usd: 20.0,
+            label: "vendor-scope".into(),
+        };
+        let err = economy.pay(&quote, &budget).await.unwrap_err();
+        assert_eq!(err.code(), "budget_exceeded");
+        assert_eq!(mock.settle_calls(), 0, "no settle before the budget check");
+        assert_eq!(mock.verify_calls(), 0, "no verify before the budget check");
+    }
+
+    #[tokio::test]
+    async fn pay_success_journals_receipt() {
+        let company = CompanyId::new("acme");
+        let (_dir, store) = seeded_store(&company).await;
+        let mock = Arc::new(MockTinyplaceClient::new().with_verify(true, None));
+        let economy = TinyplaceEconomy::new(
+            mock.clone(),
+            signer(),
+            store.clone(),
+            company.clone(),
+            Some(100.0),
+        );
+
+        let quote = Quote {
+            quote_id: "q1".into(),
+            to: AgentAddr("Vendor".into()),
+            amount_usd: 15.0,
+        };
+        let budget = BudgetScope {
+            remaining_usd: 50.0,
+            label: "vendor-scope".into(),
+        };
+        let receipt = economy.pay(&quote, &budget).await.unwrap();
+        assert_eq!(receipt.quote_id, "q1");
+        assert_eq!(receipt.amount_usd, 15.0);
+        assert_eq!(mock.settle_calls(), 1);
+
+        let ledger = ledger_of(&store, &company).await;
+        assert_eq!(ledger.len(), 1);
+        assert_eq!(ledger[0].kind, "x402.out");
+        assert_eq!(ledger[0].amount_usd, -15.0);
+    }
+
+    #[tokio::test]
+    async fn pay_rejects_when_verification_fails() {
+        let company = CompanyId::new("acme");
+        let (_dir, store) = seeded_store(&company).await;
+        let mock = Arc::new(MockTinyplaceClient::new().with_verify(false, Some("bad sig".into())));
+        let economy =
+            TinyplaceEconomy::new(mock.clone(), signer(), store.clone(), company.clone(), None);
+
+        let quote = Quote {
+            quote_id: "q1".into(),
+            to: AgentAddr("Vendor".into()),
+            amount_usd: 15.0,
+        };
+        let budget = BudgetScope {
+            remaining_usd: 50.0,
+            label: "s".into(),
+        };
+        let err = economy.pay(&quote, &budget).await.unwrap_err();
+        assert_eq!(err.code(), "tinyplace_verify_failed");
+        assert_eq!(mock.settle_calls(), 0, "never settle an unverified auth");
+        assert!(ledger_of(&store, &company).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn send_task_402_pays_under_budget() {
+        let company = CompanyId::new("acme");
+        let (_dir, store) = seeded_store(&company).await;
+        let mock = Arc::new(
+            MockTinyplaceClient::new()
+                .with_send_task(PaidOutcome::PaymentRequired(challenge("12.00")))
+                .with_send_task_paid(JsonRpcResponse::ok(
+                    "t1",
+                    serde_json::json!({ "id": "task-9" }),
+                )),
+        );
+        let economy = TinyplaceEconomy::new(
+            mock.clone(),
+            signer(),
+            store.clone(),
+            company.clone(),
+            Some(100.0),
+        );
+
+        let handle = economy
+            .send_a2a_task(
+                &AgentAddr("Vendor".into()),
+                A2aTask {
+                    skill: "seo.audit".into(),
+                    input: serde_json::json!({ "site": "x" }),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(handle, A2aTaskHandle("task-9".into()));
+
+        let ledger = ledger_of(&store, &company).await;
+        assert_eq!(ledger.len(), 1);
+        assert_eq!(ledger[0].kind, "x402.out");
+        assert_eq!(ledger[0].amount_usd, -12.0);
+    }
+
+    #[tokio::test]
+    async fn send_task_402_over_budget_rejected() {
+        let company = CompanyId::new("acme");
+        let (_dir, store) = seeded_store(&company).await;
+        let mock = Arc::new(
+            MockTinyplaceClient::new()
+                .with_send_task(PaidOutcome::PaymentRequired(challenge("80.00"))),
+        );
+        let economy = TinyplaceEconomy::new(
+            mock.clone(),
+            signer(),
+            store.clone(),
+            company.clone(),
+            Some(50.0),
+        );
+
+        let err = economy
+            .send_a2a_task(
+                &AgentAddr("Vendor".into()),
+                A2aTask {
+                    skill: "seo.audit".into(),
+                    input: serde_json::json!({}),
+                },
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), "budget_exceeded");
+        assert_eq!(mock.count("send_task_paid"), 0);
+        assert!(ledger_of(&store, &company).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn unreachable_publish_card_enqueues_outbox_not_error() {
+        let company = CompanyId::new("acme");
+        let (_dir, store) = seeded_store(&company).await;
+        let mock = Arc::new(MockTinyplaceClient::new());
+        mock.set_reachable(false);
+        let economy = TinyplaceEconomy::new(mock.clone(), signer(), store, company.clone(), None);
+
+        let card = AgentCard {
+            handle: "acme".into(),
+            ..Default::default()
+        };
+        economy
+            .publish_card(&identity(&company), &card)
+            .await
+            .expect("publish never errors offline");
+        assert_eq!(economy.outbox().len(), 1, "card queued to the outbox");
+    }
+
+    #[tokio::test]
+    async fn unreachable_send_task_enqueues_and_errors() {
+        let company = CompanyId::new("acme");
+        let (_dir, store) = seeded_store(&company).await;
+        let mock = Arc::new(MockTinyplaceClient::new());
+        mock.set_reachable(false);
+        let economy = TinyplaceEconomy::new(mock.clone(), signer(), store, company, None);
+
+        let err = economy
+            .send_a2a_task(
+                &AgentAddr("Vendor".into()),
+                A2aTask {
+                    skill: "seo.audit".into(),
+                    input: serde_json::json!({}),
+                },
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), "tinyplace_unreachable");
+        assert_eq!(economy.outbox().len(), 1, "task queued despite the error");
+    }
+
+    #[tokio::test]
+    async fn ensure_registered_already_ours_short_circuits() {
+        let company = CompanyId::new("acme");
+        let (_dir, store) = seeded_store(&company).await;
+        let sk = signer();
+        let mine = AgentAddr(sk.agent_id());
+        let mock = Arc::new(MockTinyplaceClient::new().with_resolve(Some(mine.clone())));
+        let economy = TinyplaceEconomy::new(mock.clone(), sk, store, company.clone(), Some(200.0))
+            .going_public(true);
+
+        let state = economy
+            .ensure_registered(&identity(&company))
+            .await
+            .unwrap();
+        assert_eq!(state, RegistrationState::Registered { addr: mine });
+        assert_eq!(mock.count("register_name"), 0, "no claim when already ours");
+    }
+}

--- a/src/economy/card.rs
+++ b/src/economy/card.rs
@@ -1,0 +1,182 @@
+//! Deterministic Agent Card projection from a Company Charter.
+//!
+//! [`build_agent_card`] maps a [`CompanyManifest`] plus the host's base URL onto
+//! the [`AgentCard`] wire shape tiny.place publishes. The projection is a pure
+//! function — no clock, no randomness — so the same charter always yields the
+//! same card, and the whole surface compiles and tests in the default build
+//! without any crypto or network dependency.
+
+use crate::company::CompanyManifest;
+use crate::ports::types::{AgentCard, CardPayment};
+
+/// The settlement asset advertised for priced skills.
+const CARD_ASSET: &str = "USDC";
+/// The settlement network advertised for priced skills.
+const CARD_NETWORK: &str = "solana";
+/// The single A2A interface every card advertises this phase.
+const A2A_INTERFACE: &str = "a2a-jsonrpc";
+
+/// Projects a [`CompanyManifest`] onto its published [`AgentCard`].
+///
+/// Mapping:
+/// - `handle`  ← `[company].handle` (empty if unset)
+/// - `name`    ← `[company].name`
+/// - `description` ← `[company].output`, falling back to the company name
+/// - `skills`  ← each `[place].skills[].id`
+/// - `capabilities` / `tags` ← the same skill ids
+/// - `payment_requirements` ← `{ skill_id, price = price_usd, asset, network }`
+/// - `endpoint` ← `{host_base_url}/a2a/{handle}` (trailing slash trimmed)
+/// - `supported_interfaces` ← `["a2a-jsonrpc"]`
+/// - `actor_type` ← `"agent"`
+pub fn build_agent_card(manifest: &CompanyManifest, host_base_url: &str) -> AgentCard {
+    let handle = manifest.company.handle.clone().unwrap_or_default();
+    let description = manifest
+        .company
+        .output
+        .clone()
+        .unwrap_or_else(|| manifest.company.name.clone());
+
+    let skills: Vec<String> = manifest.place.skills.iter().map(|s| s.id.clone()).collect();
+
+    let payment_requirements: Vec<CardPayment> = manifest
+        .place
+        .skills
+        .iter()
+        .map(|s| CardPayment {
+            skill_id: s.id.clone(),
+            price: s.price_usd.clone(),
+            asset: CARD_ASSET.to_string(),
+            network: CARD_NETWORK.to_string(),
+        })
+        .collect();
+
+    AgentCard {
+        handle: handle.clone(),
+        description,
+        skills: skills.clone(),
+        name: manifest.company.name.clone(),
+        actor_type: "agent".to_string(),
+        endpoint: a2a_endpoint(host_base_url, &handle),
+        supported_interfaces: vec![A2A_INTERFACE.to_string()],
+        capabilities: skills.clone(),
+        tags: skills,
+        payment_requirements,
+    }
+}
+
+/// Builds the `{base}/a2a/{handle}` endpoint, trimming a trailing slash on the
+/// base so the path never doubles up.
+fn a2a_endpoint(host_base_url: &str, handle: &str) -> String {
+    let base = host_base_url.trim_end_matches('/');
+    format!("{base}/a2a/{handle}")
+}
+
+/// Renders a card's skill catalog as human- and agent-readable `skill.md`.
+///
+/// Deterministic: lists every skill with its price and description in card
+/// order. Used by the A2A `skill.md` route in a later batch.
+pub fn render_skill_md(card: &AgentCard) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+    let title = if card.name.is_empty() {
+        card.handle.as_str()
+    } else {
+        card.name.as_str()
+    };
+    let _ = writeln!(out, "# {title}");
+    let _ = writeln!(out);
+    if !card.description.is_empty() {
+        let _ = writeln!(out, "{}", card.description);
+        let _ = writeln!(out);
+    }
+    let _ = writeln!(out, "## Skills");
+    let _ = writeln!(out);
+    if card.payment_requirements.is_empty() {
+        let _ = writeln!(out, "_No priced skills advertised._");
+    } else {
+        for pay in &card.payment_requirements {
+            let _ = writeln!(
+                out,
+                "- `{}` — {} {} ({})",
+                pay.skill_id, pay.price, pay.asset, pay.network
+            );
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn manifest_with_two_skills() -> CompanyManifest {
+        let toml_src = r#"
+            [company]
+            name = "Acme SEO"
+            output = "SEO audits and content"
+            handle = "acme"
+
+            [place]
+            discoverable = true
+            skills = [
+                { id = "seo.audit", price_usd = "25.00", description = "Full site audit" },
+                { id = "seo.brief", price_usd = "10.00" },
+            ]
+        "#;
+        toml::from_str(toml_src).expect("valid manifest")
+    }
+
+    #[test]
+    fn projects_priced_skills_deterministically() {
+        let manifest = manifest_with_two_skills();
+        let card = build_agent_card(&manifest, "https://host.example");
+
+        assert_eq!(card.handle, "acme");
+        assert_eq!(card.name, "Acme SEO");
+        assert_eq!(card.description, "SEO audits and content");
+        assert_eq!(card.actor_type, "agent");
+        assert_eq!(card.endpoint, "https://host.example/a2a/acme");
+        assert_eq!(card.supported_interfaces, vec!["a2a-jsonrpc"]);
+        assert_eq!(card.skills, vec!["seo.audit", "seo.brief"]);
+        assert_eq!(card.capabilities, card.skills);
+        assert_eq!(card.tags, card.skills);
+
+        assert_eq!(card.payment_requirements.len(), 2);
+        let audit = &card.payment_requirements[0];
+        assert_eq!(audit.skill_id, "seo.audit");
+        assert_eq!(audit.price, "25.00");
+        assert_eq!(audit.asset, "USDC");
+        assert_eq!(audit.network, "solana");
+
+        // Determinism: a second projection is byte-identical.
+        assert_eq!(build_agent_card(&manifest, "https://host.example"), card);
+    }
+
+    #[test]
+    fn endpoint_trims_trailing_slash_on_base() {
+        let manifest = manifest_with_two_skills();
+        let card = build_agent_card(&manifest, "https://host.example/");
+        assert_eq!(card.endpoint, "https://host.example/a2a/acme");
+    }
+
+    #[test]
+    fn description_falls_back_to_name_when_output_absent() {
+        let manifest: CompanyManifest =
+            toml::from_str("[company]\nname = \"Solo\"\nhandle = \"solo\"\n").expect("manifest");
+        let card = build_agent_card(&manifest, "https://h");
+        assert_eq!(card.description, "Solo");
+        assert!(card.skills.is_empty());
+        assert!(card.payment_requirements.is_empty());
+    }
+
+    #[test]
+    fn skill_md_lists_every_priced_skill() {
+        let manifest = manifest_with_two_skills();
+        let card = build_agent_card(&manifest, "https://host.example");
+        let md = render_skill_md(&card);
+        assert!(md.contains("# Acme SEO"));
+        assert!(md.contains("`seo.audit` — 25.00 USDC (solana)"));
+        assert!(md.contains("`seo.brief` — 10.00 USDC (solana)"));
+    }
+}

--- a/src/economy/client.rs
+++ b/src/economy/client.rs
@@ -1,0 +1,899 @@
+//! The [`TinyplaceClient`] REST seam: DTOs, an offline mock, and the reqwest
+//! transport.
+//!
+//! [`TinyplaceEconomy`](super::adapter::TinyplaceEconomy) speaks to tiny.place
+//! only through this trait, so its behaviour is exercised offline against
+//! [`MockTinyplaceClient`] — a pure in-memory double with scripted responses and
+//! a call log. [`HttpTinyplaceClient`] is the real transport over
+//! [`reqwest`], attaching a SIWX `Authorization` header to every request; it is
+//! a compilable scaffold reconciled against the live server in one place (the
+//! wire DTOs and [`sha256_hex`] body digest).
+//!
+//! Wire camelCase reconciliation is isolated per-DTO here via `#[serde(rename)]`;
+//! the [`AgentCard`](crate::ports::types::AgentCard) and
+//! [`X402Authorization`](super::x402::X402Authorization) shapes are reused
+//! verbatim.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::Result;
+use crate::economy::signer::LocalSigner;
+use crate::economy::siwx;
+use crate::economy::x402::{X402Authorization, X402Challenge};
+use crate::error::OpenCompanyError;
+use crate::ports::generate_id;
+use crate::ports::now_millis;
+use crate::ports::types::{AgentAddr, AgentCard};
+
+/// Current wall-clock time as epoch **seconds** (the SIWX/x402 timestamp unit).
+pub(crate) fn now_secs() -> i64 {
+    (now_millis() / 1000) as i64
+}
+
+// ---------------------------------------------------------------------------
+// Wire DTOs
+// ---------------------------------------------------------------------------
+
+/// A JSON-RPC 2.0 request, the A2A `tasks/send` envelope.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct JsonRpcRequest {
+    /// Always `"2.0"`.
+    pub jsonrpc: String,
+    /// The request id (echoed in the response).
+    pub id: String,
+    /// The RPC method, e.g. `"tasks/send"`.
+    pub method: String,
+    /// The method params.
+    pub params: Value,
+}
+
+impl JsonRpcRequest {
+    /// Builds a `2.0` request with a fresh id.
+    pub fn new(method: impl Into<String>, params: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id: generate_id(),
+            method: method.into(),
+            params,
+        }
+    }
+}
+
+/// A JSON-RPC 2.0 response.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct JsonRpcResponse {
+    /// Always `"2.0"`.
+    pub jsonrpc: String,
+    /// Echoes the request id.
+    pub id: String,
+    /// The successful result payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    /// The error payload, if the call failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<Value>,
+}
+
+impl JsonRpcResponse {
+    /// Builds a success response echoing `id`.
+    pub fn ok(id: impl Into<String>, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id: id.into(),
+            result: Some(result),
+            error: None,
+        }
+    }
+}
+
+/// A directory search filter (`skill` and/or free-form `tag`).
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct DirectoryQuery {
+    /// Filter by advertised skill id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skill: Option<String>,
+    /// Filter by discovery tag.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tag: Option<String>,
+}
+
+/// One row of a `/directory/skills` search.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DirectorySkill {
+    /// The advertising agent's id.
+    #[serde(rename = "agentId", alias = "agent_id")]
+    pub agent_id: String,
+    /// The advertised skill id.
+    #[serde(rename = "skillId", alias = "skill_id")]
+    pub skill_id: String,
+    /// The decimal price string, e.g. `"25.00"`.
+    pub price: String,
+}
+
+/// The outcome of a paid mutating call: either it completed, or the server
+/// answered `402` with a payment challenge.
+#[derive(Clone, Debug, PartialEq)]
+pub enum PaidOutcome<T> {
+    /// The call completed and returned `T`.
+    Done(T),
+    /// The server requires payment; here is the challenge.
+    PaymentRequired(X402Challenge),
+}
+
+/// A receipt for a name registration or renewal.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RegistryReceipt {
+    /// The registry record id.
+    pub id: String,
+    /// The registered agent address.
+    pub addr: AgentAddr,
+    /// The fee charged, in USD.
+    #[serde(default, rename = "feeUsd", alias = "fee_usd")]
+    pub fee_usd: f64,
+}
+
+/// The result of a `/payments/verify` call.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct VerifyOutcome {
+    /// Whether the authorization verified.
+    pub ok: bool,
+    /// Why it failed, when `ok` is false.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// The receipt from a `/payments/settle` call.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SettleReceipt {
+    /// The settlement receipt id.
+    #[serde(rename = "receiptId", alias = "receipt_id")]
+    pub receipt_id: String,
+    /// The settled amount, as a decimal string.
+    pub amount: String,
+}
+
+// ---------------------------------------------------------------------------
+// The transport seam
+// ---------------------------------------------------------------------------
+
+/// The tiny.place REST transport seam.
+///
+/// One method per endpoint. Mutating calls that may be gated behind payment
+/// return [`PaidOutcome`] so the adapter can catch a `402`, budget-check, and
+/// resubmit with an [`X402Authorization`].
+#[async_trait]
+pub trait TinyplaceClient: Send + Sync {
+    /// `POST /registry/names` — claim a `@handle`.
+    async fn register_name(&self, label: &str) -> Result<PaidOutcome<RegistryReceipt>>;
+    /// `POST /registry/names` with a payment authorization attached.
+    async fn register_name_paid(
+        &self,
+        label: &str,
+        auth: &X402Authorization,
+    ) -> Result<RegistryReceipt>;
+    /// `POST /registry/names/{id}/renew` with a payment authorization.
+    async fn renew_name(&self, id: &str, auth: &X402Authorization) -> Result<RegistryReceipt>;
+    /// `PUT /directory/agents/{id}` — publish or refresh an Agent Card.
+    async fn put_agent(&self, agent_id: &str, card: &AgentCard) -> Result<()>;
+    /// `GET /directory/agents` — list matching Agent Cards.
+    async fn list_agents(&self, query: &DirectoryQuery) -> Result<Vec<AgentCard>>;
+    /// `GET /directory/skills` — list matching priced skills.
+    async fn list_skills(&self, query: &DirectoryQuery) -> Result<Vec<DirectorySkill>>;
+    /// `GET /directory/resolve/{name}` — resolve a `@handle` to an address.
+    async fn resolve(&self, name: &str) -> Result<AgentAddr>;
+    /// `POST /a2a/{id}` — send a JSON-RPC task.
+    async fn send_task(
+        &self,
+        agent_id: &str,
+        rpc: JsonRpcRequest,
+    ) -> Result<PaidOutcome<JsonRpcResponse>>;
+    /// `POST /a2a/{id}` with a payment authorization attached.
+    async fn send_task_paid(
+        &self,
+        agent_id: &str,
+        rpc: JsonRpcRequest,
+        auth: &X402Authorization,
+    ) -> Result<JsonRpcResponse>;
+    /// `POST /payments/verify` — verify a payment authorization.
+    async fn payments_verify(&self, auth: &X402Authorization) -> Result<VerifyOutcome>;
+    /// `POST /payments/settle` — settle a verified authorization.
+    async fn payments_settle(&self, auth: &X402Authorization) -> Result<SettleReceipt>;
+}
+
+// ---------------------------------------------------------------------------
+// The offline mock
+// ---------------------------------------------------------------------------
+
+/// A network-free [`TinyplaceClient`] double for offline tests.
+///
+/// Every response is scripted via the `with_*` setters; a call log and per-call
+/// counters record what the adapter did. Setting [`Self::set_reachable`] to
+/// `false` makes every method fail with `tinyplace("unreachable", …)`, driving
+/// the outbox path.
+pub struct MockTinyplaceClient {
+    state: Mutex<MockState>,
+    settle_calls: AtomicUsize,
+    verify_calls: AtomicUsize,
+}
+
+struct MockState {
+    reachable: bool,
+    resolve: Option<AgentAddr>,
+    register_name: PaidOutcome<RegistryReceipt>,
+    register_paid: RegistryReceipt,
+    renew: RegistryReceipt,
+    send_task: PaidOutcome<JsonRpcResponse>,
+    send_task_paid: JsonRpcResponse,
+    verify_ok: bool,
+    verify_reason: Option<String>,
+    settle: SettleReceipt,
+    agents: Vec<AgentCard>,
+    skills: Vec<DirectorySkill>,
+    log: Vec<String>,
+}
+
+impl Default for MockTinyplaceClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MockTinyplaceClient {
+    /// Builds a reachable mock whose scripted responses all succeed with
+    /// placeholder values. Override any of them with the `with_*` setters.
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(MockState {
+                reachable: true,
+                resolve: None,
+                register_name: PaidOutcome::Done(RegistryReceipt {
+                    id: "reg-1".into(),
+                    addr: AgentAddr("MockAddr".into()),
+                    fee_usd: 0.0,
+                }),
+                register_paid: RegistryReceipt {
+                    id: "reg-1".into(),
+                    addr: AgentAddr("MockAddr".into()),
+                    fee_usd: 0.0,
+                },
+                renew: RegistryReceipt {
+                    id: "reg-1".into(),
+                    addr: AgentAddr("MockAddr".into()),
+                    fee_usd: 0.0,
+                },
+                send_task: PaidOutcome::Done(JsonRpcResponse::ok(
+                    "t1",
+                    serde_json::json!({ "id": "task-1", "status": "accepted" }),
+                )),
+                send_task_paid: JsonRpcResponse::ok(
+                    "t1",
+                    serde_json::json!({ "id": "task-1", "status": "accepted" }),
+                ),
+                verify_ok: true,
+                verify_reason: None,
+                settle: SettleReceipt {
+                    receipt_id: "settle-1".into(),
+                    amount: "0.00".into(),
+                },
+                agents: Vec::new(),
+                skills: Vec::new(),
+                log: Vec::new(),
+            }),
+            settle_calls: AtomicUsize::new(0),
+            verify_calls: AtomicUsize::new(0),
+        }
+    }
+
+    /// Sets whether the mock is reachable. When `false`, every call fails with
+    /// `tinyplace("unreachable", …)`.
+    pub fn set_reachable(&self, reachable: bool) {
+        self.lock().reachable = reachable;
+    }
+
+    /// Scripts what `resolve` returns. `None` (the default) resolves to a
+    /// `not_found` error.
+    pub fn with_resolve(self, addr: Option<AgentAddr>) -> Self {
+        self.lock().resolve = addr;
+        self
+    }
+
+    /// Scripts the `register_name` outcome (a `Done` receipt or a `402`
+    /// `PaymentRequired` challenge).
+    pub fn with_register_name(self, outcome: PaidOutcome<RegistryReceipt>) -> Self {
+        self.lock().register_name = outcome;
+        self
+    }
+
+    /// Scripts the receipt returned by `register_name_paid`.
+    pub fn with_register_paid(self, receipt: RegistryReceipt) -> Self {
+        self.lock().register_paid = receipt;
+        self
+    }
+
+    /// Scripts the `send_task` outcome (a `Done` response or a `402` challenge).
+    pub fn with_send_task(self, outcome: PaidOutcome<JsonRpcResponse>) -> Self {
+        self.lock().send_task = outcome;
+        self
+    }
+
+    /// Scripts the response returned by `send_task_paid`.
+    pub fn with_send_task_paid(self, resp: JsonRpcResponse) -> Self {
+        self.lock().send_task_paid = resp;
+        self
+    }
+
+    /// Scripts the `payments_verify` outcome.
+    pub fn with_verify(self, ok: bool, reason: Option<String>) -> Self {
+        {
+            let mut state = self.lock();
+            state.verify_ok = ok;
+            state.verify_reason = reason;
+        }
+        self
+    }
+
+    /// Scripts the `list_agents` result.
+    pub fn with_agents(self, agents: Vec<AgentCard>) -> Self {
+        self.lock().agents = agents;
+        self
+    }
+
+    /// Scripts the `list_skills` result.
+    pub fn with_skills(self, skills: Vec<DirectorySkill>) -> Self {
+        self.lock().skills = skills;
+        self
+    }
+
+    /// How many times `payments_settle` was called.
+    pub fn settle_calls(&self) -> usize {
+        self.settle_calls.load(Ordering::Relaxed)
+    }
+
+    /// How many times `payments_verify` was called.
+    pub fn verify_calls(&self) -> usize {
+        self.verify_calls.load(Ordering::Relaxed)
+    }
+
+    /// The recorded call log (method names, in call order).
+    pub fn calls(&self) -> Vec<String> {
+        self.lock().log.clone()
+    }
+
+    /// How many times a method matching `needle` appears in the call log.
+    pub fn count(&self, needle: &str) -> usize {
+        self.lock().log.iter().filter(|c| *c == needle).count()
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, MockState> {
+        self.state.lock().expect("mock poisoned")
+    }
+
+    fn record(&self, method: &str) -> Result<()> {
+        let mut state = self.lock();
+        state.log.push(method.to_string());
+        if state.reachable {
+            Ok(())
+        } else {
+            Err(OpenCompanyError::tinyplace(
+                "unreachable",
+                format!("tiny.place is unreachable ({method})"),
+            ))
+        }
+    }
+}
+
+#[async_trait]
+impl TinyplaceClient for MockTinyplaceClient {
+    async fn register_name(&self, _label: &str) -> Result<PaidOutcome<RegistryReceipt>> {
+        self.record("register_name")?;
+        Ok(self.lock().register_name.clone())
+    }
+
+    async fn register_name_paid(
+        &self,
+        _label: &str,
+        _auth: &X402Authorization,
+    ) -> Result<RegistryReceipt> {
+        self.record("register_name_paid")?;
+        Ok(self.lock().register_paid.clone())
+    }
+
+    async fn renew_name(&self, _id: &str, _auth: &X402Authorization) -> Result<RegistryReceipt> {
+        self.record("renew_name")?;
+        Ok(self.lock().renew.clone())
+    }
+
+    async fn put_agent(&self, _agent_id: &str, _card: &AgentCard) -> Result<()> {
+        self.record("put_agent")
+    }
+
+    async fn list_agents(&self, _query: &DirectoryQuery) -> Result<Vec<AgentCard>> {
+        self.record("list_agents")?;
+        Ok(self.lock().agents.clone())
+    }
+
+    async fn list_skills(&self, _query: &DirectoryQuery) -> Result<Vec<DirectorySkill>> {
+        self.record("list_skills")?;
+        Ok(self.lock().skills.clone())
+    }
+
+    async fn resolve(&self, name: &str) -> Result<AgentAddr> {
+        self.record("resolve")?;
+        self.lock().resolve.clone().ok_or_else(|| {
+            OpenCompanyError::tinyplace("not_found", format!("no registration for @{name}"))
+        })
+    }
+
+    async fn send_task(
+        &self,
+        _agent_id: &str,
+        _rpc: JsonRpcRequest,
+    ) -> Result<PaidOutcome<JsonRpcResponse>> {
+        self.record("send_task")?;
+        Ok(self.lock().send_task.clone())
+    }
+
+    async fn send_task_paid(
+        &self,
+        _agent_id: &str,
+        _rpc: JsonRpcRequest,
+        _auth: &X402Authorization,
+    ) -> Result<JsonRpcResponse> {
+        self.record("send_task_paid")?;
+        Ok(self.lock().send_task_paid.clone())
+    }
+
+    async fn payments_verify(&self, _auth: &X402Authorization) -> Result<VerifyOutcome> {
+        self.verify_calls.fetch_add(1, Ordering::Relaxed);
+        self.record("payments_verify")?;
+        let state = self.lock();
+        Ok(VerifyOutcome {
+            ok: state.verify_ok,
+            reason: state.verify_reason.clone(),
+        })
+    }
+
+    async fn payments_settle(&self, _auth: &X402Authorization) -> Result<SettleReceipt> {
+        self.settle_calls.fetch_add(1, Ordering::Relaxed);
+        self.record("payments_settle")?;
+        Ok(self.lock().settle.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The networked transport
+// ---------------------------------------------------------------------------
+
+/// The reqwest-backed [`TinyplaceClient`], gated behind the `tinyplace` feature.
+///
+/// Attaches a SIWX `Authorization` header (signed over method, path, and a
+/// [`sha256_hex`] body digest) to every request. A compilable scaffold: the DTO
+/// shapes and digest are the single reconciliation point against the live
+/// server. All behavioural coverage runs against [`MockTinyplaceClient`].
+pub struct HttpTinyplaceClient {
+    client: reqwest::Client,
+    base_url: String,
+    signer: std::sync::Arc<LocalSigner>,
+}
+
+impl HttpTinyplaceClient {
+    /// Builds a client against `base_url` (e.g. `https://api.tiny.place`)
+    /// signing with `signer`.
+    pub fn new(base_url: impl Into<String>, signer: std::sync::Arc<LocalSigner>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            base_url: base_url.into(),
+            signer,
+        }
+    }
+
+    /// The company's base58 `agentId`.
+    pub fn agent_id(&self) -> String {
+        self.signer.agent_id()
+    }
+
+    /// Sends a request with a SIWX header, returning the status and decoded body.
+    ///
+    /// A network failure maps to `tinyplace("unreachable", …)`; a body that will
+    /// not decode maps to `tinyplace("decode", …)`.
+    async fn send(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        body: Option<&Value>,
+    ) -> Result<(reqwest::StatusCode, Value)> {
+        let bytes = match body {
+            Some(v) => serde_json::to_vec(v)?,
+            None => Vec::new(),
+        };
+        let body_hash = sha256_hex(&bytes);
+        let header = siwx::header_value(&siwx::build_header(
+            &self.signer,
+            &siwx::SiwxPayload {
+                method: method.as_str(),
+                path,
+                timestamp: now_secs(),
+                body_hash: &body_hash,
+            },
+        ));
+
+        let url = format!("{}{}", self.base_url.trim_end_matches('/'), path);
+        let mut req = self
+            .client
+            .request(method, &url)
+            .header("Authorization", header);
+        if !bytes.is_empty() {
+            req = req.header("Content-Type", "application/json").body(bytes);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|err| OpenCompanyError::tinyplace("unreachable", format!("{path}: {err}")))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|err| OpenCompanyError::tinyplace("decode", format!("{path}: {err}")))?;
+        let value = if text.trim().is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_str(&text)
+                .map_err(|err| OpenCompanyError::tinyplace("decode", format!("{path}: {err}")))?
+        };
+        Ok((status, value))
+    }
+
+    /// Rejects a non-success, non-402 status.
+    fn require_success(status: reqwest::StatusCode, value: &Value, path: &str) -> Result<()> {
+        if status.is_success() {
+            return Ok(());
+        }
+        let message = value
+            .get("error")
+            .and_then(|e| e.as_str())
+            .or_else(|| value.get("message").and_then(|m| m.as_str()))
+            .unwrap_or("request failed")
+            .to_string();
+        Err(OpenCompanyError::tinyplace(
+            format!("http_{}", status.as_u16()),
+            format!("{path}: {message}"),
+        ))
+    }
+
+    fn decode<T: serde::de::DeserializeOwned>(value: Value, path: &str) -> Result<T> {
+        serde_json::from_value(value)
+            .map_err(|err| OpenCompanyError::tinyplace("decode", format!("{path}: {err}")))
+    }
+}
+
+impl std::fmt::Debug for HttpTinyplaceClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpTinyplaceClient")
+            .field("base_url", &self.base_url)
+            .field("agent_id", &self.signer.agent_id())
+            .field("signer", &"<redacted>")
+            .finish()
+    }
+}
+
+#[async_trait]
+impl TinyplaceClient for HttpTinyplaceClient {
+    async fn register_name(&self, label: &str) -> Result<PaidOutcome<RegistryReceipt>> {
+        let body = serde_json::json!({ "label": label });
+        let path = "/registry/names";
+        let (status, value) = self.send(reqwest::Method::POST, path, Some(&body)).await?;
+        if status.as_u16() == 402 {
+            return Ok(PaidOutcome::PaymentRequired(X402Challenge::from_body(
+                &value,
+            )?));
+        }
+        Self::require_success(status, &value, path)?;
+        Ok(PaidOutcome::Done(Self::decode(value, path)?))
+    }
+
+    async fn register_name_paid(
+        &self,
+        label: &str,
+        auth: &X402Authorization,
+    ) -> Result<RegistryReceipt> {
+        let body = serde_json::json!({ "label": label, "payment": auth });
+        let path = "/registry/names";
+        let (status, value) = self.send(reqwest::Method::POST, path, Some(&body)).await?;
+        Self::require_success(status, &value, path)?;
+        Self::decode(value, path)
+    }
+
+    async fn renew_name(&self, id: &str, auth: &X402Authorization) -> Result<RegistryReceipt> {
+        let body = serde_json::json!({ "payment": auth });
+        let path = format!("/registry/names/{id}/renew");
+        let (status, value) = self.send(reqwest::Method::POST, &path, Some(&body)).await?;
+        Self::require_success(status, &value, &path)?;
+        Self::decode(value, &path)
+    }
+
+    async fn put_agent(&self, agent_id: &str, card: &AgentCard) -> Result<()> {
+        let body = serde_json::to_value(card)?;
+        let path = format!("/directory/agents/{agent_id}");
+        let (status, value) = self.send(reqwest::Method::PUT, &path, Some(&body)).await?;
+        Self::require_success(status, &value, &path)
+    }
+
+    async fn list_agents(&self, query: &DirectoryQuery) -> Result<Vec<AgentCard>> {
+        let path = format!("/directory/agents{}", query_string(query));
+        let (status, value) = self.send(reqwest::Method::GET, &path, None).await?;
+        Self::require_success(status, &value, &path)?;
+        Self::decode(value, &path)
+    }
+
+    async fn list_skills(&self, query: &DirectoryQuery) -> Result<Vec<DirectorySkill>> {
+        let path = format!("/directory/skills{}", query_string(query));
+        let (status, value) = self.send(reqwest::Method::GET, &path, None).await?;
+        Self::require_success(status, &value, &path)?;
+        Self::decode(value, &path)
+    }
+
+    async fn resolve(&self, name: &str) -> Result<AgentAddr> {
+        let path = format!("/directory/resolve/{name}");
+        let (status, value) = self.send(reqwest::Method::GET, &path, None).await?;
+        Self::require_success(status, &value, &path)?;
+        // Accept either a bare string or `{ "addr": "…" }`.
+        if let Some(addr) = value.as_str() {
+            return Ok(AgentAddr(addr.to_string()));
+        }
+        if let Some(addr) = value.get("addr").and_then(|a| a.as_str()) {
+            return Ok(AgentAddr(addr.to_string()));
+        }
+        Self::decode(value, &path)
+    }
+
+    async fn send_task(
+        &self,
+        agent_id: &str,
+        rpc: JsonRpcRequest,
+    ) -> Result<PaidOutcome<JsonRpcResponse>> {
+        let body = serde_json::to_value(&rpc)?;
+        let path = format!("/a2a/{agent_id}");
+        let (status, value) = self.send(reqwest::Method::POST, &path, Some(&body)).await?;
+        if status.as_u16() == 402 {
+            return Ok(PaidOutcome::PaymentRequired(X402Challenge::from_body(
+                &value,
+            )?));
+        }
+        Self::require_success(status, &value, &path)?;
+        Ok(PaidOutcome::Done(Self::decode(value, &path)?))
+    }
+
+    async fn send_task_paid(
+        &self,
+        agent_id: &str,
+        rpc: JsonRpcRequest,
+        auth: &X402Authorization,
+    ) -> Result<JsonRpcResponse> {
+        let mut body = serde_json::to_value(&rpc)?;
+        if let Value::Object(map) = &mut body {
+            map.insert("payment".to_string(), serde_json::to_value(auth)?);
+        }
+        let path = format!("/a2a/{agent_id}");
+        let (status, value) = self.send(reqwest::Method::POST, &path, Some(&body)).await?;
+        Self::require_success(status, &value, &path)?;
+        Self::decode(value, &path)
+    }
+
+    async fn payments_verify(&self, auth: &X402Authorization) -> Result<VerifyOutcome> {
+        let body = serde_json::to_value(auth)?;
+        let path = "/payments/verify";
+        let (status, value) = self.send(reqwest::Method::POST, path, Some(&body)).await?;
+        Self::require_success(status, &value, path)?;
+        Self::decode(value, path)
+    }
+
+    async fn payments_settle(&self, auth: &X402Authorization) -> Result<SettleReceipt> {
+        let body = serde_json::to_value(auth)?;
+        let path = "/payments/settle";
+        let (status, value) = self.send(reqwest::Method::POST, path, Some(&body)).await?;
+        Self::require_success(status, &value, path)?;
+        Self::decode(value, path)
+    }
+}
+
+/// Renders a `DirectoryQuery` as a URL query suffix (`""` when both are unset).
+fn query_string(query: &DirectoryQuery) -> String {
+    let mut parts = Vec::new();
+    if let Some(skill) = &query.skill {
+        parts.push(format!("skill={skill}"));
+    }
+    if let Some(tag) = &query.tag {
+        parts.push(format!("tag={tag}"));
+    }
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!("?{}", parts.join("&"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dependency-free SHA-256 (matches the `signer.rs` "avoid pulling a crate"
+// precedent). Pins the SIWX body digest to sha256-hex in one isolated spot.
+// ---------------------------------------------------------------------------
+
+const SHA256_K: [u32; 64] = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+
+/// The lowercase hex SHA-256 digest of `data`.
+pub(crate) fn sha256_hex(data: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    let mut h: [u32; 8] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
+        0x5be0cd19,
+    ];
+
+    let bit_len = (data.len() as u64).wrapping_mul(8);
+    let mut msg = data.to_vec();
+    msg.push(0x80);
+    while msg.len() % 64 != 56 {
+        msg.push(0);
+    }
+    msg.extend_from_slice(&bit_len.to_be_bytes());
+
+    for chunk in msg.chunks_exact(64) {
+        let mut w = [0u32; 64];
+        for (i, slot) in w.iter_mut().enumerate().take(16) {
+            let b = i * 4;
+            *slot = u32::from_be_bytes([chunk[b], chunk[b + 1], chunk[b + 2], chunk[b + 3]]);
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+
+        let mut a = h[0];
+        let mut b = h[1];
+        let mut c = h[2];
+        let mut d = h[3];
+        let mut e = h[4];
+        let mut f = h[5];
+        let mut g = h[6];
+        let mut hh = h[7];
+
+        for i in 0..64 {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ ((!e) & g);
+            let t1 = hh
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(SHA256_K[i])
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let t2 = s0.wrapping_add(maj);
+            hh = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(t1);
+            d = c;
+            c = b;
+            b = a;
+            a = t1.wrapping_add(t2);
+        }
+
+        h[0] = h[0].wrapping_add(a);
+        h[1] = h[1].wrapping_add(b);
+        h[2] = h[2].wrapping_add(c);
+        h[3] = h[3].wrapping_add(d);
+        h[4] = h[4].wrapping_add(e);
+        h[5] = h[5].wrapping_add(f);
+        h[6] = h[6].wrapping_add(g);
+        h[7] = h[7].wrapping_add(hh);
+    }
+
+    let mut out = String::with_capacity(64);
+    for word in h {
+        for byte in word.to_be_bytes() {
+            let _ = write!(out, "{byte:02x}");
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn json_rpc_request_round_trips_with_version() {
+        let rpc = JsonRpcRequest::new("tasks/send", serde_json::json!({ "skill": "seo.audit" }));
+        assert_eq!(rpc.jsonrpc, "2.0");
+        let json = serde_json::to_string(&rpc).expect("serialize");
+        let back: JsonRpcRequest = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, rpc);
+    }
+
+    #[test]
+    fn directory_skill_decodes_camel_and_snake_case() {
+        let camel = serde_json::json!({
+            "agentId": "AgentX", "skillId": "seo.audit", "price": "25.00"
+        });
+        let snake = serde_json::json!({
+            "agent_id": "AgentX", "skill_id": "seo.audit", "price": "25.00"
+        });
+        let a: DirectorySkill = serde_json::from_value(camel).expect("camel");
+        let b: DirectorySkill = serde_json::from_value(snake).expect("snake");
+        assert_eq!(a, b);
+        assert_eq!(a.agent_id, "AgentX");
+    }
+
+    #[test]
+    fn paid_outcome_decodes_402_accepts_envelope() {
+        // The x402 `{ accepts: [ … ] }` envelope decodes into a challenge.
+        let body = serde_json::json!({
+            "accepts": [ { "maxAmountRequired": "25.00", "payTo": "Recipient" } ]
+        });
+        let challenge = X402Challenge::from_body(&body).expect("challenge");
+        let outcome: PaidOutcome<RegistryReceipt> = PaidOutcome::PaymentRequired(challenge.clone());
+        assert_eq!(outcome, PaidOutcome::PaymentRequired(challenge));
+    }
+
+    #[test]
+    fn registry_receipt_decodes_from_wire() {
+        let value = serde_json::json!({ "id": "r1", "addr": "AddrX", "feeUsd": 25.0 });
+        let receipt: RegistryReceipt = serde_json::from_value(value).expect("decode");
+        assert_eq!(receipt.addr, AgentAddr("AddrX".into()));
+        assert_eq!(receipt.fee_usd, 25.0);
+    }
+
+    #[tokio::test]
+    async fn mock_records_calls_and_honors_reachable() {
+        let mock = MockTinyplaceClient::new().with_resolve(Some(AgentAddr("Me".into())));
+        assert_eq!(mock.resolve("acme").await.unwrap(), AgentAddr("Me".into()));
+        assert_eq!(mock.count("resolve"), 1);
+
+        mock.set_reachable(false);
+        let err = mock.resolve("acme").await.unwrap_err();
+        assert_eq!(err.code(), "tinyplace_unreachable");
+        // Both attempts are logged even though the second failed.
+        assert_eq!(mock.count("resolve"), 2);
+    }
+
+    #[test]
+    fn sha256_matches_known_vectors() {
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn query_string_builds_suffix() {
+        assert_eq!(query_string(&DirectoryQuery::default()), "");
+        assert_eq!(
+            query_string(&DirectoryQuery {
+                skill: Some("seo.audit".into()),
+                tag: None,
+            }),
+            "?skill=seo.audit"
+        );
+    }
+}

--- a/src/economy/mod.rs
+++ b/src/economy/mod.rs
@@ -12,12 +12,31 @@
 //!   verification with skew + replay protection. **`tinyplace` feature.**
 //! - [`x402`] — payment-challenge parsing and authorization signing.
 //!   **`tinyplace` feature.**
+//! - [`client`] — the [`TinyplaceClient`](client::TinyplaceClient) REST seam,
+//!   its network-free [`MockTinyplaceClient`](client::MockTinyplaceClient), and
+//!   the reqwest-backed [`HttpTinyplaceClient`](client::HttpTinyplaceClient).
+//!   **`tinyplace` feature.**
+//! - [`outbox`] — an in-memory queue of outbound actions deferred while
+//!   tiny.place is unreachable. **`tinyplace` feature.**
+//! - [`adapter`] — [`TinyplaceEconomy`](adapter::TinyplaceEconomy), the
+//!   [`AgentEconomy`](crate::ports::AgentEconomy) implementation over a
+//!   [`TinyplaceClient`](client::TinyplaceClient). Budget-fail-closed, journals
+//!   every payment to the ledger, and never blocks boot when offline.
+//!   **`tinyplace` feature.**
 //!
-//! Later batches add the `TinyplaceClient` transport, the `TinyplaceEconomy`
-//! adapter, and the A2A inbound routes on top of these primitives.
+//! The whole economy adapter is feature-gated because it transitively depends on
+//! the [`signer`]/[`siwx`]/[`x402`] crypto primitives. Offline testability comes
+//! from the network-free [`MockTinyplaceClient`](client::MockTinyplaceClient),
+//! not from a default-build mock: the default build links none of this.
 
 pub mod card;
 
+#[cfg(feature = "tinyplace")]
+pub mod adapter;
+#[cfg(feature = "tinyplace")]
+pub mod client;
+#[cfg(feature = "tinyplace")]
+pub mod outbox;
 #[cfg(feature = "tinyplace")]
 pub mod signer;
 #[cfg(feature = "tinyplace")]
@@ -27,6 +46,12 @@ pub mod x402;
 
 pub use card::{build_agent_card, render_skill_md};
 
+#[cfg(feature = "tinyplace")]
+pub use adapter::TinyplaceEconomy;
+#[cfg(feature = "tinyplace")]
+pub use client::{HttpTinyplaceClient, MockTinyplaceClient, TinyplaceClient};
+#[cfg(feature = "tinyplace")]
+pub use outbox::{Outbox, OutboxAction};
 #[cfg(feature = "tinyplace")]
 pub use signer::{LocalSigner, load_or_create_signer};
 #[cfg(feature = "tinyplace")]

--- a/src/economy/mod.rs
+++ b/src/economy/mod.rs
@@ -1,0 +1,35 @@
+//! The tiny.place economy: identity, Agent Cards, SIWX auth, and x402 payments.
+//!
+//! This module is split so the default build carries everything that needs no
+//! crypto or network, and the `tinyplace` feature layers on the Ed25519
+//! identity and payment-authorization surface:
+//!
+//! - [`card`] — deterministic [`AgentCard`](crate::ports::types::AgentCard)
+//!   projection from a Company Charter. **Default build**; no crypto.
+//! - [`signer`] — the Ed25519 [`LocalSigner`](signer::LocalSigner) whose seed
+//!   persists in the company bundle. **`tinyplace` feature.**
+//! - [`siwx`] — per-action `Authorization: tiny.place …` signing and
+//!   verification with skew + replay protection. **`tinyplace` feature.**
+//! - [`x402`] — payment-challenge parsing and authorization signing.
+//!   **`tinyplace` feature.**
+//!
+//! Later batches add the `TinyplaceClient` transport, the `TinyplaceEconomy`
+//! adapter, and the A2A inbound routes on top of these primitives.
+
+pub mod card;
+
+#[cfg(feature = "tinyplace")]
+pub mod signer;
+#[cfg(feature = "tinyplace")]
+pub mod siwx;
+#[cfg(feature = "tinyplace")]
+pub mod x402;
+
+pub use card::{build_agent_card, render_skill_md};
+
+#[cfg(feature = "tinyplace")]
+pub use signer::{LocalSigner, load_or_create_signer};
+#[cfg(feature = "tinyplace")]
+pub use siwx::{NonceCache, SiwxHeader, SiwxPayload};
+#[cfg(feature = "tinyplace")]
+pub use x402::{X402Authorization, X402Challenge};

--- a/src/economy/outbox.rs
+++ b/src/economy/outbox.rs
@@ -1,0 +1,92 @@
+//! An in-memory outbox of outbound tiny.place actions deferred while the
+//! network is unreachable.
+//!
+//! When tiny.place cannot be reached, the [`TinyplaceEconomy`](super::adapter::
+//! TinyplaceEconomy) queues the action here instead of failing boot or a cycle:
+//! the published card goes stale, an outbound task waits, but the runtime keeps
+//! moving. Draining and replaying the queue is the caller's responsibility.
+//!
+//! In-memory only this phase; a durable, cross-restart outbox is a documented
+//! follow-up.
+
+use std::sync::Mutex;
+
+use crate::ports::types::{A2aTask, AgentAddr, AgentCard};
+
+/// One deferred outbound action.
+#[derive(Clone, Debug, PartialEq)]
+pub enum OutboxAction {
+    /// Publish (or refresh) the company's Agent Card.
+    PublishCard(AgentCard),
+    /// Claim or renew a `@handle` registration.
+    Register {
+        /// The `@handle` label to register.
+        label: String,
+    },
+    /// Send an A2A task to a counterparty.
+    SendTask {
+        /// The counterparty address.
+        to: AgentAddr,
+        /// The task to deliver.
+        task: A2aTask,
+    },
+}
+
+/// A thread-safe FIFO queue of [`OutboxAction`]s.
+#[derive(Default)]
+pub struct Outbox {
+    inner: Mutex<Vec<OutboxAction>>,
+}
+
+impl Outbox {
+    /// Creates an empty outbox.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Appends an action to the back of the queue.
+    pub fn enqueue(&self, action: OutboxAction) {
+        self.inner.lock().expect("outbox poisoned").push(action);
+    }
+
+    /// Removes and returns every queued action, leaving the outbox empty.
+    pub fn drain(&self) -> Vec<OutboxAction> {
+        std::mem::take(&mut *self.inner.lock().expect("outbox poisoned"))
+    }
+
+    /// The number of actions currently queued.
+    pub fn len(&self) -> usize {
+        self.inner.lock().expect("outbox poisoned").len()
+    }
+
+    /// Whether the outbox holds no actions.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn enqueue_len_and_drain_round_trip() {
+        let outbox = Outbox::new();
+        assert!(outbox.is_empty());
+        outbox.enqueue(OutboxAction::Register {
+            label: "acme".into(),
+        });
+        outbox.enqueue(OutboxAction::SendTask {
+            to: AgentAddr("peer".into()),
+            task: A2aTask {
+                skill: "seo.audit".into(),
+                input: serde_json::json!({}),
+            },
+        });
+        assert_eq!(outbox.len(), 2);
+
+        let drained = outbox.drain();
+        assert_eq!(drained.len(), 2);
+        assert!(outbox.is_empty(), "drain empties the queue");
+    }
+}

--- a/src/economy/signer.rs
+++ b/src/economy/signer.rs
@@ -1,0 +1,256 @@
+//! Ed25519 company identity: the [`LocalSigner`].
+//!
+//! A company's tiny.place identity is a single Ed25519 keypair. The 32-byte
+//! seed persists at `keys/agent.ed25519` in the company bundle, hex-encoded,
+//! restricted to `0600` on unix, and excluded from bundle exports (see
+//! [`crate::store::Bundle::EXPORT_EXCLUDES`]). The `agentId` surfaced to
+//! tiny.place is the base58 (Solana-style) encoding of the 32-byte public key.
+//!
+//! Everything here is offline: keys are generated from `OsRng`, and signing and
+//! verification never touch the network.
+
+use ed25519_dalek::{Signer as _, SigningKey, VerifyingKey};
+
+use crate::error::OpenCompanyError;
+use crate::store::Bundle;
+use crate::store::paths::restrict_file;
+use crate::{Result, ports::types::CompanyId};
+
+/// A company's local Ed25519 signer.
+///
+/// Wraps a [`SigningKey`]; the public key doubles as the tiny.place `agentId`
+/// via its base58 encoding.
+pub struct LocalSigner {
+    keypair: SigningKey,
+}
+
+impl LocalSigner {
+    /// Builds a signer from a raw 32-byte Ed25519 seed.
+    pub fn from_seed(seed: &[u8; 32]) -> Self {
+        Self {
+            keypair: SigningKey::from_bytes(seed),
+        }
+    }
+
+    /// Generates a fresh signer from the operating system's CSPRNG.
+    pub fn generate() -> Self {
+        use rand_core::RngCore as _;
+
+        let mut seed = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut seed);
+        Self::from_seed(&seed)
+    }
+
+    /// The base58 (Solana-style) address of the 32-byte public key. This is the
+    /// company's tiny.place `agentId`.
+    pub fn agent_id(&self) -> String {
+        bs58::encode(self.public_key_bytes()).into_string()
+    }
+
+    /// The raw 32-byte Ed25519 public key.
+    pub fn public_key_bytes(&self) -> [u8; 32] {
+        self.keypair.verifying_key().to_bytes()
+    }
+
+    /// The raw 32-byte seed. Kept crate-private so it is never serialized into
+    /// an exportable surface.
+    pub(crate) fn seed_bytes(&self) -> [u8; 32] {
+        self.keypair.to_bytes()
+    }
+
+    /// Signs `msg`, returning the 64-byte Ed25519 signature.
+    pub fn sign(&self, msg: &[u8]) -> [u8; 64] {
+        self.keypair.sign(msg).to_bytes()
+    }
+
+    /// Signs `msg` and returns the signature base58-encoded (the wire form used
+    /// in SIWX and x402 authorizations).
+    pub fn sign_b58(&self, msg: &[u8]) -> String {
+        bs58::encode(self.sign(msg)).into_string()
+    }
+}
+
+/// Verifies a base58-encoded Ed25519 signature over `msg` by a given base58
+/// `agent_id` (the signer's public key).
+///
+/// Returns `Ok(())` on a valid signature, or [`OpenCompanyError::InvalidRequest`]
+/// when the id or signature is malformed or the signature does not verify.
+pub fn verify_b58(agent_id: &str, msg: &[u8], signature_b58: &str) -> Result<()> {
+    let pubkey_bytes = decode_32(agent_id).ok_or_else(|| {
+        OpenCompanyError::InvalidRequest(format!(
+            "agentId `{agent_id}` is not a 32-byte base58 key"
+        ))
+    })?;
+    let verifying = VerifyingKey::from_bytes(&pubkey_bytes).map_err(|_| {
+        OpenCompanyError::InvalidRequest("agentId is not a valid Ed25519 key".into())
+    })?;
+
+    let sig_bytes = decode_64(signature_b58).ok_or_else(|| {
+        OpenCompanyError::InvalidRequest("signature is not 64 base58 bytes".into())
+    })?;
+    let signature = ed25519_dalek::Signature::from_bytes(&sig_bytes);
+
+    use ed25519_dalek::Verifier as _;
+    verifying
+        .verify(msg, &signature)
+        .map_err(|_| OpenCompanyError::InvalidRequest("signature does not verify".into()))
+}
+
+/// Loads the company's signer from `keys/agent.ed25519`, generating and
+/// persisting a fresh key (hex seed, `0600`) if the file is absent.
+pub async fn load_or_create_signer(bundle: &Bundle) -> Result<LocalSigner> {
+    bundle.ensure_dirs().await?;
+    let path = bundle.agent_key();
+
+    match tokio::fs::read_to_string(&path).await {
+        Ok(text) => {
+            let seed = decode_hex_seed(text.trim()).ok_or_else(|| {
+                OpenCompanyError::Store(format!(
+                    "identity key {} is corrupt (expected 64 hex chars)",
+                    path.display()
+                ))
+            })?;
+            Ok(LocalSigner::from_seed(&seed))
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            let signer = LocalSigner::generate();
+            let hex = encode_hex(&signer.seed_bytes());
+            tokio::fs::write(&path, hex.as_bytes())
+                .await
+                .map_err(|source| OpenCompanyError::StoreIo {
+                    path: path.clone(),
+                    source,
+                })?;
+            restrict_file(&path)?;
+            Ok(signer)
+        }
+        Err(source) => Err(OpenCompanyError::StoreIo { path, source }),
+    }
+}
+
+/// Resolves the signer for a [`CompanyId`] under an OpenCompany home root.
+pub async fn signer_for(
+    root: impl Into<std::path::PathBuf>,
+    id: &CompanyId,
+) -> Result<LocalSigner> {
+    let bundle = Bundle::new(root, id);
+    load_or_create_signer(&bundle).await
+}
+
+// ---------------------------------------------------------------------------
+// Small dependency-free codecs (avoid pulling a `hex` crate).
+// ---------------------------------------------------------------------------
+
+fn encode_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+fn decode_hex_seed(text: &str) -> Option<[u8; 32]> {
+    if text.len() != 64 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    let bytes = text.as_bytes();
+    for (i, slot) in out.iter_mut().enumerate() {
+        let hi = hex_val(bytes[i * 2])?;
+        let lo = hex_val(bytes[i * 2 + 1])?;
+        *slot = (hi << 4) | lo;
+    }
+    Some(out)
+}
+
+fn hex_val(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn decode_32(b58: &str) -> Option<[u8; 32]> {
+    let v = bs58::decode(b58).into_vec().ok()?;
+    v.try_into().ok()
+}
+
+fn decode_64(b58: &str) -> Option<[u8; 64]> {
+    let v = bs58::decode(b58).into_vec().ok()?;
+    v.try_into().ok()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn tmp_bundle() -> (tempfile::TempDir, Bundle) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bundle = Bundle::new(dir.path().to_path_buf(), &CompanyId::new("acme"));
+        (dir, bundle)
+    }
+
+    #[tokio::test]
+    async fn keygen_persists_and_reloads_same_agent_id() {
+        let (_dir, bundle) = tmp_bundle();
+        let first = load_or_create_signer(&bundle).await.expect("create");
+        assert!(bundle.agent_key().exists(), "seed file written");
+
+        let again = load_or_create_signer(&bundle).await.expect("reload");
+        assert_eq!(
+            first.agent_id(),
+            again.agent_id(),
+            "reload yields identical identity"
+        );
+    }
+
+    #[test]
+    fn agent_id_is_base58_of_32_byte_pubkey() {
+        let signer = LocalSigner::generate();
+        let id = signer.agent_id();
+        let decoded = bs58::decode(&id).into_vec().expect("base58");
+        assert_eq!(decoded.len(), 32);
+        assert_eq!(decoded, signer.public_key_bytes().to_vec());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn seed_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_dir, bundle) = tmp_bundle();
+        load_or_create_signer(&bundle).await.expect("create");
+        let meta = std::fs::metadata(bundle.agent_key()).expect("metadata");
+        assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+    }
+
+    #[test]
+    fn sign_verify_round_trip_and_wrong_key_fails() {
+        let signer = LocalSigner::generate();
+        let other = LocalSigner::generate();
+        let msg = b"canonical-payload";
+
+        let sig = signer.sign_b58(msg);
+        verify_b58(&signer.agent_id(), msg, &sig).expect("valid signature verifies");
+
+        // Same signature attributed to a different agent must fail.
+        assert!(verify_b58(&other.agent_id(), msg, &sig).is_err());
+        // Tampered message must fail.
+        assert!(verify_b58(&signer.agent_id(), b"tampered", &sig).is_err());
+    }
+
+    #[test]
+    fn hex_codec_round_trips() {
+        let seed = [
+            0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 255,
+        ];
+        let hex = encode_hex(&seed);
+        assert_eq!(hex.len(), 64);
+        assert_eq!(decode_hex_seed(&hex), Some(seed));
+        assert_eq!(decode_hex_seed("xyz"), None);
+    }
+}

--- a/src/economy/siwx.rs
+++ b/src/economy/siwx.rs
@@ -174,7 +174,7 @@ pub fn verify(
 /// Entries older than [`SKEW_SECS`] are pruned on insert, bounding memory to the
 /// skew window. In-memory only; cross-restart persistence is a documented
 /// follow-up.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct NonceCache {
     seen: Mutex<HashMap<String, i64>>,
 }

--- a/src/economy/siwx.rs
+++ b/src/economy/siwx.rs
@@ -1,0 +1,290 @@
+//! SIWX (Sign-In With X) per-action authorization over Ed25519.
+//!
+//! Every authenticated tiny.place request carries an
+//! `Authorization: tiny.place <agentId>:<signature>:<timestamp>` header. The
+//! signature covers a **canonical payload** binding the request method, path,
+//! timestamp, and a hash of the body, so a captured header cannot be replayed
+//! against a different request.
+//!
+//! Freshness and replay protection:
+//! - the timestamp must be within [`SKEW_SECS`] of the verifier's clock;
+//! - each accepted signature is recorded in a [`NonceCache`]; a second
+//!   presentation of the same signature within the skew window is rejected.
+//!   The Ed25519 signature is itself the anti-replay nonce: it is unique per
+//!   `(method, path, timestamp, body_hash)` tuple.
+//!
+//! ## Canonical byte layout (golden, versioned)
+//!
+//! ```text
+//! tiny.place-siwx-v1\n
+//! <method>\n
+//! <path>\n
+//! <timestamp>\n
+//! <body_hash>
+//! ```
+//!
+//! Isolated in [`canonical_bytes`] so reconciling with the real tiny.place
+//! server, when reachable, is a one-function change. `body_hash` is supplied by
+//! the caller (a hex digest of the request body, or an empty string for bodiless
+//! requests); this module does not hash bodies itself.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use crate::Result;
+use crate::economy::signer::{LocalSigner, verify_b58};
+use crate::error::OpenCompanyError;
+
+/// The domain-separation tag pinning the canonical layout version.
+pub const SIWX_DOMAIN: &str = "tiny.place-siwx-v1";
+
+/// The `tiny.place ` scheme prefix on the `Authorization` header.
+pub const SIWX_SCHEME: &str = "tiny.place";
+
+/// Maximum tolerated clock skew, in seconds, between signer and verifier.
+pub const SKEW_SECS: i64 = 300;
+
+/// The parts of a parsed or freshly built SIWX authorization header.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SiwxHeader {
+    /// The signer's base58 `agentId`.
+    pub agent_id: String,
+    /// The base58-encoded Ed25519 signature.
+    pub signature_b58: String,
+    /// The signing timestamp, epoch seconds.
+    pub timestamp: i64,
+}
+
+/// The fields bound by a SIWX signature.
+#[derive(Clone, Debug)]
+pub struct SiwxPayload<'a> {
+    /// HTTP method, uppercased (e.g. `POST`).
+    pub method: &'a str,
+    /// Request path (e.g. `/a2a/acme`).
+    pub path: &'a str,
+    /// Signing timestamp, epoch seconds.
+    pub timestamp: i64,
+    /// Hex digest of the request body, or empty for bodiless requests.
+    pub body_hash: &'a str,
+}
+
+/// Builds the canonical bytes a SIWX signature covers. See the module docs for
+/// the exact layout.
+pub fn canonical_bytes(p: &SiwxPayload) -> Vec<u8> {
+    format!(
+        "{SIWX_DOMAIN}\n{}\n{}\n{}\n{}",
+        p.method, p.path, p.timestamp, p.body_hash
+    )
+    .into_bytes()
+}
+
+/// Signs `payload` with `signer`, producing the header parts.
+pub fn build_header(signer: &LocalSigner, payload: &SiwxPayload) -> SiwxHeader {
+    let signature_b58 = signer.sign_b58(&canonical_bytes(payload));
+    SiwxHeader {
+        agent_id: signer.agent_id(),
+        signature_b58,
+        timestamp: payload.timestamp,
+    }
+}
+
+/// Renders a [`SiwxHeader`] as an `Authorization` header value:
+/// `tiny.place <agentId>:<signature>:<timestamp>`.
+pub fn header_value(h: &SiwxHeader) -> String {
+    format!(
+        "{SIWX_SCHEME} {}:{}:{}",
+        h.agent_id, h.signature_b58, h.timestamp
+    )
+}
+
+/// Parses an `Authorization` header value into its parts.
+pub fn parse_header(header: &str) -> Result<SiwxHeader> {
+    let rest = header
+        .strip_prefix(SIWX_SCHEME)
+        .map(str::trim_start)
+        .ok_or_else(|| {
+            OpenCompanyError::InvalidRequest("authorization is not a tiny.place scheme".into())
+        })?;
+
+    let mut parts = rest.splitn(3, ':');
+    let agent_id = parts.next().unwrap_or_default();
+    let signature_b58 = parts.next().unwrap_or_default();
+    let ts_raw = parts.next().unwrap_or_default();
+
+    if agent_id.is_empty() || signature_b58.is_empty() || ts_raw.is_empty() {
+        return Err(OpenCompanyError::InvalidRequest(
+            "authorization must be <agentId>:<signature>:<timestamp>".into(),
+        ));
+    }
+    let timestamp = ts_raw.parse::<i64>().map_err(|_| {
+        OpenCompanyError::InvalidRequest("authorization timestamp is not an integer".into())
+    })?;
+
+    Ok(SiwxHeader {
+        agent_id: agent_id.to_string(),
+        signature_b58: signature_b58.to_string(),
+        timestamp,
+    })
+}
+
+/// Verifies an inbound SIWX header against the reconstructed canonical payload.
+///
+/// Enforces, in order: header shape, clock skew ≤ [`SKEW_SECS`], Ed25519
+/// signature validity, and single-use of the signature via `seen`. On success
+/// returns the authenticated `agentId`.
+pub fn verify(
+    header: &str,
+    method: &str,
+    path: &str,
+    body_hash: &str,
+    now: i64,
+    seen: &NonceCache,
+) -> Result<String> {
+    let parsed = parse_header(header)?;
+
+    if (now - parsed.timestamp).abs() > SKEW_SECS {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "authorization timestamp is outside the ±{SKEW_SECS}s window"
+        )));
+    }
+
+    let payload = SiwxPayload {
+        method,
+        path,
+        timestamp: parsed.timestamp,
+        body_hash,
+    };
+    verify_b58(
+        &parsed.agent_id,
+        &canonical_bytes(&payload),
+        &parsed.signature_b58,
+    )?;
+
+    if !seen.check_and_insert(&parsed.signature_b58, now) {
+        return Err(OpenCompanyError::InvalidRequest(
+            "authorization signature has already been used (replay)".into(),
+        ));
+    }
+
+    Ok(parsed.agent_id)
+}
+
+/// A process-local record of accepted signatures for replay protection.
+///
+/// Entries older than [`SKEW_SECS`] are pruned on insert, bounding memory to the
+/// skew window. In-memory only; cross-restart persistence is a documented
+/// follow-up.
+#[derive(Default)]
+pub struct NonceCache {
+    seen: Mutex<HashMap<String, i64>>,
+}
+
+impl NonceCache {
+    /// Creates an empty cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records `signature` as used at `now`, pruning stale entries first.
+    ///
+    /// Returns `true` if the signature was previously unseen (accept), `false`
+    /// if it is a replay (reject).
+    pub fn check_and_insert(&self, signature: &str, now: i64) -> bool {
+        let mut guard = self.seen.lock().expect("nonce cache poisoned");
+        guard.retain(|_, ts| (now - *ts).abs() <= SKEW_SECS);
+        if guard.contains_key(signature) {
+            return false;
+        }
+        guard.insert(signature.to_string(), now);
+        true
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn payload<'a>(now: i64) -> SiwxPayload<'a> {
+        SiwxPayload {
+            method: "POST",
+            path: "/a2a/acme",
+            timestamp: now,
+            body_hash: "abc123",
+        }
+    }
+
+    #[test]
+    fn sign_and_verify_round_trip() {
+        let signer = LocalSigner::generate();
+        let now = 1_700_000_000;
+        let header = header_value(&build_header(&signer, &payload(now)));
+        let cache = NonceCache::new();
+
+        let id = verify(&header, "POST", "/a2a/acme", "abc123", now, &cache).expect("verifies");
+        assert_eq!(id, signer.agent_id());
+    }
+
+    #[test]
+    fn tampered_body_hash_fails() {
+        let signer = LocalSigner::generate();
+        let now = 1_700_000_000;
+        let header = header_value(&build_header(&signer, &payload(now)));
+        let cache = NonceCache::new();
+
+        let err = verify(&header, "POST", "/a2a/acme", "DIFFERENT", now, &cache);
+        assert!(
+            err.is_err(),
+            "signature must not verify over a changed body"
+        );
+    }
+
+    #[test]
+    fn skewed_timestamp_is_rejected() {
+        let signer = LocalSigner::generate();
+        let signed_at = 1_700_000_000;
+        let header = header_value(&build_header(&signer, &payload(signed_at)));
+        let cache = NonceCache::new();
+
+        let now = signed_at + SKEW_SECS + 100;
+        let err = verify(&header, "POST", "/a2a/acme", "abc123", now, &cache);
+        assert!(err.is_err(), "stale timestamp must be rejected");
+    }
+
+    #[test]
+    fn replayed_signature_is_rejected() {
+        let signer = LocalSigner::generate();
+        let now = 1_700_000_000;
+        let header = header_value(&build_header(&signer, &payload(now)));
+        let cache = NonceCache::new();
+
+        verify(&header, "POST", "/a2a/acme", "abc123", now, &cache).expect("first accepted");
+        let err = verify(&header, "POST", "/a2a/acme", "abc123", now, &cache);
+        assert!(err.is_err(), "second presentation must be rejected");
+    }
+
+    #[test]
+    fn wrong_path_fails_because_signature_binds_it() {
+        let signer = LocalSigner::generate();
+        let now = 1_700_000_000;
+        let header = header_value(&build_header(&signer, &payload(now)));
+        let cache = NonceCache::new();
+
+        let err = verify(&header, "POST", "/a2a/other", "abc123", now, &cache);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn malformed_headers_are_rejected() {
+        assert!(parse_header("Bearer xyz").is_err());
+        assert!(parse_header("tiny.place only-one-part").is_err());
+        assert!(parse_header("tiny.place a:b:notanint").is_err());
+    }
+
+    #[test]
+    fn nonce_cache_prunes_stale_entries() {
+        let cache = NonceCache::new();
+        assert!(cache.check_and_insert("sig-a", 1_000));
+        // Far in the future: the stale entry is pruned, so re-inserting is fine.
+        assert!(cache.check_and_insert("sig-a", 1_000 + SKEW_SECS * 4));
+    }
+}

--- a/src/economy/x402.rs
+++ b/src/economy/x402.rs
@@ -1,0 +1,270 @@
+//! x402 payment challenges and Ed25519-signed authorizations.
+//!
+//! When a counterparty gates a skill behind payment it answers `402` with a
+//! challenge naming the `amount`, `recipient`, `asset`, and `network`. The payer
+//! signs an **authorization** over a canonical payload with the same Ed25519
+//! identity key it uses for SIWX, then posts it to the settlement endpoints.
+//! This module only *builds and verifies* authorizations — no on-chain
+//! submission happens here (that is a documented SDK gap).
+//!
+//! ## Canonical byte layout (golden, versioned)
+//!
+//! ```text
+//! tiny.place-x402-v1\n
+//! <agentId>\n
+//! <amount>\n
+//! <recipient>\n
+//! <asset>\n
+//! <network>\n
+//! <nonce>\n
+//! <timestamp>
+//! ```
+//!
+//! Isolated in [`canonical_bytes`] so it is a one-function change to reconcile
+//! with the real tiny.place server when reachable.
+
+use serde::{Deserialize, Serialize};
+
+use crate::Result;
+use crate::economy::signer::{LocalSigner, verify_b58};
+use crate::error::OpenCompanyError;
+use crate::ports::generate_id;
+
+/// The domain-separation tag pinning the x402 canonical layout version.
+pub const X402_DOMAIN: &str = "tiny.place-x402-v1";
+
+/// A payment challenge parsed from a counterparty's `402` response body.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct X402Challenge {
+    /// The amount due, as a decimal string (e.g. `"25.00"`).
+    pub amount: String,
+    /// The recipient address to pay.
+    pub recipient: String,
+    /// The settlement asset (e.g. `"USDC"`).
+    pub asset: String,
+    /// The settlement network (e.g. `"solana"`).
+    pub network: String,
+}
+
+impl X402Challenge {
+    /// Parses a challenge from a `402` JSON body.
+    ///
+    /// Accepts either a flat object (`{amount, recipient, asset, network}`) or
+    /// the x402 `{ "accepts": [ { … } ] }` envelope, and tolerates the common
+    /// field aliases `maxAmountRequired`/`payTo`.
+    pub fn from_body(v: &serde_json::Value) -> Result<Self> {
+        let obj = v.get("accepts").and_then(|a| a.get(0)).unwrap_or(v);
+
+        let amount = string_field(obj, &["amount", "maxAmountRequired"]).ok_or_else(|| {
+            OpenCompanyError::InvalidRequest("x402 challenge is missing `amount`".into())
+        })?;
+        let recipient = string_field(obj, &["recipient", "payTo"]).ok_or_else(|| {
+            OpenCompanyError::InvalidRequest("x402 challenge is missing `recipient`".into())
+        })?;
+        let asset = string_field(obj, &["asset"]).unwrap_or_else(|| "USDC".to_string());
+        let network = string_field(obj, &["network"]).unwrap_or_else(|| "solana".to_string());
+
+        Ok(Self {
+            amount,
+            recipient,
+            asset,
+            network,
+        })
+    }
+}
+
+/// A signed x402 payment authorization, ready to POST to `/payments/verify`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct X402Authorization {
+    /// The payer's base58 `agentId`.
+    #[serde(rename = "agentId")]
+    pub agent_id: String,
+    /// The amount authorized. May exceed the challenge amount for an `upto`
+    /// delegated-signer grant.
+    pub amount: String,
+    /// The recipient address.
+    pub recipient: String,
+    /// The settlement asset.
+    pub asset: String,
+    /// The settlement network.
+    pub network: String,
+    /// A single-use nonce.
+    pub nonce: String,
+    /// The authorization timestamp, epoch seconds.
+    pub timestamp: i64,
+    /// The base58 Ed25519 signature over [`canonical_bytes`].
+    #[serde(rename = "signature")]
+    pub signature_b58: String,
+}
+
+/// Builds the canonical bytes an x402 authorization signs. See module docs.
+pub fn canonical_bytes(
+    agent_id: &str,
+    amount: &str,
+    recipient: &str,
+    asset: &str,
+    network: &str,
+    nonce: &str,
+    timestamp: i64,
+) -> Vec<u8> {
+    format!(
+        "{X402_DOMAIN}\n{agent_id}\n{amount}\n{recipient}\n{asset}\n{network}\n{nonce}\n{timestamp}"
+    )
+    .into_bytes()
+}
+
+/// Signs an authorization paying exactly the challenged amount.
+pub fn authorize(signer: &LocalSigner, ch: &X402Challenge, now: i64) -> X402Authorization {
+    authorize_amount(signer, ch, ch.amount.clone(), now)
+}
+
+/// Signs a delegated-signer `upto` authorization capped at `cap`, letting the
+/// counterparty settle any amount up to the cap.
+pub fn authorize_upto(
+    signer: &LocalSigner,
+    ch: &X402Challenge,
+    cap: &str,
+    now: i64,
+) -> X402Authorization {
+    authorize_amount(signer, ch, cap.to_string(), now)
+}
+
+fn authorize_amount(
+    signer: &LocalSigner,
+    ch: &X402Challenge,
+    amount: String,
+    now: i64,
+) -> X402Authorization {
+    let agent_id = signer.agent_id();
+    let nonce = generate_id();
+    let msg = canonical_bytes(
+        &agent_id,
+        &amount,
+        &ch.recipient,
+        &ch.asset,
+        &ch.network,
+        &nonce,
+        now,
+    );
+    let signature_b58 = signer.sign_b58(&msg);
+    X402Authorization {
+        agent_id,
+        amount,
+        recipient: ch.recipient.clone(),
+        asset: ch.asset.clone(),
+        network: ch.network.clone(),
+        nonce,
+        timestamp: now,
+        signature_b58,
+    }
+}
+
+/// Verifies an authorization's signature against its own declared `agentId`.
+pub fn verify(auth: &X402Authorization) -> Result<()> {
+    let msg = canonical_bytes(
+        &auth.agent_id,
+        &auth.amount,
+        &auth.recipient,
+        &auth.asset,
+        &auth.network,
+        &auth.nonce,
+        auth.timestamp,
+    );
+    verify_b58(&auth.agent_id, &msg, &auth.signature_b58)
+}
+
+fn string_field(obj: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    for key in keys {
+        if let Some(s) = obj.get(*key).and_then(|v| v.as_str()) {
+            return Some(s.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn sample_challenge() -> X402Challenge {
+        X402Challenge {
+            amount: "25.00".into(),
+            recipient: "RecipientAddr".into(),
+            asset: "USDC".into(),
+            network: "solana".into(),
+        }
+    }
+
+    #[test]
+    fn parses_flat_challenge_body() {
+        let body = serde_json::json!({
+            "amount": "25.00",
+            "recipient": "RecipientAddr",
+            "asset": "USDC",
+            "network": "solana"
+        });
+        assert_eq!(X402Challenge::from_body(&body).unwrap(), sample_challenge());
+    }
+
+    #[test]
+    fn parses_accepts_envelope_with_aliases() {
+        let body = serde_json::json!({
+            "accepts": [ { "maxAmountRequired": "10.00", "payTo": "Somebody" } ]
+        });
+        let ch = X402Challenge::from_body(&body).unwrap();
+        assert_eq!(ch.amount, "10.00");
+        assert_eq!(ch.recipient, "Somebody");
+        assert_eq!(ch.asset, "USDC");
+        assert_eq!(ch.network, "solana");
+    }
+
+    #[test]
+    fn missing_amount_is_an_error() {
+        let body = serde_json::json!({ "recipient": "x" });
+        assert!(X402Challenge::from_body(&body).is_err());
+    }
+
+    #[test]
+    fn authorize_signs_a_verifiable_payload() {
+        let signer = LocalSigner::generate();
+        let ch = sample_challenge();
+        let auth = authorize(&signer, &ch, 1_700_000_000);
+
+        assert_eq!(auth.agent_id, signer.agent_id());
+        assert_eq!(auth.amount, "25.00");
+        assert_eq!(auth.recipient, "RecipientAddr");
+        verify(&auth).expect("authorization verifies against its own key");
+    }
+
+    #[test]
+    fn authorize_upto_carries_the_cap() {
+        let signer = LocalSigner::generate();
+        let ch = sample_challenge();
+        let auth = authorize_upto(&signer, &ch, "100.00", 1_700_000_000);
+        assert_eq!(auth.amount, "100.00");
+        verify(&auth).expect("upto authorization verifies");
+    }
+
+    #[test]
+    fn tampered_authorization_fails_verification() {
+        let signer = LocalSigner::generate();
+        let ch = sample_challenge();
+        let mut auth = authorize(&signer, &ch, 1_700_000_000);
+        auth.amount = "0.01".into();
+        assert!(
+            verify(&auth).is_err(),
+            "changed amount must break the signature"
+        );
+    }
+
+    #[test]
+    fn authorization_json_round_trips() {
+        let signer = LocalSigner::generate();
+        let auth = authorize(&signer, &sample_challenge(), 1_700_000_000);
+        let json = serde_json::to_string(&auth).expect("serialize");
+        assert!(json.contains("\"agentId\""));
+        assert!(json.contains("\"signature\""));
+        let back: X402Authorization = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, auth);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -109,6 +109,17 @@ pub enum OpenCompanyError {
         message: String,
     },
 
+    /// A tiny.place economy transport or protocol failure. `code` is a stable
+    /// machine-readable token (e.g. `unreachable`, `http_502`); `message` is the
+    /// human-readable detail.
+    #[error("tinyplace error ({code}): {message}")]
+    Tinyplace {
+        /// A stable, machine-readable failure token.
+        code: String,
+        /// A human-readable description of the failure.
+        message: String,
+    },
+
     /// A port method has no implementation in the current build.
     #[error("port not implemented: {0}")]
     Unimplemented(&'static str),
@@ -119,6 +130,15 @@ impl OpenCompanyError {
     /// message. `code` is stored verbatim and surfaced by [`Self::code`].
     pub fn orchestration(code: impl Into<String>, message: impl Into<String>) -> Self {
         Self::Orchestration {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+
+    /// Builds an [`OpenCompanyError::Tinyplace`] from a failure token and
+    /// message. `code` is stored verbatim and surfaced by [`Self::code`].
+    pub fn tinyplace(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Tinyplace {
             code: code.into(),
             message: message.into(),
         }
@@ -151,6 +171,7 @@ impl OpenCompanyError {
             Self::InvalidRequest(_) => "invalid_request".to_string(),
             Self::Config(_) => "config_error".to_string(),
             Self::Orchestration { code, .. } => code.clone(),
+            Self::Tinyplace { code, .. } => format!("tinyplace_{code}"),
             Self::Unimplemented(_) => "unimplemented".to_string(),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,19 @@ pub enum OpenCompanyError {
     #[error("openhuman process error: {0}")]
     OpenHumanProcess(#[from] std::io::Error),
 
+    /// An OpenHuman JSON-RPC call failed at the transport or protocol level.
+    ///
+    /// Carries the failure as an owned `code`/`message` pair rather than a
+    /// `#[from] std::io::Error` so it never collides with the existing
+    /// `OpenHumanProcess` conversion.
+    #[error("openhuman rpc error ({code}): {message}")]
+    OpenHuman {
+        /// The JSON-RPC error code (or a synthetic transport code).
+        code: i64,
+        /// A human-readable description of the failure.
+        message: String,
+    },
+
     /// No manifest (`company.toml` or `agents.toml`) was found.
     #[error("no company.toml or agents.toml found in {0}")]
     MissingManifest(PathBuf),
@@ -76,6 +89,11 @@ pub enum OpenCompanyError {
     #[error("company is {0}")]
     LifecycleConflict(String),
 
+    /// A request was malformed or internally inconsistent (e.g. an approval
+    /// resolution that pairs a `deny` verdict with an amended payload).
+    #[error("invalid request: {0}")]
+    InvalidRequest(String),
+
     /// A port method has no implementation in the current build.
     #[error("port not implemented: {0}")]
     Unimplemented(&'static str),
@@ -90,6 +108,7 @@ impl OpenCompanyError {
         match self {
             Self::MissingOpenHumanRoot(_) => "openhuman_root_missing",
             Self::OpenHumanProcess(_) => "openhuman_process",
+            Self::OpenHuman { .. } => "openhuman_rpc",
             Self::MissingManifest(_) => "manifest_missing",
             Self::ManifestRead { .. } => "manifest_read",
             Self::ManifestParse(_, _) => "manifest_parse",
@@ -101,6 +120,7 @@ impl OpenCompanyError {
             Self::ToolNotGranted(_) => "tool_not_granted",
             Self::BudgetExceeded(_) => "budget_exceeded",
             Self::LifecycleConflict(_) => "lifecycle_conflict",
+            Self::InvalidRequest(_) => "invalid_request",
             Self::Unimplemented(_) => "unimplemented",
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -94,34 +94,64 @@ pub enum OpenCompanyError {
     #[error("invalid request: {0}")]
     InvalidRequest(String),
 
+    /// Runtime configuration could not be resolved (bad value, unreadable or
+    /// malformed `config.toml`).
+    #[error("configuration error: {0}")]
+    Config(String),
+
+    /// The hosted Medulla orchestrator (`/orchestration/v1`) reported a wire
+    /// error. `code` is the verbatim `ORCH_*` string from the server envelope.
+    #[error("orchestration error [{code}]: {message}")]
+    Orchestration {
+        /// The verbatim `ORCH_*` error code from the server envelope.
+        code: String,
+        /// The human-readable error message.
+        message: String,
+    },
+
     /// A port method has no implementation in the current build.
     #[error("port not implemented: {0}")]
     Unimplemented(&'static str),
 }
 
 impl OpenCompanyError {
+    /// Builds an [`OpenCompanyError::Orchestration`] from a wire error code and
+    /// message. `code` is stored verbatim and surfaced by [`Self::code`].
+    pub fn orchestration(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Orchestration {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+
     /// A stable, machine-readable code for this error.
     ///
     /// Surfaced in the HTTP error envelope (`{ "error", "code" }`) so clients
     /// can branch on the code rather than parsing the human-readable message.
-    pub fn code(&self) -> &'static str {
+    ///
+    /// Returns an owned `String` because [`Self::Orchestration`] carries a
+    /// runtime `ORCH_*` code that is not `'static`; every other variant maps to
+    /// a fixed string literal.
+    pub fn code(&self) -> String {
         match self {
-            Self::MissingOpenHumanRoot(_) => "openhuman_root_missing",
-            Self::OpenHumanProcess(_) => "openhuman_process",
-            Self::OpenHuman { .. } => "openhuman_rpc",
-            Self::MissingManifest(_) => "manifest_missing",
-            Self::ManifestRead { .. } => "manifest_read",
-            Self::ManifestParse(_, _) => "manifest_parse",
-            Self::ManifestInvalid { .. } => "manifest_invalid",
-            Self::Store(_) => "store_error",
-            Self::StoreIo { .. } => "store_io",
-            Self::Serde(_) => "serialization_error",
-            Self::CompanyNotFound(_) => "company_not_found",
-            Self::ToolNotGranted(_) => "tool_not_granted",
-            Self::BudgetExceeded(_) => "budget_exceeded",
-            Self::LifecycleConflict(_) => "lifecycle_conflict",
-            Self::InvalidRequest(_) => "invalid_request",
-            Self::Unimplemented(_) => "unimplemented",
+            Self::MissingOpenHumanRoot(_) => "openhuman_root_missing".to_string(),
+            Self::OpenHumanProcess(_) => "openhuman_process".to_string(),
+            Self::OpenHuman { .. } => "openhuman_rpc".to_string(),
+            Self::MissingManifest(_) => "manifest_missing".to_string(),
+            Self::ManifestRead { .. } => "manifest_read".to_string(),
+            Self::ManifestParse(_, _) => "manifest_parse".to_string(),
+            Self::ManifestInvalid { .. } => "manifest_invalid".to_string(),
+            Self::Store(_) => "store_error".to_string(),
+            Self::StoreIo { .. } => "store_io".to_string(),
+            Self::Serde(_) => "serialization_error".to_string(),
+            Self::CompanyNotFound(_) => "company_not_found".to_string(),
+            Self::ToolNotGranted(_) => "tool_not_granted".to_string(),
+            Self::BudgetExceeded(_) => "budget_exceeded".to_string(),
+            Self::LifecycleConflict(_) => "lifecycle_conflict".to_string(),
+            Self::InvalidRequest(_) => "invalid_request".to_string(),
+            Self::Config(_) => "config_error".to_string(),
+            Self::Orchestration { code, .. } => code.clone(),
+            Self::Unimplemented(_) => "unimplemented".to_string(),
         }
     }
 }

--- a/src/feedback/github.rs
+++ b/src/feedback/github.rs
@@ -1,0 +1,562 @@
+//! GitHub issue filing behind a mockable client.
+//!
+//! The [`GitHubClient`] trait and its offline [`MockGitHubClient`] compile in
+//! the default build so the whole filing flow — dedupe, rate-limit, signing,
+//! labels, and the tokenless manual-link fallback — is exercised offline. Only
+//! the real HTTP filer [`HttpGitHubClient`] is gated behind the `github`
+//! feature.
+//!
+//! Filing obligations (`docs/spec/feedback-loop/README.md`):
+//!
+//! * **Dedupe** — search existing issues first; comment instead of duplicating.
+//! * **Rate-limit** — per company, so a noisy company cannot flood the tracker.
+//! * **Sign** — the body carries the company `@handle` for provenance.
+//! * **Degrade** — without a token, return a prefilled manual issue link.
+
+use std::collections::HashMap;
+use std::sync::Mutex as StdMutex;
+
+use async_trait::async_trait;
+
+use crate::Result;
+use crate::feedback::types::ConsentMode;
+
+/// A draft issue to create.
+#[derive(Clone, Debug, PartialEq)]
+pub struct IssueDraft {
+    /// The issue title.
+    pub title: String,
+    /// The issue body (already scrubbed and signed).
+    pub body: String,
+    /// The issue labels.
+    pub labels: Vec<String>,
+}
+
+/// A pre-existing issue found by a dedupe search.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExistingIssue {
+    /// The issue number.
+    pub number: u64,
+    /// The issue URL.
+    pub url: String,
+    /// The issue title.
+    pub title: String,
+}
+
+/// A GitHub REST client scoped to issue filing.
+#[async_trait]
+pub trait GitHubClient: Send + Sync {
+    /// Searches a repo for issues matching `query` (dedupe).
+    async fn search_issues(&self, repo: &str, query: &str) -> Result<Vec<ExistingIssue>>;
+    /// Creates an issue, returning its URL.
+    async fn create_issue(&self, repo: &str, draft: &IssueDraft) -> Result<String>;
+    /// Comments on an existing issue (the dedupe path).
+    async fn comment_issue(&self, repo: &str, number: u64, body: &str) -> Result<()>;
+}
+
+/// The result of a filing attempt.
+#[derive(Clone, Debug, PartialEq)]
+pub enum FilingOutcome {
+    /// A new issue was created at this URL.
+    Filed {
+        /// The created issue URL.
+        url: String,
+    },
+    /// An existing issue matched; a comment was added instead of duplicating.
+    Deduped {
+        /// The existing issue URL.
+        url: String,
+    },
+    /// The per-company rate limit was hit; nothing was filed.
+    RateLimited,
+    /// No token (or manual consent): the operator files via this prefilled link.
+    ManualLink {
+        /// A prefilled `issues/new` URL.
+        url: String,
+    },
+}
+
+/// A simple per-company token bucket, in memory.
+///
+/// Each company may file at most `max_per_company` issues per process lifetime;
+/// exceeding that returns [`FilingOutcome::RateLimited`]. A real deployment
+/// would persist and window this, but the in-memory bucket keeps a noisy
+/// company from flooding the tracker within a run.
+#[derive(Debug)]
+pub struct RateLimiter {
+    max_per_company: usize,
+    used: StdMutex<HashMap<String, usize>>,
+}
+
+impl RateLimiter {
+    /// Builds a limiter allowing `max_per_company` filings per company.
+    pub fn new(max_per_company: usize) -> Self {
+        Self {
+            max_per_company,
+            used: StdMutex::new(HashMap::new()),
+        }
+    }
+
+    /// Records a filing for `company`, returning `true` if it is within budget.
+    pub fn allow(&self, company: &str) -> bool {
+        let mut used = self.used.lock().expect("rate limiter poisoned");
+        let count = used.entry(company.to_string()).or_insert(0);
+        if *count >= self.max_per_company {
+            return false;
+        }
+        *count += 1;
+        true
+    }
+}
+
+impl Default for RateLimiter {
+    fn default() -> Self {
+        Self::new(20)
+    }
+}
+
+/// Files a feedback issue, honoring consent, dedupe, rate-limit, and the
+/// tokenless fallback.
+///
+/// `body` must already be scrubbed and signed with the company `@handle`. When
+/// `client` is `None` or `consent` is [`ConsentMode::Manual`], the operator
+/// files via the returned [`FilingOutcome::ManualLink`]. Otherwise the client
+/// searches for a duplicate (commenting if found), checks the per-company rate
+/// limit, and creates the issue.
+#[allow(clippy::too_many_arguments)]
+pub async fn file_feedback(
+    client: Option<&dyn GitHubClient>,
+    repo: &str,
+    company: &str,
+    title: &str,
+    body: &str,
+    labels: &[String],
+    consent: ConsentMode,
+    limiter: &RateLimiter,
+) -> Result<FilingOutcome> {
+    // Manual consent or no client: degrade to a prefilled manual link.
+    let Some(client) = client.filter(|_| consent != ConsentMode::Manual) else {
+        return Ok(FilingOutcome::ManualLink {
+            url: manual_issue_url(repo, title, body, labels),
+        });
+    };
+
+    // Dedupe: comment on an existing issue instead of duplicating.
+    let existing = client.search_issues(repo, title).await?;
+    if let Some(issue) = existing.into_iter().next() {
+        client.comment_issue(repo, issue.number, body).await?;
+        return Ok(FilingOutcome::Deduped { url: issue.url });
+    }
+
+    // Rate-limit per company.
+    if !limiter.allow(company) {
+        return Ok(FilingOutcome::RateLimited);
+    }
+
+    let url = client
+        .create_issue(
+            repo,
+            &IssueDraft {
+                title: title.to_string(),
+                body: body.to_string(),
+                labels: labels.to_vec(),
+            },
+        )
+        .await?;
+    Ok(FilingOutcome::Filed { url })
+}
+
+/// Appends the company `@handle` provenance signature to an issue body.
+pub fn sign_body(body: &str, handle: &str) -> String {
+    format!("{body}\n\n— filed by @{handle}")
+}
+
+/// Builds a prefilled `issues/new` URL with a url-encoded title, body, labels.
+pub fn manual_issue_url(repo: &str, title: &str, body: &str, labels: &[String]) -> String {
+    let mut url = format!("https://github.com/{repo}/issues/new");
+    url.push_str("?title=");
+    url.push_str(&percent_encode(title));
+    url.push_str("&body=");
+    url.push_str(&percent_encode(body));
+    if !labels.is_empty() {
+        url.push_str("&labels=");
+        url.push_str(&percent_encode(&labels.join(",")));
+    }
+    url
+}
+
+/// Percent-encodes a string for a URL query value (RFC 3986 unreserved set).
+fn percent_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for byte in s.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+/// An in-memory [`GitHubClient`] for offline tests.
+///
+/// Seed canned dedupe hits with [`with_existing`](Self::with_existing); every
+/// `create_issue` and `comment_issue` is recorded so a test can assert dedupe
+/// commented rather than duplicated.
+#[derive(Debug, Default)]
+pub struct MockGitHubClient {
+    existing: StdMutex<Vec<ExistingIssue>>,
+    created: StdMutex<Vec<IssueDraft>>,
+    comments: StdMutex<Vec<(u64, String)>>,
+    next_number: StdMutex<u64>,
+}
+
+impl MockGitHubClient {
+    /// A mock with no existing issues.
+    pub fn new() -> Self {
+        Self {
+            existing: StdMutex::new(Vec::new()),
+            created: StdMutex::new(Vec::new()),
+            comments: StdMutex::new(Vec::new()),
+            next_number: StdMutex::new(100),
+        }
+    }
+
+    /// Seeds an existing issue that dedupe searches will return.
+    pub fn with_existing(self, number: u64, url: &str, title: &str) -> Self {
+        self.existing
+            .lock()
+            .expect("mock poisoned")
+            .push(ExistingIssue {
+                number,
+                url: url.to_string(),
+                title: title.to_string(),
+            });
+        self
+    }
+
+    /// A snapshot of every issue created through this mock.
+    pub fn created(&self) -> Vec<IssueDraft> {
+        self.created.lock().expect("mock poisoned").clone()
+    }
+
+    /// A snapshot of every comment `(issue_number, body)` recorded.
+    pub fn comments(&self) -> Vec<(u64, String)> {
+        self.comments.lock().expect("mock poisoned").clone()
+    }
+}
+
+#[async_trait]
+impl GitHubClient for MockGitHubClient {
+    async fn search_issues(&self, _repo: &str, query: &str) -> Result<Vec<ExistingIssue>> {
+        // A naive contains-match on the title, enough to exercise dedupe.
+        let hits = self
+            .existing
+            .lock()
+            .expect("mock poisoned")
+            .iter()
+            .filter(|issue| query.contains(&issue.title) || issue.title.contains(query))
+            .cloned()
+            .collect();
+        Ok(hits)
+    }
+
+    async fn create_issue(&self, _repo: &str, draft: &IssueDraft) -> Result<String> {
+        self.created
+            .lock()
+            .expect("mock poisoned")
+            .push(draft.clone());
+        let number = {
+            let mut number = self.next_number.lock().expect("mock poisoned");
+            let current = *number;
+            *number += 1;
+            current
+        };
+        let url = format!("https://github.com/mock/issues/{number}");
+        // Register the new issue so subsequent dedupe searches find it, exactly
+        // as the real tracker would.
+        self.existing
+            .lock()
+            .expect("mock poisoned")
+            .push(ExistingIssue {
+                number,
+                url: url.clone(),
+                title: draft.title.clone(),
+            });
+        Ok(url)
+    }
+
+    async fn comment_issue(&self, _repo: &str, number: u64, body: &str) -> Result<()> {
+        self.comments
+            .lock()
+            .expect("mock poisoned")
+            .push((number, body.to_string()));
+        Ok(())
+    }
+}
+
+/// The real HTTP GitHub client, compiled only under the `github` feature.
+#[cfg(feature = "github")]
+pub use http::HttpGitHubClient;
+
+#[cfg(feature = "github")]
+mod http {
+    use super::{ExistingIssue, GitHubClient, IssueDraft};
+    use crate::Result;
+    use crate::error::OpenCompanyError;
+    use crate::ports::types::SecretValue;
+    use async_trait::async_trait;
+
+    /// A [`GitHubClient`] backed by the GitHub REST API and a `GITHUB_TOKEN`.
+    pub struct HttpGitHubClient {
+        token: SecretValue,
+        http: reqwest::Client,
+    }
+
+    impl HttpGitHubClient {
+        /// Builds a client authenticating with `token`.
+        pub fn new(token: SecretValue) -> Self {
+            Self {
+                token,
+                http: reqwest::Client::new(),
+            }
+        }
+
+        fn err(context: &str, e: impl std::fmt::Display) -> OpenCompanyError {
+            OpenCompanyError::OpenHuman {
+                code: -1,
+                message: format!("github {context}: {e}"),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl GitHubClient for HttpGitHubClient {
+        async fn search_issues(&self, repo: &str, query: &str) -> Result<Vec<ExistingIssue>> {
+            let url = "https://api.github.com/search/issues";
+            let q = format!("repo:{repo} in:title {query}");
+            let resp = self
+                .http
+                .get(url)
+                .query(&[("q", q.as_str())])
+                .header("Authorization", format!("Bearer {}", self.token.expose()))
+                .header("User-Agent", "opencompany")
+                .header("Accept", "application/vnd.github+json")
+                .send()
+                .await
+                .map_err(|e| Self::err("search", e))?;
+            let value: serde_json::Value = resp
+                .json()
+                .await
+                .map_err(|e| Self::err("search-decode", e))?;
+            let mut out = Vec::new();
+            if let Some(items) = value.get("items").and_then(|v| v.as_array()) {
+                for item in items {
+                    let number = item.get("number").and_then(|v| v.as_u64()).unwrap_or(0);
+                    let url = item
+                        .get("html_url")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    let title = item
+                        .get("title")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    out.push(ExistingIssue { number, url, title });
+                }
+            }
+            Ok(out)
+        }
+
+        async fn create_issue(&self, repo: &str, draft: &IssueDraft) -> Result<String> {
+            let url = format!("https://api.github.com/repos/{repo}/issues");
+            let resp = self
+                .http
+                .post(&url)
+                .header("Authorization", format!("Bearer {}", self.token.expose()))
+                .header("User-Agent", "opencompany")
+                .header("Accept", "application/vnd.github+json")
+                .json(&serde_json::json!({
+                    "title": draft.title,
+                    "body": draft.body,
+                    "labels": draft.labels,
+                }))
+                .send()
+                .await
+                .map_err(|e| Self::err("create", e))?;
+            let value: serde_json::Value = resp
+                .json()
+                .await
+                .map_err(|e| Self::err("create-decode", e))?;
+            Ok(value
+                .get("html_url")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string())
+        }
+
+        async fn comment_issue(&self, repo: &str, number: u64, body: &str) -> Result<()> {
+            let url = format!("https://api.github.com/repos/{repo}/issues/{number}/comments");
+            self.http
+                .post(&url)
+                .header("Authorization", format!("Bearer {}", self.token.expose()))
+                .header("User-Agent", "opencompany")
+                .header("Accept", "application/vnd.github+json")
+                .json(&serde_json::json!({ "body": body }))
+                .send()
+                .await
+                .map_err(|e| Self::err("comment", e))?;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[tokio::test]
+    async fn no_client_degrades_to_manual_link() {
+        let limiter = RateLimiter::default();
+        let out = file_feedback(
+            None,
+            "tinyhumansai/opencompany",
+            "acme",
+            "[bug] broken route",
+            "body — filed by @acme",
+            &["feedback".into(), "source/agent-filed".into()],
+            ConsentMode::Auto,
+            &limiter,
+        )
+        .await
+        .unwrap();
+        match out {
+            FilingOutcome::ManualLink { url } => {
+                assert!(url.starts_with("https://github.com/tinyhumansai/opencompany/issues/new"));
+                assert!(url.contains("title="));
+                assert!(url.contains("body="));
+                assert!(url.contains("labels="));
+            }
+            other => panic!("expected ManualLink, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn manual_consent_never_calls_client() {
+        let client = MockGitHubClient::new();
+        let limiter = RateLimiter::default();
+        let out = file_feedback(
+            Some(&client),
+            "r/r",
+            "acme",
+            "t",
+            "b",
+            &[],
+            ConsentMode::Manual,
+            &limiter,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(out, FilingOutcome::ManualLink { .. }));
+        assert!(client.created().is_empty());
+    }
+
+    #[tokio::test]
+    async fn auto_consent_creates_issue_with_labels_and_signature() {
+        let client = MockGitHubClient::new();
+        let limiter = RateLimiter::default();
+        let body = sign_body("the route is broken", "acme");
+        let labels = vec![
+            "feedback".to_string(),
+            "type/bug".to_string(),
+            "area/runtime".to_string(),
+            "sev/annoyance".to_string(),
+            "source/agent-filed".to_string(),
+        ];
+        let out = file_feedback(
+            Some(&client),
+            "r/r",
+            "acme",
+            "[bug] route",
+            &body,
+            &labels,
+            ConsentMode::Auto,
+            &limiter,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(out, FilingOutcome::Filed { .. }));
+
+        let created = client.created();
+        assert_eq!(created.len(), 1);
+        assert!(created[0].body.contains("— filed by @acme"));
+        assert!(
+            created[0]
+                .labels
+                .contains(&"source/agent-filed".to_string())
+        );
+        assert!(created[0].labels.contains(&"type/bug".to_string()));
+    }
+
+    #[tokio::test]
+    async fn dedupe_comments_instead_of_creating() {
+        let client = MockGitHubClient::new().with_existing(
+            42,
+            "https://github.com/mock/issues/42",
+            "[bug] route",
+        );
+        let limiter = RateLimiter::default();
+        let out = file_feedback(
+            Some(&client),
+            "r/r",
+            "acme",
+            "[bug] route",
+            "body — filed by @acme",
+            &[],
+            ConsentMode::Auto,
+            &limiter,
+        )
+        .await
+        .unwrap();
+        match out {
+            FilingOutcome::Deduped { url } => assert_eq!(url, "https://github.com/mock/issues/42"),
+            other => panic!("expected Deduped, got {other:?}"),
+        }
+        assert!(client.created().is_empty());
+        assert_eq!(client.comments().len(), 1);
+        assert_eq!(client.comments()[0].0, 42);
+    }
+
+    #[tokio::test]
+    async fn rate_limit_trips_after_budget() {
+        let client = MockGitHubClient::new();
+        let limiter = RateLimiter::new(1);
+        let file = |title: &'static str| {
+            file_feedback(
+                Some(&client),
+                "r/r",
+                "acme",
+                title,
+                "b — filed by @acme",
+                &[],
+                ConsentMode::Auto,
+                &limiter,
+            )
+        };
+        assert!(matches!(
+            file("one").await.unwrap(),
+            FilingOutcome::Filed { .. }
+        ));
+        assert!(matches!(
+            file("two").await.unwrap(),
+            FilingOutcome::RateLimited
+        ));
+    }
+
+    #[test]
+    fn signature_carries_handle() {
+        assert_eq!(sign_body("x", "acme"), "x\n\n— filed by @acme");
+    }
+}

--- a/src/feedback/github.rs
+++ b/src/feedback/github.rs
@@ -52,6 +52,8 @@ pub trait GitHubClient: Send + Sync {
     async fn create_issue(&self, repo: &str, draft: &IssueDraft) -> Result<String>;
     /// Comments on an existing issue (the dedupe path).
     async fn comment_issue(&self, repo: &str, number: u64, body: &str) -> Result<()>;
+    /// Closes an existing issue (the merge-duplicate and cluster paths).
+    async fn close_issue(&self, repo: &str, number: u64) -> Result<()>;
 }
 
 /// The result of a filing attempt.
@@ -118,11 +120,13 @@ impl Default for RateLimiter {
 /// Files a feedback issue, honoring consent, dedupe, rate-limit, and the
 /// tokenless fallback.
 ///
-/// `body` must already be scrubbed and signed with the company `@handle`. When
-/// `client` is `None` or `consent` is [`ConsentMode::Manual`], the operator
-/// files via the returned [`FilingOutcome::ManualLink`]. Otherwise the client
-/// searches for a duplicate (commenting if found), checks the per-company rate
-/// limit, and creates the issue.
+/// `body` must already be scrubbed and signed with the company `@handle`. Only
+/// standing [`ConsentMode::Auto`] auto-creates the issue. `Manual` and
+/// `Assisted` (the latter is also where a throttled low-quality filer lands)
+/// return a [`FilingOutcome::ManualLink`] so the operator approves/files the
+/// exact body themselves; a missing `client` degrades the same way. When it does
+/// file, the client searches for a duplicate (commenting if found), checks the
+/// per-company rate limit, and creates the issue.
 #[allow(clippy::too_many_arguments)]
 pub async fn file_feedback(
     client: Option<&dyn GitHubClient>,
@@ -134,8 +138,10 @@ pub async fn file_feedback(
     consent: ConsentMode,
     limiter: &RateLimiter,
 ) -> Result<FilingOutcome> {
-    // Manual consent or no client: degrade to a prefilled manual link.
-    let Some(client) = client.filter(|_| consent != ConsentMode::Manual) else {
+    // Only standing Auto consent auto-files. Manual and Assisted (incl. a
+    // throttled filer downgraded to Assisted) go to the operator via a prefilled
+    // link; a missing client degrades the same way.
+    let Some(client) = client.filter(|_| consent == ConsentMode::Auto) else {
         return Ok(FilingOutcome::ManualLink {
             url: manual_issue_url(repo, title, body, labels),
         });
@@ -209,6 +215,7 @@ pub struct MockGitHubClient {
     existing: StdMutex<Vec<ExistingIssue>>,
     created: StdMutex<Vec<IssueDraft>>,
     comments: StdMutex<Vec<(u64, String)>>,
+    closed: StdMutex<Vec<u64>>,
     next_number: StdMutex<u64>,
 }
 
@@ -219,6 +226,7 @@ impl MockGitHubClient {
             existing: StdMutex::new(Vec::new()),
             created: StdMutex::new(Vec::new()),
             comments: StdMutex::new(Vec::new()),
+            closed: StdMutex::new(Vec::new()),
             next_number: StdMutex::new(100),
         }
     }
@@ -244,6 +252,11 @@ impl MockGitHubClient {
     /// A snapshot of every comment `(issue_number, body)` recorded.
     pub fn comments(&self) -> Vec<(u64, String)> {
         self.comments.lock().expect("mock poisoned").clone()
+    }
+
+    /// A snapshot of every issue number closed through this mock.
+    pub fn closed(&self) -> Vec<u64> {
+        self.closed.lock().expect("mock poisoned").clone()
     }
 }
 
@@ -292,6 +305,17 @@ impl GitHubClient for MockGitHubClient {
             .lock()
             .expect("mock poisoned")
             .push((number, body.to_string()));
+        Ok(())
+    }
+
+    async fn close_issue(&self, _repo: &str, number: u64) -> Result<()> {
+        self.closed.lock().expect("mock poisoned").push(number);
+        // Drop the issue from the open set so subsequent dedupe searches never
+        // rematch a closed duplicate, exactly as the real tracker would.
+        self.existing
+            .lock()
+            .expect("mock poisoned")
+            .retain(|issue| issue.number != number);
         Ok(())
     }
 }
@@ -410,6 +434,20 @@ mod http {
                 .map_err(|e| Self::err("comment", e))?;
             Ok(())
         }
+
+        async fn close_issue(&self, repo: &str, number: u64) -> Result<()> {
+            let url = format!("https://api.github.com/repos/{repo}/issues/{number}");
+            self.http
+                .patch(&url)
+                .header("Authorization", format!("Bearer {}", self.token.expose()))
+                .header("User-Agent", "opencompany")
+                .header("Accept", "application/vnd.github+json")
+                .json(&serde_json::json!({ "state": "closed" }))
+                .send()
+                .await
+                .map_err(|e| Self::err("close", e))?;
+            Ok(())
+        }
     }
 }
 
@@ -455,6 +493,28 @@ mod test {
             "b",
             &[],
             ConsentMode::Manual,
+            &limiter,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(out, FilingOutcome::ManualLink { .. }));
+        assert!(client.created().is_empty());
+    }
+
+    #[tokio::test]
+    async fn assisted_consent_never_auto_creates() {
+        // A throttled low-quality filer is downgraded Auto -> Assisted, which
+        // must go to the operator for approval, never silently auto-file.
+        let client = MockGitHubClient::new();
+        let limiter = RateLimiter::default();
+        let out = file_feedback(
+            Some(&client),
+            "r/r",
+            "acme",
+            "t",
+            "b",
+            &[],
+            ConsentMode::Assisted,
             &limiter,
         )
         .await

--- a/src/feedback/labels.rs
+++ b/src/feedback/labels.rs
@@ -4,25 +4,22 @@
 //! `type/`, `area/`, `sev/`, and `source/`. Agent-filed issues always carry
 //! `source/agent-filed` so triage can weight them.
 
+use crate::feedback::triage::{FeedbackSource, Severity, classify_labels};
 use crate::feedback::types::{FeedbackCategory, FeedbackItem};
 
 /// Builds the full label set for an agent-filed feedback issue.
 ///
-/// The `type/` label follows the category; `area/` defaults per category (or
-/// `template:<name>` for a template gap with a known template); `sev/` defaults
-/// to `annoyance`; `source/` is always `agent-filed`.
+/// A thin wrapper over [`classify_labels`](crate::feedback::triage::classify_labels)
+/// — the single source of truth — with the agent-filer defaults: `sev/annoyance`
+/// and `source/agent-filed`. The `type/` label follows the category; `area/`
+/// defaults per category (or `template:<name>` for a template gap with a known
+/// template).
 pub fn labels_for(item: &FeedbackItem) -> Vec<String> {
-    vec![
-        "feedback".to_string(),
-        format!("type/{}", item.category.as_str()),
-        format!("area/{}", area_for(item)),
-        "sev/annoyance".to_string(),
-        "source/agent-filed".to_string(),
-    ]
+    classify_labels(item, Severity::Annoyance, FeedbackSource::AgentFiled)
 }
 
 /// The owning surface for a feedback item.
-fn area_for(item: &FeedbackItem) -> String {
+pub(crate) fn area_for(item: &FeedbackItem) -> String {
     if item.category == FeedbackCategory::TemplateGap
         && let Some(name) = &item.template_name
         && !name.trim().is_empty()

--- a/src/feedback/labels.rs
+++ b/src/feedback/labels.rs
@@ -1,0 +1,84 @@
+//! GitHub label taxonomy (`docs/spec/feedback-loop/triage.md`).
+//!
+//! Every filed issue carries `feedback` plus one label from each axis:
+//! `type/`, `area/`, `sev/`, and `source/`. Agent-filed issues always carry
+//! `source/agent-filed` so triage can weight them.
+
+use crate::feedback::types::{FeedbackCategory, FeedbackItem};
+
+/// Builds the full label set for an agent-filed feedback issue.
+///
+/// The `type/` label follows the category; `area/` defaults per category (or
+/// `template:<name>` for a template gap with a known template); `sev/` defaults
+/// to `annoyance`; `source/` is always `agent-filed`.
+pub fn labels_for(item: &FeedbackItem) -> Vec<String> {
+    vec![
+        "feedback".to_string(),
+        format!("type/{}", item.category.as_str()),
+        format!("area/{}", area_for(item)),
+        "sev/annoyance".to_string(),
+        "source/agent-filed".to_string(),
+    ]
+}
+
+/// The owning surface for a feedback item.
+fn area_for(item: &FeedbackItem) -> String {
+    if item.category == FeedbackCategory::TemplateGap
+        && let Some(name) = &item.template_name
+        && !name.trim().is_empty()
+    {
+        return format!("template:{name}");
+    }
+    match item.category {
+        FeedbackCategory::WrongOutput => "brain",
+        FeedbackCategory::Bug | FeedbackCategory::ApprovalFriction => "runtime",
+        FeedbackCategory::MissingCapability | FeedbackCategory::TemplateGap => "product",
+        FeedbackCategory::Docs => "product",
+    }
+    .to_string()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::feedback::types::{ConsentMode, FeedbackInput};
+
+    fn item(category: FeedbackCategory, template: Option<&str>) -> FeedbackItem {
+        FeedbackItem::capture(
+            FeedbackInput {
+                category,
+                note: "n".into(),
+                work_ref: None,
+                template_name: template.map(str::to_string),
+                template_version: None,
+            },
+            "0.1.0",
+            ConsentMode::Auto,
+        )
+    }
+
+    #[test]
+    fn labels_cover_all_axes_and_source() {
+        let labels = labels_for(&item(FeedbackCategory::Bug, None));
+        assert!(labels.contains(&"feedback".to_string()));
+        assert!(labels.contains(&"type/bug".to_string()));
+        assert!(labels.contains(&"area/runtime".to_string()));
+        assert!(labels.iter().any(|l| l.starts_with("sev/")));
+        assert!(labels.contains(&"source/agent-filed".to_string()));
+    }
+
+    #[test]
+    fn template_gap_names_the_template_area() {
+        let labels = labels_for(&item(
+            FeedbackCategory::TemplateGap,
+            Some("marketing_agency"),
+        ));
+        assert!(labels.contains(&"area/template:marketing_agency".to_string()));
+    }
+
+    #[test]
+    fn wrong_output_owns_the_brain() {
+        let labels = labels_for(&item(FeedbackCategory::WrongOutput, None));
+        assert!(labels.contains(&"area/brain".to_string()));
+    }
+}

--- a/src/feedback/mod.rs
+++ b/src/feedback/mod.rs
@@ -1,0 +1,37 @@
+//! The feedback loop: capture → scrub → preview → file.
+//!
+//! In-product reactions become durable [`FeedbackItem`]s
+//! ([`types`]), persisted in the company's feedback family
+//! ([`store`]). Filing to the public tracker passes through the normative
+//! privacy [`scrub`]ber and a scrub-then-preview gate before a mockable
+//! [`github`] client files (or degrades to a manual link). [`service`] wires the
+//! whole flow; [`tool`] exposes a built-in `feedback` tool the brain can invoke;
+//! [`labels`] maps categories to the triage taxonomy.
+//!
+//! The trait + mock transport and the scrubber/store compile in the default
+//! build so the loop is exercised entirely offline; only the real HTTP filer is
+//! gated behind the `github` feature.
+
+pub mod github;
+pub mod labels;
+pub mod scrub;
+pub mod service;
+pub mod store;
+pub mod tool;
+pub mod types;
+
+pub use github::{
+    FilingOutcome, GitHubClient, IssueDraft, MockGitHubClient, RateLimiter, file_feedback,
+    manual_issue_url, sign_body,
+};
+pub use scrub::{CharterTerm, ScrubOutcome, scrub};
+pub use service::{FeedbackFiler, FeedbackResponse};
+pub use store::FeedbackStore;
+pub use tool::BuiltinToolProvider;
+pub use types::{ConsentMode, FeedbackCategory, FeedbackInput, FeedbackItem, detect_chat_intent};
+
+#[cfg(feature = "github")]
+pub use github::HttpGitHubClient;
+
+/// The public issue tracker feedback is filed against.
+pub const DEFAULT_REPO: &str = "tinyhumansai/opencompany";

--- a/src/feedback/mod.rs
+++ b/src/feedback/mod.rs
@@ -18,16 +18,21 @@ pub mod scrub;
 pub mod service;
 pub mod store;
 pub mod tool;
+pub mod triage;
 pub mod types;
 
 pub use github::{
-    FilingOutcome, GitHubClient, IssueDraft, MockGitHubClient, RateLimiter, file_feedback,
-    manual_issue_url, sign_body,
+    ExistingIssue, FilingOutcome, GitHubClient, IssueDraft, MockGitHubClient, RateLimiter,
+    file_feedback, manual_issue_url, sign_body,
 };
 pub use scrub::{CharterTerm, ScrubOutcome, scrub};
 pub use service::{FeedbackFiler, FeedbackResponse};
 pub use store::FeedbackStore;
 pub use tool::BuiltinToolProvider;
+pub use triage::{
+    ClusterPlan, DedupePlan, EscalationPlan, FeedbackSource, QualityLedger, Severity, TriageAgent,
+    classify_labels, cluster_plans, escalation_for, map_fixed_issues, process_bug_check,
+};
 pub use types::{ConsentMode, FeedbackCategory, FeedbackInput, FeedbackItem, detect_chat_intent};
 
 #[cfg(feature = "github")]

--- a/src/feedback/scrub.rs
+++ b/src/feedback/scrub.rs
@@ -1,0 +1,527 @@
+//! The **normative** privacy scrubber (`docs/spec/feedback-loop/privacy.md`).
+//!
+//! Feedback is filed to a *public* issue tracker, so this module is the
+//! non-negotiable gate between a company's private context and the internet. It
+//! removes or masks every redaction class before anything can leave the machine:
+//!
+//! | Class | Strategy |
+//! | --- | --- |
+//! | Secrets | any [`SecretStore`] value present, or a high-entropy token, **aborts** filing |
+//! | Wallet material | key-shaped tokens **abort**; addresses masked (`sol:…abcd`) |
+//! | Personal data | emails/phones → placeholders; roster names → `⟨redacted:name⟩` |
+//! | Customer content | never included by construction (excerpts are runtime output only) |
+//! | Charter specifics | prices/rules/mission → structural descriptions |
+//!
+//! Scrubbing **fails closed**: if a class cannot be evaluated (e.g. the secret
+//! store is unreadable), filing is [`Aborted`](ScrubOutcome::Aborted), never
+//! risked. The returned [`Ready`](ScrubOutcome::Ready) body is byte-exact what
+//! the preview gate shows and what is posted.
+
+use crate::Result;
+use crate::ports::SecretStore;
+use crate::ports::types::CompanyId;
+
+/// A charter specific and the structural description that replaces it.
+///
+/// The literal (a price, a client name, a never-do rule, mission text) is
+/// replaced wholesale by its structural description so the issue conveys shape
+/// without leaking the specific.
+#[derive(Clone, Debug)]
+pub struct CharterTerm {
+    /// The literal string to redact from the body.
+    pub literal: String,
+    /// The structural description that replaces it (e.g. "a priced skill").
+    pub description: String,
+}
+
+impl CharterTerm {
+    /// Builds a charter term.
+    pub fn new(literal: impl Into<String>, description: impl Into<String>) -> Self {
+        Self {
+            literal: literal.into(),
+            description: description.into(),
+        }
+    }
+}
+
+/// The outcome of scrubbing a candidate issue body.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ScrubOutcome {
+    /// The body is safe to file, byte-exact as returned.
+    Ready(String),
+    /// Filing is blocked; `reason` is safe to show the operator (it names the
+    /// class, never the offending value).
+    Aborted {
+        /// Why filing was blocked.
+        reason: String,
+    },
+}
+
+/// Minimum length for the entropy scan and wallet-address masking.
+const MIN_ENTROPY_LEN: usize = 32;
+/// Shannon-entropy threshold (bits/char) above which a long token aborts filing.
+const ENTROPY_ABORT_BITS: f64 = 3.5;
+/// Length at or above which a base58 token is treated as key material (abort).
+const WALLET_KEY_LEN: usize = 64;
+/// Length range for base58 tokens masked as wallet addresses.
+const WALLET_ADDR_MIN: usize = 32;
+
+/// Scrubs a candidate issue `body` for one company, failing closed.
+///
+/// * `secret_keys` — the [`SecretStore`] keys whose values must not appear
+///   (channel HMACs, GitHub/TinyHumans credentials). Any unreadable key aborts.
+/// * `roster` — agent handles/names redacted to `⟨redacted:name⟩`.
+/// * `charter_terms` — literals replaced by structural descriptions.
+pub async fn scrub(
+    body: &str,
+    company: &CompanyId,
+    secrets: &dyn SecretStore,
+    secret_keys: &[String],
+    roster: &[String],
+    charter_terms: &[CharterTerm],
+) -> Result<ScrubOutcome> {
+    // 1. Secrets (fail closed). Read every declared key; an unreadable store
+    //    aborts rather than risks. A present secret value aborts outright.
+    for key in secret_keys {
+        let value = match secrets.get(company, key).await {
+            Ok(value) => value,
+            // The class cannot be evaluated: fail closed.
+            Err(_) => {
+                return Ok(ScrubOutcome::Aborted {
+                    reason: "secret store unreadable".to_string(),
+                });
+            }
+        };
+        if let Some(value) = value {
+            let secret = value.expose();
+            if !secret.trim().is_empty() && body.contains(secret) {
+                return Ok(ScrubOutcome::Aborted {
+                    reason: "a secret value is present in the report".to_string(),
+                });
+            }
+        }
+    }
+
+    // 2. Wallet key material aborts (before the entropy scan, so a base58 key
+    //    is reported as wallet material rather than a generic high-entropy
+    //    token, and before masking addresses).
+    if contains_wallet_key(body) {
+        return Ok(ScrubOutcome::Aborted {
+            reason: "wallet key material is present".to_string(),
+        });
+    }
+
+    // High-entropy token scan: catches unregistered secrets (API keys pasted in).
+    if high_entropy_token(body).is_some() {
+        return Ok(ScrubOutcome::Aborted {
+            reason: "a high-entropy token that may be a secret is present".to_string(),
+        });
+    }
+
+    // 3+. Build the redacted body. Wallet addresses masked, charter specifics
+    //     replaced, then personal data redacted.
+    let mut out = mask_wallet_addresses(body);
+    for term in charter_terms {
+        if !term.literal.trim().is_empty() {
+            out = replace_all(&out, &term.literal, &term.description);
+        }
+    }
+    out = redact_emails(&out);
+    out = redact_phones(&out);
+    out = redact_names(&out, roster);
+
+    Ok(ScrubOutcome::Ready(out))
+}
+
+/// Splits a string into candidate secret/wallet tokens, trimming surrounding
+/// punctuation so `"key=ABC123,"` yields `ABC123`.
+fn tokens(s: &str) -> impl Iterator<Item = &str> {
+    s.split(|c: char| c.is_whitespace() || matches!(c, ',' | ';' | '"' | '\'' | '=' | '(' | ')'))
+        .map(|t| t.trim_matches(|c: char| matches!(c, '.' | ':' | '<' | '>' | '[' | ']')))
+        .filter(|t| !t.is_empty())
+}
+
+/// Returns the first token that looks like a secret by Shannon entropy.
+fn high_entropy_token(s: &str) -> Option<&str> {
+    tokens(s).find(|token| {
+        token.len() >= MIN_ENTROPY_LEN
+            && token.chars().all(is_secret_char)
+            && shannon_bits_per_char(token) > ENTROPY_ABORT_BITS
+    })
+}
+
+/// Characters that can appear in a base64/hex/base58 secret token.
+fn is_secret_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '+' | '/' | '_' | '-')
+}
+
+/// Shannon entropy of `s` in bits per character.
+fn shannon_bits_per_char(s: &str) -> f64 {
+    let mut counts = std::collections::HashMap::new();
+    let len = s.chars().count() as f64;
+    if len == 0.0 {
+        return 0.0;
+    }
+    for ch in s.chars() {
+        *counts.entry(ch).or_insert(0u32) += 1;
+    }
+    counts
+        .values()
+        .map(|&count| {
+            let p = count as f64 / len;
+            -p * p.log2()
+        })
+        .sum()
+}
+
+/// The base58 alphabet (Bitcoin/Solana): no `0`, `O`, `I`, `l`.
+fn is_base58(c: char) -> bool {
+    c.is_ascii_alphanumeric() && !matches!(c, '0' | 'O' | 'I' | 'l')
+}
+
+/// Whether any token is a base58 string long enough to be a private key.
+fn contains_wallet_key(s: &str) -> bool {
+    tokens(s).any(|token| token.len() >= WALLET_KEY_LEN && token.chars().all(is_base58))
+}
+
+/// Masks wallet addresses (`sol:<addr>` and bare base58 addresses) to
+/// `sol:…<last4>`, leaving key-shaped tokens for the abort path.
+fn mask_wallet_addresses(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    // Split preserving delimiters so structure is retained.
+    let mut token = String::new();
+    let flush = |token: &mut String, out: &mut String| {
+        if !token.is_empty() {
+            out.push_str(&mask_one_wallet(token));
+            token.clear();
+        }
+    };
+    for ch in s.chars() {
+        if ch.is_whitespace() || matches!(ch, ',' | ';' | '"' | '\'' | '(' | ')') {
+            flush(&mut token, &mut out);
+            out.push(ch);
+        } else {
+            token.push(ch);
+        }
+    }
+    flush(&mut token, &mut out);
+    out
+}
+
+/// Masks a single token if it is a wallet address; otherwise returns it as-is.
+fn mask_one_wallet(token: &str) -> String {
+    // `sol:<addr>` prefix form.
+    if let Some(addr) = token.strip_prefix("sol:")
+        && addr.len() >= 4
+        && addr.chars().all(is_base58)
+    {
+        return format!("sol:…{}", &addr[addr.len() - 4..]);
+    }
+    // Bare base58 address (shorter than a key).
+    let core = token.trim_matches(|c: char| matches!(c, '.' | ':' | '<' | '>' | '[' | ']'));
+    if (WALLET_ADDR_MIN..WALLET_KEY_LEN).contains(&core.len()) && core.chars().all(is_base58) {
+        return format!("sol:…{}", &core[core.len() - 4..]);
+    }
+    token.to_string()
+}
+
+/// Replaces every non-overlapping occurrence of `needle` in `haystack`.
+fn replace_all(haystack: &str, needle: &str, replacement: &str) -> String {
+    if needle.is_empty() {
+        return haystack.to_string();
+    }
+    haystack.replace(needle, replacement)
+}
+
+/// Redacts email addresses to `⟨redacted:email⟩`.
+fn redact_emails(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] == '@' {
+            // Expand left over the local part.
+            let mut start = i;
+            while start > 0 && is_email_local(chars[start - 1]) {
+                start -= 1;
+            }
+            // Expand right over the domain.
+            let mut end = i + 1;
+            while end < chars.len() && is_email_domain(chars[end]) {
+                end += 1;
+            }
+            let domain: String = chars[i + 1..end].iter().collect();
+            let has_dot = domain.contains('.') && !domain.ends_with('.');
+            if start < i && has_dot {
+                // Drop the already-emitted local part, then the whole address.
+                let local_len = i - start;
+                for _ in 0..local_len {
+                    out.pop();
+                }
+                out.push_str("⟨redacted:email⟩");
+                i = end;
+                continue;
+            }
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    out
+}
+
+fn is_email_local(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '%' | '+' | '-')
+}
+
+fn is_email_domain(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '.' | '-')
+}
+
+/// Redacts phone-number-shaped runs (10–15 digits, phone punctuation) to
+/// `⟨redacted:phone⟩`.
+fn redact_phones(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    while i < chars.len() {
+        if is_phone_char(chars[i]) {
+            let start = i;
+            let mut digits = 0;
+            while i < chars.len() && is_phone_char(chars[i]) {
+                if chars[i].is_ascii_digit() {
+                    digits += 1;
+                }
+                i += 1;
+            }
+            if (10..=15).contains(&digits) {
+                out.push_str("⟨redacted:phone⟩");
+            } else {
+                out.extend(&chars[start..i]);
+            }
+            continue;
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    out
+}
+
+fn is_phone_char(c: char) -> bool {
+    c.is_ascii_digit() || matches!(c, ' ' | '-' | '(' | ')' | '+')
+}
+
+/// Redacts roster names (case-insensitive, whole-word) to `⟨redacted:name⟩`.
+fn redact_names(s: &str, roster: &[String]) -> String {
+    let mut out = s.to_string();
+    for name in roster {
+        let name = name.trim();
+        if name.is_empty() {
+            continue;
+        }
+        out = replace_whole_word_ci(&out, name, "⟨redacted:name⟩");
+    }
+    out
+}
+
+/// Replaces whole-word, case-insensitive occurrences of `word`.
+fn replace_whole_word_ci(haystack: &str, word: &str, replacement: &str) -> String {
+    let hay_lower = haystack.to_lowercase();
+    let word_lower = word.to_lowercase();
+    let hay: Vec<char> = haystack.chars().collect();
+    let hay_l: Vec<char> = hay_lower.chars().collect();
+    let needle: Vec<char> = word_lower.chars().collect();
+    if needle.is_empty() || needle.len() > hay_l.len() {
+        return haystack.to_string();
+    }
+    let mut out = String::with_capacity(haystack.len());
+    let mut i = 0;
+    while i < hay.len() {
+        if i + needle.len() <= hay_l.len() && hay_l[i..i + needle.len()] == needle[..] {
+            let before_ok = i == 0 || !is_word_char(hay[i - 1]);
+            let after_idx = i + needle.len();
+            let after_ok = after_idx >= hay.len() || !is_word_char(hay[after_idx]);
+            if before_ok && after_ok {
+                out.push_str(replacement);
+                i = after_idx;
+                continue;
+            }
+        }
+        out.push(hay[i]);
+        i += 1;
+    }
+    out
+}
+
+fn is_word_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ports::types::SecretValue;
+    use async_trait::async_trait;
+
+    /// A secret store with canned values, plus an "unreadable" mode that returns
+    /// an error to exercise the fail-closed path.
+    struct FakeSecrets {
+        value: Option<String>,
+        unreadable: bool,
+    }
+
+    #[async_trait]
+    impl SecretStore for FakeSecrets {
+        async fn get(&self, _company: &CompanyId, _key: &str) -> Result<Option<SecretValue>> {
+            if self.unreadable {
+                return Err(crate::OpenCompanyError::Store("boom".into()));
+            }
+            Ok(self.value.clone().map(SecretValue))
+        }
+        async fn set(&self, _company: &CompanyId, _key: &str, _value: SecretValue) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn company() -> CompanyId {
+        CompanyId::new("acme")
+    }
+
+    async fn scrub_with(secrets: FakeSecrets, body: &str) -> ScrubOutcome {
+        scrub(
+            body,
+            &company(),
+            &secrets,
+            &["github_token".to_string()],
+            &["Dana Roe".to_string()],
+            &[CharterTerm::new("25.00", "a priced skill")],
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn present_secret_value_aborts() {
+        let secrets = FakeSecrets {
+            value: Some("ghp_supersecretvalue".into()),
+            unreadable: false,
+        };
+        let out = scrub_with(secrets, "the token ghp_supersecretvalue leaked").await;
+        assert!(matches!(out, ScrubOutcome::Aborted { reason } if reason.contains("secret value")));
+    }
+
+    #[tokio::test]
+    async fn unreadable_secret_store_fails_closed() {
+        let secrets = FakeSecrets {
+            value: None,
+            unreadable: true,
+        };
+        let out = scrub_with(secrets, "nothing sensitive here").await;
+        assert!(matches!(out, ScrubOutcome::Aborted { reason } if reason.contains("unreadable")));
+    }
+
+    #[tokio::test]
+    async fn high_entropy_token_aborts() {
+        let secrets = FakeSecrets {
+            value: None,
+            unreadable: false,
+        };
+        // A 40-char random-looking token.
+        let out = scrub_with(secrets, "key aB3xQ9zK7mN2pR5tV8wY1cE4gH6jL0oS3uD7fI2n").await;
+        assert!(matches!(out, ScrubOutcome::Aborted { reason } if reason.contains("high-entropy")));
+    }
+
+    #[tokio::test]
+    async fn wallet_private_key_aborts() {
+        let secrets = FakeSecrets {
+            value: None,
+            unreadable: false,
+        };
+        // A 66-char base58-only token (key-shaped).
+        let key =
+            "5Kb8kLf9zgWQnogidDA76MzPL6TsZZY36hWXMssSzNydYXYB9KF2".to_string() + "aBcDeFgHjKmNpQ";
+        let out = scrub_with(secrets, &format!("seed {key} here")).await;
+        assert!(matches!(out, ScrubOutcome::Aborted { reason } if reason.contains("wallet key")));
+    }
+
+    #[tokio::test]
+    async fn wallet_address_is_masked() {
+        let secrets = FakeSecrets {
+            value: None,
+            unreadable: false,
+        };
+        let out = scrub_with(
+            secrets,
+            "pay sol:9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM now",
+        )
+        .await;
+        match out {
+            ScrubOutcome::Ready(body) => {
+                assert!(body.contains("sol:…"), "got {body}");
+                assert!(!body.contains("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"));
+                assert!(body.ends_with("AWWM now") || body.contains("AWWM"));
+            }
+            other => panic!("expected Ready, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn email_and_name_are_redacted() {
+        let secrets = FakeSecrets {
+            value: None,
+            unreadable: false,
+        };
+        let out = scrub_with(secrets, "dana@acme.co said Dana Roe was unhappy").await;
+        match out {
+            ScrubOutcome::Ready(body) => {
+                assert!(body.contains("⟨redacted:email⟩"), "got {body}");
+                assert!(!body.contains("dana@acme.co"));
+                assert!(body.contains("⟨redacted:name⟩"));
+                assert!(!body.contains("Dana Roe"));
+            }
+            other => panic!("expected Ready, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn phone_is_redacted() {
+        let secrets = FakeSecrets {
+            value: None,
+            unreadable: false,
+        };
+        let out = scrub_with(secrets, "call +1 (415) 555-2671 today").await;
+        match out {
+            ScrubOutcome::Ready(body) => {
+                assert!(body.contains("⟨redacted:phone⟩"), "got {body}");
+                assert!(!body.contains("555-2671"));
+            }
+            other => panic!("expected Ready, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn charter_term_becomes_structural() {
+        let secrets = FakeSecrets {
+            value: None,
+            unreadable: false,
+        };
+        let out = scrub_with(secrets, "we charge 25.00 for audits").await;
+        match out {
+            ScrubOutcome::Ready(body) => {
+                assert!(body.contains("a priced skill"), "got {body}");
+                assert!(!body.contains("25.00"));
+            }
+            other => panic!("expected Ready, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn clean_body_is_ready_byte_exact() {
+        let secrets = FakeSecrets {
+            value: None,
+            unreadable: false,
+        };
+        let body = "The invoice route returned the wrong total.";
+        let out = scrub_with(secrets, body).await;
+        assert_eq!(out, ScrubOutcome::Ready(body.to_string()));
+    }
+}

--- a/src/feedback/service.rs
+++ b/src/feedback/service.rs
@@ -14,9 +14,9 @@ use crate::company::CompanyManifest;
 use crate::feedback::github::{
     FilingOutcome, GitHubClient, RateLimiter, file_feedback, manual_issue_url,
 };
-use crate::feedback::labels::labels_for;
 use crate::feedback::scrub::{CharterTerm, ScrubOutcome, scrub};
 use crate::feedback::store::FeedbackStore;
+use crate::feedback::triage::{FeedbackSource, QualityLedger, Severity, classify_labels};
 use crate::feedback::types::{ConsentMode, FeedbackItem};
 use crate::ports::SecretStore;
 use crate::ports::types::CompanyId;
@@ -32,6 +32,9 @@ pub struct FeedbackFiler {
     pub consent: ConsentMode,
     /// The per-company rate limiter.
     pub limiter: RateLimiter,
+    /// Per-handle filing quality, throttling auto-consent after repeated
+    /// low-quality filings.
+    pub quality: QualityLedger,
 }
 
 impl Default for FeedbackFiler {
@@ -41,6 +44,7 @@ impl Default for FeedbackFiler {
             repo: crate::feedback::DEFAULT_REPO.to_string(),
             consent: ConsentMode::default(),
             limiter: RateLimiter::default(),
+            quality: QualityLedger::default(),
         }
     }
 }
@@ -101,6 +105,7 @@ impl FeedbackResponse {
 /// * `preview` → the byte-exact final body plus a prefilled link.
 /// * Otherwise → file through the [`FeedbackFiler`], updating the stored item's
 ///   status on success.
+#[allow(clippy::too_many_arguments)]
 pub async fn finalize(
     store: &FeedbackStore,
     secrets: &dyn SecretStore,
@@ -108,6 +113,8 @@ pub async fn finalize(
     company: &CompanyId,
     manifest: Option<&CompanyManifest>,
     item: &FeedbackItem,
+    severity: Severity,
+    source: FeedbackSource,
     preview: bool,
 ) -> Result<FeedbackResponse> {
     let handle = manifest
@@ -116,7 +123,7 @@ pub async fn finalize(
     let roster = roster_names(manifest);
     let charter = charter_terms(manifest);
     let keys = secret_keys(manifest);
-    let labels = labels_for(item);
+    let labels = classify_labels(item, severity, source);
     let (title, body) = candidate_issue(item, &handle);
 
     let scrubbed = match scrub(&body, company, secrets, &keys, &roster, &charter).await? {
@@ -137,6 +144,10 @@ pub async fn finalize(
         });
     }
 
+    // A throttled handle (too many low-quality filings) has its standing Auto
+    // consent downgraded to Assisted before anything leaves the machine.
+    let consent = filer.quality.effective_consent(&handle, filer.consent);
+
     let outcome = file_feedback(
         filer.client.as_deref(),
         &filer.repo,
@@ -144,13 +155,15 @@ pub async fn finalize(
         &title,
         &scrubbed,
         &labels,
-        filer.consent,
+        consent,
         &filer.limiter,
     )
     .await?;
 
     Ok(match outcome {
         FilingOutcome::Filed { url } => {
+            // A clean filing counts toward the handle's quality history.
+            filer.quality.record_filed(&handle);
             store.update_status(&item.id, &url, "open").await?;
             FeedbackResponse {
                 item_id: item.id.clone(),
@@ -164,6 +177,10 @@ pub async fn finalize(
             }
         }
         FilingOutcome::Deduped { url } => {
+            // A filing that immediately duplicates an existing issue is a
+            // low-quality signal against the filing handle.
+            filer.quality.record_filed(&handle);
+            filer.quality.record_low_quality(&handle);
             store.update_status(&item.id, &url, "duplicate").await?;
             FeedbackResponse {
                 item_id: item.id.clone(),

--- a/src/feedback/service.rs
+++ b/src/feedback/service.rs
@@ -1,0 +1,275 @@
+//! The feedback filing flow: capture → scrub → preview → file.
+//!
+//! [`finalize`] runs the scrub-then-preview gate over an already-captured
+//! [`FeedbackItem`] and either previews the exact final body or files it. It is
+//! driven by the HTTP `POST .../feedback` handler through
+//! [`CompanyRuntime::submit_feedback`](crate::company::runtime::CompanyRuntime::submit_feedback).
+
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use crate::Result;
+use crate::company::CompanyManifest;
+use crate::feedback::github::{
+    FilingOutcome, GitHubClient, RateLimiter, file_feedback, manual_issue_url,
+};
+use crate::feedback::labels::labels_for;
+use crate::feedback::scrub::{CharterTerm, ScrubOutcome, scrub};
+use crate::feedback::store::FeedbackStore;
+use crate::feedback::types::{ConsentMode, FeedbackItem};
+use crate::ports::SecretStore;
+use crate::ports::types::CompanyId;
+
+/// The per-company filing configuration: the GitHub client (if any), the target
+/// repo, the standing consent mode, and the rate limiter.
+pub struct FeedbackFiler {
+    /// The GitHub client, or `None` to always degrade to a manual link.
+    pub client: Option<Arc<dyn GitHubClient>>,
+    /// The `owner/repo` issues are filed against.
+    pub repo: String,
+    /// The standing consent mode.
+    pub consent: ConsentMode,
+    /// The per-company rate limiter.
+    pub limiter: RateLimiter,
+}
+
+impl Default for FeedbackFiler {
+    fn default() -> Self {
+        Self {
+            client: None,
+            repo: crate::feedback::DEFAULT_REPO.to_string(),
+            consent: ConsentMode::default(),
+            limiter: RateLimiter::default(),
+        }
+    }
+}
+
+impl std::fmt::Debug for FeedbackFiler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FeedbackFiler")
+            .field("repo", &self.repo)
+            .field("consent", &self.consent)
+            .field("has_client", &self.client.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+/// The response body for a feedback submission, mirroring the api.md envelope.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct FeedbackResponse {
+    /// The captured item's id (it persists regardless of filing).
+    pub item_id: String,
+    /// Whether an issue was filed (created or commented).
+    pub filed: bool,
+    /// Whether filing was blocked by the scrubber (fail-closed).
+    pub blocked: bool,
+    /// A human-safe reason when blocked or rate-limited.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// The exact final issue body, returned in preview mode.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preview_body: Option<String>,
+    /// A prefilled manual issue link (preview, or the tokenless fallback).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prefilled_url: Option<String>,
+    /// The filed issue URL, when filed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issue_url: Option<String>,
+    /// Whether the filing commented on an existing issue (dedupe).
+    pub deduped: bool,
+}
+
+impl FeedbackResponse {
+    fn blocked(item_id: &str, reason: String) -> Self {
+        Self {
+            item_id: item_id.to_string(),
+            filed: false,
+            blocked: true,
+            reason: Some(reason),
+            preview_body: None,
+            prefilled_url: None,
+            issue_url: None,
+            deduped: false,
+        }
+    }
+}
+
+/// Runs the scrub-then-preview gate for `item` and either previews or files.
+///
+/// * A scrub abort → a `blocked` response that never leaks the offending value.
+/// * `preview` → the byte-exact final body plus a prefilled link.
+/// * Otherwise → file through the [`FeedbackFiler`], updating the stored item's
+///   status on success.
+pub async fn finalize(
+    store: &FeedbackStore,
+    secrets: &dyn SecretStore,
+    filer: &FeedbackFiler,
+    company: &CompanyId,
+    manifest: Option<&CompanyManifest>,
+    item: &FeedbackItem,
+    preview: bool,
+) -> Result<FeedbackResponse> {
+    let handle = manifest
+        .and_then(|m| m.company.handle.clone())
+        .unwrap_or_else(|| company.as_ref().to_string());
+    let roster = roster_names(manifest);
+    let charter = charter_terms(manifest);
+    let keys = secret_keys(manifest);
+    let labels = labels_for(item);
+    let (title, body) = candidate_issue(item, &handle);
+
+    let scrubbed = match scrub(&body, company, secrets, &keys, &roster, &charter).await? {
+        ScrubOutcome::Aborted { reason } => return Ok(FeedbackResponse::blocked(&item.id, reason)),
+        ScrubOutcome::Ready(body) => body,
+    };
+
+    if preview {
+        return Ok(FeedbackResponse {
+            item_id: item.id.clone(),
+            filed: false,
+            blocked: false,
+            reason: None,
+            prefilled_url: Some(manual_issue_url(&filer.repo, &title, &scrubbed, &labels)),
+            preview_body: Some(scrubbed),
+            issue_url: None,
+            deduped: false,
+        });
+    }
+
+    let outcome = file_feedback(
+        filer.client.as_deref(),
+        &filer.repo,
+        company.as_ref(),
+        &title,
+        &scrubbed,
+        &labels,
+        filer.consent,
+        &filer.limiter,
+    )
+    .await?;
+
+    Ok(match outcome {
+        FilingOutcome::Filed { url } => {
+            store.update_status(&item.id, &url, "open").await?;
+            FeedbackResponse {
+                item_id: item.id.clone(),
+                filed: true,
+                blocked: false,
+                reason: None,
+                preview_body: None,
+                prefilled_url: None,
+                issue_url: Some(url),
+                deduped: false,
+            }
+        }
+        FilingOutcome::Deduped { url } => {
+            store.update_status(&item.id, &url, "duplicate").await?;
+            FeedbackResponse {
+                item_id: item.id.clone(),
+                filed: true,
+                blocked: false,
+                reason: None,
+                preview_body: None,
+                prefilled_url: None,
+                issue_url: Some(url),
+                deduped: true,
+            }
+        }
+        FilingOutcome::RateLimited => FeedbackResponse {
+            item_id: item.id.clone(),
+            filed: false,
+            blocked: false,
+            reason: Some("rate limit reached; try later or file manually".to_string()),
+            preview_body: None,
+            prefilled_url: None,
+            issue_url: None,
+            deduped: false,
+        },
+        FilingOutcome::ManualLink { url } => FeedbackResponse {
+            item_id: item.id.clone(),
+            filed: false,
+            blocked: false,
+            reason: None,
+            preview_body: None,
+            prefilled_url: Some(url),
+            issue_url: None,
+            deduped: false,
+        },
+    })
+}
+
+/// The roster names/handles to redact (agent ids plus the company `@handle`
+/// stem is intentionally *not* redacted — it is the public provenance signer).
+fn roster_names(manifest: Option<&CompanyManifest>) -> Vec<String> {
+    manifest
+        .map(|m| m.agents.iter().map(|a| a.id.clone()).collect())
+        .unwrap_or_default()
+}
+
+/// Charter specifics mapped to structural descriptions.
+fn charter_terms(manifest: Option<&CompanyManifest>) -> Vec<CharterTerm> {
+    let mut terms = Vec::new();
+    let Some(manifest) = manifest else {
+        return terms;
+    };
+    for skill in &manifest.place.skills {
+        if !skill.price_usd.trim().is_empty() {
+            terms.push(CharterTerm::new(skill.price_usd.clone(), "a priced skill"));
+        }
+    }
+    if let Some(output) = &manifest.company.output
+        && !output.trim().is_empty()
+    {
+        terms.push(CharterTerm::new(
+            output.clone(),
+            "the company's stated output",
+        ));
+    }
+    terms
+}
+
+/// The `SecretStore` keys whose values must never appear in a filed body.
+fn secret_keys(manifest: Option<&CompanyManifest>) -> Vec<String> {
+    let mut keys = vec!["github_token".to_string(), "tinyhumans_token".to_string()];
+    if let Some(manifest) = manifest {
+        for name in manifest.channels.keys() {
+            keys.push(format!("channel.{name}.hmac"));
+        }
+    }
+    keys
+}
+
+/// Builds the candidate issue `(title, body)` for an item, signing the body
+/// with the company `@handle` so preview and post are byte-identical.
+fn candidate_issue(item: &FeedbackItem, handle: &str) -> (String, String) {
+    let title = format!(
+        "[{}] {}",
+        item.category.as_str(),
+        first_line(&item.operator_words, 72)
+    );
+    let mut body = String::new();
+    body.push_str(&format!("**Category:** {}\n", item.category.as_str()));
+    body.push_str(&format!("**Runtime:** v{}\n", item.runtime_version));
+    if let (Some(name), version) = (&item.template_name, &item.template_version) {
+        let version = version.as_deref().unwrap_or("?");
+        body.push_str(&format!("**Template:** {name} {version}\n"));
+    }
+    if let Some(work) = &item.work_item {
+        body.push_str(&format!("**Work item:** {work}\n"));
+    }
+    body.push('\n');
+    body.push_str(&item.context_excerpt);
+    body.push_str(&format!("\n\n— filed by @{handle}"));
+    (title, body)
+}
+
+/// The first line of `s`, truncated to `max` chars.
+fn first_line(s: &str, max: usize) -> String {
+    let line = s.lines().next().unwrap_or("").trim();
+    if line.chars().count() > max {
+        line.chars().take(max).collect()
+    } else {
+        line.to_string()
+    }
+}

--- a/src/feedback/store.rs
+++ b/src/feedback/store.rs
@@ -1,0 +1,207 @@
+//! The [`FeedbackStore`]: durable per-company persistence for feedback items.
+//!
+//! Mirrors the append-only JSONL pattern the runtime journal and memory store
+//! use. Items live under the company bundle's `feedback/items.jsonl` and persist
+//! whether or not they are ever filed. Status updates (issue URL + status) are
+//! applied by rewriting the log atomically, so the closing-the-loop poller can
+//! record where a filed issue stands.
+
+use std::path::PathBuf;
+
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex as TokioMutex;
+
+use crate::Result;
+use crate::error::OpenCompanyError;
+use crate::feedback::types::FeedbackItem;
+use crate::ports::generate_id;
+use crate::store::paths::Bundle;
+
+/// A per-company append-only store of [`FeedbackItem`]s.
+pub struct FeedbackStore {
+    path: PathBuf,
+    write_lock: TokioMutex<()>,
+}
+
+impl FeedbackStore {
+    /// Creates a store writing to `<bundle>/feedback/items.jsonl`.
+    pub fn new(bundle: &Bundle) -> Self {
+        Self {
+            path: bundle.feedback_items_jsonl(),
+            write_lock: TokioMutex::new(()),
+        }
+    }
+
+    /// Appends a feedback item to the log.
+    pub async fn append(&self, item: &FeedbackItem) -> Result<()> {
+        let line = serde_json::to_string(item)?;
+        let _guard = self.write_lock.lock().await;
+        if let Some(parent) = self.path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| self.io_err(parent.to_path_buf(), e))?;
+        }
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .await
+            .map_err(|e| self.io_err(self.path.clone(), e))?;
+        file.write_all(line.as_bytes())
+            .await
+            .map_err(|e| self.io_err(self.path.clone(), e))?;
+        file.write_all(b"\n")
+            .await
+            .map_err(|e| self.io_err(self.path.clone(), e))?;
+        Ok(())
+    }
+
+    /// Lists every stored feedback item, oldest first.
+    pub async fn list(&self) -> Result<Vec<FeedbackItem>> {
+        let contents = match tokio::fs::read_to_string(&self.path).await {
+            Ok(contents) => contents,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(self.io_err(self.path.clone(), e)),
+        };
+        let mut out = Vec::new();
+        for line in contents.lines() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            out.push(serde_json::from_str(line)?);
+        }
+        Ok(out)
+    }
+
+    /// Records a filed issue's URL and status against an item, rewriting the log
+    /// atomically. Closing-the-loop uses this to track status changes.
+    pub async fn update_status(&self, id: &str, url: &str, status: &str) -> Result<()> {
+        let _guard = self.write_lock.lock().await;
+        let mut items = self.list_unlocked().await?;
+        for item in &mut items {
+            if item.id == id {
+                item.filed_issue_url = Some(url.to_string());
+                item.issue_status = Some(status.to_string());
+            }
+        }
+        let mut body = String::new();
+        for item in &items {
+            body.push_str(&serde_json::to_string(item)?);
+            body.push('\n');
+        }
+        self.write_atomic(&body).await
+    }
+
+    /// Reads the log without taking the write lock (callers already hold it).
+    async fn list_unlocked(&self) -> Result<Vec<FeedbackItem>> {
+        let contents = match tokio::fs::read_to_string(&self.path).await {
+            Ok(contents) => contents,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(self.io_err(self.path.clone(), e)),
+        };
+        let mut out = Vec::new();
+        for line in contents.lines() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            out.push(serde_json::from_str(line)?);
+        }
+        Ok(out)
+    }
+
+    async fn write_atomic(&self, contents: &str) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| self.io_err(parent.to_path_buf(), e))?;
+        }
+        let tmp = self.path.with_extension(format!("tmp-{}", generate_id()));
+        tokio::fs::write(&tmp, contents)
+            .await
+            .map_err(|e| self.io_err(tmp.clone(), e))?;
+        tokio::fs::rename(&tmp, &self.path)
+            .await
+            .map_err(|e| self.io_err(self.path.clone(), e))
+    }
+
+    fn io_err(&self, path: PathBuf, source: std::io::Error) -> OpenCompanyError {
+        OpenCompanyError::StoreIo { path, source }
+    }
+}
+
+impl std::fmt::Debug for FeedbackStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FeedbackStore")
+            .field("path", &self.path)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::feedback::types::{ConsentMode, FeedbackCategory, FeedbackInput, FeedbackItem};
+    use crate::ports::types::CompanyId;
+
+    fn tmp_bundle() -> Bundle {
+        let root = std::env::temp_dir().join(format!("oc-feedback-{}", generate_id()));
+        Bundle::new(root, &CompanyId::new("acme"))
+    }
+
+    fn item(note: &str) -> FeedbackItem {
+        FeedbackItem::capture(
+            FeedbackInput {
+                category: FeedbackCategory::Bug,
+                note: note.into(),
+                work_ref: None,
+                template_name: None,
+                template_version: None,
+            },
+            "0.1.0",
+            ConsentMode::Manual,
+        )
+    }
+
+    #[tokio::test]
+    async fn append_and_list_round_trips() {
+        let bundle = tmp_bundle();
+        let store = FeedbackStore::new(&bundle);
+        assert!(store.list().await.unwrap().is_empty());
+
+        store.append(&item("first")).await.unwrap();
+        store.append(&item("second")).await.unwrap();
+        let all = store.list().await.unwrap();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].operator_words, "first");
+        assert_eq!(all[1].operator_words, "second");
+        tokio::fs::remove_dir_all(bundle.dir()).await.ok();
+    }
+
+    #[tokio::test]
+    async fn update_status_records_url_without_losing_others() {
+        let bundle = tmp_bundle();
+        let store = FeedbackStore::new(&bundle);
+        let a = item("a");
+        let b = item("b");
+        store.append(&a).await.unwrap();
+        store.append(&b).await.unwrap();
+
+        store
+            .update_status(&b.id, "https://example/issues/7", "open")
+            .await
+            .unwrap();
+
+        let all = store.list().await.unwrap();
+        assert_eq!(all.len(), 2);
+        let updated = all.iter().find(|i| i.id == b.id).unwrap();
+        assert_eq!(
+            updated.filed_issue_url.as_deref(),
+            Some("https://example/issues/7")
+        );
+        assert_eq!(updated.issue_status.as_deref(), Some("open"));
+        // The other item is untouched.
+        let other = all.iter().find(|i| i.id == a.id).unwrap();
+        assert!(other.filed_issue_url.is_none());
+        tokio::fs::remove_dir_all(bundle.dir()).await.ok();
+    }
+}

--- a/src/feedback/tool.rs
+++ b/src/feedback/tool.rs
@@ -1,0 +1,208 @@
+//! The built-in `feedback` tool: a [`ToolProvider`] decorator.
+//!
+//! Wraps any inner provider (the stub or the OpenHuman-backed one) and adds a
+//! single always-granted `feedback` tool so the brain can self-report when the
+//! operator complains mid-conversation. Self-reporting must never be gated, so
+//! the `feedback` tool bypasses the manifest grant; every other tool delegates
+//! to the inner provider, which enforces grants unchanged.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::Result;
+use crate::feedback::store::FeedbackStore;
+use crate::feedback::types::{ConsentMode, FeedbackCategory, FeedbackInput, FeedbackItem};
+use crate::ports::EventLog;
+use crate::ports::tools::ToolProvider;
+use crate::ports::types::{CompanyEvent, CompanyId, ToolCall, ToolResult, ToolSpec};
+
+/// The built-in tool name the brain invokes to file feedback.
+pub const FEEDBACK_TOOL: &str = "feedback";
+
+/// A [`ToolProvider`] that adds the always-granted `feedback` tool on top of an
+/// inner provider.
+pub struct BuiltinToolProvider {
+    inner: Arc<dyn ToolProvider>,
+    feedback: Arc<FeedbackStore>,
+    events: Arc<dyn EventLog>,
+    consent: ConsentMode,
+}
+
+impl BuiltinToolProvider {
+    /// Wraps `inner`, capturing feedback into `feedback` and logging a
+    /// `FeedbackFiled` event through `events`.
+    pub fn new(
+        inner: Arc<dyn ToolProvider>,
+        feedback: Arc<FeedbackStore>,
+        events: Arc<dyn EventLog>,
+        consent: ConsentMode,
+    ) -> Self {
+        Self {
+            inner,
+            feedback,
+            events,
+            consent,
+        }
+    }
+
+    /// The `ToolSpec` advertised for the built-in feedback tool.
+    fn spec() -> ToolSpec {
+        ToolSpec {
+            name: FEEDBACK_TOOL.to_string(),
+            description: "File feedback about the company's work; captured locally and, with \
+                consent, filed as a scrubbed public issue."
+                .to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "category": {
+                        "type": "string",
+                        "enum": [
+                            "wrong-output", "bug", "missing-capability",
+                            "approval-friction", "template-gap", "docs"
+                        ]
+                    },
+                    "note": { "type": "string" },
+                    "work_ref": { "type": "string" }
+                },
+                "required": ["category", "note"]
+            }),
+        }
+    }
+
+    /// Captures a feedback item from tool arguments: persists it and logs a
+    /// `FeedbackFiled` event. Never files (filing is an operator-gated flow).
+    async fn capture(&self, company: &CompanyId, call: &ToolCall) -> Result<ToolResult> {
+        let category = call
+            .args
+            .get("category")
+            .and_then(|v| serde_json::from_value::<FeedbackCategory>(v.clone()).ok())
+            .unwrap_or(FeedbackCategory::WrongOutput);
+        let note = call
+            .args
+            .get("note")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let work_ref = call
+            .args
+            .get("work_ref")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+
+        let input = FeedbackInput {
+            category,
+            note,
+            work_ref,
+            template_name: None,
+            template_version: None,
+        };
+        let item = FeedbackItem::capture(input, crate::VERSION, self.consent);
+        self.feedback.append(&item).await?;
+        self.events
+            .append(
+                company,
+                CompanyEvent::FeedbackFiled {
+                    note: item.operator_words.clone(),
+                },
+            )
+            .await?;
+        Ok(ToolResult {
+            ok: true,
+            output: serde_json::json!({ "feedback_id": item.id, "captured": true }),
+        })
+    }
+}
+
+#[async_trait]
+impl ToolProvider for BuiltinToolProvider {
+    async fn catalog(&self, company: &CompanyId) -> Result<Vec<ToolSpec>> {
+        let mut catalog = self.inner.catalog(company).await?;
+        catalog.push(Self::spec());
+        Ok(catalog)
+    }
+
+    async fn invoke(&self, company: &CompanyId, call: ToolCall) -> Result<ToolResult> {
+        if call.tool == FEEDBACK_TOOL {
+            return self.capture(company, &call).await;
+        }
+        self.inner.invoke(company, call).await
+    }
+}
+
+impl std::fmt::Debug for BuiltinToolProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BuiltinToolProvider")
+            .field("consent", &self.consent)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::feedback::types::ConsentMode;
+    use crate::runtime::tools::StubToolProvider;
+    use crate::store::FsEventLog;
+    use crate::store::paths::Bundle;
+
+    fn wiring() -> (BuiltinToolProvider, Arc<FeedbackStore>, std::path::PathBuf) {
+        let root = std::env::temp_dir().join(format!("oc-btool-{}", crate::ports::generate_id()));
+        let bundle = Bundle::new(root.clone(), &CompanyId::new("acme"));
+        let feedback = Arc::new(FeedbackStore::new(&bundle));
+        let events: Arc<dyn EventLog> = Arc::new(FsEventLog::new(root.clone()));
+        let inner: Arc<dyn ToolProvider> = Arc::new(StubToolProvider::new(vec!["email.*".into()]));
+        let provider =
+            BuiltinToolProvider::new(inner, feedback.clone(), events, ConsentMode::Manual);
+        (provider, feedback, root)
+    }
+
+    #[tokio::test]
+    async fn catalog_includes_feedback_tool() {
+        let (provider, _fb, root) = wiring();
+        let catalog = provider.catalog(&CompanyId::new("acme")).await.unwrap();
+        assert!(catalog.iter().any(|t| t.name == FEEDBACK_TOOL));
+        tokio::fs::remove_dir_all(&root).await.ok();
+    }
+
+    #[tokio::test]
+    async fn feedback_tool_captures_without_grant() {
+        let (provider, feedback, root) = wiring();
+        let result = provider
+            .invoke(
+                &CompanyId::new("acme"),
+                ToolCall {
+                    tool: FEEDBACK_TOOL.into(),
+                    args: serde_json::json!({ "category": "bug", "note": "route broke" }),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(result.ok);
+        // The item was persisted even though `feedback` is not in the grant.
+        let items = feedback.list().await.unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].operator_words, "route broke");
+        assert_eq!(items[0].category, FeedbackCategory::Bug);
+        tokio::fs::remove_dir_all(&root).await.ok();
+    }
+
+    #[tokio::test]
+    async fn non_feedback_tool_delegates_and_enforces_grants() {
+        let (provider, _fb, root) = wiring();
+        // Ungranted tool is still rejected by the inner provider.
+        let err = provider
+            .invoke(
+                &CompanyId::new("acme"),
+                ToolCall {
+                    tool: "payment.send".into(),
+                    args: serde_json::Value::Null,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, crate::OpenCompanyError::ToolNotGranted(t) if t == "payment.send"));
+        tokio::fs::remove_dir_all(&root).await.ok();
+    }
+}

--- a/src/feedback/triage.rs
+++ b/src/feedback/triage.rs
@@ -1,0 +1,693 @@
+//! Feedback triage: the full label taxonomy, dedupe/cluster, and consent
+//! throttling (`docs/spec/feedback-loop/triage.md`).
+//!
+//! Where [`labels`](super::labels) mints the label set for a single filed item,
+//! this module owns the *taxonomy* itself and the downstream triage behavior a
+//! roster-job triage agent performs over the tracker:
+//!
+//! * [`classify_labels`] — the single source of truth for the four-axis label
+//!   set (`type/`, `area/`, `sev/`, `source/`) plus the base `feedback` label.
+//! * [`TriageAgent`] — searches existing issues, merges duplicates
+//!   ([`TriageAgent::dedupe`]) by commenting on the canonical and closing the
+//!   duplicate, and maintains cluster issues
+//!   ([`TriageAgent::maintain_cluster`]).
+//! * [`cluster_plans`] / [`ClusterPlan::promote`] — group similar issues and
+//!   decide when a cluster crosses the `count × severity` promotion threshold.
+//! * [`QualityLedger`] — throttles a company's auto-consent after repeated
+//!   low-quality agent-filings.
+//! * [`escalation_for`] and the release-notes helpers ([`map_fixed_issues`],
+//!   [`process_bug_check`]) surface the normative escalation and
+//!   "You said, we did" contracts as pure functions the caller acts on.
+//!
+//! Everything here is exercised offline against
+//! [`MockGitHubClient`](super::github::MockGitHubClient); nothing touches the
+//! network.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+
+use crate::Result;
+use crate::feedback::github::{ExistingIssue, GitHubClient, IssueDraft};
+use crate::feedback::labels::area_for;
+use crate::feedback::types::{ConsentMode, FeedbackItem};
+
+/// The operator-impact axis of the label taxonomy (`sev/`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Severity {
+    /// A papercut: annoying but not blocking.
+    Annoyance,
+    /// The operator is blocked from getting work done.
+    Blocked,
+    /// The problem cost real money.
+    MoneyLost,
+}
+
+impl Severity {
+    /// The kebab-case wire token used in the `sev/` label.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Annoyance => "annoyance",
+            Self::Blocked => "blocked",
+            Self::MoneyLost => "money-lost",
+        }
+    }
+
+    /// The promotion weight of this severity (`count × weight` scores a
+    /// cluster). Higher severity pulls a cluster over the threshold sooner.
+    pub fn weight(self) -> u32 {
+        match self {
+            Self::Annoyance => 1,
+            Self::Blocked => 3,
+            Self::MoneyLost => 10,
+        }
+    }
+}
+
+/// The who-filed-it axis of the label taxonomy (`source/`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FeedbackSource {
+    /// The operator filed it themselves.
+    Operator,
+    /// The company's brain filed it on the operator's behalf.
+    AgentFiled,
+    /// The platform filed it (fleet-wide signal).
+    Platform,
+}
+
+impl FeedbackSource {
+    /// The kebab-case wire token used in the `source/` label.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Operator => "operator",
+            Self::AgentFiled => "agent-filed",
+            Self::Platform => "platform",
+        }
+    }
+}
+
+/// Builds the full four-axis label set for a feedback item.
+///
+/// Every issue carries `feedback` plus exactly one label from each axis:
+/// `type/<category>`, `area/<surface>`, `sev/<severity>`, and
+/// `source/<who>`. This is the single source of truth the filer and the triage
+/// agent both consult.
+pub fn classify_labels(
+    item: &FeedbackItem,
+    severity: Severity,
+    source: FeedbackSource,
+) -> Vec<String> {
+    vec![
+        "feedback".to_string(),
+        format!("type/{}", item.category.as_str()),
+        format!("area/{}", area_for(item)),
+        format!("sev/{}", severity.as_str()),
+        format!("source/{}", source.as_str()),
+    ]
+}
+
+/// What a [`TriageAgent::dedupe`] pass decided for one candidate issue.
+#[derive(Clone, Debug, PartialEq)]
+pub enum DedupePlan {
+    /// No earlier match; the candidate stands on its own.
+    Distinct,
+    /// The candidate duplicates an earlier `canonical` issue; a merge comment
+    /// was posted on the canonical and the candidate (`closed`) was closed.
+    Merged {
+        /// The earlier issue kept as canonical.
+        canonical: ExistingIssue,
+        /// The candidate issue number that was closed as a duplicate.
+        closed: u64,
+    },
+}
+
+/// A group of similar issues that a triage agent can fold into one cluster.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ClusterPlan {
+    /// The normalized title key the members share.
+    pub key: String,
+    /// A human-readable summary (the first member's cleaned title).
+    pub summary: String,
+    /// The member issue numbers, ascending.
+    pub members: Vec<u64>,
+    /// The number of members.
+    pub count: usize,
+    /// The cluster issue title, e.g. `"12 reports: email drafts too formal"`.
+    pub title: String,
+}
+
+impl ClusterPlan {
+    /// The promotion score for this cluster at `severity`: `count × weight`.
+    pub fn score(&self, severity: Severity) -> u32 {
+        (self.count as u32).saturating_mul(severity.weight())
+    }
+
+    /// Whether this cluster crosses the promotion `threshold` at `severity`.
+    pub fn promote(&self, severity: Severity, threshold: u32) -> bool {
+        self.score(severity) >= threshold
+    }
+}
+
+/// The escalation flags a filed issue's labels imply (`triage.md`).
+///
+/// Pure: the caller executes the side effects (paging, mirroring). We only
+/// surface the decision so it stays inspectable and testable offline.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct EscalationPlan {
+    /// `sev/money-lost` issues page maintainers.
+    pub pages_maintainers: bool,
+    /// `area/brain` issues that reproduce upstream mirror to the owning repo.
+    pub mirror_to: Option<String>,
+}
+
+/// Computes the [`EscalationPlan`] implied by an issue's `labels`.
+pub fn escalation_for(labels: &[String]) -> EscalationPlan {
+    let pages_maintainers = labels.iter().any(|l| l == "sev/money-lost");
+    let mirror_to = labels
+        .iter()
+        .any(|l| l == "area/brain")
+        .then(|| "tinyhumansai/medulla".to_string());
+    EscalationPlan {
+        pages_maintainers,
+        mirror_to,
+    }
+}
+
+/// Groups similar existing issues into candidate clusters.
+///
+/// Issues are keyed by a normalized title (lowercased, any leading `[type]`
+/// prefix stripped, whitespace collapsed); a key with two or more members
+/// becomes a [`ClusterPlan`]. Single issues are not clusters and are omitted.
+/// Returned deterministically ordered by key.
+pub fn cluster_plans(issues: &[ExistingIssue]) -> Vec<ClusterPlan> {
+    let mut groups: HashMap<String, (String, Vec<u64>)> = HashMap::new();
+    for issue in issues {
+        let key = normalize_title(&issue.title);
+        let entry = groups
+            .entry(key)
+            .or_insert_with(|| (strip_type_prefix(&issue.title), Vec::new()));
+        entry.1.push(issue.number);
+    }
+
+    let mut plans: Vec<ClusterPlan> = groups
+        .into_iter()
+        .filter(|(_, (_, members))| members.len() >= 2)
+        .map(|(key, (summary, mut members))| {
+            members.sort_unstable();
+            let count = members.len();
+            let title = format!("{count} reports: {summary}");
+            ClusterPlan {
+                key,
+                summary,
+                members,
+                count,
+                title,
+            }
+        })
+        .collect();
+    plans.sort_by(|a, b| a.key.cmp(&b.key));
+    plans
+}
+
+/// Normalizes a title into a clustering key.
+fn normalize_title(title: &str) -> String {
+    strip_type_prefix(title)
+        .to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Strips a leading `[type] ` prefix (as minted by the filer) from a title.
+fn strip_type_prefix(title: &str) -> String {
+    let trimmed = title.trim();
+    if let Some(rest) = trimmed.strip_prefix('[')
+        && let Some(idx) = rest.find(']')
+    {
+        return rest[idx + 1..].trim().to_string();
+    }
+    trimmed.to_string()
+}
+
+/// A roster-job triage agent operating over one repo's issue tracker.
+///
+/// Not kernel plumbing: it is a helper a triage company (or a maintenance
+/// sweep) drives against a [`GitHubClient`]. Every method is offline-testable
+/// against the mock client.
+pub struct TriageAgent {
+    client: Arc<dyn GitHubClient>,
+    repo: String,
+}
+
+impl TriageAgent {
+    /// Builds a triage agent filing against `repo` through `client`.
+    pub fn new(client: Arc<dyn GitHubClient>, repo: impl Into<String>) -> Self {
+        Self {
+            client,
+            repo: repo.into(),
+        }
+    }
+
+    /// Merges `candidate` into an earlier canonical issue if one exists.
+    ///
+    /// Searches the tracker for the candidate's title; if an *earlier* issue
+    /// matches, comments on that canonical noting the merge and closes the
+    /// candidate, returning [`DedupePlan::Merged`]. Otherwise the candidate is
+    /// [`DedupePlan::Distinct`].
+    pub async fn dedupe(&self, candidate: &ExistingIssue) -> Result<DedupePlan> {
+        let hits = self
+            .client
+            .search_issues(&self.repo, &candidate.title)
+            .await?;
+        // The canonical is the earliest matching issue other than the candidate.
+        let canonical = hits
+            .into_iter()
+            .filter(|issue| issue.number != candidate.number)
+            .min_by_key(|issue| issue.number);
+
+        match canonical {
+            Some(canonical) => {
+                self.client
+                    .comment_issue(
+                        &self.repo,
+                        canonical.number,
+                        &format!(
+                            "Folding in duplicate #{} — same report as this issue.",
+                            candidate.number
+                        ),
+                    )
+                    .await?;
+                self.client
+                    .close_issue(&self.repo, candidate.number)
+                    .await?;
+                Ok(DedupePlan::Merged {
+                    canonical,
+                    closed: candidate.number,
+                })
+            }
+            None => Ok(DedupePlan::Distinct),
+        }
+    }
+
+    /// Materializes a [`ClusterPlan`]: opens a cluster issue, then comments on
+    /// and closes every member, pointing each at the cluster.
+    ///
+    /// `area_label` is the owning `area/<…>` value (e.g.
+    /// `template:marketing_agency`); it is appended to the cluster title and
+    /// applied as an `area/` label. Returns the created cluster issue URL.
+    pub async fn maintain_cluster(&self, plan: &ClusterPlan, area_label: &str) -> Result<String> {
+        let title = format!("{} — {}", plan.title, area_label);
+        let body = format!(
+            "Cluster of {} similar reports: {}.\n\nMembers: {}",
+            plan.count,
+            plan.summary,
+            plan.members
+                .iter()
+                .map(|n| format!("#{n}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        let cluster_url = self
+            .client
+            .create_issue(
+                &self.repo,
+                &IssueDraft {
+                    title,
+                    body,
+                    labels: vec!["feedback".to_string(), format!("area/{area_label}")],
+                },
+            )
+            .await?;
+
+        for member in &plan.members {
+            self.client
+                .comment_issue(
+                    &self.repo,
+                    *member,
+                    &format!("Folded into cluster: {cluster_url}"),
+                )
+                .await?;
+            self.client.close_issue(&self.repo, *member).await?;
+        }
+        Ok(cluster_url)
+    }
+}
+
+impl std::fmt::Debug for TriageAgent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TriageAgent")
+            .field("repo", &self.repo)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Per-handle filing quality, used to throttle auto-consent.
+///
+/// A company that repeatedly files low-quality issues (e.g. filings that are
+/// immediately closed as duplicates, or maintainer-flagged) has its `Auto`
+/// consent downgraded to `Assisted` once its low-quality ratio crosses a
+/// threshold, so the operator confirms each filing again. In-memory, mirroring
+/// [`RateLimiter`](super::github::RateLimiter).
+#[derive(Debug)]
+pub struct QualityLedger {
+    threshold: f64,
+    min_samples: usize,
+    filings: StdMutex<HashMap<String, Counts>>,
+}
+
+/// The per-handle filing tally.
+#[derive(Clone, Copy, Debug, Default)]
+struct Counts {
+    filed: usize,
+    low_quality: usize,
+}
+
+impl QualityLedger {
+    /// Builds a ledger that downgrades `Auto` consent once a handle has at
+    /// least `min_samples` filings and a low-quality ratio at or above
+    /// `threshold` (0.0–1.0).
+    pub fn new(threshold: f64, min_samples: usize) -> Self {
+        Self {
+            threshold,
+            min_samples,
+            filings: StdMutex::new(HashMap::new()),
+        }
+    }
+
+    /// Records that `handle` filed an issue (of any quality).
+    pub fn record_filed(&self, handle: &str) {
+        let mut filings = self.filings.lock().expect("quality ledger poisoned");
+        filings.entry(handle.to_string()).or_default().filed += 1;
+    }
+
+    /// Records that `handle`'s most recent filing was low-quality (e.g. an
+    /// immediate duplicate). Callers still call [`record_filed`](Self::record_filed)
+    /// for the same filing; this only bumps the low-quality tally.
+    pub fn record_low_quality(&self, handle: &str) {
+        let mut filings = self.filings.lock().expect("quality ledger poisoned");
+        filings.entry(handle.to_string()).or_default().low_quality += 1;
+    }
+
+    /// The consent mode `handle` effectively gets given its filing history.
+    ///
+    /// Only `Auto` is subject to throttling; `Manual`/`Assisted` pass through
+    /// unchanged. An `Auto` handle over the low-quality threshold is downgraded
+    /// to `Assisted`.
+    pub fn effective_consent(&self, handle: &str, configured: ConsentMode) -> ConsentMode {
+        if configured != ConsentMode::Auto {
+            return configured;
+        }
+        let filings = self.filings.lock().expect("quality ledger poisoned");
+        if let Some(counts) = filings.get(handle)
+            && counts.filed >= self.min_samples
+            && (counts.low_quality as f64 / counts.filed as f64) >= self.threshold
+        {
+            return ConsentMode::Assisted;
+        }
+        configured
+    }
+}
+
+impl Default for QualityLedger {
+    /// Downgrades after 3+ filings with at least half low-quality.
+    fn default() -> Self {
+        Self::new(0.5, 3)
+    }
+}
+
+/// Joins fixed issue URLs to the feedback items that caused them.
+///
+/// The "You said, we did" contract: given the issue URLs closed by a release
+/// and the company's feedback items, returns each `(issue_url, item)` pair
+/// whose item links that issue, so the caller can surface *"things you flagged
+/// were fixed"* to the right operators.
+pub fn map_fixed_issues<'a>(
+    fixed: &[String],
+    items: &'a [FeedbackItem],
+) -> Vec<(String, &'a FeedbackItem)> {
+    let mut out = Vec::new();
+    for url in fixed {
+        for item in items {
+            if item.filed_issue_url.as_deref() == Some(url.as_str()) {
+                out.push((url.clone(), item));
+            }
+        }
+    }
+    out
+}
+
+/// Flags release-notes process bugs.
+///
+/// A `feedback`-labeled issue closed by a release but absent from the release
+/// notes is a process bug (`triage.md`). Returns every closed feedback issue
+/// URL missing from `notes_issue_urls`.
+pub fn process_bug_check(
+    closed_feedback_issues: &[String],
+    notes_issue_urls: &[String],
+) -> Vec<String> {
+    closed_feedback_issues
+        .iter()
+        .filter(|url| !notes_issue_urls.iter().any(|n| n == *url))
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::feedback::github::MockGitHubClient;
+    use crate::feedback::types::{FeedbackCategory, FeedbackInput};
+
+    fn item(category: FeedbackCategory, template: Option<&str>) -> FeedbackItem {
+        FeedbackItem::capture(
+            FeedbackInput {
+                category,
+                note: "n".into(),
+                work_ref: None,
+                template_name: template.map(str::to_string),
+                template_version: None,
+            },
+            "0.1.0",
+            ConsentMode::Auto,
+        )
+    }
+
+    #[test]
+    fn classify_covers_all_four_axes() {
+        let labels = classify_labels(
+            &item(FeedbackCategory::Bug, None),
+            Severity::Blocked,
+            FeedbackSource::Operator,
+        );
+        assert!(labels.contains(&"feedback".to_string()));
+        assert!(labels.contains(&"type/bug".to_string()));
+        assert!(labels.contains(&"area/runtime".to_string()));
+        assert!(labels.contains(&"sev/blocked".to_string()));
+        assert!(labels.contains(&"source/operator".to_string()));
+        // Exactly one label per axis plus the base label.
+        assert_eq!(labels.len(), 5);
+    }
+
+    #[test]
+    fn classify_names_template_area_and_money_lost() {
+        let labels = classify_labels(
+            &item(FeedbackCategory::TemplateGap, Some("marketing_agency")),
+            Severity::MoneyLost,
+            FeedbackSource::AgentFiled,
+        );
+        assert!(labels.contains(&"area/template:marketing_agency".to_string()));
+        assert!(labels.contains(&"sev/money-lost".to_string()));
+        assert!(labels.contains(&"source/agent-filed".to_string()));
+        assert!(labels.contains(&"type/template-gap".to_string()));
+    }
+
+    #[test]
+    fn severity_and_source_wire_tokens_are_exact() {
+        assert_eq!(Severity::Annoyance.as_str(), "annoyance");
+        assert_eq!(Severity::Blocked.as_str(), "blocked");
+        assert_eq!(Severity::MoneyLost.as_str(), "money-lost");
+        assert_eq!(FeedbackSource::Operator.as_str(), "operator");
+        assert_eq!(FeedbackSource::AgentFiled.as_str(), "agent-filed");
+        assert_eq!(FeedbackSource::Platform.as_str(), "platform");
+    }
+
+    #[tokio::test]
+    async fn dedupe_comments_on_canonical_and_closes_duplicate() {
+        let client = Arc::new(
+            MockGitHubClient::new()
+                .with_existing(42, "https://gh/issues/42", "email drafts too formal")
+                .with_existing(57, "https://gh/issues/57", "email drafts too formal"),
+        );
+        let agent = TriageAgent::new(client.clone(), "acme/repo");
+        let candidate = ExistingIssue {
+            number: 57,
+            url: "https://gh/issues/57".into(),
+            title: "email drafts too formal".into(),
+        };
+
+        let plan = agent.dedupe(&candidate).await.unwrap();
+        match plan {
+            DedupePlan::Merged { canonical, closed } => {
+                assert_eq!(canonical.number, 42);
+                assert_eq!(closed, 57);
+            }
+            other => panic!("expected Merged, got {other:?}"),
+        }
+        // Commented on the canonical, closed the duplicate, created nothing.
+        assert_eq!(client.comments().len(), 1);
+        assert_eq!(client.comments()[0].0, 42);
+        assert_eq!(client.closed(), vec![57]);
+        assert!(client.created().is_empty());
+    }
+
+    #[tokio::test]
+    async fn dedupe_leaves_a_distinct_issue_untouched() {
+        let client = Arc::new(MockGitHubClient::new().with_existing(
+            9,
+            "https://gh/issues/9",
+            "unique problem",
+        ));
+        let agent = TriageAgent::new(client.clone(), "acme/repo");
+        let candidate = ExistingIssue {
+            number: 9,
+            url: "https://gh/issues/9".into(),
+            title: "unique problem".into(),
+        };
+        assert_eq!(
+            agent.dedupe(&candidate).await.unwrap(),
+            DedupePlan::Distinct
+        );
+        assert!(client.comments().is_empty());
+        assert!(client.closed().is_empty());
+    }
+
+    #[test]
+    fn cluster_plans_group_similar_titles_and_score() {
+        let issues = vec![
+            ExistingIssue {
+                number: 3,
+                url: "u3".into(),
+                title: "[wrong-output] email drafts too formal".into(),
+            },
+            ExistingIssue {
+                number: 1,
+                url: "u1".into(),
+                title: "Email drafts too formal".into(),
+            },
+            ExistingIssue {
+                number: 2,
+                url: "u2".into(),
+                title: "email  drafts   too formal".into(),
+            },
+            ExistingIssue {
+                number: 8,
+                url: "u8".into(),
+                title: "a lone report".into(),
+            },
+        ];
+        let plans = cluster_plans(&issues);
+        assert_eq!(plans.len(), 1, "only the 3-member group clusters");
+        let plan = &plans[0];
+        assert_eq!(plan.count, 3);
+        assert_eq!(plan.members, vec![1, 2, 3]);
+        assert!(plan.title.starts_with("3 reports:"));
+        // count × severity.
+        assert_eq!(plan.score(Severity::Annoyance), 3);
+        assert_eq!(plan.score(Severity::MoneyLost), 30);
+        assert!(!plan.promote(Severity::Annoyance, 10));
+        assert!(plan.promote(Severity::MoneyLost, 10));
+    }
+
+    #[tokio::test]
+    async fn maintain_cluster_creates_issue_and_closes_members() {
+        let client = Arc::new(MockGitHubClient::new());
+        let agent = TriageAgent::new(client.clone(), "acme/repo");
+        let plan = ClusterPlan {
+            key: "email drafts too formal".into(),
+            summary: "email drafts too formal".into(),
+            members: vec![1, 2, 3],
+            count: 3,
+            title: "3 reports: email drafts too formal".into(),
+        };
+        let url = agent
+            .maintain_cluster(&plan, "template:marketing_agency")
+            .await
+            .unwrap();
+        assert!(url.starts_with("https://github.com/mock/issues/"));
+        let created = client.created();
+        assert_eq!(created.len(), 1);
+        assert!(created[0].title.contains("template:marketing_agency"));
+        assert!(
+            created[0]
+                .labels
+                .contains(&"area/template:marketing_agency".to_string())
+        );
+        // Every member was commented on and closed.
+        assert_eq!(client.closed(), vec![1, 2, 3]);
+        assert_eq!(client.comments().len(), 3);
+    }
+
+    #[test]
+    fn throttle_downgrades_auto_after_low_quality_filings() {
+        let ledger = QualityLedger::new(0.5, 2);
+        // Below the sample floor: no downgrade yet.
+        ledger.record_filed("noisy");
+        ledger.record_low_quality("noisy");
+        assert_eq!(
+            ledger.effective_consent("noisy", ConsentMode::Auto),
+            ConsentMode::Auto
+        );
+        // Second low-quality filing crosses the floor and the ratio.
+        ledger.record_filed("noisy");
+        ledger.record_low_quality("noisy");
+        assert_eq!(
+            ledger.effective_consent("noisy", ConsentMode::Auto),
+            ConsentMode::Assisted
+        );
+        // A clean handle keeps Auto; non-Auto modes always pass through.
+        ledger.record_filed("clean");
+        ledger.record_filed("clean");
+        assert_eq!(
+            ledger.effective_consent("clean", ConsentMode::Auto),
+            ConsentMode::Auto
+        );
+        assert_eq!(
+            ledger.effective_consent("noisy", ConsentMode::Manual),
+            ConsentMode::Manual
+        );
+    }
+
+    #[test]
+    fn escalation_flags_money_lost_and_brain() {
+        let money = escalation_for(&["sev/money-lost".to_string(), "area/product".to_string()]);
+        assert!(money.pages_maintainers);
+        assert!(money.mirror_to.is_none());
+
+        let brain = escalation_for(&["area/brain".to_string(), "sev/annoyance".to_string()]);
+        assert!(!brain.pages_maintainers);
+        assert_eq!(brain.mirror_to.as_deref(), Some("tinyhumansai/medulla"));
+    }
+
+    #[test]
+    fn release_notes_map_and_process_bug_check() {
+        let mut filed = item(FeedbackCategory::Bug, None);
+        filed.filed_issue_url = Some("https://gh/issues/7".into());
+        let other = item(FeedbackCategory::Docs, None);
+        let items = vec![filed, other];
+
+        let mapped = map_fixed_issues(&["https://gh/issues/7".to_string()], &items);
+        assert_eq!(mapped.len(), 1);
+        assert_eq!(mapped[0].0, "https://gh/issues/7");
+        assert_eq!(mapped[0].1.category, FeedbackCategory::Bug);
+
+        // A closed feedback issue missing from the notes is a process bug.
+        let bugs = process_bug_check(
+            &[
+                "https://gh/issues/7".to_string(),
+                "https://gh/issues/9".to_string(),
+            ],
+            &["https://gh/issues/7".to_string()],
+        );
+        assert_eq!(bugs, vec!["https://gh/issues/9".to_string()]);
+    }
+}

--- a/src/feedback/types.rs
+++ b/src/feedback/types.rs
@@ -1,0 +1,296 @@
+//! Core feedback types: the [`FeedbackItem`] snapshot, its category, and the
+//! per-company consent mode.
+//!
+//! A `FeedbackItem` is captured whenever an operator (or the brain on their
+//! behalf) reacts to the company's work. It persists in the company's feedback
+//! family whether or not it is ever filed as a public issue. The operator's
+//! *unscrubbed* words stay local in the item; only a scrubbed candidate body
+//! ever leaves the machine (see [`super::scrub`]).
+
+use serde::{Deserialize, Serialize};
+
+use crate::ports::generate_id;
+use crate::ports::now_millis;
+
+/// The kind of problem a feedback item reports.
+///
+/// Serialized in kebab-case so the wire form matches the `type/<value>` GitHub
+/// label taxonomy in `docs/spec/feedback-loop/triage.md`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FeedbackCategory {
+    /// The company produced incorrect or low-quality work.
+    WrongOutput,
+    /// Runtime misbehavior: a crash, a lost event, a broken route.
+    Bug,
+    /// "It can't do X" — a capability the company lacks.
+    MissingCapability,
+    /// The approval fence is wrong: it over- or under-asks.
+    ApprovalFriction,
+    /// A template's roster, charter, or defaults fall short.
+    TemplateGap,
+    /// Documentation is wrong or missing.
+    Docs,
+}
+
+impl FeedbackCategory {
+    /// The kebab-case wire token used in the `type/` label and issue titles.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::WrongOutput => "wrong-output",
+            Self::Bug => "bug",
+            Self::MissingCapability => "missing-capability",
+            Self::ApprovalFriction => "approval-friction",
+            Self::TemplateGap => "template-gap",
+            Self::Docs => "docs",
+        }
+    }
+}
+
+/// How much standing consent the operator has granted for filing.
+///
+/// The scrub-then-preview gate (`docs/spec/feedback-loop/privacy.md`) applies in
+/// every mode; the mode only decides whether the operator taps confirm each
+/// time or has pre-authorized a category.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConsentMode {
+    /// Nothing leaves the machine automatically; the operator files via a
+    /// prefilled issue link. The default.
+    #[default]
+    Manual,
+    /// The company drafts the issue; the operator approves the exact final body.
+    Assisted,
+    /// Standing per-category consent; still scrubbed, previewed, and journaled.
+    Auto,
+}
+
+/// The fields a capture surface supplies to mint a [`FeedbackItem`].
+#[derive(Clone, Debug, Deserialize)]
+pub struct FeedbackInput {
+    /// The reported category.
+    pub category: FeedbackCategory,
+    /// The operator's own words. Kept local unscrubbed; scrubbed before filing.
+    pub note: String,
+    /// The work item the feedback concerns (an effect kind, route, or ref).
+    #[serde(default)]
+    pub work_ref: Option<String>,
+    /// The template name the company was created from, if known.
+    #[serde(default)]
+    pub template_name: Option<String>,
+    /// The template version the company was created from, if known.
+    #[serde(default)]
+    pub template_version: Option<String>,
+}
+
+/// A durable snapshot of one piece of feedback.
+///
+/// The `operator_words` field stays local and unscrubbed; a scrubbed candidate
+/// body is derived from it only at filing time.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct FeedbackItem {
+    /// A process-unique id.
+    pub id: String,
+    /// The reported category.
+    pub category: FeedbackCategory,
+    /// The operator's own words. **Local only** — never leaves unscrubbed.
+    pub operator_words: String,
+    /// The work item the feedback concerns.
+    pub work_item: Option<String>,
+    /// The template the company was created from, if known.
+    pub template_name: Option<String>,
+    /// The template version, if known.
+    pub template_version: Option<String>,
+    /// The runtime version that produced the work.
+    pub runtime_version: String,
+    /// A capped, scrubbed-at-filing excerpt of runtime/brain output.
+    pub context_excerpt: String,
+    /// Epoch-millis the item was captured.
+    pub at_millis: u64,
+    /// The filed issue URL, once the item is filed.
+    pub filed_issue_url: Option<String>,
+    /// The last-observed issue status, once the item is filed.
+    pub issue_status: Option<String>,
+    /// The consent mode in force when the item was captured.
+    pub consent_mode: ConsentMode,
+}
+
+/// The maximum length of a captured context excerpt, in bytes. Data
+/// minimization: issues carry the minimum needed to reproduce.
+pub const CONTEXT_EXCERPT_CAP: usize = 2000;
+
+impl FeedbackItem {
+    /// Mints an item from a capture [`FeedbackInput`], stamping the current
+    /// runtime version, time, and a fresh id. The context excerpt is capped.
+    pub fn capture(input: FeedbackInput, runtime_version: &str, consent_mode: ConsentMode) -> Self {
+        let mut excerpt = input.note.clone();
+        if excerpt.len() > CONTEXT_EXCERPT_CAP {
+            // Truncate on a UTF-8 char boundary at or below the cap so a
+            // multi-byte character straddling the cap never panics.
+            let mut end = CONTEXT_EXCERPT_CAP;
+            while end > 0 && !excerpt.is_char_boundary(end) {
+                end -= 1;
+            }
+            excerpt.truncate(end);
+        }
+        Self {
+            id: generate_id(),
+            category: input.category,
+            operator_words: input.note,
+            work_item: input.work_ref,
+            template_name: input.template_name,
+            template_version: input.template_version,
+            runtime_version: runtime_version.to_string(),
+            context_excerpt: excerpt,
+            at_millis: now_millis(),
+            filed_issue_url: None,
+            issue_status: None,
+            consent_mode,
+        }
+    }
+}
+
+/// Detects a feedback intent in an operator chat message.
+///
+/// Recognizes a small set of complaint phrases ("that was wrong", "flag it",
+/// "this is a bug", "it can't") so an operator can file feedback mid-chat
+/// without a separate call. Returns the inferred category, or `None` when the
+/// message carries no feedback intent (the common case, so normal chat is
+/// untouched). Conservative by design: it never fires on neutral messages.
+pub fn detect_chat_intent(text: &str) -> Option<FeedbackCategory> {
+    let lower = text.to_lowercase();
+    // Ordered most-specific first so a message matches its truest category.
+    const RULES: &[(&[&str], FeedbackCategory)] = &[
+        (
+            &["can't do", "cannot do", "can it ", "unable to"],
+            FeedbackCategory::MissingCapability,
+        ),
+        (
+            &["asked me again", "why approve", "too many approvals"],
+            FeedbackCategory::ApprovalFriction,
+        ),
+        (
+            &["crashed", "is a bug", "broken", "lost my"],
+            FeedbackCategory::Bug,
+        ),
+        (
+            &["docs are", "documentation is", "docs wrong"],
+            FeedbackCategory::Docs,
+        ),
+        (
+            &[
+                "was wrong",
+                "is wrong",
+                "flag it",
+                "flag this",
+                "this was wrong",
+                "that was wrong",
+                "thumbs down",
+            ],
+            FeedbackCategory::WrongOutput,
+        ),
+    ];
+    for (needles, category) in RULES {
+        if needles.iter().any(|needle| lower.contains(needle)) {
+            return Some(*category);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn detects_complaint_intents_only() {
+        assert_eq!(
+            detect_chat_intent("that invoice was wrong — flag it"),
+            Some(FeedbackCategory::WrongOutput)
+        );
+        assert_eq!(
+            detect_chat_intent("it can't do multi-currency"),
+            Some(FeedbackCategory::MissingCapability)
+        );
+        assert_eq!(
+            detect_chat_intent("the server crashed"),
+            Some(FeedbackCategory::Bug)
+        );
+        // Neutral chat carries no intent.
+        assert_eq!(detect_chat_intent("hi"), None);
+        assert_eq!(detect_chat_intent("file it under Q3"), None);
+    }
+
+    #[test]
+    fn category_serializes_kebab_case() {
+        assert_eq!(
+            serde_json::to_string(&FeedbackCategory::WrongOutput).unwrap(),
+            "\"wrong-output\""
+        );
+        assert_eq!(
+            FeedbackCategory::MissingCapability.as_str(),
+            "missing-capability"
+        );
+    }
+
+    #[test]
+    fn consent_defaults_to_manual() {
+        assert_eq!(ConsentMode::default(), ConsentMode::Manual);
+        assert_eq!(
+            serde_json::to_string(&ConsentMode::Auto).unwrap(),
+            "\"auto\""
+        );
+    }
+
+    #[test]
+    fn capture_stamps_version_and_caps_excerpt() {
+        let input = FeedbackInput {
+            category: FeedbackCategory::Bug,
+            note: "x".repeat(CONTEXT_EXCERPT_CAP + 500),
+            work_ref: Some("email.send".into()),
+            template_name: None,
+            template_version: None,
+        };
+        let item = FeedbackItem::capture(input, "9.9.9", ConsentMode::Manual);
+        assert_eq!(item.runtime_version, "9.9.9");
+        assert_eq!(item.context_excerpt.len(), CONTEXT_EXCERPT_CAP);
+        // The full operator words stay local, uncapped.
+        assert_eq!(item.operator_words.len(), CONTEXT_EXCERPT_CAP + 500);
+        assert_eq!(item.work_item.as_deref(), Some("email.send"));
+    }
+
+    #[test]
+    fn capture_caps_multibyte_excerpt_on_a_char_boundary() {
+        // "😀" is 4 bytes; a run of them makes byte CONTEXT_EXCERPT_CAP land
+        // mid-character, which would panic a naive String::truncate.
+        let input = FeedbackInput {
+            category: FeedbackCategory::Bug,
+            note: "😀".repeat(CONTEXT_EXCERPT_CAP),
+            work_ref: None,
+            template_name: None,
+            template_version: None,
+        };
+        let item = FeedbackItem::capture(input, "9.9.9", ConsentMode::Manual);
+        assert!(item.context_excerpt.len() <= CONTEXT_EXCERPT_CAP);
+        // Truncated on a boundary: the excerpt is still valid UTF-8 emoji.
+        assert!(item.context_excerpt.chars().all(|c| c == '😀'));
+    }
+
+    #[test]
+    fn item_round_trips_through_json() {
+        let item = FeedbackItem::capture(
+            FeedbackInput {
+                category: FeedbackCategory::TemplateGap,
+                note: "roster too thin".into(),
+                work_ref: None,
+                template_name: Some("marketing_agency".into()),
+                template_version: Some("1.2".into()),
+            },
+            "0.1.0",
+            ConsentMode::Auto,
+        );
+        let json = serde_json::to_string(&item).unwrap();
+        let back: FeedbackItem = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, item);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod app;
 pub mod brain;
 pub mod company;
+pub mod economy;
 pub mod error;
 pub mod feedback;
 pub mod openhuman;
@@ -20,6 +21,7 @@ pub mod tiny;
 pub use app::{AppConfig, AppState};
 pub use brain::EchoBrain;
 pub use company::{CompanyManifest, run_company};
+pub use economy::{build_agent_card, render_skill_md};
 pub use error::{OpenCompanyError, Result};
 pub use feedback::{
     ConsentMode, FeedbackCategory, FeedbackInput, FeedbackItem, FeedbackResponse, FeedbackStore,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod app;
 pub mod brain;
 pub mod company;
 pub mod error;
+pub mod feedback;
 pub mod openhuman;
 pub mod policy;
 pub mod ports;
@@ -20,6 +21,9 @@ pub use app::{AppConfig, AppState};
 pub use brain::EchoBrain;
 pub use company::{CompanyManifest, run_company};
 pub use error::{OpenCompanyError, Result};
+pub use feedback::{
+    ConsentMode, FeedbackCategory, FeedbackInput, FeedbackItem, FeedbackResponse, FeedbackStore,
+};
 pub use policy::ManifestApprovalGate;
 pub use ports::{CompanyEvent, CompanyId, Effect, EffectDisposition, PolicyDecision, Verdict};
 pub use runtime::{CompanyRegistry, CompanyRuntime, CycleReport, RuntimeBuilder};

--- a/src/openhuman/channel.rs
+++ b/src/openhuman/channel.rs
@@ -1,0 +1,103 @@
+//! [`OpenHumanChannelAdapter`]: a [`ChannelAdapter`] backed by openhuman-core.
+//!
+//! Outbound messages are delivered over JSON-RPC (`openhuman.channels_send`).
+//! Inbound delivery rides a signed webhook route in a later batch, so
+//! [`inbound`](OpenHumanChannelAdapter::inbound) is an empty stream for now —
+//! openhuman-core's `/events` schema is upstream-unstable and drives no control
+//! flow here.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::stream::{self, BoxStream};
+
+use crate::Result;
+use crate::openhuman::rpc::{OpenHumanRpc, rpc_method};
+use crate::ports::channel::ChannelAdapter;
+use crate::ports::types::{InboundMessage, OutboundMessage};
+
+/// A conversation surface (email, slack, …) delegated to openhuman-core.
+pub struct OpenHumanChannelAdapter {
+    channel_id: String,
+    rpc: Arc<dyn OpenHumanRpc>,
+}
+
+impl OpenHumanChannelAdapter {
+    /// Wires an adapter for `channel_id` (e.g. `"email"`) over `rpc`.
+    pub fn new(channel_id: impl Into<String>, rpc: Arc<dyn OpenHumanRpc>) -> Self {
+        Self {
+            channel_id: channel_id.into(),
+            rpc,
+        }
+    }
+}
+
+#[async_trait]
+impl ChannelAdapter for OpenHumanChannelAdapter {
+    fn channel_id(&self) -> &str {
+        &self.channel_id
+    }
+
+    fn inbound(&self) -> BoxStream<'static, InboundMessage> {
+        // Inbound arrives via the HMAC webhook route (a later batch), not here.
+        Box::pin(stream::empty())
+    }
+
+    async fn send(&self, msg: OutboundMessage) -> Result<()> {
+        let params = serde_json::json!({ "channel": msg.channel, "text": msg.text });
+        self.rpc
+            .call(&rpc_method("channels", "send"), params)
+            .await
+            .map(|_| ())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::openhuman::rpc::MockOpenHumanRpc;
+    use futures::StreamExt;
+
+    #[tokio::test]
+    async fn send_issues_channels_send_with_params() {
+        let rpc = Arc::new(
+            MockOpenHumanRpc::new().with_result("openhuman.channels_send", serde_json::json!({})),
+        );
+        let adapter = OpenHumanChannelAdapter::new("email", rpc.clone());
+        assert_eq!(adapter.channel_id(), "email");
+        adapter
+            .send(OutboundMessage {
+                channel: "email".into(),
+                text: "hello".into(),
+            })
+            .await
+            .unwrap();
+        let calls = rpc.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "openhuman.channels_send");
+        assert_eq!(calls[0].1["channel"], "email");
+        assert_eq!(calls[0].1["text"], "hello");
+    }
+
+    #[tokio::test]
+    async fn inbound_is_empty() {
+        let rpc = Arc::new(MockOpenHumanRpc::new());
+        let adapter = OpenHumanChannelAdapter::new("email", rpc);
+        assert_eq!(adapter.inbound().count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn send_propagates_rpc_error() {
+        // No handler → the mock errors, standing in for a transport failure.
+        let rpc = Arc::new(MockOpenHumanRpc::new());
+        let adapter = OpenHumanChannelAdapter::new("email", rpc);
+        let err = adapter
+            .send(OutboundMessage {
+                channel: "email".into(),
+                text: "hi".into(),
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, crate::OpenCompanyError::OpenHuman { .. }));
+    }
+}

--- a/src/openhuman/http_client.rs
+++ b/src/openhuman/http_client.rs
@@ -1,0 +1,91 @@
+//! [`HttpOpenHumanRpc`]: the real HTTP transport to openhuman-core.
+//!
+//! Compiled only under the `openhuman-rpc` feature — the trait, envelopes, and
+//! [`MockOpenHumanRpc`](super::rpc::MockOpenHumanRpc) keep the default build
+//! network-free while every provider/adapter stays testable offline.
+//!
+//! Attach to a running openhuman-core with [`HttpOpenHumanRpc::attach`], passing
+//! the base URL (from `OPENCOMPANY_OPENHUMAN_URL`) and the per-launch bearer.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+
+use crate::Result;
+use crate::error::OpenCompanyError;
+use crate::openhuman::rpc::{OpenHumanRpc, RpcRequest, RpcResponse};
+use crate::ports::types::SecretValue;
+
+/// A JSON-RPC client that talks to openhuman-core over HTTP.
+pub struct HttpOpenHumanRpc {
+    base_url: String,
+    bearer: SecretValue,
+    http: reqwest::Client,
+    id: AtomicU64,
+}
+
+impl HttpOpenHumanRpc {
+    /// Attaches to an already-running openhuman-core at `base_url`, using
+    /// `bearer` as the per-launch `Authorization: Bearer` credential.
+    pub fn attach(base_url: impl Into<String>, bearer: SecretValue) -> Self {
+        Self {
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            bearer,
+            http: reqwest::Client::new(),
+            id: AtomicU64::new(1),
+        }
+    }
+
+    fn rpc_url(&self) -> String {
+        format!("{}/rpc", self.base_url)
+    }
+}
+
+/// Wraps a transport error into the crate error type.
+fn transport(err: impl std::fmt::Display) -> OpenCompanyError {
+    OpenCompanyError::OpenHuman {
+        code: -32000,
+        message: err.to_string(),
+    }
+}
+
+#[async_trait]
+impl OpenHumanRpc for HttpOpenHumanRpc {
+    async fn call(&self, method: &str, params: serde_json::Value) -> Result<serde_json::Value> {
+        let request = RpcRequest {
+            jsonrpc: "2.0",
+            id: self.id.fetch_add(1, Ordering::Relaxed),
+            method,
+            params,
+        };
+        let response = self
+            .http
+            .post(self.rpc_url())
+            .bearer_auth(self.bearer.expose())
+            .json(&request)
+            .send()
+            .await
+            .map_err(transport)?;
+        let envelope: RpcResponse = response.json().await.map_err(transport)?;
+        if let Some(err) = envelope.error {
+            return Err(OpenCompanyError::OpenHuman {
+                code: err.code,
+                message: err.message,
+            });
+        }
+        Ok(envelope.result)
+    }
+
+    async fn health(&self) -> Result<bool> {
+        // Any transport error degrades to "unhealthy" so boot never fails on it.
+        match self
+            .http
+            .get(format!("{}/health", self.base_url))
+            .send()
+            .await
+        {
+            Ok(response) => Ok(response.status().is_success()),
+            Err(_) => Ok(false),
+        }
+    }
+}

--- a/src/openhuman/mod.rs
+++ b/src/openhuman/mod.rs
@@ -1,3 +1,24 @@
+//! OpenHuman integration: process launcher plus the JSON-RPC seam.
+//!
+//! [`launcher`] shells out to a sibling OpenHuman checkout. [`rpc`] defines the
+//! transport trait and an offline mock; [`tools`] and [`channel`] build the
+//! OpenHuman-backed [`ToolProvider`](crate::ports::ToolProvider) and
+//! [`ChannelAdapter`](crate::ports::ChannelAdapter) on top of it. The real HTTP
+//! client in [`http_client`] compiles only under the `openhuman-rpc` feature.
+
 mod launcher;
 
+pub mod channel;
+pub mod rpc;
+pub mod tools;
+
+#[cfg(feature = "openhuman-rpc")]
+pub mod http_client;
+
+pub use channel::OpenHumanChannelAdapter;
 pub use launcher::{LaunchMode, OpenHumanLaunch};
+pub use rpc::{MockOpenHumanRpc, OpenHumanRpc, rpc_method};
+pub use tools::OpenHumanToolProvider;
+
+#[cfg(feature = "openhuman-rpc")]
+pub use http_client::HttpOpenHumanRpc;

--- a/src/openhuman/rpc.rs
+++ b/src/openhuman/rpc.rs
@@ -1,0 +1,220 @@
+//! The [`OpenHumanRpc`] transport seam: a JSON-RPC channel to `openhuman-core`.
+//!
+//! openhuman-core exposes a single JSON-RPC endpoint at `POST /rpc` plus a few
+//! REST probes (`GET /health`, `/schema`, `/events`). This module defines the
+//! transport *trait* and its wire envelopes so the [`OpenHumanToolProvider`]
+//! and [`OpenHumanChannelAdapter`] can be exercised entirely offline against
+//! [`MockOpenHumanRpc`] in the default build; the real HTTP client lives behind
+//! the `openhuman-rpc` feature in [`super::http_client`].
+//!
+//! [`OpenHumanToolProvider`]: super::tools::OpenHumanToolProvider
+//! [`OpenHumanChannelAdapter`]: super::channel::OpenHumanChannelAdapter
+
+use std::collections::HashMap;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::Result;
+
+/// A JSON-RPC transport to `openhuman-core`.
+///
+/// Object-safe so it can be held as `Arc<dyn OpenHumanRpc>` and shared between
+/// the tool provider and channel adapters of one company.
+#[async_trait]
+pub trait OpenHumanRpc: Send + Sync {
+    /// Invokes a JSON-RPC method (`POST /rpc`), returning its `result` value.
+    ///
+    /// `method` is the fully-qualified wire name, e.g. `openhuman.tools_invoke`;
+    /// build it with [`rpc_method`]. A protocol- or transport-level failure is
+    /// surfaced as [`OpenCompanyError::OpenHuman`](crate::OpenCompanyError::OpenHuman).
+    async fn call(&self, method: &str, params: serde_json::Value) -> Result<serde_json::Value>;
+
+    /// Liveness probe (`GET /health`).
+    ///
+    /// Returns `Ok(false)` — never `Err` — when openhuman-core is unreachable,
+    /// so a boot-time degradation decision can distinguish "down" from a genuine
+    /// caller error.
+    async fn health(&self) -> Result<bool>;
+}
+
+/// Formats the JSON-RPC wire method name for an openhuman namespace/function.
+///
+/// openhuman-core names methods `openhuman.<namespace>_<function>`, e.g.
+/// `rpc_method("tools", "invoke") == "openhuman.tools_invoke"`.
+pub fn rpc_method(namespace: &str, function: &str) -> String {
+    format!("openhuman.{namespace}_{function}")
+}
+
+/// A JSON-RPC 2.0 request envelope.
+///
+/// Only constructed by the feature-gated HTTP client; the default build carries
+/// it as a shared wire type.
+#[cfg_attr(not(feature = "openhuman-rpc"), allow(dead_code))]
+#[derive(Debug, Serialize)]
+pub(crate) struct RpcRequest<'a> {
+    /// Protocol marker, always `"2.0"`.
+    pub jsonrpc: &'a str,
+    /// A per-connection monotonic request id.
+    pub id: u64,
+    /// The fully-qualified method name.
+    pub method: &'a str,
+    /// The method parameters.
+    pub params: serde_json::Value,
+}
+
+/// A JSON-RPC 2.0 response envelope.
+///
+/// Decoded by the feature-gated HTTP client (and the offline envelope test).
+#[cfg_attr(not(feature = "openhuman-rpc"), allow(dead_code))]
+#[derive(Debug, Deserialize)]
+pub(crate) struct RpcResponse {
+    /// The successful result, if any.
+    #[serde(default)]
+    pub result: serde_json::Value,
+    /// The error, if the call failed.
+    #[serde(default)]
+    pub error: Option<RpcError>,
+}
+
+/// A JSON-RPC 2.0 error object.
+#[derive(Debug, Deserialize)]
+pub struct RpcError {
+    /// The protocol error code.
+    pub code: i64,
+    /// A human-readable error message.
+    pub message: String,
+}
+
+/// An in-memory [`OpenHumanRpc`] for offline tests.
+///
+/// Register canned results per method with [`with_result`](Self::with_result);
+/// an unregistered method resolves to an
+/// [`OpenCompanyError::OpenHuman`](crate::OpenCompanyError::OpenHuman) error,
+/// which lets tests exercise the degradation/fallback paths. Every `call` is
+/// recorded so a test can assert both the parameters and the *count* (e.g. that
+/// an ungranted invocation issues zero RPC calls).
+#[derive(Debug, Default)]
+pub struct MockOpenHumanRpc {
+    handlers: StdMutex<HashMap<String, serde_json::Value>>,
+    calls: StdMutex<Vec<(String, serde_json::Value)>>,
+    healthy: AtomicBool,
+}
+
+impl MockOpenHumanRpc {
+    /// Creates a healthy mock with no registered methods.
+    pub fn new() -> Self {
+        Self {
+            handlers: StdMutex::new(HashMap::new()),
+            calls: StdMutex::new(Vec::new()),
+            healthy: AtomicBool::new(true),
+        }
+    }
+
+    /// Registers a canned `result` for `method` (the fully-qualified wire name).
+    pub fn with_result(self, method: &str, result: serde_json::Value) -> Self {
+        self.handlers
+            .lock()
+            .expect("mock handlers poisoned")
+            .insert(method.to_string(), result);
+        self
+    }
+
+    /// Marks the mock unhealthy so [`health`](OpenHumanRpc::health) returns
+    /// `Ok(false)`.
+    pub fn unhealthy(self) -> Self {
+        self.healthy.store(false, Ordering::SeqCst);
+        self
+    }
+
+    /// The number of `call`s issued so far.
+    pub fn call_count(&self) -> usize {
+        self.calls.lock().expect("mock calls poisoned").len()
+    }
+
+    /// A snapshot of every `(method, params)` pair issued so far.
+    pub fn calls(&self) -> Vec<(String, serde_json::Value)> {
+        self.calls.lock().expect("mock calls poisoned").clone()
+    }
+}
+
+#[async_trait]
+impl OpenHumanRpc for MockOpenHumanRpc {
+    async fn call(&self, method: &str, params: serde_json::Value) -> Result<serde_json::Value> {
+        self.calls
+            .lock()
+            .expect("mock calls poisoned")
+            .push((method.to_string(), params));
+        match self
+            .handlers
+            .lock()
+            .expect("mock handlers poisoned")
+            .get(method)
+            .cloned()
+        {
+            Some(result) => Ok(result),
+            None => Err(crate::OpenCompanyError::OpenHuman {
+                code: -32601,
+                message: format!("mock has no handler for method `{method}`"),
+            }),
+        }
+    }
+
+    async fn health(&self) -> Result<bool> {
+        Ok(self.healthy.load(Ordering::SeqCst))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn rpc_method_formats_namespace_and_function() {
+        assert_eq!(rpc_method("tools", "invoke"), "openhuman.tools_invoke");
+        assert_eq!(rpc_method("channels", "send"), "openhuman.channels_send");
+    }
+
+    #[test]
+    fn response_envelope_defaults_missing_fields() {
+        let ok: RpcResponse = serde_json::from_str(r#"{"result": {"ok": true}}"#).unwrap();
+        assert!(ok.error.is_none());
+        assert_eq!(ok.result["ok"], true);
+
+        let err: RpcResponse =
+            serde_json::from_str(r#"{"error": {"code": -1, "message": "boom"}}"#).unwrap();
+        assert!(err.result.is_null());
+        assert_eq!(err.error.unwrap().message, "boom");
+    }
+
+    #[tokio::test]
+    async fn mock_returns_registered_result_and_records_calls() {
+        let rpc =
+            MockOpenHumanRpc::new().with_result("openhuman.tools_list", serde_json::json!([]));
+        let out = rpc
+            .call("openhuman.tools_list", serde_json::json!({}))
+            .await
+            .unwrap();
+        assert!(out.is_array());
+        assert_eq!(rpc.call_count(), 1);
+        assert_eq!(rpc.calls()[0].0, "openhuman.tools_list");
+    }
+
+    #[tokio::test]
+    async fn mock_unknown_method_errors() {
+        let rpc = MockOpenHumanRpc::new();
+        let err = rpc
+            .call("openhuman.tools_list", serde_json::Value::Null)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, crate::OpenCompanyError::OpenHuman { code, .. } if code == -32601));
+    }
+
+    #[tokio::test]
+    async fn mock_health_reflects_flag() {
+        assert!(MockOpenHumanRpc::new().health().await.unwrap());
+        assert!(!MockOpenHumanRpc::new().unhealthy().health().await.unwrap());
+    }
+}

--- a/src/openhuman/tools.rs
+++ b/src/openhuman/tools.rs
@@ -1,0 +1,208 @@
+//! [`OpenHumanToolProvider`]: a [`ToolProvider`] backed by openhuman-core.
+//!
+//! The catalog is fetched over JSON-RPC and **filtered by the company's tool
+//! grants** (`[tools].allow` intersected with per-agent `tools`, precomputed by
+//! the builder). `invoke` re-checks the grant *before* issuing any RPC, so an
+//! ungranted call is side-effect-free. When openhuman-core is unreachable the
+//! provider degrades to a built-in `fallback` rather than failing.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::Result;
+use crate::error::OpenCompanyError;
+use crate::openhuman::rpc::{OpenHumanRpc, rpc_method};
+use crate::ports::tools::ToolProvider;
+use crate::ports::types::{CompanyId, ToolCall, ToolResult, ToolSpec};
+use crate::runtime::tools::grant_matches;
+
+/// A [`ToolProvider`] that delegates to openhuman-core over JSON-RPC.
+pub struct OpenHumanToolProvider {
+    rpc: Arc<dyn OpenHumanRpc>,
+    grants: Vec<String>,
+    fallback: Arc<dyn ToolProvider>,
+}
+
+impl OpenHumanToolProvider {
+    /// Wires a provider over `rpc`, restricting the catalog/invocations to
+    /// `grants` and degrading to `fallback` when openhuman-core fails.
+    pub fn new(
+        rpc: Arc<dyn OpenHumanRpc>,
+        grants: Vec<String>,
+        fallback: Arc<dyn ToolProvider>,
+    ) -> Self {
+        Self {
+            rpc,
+            grants,
+            fallback,
+        }
+    }
+
+    /// Whether `tool` is covered by any of the company's grant globs.
+    fn is_granted(&self, tool: &str) -> bool {
+        self.grants.iter().any(|grant| grant_matches(grant, tool))
+    }
+}
+
+#[async_trait]
+impl ToolProvider for OpenHumanToolProvider {
+    async fn catalog(&self, company: &CompanyId) -> Result<Vec<ToolSpec>> {
+        // On any RPC failure, degrade to the built-in catalog rather than error.
+        let value = match self
+            .rpc
+            .call(&rpc_method("tools", "list"), serde_json::json!({}))
+            .await
+        {
+            Ok(value) => value,
+            Err(_) => return self.fallback.catalog(company).await,
+        };
+        let specs: Vec<ToolSpec> = serde_json::from_value(value)?;
+        Ok(specs
+            .into_iter()
+            .filter(|spec| self.is_granted(&spec.name))
+            .collect())
+    }
+
+    async fn invoke(&self, _company: &CompanyId, call: ToolCall) -> Result<ToolResult> {
+        // Enforce the grant *before* any RPC/side effect.
+        if !self.is_granted(&call.tool) {
+            return Err(OpenCompanyError::ToolNotGranted(call.tool));
+        }
+        let params = serde_json::json!({ "tool": call.tool, "args": call.args });
+        match self.rpc.call(&rpc_method("tools", "invoke"), params).await {
+            // The wire result is a `ToolResult`; fall back to a well-formed
+            // failure if openhuman returns a shape we cannot decode.
+            Ok(value) => Ok(serde_json::from_value(value.clone()).unwrap_or(ToolResult {
+                ok: false,
+                output: value,
+            })),
+            // Granted but the RPC failed: report a failed-but-well-formed result
+            // so a grant misconfiguration and a runtime failure stay distinct.
+            Err(err) => Ok(ToolResult {
+                ok: false,
+                output: serde_json::json!({
+                    "error": "openhuman rpc failed",
+                    "tool": call.tool,
+                    "detail": err.to_string(),
+                }),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::openhuman::rpc::MockOpenHumanRpc;
+    use crate::runtime::tools::StubToolProvider;
+
+    fn company() -> CompanyId {
+        CompanyId::new("acme")
+    }
+
+    fn spec(name: &str) -> serde_json::Value {
+        serde_json::json!({ "name": name, "description": "", "input_schema": {} })
+    }
+
+    #[tokio::test]
+    async fn catalog_filters_by_grants() {
+        let rpc = Arc::new(MockOpenHumanRpc::new().with_result(
+            "openhuman.tools_list",
+            serde_json::json!([spec("email.send"), spec("payment.send")]),
+        ));
+        let provider = OpenHumanToolProvider::new(
+            rpc,
+            vec!["email.*".into()],
+            Arc::new(StubToolProvider::new(vec!["email.*".into()])),
+        );
+        let catalog = provider.catalog(&company()).await.unwrap();
+        assert_eq!(catalog.len(), 1);
+        assert_eq!(catalog[0].name, "email.send");
+    }
+
+    #[tokio::test]
+    async fn ungranted_invoke_rejected_before_rpc() {
+        let rpc = Arc::new(MockOpenHumanRpc::new());
+        let provider = OpenHumanToolProvider::new(
+            rpc.clone(),
+            vec!["email.*".into()],
+            Arc::new(StubToolProvider::new(vec!["email.*".into()])),
+        );
+        let err = provider
+            .invoke(
+                &company(),
+                ToolCall {
+                    tool: "payment.send".into(),
+                    args: serde_json::Value::Null,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OpenCompanyError::ToolNotGranted(t) if t == "payment.send"));
+        // Rejection must be side-effect-free: no RPC issued.
+        assert_eq!(rpc.call_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn granted_invoke_decodes_tool_result() {
+        let rpc = Arc::new(MockOpenHumanRpc::new().with_result(
+            "openhuman.tools_invoke",
+            serde_json::json!({ "ok": true, "output": { "id": "msg_1" } }),
+        ));
+        let provider = OpenHumanToolProvider::new(
+            rpc.clone(),
+            vec!["email.*".into()],
+            Arc::new(StubToolProvider::new(vec!["email.*".into()])),
+        );
+        let result = provider
+            .invoke(
+                &company(),
+                ToolCall {
+                    tool: "email.send".into(),
+                    args: serde_json::json!({ "to": "a@b.c" }),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(result.ok);
+        assert_eq!(result.output["id"], "msg_1");
+        assert_eq!(rpc.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn granted_invoke_rpc_failure_is_well_formed() {
+        // No handler registered → the mock errors, standing in for an RPC failure.
+        let rpc = Arc::new(MockOpenHumanRpc::new());
+        let provider = OpenHumanToolProvider::new(
+            rpc,
+            vec!["email.*".into()],
+            Arc::new(StubToolProvider::new(vec!["email.*".into()])),
+        );
+        let result = provider
+            .invoke(
+                &company(),
+                ToolCall {
+                    tool: "email.send".into(),
+                    args: serde_json::Value::Null,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(!result.ok);
+        assert_eq!(result.output["error"], "openhuman rpc failed");
+    }
+
+    #[tokio::test]
+    async fn rpc_failure_falls_back_to_builtin_catalog() {
+        // Unhealthy/erroring mock (no tools_list handler) → the stub's catalog.
+        let rpc = Arc::new(MockOpenHumanRpc::new().unhealthy());
+        let provider = OpenHumanToolProvider::new(
+            rpc,
+            vec!["email.*".into()],
+            Arc::new(StubToolProvider::new(vec!["email.*".into()])),
+        );
+        let catalog = provider.catalog(&company()).await.unwrap();
+        assert!(catalog.is_empty());
+    }
+}

--- a/src/policy/gate.rs
+++ b/src/policy/gate.rs
@@ -9,8 +9,18 @@
 //! 3. mode dispatch: `readonly` gates everything, `full` allows everything,
 //!    `supervised` applies the checkpoint taxonomy by [`EffectGroup`].
 //!
+//! The three policy modes map 1:1 onto OpenHuman's security tiers — `readonly`,
+//! `supervised`, and `full` — so a company's autonomy setting means the same
+//! thing to the gate and to the OpenHuman daemon that ultimately runs the tools.
+//!
 //! `evaluate` returns a bare [`PolicyDecision`]; the [`ApprovalId`] for a
 //! `RequireApproval` outcome is minted separately by [`park`](ManifestApprovalGate::park).
+//!
+//! Silence is a default-deny: a parked approval left unresolved past its TTL
+//! (default [`DEFAULT_TTL_MILLIS`]) resolves to deny, whether swept by
+//! [`sweep_expired`](ManifestApprovalGate::sweep_expired) or observed at
+//! resolution time by [`resolve_at`](ManifestApprovalGate::resolve_at) /
+//! [`resolve_amended`](ManifestApprovalGate::resolve_amended).
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -94,6 +104,42 @@ impl ManifestApprovalGate {
             map.remove(id);
         }
         expired
+    }
+
+    /// A clone of a parked effect without resolving it.
+    ///
+    /// Used by the amend path to overlay an operator's payload edit onto the
+    /// original before re-submitting it for execution.
+    pub fn parked_effect(&self, id: &ApprovalId) -> Option<Effect> {
+        self.parked
+            .lock()
+            .expect("parked map poisoned")
+            .get(id)
+            .map(|pe| pe.effect.clone())
+    }
+
+    /// Resolves a parked approval to an operator-amended effect
+    /// (approve-with-edit), as of `now`.
+    ///
+    /// Removes the parked entry and returns the `amended` effect to execute, or
+    /// `None` when the approval is unknown or has expired past its TTL — the
+    /// same default-deny-on-silence that governs [`resolve_at`](Self::resolve_at).
+    pub fn resolve_amended(
+        &self,
+        id: &ApprovalId,
+        amended: Effect,
+        _by: Actor,
+        now_millis: u64,
+    ) -> Option<Effect> {
+        let parked = self
+            .parked
+            .lock()
+            .expect("parked map poisoned")
+            .remove(id)?;
+        if now_millis.saturating_sub(parked.parked_at_millis) >= self.ttl_millis {
+            return None;
+        }
+        Some(amended)
     }
 
     /// Resolves a parked approval as of `now`, so expiry is testable.
@@ -383,6 +429,42 @@ mod test {
         let future = now_millis() + 10_000;
         let resolved = gate.resolve_at(&id, Verdict::Approve, operator(), future);
         assert_eq!(resolved, None);
+    }
+
+    #[tokio::test]
+    async fn resolve_amended_returns_amended_effect() {
+        let gate = ManifestApprovalGate::new(policy("supervised", None));
+        let original = effect("filing.submit", EffectGroup::Sign);
+        let id = gate.park(&company(), original.clone()).await.unwrap();
+
+        // The operator peeks the original, edits its payload, and approves it.
+        let parked = gate.parked_effect(&id).expect("parked effect readable");
+        assert_eq!(parked, original);
+        let mut amended = parked;
+        amended.payload = serde_json::json!({ "edited": true });
+
+        let resolved = gate.resolve_amended(&id, amended.clone(), operator(), now_millis());
+        assert_eq!(resolved, Some(amended));
+        // Resolving drains the queue.
+        assert!(gate.parked_ids().is_empty());
+    }
+
+    #[tokio::test]
+    async fn resolve_amended_expired_denies() {
+        let gate = ManifestApprovalGate::new(policy("supervised", None)).with_ttl_millis(1000);
+        let id = gate
+            .park(&company(), effect("filing.submit", EffectGroup::Sign))
+            .await
+            .unwrap();
+        let mut amended = effect("filing.submit", EffectGroup::Sign);
+        amended.payload = serde_json::json!({ "edited": true });
+
+        // Past the TTL: the amend resolves to deny even though a payload was
+        // supplied — default-deny-on-silence wins.
+        let future = now_millis() + 10_000;
+        let resolved = gate.resolve_amended(&id, amended, operator(), future);
+        assert_eq!(resolved, None);
+        assert!(gate.parked_ids().is_empty());
     }
 
     #[tokio::test]

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -667,8 +667,12 @@ pub enum RegistrationState {
     },
 }
 
-/// A published Agent Card advertising skills.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+/// A published Agent Card advertising a company's skills on tiny.place.
+///
+/// The three original fields (`handle`, `description`, `skills`) are unchanged;
+/// every field added for the A2A wire shape carries `#[serde(default)]` so
+/// records written by earlier phases round-trip without loss.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct AgentCard {
     /// The advertised `@handle`.
     pub handle: String,
@@ -676,6 +680,40 @@ pub struct AgentCard {
     pub description: String,
     /// The advertised skill ids.
     pub skills: Vec<String>,
+    /// Human-readable display name (the company name).
+    #[serde(default)]
+    pub name: String,
+    /// The actor kind; always `"agent"` for a company.
+    #[serde(default)]
+    pub actor_type: String,
+    /// The A2A endpoint, e.g. `https://host/a2a/{handle}`.
+    #[serde(default)]
+    pub endpoint: String,
+    /// Interfaces the endpoint speaks, e.g. `["a2a-jsonrpc"]`.
+    #[serde(default)]
+    pub supported_interfaces: Vec<String>,
+    /// Capability tokens derived from the advertised skills.
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    /// Free-form discovery tags.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Per-skill payment requirements advertised to counterparties.
+    #[serde(default)]
+    pub payment_requirements: Vec<CardPayment>,
+}
+
+/// A single priced skill on an [`AgentCard`], in x402 terms.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct CardPayment {
+    /// The skill this price applies to.
+    pub skill_id: String,
+    /// The decimal price string, e.g. `"25.00"`.
+    pub price: String,
+    /// The settlement asset, e.g. `"USDC"`.
+    pub asset: String,
+    /// The settlement network, e.g. `"solana"`.
+    pub network: String,
 }
 
 /// An addressable agent on tiny.place.
@@ -851,5 +889,39 @@ mod test {
     fn event_seq_orders_numerically() {
         assert!(EventSeq::new(1) < EventSeq::new(2));
         assert_eq!(EventSeq::new(7).value(), 7);
+    }
+
+    #[test]
+    fn agent_card_round_trips_with_extended_fields() {
+        let card = AgentCard {
+            handle: "acme".into(),
+            description: "We audit SEO.".into(),
+            skills: vec!["seo.audit".into()],
+            name: "Acme SEO".into(),
+            actor_type: "agent".into(),
+            endpoint: "https://host/a2a/acme".into(),
+            supported_interfaces: vec!["a2a-jsonrpc".into()],
+            capabilities: vec!["seo.audit".into()],
+            tags: vec!["seo.audit".into()],
+            payment_requirements: vec![CardPayment {
+                skill_id: "seo.audit".into(),
+                price: "25.00".into(),
+                asset: "USDC".into(),
+                network: "solana".into(),
+            }],
+        };
+        assert_eq!(round_trip(&card), card);
+    }
+
+    #[test]
+    fn legacy_agent_card_json_deserializes_with_defaults() {
+        // A card written by an earlier phase carried only three fields; the new
+        // `#[serde(default)]` fields must fill in without error.
+        let json = r#"{"handle":"acme","description":"d","skills":["a"]}"#;
+        let card: AgentCard = serde_json::from_str(json).expect("deserialize legacy card");
+        assert_eq!(card.handle, "acme");
+        assert!(card.name.is_empty());
+        assert!(card.payment_requirements.is_empty());
+        assert!(card.supported_interfaces.is_empty());
     }
 }

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -253,6 +253,16 @@ pub enum CompanyEvent {
         /// A memo describing the payment.
         memo: String,
     },
+    /// The company's lifecycle state changed (e.g. `running` → `paused`),
+    /// recorded with the acting actor for the audit trail.
+    LifecycleChanged {
+        /// The previous lifecycle state.
+        from: String,
+        /// The new lifecycle state.
+        to: String,
+        /// Who performed the transition.
+        by: Actor,
+    },
 }
 
 /// A `CompanyEvent` durably appended to the log with its sequence and time.

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -435,6 +435,13 @@ pub struct CycleRequest {
     pub company_id: CompanyId,
     /// The batch of events driving this cycle.
     pub events: Vec<CompanyEvent>,
+    /// The [`EventLog`](crate::ports::EventLog) sequence of each event in
+    /// [`Self::events`], positionally aligned. Empty when a caller builds a
+    /// request without threading seqs (a brain then falls back to the event's
+    /// index); the runtime always populates it so hosted cognition can key its
+    /// idempotent `POST /events` on the durable log seq.
+    #[serde(default)]
+    pub event_seqs: Vec<EventSeq>,
     /// Compressed traces of prior cycles.
     pub compressed_history: Vec<CompressedTrace>,
     /// The company roster (agent ids).

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -13,7 +13,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::Result;
-use crate::brain::EchoBrain;
+use crate::app::config::BrainMode;
+use crate::brain::medulla::MedullaTransport;
+use crate::brain::medulla::wire::ToolManifestEntry;
+use crate::brain::{EchoBrain, HostedMedullaBrain};
 use crate::company::CompanyManifest;
 use crate::company::runtime::CompanyRuntime;
 use crate::feedback::github::{GitHubClient, RateLimiter};
@@ -24,7 +27,7 @@ use crate::feedback::types::ConsentMode;
 use crate::openhuman::rpc::OpenHumanRpc;
 use crate::openhuman::{OpenHumanChannelAdapter, OpenHumanToolProvider};
 use crate::policy::ManifestApprovalGate;
-use crate::ports::types::{CompanyId, CompanyRecord};
+use crate::ports::types::{CompanyId, CompanyRecord, SecretValue};
 use crate::ports::{
     AgentEconomy, Brain, ChannelAdapter, CompanyStore, ContextStore, EventLog, MemoryStore,
     SecretStore, ToolProvider,
@@ -107,6 +110,10 @@ pub struct RuntimeBuilder {
     id: CompanyId,
     manifest: CompanyManifest,
     brain: Option<Arc<dyn Brain>>,
+    brain_mode: Option<BrainMode>,
+    credential: Option<SecretValue>,
+    api_url: Option<String>,
+    transport: Option<Arc<dyn MedullaTransport>>,
     store: Option<Arc<dyn CompanyStore>>,
     events: Option<Arc<dyn EventLog>>,
     memory: Option<Arc<dyn MemoryStore>>,
@@ -134,6 +141,10 @@ impl RuntimeBuilder {
             id,
             manifest,
             brain: None,
+            brain_mode: None,
+            credential: None,
+            api_url: None,
+            transport: None,
             store: None,
             events: None,
             memory: None,
@@ -157,8 +168,47 @@ impl RuntimeBuilder {
     }
 
     /// Swaps the cognition brain (default [`EchoBrain`]).
+    ///
+    /// An explicit brain wins over hosted-brain selection: setting this bypasses
+    /// [`with_brain_mode`](Self::with_brain_mode) entirely.
     pub fn with_brain(mut self, brain: Arc<dyn Brain>) -> Self {
         self.brain = Some(brain);
+        self
+    }
+
+    /// Sets the brain mode driving hosted-brain selection (default
+    /// [`BrainMode::Hosted`]).
+    ///
+    /// Hosted mode plus a credential selects the
+    /// [`HostedMedullaBrain`](crate::brain::HostedMedullaBrain); anything else
+    /// falls back to the degraded [`EchoBrain`].
+    pub fn with_brain_mode(mut self, mode: BrainMode) -> Self {
+        self.brain_mode = Some(mode);
+        self
+    }
+
+    /// Provides the TinyHumans hosted-brain credential. Without it, hosted mode
+    /// degrades to [`EchoBrain`]. Never logged.
+    pub fn with_credential(mut self, credential: SecretValue) -> Self {
+        self.credential = Some(credential);
+        self
+    }
+
+    /// Sets the orchestration API base URL used to build the networked
+    /// transport under the `medulla` feature.
+    pub fn with_api_url(mut self, api_url: impl Into<String>) -> Self {
+        self.api_url = Some(api_url.into());
+        self
+    }
+
+    /// Injects a [`MedullaTransport`] for the hosted brain to drive.
+    ///
+    /// Always available (not feature-gated) so offline tests can wire the
+    /// in-memory mock transport and exercise [`HostedMedullaBrain`] end-to-end
+    /// in the default build. An injected transport takes precedence over the
+    /// networked transport the `medulla` feature would otherwise construct.
+    pub fn with_transport(mut self, transport: Arc<dyn MedullaTransport>) -> Self {
+        self.transport = Some(transport);
         self
     }
 
@@ -273,8 +323,6 @@ impl RuntimeBuilder {
         let context: Arc<dyn ContextStore> = self
             .context
             .unwrap_or_else(|| Arc::new(FsContextStore::new(home.clone())));
-        let brain: Arc<dyn Brain> = self.brain.unwrap_or_else(|| Arc::new(EchoBrain::new()));
-
         // Effective grants narrow the company allow-list by per-agent tools.
         let grants = effective_grants(&self.manifest);
         let openhuman = self.openhuman;
@@ -375,6 +423,37 @@ impl RuntimeBuilder {
             }
         };
 
+        // Brain selection: an explicit brain wins; otherwise hosted mode plus a
+        // credential selects the hosted Medulla brain (over an injected or, under
+        // the `medulla` feature, a networked transport). Every other combination
+        // — no credential, sidecar mode, or a hosted default build with no
+        // transport — degrades to the offline echo brain so the default build
+        // stays green.
+        let brain: Arc<dyn Brain> = match self.brain {
+            Some(brain) => brain,
+            None => {
+                let tool_catalog: Vec<ToolManifestEntry> = self
+                    .manifest
+                    .tools
+                    .allow
+                    .iter()
+                    .map(|name| ToolManifestEntry {
+                        name: name.clone(),
+                        description: None,
+                        input_schema: None,
+                    })
+                    .collect();
+                select_hosted_or_echo(
+                    self.brain_mode.unwrap_or(BrainMode::Hosted),
+                    self.credential,
+                    self.transport,
+                    self.api_url,
+                    &id,
+                    tool_catalog,
+                )
+            }
+        };
+
         // Materialize the manifest so status/roster loads have a record to read.
         // `save` only writes company.toml + meta.json; the append-only ledger
         // file is left untouched, so an existing ledger survives a rebuild.
@@ -424,6 +503,68 @@ impl RuntimeBuilder {
             filer,
         ))
     }
+}
+
+/// Chooses the hosted Medulla brain or the degraded echo brain.
+///
+/// An injected transport is used verbatim; otherwise the networked transport is
+/// built under the `medulla` feature (and degrades to echo without it).
+fn select_hosted_or_echo(
+    mode: BrainMode,
+    credential: Option<SecretValue>,
+    transport: Option<Arc<dyn MedullaTransport>>,
+    api_url: Option<String>,
+    id: &CompanyId,
+    tool_catalog: Vec<ToolManifestEntry>,
+) -> Arc<dyn Brain> {
+    match (mode, credential) {
+        (BrainMode::Hosted, Some(credential)) => match transport {
+            Some(transport) => Arc::new(HostedMedullaBrain::new(
+                transport,
+                id,
+                id.as_ref(),
+                credential,
+                tool_catalog,
+            )),
+            None => build_networked_brain(credential, api_url, id, tool_catalog),
+        },
+        // No credential (degraded) or sidecar mode (a later phase): offline echo.
+        _ => Arc::new(EchoBrain::new()),
+    }
+}
+
+/// Builds the hosted brain over the networked `HttpSocketTransport`.
+#[cfg(feature = "medulla")]
+fn build_networked_brain(
+    credential: SecretValue,
+    api_url: Option<String>,
+    id: &CompanyId,
+    tool_catalog: Vec<ToolManifestEntry>,
+) -> Arc<dyn Brain> {
+    use crate::brain::medulla::HttpSocketTransport;
+
+    let base = api_url.unwrap_or_else(|| crate::app::config::DEFAULT_API_URL.to_string());
+    let transport = Arc::new(HttpSocketTransport::new(base, credential.clone()));
+    Arc::new(HostedMedullaBrain::new(
+        transport,
+        id,
+        id.as_ref(),
+        credential,
+        tool_catalog,
+    ))
+}
+
+/// Default build: no network transport is linked, so hosted-with-credential
+/// degrades to the offline echo brain. Rebuild with `--features medulla` to get
+/// real hosted cognition.
+#[cfg(not(feature = "medulla"))]
+fn build_networked_brain(
+    _credential: SecretValue,
+    _api_url: Option<String>,
+    _id: &CompanyId,
+    _tool_catalog: Vec<ToolManifestEntry>,
+) -> Arc<dyn Brain> {
+    Arc::new(EchoBrain::new())
 }
 
 #[cfg(test)]

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -375,6 +375,7 @@ impl RuntimeBuilder {
             repo: crate::feedback::DEFAULT_REPO.to_string(),
             consent,
             limiter: RateLimiter::default(),
+            quality: crate::feedback::QualityLedger::default(),
         });
 
         // Probe OpenHuman once; an unreachable daemon degrades, never fails.
@@ -706,9 +707,39 @@ fn select_hosted_or_echo(
             )),
             None => build_networked_brain(credential, api_url, id, tool_catalog),
         },
-        // No credential (degraded) or sidecar mode (a later phase): offline echo.
+        // Sidecar mode routes to the local sidecar brain under the `sidecar`
+        // feature, degrading to echo when no sidecar process is configured.
+        (BrainMode::Sidecar, _) => build_sidecar_brain(id, tool_catalog),
+        // No credential in hosted mode: offline echo.
         _ => Arc::new(EchoBrain::new()),
     }
+}
+
+/// Builds the local-sidecar brain over the stdio transport with a host-bound
+/// inference client.
+///
+/// The offline end-to-end test injects a fully mocked [`SidecarBrain`] through
+/// [`RuntimeBuilder::with_brain`], so this path only needs to serve a real
+/// deployment. Because no sidecar process endpoint is configured today, it
+/// degrades to the offline echo brain with a warning — mirroring
+/// [`build_networked_brain`]'s degrade-to-echo behavior. Rebuild with
+/// `--features sidecar` and inject a configured transport to drive a real
+/// sidecar.
+#[cfg(feature = "sidecar")]
+fn build_sidecar_brain(id: &CompanyId, _tool_catalog: Vec<ToolManifestEntry>) -> Arc<dyn Brain> {
+    tracing::warn!(
+        company = %id,
+        "sidecar brain requires a configured sidecar process; using the offline echo brain"
+    );
+    Arc::new(EchoBrain::new())
+}
+
+/// Default build: the sidecar brain is not linked, so sidecar mode degrades to
+/// the offline echo brain. Rebuild with `--features sidecar` for the sidecar
+/// brain.
+#[cfg(not(feature = "sidecar"))]
+fn build_sidecar_brain(_id: &CompanyId, _tool_catalog: Vec<ToolManifestEntry>) -> Arc<dyn Brain> {
+    Arc::new(EchoBrain::new())
 }
 
 /// Builds the hosted brain over the networked `HttpSocketTransport`.

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -121,6 +121,9 @@ pub struct RuntimeBuilder {
     tools: Option<Arc<dyn ToolProvider>>,
     channels: Option<Vec<Arc<dyn ChannelAdapter>>>,
     economy: Option<Arc<dyn AgentEconomy>>,
+    discoverable_override: Option<bool>,
+    tinyplace_api_url: Option<String>,
+    host_base_url: Option<String>,
     approvals: Option<Arc<ManifestApprovalGate>>,
     openhuman: Option<Arc<dyn OpenHumanRpc>>,
     secrets: Option<Arc<dyn SecretStore>>,
@@ -152,6 +155,9 @@ impl RuntimeBuilder {
             tools: None,
             channels: None,
             economy: None,
+            discoverable_override: None,
+            tinyplace_api_url: None,
+            host_base_url: None,
             approvals: None,
             openhuman: None,
             secrets: None,
@@ -249,8 +255,34 @@ impl RuntimeBuilder {
     }
 
     /// Wires an agent economy (default: none).
+    ///
+    /// An injected economy wins over the auto-wired tiny.place economy the
+    /// `tinyplace` feature would otherwise construct at [`build`](Self::build).
     pub fn with_economy(mut self, economy: Arc<dyn AgentEconomy>) -> Self {
         self.economy = Some(economy);
+        self
+    }
+
+    /// Forces going-public on (or off) regardless of `[place].discoverable`.
+    ///
+    /// Powers `serve --discoverable`, which opts every loaded company into the
+    /// tiny.place economy. Left unset, the manifest's `[place].discoverable`
+    /// decides.
+    pub fn with_discoverable(mut self, discoverable: bool) -> Self {
+        self.discoverable_override = Some(discoverable);
+        self
+    }
+
+    /// Sets the tiny.place economy API base URL used to build the networked
+    /// client under the `tinyplace` feature.
+    pub fn with_tinyplace_api_url(mut self, api_url: impl Into<String>) -> Self {
+        self.tinyplace_api_url = Some(api_url.into());
+        self
+    }
+
+    /// Sets the host base URL embedded in the published Agent Card endpoint.
+    pub fn with_host_base_url(mut self, host_base_url: impl Into<String>) -> Self {
+        self.host_base_url = Some(host_base_url.into());
         self
     }
 
@@ -486,8 +518,29 @@ impl RuntimeBuilder {
             gate.rehydrate(pending.id, pending.effect, pending.at_millis);
         }
 
-        Ok(CompanyRuntime::new(
-            id,
+        // Economy: an injected economy wins; otherwise the `tinyplace` feature
+        // auto-wires one for a discoverable company with a handle. Going-public
+        // (the paid handle-claim) fires only when discovery is enabled.
+        let going_public = self
+            .discoverable_override
+            .unwrap_or(self.manifest.place.discoverable);
+        let economy: Option<Arc<dyn AgentEconomy>> = match self.economy {
+            Some(economy) => Some(economy),
+            None => {
+                maybe_build_economy(
+                    &self.manifest,
+                    &home,
+                    &id,
+                    store.clone(),
+                    self.tinyplace_api_url.clone(),
+                    going_public,
+                )
+                .await
+            }
+        };
+
+        let runtime = CompanyRuntime::new(
+            id.clone(),
             brain,
             store,
             events,
@@ -495,14 +548,139 @@ impl RuntimeBuilder {
             context,
             tools,
             channels,
-            self.economy,
+            economy.clone(),
             gate,
             journal,
             secrets,
             feedback,
             filer,
-        ))
+        );
+
+        // Boot lifecycle step 3: going-public. Best-effort and non-blocking —
+        // any failure degrades to "private" with a warning and never fails boot.
+        maybe_go_public(
+            &economy,
+            &self.manifest,
+            &id,
+            going_public,
+            self.host_base_url.as_deref(),
+        )
+        .await;
+
+        Ok(runtime)
     }
+}
+
+/// Auto-wires the tiny.place economy for a discoverable company (feature build).
+///
+/// Returns `None` unless `[place].discoverable` is set and a `@handle` is
+/// present; a missing/unreadable identity key degrades to `None` with a warning.
+#[cfg(feature = "tinyplace")]
+async fn maybe_build_economy(
+    manifest: &CompanyManifest,
+    home: &std::path::Path,
+    id: &CompanyId,
+    store: Arc<dyn CompanyStore>,
+    tinyplace_api_url: Option<String>,
+    going_public: bool,
+) -> Option<Arc<dyn AgentEconomy>> {
+    use crate::economy::signer::load_or_create_signer;
+    use crate::economy::{HttpTinyplaceClient, TinyplaceEconomy};
+    use crate::store::paths::Bundle;
+
+    if !(manifest.place.discoverable && manifest.company.handle.is_some()) {
+        return None;
+    }
+
+    let bundle = Bundle::new(home.to_path_buf(), id);
+    let signer = match load_or_create_signer(&bundle).await {
+        Ok(signer) => Arc::new(signer),
+        Err(err) => {
+            tracing::warn!(company = %id, "tiny.place identity unavailable ({err}); staying private");
+            return None;
+        }
+    };
+
+    let base = tinyplace_api_url
+        .unwrap_or_else(|| crate::app::config::DEFAULT_TINYPLACE_API_URL.to_string());
+    let client = Arc::new(HttpTinyplaceClient::new(base, signer.clone()));
+    let economy = TinyplaceEconomy::new(
+        client,
+        signer,
+        store,
+        id.clone(),
+        manifest.budget.monthly_usd,
+    )
+    .going_public(going_public);
+    Some(Arc::new(economy))
+}
+
+/// Default build: no tiny.place economy is linked.
+#[cfg(not(feature = "tinyplace"))]
+async fn maybe_build_economy(
+    _manifest: &CompanyManifest,
+    _home: &std::path::Path,
+    _id: &CompanyId,
+    _store: Arc<dyn CompanyStore>,
+    _tinyplace_api_url: Option<String>,
+    _going_public: bool,
+) -> Option<Arc<dyn AgentEconomy>> {
+    None
+}
+
+/// Runs the going-public flow best-effort: `ensure_registered` then, on success,
+/// `publish_card`. Every outcome degrades to a warning; boot never blocks.
+#[cfg(feature = "tinyplace")]
+async fn maybe_go_public(
+    economy: &Option<Arc<dyn AgentEconomy>>,
+    manifest: &CompanyManifest,
+    id: &CompanyId,
+    going_public: bool,
+    host_base_url: Option<&str>,
+) {
+    use crate::economy::build_agent_card;
+    use crate::ports::types::{CompanyIdentity, RegistrationState};
+
+    if !going_public {
+        return;
+    }
+    let (Some(economy), Some(handle)) = (economy, manifest.company.handle.clone()) else {
+        return;
+    };
+    let identity = CompanyIdentity {
+        company: id.clone(),
+        handle,
+    };
+    match economy.ensure_registered(&identity).await {
+        Ok(RegistrationState::Registered { .. }) => {
+            let base = host_base_url
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("http://{}", crate::app::config::DEFAULT_BIND));
+            let card = build_agent_card(manifest, &base);
+            if let Err(err) = economy.publish_card(&identity, &card).await {
+                tracing::warn!(company = %id, "tiny.place publish_card failed ({err}); card is stale");
+            } else {
+                tracing::info!(company = %id, handle = %identity.handle, "tiny.place: discoverable (public)");
+            }
+        }
+        Ok(RegistrationState::Unregistered) => {
+            tracing::warn!(company = %id, "tiny.place: private (awaiting funding/identity approval)");
+        }
+        Err(err) => {
+            tracing::warn!(company = %id, "tiny.place go-public failed ({err}); staying private");
+        }
+    }
+}
+
+/// Default build: going-public is a no-op with no tiny.place economy.
+#[cfg(not(feature = "tinyplace"))]
+async fn maybe_go_public(
+    _economy: &Option<Arc<dyn AgentEconomy>>,
+    _manifest: &CompanyManifest,
+    _id: &CompanyId,
+    _going_public: bool,
+    _host_base_url: Option<&str>,
+) {
 }
 
 /// Chooses the hosted Medulla brain or the degraded echo brain.
@@ -713,5 +891,47 @@ mod test {
         assert!(!granted.ok);
         // Only the boot-time `health()` probe touched the transport.
         assert_eq!(rpc.call_count(), 0);
+    }
+
+    #[cfg(feature = "tinyplace")]
+    #[tokio::test]
+    async fn discoverable_company_registers_and_publishes_without_blocking() {
+        use crate::economy::signer::LocalSigner;
+        use crate::economy::{MockTinyplaceClient, TinyplaceEconomy};
+        use crate::ports::AgentEconomy;
+        use crate::ports::CompanyStore;
+        use crate::store::FsCompanyStore;
+
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = parse(
+            r#"
+            [company]
+            name = "Acme"
+            handle = "acme"
+            [place]
+            discoverable = true
+            skills = [{ id = "seo.audit", price_usd = "25.00" }]
+            "#,
+        );
+        let id = CompanyId::new("acme");
+        let store: Arc<dyn CompanyStore> = Arc::new(FsCompanyStore::new(dir.path().to_path_buf()));
+        let signer = Arc::new(LocalSigner::generate());
+        let mock = Arc::new(MockTinyplaceClient::new());
+        let economy: Arc<dyn AgentEconomy> = Arc::new(
+            TinyplaceEconomy::new(mock.clone(), signer, store, id.clone(), None).going_public(true),
+        );
+
+        let runtime = RuntimeBuilder::new(dir.path().to_path_buf(), manifest)
+            .with_id(id)
+            .with_economy(economy)
+            .with_discoverable(true)
+            .build()
+            .await
+            .unwrap();
+
+        // The economy is wired, and boot registered + published the card.
+        assert!(runtime.has_economy());
+        assert_eq!(mock.count("register_name"), 1, "boot claimed the handle");
+        assert_eq!(mock.count("put_agent"), 1, "boot published the card");
     }
 }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -16,17 +16,24 @@ use crate::Result;
 use crate::brain::EchoBrain;
 use crate::company::CompanyManifest;
 use crate::company::runtime::CompanyRuntime;
+use crate::feedback::github::{GitHubClient, RateLimiter};
+use crate::feedback::service::FeedbackFiler;
+use crate::feedback::store::FeedbackStore;
+use crate::feedback::tool::BuiltinToolProvider;
+use crate::feedback::types::ConsentMode;
+use crate::openhuman::rpc::OpenHumanRpc;
+use crate::openhuman::{OpenHumanChannelAdapter, OpenHumanToolProvider};
 use crate::policy::ManifestApprovalGate;
 use crate::ports::types::{CompanyId, CompanyRecord};
 use crate::ports::{
-    AgentEconomy, ApprovalGate, Brain, ChannelAdapter, CompanyStore, ContextStore, EventLog,
-    MemoryStore, ToolProvider,
+    AgentEconomy, Brain, ChannelAdapter, CompanyStore, ContextStore, EventLog, MemoryStore,
+    SecretStore, ToolProvider,
 };
-use crate::runtime::channel::OperatorChannel;
+use crate::runtime::channel::{OPERATOR_CHANNEL, OperatorChannel};
 use crate::runtime::journal::RuntimeJournal;
-use crate::runtime::tools::StubToolProvider;
+use crate::runtime::tools::{StubToolProvider, grant_matches};
 use crate::store::paths::Bundle;
-use crate::store::{FsCompanyStore, FsContextStore, FsEventLog, FsMemoryStore};
+use crate::store::{FsCompanyStore, FsContextStore, FsEventLog, FsMemoryStore, FsSecretStore};
 
 /// Derives a filesystem-and-URL-safe company id from a display name.
 ///
@@ -52,6 +59,48 @@ pub fn company_id_from_name(name: &str) -> CompanyId {
     })
 }
 
+/// Computes a company's effective tool grants: the company-wide
+/// `[tools].allow` narrowed by per-agent `tools` (most-restrictive-wins).
+///
+/// An agent with no explicit `tools` inherits the full company allow-list; an
+/// agent that lists tools contributes only those covered by the allow-list. The
+/// result is the de-duplicated union across the roster, preserving order. A
+/// company with no roster yields the allow-list unchanged.
+pub fn effective_grants(manifest: &CompanyManifest) -> Vec<String> {
+    let allow = &manifest.tools.allow;
+    if manifest.agents.is_empty() {
+        return dedup(allow.clone());
+    }
+    let mut grants: Vec<String> = Vec::new();
+    for agent in &manifest.agents {
+        if agent.tools.is_empty() {
+            grants.extend(allow.iter().cloned());
+        } else {
+            for tool in &agent.tools {
+                if allow_covers(allow, tool) {
+                    grants.push(tool.clone());
+                }
+            }
+        }
+    }
+    dedup(grants)
+}
+
+/// Whether the company allow-list covers an agent-requested grant glob.
+fn allow_covers(allow: &[String], tool: &str) -> bool {
+    let literal = tool.strip_suffix('*').unwrap_or(tool);
+    allow.iter().any(|grant| grant_matches(grant, literal))
+}
+
+/// De-duplicates a grant list while preserving first-seen order.
+fn dedup(grants: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    grants
+        .into_iter()
+        .filter(|grant| seen.insert(grant.clone()))
+        .collect()
+}
+
 /// Builds one company's [`CompanyRuntime`] over a filesystem home.
 pub struct RuntimeBuilder {
     home: PathBuf,
@@ -66,6 +115,11 @@ pub struct RuntimeBuilder {
     channels: Option<Vec<Arc<dyn ChannelAdapter>>>,
     economy: Option<Arc<dyn AgentEconomy>>,
     approvals: Option<Arc<ManifestApprovalGate>>,
+    openhuman: Option<Arc<dyn OpenHumanRpc>>,
+    secrets: Option<Arc<dyn SecretStore>>,
+    feedback: Option<Arc<FeedbackStore>>,
+    github: Option<Arc<dyn GitHubClient>>,
+    consent: ConsentMode,
 }
 
 impl RuntimeBuilder {
@@ -88,6 +142,11 @@ impl RuntimeBuilder {
             channels: None,
             economy: None,
             approvals: None,
+            openhuman: None,
+            secrets: None,
+            feedback: None,
+            github: None,
+            consent: ConsentMode::default(),
         }
     }
 
@@ -151,6 +210,43 @@ impl RuntimeBuilder {
         self
     }
 
+    /// Attaches an OpenHuman JSON-RPC transport.
+    ///
+    /// When present and healthy at [`build`](Self::build) time, an
+    /// `openhuman`-provider manifest routes tools (and `openhuman` channels)
+    /// through it; otherwise the runtime degrades to built-in tools and the
+    /// operator channel with a boot warning.
+    pub fn with_openhuman_rpc(mut self, rpc: Arc<dyn OpenHumanRpc>) -> Self {
+        self.openhuman = Some(rpc);
+        self
+    }
+
+    /// Swaps the secret store (default: fs-backed). The feedback scrubber reads
+    /// it to fail closed on secret leaks.
+    pub fn with_secrets(mut self, secrets: Arc<dyn SecretStore>) -> Self {
+        self.secrets = Some(secrets);
+        self
+    }
+
+    /// Overrides the feedback store (default: the company bundle's feedback
+    /// family).
+    pub fn with_feedback(mut self, feedback: Arc<FeedbackStore>) -> Self {
+        self.feedback = Some(feedback);
+        self
+    }
+
+    /// Wires a GitHub client for feedback filing (default: none → manual links).
+    pub fn with_github(mut self, github: Arc<dyn GitHubClient>) -> Self {
+        self.github = Some(github);
+        self
+    }
+
+    /// Sets the standing feedback consent mode (default: `manual`).
+    pub fn with_feedback_consent(mut self, consent: ConsentMode) -> Self {
+        self.consent = consent;
+        self
+    }
+
     /// Convenience: build a fully fs-backed runtime with all Phase-1 defaults.
     pub async fn fs_defaults(
         home: impl Into<PathBuf>,
@@ -177,13 +273,107 @@ impl RuntimeBuilder {
         let context: Arc<dyn ContextStore> = self
             .context
             .unwrap_or_else(|| Arc::new(FsContextStore::new(home.clone())));
-        let tools: Arc<dyn ToolProvider> = self
-            .tools
-            .unwrap_or_else(|| Arc::new(StubToolProvider::new(self.manifest.tools.allow.clone())));
         let brain: Arc<dyn Brain> = self.brain.unwrap_or_else(|| Arc::new(EchoBrain::new()));
-        let channels = self
-            .channels
-            .unwrap_or_else(|| vec![Arc::new(OperatorChannel::new()) as Arc<dyn ChannelAdapter>]);
+
+        // Effective grants narrow the company allow-list by per-agent tools.
+        let grants = effective_grants(&self.manifest);
+        let openhuman = self.openhuman;
+
+        // Feedback family: the item store, secret store (for the scrubber), and
+        // filing configuration. The consent mode is also the built-in feedback
+        // tool's capture mode.
+        let bundle = Bundle::new(home.clone(), &id);
+        let feedback = self
+            .feedback
+            .unwrap_or_else(|| Arc::new(FeedbackStore::new(&bundle)));
+        let secrets: Arc<dyn SecretStore> = self
+            .secrets
+            .unwrap_or_else(|| Arc::new(FsSecretStore::new(home.clone())));
+        let consent = self.consent;
+        let filer = Arc::new(FeedbackFiler {
+            client: self.github,
+            repo: crate::feedback::DEFAULT_REPO.to_string(),
+            consent,
+            limiter: RateLimiter::default(),
+        });
+
+        // Probe OpenHuman once; an unreachable daemon degrades, never fails.
+        let openhuman_healthy = match &openhuman {
+            Some(rpc) => rpc.health().await.unwrap_or(false),
+            None => false,
+        };
+
+        // Tools: route through OpenHuman only when the manifest asks for it and
+        // the daemon is reachable; otherwise use the grant-enforcing built-in.
+        let tools: Arc<dyn ToolProvider> = match self.tools {
+            Some(tools) => tools,
+            None => {
+                let builtin: Arc<dyn ToolProvider> =
+                    Arc::new(StubToolProvider::new(grants.clone()));
+                if self.manifest.tools.provider == "openhuman" {
+                    match &openhuman {
+                        Some(rpc) if openhuman_healthy => Arc::new(OpenHumanToolProvider::new(
+                            rpc.clone(),
+                            grants.clone(),
+                            builtin,
+                        )),
+                        Some(_) => {
+                            tracing::warn!(
+                                company = %id,
+                                "openhuman tool provider requested but unreachable; using built-in tools"
+                            );
+                            builtin
+                        }
+                        None => builtin,
+                    }
+                } else {
+                    builtin
+                }
+            }
+        };
+
+        // Wrap with the built-in `feedback` tool so the brain can always
+        // self-report (the feedback tool is never gated); every other tool
+        // still delegates to the selected provider, which enforces grants.
+        let tools: Arc<dyn ToolProvider> = Arc::new(BuiltinToolProvider::new(
+            tools,
+            feedback.clone(),
+            events.clone(),
+            consent,
+        ));
+
+        // Channels: always the operator surface, plus any `openhuman` channel
+        // the manifest enables when the daemon is reachable.
+        let channels = match self.channels {
+            Some(channels) => channels,
+            None => {
+                let mut channels: Vec<Arc<dyn ChannelAdapter>> =
+                    vec![Arc::new(OperatorChannel::new())];
+                if let Some(rpc) = &openhuman {
+                    for (name, config) in &self.manifest.channels {
+                        if name == OPERATOR_CHANNEL
+                            || config.enabled == Some(false)
+                            || config.provider.as_deref() != Some("openhuman")
+                        {
+                            continue;
+                        }
+                        if openhuman_healthy {
+                            channels.push(Arc::new(OpenHumanChannelAdapter::new(
+                                name.clone(),
+                                rpc.clone(),
+                            )));
+                        } else {
+                            tracing::warn!(
+                                company = %id,
+                                channel = %name,
+                                "openhuman channel requested but unreachable; skipping"
+                            );
+                        }
+                    }
+                }
+                channels
+            }
+        };
 
         // Materialize the manifest so status/roster loads have a record to read.
         // `save` only writes company.toml + meta.json; the append-only ledger
@@ -216,7 +406,6 @@ impl RuntimeBuilder {
         for pending in journal.pending() {
             gate.rehydrate(pending.id, pending.effect, pending.at_millis);
         }
-        let approvals: Arc<dyn ApprovalGate> = gate;
 
         Ok(CompanyRuntime::new(
             id,
@@ -228,8 +417,11 @@ impl RuntimeBuilder {
             tools,
             channels,
             self.economy,
-            approvals,
+            gate,
             journal,
+            secrets,
+            feedback,
+            filer,
         ))
     }
 }
@@ -237,11 +429,148 @@ impl RuntimeBuilder {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::openhuman::MockOpenHumanRpc;
+    use crate::ports::types::ToolCall;
 
     #[test]
     fn slugifies_display_names() {
         assert_eq!(company_id_from_name("Acme Co!").as_ref(), "acme-co");
         assert_eq!(company_id_from_name("  Widgets  ").as_ref(), "widgets");
         assert_eq!(company_id_from_name("***").as_ref(), "company");
+    }
+
+    fn parse(toml_src: &str) -> CompanyManifest {
+        toml::from_str(toml_src).expect("valid manifest")
+    }
+
+    #[test]
+    fn effective_grants_no_roster_is_company_allow() {
+        let manifest = parse("[company]\nname=\"X\"\n[tools]\nallow=[\"email.*\",\"email.*\"]\n");
+        assert_eq!(effective_grants(&manifest), vec!["email.*".to_string()]);
+    }
+
+    #[test]
+    fn effective_grants_agent_without_tools_inherits_allow() {
+        let manifest = parse(
+            "[company]\nname=\"X\"\n[[agent]]\nid=\"a\"\nrole=\"A\"\n[tools]\nallow=[\"email.*\"]\n",
+        );
+        assert_eq!(effective_grants(&manifest), vec!["email.*".to_string()]);
+    }
+
+    #[test]
+    fn effective_grants_agent_tools_intersect_allow() {
+        let manifest = parse(
+            r#"
+            [company]
+            name = "X"
+            [[agent]]
+            id = "a"
+            role = "A"
+            tools = ["email.send", "payment.send"]
+            [tools]
+            allow = ["email.*"]
+            "#,
+        );
+        // `email.send` is covered by `email.*`; `payment.send` is not.
+        assert_eq!(effective_grants(&manifest), vec!["email.send".to_string()]);
+    }
+
+    fn openhuman_manifest() -> CompanyManifest {
+        parse(
+            r#"
+            [company]
+            name = "Acme"
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+            [tools]
+            provider = "openhuman"
+            allow = ["email.*"]
+            [channels.email]
+            provider = "openhuman"
+            "#,
+        )
+    }
+
+    #[tokio::test]
+    async fn healthy_openhuman_wires_provider_and_channel() {
+        let dir = tempfile::tempdir().unwrap();
+        let rpc = Arc::new(MockOpenHumanRpc::new().with_result(
+            "openhuman.tools_invoke",
+            serde_json::json!({ "ok": true, "output": {} }),
+        ));
+        let runtime = RuntimeBuilder::new(dir.path(), openhuman_manifest())
+            .with_openhuman_rpc(rpc.clone())
+            .build()
+            .await
+            .unwrap();
+
+        // Operator + the openhuman-backed email channel.
+        assert_eq!(runtime.channels.len(), 2);
+        assert!(runtime.channels.iter().any(|c| c.channel_id() == "email"));
+
+        // A granted call routes through the OpenHuman transport.
+        let result = runtime
+            .tools
+            .invoke(
+                runtime.id(),
+                ToolCall {
+                    tool: "email.send".into(),
+                    args: serde_json::Value::Null,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(result.ok);
+        assert_eq!(rpc.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn unreachable_openhuman_degrades_to_builtins() {
+        let dir = tempfile::tempdir().unwrap();
+        let rpc = Arc::new(MockOpenHumanRpc::new().unhealthy());
+        let runtime = RuntimeBuilder::new(dir.path(), openhuman_manifest())
+            .with_openhuman_rpc(rpc.clone())
+            .build()
+            .await
+            .unwrap();
+
+        // No openhuman channel is added when the daemon is unreachable.
+        assert_eq!(runtime.channels.len(), 1);
+        assert_eq!(runtime.channels[0].channel_id(), "operator");
+
+        // Tools degrade to the grant-enforcing built-in: ungranted rejected,
+        // granted returns a well-formed not-implemented result — and the RPC
+        // transport is never touched.
+        let ungranted = runtime
+            .tools
+            .invoke(
+                runtime.id(),
+                ToolCall {
+                    tool: "payment.send".into(),
+                    args: serde_json::Value::Null,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            ungranted,
+            crate::OpenCompanyError::ToolNotGranted(t) if t == "payment.send"
+        ));
+
+        let granted = runtime
+            .tools
+            .invoke(
+                runtime.id(),
+                ToolCall {
+                    tool: "email.send".into(),
+                    args: serde_json::Value::Null,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(!granted.ok);
+        // Only the boot-time `health()` probe touched the transport.
+        assert_eq!(rpc.call_count(), 0);
     }
 }

--- a/src/runtime/cron.rs
+++ b/src/runtime/cron.rs
@@ -1,0 +1,428 @@
+//! A dependency-light 5-field cron matcher.
+//!
+//! Parses a standard `minute hour day-of-month month day-of-week` expression
+//! into a [`CronExpr`], then answers two questions against a wall-clock-free
+//! [`CivilTime`]:
+//!
+//! - [`CronExpr::matches`] — does this minute satisfy the schedule?
+//! - [`CronExpr::next_after`] — what is the next minute that does?
+//!
+//! No `chrono`/`cron` dependency: civil-time conversion is hand-rolled
+//! (days-from-epoch, Howard Hinnant's algorithms) so the whole matcher is std
+//! only and trivially testable with a fake clock. Every field supports `*`,
+//! comma lists, `a-b` ranges, `*/step` (and `a-b/step`), and — for the month
+//! and weekday fields — the usual three-letter names (`JAN`…`DEC`,
+//! `SUN`…`SAT`). Day-of-week accepts both `0` and `7` for Sunday.
+//!
+//! Day-of-month and day-of-week combine with cron's historical "or" rule: when
+//! *both* fields are restricted (neither is `*`), a day matches if it satisfies
+//! *either* field; otherwise the two combine with the usual "and".
+
+use crate::Result;
+use crate::error::OpenCompanyError;
+
+/// Milliseconds in one minute.
+const MINUTE_MS: u64 = 60_000;
+/// Milliseconds in one day.
+const DAY_MS: u64 = 86_400_000;
+/// Upper bound on the minute-by-minute search in [`CronExpr::next_after`].
+///
+/// Four years (with a leap day) is the widest gap any valid 5-field expression
+/// can have between fire times (e.g. `0 0 29 2 *`), so a match is guaranteed
+/// inside this window when one exists.
+const NEXT_SEARCH_LIMIT_MINUTES: u64 = 4 * 366 * 24 * 60;
+
+/// The set of permitted values for one cron field, as a 64-bit mask.
+///
+/// Bit `v` is set when value `v` is allowed. Every cron field value fits in
+/// `0..=59`, well inside 64 bits. `restricted` records whether the source field
+/// was anything other than `*`, which the day-of-month/day-of-week "or" rule
+/// depends on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct FieldSet {
+    mask: u64,
+    restricted: bool,
+}
+
+impl FieldSet {
+    /// Whether `value` is a member of this set.
+    fn contains(&self, value: u32) -> bool {
+        value < 64 && self.mask & (1u64 << value) != 0
+    }
+}
+
+/// A parsed 5-field cron expression.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CronExpr {
+    minute: FieldSet,
+    hour: FieldSet,
+    dom: FieldSet,
+    month: FieldSet,
+    dow: FieldSet,
+}
+
+impl CronExpr {
+    /// Parses a standard 5-field cron expression.
+    ///
+    /// Returns [`OpenCompanyError::InvalidRequest`] with a prosumer-readable
+    /// message when the expression does not have exactly five fields or a field
+    /// is malformed or out of range.
+    pub fn parse(expr: &str) -> Result<Self> {
+        let fields: Vec<&str> = expr.split_whitespace().collect();
+        if fields.len() != 5 {
+            return Err(OpenCompanyError::InvalidRequest(format!(
+                "cron `{expr}` needs 5 fields (minute hour day month weekday), found {}",
+                fields.len()
+            )));
+        }
+        Ok(Self {
+            minute: parse_field(fields[0], 0, 59, &[])?,
+            hour: parse_field(fields[1], 0, 23, &[])?,
+            dom: parse_field(fields[2], 1, 31, &[])?,
+            month: parse_field(fields[3], 1, 12, MONTHS)?,
+            dow: parse_dow(fields[4])?,
+        })
+    }
+
+    /// Whether `t` (truncated to the minute) satisfies this schedule.
+    pub fn matches(&self, t: &CivilTime) -> bool {
+        if !self.minute.contains(t.minute)
+            || !self.hour.contains(t.hour)
+            || !self.month.contains(t.month)
+        {
+            return false;
+        }
+        // Cron's day rule: OR the two day fields when both are restricted.
+        let dom_hit = self.dom.contains(t.day);
+        let dow_hit = self.dow.contains(t.weekday);
+        if self.dom.restricted && self.dow.restricted {
+            dom_hit || dow_hit
+        } else {
+            dom_hit && dow_hit
+        }
+    }
+
+    /// The next minute strictly after `t` that satisfies this schedule.
+    ///
+    /// Searches minute-by-minute over a bounded window (four leap years), so it
+    /// returns `None` only for an expression that can never fire (impossible for
+    /// a value that parsed successfully). Purely arithmetic — no wall clock.
+    pub fn next_after(&self, t: &CivilTime) -> Option<CivilTime> {
+        let start = t.floor_to_minute_millis();
+        let mut cursor = start + MINUTE_MS;
+        for _ in 0..NEXT_SEARCH_LIMIT_MINUTES {
+            let candidate = CivilTime::from_unix_millis(cursor);
+            if self.matches(&candidate) {
+                return Some(candidate);
+            }
+            cursor += MINUTE_MS;
+        }
+        None
+    }
+}
+
+/// Three-letter month names, index 0 = `JAN` (value 1).
+const MONTHS: &[&str] = &[
+    "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC",
+];
+/// Three-letter weekday names, index 0 = `SUN` (value 0).
+const WEEKDAYS: &[&str] = &["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+
+/// Parses the day-of-week field, normalizing `7` (and `SUN`) to `0`.
+fn parse_dow(spec: &str) -> Result<FieldSet> {
+    // Accept 0..=7 on input, then fold bit 7 down onto bit 0 (both = Sunday) so
+    // matching against a `0..=6` civil weekday works uniformly.
+    let mut set = parse_field(spec, 0, 7, WEEKDAYS)?;
+    if set.mask & (1u64 << 7) != 0 {
+        set.mask &= !(1u64 << 7);
+        set.mask |= 1u64;
+    }
+    Ok(set)
+}
+
+/// Parses one cron field into a [`FieldSet`] bounded by `[min, max]`.
+///
+/// `names` maps three-letter aliases to values (`names[i]` = `min + i`); it is
+/// empty for the purely numeric fields.
+fn parse_field(spec: &str, min: u32, max: u32, names: &[&str]) -> Result<FieldSet> {
+    let mut mask = 0u64;
+    // A field is "unrestricted" only when it is exactly `*`; any list, range, or
+    // step restricts it. This flag drives the day-of-month/day-of-week or-rule.
+    let restricted = spec.trim() != "*";
+    for part in spec.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            return Err(field_error(spec, "an empty item"));
+        }
+        // Split off an optional `/step`.
+        let (range_spec, step) = match part.split_once('/') {
+            Some((range, step_str)) => {
+                let step: u32 = step_str
+                    .parse()
+                    .map_err(|_| field_error(spec, "a non-numeric step"))?;
+                if step == 0 {
+                    return Err(field_error(spec, "a zero step"));
+                }
+                (range, step)
+            }
+            None => (part, 1),
+        };
+
+        let (lo, hi) = if range_spec == "*" {
+            (min, max)
+        } else if let Some((a, b)) = range_spec.split_once('-') {
+            (
+                resolve_value(a, min, max, names, spec)?,
+                resolve_value(b, min, max, names, spec)?,
+            )
+        } else {
+            let value = resolve_value(range_spec, min, max, names, spec)?;
+            (value, value)
+        };
+        if lo > hi {
+            return Err(field_error(spec, "a descending range"));
+        }
+        let mut value = lo;
+        while value <= hi {
+            mask |= 1u64 << value;
+            value += step;
+        }
+    }
+    if mask == 0 {
+        return Err(field_error(spec, "no values"));
+    }
+    Ok(FieldSet { mask, restricted })
+}
+
+/// Resolves a single numeric-or-named token to a value inside `[min, max]`.
+fn resolve_value(token: &str, min: u32, max: u32, names: &[&str], spec: &str) -> Result<u32> {
+    let token = token.trim();
+    let value = if let Some(idx) = names.iter().position(|n| n.eq_ignore_ascii_case(token)) {
+        min + idx as u32
+    } else {
+        token
+            .parse::<u32>()
+            .map_err(|_| field_error(spec, "an unrecognized value"))?
+    };
+    if value < min || value > max {
+        return Err(field_error(spec, "a value out of range"));
+    }
+    Ok(value)
+}
+
+/// Builds a uniform field-parse error.
+fn field_error(spec: &str, why: &str) -> OpenCompanyError {
+    OpenCompanyError::InvalidRequest(format!("cron field `{spec}` has {why}"))
+}
+
+/// A minute-granular civil (UTC) timestamp derived from unix milliseconds.
+///
+/// Carries the pre-computed weekday (`0` = Sunday) so the matcher never touches
+/// a wall clock. Constructed with [`CivilTime::from_unix_millis`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CivilTime {
+    /// Proleptic Gregorian year (e.g. `2026`).
+    pub year: i64,
+    /// Month of year, `1`–`12`.
+    pub month: u32,
+    /// Day of month, `1`–`31`.
+    pub day: u32,
+    /// Hour of day, `0`–`23`.
+    pub hour: u32,
+    /// Minute of hour, `0`–`59`.
+    pub minute: u32,
+    /// Day of week, `0` = Sunday … `6` = Saturday.
+    pub weekday: u32,
+}
+
+impl CivilTime {
+    /// Converts unix epoch milliseconds (UTC) into civil fields.
+    pub fn from_unix_millis(ms: u64) -> Self {
+        let days = (ms / DAY_MS) as i64;
+        let rem = ms % DAY_MS;
+        let hour = (rem / 3_600_000) as u32;
+        let minute = ((rem % 3_600_000) / MINUTE_MS) as u32;
+        // Epoch day 0 (1970-01-01) is a Thursday; `(days + 4) % 7` maps to the
+        // Sunday-indexed weekday. `days` is non-negative for any real timestamp.
+        let weekday = ((days % 7 + 4) % 7) as u32;
+        let (year, month, day) = civil_from_days(days);
+        Self {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            weekday,
+        }
+    }
+
+    /// Unix milliseconds at the start of this civil minute.
+    fn floor_to_minute_millis(&self) -> u64 {
+        let days = days_from_civil(self.year, self.month, self.day);
+        (days as u64) * DAY_MS + (self.hour as u64) * 3_600_000 + (self.minute as u64) * MINUTE_MS
+    }
+}
+
+/// Civil date from a days-since-epoch count (Howard Hinnant's algorithm).
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
+    let year = if m <= 2 { y + 1 } else { y };
+    (year, m as u32, d as u32)
+}
+
+/// Days-since-epoch from a civil date (inverse of [`civil_from_days`]).
+fn days_from_civil(year: i64, month: u32, day: u32) -> i64 {
+    let m = month as i64;
+    let d = day as i64;
+    let y = if m <= 2 { year - 1 } else { year };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400; // [0, 399]
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1; // [0, 365]
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; // [0, 146096]
+    era * 146_097 + doe - 719_468
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Builds a `CivilTime` from a `YYYY-MM-DD HH:MM` UTC literal via its unix
+    /// millis, exercising the same path the scheduler uses.
+    fn at(year: i64, month: u32, day: u32, hour: u32, minute: u32) -> CivilTime {
+        let ms = ((days_from_civil(year, month, day) as u64) * DAY_MS)
+            + (hour as u64) * 3_600_000
+            + (minute as u64) * MINUTE_MS;
+        CivilTime::from_unix_millis(ms)
+    }
+
+    #[test]
+    fn epoch_is_a_thursday() {
+        let t = CivilTime::from_unix_millis(0);
+        assert_eq!((t.year, t.month, t.day), (1970, 1, 1));
+        assert_eq!(t.weekday, 4); // Thursday
+        assert_eq!((t.hour, t.minute), (0, 0));
+    }
+
+    #[test]
+    fn known_weekdays_round_trip() {
+        // 2026-07-10 is a Friday (weekday 5).
+        let friday = at(2026, 7, 10, 12, 0);
+        assert_eq!(friday.weekday, 5);
+        // 2000-01-01 was a Saturday (weekday 6).
+        assert_eq!(at(2000, 1, 1, 0, 0).weekday, 6);
+        // 2024-02-29 (leap day) was a Thursday (weekday 4).
+        assert_eq!(at(2024, 2, 29, 0, 0).weekday, 4);
+    }
+
+    #[test]
+    fn every_field_wildcard_matches_any_minute() {
+        let expr = CronExpr::parse("* * * * *").unwrap();
+        assert!(expr.matches(&at(2026, 7, 10, 3, 27)));
+        assert!(expr.matches(&at(1999, 12, 31, 23, 59)));
+    }
+
+    #[test]
+    fn step_minute_matches_quarter_hours() {
+        let expr = CronExpr::parse("*/15 * * * *").unwrap();
+        for minute in [0, 15, 30, 45] {
+            assert!(expr.matches(&at(2026, 7, 10, 9, minute)), "minute {minute}");
+        }
+        for minute in [1, 14, 16, 29, 44, 59] {
+            assert!(
+                !expr.matches(&at(2026, 7, 10, 9, minute)),
+                "minute {minute}"
+            );
+        }
+    }
+
+    #[test]
+    fn named_weekday_matches_only_that_day() {
+        // 09:00 every Monday. 2026-07-13 is a Monday; 2026-07-14 a Tuesday.
+        let expr = CronExpr::parse("0 9 * * MON").unwrap();
+        assert!(expr.matches(&at(2026, 7, 13, 9, 0)));
+        assert!(!expr.matches(&at(2026, 7, 14, 9, 0)));
+        assert!(!expr.matches(&at(2026, 7, 13, 10, 0)));
+    }
+
+    #[test]
+    fn sunday_accepts_zero_and_seven() {
+        let zero = CronExpr::parse("0 0 * * 0").unwrap();
+        let seven = CronExpr::parse("0 0 * * 7").unwrap();
+        // 2026-07-12 is a Sunday.
+        let sunday = at(2026, 7, 12, 0, 0);
+        assert!(zero.matches(&sunday));
+        assert!(seven.matches(&sunday));
+        assert_eq!(zero, seven);
+    }
+
+    #[test]
+    fn day_of_month_field() {
+        let expr = CronExpr::parse("0 0 1 * *").unwrap();
+        assert!(expr.matches(&at(2026, 3, 1, 0, 0)));
+        assert!(!expr.matches(&at(2026, 3, 2, 0, 0)));
+    }
+
+    #[test]
+    fn named_month_range_and_business_hours() {
+        // 09:00 and 17:00 on weekdays (Mon–Fri).
+        let expr = CronExpr::parse("0 9,17 * * 1-5").unwrap();
+        assert!(expr.matches(&at(2026, 7, 10, 9, 0))); // Friday 09:00
+        assert!(expr.matches(&at(2026, 7, 10, 17, 0))); // Friday 17:00
+        assert!(!expr.matches(&at(2026, 7, 11, 9, 0))); // Saturday
+        assert!(!expr.matches(&at(2026, 7, 10, 12, 0))); // midday, not on the hour list
+
+        let named = CronExpr::parse("0 0 * JAN-MAR *").unwrap();
+        assert!(named.matches(&at(2026, 2, 15, 0, 0)));
+        assert!(!named.matches(&at(2026, 4, 1, 0, 0)));
+    }
+
+    #[test]
+    fn day_or_rule_when_both_restricted() {
+        // "Fire on the 1st OR on any Monday." 2026-07-13 is a Monday but not the
+        // 1st; 2026-07-01 is the 1st (a Wednesday).
+        let expr = CronExpr::parse("0 0 1 * MON").unwrap();
+        assert!(expr.matches(&at(2026, 7, 13, 0, 0))); // Monday
+        assert!(expr.matches(&at(2026, 7, 1, 0, 0))); // the 1st
+        assert!(!expr.matches(&at(2026, 7, 8, 0, 0))); // neither
+    }
+
+    #[test]
+    fn next_after_finds_the_following_tick() {
+        let expr = CronExpr::parse("*/15 * * * *").unwrap();
+        let next = expr.next_after(&at(2026, 7, 10, 9, 7)).unwrap();
+        assert_eq!((next.hour, next.minute), (9, 15));
+
+        let weekly = CronExpr::parse("0 9 * * MON").unwrap();
+        // From Friday, the next Monday 09:00 is 2026-07-13.
+        let next = weekly.next_after(&at(2026, 7, 10, 9, 0)).unwrap();
+        assert_eq!((next.year, next.month, next.day), (2026, 7, 13));
+        assert_eq!((next.hour, next.minute), (9, 0));
+    }
+
+    #[test]
+    fn next_after_crosses_the_leap_day() {
+        let expr = CronExpr::parse("0 0 29 2 *").unwrap();
+        // From 2025 (not a leap year) the next 29 Feb is 2028.
+        let next = expr.next_after(&at(2025, 3, 1, 0, 0)).unwrap();
+        assert_eq!((next.year, next.month, next.day), (2028, 2, 29));
+    }
+
+    #[test]
+    fn rejects_malformed_expressions() {
+        assert!(CronExpr::parse("* * * *").is_err()); // 4 fields
+        assert!(CronExpr::parse("* * * * * *").is_err()); // 6 fields
+        assert!(CronExpr::parse("60 * * * *").is_err()); // minute out of range
+        assert!(CronExpr::parse("* 24 * * *").is_err()); // hour out of range
+        assert!(CronExpr::parse("*/0 * * * *").is_err()); // zero step
+        assert!(CronExpr::parse("5-1 * * * *").is_err()); // descending range
+        assert!(CronExpr::parse("* * * FOO *").is_err()); // bad month name
+    }
+}

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -55,8 +55,11 @@ impl<'a> CycleRunner<'a> {
 
         // 2. Persist input — durable before any thinking.
         let mut persisted_seq = None;
+        let mut event_seqs = Vec::with_capacity(events.len());
         for event in &events {
-            persisted_seq = Some(self.rt.events.append(&company, event.clone()).await?);
+            let seq = self.rt.events.append(&company, event.clone()).await?;
+            event_seqs.push(seq);
+            persisted_seq = Some(seq);
         }
 
         // 3. Load — history, context index, roster.
@@ -81,6 +84,7 @@ impl<'a> CycleRunner<'a> {
             cycle_id: cycle_id.clone(),
             company_id: company.clone(),
             events,
+            event_seqs,
             compressed_history,
             roster,
             context_index,

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -135,6 +135,57 @@ impl<'a> CycleRunner<'a> {
         .await
     }
 
+    /// Resolves a parked approval to an operator-amended effect
+    /// (approve-with-edit): overlays `amended_payload` onto the parked effect,
+    /// executes the amended version (at-most-once), and runs a follow-up cycle.
+    ///
+    /// Both the original and the amended effect are preserved in the immutable
+    /// journal (`ApprovalParked` + `ApprovalAmended`), so the audit trail shows
+    /// what the brain requested and what the operator approved.
+    pub async fn resolve_approval_amended(
+        &self,
+        id: &ApprovalId,
+        amended_payload: serde_json::Value,
+        by: Actor,
+    ) -> Result<CycleReport> {
+        let now = now_millis();
+
+        // Overlay the operator's edit onto the parked effect. A missing id (or
+        // an expired one, caught by the gate below) yields no executable effect.
+        let amended = self.rt.approval_gate.parked_effect(id).map(|mut original| {
+            original.payload = overlay_payload(original.payload, amended_payload);
+            original
+        });
+        let executed = match amended {
+            Some(effect) => self
+                .rt
+                .approval_gate
+                .resolve_amended(id, effect, by.clone(), now),
+            None => None,
+        };
+
+        // Audit the amendment (when one ran) and drain the queue durably.
+        if let Some(effect) = &executed {
+            self.rt.journal.record_amended(id, effect, now).await?;
+        }
+        self.rt.journal.record_resolved(id).await?;
+
+        if let Some(effect) = &executed {
+            let key = format!("approval:{id}");
+            execute_effect_once(self.rt, &key, effect).await?;
+        }
+
+        // Follow-up cycle so the brain learns the approval resolved (with an
+        // edit). `CompanyEvent` is closed, so the verdict rides as `Approve`;
+        // the edit itself lives in the journal audit trail.
+        self.run(vec![CompanyEvent::ApprovalResolved {
+            approval_id: id.clone(),
+            verdict: Verdict::Approve,
+            by,
+        }])
+        .await
+    }
+
     /// Replays the journal to rebuild the executed-key set and approval queue.
     pub async fn recover(&self) -> Result<()> {
         self.rt.journal.load().await
@@ -149,6 +200,23 @@ impl<'a> CycleRunner<'a> {
         }
         // No adapter for this channel id: drop silently in Phase 1.
         Ok(())
+    }
+}
+
+/// Overlays an operator's payload edit onto the original effect payload.
+///
+/// When both are JSON objects the top-level keys are merged (the edit wins);
+/// otherwise the edit replaces the original wholesale. An operator can thus
+/// tweak individual fields (e.g. lower an amount) without restating the payload.
+fn overlay_payload(original: serde_json::Value, edit: serde_json::Value) -> serde_json::Value {
+    match (original, edit) {
+        (serde_json::Value::Object(mut base), serde_json::Value::Object(over)) => {
+            for (key, value) in over {
+                base.insert(key, value);
+            }
+            serde_json::Value::Object(base)
+        }
+        (_, edit) => edit,
     }
 }
 
@@ -301,11 +369,15 @@ mod test {
     use std::sync::atomic::AtomicUsize;
 
     use crate::company::CompanyManifest;
+    use crate::policy::ManifestApprovalGate;
+    use crate::ports::ChannelAdapter;
     use crate::ports::brain::Brain;
     use crate::ports::types::{
         ActorKind, CompressedTrace, CycleResult, EffectGroup, EventSeq, TokenUsage,
     };
     use crate::runtime::RuntimeBuilder;
+    use crate::runtime::channel::OperatorChannel;
+    use crate::store::paths::Bundle;
 
     fn tmp_home() -> std::path::PathBuf {
         std::env::temp_dir().join(format!("opencompany-cycle-{}", crate::ports::generate_id()))
@@ -515,6 +587,115 @@ mod test {
             .await
             .unwrap();
         assert!(rt2.pending_approvals().is_empty());
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    #[tokio::test]
+    async fn amend_then_approve_executes_edited_effect() {
+        let home = tmp_home();
+        // A parked Sign effect whose payload the operator will overwrite so the
+        // executed effect routes an amended message to the operator channel.
+        let sign_effect = Effect {
+            kind: "filing.submit".into(),
+            group: EffectGroup::Sign,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::json!({ "channel": "operator", "text": "ORIGINAL" }),
+        };
+        // A recording operator channel we keep a handle to (Arc-shared buffer).
+        let operator_channel = OperatorChannel::new();
+        let channels: Vec<Arc<dyn ChannelAdapter>> = vec![Arc::new(operator_channel.clone())];
+        let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
+            .with_brain(Arc::new(EffectBrain {
+                effect: sign_effect,
+            }))
+            .with_channels(channels)
+            .build()
+            .await
+            .unwrap();
+
+        let report = rt
+            .run_cycle(vec![CompanyEvent::OperatorMessage {
+                text: "file it".into(),
+            }])
+            .await
+            .unwrap();
+        let approval_id = report.parked[0].clone();
+
+        // Approve with an edited payload: only `text` changes.
+        let follow_up = rt
+            .resolve_approval_amended(
+                &approval_id,
+                serde_json::json!({ "text": "AMENDED" }),
+                operator(),
+            )
+            .await
+            .unwrap();
+        assert!(follow_up.parked.is_empty());
+        assert!(rt.pending_approvals().is_empty());
+
+        // The amended effect executed: the operator channel saw "AMENDED",
+        // never the original "ORIGINAL" text.
+        let sent = operator_channel.sent();
+        assert!(
+            sent.iter().any(|m| m.text == "AMENDED"),
+            "amended text was routed, got {sent:?}"
+        );
+        assert!(sent.iter().all(|m| m.text != "ORIGINAL"));
+
+        // The immutable journal records both the original park and the amend.
+        let raw = tokio::fs::read_to_string(Bundle::new(&home, rt.id()).journal_jsonl())
+            .await
+            .unwrap();
+        assert!(raw.contains("ApprovalParked"));
+        assert!(raw.contains("ApprovalAmended"));
+        assert!(raw.contains("AMENDED"));
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    #[tokio::test]
+    async fn sweep_expires_parked_approval_to_deny() {
+        let home = tmp_home();
+        let sign_effect = Effect {
+            kind: "filing.submit".into(),
+            group: EffectGroup::Sign,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::Value::Null,
+        };
+        // A zero-TTL gate: anything parked is immediately past its deadline.
+        let gate = Arc::new(
+            ManifestApprovalGate::new(manifest("supervised").policy.clone()).with_ttl_millis(0),
+        );
+        let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
+            .with_brain(Arc::new(EffectBrain {
+                effect: sign_effect,
+            }))
+            .with_approvals(gate)
+            .build()
+            .await
+            .unwrap();
+
+        let report = rt
+            .run_cycle(vec![CompanyEvent::OperatorMessage {
+                text: "file it".into(),
+            }])
+            .await
+            .unwrap();
+        let approval_id = report.parked[0].clone();
+        assert_eq!(rt.pending_approvals().len(), 1);
+
+        // The maintenance sweep resolves the silent approval to a default-deny.
+        let expired = rt.sweep_expired_approvals().await.unwrap();
+        assert_eq!(expired, vec![approval_id]);
+        assert!(rt.pending_approvals().is_empty());
+
+        let raw = tokio::fs::read_to_string(Bundle::new(&home, rt.id()).journal_jsonl())
+            .await
+            .unwrap();
+        assert!(raw.contains("ApprovalExpired"));
         tokio::fs::remove_dir_all(&home).await.ok();
     }
 

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -51,6 +51,28 @@ enum JournalRecord {
         /// The resolved approval's id.
         id: ApprovalId,
     },
+    /// A parked approval that expired to a default-deny with no operator action.
+    ApprovalExpired {
+        /// The expired approval's id.
+        id: ApprovalId,
+        /// Epoch-millis the expiry was recorded.
+        at_millis: u64,
+    },
+    /// A parked approval the operator approved with an amended effect payload.
+    ///
+    /// Audit-only: the queue removal is recorded by the paired
+    /// [`ApprovalResolved`](JournalRecord::ApprovalResolved). The original
+    /// effect stays recoverable from the earlier
+    /// [`ApprovalParked`](JournalRecord::ApprovalParked), so the immutable log
+    /// shows both what was requested and what the operator approved.
+    ApprovalAmended {
+        /// The amended approval's id.
+        id: ApprovalId,
+        /// The operator-amended effect that was executed.
+        amended_effect: Effect,
+        /// Epoch-millis the amendment was recorded.
+        at_millis: u64,
+    },
 }
 
 /// A parked approval awaiting resolution.
@@ -119,6 +141,11 @@ impl RuntimeJournal {
                 JournalRecord::ApprovalResolved { id } => {
                     state.parked.remove(&id);
                 }
+                JournalRecord::ApprovalExpired { id, .. } => {
+                    state.parked.remove(&id);
+                }
+                // Audit-only: the paired `ApprovalResolved` handles removal.
+                JournalRecord::ApprovalAmended { .. } => {}
             }
         }
         *self.state.lock().expect("journal state poisoned") = state;
@@ -179,6 +206,39 @@ impl RuntimeJournal {
             .remove(id);
         self.append(&JournalRecord::ApprovalResolved { id: id.clone() })
             .await
+    }
+
+    /// Records that a parked approval expired to a default-deny, removing it
+    /// from the queue. This is the durable audit entry for
+    /// default-deny-on-silence.
+    pub async fn record_expired(&self, id: &ApprovalId, at_millis: u64) -> Result<()> {
+        self.state
+            .lock()
+            .expect("journal state poisoned")
+            .parked
+            .remove(id);
+        self.append(&JournalRecord::ApprovalExpired {
+            id: id.clone(),
+            at_millis,
+        })
+        .await
+    }
+
+    /// Records an operator-amended approval (an approve-with-edit) for the audit
+    /// trail. Removal from the queue is recorded separately by
+    /// [`record_resolved`](Self::record_resolved).
+    pub async fn record_amended(
+        &self,
+        id: &ApprovalId,
+        amended_effect: &Effect,
+        at_millis: u64,
+    ) -> Result<()> {
+        self.append(&JournalRecord::ApprovalAmended {
+            id: id.clone(),
+            amended_effect: amended_effect.clone(),
+            at_millis,
+        })
+        .await
     }
 
     /// A snapshot of the currently parked approvals, oldest first.
@@ -312,5 +372,85 @@ mod test {
         after.load().await.unwrap();
         assert!(after.pending().is_empty());
         tokio::fs::remove_file(&path).await.ok();
+    }
+
+    #[tokio::test]
+    async fn expired_record_removes_parked_and_survives_reload() {
+        let path = tmp_path();
+        let journal = RuntimeJournal::new(&path);
+        let id = ApprovalId::new("appr-exp");
+        journal
+            .record_parked(&id, &effect(), now_millis())
+            .await
+            .unwrap();
+        assert_eq!(journal.pending().len(), 1);
+
+        journal.record_expired(&id, now_millis()).await.unwrap();
+        assert!(journal.pending().is_empty());
+
+        // A restart replays the expiry: the approval stays gone.
+        let reloaded = RuntimeJournal::new(&path);
+        reloaded.load().await.unwrap();
+        assert!(reloaded.pending().is_empty());
+
+        let raw = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(raw.contains("ApprovalExpired"));
+        tokio::fs::remove_file(&path).await.ok();
+    }
+
+    #[tokio::test]
+    async fn amended_record_is_audit_only_and_round_trips() {
+        let path = tmp_path();
+        let journal = RuntimeJournal::new(&path);
+        let id = ApprovalId::new("appr-amend");
+        journal
+            .record_parked(&id, &effect(), now_millis())
+            .await
+            .unwrap();
+
+        let mut amended = effect();
+        amended.payload = serde_json::json!({ "edited": true });
+        journal
+            .record_amended(&id, &amended, now_millis())
+            .await
+            .unwrap();
+        // The audit record alone does not drain the queue.
+        assert_eq!(journal.pending().len(), 1);
+        // The paired resolution removes it.
+        journal.record_resolved(&id).await.unwrap();
+        assert!(journal.pending().is_empty());
+
+        let reloaded = RuntimeJournal::new(&path);
+        reloaded.load().await.unwrap();
+        assert!(reloaded.pending().is_empty());
+
+        let raw = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(raw.contains("ApprovalAmended"));
+        assert!(raw.contains("\"edited\":true"));
+        tokio::fs::remove_file(&path).await.ok();
+    }
+
+    #[test]
+    fn expired_and_amended_records_round_trip_under_record_tag() {
+        for record in [
+            JournalRecord::ApprovalExpired {
+                id: ApprovalId::new("x"),
+                at_millis: 42,
+            },
+            JournalRecord::ApprovalAmended {
+                id: ApprovalId::new("y"),
+                amended_effect: effect(),
+                at_millis: 7,
+            },
+        ] {
+            let json = serde_json::to_value(&record).unwrap();
+            assert!(json.get("record").is_some());
+            let back: JournalRecord = serde_json::from_value(json).unwrap();
+            // Re-serialize to compare (JournalRecord has no PartialEq).
+            assert_eq!(
+                serde_json::to_string(&back).unwrap(),
+                serde_json::to_string(&record).unwrap()
+            );
+        }
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -11,16 +11,20 @@
 
 pub mod builder;
 pub mod channel;
+pub mod cron;
 pub mod cycle;
 pub mod journal;
 pub mod registry;
+pub mod scheduler;
 pub mod tools;
 pub mod types;
 
 pub use builder::{RuntimeBuilder, company_id_from_name};
 pub use channel::{OPERATOR_CHANNEL, OperatorChannel};
+pub use cron::{CivilTime, CronExpr};
 pub use cycle::CycleRunner;
 pub use registry::CompanyRegistry;
+pub use scheduler::{Clock, CompanyScheduler, FakeClock, SystemClock};
 pub use tools::StubToolProvider;
 pub use types::{ApprovalSummary, CompanyStatus, CycleReport};
 

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -41,6 +41,14 @@ impl CompanyRegistry {
             .insert(id, runtime);
     }
 
+    /// Removes and returns the runtime registered under `id`, if any.
+    ///
+    /// Used by the archive lifecycle transition to park a company: once removed,
+    /// the company is no longer addressable and chatting it returns a 404.
+    pub fn remove(&self, id: &CompanyId) -> Option<Arc<CompanyRuntime>> {
+        self.inner.write().expect("registry poisoned").remove(id)
+    }
+
     /// The ids of every registered company, sorted.
     pub fn list(&self) -> Vec<CompanyId> {
         let mut ids: Vec<CompanyId> = self
@@ -123,6 +131,21 @@ mod test {
         assert!(registry.sole().is_none());
         assert_eq!(registry.len(), 2);
         assert!(registry.get(&CompanyId::new("globex")).is_some());
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    #[tokio::test]
+    async fn remove_unregisters_the_company() {
+        let home =
+            std::env::temp_dir().join(format!("opencompany-reg-{}", crate::ports::generate_id()));
+        let registry = CompanyRegistry::new();
+        registry.insert(CompanyId::new("acme"), runtime(&home, "acme").await);
+        assert!(registry.get(&CompanyId::new("acme")).is_some());
+
+        let removed = registry.remove(&CompanyId::new("acme"));
+        assert!(removed.is_some());
+        assert!(registry.get(&CompanyId::new("acme")).is_none());
+        assert!(registry.remove(&CompanyId::new("acme")).is_none());
         tokio::fs::remove_dir_all(&home).await.ok();
     }
 }

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1,0 +1,495 @@
+//! [`CompanyScheduler`]: drives a company's `[[schedule]]` crons into cycles.
+//!
+//! Boot lifecycle step 4 starts one scheduler per live company. On each tick it
+//! asks an injectable [`Clock`] for the current minute, matches every parsed
+//! [`CronExpr`](crate::runtime::cron::CronExpr) against it, and — for each
+//! schedule that is due and has not already fired this minute — enqueues a
+//! [`CompanyEvent::ScheduleFired`] into the company's serial cycle queue via
+//! [`CompanyRuntime::run_cycle`]. Because the runtime holds a per-company serial
+//! lock, scheduled cycles interleave safely with operator chat and webhooks.
+//!
+//! The clock is a trait so tests are fully deterministic: [`FakeClock`] lets a
+//! test set or advance the current time and assert exactly which ticks fire,
+//! with no wall-clock sleeps. In production [`SystemClock`] reads
+//! [`now_millis`](crate::ports::now_millis) and [`CompanyScheduler::spawn`]
+//! sleeps to each minute boundary until a shutdown signal fires.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+
+use crate::Result;
+use crate::company::Schedule;
+use crate::company::runtime::CompanyRuntime;
+use crate::ports::now_millis;
+use crate::ports::types::CompanyEvent;
+use crate::runtime::cron::{CivilTime, CronExpr};
+
+/// Milliseconds in one minute.
+const MINUTE_MS: u64 = 60_000;
+
+/// A source of the current wall-clock time, in unix epoch milliseconds.
+///
+/// Injected so the scheduler never reads a real clock in tests.
+pub trait Clock: Send + Sync {
+    /// The current time as unix epoch milliseconds.
+    fn now_millis(&self) -> u64;
+}
+
+/// The production clock: reads the system wall clock.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now_millis(&self) -> u64 {
+        now_millis()
+    }
+}
+
+/// A test clock whose time is set or advanced explicitly.
+#[derive(Debug, Default)]
+pub struct FakeClock(AtomicU64);
+
+impl FakeClock {
+    /// A fake clock parked at `ms`.
+    pub fn new(ms: u64) -> Self {
+        Self(AtomicU64::new(ms))
+    }
+
+    /// Jumps the clock to an absolute `ms`.
+    pub fn set(&self, ms: u64) {
+        self.0.store(ms, Ordering::SeqCst);
+    }
+
+    /// Advances the clock by `delta` milliseconds.
+    pub fn advance(&self, delta: u64) {
+        self.0.fetch_add(delta, Ordering::SeqCst);
+    }
+}
+
+impl Clock for FakeClock {
+    fn now_millis(&self) -> u64 {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+/// One parsed schedule: its matcher plus the prompt to deliver when it fires.
+struct ParsedSchedule {
+    expr: CronExpr,
+    cron: String,
+    prompt: String,
+}
+
+/// Drives the cron schedules of a single [`CompanyRuntime`].
+pub struct CompanyScheduler {
+    runtime: Arc<CompanyRuntime>,
+    schedules: Vec<ParsedSchedule>,
+    clock: Arc<dyn Clock>,
+    /// Per-schedule last-fired epoch minute, so a schedule fires at most once per
+    /// minute no matter how often [`tick`](Self::tick) is called.
+    last_fired: HashMap<usize, u64>,
+}
+
+impl CompanyScheduler {
+    /// Parses `schedules` and binds them to `runtime`, driven by `clock`.
+    ///
+    /// Returns an error only when a cron expression fails to parse; callers at
+    /// boot log the error and skip scheduling for that company rather than
+    /// aborting the whole server.
+    pub fn new(
+        runtime: Arc<CompanyRuntime>,
+        schedules: &[Schedule],
+        clock: Arc<dyn Clock>,
+    ) -> Result<Self> {
+        let mut parsed = Vec::with_capacity(schedules.len());
+        for schedule in schedules {
+            parsed.push(ParsedSchedule {
+                expr: CronExpr::parse(&schedule.cron)?,
+                cron: schedule.cron.clone(),
+                prompt: schedule.prompt.clone(),
+            });
+        }
+        Ok(Self {
+            runtime,
+            schedules: parsed,
+            clock,
+            last_fired: HashMap::new(),
+        })
+    }
+
+    /// Whether this scheduler has any schedules to drive.
+    pub fn is_empty(&self) -> bool {
+        self.schedules.is_empty()
+    }
+
+    /// Runs one tick: fires every schedule that is due this minute and has not
+    /// already fired this minute, running a cycle per fire. Returns how many
+    /// schedules fired.
+    ///
+    /// A paused or archived company fires nothing (its `ensure_running` guard
+    /// rejects), so schedules resume cleanly when the company is unpaused.
+    pub async fn tick(&mut self) -> Result<usize> {
+        if self.schedules.is_empty() {
+            return Ok(0);
+        }
+        // Skip firing for a company that is not accepting work.
+        if self.runtime.ensure_running().await.is_err() {
+            return Ok(0);
+        }
+
+        let now = self.clock.now_millis();
+        let minute = now / MINUTE_MS;
+        let civil = CivilTime::from_unix_millis(now);
+
+        let mut fired = 0;
+        for (idx, schedule) in self.schedules.iter().enumerate() {
+            if !schedule.expr.matches(&civil) {
+                continue;
+            }
+            if self.last_fired.get(&idx) == Some(&minute) {
+                continue; // already fired this minute
+            }
+            self.last_fired.insert(idx, minute);
+            self.runtime
+                .run_cycle(vec![CompanyEvent::ScheduleFired {
+                    cron: schedule.cron.clone(),
+                    prompt: schedule.prompt.clone(),
+                }])
+                .await?;
+            fired += 1;
+        }
+        Ok(fired)
+    }
+
+    /// Runs the per-tick maintenance that rides the same minute boundary as
+    /// scheduled fires: sweep parked approvals past their TTL to a default-deny.
+    pub async fn tick_maintenance(&self) -> Result<Vec<crate::ports::types::ApprovalId>> {
+        self.runtime.sweep_expired_approvals().await
+    }
+
+    /// Spawns a background task that ticks on every minute boundary until
+    /// `shutdown` is notified, then returns. Boot holds the join handle and the
+    /// shared `shutdown` so the scheduler stops cleanly when the server does.
+    pub fn spawn(mut self, shutdown: Arc<Notify>) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            loop {
+                let sleep_ms = millis_to_next_minute(self.clock.now_millis());
+                tokio::select! {
+                    _ = shutdown.notified() => break,
+                    _ = tokio::time::sleep(Duration::from_millis(sleep_ms)) => {
+                        if let Err(err) = self.tick().await {
+                            tracing::warn!(company = %self.runtime.id(), %err, "scheduled cycle failed");
+                        }
+                        if let Err(err) = self.tick_maintenance().await {
+                            tracing::warn!(company = %self.runtime.id(), %err, "approval sweep failed");
+                        }
+                    }
+                }
+            }
+        })
+    }
+}
+
+/// Milliseconds from `now` to the next whole-minute boundary (always `>= 1` so
+/// the spawn loop never busy-spins on an exact boundary).
+fn millis_to_next_minute(now: u64) -> u64 {
+    let into_minute = now % MINUTE_MS;
+    MINUTE_MS - into_minute
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use async_trait::async_trait;
+
+    use crate::company::CompanyManifest;
+    use crate::policy::ManifestApprovalGate;
+    use crate::ports::brain::{Brain, CycleHost};
+    use crate::ports::types::{
+        CompressedTrace, CycleRequest, CycleResult, Effect, EffectGroup, EventSeq, OutboundMessage,
+        TokenUsage,
+    };
+    use crate::runtime::RuntimeBuilder;
+    use crate::runtime::cron::CivilTime;
+
+    fn tmp_home() -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("opencompany-sched-{}", crate::ports::generate_id()))
+    }
+
+    fn manifest(policy_mode: &str) -> CompanyManifest {
+        let toml_src = format!(
+            r#"
+            [company]
+            name = "Acme"
+
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+
+            [policy]
+            mode = "{policy_mode}"
+            "#
+        );
+        toml::from_str(&toml_src).expect("parse manifest")
+    }
+
+    /// Unix millis for a UTC civil minute, reusing the cron module's math.
+    fn millis_at(year: i64, month: u32, day: u32, hour: u32, minute: u32) -> u64 {
+        // Search forward from a coarse lower bound is overkill; instead binary
+        // via the known conversion: rebuild through CivilTime round-trip.
+        // Simpler: brute a direct computation using days-from-civil is private,
+        // so derive from a probe. We reconstruct by scanning day starts.
+        let mut probe = 0u64;
+        // Jump in ~day steps to the target date, then add hour/minute.
+        loop {
+            let c = CivilTime::from_unix_millis(probe);
+            if (c.year, c.month, c.day) == (year, month, day) {
+                break;
+            }
+            probe += 86_400_000;
+            if probe > 4_102_444_800_000 {
+                panic!("date out of probe range");
+            }
+        }
+        probe + (hour as u64) * 3_600_000 + (minute as u64) * MINUTE_MS
+    }
+
+    /// A brain that echoes ScheduleFired events into an operator response, so a
+    /// test can assert a scheduled cycle actually ran.
+    struct ScheduleBrain;
+
+    #[async_trait]
+    impl Brain for ScheduleBrain {
+        async fn run_cycle(&self, req: CycleRequest, _host: &dyn CycleHost) -> Result<CycleResult> {
+            let mut responses = Vec::new();
+            for event in &req.events {
+                if let CompanyEvent::ScheduleFired { prompt, .. } = event {
+                    responses.push(OutboundMessage {
+                        channel: "operator".into(),
+                        text: format!("scheduled: {prompt}"),
+                    });
+                }
+            }
+            Ok(CycleResult {
+                channel_responses: responses,
+                new_traces: vec![CompressedTrace::now(&req.cycle_id, "scheduled")],
+                ledger_deltas: Vec::new(),
+                token_usage: TokenUsage::default(),
+            })
+        }
+    }
+
+    fn scheduled_manifest() -> CompanyManifest {
+        let toml_src = r#"
+            [company]
+            name = "Acme"
+
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+
+            [[schedule]]
+            cron = "0 9 * * MON"
+            prompt = "weekly standup"
+
+            [policy]
+            mode = "full"
+        "#;
+        toml::from_str(toml_src).expect("parse manifest")
+    }
+
+    #[tokio::test]
+    async fn fires_once_per_matching_minute_and_dedupes() {
+        let home = tmp_home();
+        let manifest = scheduled_manifest();
+        let schedules = manifest.schedules.clone();
+        let rt = Arc::new(
+            RuntimeBuilder::new(home.clone(), manifest)
+                .with_brain(Arc::new(ScheduleBrain))
+                .build()
+                .await
+                .unwrap(),
+        );
+
+        // Park the clock at Monday 2026-07-13 09:00 UTC — the schedule matches.
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = CompanyScheduler::new(rt.clone(), &schedules, clock.clone()).unwrap();
+
+        assert_eq!(scheduler.tick().await.unwrap(), 1);
+
+        // A ScheduleFired event landed in the log and the brain answered.
+        let events = rt
+            .events
+            .read_from(rt.id(), EventSeq::new(0), 10)
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0].event,
+            CompanyEvent::ScheduleFired { .. }
+        ));
+
+        // A second tick within the same minute does not re-fire (dedupe).
+        clock.advance(30_000);
+        assert_eq!(scheduler.tick().await.unwrap(), 0);
+
+        // Advancing into a non-matching minute (09:01) fires nothing.
+        clock.set(millis_at(2026, 7, 13, 9, 1));
+        assert_eq!(scheduler.tick().await.unwrap(), 0);
+
+        // The following Monday 09:00 fires again.
+        clock.set(millis_at(2026, 7, 20, 9, 0));
+        assert_eq!(scheduler.tick().await.unwrap(), 1);
+
+        let events = rt
+            .events
+            .read_from(rt.id(), EventSeq::new(0), 10)
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 2);
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    #[tokio::test]
+    async fn non_matching_minute_never_fires() {
+        let home = tmp_home();
+        let manifest = scheduled_manifest();
+        let schedules = manifest.schedules.clone();
+        let rt = Arc::new(
+            RuntimeBuilder::new(home.clone(), manifest)
+                .with_brain(Arc::new(ScheduleBrain))
+                .build()
+                .await
+                .unwrap(),
+        );
+        // A Tuesday 09:00 — the Monday schedule must not fire.
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 14, 9, 0)));
+        let mut scheduler = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
+        assert_eq!(scheduler.tick().await.unwrap(), 0);
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    #[tokio::test]
+    async fn empty_schedule_set_is_a_noop() {
+        let home = tmp_home();
+        let rt = Arc::new(
+            RuntimeBuilder::fs_defaults(home.clone(), manifest("full"))
+                .await
+                .unwrap(),
+        );
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = CompanyScheduler::new(rt, &[], clock).unwrap();
+        assert!(scheduler.is_empty());
+        assert_eq!(scheduler.tick().await.unwrap(), 0);
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    #[tokio::test]
+    async fn tick_maintenance_expires_parked_approval() {
+        let home = tmp_home();
+        // A brain that parks a Sign effect so there is something to expire.
+        struct ParkBrain;
+        #[async_trait]
+        impl Brain for ParkBrain {
+            async fn run_cycle(
+                &self,
+                req: CycleRequest,
+                host: &dyn CycleHost,
+            ) -> Result<CycleResult> {
+                for event in &req.events {
+                    if let CompanyEvent::ScheduleFired { .. } = event {
+                        host.emit_effect(Effect {
+                            kind: "filing.submit".into(),
+                            group: EffectGroup::Sign,
+                            amount_usd: None,
+                            established_thread: false,
+                            first_time_counterparty: false,
+                            payload: serde_json::Value::Null,
+                        })
+                        .await?;
+                    }
+                }
+                Ok(CycleResult {
+                    channel_responses: Vec::new(),
+                    new_traces: vec![CompressedTrace::now(&req.cycle_id, "park")],
+                    ledger_deltas: Vec::new(),
+                    token_usage: TokenUsage::default(),
+                })
+            }
+        }
+
+        let manifest = scheduled_manifest_supervised();
+        let schedules = manifest.schedules.clone();
+        // Zero-TTL gate: anything parked is instantly past its deadline.
+        let gate = Arc::new(ManifestApprovalGate::new(manifest.policy.clone()).with_ttl_millis(0));
+        let rt = Arc::new(
+            RuntimeBuilder::new(home.clone(), manifest)
+                .with_brain(Arc::new(ParkBrain))
+                .with_approvals(gate)
+                .build()
+                .await
+                .unwrap(),
+        );
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
+
+        // The scheduled cycle parks one approval.
+        assert_eq!(scheduler.tick().await.unwrap(), 1);
+        assert_eq!(rt.pending_approvals().len(), 1);
+
+        // Maintenance sweeps it to a default-deny.
+        let expired = scheduler.tick_maintenance().await.unwrap();
+        assert_eq!(expired.len(), 1);
+        assert!(rt.pending_approvals().is_empty());
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    fn scheduled_manifest_supervised() -> CompanyManifest {
+        let toml_src = r#"
+            [company]
+            name = "Acme"
+
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+
+            [[schedule]]
+            cron = "0 9 * * MON"
+            prompt = "weekly standup"
+
+            [policy]
+            mode = "supervised"
+        "#;
+        toml::from_str(toml_src).expect("parse manifest")
+    }
+
+    #[tokio::test]
+    async fn bad_cron_fails_construction() {
+        // A scheduler over an unparsable cron surfaces the error at construction.
+        let bad = [Schedule {
+            cron: "not a cron".into(),
+            prompt: "x".into(),
+        }];
+        let home = tmp_home();
+        let rt = Arc::new(
+            RuntimeBuilder::fs_defaults(home.clone(), manifest("full"))
+                .await
+                .unwrap(),
+        );
+        let clock = Arc::new(FakeClock::new(0));
+        assert!(CompanyScheduler::new(rt, &bad, clock).is_err());
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    #[test]
+    fn next_minute_sleep_is_bounded() {
+        assert_eq!(millis_to_next_minute(0), MINUTE_MS);
+        assert_eq!(millis_to_next_minute(1), MINUTE_MS - 1);
+        assert_eq!(millis_to_next_minute(MINUTE_MS - 1), 1);
+        assert_eq!(millis_to_next_minute(MINUTE_MS), MINUTE_MS);
+    }
+}

--- a/src/runtime/tools.rs
+++ b/src/runtime/tools.rs
@@ -34,7 +34,11 @@ impl StubToolProvider {
 }
 
 /// Matches a single grant glob against a tool name.
-fn grant_matches(grant: &str, tool: &str) -> bool {
+///
+/// A tool is granted when the glob matches it exactly, via a trailing `*`
+/// prefix (`email.*`), or the catch-all `*`. Shared with the OpenHuman-backed
+/// provider so both enforce grants identically.
+pub(crate) fn grant_matches(grant: &str, tool: &str) -> bool {
     if grant == "*" {
         return true;
     }

--- a/src/server/a2a.rs
+++ b/src/server/a2a.rs
@@ -1,0 +1,784 @@
+//! Inbound tiny.place A2A surface: JSON-RPC `tasks/send`, discovery records, and
+//! the human-readable skill catalog.
+//!
+//! This whole module is gated behind the `tinyplace` feature — with the feature
+//! off no A2A routes are mounted and the default build links no crypto. When on,
+//! [`router`] serves:
+//!
+//! ```text
+//! POST /a2a/{handle}                                    -> a2a_task
+//! GET  /a2a/{handle}/skill.md                           -> skill_md
+//! GET  /a2a/{handle}                                    -> agent_card
+//! GET  /.well-known/agent-card.json                     -> well_known_sole
+//! GET  /companies/{handle}/.well-known/agent-card.json  -> well_known_platform
+//! ```
+//!
+//! The `tasks/send` handler enforces the tiny.place trust boundary in a fixed
+//! order: resolve a **discoverable** company, verify the SIWX `Authorization`
+//! (skew + single-use replay protection via the host-global
+//! [`NonceCache`](crate::economy::NonceCache)) before anything reaches cognition,
+//! answer a `402` challenge for a priced skill lacking a valid
+//! [`X402Authorization`](crate::economy::X402Authorization), sanitize the
+//! counterparty payload (a minimal promptguard pass), and only then append an
+//! [`A2aTaskReceived`](crate::ports::types::CompanyEvent::A2aTaskReceived) event
+//! and run one cycle. A paying customer runs under the same approval gates as any
+//! other stimulus — there is no fence bypass.
+
+use std::sync::Arc;
+
+use axum::body::Bytes;
+use axum::http::HeaderMap;
+use axum::http::StatusCode;
+use axum::http::header::{AUTHORIZATION, CONTENT_TYPE};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde_json::{Value, json};
+
+use crate::AppState;
+use crate::company::CompanyManifest;
+use crate::company::runtime::CompanyRuntime;
+use crate::economy::client::{JsonRpcRequest, JsonRpcResponse, now_secs, sha256_hex};
+use crate::economy::signer::signer_for;
+use crate::economy::x402::{self, X402Authorization};
+use crate::economy::{build_agent_card, render_skill_md, siwx};
+use crate::error::OpenCompanyError;
+use crate::ports::now_millis;
+use crate::ports::types::{AgentCard, CardPayment, CompanyEvent, LedgerEntry};
+use crate::server::error::ApiError;
+
+/// Builds the tiny.place A2A route fragment, merged into the main router.
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/a2a/{handle}", post(a2a_task).get(agent_card))
+        .route("/a2a/{handle}/skill.md", get(skill_md))
+        .route("/.well-known/agent-card.json", get(well_known_sole))
+        .route(
+            "/companies/{handle}/.well-known/agent-card.json",
+            get(well_known_platform),
+        )
+}
+
+// ---------------------------------------------------------------------------
+// Company resolution
+// ---------------------------------------------------------------------------
+
+/// Resolves a `@handle` to a running, **discoverable** company.
+///
+/// Scans the registry for a company whose manifest sets `[place].discoverable`
+/// and whose `[company].handle` matches, falling back to the sole registered
+/// company in prosumer mode when it too is discoverable. A miss is a 404. The
+/// linear scan is fine at prosumer / small-platform scale; a handle index is a
+/// documented follow-up.
+async fn resolve_company(state: &AppState, handle: &str) -> Result<Arc<CompanyRuntime>, ApiError> {
+    for id in state.registry().list() {
+        let Some(runtime) = state.registry().get(&id) else {
+            continue;
+        };
+        if let Some(record) = runtime.store.load(&id).await?
+            && record.manifest.place.discoverable
+            && record.manifest.company.handle.as_deref() == Some(handle)
+        {
+            return Ok(runtime);
+        }
+    }
+
+    // Prosumer fallback: a lone discoverable company answers any handle.
+    if let Some(runtime) = state.registry().sole()
+        && let Some(record) = runtime.store.load(runtime.id()).await?
+        && record.manifest.place.discoverable
+    {
+        return Ok(runtime);
+    }
+
+    Err(ApiError(OpenCompanyError::CompanyNotFound(
+        handle.to_string(),
+    )))
+}
+
+/// Loads a resolved company's manifest, erroring 404 when the record is missing.
+async fn load_manifest(runtime: &CompanyRuntime) -> Result<CompanyManifest, ApiError> {
+    runtime
+        .store
+        .load(runtime.id())
+        .await?
+        .map(|record| record.manifest)
+        .ok_or_else(|| ApiError(OpenCompanyError::CompanyNotFound(runtime.id().to_string())))
+}
+
+/// Builds a resolved company's Agent Card against the host base URL.
+async fn card_for(state: &AppState, runtime: &CompanyRuntime) -> Result<AgentCard, ApiError> {
+    let manifest = load_manifest(runtime).await?;
+    Ok(build_agent_card(&manifest, &state.config().host_base_url()))
+}
+
+// ---------------------------------------------------------------------------
+// Read-only discovery routes (no SIWX)
+// ---------------------------------------------------------------------------
+
+/// `GET /a2a/{handle}` — the company's Agent Card (a directory-record convenience).
+async fn agent_card(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    axum::extract::Path(handle): axum::extract::Path<String>,
+) -> Result<Json<AgentCard>, ApiError> {
+    let runtime = resolve_company(&state, &handle).await?;
+    Ok(Json(card_for(&state, &runtime).await?))
+}
+
+/// `GET /.well-known/agent-card.json` — the sole company's card (prosumer mode).
+async fn well_known_sole(
+    axum::extract::State(state): axum::extract::State<AppState>,
+) -> Result<Json<AgentCard>, ApiError> {
+    let runtime = state.registry().sole().ok_or_else(|| {
+        ApiError(OpenCompanyError::CompanyNotFound(
+            "single-company".to_string(),
+        ))
+    })?;
+    // Discoverability is opt-in: an undiscoverable sole company is not published
+    // through the well-known card either.
+    let discoverable = runtime
+        .store
+        .load(runtime.id())
+        .await?
+        .map(|record| record.manifest.place.discoverable)
+        .unwrap_or(false);
+    if !discoverable {
+        return Err(ApiError(OpenCompanyError::CompanyNotFound(
+            "single-company".to_string(),
+        )));
+    }
+    Ok(Json(card_for(&state, &runtime).await?))
+}
+
+/// `GET /companies/{handle}/.well-known/agent-card.json` — a named company's card.
+async fn well_known_platform(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    axum::extract::Path(handle): axum::extract::Path<String>,
+) -> Result<Json<AgentCard>, ApiError> {
+    let runtime = resolve_company(&state, &handle).await?;
+    Ok(Json(card_for(&state, &runtime).await?))
+}
+
+/// `GET /a2a/{handle}/skill.md` — the human- and agent-readable skill catalog.
+async fn skill_md(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    axum::extract::Path(handle): axum::extract::Path<String>,
+) -> Result<Response, ApiError> {
+    let runtime = resolve_company(&state, &handle).await?;
+    let card = card_for(&state, &runtime).await?;
+    let body = render_skill_md(&card);
+    Ok(([(CONTENT_TYPE, "text/markdown; charset=utf-8")], body).into_response())
+}
+
+// ---------------------------------------------------------------------------
+// The inbound task route
+// ---------------------------------------------------------------------------
+
+/// `POST /a2a/{handle}` — a SIWX-authenticated JSON-RPC `tasks/send`.
+async fn a2a_task(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    axum::extract::Path(handle): axum::extract::Path<String>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    // 1. Resolve a discoverable company; 404 otherwise.
+    let runtime = match resolve_company(&state, &handle).await {
+        Ok(runtime) => runtime,
+        Err(err) => return err.into_response(),
+    };
+
+    // A company with no economy wired is not reachable for commerce → 503.
+    if !runtime.has_economy() {
+        return ApiError(OpenCompanyError::tinyplace(
+            "unreachable",
+            format!("@{handle} is not reachable for A2A tasks"),
+        ))
+        .into_response();
+    }
+
+    // Lifecycle: a paused/archived company rejects work → 409.
+    if let Err(err) = runtime.ensure_running().await {
+        return ApiError(err).into_response();
+    }
+
+    // 2. SIWX — verified before anything reaches cognition. A bad or missing
+    // header is a 401; nothing is logged from the request until it verifies.
+    let path = format!("/a2a/{handle}");
+    let body_hash = sha256_hex(&body);
+    let auth_header = headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    let from = match siwx::verify(
+        auth_header,
+        "POST",
+        &path,
+        &body_hash,
+        now_secs(),
+        state.nonce(),
+    ) {
+        Ok(agent_id) => agent_id,
+        Err(err) => return unauthorized(&err),
+    };
+
+    // 3. Parse the JSON-RPC `tasks/send` envelope.
+    let rpc: JsonRpcRequest = match serde_json::from_slice(&body) {
+        Ok(rpc) => rpc,
+        Err(err) => {
+            return ApiError(OpenCompanyError::InvalidRequest(format!(
+                "body is not a JSON-RPC request: {err}"
+            )))
+            .into_response();
+        }
+    };
+    if rpc.method != "tasks/send" {
+        return ApiError(OpenCompanyError::InvalidRequest(format!(
+            "unsupported method `{}`; only `tasks/send` is served",
+            rpc.method
+        )))
+        .into_response();
+    }
+    let skill = rpc
+        .params
+        .get("skill")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+
+    // Pricing comes from the company's own Agent Card.
+    let card = match card_for(&state, &runtime).await {
+        Ok(card) => card,
+        Err(err) => return err.into_response(),
+    };
+
+    // 4. If the requested skill is priced above zero, require a valid x402
+    // authorization. A `0.00` (or unparsable) price is served for free.
+    if let Some(pay) = card.payment_requirements.iter().find(|p| {
+        p.skill_id == skill
+            && p.price
+                .trim()
+                .parse::<f64>()
+                .map(|v| v > 0.0)
+                .unwrap_or(false)
+    }) {
+        match extract_payment(&rpc.params) {
+            None => return payment_required(&state, &runtime, pay).await,
+            Some(auth) => {
+                if x402::verify(&auth).is_err() {
+                    return ApiError(OpenCompanyError::InvalidRequest(
+                        "x402 payment authorization did not verify".into(),
+                    ))
+                    .into_response();
+                }
+                // Bind the payment to THIS company: the payer must have signed a
+                // `recipient` equal to our own agent id. Without this a
+                // counterparty could self-sign an authorization paying anyone
+                // else and still obtain priced work.
+                let our_id = match signer_for(state.home(), runtime.id()).await {
+                    Ok(signer) => signer.agent_id(),
+                    Err(err) => return ApiError(err).into_response(),
+                };
+                if auth.recipient != our_id {
+                    return payment_required(&state, &runtime, pay).await;
+                }
+                let paid = auth.amount.trim().parse::<f64>().unwrap_or(0.0);
+                let price = pay.price.trim().parse::<f64>().unwrap_or(f64::INFINITY);
+                if paid < price {
+                    // Underpaid: re-challenge for the correct amount.
+                    return payment_required(&state, &runtime, pay).await;
+                }
+                // Journal the inbound receipt before doing the work.
+                let entry = LedgerEntry {
+                    at_millis: now_millis(),
+                    kind: "x402.in".to_string(),
+                    amount_usd: paid,
+                    memo: format!("a2a `{skill}` from {from}"),
+                };
+                if let Err(err) = runtime.store.append_ledger(runtime.id(), entry).await {
+                    return ApiError(err).into_response();
+                }
+            }
+        }
+    }
+
+    // 5. Promptguard: sanitize the counterparty payload before it becomes an
+    // event. Deliberately minimal — a control-character strip seam, not a full
+    // model-based guard.
+    let task = sanitize_value(rpc.params.clone());
+
+    // 6. Append the event and run one cycle (run_cycle persists the event).
+    let report = match runtime
+        .run_cycle(vec![CompanyEvent::A2aTaskReceived {
+            from: from.clone(),
+            task,
+        }])
+        .await
+    {
+        Ok(report) => report,
+        Err(err) => return ApiError(err).into_response(),
+    };
+
+    let result = json!({
+        "cycleId": report.cycle_id,
+        "responses": report.responses,
+    });
+    (StatusCode::OK, Json(JsonRpcResponse::ok(rpc.id, result))).into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Renders a SIWX failure as a `401` in the api.md error envelope.
+fn unauthorized(err: &OpenCompanyError) -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({ "error": err.to_string(), "code": err.code() })),
+    )
+        .into_response()
+}
+
+/// Builds the `402` challenge naming the price and the company's own address.
+async fn payment_required(
+    state: &AppState,
+    runtime: &CompanyRuntime,
+    pay: &CardPayment,
+) -> Response {
+    let recipient = match signer_for(state.home(), runtime.id()).await {
+        Ok(signer) => signer.agent_id(),
+        Err(err) => return ApiError(err).into_response(),
+    };
+    let challenge = json!({
+        "amount": pay.price,
+        "recipient": recipient,
+        "asset": pay.asset,
+        "network": pay.network,
+    });
+    (StatusCode::PAYMENT_REQUIRED, Json(challenge)).into_response()
+}
+
+/// Extracts an [`X402Authorization`] from a `payment` param, if present and valid.
+fn extract_payment(params: &Value) -> Option<X402Authorization> {
+    let payment = params.get("payment")?;
+    serde_json::from_value(payment.clone()).ok()
+}
+
+/// Strips control characters (keeping ordinary whitespace) from counterparty
+/// text so an injected escape/marker never reaches the brain verbatim.
+fn sanitize_text(text: &str) -> String {
+    text.chars()
+        .filter(|c| !c.is_control() || matches!(c, '\n' | '\r' | '\t'))
+        .collect()
+}
+
+/// Recursively sanitizes every string in a JSON value.
+fn sanitize_value(value: Value) -> Value {
+    match value {
+        Value::String(s) => Value::String(sanitize_text(&s)),
+        Value::Array(items) => Value::Array(items.into_iter().map(sanitize_value).collect()),
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .map(|(k, v)| (k, sanitize_value(v)))
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    use crate::AppConfig;
+    use crate::company::CompanyManifest;
+    use crate::economy::signer::LocalSigner;
+    use crate::economy::x402::X402Challenge;
+    use crate::economy::{MockTinyplaceClient, TinyplaceEconomy};
+    use crate::ports::types::{CompanyId, EventSeq};
+    use crate::ports::{AgentEconomy, CompanyStore};
+    use crate::runtime::RuntimeBuilder;
+    use crate::store::FsCompanyStore;
+
+    const DISCOVERABLE_TOML: &str = r#"
+        [company]
+        name = "Acme SEO"
+        output = "SEO audits"
+        handle = "acme"
+
+        [place]
+        discoverable = true
+        skills = [
+            { id = "seo.audit", price_usd = "25.00", description = "Full audit" },
+            { id = "seo.free", price_usd = "0.00" },
+        ]
+    "#;
+
+    /// Builds an `AppState` with one discoverable company wired to a mock
+    /// economy, rooted at `home`, and returns the client-side signer to sign
+    /// inbound requests with.
+    async fn seeded_state(home: &std::path::Path) -> (AppState, Arc<LocalSigner>) {
+        let manifest: CompanyManifest = toml::from_str(DISCOVERABLE_TOML).unwrap();
+        let id = CompanyId::new("acme");
+        let store: Arc<dyn CompanyStore> = Arc::new(FsCompanyStore::new(home.to_path_buf()));
+        let signer = Arc::new(LocalSigner::generate());
+        let mock = Arc::new(MockTinyplaceClient::new());
+        let economy: Arc<dyn AgentEconomy> = Arc::new(
+            TinyplaceEconomy::new(mock, signer.clone(), store.clone(), id.clone(), None)
+                .going_public(true),
+        );
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id)
+            .with_economy(economy)
+            .build()
+            .await
+            .unwrap();
+
+        let state = AppState::new(AppConfig::default()).with_home(home.to_path_buf());
+        state
+            .registry()
+            .insert(runtime.id().clone(), Arc::new(runtime));
+
+        // The counterparty (client) signs with its own identity.
+        let client_signer = Arc::new(LocalSigner::generate());
+        (state, client_signer)
+    }
+
+    /// Signs a POST body for `/a2a/{handle}` and returns the SIWX header value.
+    fn siwx_header(signer: &LocalSigner, handle: &str, body: &[u8], ts: i64) -> String {
+        let hash = sha256_hex(body);
+        let header = siwx::build_header(
+            signer,
+            &siwx::SiwxPayload {
+                method: "POST",
+                path: &format!("/a2a/{handle}"),
+                timestamp: ts,
+                body_hash: &hash,
+            },
+        );
+        siwx::header_value(&header)
+    }
+
+    fn task_body(skill: &str) -> Vec<u8> {
+        serde_json::to_vec(&JsonRpcRequest::new(
+            "tasks/send",
+            json!({ "skill": skill, "input": { "site": "x.com" } }),
+        ))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn siwx_invalid_inbound_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, _client) = seeded_state(dir.path()).await;
+        let app = router().with_state(state);
+
+        let body = task_body("seo.free");
+        // No Authorization header at all.
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/a2a/acme")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn priced_skill_without_payment_returns_402() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, client) = seeded_state(dir.path()).await;
+        // Our address is the on-disk signer for the company id.
+        let our_id = signer_for(dir.path(), &CompanyId::new("acme"))
+            .await
+            .unwrap()
+            .agent_id();
+        let app = router().with_state(state);
+
+        let body = task_body("seo.audit");
+        let header = siwx_header(&client, "acme", &body, now_secs());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/a2a/acme")
+                    .header(AUTHORIZATION, header)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let challenge: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(challenge["amount"], "25.00");
+        assert_eq!(challenge["recipient"], our_id);
+        assert_eq!(challenge["asset"], "USDC");
+        assert_eq!(challenge["network"], "solana");
+    }
+
+    #[tokio::test]
+    async fn valid_signed_free_task_routes_to_cycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, client) = seeded_state(dir.path()).await;
+        let runtime = state.registry().sole().unwrap();
+        let app = router().with_state(state);
+
+        let body = task_body("seo.free");
+        let header = siwx_header(&client, "acme", &body, now_secs());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/a2a/acme")
+                    .header(AUTHORIZATION, header)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let envelope: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(envelope["jsonrpc"], "2.0");
+        assert!(envelope["result"]["cycleId"].is_string());
+
+        // The A2aTaskReceived event was persisted by the cycle.
+        let stored = runtime
+            .events
+            .read_from(runtime.id(), EventSeq::new(0), 10)
+            .await
+            .unwrap();
+        assert!(stored.iter().any(|e| matches!(
+            &e.event,
+            CompanyEvent::A2aTaskReceived { from, .. } if from == &client.agent_id()
+        )));
+    }
+
+    #[tokio::test]
+    async fn paid_skill_with_valid_x402_routes_and_journals() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, client) = seeded_state(dir.path()).await;
+        let runtime = state.registry().sole().unwrap();
+        let our_id = signer_for(dir.path(), &CompanyId::new("acme"))
+            .await
+            .unwrap()
+            .agent_id();
+        let app = router().with_state(state);
+
+        // Build a valid x402 authorization paying the 25.00 seo.audit price.
+        let challenge = X402Challenge {
+            amount: "25.00".into(),
+            recipient: our_id,
+            asset: "USDC".into(),
+            network: "solana".into(),
+        };
+        let auth = x402::authorize(&client, &challenge, now_secs());
+        let rpc = JsonRpcRequest::new(
+            "tasks/send",
+            json!({ "skill": "seo.audit", "input": {}, "payment": auth }),
+        );
+        let body = serde_json::to_vec(&rpc).unwrap();
+        let header = siwx_header(&client, "acme", &body, now_secs());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/a2a/acme")
+                    .header(AUTHORIZATION, header)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        // The inbound receipt was journaled as x402.in.
+        let record = runtime.store.load(runtime.id()).await.unwrap().unwrap();
+        let inflow = record
+            .ledger
+            .iter()
+            .find(|e| e.kind == "x402.in")
+            .expect("x402.in row");
+        assert_eq!(inflow.amount_usd, 25.0);
+    }
+
+    #[tokio::test]
+    async fn paid_skill_with_wrong_recipient_is_rechallenged() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, client) = seeded_state(dir.path()).await;
+        let app = router().with_state(state);
+
+        // A well-formed, correctly-signed authorization that pays SOMEONE ELSE
+        // (a self-dealing payer) must not buy priced work from this company.
+        let challenge = X402Challenge {
+            amount: "25.00".into(),
+            recipient: client.agent_id(), // not our company's agent id
+            asset: "USDC".into(),
+            network: "solana".into(),
+        };
+        let auth = x402::authorize(&client, &challenge, now_secs());
+        let rpc = JsonRpcRequest::new(
+            "tasks/send",
+            json!({ "skill": "seo.audit", "input": {}, "payment": auth }),
+        );
+        let body = serde_json::to_vec(&rpc).unwrap();
+        let header = siwx_header(&client, "acme", &body, now_secs());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/a2a/acme")
+                    .header(AUTHORIZATION, header)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Re-challenged with a 402, not served for free.
+        assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+    }
+
+    #[tokio::test]
+    async fn replayed_signature_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, client) = seeded_state(dir.path()).await;
+        let app = router().with_state(state);
+
+        let body = task_body("seo.free");
+        let header = siwx_header(&client, "acme", &body, now_secs());
+
+        let build = || {
+            Request::builder()
+                .method("POST")
+                .uri("/a2a/acme")
+                .header(AUTHORIZATION, header.clone())
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from(body.clone()))
+                .unwrap()
+        };
+
+        let first = app.clone().oneshot(build()).await.unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+        // The identical signature is rejected on replay.
+        let second = app.oneshot(build()).await.unwrap();
+        assert_eq!(second.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn promptguard_sanitizes_control_chars_before_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, client) = seeded_state(dir.path()).await;
+        let runtime = state.registry().sole().unwrap();
+        let app = router().with_state(state);
+
+        // A bell (0x07) and ESC (0x1b) must be stripped; newline survives.
+        let rpc = JsonRpcRequest::new(
+            "tasks/send",
+            json!({ "skill": "seo.free", "note": "hi\u{0007}there\u{001b}\nok" }),
+        );
+        let body = serde_json::to_vec(&rpc).unwrap();
+        let header = siwx_header(&client, "acme", &body, now_secs());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/a2a/acme")
+                    .header(AUTHORIZATION, header)
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let stored = runtime
+            .events
+            .read_from(runtime.id(), EventSeq::new(0), 10)
+            .await
+            .unwrap();
+        let task = stored
+            .iter()
+            .find_map(|e| match &e.event {
+                CompanyEvent::A2aTaskReceived { task, .. } => Some(task.clone()),
+                _ => None,
+            })
+            .expect("a2a event");
+        let note = task["note"].as_str().unwrap();
+        assert_eq!(note, "hithere\nok");
+    }
+
+    #[tokio::test]
+    async fn well_known_and_skill_md_bodies() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, _client) = seeded_state(dir.path()).await;
+        let app = router().with_state(state);
+
+        // The platform well-known returns the card with the a2a endpoint.
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/companies/acme/.well-known/agent-card.json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let card: AgentCard = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(card.endpoint, "http://127.0.0.1:8080/a2a/acme");
+        assert!(card.skills.contains(&"seo.audit".to_string()));
+
+        // skill.md lists each priced skill line.
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/a2a/acme/skill.md")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("text/markdown; charset=utf-8")
+        );
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let md = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(md.contains("`seo.audit` — 25.00 USDC (solana)"));
+    }
+}

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -30,7 +30,8 @@ impl ApiError {
             OpenCompanyError::CompanyNotFound(_) => StatusCode::NOT_FOUND,
             OpenCompanyError::ManifestInvalid { .. }
             | OpenCompanyError::ManifestParse(_, _)
-            | OpenCompanyError::MissingManifest(_) => StatusCode::BAD_REQUEST,
+            | OpenCompanyError::MissingManifest(_)
+            | OpenCompanyError::InvalidRequest(_) => StatusCode::BAD_REQUEST,
             OpenCompanyError::LifecycleConflict(_) => StatusCode::CONFLICT,
             OpenCompanyError::ToolNotGranted(_) => StatusCode::FORBIDDEN,
             OpenCompanyError::BudgetExceeded(_) => StatusCode::PAYMENT_REQUIRED,

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -35,6 +35,12 @@ impl ApiError {
             OpenCompanyError::LifecycleConflict(_) => StatusCode::CONFLICT,
             OpenCompanyError::ToolNotGranted(_) => StatusCode::FORBIDDEN,
             OpenCompanyError::BudgetExceeded(_) => StatusCode::PAYMENT_REQUIRED,
+            // tiny.place transport: an unreachable backend degrades to 503 so
+            // callers retry; any other protocol failure is an upstream 502.
+            OpenCompanyError::Tinyplace { code, .. } if code == "unreachable" => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
+            OpenCompanyError::Tinyplace { .. } => StatusCode::BAD_GATEWAY,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -76,5 +82,15 @@ mod test {
 
         let other = ApiError(OpenCompanyError::Store("disk full".into()));
         assert_eq!(other.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn maps_tinyplace_transport_to_503_and_502() {
+        let unreachable = ApiError(OpenCompanyError::tinyplace("unreachable", "offline"));
+        assert_eq!(unreachable.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(unreachable.0.code(), "tinyplace_unreachable");
+
+        let upstream = ApiError(OpenCompanyError::tinyplace("http_500", "boom"));
+        assert_eq!(upstream.status(), StatusCode::BAD_GATEWAY);
     }
 }

--- a/src/server/feedback.rs
+++ b/src/server/feedback.rs
@@ -1,0 +1,259 @@
+//! Operator HTTP surface for the feedback loop.
+//!
+//! `POST /api/v1/companies/{id}/feedback` (and the single-company alias
+//! `POST /api/v1/company/feedback`) captures a feedback item and runs the
+//! scrub-then-preview gate. The response never leaks a blocked value: a scrub
+//! abort returns `{ blocked: true, reason }`, a `preview` returns the byte-exact
+//! final body, and a satisfied consent returns the filed issue URL (or a
+//! prefilled manual link when no token is configured).
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::routing::post;
+use axum::{Json, Router};
+use serde::Deserialize;
+
+use crate::AppState;
+use crate::company::runtime::CompanyRuntime;
+use crate::error::OpenCompanyError;
+use crate::feedback::service::FeedbackResponse;
+use crate::feedback::types::FeedbackInput;
+use crate::ports::types::CompanyId;
+use crate::server::error::ApiError;
+use crate::server::operator::OperatorAuth;
+
+/// Builds the feedback route fragment, merged into the main router.
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/api/v1/companies/{id}/feedback", post(submit))
+        .route("/api/v1/company/feedback", post(submit_single))
+}
+
+/// The feedback submission body: the capture input plus a `preview` flag.
+#[derive(Debug, Deserialize)]
+struct FeedbackRequest {
+    /// The capture fields (category, note, work_ref, template).
+    #[serde(flatten)]
+    input: FeedbackInput,
+    /// When true, return the exact final body instead of filing.
+    #[serde(default)]
+    preview: bool,
+}
+
+fn lookup(state: &AppState, id: &str) -> Result<Arc<CompanyRuntime>, ApiError> {
+    state
+        .registry()
+        .get(&CompanyId::new(id))
+        .ok_or_else(|| ApiError(OpenCompanyError::CompanyNotFound(id.to_string())))
+}
+
+fn sole(state: &AppState) -> Result<Arc<CompanyRuntime>, ApiError> {
+    state.registry().sole().ok_or_else(|| {
+        ApiError(OpenCompanyError::CompanyNotFound(
+            "single-company".to_string(),
+        ))
+    })
+}
+
+async fn run(
+    runtime: Arc<CompanyRuntime>,
+    body: FeedbackRequest,
+) -> Result<Json<FeedbackResponse>, ApiError> {
+    runtime.ensure_running().await?;
+    let response = runtime.submit_feedback(body.input, body.preview).await?;
+    Ok(Json(response))
+}
+
+/// `POST /api/v1/companies/{id}/feedback`.
+async fn submit(
+    _auth: OperatorAuth,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<FeedbackRequest>,
+) -> Result<Json<FeedbackResponse>, ApiError> {
+    run(lookup(&state, &id)?, body).await
+}
+
+/// `POST /api/v1/company/feedback` (single-company alias).
+async fn submit_single(
+    _auth: OperatorAuth,
+    State(state): State<AppState>,
+    Json(body): Json<FeedbackRequest>,
+) -> Result<Json<FeedbackResponse>, ApiError> {
+    run(sole(&state)?, body).await
+}
+
+#[cfg(test)]
+mod test {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::company::CompanyManifest;
+    use crate::feedback::MockGitHubClient;
+    use crate::feedback::types::ConsentMode;
+    use crate::ports::SecretStore;
+    use crate::ports::types::SecretValue;
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+    use crate::store::FsSecretStore;
+    use crate::{AppConfig, AppState};
+
+    fn home() -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "opencompany-feedback-{}",
+            crate::ports::generate_id()
+        ))
+    }
+
+    fn manifest() -> CompanyManifest {
+        toml::from_str(
+            r#"
+            [company]
+            name = "Acme"
+            handle = "acme"
+            [[agent]]
+            id = "dana_roe"
+            role = "Analyst"
+            [policy]
+            mode = "full"
+            "#,
+        )
+        .unwrap()
+    }
+
+    /// Builds state with a company wired for `auto` consent and a mock GitHub
+    /// client, plus a seeded secret to exercise the scrub-abort path.
+    async fn state_with_company(home: &std::path::Path, github: Arc<MockGitHubClient>) -> AppState {
+        let id = CompanyId::new("acme");
+        // Seed a secret whose value the scrubber must abort on if it appears.
+        let secrets = FsSecretStore::new(home.to_path_buf());
+        secrets
+            .set(&id, "github_token", SecretValue("ghp_LEAKEDSECRET".into()))
+            .await
+            .unwrap();
+
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest())
+            .with_id(id.clone())
+            .with_github(github)
+            .with_feedback_consent(ConsentMode::Auto)
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, Arc::new(runtime));
+        state
+    }
+
+    async fn post_json(app: &Router, uri: &str, body: &str) -> (StatusCode, serde_json::Value) {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(uri)
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+        (status, value)
+    }
+
+    // The offline end-to-end path: capture → scrub (secret aborts, email
+    // redacted) → preview → mock-file with dedupe.
+    #[tokio::test]
+    async fn capture_scrub_preview_file_and_dedupe() {
+        let home = home();
+        let github = Arc::new(MockGitHubClient::new());
+        let state = state_with_company(&home, github.clone()).await;
+        let app = router(state);
+
+        // 1. A report containing the seeded secret is blocked (scrub fail-closed)
+        //    and nothing is filed.
+        let (status, value) = post_json(
+            &app,
+            "/api/v1/company/feedback",
+            r#"{"category":"bug","note":"token ghp_LEAKEDSECRET broke the run"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(value["blocked"], true);
+        assert_eq!(value["filed"], false);
+        assert!(github.created().is_empty());
+
+        // 2. A clean report with an email, in preview mode, returns the byte-exact
+        //    final body with the email redacted and nothing filed.
+        let (status, value) = post_json(
+            &app,
+            "/api/v1/company/feedback",
+            r#"{"category":"wrong-output","note":"email dana@acme.co bounced","preview":true}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(value["filed"], false);
+        let preview = value["preview_body"].as_str().expect("preview body");
+        assert!(preview.contains("⟨redacted:email⟩"), "got {preview}");
+        assert!(!preview.contains("dana@acme.co"));
+        // Signed with the company @handle for provenance.
+        assert!(preview.contains("— filed by @acme"));
+        assert!(github.created().is_empty());
+
+        // 3. Filing (auto consent) creates one issue with the agent-filed label.
+        let (status, value) = post_json(
+            &app,
+            "/api/v1/company/feedback",
+            r#"{"category":"wrong-output","note":"the invoice total was wrong"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(value["filed"], true);
+        assert!(value["issue_url"].is_string());
+        let created = github.created();
+        assert_eq!(created.len(), 1);
+        assert!(
+            created[0]
+                .labels
+                .contains(&"source/agent-filed".to_string())
+        );
+
+        // 4. A second filing with the same title dedupes: it comments, does not
+        //    create a duplicate.
+        let (status, value) = post_json(
+            &app,
+            "/api/v1/company/feedback",
+            r#"{"category":"wrong-output","note":"the invoice total was wrong"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(value["deduped"], true);
+        assert_eq!(github.created().len(), 1);
+        assert_eq!(github.comments().len(), 1);
+
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    #[tokio::test]
+    async fn feedback_for_unknown_company_is_404() {
+        let home = home();
+        let github = Arc::new(MockGitHubClient::new());
+        let state = state_with_company(&home, github).await;
+        let app = router(state);
+
+        let (status, value) = post_json(
+            &app,
+            "/api/v1/companies/ghost/feedback",
+            r#"{"category":"bug","note":"x"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(value["code"], "company_not_found");
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+}

--- a/src/server/feedback.rs
+++ b/src/server/feedback.rs
@@ -10,6 +10,7 @@
 use std::sync::Arc;
 
 use axum::extract::{Path, State};
+use axum::response::{IntoResponse, Response};
 use axum::routing::post;
 use axum::{Json, Router};
 use serde::Deserialize;
@@ -22,6 +23,7 @@ use crate::feedback::types::FeedbackInput;
 use crate::ports::types::CompanyId;
 use crate::server::error::ApiError;
 use crate::server::operator::OperatorAuth;
+use crate::server::platform_auth::{PlatformOrOperatorAuth, authorize_address};
 
 /// Builds the feedback route fragment, merged into the main router.
 pub fn router() -> Router<AppState> {
@@ -66,13 +68,24 @@ async fn run(
 }
 
 /// `POST /api/v1/companies/{id}/feedback`.
+///
+/// A per-company route: like every other `/companies/{id}/…` handler it takes
+/// platform-or-operator auth and enforces tenant ownership, so one tenant can
+/// never file feedback (or trigger issue-filing) against another's company.
 async fn submit(
-    _auth: OperatorAuth,
+    PlatformOrOperatorAuth(claims): PlatformOrOperatorAuth,
     State(state): State<AppState>,
     Path(id): Path<String>,
     Json(body): Json<FeedbackRequest>,
-) -> Result<Json<FeedbackResponse>, ApiError> {
-    run(lookup(&state, &id)?, body).await
+) -> Result<Json<FeedbackResponse>, Response> {
+    let company = CompanyId::new(&id);
+    if let Some(resp) = authorize_address(&state, &claims, &company) {
+        return Err(resp);
+    }
+    let runtime = lookup(&state, &id).map_err(IntoResponse::into_response)?;
+    run(runtime, body)
+        .await
+        .map_err(IntoResponse::into_response)
 }
 
 /// `POST /api/v1/company/feedback` (single-company alias).

--- a/src/server/feedback.rs
+++ b/src/server/feedback.rs
@@ -218,7 +218,9 @@ mod test {
         assert!(preview.contains("— filed by @acme"));
         assert!(github.created().is_empty());
 
-        // 3. Filing (auto consent) creates one issue with the agent-filed label.
+        // 3. Filing (auto consent) creates one issue. The `POST .../feedback`
+        //    route is operator-driven, so it carries the `source/operator`
+        //    label from the four-axis triage taxonomy.
         let (status, value) = post_json(
             &app,
             "/api/v1/company/feedback",
@@ -230,11 +232,9 @@ mod test {
         assert!(value["issue_url"].is_string());
         let created = github.created();
         assert_eq!(created.len(), 1);
-        assert!(
-            created[0]
-                .labels
-                .contains(&"source/agent-filed".to_string())
-        );
+        assert!(created[0].labels.contains(&"source/operator".to_string()));
+        assert!(created[0].labels.contains(&"sev/annoyance".to_string()));
+        assert!(created[0].labels.contains(&"type/wrong-output".to_string()));
 
         // 4. A second filing with the same title dedupes: it comments, does not
         //    create a duplicate.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,7 +3,10 @@ pub mod a2a;
 mod error;
 pub mod feedback;
 pub mod operator;
+pub mod platform_auth;
+pub mod provision;
 mod routes;
+pub mod webhook;
 
 pub use error::ApiError;
 pub use routes::{router, serve};

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,4 +1,5 @@
 mod error;
+pub mod feedback;
 pub mod operator;
 mod routes;
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "tinyplace")]
+pub mod a2a;
 mod error;
 pub mod feedback;
 pub mod operator;

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -142,6 +142,20 @@ async fn run_chat(
     message: ChatMessage,
 ) -> Result<Json<ChatResponse>, ApiError> {
     runtime.ensure_running().await?;
+    // Operator-chat feedback intent: a complaint phrase ("that was wrong — flag
+    // it") captures a feedback item alongside the normal cycle. Neutral chat
+    // carries no intent, so ordinary messages are untouched.
+    if let Some(category) = crate::feedback::detect_chat_intent(&message.text) {
+        runtime
+            .capture_feedback(crate::feedback::FeedbackInput {
+                category,
+                note: message.text.clone(),
+                work_ref: None,
+                template_name: None,
+                template_version: None,
+            })
+            .await?;
+    }
     let report = runtime
         .run_cycle(vec![CompanyEvent::OperatorMessage { text: message.text }])
         .await?;
@@ -187,6 +201,11 @@ async fn list_approvals_single(
 }
 
 /// The operator's resolution of a parked approval.
+///
+/// `verdict` stays `approve`/`deny`; the api.md wire enum gains no `edit`
+/// verdict. Instead, an optional `amended_payload` paired with an `approve`
+/// verdict routes to the approve-with-edit path. Pairing `amended_payload` with
+/// `deny` is a contradiction and is rejected as a 400.
 #[derive(Debug, Deserialize)]
 struct ResolveApproval {
     /// `approve` or `deny`.
@@ -195,6 +214,9 @@ struct ResolveApproval {
     #[allow(dead_code)]
     #[serde(default)]
     note: Option<String>,
+    /// An optional payload edit; overlaid onto the parked effect on `approve`.
+    #[serde(default)]
+    amended_payload: Option<serde_json::Value>,
 }
 
 async fn run_resolve(
@@ -207,9 +229,20 @@ async fn run_resolve(
         kind: ActorKind::Operator,
         id: "operator".to_string(),
     };
-    let report = runtime
-        .resolve_approval(&ApprovalId::new(approval_id), body.verdict, actor)
-        .await?;
+    let id = ApprovalId::new(approval_id);
+    let report = match (body.verdict, body.amended_payload) {
+        (Verdict::Approve, Some(payload)) => {
+            runtime
+                .resolve_approval_amended(&id, payload, actor)
+                .await?
+        }
+        (Verdict::Deny, Some(_)) => {
+            return Err(ApiError(OpenCompanyError::InvalidRequest(
+                "amended_payload cannot accompany a deny verdict".to_string(),
+            )));
+        }
+        (verdict, None) => runtime.resolve_approval(&id, verdict, actor).await?,
+    };
     Ok(Json(ChatResponse {
         responses: report.responses,
     }))
@@ -436,6 +469,61 @@ mod test {
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(value.as_array().unwrap().len(), 0);
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    #[tokio::test]
+    async fn amended_approve_resolves_and_returns_responses() {
+        let home = home();
+        let state = state_with_company(&home, "running").await;
+        let app = router(state);
+
+        // An `approve` verdict carrying an amended payload routes to the
+        // approve-with-edit path. Even against an unknown id it resolves
+        // cleanly (nothing to execute) and the follow-up cycle replies.
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/company/approvals/missing")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"verdict":"approve","amended_payload":{"text":"edited"}}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(value["responses"].is_array());
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    #[tokio::test]
+    async fn deny_with_amended_payload_is_400() {
+        let home = home();
+        let state = state_with_company(&home, "running").await;
+        let app = router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/company/approvals/missing")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"verdict":"deny","amended_payload":{"text":"edited"}}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["code"], "invalid_request");
         tokio::fs::remove_dir_all(&home).await.ok();
     }
 

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -31,8 +31,10 @@ use crate::error::OpenCompanyError;
 use crate::ports::types::{
     Actor, ActorKind, ApprovalId, CompanyEvent, CompanyId, OutboundMessage, Verdict,
 };
-use crate::runtime::types::{ApprovalSummary, CompanyStatus};
+use crate::runtime::types::{ApprovalSummary, CompanyStatus, CycleReport};
 use crate::server::error::ApiError;
+use crate::server::platform_auth::{PlatformOrOperatorAuth, authorize_address};
+use crate::server::provision::{emit_cycle_webhooks, emit_feedback_webhook};
 
 /// Builds the operator route fragment, merged into the main router.
 pub fn router() -> Router<AppState> {
@@ -100,12 +102,26 @@ fn sole(state: &AppState) -> Result<Arc<CompanyRuntime>, ApiError> {
 }
 
 /// `GET /api/v1/companies` — status of every registered company.
+///
+/// In platform mode a tenant token without the `platform` scope sees only the
+/// companies it owns; a platform-scope token (and the prosumer operator) sees
+/// all of them.
 async fn list_companies(
-    _auth: OperatorAuth,
+    PlatformOrOperatorAuth(claims): PlatformOrOperatorAuth,
     State(state): State<AppState>,
 ) -> Result<Json<Vec<CompanyStatus>>, ApiError> {
+    // A scoped tenant is confined to the companies it owns.
+    let tenant_filter = claims
+        .as_ref()
+        .filter(|c| !c.has_platform_scope())
+        .map(|c| c.tenant.clone());
     let mut out = Vec::new();
     for id in state.registry().list() {
+        if let Some(tenant) = &tenant_filter
+            && state.owner_of(&id).as_deref() != Some(tenant.as_str())
+        {
+            continue;
+        }
         if let Some(runtime) = state.registry().get(&id) {
             out.push(runtime.status().await?);
         }
@@ -115,12 +131,20 @@ async fn list_companies(
 
 /// `GET /api/v1/companies/{id}` — one company's status.
 async fn company_status(
-    _auth: OperatorAuth,
+    PlatformOrOperatorAuth(claims): PlatformOrOperatorAuth,
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> Result<Json<CompanyStatus>, ApiError> {
-    let runtime = lookup(&state, &id)?;
-    Ok(Json(runtime.status().await?))
+) -> Result<Json<CompanyStatus>, Response> {
+    let company = CompanyId::new(&id);
+    if let Some(resp) = authorize_address(&state, &claims, &company) {
+        return Err(resp);
+    }
+    let runtime = lookup(&state, &id).map_err(IntoResponse::into_response)?;
+    runtime
+        .status()
+        .await
+        .map(Json)
+        .map_err(|e| ApiError(e).into_response())
 }
 
 /// The operator's chat request body.
@@ -137,15 +161,18 @@ struct ChatResponse {
     responses: Vec<OutboundMessage>,
 }
 
+/// Runs one operator-chat cycle, returning the report and, when a complaint
+/// intent captured feedback, the note that was captured (so the caller can emit
+/// the `feedback.created` webhook).
 async fn run_chat(
     runtime: Arc<CompanyRuntime>,
     message: ChatMessage,
-) -> Result<Json<ChatResponse>, ApiError> {
+) -> Result<(CycleReport, Option<String>), ApiError> {
     runtime.ensure_running().await?;
     // Operator-chat feedback intent: a complaint phrase ("that was wrong — flag
     // it") captures a feedback item alongside the normal cycle. Neutral chat
     // carries no intent, so ordinary messages are untouched.
-    if let Some(category) = crate::feedback::detect_chat_intent(&message.text) {
+    let feedback_note = if let Some(category) = crate::feedback::detect_chat_intent(&message.text) {
         runtime
             .capture_feedback(crate::feedback::FeedbackInput {
                 category,
@@ -155,10 +182,28 @@ async fn run_chat(
                 template_version: None,
             })
             .await?;
-    }
+        Some(message.text.clone())
+    } else {
+        None
+    };
     let report = runtime
         .run_cycle(vec![CompanyEvent::OperatorMessage { text: message.text }])
         .await?;
+    Ok((report, feedback_note))
+}
+
+/// Runs a chat cycle and emits any implied webhooks, rendering the responses.
+async fn chat_and_emit(
+    state: &AppState,
+    id: &CompanyId,
+    runtime: Arc<CompanyRuntime>,
+    message: ChatMessage,
+) -> Result<Json<ChatResponse>, ApiError> {
+    let (report, feedback_note) = run_chat(runtime, message).await?;
+    emit_cycle_webhooks(state, id, &report).await;
+    if let Some(note) = feedback_note {
+        emit_feedback_webhook(state, id, &note).await;
+    }
     Ok(Json(ChatResponse {
         responses: report.responses,
     }))
@@ -166,12 +211,19 @@ async fn run_chat(
 
 /// `POST /api/v1/companies/{id}/chat`.
 async fn operator_chat(
-    _auth: OperatorAuth,
+    PlatformOrOperatorAuth(claims): PlatformOrOperatorAuth,
     State(state): State<AppState>,
     Path(id): Path<String>,
     Json(message): Json<ChatMessage>,
-) -> Result<Json<ChatResponse>, ApiError> {
-    run_chat(lookup(&state, &id)?, message).await
+) -> Result<Json<ChatResponse>, Response> {
+    let company = CompanyId::new(&id);
+    if let Some(resp) = authorize_address(&state, &claims, &company) {
+        return Err(resp);
+    }
+    let runtime = lookup(&state, &id).map_err(IntoResponse::into_response)?;
+    chat_and_emit(&state, &company, runtime, message)
+        .await
+        .map_err(IntoResponse::into_response)
 }
 
 /// `POST /api/v1/company/chat` (single-company alias).
@@ -180,16 +232,23 @@ async fn operator_chat_single(
     State(state): State<AppState>,
     Json(message): Json<ChatMessage>,
 ) -> Result<Json<ChatResponse>, ApiError> {
-    run_chat(sole(&state)?, message).await
+    let runtime = sole(&state)?;
+    let id = runtime.id().clone();
+    chat_and_emit(&state, &id, runtime, message).await
 }
 
 /// `GET /api/v1/companies/{id}/approvals`.
 async fn list_approvals(
-    _auth: OperatorAuth,
+    PlatformOrOperatorAuth(claims): PlatformOrOperatorAuth,
     State(state): State<AppState>,
     Path(id): Path<String>,
-) -> Result<Json<Vec<ApprovalSummary>>, ApiError> {
-    Ok(Json(lookup(&state, &id)?.pending_approvals()))
+) -> Result<Json<Vec<ApprovalSummary>>, Response> {
+    let company = CompanyId::new(&id);
+    if let Some(resp) = authorize_address(&state, &claims, &company) {
+        return Err(resp);
+    }
+    let runtime = lookup(&state, &id).map_err(IntoResponse::into_response)?;
+    Ok(Json(runtime.pending_approvals()))
 }
 
 /// `GET /api/v1/company/approvals` (single-company alias).
@@ -220,6 +279,8 @@ struct ResolveApproval {
 }
 
 async fn run_resolve(
+    state: &AppState,
+    company: &CompanyId,
     runtime: Arc<CompanyRuntime>,
     approval_id: String,
     body: ResolveApproval,
@@ -243,6 +304,7 @@ async fn run_resolve(
         }
         (verdict, None) => runtime.resolve_approval(&id, verdict, actor).await?,
     };
+    emit_cycle_webhooks(state, company, &report).await;
     Ok(Json(ChatResponse {
         responses: report.responses,
     }))
@@ -250,12 +312,19 @@ async fn run_resolve(
 
 /// `POST /api/v1/companies/{id}/approvals/{aid}`.
 async fn resolve_approval(
-    _auth: OperatorAuth,
+    PlatformOrOperatorAuth(claims): PlatformOrOperatorAuth,
     State(state): State<AppState>,
     Path((id, aid)): Path<(String, String)>,
     Json(body): Json<ResolveApproval>,
-) -> Result<Json<ChatResponse>, ApiError> {
-    run_resolve(lookup(&state, &id)?, aid, body).await
+) -> Result<Json<ChatResponse>, Response> {
+    let company = CompanyId::new(&id);
+    if let Some(resp) = authorize_address(&state, &claims, &company) {
+        return Err(resp);
+    }
+    let runtime = lookup(&state, &id).map_err(IntoResponse::into_response)?;
+    run_resolve(&state, &company, runtime, aid, body)
+        .await
+        .map_err(IntoResponse::into_response)
 }
 
 /// `POST /api/v1/company/approvals/{aid}` (single-company alias).
@@ -265,7 +334,9 @@ async fn resolve_approval_single(
     Path(aid): Path<String>,
     Json(body): Json<ResolveApproval>,
 ) -> Result<Json<ChatResponse>, ApiError> {
-    run_resolve(sole(&state)?, aid, body).await
+    let runtime = sole(&state)?;
+    let id = runtime.id().clone();
+    run_resolve(&state, &id, runtime, aid, body).await
 }
 
 #[cfg(test)]

--- a/src/server/platform_auth.rs
+++ b/src/server/platform_auth.rs
@@ -1,0 +1,447 @@
+//! Platform authentication: a tenant-scoped bearer credential distinct from the
+//! prosumer operator token.
+//!
+//! The operator token (`AppConfig::operator_token`) authorizes a single
+//! company's owner. Platform mode adds a *second* surface: a platform-issued
+//! bearer whose verified [`PlatformClaims`] carry a `tenant`, a set of `scopes`,
+//! and an optional company allow-list. Provisioning and suspension require the
+//! `platform` scope; every tenant token is confined to the companies it owns, so
+//! it can never cross tenants.
+//!
+//! The verification seam is [`PlatformVerifier`]. The default build ships an
+//! offline [`StaticPlatformVerifier`] (a shared platform secret plus unsigned,
+//! structured tenant tokens) so the scope-gate and cross-tenant logic are fully
+//! covered by `cargo test`. Real signed-JWT verification is added under the
+//! `platform-jwt` feature; the gate logic here is verifier-agnostic.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use axum::extract::FromRequestParts;
+use axum::http::StatusCode;
+use axum::http::header::AUTHORIZATION;
+use axum::http::request::Parts;
+use axum::response::{IntoResponse, Response};
+use axum::{Json, http::HeaderMap};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::AppState;
+use crate::error::OpenCompanyError;
+use crate::ports::types::CompanyId;
+
+/// The `platform` scope, required for provisioning and suspension.
+pub const SCOPE_PLATFORM: &str = "platform";
+
+/// Claims a verified platform token carries.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PlatformClaims {
+    /// The owning tenant, e.g. `tenant:acme`.
+    pub tenant: String,
+    /// The granted scopes, e.g. `{"operator", "platform"}`.
+    #[serde(default)]
+    pub scopes: HashSet<String>,
+    /// An explicit company allow-list. `None` means "any company this tenant
+    /// owns" (ownership is enforced separately against the registry map).
+    #[serde(default)]
+    pub companies: Option<HashSet<String>>,
+}
+
+impl PlatformClaims {
+    /// Whether these claims carry the `platform` scope (provisioning/suspension).
+    pub fn has_platform_scope(&self) -> bool {
+        self.scopes.contains(SCOPE_PLATFORM)
+    }
+
+    /// Whether the token's own allow-list permits addressing `id`. `None`
+    /// allow-list permits any id (ownership is checked separately).
+    pub fn may_address(&self, id: &CompanyId) -> bool {
+        match &self.companies {
+            Some(allow) => allow.contains(id.as_ref()),
+            None => true,
+        }
+    }
+}
+
+/// The verification seam: turns a bearer string into [`PlatformClaims`] or an
+/// error. Implementations are offline-testable; only real JWT signature
+/// verification is feature-gated.
+pub trait PlatformVerifier: Send + Sync {
+    /// Verifies `bearer` and returns its claims, or an error if invalid.
+    fn verify(&self, bearer: &str) -> crate::Result<PlatformClaims>;
+}
+
+/// An offline/dev verifier. A bearer equal to `platform_secret` is a
+/// platform-scope token; a `oc_tenant.<base64url(json)>` bearer carries
+/// structured (UNSIGNED) tenant claims. Clearly insecure — for local use and
+/// tests. Real signed verification is `platform-jwt`.
+#[derive(Clone)]
+pub struct StaticPlatformVerifier {
+    /// The shared secret that grants a full platform-scope token.
+    pub platform_secret: String,
+}
+
+impl StaticPlatformVerifier {
+    /// The prefix marking an unsigned structured tenant token.
+    pub const TENANT_PREFIX: &'static str = "oc_tenant.";
+
+    /// Builds a verifier around a shared platform secret.
+    pub fn new(platform_secret: impl Into<String>) -> Self {
+        Self {
+            platform_secret: platform_secret.into(),
+        }
+    }
+
+    /// Encodes structured claims into a dev tenant token (test helper).
+    pub fn tenant_token(claims: &PlatformClaims) -> String {
+        let json = serde_json::to_vec(claims).expect("claims serialize");
+        format!("{}{}", Self::TENANT_PREFIX, b64url_encode(&json))
+    }
+}
+
+impl PlatformVerifier for StaticPlatformVerifier {
+    fn verify(&self, bearer: &str) -> crate::Result<PlatformClaims> {
+        if bearer == self.platform_secret {
+            return Ok(PlatformClaims {
+                tenant: "tenant:platform".to_string(),
+                scopes: HashSet::from([SCOPE_PLATFORM.to_string(), "operator".to_string()]),
+                companies: None,
+            });
+        }
+        if let Some(encoded) = bearer.strip_prefix(Self::TENANT_PREFIX) {
+            let bytes = b64url_decode(encoded).ok_or_else(|| {
+                OpenCompanyError::InvalidRequest("malformed platform token".to_string())
+            })?;
+            let claims: PlatformClaims = serde_json::from_slice(&bytes)?;
+            return Ok(claims);
+        }
+        Err(OpenCompanyError::InvalidRequest(
+            "unrecognized token".to_string(),
+        ))
+    }
+}
+
+/// A real signed-JWT verifier (HS256), gated behind `platform-jwt`. The claim
+/// shape mirrors [`PlatformClaims`] (`tenant`, `scopes`, `companies`); `exp` is
+/// honored when present. The offline [`StaticPlatformVerifier`] covers the
+/// scope-gate logic without this feature.
+#[cfg(feature = "platform-jwt")]
+pub struct JwtPlatformVerifier {
+    secret: String,
+}
+
+#[cfg(feature = "platform-jwt")]
+impl JwtPlatformVerifier {
+    /// Builds an HS256 verifier around a shared signing secret.
+    pub fn new(secret: impl Into<String>) -> Self {
+        Self {
+            secret: secret.into(),
+        }
+    }
+}
+
+#[cfg(feature = "platform-jwt")]
+impl PlatformVerifier for JwtPlatformVerifier {
+    fn verify(&self, bearer: &str) -> crate::Result<PlatformClaims> {
+        use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
+
+        let mut validation = Validation::new(Algorithm::HS256);
+        // Callers may omit registered claims; only signature (and `exp` when
+        // present) matter for the platform gate.
+        validation.required_spec_claims.clear();
+        validation.validate_exp = true;
+
+        let token = decode::<PlatformClaims>(
+            bearer,
+            &DecodingKey::from_secret(self.secret.as_bytes()),
+            &validation,
+        )
+        .map_err(|e| OpenCompanyError::InvalidRequest(format!("invalid jwt: {e}")))?;
+        Ok(token.claims)
+    }
+}
+
+/// Platform auth configuration held on [`AppConfig`](crate::AppConfig): the
+/// verifier plus optional expected issuer/audience (used by the JWT verifier).
+#[derive(Clone)]
+pub struct PlatformAuthConfig {
+    /// The token verifier.
+    pub verifier: Arc<dyn PlatformVerifier>,
+}
+
+impl PlatformAuthConfig {
+    /// Builds a config around a verifier.
+    pub fn new(verifier: Arc<dyn PlatformVerifier>) -> Self {
+        Self { verifier }
+    }
+}
+
+impl std::fmt::Debug for PlatformAuthConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PlatformAuthConfig").finish_non_exhaustive()
+    }
+}
+
+/// Extracts the bearer token from the `Authorization` header.
+fn bearer(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+}
+
+fn unauthorized() -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({ "error": "unauthorized", "code": "unauthorized" })),
+    )
+        .into_response()
+}
+
+pub(crate) fn forbidden() -> Response {
+    (
+        StatusCode::FORBIDDEN,
+        Json(json!({ "error": "forbidden", "code": "forbidden" })),
+    )
+        .into_response()
+}
+
+/// An extractor that accepts either a platform token (platform mode) or the
+/// prosumer operator token (prosumer mode).
+///
+/// - Platform mode (`platform_auth` configured): a valid platform/tenant token
+///   yields `Some(claims)`; a missing or invalid token is `401`.
+/// - Prosumer mode: mirrors [`OperatorAuth`](crate::server::operator) — dev mode
+///   (no `operator_token`) allows the call with `None`; a configured token must
+///   match, else `401`.
+pub struct PlatformOrOperatorAuth(pub Option<PlatformClaims>);
+
+impl FromRequestParts<AppState> for PlatformOrOperatorAuth {
+    type Rejection = Response;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        if let Some(platform) = state.config().platform_auth.as_ref() {
+            let token = bearer(&parts.headers).ok_or_else(unauthorized)?;
+            let claims = platform
+                .verifier
+                .verify(token)
+                .map_err(|_| unauthorized())?;
+            return Ok(Self(Some(claims)));
+        }
+        // Prosumer mode: operator-token semantics.
+        match state.config().operator_token.as_deref() {
+            None => Ok(Self(None)),
+            Some(expected) if bearer(&parts.headers) == Some(expected) => Ok(Self(None)),
+            Some(_) => Err(unauthorized()),
+        }
+    }
+}
+
+/// An extractor that requires the `platform` scope in platform mode. In prosumer
+/// mode it falls back to operator-token semantics (the single-tenant operator is
+/// the platform admin).
+pub struct PlatformScope(pub Option<PlatformClaims>);
+
+impl FromRequestParts<AppState> for PlatformScope {
+    type Rejection = Response;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        if let Some(platform) = state.config().platform_auth.as_ref() {
+            let token = bearer(&parts.headers).ok_or_else(unauthorized)?;
+            let claims = platform
+                .verifier
+                .verify(token)
+                .map_err(|_| unauthorized())?;
+            if claims.has_platform_scope() {
+                return Ok(Self(Some(claims)));
+            }
+            return Err(forbidden());
+        }
+        match state.config().operator_token.as_deref() {
+            None => Ok(Self(None)),
+            Some(expected) if bearer(&parts.headers) == Some(expected) => Ok(Self(None)),
+            Some(_) => Err(unauthorized()),
+        }
+    }
+}
+
+/// Authorizes addressing a specific company under the given claims.
+///
+/// - Platform scope may address any company.
+/// - A tenant token may address a company only when it owns it (the registry
+///   ownership map records `id -> tenant`) and its own allow-list permits it.
+/// - `None` claims (prosumer/dev) are always allowed.
+///
+/// Returns `Some(403 forbidden)` on a cross-tenant or out-of-allow-list attempt,
+/// or `None` when the caller is allowed to address `id`.
+pub fn authorize_address(
+    state: &AppState,
+    claims: &Option<PlatformClaims>,
+    id: &CompanyId,
+) -> Option<Response> {
+    let Some(claims) = claims else {
+        return None;
+    };
+    if claims.has_platform_scope() {
+        return None;
+    }
+    let owner = state.owner_of(id);
+    if owner.as_deref() == Some(claims.tenant.as_str()) && claims.may_address(id) {
+        None
+    } else {
+        Some(forbidden())
+    }
+}
+
+/// The tenant a token acts as, for ownership recording. Platform-scope and dev
+/// callers act as the `tenant:platform` account.
+pub fn acting_tenant(claims: &Option<PlatformClaims>) -> String {
+    match claims {
+        Some(claims) => claims.tenant.clone(),
+        None => "tenant:platform".to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// base64url (no padding) — std-only, used by the offline dev token codec.
+// ---------------------------------------------------------------------------
+
+const B64URL: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+/// Encodes bytes as unpadded base64url.
+fn b64url_encode(input: &[u8]) -> String {
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = *chunk.get(1).unwrap_or(&0) as u32;
+        let b2 = *chunk.get(2).unwrap_or(&0) as u32;
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(B64URL[(n >> 18) as usize & 0x3f] as char);
+        out.push(B64URL[(n >> 12) as usize & 0x3f] as char);
+        if chunk.len() > 1 {
+            out.push(B64URL[(n >> 6) as usize & 0x3f] as char);
+        }
+        if chunk.len() > 2 {
+            out.push(B64URL[n as usize & 0x3f] as char);
+        }
+    }
+    out
+}
+
+/// Decodes unpadded base64url, returning `None` on any invalid input.
+fn b64url_decode(input: &str) -> Option<Vec<u8>> {
+    fn val(c: u8) -> Option<u32> {
+        match c {
+            b'A'..=b'Z' => Some((c - b'A') as u32),
+            b'a'..=b'z' => Some((c - b'a' + 26) as u32),
+            b'0'..=b'9' => Some((c - b'0' + 52) as u32),
+            b'-' => Some(62),
+            b'_' => Some(63),
+            _ => None,
+        }
+    }
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(input.len() / 4 * 3);
+    for chunk in bytes.chunks(4) {
+        if chunk.len() < 2 {
+            return None;
+        }
+        let mut n = 0u32;
+        for (i, &c) in chunk.iter().enumerate() {
+            n |= val(c)? << (18 - 6 * i);
+        }
+        out.push((n >> 16) as u8);
+        if chunk.len() > 2 {
+            out.push((n >> 8) as u8);
+        }
+        if chunk.len() > 3 {
+            out.push(n as u8);
+        }
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn tenant_claims(tenant: &str, scopes: &[&str]) -> PlatformClaims {
+        PlatformClaims {
+            tenant: tenant.to_string(),
+            scopes: scopes.iter().map(|s| s.to_string()).collect(),
+            companies: None,
+        }
+    }
+
+    #[test]
+    fn b64url_round_trips() {
+        for sample in [&b""[..], b"a", b"ab", b"abc", b"abcd", b"hello world!"] {
+            let encoded = b64url_encode(sample);
+            assert_eq!(b64url_decode(&encoded).unwrap(), sample);
+        }
+    }
+
+    #[test]
+    fn platform_secret_grants_platform_scope() {
+        let verifier = StaticPlatformVerifier::new("top-secret");
+        let claims = verifier.verify("top-secret").unwrap();
+        assert!(claims.has_platform_scope());
+        assert_eq!(claims.tenant, "tenant:platform");
+    }
+
+    #[test]
+    fn tenant_token_carries_structured_claims_without_platform_scope() {
+        let verifier = StaticPlatformVerifier::new("top-secret");
+        let token =
+            StaticPlatformVerifier::tenant_token(&tenant_claims("tenant:acme", &["operator"]));
+        let claims = verifier.verify(&token).unwrap();
+        assert_eq!(claims.tenant, "tenant:acme");
+        assert!(!claims.has_platform_scope());
+    }
+
+    #[test]
+    fn unrecognized_token_is_rejected() {
+        let verifier = StaticPlatformVerifier::new("top-secret");
+        assert!(verifier.verify("nope").is_err());
+        assert!(verifier.verify("oc_tenant.@@@not-base64@@@").is_err());
+    }
+
+    #[test]
+    fn may_address_honors_allow_list() {
+        let mut claims = tenant_claims("tenant:acme", &["operator"]);
+        assert!(claims.may_address(&CompanyId::new("anything")));
+        claims.companies = Some(HashSet::from(["acme".to_string()]));
+        assert!(claims.may_address(&CompanyId::new("acme")));
+        assert!(!claims.may_address(&CompanyId::new("globex")));
+    }
+
+    #[cfg(feature = "platform-jwt")]
+    #[test]
+    fn jwt_verifier_round_trips_signed_claims() {
+        use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+
+        let secret = "signing-secret";
+        let claims = tenant_claims("tenant:acme", &["platform", "operator"]);
+        let token = encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(secret.as_bytes()),
+        )
+        .unwrap();
+
+        let verifier = JwtPlatformVerifier::new(secret);
+        let verified = verifier.verify(&token).unwrap();
+        assert_eq!(verified.tenant, "tenant:acme");
+        assert!(verified.has_platform_scope());
+
+        // A token signed with the wrong secret is rejected.
+        let wrong = JwtPlatformVerifier::new("other-secret");
+        assert!(wrong.verify(&token).is_err());
+    }
+}

--- a/src/server/provision.rs
+++ b/src/server/provision.rs
@@ -1,0 +1,360 @@
+//! Hosted multi-tenant provisioning and per-company lifecycle controls.
+//!
+//! `POST /api/v1/companies` provisions a company from a manifest body (raw TOML
+//! or `{ "manifest_toml", "id"? }` JSON), validates it, builds a
+//! [`CompanyRuntime`](crate::company::runtime::CompanyRuntime) over the data
+//! dir, registers it, and records its owning tenant. Provisioning and suspension
+//! require the `platform` scope; pause/resume/archive are owner-scoped and never
+//! cross tenants.
+//!
+//! Lifecycle transitions persist the new [`CompanyRecord`](crate::ports::types::CompanyRecord)
+//! `lifecycle` and append a [`LifecycleChanged`](crate::ports::types::CompanyEvent::LifecycleChanged)
+//! audit event. Archive additionally removes the company from the registry so it
+//! is no longer addressable.
+//!
+//! Webhook emission (`approval.requested`, `work.completed`, `feedback.created`,
+//! `budget.exhausted`) runs through the offline-mockable
+//! [`WebhookSink`](crate::server::webhook::WebhookSink); the default build
+//! records deliveries in memory.
+
+use axum::extract::{Path, State};
+use axum::http::header::CONTENT_TYPE;
+use axum::http::{HeaderMap, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::AppState;
+use crate::company::CompanyManifest;
+use crate::ports::types::{Actor, ActorKind, CompanyId};
+use crate::runtime::types::CycleReport;
+use crate::runtime::{RuntimeBuilder, company_id_from_name};
+use crate::server::error::ApiError;
+use crate::server::platform_auth::{
+    PlatformClaims, PlatformScope, acting_tenant, authorize_address,
+};
+use crate::server::webhook::{WebhookEvent, WebhookKind};
+
+/// Builds the provisioning + lifecycle route fragment.
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/api/v1/companies", post(provision))
+        .route("/api/v1/companies/{id}/pause", post(pause))
+        .route("/api/v1/companies/{id}/resume", post(resume))
+        .route("/api/v1/companies/{id}/suspend", post(suspend))
+        .route("/api/v1/companies/{id}/archive", post(archive))
+}
+
+// ---------------------------------------------------------------------------
+// Response envelopes
+// ---------------------------------------------------------------------------
+
+fn envelope(status: StatusCode, code: &str, error: &str) -> Response {
+    (status, Json(json!({ "error": error, "code": code }))).into_response()
+}
+
+fn not_found(id: &str) -> Response {
+    envelope(
+        StatusCode::NOT_FOUND,
+        "company_not_found",
+        &format!("company not found: {id}"),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Provisioning
+// ---------------------------------------------------------------------------
+
+/// The JSON provisioning body: a manifest string plus an optional explicit id.
+#[derive(Debug, Deserialize)]
+struct ProvisionBody {
+    /// The company manifest as TOML.
+    manifest_toml: String,
+    /// An explicit company id; derived from the name when omitted.
+    #[serde(default)]
+    id: Option<String>,
+}
+
+/// `POST /api/v1/companies` — provision a company from a manifest body.
+async fn provision(
+    PlatformScope(claims): PlatformScope,
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: String,
+) -> Response {
+    // Accept raw TOML or a JSON envelope carrying the TOML.
+    let is_json = headers
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.contains("json"))
+        .unwrap_or(false);
+    let (manifest_toml, explicit_id) = if is_json {
+        match serde_json::from_str::<ProvisionBody>(&body) {
+            Ok(parsed) => (parsed.manifest_toml, parsed.id),
+            Err(err) => {
+                return envelope(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request",
+                    &format!("invalid provisioning body: {err}"),
+                );
+            }
+        }
+    } else {
+        (body, None)
+    };
+
+    let manifest: CompanyManifest = match toml::from_str(&manifest_toml) {
+        Ok(manifest) => manifest,
+        Err(err) => {
+            return envelope(
+                StatusCode::BAD_REQUEST,
+                "manifest_parse",
+                &format!("manifest is not valid TOML: {}", err.message()),
+            );
+        }
+    };
+    let problems = manifest.validate();
+    if !problems.is_empty() {
+        // Render the prosumer problem list; never leak serde traces.
+        return ApiError(crate::error::OpenCompanyError::ManifestInvalid {
+            path: std::path::PathBuf::from("company.toml"),
+            problems,
+        })
+        .into_response();
+    }
+
+    let id = match explicit_id {
+        Some(raw) => CompanyId::new(raw),
+        None => company_id_from_name(&manifest.company.name),
+    };
+
+    // Reject a duplicate id.
+    if state.registry().get(&id).is_some() {
+        return envelope(
+            StatusCode::CONFLICT,
+            "company_exists",
+            &format!("company already exists: {id}"),
+        );
+    }
+
+    // Quota: per-tenant then global.
+    let tenant = acting_tenant(&claims);
+    if let Some(max) = state.config().max_companies_per_tenant
+        && state.tenant_company_count(&tenant) >= max
+    {
+        return envelope(
+            StatusCode::TOO_MANY_REQUESTS,
+            "quota_exceeded",
+            &format!("tenant company quota of {max} reached"),
+        );
+    }
+    if let Some(max) = state.config().max_companies
+        && state.registry().len() >= max
+    {
+        return envelope(
+            StatusCode::TOO_MANY_REQUESTS,
+            "quota_exceeded",
+            &format!("global company quota of {max} reached"),
+        );
+    }
+
+    // Build over the data dir with fs defaults.
+    let runtime = match RuntimeBuilder::new(state.home().to_path_buf(), manifest)
+        .with_id(id.clone())
+        .with_tinyplace_api_url(state.config().tinyplace_api_url.clone())
+        .with_host_base_url(state.config().host_base_url())
+        .build()
+        .await
+    {
+        Ok(runtime) => runtime,
+        Err(err) => return ApiError(err).into_response(),
+    };
+
+    let status = match runtime.status().await {
+        Ok(status) => status,
+        Err(err) => return ApiError(err).into_response(),
+    };
+    state
+        .registry()
+        .insert(id.clone(), std::sync::Arc::new(runtime));
+    state.set_owner(id, tenant);
+
+    (StatusCode::CREATED, Json(status)).into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle controls
+// ---------------------------------------------------------------------------
+
+/// The actor recorded for a platform/operator-driven lifecycle transition.
+fn lifecycle_actor(claims: &Option<PlatformClaims>) -> Actor {
+    Actor {
+        kind: ActorKind::Operator,
+        id: acting_tenant(claims),
+    }
+}
+
+/// Whether the request carries `?reason=budget`, without pulling in axum's
+/// `query` feature.
+fn reason_is_budget(uri: &Uri) -> bool {
+    uri.query()
+        .map(|q| q.split('&').any(|pair| pair == "reason=budget"))
+        .unwrap_or(false)
+}
+
+/// Applies a lifecycle transition to `to`, returning the fresh status.
+async fn transition(
+    state: &AppState,
+    claims: &Option<PlatformClaims>,
+    id: &CompanyId,
+    to: &str,
+) -> Response {
+    let Some(runtime) = state.registry().get(id) else {
+        return not_found(id.as_ref());
+    };
+    if let Err(err) = runtime.set_lifecycle(to, lifecycle_actor(claims)).await {
+        return ApiError(err).into_response();
+    }
+    match runtime.status().await {
+        Ok(status) => (StatusCode::OK, Json(status)).into_response(),
+        Err(err) => ApiError(err).into_response(),
+    }
+}
+
+/// `POST /api/v1/companies/{id}/pause` — stop accepting work (owner-scoped).
+async fn pause(
+    crate::server::platform_auth::PlatformOrOperatorAuth(claims): crate::server::platform_auth::PlatformOrOperatorAuth,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    uri: Uri,
+) -> Response {
+    let id = CompanyId::new(id);
+    if let Some(resp) = authorize_address(&state, &claims, &id) {
+        return resp;
+    }
+    let response = transition(&state, &claims, &id, "paused").await;
+    // A budget-triggered pause emits the `budget.exhausted` webhook.
+    if response.status() == StatusCode::OK && reason_is_budget(&uri) {
+        emit_budget_exhausted(&state, &id).await;
+    }
+    response
+}
+
+/// `POST /api/v1/companies/{id}/resume` — resume accepting work (owner-scoped).
+async fn resume(
+    crate::server::platform_auth::PlatformOrOperatorAuth(claims): crate::server::platform_auth::PlatformOrOperatorAuth,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Response {
+    let id = CompanyId::new(id);
+    if let Some(resp) = authorize_address(&state, &claims, &id) {
+        return resp;
+    }
+    // `suspended` is a platform-forced pause (billing/abuse); only a
+    // platform-scope caller may lift it. An owner token must not be able to
+    // resume its own suspended company.
+    let platform = claims
+        .as_ref()
+        .is_some_and(PlatformClaims::has_platform_scope);
+    if !platform {
+        match state.registry().get(&id) {
+            Some(runtime) => match runtime.status().await {
+                Ok(status) if status.lifecycle == "suspended" => {
+                    return crate::server::platform_auth::forbidden();
+                }
+                Ok(_) => {}
+                Err(err) => return ApiError(err).into_response(),
+            },
+            None => return not_found(id.as_ref()),
+        }
+    }
+    transition(&state, &claims, &id, "running").await
+}
+
+/// `POST /api/v1/companies/{id}/suspend` — park a company (platform-scoped).
+async fn suspend(
+    PlatformScope(claims): PlatformScope,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Response {
+    let id = CompanyId::new(id);
+    if let Some(resp) = authorize_address(&state, &claims, &id) {
+        return resp;
+    }
+    transition(&state, &claims, &id, "suspended").await
+}
+
+/// `POST /api/v1/companies/{id}/archive` — terminally archive a company and
+/// remove it from the registry (platform-scoped).
+async fn archive(
+    PlatformScope(claims): PlatformScope,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Response {
+    let id = CompanyId::new(id);
+    if let Some(resp) = authorize_address(&state, &claims, &id) {
+        return resp;
+    }
+    let response = transition(&state, &claims, &id, "archived").await;
+    if response.status() == StatusCode::OK {
+        state.registry().remove(&id);
+        state.remove_owner(&id);
+    }
+    response
+}
+
+// ---------------------------------------------------------------------------
+// Webhook emission (shared with the operator chat surface)
+// ---------------------------------------------------------------------------
+
+/// Emits the webhooks a completed cycle implies: one `approval.requested` per
+/// newly parked approval, and one `work.completed` when the cycle produced
+/// output. A no-op when no webhook is configured.
+pub(crate) async fn emit_cycle_webhooks(state: &AppState, id: &CompanyId, report: &CycleReport) {
+    let Some(webhook) = state.webhook() else {
+        return;
+    };
+    for approval_id in &report.parked {
+        let event = WebhookEvent::now(
+            WebhookKind::ApprovalRequested,
+            id.clone(),
+            json!({ "approval_id": approval_id.as_ref() }),
+        );
+        webhook.emit(&event).await;
+    }
+    if !report.responses.is_empty() {
+        let event = WebhookEvent::now(
+            WebhookKind::WorkCompleted,
+            id.clone(),
+            json!({ "responses": report.responses.len() }),
+        );
+        webhook.emit(&event).await;
+    }
+}
+
+/// Emits a `feedback.created` webhook. A no-op when no webhook is configured.
+pub(crate) async fn emit_feedback_webhook(state: &AppState, id: &CompanyId, note: &str) {
+    let Some(webhook) = state.webhook() else {
+        return;
+    };
+    let event = WebhookEvent::now(
+        WebhookKind::FeedbackCreated,
+        id.clone(),
+        json!({ "note": note }),
+    );
+    webhook.emit(&event).await;
+}
+
+/// Emits a `budget.exhausted` webhook. A no-op when no webhook is configured.
+async fn emit_budget_exhausted(state: &AppState, id: &CompanyId) {
+    let Some(webhook) = state.webhook() else {
+        return;
+    };
+    let event = WebhookEvent::now(WebhookKind::BudgetExhausted, id.clone(), json!({}));
+    webhook.emit(&event).await;
+}
+
+#[cfg(test)]
+mod test;

--- a/src/server/provision/test.rs
+++ b/src/server/provision/test.rs
@@ -1,0 +1,605 @@
+//! End-to-end axum tests for provisioning, per-tenant auth, lifecycle controls,
+//! quotas, and webhook emission. All offline (default build, no features).
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use crate::company::CompanyManifest;
+use crate::ports::Brain;
+use crate::ports::types::{
+    CompanyEvent, CompanyId, CompressedTrace, CycleRequest, CycleResult, Effect, EffectGroup,
+    EventSeq, OutboundMessage, TokenUsage,
+};
+use crate::ports::{CycleHost, EventLog};
+use crate::runtime::RuntimeBuilder;
+use crate::server::platform_auth::{PlatformAuthConfig, PlatformClaims, StaticPlatformVerifier};
+use crate::server::router;
+use crate::server::webhook::{WebhookConfig, WebhookKind};
+use crate::store::FsEventLog;
+use crate::{AppConfig, AppState};
+
+const PLATFORM_SECRET: &str = "plat-secret";
+
+const ACME_TOML: &str = "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n";
+
+fn home() -> std::path::PathBuf {
+    std::env::temp_dir().join(format!("oc-provision-{}", crate::ports::generate_id()))
+}
+
+fn platform_state(home: &std::path::Path, max_per_tenant: Option<usize>) -> AppState {
+    let verifier = Arc::new(StaticPlatformVerifier::new(PLATFORM_SECRET));
+    AppState::new(AppConfig::default())
+        .with_home(home.to_path_buf())
+        .with_platform_auth(PlatformAuthConfig::new(verifier))
+        .with_quota(None, max_per_tenant)
+}
+
+fn tenant_token(tenant: &str, scopes: &[&str]) -> String {
+    StaticPlatformVerifier::tenant_token(&PlatformClaims {
+        tenant: tenant.to_string(),
+        scopes: scopes.iter().map(|s| s.to_string()).collect::<HashSet<_>>(),
+        companies: None,
+    })
+}
+
+fn provision_req(token: Option<&str>, toml: &str) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/api/v1/companies")
+        .header("content-type", "text/plain");
+    if let Some(token) = token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    builder.body(Body::from(toml.to_string())).unwrap()
+}
+
+fn get_req(uri: &str, token: Option<&str>) -> Request<Body> {
+    let mut builder = Request::builder().uri(uri);
+    if let Some(token) = token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    builder.body(Body::empty()).unwrap()
+}
+
+fn post_req(uri: &str, token: Option<&str>) -> Request<Body> {
+    let mut builder = Request::builder().method("POST").uri(uri);
+    if let Some(token) = token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    builder.body(Body::empty()).unwrap()
+}
+
+fn chat_req(uri: &str, token: Option<&str>, text: &str) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json");
+    if let Some(token) = token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    builder
+        .body(Body::from(format!(r#"{{"text":"{text}"}}"#)))
+        .unwrap()
+}
+
+async fn json_body(response: axum::response::Response) -> serde_json::Value {
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Provisioning + status
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn provision_then_list_then_status() {
+    let home = home();
+    let state = platform_state(&home, None);
+    let app = router(state);
+
+    // Provision with a platform-scope token.
+    let response = app
+        .clone()
+        .oneshot(provision_req(Some(PLATFORM_SECRET), ACME_TOML))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = json_body(response).await;
+    assert_eq!(body["id"], "acme");
+    assert_eq!(body["lifecycle"], "running");
+
+    // List shows it.
+    let list = app
+        .clone()
+        .oneshot(get_req("/api/v1/companies", Some(PLATFORM_SECRET)))
+        .await
+        .unwrap();
+    assert_eq!(list.status(), StatusCode::OK);
+    let list_body = json_body(list).await;
+    assert_eq!(list_body.as_array().unwrap().len(), 1);
+
+    // Status by id.
+    let status = app
+        .oneshot(get_req("/api/v1/companies/acme", Some(PLATFORM_SECRET)))
+        .await
+        .unwrap();
+    assert_eq!(status.status(), StatusCode::OK);
+    assert_eq!(json_body(status).await["id"], "acme");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[tokio::test]
+async fn provision_accepts_json_envelope_with_explicit_id() {
+    let home = home();
+    let state = platform_state(&home, None);
+    let app = router(state);
+
+    let body = serde_json::json!({ "manifest_toml": ACME_TOML, "id": "custom-id" }).to_string();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/companies")
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {PLATFORM_SECRET}"))
+        .body(Body::from(body))
+        .unwrap();
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    assert_eq!(json_body(response).await["id"], "custom-id");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[tokio::test]
+async fn provision_requires_platform_scope() {
+    let home = home();
+    let state = platform_state(&home, None);
+    let app = router(state);
+
+    // No token → 401.
+    let unauthorized = app
+        .clone()
+        .oneshot(provision_req(None, ACME_TOML))
+        .await
+        .unwrap();
+    assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+    // Tenant-only token (no platform scope) → 403.
+    let token = tenant_token("tenant:acme", &["operator"]);
+    let forbidden = app
+        .oneshot(provision_req(Some(&token), ACME_TOML))
+        .await
+        .unwrap();
+    assert_eq!(forbidden.status(), StatusCode::FORBIDDEN);
+    assert_eq!(json_body(forbidden).await["code"], "forbidden");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[tokio::test]
+async fn invalid_manifest_is_400() {
+    let home = home();
+    let state = platform_state(&home, None);
+    let app = router(state);
+
+    // Empty company name fails validation.
+    let bad = "[company]\nname = \"\"\n";
+    let response = app
+        .oneshot(provision_req(Some(PLATFORM_SECRET), bad))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(json_body(response).await["code"], "manifest_invalid");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[tokio::test]
+async fn quota_rejects_when_exceeded() {
+    let home = home();
+    let state = platform_state(&home, Some(1));
+    let app = router(state);
+
+    let first = app
+        .clone()
+        .oneshot(provision_req(Some(PLATFORM_SECRET), ACME_TOML))
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::CREATED);
+
+    let globex = "[company]\nname = \"Globex\"\n";
+    let second = app
+        .oneshot(provision_req(Some(PLATFORM_SECRET), globex))
+        .await
+        .unwrap();
+    assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(json_body(second).await["code"], "quota_exceeded");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[tokio::test]
+async fn duplicate_id_conflicts() {
+    let home = home();
+    let state = platform_state(&home, None);
+    let app = router(state);
+
+    let first = app
+        .clone()
+        .oneshot(provision_req(Some(PLATFORM_SECRET), ACME_TOML))
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::CREATED);
+
+    let dup = app
+        .oneshot(provision_req(Some(PLATFORM_SECRET), ACME_TOML))
+        .await
+        .unwrap();
+    assert_eq!(dup.status(), StatusCode::CONFLICT);
+    assert_eq!(json_body(dup).await["code"], "company_exists");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pause_toggles_and_chat_409() {
+    let home = home();
+    let state = platform_state(&home, None);
+    let app = router(state);
+
+    app.clone()
+        .oneshot(provision_req(Some(PLATFORM_SECRET), ACME_TOML))
+        .await
+        .unwrap();
+
+    // Pause → paused.
+    let paused = app
+        .clone()
+        .oneshot(post_req(
+            "/api/v1/companies/acme/pause",
+            Some(PLATFORM_SECRET),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(paused.status(), StatusCode::OK);
+    assert_eq!(json_body(paused).await["lifecycle"], "paused");
+
+    // Chat is 409 while paused.
+    let conflict = app
+        .clone()
+        .oneshot(chat_req(
+            "/api/v1/companies/acme/chat",
+            Some(PLATFORM_SECRET),
+            "hi",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(conflict.status(), StatusCode::CONFLICT);
+
+    // Resume → running, chat 200.
+    let resumed = app
+        .clone()
+        .oneshot(post_req(
+            "/api/v1/companies/acme/resume",
+            Some(PLATFORM_SECRET),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resumed.status(), StatusCode::OK);
+    assert_eq!(json_body(resumed).await["lifecycle"], "running");
+
+    let ok = app
+        .oneshot(chat_req(
+            "/api/v1/companies/acme/chat",
+            Some(PLATFORM_SECRET),
+            "hi",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(ok.status(), StatusCode::OK);
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[tokio::test]
+async fn suspend_requires_platform_scope_and_blocks_chat() {
+    let home = home();
+    let state = platform_state(&home, None);
+    let app = router(state);
+
+    app.clone()
+        .oneshot(provision_req(Some(PLATFORM_SECRET), ACME_TOML))
+        .await
+        .unwrap();
+
+    // A tenant-only token cannot suspend.
+    let tenant = tenant_token("tenant:platform", &["operator"]);
+    let forbidden = app
+        .clone()
+        .oneshot(post_req("/api/v1/companies/acme/suspend", Some(&tenant)))
+        .await
+        .unwrap();
+    assert_eq!(forbidden.status(), StatusCode::FORBIDDEN);
+
+    // Platform scope suspends.
+    let suspended = app
+        .clone()
+        .oneshot(post_req(
+            "/api/v1/companies/acme/suspend",
+            Some(PLATFORM_SECRET),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(suspended.status(), StatusCode::OK);
+    assert_eq!(json_body(suspended).await["lifecycle"], "suspended");
+
+    // Chat is blocked.
+    let conflict = app
+        .oneshot(chat_req(
+            "/api/v1/companies/acme/chat",
+            Some(PLATFORM_SECRET),
+            "hi",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(conflict.status(), StatusCode::CONFLICT);
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[tokio::test]
+async fn foreign_tenant_cannot_file_feedback() {
+    let home = home();
+    let state = platform_state(&home, None);
+    let app = router(state);
+
+    // acme is owned by tenant:platform.
+    app.clone()
+        .oneshot(provision_req(Some(PLATFORM_SECRET), ACME_TOML))
+        .await
+        .unwrap();
+
+    // A different tenant's token must not reach acme's feedback route.
+    let other = tenant_token("tenant:other", &["operator"]);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/v1/companies/acme/feedback")
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {other}"))
+        .body(Body::from(r#"{"category":"bug","note":"not yours"}"#))
+        .unwrap();
+    let denied = app.oneshot(req).await.unwrap();
+    assert_eq!(denied.status(), StatusCode::FORBIDDEN);
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[tokio::test]
+async fn owner_cannot_resume_a_platform_suspension() {
+    let home = home();
+    let state = platform_state(&home, None);
+    let app = router(state);
+
+    app.clone()
+        .oneshot(provision_req(Some(PLATFORM_SECRET), ACME_TOML))
+        .await
+        .unwrap();
+
+    // Platform suspends the tenant.
+    let suspended = app
+        .clone()
+        .oneshot(post_req(
+            "/api/v1/companies/acme/suspend",
+            Some(PLATFORM_SECRET),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(suspended.status(), StatusCode::OK);
+
+    // The owner's tenant token must NOT be able to lift the suspension.
+    let tenant = tenant_token("tenant:platform", &["operator"]);
+    let denied = app
+        .clone()
+        .oneshot(post_req("/api/v1/companies/acme/resume", Some(&tenant)))
+        .await
+        .unwrap();
+    assert_eq!(denied.status(), StatusCode::FORBIDDEN);
+
+    // Platform scope can lift it.
+    let resumed = app
+        .oneshot(post_req(
+            "/api/v1/companies/acme/resume",
+            Some(PLATFORM_SECRET),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resumed.status(), StatusCode::OK);
+    assert_eq!(json_body(resumed).await["lifecycle"], "running");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[tokio::test]
+async fn archive_removes_from_registry() {
+    let home = home();
+    let state = platform_state(&home, None);
+    let app = router(state);
+
+    app.clone()
+        .oneshot(provision_req(Some(PLATFORM_SECRET), ACME_TOML))
+        .await
+        .unwrap();
+
+    let archived = app
+        .clone()
+        .oneshot(post_req(
+            "/api/v1/companies/acme/archive",
+            Some(PLATFORM_SECRET),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(archived.status(), StatusCode::OK);
+    assert_eq!(json_body(archived).await["lifecycle"], "archived");
+
+    // Now unaddressable: status 404, chat 404.
+    let status = app
+        .clone()
+        .oneshot(get_req("/api/v1/companies/acme", Some(PLATFORM_SECRET)))
+        .await
+        .unwrap();
+    assert_eq!(status.status(), StatusCode::NOT_FOUND);
+
+    let chat = app
+        .oneshot(chat_req(
+            "/api/v1/companies/acme/chat",
+            Some(PLATFORM_SECRET),
+            "hi",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(chat.status(), StatusCode::NOT_FOUND);
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[tokio::test]
+async fn cross_tenant_access_forbidden() {
+    let home = home();
+    let state = platform_state(&home, None);
+    let app = router(state);
+
+    // Tenant B provisions (its token carries the platform scope).
+    let b_platform = tenant_token("tenant:b", &["platform", "operator"]);
+    let created = app
+        .clone()
+        .oneshot(provision_req(Some(&b_platform), ACME_TOML))
+        .await
+        .unwrap();
+    assert_eq!(created.status(), StatusCode::CREATED);
+
+    // Tenant A (no platform scope, different tenant) cannot address it.
+    let a_token = tenant_token("tenant:a", &["operator"]);
+    let forbidden = app
+        .oneshot(get_req("/api/v1/companies/acme", Some(&a_token)))
+        .await
+        .unwrap();
+    assert_eq!(forbidden.status(), StatusCode::FORBIDDEN);
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[tokio::test]
+async fn lifecycle_transition_recorded_as_event() {
+    let home = home();
+    let state = platform_state(&home, None);
+    let app = router(state);
+
+    app.clone()
+        .oneshot(provision_req(Some(PLATFORM_SECRET), ACME_TOML))
+        .await
+        .unwrap();
+    app.oneshot(post_req(
+        "/api/v1/companies/acme/pause",
+        Some(PLATFORM_SECRET),
+    ))
+    .await
+    .unwrap();
+
+    // The audit trail carries a LifecycleChanged running -> paused.
+    let events = FsEventLog::new(home.clone());
+    let stored = events
+        .read_from(&CompanyId::new("acme"), EventSeq::new(0), usize::MAX)
+        .await
+        .unwrap();
+    let found = stored.iter().any(|e| {
+        matches!(
+            &e.event,
+            CompanyEvent::LifecycleChanged { from, to, .. } if from == "running" && to == "paused"
+        )
+    });
+    assert!(found, "expected a LifecycleChanged event, got {stored:?}");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// ---------------------------------------------------------------------------
+// Webhooks
+// ---------------------------------------------------------------------------
+
+/// A brain that emits one supervised effect per operator message (parks under a
+/// supervised policy), so a cycle produces an `approval.requested` webhook.
+struct EffectBrain {
+    effect: Effect,
+}
+
+#[async_trait]
+impl Brain for EffectBrain {
+    async fn run_cycle(
+        &self,
+        req: CycleRequest,
+        host: &dyn CycleHost,
+    ) -> crate::Result<CycleResult> {
+        let mut responses = Vec::new();
+        for event in &req.events {
+            if let CompanyEvent::OperatorMessage { text } = event {
+                host.emit_effect(self.effect.clone()).await?;
+                responses.push(OutboundMessage {
+                    channel: "operator".into(),
+                    text: format!("handled: {text}"),
+                });
+            }
+        }
+        Ok(CycleResult {
+            channel_responses: responses,
+            new_traces: vec![CompressedTrace::now(&req.cycle_id, "effect cycle")],
+            ledger_deltas: Vec::new(),
+            token_usage: TokenUsage::default(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn webhook_emitted_on_approval_requested() {
+    let home = home();
+    // Prosumer mode (no platform_auth) plus a recording webhook sink.
+    let (webhook, sink) = WebhookConfig::recording("tenant-secret");
+    let state = AppState::new(AppConfig::default())
+        .with_home(home.clone())
+        .with_webhook(webhook);
+
+    // A supervised company whose brain parks a filing.submit effect.
+    let manifest: CompanyManifest =
+        toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"supervised\"\n").unwrap();
+    let sign_effect = Effect {
+        kind: "filing.submit".into(),
+        group: EffectGroup::Sign,
+        amount_usd: None,
+        established_thread: false,
+        first_time_counterparty: false,
+        payload: serde_json::Value::Null,
+    };
+    let runtime = RuntimeBuilder::new(home.clone(), manifest)
+        .with_id(CompanyId::new("acme"))
+        .with_brain(Arc::new(EffectBrain {
+            effect: sign_effect,
+        }))
+        .build()
+        .await
+        .unwrap();
+    state
+        .registry()
+        .insert(CompanyId::new("acme"), Arc::new(runtime));
+
+    let app = router(state);
+    let chat = app
+        .oneshot(chat_req("/api/v1/companies/acme/chat", None, "file it"))
+        .await
+        .unwrap();
+    assert_eq!(chat.status(), StatusCode::OK);
+
+    let delivered = sink.delivered();
+    let approval = delivered
+        .iter()
+        .find(|(event, _)| event.kind == WebhookKind::ApprovalRequested)
+        .expect("an approval_requested webhook was delivered");
+    // The delivery carries a non-empty signature header value.
+    assert!(!approval.1.is_empty());
+    assert!(approval.1.starts_with("kh1="));
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -11,6 +11,7 @@ pub fn router(state: AppState) -> Router {
         .route("/spec", get(spec))
         .route("/tiny", get(tiny))
         .merge(crate::server::operator::router())
+        .merge(crate::server::provision::router())
         .merge(crate::server::feedback::router());
     // tiny.place A2A inbound + discovery routes, only when the feature is on.
     #[cfg(feature = "tinyplace")]

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -6,13 +6,16 @@ use crate::{AppState, Result};
 
 /// Builds the Axum router.
 pub fn router(state: AppState) -> Router {
-    Router::new()
+    let router = Router::new()
         .route("/healthz", get(healthz))
         .route("/spec", get(spec))
         .route("/tiny", get(tiny))
         .merge(crate::server::operator::router())
-        .merge(crate::server::feedback::router())
-        .with_state(state)
+        .merge(crate::server::feedback::router());
+    // tiny.place A2A inbound + discovery routes, only when the feature is on.
+    #[cfg(feature = "tinyplace")]
+    let router = router.merge(crate::server::a2a::router());
+    router.with_state(state)
 }
 
 /// Serves the Axum application.

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -11,6 +11,7 @@ pub fn router(state: AppState) -> Router {
         .route("/spec", get(spec))
         .route("/tiny", get(tiny))
         .merge(crate::server::operator::router())
+        .merge(crate::server::feedback::router())
         .with_state(state)
 }
 

--- a/src/server/webhook.rs
+++ b/src/server/webhook.rs
@@ -1,0 +1,320 @@
+//! Outbound platform webhooks: an at-least-once delivery seam behind a
+//! mockable [`WebhookSink`] trait.
+//!
+//! The default build ships an in-memory [`RecordingWebhookSink`] and a
+//! deterministic, non-cryptographic signer ([`DefaultHashSigner`]) so the whole
+//! surface is exercised offline by `cargo test`. Real HTTP POST with an
+//! HMAC-SHA256 signature is added under the `webhooks` feature (via
+//! `HttpWebhookSink` and `HmacSha256Signer`); nothing here links a network or
+//! crypto crate in the default build.
+//!
+//! Every delivery carries an `X-OpenCompany-Signature`-equivalent header value
+//! computed by the configured [`WebhookSigner`] over the JSON body: `kh1=<hex>`
+//! by default, `sha256=<hex>` under `webhooks`.
+
+use std::sync::{Arc, Mutex};
+
+use serde::Serialize;
+
+use crate::Result;
+use crate::ports::types::CompanyId;
+
+/// The category of a platform webhook (api.md §Platform webhooks).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WebhookKind {
+    /// An effect was parked and awaits operator approval.
+    ApprovalRequested,
+    /// A company completed a unit of work (a cycle produced output).
+    WorkCompleted,
+    /// A feedback item was captured.
+    FeedbackCreated,
+    /// A company's budget was exhausted.
+    BudgetExhausted,
+}
+
+impl WebhookKind {
+    /// The stable wire string for this kind.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ApprovalRequested => "approval_requested",
+            Self::WorkCompleted => "work_completed",
+            Self::FeedbackCreated => "feedback_created",
+            Self::BudgetExhausted => "budget_exhausted",
+        }
+    }
+}
+
+/// A platform webhook event delivered to the tenant's configured sink.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct WebhookEvent {
+    /// The event category.
+    #[serde(rename = "type")]
+    pub kind: WebhookKind,
+    /// The company the event is about.
+    pub company_id: CompanyId,
+    /// Epoch-millis timestamp the event was produced.
+    pub at_millis: u64,
+    /// Event-specific payload.
+    pub data: serde_json::Value,
+}
+
+impl WebhookEvent {
+    /// Builds an event stamped with the current time.
+    pub fn now(kind: WebhookKind, company_id: CompanyId, data: serde_json::Value) -> Self {
+        Self {
+            kind,
+            company_id,
+            at_millis: crate::ports::now_millis(),
+            data,
+        }
+    }
+}
+
+/// The at-least-once delivery seam. The default build uses the in-memory
+/// [`RecordingWebhookSink`]; real HTTP POST is added under `webhooks`.
+#[async_trait::async_trait]
+pub trait WebhookSink: Send + Sync {
+    /// Delivers `event` with the precomputed `signature` header value. An
+    /// implementation may retry internally; a returned error means every attempt
+    /// failed (and the caller logs, never blocking the cycle).
+    async fn deliver(&self, event: &WebhookEvent, signature: &str) -> Result<()>;
+}
+
+/// An offline mock sink that records every delivery for assertions and never
+/// fails. Used by the default build and tests.
+#[derive(Clone, Default)]
+pub struct RecordingWebhookSink {
+    sent: Arc<Mutex<Vec<(WebhookEvent, String)>>>,
+}
+
+impl RecordingWebhookSink {
+    /// Creates an empty recording sink.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A snapshot of every `(event, signature)` delivered so far.
+    pub fn delivered(&self) -> Vec<(WebhookEvent, String)> {
+        self.sent.lock().expect("webhook sink poisoned").clone()
+    }
+
+    /// The number of deliveries recorded.
+    pub fn count(&self) -> usize {
+        self.sent.lock().expect("webhook sink poisoned").len()
+    }
+}
+
+#[async_trait::async_trait]
+impl WebhookSink for RecordingWebhookSink {
+    async fn deliver(&self, event: &WebhookEvent, signature: &str) -> Result<()> {
+        self.sent
+            .lock()
+            .expect("webhook sink poisoned")
+            .push((event.clone(), signature.to_string()));
+        Ok(())
+    }
+}
+
+/// The signing seam so the delivery header is deterministic and offline-testable.
+pub trait WebhookSigner: Send + Sync {
+    /// Signs `body` with the tenant `secret`, returning the header value.
+    fn sign(&self, secret: &str, body: &[u8]) -> String;
+}
+
+/// The default-build signer: a deterministic, non-cryptographic keyed hash over
+/// `secret ‖ body`, rendered `kh1=<hex>`. Clearly labelled insecure; real
+/// HMAC-SHA256 lives behind the `webhooks` feature.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DefaultHashSigner;
+
+impl WebhookSigner for DefaultHashSigner {
+    fn sign(&self, secret: &str, body: &[u8]) -> String {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        secret.as_bytes().hash(&mut hasher);
+        body.hash(&mut hasher);
+        format!("kh1={:016x}", hasher.finish())
+    }
+}
+
+/// A tenant's webhook delivery configuration: the sink, the signer, and the
+/// per-tenant signing secret.
+#[derive(Clone)]
+pub struct WebhookConfig {
+    /// The delivery sink (recording mock by default; HTTP under `webhooks`).
+    pub sink: Arc<dyn WebhookSink>,
+    /// The signer that computes the delivery header value.
+    pub signer: Arc<dyn WebhookSigner>,
+    /// The shared secret mixed into the signature.
+    pub secret: String,
+}
+
+impl WebhookConfig {
+    /// Builds a config over the in-memory recording sink and the deterministic
+    /// signer — the offline default used by the CLI when no real transport is
+    /// linked, and by tests.
+    pub fn recording(secret: impl Into<String>) -> (Self, RecordingWebhookSink) {
+        let sink = RecordingWebhookSink::new();
+        (
+            Self {
+                sink: Arc::new(sink.clone()),
+                signer: Arc::new(DefaultHashSigner),
+                secret: secret.into(),
+            },
+            sink,
+        )
+    }
+
+    /// Signs and delivers `event` with bounded best-effort retry. A delivery
+    /// failure is logged and swallowed so a webhook never blocks a cycle.
+    pub async fn emit(&self, event: &WebhookEvent) {
+        let body = match serde_json::to_vec(event) {
+            Ok(body) => body,
+            Err(err) => {
+                tracing::warn!(company = %event.company_id, "webhook serialize failed: {err}");
+                return;
+            }
+        };
+        let signature = self.signer.sign(&self.secret, &body);
+        // At-least-once: a few bounded attempts, then give up with a warning.
+        for attempt in 1..=3u32 {
+            match self.sink.deliver(event, &signature).await {
+                Ok(()) => return,
+                Err(err) if attempt == 3 => {
+                    tracing::warn!(
+                        company = %event.company_id,
+                        kind = event.kind.as_str(),
+                        "webhook delivery failed after {attempt} attempts: {err}"
+                    );
+                }
+                Err(_) => continue,
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for WebhookConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebhookConfig")
+            .field("secret", &"<redacted>")
+            .finish_non_exhaustive()
+    }
+}
+
+/// Real HMAC-SHA256 signer, emitting `sha256=<hex>`. Gated so the default build
+/// links no crypto.
+#[cfg(feature = "webhooks")]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct HmacSha256Signer;
+
+#[cfg(feature = "webhooks")]
+impl WebhookSigner for HmacSha256Signer {
+    fn sign(&self, secret: &str, body: &[u8]) -> String {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+        let mut mac =
+            <Hmac<Sha256> as Mac>::new_from_slice(secret.as_bytes()).expect("hmac accepts any key");
+        mac.update(body);
+        let bytes = mac.finalize().into_bytes();
+        let mut hex = String::with_capacity(bytes.len() * 2 + 7);
+        hex.push_str("sha256=");
+        for byte in bytes {
+            use std::fmt::Write as _;
+            let _ = write!(hex, "{byte:02x}");
+        }
+        hex
+    }
+}
+
+/// Real HTTP POST sink. Delivers the event as JSON with the signature header,
+/// retrying a bounded number of times. Gated behind `webhooks`.
+#[cfg(feature = "webhooks")]
+pub struct HttpWebhookSink {
+    url: String,
+    client: reqwest::Client,
+}
+
+#[cfg(feature = "webhooks")]
+impl HttpWebhookSink {
+    /// The header carrying the delivery signature.
+    pub const SIGNATURE_HEADER: &'static str = "X-OpenCompany-Signature";
+
+    /// Builds a sink posting to `url`.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+#[cfg(feature = "webhooks")]
+#[async_trait::async_trait]
+impl WebhookSink for HttpWebhookSink {
+    async fn deliver(&self, event: &WebhookEvent, signature: &str) -> Result<()> {
+        let resp = self
+            .client
+            .post(&self.url)
+            .header(Self::SIGNATURE_HEADER, signature)
+            .json(event)
+            .send()
+            .await
+            .map_err(|e| {
+                crate::error::OpenCompanyError::Store(format!("webhook POST failed: {e}"))
+            })?;
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(crate::error::OpenCompanyError::Store(format!(
+                "webhook endpoint returned {}",
+                resp.status()
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn default_signer_is_deterministic_and_prefixed() {
+        let signer = DefaultHashSigner;
+        let a = signer.sign("secret", b"body");
+        let b = signer.sign("secret", b"body");
+        assert_eq!(a, b);
+        assert!(a.starts_with("kh1="));
+        // A different secret or body changes the signature.
+        assert_ne!(a, signer.sign("other", b"body"));
+        assert_ne!(a, signer.sign("secret", b"other"));
+    }
+
+    #[tokio::test]
+    async fn recording_sink_captures_deliveries() {
+        let (config, sink) = WebhookConfig::recording("s3cret");
+        let event = WebhookEvent::now(
+            WebhookKind::ApprovalRequested,
+            CompanyId::new("acme"),
+            serde_json::json!({ "approval_id": "a1" }),
+        );
+        config.emit(&event).await;
+
+        let delivered = sink.delivered();
+        assert_eq!(delivered.len(), 1);
+        assert_eq!(delivered[0].0.kind, WebhookKind::ApprovalRequested);
+        assert!(delivered[0].1.starts_with("kh1="));
+    }
+
+    #[test]
+    fn webhook_event_serializes_type_and_snake_case_kind() {
+        let event = WebhookEvent::now(
+            WebhookKind::WorkCompleted,
+            CompanyId::new("acme"),
+            serde_json::Value::Null,
+        );
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "work_completed");
+        assert_eq!(json["company_id"], "acme");
+    }
+}

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -1,0 +1,329 @@
+//! Backend-agnostic port-conformance assertions.
+//!
+//! Each `assert_*` function drives a set of storage-port trait objects through
+//! the invariants every backend must uphold, so the fs and sqlite stores prove
+//! conformance against the *same* suite rather than duplicating hand-written
+//! per-backend tests. The functions are parameterized over `Arc<dyn Port>` and
+//! make no assumption about the concrete implementation beyond the trait
+//! contract.
+//!
+//! Callers supply *freshly constructed, empty* stores per function: the suite
+//! writes company `alpha` and company `beta` and asserts they never observe
+//! each other's data, that event/ledger logs are append-only, that event
+//! sequences are 0-based and strictly monotonic per company, and that
+//! everything written through the ports reads back byte-identically (the
+//! export-totality precondition).
+
+use std::sync::Arc;
+
+use crate::ports::context::ContextStore;
+use crate::ports::events::EventLog;
+use crate::ports::memory::MemoryStore;
+use crate::ports::now_millis;
+use crate::ports::store::CompanyStore;
+use crate::ports::types::{
+    CompanyEvent, CompanyId, CompanyRecord, CompressedTrace, ContextChunk, EventSeq, LedgerEntry,
+};
+
+/// A minimal valid manifest used to seed [`CompanyRecord`]s in the suite.
+fn sample_manifest() -> crate::company::CompanyManifest {
+    let toml_src = r#"
+        [company]
+        name = "Conformance Co"
+        output = "widgets"
+
+        [[agent]]
+        id = "ceo"
+        role = "Chief"
+
+        [policy]
+        mode = "supervised"
+    "#;
+    toml::from_str(toml_src).expect("parse sample manifest")
+}
+
+/// Builds an empty running record for `id`.
+fn record(id: &CompanyId) -> CompanyRecord {
+    CompanyRecord {
+        id: id.clone(),
+        manifest: sample_manifest(),
+        ledger: Vec::new(),
+        lifecycle: "running".to_string(),
+    }
+}
+
+fn ledger_entry(i: usize) -> LedgerEntry {
+    LedgerEntry {
+        at_millis: now_millis(),
+        kind: "inference.spend".to_string(),
+        amount_usd: i as f64,
+        memo: format!("entry {i}"),
+    }
+}
+
+/// Every port keeps company `alpha`'s data invisible to company `beta`.
+///
+/// Writes across all four durable ports for `alpha` and asserts `beta` reads
+/// empty from each — no key-prefix bleed, no shared table leak.
+pub async fn assert_isolation_by_company(
+    store: Arc<dyn CompanyStore>,
+    events: Arc<dyn EventLog>,
+    memory: Arc<dyn MemoryStore>,
+    context: Arc<dyn ContextStore>,
+) {
+    let alpha = CompanyId::new("alpha");
+    let beta = CompanyId::new("beta");
+
+    store.save(&record(&alpha)).await.unwrap();
+    store.append_ledger(&alpha, ledger_entry(0)).await.unwrap();
+    events
+        .append(&alpha, CompanyEvent::OperatorMessage { text: "a".into() })
+        .await
+        .unwrap();
+    memory
+        .save_trace(&alpha, CompressedTrace::now("c0", "s0"))
+        .await
+        .unwrap();
+    context
+        .put(
+            &alpha,
+            ContextChunk {
+                label: "notes/intro".into(),
+                body: "alpha body".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+    // `beta` was never written: every port reads empty for it.
+    assert!(
+        store.load(&beta).await.unwrap().is_none(),
+        "beta record leaked"
+    );
+    assert!(
+        events
+            .read_from(&beta, EventSeq::new(0), usize::MAX)
+            .await
+            .unwrap()
+            .is_empty(),
+        "beta events leaked"
+    );
+    assert!(
+        memory
+            .recent_traces(&beta, usize::MAX)
+            .await
+            .unwrap()
+            .is_empty(),
+        "beta traces leaked"
+    );
+    assert!(
+        context.list(&beta, "").await.unwrap().is_empty(),
+        "beta context leaked"
+    );
+
+    // `alpha` still sees its own data.
+    let loaded = store.load(&alpha).await.unwrap().expect("alpha record");
+    assert_eq!(loaded.ledger.len(), 1);
+    assert_eq!(
+        events
+            .read_from(&alpha, EventSeq::new(0), usize::MAX)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        memory
+            .recent_traces(&alpha, usize::MAX)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(context.list(&alpha, "").await.unwrap().len(), 1);
+}
+
+/// Event and ledger logs are append-only: prior entries never move or mutate
+/// when new ones are written, and a record re-save does not rewrite the ledger.
+pub async fn assert_append_only_event_and_ledger(
+    store: Arc<dyn CompanyStore>,
+    events: Arc<dyn EventLog>,
+) {
+    let id = CompanyId::new("alpha");
+    store.save(&record(&id)).await.unwrap();
+
+    for i in 0..3 {
+        store.append_ledger(&id, ledger_entry(i)).await.unwrap();
+    }
+    let ledger_before = store.load(&id).await.unwrap().unwrap().ledger;
+    assert_eq!(ledger_before.len(), 3);
+
+    // Re-saving the record must not disturb the append-only ledger.
+    store.save(&record(&id)).await.unwrap();
+    let ledger_after = store.load(&id).await.unwrap().unwrap().ledger;
+    assert_eq!(ledger_after, ledger_before, "save() rewrote the ledger");
+
+    let s0 = events
+        .append(&id, CompanyEvent::OperatorMessage { text: "e0".into() })
+        .await
+        .unwrap();
+    let s1 = events
+        .append(&id, CompanyEvent::OperatorMessage { text: "e1".into() })
+        .await
+        .unwrap();
+    let prefix_before = events
+        .read_from(&id, EventSeq::new(0), usize::MAX)
+        .await
+        .unwrap();
+
+    // Further appends never reorder or rewrite the existing prefix.
+    events
+        .append(&id, CompanyEvent::OperatorMessage { text: "e2".into() })
+        .await
+        .unwrap();
+    let all = events
+        .read_from(&id, EventSeq::new(0), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(&all[..2], &prefix_before[..], "append reordered the prefix");
+    assert_eq!(all[0].seq, s0);
+    assert_eq!(all[1].seq, s1);
+    assert_eq!(all.len(), 3);
+    // More ledger appends still grow monotonically after the re-save.
+    store.append_ledger(&id, ledger_entry(99)).await.unwrap();
+    let grown = store.load(&id).await.unwrap().unwrap().ledger;
+    assert_eq!(grown.len(), 4);
+    assert_eq!(grown[..3], ledger_before[..]);
+}
+
+/// Event sequences are 0-based, increase by exactly one per append, and are
+/// independent per company.
+pub async fn assert_monotonic_event_seq(events: Arc<dyn EventLog>) {
+    let alpha = CompanyId::new("alpha");
+    let beta = CompanyId::new("beta");
+
+    for expected in 0..5u64 {
+        let seq = events
+            .append(
+                &alpha,
+                CompanyEvent::OperatorMessage {
+                    text: format!("a{expected}"),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(seq, EventSeq::new(expected), "alpha seq not 0-based +1");
+    }
+
+    // A second company starts its own sequence at 0.
+    let first_beta = events
+        .append(&beta, CompanyEvent::OperatorMessage { text: "b0".into() })
+        .await
+        .unwrap();
+    assert_eq!(
+        first_beta,
+        EventSeq::new(0),
+        "beta seq did not restart at 0"
+    );
+
+    // Stored seqs read back in order and match the returned values.
+    let stored = events
+        .read_from(&alpha, EventSeq::new(0), usize::MAX)
+        .await
+        .unwrap();
+    for (i, ev) in stored.iter().enumerate() {
+        assert_eq!(ev.seq, EventSeq::new(i as u64));
+        assert_eq!(ev.company, alpha);
+    }
+    // `read_from` honours the `seq >=` lower bound.
+    let tail = events
+        .read_from(&alpha, EventSeq::new(3), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(tail.len(), 2);
+    assert_eq!(tail[0].seq, EventSeq::new(3));
+}
+
+/// Everything written through the ports reads back through the ports,
+/// byte-identically — the totality precondition an export relies on.
+pub async fn assert_export_totality(
+    store: Arc<dyn CompanyStore>,
+    events: Arc<dyn EventLog>,
+    memory: Arc<dyn MemoryStore>,
+    context: Arc<dyn ContextStore>,
+) {
+    let id = CompanyId::new("alpha");
+    store.save(&record(&id)).await.unwrap();
+
+    let mut ledger = Vec::new();
+    for i in 0..4 {
+        let e = ledger_entry(i);
+        ledger.push(e.clone());
+        store.append_ledger(&id, e).await.unwrap();
+    }
+
+    let mut appended = Vec::new();
+    for i in 0..4 {
+        let ev = CompanyEvent::OperatorMessage {
+            text: format!("event {i}"),
+        };
+        events.append(&id, ev.clone()).await.unwrap();
+        appended.push(ev);
+    }
+
+    let mut traces = Vec::new();
+    for i in 0..3 {
+        let t = CompressedTrace::now(format!("c{i}"), format!("summary {i}"));
+        traces.push(t.clone());
+        memory.save_trace(&id, t).await.unwrap();
+    }
+
+    let bodies = ["export alpha", "export beta", "export gamma"];
+    let mut addrs = Vec::new();
+    for (i, body) in bodies.iter().enumerate() {
+        let addr = context
+            .put(
+                &id,
+                ContextChunk {
+                    label: format!("doc/{i}"),
+                    body: (*body).to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        addrs.push(addr);
+    }
+
+    // Company record + ledger round-trip.
+    let loaded = store.load(&id).await.unwrap().expect("record");
+    assert_eq!(loaded.manifest.company.name, "Conformance Co");
+    assert_eq!(loaded.lifecycle, "running");
+    assert_eq!(loaded.ledger, ledger);
+
+    // Full event log round-trips with seqs and payloads intact.
+    let read = events
+        .read_from(&id, EventSeq::new(0), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(read.len(), appended.len());
+    for (i, stored) in read.iter().enumerate() {
+        assert_eq!(stored.seq, EventSeq::new(i as u64));
+        assert_eq!(stored.event, appended[i]);
+    }
+
+    // All traces round-trip, newest last.
+    let recent = memory.recent_traces(&id, usize::MAX).await.unwrap();
+    assert_eq!(recent, traces);
+
+    // Every context chunk is listable and its body reads back exactly.
+    let metas = context.list(&id, "").await.unwrap();
+    assert_eq!(metas.len(), bodies.len());
+    for (addr, body) in addrs.iter().zip(bodies.iter()) {
+        let read_body = context.peek(&id, addr, None).await.unwrap();
+        assert_eq!(&read_body, body);
+    }
+    // Search finds a written body.
+    let hits = context.search(&id, "gamma", usize::MAX).await.unwrap();
+    assert_eq!(hits.len(), 1);
+    assert!(hits[0].snippet.contains("gamma"));
+}

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -1,0 +1,815 @@
+//! Store-agnostic bundle export and import.
+//!
+//! Export reads *everything* for a company through the four durable storage
+//! ports ([`CompanyStore`], [`EventLog`], [`MemoryStore`], [`ContextStore`]) and
+//! writes the canonical filesystem [`Bundle`](crate::store::paths::Bundle)
+//! layout. Because it drives the ports rather than a backend's private files, an
+//! export is *total by construction* for any backend — the fs and sqlite stores
+//! produce identical bundles. Import is the exact inverse: it reads a bundle
+//! directory and replays every record through the ports, so it materializes into
+//! whichever backend the target ports are wired to.
+//!
+//! The dep-free core operates on an *unpacked bundle directory*. A single-file
+//! `.tar` wrapper ([`pack_tar`]/[`unpack_tar`]) is gated behind the `export`
+//! feature so the default build links no archive crate.
+//!
+//! `secrets/` and `keys/` are fs-only artifacts (the builder keeps them on the
+//! filesystem even under a non-fs store) with no enumeration port, so they are
+//! excluded from an export unless [`ExportOpts::include_secrets`] is set and a
+//! source bundle directory is supplied.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::Result;
+use crate::company::CompanyManifest;
+use crate::error::OpenCompanyError;
+use crate::ports::context::ContextStore;
+use crate::ports::events::EventLog;
+use crate::ports::memory::MemoryStore;
+use crate::ports::store::CompanyStore;
+use crate::ports::types::{
+    CompanyId, CompanyRecord, CompressedTrace, ContextChunk, EventSeq, LedgerEntry, StoredEvent,
+};
+
+/// Canonical bundle file and directory names, matching the fs
+/// [`Bundle`](crate::store::paths::Bundle) layout.
+const COMPANY_TOML: &str = "company.toml";
+const META_JSON: &str = "meta.json";
+const EVENTS_JSONL: &str = "events.jsonl";
+const LEDGER_JSONL: &str = "ledger.jsonl";
+const MEMORY_DIR: &str = "memory";
+const TRACES_JSONL: &str = "traces.jsonl";
+const CONTEXT_DIR: &str = "context";
+const CONTEXT_INDEX_JSONL: &str = "index.jsonl";
+const CONTEXT_BLOBS_DIR: &str = "blobs";
+const SECRETS_DIR: &str = "secrets";
+const KEYS_DIR: &str = "keys";
+
+/// The four durable storage ports as trait objects, in export/import order
+/// (`CompanyStore`, `EventLog`, `MemoryStore`, `ContextStore`).
+pub type Ports = (
+    Arc<dyn CompanyStore>,
+    Arc<dyn EventLog>,
+    Arc<dyn MemoryStore>,
+    Arc<dyn ContextStore>,
+);
+
+/// Options controlling what an export includes.
+#[derive(Clone, Debug, Default)]
+pub struct ExportOpts {
+    /// Include the fs-only `secrets/` and `keys/` directories. Off by default so
+    /// a shared bundle never leaks the company's signing key or secrets.
+    pub include_secrets: bool,
+    /// The source fs bundle directory to copy `secrets/`/`keys/` from when
+    /// [`Self::include_secrets`] is set. Left `None` for a non-fs source (which
+    /// has no such artifacts to copy).
+    pub fs_bundle: Option<PathBuf>,
+}
+
+fn io_err(path: &Path, source: std::io::Error) -> OpenCompanyError {
+    OpenCompanyError::StoreIo {
+        path: path.to_path_buf(),
+        source,
+    }
+}
+
+/// Bundle metadata persisted alongside the manifest. Carries the company id so an
+/// import can restore the original id even when it diverges from the manifest
+/// slug. The fs [`CompanyStore`] reads only `lifecycle`; the extra field is
+/// ignored there (serde skips unknown fields).
+#[derive(Serialize, Deserialize)]
+struct BundleMeta {
+    lifecycle: String,
+    id: String,
+}
+
+/// One exported context chunk: its content address, label, and body.
+struct ExportedChunk {
+    addr: String,
+    label: String,
+    body: String,
+}
+
+/// A context-index line pairing an address with its label and length. Matches the
+/// fs [`ContextStore`] index shape.
+#[derive(Serialize, Deserialize)]
+struct IndexEntry {
+    addr: String,
+    label: String,
+    len: usize,
+}
+
+/// Everything an export carries for one company, read through the ports.
+struct BundleContents {
+    id: CompanyId,
+    manifest: CompanyManifest,
+    lifecycle: String,
+    ledger: Vec<LedgerEntry>,
+    events: Vec<StoredEvent>,
+    traces: Vec<CompressedTrace>,
+    context: Vec<ExportedChunk>,
+}
+
+impl BundleContents {
+    /// Reads the complete company state through the four durable ports.
+    async fn read_via_ports(
+        id: &CompanyId,
+        store: Arc<dyn CompanyStore>,
+        events: Arc<dyn EventLog>,
+        memory: Arc<dyn MemoryStore>,
+        context: Arc<dyn ContextStore>,
+    ) -> Result<Self> {
+        let record = store
+            .load(id)
+            .await?
+            .ok_or_else(|| OpenCompanyError::CompanyNotFound(id.to_string()))?;
+
+        let events = events.read_from(id, EventSeq::new(0), usize::MAX).await?;
+        let traces = memory.recent_traces(id, usize::MAX).await?;
+
+        let metas = context.list(id, "").await?;
+        let mut chunks = Vec::with_capacity(metas.len());
+        for meta in metas {
+            let body = context.peek(id, &meta.addr, None).await?;
+            chunks.push(ExportedChunk {
+                addr: meta.addr.as_ref().to_string(),
+                label: meta.label,
+                body,
+            });
+        }
+
+        Ok(Self {
+            id: id.clone(),
+            manifest: record.manifest,
+            lifecycle: record.lifecycle,
+            ledger: record.ledger,
+            events,
+            traces,
+            context: chunks,
+        })
+    }
+
+    /// Replays the complete company state through the four durable ports. Events
+    /// are appended in order, so a fresh target log reproduces the original
+    /// 0-based sequence numbers; context chunks re-derive their original content
+    /// address from the body.
+    async fn write_via_ports(
+        &self,
+        store: Arc<dyn CompanyStore>,
+        events: Arc<dyn EventLog>,
+        memory: Arc<dyn MemoryStore>,
+        context: Arc<dyn ContextStore>,
+    ) -> Result<()> {
+        // The manifest + lifecycle; ledger is appended separately so the store's
+        // append-only ledger stays authoritative.
+        store
+            .save(&CompanyRecord {
+                id: self.id.clone(),
+                manifest: self.manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: self.lifecycle.clone(),
+            })
+            .await?;
+        for entry in &self.ledger {
+            store.append_ledger(&self.id, entry.clone()).await?;
+        }
+        for stored in &self.events {
+            events.append(&self.id, stored.event.clone()).await?;
+        }
+        for trace in &self.traces {
+            memory.save_trace(&self.id, trace.clone()).await?;
+        }
+        for chunk in &self.context {
+            context
+                .put(
+                    &self.id,
+                    ContextChunk {
+                        label: chunk.label.clone(),
+                        body: chunk.body.clone(),
+                    },
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Writes the canonical fs bundle layout under `dest`.
+    async fn write_to_dir(&self, dest: &Path) -> Result<()> {
+        create_dir(dest).await?;
+
+        let toml_src = toml::to_string(&self.manifest)
+            .map_err(|e| OpenCompanyError::Store(format!("cannot serialize manifest: {e}")))?;
+        write_file(&dest.join(COMPANY_TOML), toml_src.as_bytes()).await?;
+
+        let meta = BundleMeta {
+            lifecycle: self.lifecycle.clone(),
+            id: self.id.as_ref().to_string(),
+        };
+        write_file(
+            &dest.join(META_JSON),
+            serde_json::to_string(&meta)?.as_bytes(),
+        )
+        .await?;
+
+        write_file(&dest.join(LEDGER_JSONL), jsonl(&self.ledger)?.as_bytes()).await?;
+        write_file(&dest.join(EVENTS_JSONL), jsonl(&self.events)?.as_bytes()).await?;
+
+        let memory_dir = dest.join(MEMORY_DIR);
+        create_dir(&memory_dir).await?;
+        write_file(
+            &memory_dir.join(TRACES_JSONL),
+            jsonl(&self.traces)?.as_bytes(),
+        )
+        .await?;
+
+        let context_dir = dest.join(CONTEXT_DIR);
+        let blobs_dir = context_dir.join(CONTEXT_BLOBS_DIR);
+        create_dir(&blobs_dir).await?;
+        let index: Vec<IndexEntry> = self
+            .context
+            .iter()
+            .map(|c| IndexEntry {
+                addr: c.addr.clone(),
+                label: c.label.clone(),
+                len: c.body.len(),
+            })
+            .collect();
+        write_file(
+            &context_dir.join(CONTEXT_INDEX_JSONL),
+            jsonl(&index)?.as_bytes(),
+        )
+        .await?;
+        for chunk in &self.context {
+            write_file(&blobs_dir.join(&chunk.addr), chunk.body.as_bytes()).await?;
+        }
+        Ok(())
+    }
+
+    /// Reads a bundle directory (the inverse of [`Self::write_to_dir`]).
+    async fn read_from_dir(src: &Path) -> Result<Self> {
+        let toml_path = src.join(COMPANY_TOML);
+        let toml_src = read_to_string(&toml_path).await?;
+        let manifest: CompanyManifest = toml::from_str(&toml_src)
+            .map_err(|e| OpenCompanyError::Store(format!("invalid {COMPANY_TOML}: {e}")))?;
+
+        let meta: BundleMeta = serde_json::from_str(&read_to_string(&src.join(META_JSON)).await?)?;
+
+        let ledger = read_jsonl::<LedgerEntry>(&src.join(LEDGER_JSONL)).await?;
+        let events = read_jsonl::<StoredEvent>(&src.join(EVENTS_JSONL)).await?;
+        let traces =
+            read_jsonl::<CompressedTrace>(&src.join(MEMORY_DIR).join(TRACES_JSONL)).await?;
+
+        let context_dir = src.join(CONTEXT_DIR);
+        let index = read_jsonl::<IndexEntry>(&context_dir.join(CONTEXT_INDEX_JSONL)).await?;
+        let blobs_dir = context_dir.join(CONTEXT_BLOBS_DIR);
+        let mut context = Vec::with_capacity(index.len());
+        for entry in index {
+            let body = read_to_string(&blobs_dir.join(&entry.addr)).await?;
+            context.push(ExportedChunk {
+                addr: entry.addr,
+                label: entry.label,
+                body,
+            });
+        }
+
+        Ok(Self {
+            id: CompanyId::new(meta.id),
+            manifest,
+            lifecycle: meta.lifecycle,
+            ledger,
+            events,
+            traces,
+            context,
+        })
+    }
+}
+
+/// Exports `id`'s complete state through the ports into an unpacked bundle
+/// directory at `dest`.
+///
+/// Total by construction: every port is drained (`read_from(0, MAX)`,
+/// `recent_traces(MAX)`, `list("")` + `peek`), so an export never depends on a
+/// backend's private on-disk shape. When [`ExportOpts::include_secrets`] is set
+/// and [`ExportOpts::fs_bundle`] points at the source fs bundle, the fs-only
+/// `secrets/` and `keys/` directories are copied verbatim.
+pub async fn export_bundle(
+    id: &CompanyId,
+    dest: &Path,
+    store: Arc<dyn CompanyStore>,
+    events: Arc<dyn EventLog>,
+    memory: Arc<dyn MemoryStore>,
+    context: Arc<dyn ContextStore>,
+    opts: ExportOpts,
+) -> Result<()> {
+    let contents = BundleContents::read_via_ports(id, store, events, memory, context).await?;
+    contents.write_to_dir(dest).await?;
+
+    if opts.include_secrets
+        && let Some(src_bundle) = &opts.fs_bundle
+    {
+        for sub in [SECRETS_DIR, KEYS_DIR] {
+            copy_dir(&src_bundle.join(sub), &dest.join(sub)).await?;
+        }
+    }
+    Ok(())
+}
+
+/// Imports a bundle directory at `src` through the target ports, returning the
+/// restored company id.
+///
+/// The inverse of [`export_bundle`] for the port-driven records: the manifest,
+/// lifecycle, ledger, events, traces, and context are replayed through the
+/// supplied ports. `secrets/`/`keys/` are fs artifacts restored separately via
+/// [`restore_fs_artifacts`].
+pub async fn import_bundle(
+    src: &Path,
+    store: Arc<dyn CompanyStore>,
+    events: Arc<dyn EventLog>,
+    memory: Arc<dyn MemoryStore>,
+    context: Arc<dyn ContextStore>,
+) -> Result<CompanyId> {
+    let contents = BundleContents::read_from_dir(src).await?;
+    let id = contents.id.clone();
+    contents
+        .write_via_ports(store, events, memory, context)
+        .await?;
+    Ok(id)
+}
+
+/// Copies the fs-only `secrets/` and `keys/` directories from an imported bundle
+/// at `src` into the live fs bundle directory `dest_bundle_dir`, if present.
+///
+/// A no-op for subdirectories the bundle did not carry (the common case, since
+/// they are excluded from exports by default).
+pub async fn restore_fs_artifacts(src: &Path, dest_bundle_dir: &Path) -> Result<()> {
+    for sub in [SECRETS_DIR, KEYS_DIR] {
+        let from = src.join(sub);
+        if tokio::fs::metadata(&from).await.is_ok() {
+            copy_dir(&from, &dest_bundle_dir.join(sub)).await?;
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Directory helpers
+// ---------------------------------------------------------------------------
+
+async fn create_dir(dir: &Path) -> Result<()> {
+    tokio::fs::create_dir_all(dir)
+        .await
+        .map_err(|e| io_err(dir, e))
+}
+
+async fn write_file(path: &Path, bytes: &[u8]) -> Result<()> {
+    tokio::fs::write(path, bytes)
+        .await
+        .map_err(|e| io_err(path, e))
+}
+
+async fn read_to_string(path: &Path) -> Result<String> {
+    tokio::fs::read_to_string(path)
+        .await
+        .map_err(|e| io_err(path, e))
+}
+
+/// Serializes a slice as newline-delimited JSON (one value per line).
+fn jsonl<T: Serialize>(items: &[T]) -> Result<String> {
+    let mut out = String::new();
+    for item in items {
+        out.push_str(&serde_json::to_string(item)?);
+        out.push('\n');
+    }
+    Ok(out)
+}
+
+/// Parses every non-empty JSONL line of `path`, skipping an absent file.
+async fn read_jsonl<T: serde::de::DeserializeOwned>(path: &Path) -> Result<Vec<T>> {
+    let contents = match tokio::fs::read_to_string(path).await {
+        Ok(contents) => contents,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(io_err(path, e)),
+    };
+    let mut out = Vec::new();
+    for line in contents.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        out.push(serde_json::from_str(line)?);
+    }
+    Ok(out)
+}
+
+/// Recursively copies `from` into `to`. A no-op when `from` does not exist.
+async fn copy_dir(from: &Path, to: &Path) -> Result<()> {
+    if tokio::fs::metadata(from).await.is_err() {
+        return Ok(());
+    }
+    create_dir(to).await?;
+    let mut entries = tokio::fs::read_dir(from)
+        .await
+        .map_err(|e| io_err(from, e))?;
+    while let Some(entry) = entries.next_entry().await.map_err(|e| io_err(from, e))? {
+        let path = entry.path();
+        let dest = to.join(entry.file_name());
+        let file_type = entry.file_type().await.map_err(|e| io_err(&path, e))?;
+        if file_type.is_dir() {
+            Box::pin(copy_dir(&path, &dest)).await?;
+        } else {
+            tokio::fs::copy(&path, &dest)
+                .await
+                .map_err(|e| io_err(&path, e))?;
+        }
+    }
+    Ok(())
+}
+
+/// Locates the bundle root under `dir`: `dir` itself when it holds a
+/// `company.toml`, else the single immediate subdirectory that does (as produced
+/// by [`pack_tar`], which nests the bundle under a top-level slug directory).
+pub fn find_bundle_root(dir: &Path) -> Result<PathBuf> {
+    if dir.join(COMPANY_TOML).is_file() {
+        return Ok(dir.to_path_buf());
+    }
+    let entries = std::fs::read_dir(dir).map_err(|e| io_err(dir, e))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| io_err(dir, e))?;
+        let path = entry.path();
+        if path.join(COMPANY_TOML).is_file() {
+            return Ok(path);
+        }
+    }
+    Err(OpenCompanyError::Store(format!(
+        "no {COMPANY_TOML} found under {}",
+        dir.display()
+    )))
+}
+
+// ---------------------------------------------------------------------------
+// Tar wrapper (feature `export`)
+// ---------------------------------------------------------------------------
+
+/// Packs an unpacked bundle directory into a single `.tar` at `out`.
+///
+/// The bundle is nested under a top-level directory named after `bundle_dir`, so
+/// [`unpack_tar`] followed by [`find_bundle_root`] recovers it unambiguously.
+#[cfg(feature = "export")]
+pub fn pack_tar(bundle_dir: &Path, out: &Path) -> Result<()> {
+    let file = std::fs::File::create(out).map_err(|e| io_err(out, e))?;
+    let mut builder = tar::Builder::new(file);
+    let top = bundle_dir
+        .file_name()
+        .map(std::ffi::OsStr::to_os_string)
+        .unwrap_or_else(|| std::ffi::OsString::from("bundle"));
+    builder
+        .append_dir_all(&top, bundle_dir)
+        .map_err(|e| io_err(bundle_dir, e))?;
+    builder.finish().map_err(|e| io_err(out, e))?;
+    Ok(())
+}
+
+/// Unpacks a `.tar` produced by [`pack_tar`] into `dest`.
+#[cfg(feature = "export")]
+pub fn unpack_tar(tar_path: &Path, dest: &Path) -> Result<()> {
+    std::fs::create_dir_all(dest).map_err(|e| io_err(dest, e))?;
+    let file = std::fs::File::open(tar_path).map_err(|e| io_err(tar_path, e))?;
+    let mut archive = tar::Archive::new(file);
+    archive.unpack(dest).map_err(|e| io_err(dest, e))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ports::SecretStore;
+    use crate::ports::types::{Actor, ActorKind, CompanyEvent};
+    use crate::runtime::RuntimeBuilder;
+    use crate::store::paths::Bundle;
+    use crate::store::{FsCompanyStore, FsContextStore, FsEventLog, FsMemoryStore, FsSecretStore};
+
+    fn tmp_root(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "opencompany-export-{tag}-{}-{}",
+            std::process::id(),
+            crate::ports::now_millis()
+        ))
+    }
+
+    fn manifest() -> CompanyManifest {
+        let toml_src = r#"
+            [company]
+            name = "Export Co"
+            output = "widgets"
+
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+
+            [policy]
+            mode = "supervised"
+        "#;
+        toml::from_str(toml_src).expect("parse manifest")
+    }
+
+    fn fs_ports(root: &Path) -> Ports {
+        (
+            Arc::new(FsCompanyStore::new(root.to_path_buf())),
+            Arc::new(FsEventLog::new(root.to_path_buf())),
+            Arc::new(FsMemoryStore::new(root.to_path_buf())),
+            Arc::new(FsContextStore::new(root.to_path_buf())),
+        )
+    }
+
+    /// The mandatory end-to-end round-trip: build a company, run a cycle to
+    /// populate events/traces/ledger, seed a ledger entry and context chunk,
+    /// export to a bundle directory, import into a *fresh* home through the fs
+    /// ports, and assert the charter + event log + ledger survive intact.
+    #[tokio::test]
+    async fn export_import_roundtrip_fs() {
+        let home1 = tmp_root("src");
+        let home2 = tmp_root("dst");
+        let dest = tmp_root("bundle");
+
+        // Build + populate the source company.
+        let runtime = RuntimeBuilder::fs_defaults(home1.clone(), manifest())
+            .await
+            .expect("build");
+        let id = runtime.id().clone();
+        runtime
+            .run_cycle(vec![CompanyEvent::OperatorMessage {
+                text: "kick off".into(),
+            }])
+            .await
+            .expect("cycle");
+
+        let (s1, e1, m1, c1) = fs_ports(&home1);
+        s1.append_ledger(
+            &id,
+            LedgerEntry {
+                at_millis: 42,
+                kind: "inference.spend".into(),
+                amount_usd: 1.25,
+                memo: "seed".into(),
+            },
+        )
+        .await
+        .unwrap();
+        c1.put(
+            &id,
+            ContextChunk {
+                label: "notes/intro".into(),
+                body: "the quick brown fox".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Snapshot the source state through the ports for later comparison.
+        let src_record = s1.load(&id).await.unwrap().unwrap();
+        let src_events = e1
+            .read_from(&id, EventSeq::new(0), usize::MAX)
+            .await
+            .unwrap();
+        assert!(!src_events.is_empty(), "cycle should log the input event");
+
+        // Export → import into a fresh home.
+        export_bundle(
+            &id,
+            &dest,
+            s1.clone(),
+            e1.clone(),
+            m1.clone(),
+            c1.clone(),
+            ExportOpts::default(),
+        )
+        .await
+        .expect("export");
+
+        let (s2, e2, m2, c2) = fs_ports(&home2);
+        let imported_id = import_bundle(&dest, s2.clone(), e2.clone(), m2.clone(), c2.clone())
+            .await
+            .expect("import");
+        assert_eq!(imported_id, id, "id preserved through the bundle");
+
+        // Charter + lifecycle identical.
+        let dst_record = s2.load(&id).await.unwrap().expect("imported record");
+        assert_eq!(
+            dst_record.manifest.company.name,
+            src_record.manifest.company.name
+        );
+        assert_eq!(dst_record.manifest.company.name, "Export Co");
+        assert_eq!(dst_record.lifecycle, src_record.lifecycle);
+
+        // Ledger byte-identical (entries carry their original timestamps).
+        assert_eq!(dst_record.ledger, src_record.ledger);
+        assert!(dst_record.ledger.iter().any(|e| e.memo == "seed"));
+
+        // Event log identical: same seqs and payloads (timestamps are re-stamped
+        // on append, so compare seq + event only).
+        let dst_events = e2
+            .read_from(&id, EventSeq::new(0), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(dst_events.len(), src_events.len());
+        for (a, b) in src_events.iter().zip(dst_events.iter()) {
+            assert_eq!(a.seq, b.seq);
+            assert_eq!(a.event, b.event);
+        }
+
+        // Traces + context round-trip through the ports.
+        let src_traces = m1.recent_traces(&id, usize::MAX).await.unwrap();
+        let dst_traces = m2.recent_traces(&id, usize::MAX).await.unwrap();
+        assert_eq!(src_traces, dst_traces);
+        let chunk = c2.list(&id, "notes/").await.unwrap();
+        assert_eq!(chunk.len(), 1);
+        assert_eq!(
+            c2.peek(&id, &chunk[0].addr, None).await.unwrap(),
+            "the quick brown fox"
+        );
+
+        for dir in [home1, home2, dest] {
+            tokio::fs::remove_dir_all(&dir).await.ok();
+        }
+    }
+
+    /// Secrets and keys are excluded from an export by default and only appear
+    /// when `include_secrets` is set with a source bundle.
+    #[tokio::test]
+    async fn secrets_excluded_by_default() {
+        let home = tmp_root("sec-home");
+        let runtime = RuntimeBuilder::fs_defaults(home.clone(), manifest())
+            .await
+            .expect("build");
+        let id = runtime.id().clone();
+
+        // Seed a secret and a key file in the source fs bundle.
+        let secrets = FsSecretStore::new(home.clone());
+        secrets
+            .set(
+                &id,
+                "github_token",
+                crate::ports::SecretValue("ghp_x".into()),
+            )
+            .await
+            .unwrap();
+        let bundle = Bundle::new(home.clone(), &id);
+        tokio::fs::write(bundle.agent_key(), b"seed-bytes")
+            .await
+            .unwrap();
+
+        let (s, e, m, c) = fs_ports(&home);
+
+        // Default: no secrets/ or keys/ in the export.
+        let plain = tmp_root("sec-plain");
+        export_bundle(
+            &id,
+            &plain,
+            s.clone(),
+            e.clone(),
+            m.clone(),
+            c.clone(),
+            ExportOpts::default(),
+        )
+        .await
+        .unwrap();
+        assert!(
+            !plain.join(SECRETS_DIR).exists(),
+            "secrets leaked by default"
+        );
+        assert!(!plain.join(KEYS_DIR).exists(), "keys leaked by default");
+
+        // With include_secrets + a source bundle: both are copied.
+        let withsec = tmp_root("sec-with");
+        export_bundle(
+            &id,
+            &withsec,
+            s,
+            e,
+            m,
+            c,
+            ExportOpts {
+                include_secrets: true,
+                fs_bundle: Some(bundle.dir().to_path_buf()),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(withsec.join(SECRETS_DIR).exists(), "secrets not included");
+        assert!(
+            withsec.join(KEYS_DIR).join("agent.ed25519").exists(),
+            "key not included"
+        );
+
+        for dir in [home, plain, withsec] {
+            tokio::fs::remove_dir_all(&dir).await.ok();
+        }
+    }
+
+    /// A `LifecycleChanged` event survives an export/import round-trip, proving
+    /// the closed event enum tunnels through the bundle intact.
+    #[tokio::test]
+    async fn lifecycle_event_survives_roundtrip() {
+        let home1 = tmp_root("lc-src");
+        let home2 = tmp_root("lc-dst");
+        let dest = tmp_root("lc-bundle");
+        let id = CompanyId::new("lc-co");
+
+        let (s1, e1, m1, c1) = fs_ports(&home1);
+        s1.save(&CompanyRecord {
+            id: id.clone(),
+            manifest: manifest(),
+            ledger: Vec::new(),
+            lifecycle: "paused".into(),
+        })
+        .await
+        .unwrap();
+        e1.append(
+            &id,
+            CompanyEvent::LifecycleChanged {
+                from: "running".into(),
+                to: "paused".into(),
+                by: Actor {
+                    kind: ActorKind::Operator,
+                    id: "owner".into(),
+                },
+            },
+        )
+        .await
+        .unwrap();
+
+        export_bundle(&id, &dest, s1, e1, m1, c1, ExportOpts::default())
+            .await
+            .unwrap();
+        let (s2, e2, m2, c2) = fs_ports(&home2);
+        import_bundle(&dest, s2.clone(), e2.clone(), m2, c2)
+            .await
+            .unwrap();
+
+        let rec = s2.load(&id).await.unwrap().unwrap();
+        assert_eq!(rec.lifecycle, "paused");
+        let events = e2
+            .read_from(&id, EventSeq::new(0), usize::MAX)
+            .await
+            .unwrap();
+        assert!(matches!(
+            events[0].event,
+            CompanyEvent::LifecycleChanged { .. }
+        ));
+
+        for dir in [home1, home2, dest] {
+            tokio::fs::remove_dir_all(&dir).await.ok();
+        }
+    }
+
+    #[cfg(feature = "export")]
+    #[tokio::test]
+    async fn tar_pack_unpack_roundtrip() {
+        let home = tmp_root("tar-home");
+        let runtime = RuntimeBuilder::fs_defaults(home.clone(), manifest())
+            .await
+            .expect("build");
+        let id = runtime.id().clone();
+        runtime
+            .run_cycle(vec![CompanyEvent::OperatorMessage { text: "hi".into() }])
+            .await
+            .unwrap();
+
+        let (s, e, m, c) = fs_ports(&home);
+        let bundle_dir = tmp_root("tar-bundle").join(id.as_ref());
+        export_bundle(&id, &bundle_dir, s, e, m, c, ExportOpts::default())
+            .await
+            .unwrap();
+
+        let tar_path = tmp_root("tar-out").join("company.tar");
+        tokio::fs::create_dir_all(tar_path.parent().unwrap())
+            .await
+            .unwrap();
+        pack_tar(&bundle_dir, &tar_path).unwrap();
+        assert!(tar_path.is_file());
+
+        let unpacked = tmp_root("tar-unpacked");
+        unpack_tar(&tar_path, &unpacked).unwrap();
+        let root = find_bundle_root(&unpacked).unwrap();
+
+        // Import the unpacked bundle into a fresh home.
+        let home2 = tmp_root("tar-dst");
+        let (s2, e2, m2, c2) = fs_ports(&home2);
+        let imported = import_bundle(&root, s2.clone(), e2, m2, c2).await.unwrap();
+        assert_eq!(imported, id);
+        let rec = s2.load(&id).await.unwrap().unwrap();
+        assert_eq!(rec.manifest.company.name, "Export Co");
+
+        for dir in [
+            home,
+            home2,
+            bundle_dir.parent().unwrap().to_path_buf(),
+            tar_path.parent().unwrap().to_path_buf(),
+            unpacked,
+        ] {
+            tokio::fs::remove_dir_all(&dir).await.ok();
+        }
+    }
+}

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -6,7 +6,6 @@
 //! `tokio::sync::Mutex` locks serialize concurrent writers within a process.
 
 use std::collections::HashMap;
-use std::hash::{DefaultHasher, Hash, Hasher};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex};
@@ -29,6 +28,7 @@ use crate::ports::types::{
     TaskResult,
 };
 use crate::ports::{generate_id, now_millis};
+use crate::store::content_address;
 use crate::store::paths::Bundle;
 
 // ---------------------------------------------------------------------------
@@ -454,12 +454,6 @@ impl FsContextStore {
     }
 }
 
-fn content_address(body: &str) -> String {
-    let mut hasher = DefaultHasher::new();
-    body.hash(&mut hasher);
-    format!("{:016x}", hasher.finish())
-}
-
 #[async_trait]
 impl ContextStore for FsContextStore {
     async fn put(&self, id: &CompanyId, chunk: ContextChunk) -> Result<ChunkAddr> {
@@ -597,10 +591,58 @@ impl SecretStore for FsSecretStore {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::store::conformance;
     use futures::StreamExt;
 
     fn tmp_root() -> PathBuf {
         std::env::temp_dir().join(format!("opencompany-test-{}", generate_id()))
+    }
+
+    // The fs backend runs the identical port-conformance suite the sqlite
+    // backend runs under `--features sqlite`. Each test gets a fresh root so the
+    // stores start empty.
+    #[tokio::test]
+    async fn conformance_isolation_by_company() {
+        let root = tmp_root();
+        conformance::assert_isolation_by_company(
+            Arc::new(FsCompanyStore::new(&root)),
+            Arc::new(FsEventLog::new(&root)),
+            Arc::new(FsMemoryStore::new(&root)),
+            Arc::new(FsContextStore::new(&root)),
+        )
+        .await;
+        tokio::fs::remove_dir_all(&root).await.ok();
+    }
+
+    #[tokio::test]
+    async fn conformance_append_only_event_and_ledger() {
+        let root = tmp_root();
+        conformance::assert_append_only_event_and_ledger(
+            Arc::new(FsCompanyStore::new(&root)),
+            Arc::new(FsEventLog::new(&root)),
+        )
+        .await;
+        tokio::fs::remove_dir_all(&root).await.ok();
+    }
+
+    #[tokio::test]
+    async fn conformance_monotonic_event_seq() {
+        let root = tmp_root();
+        conformance::assert_monotonic_event_seq(Arc::new(FsEventLog::new(&root))).await;
+        tokio::fs::remove_dir_all(&root).await.ok();
+    }
+
+    #[tokio::test]
+    async fn conformance_export_totality() {
+        let root = tmp_root();
+        conformance::assert_export_totality(
+            Arc::new(FsCompanyStore::new(&root)),
+            Arc::new(FsEventLog::new(&root)),
+            Arc::new(FsMemoryStore::new(&root)),
+            Arc::new(FsContextStore::new(&root)),
+        )
+        .await;
+        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     fn sample_manifest() -> crate::company::CompanyManifest {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -19,6 +19,14 @@ pub mod paths;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 
+/// TinyCortex-backed memory and context ports over a mockable client. TinyCortex
+/// is not checked out here, so the compiled backend is an offline in-memory
+/// client; a real HTTP client (inert until the service is reachable through the
+/// OpenHuman seam) is present behind the same feature. Only links under
+/// `tinycortex`.
+#[cfg(feature = "tinycortex")]
+pub mod tinycortex;
+
 /// A backend-agnostic port-conformance suite: async assertions parameterized
 /// over any [`CompanyStore`](crate::ports::CompanyStore) /
 /// [`EventLog`](crate::ports::EventLog) /
@@ -35,6 +43,11 @@ pub use paths::{Bundle, default_home};
 
 #[cfg(feature = "sqlite")]
 pub use sqlite::SqliteStore;
+
+#[cfg(feature = "tinycortex")]
+pub use tinycortex::{
+    CortexClient, CortexContextStore, CortexMemoryStore, HttpCortexClient, InMemoryCortex,
+};
 
 use std::hash::{DefaultHasher, Hash, Hasher};
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -8,8 +8,44 @@
 //! [`ContextStore`](crate::ports::ContextStore), and
 //! [`SecretStore`](crate::ports::SecretStore) over that layout.
 
+/// Store-agnostic bundle export and import: read everything through the four
+/// durable ports and write the canonical fs [`Bundle`](paths::Bundle) layout
+/// (and the inverse). The dep-free core operates on an unpacked bundle
+/// directory; a single-file `.tar` wrapper is gated behind the `export` feature.
+pub mod export;
 pub mod fs;
 pub mod paths;
 
+#[cfg(feature = "sqlite")]
+pub mod sqlite;
+
+/// A backend-agnostic port-conformance suite: async assertions parameterized
+/// over any [`CompanyStore`](crate::ports::CompanyStore) /
+/// [`EventLog`](crate::ports::EventLog) /
+/// [`MemoryStore`](crate::ports::MemoryStore) /
+/// [`ContextStore`](crate::ports::ContextStore) implementation. Both the fs and
+/// sqlite backends run the identical suite, so a new store proves it upholds the
+/// port contract (per-company isolation, append-only logs, monotonic seqs,
+/// export totality) rather than re-testing each backend by hand. Test-only.
+#[cfg(test)]
+pub mod conformance;
+
 pub use fs::{FsCompanyStore, FsContextStore, FsEventLog, FsMemoryStore, FsSecretStore};
 pub use paths::{Bundle, default_home};
+
+#[cfg(feature = "sqlite")]
+pub use sqlite::SqliteStore;
+
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+/// Computes the content address of a context-chunk body.
+///
+/// Shared by every [`ContextStore`](crate::ports::ContextStore) backend so the
+/// fs and sqlite stores mint identical addresses for identical bodies. Phase 1
+/// uses a non-cryptographic [`DefaultHasher`]; a real content hash (sha-256) is
+/// a documented follow-up.
+pub(crate) fn content_address(body: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    body.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}

--- a/src/store/paths.rs
+++ b/src/store/paths.rs
@@ -11,7 +11,12 @@
 //!   memory/           # compressed traces + task results
 //!   context/          # content-addressed context blobs + index
 //!   secrets/          # per-company secret files (0700 on unix)
+//!   keys/             # Ed25519 identity seed (0700 dir, 0600 files)
 //! ```
+//!
+//! `secrets/` and `keys/` are excluded from bundle exports (see
+//! [`Bundle::EXPORT_EXCLUDES`]) so a shared bundle never leaks the company's
+//! signing key or per-company secrets.
 
 use std::path::{Path, PathBuf};
 
@@ -149,6 +154,26 @@ impl Bundle {
         self.secrets_dir().join(slug(&CompanyId::new(key)))
     }
 
+    /// The per-company key material subdirectory (`0700` on unix).
+    pub fn keys_dir(&self) -> PathBuf {
+        self.dir.join("keys")
+    }
+
+    /// Path to the Ed25519 identity seed (`0600` on unix).
+    pub fn agent_key(&self) -> PathBuf {
+        self.keys_dir().join("agent.ed25519")
+    }
+
+    /// Bundle subdirectories excluded from exports. A shared or copied bundle
+    /// must never carry the company's private key or per-company secrets; an
+    /// export flow honours this list unless explicitly overridden.
+    pub const EXPORT_EXCLUDES: &'static [&'static str] = &["secrets", "keys"];
+
+    /// Returns the bundle subdirectories a copy/export must skip.
+    pub fn export_excludes() -> &'static [&'static str] {
+        Self::EXPORT_EXCLUDES
+    }
+
     /// Creates every directory in the bundle layout if absent.
     pub async fn ensure_dirs(&self) -> Result<()> {
         for dir in [
@@ -156,6 +181,7 @@ impl Bundle {
             self.memory_dir(),
             self.context_blobs_dir(),
             self.secrets_dir(),
+            self.keys_dir(),
         ] {
             tokio::fs::create_dir_all(&dir)
                 .await
@@ -165,6 +191,7 @@ impl Bundle {
                 })?;
         }
         restrict_dir(&self.secrets_dir())?;
+        restrict_dir(&self.keys_dir())?;
         Ok(())
     }
 }
@@ -187,6 +214,27 @@ fn restrict_dir(dir: &Path) -> Result<()> {
 
 #[cfg(not(unix))]
 fn restrict_dir(_dir: &Path) -> Result<()> {
+    Ok(())
+}
+
+/// Restricts a file to owner read/write only (`0600`) on unix.
+///
+/// Used for identity key material (`keys/agent.ed25519`). A no-op on non-unix
+/// targets, which rely on directory isolation instead. Gated to the sole
+/// consumer (the `tinyplace` signer) so the default build has no dead code.
+#[cfg(all(unix, feature = "tinyplace"))]
+pub(crate) fn restrict_file(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let perms = std::fs::Permissions::from_mode(0o600);
+    std::fs::set_permissions(path, perms).map_err(|source| OpenCompanyError::StoreIo {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+#[cfg(all(not(unix), feature = "tinyplace"))]
+pub(crate) fn restrict_file(_path: &Path) -> Result<()> {
     Ok(())
 }
 
@@ -216,6 +264,15 @@ mod test {
                 .context_index_jsonl()
                 .ends_with("context/index.jsonl")
         );
+    }
+
+    #[test]
+    fn keys_paths_nest_and_are_excluded_from_exports() {
+        let bundle = Bundle::new("/root", &CompanyId::new("acme"));
+        assert!(bundle.keys_dir().ends_with("companies/acme/keys"));
+        assert!(bundle.agent_key().ends_with("keys/agent.ed25519"));
+        assert!(Bundle::export_excludes().contains(&"keys"));
+        assert!(Bundle::export_excludes().contains(&"secrets"));
     }
 
     #[test]

--- a/src/store/paths.rs
+++ b/src/store/paths.rs
@@ -129,6 +129,16 @@ impl Bundle {
         self.context_dir().join("index.jsonl")
     }
 
+    /// The per-company feedback subdirectory (the "feedback family").
+    pub fn feedback_dir(&self) -> PathBuf {
+        self.dir.join("feedback")
+    }
+
+    /// Path to the append-only feedback-item log.
+    pub fn feedback_items_jsonl(&self) -> PathBuf {
+        self.feedback_dir().join("items.jsonl")
+    }
+
     /// The per-company secrets subdirectory.
     pub fn secrets_dir(&self) -> PathBuf {
         self.dir.join("secrets")

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1,0 +1,792 @@
+//! SQLite-backed implementations of the storage ports.
+//!
+//! One [`SqliteStore`] opens a single bundled-SQLite connection and implements
+//! every durable port — [`CompanyStore`], [`EventLog`], [`MemoryStore`],
+//! [`ContextStore`], and [`SecretStore`] — sharing that connection behind an
+//! `Arc<Mutex<_>>`. The same `Arc<SqliteStore>` can therefore be injected into
+//! all four `RuntimeBuilder::with_*` setters so one database file serves the
+//! whole company.
+//!
+//! ## Isolation and append-only semantics
+//!
+//! Every table is keyed on `company_id` first and every query filters
+//! `WHERE company_id = ?`, so company A can never read company B's rows. Event
+//! and ledger tables are append-only: sequence and index columns are assigned
+//! `COALESCE(MAX(..)+1, 0)` under the connection lock, reproducing the fs
+//! stores' 0-based, monotonic-per-company semantics.
+//!
+//! ## Concurrency
+//!
+//! `rusqlite` is synchronous. Each async method locks the `std::sync::Mutex`,
+//! does its work, and releases the guard *without* crossing an `.await`, so the
+//! non-`Send` guard never escapes a suspension point and the boxed futures stay
+//! `Send`.
+
+use std::collections::HashMap;
+use std::ops::Range;
+use std::path::Path;
+use std::sync::{Arc, Mutex as StdMutex, MutexGuard};
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use rusqlite::{Connection, OptionalExtension, params};
+use tokio::sync::broadcast;
+
+use crate::Result;
+use crate::company::CompanyManifest;
+use crate::error::OpenCompanyError;
+use crate::ports::context::ContextStore;
+use crate::ports::events::EventLog;
+use crate::ports::memory::MemoryStore;
+use crate::ports::now_millis;
+use crate::ports::secrets::SecretStore;
+use crate::ports::store::CompanyStore;
+use crate::ports::types::{
+    ChunkAddr, ChunkHit, ChunkMeta, CompanyEvent, CompanyId, CompanyRecord, CompanySummary,
+    CompressedTrace, ContextChunk, EventSeq, EvictionPolicy, LedgerEntry, SecretValue, StoredEvent,
+    TaskResult,
+};
+use crate::store::content_address;
+
+/// Schema for every port table. Idempotent: safe to run on each `open`.
+const MIGRATIONS: &str = r#"
+CREATE TABLE IF NOT EXISTS company (
+    company_id    TEXT PRIMARY KEY,
+    manifest_toml TEXT NOT NULL,
+    lifecycle     TEXT NOT NULL,
+    updated_ms    INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS ledger (
+    company_id TEXT NOT NULL,
+    idx        INTEGER NOT NULL,
+    entry_json TEXT NOT NULL,
+    at_ms      INTEGER NOT NULL,
+    PRIMARY KEY (company_id, idx)
+);
+CREATE TABLE IF NOT EXISTS events (
+    company_id TEXT NOT NULL,
+    seq        INTEGER NOT NULL,
+    event_json TEXT NOT NULL,
+    at_ms      INTEGER NOT NULL,
+    PRIMARY KEY (company_id, seq)
+);
+CREATE TABLE IF NOT EXISTS memory_traces (
+    company_id TEXT NOT NULL,
+    seq        INTEGER NOT NULL,
+    trace_json TEXT NOT NULL,
+    at_ms      INTEGER NOT NULL,
+    PRIMARY KEY (company_id, seq)
+);
+CREATE TABLE IF NOT EXISTS memory_tasks (
+    company_id  TEXT NOT NULL,
+    id          TEXT NOT NULL,
+    result_json TEXT NOT NULL,
+    at_ms       INTEGER NOT NULL,
+    PRIMARY KEY (company_id, id)
+);
+CREATE TABLE IF NOT EXISTS context_chunks (
+    company_id TEXT NOT NULL,
+    addr       TEXT NOT NULL,
+    label      TEXT NOT NULL,
+    body       TEXT NOT NULL,
+    len        INTEGER NOT NULL,
+    PRIMARY KEY (company_id, addr)
+);
+CREATE TABLE IF NOT EXISTS secrets (
+    company_id TEXT NOT NULL,
+    key        TEXT NOT NULL,
+    value      TEXT NOT NULL,
+    PRIMARY KEY (company_id, key)
+);
+"#;
+
+/// Maps a `rusqlite` failure onto the crate error type without a bare `?` on
+/// I/O (which would collide with the existing `#[from] io::Error` mapping).
+fn sql_err(e: rusqlite::Error) -> OpenCompanyError {
+    OpenCompanyError::Store(format!("sqlite error: {e}"))
+}
+
+/// Translates a `usize` limit into a SQLite `LIMIT` value. `usize::MAX` (the
+/// "read everything" sentinel used by export/replay) maps to `-1`, SQLite's
+/// unbounded-limit encoding.
+fn sql_limit(limit: usize) -> i64 {
+    if limit > i64::MAX as usize {
+        -1
+    } else {
+        limit as i64
+    }
+}
+
+/// A single SQLite database implementing all five storage ports.
+#[derive(Clone)]
+pub struct SqliteStore {
+    conn: Arc<StdMutex<Connection>>,
+    senders: Arc<StdMutex<HashMap<CompanyId, broadcast::Sender<StoredEvent>>>>,
+}
+
+impl SqliteStore {
+    /// Opens (creating if absent) the database at `path` and runs migrations.
+    /// Pass `":memory:"` for an ephemeral database, or use [`Self::open_in_memory`].
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let conn = Connection::open(path).map_err(sql_err)?;
+        Self::from_conn(conn)
+    }
+
+    /// Opens a private in-memory database (migrated), primarily for tests.
+    pub fn open_in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory().map_err(sql_err)?;
+        Self::from_conn(conn)
+    }
+
+    fn from_conn(conn: Connection) -> Result<Self> {
+        conn.execute_batch(MIGRATIONS).map_err(sql_err)?;
+        Ok(Self {
+            conn: Arc::new(StdMutex::new(conn)),
+            senders: Arc::new(StdMutex::new(HashMap::new())),
+        })
+    }
+
+    fn conn(&self) -> MutexGuard<'_, Connection> {
+        self.conn.lock().expect("sqlite connection mutex poisoned")
+    }
+
+    fn sender_for(&self, id: &CompanyId) -> broadcast::Sender<StoredEvent> {
+        let mut map = self.senders.lock().expect("sender map poisoned");
+        map.entry(id.clone())
+            .or_insert_with(|| broadcast::channel(256).0)
+            .clone()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CompanyStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl CompanyStore for SqliteStore {
+    async fn load(&self, id: &CompanyId) -> Result<Option<CompanyRecord>> {
+        let conn = self.conn();
+        let row: Option<(String, String)> = conn
+            .query_row(
+                "SELECT manifest_toml, lifecycle FROM company WHERE company_id = ?1",
+                params![id.as_ref()],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .optional()
+            .map_err(sql_err)?;
+        let Some((manifest_toml, lifecycle)) = row else {
+            return Ok(None);
+        };
+        let manifest: CompanyManifest = toml::from_str(&manifest_toml)
+            .map_err(|e| OpenCompanyError::Store(format!("invalid company.toml: {e}")))?;
+
+        let mut stmt = conn
+            .prepare("SELECT entry_json FROM ledger WHERE company_id = ?1 ORDER BY idx")
+            .map_err(sql_err)?;
+        let rows = stmt
+            .query_map(params![id.as_ref()], |r| r.get::<_, String>(0))
+            .map_err(sql_err)?;
+        let mut ledger = Vec::new();
+        for row in rows {
+            let json = row.map_err(sql_err)?;
+            ledger.push(serde_json::from_str::<LedgerEntry>(&json)?);
+        }
+
+        Ok(Some(CompanyRecord {
+            id: id.clone(),
+            manifest,
+            ledger,
+            lifecycle,
+        }))
+    }
+
+    async fn save(&self, record: &CompanyRecord) -> Result<()> {
+        let manifest_toml = toml::to_string(&record.manifest)
+            .map_err(|e| OpenCompanyError::Store(format!("cannot serialize manifest: {e}")))?;
+        let conn = self.conn();
+        // Append-only: `save` upserts the company row and never touches ledger.
+        conn.execute(
+            "INSERT INTO company (company_id, manifest_toml, lifecycle, updated_ms) \
+             VALUES (?1, ?2, ?3, ?4) \
+             ON CONFLICT(company_id) DO UPDATE SET \
+               manifest_toml = excluded.manifest_toml, \
+               lifecycle = excluded.lifecycle, \
+               updated_ms = excluded.updated_ms",
+            params![
+                record.id.as_ref(),
+                manifest_toml,
+                record.lifecycle,
+                now_millis() as i64
+            ],
+        )
+        .map_err(sql_err)?;
+        Ok(())
+    }
+
+    async fn list(&self) -> Result<Vec<CompanySummary>> {
+        let conn = self.conn();
+        let mut stmt = conn
+            .prepare("SELECT company_id, manifest_toml, lifecycle FROM company ORDER BY company_id")
+            .map_err(sql_err)?;
+        let rows = stmt
+            .query_map(params![], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                ))
+            })
+            .map_err(sql_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            let (id, manifest_toml, lifecycle) = row.map_err(sql_err)?;
+            let Ok(manifest) = toml::from_str::<CompanyManifest>(&manifest_toml) else {
+                continue;
+            };
+            out.push(CompanySummary {
+                id: CompanyId::new(id),
+                name: manifest.company.name,
+                lifecycle,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn append_ledger(&self, id: &CompanyId, entry: LedgerEntry) -> Result<()> {
+        let entry_json = serde_json::to_string(&entry)?;
+        let conn = self.conn();
+        conn.execute(
+            "INSERT INTO ledger (company_id, idx, entry_json, at_ms) VALUES \
+             (?1, (SELECT COALESCE(MAX(idx) + 1, 0) FROM ledger WHERE company_id = ?1), ?2, ?3)",
+            params![id.as_ref(), entry_json, entry.at_millis as i64],
+        )
+        .map_err(sql_err)?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EventLog
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl EventLog for SqliteStore {
+    async fn append(&self, id: &CompanyId, event: CompanyEvent) -> Result<EventSeq> {
+        let event_json = serde_json::to_string(&event)?;
+        let at_millis = now_millis();
+        let seq = {
+            let conn = self.conn();
+            let seq: i64 = conn
+                .query_row(
+                    "SELECT COALESCE(MAX(seq) + 1, 0) FROM events WHERE company_id = ?1",
+                    params![id.as_ref()],
+                    |r| r.get(0),
+                )
+                .map_err(sql_err)?;
+            conn.execute(
+                "INSERT INTO events (company_id, seq, event_json, at_ms) VALUES (?1, ?2, ?3, ?4)",
+                params![id.as_ref(), seq, event_json, at_millis as i64],
+            )
+            .map_err(sql_err)?;
+            seq as u64
+        };
+
+        let stored = StoredEvent {
+            seq: EventSeq::new(seq),
+            company: id.clone(),
+            event,
+            at_millis,
+        };
+        // Best-effort fan-out; an error only means no live subscribers.
+        let _ = self.sender_for(id).send(stored);
+        Ok(EventSeq::new(seq))
+    }
+
+    async fn read_from(
+        &self,
+        id: &CompanyId,
+        seq: EventSeq,
+        limit: usize,
+    ) -> Result<Vec<StoredEvent>> {
+        let conn = self.conn();
+        let mut stmt = conn
+            .prepare(
+                "SELECT seq, event_json, at_ms FROM events \
+                 WHERE company_id = ?1 AND seq >= ?2 ORDER BY seq LIMIT ?3",
+            )
+            .map_err(sql_err)?;
+        let rows = stmt
+            .query_map(
+                params![id.as_ref(), seq.value() as i64, sql_limit(limit)],
+                |r| {
+                    Ok((
+                        r.get::<_, i64>(0)?,
+                        r.get::<_, String>(1)?,
+                        r.get::<_, i64>(2)?,
+                    ))
+                },
+            )
+            .map_err(sql_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            let (seq, event_json, at_ms) = row.map_err(sql_err)?;
+            out.push(StoredEvent {
+                seq: EventSeq::new(seq as u64),
+                company: id.clone(),
+                event: serde_json::from_str(&event_json)?,
+                at_millis: at_ms as u64,
+            });
+        }
+        Ok(out)
+    }
+
+    fn subscribe(&self, id: &CompanyId) -> BoxStream<'static, StoredEvent> {
+        let rx = self.sender_for(id).subscribe();
+        let stream = futures::stream::unfold(rx, |mut rx| async move {
+            loop {
+                match rx.recv().await {
+                    Ok(event) => return Some((event, rx)),
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => return None,
+                }
+            }
+        });
+        Box::pin(stream)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MemoryStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl MemoryStore for SqliteStore {
+    async fn save_trace(&self, id: &CompanyId, trace: CompressedTrace) -> Result<()> {
+        let trace_json = serde_json::to_string(&trace)?;
+        let conn = self.conn();
+        conn.execute(
+            "INSERT INTO memory_traces (company_id, seq, trace_json, at_ms) VALUES \
+             (?1, (SELECT COALESCE(MAX(seq) + 1, 0) FROM memory_traces WHERE company_id = ?1), ?2, ?3)",
+            params![id.as_ref(), trace_json, trace.at_millis as i64],
+        )
+        .map_err(sql_err)?;
+        Ok(())
+    }
+
+    async fn recent_traces(&self, id: &CompanyId, limit: usize) -> Result<Vec<CompressedTrace>> {
+        let conn = self.conn();
+        let mut stmt = conn
+            .prepare(
+                "SELECT trace_json FROM memory_traces WHERE company_id = ?1 \
+                 ORDER BY seq DESC LIMIT ?2",
+            )
+            .map_err(sql_err)?;
+        let rows = stmt
+            .query_map(params![id.as_ref(), sql_limit(limit)], |r| {
+                r.get::<_, String>(0)
+            })
+            .map_err(sql_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            let json = row.map_err(sql_err)?;
+            out.push(serde_json::from_str::<CompressedTrace>(&json)?);
+        }
+        // Query returned newest-first; the port contract is newest-last.
+        out.reverse();
+        Ok(out)
+    }
+
+    async fn save_task_result(&self, id: &CompanyId, result: TaskResult) -> Result<()> {
+        let result_json = serde_json::to_string(&result)?;
+        let conn = self.conn();
+        conn.execute(
+            "INSERT INTO memory_tasks (company_id, id, result_json, at_ms) VALUES (?1, ?2, ?3, ?4) \
+             ON CONFLICT(company_id, id) DO UPDATE SET \
+               result_json = excluded.result_json, at_ms = excluded.at_ms",
+            params![
+                id.as_ref(),
+                result.task_id,
+                result_json,
+                now_millis() as i64
+            ],
+        )
+        .map_err(sql_err)?;
+        Ok(())
+    }
+
+    async fn evict(&self, id: &CompanyId, policy: EvictionPolicy) -> Result<u64> {
+        let conn = self.conn();
+        let removed = match policy {
+            EvictionPolicy::KeepRecent { n } => conn
+                .execute(
+                    "DELETE FROM memory_traces WHERE company_id = ?1 AND seq NOT IN \
+                     (SELECT seq FROM memory_traces WHERE company_id = ?1 ORDER BY seq DESC LIMIT ?2)",
+                    params![id.as_ref(), sql_limit(n)],
+                )
+                .map_err(sql_err)?,
+            EvictionPolicy::OlderThan { before_millis } => conn
+                .execute(
+                    "DELETE FROM memory_traces WHERE company_id = ?1 AND at_ms < ?2",
+                    params![id.as_ref(), before_millis as i64],
+                )
+                .map_err(sql_err)?,
+        };
+        Ok(removed as u64)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ContextStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl ContextStore for SqliteStore {
+    async fn put(&self, id: &CompanyId, chunk: ContextChunk) -> Result<ChunkAddr> {
+        let addr = content_address(&chunk.body);
+        let conn = self.conn();
+        conn.execute(
+            "INSERT OR IGNORE INTO context_chunks (company_id, addr, label, body, len) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                id.as_ref(),
+                addr,
+                chunk.label,
+                chunk.body,
+                chunk.body.len() as i64
+            ],
+        )
+        .map_err(sql_err)?;
+        Ok(ChunkAddr::new(addr))
+    }
+
+    async fn list(&self, id: &CompanyId, prefix: &str) -> Result<Vec<ChunkMeta>> {
+        let conn = self.conn();
+        let mut stmt = conn
+            .prepare(
+                "SELECT addr, label, len FROM context_chunks WHERE company_id = ?1 ORDER BY rowid",
+            )
+            .map_err(sql_err)?;
+        let rows = stmt
+            .query_map(params![id.as_ref()], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, i64>(2)?,
+                ))
+            })
+            .map_err(sql_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            let (addr, label, len) = row.map_err(sql_err)?;
+            if label.starts_with(prefix) {
+                out.push(ChunkMeta {
+                    addr: ChunkAddr::new(addr),
+                    label,
+                    len: len as usize,
+                });
+            }
+        }
+        Ok(out)
+    }
+
+    async fn peek(
+        &self,
+        id: &CompanyId,
+        addr: &ChunkAddr,
+        range: Option<Range<usize>>,
+    ) -> Result<String> {
+        let conn = self.conn();
+        let body: Option<String> = conn
+            .query_row(
+                "SELECT body FROM context_chunks WHERE company_id = ?1 AND addr = ?2",
+                params![id.as_ref(), addr.as_ref()],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(sql_err)?;
+        let body = body.ok_or_else(|| {
+            OpenCompanyError::Store(format!("context chunk not found: {}", addr.as_ref()))
+        })?;
+        match range {
+            None => Ok(body),
+            Some(r) => {
+                let start = r.start.min(body.len());
+                let end = r.end.min(body.len());
+                if start >= end {
+                    return Ok(String::new());
+                }
+                Ok(body[start..end].to_string())
+            }
+        }
+    }
+
+    async fn search(&self, id: &CompanyId, query: &str, limit: usize) -> Result<Vec<ChunkHit>> {
+        let conn = self.conn();
+        let mut stmt = conn
+            .prepare("SELECT addr, body FROM context_chunks WHERE company_id = ?1 ORDER BY rowid")
+            .map_err(sql_err)?;
+        let rows = stmt
+            .query_map(params![id.as_ref()], |r| {
+                Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+            })
+            .map_err(sql_err)?;
+        let mut hits = Vec::new();
+        for row in rows {
+            if hits.len() >= limit {
+                break;
+            }
+            let (addr, body) = row.map_err(sql_err)?;
+            if let Some(pos) = body.find(query) {
+                let start = pos.saturating_sub(24);
+                let end = (pos + query.len() + 24).min(body.len());
+                hits.push(ChunkHit {
+                    addr: ChunkAddr::new(addr),
+                    snippet: body[start..end].to_string(),
+                    score: 1.0,
+                });
+            }
+        }
+        Ok(hits)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SecretStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl SecretStore for SqliteStore {
+    async fn get(&self, company: &CompanyId, key: &str) -> Result<Option<SecretValue>> {
+        let conn = self.conn();
+        let value: Option<String> = conn
+            .query_row(
+                "SELECT value FROM secrets WHERE company_id = ?1 AND key = ?2",
+                params![company.as_ref(), key],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(sql_err)?;
+        Ok(value.map(SecretValue))
+    }
+
+    async fn set(&self, company: &CompanyId, key: &str, value: SecretValue) -> Result<()> {
+        let conn = self.conn();
+        conn.execute(
+            "INSERT INTO secrets (company_id, key, value) VALUES (?1, ?2, ?3) \
+             ON CONFLICT(company_id, key) DO UPDATE SET value = excluded.value",
+            params![company.as_ref(), key, value.expose()],
+        )
+        .map_err(sql_err)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::store::conformance;
+    use futures::StreamExt;
+
+    fn store() -> Arc<SqliteStore> {
+        Arc::new(SqliteStore::open_in_memory().expect("open in-memory sqlite"))
+    }
+
+    #[tokio::test]
+    async fn conformance_isolation_by_company() {
+        let s = store();
+        conformance::assert_isolation_by_company(s.clone(), s.clone(), s.clone(), s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_append_only_event_and_ledger() {
+        let s = store();
+        conformance::assert_append_only_event_and_ledger(s.clone(), s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_monotonic_event_seq() {
+        let s = store();
+        conformance::assert_monotonic_event_seq(s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_export_totality() {
+        let s = store();
+        conformance::assert_export_totality(s.clone(), s.clone(), s.clone(), s).await;
+    }
+
+    #[tokio::test]
+    async fn one_store_serves_every_port_through_arc() {
+        // A single Arc<SqliteStore> satisfies all five port trait objects — the
+        // shape a platform-mode `build_runtime` injects into every `with_*`.
+        let s = store();
+        let company: Arc<dyn CompanyStore> = s.clone();
+        let events: Arc<dyn EventLog> = s.clone();
+        let memory: Arc<dyn MemoryStore> = s.clone();
+        let context: Arc<dyn ContextStore> = s.clone();
+        let secrets: Arc<dyn SecretStore> = s.clone();
+
+        let id = CompanyId::new("acme");
+        company
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: toml::from_str(
+                    "[company]\nname=\"Acme\"\noutput=\"widgets\"\n[[agent]]\nid=\"ceo\"\nrole=\"Chief\"\n[policy]\nmode=\"supervised\"\n",
+                )
+                .unwrap(),
+                ledger: Vec::new(),
+                lifecycle: "running".into(),
+            })
+            .await
+            .unwrap();
+        events
+            .append(&id, CompanyEvent::OperatorMessage { text: "hi".into() })
+            .await
+            .unwrap();
+        memory
+            .save_trace(&id, CompressedTrace::now("c0", "s0"))
+            .await
+            .unwrap();
+        context
+            .put(
+                &id,
+                ContextChunk {
+                    label: "notes".into(),
+                    body: "body".into(),
+                },
+            )
+            .await
+            .unwrap();
+        secrets
+            .set(&id, "token", SecretValue("secret".into()))
+            .await
+            .unwrap();
+
+        assert!(company.load(&id).await.unwrap().is_some());
+        assert_eq!(
+            events
+                .read_from(&id, EventSeq::new(0), 10)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(memory.recent_traces(&id, 10).await.unwrap().len(), 1);
+        assert_eq!(context.list(&id, "").await.unwrap().len(), 1);
+        assert_eq!(
+            secrets.get(&id, "token").await.unwrap(),
+            Some(SecretValue("secret".into()))
+        );
+    }
+
+    #[tokio::test]
+    async fn subscribe_delivers_new_event() {
+        let s = store();
+        let id = CompanyId::new("acme");
+        let mut stream = s.subscribe(&id);
+        s.append(&id, CompanyEvent::OperatorMessage { text: "hi".into() })
+            .await
+            .unwrap();
+        let received = stream.next().await.expect("event delivered");
+        assert_eq!(
+            received.event,
+            CompanyEvent::OperatorMessage { text: "hi".into() }
+        );
+    }
+
+    #[tokio::test]
+    async fn task_result_upserts_by_id() {
+        let s = store();
+        let id = CompanyId::new("acme");
+        s.save_task_result(
+            &id,
+            TaskResult {
+                task_id: "t1".into(),
+                ok: false,
+                output: serde_json::json!({"v": 1}),
+            },
+        )
+        .await
+        .unwrap();
+        // Same id again overwrites rather than duplicating.
+        s.save_task_result(
+            &id,
+            TaskResult {
+                task_id: "t1".into(),
+                ok: true,
+                output: serde_json::json!({"v": 2}),
+            },
+        )
+        .await
+        .unwrap();
+        let count: i64 = s
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM memory_tasks WHERE company_id = ?1 AND id = ?2",
+                params![id.as_ref(), "t1"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn evict_keep_recent_and_older_than() {
+        let s = store();
+        let id = CompanyId::new("acme");
+        for i in 0..5 {
+            s.save_trace(&id, CompressedTrace::now(format!("c{i}"), format!("s{i}")))
+                .await
+                .unwrap();
+        }
+        let removed = s
+            .evict(&id, EvictionPolicy::KeepRecent { n: 2 })
+            .await
+            .unwrap();
+        assert_eq!(removed, 3);
+        let kept = s.recent_traces(&id, 10).await.unwrap();
+        assert_eq!(kept.len(), 2);
+        assert_eq!(kept[1].cycle_id, "c4");
+
+        // A cutoff comfortably in the future evicts every remaining trace.
+        let removed = s
+            .evict(
+                &id,
+                EvictionPolicy::OlderThan {
+                    before_millis: now_millis() + 60_000,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(removed, 2);
+        assert!(s.recent_traces(&id, 10).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn data_survives_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("company.db");
+        let id = CompanyId::new("acme");
+        {
+            let s = SqliteStore::open(&path).unwrap();
+            s.append(
+                &id,
+                CompanyEvent::OperatorMessage {
+                    text: "persist".into(),
+                },
+            )
+            .await
+            .unwrap();
+        }
+        // A fresh handle over the same file sees the durable event.
+        let s = SqliteStore::open(&path).unwrap();
+        let events = s.read_from(&id, EventSeq::new(0), 10).await.unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].event,
+            CompanyEvent::OperatorMessage {
+                text: "persist".into()
+            }
+        );
+    }
+}

--- a/src/store/tinycortex.rs
+++ b/src/store/tinycortex.rs
@@ -1,0 +1,836 @@
+//! TinyCortex-backed implementations of the memory and context ports.
+//!
+//! TinyCortex is the TinyHumans managed memory service. It is **not** checked
+//! out in this repository, so this module depends on nothing external: the
+//! storage seam is the [`CortexClient`] trait, and the compiled-and-tested
+//! backend is [`InMemoryCortex`], an offline in-memory implementation. A real
+//! HTTP client ([`HttpCortexClient`]) is present but inert — it returns
+//! [`OpenCompanyError::Unimplemented`] until the service is reachable through
+//! the OpenHuman seam. Nothing here touches the network.
+//!
+//! [`CortexMemoryStore`] implements [`MemoryStore`] and [`CortexContextStore`]
+//! implements [`ContextStore`], both by translating each port call into a
+//! company-scoped [`CortexClient`] call. Every method takes the company id as
+//! its first argument so the adapter enforces isolation regardless of how the
+//! backend namespaces tenants.
+//!
+//! ## Isolation
+//!
+//! [`InMemoryCortex`] keys everything on the company string, so company A can
+//! never read company B's traces, tasks, or chunks.
+//!
+//! ## Eviction archives rather than destroys
+//!
+//! [`MemoryStore::evict`] routes to [`CortexClient::archive_traces`], which
+//! moves live traces into a separate archive rather than dropping them. Only the
+//! inherent operator-rights methods ([`CortexMemoryStore::hard_delete_trace`],
+//! [`CortexContextStore::hard_delete_chunk`], [`CortexMemoryStore::redact_all`])
+//! mutate or remove data for good, and they propagate to the backing store, not
+//! just to an index.
+
+use std::collections::HashMap;
+use std::ops::Range;
+use std::sync::{Arc, Mutex as StdMutex};
+
+use async_trait::async_trait;
+
+use crate::Result;
+use crate::error::OpenCompanyError;
+use crate::ports::context::ContextStore;
+use crate::ports::memory::MemoryStore;
+use crate::ports::types::{
+    ChunkAddr, ChunkHit, ChunkMeta, CompanyId, CompressedTrace, ContextChunk, EvictionPolicy,
+    TaskResult,
+};
+use crate::store::content_address;
+
+// ---------------------------------------------------------------------------
+// The storage seam
+// ---------------------------------------------------------------------------
+
+/// The company-scoped storage seam the cortex stores translate port calls into.
+///
+/// Every method takes the company id as a `&str` first argument so the adapter
+/// enforces tenant isolation regardless of how a backend namespaces companies.
+/// The offline [`InMemoryCortex`] is the compiled-and-tested implementation; a
+/// networked implementation would reach TinyCortex through the OpenHuman seam.
+#[async_trait]
+pub trait CortexClient: Send + Sync {
+    /// Appends one compressed trace for a company.
+    async fn append_trace(&self, company: &str, trace: CompressedTrace) -> Result<()>;
+    /// Returns up to `limit` most-recent live traces, newest last.
+    async fn recent_traces(&self, company: &str, limit: usize) -> Result<Vec<CompressedTrace>>;
+    /// Upserts a completed background task's result.
+    async fn put_task_result(&self, company: &str, result: TaskResult) -> Result<()>;
+    /// Moves live traces matching `policy` into the archive, returning how many
+    /// were archived. Archiving retains the data; it never destroys it.
+    async fn archive_traces(&self, company: &str, policy: EvictionPolicy) -> Result<u64>;
+
+    /// Stores a context chunk under its content `addr`.
+    async fn put_chunk(&self, company: &str, addr: &str, chunk: ContextChunk) -> Result<()>;
+    /// Lists metadata for chunks whose label starts with `prefix`.
+    async fn list_chunks(&self, company: &str, prefix: &str) -> Result<Vec<ChunkMeta>>;
+    /// Reads a chunk body by address, `None` if absent.
+    async fn peek_chunk(&self, company: &str, addr: &str) -> Result<Option<String>>;
+    /// Searches chunk bodies for `query`, returning up to `limit` ranked hits.
+    async fn search_chunks(
+        &self,
+        company: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<ChunkHit>>;
+
+    /// Permanently removes every trace (live or archived) with `cycle_id`,
+    /// returning whether anything was removed. Propagates to the backing store.
+    async fn hard_delete_trace(&self, company: &str, cycle_id: &str) -> Result<bool>;
+    /// Permanently removes the chunk at `addr`, returning whether it existed.
+    /// Propagates to the backing store.
+    async fn hard_delete_chunk(&self, company: &str, addr: &str) -> Result<bool>;
+    /// Rewrites every occurrence of `needle` with `replacement` across a
+    /// company's traces (live and archived) and chunk bodies, returning the
+    /// number of occurrences replaced. Propagates to the backing store.
+    async fn redact(&self, company: &str, needle: &str, replacement: &str) -> Result<u64>;
+}
+
+// ---------------------------------------------------------------------------
+// Offline in-memory backend
+// ---------------------------------------------------------------------------
+
+/// One company's live traces, archived traces, task results, and chunks.
+#[derive(Default)]
+struct CompanyCells {
+    /// Live traces in insertion order (newest last).
+    traces: Vec<CompressedTrace>,
+    /// Traces archived by [`CortexClient::archive_traces`].
+    archive: Vec<CompressedTrace>,
+    /// Task results keyed by task id.
+    tasks: HashMap<String, TaskResult>,
+    /// Context chunks in insertion order.
+    chunks: Vec<StoredChunk>,
+}
+
+/// A stored context chunk: its content address, label, and body.
+#[derive(Clone)]
+struct StoredChunk {
+    addr: String,
+    label: String,
+    body: String,
+}
+
+/// An offline, in-memory [`CortexClient`] backing the cortex stores.
+///
+/// Per-company data lives in a `HashMap<String, CompanyCells>` behind a
+/// [`StdMutex`]. Archived traces are held separately from live ones so
+/// [`Self`]'s eviction archives rather than destroys, while the `hard_delete_*`
+/// methods remove data outright.
+#[derive(Default)]
+pub struct InMemoryCortex {
+    cells: StdMutex<HashMap<String, CompanyCells>>,
+}
+
+impl InMemoryCortex {
+    /// Builds an empty in-memory cortex.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Runs `f` against the (created-on-demand) cells for `company`.
+    fn with_company<R>(&self, company: &str, f: impl FnOnce(&mut CompanyCells) -> R) -> R {
+        let mut map = self.cells.lock().expect("cortex mutex poisoned");
+        let cells = map.entry(company.to_string()).or_default();
+        f(cells)
+    }
+}
+
+#[async_trait]
+impl CortexClient for InMemoryCortex {
+    async fn append_trace(&self, company: &str, trace: CompressedTrace) -> Result<()> {
+        self.with_company(company, |c| c.traces.push(trace));
+        Ok(())
+    }
+
+    async fn recent_traces(&self, company: &str, limit: usize) -> Result<Vec<CompressedTrace>> {
+        Ok(self.with_company(company, |c| {
+            let start = c.traces.len().saturating_sub(limit);
+            c.traces[start..].to_vec()
+        }))
+    }
+
+    async fn put_task_result(&self, company: &str, result: TaskResult) -> Result<()> {
+        self.with_company(company, |c| {
+            c.tasks.insert(result.task_id.clone(), result);
+        });
+        Ok(())
+    }
+
+    async fn archive_traces(&self, company: &str, policy: EvictionPolicy) -> Result<u64> {
+        Ok(self.with_company(company, |c| {
+            let archived: Vec<CompressedTrace> = match policy {
+                EvictionPolicy::KeepRecent { n } => {
+                    let cut = c.traces.len().saturating_sub(n);
+                    c.traces.drain(..cut).collect()
+                }
+                EvictionPolicy::OlderThan { before_millis } => {
+                    let mut kept = Vec::with_capacity(c.traces.len());
+                    let mut moved = Vec::new();
+                    for t in c.traces.drain(..) {
+                        if t.at_millis < before_millis {
+                            moved.push(t);
+                        } else {
+                            kept.push(t);
+                        }
+                    }
+                    c.traces = kept;
+                    moved
+                }
+            };
+            let count = archived.len() as u64;
+            c.archive.extend(archived);
+            count
+        }))
+    }
+
+    async fn put_chunk(&self, company: &str, addr: &str, chunk: ContextChunk) -> Result<()> {
+        self.with_company(company, |c| {
+            // Content-addressed: an identical body is stored once.
+            if !c.chunks.iter().any(|s| s.addr == addr) {
+                c.chunks.push(StoredChunk {
+                    addr: addr.to_string(),
+                    label: chunk.label,
+                    body: chunk.body,
+                });
+            }
+        });
+        Ok(())
+    }
+
+    async fn list_chunks(&self, company: &str, prefix: &str) -> Result<Vec<ChunkMeta>> {
+        Ok(self.with_company(company, |c| {
+            c.chunks
+                .iter()
+                .filter(|s| s.label.starts_with(prefix))
+                .map(|s| ChunkMeta {
+                    addr: ChunkAddr::new(s.addr.clone()),
+                    label: s.label.clone(),
+                    len: s.body.len(),
+                })
+                .collect()
+        }))
+    }
+
+    async fn peek_chunk(&self, company: &str, addr: &str) -> Result<Option<String>> {
+        Ok(self.with_company(company, |c| {
+            c.chunks
+                .iter()
+                .find(|s| s.addr == addr)
+                .map(|s| s.body.clone())
+        }))
+    }
+
+    async fn search_chunks(
+        &self,
+        company: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<ChunkHit>> {
+        let chunks = self.with_company(company, |c| c.chunks.clone());
+        let mut hits = score_chunks(&chunks, query);
+        hits.truncate(limit);
+        Ok(hits)
+    }
+
+    async fn hard_delete_trace(&self, company: &str, cycle_id: &str) -> Result<bool> {
+        Ok(self.with_company(company, |c| {
+            let before = c.traces.len() + c.archive.len();
+            c.traces.retain(|t| t.cycle_id != cycle_id);
+            c.archive.retain(|t| t.cycle_id != cycle_id);
+            before != c.traces.len() + c.archive.len()
+        }))
+    }
+
+    async fn hard_delete_chunk(&self, company: &str, addr: &str) -> Result<bool> {
+        Ok(self.with_company(company, |c| {
+            let before = c.chunks.len();
+            c.chunks.retain(|s| s.addr != addr);
+            before != c.chunks.len()
+        }))
+    }
+
+    async fn redact(&self, company: &str, needle: &str, replacement: &str) -> Result<u64> {
+        if needle.is_empty() {
+            return Ok(0);
+        }
+        Ok(self.with_company(company, |c| {
+            let mut replaced = 0u64;
+            for t in c.traces.iter_mut().chain(c.archive.iter_mut()) {
+                replaced += replace_in_place(&mut t.summary, needle, replacement);
+            }
+            for s in c.chunks.iter_mut() {
+                replaced += replace_in_place(&mut s.body, needle, replacement);
+            }
+            replaced
+        }))
+    }
+}
+
+/// Replaces every occurrence of `needle` in `s`, returning the count replaced.
+fn replace_in_place(s: &mut String, needle: &str, replacement: &str) -> u64 {
+    let count = s.matches(needle).count() as u64;
+    if count > 0 {
+        *s = s.replace(needle, replacement);
+    }
+    count
+}
+
+/// Ranks chunks by token-overlap against `query`, best first.
+///
+/// A chunk's score is the fraction of distinct query tokens that appear in its
+/// body (case-insensitive). Chunks with no overlap are dropped. This is
+/// strictly better than a raw substring scan yet stays lexical and offline; the
+/// seam allows a networked backend to answer with semantic recall instead.
+fn score_chunks(chunks: &[StoredChunk], query: &str) -> Vec<ChunkHit> {
+    let terms: Vec<String> = query
+        .split_whitespace()
+        .map(|t| t.to_lowercase())
+        .filter(|t| !t.is_empty())
+        .collect();
+    if terms.is_empty() {
+        return Vec::new();
+    }
+    let mut distinct: Vec<&String> = Vec::new();
+    for t in &terms {
+        if !distinct.contains(&t) {
+            distinct.push(t);
+        }
+    }
+
+    let mut scored: Vec<ChunkHit> = Vec::new();
+    for chunk in chunks {
+        let body_lower = chunk.body.to_lowercase();
+        let matched = distinct
+            .iter()
+            .filter(|t| body_lower.contains(t.as_str()))
+            .count();
+        if matched == 0 {
+            continue;
+        }
+        let score = matched as f64 / distinct.len() as f64;
+        // Anchor the snippet on the first matching term.
+        let pos = distinct
+            .iter()
+            .filter_map(|t| body_lower.find(t.as_str()).map(|p| (p, t.len())))
+            .min_by_key(|(p, _)| *p);
+        let snippet = match pos {
+            Some((p, len)) => snippet_around(&chunk.body, p, len),
+            None => chunk.body.clone(),
+        };
+        scored.push(ChunkHit {
+            addr: ChunkAddr::new(chunk.addr.clone()),
+            snippet,
+            score,
+        });
+    }
+    scored.sort_by(|a, b| b.score.total_cmp(&a.score));
+    scored
+}
+
+/// Extracts a char-boundary-safe window around `pos` of a matched term.
+fn snippet_around(body: &str, pos: usize, term_len: usize) -> String {
+    let raw_start = pos.saturating_sub(24);
+    let raw_end = (pos + term_len + 24).min(body.len());
+    let start = (raw_start..=pos)
+        .find(|&i| body.is_char_boundary(i))
+        .unwrap_or(pos);
+    let end = (raw_end..=body.len())
+        .find(|&i| body.is_char_boundary(i))
+        .unwrap_or(body.len());
+    body[start..end].to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Inert real client
+// ---------------------------------------------------------------------------
+
+/// A networked [`CortexClient`] that reaches TinyCortex through the OpenHuman
+/// seam.
+///
+/// TinyCortex is not checked out in this repository, so every method is inert
+/// and returns [`OpenCompanyError::Unimplemented`]. It ships compiled-but-inert
+/// so the feature graph is real; wiring it to the service — once
+/// `vendor/openhuman/vendor/tinycortex` is present — is a documented follow-up.
+/// No network dependency is added.
+#[derive(Default)]
+pub struct HttpCortexClient {
+    _private: (),
+}
+
+impl HttpCortexClient {
+    /// Builds the inert client.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl CortexClient for HttpCortexClient {
+    async fn append_trace(&self, _company: &str, _trace: CompressedTrace) -> Result<()> {
+        Err(OpenCompanyError::Unimplemented("tinycortex http client"))
+    }
+    async fn recent_traces(&self, _company: &str, _limit: usize) -> Result<Vec<CompressedTrace>> {
+        Err(OpenCompanyError::Unimplemented("tinycortex http client"))
+    }
+    async fn put_task_result(&self, _company: &str, _result: TaskResult) -> Result<()> {
+        Err(OpenCompanyError::Unimplemented("tinycortex http client"))
+    }
+    async fn archive_traces(&self, _company: &str, _policy: EvictionPolicy) -> Result<u64> {
+        Err(OpenCompanyError::Unimplemented("tinycortex http client"))
+    }
+    async fn put_chunk(&self, _company: &str, _addr: &str, _chunk: ContextChunk) -> Result<()> {
+        Err(OpenCompanyError::Unimplemented("tinycortex http client"))
+    }
+    async fn list_chunks(&self, _company: &str, _prefix: &str) -> Result<Vec<ChunkMeta>> {
+        Err(OpenCompanyError::Unimplemented("tinycortex http client"))
+    }
+    async fn peek_chunk(&self, _company: &str, _addr: &str) -> Result<Option<String>> {
+        Err(OpenCompanyError::Unimplemented("tinycortex http client"))
+    }
+    async fn search_chunks(
+        &self,
+        _company: &str,
+        _query: &str,
+        _limit: usize,
+    ) -> Result<Vec<ChunkHit>> {
+        Err(OpenCompanyError::Unimplemented("tinycortex http client"))
+    }
+    async fn hard_delete_trace(&self, _company: &str, _cycle_id: &str) -> Result<bool> {
+        Err(OpenCompanyError::Unimplemented("tinycortex http client"))
+    }
+    async fn hard_delete_chunk(&self, _company: &str, _addr: &str) -> Result<bool> {
+        Err(OpenCompanyError::Unimplemented("tinycortex http client"))
+    }
+    async fn redact(&self, _company: &str, _needle: &str, _replacement: &str) -> Result<u64> {
+        Err(OpenCompanyError::Unimplemented("tinycortex http client"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Port adapters
+// ---------------------------------------------------------------------------
+
+/// A [`MemoryStore`] backed by a [`CortexClient`].
+#[derive(Clone)]
+pub struct CortexMemoryStore {
+    client: Arc<dyn CortexClient>,
+}
+
+impl CortexMemoryStore {
+    /// Wraps a client as a memory store.
+    pub fn new(client: Arc<dyn CortexClient>) -> Self {
+        Self { client }
+    }
+
+    /// Operator right: permanently removes every trace with `cycle_id` (live or
+    /// archived), returning whether anything was removed. Not a port method —
+    /// this propagates a hard delete to the backing store.
+    pub async fn hard_delete_trace(&self, id: &CompanyId, cycle_id: &str) -> Result<bool> {
+        self.client.hard_delete_trace(id.as_ref(), cycle_id).await
+    }
+
+    /// Operator right: rewrites every occurrence of `needle` across the
+    /// company's traces and chunks, returning the number of occurrences
+    /// replaced. Propagates to the backing store, not just an index.
+    pub async fn redact_all(&self, id: &CompanyId, needle: &str, replacement: &str) -> Result<u64> {
+        self.client.redact(id.as_ref(), needle, replacement).await
+    }
+}
+
+#[async_trait]
+impl MemoryStore for CortexMemoryStore {
+    async fn save_trace(&self, id: &CompanyId, trace: CompressedTrace) -> Result<()> {
+        self.client.append_trace(id.as_ref(), trace).await
+    }
+
+    async fn recent_traces(&self, id: &CompanyId, limit: usize) -> Result<Vec<CompressedTrace>> {
+        self.client.recent_traces(id.as_ref(), limit).await
+    }
+
+    async fn save_task_result(&self, id: &CompanyId, result: TaskResult) -> Result<()> {
+        self.client.put_task_result(id.as_ref(), result).await
+    }
+
+    async fn evict(&self, id: &CompanyId, policy: EvictionPolicy) -> Result<u64> {
+        // Eviction archives rather than destroys.
+        self.client.archive_traces(id.as_ref(), policy).await
+    }
+}
+
+/// A [`ContextStore`] backed by a [`CortexClient`].
+#[derive(Clone)]
+pub struct CortexContextStore {
+    client: Arc<dyn CortexClient>,
+}
+
+impl CortexContextStore {
+    /// Wraps a client as a context store.
+    pub fn new(client: Arc<dyn CortexClient>) -> Self {
+        Self { client }
+    }
+
+    /// Operator right: permanently removes the chunk at `addr`, returning
+    /// whether it existed. Propagates the hard delete to the backing store.
+    pub async fn hard_delete_chunk(&self, id: &CompanyId, addr: &ChunkAddr) -> Result<bool> {
+        self.client
+            .hard_delete_chunk(id.as_ref(), addr.as_ref())
+            .await
+    }
+
+    /// Operator right: rewrites every occurrence of `needle` across the
+    /// company's chunks and traces, returning the number replaced. Propagates
+    /// to the backing store.
+    pub async fn redact_all(&self, id: &CompanyId, needle: &str, replacement: &str) -> Result<u64> {
+        self.client.redact(id.as_ref(), needle, replacement).await
+    }
+}
+
+#[async_trait]
+impl ContextStore for CortexContextStore {
+    async fn put(&self, id: &CompanyId, chunk: ContextChunk) -> Result<ChunkAddr> {
+        // Mint the same content address the fs/sqlite backends mint.
+        let addr = content_address(&chunk.body);
+        self.client.put_chunk(id.as_ref(), &addr, chunk).await?;
+        Ok(ChunkAddr::new(addr))
+    }
+
+    async fn list(&self, id: &CompanyId, prefix: &str) -> Result<Vec<ChunkMeta>> {
+        self.client.list_chunks(id.as_ref(), prefix).await
+    }
+
+    async fn peek(
+        &self,
+        id: &CompanyId,
+        addr: &ChunkAddr,
+        range: Option<Range<usize>>,
+    ) -> Result<String> {
+        let body = self
+            .client
+            .peek_chunk(id.as_ref(), addr.as_ref())
+            .await?
+            .ok_or_else(|| {
+                OpenCompanyError::Store(format!("context chunk not found: {}", addr.as_ref()))
+            })?;
+        match range {
+            None => Ok(body),
+            Some(r) => {
+                let start = r.start.min(body.len());
+                let end = r.end.min(body.len());
+                if start >= end {
+                    return Ok(String::new());
+                }
+                Ok(body[start..end].to_string())
+            }
+        }
+    }
+
+    async fn search(&self, id: &CompanyId, query: &str, limit: usize) -> Result<Vec<ChunkHit>> {
+        self.client.search_chunks(id.as_ref(), query, limit).await
+    }
+}
+
+/// Builds a [`MemoryStore`] + [`ContextStore`] pair over one shared
+/// [`InMemoryCortex`], so both ports read and write the same offline backend.
+///
+/// This is the injection shape a platform operator uses: feed the returned
+/// stores into `RuntimeBuilder::with_memory` / `with_context`.
+pub fn in_memory() -> (Arc<CortexMemoryStore>, Arc<CortexContextStore>) {
+    let client: Arc<dyn CortexClient> = Arc::new(InMemoryCortex::new());
+    (
+        Arc::new(CortexMemoryStore::new(client.clone())),
+        Arc::new(CortexContextStore::new(client)),
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ports::events::EventLog;
+    use crate::ports::now_millis;
+    use crate::ports::store::CompanyStore;
+    use crate::store::conformance;
+    use crate::store::{FsCompanyStore, FsEventLog};
+
+    /// The four port trait objects the conformance suite drives: fs company and
+    /// event stores paired with the cortex memory and context stores.
+    type ConformanceStores = (
+        Arc<dyn CompanyStore>,
+        Arc<dyn EventLog>,
+        Arc<CortexMemoryStore>,
+        Arc<CortexContextStore>,
+    );
+
+    /// Builds cortex memory+context stores over one shared client, plus fs
+    /// company/event stores (over a tempdir) for the two conformance slots the
+    /// cortex backend does not implement.
+    fn stores(dir: &std::path::Path) -> ConformanceStores {
+        let (mem, ctx) = in_memory();
+        (
+            Arc::new(FsCompanyStore::new(dir.to_path_buf())),
+            Arc::new(FsEventLog::new(dir.to_path_buf())),
+            mem,
+            ctx,
+        )
+    }
+
+    #[tokio::test]
+    async fn conformance_isolation_by_company() {
+        let dir = tempfile::tempdir().unwrap();
+        let (store, events, mem, ctx) = stores(dir.path());
+        conformance::assert_isolation_by_company(store, events, mem, ctx).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_export_totality() {
+        let dir = tempfile::tempdir().unwrap();
+        let (store, events, mem, ctx) = stores(dir.path());
+        conformance::assert_export_totality(store, events, mem, ctx).await;
+    }
+
+    fn company() -> CompanyId {
+        CompanyId::new("acme")
+    }
+
+    #[tokio::test]
+    async fn recent_traces_newest_last() {
+        let (mem, _ctx) = in_memory();
+        let id = company();
+        for i in 0..4 {
+            mem.save_trace(&id, CompressedTrace::now(format!("c{i}"), format!("s{i}")))
+                .await
+                .unwrap();
+        }
+        let recent = mem.recent_traces(&id, 2).await.unwrap();
+        assert_eq!(recent.len(), 2);
+        assert_eq!(recent[0].cycle_id, "c2");
+        assert_eq!(
+            recent[1].cycle_id, "c3",
+            "recent_traces must be newest last"
+        );
+    }
+
+    #[tokio::test]
+    async fn evict_keep_recent_and_older_than_archives_not_destroys() {
+        // Hold the shared client directly so the test can inspect the archive.
+        let client: Arc<InMemoryCortex> = Arc::new(InMemoryCortex::new());
+        let mem = CortexMemoryStore::new(client.clone());
+        let id = company();
+        for i in 0..5 {
+            mem.save_trace(&id, CompressedTrace::now(format!("c{i}"), format!("s{i}")))
+                .await
+                .unwrap();
+        }
+
+        let archived = mem
+            .evict(&id, EvictionPolicy::KeepRecent { n: 2 })
+            .await
+            .unwrap();
+        assert_eq!(archived, 3, "three of five traces archived");
+
+        let kept = mem.recent_traces(&id, 10).await.unwrap();
+        assert_eq!(kept.len(), 2, "live set shrank to the recent two");
+        assert_eq!(kept[1].cycle_id, "c4");
+
+        // The archive retained the evicted traces rather than destroying them.
+        let archive_len = client.with_company(id.as_ref(), |c| c.archive.len());
+        assert_eq!(archive_len, 3, "evicted traces live on in the archive");
+
+        // OlderThan with a future cutoff archives the remaining live traces.
+        let archived = mem
+            .evict(
+                &id,
+                EvictionPolicy::OlderThan {
+                    before_millis: now_millis() + 60_000,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(archived, 2);
+        assert!(mem.recent_traces(&id, 10).await.unwrap().is_empty());
+        let archive_len = client.with_company(id.as_ref(), |c| c.archive.len());
+        assert_eq!(archive_len, 5, "every evicted trace is archived, none lost");
+    }
+
+    #[tokio::test]
+    async fn hard_delete_trace_and_chunk_propagate() {
+        let client: Arc<InMemoryCortex> = Arc::new(InMemoryCortex::new());
+        let mem = CortexMemoryStore::new(client.clone());
+        let ctx = CortexContextStore::new(client.clone());
+        let id = company();
+
+        mem.save_trace(&id, CompressedTrace::now("c0", "keep"))
+            .await
+            .unwrap();
+        mem.save_trace(&id, CompressedTrace::now("c1", "drop"))
+            .await
+            .unwrap();
+        // Archive c0 so the hard delete must reach the archive, not just live.
+        mem.evict(&id, EvictionPolicy::KeepRecent { n: 1 })
+            .await
+            .unwrap();
+
+        assert!(mem.hard_delete_trace(&id, "c0").await.unwrap());
+        assert!(!mem.hard_delete_trace(&id, "missing").await.unwrap());
+        // Gone from live and archive alike.
+        assert!(
+            mem.recent_traces(&id, 10)
+                .await
+                .unwrap()
+                .iter()
+                .all(|t| t.cycle_id != "c0")
+        );
+        let archive_has_c0 = client.with_company(id.as_ref(), |c| {
+            c.archive.iter().any(|t| t.cycle_id == "c0")
+        });
+        assert!(!archive_has_c0, "hard delete reached the backing archive");
+
+        let addr = ctx
+            .put(
+                &id,
+                ContextChunk {
+                    label: "doc/a".into(),
+                    body: "secret body".into(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(ctx.hard_delete_chunk(&id, &addr).await.unwrap());
+        assert!(ctx.list(&id, "").await.unwrap().is_empty());
+        assert!(ctx.peek(&id, &addr, None).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn redact_rewrites_traces_and_chunks() {
+        let client: Arc<InMemoryCortex> = Arc::new(InMemoryCortex::new());
+        let mem = CortexMemoryStore::new(client.clone());
+        let ctx = CortexContextStore::new(client);
+        let id = company();
+
+        mem.save_trace(
+            &id,
+            CompressedTrace::now("c0", "email alice@example.com noted"),
+        )
+        .await
+        .unwrap();
+        let addr = ctx
+            .put(
+                &id,
+                ContextChunk {
+                    label: "doc/a".into(),
+                    body: "contact alice@example.com twice: alice@example.com".into(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let replaced = mem
+            .redact_all(&id, "alice@example.com", "[redacted]")
+            .await
+            .unwrap();
+        assert_eq!(replaced, 3, "one in the trace, two in the chunk");
+
+        let trace = mem.recent_traces(&id, 1).await.unwrap();
+        assert!(!trace[0].summary.contains("alice@example.com"));
+        let body = ctx.peek(&id, &addr, None).await.unwrap();
+        assert!(!body.contains("alice@example.com"));
+        assert!(body.contains("[redacted]"));
+    }
+
+    #[tokio::test]
+    async fn search_ranks_by_relevance() {
+        let (_mem, ctx) = in_memory();
+        let id = company();
+        ctx.put(
+            &id,
+            ContextChunk {
+                label: "doc/a".into(),
+                body: "quarterly revenue growth strategy".into(),
+            },
+        )
+        .await
+        .unwrap();
+        ctx.put(
+            &id,
+            ContextChunk {
+                label: "doc/b".into(),
+                body: "revenue only".into(),
+            },
+        )
+        .await
+        .unwrap();
+        ctx.put(
+            &id,
+            ContextChunk {
+                label: "doc/c".into(),
+                body: "unrelated note".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let hits = ctx.search(&id, "revenue growth", 10).await.unwrap();
+        assert_eq!(
+            hits.len(),
+            2,
+            "the unrelated chunk scores zero and is dropped"
+        );
+        // The chunk matching both query terms outranks the one matching one.
+        assert!(hits[0].score > hits[1].score);
+        assert!(hits[0].snippet.contains("revenue"));
+
+        // A limit truncates the ranked list.
+        let one = ctx.search(&id, "revenue growth", 1).await.unwrap();
+        assert_eq!(one.len(), 1);
+        assert!(one[0].score >= hits[1].score);
+    }
+
+    #[tokio::test]
+    async fn task_result_round_trips() {
+        let client: Arc<InMemoryCortex> = Arc::new(InMemoryCortex::new());
+        let mem = CortexMemoryStore::new(client.clone());
+        let id = company();
+        mem.save_task_result(
+            &id,
+            TaskResult {
+                task_id: "t1".into(),
+                ok: false,
+                output: serde_json::json!({"v": 1}),
+            },
+        )
+        .await
+        .unwrap();
+        // Same id overwrites rather than duplicating.
+        mem.save_task_result(
+            &id,
+            TaskResult {
+                task_id: "t1".into(),
+                ok: true,
+                output: serde_json::json!({"v": 2}),
+            },
+        )
+        .await
+        .unwrap();
+        let (ok, count) = client.with_company(id.as_ref(), |c| {
+            (c.tasks.get("t1").map(|t| t.ok), c.tasks.len())
+        });
+        assert_eq!(count, 1);
+        assert_eq!(ok, Some(true));
+    }
+
+    #[tokio::test]
+    async fn http_client_is_inert() {
+        let client = HttpCortexClient::new();
+        let err = client
+            .recent_traces("acme", 1)
+            .await
+            .expect_err("http client is not implemented");
+        assert!(matches!(err, OpenCompanyError::Unimplemented(_)));
+    }
+}


### PR DESCRIPTION
Executes `docs/spec/README.md` end to end — Stages 0→3 (Phases 0–6) of the roadmap — building the OpenCompany runtime on top of the Phase-1 kernel. `main` stays releasable; each phase is an independently green slice.

## What's implemented

| Phase | Summary |
| --- | --- |
| **0 — Spec + manifest** | `CompanyManifest` parser + prosumer-language validation, `opencompany check`, `run_company`; examples boot instead of printing TOML |
| **1 — Kernel** | 9 port traits, fs stores, `CycleRunner` (serial per company, at-most-once effects), offline `EchoBrain`, operator HTTP API |
| **2 — Hosted Medulla** | `config`/`doctor`; `HostedMedullaBrain` as a **client** over `/orchestration/v1` (no Medulla code copied), `medulla` feature |
| **3 — OpenHuman** | JSON-RPC tools/channels, approval taxonomy + 7-day default-deny + edit path, cron scheduler, feedback loop with the normative privacy scrubber |
| **4 — tiny.place** | Ed25519 identity, SIWX/x402, deterministic Agent Card, `/a2a` inbound, one-switch `serve --discoverable` |
| **5 — Platform** | Provisioning, per-tenant platform auth, webhooks, sqlite store + port-conformance suite, export/import |
| **6 — Memory + brains** | TinyCortex memory adapter, `SidecarBrain`, feedback triage + label taxonomy, Signals/Opportunity-Engine as a **template** not kernel code |

Every network integration is feature-gated and offline-testable with mocks; the default build stays small and green, honoring the one-key (`TINYHUMANS_API_KEY`) invariant.

## Design decisions

- No Medulla / tiny.place / TinyCortex code is vendored — each is a Rust client behind a mockable transport trait, real impl behind a feature.
- `async fn` in `dyn` traits via `async-trait`; streams via `futures::BoxStream`.
- All new feature flags: `medulla`, `openhuman-rpc`, `github`, `tinyplace`, `sqlite`, `webhooks`, `platform-jwt`, `tinycortex`, `sidecar`.

## Security fixes (from adversarial review, each with a regression test)

- x402 inbound gate now binds the payment `recipient` to the company (was obtainable without paying it).
- Per-company feedback route now enforces platform-or-operator auth + tenant ownership (was operator-only → open in platform mode).
- `resume` refuses to lift a platform-forced `suspended` state without platform scope.
- `Assisted` consent no longer auto-files feedback; only standing `Auto` does.
- Fixed a feedback context-excerpt UTF-8 truncation panic.

## Commands run locally

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅ (default and all-features)
- `cargo test` → **259 passed** (default); **337 passed** with all features
- `cargo build --workspace` ✅ (host + 19 example companies)
- Live end-to-end: `serve`/`doctor`/`check`, operator chat, feedback route, `serve --discoverable` (degrades to outbox offline)

https://claude.ai/code/session_01NrUeF6CPgbNsDpvNaUQvsr