### PR TITLE
Add MongoDB storage backend with config-driven selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,10 @@ TINYHUMANS_API_KEY=
 GITHUB_TOKEN=
 # Provider credential used by future live examples.
 OPENAI_API_KEY=
+
+# Storage backend: fs (default), sqlite, or mongodb. The mongodb backend is
+# the multi-tenant platform option — the hosting layer injects a per-tenant
+# database and scoped credentials (see docs/spec/runtime/storage.md).
+OPENCOMPANY_STORAGE=fs
+OPENCOMPANY_MONGODB_URI=
+OPENCOMPANY_MONGODB_DB=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,27 @@ Keep every Markdown file, including this one, at 500 lines or fewer. When a
 topic grows past that limit, split it into focused files and link them from the
 module's `README.md`.
 
+## Running under the platform harness (hosted mode)
+
+This repo is also the tenant workload of the OpenCompany hosting platform:
+the `opencompany-manager` control plane (the superproject at
+`tinyhumansai/opencompany-microservices`, where this repo is the
+`opencompany/` submodule) builds this crate into a per-tenant container and
+injects its environment. When developing hosted behavior, know the seams:
+
+- The manager injects `OPENCOMPANY_COMPANY`, `OPENCOMPANY_BIND=0.0.0.0:8080`,
+  `OPENCOMPANY_DATA_DIR=/data`, and `OPENCOMPANY_PUBLIC_URL` into every
+  tenant container, plus — when database-per-tenant storage is enabled —
+  `OPENCOMPANY_STORAGE=mongodb`, `OPENCOMPANY_MONGODB_URI` (credentials
+  scoped to that tenant's database only), and `OPENCOMPANY_MONGODB_DB`.
+- Storage backend selection and the MongoDB backend are documented in
+  `docs/spec/runtime/storage.md`; the port traits it implements are the
+  entire persistence contract (`docs/spec/runtime/ports.md`).
+- The container must serve `/healthz` on `:8080` quickly — the manager's
+  wake-on-request proxy blocks on it and gives up after its startup timeout.
+- Run the full platform locally by following
+  `docs/local-development.md` in the superproject.
+
 ## Commit & Pull Request Guidelines
 
 Use concise, imperative commit subjects. Keep the first line specific to the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +210,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
+]
+
+[[package]]
+name = "bson"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969a9ba84b0ff843813e7249eed1678d9b6607ce5a3b8f0a47af3fcf7978e6e"
+dependencies = [
+ "ahash",
+ "base64",
+ "bitvec",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "hex",
+ "indexmap",
+ "js-sys",
+ "once_cell",
+ "rand 0.9.5",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "time",
+ "uuid",
 ]
 
 [[package]]
@@ -309,10 +344,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "const-oid"
@@ -347,6 +398,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +441,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +493,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -423,6 +532,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +586,51 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive-syn-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
+]
 
 [[package]]
 name = "digest"
