### PR TITLE
docs(specs): implementation plan for the real backend, openhuman harness, and remaining surfaces

### DIFF
--- a/docs/specs/01-parsers.md
+++ b/docs/specs/01-parsers.md
@@ -5,12 +5,12 @@
 Rust readers for the company-directory files that exist as data-only
 conventions today (established in PR #4) but have no parser:
 
-| File | Feeds |
-|---|---|
-| `companies/<name>/workflows/<id>.toml` | Workflows canvas (GraphQL `workflow(id)`) |
-| `companies/<name>/skills/<slug>/SKILL.md` | Skills view + harness `workflows(...)` |
-| `companies/<name>/workspace/**` | Workspace seeding + backlinks |
-| repo-level `skills/<slug>/SKILL.md` | Shared skill registry (`skillRegistry`) |
+| File                                      | Feeds                                     |
+| ----------------------------------------- | ----------------------------------------- |
+| `companies/<name>/workflows/<id>.toml`    | Workflows canvas (GraphQL `workflow(id)`) |
+| `companies/<name>/skills/<slug>/SKILL.md` | Skills view + harness `workflows(...)`    |
+| `companies/<name>/workspace/**`           | Workspace seeding + backlinks             |
+| repo-level `skills/<slug>/SKILL.md`       | Shared skill registry (`skillRegistry`)   |
 
 These parsers are the format freeze for WS8 (content authoring) and the data
 source for WS2a/b (GraphQL reads) and WS3 (workspace seeding, skill install).
@@ -45,6 +45,7 @@ TOML shape (already shipped in
 top-level `id`/`name`/`description`, repeated `[[node]]` and `[[edge]]`.
 
 Validation (prosumer messages, matching `manifest.rs` style):
+
 - node ids unique; edges reference existing nodes; no self-loop edges;
 - at least one `trigger` node;
 - `kind` limited to the six known kinds; `agent` set only on `agent` nodes.

--- a/docs/specs/01-parsers.md
+++ b/docs/specs/01-parsers.md
@@ -1,0 +1,110 @@
+# 01 — WS1: Manifest & Data Parsers
+
+## Scope
+
+Rust readers for the company-directory files that exist as data-only
+conventions today (established in PR #4) but have no parser:
+
+| File | Feeds |
+|---|---|
+| `companies/<name>/workflows/<id>.toml` | Workflows canvas (GraphQL `workflow(id)`) |
+| `companies/<name>/skills/<slug>/SKILL.md` | Skills view + harness `workflows(...)` |
+| `companies/<name>/workspace/**` | Workspace seeding + backlinks |
+| repo-level `skills/<slug>/SKILL.md` | Shared skill registry (`skillRegistry`) |
+
+These parsers are the format freeze for WS8 (content authoring) and the data
+source for WS2a/b (GraphQL reads) and WS3 (workspace seeding, skill install).
+
+## Design
+
+New modules in `src/company/` (registered in `src/company/mod.rs`), following
+the existing `manifest.rs`/`types.rs` conventions — serde where the format is
+structured, prosumer-language validation messages, `crate::error::Result`.
+
+### `src/company/workflow_file.rs`
+
+```rust
+pub struct WorkflowFile {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub nodes: Vec<WorkflowNodeDef>,
+    pub edges: Vec<WorkflowEdgeDef>,
+}
+pub struct WorkflowNodeDef { pub id: String, pub kind: WorkflowNodeKind,
+    pub name: String, pub summary: Option<String>, pub agent: Option<String> }
+pub enum WorkflowNodeKind { Trigger, Agent, ToolCall, HttpRequest, Condition, Output }
+pub struct WorkflowEdgeDef { pub from: String, pub to: String, pub label: Option<String> }
+
+pub fn parse_workflow(toml_src: &str) -> Result<WorkflowFile>;
+pub fn load_company_workflows(dir: &Path, enabled: &[String]) -> Result<Vec<WorkflowFile>>;
+```
+
+TOML shape (already shipped in
+`companies/agentic_marketing_agency/workflows/campaign_pipeline.toml`):
+top-level `id`/`name`/`description`, repeated `[[node]]` and `[[edge]]`.
+
+Validation (prosumer messages, matching `manifest.rs` style):
+- node ids unique; edges reference existing nodes; no self-loop edges;
+- at least one `trigger` node;
+- `kind` limited to the six known kinds; `agent` set only on `agent` nodes.
+
+### `src/company/skill_file.rs`
+
+```rust
+pub struct SkillDoc {
+    pub slug: String,          // directory name
+    pub name: String,          // frontmatter
+    pub description: String,   // frontmatter
+    pub category: Option<String>,
+    pub body: String,          // markdown after frontmatter, verbatim
+}
+pub fn parse_skill_md(slug: &str, src: &str) -> Result<SkillDoc>;
+pub fn load_dir_skills(dir: &Path) -> Result<Vec<SkillDoc>>;   // skills/*/SKILL.md
+```
+
+Frontmatter is `key: value` lines between `---` fences. **Hand-parse the known
+keys** (`name`, `description`, optional `category`) — no serde_yaml dependency.
+The body is preserved verbatim so WS4 can feed it to
+`openhuman::skills::ops_parse` unchanged.
+
+### `src/company/workspace_seed.rs`
+
+```rust
+pub struct SeedNode { pub rel_path: PathBuf, pub kind: NodeKind, pub content: Option<String> }
+pub fn walk_workspace(dir: &Path) -> Result<Vec<SeedNode>>;  // folders + markdown only
+pub fn extract_wikilinks(md: &str) -> Vec<String>;           // [[target]] and [[target|alias]]
+```
+
+- Deterministic ordering (sorted walk) so seeding is reproducible.
+- Skips non-markdown files; rejects paths escaping the root (`../`, absolute).
+- `extract_wikilinks` powers the `WorkspaceFile.backlinks` resolver (WS2) —
+  keep it a pure function here so both seeding and reads share it.
+
+### Registry loader
+
+`load_dir_skills` doubles for the repo-level `skills/` library. `AppState`
+caches the parsed registry (invalidation not needed — repo content is
+immutable at runtime).
+
+## Subtasks (commit-sized)
+
+1. `feat(company): parse workflow TOML into a validated node/edge graph`
+2. `feat(company): parse SKILL.md frontmatter and body`
+3. `feat(company): walk workspace/ into a seed tree with wikilink extraction`
+4. `feat(company): shared skills registry loader + AppState cache`
+5. `test(company): content-validation walk over companies/* and skills/*`
+
+Subtasks 1–4 are independent (one subagent each is fine); 5 lands last.
+
+## Dependencies
+
+None. Unblocks WS2a/b, WS3 (seeding, skill install), WS8 (format freeze).
+
+## Tests & exit criteria
+
+Unit tests per [09-verification.md §1](09-verification.md): parser happy
+paths, validation failures, round-trips against the real
+`agentic_marketing_agency` files and both repo skills, wikilink alias
+handling, path-traversal rejection. Exit: content-validation walk green over
+every `companies/*` directory; `cargo test` green.

--- a/docs/specs/02-graphql-reads.md
+++ b/docs/specs/02-graphql-reads.md
@@ -6,7 +6,7 @@ Expand `src/server/graphql.rs` (today: query-only `companies` / `company(id)`
 / `approvals`) into the complete read surface for every console view. Reads
 land in GraphQL first; the existing REST reads (`GET …/team`, `…/chats`,
 `…/connections`, status, approvals) stay as **compat** until the console is
-GraphQL-only — no *new* REST reads.
+GraphQL-only — no _new_ REST reads.
 
 ## Design
 
@@ -38,56 +38,173 @@ request — fix that in the foundation commit.)
 
 ```graphql
 type Query {
-  companies: [Company!]!            # platform: all visible; operator: local
-  company(id: ID): Company          # id optional in single-company mode (registry.sole())
-  skillRegistry: [RegistrySkill!]!  # repo-level skills/ library (unscoped)
+  companies: [Company!]! # platform: all visible; operator: local
+  company(id: ID): Company # id optional in single-company mode (registry.sole())
+  skillRegistry: [RegistrySkill!]! # repo-level skills/ library (unscoped)
 }
 
 type Company {
-  id: ID!  name: String!  lifecycle: String!  pendingApprovals: Int!
+  id: ID!
+  name: String!
+  lifecycle: String!
+  pendingApprovals: Int!
   approvals: [Approval!]!
   team: [TeamMember!]!
-  chats: [Chat!]!  chat(id: ID!): Chat
+  chats: [Chat!]!
+  chat(id: ID!): Chat
   inboxes: [Inbox!]!
   tasks(column: String, first: Int = 100, offset: Int = 0): TaskPage!
   skills: [Skill!]!
-  workspaceTree: [FsNode!]!  workspaceFile(id: ID!): WorkspaceFile
-  memory(query: String, kind: MemoryKind, first: Int = 50, offset: Int = 0): MemoryFactPage!
-  workflows: [WorkflowSummary!]!  workflow(id: ID!): Workflow
+  workspaceTree: [FsNode!]!
+  workspaceFile(id: ID!): WorkspaceFile
+  memory(
+    query: String
+    kind: MemoryKind
+    first: Int = 50
+    offset: Int = 0
+  ): MemoryFactPage!
+  workflows: [WorkflowSummary!]!
+  workflow(id: ID!): Workflow
   usage(range: UsageRange! = D30): Usage!
   finances: Finances!
   connections: [ConnectionState!]!
   domain: DomainStatus
-  smtp: SmtpStatus                  # host/port/username only — never the password
+  smtp: SmtpStatus # host/port/username only — never the password
 }
 
-type TeamMember { id: ID! name: String role: String! description: String inboxEnabled: Boolean! }
-type Chat { id: ID! name: String! description: String members: [ID!]!
-            history(first: Int = 50, before: String): MessagePage! }
-type Message { id: ID! channel: String! author: String! text: String! atMillis: Float! mine: Boolean! }
-type Inbox { key: ID! name: String! address: String! unread: Int!
-             messages(first: Int = 50, offset: Int = 0): EmailPage! }
-type Task { id: ID! title: String! note: String column: String! priority: String! assignee: String! }
-type Skill { id: ID! name: String! description: String! category: String!
-             source: String!  # "built-in" | "library" | "custom"
-             enabled: Boolean! }
-type FsNode { id: ID! name: String! kind: String! parentId: ID updatedAt: String! }
-type WorkspaceFile { id: ID! name: String! content: String! updatedAt: String! backlinks: [FsNode!]! }
-enum MemoryKind { FACT PREFERENCE PERSON PROJECT REFERENCE }
-type MemoryFact { id: ID! kind: MemoryKind! title: String! body: String! source: String! updatedAt: String! }
-type WorkflowSummary { id: ID! name: String! enabled: Boolean! }
-type Workflow { id: ID! name: String! nodes: [WorkflowNode!]! edges: [WorkflowEdge!]! }
-type WorkflowNode { id: ID! kind: String! name: String! summary: String }
-type WorkflowEdge { from: ID! to: ID! label: String }
-enum UsageRange { D7 D30 D90 }
-type Usage { series: [UsagePoint!]! byAgent: [AgentTokens!]! byProvider: [ProviderCalls!]!
-             totals: UsageTotals! }
-type Finances { balanceUsd: Float! budgetUsd: Float! spentUsd: Float! revenueUsd: Float!
-                netUsd: Float! byCategory: [CategorySpend!]!
-                transactions(first: Int = 50, offset: Int = 0): [Transaction!]! }
-type ConnectionState { provider: String! connected: Boolean! account: String reason: String }
-type DomainStatus { domain: String! verified: Boolean! records: [DnsRecord!]! }
-type SmtpStatus { host: String! port: Int! username: String! configured: Boolean! }
+type TeamMember {
+  id: ID!
+  name: String
+  role: String!
+  description: String
+  inboxEnabled: Boolean!
+}
+type Chat {
+  id: ID!
+  name: String!
+  description: String
+  members: [ID!]!
+  history(first: Int = 50, before: String): MessagePage!
+}
+type Message {
+  id: ID!
+  channel: String!
+  author: String!
+  text: String!
+  atMillis: Float!
+  mine: Boolean!
+}
+type Inbox {
+  key: ID!
+  name: String!
+  address: String!
+  unread: Int!
+  messages(first: Int = 50, offset: Int = 0): EmailPage!
+}
+type Task {
+  id: ID!
+  title: String!
+  note: String
+  column: String!
+  priority: String!
+  assignee: String!
+}
+type Skill {
+  id: ID!
+  name: String!
+  description: String!
+  category: String!
+  source: String! # "built-in" | "library" | "custom"
+  enabled: Boolean!
+}
+type FsNode {
+  id: ID!
+  name: String!
+  kind: String!
+  parentId: ID
+  updatedAt: String!
+}
+type WorkspaceFile {
+  id: ID!
+  name: String!
+  content: String!
+  updatedAt: String!
+  backlinks: [FsNode!]!
+}
+enum MemoryKind {
+  FACT
+  PREFERENCE
+  PERSON
+  PROJECT
+  REFERENCE
+}
+type MemoryFact {
+  id: ID!
+  kind: MemoryKind!
+  title: String!
+  body: String!
+  source: String!
+  updatedAt: String!
+}
+type WorkflowSummary {
+  id: ID!
+  name: String!
+  enabled: Boolean!
+}
+type Workflow {
+  id: ID!
+  name: String!
+  nodes: [WorkflowNode!]!
+  edges: [WorkflowEdge!]!
+}
+type WorkflowNode {
+  id: ID!
+  kind: String!
+  name: String!
+  summary: String
+}
+type WorkflowEdge {
+  from: ID!
+  to: ID!
+  label: String
+}
+enum UsageRange {
+  D7
+  D30
+  D90
+}
+type Usage {
+  series: [UsagePoint!]!
+  byAgent: [AgentTokens!]!
+  byProvider: [ProviderCalls!]!
+  totals: UsageTotals!
+}
+type Finances {
+  balanceUsd: Float!
+  budgetUsd: Float!
+  spentUsd: Float!
+  revenueUsd: Float!
+  netUsd: Float!
+  byCategory: [CategorySpend!]!
+  transactions(first: Int = 50, offset: Int = 0): [Transaction!]!
+}
+type ConnectionState {
+  provider: String!
+  connected: Boolean!
+  account: String
+  reason: String
+}
+type DomainStatus {
+  domain: String!
+  verified: Boolean!
+  records: [DnsRecord!]!
+}
+type SmtpStatus {
+  host: String!
+  port: Int!
+  username: String!
+  configured: Boolean!
+}
 ```
 
 Page wrappers (`TaskPage`, `MemoryFactPage`, `EmailPage`, `MessagePage`) are a
@@ -101,7 +218,7 @@ append-only and long.
 - **`Company` is the aggregation root.** Every per-company read hangs off it;
   the only top-level fields are `companies`, `company`, `skillRegistry`.
 - **`Company` is a handle, not a `SimpleObject`**: `CompanyGql { id,
-  runtime: Arc<CompanyRuntime> }` with `#[Object]` async field resolvers, each
+runtime: Arc<CompanyRuntime> }` with `#[Object]` async field resolvers, each
   awaiting the relevant port/parser — no eager loading.
 - **Timestamps**: `atMillis: Float` where the console model uses epoch millis;
   ISO-8601 `String` where it uses `at`/`updatedAt` strings. Match
@@ -129,17 +246,17 @@ reachable through an authorized `Company`.
 
 ### Data sources per field
 
-| Field | Source |
-|---|---|
-| team, chats, connections (state intent), workflows summaries | manifest (`CompanyManifest`) |
-| workflow(id) | WS1 `workflow_file.rs` |
-| skills, skillRegistry | WS1 `skill_file.rs` ∪ WS3 `SkillStateStore` |
-| workspaceTree/File, tasks, memory, inboxes | WS3 ports |
-| chat history | `EventLog` (`OperatorMessage` + new `AgentReply`) |
-| usage | WS5 `UsageMeter` |
-| finances | ledger (`CompanyStore`) + `[budget]` + economy (feature `tinyplace`) |
-| domain/smtp status | `SecretStore` reserved keys (non-secret projection) |
-| connections connected/account | `SecretStore` oauth entries (WS6) |
+| Field                                                        | Source                                                               |
+| ------------------------------------------------------------ | -------------------------------------------------------------------- |
+| team, chats, connections (state intent), workflows summaries | manifest (`CompanyManifest`)                                         |
+| workflow(id)                                                 | WS1 `workflow_file.rs`                                               |
+| skills, skillRegistry                                        | WS1 `skill_file.rs` ∪ WS3 `SkillStateStore`                          |
+| workspaceTree/File, tasks, memory, inboxes                   | WS3 ports                                                            |
+| chat history                                                 | `EventLog` (`OperatorMessage` + new `AgentReply`)                    |
+| usage                                                        | WS5 `UsageMeter`                                                     |
+| finances                                                     | ledger (`CompanyStore`) + `[budget]` + economy (feature `tinyplace`) |
+| domain/smtp status                                           | `SecretStore` reserved keys (non-secret projection)                  |
+| connections connected/account                                | `SecretStore` oauth entries (WS6)                                    |
 
 ### Frontend consumption
 
@@ -158,7 +275,7 @@ graphql-code-generator is a later nicety, not a dependency.
 ## Subtasks (commit-sized)
 
 1. `refactor(graphql): module split, schema-at-startup, GqlAuth context,
-   Page<T>` — port the three existing reads onto the `Company` handle.
+Page<T>` — port the three existing reads onto the `Company` handle.
 2. `feat(graphql): manifest-derived reads` — team, chats, connections,
    workflow summaries (**WS2a**).
 3. `feat(graphql): workflow(id) + skills + skillRegistry` (**WS2b**, needs WS1).

--- a/docs/specs/02-graphql-reads.md
+++ b/docs/specs/02-graphql-reads.md
@@ -1,0 +1,183 @@
+# 02 — WS2: The GraphQL Read Plane
+
+## Scope
+
+Expand `src/server/graphql.rs` (today: query-only `companies` / `company(id)`
+/ `approvals`) into the complete read surface for every console view. Reads
+land in GraphQL first; the existing REST reads (`GET …/team`, `…/chats`,
+`…/connections`, status, approvals) stay as **compat** until the console is
+GraphQL-only — no *new* REST reads.
+
+## Design
+
+### Module split
+
+`src/server/graphql.rs` becomes a directory module:
+
+```
+src/server/graphql/
+  mod.rs          # router(), schema build (once, at startup), GraphiQL
+  auth.rs         # GqlAuth context, authorize(), visible_companies()
+  pagination.rs   # Page<T> (offset/limit), PageArgs
+  company.rs      # Company root object, Approval, TeamMember, Chat/Message
+  workspace.rs    # FsNode, WorkspaceFile (+backlinks)
+  tasks.rs        # Task
+  skills.rs       # Skill, RegistrySkill
+  memory_facts.rs # MemoryFact
+  workflows.rs    # WorkflowSummary, Workflow, nodes/edges
+  usage.rs        # Usage series/totals
+  finances.rs     # Finances, Transaction
+  inbox.rs        # Inbox, EmailMessage
+```
+
+Build the `Schema` **once at startup** and store it in `AppState`; inject
+per-request auth via `req.data(GqlAuth)`. (Today the schema is rebuilt per
+request — fix that in the foundation commit.)
+
+### SDL sketch
+
+```graphql
+type Query {
+  companies: [Company!]!            # platform: all visible; operator: local
+  company(id: ID): Company          # id optional in single-company mode (registry.sole())
+  skillRegistry: [RegistrySkill!]!  # repo-level skills/ library (unscoped)
+}
+
+type Company {
+  id: ID!  name: String!  lifecycle: String!  pendingApprovals: Int!
+  approvals: [Approval!]!
+  team: [TeamMember!]!
+  chats: [Chat!]!  chat(id: ID!): Chat
+  inboxes: [Inbox!]!
+  tasks(column: String, first: Int = 100, offset: Int = 0): TaskPage!
+  skills: [Skill!]!
+  workspaceTree: [FsNode!]!  workspaceFile(id: ID!): WorkspaceFile
+  memory(query: String, kind: MemoryKind, first: Int = 50, offset: Int = 0): MemoryFactPage!
+  workflows: [WorkflowSummary!]!  workflow(id: ID!): Workflow
+  usage(range: UsageRange! = D30): Usage!
+  finances: Finances!
+  connections: [ConnectionState!]!
+  domain: DomainStatus
+  smtp: SmtpStatus                  # host/port/username only — never the password
+}
+
+type TeamMember { id: ID! name: String role: String! description: String inboxEnabled: Boolean! }
+type Chat { id: ID! name: String! description: String members: [ID!]!
+            history(first: Int = 50, before: String): MessagePage! }
+type Message { id: ID! channel: String! author: String! text: String! atMillis: Float! mine: Boolean! }
+type Inbox { key: ID! name: String! address: String! unread: Int!
+             messages(first: Int = 50, offset: Int = 0): EmailPage! }
+type Task { id: ID! title: String! note: String column: String! priority: String! assignee: String! }
+type Skill { id: ID! name: String! description: String! category: String!
+             source: String!  # "built-in" | "library" | "custom"
+             enabled: Boolean! }
+type FsNode { id: ID! name: String! kind: String! parentId: ID updatedAt: String! }
+type WorkspaceFile { id: ID! name: String! content: String! updatedAt: String! backlinks: [FsNode!]! }
+enum MemoryKind { FACT PREFERENCE PERSON PROJECT REFERENCE }
+type MemoryFact { id: ID! kind: MemoryKind! title: String! body: String! source: String! updatedAt: String! }
+type WorkflowSummary { id: ID! name: String! enabled: Boolean! }
+type Workflow { id: ID! name: String! nodes: [WorkflowNode!]! edges: [WorkflowEdge!]! }
+type WorkflowNode { id: ID! kind: String! name: String! summary: String }
+type WorkflowEdge { from: ID! to: ID! label: String }
+enum UsageRange { D7 D30 D90 }
+type Usage { series: [UsagePoint!]! byAgent: [AgentTokens!]! byProvider: [ProviderCalls!]!
+             totals: UsageTotals! }
+type Finances { balanceUsd: Float! budgetUsd: Float! spentUsd: Float! revenueUsd: Float!
+                netUsd: Float! byCategory: [CategorySpend!]!
+                transactions(first: Int = 50, offset: Int = 0): [Transaction!]! }
+type ConnectionState { provider: String! connected: Boolean! account: String reason: String }
+type DomainStatus { domain: String! verified: Boolean! records: [DnsRecord!]! }
+type SmtpStatus { host: String! port: Int! username: String! configured: Boolean! }
+```
+
+Page wrappers (`TaskPage`, `MemoryFactPage`, `EmailPage`, `MessagePage`) are a
+generic `Page<T> { items, total }` in `pagination.rs`. **Offset/limit, not
+Relay cursors** — the console renders full lists. Exception: `Chat.history`
+takes an opaque `before` cursor (EventLog position) because the log is
+append-only and long.
+
+### Key decisions
+
+- **`Company` is the aggregation root.** Every per-company read hangs off it;
+  the only top-level fields are `companies`, `company`, `skillRegistry`.
+- **`Company` is a handle, not a `SimpleObject`**: `CompanyGql { id,
+  runtime: Arc<CompanyRuntime> }` with `#[Object]` async field resolvers, each
+  awaiting the relevant port/parser — no eager loading.
+- **Timestamps**: `atMillis: Float` where the console model uses epoch millis;
+  ISO-8601 `String` where it uses `at`/`updatedAt` strings. Match
+  `frontend/src/lib/*` exactly.
+- **Not-wired = absent.** Fields for unshipped surfaces are added to the
+  schema only when their workstream lands; resolver-level unavailability
+  returns a GraphQL error with `extensions.code = "NOT_WIRED"`, which the
+  console's bare-catch treats like a 404.
+
+### Auth (`auth.rs`)
+
+```rust
+pub enum GqlAuth { Dev, Operator, Platform(PlatformClaims) }
+impl GqlAuth {
+    pub fn authorize(&self, company: &CompanyId) -> async_graphql::Result<()>;
+    pub fn visible_companies(&self, registry: &CompanyRegistry) -> Vec<CompanyId>;
+}
+```
+
+Refactor the claims resolution out of `platform_auth.rs` into a shared
+`fn resolve_claims(headers) -> Result<GqlAuth>` used by both the REST
+extractors and `graphql_handler`. `Query::company`/`companies` call
+`authorize`/`visible_companies`; nested fields are safe because they're only
+reachable through an authorized `Company`.
+
+### Data sources per field
+
+| Field | Source |
+|---|---|
+| team, chats, connections (state intent), workflows summaries | manifest (`CompanyManifest`) |
+| workflow(id) | WS1 `workflow_file.rs` |
+| skills, skillRegistry | WS1 `skill_file.rs` ∪ WS3 `SkillStateStore` |
+| workspaceTree/File, tasks, memory, inboxes | WS3 ports |
+| chat history | `EventLog` (`OperatorMessage` + new `AgentReply`) |
+| usage | WS5 `UsageMeter` |
+| finances | ledger (`CompanyStore`) + `[budget]` + economy (feature `tinyplace`) |
+| domain/smtp status | `SecretStore` reserved keys (non-secret projection) |
+| connections connected/account | `SecretStore` oauth entries (WS6) |
+
+### Frontend consumption
+
+No codegen, no Apollo. One method on the existing client
+(`frontend/src/api/client.ts`):
+
+```ts
+async gql<T>(query: string, variables?: Record<string, unknown>): Promise<T>
+```
+
+POSTs to `{baseUrl}/graphql` with the same bearer header; throws `ApiError`
+from `errors[0]` (`extensions.code`). Query constants live next to the views
+(`src/views/queries.ts`); response types already exist in `src/lib/*`.
+graphql-code-generator is a later nicety, not a dependency.
+
+## Subtasks (commit-sized)
+
+1. `refactor(graphql): module split, schema-at-startup, GqlAuth context,
+   Page<T>` — port the three existing reads onto the `Company` handle.
+2. `feat(graphql): manifest-derived reads` — team, chats, connections,
+   workflow summaries (**WS2a**).
+3. `feat(graphql): workflow(id) + skills + skillRegistry` (**WS2b**, needs WS1).
+4. `feat(graphql): workspace tree/file with backlinks` (**WS2b**, needs WS3
+   workspace port for live data; can land against seed-only reads first).
+5. `feat(graphql): tasks + memory + inboxes + chat history` (**WS2c**, needs
+   WS3 ports + WS4 `AgentReply` for history).
+6. `feat(graphql): usage + finances` (**WS2d**, needs WS5).
+7. `test(graphql): SDL snapshot` — updated in every schema commit thereafter.
+
+## Dependencies
+
+WS1 for 2–4; WS3 for 4–5; WS4 (AgentReply event) for history; WS5 for 6.
+Subtask 1 depends on nothing — land it first; it also unblocks WS7's `gql()`
+helper.
+
+## Tests & exit criteria
+
+Four-case suite per query + SDL snapshot per
+[09-verification.md §2](09-verification.md). Exit: every field above resolves
+against `companies/agentic_marketing_agency` in the e2e harness; GraphiQL
+spot-check documented in the PR.

--- a/docs/specs/03-ports-and-rest-writes.md
+++ b/docs/specs/03-ports-and-rest-writes.md
@@ -1,0 +1,198 @@
+# 03 — WS3: New Ports/Stores + the REST Write Plane
+
+## Scope
+
+Durable state and mutations for the console surfaces that are client-only
+today: tasks, memory facts, workspace files, skill install state, inboxes,
+usage samples — six new port traits with fs/sqlite/mongodb backends — plus a
+new `src/server/ops/` REST router family carrying every write.
+
+## Design — ports
+
+All traits `#[async_trait]`, `Send + Sync`, used as `Arc<dyn …>`, keyed by
+`&CompanyId`, one file per port in `src/ports/` (re-exported in `mod.rs`):
+
+```rust
+// ports/tasks.rs
+pub struct TaskRecord { pub id: String, pub title: String, pub note: Option<String>,
+    pub column: String, pub priority: String, pub assignee: String, pub updated_at_millis: u64 }
+pub trait TaskStore {
+    async fn list(&self, company: &CompanyId) -> Result<Vec<TaskRecord>>;
+    async fn upsert(&self, company: &CompanyId, task: &TaskRecord) -> Result<()>;
+    async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool>;
+}
+
+// ports/workspace.rs — node ids are stable ULIDs, not paths (rename-safe)
+pub struct WorkspaceNode { pub id: String, pub name: String, pub kind: NodeKind,
+    pub parent_id: Option<String>, pub updated_at_millis: u64 }
+pub trait WorkspaceStore {
+    async fn tree(&self, company: &CompanyId) -> Result<Vec<WorkspaceNode>>;
+    async fn read(&self, company: &CompanyId, id: &str) -> Result<Option<(WorkspaceNode, String)>>;
+    async fn write(&self, company: &CompanyId, id: &str, content: &str) -> Result<WorkspaceNode>;
+    async fn create(&self, company: &CompanyId, node: &WorkspaceNode, content: Option<&str>) -> Result<()>;
+    async fn rename_move(&self, company: &CompanyId, id: &str,
+        name: Option<&str>, parent: Option<&str>) -> Result<WorkspaceNode>;
+    async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool>;  // folders recursive
+    async fn is_empty(&self, company: &CompanyId) -> Result<bool>;          // gates seeding
+}
+
+// ports/facts.rs — the console's durable Memory view. Distinct from the existing
+// MemoryStore (traces/task_results = runtime working memory).
+pub struct FactRecord { pub id: String, pub kind: FactKind, pub title: String,
+    pub body: String, pub source: String, pub updated_at_millis: u64 }
+pub trait FactStore {
+    async fn list(&self, company: &CompanyId, query: Option<&str>, kind: Option<FactKind>)
+        -> Result<Vec<FactRecord>>;
+    async fn upsert(&self, company: &CompanyId, fact: &FactRecord) -> Result<()>;
+    async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool>;
+}
+
+// ports/inbox.rs
+pub struct InboxMeta { pub key: String, pub name: String, pub address: String, pub enabled: bool }
+pub struct EmailRecord { pub id: String, pub inbox: String, pub from_name: String,
+    pub from_email: String, pub subject: String, pub body: String,
+    pub at_millis: u64, pub read: bool, pub outbound: bool }
+pub trait InboxStore {
+    async fn inboxes(&self, company: &CompanyId) -> Result<Vec<InboxMeta>>;
+    async fn set_enabled(&self, company: &CompanyId, key: &str, meta: &InboxMeta) -> Result<()>;
+    async fn messages(&self, company: &CompanyId, key: &str, limit: usize, offset: usize)
+        -> Result<Vec<EmailRecord>>;
+    async fn append(&self, company: &CompanyId, msg: &EmailRecord) -> Result<()>;
+    async fn mark_read(&self, company: &CompanyId, key: &str, ids: Option<&[String]>) -> Result<u64>;
+}
+
+// ports/usage.rs — written by the WS4 cost hook, read by WS5
+pub struct UsageSample { pub at_millis: u64, pub agent: String, pub provider: String,
+    pub input_tokens: u64, pub output_tokens: u64, pub cached_input_tokens: u64,
+    pub cost_usd: f64, pub kind: SampleKind /* Inference | OauthCall */ }
+pub trait UsageMeter {
+    async fn record(&self, company: &CompanyId, sample: &UsageSample) -> Result<()>;
+    async fn query(&self, company: &CompanyId, since_millis: u64) -> Result<Vec<UsageSample>>;
+}
+
+// ports/skills_state.rs — deltas only; built-in content stays on disk
+pub struct SkillState { pub slug: String, pub enabled: bool, pub source: SkillSource,
+    pub custom_doc: Option<String> /* full SKILL.md for custom skills */ }
+pub trait SkillStateStore {
+    async fn list(&self, company: &CompanyId) -> Result<Vec<SkillState>>;
+    async fn set(&self, company: &CompanyId, state: &SkillState) -> Result<()>;
+    async fn remove(&self, company: &CompanyId, slug: &str) -> Result<bool>;
+}
+```
+
+**Deliberately not ports:** domain + SMTP config are JSON blobs under
+`SecretStore` reserved keys (`__domain`, `__smtp`); finances resolve from the
+existing ledger + `[budget]` + economy.
+
+`FactStore` deliberately sits **beside** the two memory ports specified in
+[`docs/spec/company-brain/memory.md`](../spec/company-brain/memory.md)
+(`MemoryStore` = traces/task results, `ContextStore` = the RLM environment):
+facts are the Operator's durable, hand-curated view, not cycle working
+memory. The Operator-rights section of that spec applies — deletes propagate
+to the backing store and the deletion is journaled to the `EventLog`.
+
+### Backends & wiring
+
+`StorageHandles` (`src/store/select.rs`) grows `tasks`, `workspace`, `facts`,
+`inbox`, `usage`, `skills` fields; `open_storage` wires each backend:
+
+- **fs** — JSON/JSONL under the company bundle: `tasks.json`, `facts.jsonl`,
+  `inbox/<key>.jsonl`, `usage.jsonl`, `skills.json`; workspace as real files
+  plus `.workspace-index.json` (ULID → path).
+- **sqlite** — one table per port on the shared bundled connection
+  (`tasks`, `facts`, `inbox_messages`, `usage_samples`, `skill_state`,
+  `workspace_nodes` with a content column).
+- **mongodb** — one collection per port, every doc keyed by `company_id`.
+
+Each port gets a conformance function in `src/store/conformance.rs`
+(`task_store_conformance(&dyn TaskStore)`, …) invoked from all three backends'
+test mods — the existing pattern.
+
+### Seeding (idempotent, in `RuntimeBuilder::build`)
+
+- **Workspace**: if `is_empty`, walk `companies/<name>/workspace/**` (WS1
+  walker) and create the tree. Never re-seed — operator deletions stick.
+- **Skills**: effective set = company-dir skills (`source: "built-in"`,
+  enabled by default) ∪ `SkillStateStore` rows (library installs, custom
+  skills, disable overrides). The store holds deltas only.
+
+## Design — REST write plane (`src/server/ops/`)
+
+One file per domain, merged via `ops::router()` in `routes.rs`. A `scoped()`
+helper registers each route under **both** addressing forms, and a
+`ScopedCompany` extractor resolves `Arc<CompanyRuntime>` + authorization
+(`PlatformOrOperatorAuth` + `authorize_address` on `/companies/{id}`;
+`OperatorAuth` + `registry.sole()` on `/company`):
+
+```rust
+pub(crate) fn scoped(path: &str, mr: MethodRouter<AppState>) -> Router<AppState>;
+// handlers: async fn(company: ScopedCompany, Json<Body>) -> Result<Json<Resp>, ApiError>
+```
+
+Errors reuse `server/error.rs`: the `{error, code}` envelope with stable
+codes and status semantics already normative in
+[`docs/spec/runtime/api.md`](../spec/runtime/api.md) (4xx caller mistakes,
+409 lifecycle conflicts). Strings follow the glossary via a shared
+`ops/language.rs` const table. Bodies mirror `frontend/src/api/types.ts` /
+`src/lib/*` (camelCase serde). Chat stays request/response JSON for now; the
+SSE streaming form in `runtime/api.md` is a compatible later upgrade.
+
+### Route table (under both `…/companies/{id}` and `…/company`)
+
+| Method | Path | Body → Response |
+|---|---|---|
+| POST | `/tasks` | `{title, note?, column?, priority?, assignee?}` → `TaskCard` |
+| PATCH | `/tasks/{taskId}` | partial `TaskCard` → `TaskCard` (drag = `{column}`) |
+| DELETE | `/tasks/{taskId}` | → 204 |
+| POST | `/memory` | `{kind, title, body, source?}` → `MemoryEntry` |
+| DELETE | `/memory/{factId}` | → 204 |
+| POST | `/workspace` | `{name, kind, parentId?, content?}` → `FsNode` |
+| PUT | `/workspace/file/{nodeId}` | `{content}` → `{updatedAt}` |
+| PATCH | `/workspace/{nodeId}` | `{name?, parentId?}` → `FsNode` (reject cycles) |
+| DELETE | `/workspace/{nodeId}` | → 204 (folders recursive) |
+| POST | `/skills/{slug}/install` | → `InstalledSkill` (from registry) |
+| POST | `/skills/{slug}/uninstall` | → 204 (built-in → 409) |
+| PUT | `/skills/{slug}` | `{enabled}` → `InstalledSkill` |
+| POST | `/skills` | `{name, description, category?, body?}` → `InstalledSkill` (custom) |
+| POST | `/team` | `{name, role, description?}` → `TeamMemberDto` (operator overlay) |
+| DELETE | `/team/{agentId}` | → 204 (manifest agents → 409) |
+| PUT | `/team/{agentId}/inbox` | `{enabled}` → `{key, address}` |
+| POST | `/chat` | `{message, chat?}` → `{responses:[{channel,text}]}` (extends operator chat with a desk id) |
+| POST | `/inboxes/{key}/read` | `{ids?}` → `{unread}` (omit ids = all) |
+
+Connections/domain/SMTP writes are specified in
+[06-connections-domain-email.md](06-connections-domain-email.md); approvals,
+feedback, lifecycle, provision already exist and are untouched.
+
+**Team writes** use the operator-overlay model (see README open question 1):
+overlay agents persist via `CompanyStore` (field on `CompanyRecord`) and merge
+into the roster at read/build time; the version-controlled `company.toml` is
+never rewritten. Overlay agents are roster-only in v1.
+
+## Subtasks (commit-sized; one subagent per surface)
+
+Per surface — tasks, memory, workspace, skills, inbox — two commits each:
+
+1. `feat(<surface>): port trait + fs/sqlite/mongodb impls + conformance`
+2. `feat(server): <surface> REST routes + tests`
+
+Plus, first: `feat(server): ops router scaffolding (scoped(), ScopedCompany,
+language table)`; and `feat(runtime): workspace/skills seeding in
+RuntimeBuilder` after the workspace/skills ports land. The `UsageMeter` port
+ships here (trait + backends) but is written to by WS4 and read by WS5.
+
+Coordination: registration lines in `ports/mod.rs` / `store/*` /
+`routes.rs` land serially; everything else parallel.
+
+## Dependencies
+
+WS1 (workspace walker, skill loader for seeding/install). Unblocks WS2c, WS5
+(UsageMeter), WS7. Inbox delivery becomes real only with WS6.
+
+## Tests & exit criteria
+
+Conformance suite per port on all backends; four-case REST suites plus
+per-surface cases (restart persistence, traversal/cycle rejection, built-in
+uninstall 409) per [09-verification.md](09-verification.md). Exit: e2e
+restart-persistence green; console views wire up in WS7 without contract
+changes.

--- a/docs/specs/04-openhuman-harness.md
+++ b/docs/specs/04-openhuman-harness.md
@@ -1,0 +1,170 @@
+# 04 — WS4: openhuman as a Library (the Harness)
+
+## Scope
+
+Replace the out-of-process OpenHuman seam (`src/openhuman/{launcher,rpc,
+tools,channel}.rs`, JSON-RPC behind feature `openhuman-rpc`) with **direct
+library embedding** of `vendor/openhuman` (`openhuman_core`): one openhuman
+`Agent` per manifest `[[agent]]`, with memory, inference provider, tools,
+skills, and approval policy injected through `AgentBuilder`.
+
+This supersedes the JSON-RPC integration described in
+[`docs/spec/integrations/openhuman.md`](../spec/integrations/openhuman.md) —
+the "library-crate split" that doc lists as an upstream candidate is realized
+by linking `openhuman_core` directly. WS9 updates that doc and the roadmap
+(including the "TinyAgents is the harness" non-goal) to match.
+
+## Design
+
+### Cargo strategy
+
+```toml
+openhuman_core = { package = "openhuman", path = "vendor/openhuman",
+                   optional = true, default-features = false }
+
+[features]
+openhuman = ["dep:openhuman_core"]   # NEW: library harness
+openhuman-rpc = ["dep:reqwest"]      # legacy; kept one release, then deleted
+```
+
+`src/harness/` compiles only under `feature = "openhuman"`. The default build
+stays offline and echo-brained — the spec's one-key promise holds. Legacy
+`src/openhuman/` modules survive one release behind `openhuman-rpc`; the
+reusable tool/channel definitions in `tools.rs`/`channel.rs` are ported into
+`harness/build.rs` before the module is retired.
+
+### Module layout
+
+```
+src/harness/
+  mod.rs        # HarnessPool: CompanyId -> Vec<Arc<CompanyAgent>>
+  build.rs      # manifest [[agent]] -> AgentBuilder
+  provider.rs   # inference Provider (hosted Medulla only)
+  memory.rs     # OcMemory: openhuman Memory trait over opencompany ports
+  policy.rs     # tool_policy -> ApprovalGate bridge
+  cost.rs       # TurnCost -> LedgerEntry + UsageMeter
+```
+
+### Core types
+
+```rust
+pub struct CompanyAgent {
+    pub agent_id: String,
+    pub role: String,
+    agent: tokio::sync::Mutex<openhuman_core::agent::harness::session::Agent>,
+}
+pub struct HarnessPool { agents: RwLock<HashMap<CompanyId, Vec<Arc<CompanyAgent>>>> }
+impl HarnessPool {
+    pub async fn ensure(&self, company: &CompanyRecord, deps: &HarnessDeps) -> Result<()>;
+    pub async fn run(&self, company: &CompanyId, agent_id: &str, message: &str) -> Result<String>;
+}
+```
+
+`build_agent` (in `build.rs`) wires each manifest agent:
+
+```rust
+AgentBuilder::default()
+    .provider(hosted_provider(&config)?)          // provider.rs
+    .memory(Arc::new(OcMemory::new(company_id, agent_id, deps.memory, deps.context)))
+    .workflows(enabled_skills)                    // parsed SKILL.md bodies via
+                                                  // openhuman::skills::ops_parse
+    .tools(company_tools(manifest, agent))        // manifest.tools ∩ agent.tools
+    .tool_policy(ApprovalPolicy::new(deps.approvals, agent.budget_usd_daily))
+    .workspace_dir(company_home.join("workspace"))
+    .model_name(model_for_tier(&agent.tier))
+    .post_turn_hooks(vec![cost_hook])             // cost.rs
+    .build()
+```
+
+### Provider (`provider.rs`)
+
+openhuman's `inference::provider::Provider` is a trait, so opencompany brings
+its own implementation speaking to the **hosted Medulla brain / TinyHumans
+API** — consistent with the spec non-goal "not a model host": no local-LLM or
+BYO-model path ships. A `MockProvider` exists for tests only. `BrainMode`
+continues to select hosted vs echo; the sidecar mode is subsumed by the
+embedded harness.
+
+### Memory adapter (`memory.rs`)
+
+`OcMemory` implements `openhuman_core::memory::traits::Memory` over the
+existing `MemoryStore` + `ContextStore` ports, namespacing entries
+`{company}/{agent}`. When the `tinycortex` backend is active, delegate
+directly — openhuman's memory value types are re-exported from the tinycortex
+crate, so translation is near-zero. `recall_relevant_by_vector` degrades to
+FTS/substring recall on the fs backend (best effort, never errors). This is
+exactly the "memory pluggable and configurable" requirement: the backend is
+chosen by `OPENCOMPANY_STORAGE`, not by openhuman.
+
+Operator rights from
+[`company-brain/memory.md`](../spec/company-brain/memory.md) flow through
+unchanged: everything `OcMemory` stores is inspectable/deletable/exportable
+via the opencompany ports it writes to.
+
+### Approval bridge (`policy.rs`)
+
+The `tool_policy` closure returns `ToolPolicyDecision::require_approval` for
+effects matching manifest policy — `[policy].mode` uses the same three words
+as OpenHuman's security tiers (readonly/supervised/full) by design, so the
+mapping is 1:1, plus `always_approve` kinds and per-agent
+`budget_usd_daily` / `auto_approve_under_usd` thresholds. Parked decisions go
+through the existing `ApprovalGate` port and journal, so the console's
+approvals surface and `resolve_approval` flow work unchanged; approve/deny
+resumes the suspended tool call inside the agent turn.
+
+### Cost hook (`cost.rs`)
+
+A post-turn hook reads openhuman's `TurnCost`
+(`UsageInfo { input_tokens, output_tokens, cached_input_tokens }`,
+`total_usd()`) and writes both:
+
+1. `CompanyStore::append_ledger(LedgerEntry { kind: "inference.spend",
+   amount_usd, memo: agent_id })` — feeds Finances;
+2. `UsageMeter::record(UsageSample { agent, provider, tokens…, cost_usd })` —
+   feeds Usage (WS5).
+
+OAuth-connected tool invocations record `SampleKind::OauthCall` samples with
+the provider name — that populates the console's calls-by-provider chart.
+
+### Multi-agent & desk routing
+
+openhuman is single-agent; **group-chat routing stays opencompany's job**.
+The ops `chat` handler (WS3) resolves the target desk's `members`, picks the
+addressed agent (mention-parse; else the first member as desk lead), calls
+`HarnessPool::run`, and journals both directions to the `EventLog` — the
+operator message as today, the reply as a new variant:
+
+```rust
+CompanyEvent::AgentReply { chat_id: String, agent_id: String, text: String }
+```
+
+which is what the GraphQL `Chat.history` resolver reads back. Fan-out (every
+member responds) is a later policy flag; v1 is single-responder.
+
+`RuntimeBuilder` grows `.with_harness(Arc<HarnessPool>)`;
+`CompanyRuntime::run_cycle` routes agent turns through the pool when the
+feature is on, echo brain otherwise.
+
+## Subtasks (commit-sized; serial within this workstream)
+
+1. `feat(harness): openhuman feature + path dep, compile-only scaffold`
+2. `feat(harness): hosted provider + MockProvider`
+3. `feat(harness): OcMemory adapter over MemoryStore/ContextStore`
+4. `feat(harness): approval bridge (tool_policy -> ApprovalGate)`
+5. `feat(harness): cost hook (ledger + UsageMeter)`
+6. `feat(runtime): HarnessPool wiring, AgentReply event, desk routing in chat`
+7. `chore(openhuman): deprecate openhuman-rpc modules` (one release later)
+
+## Dependencies
+
+None to start (day one, parallel with WS1). Consumes WS1 skill parsing (step
+build), WS3's `UsageMeter` port (step 5). Feeds WS5 and WS2c (chat history).
+
+## Tests & exit criteria
+
+Unit: memory-adapter isolation + namespacing; cost mapping (zero-usage → no
+entry). Feature (under `--features openhuman`): full chat cycle with
+`MockProvider` → reply + ledger delta + usage sample; gated tool → parked →
+resolve → resumed turn. Exit: default build (no features) is byte-for-byte
+unaffected; e2e chat round-trip green per
+[09-verification.md](09-verification.md).

--- a/docs/specs/05-usage-finances.md
+++ b/docs/specs/05-usage-finances.md
@@ -1,0 +1,89 @@
+# 05 — WS5: Usage & Finances (Metering)
+
+## Scope
+
+Turn the raw spend/usage data the runtime already models (`TokenUsage`,
+`LedgerEntry`, `[budget]`, tiny.place economy payments) plus the new
+`UsageSample` stream (WS4 cost hook) into the two console read surfaces:
+
+- **Usage** — token burn over time, tokens by teammate, calls by provider,
+  totals, over 7/30/90 days.
+- **Finances** — balance, budget vs spend, revenue, spend by category,
+  transactions.
+
+No new port beyond WS3's `UsageMeter`; finances resolve entirely from
+existing data.
+
+## Design
+
+### Aggregation module — `src/metering/`
+
+```rust
+pub fn bucket_usage(samples: &[UsageSample], range: UsageRange, now_millis: u64) -> Usage;
+// - series: one UsagePoint per day in range (zero-filled), input/output tokens
+// - by_agent: sum tokens per sample.agent (teammate display names resolved
+//   from the roster; prosumer language)
+// - by_provider: count SampleKind::OauthCall per provider
+// - totals: token sums, cost_usd sum, oauth call count, connected count
+
+pub fn finances_from(ledger: &[LedgerEntry], budget: &Budget,
+                     economy_balance: Option<f64>, now_millis: u64) -> Finances;
+// - spent_usd: current-month outgoing entries; budget_usd from [budget].monthly_usd
+// - revenue_usd: incoming entries (payment.received / a2a sale receipts)
+// - balance_usd: economy wallet when the tinyplace feature is on, else
+//   revenue - spend (bookkeeping balance)
+// - by_category: LedgerEntry.kind prefix mapping (inference.* -> "Inference",
+//   tools.* -> "Tools", payment.* -> "Payments", …) with prosumer labels
+// - transactions: ledger entries newest-first, paged
+```
+
+Pure functions over port data — trivially unit-testable, no I/O.
+
+### Data flow
+
+```
+openhuman TurnCost ──(WS4 cost hook)──► LedgerEntry("inference.spend") ─► Finances
+                                    └─► UsageMeter::record(UsageSample) ─► Usage
+tiny.place payments ──(existing economy adapter journals)──► ledger ─────► Finances
+OAuth tool calls ──(WS4 hook, SampleKind::OauthCall)──► UsageMeter ──────► Usage.byProvider
+```
+
+The GraphQL resolvers (WS2d, `graphql/usage.rs` + `graphql/finances.rs`) call
+`UsageMeter::query(company, since)` / `CompanyStore::load(...).ledger` and
+feed these functions.
+
+### Retention
+
+`UsageMeter` backends evict samples older than **90 days** (the console's max
+range) — fs compacts `usage.jsonl` on write past a threshold; sqlite/mongo
+delete by `at_millis`. (README open question 4; this is the recommended
+default.)
+
+### Spec alignment
+
+- The ledger stays the single financial source of truth, as
+  [`docs/spec/company-as-agent/commerce.md`](../spec/company-as-agent/commerce.md)
+  assumes; metering never writes the ledger, only reads it.
+- Budget exhaustion behavior is unchanged (pause + `budget.exhausted`
+  webhook); Finances merely reports the same numbers.
+- Category and teammate labels follow the glossary — no "cycle", no "tier".
+
+## Subtasks (commit-sized)
+
+1. `feat(metering): usage bucketing + finances projection (pure functions)`
+2. `feat(graphql): usage + finances resolvers` (= WS2 subtask 6)
+3. `feat(store): usage retention/eviction in fs/sqlite/mongodb`
+
+## Dependencies
+
+WS3 (`UsageMeter` port exists), WS4 (cost hook produces real samples —
+resolvers can land earlier against seeded data). Feeds WS2d and WS7's Usage +
+Finances views.
+
+## Tests & exit criteria
+
+Unit: bucketing across ranges (zero-fill, day boundaries), category mapping,
+budget math, empty inputs. Feature: seed samples + ledger entries via ports,
+assert the GraphQL aggregates. E2E: one chat round-trip produces a visible
+`inference.spend` transaction and a usage point. Exit per
+[09-verification.md](09-verification.md) WS5 row.

--- a/docs/specs/06-connections-domain-email.md
+++ b/docs/specs/06-connections-domain-email.md
@@ -1,0 +1,121 @@
+# 06 — WS6: Connections (OAuth), Domain/DNS, SMTP & Email
+
+## Scope
+
+The credential-bearing surfaces: OAuth connect/disconnect for the connections
+catalog, custom-domain provisioning with DNS verification, SMTP credentials +
+test send, and the email transport that makes per-teammate inboxes real.
+Everything secret-shaped lives in `SecretStore`; the default build stays
+offline (all network I/O feature-gated).
+
+## Design
+
+### Connections OAuth
+
+Routes (dual-scoped like all WS3 ops routes, except the callback):
+
+| Method | Path | Behavior |
+|---|---|---|
+| POST | `…/connections/{provider}/start` | → `{url}`: provider authorize URL with a signed `state` nonce (company+provider+expiry), redirect URI from config |
+| GET | `/api/v1/oauth/callback` (unscoped) | verifies `state`, exchanges `code` server-side, stores tokens at `SecretStore["oauth/{provider}"]`, captures the account label, redirects back to the console |
+| POST | `…/connections/{provider}/disconnect` | best-effort revoke, delete the secret |
+
+- **Callback hosting:** this crate hosts it. In managed deployments the
+  manager may front the same path; `OPENCOMPANY_OAUTH_REDIRECT_BASE`
+  overrides the redirect URI so the authorize URL points wherever the
+  operator's browser can reach (README open question resolution).
+- **Provider app credentials** (client_id/client_secret) are host-level
+  configuration (`OPENCOMPANY_OAUTH_<PROVIDER>_ID/_SECRET`), never
+  per-company; per-company state is tokens only.
+- Read side (GraphQL `connections`): catalog priorities from `[[connection]]`
+  manifest intent ∪ connected state from the secret store — `{provider,
+  connected, account?, reason?}`. **Account label and connected flag only;
+  token material never appears in any response** (feature-tested).
+- Token exchange needs `reqwest` → gate the write routes behind a small
+  `oauth` feature; without it they 404 and the console shows the read-only
+  catalog (existing seam behavior).
+
+### Domain & DNS
+
+| Method | Path | Behavior |
+|---|---|---|
+| PUT | `…/domain` | `{domain}` → `DomainStatus` with generated records |
+| POST | `…/domain/verify` | server-side DNS lookups → updated `DomainStatus` |
+
+- `src/company/dns.rs`: pure record generation — verification TXT
+  (deterministic token derived per company+domain), mail CNAME, two DKIM
+  CNAMEs, SPF TXT — mirroring `frontend/src/lib/domain.ts::dnsRecords` so the
+  console renders identically.
+- Verification via a mockable trait:
+
+```rust
+pub trait DnsResolver: Send + Sync {
+    async fn txt(&self, name: &str) -> Result<Vec<String>>;
+    async fn cname(&self, name: &str) -> Result<Option<String>>;
+}
+```
+
+Real impl uses `hickory-resolver` behind feature `dns`; without the feature
+`verify` returns the not-wired 404. Config JSON persists at
+`SecretStore["__domain"]`.
+
+### SMTP & outbound email
+
+| Method | Path | Behavior |
+|---|---|---|
+| PUT | `…/smtp` | credentials → `SecretStore["__smtp"]`; response is non-secret `SmtpStatus` |
+| POST | `…/smtp/test` | `{to?}` → `{ok, message}` — sends a test email |
+
+Sending via a mockable `MailSender` trait; the real impl uses `lettre` behind
+feature `smtp`, pulling credentials from the secret store per send. Every
+outbound send also appends an `EmailRecord { outbound: true }` to `InboxStore`
+so the console shows sent mail. The WS4 harness exposes a `send_email` tool to
+agents whose inbox is enabled — gated by the approval policy
+(`external.publish`-class effect).
+
+### Inbound email
+
+Reuse the webhook surface already specified in
+[`docs/spec/runtime/api.md`](../spec/runtime/api.md) rather than inventing a
+new route:
+
+```
+POST /hooks/{companyId}/email
+```
+
+HMAC-verified per-channel secret from `SecretStore` (the existing `webhooks`
+feature signer); unverifiable payloads are dropped with 401 and never become
+events. The handler parses the payload (from/subject/body/to), resolves the
+target inbox by address, appends to `InboxStore`, and enqueues a
+`CompanyEvent::WebhookReceived`-derived event so the addressed teammate can
+act on the mail. A mail-forwarding provider or the platform manager (which
+owns MX in managed deployments) pushes into this hook — no IMAP polling in v1
+(README open question 2).
+
+Inbox addresses: `{agent_id}@{domain}` once a domain is verified; before
+that, inboxes exist but are marked "pending domain" in the read surface.
+
+## Subtasks (commit-sized)
+
+1. `feat(company): dns record generation + DnsResolver trait` (pure, no features)
+2. `feat(server): domain routes + verify behind feature dns`
+3. `feat(server): smtp routes + MailSender behind feature smtp`
+4. `feat(server): oauth start/callback/disconnect behind feature oauth`
+5. `feat(server): inbound email hook -> InboxStore + event`
+6. `feat(harness): send_email tool wired to MailSender + approval policy`
+
+1–5 are parallelizable across subagents (distinct files); 6 lands after WS4.
+
+## Dependencies
+
+WS3 (`InboxStore`, ops scaffolding, SecretStore keys). Feeds WS7
+(Connections, Settings, Inbox views) and completes WS3's inbox surface.
+
+## Tests & exit criteria
+
+Unit: DNS record generation determinism; mock-resolver verify outcomes.
+Feature: the four-case suite per route plus — no token/password material in
+any serialized response; callback with tampered `state` → 401; inbound hook
+with bad HMAC → 401 and no event; smtp test with mock sender. Default build
+compiles with no network crates. Exit per
+[09-verification.md](09-verification.md) WS6 row.

--- a/docs/specs/07-frontend-wiring.md
+++ b/docs/specs/07-frontend-wiring.md
@@ -1,0 +1,102 @@
+# 07 — WS7: Frontend Wiring (Seam Swaps)
+
+## Scope
+
+Move every console view from its localStorage/sample seam to the real
+backend: GraphQL for reads, REST for writes — keeping the graceful-fallback
+behavior so the console still works against older hosts.
+
+## Design
+
+### The `gql()` helper
+
+One new method on the existing client (`frontend/src/api/client.ts` — the
+only place HTTP happens):
+
+```ts
+async gql<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+  const res = await fetch(`${this.baseUrl}/graphql`, {
+    method: "POST",
+    headers: this.headers({ json: true }),
+    body: JSON.stringify({ query, variables }),
+  });
+  const { data, errors } = await res.json();
+  if (errors?.length)
+    throw new ApiError(res.status, errors[0].extensions?.code ?? "graphql", errors[0].message);
+  return data as T;
+}
+```
+
+Same bearer/scope resolution as `request()`. Query constants live in
+`src/views/queries.ts`; response types are the existing `src/lib/*` models —
+the SDL (WS2) was designed to match them field-for-field. New REST write
+methods are added to the client per surface, following the existing method
+style. No Apollo/urql/react-query; codegen is a later nicety.
+
+### The swap pattern (per view)
+
+Each view keeps its three-state seam (`loading | ready | unavailable`), but:
+
+1. read: `client.gql<…>(QUERY, { id: company })` replaces the localStorage
+   load;
+2. writes: optimistic UI + REST call + toast-on-error (pattern already used
+   by Team/Connections);
+3. the sample/seed module is **deleted** (or reduced to the fallback shown in
+   the `unavailable` state);
+4. the `fromHost`/`unavailable` copy stays so operators know when data is
+   local.
+
+localStorage remains only where it is genuinely client state (theme, token,
+last-selected desk) — not for domain data.
+
+### Per-view checklist (one commit each, in backend-landing order)
+
+| View | Read | Writes | Deletes |
+|---|---|---|---|
+| Team | `company.team` | POST/DELETE `…/team`, PUT `…/team/{id}/inbox` | `starterTeam()` fallback trimmed |
+| Conversation | `company.chats` + `chat.history` | `POST …/chat {message, chat}` | `defaultThreads()` sample |
+| Skills | `company.skills` + `skillRegistry` | install/uninstall/enable/custom | `SKILL_REGISTRY`, `seedSkills()` |
+| Workflows | `company.workflows` / `workflow(id)` | — (read-only canvas) | `SAMPLE_WORKFLOW` |
+| Workspace | `workspaceTree` / `workspaceFile` | POST/PUT/PATCH/DELETE `…/workspace` | `seedWorkspace()` + localStorage store |
+| Tasks | `company.tasks` | POST/PATCH/DELETE `…/tasks` | `sampleTasks()` |
+| Memory | `company.memory` | POST/DELETE `…/memory` | `seedMemory()` |
+| Usage | `company.usage(range)` | — | `buildUsage()` RNG sample |
+| Finances | `company.finances` | — | `buildFinance()` sample |
+| Connections | `company.connections` | start/disconnect (existing methods) | catalog stays (it's static UI data) |
+| Settings (domain/SMTP) | `company.domain` / `company.smtp` | PUT domain, POST verify, PUT smtp, POST test | localStorage `oc-mail` draft |
+| Inbox | `company.inboxes` + messages | POST `…/inboxes/{key}/read`, toggle via Team | `seedInboxes()` |
+
+Each commit also updates the matching row in `frontend/ARCHITECTURE.md`
+(seam/client-only → real) — that file stays the live contract map.
+
+### Tests (new Vitest setup — see 09-verification.md §3)
+
+- `src/api/client.test.ts` grows a contract test per new method (URL, verb,
+  body, error shaping) plus `gql()` error unwrapping.
+- Pure-logic lib tests (workspace tree ops, wikilinks, language) land with
+  the Vitest bootstrap commit, before any view swap.
+- `npm run typecheck && npm run build && npm test` green per commit.
+
+## Subtasks
+
+1. `feat(console): vitest bootstrap + client contract tests`
+2. `feat(console): gql() helper + queries.ts scaffold`
+3. Per view, one commit: `feat(console): wire <view> to the host` — in the
+   order the backend lands (Team/Conversation/Skills/Workflows first after
+   WS2a/b; Workspace/Tasks/Memory after WS2c+WS3; Usage/Finances after WS5;
+   Connections/Settings/Inbox after WS6).
+
+At most 2–3 subagents in parallel (shared `client.ts`/`types.ts` — the
+merge-conflict hotspot; registration edits land serially).
+
+## Dependencies
+
+Trails WS2/WS3/WS5/WS6 surface-by-surface. Subtasks 1–2 only need WS2's
+foundation commit.
+
+## Tests & exit criteria
+
+Per view: sample module deleted, fallback retained, typecheck+build+vitest
+green, manual pass against a live host running
+`companies/agentic_marketing_agency`. Playwright flows follow once the
+majority of views are wired ([09-verification.md §4](09-verification.md)).

--- a/docs/specs/08-company-content.md
+++ b/docs/specs/08-company-content.md
@@ -1,0 +1,94 @@
+# 08 — WS8: Skills Library & Company Starter Content
+
+## Scope
+
+Content, not code. Two gaps:
+
+1. The **shared skills library** (repo-level `skills/`) has only
+   `web-research` and `weekly-report` — the console's install registry needs
+   a real catalog.
+2. Of the 19 company templates under `companies/`, only
+   `agentic_marketing_agency` ships the full directory (skills, workflows,
+   workspace). The other 18 have just `company.toml` + `README.md`, so their
+   consoles boot empty.
+
+Templates are the productized manifests of
+[`docs/spec/product/templates.md`](../spec/product/templates.md) — this
+workstream makes each one feel staffed and ready on first boot.
+
+## Design
+
+### Formats (frozen by WS1)
+
+- `SKILL.md`: `---` frontmatter with `name`, `description` (+ optional
+  `category`), then `# Title / ## When to use / ## Steps / ## Output`
+  sections. Same format for library and company skills — they move between
+  the two unchanged, and the body feeds the WS4 harness directly.
+- `workflows/<id>.toml`: `id`/`name`/`description` + `[[node]]`
+  (trigger/agent/tool_call/http_request/condition/output, `agent` refs a
+  roster id) + `[[edge]]`. Every workflow referenced from
+  `[workflows].enabled` must exist and validate.
+- `workspace/**`: topic folders of Markdown with `[[wikilinks]]`; a
+  `README.md` orienting the operator.
+
+All content follows the [glossary](../spec/glossary.md) — prosumer language
+only.
+
+### Shared library target (~12 skills)
+
+Category-balanced against the console's `SkillCategory` set (Marketing,
+Research, Ops, Content, Finance):
+
+`cold-outreach`, `competitor-scan`, `meeting-brief`, `invoice-drafting`,
+`expense-report`, `seo-audit` (promoted from the marketing company),
+`landing-page` (likewise), `changelog-writer`, `social-calendar`,
+`customer-followup`, `hiring-screen`, `deal-memo` — plus the existing
+`web-research` and `weekly-report`. Each ≤80 lines, concrete steps, one
+clearly stated output.
+
+### Per-company starters (18 companies)
+
+For each bare company, using `agentic_marketing_agency` as the template:
+
+- **2–4 skills** specific to the business (law firm: `contract-review`,
+  `client-intake`; VC: `deal-memo`, `diligence-checklist`; support:
+  `ticket-triage`, `kb-article`; …),
+- **1 workflow** — the company's core pipeline, agents mapped to its actual
+  roster ids,
+- **workspace/** — README + 2–3 seed notes (playbook checklist, a brand/voice
+  or policies note, one worked example) cross-linked with wikilinks,
+- `[workflows].enabled` updated in `company.toml`.
+
+Batches (one subagent each, zero file overlap):
+
+1. Professional services: law, accounting, consultation, recruiting.
+2. Product/tech: software, design studio, game studio, game business, pharma.
+3. Go-to-market: enterprise sales, customer support, influencer, media.
+4. Capital: VC, venture studio, real estate, accelerator misc
+   (`signals_opportunity_studio`, `startup_accelerator`).
+
+### The guardrail
+
+WS1's content-validation test (`companies/*` + `skills/*` walk) runs in CI —
+malformed content fails the build, so authored content can never drift from
+the parsers.
+
+## Subtasks
+
+1. `feat(skills): expand the shared library to ~12 skills`
+2. `feat(companies): starter content — professional services batch`
+3. `feat(companies): starter content — product/tech batch`
+4. `feat(companies): starter content — go-to-market batch`
+5. `feat(companies): starter content — capital batch`
+
+## Dependencies
+
+WS1 (format freeze + validation test). Nothing depends on WS8 — it can land
+any time after, in parallel with everything.
+
+## Tests & exit criteria
+
+Content-validation walk green over every directory; each new SKILL.md renders
+correctly in the console Skills view and each workflow renders on the canvas
+(manual spot-check per batch, noted in the PR). `opencompany check
+companies/<name>` passes for every touched company.

--- a/docs/specs/09-verification.md
+++ b/docs/specs/09-verification.md
@@ -1,0 +1,154 @@
+# 09 — Verification Plan
+
+Cross-cutting test strategy for every workstream. Reuses the repo's existing
+test infrastructure — do not invent parallel harnesses:
+
+- Rust tests live in-module (`#[cfg(test)] mod test`) or a sibling `test.rs`.
+- HTTP tests use `tower::ServiceExt::oneshot` against `crate::server::router(state)`
+  with an `AppState` built over `FsCompanyStore` in a `tempfile` dir — the
+  canonical pattern is the test mod in `src/server/operator.rs`.
+- Store backends prove the port contract via the shared suite in
+  `src/store/conformance.rs`, invoked identically from `fs.rs`, `sqlite.rs`,
+  `mongodb.rs`.
+- CI gates: `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D
+  warnings`, `cargo test` (plus feature matrices), frontend
+  `typecheck`/`build`.
+
+## 1. Unit tests
+
+| Module | Location | Cases |
+|---|---|---|
+| Workflow TOML parser | `src/company/workflow_file.rs` | happy graph; edge referencing missing node → error; no trigger node → error; empty workflow; unknown keys tolerated; round-trip against `companies/agentic_marketing_agency/workflows/campaign_pipeline.toml` |
+| SKILL.md parser | `src/company/skill_file.rs` | frontmatter name/description(+category); missing/malformed frontmatter → error; body preserved verbatim; parses both existing repo skills (`web-research`, `weekly-report`) |
+| Workspace walker | `src/company/workspace_seed.rs` | nested tree; wikilink extraction incl. `[[target\|alias]]`; non-markdown files skipped; `../` path traversal rejected |
+| Conformance extensions | `src/store/conformance.rs` + backend test mods | one `assert_*` suite per new port (tasks, workspace, facts, inbox, usage, skills-state): CRUD, company isolation, ordering; every backend runs the identical suite |
+| Memory adapter | `src/harness/memory.rs` | store/recall round-trips through `MemoryStore`/`ContextStore`; `{company}/{agent}` namespacing; cross-company isolation; degraded vector recall never errors |
+| Cost mapping | `src/harness/cost.rs` | `TurnCost`/`UsageInfo` → `LedgerEntry{kind:"inference.spend"}` amount + memo; zero-usage turn → no entry; `UsageSample` fields populated |
+| DNS records | `src/company/dns.rs` | deterministic TXT/CNAME/DKIM/SPF generation for a domain; `verify()` with a mock `DnsResolver`: found / missing / partial |
+| Metering aggregation | `src/metering/` (WS5) | 7/30/90d bucketing; byAgent/byProvider grouping; budget-cap math; empty range |
+| Prosumer language | `src/server/ops/language.rs` | server-authored strings contain no banned runtime jargon (mirror the `frontend/src/lib/language.ts` list) |
+| Content validation | `src/company/manifest.rs` (or `validate.rs`) | walk `companies/*`: every `company.toml`, `workflows/*.toml`, `skills/*/SKILL.md`, `workspace/**` parses — guards WS8 content forever |
+
+Commands: `cargo test`, plus `cargo test --features sqlite` /
+`--features mongodb` (Mongo cases skip without a live server, per existing
+convention) and `cargo test --features openhuman` for harness modules.
+
+## 2. Feature/API tests
+
+Extract the copy-pasted state builders into a shared
+`src/server/test_support.rs` (`#[cfg(test)]`-only module):
+
+```rust
+pub fn build_state(home: &Path, lifecycle: &str, config: AppConfig) -> AppState;
+pub fn state_with_company_dir(dir: &Path) -> AppState; // loads a real companies/<name>/
+```
+
+**Four-case minimum for every new REST endpoint and GraphQL query**, in the
+owning module's test mod:
+
+1. **Happy path** — status + payload shape (field-level assertions against the
+   TS contract).
+2. **Auth failure** — `operator_token` configured, missing/wrong bearer → 401.
+3. **Cross-tenant 403** — platform claims for tenant A addressing company B
+   (the `platform_auth.rs` path).
+4. **Not-wired/unknown** — unknown company or unshipped surface → 404 with the
+   `{error, code}` envelope (GraphQL: error with `extensions.code`), preserving
+   the console's graceful-degrade contract.
+
+Per-surface additions:
+
+- **Tasks** — create→list→patch (column drag, priority)→delete; invalid column
+  → 400; **restart persistence**: rebuild `AppState` on the same home dir and
+  re-read.
+- **Memory** — add/search/delete; search miss → empty page.
+- **Workspace** — tree seeded from the company `workspace/**`; file read/save;
+  create/rename/move/delete; move-into-own-subtree → 400; `../` → 400; save
+  persists across restart.
+- **Skills** — installed list = company dir ∪ state store; registry list;
+  install from registry → appears installed; enable/disable; uninstall custom
+  ok, built-in → 409; unknown slug → 404.
+- **Workflows (GraphQL)** — `workflow("campaign_pipeline")` nodes/edges match
+  the TOML on disk; unknown id → null.
+- **Chat threading** — `{message, chat}` routes to the desk and journals
+  `AgentReply`; unknown desk → 400; `Chat.history` returns both directions.
+- **Connections** — `start` returns an authorize URL (mock provider config);
+  callback exchanges the signed state and stores the token; `disconnect`
+  clears the secret; **no token material in any response body** (assert
+  serialized JSON).
+- **Domain/SMTP** — PUT domain → generated records; verify with mock resolver
+  (both outcomes); PUT smtp writes to `SecretStore` and the read surface
+  exposes host/username only; smtp test with mock `MailSender`.
+- **Usage/Finances (GraphQL)** — seed `UsageSample`s + ledger entries through
+  the ports; aggregates match.
+- **Harness feature test** (`src/harness/`, `--features openhuman`) — full
+  chat cycle with a mock `Provider` → response text, ledger delta, usage
+  sample; tool requiring approval → parked → console resolve → turn resumes.
+- **GraphQL SDL snapshot** — assert `schema.sdl()` against a checked-in
+  expected string so every schema change is a reviewed diff.
+
+## 3. Frontend
+
+No test framework exists today (`typecheck` + `build` only). Add **Vitest**
+(dev-dep only, no jsdom) with script `"test": "vitest run"`; colocated
+`*.test.ts`:
+
+- `src/lib/workspace.test.ts` — tree ops (create/rename/move/delete),
+  wikilink parse, backlinks.
+- `src/lib/threads.test.ts`, `src/lib/tasks.test.ts` (column moves),
+  `src/lib/language.test.ts` (glossary relabeling), `src/lib/domain.test.ts`
+  (record shaping).
+- `src/api/client.test.ts` — contract tests with stubbed `globalThis.fetch`:
+  scope resolution (`/company` vs `/companies/{id}`), bearer header, `ApiError`
+  shaping on 404/network error, `gql()` error unwrapping, and one test per new
+  client method asserting URL/method/body.
+
+Component-level (jsdom/RTL) tests are **deferred** — the views are thin over
+`lib/` + the client.
+
+## 4. End-to-end
+
+### Server-level (build now): `tests/e2e.rs`
+
+First use of the crate's `tests/` integration dir. The test:
+
+1. Builds the router in-process but serves over a **real ephemeral port**
+   (`TcpListener::bind("127.0.0.1:0")` + `axum::serve`) — exercises real HTTP,
+   unlike oneshot.
+2. Loads `companies/agentic_marketing_agency` with sqlite storage in a
+   tempdir and a mock `Provider` harness.
+3. Drives with `reqwest` (dev-dependency):
+   - GraphQL `team`/`chats`/`skills`/`workflow("campaign_pipeline")` match the
+     manifest/TOML/SKILL.md on disk;
+   - REST writes (task, memory fact, workspace edit) → **stop, rebuild state
+     on the same data dir, restart, re-read** (restart-persistence);
+   - chat round-trip → mock-provider reply + an `inference.spend` ledger entry
+     visible via the `finances` query;
+   - approval flow: gated tool → appears in approvals → approve → follow-up;
+   - skill install from registry → visible in `skills`.
+
+Run: `cargo test --test e2e --features "sqlite openhuman"`, wrapped in
+`scripts/e2e.sh`, as a dedicated (serial) CI job so unit CI stays fast.
+
+### Browser-level (Playwright): deferred until WS7 lands
+
+Until surfaces are real, Playwright would test localStorage samples. Once WS7
+is substantially merged, add `frontend/e2e/` covering exactly:
+
+1. token login → Overview shows the real company name;
+2. Conversation: send → reply renders in the right desk;
+3. Approvals: pending → approve → confirmation;
+4. Workspace: create + edit note → survives reload;
+5. Tasks: drag between columns → survives reload.
+
+## 5. Per-workstream exit criteria
+
+| WS | Exit criteria |
+|---|---|
+| 1 | Parsers merged; content-validation walk green over all `companies/*` + `skills/*`; `cargo test` green |
+| 2 | SDL snapshot updated; every query has the 4-case suite; GraphiQL spot-checked |
+| 3 | Conformance suites green on fs+sqlite(+mongo); REST 4-case suites; restart-persistence in e2e |
+| 4 | Harness feature test green under `--features openhuman`; default (echo) build unaffected; approval-bridge + cost unit tests |
+| 5 | Metering unit tests; usage/finances queries match seeded data; e2e chat produces a ledger entry |
+| 6 | DNS/SMTP mocked tests; no-secret-leak assertions; default build stays offline |
+| 7 | Per surface: sample/localStorage code deleted, fallback retained; typecheck+build+vitest green; manual pass against a live host |
+| 8 | Content-validation test green; every SKILL.md renders in the console Skills view |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -33,9 +33,52 @@ Each workstream spec follows one template: **Scope → Design → Subtasks
    yet" and fall back — so every workstream can merge independently.
 6. **Secrets never leave the host.** SMTP credentials and OAuth tokens go to
    `SecretStore` only; responses expose non-secret status.
-7. **Prosumer language everywhere.** Server-authored strings follow the same
-   glossary the console enforces in `frontend/src/lib/language.ts` (desk, not
-   group-chat channel; teammate, not agent tier; approval, not parked effect).
+7. **Prosumer language everywhere.** [`docs/spec/glossary.md`](../spec/glossary.md)
+   is the authoritative vocabulary (its translation table is normative);
+   `frontend/src/lib/language.ts` mirrors it. Server-authored strings never
+   expose runtime internals (desk, not group-chat channel; teammate, not
+   agent tier; approval, not parked effect).
+
+## Relationship to `docs/spec/`
+
+[`docs/spec/`](../spec/README.md) is the normative **target-design** spec;
+`docs/modules/` describes the code as it exists. This folder is the
+**execution plan** that closes the gap, and it adopts the spec's conventions
+(RFC-2119 keywords, ≤500-line files, glossary-first language).
+
+Mapping onto the [roadmap](../spec/roadmap.md):
+
+- WS1–WS3, WS7 deliver the console/API side of **Stage 1** and the
+  platform-mode reads/writes of **Phase 5**.
+- WS4 delivers **Phase 3** (tools, channels, approvals via OpenHuman) — but
+  by a *revised* route: PR #4's decision to embed openhuman as a library
+  supersedes the JSON-RPC seam in
+  [`integrations/openhuman.md`](../spec/integrations/openhuman.md). The
+  "library-crate split" that doc lists as upstream candidate #2 is realized
+  by linking `openhuman_core` directly; the launcher/RPC wire section becomes
+  legacy. WS4 also revises the roadmap non-goal "TinyAgents is the harness".
+- WS5/WS6 extend **Phase 4/5** surfaces (ledger-fed finances, platform
+  webhooks reuse).
+
+Where these specs and `docs/spec/` disagree, these specs win for the work
+planned here — and **WS9 updates `docs/spec/` in the same PR train**:
+`roadmap.md`, `integrations/openhuman.md`, `runtime/api.md` (new write routes
++ the GraphQL read plane), `runtime/ports.md` + `runtime/storage.md` (six new
+ports), `company-brain/memory.md` (FactStore alongside the two existing
+memory ports), and the touched `docs/modules/*` pages.
+
+Alignment notes carried through the workstreams:
+
+- [`runtime/api.md`](../spec/runtime/api.md) already specifies the error
+  envelope `{error, code}`, the dual scoping, webhook ingestion
+  (`POST /hooks/{companyId}/{channel}`), and future SSE surfaces (`/chat`
+  streaming, `/events?since=SEQ` work feed, `/memory/traces`, `/export`).
+  New routes follow it; SSE stays out of scope here (the console is
+  request/response today) but nothing in this plan blocks it.
+- Manifest `[policy].mode` deliberately uses OpenHuman's security-tier words
+  (readonly/supervised/full) — the WS4 approval bridge maps 1:1.
+- The spec's one-key promise holds: every new dependency is feature-gated and
+  the default build stays offline.
 
 ## The specs
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,128 @@
+# Implementation Specs — Making Every Console Surface Real
+
+This folder is the implementation plan for the work that remains after
+[PR #4](https://github.com/tinyhumansai/opencompany/pull/4) shipped the shadcn
+operator console. The console was built to a **seam pattern**: each surface
+calls a forward-looking host endpoint and, until it exists, degrades to a
+localStorage sample. [`frontend/ARCHITECTURE.md`](../../frontend/ARCHITECTURE.md)
+is the product brief; these specs are the engineering plan that moves every
+surface from *seam/client-only* to *real* — and swaps the agent harness to
+openhuman embedded as a library.
+
+Each workstream spec follows one template: **Scope → Design → Subtasks
+(commit-sized, subagent-assignable) → Dependencies → Tests & exit criteria**.
+
+## Decisions (locked)
+
+1. **GraphQL is the read plane.** async-graphql 7 is already wired query-only
+   at `/graphql` (`src/server/graphql.rs`). All new reads land there, rooted at
+   a `Company` aggregation object so a view fetches in one round trip.
+2. **REST is the write plane.** New writes live in a `src/server/ops/` router
+   family following the existing dual-scope convention
+   (`/api/v1/companies/{id}/…` and `/api/v1/company/…`).
+3. **openhuman as a library.** The tenant harness embeds
+   `vendor/openhuman` (`openhuman_core`) directly via `AgentBuilder` — the RPC
+   transport, launcher, and sidecar process go away. Memory, inference
+   provider, tools, skills, and approval policy are all injected through the
+   builder's seams.
+4. **Persistence through ports.** New durable state gets port traits in
+   `src/ports/`, backends in `src/store/{fs,sqlite,mongodb}.rs`, registration
+   in `StorageHandles`, and coverage in the backend-agnostic conformance suite.
+5. **Graceful rollout.** Anything unshipped 404s (REST) or is absent from the
+   schema (GraphQL); the console's bare-catch seams treat both as "not wired
+   yet" and fall back — so every workstream can merge independently.
+6. **Secrets never leave the host.** SMTP credentials and OAuth tokens go to
+   `SecretStore` only; responses expose non-secret status.
+7. **Prosumer language everywhere.** Server-authored strings follow the same
+   glossary the console enforces in `frontend/src/lib/language.ts` (desk, not
+   group-chat channel; teammate, not agent tier; approval, not parked effect).
+
+## The specs
+
+| Doc | Workstream | Depends on |
+|---|---|---|
+| [01-parsers.md](01-parsers.md) | WS1 — manifest/data parsers (workflow TOML, SKILL.md, workspace) | — |
+| [02-graphql-reads.md](02-graphql-reads.md) | WS2 — GraphQL read plane | WS1 (a/b), WS3 (c), WS5 (d) |
+| [03-ports-and-rest-writes.md](03-ports-and-rest-writes.md) | WS3 — new ports/stores + REST write plane | WS1 |
+| [04-openhuman-harness.md](04-openhuman-harness.md) | WS4 — openhuman-as-library embedding | — |
+| [05-usage-finances.md](05-usage-finances.md) | WS5 — metering pipeline + Usage/Finances | WS4 |
+| [06-connections-domain-email.md](06-connections-domain-email.md) | WS6 — OAuth, domain/DNS, SMTP, inbox transport | — |
+| [07-frontend-wiring.md](07-frontend-wiring.md) | WS7 — console seam swaps | trails WS2/3/5/6 |
+| [08-company-content.md](08-company-content.md) | WS8 — skills library + company starter content | WS1 |
+| [09-verification.md](09-verification.md) | cross-cutting test strategy + exit criteria | all |
+
+## Dependency graph & critical path
+
+```
+WS1 (parsers) ──► WS2a/b (manifest+workspace reads) ──► WS7 (per surface)
+WS3 (ports/stores/REST) ───────► WS2c ─────────────────┘
+WS4 (harness) ──► WS5 (metering) ──► WS2d (usage/finances) ──► WS7 usage/finances
+WS6 (OAuth/domain/SMTP) ──► WS3-inbox real delivery ──► WS7 inbox
+WS8 (content) — anytime after WS1 freezes the file formats
+```
+
+**Critical path: WS4 → WS5 → WS2d** — the only serial three-chain that touches
+the runtime core. Start WS4 on day one, in parallel with WS1.
+
+## Subagent execution model
+
+Implementation is executed by parallel agents, one per workstream (WS3 and WS8
+fan out further — one agent per surface / per company batch). Coordination
+rules:
+
+- **Merge-conflict hotspots** are the registration files: `src/ports/mod.rs`,
+  `src/store/mod.rs`/`select.rs`, `src/server/routes.rs`, `src/server/mod.rs`,
+  `frontend/src/api/client.ts`. Registration commits land serially; everything
+  else is parallel.
+- **Format freezes**: WS1's parser types freeze the on-disk formats before WS8
+  authors content at scale; WS2's SDL snapshot freezes the read contract
+  before WS7 wires views.
+- Every commit is small, conventional-prefix, and green on the full local gate
+  (below) before it lands.
+
+## PR slicing
+
+Small PRs against `tinyhumansai/opencompany` `main`, in this order (parallel
+tracks interleave):
+
+1. `feat(company): workflow/skill/workspace parsers` (WS1)
+2. `feat(graphql): manifest-derived reads` (WS2a/b)
+3. Per surface: `feat(<surface>): port + stores + REST routes` (WS3, ~5 PRs)
+4. `feat(graphql): store-backed reads` (WS2c)
+5. `feat(harness): embedded openhuman` (WS4, 3–4 PRs: scaffold+provider,
+   memory adapter, approval bridge, cost hook)
+6. `feat(metering): usage pipeline + usage/finances reads` (WS5 + WS2d)
+7. `feat(server): connections oauth` / `feat(server): domain + smtp` (WS6)
+8. Per view: `feat(console): wire <surface>` (WS7, ~10 tiny PRs)
+9. `feat(companies): starter content for <batch>` (WS8, 3–4 PRs)
+10. `docs: …` trailing each workstream (flip rows in
+    `frontend/ARCHITECTURE.md`, update `docs/spec/runtime/*`, module docs)
+
+Local gate for every PR:
+
+```sh
+cargo fmt --all -- --check \
+  && cargo clippy --all-targets -- -D warnings \
+  && cargo test
+(cd frontend && npm run typecheck && npm run build && npm test)
+```
+
+## Open questions (recommendations inline)
+
+1. **Team writes vs the manifest.** `POST …/team` adds agents `company.toml`
+   doesn't know. *Recommended:* an operator-overlay persisted through
+   `CompanyStore` (extra field on `CompanyRecord`), merged into the roster at
+   read/build time — rewriting the version-controlled manifest is not an
+   option. Open: whether overlay agents get harness `Agent`s immediately or
+   are roster-only at first (roster-only recommended for v1).
+2. **Inbound email transport.** *Recommended:* v1 is an HMAC-signed ingest
+   webhook (`POST …/inboxes/ingest`) a mail-forwarding provider or the manager
+   pushes into; IMAP polling and manager-owned MX are alternatives that add
+   deps and ops burden.
+3. **Chat-history backfill.** Pre-threading `OperatorMessage` events carry no
+   desk id. *Recommended:* attribute them to a synthetic "General" desk.
+4. **Usage retention.** `UsageMeter` grows unbounded. *Recommended:* evict
+   samples older than 90 days (the console's max range).
+5. **Vector recall on the fs backend.** *Recommended:* degrade
+   `recall_relevant_by_vector` to FTS/substring recall rather than requiring
+   sqlite/tinycortex when the harness feature is on.


### PR DESCRIPTION
## What

Adds `docs/specs/` — the implementation plan that takes the operator console from PR #4's seam/sample state to fully real, and swaps the agent harness to **openhuman embedded as a library**. Docs only; no code changes.

## Decisions encoded

- **GraphQL for reads** (expanding the existing query-only `/graphql`), **REST for writes** (new `src/server/ops/` router family on the existing dual-scope + auth conventions).
- **openhuman as a library**: `vendor/openhuman`'s `AgentBuilder` with injected provider (hosted Medulla only), pluggable memory (`Memory` trait over the `MemoryStore`/`ContextStore` ports), skills from SKILL.md, and a `tool_policy` → `ApprovalGate` bridge; replaces the JSON-RPC/launcher seam. Cost hook feeds both the ledger and a new `UsageMeter`.
- **Six new ports** (tasks, workspace, facts, inbox, usage, skills-state) with fs/sqlite/mongodb backends + conformance suites; domain/SMTP live in `SecretStore`.
- Aligned with `docs/spec/` (glossary, `runtime/api.md` envelope + `/hooks/{companyId}/{channel}` reuse for inbound email, policy-tier word mapping); WS9 updates the target spec where these decisions supersede it (`integrations/openhuman.md`, roadmap).

## Structure

`README.md` (index, dependency graph, critical path WS4→WS5→WS2d, PR slicing, subagent execution model, open questions) + one spec per workstream (WS1 parsers … WS8 content) + `09-verification.md` (unit / feature-API four-case suites / `tests/e2e.rs` harness / Vitest bootstrap / per-WS exit criteria).

## Commands run

Docs-only diff — no build needed. All files ≤500 lines per repo convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specifications for data parsing, GraphQL reads, REST writes, storage, agent integration, usage and finances, connections, frontend wiring, company content, and verification.
  * Documented implementation plans, API behavior, testing requirements, feature fallbacks, security rules, and workstream dependencies.
  * Added a roadmap README describing the execution plan and release sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->