### PR TITLE
feat(harness): run a company agent on the embedded OpenHuman runtime (#9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
           git -C vendor/openhuman submodule update --init --depth 1 \
             vendor/tinyflows vendor/tinycortex vendor/tinyjuice \
             vendor/tinychannels vendor/tinyplace
+          # tinycortex declares its own `tinyagents` path dependency, so its
+          # manifest must resolve too. Harmless for the default build; required
+          # for any `--features openhuman` build.
+          git -C vendor/openhuman/vendor/tinycortex submodule update --init --depth 1 \
+            vendor/tinyagents
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5150,7 +5150,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
- "tinyagents 1.8.0",
+ "tinyagents 1.9.0",
  "tokio",
  "toml 0.8.23",
  "tower",
@@ -5258,7 +5258,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
- "tinyagents 1.8.0",
+ "tinyagents 1.9.0",
  "tinychannels",
  "tinycortex",
  "tinyflows",
@@ -7821,7 +7821,7 @@ dependencies = [
 
 [[package]]
 name = "tinyagents"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7837,6 +7837,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -7941,7 +7942,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tinyagents 1.8.0",
+ "tinyagents 1.9.0",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,15 @@ categories = ["web-programming", "asynchronous"]
 # target of the host crate.
 autoexamples = false
 
+# Live end-to-end smoke for issue #9: one company agent on the embedded
+# OpenHuman runtime, one turn against the hosted brain. Needs a credential, so
+# it is an explicit example gated on the `openhuman` feature — never built by
+# the default `cargo build`/CI.
+[[example]]
+name = "live_company_turn"
+path = "examples/live_company_turn.rs"
+required-features = ["openhuman"]
+
 [dependencies]
 async-graphql = "7"
 async-graphql-axum = "7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,13 @@ tinyagents = { path = "vendor/tinyagents", optional = true, features = ["sqlite"
 
 # WS4: openhuman embedded as a library (the harness). Only links under the
 # `openhuman` feature; the default build pulls none of this enormous native
-# dependency tree. `default-features = false` drops only the treesitter code
-# compressor — openhuman has no other optional heavy deps to shed.
+# dependency tree. `default-features = false` sheds openhuman's whole default
+# set — `tokenjuice-treesitter`, `voice`, `web3`, `media`, `meet`, `skills`,
+# `flows`, `mcp` — none of which a company agent needs; it wants the agent
+# loop, memory, and an inference provider. Keep `vendor/tinyagents` on the
+# same commit openhuman's own `vendor/tinyagents` pins: the two are a
+# lockstep pair, and a skew fails to compile (only under this feature, which
+# CI does not build).
 openhuman_core = { package = "openhuman", path = "vendor/openhuman", optional = true, default-features = false }
 # The openhuman `Provider`/`Memory` traits return `anyhow::Result` and log via
 # the `log` facade; both only link under the `openhuman` feature.

--- a/companies/openhuman_demo/README.md
+++ b/companies/openhuman_demo/README.md
@@ -1,0 +1,54 @@
+# OpenHuman Demo Co
+
+> A three-agent company whose cognition runs on the **embedded OpenHuman
+> runtime** (issue #9). It is the smallest end-to-end demonstration that an
+> OpenCompany agent sits on the OpenHuman harness: one turn of chat goes
+> operator → cycle → `HarnessBrain` → a live OpenHuman agent → reply.
+
+## What it can do
+
+- Answer questions about the company in the voice of whichever agent you address.
+- Sketch a technical plan (via the Engineer).
+- Turn rough notes into a short written draft (via the Writer).
+
+## Agent roster
+
+| Agent | Responsibility |
+| --- | --- |
+| Chief Executive | Sets direction, answers about the company, delegates the work. |
+| Engineer | Explains how things are built and proposes technical plans. |
+| Writer | Turns rough notes into short, clear written drafts. |
+
+## Running it on the OpenHuman brain
+
+The harness brain activates when an inference credential is present in the
+environment; otherwise the company boots on the offline echo brain.
+
+```bash
+TINYHUMANS_API_KEY=<jwt> \
+OPENCOMPANY_INFERENCE_URL=https://api.tinyhumans.ai/openai/v1 \
+cargo run --features openhuman --bin opencompany -- \
+  serve --company companies/openhuman_demo
+```
+
+Then chat with it:
+
+```bash
+curl -s localhost:8080/api/v1/company/chat \
+  -H 'content-type: application/json' \
+  -d '{"text": "Who are you, and what does this company do?"}'
+```
+
+For a credential-only smoke without the HTTP server, the
+`live_company_turn` example runs a single turn and prints the metered usage:
+
+```bash
+TINYHUMANS_API_KEY=<jwt> \
+cargo run --features openhuman --example live_company_turn -- "Introduce yourself."
+```
+
+## Human in the loop
+
+You keep **steering the company and approving anything costly**; the agents run
+everything else. The harness's output is **answers, plans, and short written
+drafts**.

--- a/companies/openhuman_demo/company.toml
+++ b/companies/openhuman_demo/company.toml
@@ -1,0 +1,39 @@
+# A minimal company for the embedded OpenHuman harness (issue #9).
+#
+# Every [[agent]] becomes one live openhuman agent, wired with memory, an
+# approval policy, and the hosted inference provider. Run it with the harness
+# brain by setting an inference credential in the environment:
+#
+#   TINYHUMANS_API_KEY=<jwt> \
+#   OPENCOMPANY_INFERENCE_URL=https://api.tinyhumans.ai/openai/v1 \
+#   cargo run --features openhuman --bin opencompany -- \
+#     serve --company companies/openhuman_demo
+#
+# Without a credential the same company still boots — it just answers with the
+# offline echo brain instead of a real agent turn.
+
+[company]
+name = "OpenHuman Demo Co"
+output = "Answers, plans, and short written drafts"
+human_role = "Steering the company and approving anything costly"
+
+[policy]
+# `full` lets ordinary turns flow without an approval prompt; costly or
+# external effects still route through the gate. Use `supervised` to approve
+# every agent action, or `readonly` to block mutations entirely.
+mode = "full"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+description = "Sets direction, answers about the company, and delegates the work."
+
+[[agent]]
+id = "engineer"
+role = "Engineer"
+description = "Explains how things are built and proposes technical plans."
+
+[[agent]]
+id = "writer"
+role = "Writer"
+description = "Turns rough notes into short, clear written drafts."

--- a/docs/modules/openhuman/README.md
+++ b/docs/modules/openhuman/README.md
@@ -8,10 +8,16 @@ keeps its offline, echo-brained behaviour.
 
 The builder seams are wired to OpenCompany's own ports:
 
+- **Persona** → each agent gets a system prompt framing it as its manifest
+  `role` at the company, built with `SystemPromptBuilder::for_subagent` and
+  `omit_identity` so it speaks as that role rather than openhuman's own
+  assistant identity.
 - **Memory** → `harness::memory::OcMemory`, an openhuman `Memory` over the
   OpenCompany `ContextStore`.
-- **Inference provider** → the hosted Medulla `Provider` (`harness::provider`),
-  with a `MockProvider` for offline tests.
+- **Inference provider** → `harness::provider::HostedProvider`, an
+  OpenAI-compatible client for the hosted TinyHumans brain (`chat()` sends the
+  full history and parses token/cost usage back out), with a `MockProvider`
+  for offline tests.
 - **Approval policy** → `harness::policy::ApprovalPolicy` maps `[policy].mode`
   onto openhuman's `ToolPolicy`; the security-tier words
   (readonly/supervised/full) line up 1:1.
@@ -21,14 +27,43 @@ See [`docs/modules/runtime/README.md`](../runtime/README.md) for `HarnessPool`
 and [`docs/spec/integrations/openhuman.md`](../../spec/integrations/openhuman.md)
 for the full integration contract.
 
-## Cost metering (partial — pending openhuman#4940)
+## `HarnessBrain` — cognition on the embedded runtime
 
-`harness::cost` maps a completed turn's `TurnCost` onto the ledger and the
-`UsageMeter`. The mapping is complete and tested, but openhuman exposes turn
-usage only through a `pub(crate)` accessor, so until the upstream public
-turn-usage accessor (tinyhumansai/openhuman#4940) lands, `HarnessPool::run`
-records a **zero-usage** turn (which, per the cost contract, writes nothing).
-That PR is the seam for real inference-cost metering.
+`harness::brain::HarnessBrain` implements the `Brain` cognition port over a
+`HarnessPool`: each operator message runs one openhuman agent turn and returns
+the agent's reply, in place of the offline `EchoBrain`'s `"You said: …"`. A
+company routes through it when the `RuntimeBuilder` has both a harness pool
+(`with_harness`) and a hosted-inference config (`with_harness_inference`) and
+no explicit brain — brain precedence is `with_brain` > harness > hosted/echo.
+The `opencompany` binary's `attach_harness` resolves that config from the
+environment (below), so `serve` boots on the harness brain automatically when a
+credential is present.
+
+## Inference config (environment)
+
+`harness::provider::harness_inference_from_env` resolves the endpoint, key, and
+default model, most specific first:
+
+| Value | Source | Fallback |
+| --- | --- | --- |
+| key | `OPENCOMPANY_INFERENCE_KEY` | `TINYHUMANS_API_KEY` — **no key ⇒ echo brain** |
+| url | `OPENCOMPANY_INFERENCE_URL` | `https://api.tinyhumans.ai/openai/v1` |
+| model | `OPENCOMPANY_INFERENCE_MODEL` | `chat-v1` |
+
+The two key names keep a per-tenant override distinct from the platform-wide
+credential the hosting manager injects.
+
+## Cost metering
+
+`harness::cost` maps a completed turn's usage onto the ledger and the
+`UsageMeter`. `HarnessPool::run` reads the real per-turn token/cost totals from
+openhuman's public `Agent::last_turn_usage()` accessor
+(tinyhumansai/openhuman#4940), so metering is **live**. Gating differs by
+surface: a usage sample is recorded whenever tokens moved (the `/openai/v1`
+passthrough reports tokens but bills backend-side, echoing no USD), while a
+ledger `inference.spend` entry is written only when the turn actually cost USD —
+so a token-bearing zero-cost turn meters usage without a `$0.00` spend line. An
+offline provider that reports no usage yields a zero turn, which writes nothing.
 
 ## `src/openhuman/` — legacy JSON-RPC path (behind `openhuman-rpc`)
 

--- a/docs/spec/runtime/config.md
+++ b/docs/spec/runtime/config.md
@@ -47,6 +47,9 @@ layer set it, and what is missing for each optional capability.
 | `OPENCOMPANY_DATA_DIR` | `~/.opencompany` | Bundle root for fs stores |
 | `OPENCOMPANY_BRAIN_MODE` | `hosted` | `hosted` \| `sidecar` (overrides `[brain].mode`) |
 | `OPENCOMPANY_OPENHUMAN_URL` | — | Attach to a running `openhuman-core serve` instead of launching |
+| `OPENCOMPANY_INFERENCE_KEY` | `TINYHUMANS_API_KEY` | Harness-brain credential (`openhuman` feature). Per-tenant override of the platform key |
+| `OPENCOMPANY_INFERENCE_URL` | `https://api.tinyhumans.ai/openai/v1` | Harness-brain OpenAI-compatible endpoint (`openhuman` feature) |
+| `OPENCOMPANY_INFERENCE_MODEL` | `chat-v1` | Roster-wide default model/tier for the harness brain (`openhuman` feature) |
 | `TINYPLACE_API_URL` | `https://api.tiny.place` | tiny.place base (staging/local override) |
 | `GITHUB_TOKEN` | — | Only for the feedback→issue flow; without it, feedback is stored locally and a prefilled "file it yourself" link is shown |
 | `OPENCOMPANY_MAIL_PROVIDER` | `smtp` when any `OPENCOMPANY_MAIL_*` is set | Host-level outbound mail transport. Supported: `smtp` |

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -97,6 +97,7 @@ async fn main() -> anyhow::Result<()> {
         store: Arc::new(FsCompanyStore::new(dir.path())),
         meter: Some(meter.clone()),
         workspace_root: dir.path().to_path_buf(),
+        model_override: Some(default_model.clone()),
     };
 
     let pool = HarnessPool::new();

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -1,0 +1,118 @@
+//! Live smoke: build one company agent on the embedded OpenHuman runtime and
+//! run a single turn against the hosted TinyHumans inference endpoint.
+//!
+//! This is the end-to-end proof for issue #9 — a company agent whose cognition
+//! runs on the real hosted brain, with the turn's token usage metered back.
+//! It needs a live credential, so it is an example (run by hand), not a test.
+//!
+//! ```bash
+//! TINYHUMANS_API_KEY=<jwt> \
+//! OPENCOMPANY_INFERENCE_URL=https://staging-api.tinyhumans.ai/openai/v1 \
+//! cargo run --example live_company_turn --features openhuman -- "Who are you?"
+//! ```
+//!
+//! With no key set it prints how to supply one and exits non-zero, so it is
+//! safe to invoke in any environment.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+
+use opencompany::app::config::ProcessEnv;
+use opencompany::company::CompanyManifest;
+use opencompany::harness::provider::{HostedProvider, harness_inference_from_env};
+use opencompany::harness::{HarnessDeps, HarnessPool};
+use opencompany::ports::types::{CompanyId, CompanyRecord};
+use opencompany::ports::usage::{UsageMeter, UsageSample};
+use opencompany::store::{FsCompanyStore, FsContextStore};
+
+/// A [`UsageMeter`] that keeps every sample in memory so the run can print the
+/// turn's metered token/cost totals.
+#[derive(Default)]
+struct CapturingMeter {
+    samples: Mutex<Vec<UsageSample>>,
+}
+
+#[async_trait]
+impl UsageMeter for CapturingMeter {
+    async fn record(&self, _company: &CompanyId, sample: &UsageSample) -> opencompany::Result<()> {
+        self.samples.lock().unwrap().push(sample.clone());
+        Ok(())
+    }
+    async fn query(
+        &self,
+        _company: &CompanyId,
+        _since_millis: u64,
+    ) -> opencompany::Result<Vec<UsageSample>> {
+        Ok(self.samples.lock().unwrap().clone())
+    }
+}
+
+/// A one-agent company: the CEO of a tiny robotics firm.
+const MANIFEST: &str = r#"
+[company]
+name = "Tiny Robotics"
+
+[policy]
+mode = "full"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+description = "Runs Tiny Robotics. Speaks in the first person, crisp and factual."
+"#;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let prompt = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "Introduce yourself in one sentence.".to_string());
+
+    let (cfg, default_model) = harness_inference_from_env(&ProcessEnv).ok_or_else(|| {
+        anyhow::anyhow!(
+            "no inference credential — set TINYHUMANS_API_KEY (or OPENCOMPANY_INFERENCE_KEY), \
+             optionally OPENCOMPANY_INFERENCE_URL / _MODEL"
+        )
+    })?;
+    eprintln!(
+        "[live] endpoint={}  default_model={}",
+        cfg.base_url, default_model
+    );
+
+    let manifest: CompanyManifest = toml::from_str(MANIFEST)?;
+    let record = CompanyRecord {
+        id: CompanyId::new("demo"),
+        manifest,
+        ledger: Vec::new(),
+        lifecycle: "running".to_string(),
+        overlay_agents: Vec::new(),
+    };
+
+    let dir = tempfile::tempdir()?;
+    let meter = Arc::new(CapturingMeter::default());
+    let deps = HarnessDeps {
+        provider: Arc::new(HostedProvider::new(cfg)),
+        provider_slug: "managed".to_string(),
+        context: Arc::new(FsContextStore::new(dir.path())),
+        store: Arc::new(FsCompanyStore::new(dir.path())),
+        meter: Some(meter.clone()),
+        workspace_root: dir.path().to_path_buf(),
+    };
+
+    let pool = HarnessPool::new();
+    pool.ensure(&record, &deps).await?;
+
+    println!("── prompt → ceo ──\n{prompt}\n");
+    let reply = pool.run(&record.id, "ceo", &prompt, &deps).await?;
+    println!("── ceo reply ──\n{reply}\n");
+
+    match meter.samples.lock().unwrap().last() {
+        Some(s) => println!(
+            "── metered usage ──\nprovider={}  in={}  out={}  cached={}  cost_usd={}",
+            s.provider, s.input_tokens, s.output_tokens, s.cached_input_tokens, s.cost_usd
+        ),
+        None => println!("── metered usage ──\n(provider reported no usage)"),
+    }
+
+    Ok(())
+}

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -182,10 +182,13 @@ async fn register_company(
     // The company's on-disk source directory (`companies/<name>`) seeds the
     // workspace tree on first boot and lets read resolvers find its committed
     // skills/workflows content.
-    let mut builder = attach_openhuman(RuntimeBuilder::new(home.to_path_buf(), manifest))
-        .with_seed_dir(company_source_dir(dir))
-        .with_tinyplace_api_url(state.config().tinyplace_api_url.clone())
-        .with_host_base_url(state.config().host_base_url());
+    let mut builder = attach_harness(attach_openhuman(RuntimeBuilder::new(
+        home.to_path_buf(),
+        manifest,
+    )))
+    .with_seed_dir(company_source_dir(dir))
+    .with_tinyplace_api_url(state.config().tinyplace_api_url.clone())
+    .with_host_base_url(state.config().host_base_url());
     if let Some(stores) = state.stores() {
         builder = builder.with_stores(stores);
     }
@@ -247,6 +250,33 @@ fn attach_openhuman(builder: RuntimeBuilder) -> RuntimeBuilder {
             builder.with_openhuman_rpc(Arc::new(HttpOpenHumanRpc::attach(url, bearer)))
         }
         _ => builder,
+    }
+}
+
+/// Attaches the embedded OpenHuman harness brain when the `openhuman` feature
+/// is enabled and a hosted-inference credential is present in the environment
+/// (`TINYHUMANS_API_KEY` / `OPENCOMPANY_INFERENCE_*`). With it, `/company/chat`
+/// routes each operator message through a live company agent on the hosted
+/// brain; without a credential the runtime keeps its hosted/echo brain.
+///
+/// Without the feature this is the identity function, so the default build is
+/// unaffected.
+#[cfg(not(feature = "openhuman"))]
+fn attach_harness(builder: RuntimeBuilder) -> RuntimeBuilder {
+    builder
+}
+
+#[cfg(feature = "openhuman")]
+fn attach_harness(builder: RuntimeBuilder) -> RuntimeBuilder {
+    use opencompany::app::config::ProcessEnv;
+    use opencompany::harness::HarnessPool;
+    use opencompany::harness::provider::harness_inference_from_env;
+
+    match harness_inference_from_env(&ProcessEnv) {
+        Some((config, model)) => builder
+            .with_harness(Arc::new(HarnessPool::new()))
+            .with_harness_inference(config, model),
+        None => builder,
     }
 }
 

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -1,0 +1,242 @@
+//! [`HarnessBrain`]: the cognition [`Brain`] backed by the embedded OpenHuman
+//! runtime.
+//!
+//! Where [`EchoBrain`](crate::brain::EchoBrain) turns every operator message
+//! into `"You said: …"`, `HarnessBrain` routes it to a live openhuman
+//! [`Agent`](openhuman_core::openhuman::agent::Agent) through a
+//! [`HarnessPool`], so the reply comes from the hosted brain and the turn's
+//! token/cost usage is metered into the company ledger.
+//!
+//! v1 is **single-responder**: one agent (the first on the roster, or the id
+//! given to [`HarnessBrain::with_responder`]) answers every operator message.
+//! Desk routing — resolving which roster member owns a given group chat — is the
+//! WS3 chat handler's job and lands separately.
+//!
+//! Compiled only under `feature = "openhuman"`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::Result;
+use crate::harness::{HarnessDeps, HarnessPool};
+use crate::ports::brain::{Brain, CycleHost};
+use crate::ports::types::{
+    CompanyEvent, CompanyRecord, CompressedTrace, CycleRequest, CycleResult, OutboundMessage,
+    TokenUsage,
+};
+
+/// A [`Brain`] that answers with a live openhuman agent turn.
+pub struct HarnessBrain {
+    pool: Arc<HarnessPool>,
+    deps: HarnessDeps,
+    record: CompanyRecord,
+    responder: String,
+}
+
+impl HarnessBrain {
+    /// Builds a harness brain for `record`, answering with the first roster
+    /// agent. The pool is shared so the roster is built once and reused across
+    /// cycles.
+    pub fn new(pool: Arc<HarnessPool>, deps: HarnessDeps, record: CompanyRecord) -> Self {
+        let responder = record
+            .manifest
+            .agents
+            .first()
+            .map(|a| a.id.clone())
+            .unwrap_or_default();
+        Self {
+            pool,
+            deps,
+            record,
+            responder,
+        }
+    }
+
+    /// Overrides which roster agent answers operator messages.
+    pub fn with_responder(mut self, agent_id: impl Into<String>) -> Self {
+        self.responder = agent_id.into();
+        self
+    }
+}
+
+#[async_trait]
+impl Brain for HarnessBrain {
+    async fn run_cycle(&self, req: CycleRequest, _host: &dyn CycleHost) -> Result<CycleResult> {
+        // Idempotent — builds the roster on the first cycle, a no-op after.
+        self.pool.ensure(&self.record, &self.deps).await?;
+
+        let mut channel_responses = Vec::new();
+        for event in &req.events {
+            if let CompanyEvent::OperatorMessage { text, .. } = event {
+                // `run` executes the turn on the openhuman runtime and meters
+                // its usage into the ledger/meter through `deps`. The reply is
+                // the agent's own text.
+                let reply = self
+                    .pool
+                    .run(&self.record.id, &self.responder, text, &self.deps)
+                    .await?;
+                channel_responses.push(OutboundMessage {
+                    channel: "operator".to_string(),
+                    text: reply,
+                });
+            }
+        }
+        // The runtime requires at least one channel response per cycle.
+        if channel_responses.is_empty() {
+            channel_responses.push(OutboundMessage {
+                channel: "operator".to_string(),
+                text: "Acknowledged.".to_string(),
+            });
+        }
+
+        let trace = CompressedTrace::now(
+            req.cycle_id.clone(),
+            format!("harness cycle handled {} event(s)", req.events.len()),
+        );
+
+        // No `ledger_deltas` / `token_usage` here on purpose: `HarnessPool::run`
+        // is the single cost-accounting site (it writes the ledger entry and the
+        // usage sample through `deps`), so surfacing the same spend again would
+        // double-count it.
+        Ok(CycleResult {
+            channel_responses,
+            new_traces: vec![trace],
+            ledger_deltas: Vec::new(),
+            token_usage: TokenUsage::default(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::harness::provider::MockProvider;
+    use crate::ports::brain::CycleHost;
+    use crate::ports::types::{
+        CompanyId, ContextOp, ContextOpResult, Effect, EffectDisposition, ToolCall, ToolResult,
+    };
+    use crate::store::{FsCompanyStore, FsContextStore, FsOps};
+
+    /// A `CycleHost` that auto-executes anything the brain asks for; the harness
+    /// brain v1 makes no host calls, so it stays inert.
+    #[derive(Default)]
+    struct NoopHost;
+
+    #[async_trait]
+    impl CycleHost for NoopHost {
+        async fn call_tool(&self, _call: ToolCall) -> Result<ToolResult> {
+            Ok(ToolResult {
+                ok: true,
+                output: serde_json::Value::Null,
+            })
+        }
+        async fn context_op(&self, _op: ContextOp) -> Result<ContextOpResult> {
+            Ok(ContextOpResult::Text(String::new()))
+        }
+        async fn emit_effect(&self, _effect: Effect) -> Result<EffectDisposition> {
+            Ok(EffectDisposition::Executed)
+        }
+    }
+
+    fn record() -> CompanyRecord {
+        let manifest = toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+description = "Runs Acme."
+"#,
+        )
+        .expect("valid manifest");
+        CompanyRecord {
+            id: CompanyId::new("acme"),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+        }
+    }
+
+    fn brain_over_mock(dir: &std::path::Path) -> HarnessBrain {
+        let deps = HarnessDeps {
+            provider: Arc::new(MockProvider::new("mock: ")),
+            provider_slug: "mock".to_string(),
+            context: Arc::new(FsContextStore::new(dir)),
+            store: Arc::new(FsCompanyStore::new(dir)),
+            meter: Some(Arc::new(FsOps::new(dir))),
+            workspace_root: dir.to_path_buf(),
+            model_override: None,
+        };
+        HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record())
+    }
+
+    fn request(events: Vec<CompanyEvent>) -> CycleRequest {
+        CycleRequest {
+            cycle_id: "cycle-1".to_string(),
+            company_id: CompanyId::new("acme"),
+            events,
+            event_seqs: Vec::new(),
+            compressed_history: Vec::new(),
+            roster: Vec::new(),
+            context_index: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn operator_message_gets_an_agent_reply() {
+        let dir = tempfile::tempdir().unwrap();
+        let brain = brain_over_mock(dir.path());
+        let result = brain
+            .run_cycle(
+                request(vec![CompanyEvent::OperatorMessage {
+                    text: "status?".into(),
+                    by: None,
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        assert_eq!(result.channel_responses.len(), 1);
+        assert_eq!(result.channel_responses[0].channel, "operator");
+        // The mock provider prefixes the routed message, proving the turn ran
+        // through the openhuman agent rather than an echo.
+        assert!(
+            result.channel_responses[0].text.contains("status?"),
+            "{:?}",
+            result.channel_responses[0].text
+        );
+        assert_eq!(result.new_traces.len(), 1);
+        // Single cost-accounting site: the cycle result carries no ledger delta.
+        assert!(result.ledger_deltas.is_empty());
+    }
+
+    #[tokio::test]
+    async fn no_events_still_acknowledges() {
+        let dir = tempfile::tempdir().unwrap();
+        let brain = brain_over_mock(dir.path());
+        let result = brain
+            .run_cycle(request(Vec::new()), &NoopHost)
+            .await
+            .expect("cycle runs");
+        assert_eq!(result.channel_responses.len(), 1);
+        assert_eq!(result.channel_responses[0].text, "Acknowledged.");
+    }
+
+    #[test]
+    fn responder_defaults_to_first_roster_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let brain = brain_over_mock(dir.path());
+        assert_eq!(brain.responder, "ceo");
+        let brain = brain.with_responder("cfo");
+        assert_eq!(brain.responder, "cfo");
+    }
+}

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -22,6 +22,7 @@ use openhuman_core::openhuman as oh;
 
 use oh::agent::dispatcher::XmlToolDispatcher;
 use oh::agent::{Agent, AgentBuilder};
+use oh::context::prompt::SystemPromptBuilder;
 use oh::tools::Tool;
 
 use crate::company::Agent as ManifestAgent;
@@ -46,9 +47,32 @@ pub fn model_for_tier(tier: Option<&str>) -> String {
     .to_string()
 }
 
+/// The persona system prompt for a company agent.
+///
+/// Frames the agent as its manifest role at the company, in the first person.
+/// This is what makes the agent answer *as* the CEO of Acme rather than falling
+/// back to openhuman's own assistant identity — the harness passes it as the
+/// archetype body with the default identity section omitted.
+pub fn persona_prompt(company_name: &str, agent: &ManifestAgent) -> String {
+    let mut prompt = format!(
+        "You are the {role} at {company}. Speak in the first person as this role.",
+        role = agent.role,
+        company = company_name,
+    );
+    if let Some(description) = agent.description.as_deref() {
+        let description = description.trim();
+        if !description.is_empty() {
+            prompt.push(' ');
+            prompt.push_str(description);
+        }
+    }
+    prompt
+}
+
 /// Build one openhuman [`Agent`] for `manifest_agent` within `company`.
 pub fn build_agent(
     company: &CompanyId,
+    company_name: &str,
     manifest_agent: &ManifestAgent,
     policy: ApprovalPolicy,
     deps: &HarnessDeps,
@@ -69,13 +93,27 @@ pub fn build_agent(
         .join(&manifest_agent.id)
         .join("workspace");
 
+    // Persona over openhuman's own identity: `omit_identity = true` drops the
+    // "you are OpenHuman" preamble so the agent speaks as its company role.
+    let persona = persona_prompt(company_name, manifest_agent);
+    let prompt_builder = SystemPromptBuilder::for_subagent(
+        persona, /* omit_identity */ true, /* omit_safety_preamble */ false,
+        /* omit_skills_catalog */ true,
+    );
+
+    let model = deps
+        .model_override
+        .clone()
+        .unwrap_or_else(|| model_for_tier(manifest_agent.tier.as_deref()));
+
     AgentBuilder::default()
         .provider_arc(deps.provider.clone())
         .memory(Arc::new(memory))
         .tools(tools)
         .tool_dispatcher(Box::new(XmlToolDispatcher))
         .tool_policy(Arc::new(policy))
-        .model_name(model_for_tier(manifest_agent.tier.as_deref()))
+        .prompt_builder(prompt_builder)
+        .model_name(model)
         .workspace_dir(workspace)
         .agent_definition_name(manifest_agent.id.clone())
         .auto_save(false)
@@ -93,5 +131,35 @@ mod tests {
         assert_eq!(model_for_tier(Some("AGENTIC")), "agentic-v1");
         assert_eq!(model_for_tier(None), "chat-v1");
         assert_eq!(model_for_tier(Some("mystery")), "chat-v1");
+    }
+
+    fn manifest_agent(role: &str, description: Option<&str>) -> ManifestAgent {
+        ManifestAgent {
+            id: "ceo".to_string(),
+            role: role.to_string(),
+            description: description.map(str::to_string),
+            tier: None,
+            tools: Vec::new(),
+            budget_usd_daily: None,
+        }
+    }
+
+    #[test]
+    fn persona_frames_role_company_and_description() {
+        let agent = manifest_agent("Chief Executive", Some("Sets direction."));
+        let persona = persona_prompt("Acme", &agent);
+        assert!(persona.contains("Chief Executive"), "{persona}");
+        assert!(persona.contains("Acme"), "{persona}");
+        assert!(persona.contains("first person"), "{persona}");
+        assert!(persona.ends_with("Sets direction."), "{persona}");
+    }
+
+    #[test]
+    fn persona_omits_absent_or_blank_description() {
+        let persona = persona_prompt("Acme", &manifest_agent("Engineer", Some("   ")));
+        assert!(persona.contains("Engineer"));
+        assert!(!persona.contains("   Engineer"));
+        // No trailing description clause.
+        assert!(persona.trim_end().ends_with("role."), "{persona}");
     }
 }

--- a/src/harness/cost.rs
+++ b/src/harness/cost.rs
@@ -45,14 +45,17 @@ pub struct TurnUsage {
     pub cached_input_tokens: u64,
     /// Best-available USD cost for the turn (charged + estimated).
     pub cost_usd: f64,
-    /// Number of model calls made during the turn.
-    pub call_count: u32,
 }
 
 /// Build the `inference.spend` [`LedgerEntry`] for a turn, or `None` when the
-/// turn consumed nothing (no model calls / no cost).
+/// turn cost nothing.
+///
+/// Gated on **cost**, not tokens: the `/openai/v1` passthrough reports tokens
+/// but bills backend-side and echoes no USD, so a token-bearing zero-cost turn
+/// must not post a meaningless `$0.00` spend line to Finances. Its tokens are
+/// still recorded through [`usage_sample_for`] on the Usage surface.
 pub fn ledger_entry_for(turn: &TurnUsage, agent_id: &str) -> Option<LedgerEntry> {
-    if is_zero_usage(turn) {
+    if turn.cost_usd == 0.0 {
         return None;
     }
     Some(LedgerEntry {
@@ -80,12 +83,11 @@ pub fn usage_sample_for(turn: &TurnUsage, agent_id: &str, provider: &str) -> Opt
     })
 }
 
-/// A turn is zero-usage when it made no calls and moved no tokens or cost.
+/// A turn is zero-usage when it moved no tokens and cost nothing — e.g. the
+/// offline [`MockProvider`](super::provider::MockProvider), whose replies carry
+/// no usage. Such a turn writes neither a ledger entry nor a usage sample.
 fn is_zero_usage(turn: &TurnUsage) -> bool {
-    turn.call_count == 0
-        && turn.input_tokens == 0
-        && turn.output_tokens == 0
-        && turn.cost_usd == 0.0
+    turn.input_tokens == 0 && turn.output_tokens == 0 && turn.cost_usd == 0.0
 }
 
 /// Record a completed turn's cost: append the ledger entry (always available)
@@ -159,13 +161,12 @@ mod tests {
         }
     }
 
-    fn turn_with(cost: f64, calls: u32) -> TurnUsage {
+    fn turn_with(cost: f64) -> TurnUsage {
         TurnUsage {
             input_tokens: 100,
             output_tokens: 50,
             cached_input_tokens: 10,
             cost_usd: cost,
-            call_count: calls,
         }
     }
 
@@ -176,9 +177,25 @@ mod tests {
         assert!(usage_sample_for(&turn, "ceo", "managed").is_none());
     }
 
+    /// The `/openai/v1` passthrough reports tokens but no USD (billing happens
+    /// backend-side, off the wire). A token-bearing, zero-cost turn is still
+    /// real usage — it must produce a sample so the Usage surface is not blind.
+    #[test]
+    fn token_only_zero_cost_turn_is_not_zero_usage() {
+        let turn = TurnUsage {
+            input_tokens: 22,
+            output_tokens: 2,
+            cached_input_tokens: 0,
+            cost_usd: 0.0,
+        };
+        assert!(usage_sample_for(&turn, "ceo", "managed").is_some());
+        // No USD ⇒ no ledger entry, but the token sample still lands.
+        assert!(ledger_entry_for(&turn, "ceo").is_none());
+    }
+
     #[test]
     fn spend_maps_to_inference_ledger_entry() {
-        let turn = turn_with(0.42, 1);
+        let turn = turn_with(0.42);
         let entry = ledger_entry_for(&turn, "ceo").unwrap();
         assert_eq!(entry.kind, "inference.spend");
         assert_eq!(entry.amount_usd, 0.42);
@@ -189,7 +206,7 @@ mod tests {
     async fn record_turn_cost_writes_ledger_and_sample() {
         let store = RecordingStore::default();
         let meter = RecordingMeter::default();
-        let turn = turn_with(1.5, 2);
+        let turn = turn_with(1.5);
         record_turn_cost(
             &turn,
             "ceo",

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -204,7 +204,7 @@ impl HarnessPool {
 }
 
 /// Build every roster agent for a company from its manifest.
-fn build_roster(
+pub(crate) fn build_roster(
     company: &CompanyRecord,
     deps: &HarnessDeps,
 ) -> crate::Result<Vec<Arc<CompanyAgent>>> {
@@ -223,4 +223,283 @@ fn build_roster(
             }))
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    use async_trait::async_trait;
+
+    use crate::company::CompanyManifest;
+    use crate::harness::provider::MockProvider;
+    use crate::ports::UsageSample;
+    use crate::ports::types::{
+        ChunkAddr, ChunkHit, ChunkMeta, CompanySummary, ContextChunk, LedgerEntry,
+    };
+
+    /// In-memory `ContextStore` so `OcMemory` has somewhere to land.
+    #[derive(Default)]
+    struct MockContext {
+        chunks: StdMutex<Vec<(ChunkAddr, ContextChunk)>>,
+    }
+
+    #[async_trait]
+    impl ContextStore for MockContext {
+        async fn put(&self, _id: &CompanyId, chunk: ContextChunk) -> crate::Result<ChunkAddr> {
+            let mut guard = self.chunks.lock().unwrap();
+            let addr = ChunkAddr::new(format!("addr-{}", guard.len()));
+            guard.push((addr.clone(), chunk));
+            Ok(addr)
+        }
+        async fn list(&self, _id: &CompanyId, prefix: &str) -> crate::Result<Vec<ChunkMeta>> {
+            let guard = self.chunks.lock().unwrap();
+            Ok(guard
+                .iter()
+                .filter(|(_, c)| c.label.starts_with(prefix))
+                .map(|(addr, c)| ChunkMeta {
+                    addr: addr.clone(),
+                    label: c.label.clone(),
+                    len: c.body.len(),
+                })
+                .collect())
+        }
+        async fn peek(
+            &self,
+            _id: &CompanyId,
+            addr: &ChunkAddr,
+            _range: Option<std::ops::Range<usize>>,
+        ) -> crate::Result<String> {
+            let guard = self.chunks.lock().unwrap();
+            Ok(guard
+                .iter()
+                .find(|(a, _)| a == addr)
+                .map(|(_, c)| c.body.clone())
+                .unwrap_or_default())
+        }
+        async fn search(
+            &self,
+            _id: &CompanyId,
+            query: &str,
+            limit: usize,
+        ) -> crate::Result<Vec<ChunkHit>> {
+            let guard = self.chunks.lock().unwrap();
+            Ok(guard
+                .iter()
+                .filter(|(_, c)| c.body.contains(query))
+                .take(limit)
+                .map(|(addr, c)| ChunkHit {
+                    addr: addr.clone(),
+                    snippet: c.body.clone(),
+                    score: 1.0,
+                })
+                .collect())
+        }
+    }
+
+    /// `CompanyStore` that records what the cost hook appends.
+    #[derive(Default)]
+    struct RecordingStore {
+        ledger: StdMutex<Vec<LedgerEntry>>,
+    }
+
+    #[async_trait]
+    impl CompanyStore for RecordingStore {
+        async fn load(&self, _id: &CompanyId) -> crate::Result<Option<CompanyRecord>> {
+            Ok(None)
+        }
+        async fn save(&self, _record: &CompanyRecord) -> crate::Result<()> {
+            Ok(())
+        }
+        async fn list(&self) -> crate::Result<Vec<CompanySummary>> {
+            Ok(Vec::new())
+        }
+        async fn append_ledger(&self, _id: &CompanyId, entry: LedgerEntry) -> crate::Result<()> {
+            self.ledger.lock().unwrap().push(entry);
+            Ok(())
+        }
+    }
+
+    /// Records usage samples so a zero-usage turn can be asserted inert.
+    #[derive(Default)]
+    struct RecordingMeter {
+        samples: StdMutex<Vec<UsageSample>>,
+    }
+
+    #[async_trait]
+    impl UsageMeter for RecordingMeter {
+        async fn record(&self, _company: &CompanyId, sample: &UsageSample) -> crate::Result<()> {
+            self.samples.lock().unwrap().push(sample.clone());
+            Ok(())
+        }
+        async fn query(
+            &self,
+            _company: &CompanyId,
+            _since: u64,
+        ) -> crate::Result<Vec<UsageSample>> {
+            Ok(self.samples.lock().unwrap().clone())
+        }
+    }
+
+    fn manifest() -> CompanyManifest {
+        toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+description = "Sets direction."
+
+[[agent]]
+id = "engineer"
+role = "Engineer"
+description = "Builds the product."
+"#,
+        )
+        .expect("valid manifest")
+    }
+
+    fn record() -> CompanyRecord {
+        CompanyRecord {
+            id: CompanyId::new("acme"),
+            manifest: manifest(),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+        }
+    }
+
+    struct Fixture {
+        deps: HarnessDeps,
+        store: Arc<RecordingStore>,
+        meter: Arc<RecordingMeter>,
+        _dir: tempfile::TempDir,
+    }
+
+    fn fixture() -> Fixture {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(RecordingStore::default());
+        let meter = Arc::new(RecordingMeter::default());
+        Fixture {
+            deps: HarnessDeps {
+                provider: Arc::new(MockProvider::new("mock: ")),
+                provider_slug: "mock".to_string(),
+                context: Arc::new(MockContext::default()),
+                store: store.clone(),
+                meter: Some(meter.clone()),
+                workspace_root: dir.path().to_path_buf(),
+            },
+            store,
+            meter,
+            _dir: dir,
+        }
+    }
+
+    #[tokio::test]
+    async fn roster_builds_every_manifest_agent() {
+        let fx = fixture();
+        let roster = build_roster(&record(), &fx.deps).expect("roster builds");
+        let ids: Vec<_> = roster.iter().map(|a| a.agent_id.as_str()).collect();
+        assert_eq!(ids, vec!["ceo", "engineer"]);
+        assert_eq!(roster[0].role, "Chief Executive");
+    }
+
+    #[tokio::test]
+    async fn run_executes_a_turn_on_the_openhuman_runtime() {
+        let fx = fixture();
+        let pool = HarnessPool::new();
+        let rec = record();
+        pool.ensure(&rec, &fx.deps).await.expect("ensure");
+
+        let reply = pool
+            .run(&rec.id, "ceo", "hello-marker", &fx.deps)
+            .await
+            .expect("turn runs");
+
+        assert!(
+            reply.contains("hello-marker"),
+            "reply should echo the prompt through the agent: {reply:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_is_idempotent() {
+        let fx = fixture();
+        let pool = HarnessPool::new();
+        let rec = record();
+        pool.ensure(&rec, &fx.deps).await.expect("first ensure");
+        pool.ensure(&rec, &fx.deps).await.expect("second ensure");
+        assert_eq!(pool.resident_companies().await, 1);
+    }
+
+    #[tokio::test]
+    async fn turns_are_serialised_and_history_survives() {
+        let fx = fixture();
+        let pool = HarnessPool::new();
+        let rec = record();
+        pool.ensure(&rec, &fx.deps).await.expect("ensure");
+
+        pool.run(&rec.id, "ceo", "first", &fx.deps)
+            .await
+            .expect("first turn");
+        let second = pool
+            .run(&rec.id, "ceo", "second", &fx.deps)
+            .await
+            .expect("second turn");
+
+        assert!(second.contains("second"));
+    }
+
+    #[tokio::test]
+    async fn unknown_agent_is_invalid_request() {
+        let fx = fixture();
+        let pool = HarnessPool::new();
+        let rec = record();
+        pool.ensure(&rec, &fx.deps).await.expect("ensure");
+
+        let err = pool
+            .run(&rec.id, "nobody", "hi", &fx.deps)
+            .await
+            .expect_err("unknown agent rejected");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_company_is_not_found() {
+        let fx = fixture();
+        let pool = HarnessPool::new();
+        let err = pool
+            .run(&CompanyId::new("ghost"), "ceo", "hi", &fx.deps)
+            .await
+            .expect_err("unknown company rejected");
+        assert!(
+            matches!(err, OpenCompanyError::CompanyNotFound(_)),
+            "{err:?}"
+        );
+    }
+
+    /// Pins the documented inert-metering contract: until the provider reports
+    /// usage, a turn writes neither a ledger entry nor a usage sample.
+    #[tokio::test]
+    async fn zero_usage_turn_writes_nothing() {
+        let fx = fixture();
+        let pool = HarnessPool::new();
+        let rec = record();
+        pool.ensure(&rec, &fx.deps).await.expect("ensure");
+        pool.run(&rec.id, "ceo", "hi", &fx.deps)
+            .await
+            .expect("turn");
+
+        assert!(fx.store.ledger.lock().unwrap().is_empty());
+        assert!(fx.meter.samples.lock().unwrap().is_empty());
+    }
 }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -35,11 +35,14 @@
 //! offline [`MockProvider`](provider::MockProvider) does not, so test turns stay
 //! inert.
 
+pub mod brain;
 pub mod build;
 pub mod cost;
 pub mod memory;
 pub mod policy;
 pub mod provider;
+
+pub use brain::HarnessBrain;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -219,8 +222,13 @@ pub(crate) fn build_roster(
         .iter()
         .map(|manifest_agent| {
             let agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily);
-            let agent =
-                build::build_agent(&company.id, company_name, manifest_agent, agent_policy, deps)?;
+            let agent = build::build_agent(
+                &company.id,
+                company_name,
+                manifest_agent,
+                agent_policy,
+                deps,
+            )?;
             Ok(Arc::new(CompanyAgent {
                 agent_id: manifest_agent.id.clone(),
                 role: manifest_agent.role.clone(),

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -74,6 +74,11 @@ pub struct HarnessDeps {
     /// Root under which per-agent workspace directories are created
     /// (`{root}/{company}/{agent}/workspace`).
     pub workspace_root: PathBuf,
+    /// Optional model/tier applied to every agent, overriding the per-agent
+    /// `tier` → model mapping. Set from the resolved hosted-inference model so
+    /// the whole roster addresses the configured workload (e.g. `chat-v1`).
+    /// `None` keeps each agent's tier-derived default.
+    pub model_override: Option<String>,
 }
 
 /// One live openhuman agent, keyed by its manifest id.
@@ -207,13 +212,15 @@ pub(crate) fn build_roster(
     deps: &HarnessDeps,
 ) -> crate::Result<Vec<Arc<CompanyAgent>>> {
     let policy: &Policy = &company.manifest.policy;
+    let company_name = &company.manifest.company.name;
     company
         .manifest
         .agents
         .iter()
         .map(|manifest_agent| {
             let agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily);
-            let agent = build::build_agent(&company.id, manifest_agent, agent_policy, deps)?;
+            let agent =
+                build::build_agent(&company.id, company_name, manifest_agent, agent_policy, deps)?;
             Ok(Arc::new(CompanyAgent {
                 agent_id: manifest_agent.id.clone(),
                 role: manifest_agent.role.clone(),
@@ -392,6 +399,7 @@ description = "Builds the product."
                 store: store.clone(),
                 meter: Some(meter.clone()),
                 workspace_root: dir.path().to_path_buf(),
+                model_override: None,
             },
             store,
             meter,

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -22,16 +22,18 @@
 //!
 //! ## Flagged seams
 //!
-//! * **Live turn cost.** openhuman exposes the completed turn's token/cost
-//!   totals only through a `pub(crate)` accessor
-//!   (`Agent::take_last_turn_usage_totals`), so a host crate cannot read the
-//!   real [`TurnCost`] after `turn()`. Until openhuman adds a public accessor
-//!   (or the harness ships a usage-accumulating provider), [`HarnessPool::run`]
-//!   records a zero-usage turn — which, per the cost contract, writes nothing.
-//!   The [`cost`] mapping itself is complete and tested.
 //! * **Group-chat / desk routing** is opencompany's job (openhuman is
 //!   single-agent). v1 is single-responder; the full ops `chat` handler that
 //!   resolves a desk's members and journals the `AgentReply` is WS3.
+//!
+//! Live turn cost is **wired**: [`CompanyAgent::run`] reads the completed turn's
+//! token/cost totals from openhuman's public
+//! [`Agent::last_turn_usage`](oh::agent::Agent::last_turn_usage) accessor and
+//! [`HarnessPool::run`] records them through [`cost::record_turn_cost`]. Usage
+//! only reaches the ledger/meter when the provider reports it — the
+//! [`HostedProvider`](provider::HostedProvider) parses it off the wire; the
+//! offline [`MockProvider`](provider::MockProvider) does not, so test turns stay
+//! inert.
 
 pub mod build;
 pub mod cost;
@@ -86,13 +88,30 @@ pub struct CompanyAgent {
 }
 
 impl CompanyAgent {
-    /// Runs one turn against this agent, returning its reply text.
-    pub async fn run(&self, message: &str) -> crate::Result<String> {
+    /// Runs one turn against this agent, returning its reply text and the turn's
+    /// token/cost totals.
+    ///
+    /// The usage is read from the just-completed turn via openhuman's public
+    /// [`Agent::last_turn_usage`](oh::agent::Agent::last_turn_usage) accessor
+    /// while the agent lock is still held (so a concurrent turn can't overwrite
+    /// it). An offline provider that reports no usage yields a zero
+    /// [`TurnUsage`], which the cost hook treats as inert.
+    pub async fn run(&self, message: &str) -> crate::Result<(String, TurnUsage)> {
         let mut agent = self.agent.lock().await;
-        agent
+        let reply = agent
             .turn(message)
             .await
-            .map_err(|e| OpenCompanyError::Harness(format!("turn for '{}': {e}", self.agent_id)))
+            .map_err(|e| OpenCompanyError::Harness(format!("turn for '{}': {e}", self.agent_id)))?;
+        let usage = agent
+            .last_turn_usage()
+            .map(|u| TurnUsage {
+                input_tokens: u.input_tokens,
+                output_tokens: u.output_tokens,
+                cached_input_tokens: u.cached_input_tokens,
+                cost_usd: u.cost_usd,
+            })
+            .unwrap_or_default();
+        Ok((reply, usage))
     }
 }
 
@@ -159,31 +178,10 @@ impl HarnessPool {
                 })?
         };
 
-        let reply = agent.run(message).await?;
-
-        // Cost accounting. openhuman only exposes the completed turn's usage via
-        // a `pub(crate)` accessor, so we cannot read the real `TurnCost` here yet
-        // (see module docs — flagged seam). A zero-usage turn writes nothing, so
-        // this is correct-but-inert until a public accessor lands; the mapping is
-        // fully wired so it becomes real with a one-line swap.
-        //
-        // FOLLOW-UP(openhuman#4940): once the vendored openhuman submodule
-        // pointer bumps to include the public `Agent::last_turn_usage()`
-        // accessor, replace this line with a read of the real per-turn totals,
-        // e.g.:
-        //     let u = agent.last_turn_usage();
-        //     let turn_cost = TurnUsage {
-        //         input_tokens: u.input_tokens,
-        //         output_tokens: u.output_tokens,
-        //         cached_input_tokens: u.cached_input_tokens,
-        //         cost_usd: u.cost_usd,
-        //         call_count: u.call_count,
-        //     };
-        // The mapping in `cost::usage_sample_for` / `cost::ledger_entry_for` is
-        // already correct, so this swap alone turns on the WS5 Usage/Finances
-        // data stream. Until then the accessor is absent from the pinned
-        // submodule and calling it would not compile under `--features openhuman`.
-        let turn_cost = TurnUsage::default();
+        // Run the turn and record its real cost. `CompanyAgent::run` reads the
+        // turn's token/cost totals from openhuman's public `last_turn_usage()`
+        // accessor; a zero-usage turn (offline provider) writes nothing.
+        let (reply, turn_cost) = agent.run(message).await?;
         record_turn_cost(
             &turn_cost,
             agent_id,

--- a/src/harness/provider.rs
+++ b/src/harness/provider.rs
@@ -16,7 +16,43 @@
 use async_trait::async_trait;
 use openhuman_core::openhuman as oh;
 
-use oh::inference::provider::Provider;
+use oh::inference::provider::{ChatRequest, ChatResponse, Provider, UsageInfo};
+
+use crate::app::config::EnvSource;
+
+/// Default hosted inference endpoint when only a bare `TINYHUMANS_API_KEY` is
+/// supplied — the OpenAI-compatible surface a company agent's `chat-v1` /
+/// `reasoning-v1` / … workloads resolve against.
+pub const DEFAULT_TINYHUMANS_INFERENCE_URL: &str = "https://api.tinyhumans.ai/openai/v1";
+
+/// Default hosted model/tier when none is configured.
+pub const DEFAULT_HOSTED_MODEL: &str = "chat-v1";
+
+/// Resolve a [`HostedProvider`] configuration (and its default model) from the
+/// environment, or `None` when no credential is present.
+///
+/// Precedence, most specific first:
+///
+/// * key — `OPENCOMPANY_INFERENCE_KEY`, else `TINYHUMANS_API_KEY`. **No key ⇒
+///   `None`**, and the runtime keeps its offline echo brain.
+/// * url — `OPENCOMPANY_INFERENCE_URL`, else [`DEFAULT_TINYHUMANS_INFERENCE_URL`].
+/// * model — `OPENCOMPANY_INFERENCE_MODEL`, else [`DEFAULT_HOSTED_MODEL`].
+///
+/// The two-name key precedence keeps a per-tenant override
+/// (`OPENCOMPANY_INFERENCE_KEY`) distinct from the platform-wide TinyHumans
+/// credential the manager injects (`TINYHUMANS_API_KEY`).
+pub fn harness_inference_from_env(env: &dyn EnvSource) -> Option<(HostedProviderConfig, String)> {
+    let api_key = env
+        .get("OPENCOMPANY_INFERENCE_KEY")
+        .or_else(|| env.get("TINYHUMANS_API_KEY"))?;
+    let base_url = env
+        .get("OPENCOMPANY_INFERENCE_URL")
+        .unwrap_or_else(|| DEFAULT_TINYHUMANS_INFERENCE_URL.to_string());
+    let model = env
+        .get("OPENCOMPANY_INFERENCE_MODEL")
+        .unwrap_or_else(|| DEFAULT_HOSTED_MODEL.to_string());
+    Some((HostedProviderConfig { base_url, api_key }, model))
+}
 
 /// Deterministic offline [`Provider`] for tests and offline harness wiring.
 ///
@@ -157,11 +193,166 @@ impl Provider for HostedProvider {
             })?;
         Ok(content.to_string())
     }
+
+    /// Structured multi-turn chat — the path [`Agent::turn`](oh::agent::Agent)
+    /// actually calls.
+    ///
+    /// Overriding `chat()` (rather than inheriting the trait default, which
+    /// collapses the conversation to system + last-user and reports no usage)
+    /// buys two things the harness needs: the **full history** reaches the
+    /// backend so multi-turn context survives, and the response's token/cost
+    /// **usage** is parsed back out — the signal the WS5 metering hook records.
+    /// The optional `request.stream` sink is ignored: the harness consumes the
+    /// aggregated reply, not the SSE deltas.
+    async fn chat(
+        &self,
+        request: ChatRequest<'_>,
+        model: &str,
+        temperature: f64,
+    ) -> anyhow::Result<ChatResponse> {
+        let messages: Vec<serde_json::Value> = request
+            .messages
+            .iter()
+            .map(|m| serde_json::json!({ "role": m.role, "content": m.content }))
+            .collect();
+
+        let mut body = serde_json::json!({
+            "model": model,
+            "temperature": temperature,
+            "messages": messages,
+        });
+        if let Some(cap) = request.max_tokens {
+            body["max_tokens"] = serde_json::json!(cap);
+        }
+
+        let url = format!(
+            "{}/chat/completions",
+            self.config.base_url.trim_end_matches('/')
+        );
+        let mut http = self.client.post(&url).json(&body);
+        if !self.config.api_key.is_empty() {
+            http = http.bearer_auth(&self.config.api_key);
+        }
+
+        let response = http
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("hosted inference request failed: {e}"))?;
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(anyhow::anyhow!(
+                "hosted inference returned {status}: {text}"
+            ));
+        }
+
+        let payload: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| anyhow::anyhow!("hosted inference response was not JSON: {e}"))?;
+        chat_response_from_payload(&payload)
+    }
+}
+
+/// Parse an OpenAI-compatible chat-completion payload into a [`ChatResponse`],
+/// carrying token usage when the backend reports it.
+fn chat_response_from_payload(payload: &serde_json::Value) -> anyhow::Result<ChatResponse> {
+    let message = payload.pointer("/choices/0/message");
+    let content = message
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_str())
+        .ok_or_else(|| {
+            anyhow::anyhow!("hosted inference response missing choices[0].message.content")
+        })?;
+    Ok(ChatResponse {
+        text: Some(content.to_string()),
+        tool_calls: Vec::new(),
+        usage: parse_usage(payload),
+        reasoning_content: message
+            .and_then(|m| m.get("reasoning_content"))
+            .and_then(|c| c.as_str())
+            .map(str::to_string),
+    })
+}
+
+/// Extract token/cost usage from a chat-completion payload.
+///
+/// Reads the standard OpenAI `usage` block, and — when the hosted backend wraps
+/// its metered totals in an `openhuman.{usage,billing}` envelope (the managed
+/// path, not the raw `/openai/v1` passthrough) — prefers those richer figures
+/// for cached-input tokens and the charged USD amount. Returns `None` when the
+/// payload carries no `usage` block at all.
+fn parse_usage(payload: &serde_json::Value) -> Option<UsageInfo> {
+    let usage = payload.get("usage")?;
+    let input_tokens = usage
+        .get("prompt_tokens")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let output_tokens = usage
+        .get("completion_tokens")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    // Cached-input tokens: the openhuman envelope wins, else the standard
+    // `prompt_tokens_details.cached_tokens`.
+    let cached_input_tokens = payload
+        .pointer("/openhuman/usage/cached_input_tokens")
+        .and_then(serde_json::Value::as_u64)
+        .or_else(|| {
+            usage
+                .pointer("/prompt_tokens_details/cached_tokens")
+                .and_then(serde_json::Value::as_u64)
+        })
+        .unwrap_or(0);
+    // USD is only present on the managed envelope; the raw `/openai/v1`
+    // passthrough bills backend-side and does not echo a charge.
+    let charged_amount_usd = payload
+        .pointer("/openhuman/billing/charged_amount_usd")
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(0.0);
+    Some(UsageInfo {
+        input_tokens,
+        output_tokens,
+        cached_input_tokens,
+        charged_amount_usd,
+        ..Default::default()
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::config::MapEnv;
+
+    #[test]
+    fn env_config_prefers_specific_key_and_fills_defaults() {
+        let env = MapEnv::new([("OPENCOMPANY_INFERENCE_KEY", "sk-specific")]);
+        let (cfg, model) = harness_inference_from_env(&env).expect("configured");
+        assert_eq!(cfg.api_key, "sk-specific");
+        assert_eq!(cfg.base_url, DEFAULT_TINYHUMANS_INFERENCE_URL);
+        assert_eq!(model, "chat-v1");
+    }
+
+    #[test]
+    fn env_config_falls_back_to_tinyhumans_key_and_honors_overrides() {
+        let env = MapEnv::new([
+            ("TINYHUMANS_API_KEY", "sk-platform"),
+            (
+                "OPENCOMPANY_INFERENCE_URL",
+                "https://staging-api.tinyhumans.ai/openai/v1",
+            ),
+            ("OPENCOMPANY_INFERENCE_MODEL", "reasoning-v1"),
+        ]);
+        let (cfg, model) = harness_inference_from_env(&env).expect("configured");
+        assert_eq!(cfg.api_key, "sk-platform");
+        assert_eq!(cfg.base_url, "https://staging-api.tinyhumans.ai/openai/v1");
+        assert_eq!(model, "reasoning-v1");
+    }
+
+    #[test]
+    fn env_config_is_none_without_any_key() {
+        let env = MapEnv::new([("OPENCOMPANY_INFERENCE_URL", "https://x/v1")]);
+        assert!(harness_inference_from_env(&env).is_none());
+    }
 
     #[tokio::test]
     async fn mock_provider_echoes_with_prefix() {
@@ -191,5 +382,70 @@ mod tests {
             api_key: String::new(),
         });
         assert_eq!(provider.telemetry_provider_id(), "managed");
+    }
+
+    /// The exact `/openai/v1` staging response shape: reply text plus a standard
+    /// `usage` block with a `prompt_tokens_details.cached_tokens` field and no
+    /// openhuman billing envelope.
+    #[test]
+    fn parses_openai_v1_completion_with_usage() {
+        let payload = serde_json::json!({
+            "model": "chat-v1",
+            "choices": [{ "message": { "role": "assistant", "content": "pong" } }],
+            "usage": {
+                "prompt_tokens": 22,
+                "completion_tokens": 2,
+                "total_tokens": 24,
+                "prompt_tokens_details": { "cached_tokens": 5 }
+            }
+        });
+        let resp = chat_response_from_payload(&payload).expect("parses");
+        assert_eq!(resp.text.as_deref(), Some("pong"));
+        assert!(resp.tool_calls.is_empty());
+        let usage = resp.usage.expect("usage present");
+        assert_eq!(usage.input_tokens, 22);
+        assert_eq!(usage.output_tokens, 2);
+        assert_eq!(usage.cached_input_tokens, 5);
+        assert_eq!(usage.charged_amount_usd, 0.0);
+    }
+
+    /// The managed envelope wins for cached tokens and carries the USD charge.
+    #[test]
+    fn managed_envelope_supplies_cost_and_cached_tokens() {
+        let payload = serde_json::json!({
+            "choices": [{ "message": { "content": "ok" } }],
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 40,
+                "prompt_tokens_details": { "cached_tokens": 1 }
+            },
+            "openhuman": {
+                "usage": { "cached_input_tokens": 64 },
+                "billing": { "charged_amount_usd": 0.0123 }
+            }
+        });
+        let usage = chat_response_from_payload(&payload)
+            .expect("parses")
+            .usage
+            .expect("usage present");
+        assert_eq!(usage.input_tokens, 100);
+        assert_eq!(usage.output_tokens, 40);
+        assert_eq!(
+            usage.cached_input_tokens, 64,
+            "envelope beats prompt_tokens_details"
+        );
+        assert_eq!(usage.charged_amount_usd, 0.0123);
+    }
+
+    #[test]
+    fn missing_content_is_an_error_and_no_usage_is_none() {
+        let no_content = serde_json::json!({ "choices": [{ "message": {} }] });
+        assert!(chat_response_from_payload(&no_content).is_err());
+
+        let no_usage = serde_json::json!({
+            "choices": [{ "message": { "content": "hi" } }]
+        });
+        let resp = chat_response_from_payload(&no_usage).expect("parses");
+        assert!(resp.usage.is_none());
     }
 }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -24,6 +24,10 @@ use crate::feedback::service::FeedbackFiler;
 use crate::feedback::store::FeedbackStore;
 use crate::feedback::tool::BuiltinToolProvider;
 use crate::feedback::types::ConsentMode;
+#[cfg(feature = "openhuman")]
+use crate::harness::provider::{HostedProvider, HostedProviderConfig};
+#[cfg(feature = "openhuman")]
+use crate::harness::{HarnessBrain, HarnessDeps};
 use crate::openhuman::rpc::OpenHumanRpc;
 use crate::openhuman::{OpenHumanChannelAdapter, OpenHumanToolProvider};
 use crate::policy::ManifestApprovalGate;
@@ -147,6 +151,11 @@ pub struct RuntimeBuilder {
     /// build is unaffected; wired through to [`CompanyRuntime`] when present.
     #[cfg(feature = "openhuman")]
     harness: Option<Arc<crate::harness::HarnessPool>>,
+    /// WS4: hosted-inference config (endpoint + default model) for the harness
+    /// brain. With both this and [`harness`](Self::harness) set — and no
+    /// explicit brain — cognition routes through the embedded openhuman runtime.
+    #[cfg(feature = "openhuman")]
+    harness_inference: Option<(HostedProviderConfig, String)>,
 }
 
 impl RuntimeBuilder {
@@ -193,6 +202,8 @@ impl RuntimeBuilder {
             consent: ConsentMode::default(),
             #[cfg(feature = "openhuman")]
             harness: None,
+            #[cfg(feature = "openhuman")]
+            harness_inference: None,
         }
     }
 
@@ -417,6 +428,21 @@ impl RuntimeBuilder {
         self
     }
 
+    /// WS4: sets the hosted-inference config (endpoint + default model) the
+    /// harness brain drives. Combined with [`with_harness`](Self::with_harness)
+    /// and no explicit brain, cognition routes through the embedded openhuman
+    /// runtime; without it the harness pool stays wired but unused and the
+    /// runtime keeps its hosted/echo brain. Feature-gated.
+    #[cfg(feature = "openhuman")]
+    pub fn with_harness_inference(
+        mut self,
+        config: HostedProviderConfig,
+        default_model: impl Into<String>,
+    ) -> Self {
+        self.harness_inference = Some((config, default_model.into()));
+        self
+    }
+
     /// Swaps the secret store (default: fs-backed). The feedback scrubber reads
     /// it to fail closed on secret leaks.
     pub fn with_secrets(mut self, secrets: Arc<dyn SecretStore>) -> Self {
@@ -603,34 +629,72 @@ impl RuntimeBuilder {
             }
         };
 
-        // Brain selection: an explicit brain wins; otherwise hosted mode plus a
-        // credential selects the hosted Medulla brain (over an injected or, under
-        // the `medulla` feature, a networked transport). Every other combination
-        // — no credential, sidecar mode, or a hosted default build with no
-        // transport — degrades to the offline echo brain so the default build
-        // stays green.
+        // Brain selection, in precedence order:
+        //   1. an explicit brain (test injection) always wins;
+        //   2. under the `openhuman` feature, an attached harness pool + a
+        //      hosted-inference config routes cognition through the embedded
+        //      openhuman runtime (a real agent turn per operator message);
+        //   3. otherwise hosted mode plus a credential selects the hosted
+        //      Medulla brain (over an injected or, under `medulla`, a networked
+        //      transport);
+        //   4. every other combination degrades to the offline echo brain so
+        //      the default build stays green.
         let brain: Arc<dyn Brain> = match self.brain {
             Some(brain) => brain,
             None => {
-                let tool_catalog: Vec<ToolManifestEntry> = self
-                    .manifest
-                    .tools
-                    .allow
-                    .iter()
-                    .map(|name| ToolManifestEntry {
-                        name: name.clone(),
-                        description: None,
-                        input_schema: None,
-                    })
-                    .collect();
-                select_hosted_or_echo(
-                    self.brain_mode.unwrap_or(BrainMode::Hosted),
-                    self.credential,
-                    self.transport,
-                    self.api_url,
-                    &id,
-                    tool_catalog,
-                )
+                // Clone the pool so it stays available for the downstream
+                // `CompanyRuntime::harness` wiring — the brain and the runtime
+                // deliberately share one pool.
+                #[cfg(feature = "openhuman")]
+                let harness_brain: Option<Arc<dyn Brain>> =
+                    match (self.harness.clone(), self.harness_inference.clone()) {
+                        (Some(pool), Some((provider_config, model))) => {
+                            let deps = HarnessDeps {
+                                provider: Arc::new(HostedProvider::new(provider_config)),
+                                provider_slug: "managed".to_string(),
+                                context: context.clone(),
+                                store: store.clone(),
+                                meter: Some(fs_ops.clone()),
+                                workspace_root: home.join("harness"),
+                                model_override: Some(model),
+                            };
+                            let record = CompanyRecord {
+                                id: id.clone(),
+                                manifest: self.manifest.clone(),
+                                ledger: Vec::new(),
+                                lifecycle: "running".to_string(),
+                                overlay_agents: Vec::new(),
+                            };
+                            Some(Arc::new(HarnessBrain::new(pool, deps, record)) as Arc<dyn Brain>)
+                        }
+                        _ => None,
+                    };
+                #[cfg(not(feature = "openhuman"))]
+                let harness_brain: Option<Arc<dyn Brain>> = None;
+
+                if let Some(brain) = harness_brain {
+                    brain
+                } else {
+                    let tool_catalog: Vec<ToolManifestEntry> = self
+                        .manifest
+                        .tools
+                        .allow
+                        .iter()
+                        .map(|name| ToolManifestEntry {
+                            name: name.clone(),
+                            description: None,
+                            input_schema: None,
+                        })
+                        .collect();
+                    select_hosted_or_echo(
+                        self.brain_mode.unwrap_or(BrainMode::Hosted),
+                        self.credential,
+                        self.transport,
+                        self.api_url,
+                        &id,
+                        tool_catalog,
+                    )
+                }
             }
         };
 

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -465,6 +465,92 @@ mod test {
         tokio::fs::remove_dir_all(&home).await.ok();
     }
 
+    /// End-to-end proof of the WS4 wire: with a [`HarnessBrain`] as the runtime's
+    /// cognition, `POST /company/chat` returns the **agent's** reply rather than
+    /// the echo brain's `"You said: …"`. The mock provider prefixes the routed
+    /// message, so `"mock: hi"` proves the operator message reached an openhuman
+    /// agent turn through the HTTP handler → `run_cycle` → brain path.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn chat_routes_through_the_harness_brain() {
+        use crate::harness::provider::MockProvider;
+        use crate::harness::{HarnessBrain, HarnessDeps, HarnessPool};
+        use crate::ports::CompanyStore;
+        use crate::store::{FsContextStore, FsOps};
+
+        let home = home();
+        let id = CompanyId::new("acme");
+        let manifest: CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+             [[agent]]\nid = \"ceo\"\nrole = \"Chief Executive\"\n",
+        )
+        .unwrap();
+
+        let record = CompanyRecord {
+            id: id.clone(),
+            manifest: manifest.clone(),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+        };
+        FsCompanyStore::new(home.to_path_buf())
+            .save(&record)
+            .await
+            .unwrap();
+
+        let deps = HarnessDeps {
+            provider: Arc::new(MockProvider::new("mock: ")),
+            provider_slug: "mock".to_string(),
+            context: Arc::new(FsContextStore::new(home.to_path_buf())),
+            store: Arc::new(FsCompanyStore::new(home.to_path_buf())),
+            meter: Some(Arc::new(FsOps::new(home.to_path_buf()))),
+            workspace_root: home.to_path_buf(),
+            model_override: None,
+        };
+        let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record);
+
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id.clone())
+            .with_brain(Arc::new(brain))
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        let app = router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/company/chat")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"text":"hi"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let text = value["responses"][0]["text"].as_str().unwrap();
+        // The mock provider's `mock: ` prefix proves the message went through an
+        // openhuman agent turn; the trailing `hi` is the operator message the
+        // agent forwarded (the agent prepends a date/time context line). Crucially
+        // it is NOT the echo brain's `"You said: hi"`.
+        assert!(text.starts_with("mock: "), "not an agent reply: {text:?}");
+        assert!(
+            text.trim_end().ends_with("hi"),
+            "message not forwarded: {text:?}"
+        );
+        assert_ne!(text, "You said: hi", "still routing through the echo brain");
+        assert_eq!(value["responses"][0]["channel"], "operator");
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
     #[tokio::test]
     async fn chat_by_id_matches_registered_company() {
         let home = home();


### PR DESCRIPTION
## Summary

> **Draft — feature-complete, held for review.** All eight commits have landed: `/company/chat` answers with a **real company agent on the hosted brain, in-character and metered** (transcript below), and the first commit **fixes a build that is broken on `main` right now**. Kept in draft pending the three questions at the bottom (the endpoint-pricing one in particular gates the hosted default).

Closes #9.

`opencompany has an agent, which then sits on the openhuman runtime` — this PR wires that, one turn end to end.

`src/harness/` is already a complete OpenHuman embedding: `build_roster` maps every manifest `[[agent]]` to an openhuman `Agent` via `AgentBuilder`, and `HarnessPool::run(agent_id, instruction) -> reply` is the per-agent entry point. It was never constructed and never executed. Every cycle falls through to `EchoBrain`, so `serve` answers chat with `"You said: …"` even under `--features openhuman`.

### What lands here

```mermaid
sequenceDiagram
    autonumber
    actor Owner
    participant HTTP as POST /company/chat
    participant Cycle as CycleRunner
    participant Brain as Brain seam
    participant Echo as EchoBrain
    participant Pool as HarnessPool
    participant OH as openhuman Agent

    Owner->>HTTP: {"text": "Who are you?"}
    HTTP->>Cycle: run_cycle(OperatorMessage)
    Cycle->>Brain: run_cycle

    rect rgb(255, 235, 235)
        Note over Brain,Echo: today — the only wired path
        Brain->>Echo: run_cycle
        Echo-->>Owner: "You said: Who are you?"
    end

    rect rgb(232, 245, 233)
        Note over Brain,OH: this PR — HarnessBrain
        Brain->>Pool: run(agent_id, text)
        Pool->>OH: Agent::turn(text)
        OH-->>Pool: reply + usage
        Pool-->>Owner: "I'm the Legal Researcher at …"
    end
```

The turn reaches the pool through a `Brain` impl rather than a branch in the chat handler, so the cycle keeps event persistence, the per-company serial lock, trace persistence and `AgentReply` journaling — and the HTTP surface is unchanged. The `with_harness` / `CompanyRuntime::harness()` seam stays wired with the same `Arc`, so WS3 desk routing can still take it later.

### Commits

| | | |
|---|---|---|
| ✅ | `fix(build)` | bump vendored tinyagents to openhuman's pin — **fixes a broken build on `main`** |
| ✅ | `test(harness)` | execute the roster build and an agent turn — **the embedding provably works** |
| ✅ | `feat(harness)` | `HostedProvider` speaks full history + parses usage; inference config from env |
| ✅ | `feat(harness)` | meter real turn usage into the ledger (via public `last_turn_usage()`) |
| ✅ | `feat(harness)` | live company-turn example against the hosted brain |
| ✅ | `feat(harness)` | persona system prompt + roster-wide model override (agent answers in-character) |
| ✅ | `feat(runtime)` | **`HarnessBrain`** — `/company/chat` routed through the agent pool (echo→harness) |
| ✅ | `feat(companies)` | `openhuman_demo` company + refreshed harness docs |

---

### 🔴 `--features openhuman` does not compile on `main`

Worth pulling out, since it is independent of the rest of this PR:

```
error[E0599]: no function `with_responses_api_primary` on `OpenAiModel`
error[E0560]: struct `HarnessToolCall` has no field named `invalid`
...
error: could not compile `openhuman` (lib) due to 36 previous errors
```

`vendor/openhuman` moved to `4eab04a7`, which builds against its own vendored tinyagents `19dc2c43` (1.9.0). This repo's `[patch.crates-io]` points `vendor/tinyagents` at `b580f1ab` (1.8.0), so openhuman compiles against an API that predates it. **The two submodules are a lockstep pair.**

CI only builds default features, so nothing caught it — and nothing will catch the next one.

Also corrected the `default-features = false` comment, which claimed it "drops only the treesitter code compressor". At the new pin openhuman's default set is eight features (`tokenjuice-treesitter`, `voice`, `web3`, `media`, `meet`, `skills`, `flows`, `mcp`) and shedding all of them is deliberate — a company agent wants the agent loop, memory and a provider, none of the rest.

And CI's submodule init now covers `vendor/openhuman/vendor/tinycortex/vendor/tinyagents`; tinycortex declares its own `tinyagents` path dependency, so its manifest has to resolve for any harness build.

### The harness had never run

`src/harness/mod.rs` had no tests. Every tested unit under `harness/` was a leaf (`build`, `cost`, `memory`, `policy`, `provider`); the path that matters — `build_roster` → `AgentBuilder::build` → `Agent::turn` — had never executed once, in any test or any binary.

It does now, offline over `MockProvider`:

```
test harness::tests::roster_builds_every_manifest_agent ... ok
test harness::tests::run_executes_a_turn_on_the_openhuman_runtime ... ok
test harness::tests::ensure_is_idempotent ... ok
test harness::tests::turns_are_serialised_and_history_survives ... ok
test harness::tests::unknown_agent_is_invalid_request ... ok
test harness::tests::unknown_company_is_not_found ... ok
test harness::tests::zero_usage_turn_writes_nothing ... ok

test result: ok. 7 passed; 0 failed
```

No panics, no missing globals, no prompt-file surprises. **The embedding works; the rest of this PR is reachability.**

`zero_usage_turn_writes_nothing` pins the documented inert-metering contract on purpose, so turning usage on has to flip it deliberately rather than silently.

### 🟢 A company agent, live on the hosted brain

`cargo run --example live_company_turn --features openhuman` builds a one-agent company (`Tiny Robotics`, a CEO), points its `HostedProvider` at a hosted inference endpoint, and runs one turn. Against staging `/openai/v1`:

```
── prompt → ceo ──
Who are you, and what does Tiny Robotics do? Answer in one sentence.

── ceo reply ──
I'm the CEO of Tiny Robotics, where we design and manufacture miniature
robotic systems for industrial inspection, medical procedures, and research
applications.

── metered usage ──
provider=managed  in=945  out=27  cached=0  cost_usd=0.000181818
```

This is the whole path end to end: `build_roster` → `AgentBuilder` → `Agent::turn` → `HostedProvider::chat()` (full history, real endpoint) → usage parsed off the wire → `record_turn_cost` → a `UsageSample` on the meter and an `inference.spend` ledger entry. The agent answers **in the first person as its manifest role** — the persona system prompt with `omit_identity` replaces openhuman's own assistant identity (it dropped the input tokens from 2,343 to 945). Metering is live, not inert.

The example reads its credential from the environment and, with none set, prints how to supply one and exits non-zero — so it is safe to run anywhere and is never built by the default `cargo build` or CI.

### 🟢 …and over HTTP

The same path is reachable through the product surface: with the harness brain wired, `POST /api/v1/company/chat {"text": "…"}` runs one agent turn and returns the reply instead of `EchoBrain`'s `"You said: …"`. The `chat_routes_through_the_harness_brain` integration test asserts exactly this over the real Axum router (deterministically, over `MockProvider`, so it runs in CI). Brain selection precedence is explicit: `with_brain` (test injection) > harness (attached pool + inference config) > hosted/echo — and `serve` picks the harness brain automatically when an inference credential is in the environment.

## API Or Behavior Changes

**The default build is untouched** throughout — everything below is `--features openhuman` only, and the default `cargo build`/CI links none of it.

Landed:

- `harness_inference_from_env` reads `OPENCOMPANY_INFERENCE_{URL,KEY,MODEL}`, falling back to `TINYHUMANS_API_KEY` + `/openai/v1`. No key ⇒ `None` ⇒ the runtime keeps its echo brain.
- `HostedProvider` overrides `chat()` (full history + usage) alongside `chat_with_system`.
- `CompanyAgent::run` returns `(reply, TurnUsage)`; `TurnUsage` drops `call_count`. Turn usage is now metered (was inert).
- `HarnessBrain` implements the `Brain` port; `RuntimeBuilder` gains `with_harness_inference`, and brain precedence is `with_brain` > harness > hosted/echo. `serve` boots on the harness brain when an inference credential is present.
- Each agent gets a persona system prompt (`omit_identity`); `HarnessDeps.model_override` applies a roster-wide model.
- New gated example target `live_company_turn`; new demo company `companies/openhuman_demo`.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 460 (456 lib + 4 bin)

Feature legs (not run by CI):

- [x] `cargo check --features openhuman` — clean (36 errors before the tinyagents bump)
- [x] `cargo check --features tiny` — clean
- [x] `cargo test --features openhuman` — 500 (496 lib + 4 bin)
- [x] `chat_routes_through_the_harness_brain` — HTTP `POST /company/chat` returns the agent reply, not echo
- [x] **live turn against staging `/openai/v1`** — real in-character reply + metered usage (transcript above)

> ⚠️ `cargo clippy --all-targets --features openhuman -- -D warnings` **does not pass, and cannot today.** Vendored tinyagents 1.9.0 trips two `large_enum_variant` lints, and a `[patch.crates-io]` path dependency does not get `cap-lints`, so `-D warnings` denies them. No lint points at opencompany code. It only became reachable now that the feature compiles at all — flagging it because it would block a `--features openhuman` CI leg.

## Documentation

- `docs/modules/openhuman/README.md` — documents `HarnessBrain`, the brain precedence, the `OPENCOMPANY_INFERENCE_*` resolution and the persona seam, and rewrites the cost-metering section now that `last_turn_usage()` makes it live.
- `docs/spec/runtime/config.md` — the three new inference env vars.
- `companies/openhuman_demo/README.md` — how to run the demo on the harness brain (server + `curl`, and the example).

---

### Questions

1. **OK to bump `vendor/tinyagents` → `19dc2c43` here?** Without it the feature does not build. Happy to split it into its own PR if you'd rather land it immediately — it is independent of the harness work.
2. **Want a cached `--features openhuman` CI job?** Green default CI does not prove this leg, which is exactly how the lockstep break landed. Would need the vendored-lint question above resolved first.
3. **Is `TINYHUMANS_API_KEY` against `api.tinyhumans.ai/openai/v1` with SKU `chat-v1` the right hosted default for company agents** — or should they go through `/orchestration/v1`? Worth being deliberate: the two surfaces price the same tokens ~6× apart, and `HostedProvider`'s OpenAI-compatible shape fits `/openai/v1` but not `/orchestration/v1`.
