### PR TITLE
fix: address #6 review findings (P1 credential-route authz + serve-path resolution)

### DIFF
--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -126,6 +126,10 @@ pub struct AppState {
     /// selected (`OPENCOMPANY_STORAGE`). Provisioning injects these into each
     /// new company's builder; `None` means fs defaults.
     stores: Option<crate::store::StorageHandles>,
+    /// The repo-level shared skill library directory (`skills/`), set on the
+    /// serve path. `None` in platform-provisioned mode (no repo checkout), where
+    /// the `skillRegistry` query degrades to empty.
+    skills_root: Option<std::path::PathBuf>,
     /// Cache of the repo-level shared skill registry (`skills/*/SKILL.md`).
     /// Populated on first read via [`AppState::skill_registry`]; never
     /// invalidated because the repo's skill library is immutable at runtime.
@@ -163,6 +167,7 @@ impl AppState {
             home: std::path::PathBuf::from("."),
             ownership: Arc::new(RwLock::new(HashMap::new())),
             stores: None,
+            skills_root: None,
             skill_registry: Arc::new(OnceLock::new()),
             schema: crate::server::graphql::build_schema(),
             connections: crate::server::ops::ConnectionsRuntime::new(),
@@ -175,6 +180,19 @@ impl AppState {
     pub fn with_home(mut self, home: impl Into<std::path::PathBuf>) -> Self {
         self.home = home.into();
         self
+    }
+
+    /// Sets the repo-level shared skill library directory (`skills/`) backing the
+    /// top-level `skillRegistry` query. Set on the serve path; unset in
+    /// platform-provisioned mode.
+    pub fn with_skills_root(mut self, skills_root: impl Into<std::path::PathBuf>) -> Self {
+        self.skills_root = Some(skills_root.into());
+        self
+    }
+
+    /// The repo-level shared skill library directory, when set.
+    pub fn skills_root(&self) -> Option<&std::path::Path> {
+        self.skills_root.as_deref()
     }
 
     /// Installs the opened storage backend's port handles (non-fs backends).

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -164,7 +164,11 @@ async fn register_company(
     // Capture the schedules before the manifest is moved into the builder; boot
     // uses them to start this company's cron scheduler (lifecycle step 4).
     let schedules = manifest.schedules.clone();
+    // The company's on-disk source directory (`companies/<name>`) seeds the
+    // workspace tree on first boot and lets read resolvers find its committed
+    // skills/workflows content.
     let mut builder = attach_openhuman(RuntimeBuilder::new(home.to_path_buf(), manifest))
+        .with_seed_dir(dir.to_path_buf())
         .with_tinyplace_api_url(state.config().tinyplace_api_url.clone())
         .with_host_base_url(state.config().host_base_url());
     if let Some(stores) = state.stores() {
@@ -509,6 +513,17 @@ async fn main() -> Result<()> {
             // test send and outbound mail. Absent the features these stay `None`
             // and the surfaces degrade to "not wired yet" (404).
             state = state.with_connections(connections_runtime());
+            // The repo-level shared skill library (`skills/`) sits beside the
+            // `companies/` dir; derive it from the first loaded company's source
+            // dir so the `skillRegistry` query resolves the committed library.
+            if let Some(skills_root) = companies
+                .first()
+                .and_then(|dir| dir.parent())
+                .and_then(|companies_dir| companies_dir.parent())
+                .map(|repo_root| repo_root.join("skills"))
+            {
+                state = state.with_skills_root(skills_root);
+            }
             // Schedulers stop cleanly when this is notified (Ctrl-C below).
             let shutdown = Arc::new(Notify::new());
             let mut scheduler_handles = Vec::new();
@@ -648,7 +663,15 @@ mod test {
         assert_eq!(name, "Agentic Law Firm");
         assert_eq!(id, "agentic-law-firm");
         assert_eq!(state.registry().list().len(), 1);
-        assert!(state.registry().sole().is_some());
+        let runtime = state.registry().sole().expect("sole company");
+
+        // The serve path records the source dir and seeds the workspace from
+        // `companies/<name>/workspace/**` on first boot.
+        assert_eq!(runtime.source_dir(), Some(dir));
+        assert!(
+            !runtime.workspace().is_empty(runtime.id()).await.unwrap(),
+            "workspace seeded from the company source dir"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -139,6 +139,21 @@ fn default_home() -> PathBuf {
     }
 }
 
+/// Resolves a `--company` argument to its source *directory*. `--company`
+/// accepts either the company directory (`companies/<name>`) or the manifest
+/// file inside it (`companies/<name>/company.toml`); the file form is normalized
+/// to its parent so workspace seeding and the skill/workflow read resolvers look
+/// under the company directory rather than under `company.toml/…`.
+fn company_source_dir(path: &std::path::Path) -> std::path::PathBuf {
+    if path.is_file() {
+        path.parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_else(|| path.to_path_buf())
+    } else {
+        path.to_path_buf()
+    }
+}
+
 /// Loads the manifest under `dir`, builds a runtime over `home`, and registers
 /// it in `state`. Returns the derived company id and display name.
 async fn register_company(
@@ -168,7 +183,7 @@ async fn register_company(
     // workspace tree on first boot and lets read resolvers find its committed
     // skills/workflows content.
     let mut builder = attach_openhuman(RuntimeBuilder::new(home.to_path_buf(), manifest))
-        .with_seed_dir(dir.to_path_buf())
+        .with_seed_dir(company_source_dir(dir))
         .with_tinyplace_api_url(state.config().tinyplace_api_url.clone())
         .with_host_base_url(state.config().host_base_url());
     if let Some(stores) = state.stores() {
@@ -516,12 +531,12 @@ async fn main() -> Result<()> {
             // The repo-level shared skill library (`skills/`) sits beside the
             // `companies/` dir; derive it from the first loaded company's source
             // dir so the `skillRegistry` query resolves the committed library.
-            if let Some(skills_root) = companies
-                .first()
-                .and_then(|dir| dir.parent())
-                .and_then(|companies_dir| companies_dir.parent())
-                .map(|repo_root| repo_root.join("skills"))
-            {
+            if let Some(skills_root) = companies.first().and_then(|path| {
+                let dir = company_source_dir(path);
+                dir.parent()
+                    .and_then(|companies_dir| companies_dir.parent())
+                    .map(|repo_root| repo_root.join("skills"))
+            }) {
                 state = state.with_skills_root(skills_root);
             }
             // Schedulers stop cleanly when this is notified (Ctrl-C below).
@@ -671,6 +686,39 @@ mod test {
         assert!(
             !runtime.workspace().is_empty(runtime.id()).await.unwrap(),
             "workspace seeded from the company source dir"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn company_source_dir_normalizes_manifest_file_to_its_directory() {
+        let dir = std::path::Path::new("companies/agentic_law_firm");
+        // A directory argument is returned unchanged.
+        assert_eq!(company_source_dir(dir), dir);
+        // A manifest-file argument resolves to its parent company directory, so
+        // the serve-path `workspace`/`skills`/`workflows` lookups stay correct.
+        assert_eq!(company_source_dir(&dir.join("company.toml")), dir);
+    }
+
+    #[tokio::test]
+    async fn register_company_accepts_a_manifest_file_path() {
+        let home = std::env::temp_dir().join(format!("oc-bin-file-{}", std::process::id()));
+        let state = AppState::new(AppConfig::default());
+        // `--company` also accepts the manifest file inside the company dir.
+        let file = std::path::Path::new("companies/agentic_law_firm/company.toml");
+
+        let (_id, name, _schedules) = register_company(&state, &home, file, false).await.unwrap();
+
+        assert_eq!(name, "Agentic Law Firm");
+        let runtime = state.registry().sole().expect("sole company");
+        // The recorded source dir is the company directory, not `company.toml`.
+        assert_eq!(
+            runtime.source_dir(),
+            Some(std::path::Path::new("companies/agentic_law_firm"))
+        );
+        assert!(
+            !runtime.workspace().is_empty(runtime.id()).await.unwrap(),
+            "workspace still seeds when --company is a manifest file"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -10,6 +10,7 @@
 //! the methods here are thin delegations so callers hold a single
 //! `Arc<CompanyRuntime>`.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use tokio::sync::Mutex as TokioMutex;
@@ -77,6 +78,11 @@ pub struct CompanyRuntime {
     pub(crate) feedback: Arc<FeedbackStore>,
     /// Filing configuration: the GitHub client, target repo, consent, limiter.
     pub(crate) filer: Arc<FeedbackFiler>,
+    /// The company's on-disk source definition directory (`companies/<name>`),
+    /// set on the `serve`/CLI path so read resolvers can find the committed
+    /// `skills/` and `workflows/` content. `None` in platform-provisioned mode
+    /// (no source dir), where those resolvers degrade to manifest-derived/empty.
+    pub(crate) source_dir: Option<PathBuf>,
     /// Held for the duration of a cycle so cycles never interleave per company.
     pub(crate) serial: TokioMutex<()>,
     /// WS4: the embedded openhuman harness pool, when wired via
@@ -127,10 +133,24 @@ impl CompanyRuntime {
             ops,
             feedback,
             filer,
+            source_dir: None,
             serial: TokioMutex::new(()),
             #[cfg(feature = "openhuman")]
             harness: None,
         }
+    }
+
+    /// Records the company's on-disk source directory (`companies/<name>`), set
+    /// by the [`RuntimeBuilder`](crate::runtime::RuntimeBuilder) on the serve
+    /// path so read resolvers can resolve committed skills/workflows content.
+    pub fn set_source_dir(&mut self, dir: Option<PathBuf>) {
+        self.source_dir = dir;
+    }
+
+    /// The company's on-disk source directory, when built on the serve path.
+    /// `None` in platform-provisioned mode.
+    pub fn source_dir(&self) -> Option<&Path> {
+        self.source_dir.as_deref()
     }
 
     /// WS4: attach an embedded harness pool after construction (called by the

--- a/src/ports/workspace.rs
+++ b/src/ports/workspace.rs
@@ -63,12 +63,16 @@ pub trait WorkspaceStore: Send + Sync {
     ) -> Result<()>;
     /// Renames and/or reparents a node, returning the updated node. Moving a
     /// folder under its own descendant (a cycle) is rejected.
+    ///
+    /// `parent` distinguishes three intents: `None` leaves the parent
+    /// unchanged, `Some(None)` moves the node to the workspace root, and
+    /// `Some(Some(id))` reparents it under folder `id`.
     async fn rename_move(
         &self,
         company: &CompanyId,
         id: &str,
         name: Option<&str>,
-        parent: Option<&str>,
+        parent: Option<Option<&str>>,
     ) -> Result<WorkspaceNode>;
     /// Deletes a node; folders are removed recursively. Returns whether a node
     /// was removed.

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -665,7 +665,6 @@ impl RuntimeBuilder {
             }
         };
 
-        #[cfg_attr(not(feature = "openhuman"), allow(unused_mut))]
         let mut runtime = CompanyRuntime::new(
             id.clone(),
             brain,
@@ -684,6 +683,11 @@ impl RuntimeBuilder {
             feedback,
             filer,
         );
+
+        // The seed dir is the company's on-disk source directory
+        // (`companies/<name>`); record it so read resolvers can find committed
+        // skills/workflows content on the serve path.
+        runtime.set_source_dir(self.seed_dir.clone());
 
         // WS4: attach the embedded harness pool when one was provided.
         #[cfg(feature = "openhuman")]

--- a/src/server/graphql/skills.rs
+++ b/src/server/graphql/skills.rs
@@ -15,7 +15,6 @@ use crate::AppState;
 use crate::company::runtime::CompanyRuntime;
 use crate::company::{SkillDoc, load_dir_skills, parse_skill_md};
 use crate::ports::skills_state::{SkillSource, SkillState};
-use crate::store::Bundle;
 
 /// One skill installed in a company. Mirrors `frontend/src/lib/skills.ts`.
 #[derive(SimpleObject)]
@@ -92,10 +91,14 @@ fn from_doc(doc: &SkillDoc, source: &str, enabled: bool) -> SkillGql {
     }
 }
 
-/// The repo-level skill registry docs, loaded from `{home}/skills`.
+/// The repo-level skill registry docs, loaded from the shared `skills/` library
+/// directory. Empty when no source checkout is present (platform-provisioned
+/// mode), where the registry has nothing to serve.
 fn registry_docs(state: &AppState) -> Arc<[SkillDoc]> {
-    let dir = state.home().join("skills");
-    state.skill_registry(&dir).unwrap_or_else(|_| Arc::from([]))
+    let Some(dir) = state.skills_root() else {
+        return Arc::from([]);
+    };
+    state.skill_registry(dir).unwrap_or_else(|_| Arc::from([]))
 }
 
 /// Resolves `Company.skills`: company-dir docs overlaid with store deltas.
@@ -106,9 +109,13 @@ pub(crate) async fn resolve_company(
     let state = ctx.data::<AppState>()?;
     let registry = registry_docs(state);
 
-    // Base: the company's own on-disk skills, all enabled by default.
-    let company_dir = Bundle::new(state.home(), runtime.id()).dir().join("skills");
-    let mut by_slug: HashMap<String, SkillGql> = load_dir_skills(&company_dir)
+    // Base: the company's own on-disk skills (`companies/<name>/skills`), all
+    // enabled by default. In platform-provisioned mode there is no source dir,
+    // so the base is empty and only the store deltas below contribute.
+    let mut by_slug: HashMap<String, SkillGql> = runtime
+        .source_dir()
+        .map(|dir| dir.join("skills"))
+        .and_then(|dir| load_dir_skills(&dir).ok())
         .unwrap_or_default()
         .iter()
         .map(|doc| (doc.slug.clone(), from_doc(doc, "company", true)))

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -445,6 +445,94 @@ async fn finances_fold_the_ledger() {
     tokio::fs::remove_dir_all(&home).await.ok();
 }
 
+/// On the serve path a company has an on-disk source dir; `Company.skills`,
+/// `Company.workflow`, and the top-level `skillRegistry` resolve their content
+/// from it (and the repo-level `skills/` root) rather than the empty bundle.
+#[tokio::test]
+async fn skills_and_workflows_resolve_from_source_dir() {
+    let home = home();
+    let id = CompanyId::new("acme");
+
+    // A company source directory with a committed skill and workflow.
+    let source_dir = home.join("companies").join("acme");
+    tokio::fs::create_dir_all(source_dir.join("skills/deal-memo"))
+        .await
+        .unwrap();
+    tokio::fs::write(
+        source_dir.join("skills/deal-memo/SKILL.md"),
+        "---\nname: Deal Memo\ndescription: Write a deal memo.\ncategory: Research\n---\n# Deal Memo\n",
+    )
+    .await
+    .unwrap();
+    tokio::fs::create_dir_all(source_dir.join("workflows"))
+        .await
+        .unwrap();
+    tokio::fs::write(
+        source_dir.join("workflows/flow.toml"),
+        "id = \"flow\"\nname = \"Test Flow\"\n[[node]]\nid = \"n1\"\nkind = \"trigger\"\nname = \"Start\"\n",
+    )
+    .await
+    .unwrap();
+
+    // A separate repo-level shared skill library backing `skillRegistry`.
+    let skills_root = home.join("skills");
+    tokio::fs::create_dir_all(skills_root.join("web-research"))
+        .await
+        .unwrap();
+    tokio::fs::write(
+        skills_root.join("web-research/SKILL.md"),
+        "---\nname: Web Research\ndescription: Research on the web.\ncategory: Research\n---\n# Web Research\n",
+    )
+    .await
+    .unwrap();
+
+    let manifest: CompanyManifest = toml::from_str(
+        "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[workflows]\nenabled = [\"flow\"]\n",
+    )
+    .unwrap();
+    let store = FsCompanyStore::new(home.to_path_buf());
+    store
+        .save(&CompanyRecord {
+            id: id.clone(),
+            manifest: manifest.clone(),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+        .with_id(id.clone())
+        .with_seed_dir(source_dir.clone())
+        .build()
+        .await
+        .unwrap();
+    let state = AppState::new(AppConfig::default())
+        .with_home(home.to_path_buf())
+        .with_skills_root(skills_root);
+    state.registry().insert(id, Arc::new(runtime));
+
+    // Company.skills reads the committed source-dir skill.
+    let value = query(
+        router(state.clone()),
+        r#"{"query":"{ company(id:\"acme\"){ skills { id name source } workflow(id:\"flow\"){ id name nodes { id } } } skillRegistry { id name } }"}"#,
+    )
+    .await;
+    let company = &value["data"]["company"];
+    let skills = company["skills"].as_array().unwrap();
+    assert_eq!(skills.len(), 1, "source-dir skill resolves");
+    assert_eq!(skills[0]["id"], "deal-memo");
+    assert_eq!(skills[0]["source"], "company");
+    // Company.workflow reads the graph from the source dir.
+    assert_eq!(company["workflow"]["name"], "Test Flow");
+    assert_eq!(company["workflow"]["nodes"].as_array().unwrap().len(), 1);
+    // skillRegistry reads the repo-level shared library.
+    let registry = value["data"]["skillRegistry"].as_array().unwrap();
+    assert!(registry.iter().any(|s| s["id"] == "web-research"));
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
 /// The committed SDL snapshot freezes the read contract. Regenerate with
 /// `cargo test -- --ignored regenerate_sdl_snapshot` after any schema change.
 #[test]

--- a/src/server/graphql/workflows.rs
+++ b/src/server/graphql/workflows.rs
@@ -7,10 +7,8 @@ use std::sync::Arc;
 
 use async_graphql::{Context, ID, SimpleObject};
 
-use crate::AppState;
 use crate::company::runtime::CompanyRuntime;
 use crate::company::{WorkflowFile, parse_workflow};
-use crate::store::Bundle;
 
 /// A one-line workflow summary for the workflows list.
 #[derive(SimpleObject)]
@@ -92,9 +90,11 @@ impl From<WorkflowFile> for WorkflowGql {
     }
 }
 
-/// Best-effort parse of one workflow graph from a company directory.
-fn load_one(dir: &Path, id: &str) -> Option<WorkflowFile> {
-    let path = dir.join("workflows").join(format!("{id}.toml"));
+/// Best-effort parse of one workflow graph from the company source directory
+/// (`companies/<name>/workflows/<id>.toml`). Yields `None` when the company has
+/// no source dir (platform-provisioned mode) or the file is missing/invalid.
+fn load_one(dir: Option<&Path>, id: &str) -> Option<WorkflowFile> {
+    let path = dir?.join("workflows").join(format!("{id}.toml"));
     let text = std::fs::read_to_string(path).ok()?;
     parse_workflow(&text).ok()
 }
@@ -109,16 +109,15 @@ async fn enabled_ids(runtime: &Arc<CompanyRuntime>) -> async_graphql::Result<Vec
 
 /// Resolves `Company.workflows`.
 pub(crate) async fn resolve_summaries(
-    ctx: &Context<'_>,
+    _ctx: &Context<'_>,
     runtime: &Arc<CompanyRuntime>,
 ) -> async_graphql::Result<Vec<WorkflowSummaryGql>> {
-    let state = ctx.data::<AppState>()?;
-    let dir = Bundle::new(state.home(), runtime.id()).dir().to_path_buf();
+    let dir = runtime.source_dir();
     let ids = enabled_ids(runtime).await?;
     Ok(ids
         .into_iter()
         .map(|id| {
-            let name = load_one(&dir, &id)
+            let name = load_one(dir, &id)
                 .map(|file| file.name)
                 .unwrap_or_else(|| id.clone());
             WorkflowSummaryGql {
@@ -132,11 +131,9 @@ pub(crate) async fn resolve_summaries(
 
 /// Resolves `Company.workflow(id)`, returning null when the graph is unavailable.
 pub(crate) async fn resolve_one(
-    ctx: &Context<'_>,
+    _ctx: &Context<'_>,
     runtime: &Arc<CompanyRuntime>,
     id: &str,
 ) -> async_graphql::Result<Option<WorkflowGql>> {
-    let state = ctx.data::<AppState>()?;
-    let dir = Bundle::new(state.home(), runtime.id()).dir().to_path_buf();
-    Ok(load_one(&dir, id).map(WorkflowGql::from))
+    Ok(load_one(runtime.source_dir(), id).map(WorkflowGql::from))
 }

--- a/src/server/ops/connections.rs
+++ b/src/server/ops/connections.rs
@@ -19,7 +19,7 @@ use axum::http::{StatusCode, Uri};
 use axum::response::{IntoResponse, Redirect, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::AppState;
@@ -28,8 +28,7 @@ use crate::error::OpenCompanyError;
 use crate::ports::now_millis;
 use crate::ports::types::{CompanyId, SecretValue};
 use crate::server::error::ApiError;
-use crate::server::operator::OperatorAuth;
-use crate::server::ops::{oauth_key, resolve, resolve_sole};
+use crate::server::ops::{ScopedCompany, oauth_key, scoped};
 use crate::server::webhook::{DefaultHashSigner, WebhookSigner};
 
 /// How long a signed `state` nonce stays valid.
@@ -37,25 +36,20 @@ const STATE_TTL_MS: u64 = 10 * 60 * 1000;
 
 /// Builds the OAuth route fragment.
 pub fn router() -> Router<AppState> {
-    Router::new()
-        .route(
-            "/api/v1/companies/{id}/connections/{provider}/start",
-            post(start),
-        )
-        .route(
-            "/api/v1/companies/{id}/connections/{provider}/disconnect",
+    scoped("/connections/{provider}/start", post(start))
+        .merge(scoped(
+            "/connections/{provider}/disconnect",
             post(disconnect),
-        )
-        .route(
-            "/api/v1/company/connections/{provider}/start",
-            post(start_single),
-        )
-        .route(
-            "/api/v1/company/connections/{provider}/disconnect",
-            post(disconnect_single),
-        )
+        ))
         // The callback is unscoped: the signed `state` carries the company id.
         .route("/api/v1/oauth/callback", get(callback))
+}
+
+/// The provider sub-resource path (`provider`); the scope `id` is consumed by
+/// the [`ScopedCompany`] extractor.
+#[derive(Debug, Deserialize)]
+struct ProviderPath {
+    provider: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -194,24 +188,13 @@ fn build_authorize(
     Ok(StartResponse { url })
 }
 
-/// `POST /api/v1/companies/{id}/connections/{provider}/start`.
+/// `POST …/connections/{provider}/start` (both scope forms).
 async fn start(
-    _auth: OperatorAuth,
+    company: ScopedCompany,
     State(state): State<AppState>,
-    Path((id, provider)): Path<(String, String)>,
+    Path(ProviderPath { provider }): Path<ProviderPath>,
 ) -> Result<Json<StartResponse>, ApiError> {
-    let runtime = resolve(&state, &id)?;
-    Ok(Json(build_authorize(&state, runtime.id(), &provider)?))
-}
-
-/// `POST /api/v1/company/connections/{provider}/start` (single-company alias).
-async fn start_single(
-    _auth: OperatorAuth,
-    State(state): State<AppState>,
-    Path(provider): Path<String>,
-) -> Result<Json<StartResponse>, ApiError> {
-    let runtime = resolve_sole(&state)?;
-    Ok(Json(build_authorize(&state, runtime.id(), &provider)?))
+    Ok(Json(build_authorize(&state, company.id(), &provider)?))
 }
 
 // ---------------------------------------------------------------------------
@@ -384,22 +367,12 @@ async fn do_disconnect(
     Ok(Json(json!({ "connected": false, "provider": provider })))
 }
 
-/// `POST /api/v1/companies/{id}/connections/{provider}/disconnect`.
+/// `POST …/connections/{provider}/disconnect` (both scope forms).
 async fn disconnect(
-    _auth: OperatorAuth,
-    State(state): State<AppState>,
-    Path((id, provider)): Path<(String, String)>,
+    company: ScopedCompany,
+    Path(ProviderPath { provider }): Path<ProviderPath>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    do_disconnect(resolve(&state, &id)?, &provider).await
-}
-
-/// `POST /api/v1/company/connections/{provider}/disconnect` (single-company alias).
-async fn disconnect_single(
-    _auth: OperatorAuth,
-    State(state): State<AppState>,
-    Path(provider): Path<String>,
-) -> Result<Json<serde_json::Value>, ApiError> {
-    do_disconnect(resolve_sole(&state)?, &provider).await
+    do_disconnect(company.runtime, &provider).await
 }
 
 /// Minimal percent-encoding for URL query values (RFC 3986 unreserved set kept).

--- a/src/server/ops/domain.rs
+++ b/src/server/ops/domain.rs
@@ -12,7 +12,7 @@
 
 use std::sync::Arc;
 
-use axum::extract::{Path, State};
+use axum::extract::State;
 use axum::response::Response;
 use axum::routing::{post, put};
 use axum::{Json, Router};
@@ -23,16 +23,11 @@ use crate::company::dns::{self, DomainStatus};
 use crate::company::runtime::CompanyRuntime;
 use crate::ports::types::SecretValue;
 use crate::server::error::ApiError;
-use crate::server::operator::OperatorAuth;
-use crate::server::ops::{DOMAIN_KEY, resolve, resolve_sole};
+use crate::server::ops::{DOMAIN_KEY, ScopedCompany, scoped};
 
 /// Builds the domain route fragment.
 pub fn router() -> Router<AppState> {
-    Router::new()
-        .route("/api/v1/companies/{id}/domain", put(put_domain))
-        .route("/api/v1/companies/{id}/domain/verify", post(verify_domain))
-        .route("/api/v1/company/domain", put(put_domain_single))
-        .route("/api/v1/company/domain/verify", post(verify_domain_single))
+    scoped("/domain", put(put_domain)).merge(scoped("/domain/verify", post(verify_domain)))
 }
 
 /// The set-domain request body.
@@ -70,23 +65,12 @@ async fn load_domain(runtime: &CompanyRuntime) -> Result<Option<DomainStatus>, A
     Ok(Some(serde_json::from_str(value.expose())?))
 }
 
-/// `PUT /api/v1/companies/{id}/domain`.
+/// `PUT …/domain` (both scope forms).
 async fn put_domain(
-    _auth: OperatorAuth,
-    State(state): State<AppState>,
-    Path(id): Path<String>,
+    company: ScopedCompany,
     Json(body): Json<SetDomain>,
 ) -> Result<Json<DomainStatus>, ApiError> {
-    store_domain(resolve(&state, &id)?, &body.domain).await
-}
-
-/// `PUT /api/v1/company/domain` (single-company alias).
-async fn put_domain_single(
-    _auth: OperatorAuth,
-    State(state): State<AppState>,
-    Json(body): Json<SetDomain>,
-) -> Result<Json<DomainStatus>, ApiError> {
-    store_domain(resolve_sole(&state)?, &body.domain).await
+    store_domain(company.runtime, &body.domain).await
 }
 
 /// Runs a verification pass through the injected resolver and persists it.
@@ -116,23 +100,10 @@ async fn run_verify(
     Ok(Json(status))
 }
 
-/// `POST /api/v1/companies/{id}/domain/verify`.
+/// `POST …/domain/verify` (both scope forms).
 async fn verify_domain(
-    _auth: OperatorAuth,
-    State(state): State<AppState>,
-    Path(id): Path<String>,
-) -> Result<Json<DomainStatus>, Response> {
-    use axum::response::IntoResponse;
-    let runtime = resolve(&state, &id).map_err(IntoResponse::into_response)?;
-    run_verify(&state, runtime).await
-}
-
-/// `POST /api/v1/company/domain/verify` (single-company alias).
-async fn verify_domain_single(
-    _auth: OperatorAuth,
+    company: ScopedCompany,
     State(state): State<AppState>,
 ) -> Result<Json<DomainStatus>, Response> {
-    use axum::response::IntoResponse;
-    let runtime = resolve_sole(&state).map_err(IntoResponse::into_response)?;
-    run_verify(&state, runtime).await
+    run_verify(&state, company.runtime).await
 }

--- a/src/server/ops/smtp.rs
+++ b/src/server/ops/smtp.rs
@@ -12,7 +12,7 @@
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use axum::extract::{Path, State};
+use axum::extract::State;
 use axum::response::Response;
 use axum::routing::{post, put};
 use axum::{Json, Router};
@@ -25,8 +25,7 @@ use crate::ports::inbox::EmailRecord;
 use crate::ports::types::SecretValue;
 use crate::ports::{generate_id, now_millis};
 use crate::server::error::ApiError;
-use crate::server::operator::OperatorAuth;
-use crate::server::ops::{SMTP_KEY, resolve, resolve_sole};
+use crate::server::ops::{SMTP_KEY, ScopedCompany, scoped};
 
 /// The SMTP security mode. Mirrors the console's `SmtpSecurity`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -177,11 +176,7 @@ impl MailSender for RecordingMailSender {
 
 /// Builds the SMTP route fragment.
 pub fn router() -> Router<AppState> {
-    Router::new()
-        .route("/api/v1/companies/{id}/smtp", put(put_smtp))
-        .route("/api/v1/companies/{id}/smtp/test", post(test_smtp))
-        .route("/api/v1/company/smtp", put(put_smtp_single))
-        .route("/api/v1/company/smtp/test", post(test_smtp_single))
+    scoped("/smtp", put(put_smtp)).merge(scoped("/smtp/test", post(test_smtp)))
 }
 
 // -- PUT smtp ---------------------------------------------------------------
@@ -199,23 +194,12 @@ async fn store_credentials(
     Ok(Json(SmtpStatus::from_credentials(&creds)))
 }
 
-/// `PUT /api/v1/companies/{id}/smtp`.
+/// `PUT …/smtp` (both scope forms).
 async fn put_smtp(
-    _auth: OperatorAuth,
-    State(state): State<AppState>,
-    Path(id): Path<String>,
+    company: ScopedCompany,
     Json(creds): Json<SmtpCredentials>,
 ) -> Result<Json<SmtpStatus>, ApiError> {
-    store_credentials(resolve(&state, &id)?, creds).await
-}
-
-/// `PUT /api/v1/company/smtp` (single-company alias).
-async fn put_smtp_single(
-    _auth: OperatorAuth,
-    State(state): State<AppState>,
-    Json(creds): Json<SmtpCredentials>,
-) -> Result<Json<SmtpStatus>, ApiError> {
-    store_credentials(resolve_sole(&state)?, creds).await
+    store_credentials(company.runtime, creds).await
 }
 
 // -- POST smtp/test ---------------------------------------------------------
@@ -316,27 +300,18 @@ pub(crate) fn local_part(address: &str) -> String {
         .unwrap_or_else(|| address.to_string())
 }
 
-/// `POST /api/v1/companies/{id}/smtp/test`.
+/// `POST …/smtp/test` (both scope forms).
 async fn test_smtp(
-    _auth: OperatorAuth,
-    State(state): State<AppState>,
-    Path(id): Path<String>,
-    body: Option<Json<TestSend>>,
-) -> Result<Json<TestResult>, Response> {
-    use axum::response::IntoResponse;
-    let runtime = resolve(&state, &id).map_err(IntoResponse::into_response)?;
-    run_test(&state, runtime, body.map(|b| b.0).unwrap_or_default()).await
-}
-
-/// `POST /api/v1/company/smtp/test` (single-company alias).
-async fn test_smtp_single(
-    _auth: OperatorAuth,
+    company: ScopedCompany,
     State(state): State<AppState>,
     body: Option<Json<TestSend>>,
 ) -> Result<Json<TestResult>, Response> {
-    use axum::response::IntoResponse;
-    let runtime = resolve_sole(&state).map_err(IntoResponse::into_response)?;
-    run_test(&state, runtime, body.map(|b| b.0).unwrap_or_default()).await
+    run_test(
+        &state,
+        company.runtime,
+        body.map(|b| b.0).unwrap_or_default(),
+    )
+    .await
 }
 
 /// The real `lettre` SMTP transport. Gated behind the `smtp` feature so the

--- a/src/server/ops/workspace.rs
+++ b/src/server/ops/workspace.rs
@@ -74,13 +74,28 @@ struct WriteFile {
 }
 
 /// The rename/move body.
+///
+/// `parent_id` uses a double option so an omitted `parentId` (leave the parent
+/// unchanged) is distinguished from an explicit `"parentId": null` (move the
+/// node back to the workspace root).
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct RenameMove {
     #[serde(default)]
     name: Option<String>,
-    #[serde(default)]
-    parent_id: Option<String>,
+    #[serde(default, deserialize_with = "double_option")]
+    parent_id: Option<Option<String>>,
+}
+
+/// Deserializes into `Some(inner)` when the field is present (so an explicit
+/// `null` becomes `Some(None)`); the `#[serde(default)]` leaves an omitted field
+/// as `None`.
+fn double_option<'de, D, T>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Option::deserialize(deserializer).map(Some)
 }
 
 /// The overwrite-file response.
@@ -146,7 +161,7 @@ async fn rename_move(
             company.id(),
             &node_id,
             body.name.as_deref(),
-            body.parent_id.as_deref(),
+            body.parent_id.as_ref().map(Option::as_deref),
         )
         .await?;
     let content = match node.kind {

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -201,6 +201,20 @@ async fn workspace_create_write_move_and_cycle_rejection() {
     assert_eq!(status, StatusCode::OK);
     assert!(ack["updatedAt"].is_number());
 
+    // Explicit `"parentId": null` moves the file back to the workspace root.
+    let (status, moved) = send(
+        &state,
+        "PATCH",
+        &format!("/api/v1/company/workspace/{file_id}"),
+        Some(json!({"parentId": null})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        moved.get("parentId").is_none(),
+        "node moved to root has no parentId"
+    );
+
     // Cycle rejection: move a folder under its own child.
     let (_, child) = send(
         &state,

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -55,7 +55,20 @@ async fn send(
     uri: &str,
     body: Option<Value>,
 ) -> (StatusCode, Value) {
-    let request = Request::builder().method(method).uri(uri);
+    send_auth(state, method, uri, body, None).await
+}
+
+async fn send_auth(
+    state: &AppState,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+    token: Option<&str>,
+) -> (StatusCode, Value) {
+    let mut request = Request::builder().method(method).uri(uri);
+    if let Some(token) = token {
+        request = request.header("authorization", format!("Bearer {token}"));
+    }
     let request = match body {
         Some(body) => request
             .header("content-type", "application/json")
@@ -390,6 +403,63 @@ async fn chat_accepts_desk_id_and_replies() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert!(body["responses"].is_array());
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+#[tokio::test]
+async fn credential_route_rejects_foreign_tenant() {
+    use crate::server::platform_auth::{
+        PlatformAuthConfig, PlatformClaims, StaticPlatformVerifier,
+    };
+    use std::collections::HashSet;
+
+    let home = home();
+    // Platform mode: `acme` is owned by `tenant:acme`.
+    let verifier = std::sync::Arc::new(StaticPlatformVerifier::new("plat-secret"));
+    let state = AppState::new(AppConfig::default())
+        .with_home(home.clone())
+        .with_platform_auth(PlatformAuthConfig::new(verifier));
+    let id = CompanyId::new("acme");
+    let runtime = RuntimeBuilder::new(home.clone(), manifest())
+        .with_id(id.clone())
+        .build()
+        .await
+        .unwrap();
+    state
+        .registry()
+        .insert(id.clone(), std::sync::Arc::new(runtime));
+    state.set_owner(id.clone(), "tenant:acme");
+
+    let token = |tenant: &str| {
+        StaticPlatformVerifier::tenant_token(&PlatformClaims {
+            tenant: tenant.to_string(),
+            scopes: HashSet::from(["operator".to_string()]),
+            companies: None,
+        })
+    };
+
+    // A foreign tenant cannot set acme's domain (credential route is scoped).
+    let (status, _) = send_auth(
+        &state,
+        "PUT",
+        "/api/v1/companies/acme/domain",
+        Some(json!({"domain": "acme.test"})),
+        Some(&token("tenant:evil")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+
+    // The owning tenant succeeds.
+    let (status, _) = send_auth(
+        &state,
+        "PUT",
+        "/api/v1/companies/acme/domain",
+        Some(json!({"domain": "acme.test"})),
+        Some(&token("tenant:acme")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
 
     tokio::fs::remove_dir_all(&home).await.ok();
 }

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -768,7 +768,7 @@ pub async fn assert_workspace_store(ws: Arc<dyn WorkspaceStore>) {
     .await
     .unwrap();
     assert!(
-        ws.rename_move(&alpha, "root", None, Some("child"))
+        ws.rename_move(&alpha, "root", None, Some(Some("child")))
             .await
             .is_err(),
         "moving a folder under its descendant must be rejected"
@@ -776,7 +776,7 @@ pub async fn assert_workspace_store(ws: Arc<dyn WorkspaceStore>) {
 
     // Rename + reparent the note under Campaigns.
     let moved = ws
-        .rename_move(&alpha, "note", Some("voice-final.md"), Some("root2"))
+        .rename_move(&alpha, "note", Some("voice-final.md"), Some(Some("root2")))
         .await
         .unwrap();
     assert_eq!(moved.name, "voice-final.md");
@@ -785,6 +785,20 @@ pub async fn assert_workspace_store(ws: Arc<dyn WorkspaceStore>) {
         ws.read(&alpha, "note").await.unwrap().unwrap().1,
         "# Voice v2",
         "content survives the move"
+    );
+
+    // Move the note back to the workspace root (`Some(None)` — an explicit
+    // detach, distinct from `None` which would leave the parent unchanged).
+    let to_root = ws
+        .rename_move(&alpha, "note", None, Some(None))
+        .await
+        .unwrap();
+    assert_eq!(to_root.parent_id, None, "explicit null moves to root");
+    // A subsequent `None` leaves the (root) parent unchanged.
+    let unchanged = ws.rename_move(&alpha, "note", None, None).await.unwrap();
+    assert_eq!(
+        unchanged.parent_id, None,
+        "omitted parent leaves it at root"
     );
 
     // Recursive delete of a folder removes its descendants.

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -341,7 +341,7 @@ impl WorkspaceStore for FsOps {
         company: &CompanyId,
         id: &str,
         name: Option<&str>,
-        parent: Option<&str>,
+        parent: Option<Option<&str>>,
     ) -> Result<WorkspaceNode> {
         if let Some(name) = name {
             reject_unsafe_name(name)?;
@@ -356,7 +356,8 @@ impl WorkspaceStore for FsOps {
             )));
         }
         // Reject cycles: a node cannot be reparented under itself or a descendant.
-        if let Some(parent) = parent {
+        // A move to root (`Some(None)`) never forms a cycle.
+        if let Some(Some(parent)) = parent {
             if parent == id || descendants(&index, id).contains(parent) {
                 return Err(OpenCompanyError::InvalidRequest(
                     "cannot move a folder into its own subtree".to_string(),
@@ -375,7 +376,7 @@ impl WorkspaceStore for FsOps {
                 node.name = name.to_string();
             }
             if let Some(parent) = parent {
-                node.parent_id = Some(parent.to_string());
+                node.parent_id = parent.map(str::to_string);
             }
             node.updated_at_millis = now_millis();
         }

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -1123,7 +1123,7 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
         company: &CompanyId,
         id: &str,
         name: Option<&str>,
-        parent: Option<&str>,
+        parent: Option<Option<&str>>,
     ) -> Result<crate::ports::workspace::WorkspaceNode> {
         use crate::ports::workspace::NodeKind;
         let nodes = self.workspace_nodes(company).await?;
@@ -1132,7 +1132,8 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
                 "workspace node {id}"
             )));
         }
-        if let Some(parent) = parent {
+        // A move to root (`Some(None)`) never forms a cycle.
+        if let Some(Some(parent)) = parent {
             if parent == id || mongo_workspace_descendants(&nodes, id).contains(parent) {
                 return Err(OpenCompanyError::InvalidRequest(
                     "cannot move a folder into its own subtree".to_string(),
@@ -1149,7 +1150,7 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
             node.name = name.to_string();
         }
         if let Some(parent) = parent {
-            node.parent_id = Some(parent.to_string());
+            node.parent_id = parent.map(str::to_string);
         }
         node.updated_at_millis = now_millis();
         self.collection("workspace_nodes")

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1174,7 +1174,7 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
         company: &CompanyId,
         id: &str,
         name: Option<&str>,
-        parent: Option<&str>,
+        parent: Option<Option<&str>>,
     ) -> Result<crate::ports::workspace::WorkspaceNode> {
         use crate::ports::workspace::NodeKind;
         let conn = self.conn();
@@ -1184,7 +1184,8 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
                 "workspace node {id}"
             )));
         }
-        if let Some(parent) = parent {
+        // A move to root (`Some(None)`) never forms a cycle.
+        if let Some(Some(parent)) = parent {
             if parent == id || workspace_descendants(&nodes, id).contains(parent) {
                 return Err(OpenCompanyError::InvalidRequest(
                     "cannot move a folder into its own subtree".to_string(),
@@ -1201,7 +1202,7 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
             node.name = name.to_string();
         }
         if let Some(parent) = parent {
-            node.parent_id = Some(parent.to_string());
+            node.parent_id = parent.map(str::to_string);
         }
         node.updated_at_millis = now_millis();
         conn.execute(


### PR DESCRIPTION
## Summary

Follow-up to #6. The Codex review on #6 raised 1 P1 + 5 P2 findings; the fixes for them were pushed to the branch **after** #6 was merged (merge captured `b086a12`, the CI fix, not the review fixes), so they did not land in `main`. This PR carries exactly those three fix commits.

**`main` currently contains a P1 cross-tenant authorization bug** (the WS6 credential routes still use bare `OperatorAuth`) — this PR closes it.

## Commits

- `fix(ops): platform-scope credential routes` — **P1.** WS6 by-id `domain`/`smtp`/`connections` routes were guarded only by `OperatorAuth` + `resolve(&state, &id)`, so in `platform_auth` mode a tenant token could act on another tenant's company by choosing its id. Migrated them to the WS3 `scoped()` + `ScopedCompany` extractor (`PlatformOrOperatorAuth` + `authorize_address`; single-company alias uses `OperatorAuth` + `registry.sole()`). Added `credential_route_rejects_foreign_tenant` (foreign tenant → 403). HMAC inbox ingest left as-is (per-company signed secret already gates cross-tenant use).
- `fix(ops): allow moving workspace nodes to root` — **P2.** `WorkspaceStore::rename_move` parent widened to `Option<Option<&str>>` (`None` = unchanged, `Some(None)` = detach to root, `Some(Some(id))` = reparent) across trait + fs/sqlite/mongodb; PATCH `parentId` uses a `double_option` deserializer so omitted vs explicit `null` are distinct. Conformance + HTTP tests added.
- `fix(runtime,graphql): resolve skills/workflows from company source dir` — **P2 ×4.** `register_company` now calls `with_seed_dir` (serve-path workspace seeding); a new `CompanyRuntime::source_dir() -> Option<&Path>` seam makes `Company.skills`, `Company.workflow`/`workflows`, and `skillRegistry` read the real `companies/<name>/{skills,workflows}` + repo-level `skills/`. Platform-provisioned companies (no source dir) degrade to manifest-derived/empty — no behavior change there.

## Verification (all green)

```
cargo fmt --all -- --check            # clean
cargo clippy --all-targets -- -D warnings   # clean
cargo test                            # 359 passed
cargo test --features sqlite          # 375 passed
cargo check --features mongodb        # ok
cargo check --features openhuman      # ok
cargo test --lib content              # 5/5
```