@@ -458,6 +652,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -500,6 +695,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -571,6 +772,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -690,9 +897,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -743,12 +952,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.2",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.2",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -972,6 +1266,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,10 +1303,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1019,6 +1335,55 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
@@ -1082,6 +1447,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1466,54 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "macro_magic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc33f9f0351468d26fbc53d9ce00a096c8522ecb42f19b50f34f2c422f76d21d"
+dependencies = [
+ "macro_magic_core",
+ "macro_magic_macros",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "macro_magic_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1687dc887e42f352865a393acae7cf79d98fab6351cde1f58e9e057da89bf150"
+dependencies = [
+ "const-random",
+ "derive-syn-parse",
+ "macro_magic_core_macros",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "macro_magic_core_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "macro_magic_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
+dependencies = [
+ "macro_magic_core",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "matchers"
@@ -1107,6 +1529,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "memchr"
@@ -1130,6 +1562,105 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
+name = "mongocrypt"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8426a875ded61430d4a811dbfda7633b6b8af0225c547fc6c28b8b0aa7d79a13"
+dependencies = [
+ "bson",
+ "mongocrypt-sys",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "mongocrypt-sys"
+version = "0.1.6+1.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851fac73f7fe22f6a3ab87f720ce509cae7c9fd08e7dd27866cc232dee07ccf4"
+
+[[package]]
+name = "mongodb"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b814038f367d212f55de0a630cb35102a9b8ca23785a86955d62c0087c93846d"
+dependencies = [
+ "base64",
+ "bitflags",
+ "bson",
+ "derive-where",
+ "derive_more",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hickory-net",
+ "hickory-proto",
+ "hickory-resolver",
+ "hmac 0.13.0",
+ "macro_magic",
+ "md-5",
+ "mongocrypt",
+ "mongodb-internal-macros",
+ "pbkdf2",
+ "percent-encoding",
+ "rand 0.9.5",
+ "rustc_version_runtime",
+ "rustls",
+ "serde",
+ "serde_bytes",
+ "serde_with",
+ "sha1",
+ "sha2 0.11.0",
+ "socket2",
+ "stringprep",
+ "strsim",
+ "take_mut",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "typed-builder",
+ "uuid",
+ "webpki-roots",
+]
+
+[[package]]
+name = "mongodb-internal-macros"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f736d2fbc56e0011a341fbb9172bd822fda75c5f93b82fae1c7aab1e2613c810"
+dependencies = [
+ "macro_magic",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "no-std-compat"
@@ -1189,6 +1720,7 @@ version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
+ "critical-section",
  "portable-atomic",
 ]
 
@@ -1208,8 +1740,9 @@ dependencies = [
  "clap",
  "ed25519-dalek",
  "futures",
- "hmac",
+ "hmac 0.12.1",
  "jsonwebtoken",
+ "mongodb",
  "rand_core 0.6.4",
  "reqwest",
  "rusqlite",
@@ -1225,6 +1758,38 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1305,6 +1870,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,7 +1927,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -1391,6 +1976,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,12 +2003,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1423,6 +2043,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1482,6 +2111,12 @@ dependencies = [
  "web-sys",
  "webpki-roots",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rhai"
@@ -1567,6 +2202,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,6 +2230,7 @@ version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1627,6 +2273,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,6 +2301,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1668,6 +2339,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -1705,6 +2377,39 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "serde_core",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1762,6 +2467,22 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -1855,6 +2576,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,6 +2628,45 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -2085,7 +2856,9 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -2244,16 +3017,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-builder"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398a3a3c918c96de527dc11e6e846cd549d4508030b8a33e1da12789c856b81a"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e48cea23f68d1f78eb7bc092881b6bb88d3d6b5b7e6234f6f9c911da1ffb221"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -2286,6 +3112,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2302,6 +3140,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2425,6 +3273,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,6 +3327,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -2585,6 +3459,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xattr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,10 @@ jsonwebtoken = { version = "9", optional = true }
 # compile stays fully offline. Only links under the `sqlite` feature.
 rusqlite = { version = "0.40", features = ["bundled"], optional = true }
 
+# MongoDB-backed implementations of the storage ports (official async driver).
+# Only links under the `mongodb` feature; the default build stays offline.
+mongodb = { version = "3", optional = true }
+
 # Single-file `.tar` packing/unpacking for `opencompany export`/`import`. Pure
 # Rust, no system libs, no network. Only links under the `export` feature; the
 # port-driven bundle core works on an unpacked directory without it.
@@ -105,6 +109,12 @@ platform-jwt = ["dep:jsonwebtoken"]
 # plus SecretStore) sharing one bundled connection. The fs stores and the
 # port-conformance suite compile without this; only `SqliteStore` is gated here.
 sqlite = ["dep:rusqlite"]
+# MongoDB-backed storage ports (CompanyStore/EventLog/MemoryStore/ContextStore
+# plus SecretStore) sharing one database handle — the multi-tenant platform
+# backend: every document is keyed by company_id and the hosting layer gives
+# each tenant its own database on a shared cluster. The fs stores and the
+# port-conformance suite compile without this; only `MongoStore` is gated here.
+mongodb = ["dep:mongodb"]
 # TinyCortex-backed MemoryStore + ContextStore over a mockable CortexClient.
 # TinyCortex itself is not vendored, so this feature adds no dependency: the
 # compiled backend is an offline in-memory client and the real HTTP client is

--- a/docs/spec/runtime/storage.md
+++ b/docs/spec/runtime/storage.md
@@ -1,0 +1,75 @@
+# Storage backends
+
+The five storage ports (`CompanyStore`, `EventLog`, `MemoryStore`,
+`ContextStore`, `SecretStore` — see [ports.md](ports.md)) are the entire
+persistence contract. The kernel never names an engine; a backend is anything
+that implements those traits and passes the conformance suite
+(`src/store/conformance.rs`). This file documents the shipped backends and
+how one is selected at boot.
+
+## Selection
+
+`OPENCOMPANY_STORAGE` picks the backend once per process; `serve` and
+platform provisioning inject the same opened handles into every company's
+`RuntimeBuilder` (`src/store/select.rs`). A selected-but-unavailable backend
+aborts boot — there is never a silent fallback to the filesystem.
+
+| Value | Backend | Feature flag | Notes |
+|---|---|---|---|
+| `fs` (default) | Per-company bundle directories | — | Human-inspectable; no external service |
+| `sqlite` | One SQLite file under the data dir | `sqlite` | Single-file, offline |
+| `mongodb` | A MongoDB database on a shared cluster | `mongodb` | The multi-tenant platform backend |
+
+MongoDB settings:
+
+- `OPENCOMPANY_MONGODB_URI` — connection string (required for `mongodb`).
+- `OPENCOMPANY_MONGODB_DB` — database name (default `opencompany`).
+
+## MongoDB backend (`src/store/mongodb.rs`)
+
+One `MongoStore` wraps a single database and implements all five ports.
+Payloads are stored as the same JSON strings the fs/sqlite backends persist,
+so records round-trip byte-identically across backends and `export`/`import`
+migrate between any two backends unchanged. Monotonic 0-based sequences come
+from a `counters` collection via atomic `findOneAndUpdate {$inc}`.
+
+Collections (all uniquely indexed on `company_id` + their key):
+`companies`, `ledger`, `events`, `memory_traces`, `memory_tasks`,
+`context_chunks`, `secrets`, plus `counters` and `owners`.
+
+### Multi-tenant isolation (two layers)
+
+1. **Database per tenant (recommended).** The hosting layer (the
+   opencompany-manager control plane) runs one shared MongoDB but creates one
+   logical database per tenant (`oc-<slug>`) and one database-level user
+   whose only role is `readWrite` on that database. The credentials are
+   injected as `OPENCOMPANY_MONGODB_URI`/`OPENCOMPANY_MONGODB_DB` when the
+   tenant workload is created. A compromised tenant container cannot address
+   any other tenant's data — isolation is MongoDB auth, not an application
+   filter.
+2. **Company scoping inside a database.** Mirroring the sqlite backend, every
+   document carries `company_id` and every query filters on it, so one
+   database can also host multiple companies (platform mode). The `owners`
+   collection makes the company → tenant map durable: `serve` hydrates the
+   in-memory `AppState` ownership map from it at boot, and provisioning
+   updates it — closing the previous restart-loses-ownership stub.
+
+### Adding another backend (e.g. DynamoDB)
+
+Implement the five traits in a new `src/store/<engine>.rs` behind a feature
+flag, key everything on `company_id`, run the conformance suite against it,
+and add a `StorageKind` arm in `src/store/select.rs`. No business logic
+changes.
+
+## Testing
+
+`cargo test --features mongodb,sqlite` runs everything; the MongoDB
+conformance tests are env-gated and skip unless
+`OPENCOMPANY_TEST_MONGODB_URI` points at a live server:
+
+```sh
+OPENCOMPANY_TEST_MONGODB_URI=mongodb://127.0.0.1:27017 \
+  cargo test --features mongodb
+```
+
+Each test creates (and drops) a uniquely named throwaway database.

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -121,6 +121,10 @@ pub struct AppState {
     /// Batch-1 durability is a documented stub: this map is in-memory and resets
     /// on restart until a durable `tenant_id` slot exists on the company record.
     ownership: Arc<RwLock<HashMap<CompanyId, String>>>,
+    /// The opened storage backend's port handles, when a non-fs backend is
+    /// selected (`OPENCOMPANY_STORAGE`). Provisioning injects these into each
+    /// new company's builder; `None` means fs defaults.
+    stores: Option<crate::store::StorageHandles>,
     /// Host-global replay-protection cache shared across every inbound A2A
     /// request. Gated behind `tinyplace` so the default build links no crypto.
     #[cfg(feature = "tinyplace")]
@@ -135,6 +139,7 @@ impl AppState {
             registry: CompanyRegistry::new(),
             home: std::path::PathBuf::from("."),
             ownership: Arc::new(RwLock::new(HashMap::new())),
+            stores: None,
             #[cfg(feature = "tinyplace")]
             nonce: std::sync::Arc::new(crate::economy::NonceCache::new()),
         }
@@ -144,6 +149,17 @@ impl AppState {
     pub fn with_home(mut self, home: impl Into<std::path::PathBuf>) -> Self {
         self.home = home.into();
         self
+    }
+
+    /// Installs the opened storage backend's port handles (non-fs backends).
+    pub fn with_stores(mut self, stores: crate::store::StorageHandles) -> Self {
+        self.stores = Some(stores);
+        self
+    }
+
+    /// The opened storage backend's handles, if a non-fs backend is selected.
+    pub fn stores(&self) -> Option<&crate::store::StorageHandles> {
+        self.stores.as_ref()
     }
 
     /// Installs platform (multi-tenant) auth. Mirrors [`Self::with_home`].

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -167,6 +167,9 @@ async fn register_company(
     let mut builder = attach_openhuman(RuntimeBuilder::new(home.to_path_buf(), manifest))
         .with_tinyplace_api_url(state.config().tinyplace_api_url.clone())
         .with_host_base_url(state.config().host_base_url());
+    if let Some(stores) = state.stores() {
+        builder = builder.with_stores(stores);
+    }
     if discoverable {
         builder = builder.with_discoverable(true);
     }
@@ -438,6 +441,24 @@ async fn main() -> Result<()> {
                 env_usize("OPENCOMPANY_MAX_COMPANIES"),
                 env_usize("OPENCOMPANY_MAX_COMPANIES_PER_TENANT"),
             );
+            // Storage backend selection: fs (default) needs nothing; sqlite and
+            // mongodb are opened once here and injected into every company's
+            // builder. A selected-but-unavailable backend aborts boot rather
+            // than silently falling back to fs.
+            let storage_settings = opencompany::store::StorageSettings::from_env()?;
+            if let Some(handles) =
+                opencompany::store::open_storage(&storage_settings, &home).await?
+            {
+                // Shared-database platform mode: restore the durable company →
+                // tenant map so ownership survives restarts.
+                if let Some(ownership) = &handles.ownership {
+                    for (id, tenant) in ownership.owners().await? {
+                        state.set_owner(id, tenant);
+                    }
+                }
+                state = state.with_stores(handles);
+                println!("storage backend: {:?}", storage_settings.kind);
+            }
             // Platform (multi-tenant) auth: a shared platform token enables the
             // provisioning/lifecycle surface. Without it the prosumer operator
             // path stays in force. Real signed JWT is `platform-jwt`.

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -242,6 +242,16 @@ impl RuntimeBuilder {
         self
     }
 
+    /// Swaps every durable port at once from one opened storage backend
+    /// (see [`crate::store::select`]).
+    pub fn with_stores(self, handles: &crate::store::StorageHandles) -> Self {
+        self.with_store(handles.company.clone())
+            .with_events(handles.events.clone())
+            .with_memory(handles.memory.clone())
+            .with_context(handles.context.clone())
+            .with_secrets(handles.secrets.clone())
+    }
+
     /// Swaps the tool provider.
     pub fn with_tools(mut self, tools: Arc<dyn ToolProvider>) -> Self {
         self.tools = Some(tools);

--- a/src/server/provision.rs
+++ b/src/server/provision.rs
@@ -160,14 +160,16 @@ async fn provision(
         );
     }
 
-    // Build over the data dir with fs defaults.
-    let runtime = match RuntimeBuilder::new(state.home().to_path_buf(), manifest)
+    // Build over the data dir, honoring the selected storage backend (fs
+    // defaults when none is configured).
+    let mut builder = RuntimeBuilder::new(state.home().to_path_buf(), manifest)
         .with_id(id.clone())
         .with_tinyplace_api_url(state.config().tinyplace_api_url.clone())
-        .with_host_base_url(state.config().host_base_url())
-        .build()
-        .await
-    {
+        .with_host_base_url(state.config().host_base_url());
+    if let Some(stores) = state.stores() {
+        builder = builder.with_stores(stores);
+    }
+    let runtime = match builder.build().await {
         Ok(runtime) => runtime,
         Err(err) => return ApiError(err).into_response(),
     };
@@ -179,7 +181,14 @@ async fn provision(
     state
         .registry()
         .insert(id.clone(), std::sync::Arc::new(runtime));
-    state.set_owner(id, tenant);
+    state.set_owner(id.clone(), tenant.clone());
+    // Persist ownership when the backend supports it, so the tenant map
+    // survives restarts (best-effort: the in-memory map already reflects it).
+    if let Some(ownership) = state.stores().and_then(|s| s.ownership.clone())
+        && let Err(err) = ownership.set_owner(&id, &tenant).await
+    {
+        tracing::warn!(company = %id, error = %err, "failed to persist company ownership");
+    }
 
     (StatusCode::CREATED, Json(status)).into_response()
 }
@@ -301,6 +310,11 @@ async fn archive(
     if response.status() == StatusCode::OK {
         state.registry().remove(&id);
         state.remove_owner(&id);
+        if let Some(ownership) = state.stores().and_then(|s| s.ownership.clone())
+            && let Err(err) = ownership.remove_owner(&id).await
+        {
+            tracing::warn!(company = %id, error = %err, "failed to remove persisted ownership");
+        }
     }
     response
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -19,6 +19,14 @@ pub mod paths;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 
+/// MongoDB-backed implementations of all five storage ports over the official
+/// async driver — the multi-tenant platform backend: every document is keyed
+/// on `company_id`, the hosting layer points each tenant at its own database
+/// on a shared cluster, and an `owners` collection makes the company → tenant
+/// map durable for shared-database platform mode. Only links under `mongodb`.
+#[cfg(feature = "mongodb")]
+pub mod mongodb;
+
 /// TinyCortex-backed memory and context ports over a mockable client. TinyCortex
 /// is not checked out here, so the compiled backend is an offline in-memory
 /// client; a real HTTP client (inert until the service is reachable through the
@@ -43,6 +51,9 @@ pub use paths::{Bundle, default_home};
 
 #[cfg(feature = "sqlite")]
 pub use sqlite::SqliteStore;
+
+#[cfg(feature = "mongodb")]
+pub use mongodb::MongoStore;
 
 #[cfg(feature = "tinycortex")]
 pub use tinycortex::{

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -16,6 +16,11 @@ pub mod export;
 pub mod fs;
 pub mod paths;
 
+/// Config-driven backend selection: maps `OPENCOMPANY_STORAGE` (fs | sqlite |
+/// mongodb) onto opened port implementations, injected once per process into
+/// every company's `RuntimeBuilder`.
+pub mod select;
+
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 
@@ -48,6 +53,7 @@ pub mod conformance;
 
 pub use fs::{FsCompanyStore, FsContextStore, FsEventLog, FsMemoryStore, FsSecretStore};
 pub use paths::{Bundle, default_home};
+pub use select::{StorageHandles, StorageKind, StorageSettings, open_storage};
 
 #[cfg(feature = "sqlite")]
 pub use sqlite::SqliteStore;

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -1,0 +1,698 @@
+//! MongoDB-backed implementations of the storage ports.
+//!
+//! One [`MongoStore`] wraps a single [`mongodb::Database`] and implements
+//! every durable port — [`CompanyStore`], [`EventLog`], [`MemoryStore`],
+//! [`ContextStore`], and [`SecretStore`] — so the same `Arc<MongoStore>` can
+//! be injected into all of the `RuntimeBuilder::with_*` setters.
+//!
+//! ## Multi-tenancy
+//!
+//! This is the platform backend for hosting many companies on one shared
+//! MongoDB cluster (the same cluster the platform's Node backend uses for
+//! users/teams/billing). Isolation is layered:
+//!
+//! - **Database per tenant** (recommended): the hosting layer points each
+//!   tenant workload at its own database (`OPENCOMPANY_MONGODB_DB`, e.g.
+//!   `oc-<tenant-slug>`), so tenants can never address each other's data and
+//!   per-tenant export/drop is a database-level operation.
+//! - **Company scoping inside a database**: mirroring the sqlite backend,
+//!   every document carries `company_id` and every query filters on it, so a
+//!   single database can also host multiple companies (platform mode). The
+//!   `owners` collection additionally records the durable company → tenant
+//!   mapping for shared-database deployments.
+//!
+//! ## Semantics
+//!
+//! Payloads are stored as the same JSON strings the fs/sqlite backends
+//! persist, so records round-trip byte-identically across backends and the
+//! export/import bundle path works unchanged. Monotonic 0-based sequences are
+//! allocated from a `counters` collection with an atomic
+//! `findOneAndUpdate {$inc}` per `(company, kind)` key.
+
+use std::collections::HashMap;
+use std::ops::Range;
+use std::sync::{Arc, Mutex as StdMutex};
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use futures::stream::TryStreamExt;
+use mongodb::bson::{Document, doc};
+use mongodb::options::{FindOneAndUpdateOptions, IndexOptions, ReturnDocument, UpdateOptions};
+use mongodb::{Client, Collection, Database, IndexModel};
+use tokio::sync::broadcast;
+
+use crate::Result;
+use crate::company::CompanyManifest;
+use crate::error::OpenCompanyError;
+use crate::ports::context::ContextStore;
+use crate::ports::events::EventLog;
+use crate::ports::memory::MemoryStore;
+use crate::ports::now_millis;
+use crate::ports::secrets::SecretStore;
+use crate::ports::store::CompanyStore;
+use crate::ports::types::{
+    ChunkAddr, ChunkHit, ChunkMeta, CompanyEvent, CompanyId, CompanyRecord, CompanySummary,
+    CompressedTrace, ContextChunk, EventSeq, EvictionPolicy, LedgerEntry, SecretValue, StoredEvent,
+    TaskResult,
+};
+use crate::store::content_address;
+
+fn mongo_err(e: impl std::fmt::Display) -> OpenCompanyError {
+    OpenCompanyError::Store(format!("mongodb error: {e}"))
+}
+
+/// The port contract's "read everything" sentinel (`usize::MAX`) means no
+/// limit; everything else maps onto the driver's `i64` limit.
+fn find_limit(limit: usize) -> Option<i64> {
+    if limit > i64::MAX as usize {
+        None
+    } else {
+        Some(limit as i64)
+    }
+}
+
+fn get_str(doc: &Document, key: &str) -> Result<String> {
+    doc.get_str(key)
+        .map(str::to_owned)
+        .map_err(|e| mongo_err(format!("missing field {key}: {e}")))
+}
+
+fn get_i64(doc: &Document, key: &str) -> Result<i64> {
+    doc.get_i64(key)
+        .map_err(|e| mongo_err(format!("missing field {key}: {e}")))
+}
+
+/// A single MongoDB database implementing all five storage ports.
+#[derive(Clone)]
+pub struct MongoStore {
+    db: Database,
+    senders: Arc<StdMutex<HashMap<CompanyId, broadcast::Sender<StoredEvent>>>>,
+}
+
+impl MongoStore {
+    /// Connects to `uri` and opens `db_name`, creating the port indexes.
+    pub async fn connect(uri: &str, db_name: &str) -> Result<Self> {
+        let client = Client::with_uri_str(uri).await.map_err(mongo_err)?;
+        Self::from_database(client.database(db_name)).await
+    }
+
+    /// Wraps an existing database handle (e.g. for tests), creating indexes.
+    pub async fn from_database(db: Database) -> Result<Self> {
+        let store = Self {
+            db,
+            senders: Arc::new(StdMutex::new(HashMap::new())),
+        };
+        store.ensure_indexes().await?;
+        Ok(store)
+    }
+
+    /// Idempotent index creation — the MongoDB equivalent of the sqlite
+    /// backend's `CREATE TABLE IF NOT EXISTS` migrations.
+    async fn ensure_indexes(&self) -> Result<()> {
+        let unique = |keys: Document| {
+            IndexModel::builder()
+                .keys(keys)
+                .options(IndexOptions::builder().unique(true).build())
+                .build()
+        };
+        let plans: [(&str, IndexModel); 7] = [
+            ("companies", unique(doc! {"company_id": 1})),
+            ("ledger", unique(doc! {"company_id": 1, "idx": 1})),
+            ("events", unique(doc! {"company_id": 1, "seq": 1})),
+            ("memory_traces", unique(doc! {"company_id": 1, "seq": 1})),
+            ("memory_tasks", unique(doc! {"company_id": 1, "task_id": 1})),
+            ("context_chunks", unique(doc! {"company_id": 1, "addr": 1})),
+            ("secrets", unique(doc! {"company_id": 1, "key": 1})),
+        ];
+        for (name, index) in plans {
+            self.collection(name)
+                .create_index(index)
+                .await
+                .map_err(mongo_err)?;
+        }
+        self.collection("owners")
+            .create_index(unique(doc! {"company_id": 1}))
+            .await
+            .map_err(mongo_err)?;
+        Ok(())
+    }
+
+    fn collection(&self, name: &str) -> Collection<Document> {
+        self.db.collection::<Document>(name)
+    }
+
+    /// Atomically allocates the next 0-based sequence for `(company, kind)`.
+    async fn next_seq(&self, id: &CompanyId, kind: &str) -> Result<u64> {
+        let counters = self.collection("counters");
+        let key = format!("{}:{kind}", id.as_ref());
+        let doc = counters
+            .find_one_and_update(doc! {"_id": &key}, doc! {"$inc": {"next": 1_i64}})
+            .with_options(
+                FindOneAndUpdateOptions::builder()
+                    .upsert(true)
+                    .return_document(ReturnDocument::Before)
+                    .build(),
+            )
+            .await
+            .map_err(mongo_err)?;
+        // Before the first allocation there is no document: the seq is 0.
+        Ok(doc.and_then(|d| d.get_i64("next").ok()).unwrap_or_default() as u64)
+    }
+
+    fn sender_for(&self, id: &CompanyId) -> broadcast::Sender<StoredEvent> {
+        let mut map = self.senders.lock().expect("sender map poisoned");
+        map.entry(id.clone())
+            .or_insert_with(|| broadcast::channel(256).0)
+            .clone()
+    }
+
+    // -- Durable tenant ownership (shared-database platform mode) ----------
+
+    /// Records the owning tenant of a company. Used by platform mode to make
+    /// the company → tenant map survive restarts (the in-memory `AppState`
+    /// ownership map is hydrated from this at boot).
+    pub async fn set_owner(&self, id: &CompanyId, tenant: &str) -> Result<()> {
+        self.collection("owners")
+            .update_one(
+                doc! {"company_id": id.as_ref()},
+                doc! {"$set": {"tenant_id": tenant, "updated_ms": now_millis() as i64}},
+            )
+            .with_options(UpdateOptions::builder().upsert(true).build())
+            .await
+            .map_err(mongo_err)?;
+        Ok(())
+    }
+
+    /// Removes the ownership record (company deleted).
+    pub async fn remove_owner(&self, id: &CompanyId) -> Result<()> {
+        self.collection("owners")
+            .delete_one(doc! {"company_id": id.as_ref()})
+            .await
+            .map_err(mongo_err)?;
+        Ok(())
+    }
+
+    /// Every durable company → tenant mapping in this database.
+    pub async fn owners(&self) -> Result<Vec<(CompanyId, String)>> {
+        let mut cursor = self
+            .collection("owners")
+            .find(doc! {})
+            .await
+            .map_err(mongo_err)?;
+        let mut out = Vec::new();
+        while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
+            out.push((
+                CompanyId::new(get_str(&doc, "company_id")?),
+                get_str(&doc, "tenant_id")?,
+            ));
+        }
+        Ok(out)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CompanyStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl CompanyStore for MongoStore {
+    async fn load(&self, id: &CompanyId) -> Result<Option<CompanyRecord>> {
+        let Some(company) = self
+            .collection("companies")
+            .find_one(doc! {"company_id": id.as_ref()})
+            .await
+            .map_err(mongo_err)?
+        else {
+            return Ok(None);
+        };
+        let manifest: CompanyManifest = toml::from_str(&get_str(&company, "manifest_toml")?)
+            .map_err(|e| OpenCompanyError::Store(format!("invalid company.toml: {e}")))?;
+
+        let mut cursor = self
+            .collection("ledger")
+            .find(doc! {"company_id": id.as_ref()})
+            .sort(doc! {"idx": 1})
+            .await
+            .map_err(mongo_err)?;
+        let mut ledger = Vec::new();
+        while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
+            ledger.push(serde_json::from_str::<LedgerEntry>(&get_str(
+                &doc,
+                "entry_json",
+            )?)?);
+        }
+
+        Ok(Some(CompanyRecord {
+            id: id.clone(),
+            manifest,
+            ledger,
+            lifecycle: get_str(&company, "lifecycle")?,
+        }))
+    }
+
+    async fn save(&self, record: &CompanyRecord) -> Result<()> {
+        let manifest_toml = toml::to_string(&record.manifest)
+            .map_err(|e| OpenCompanyError::Store(format!("cannot serialize manifest: {e}")))?;
+        // Append-only: `save` upserts the company document, never the ledger.
+        self.collection("companies")
+            .update_one(
+                doc! {"company_id": record.id.as_ref()},
+                doc! {"$set": {
+                    "manifest_toml": manifest_toml,
+                    "lifecycle": &record.lifecycle,
+                    "updated_ms": now_millis() as i64,
+                }},
+            )
+            .with_options(UpdateOptions::builder().upsert(true).build())
+            .await
+            .map_err(mongo_err)?;
+        Ok(())
+    }
+
+    async fn list(&self) -> Result<Vec<CompanySummary>> {
+        let mut cursor = self
+            .collection("companies")
+            .find(doc! {})
+            .sort(doc! {"company_id": 1})
+            .await
+            .map_err(mongo_err)?;
+        let mut out = Vec::new();
+        while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
+            let Ok(manifest) = toml::from_str::<CompanyManifest>(&get_str(&doc, "manifest_toml")?)
+            else {
+                continue;
+            };
+            out.push(CompanySummary {
+                id: CompanyId::new(get_str(&doc, "company_id")?),
+                name: manifest.company.name,
+                lifecycle: get_str(&doc, "lifecycle")?,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn append_ledger(&self, id: &CompanyId, entry: LedgerEntry) -> Result<()> {
+        let entry_json = serde_json::to_string(&entry)?;
+        let idx = self.next_seq(id, "ledger").await?;
+        self.collection("ledger")
+            .insert_one(doc! {
+                "company_id": id.as_ref(),
+                "idx": idx as i64,
+                "entry_json": entry_json,
+                "at_ms": entry.at_millis as i64,
+            })
+            .await
+            .map_err(mongo_err)?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EventLog
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl EventLog for MongoStore {
+    async fn append(&self, id: &CompanyId, event: CompanyEvent) -> Result<EventSeq> {
+        let event_json = serde_json::to_string(&event)?;
+        let at_millis = now_millis();
+        let seq = self.next_seq(id, "events").await?;
+        self.collection("events")
+            .insert_one(doc! {
+                "company_id": id.as_ref(),
+                "seq": seq as i64,
+                "event_json": event_json,
+                "at_ms": at_millis as i64,
+            })
+            .await
+            .map_err(mongo_err)?;
+
+        let stored = StoredEvent {
+            seq: EventSeq::new(seq),
+            company: id.clone(),
+            event,
+            at_millis,
+        };
+        // Best-effort fan-out; an error only means no live subscribers.
+        let _ = self.sender_for(id).send(stored);
+        Ok(EventSeq::new(seq))
+    }
+
+    async fn read_from(
+        &self,
+        id: &CompanyId,
+        seq: EventSeq,
+        limit: usize,
+    ) -> Result<Vec<StoredEvent>> {
+        let events = self.collection("events");
+        let mut find = events
+            .find(doc! {
+                "company_id": id.as_ref(),
+                "seq": {"$gte": seq.value() as i64},
+            })
+            .sort(doc! {"seq": 1});
+        if let Some(limit) = find_limit(limit) {
+            find = find.limit(limit);
+        }
+        let mut cursor = find.await.map_err(mongo_err)?;
+        let mut out = Vec::new();
+        while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
+            out.push(StoredEvent {
+                seq: EventSeq::new(get_i64(&doc, "seq")? as u64),
+                company: id.clone(),
+                event: serde_json::from_str(&get_str(&doc, "event_json")?)?,
+                at_millis: get_i64(&doc, "at_ms")? as u64,
+            });
+        }
+        Ok(out)
+    }
+
+    fn subscribe(&self, id: &CompanyId) -> BoxStream<'static, StoredEvent> {
+        let rx = self.sender_for(id).subscribe();
+        let stream = futures::stream::unfold(rx, |mut rx| async move {
+            loop {
+                match rx.recv().await {
+                    Ok(event) => return Some((event, rx)),
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => return None,
+                }
+            }
+        });
+        Box::pin(stream)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MemoryStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl MemoryStore for MongoStore {
+    async fn save_trace(&self, id: &CompanyId, trace: CompressedTrace) -> Result<()> {
+        let trace_json = serde_json::to_string(&trace)?;
+        let seq = self.next_seq(id, "memory_traces").await?;
+        self.collection("memory_traces")
+            .insert_one(doc! {
+                "company_id": id.as_ref(),
+                "seq": seq as i64,
+                "trace_json": trace_json,
+                "at_ms": trace.at_millis as i64,
+            })
+            .await
+            .map_err(mongo_err)?;
+        Ok(())
+    }
+
+    async fn recent_traces(&self, id: &CompanyId, limit: usize) -> Result<Vec<CompressedTrace>> {
+        let traces = self.collection("memory_traces");
+        let mut find = traces
+            .find(doc! {"company_id": id.as_ref()})
+            .sort(doc! {"seq": -1});
+        if let Some(limit) = find_limit(limit) {
+            find = find.limit(limit);
+        }
+        let mut cursor = find.await.map_err(mongo_err)?;
+        let mut out = Vec::new();
+        while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
+            out.push(serde_json::from_str::<CompressedTrace>(&get_str(
+                &doc,
+                "trace_json",
+            )?)?);
+        }
+        // Query returned newest-first; the port contract is newest-last.
+        out.reverse();
+        Ok(out)
+    }
+
+    async fn save_task_result(&self, id: &CompanyId, result: TaskResult) -> Result<()> {
+        let result_json = serde_json::to_string(&result)?;
+        self.collection("memory_tasks")
+            .update_one(
+                doc! {"company_id": id.as_ref(), "task_id": &result.task_id},
+                doc! {"$set": {
+                    "result_json": result_json,
+                    "at_ms": now_millis() as i64,
+                }},
+            )
+            .with_options(UpdateOptions::builder().upsert(true).build())
+            .await
+            .map_err(mongo_err)?;
+        Ok(())
+    }
+
+    async fn evict(&self, id: &CompanyId, policy: EvictionPolicy) -> Result<u64> {
+        let traces = self.collection("memory_traces");
+        let removed = match policy {
+            EvictionPolicy::KeepRecent { n } => {
+                // Collect the seqs to keep (newest n), delete the rest.
+                let mut keep = Vec::new();
+                if n > 0 {
+                    let mut find = traces
+                        .find(doc! {"company_id": id.as_ref()})
+                        .sort(doc! {"seq": -1});
+                    if let Some(limit) = find_limit(n) {
+                        find = find.limit(limit);
+                    }
+                    let mut cursor = find.await.map_err(mongo_err)?;
+                    while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
+                        keep.push(get_i64(&doc, "seq")?);
+                    }
+                }
+                traces
+                    .delete_many(doc! {
+                        "company_id": id.as_ref(),
+                        "seq": {"$nin": keep},
+                    })
+                    .await
+                    .map_err(mongo_err)?
+                    .deleted_count
+            }
+            EvictionPolicy::OlderThan { before_millis } => {
+                traces
+                    .delete_many(doc! {
+                        "company_id": id.as_ref(),
+                        "at_ms": {"$lt": before_millis as i64},
+                    })
+                    .await
+                    .map_err(mongo_err)?
+                    .deleted_count
+            }
+        };
+        Ok(removed)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ContextStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl ContextStore for MongoStore {
+    async fn put(&self, id: &CompanyId, chunk: ContextChunk) -> Result<ChunkAddr> {
+        let addr = content_address(&chunk.body);
+        // Insertion order stands in for the sqlite backend's rowid ordering.
+        let ord = self.next_seq(id, "context_ord").await?;
+        let result = self
+            .collection("context_chunks")
+            .update_one(
+                doc! {"company_id": id.as_ref(), "addr": &addr},
+                doc! {"$setOnInsert": {
+                    "label": &chunk.label,
+                    "body": &chunk.body,
+                    "len": chunk.body.len() as i64,
+                    "ord": ord as i64,
+                }},
+            )
+            .with_options(UpdateOptions::builder().upsert(true).build())
+            .await;
+        match result {
+            Ok(_) => Ok(ChunkAddr::new(addr)),
+            Err(e) => Err(mongo_err(e)),
+        }
+    }
+
+    async fn list(&self, id: &CompanyId, prefix: &str) -> Result<Vec<ChunkMeta>> {
+        let mut cursor = self
+            .collection("context_chunks")
+            .find(doc! {"company_id": id.as_ref()})
+            .sort(doc! {"ord": 1})
+            .await
+            .map_err(mongo_err)?;
+        let mut out = Vec::new();
+        while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
+            let label = get_str(&doc, "label")?;
+            if label.starts_with(prefix) {
+                out.push(ChunkMeta {
+                    addr: ChunkAddr::new(get_str(&doc, "addr")?),
+                    label,
+                    len: get_i64(&doc, "len")? as usize,
+                });
+            }
+        }
+        Ok(out)
+    }
+
+    async fn peek(
+        &self,
+        id: &CompanyId,
+        addr: &ChunkAddr,
+        range: Option<Range<usize>>,
+    ) -> Result<String> {
+        let doc = self
+            .collection("context_chunks")
+            .find_one(doc! {"company_id": id.as_ref(), "addr": addr.as_ref()})
+            .await
+            .map_err(mongo_err)?
+            .ok_or_else(|| {
+                OpenCompanyError::Store(format!("context chunk not found: {}", addr.as_ref()))
+            })?;
+        let body = get_str(&doc, "body")?;
+        match range {
+            None => Ok(body),
+            Some(r) => {
+                let start = r.start.min(body.len());
+                let end = r.end.min(body.len());
+                if start >= end {
+                    return Ok(String::new());
+                }
+                Ok(body[start..end].to_string())
+            }
+        }
+    }
+
+    async fn search(&self, id: &CompanyId, query: &str, limit: usize) -> Result<Vec<ChunkHit>> {
+        let mut cursor = self
+            .collection("context_chunks")
+            .find(doc! {"company_id": id.as_ref()})
+            .sort(doc! {"ord": 1})
+            .await
+            .map_err(mongo_err)?;
+        let mut hits = Vec::new();
+        while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
+            if hits.len() >= limit {
+                break;
+            }
+            let body = get_str(&doc, "body")?;
+            if let Some(pos) = body.find(query) {
+                let start = pos.saturating_sub(24);
+                let end = (pos + query.len() + 24).min(body.len());
+                hits.push(ChunkHit {
+                    addr: ChunkAddr::new(get_str(&doc, "addr")?),
+                    snippet: body[start..end].to_string(),
+                    score: 1.0,
+                });
+            }
+        }
+        Ok(hits)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SecretStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl SecretStore for MongoStore {
+    async fn get(&self, company: &CompanyId, key: &str) -> Result<Option<SecretValue>> {
+        let doc = self
+            .collection("secrets")
+            .find_one(doc! {"company_id": company.as_ref(), "key": key})
+            .await
+            .map_err(mongo_err)?;
+        doc.map(|d| get_str(&d, "value").map(SecretValue))
+            .transpose()
+    }
+
+    async fn set(&self, company: &CompanyId, key: &str, value: SecretValue) -> Result<()> {
+        self.collection("secrets")
+            .update_one(
+                doc! {"company_id": company.as_ref(), "key": key},
+                doc! {"$set": {"value": value.expose()}},
+            )
+            .with_options(UpdateOptions::builder().upsert(true).build())
+            .await
+            .map_err(mongo_err)?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — env-gated conformance against a real MongoDB
+// ---------------------------------------------------------------------------
+
+/// The conformance suite needs a live server; there is no in-process MongoDB.
+/// Set `OPENCOMPANY_TEST_MONGODB_URI` (e.g. `mongodb://localhost:27017`) to
+/// run these; without it every test is a skip, keeping `cargo test` offline.
+#[cfg(test)]
+mod test {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+    use crate::store::conformance;
+
+    static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    async fn store() -> Option<Arc<MongoStore>> {
+        let Ok(uri) = std::env::var("OPENCOMPANY_TEST_MONGODB_URI") else {
+            eprintln!("skipping: OPENCOMPANY_TEST_MONGODB_URI is not set");
+            return None;
+        };
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_millis();
+        let db = format!(
+            "oc_test_{}_{}_{}",
+            std::process::id(),
+            nonce,
+            DB_COUNTER.fetch_add(1, Ordering::Relaxed)
+        );
+        let store = MongoStore::connect(&uri, &db).await.expect("connect");
+        Some(Arc::new(store))
+    }
+
+    async fn drop_db(store: &MongoStore) {
+        let _ = store.db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn conformance_isolation_by_company() {
+        let Some(s) = store().await else { return };
+        conformance::assert_isolation_by_company(s.clone(), s.clone(), s.clone(), s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_append_only_event_and_ledger() {
+        let Some(s) = store().await else { return };
+        conformance::assert_append_only_event_and_ledger(s.clone(), s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_monotonic_event_seq() {
+        let Some(s) = store().await else { return };
+        conformance::assert_monotonic_event_seq(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_export_totality() {
+        let Some(s) = store().await else { return };
+        conformance::assert_export_totality(s.clone(), s.clone(), s.clone(), s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn durable_ownership_round_trip() {
+        let Some(s) = store().await else { return };
+        let id = CompanyId::new("acme");
+        s.set_owner(&id, "tenant-a").await.expect("set owner");
+        s.set_owner(&id, "tenant-b").await.expect("update owner");
+        let owners = s.owners().await.expect("owners");
+        assert_eq!(owners, vec![(id.clone(), "tenant-b".to_string())]);
+        s.remove_owner(&id).await.expect("remove owner");
+        assert!(s.owners().await.expect("owners").is_empty());
+        drop_db(&s).await;
+    }
+}

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -1,0 +1,225 @@
+//! Config-driven storage backend selection.
+//!
+//! The five storage ports are the entire persistence contract; this module is
+//! the one place that maps a backend *name* onto concrete port
+//! implementations. `serve` (and platform provisioning) resolve a
+//! [`StorageKind`] from `OPENCOMPANY_STORAGE`, open the backend once, and
+//! inject the same [`StorageHandles`] into every company's `RuntimeBuilder` —
+//! the kernel itself never names an engine.
+//!
+//! Backends behind disabled cargo features fail loudly at open time rather
+//! than silently falling back to the filesystem.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::Result;
+use crate::error::OpenCompanyError;
+use crate::ports::context::ContextStore;
+use crate::ports::events::EventLog;
+use crate::ports::memory::MemoryStore;
+use crate::ports::secrets::SecretStore;
+use crate::ports::store::CompanyStore;
+use crate::ports::types::CompanyId;
+
+/// Which storage backend hosts the durable ports.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum StorageKind {
+    /// Per-company filesystem bundles (the default; no external service).
+    #[default]
+    Fs,
+    /// One SQLite database file under the data dir (`sqlite` feature).
+    Sqlite,
+    /// A MongoDB database on a shared cluster (`mongodb` feature) — the
+    /// multi-tenant platform backend.
+    Mongodb,
+}
+
+impl std::str::FromStr for StorageKind {
+    type Err = OpenCompanyError;
+    fn from_str(value: &str) -> Result<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "fs" | "" => Ok(Self::Fs),
+            "sqlite" => Ok(Self::Sqlite),
+            "mongodb" | "mongo" => Ok(Self::Mongodb),
+            other => Err(OpenCompanyError::Config(format!(
+                "OPENCOMPANY_STORAGE must be 'fs', 'sqlite', or 'mongodb', got '{other}'"
+            ))),
+        }
+    }
+}
+
+/// Durable company → tenant ownership, for shared-database platform mode.
+/// Backends that can persist ownership (MongoDB today) expose it here so the
+/// in-memory `AppState` map can be hydrated at boot and updated on provision.
+#[async_trait]
+pub trait OwnershipStore: Send + Sync {
+    async fn set_owner(&self, id: &CompanyId, tenant: &str) -> Result<()>;
+    async fn remove_owner(&self, id: &CompanyId) -> Result<()>;
+    async fn owners(&self) -> Result<Vec<(CompanyId, String)>>;
+}
+
+/// One opened backend's implementations of every durable port, ready to be
+/// injected into `RuntimeBuilder::with_stores`.
+#[derive(Clone)]
+pub struct StorageHandles {
+    pub company: Arc<dyn CompanyStore>,
+    pub events: Arc<dyn EventLog>,
+    pub memory: Arc<dyn MemoryStore>,
+    pub context: Arc<dyn ContextStore>,
+    pub secrets: Arc<dyn SecretStore>,
+    /// Present when the backend persists company → tenant ownership.
+    pub ownership: Option<Arc<dyn OwnershipStore>>,
+}
+
+impl std::fmt::Debug for StorageHandles {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StorageHandles")
+            .field("ownership", &self.ownership.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Connection settings for [`open_storage`]. `fs` needs nothing beyond the
+/// runtime's home directory (handled by the builder's defaults), so it yields
+/// `None` handles.
+#[derive(Clone, Debug, Default)]
+pub struct StorageSettings {
+    pub kind: StorageKind,
+    /// MongoDB connection string (`OPENCOMPANY_MONGODB_URI`).
+    pub mongodb_uri: Option<String>,
+    /// MongoDB database name (`OPENCOMPANY_MONGODB_DB`); the hosting layer
+    /// sets a per-tenant name (e.g. `oc-<tenant>`) on a shared cluster.
+    pub mongodb_db: Option<String>,
+}
+
+impl StorageSettings {
+    /// Reads the CLI-surface storage env vars (`OPENCOMPANY_STORAGE`,
+    /// `OPENCOMPANY_MONGODB_URI`, `OPENCOMPANY_MONGODB_DB`).
+    pub fn from_env() -> Result<Self> {
+        let kind = match std::env::var("OPENCOMPANY_STORAGE") {
+            Ok(raw) => raw.parse()?,
+            Err(_) => StorageKind::Fs,
+        };
+        let non_empty = |key: &str| std::env::var(key).ok().filter(|value| !value.is_empty());
+        Ok(Self {
+            kind,
+            mongodb_uri: non_empty("OPENCOMPANY_MONGODB_URI"),
+            mongodb_db: non_empty("OPENCOMPANY_MONGODB_DB"),
+        })
+    }
+}
+
+/// Opens the selected backend once. `Ok(None)` means "use the builder's fs
+/// defaults"; a selected-but-unavailable backend is an error, never a silent
+/// fs fallback.
+pub async fn open_storage(
+    settings: &StorageSettings,
+    data_dir: &Path,
+) -> Result<Option<StorageHandles>> {
+    match settings.kind {
+        StorageKind::Fs => Ok(None),
+        StorageKind::Sqlite => open_sqlite(data_dir),
+        StorageKind::Mongodb => open_mongodb(settings).await,
+    }
+}
+
+#[cfg(feature = "sqlite")]
+fn open_sqlite(data_dir: &Path) -> Result<Option<StorageHandles>> {
+    let store = Arc::new(crate::store::SqliteStore::open(
+        data_dir.join("opencompany.db"),
+    )?);
+    Ok(Some(StorageHandles {
+        company: store.clone(),
+        events: store.clone(),
+        memory: store.clone(),
+        context: store.clone(),
+        secrets: store,
+        ownership: None,
+    }))
+}
+
+#[cfg(not(feature = "sqlite"))]
+fn open_sqlite(_data_dir: &Path) -> Result<Option<StorageHandles>> {
+    Err(OpenCompanyError::Config(
+        "OPENCOMPANY_STORAGE=sqlite requires a build with the `sqlite` feature".into(),
+    ))
+}
+
+#[cfg(feature = "mongodb")]
+async fn open_mongodb(settings: &StorageSettings) -> Result<Option<StorageHandles>> {
+    let uri = settings.mongodb_uri.as_deref().ok_or_else(|| {
+        OpenCompanyError::Config(
+            "OPENCOMPANY_STORAGE=mongodb requires OPENCOMPANY_MONGODB_URI".into(),
+        )
+    })?;
+    let db = settings.mongodb_db.as_deref().unwrap_or("opencompany");
+    let store = Arc::new(crate::store::MongoStore::connect(uri, db).await?);
+    Ok(Some(StorageHandles {
+        company: store.clone(),
+        events: store.clone(),
+        memory: store.clone(),
+        context: store.clone(),
+        secrets: store.clone(),
+        ownership: Some(store),
+    }))
+}
+
+#[cfg(not(feature = "mongodb"))]
+async fn open_mongodb(_settings: &StorageSettings) -> Result<Option<StorageHandles>> {
+    Err(OpenCompanyError::Config(
+        "OPENCOMPANY_STORAGE=mongodb requires a build with the `mongodb` feature".into(),
+    ))
+}
+
+#[cfg(feature = "mongodb")]
+#[async_trait]
+impl OwnershipStore for crate::store::MongoStore {
+    async fn set_owner(&self, id: &CompanyId, tenant: &str) -> Result<()> {
+        crate::store::MongoStore::set_owner(self, id, tenant).await
+    }
+    async fn remove_owner(&self, id: &CompanyId) -> Result<()> {
+        crate::store::MongoStore::remove_owner(self, id).await
+    }
+    async fn owners(&self) -> Result<Vec<(CompanyId, String)>> {
+        crate::store::MongoStore::owners(self).await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn parses_storage_kinds() {
+        assert_eq!("fs".parse::<StorageKind>().unwrap(), StorageKind::Fs);
+        assert_eq!(
+            "sqlite".parse::<StorageKind>().unwrap(),
+            StorageKind::Sqlite
+        );
+        assert_eq!(
+            "MongoDB".parse::<StorageKind>().unwrap(),
+            StorageKind::Mongodb
+        );
+        assert!("postgres".parse::<StorageKind>().is_err());
+    }
+
+    #[tokio::test]
+    async fn fs_selection_uses_builder_defaults() {
+        let settings = StorageSettings::default();
+        let handles = open_storage(&settings, Path::new("/tmp")).await.unwrap();
+        assert!(handles.is_none());
+    }
+
+    #[cfg(feature = "mongodb")]
+    #[tokio::test]
+    async fn mongodb_selection_requires_uri() {
+        let settings = StorageSettings {
+            kind: StorageKind::Mongodb,
+            ..Default::default()
+        };
+        assert!(open_storage(&settings, Path::new("/tmp")).await.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Adds a MongoDB implementation of all five storage ports and a config-driven backend selector, making OpenCompany hostable multi-tenant on a shared MongoDB cluster (one logical database per tenant, injected by the hosting layer).

## Changes

- src/store/mongodb.rs (feature: mongodb, official async driver): MongoStore implements CompanyStore/EventLog/MemoryStore/ContextStore/SecretStore. Mirrors the sqlite backend: every document keyed on company_id, payloads stored as the same JSON strings (byte-identical cross-backend round-trips, export/import unchanged), monotonic 0-based seqs via an atomic counters collection, unique compound indexes.
- Durable ownership: an owners collection records company -> tenant; serve hydrates the in-memory AppState ownership map at boot and provisioning/archival update it, closing the documented restarts-lose-ownership stub for platform mode.
- src/store/select.rs: OPENCOMPANY_STORAGE (fs | sqlite | mongodb) + OPENCOMPANY_MONGODB_URI/_DB. StorageHandles are opened once and injected into every company's RuntimeBuilder (serve + platform provisioning). A selected-but-unavailable backend aborts boot; never a silent fs fallback.
- RuntimeBuilder::with_stores, AppState::with_stores/stores.
- docs/spec/runtime/storage.md, .env.example, AGENTS.md hosted-mode section.

## Commands run

- cargo fmt --all -- --check, cargo clippy --features mongodb,sqlite --all-targets -- -D warnings
- cargo test (default features, offline) and OPENCOMPANY_TEST_MONGODB_URI=... cargo test --features mongodb,sqlite against a live mongod: 281 passed. The MongoDB conformance tests (isolation, append-only, monotonic seq, export totality) are env-gated and skip offline.

## Behavior changes

None by default: fs remains the default backend and the default build links no new dependencies (mongodb is feature-gated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable storage backends: filesystem, SQLite, and optional MongoDB.
  - Added MongoDB support for durable data, events, memory, context, secrets, and tenant ownership.
  - Added environment-based storage configuration and tenant ownership persistence.
  - Storage selection now occurs at startup, with clear errors when the selected backend is unavailable.

- **Documentation**
  - Documented storage behavior, multi-tenant isolation, platform hosting configuration, and runtime requirements.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->