### PR TITLE
feat(feedback): forward reports to TinyHumans on provisioned instances

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,11 @@ openhuman-rpc = ["dep:reqwest"]
 # mock + the whole filing flow compile without this; only `HttpGitHubClient` is
 # gated behind it.
 github = ["dep:reqwest"]
+# Real HTTP forwarding of feedback to the TinyHumans hub, so a provisioned
+# instance records reports against its credential's owner. The
+# `TinyHumansClient` trait + offline mock + the whole routing decision compile
+# without this; only `HttpTinyHumansClient` is gated behind it.
+tinyhumans = ["dep:reqwest"]
 # Real HTTP/Socket.IO transport to hosted Medulla. The wire types + offline
 # MockTransport compile without this; only the networked transport is gated.
 medulla = ["dep:reqwest"]

--- a/docs/modules/feedback/README.md
+++ b/docs/modules/feedback/README.md
@@ -1,8 +1,8 @@
 # Feedback Module
 
 The feedback module implements the [feedback loop](../../spec/feedback-loop/README.md):
-in-product feedback becomes public GitHub issues, with a non-negotiable privacy
-gate in between.
+in-product feedback reaches the TinyHumans hub or the public issue tracker, with
+a non-negotiable privacy gate in between.
 
 - `types.rs` — the `FeedbackItem` (category, operator words, work item, template
   + runtime version, capped/redacted excerpt) and consent modes
@@ -17,8 +17,15 @@ gate in between.
   rate-limits per company, signs the body with the company `@handle`, and labels
   `source/agent-filed`. Without `GITHUB_TOKEN` it degrades to a prefilled manual
   issue link.
+- the **hub client** (`tinyhumans.rs`) — a mockable `TinyHumansClient` (real
+  HTTP client behind the optional `tinyhumans` feature). On a provisioned
+  instance it forwards the scrubbed report to the backend's
+  `POST /feedback/ingest`, where it is recorded on behalf of the credential's
+  owner, and the filer above is skipped.
 
 The scrub-then-preview gate returns the exact, byte-for-byte final issue body;
-nothing is transmitted without confirmation or standing per-category consent.
-Capture routes: `POST /api/v1/companies/{id}/feedback`, a built-in `feedback`
-tool, and an operator-chat intent.
+nothing is transmitted without confirmation or standing per-category consent,
+and both destinations receive that identical body. Capture routes:
+`POST /api/v1/companies/{id}/feedback`, a built-in `feedback` tool, and an
+operator-chat intent. `GET` on the same path lists past reports as the
+`FeedbackSummary` projection, which omits the operator's local-only words.

--- a/docs/spec/feedback-loop/README.md
+++ b/docs/spec/feedback-loop/README.md
@@ -12,8 +12,10 @@ Supporting docs: [privacy.md](privacy.md) (normative scrubbing rules),
 ## The loop
 
 ```text
-operator reaction ─▶ Feedback Item ─▶ scrub ─▶ preview ─▶ GitHub issue
-        ▲                                                     │
+                                                    ┌─▶ TinyHumans hub  (provisioned)
+operator reaction ─▶ Feedback Item ─▶ scrub ─▶ preview ─┤
+        ▲                                           └─▶ GitHub issue    (otherwise)
+        │                                                     │
         │                                              triage / cluster
         │                                                     │
 "2 things you flagged were fixed in v0.4" ◀── release ◀── roadmap item
@@ -46,6 +48,35 @@ In every mode the **scrub-then-preview** gate of
 [privacy.md](privacy.md) applies: the operator (or their standing consent)
 sees exactly what becomes public. Filing without `GITHUB_TOKEN` degrades to
 the manual prefilled link ([runtime/config.md](../runtime/config.md)).
+
+## Destination: where a report goes
+
+The scrub-then-preview gate is the same everywhere; what differs is the
+destination, decided by whether this instance is **provisioned** — that is,
+whether it has a TinyHumans credential
+([runtime/config.md](../runtime/config.md)).
+
+| Instance | Destination | Behavior |
+| --- | --- | --- |
+| **Provisioned** (credential present) | TinyHumans hub | Forwarded to `POST /feedback/ingest` and recorded on behalf of the credential's **owner**. The hub's enrichment pipeline decides whether an issue is filed, so the runtime files none itself. |
+| **Unprovisioned** | GitHub | The path above: file an issue, or degrade to a prefilled manual link. |
+
+Rules that hold on both paths:
+
+- The forwarded body is the **byte-identical scrubbed body** the preview
+  showed. Forwarding is not a second exit around [privacy.md](privacy.md).
+- The credential travels only as an `Authorization` header. It must never
+  appear in a body, a log line, or a stored item.
+- The local Feedback Item is stored **before** the send, so a hub that is
+  unreachable or refuses is a degraded success — the operator keeps their note
+  and gets a plain reason — never a lost report and never a silent fallback to
+  filing a public issue instead.
+- The report carries `product: opencompany`, the company `@handle` as `origin`,
+  and the local item id as `externalRef`, so a hub item is traceable back
+  without carrying anything private across.
+
+The runtime reports the outcome as `destination` (`tinyhumans` | `github` |
+`local`) so the console can describe what happened rather than infer it.
 
 ## Agent-filed issues
 

--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -22,7 +22,8 @@ POST   /api/v1/companies/{id}/chat             operator message → event; SSE r
 GET    /api/v1/companies/{id}/events?since=SEQ SSE stream of events/effects (work feed)
 GET    /api/v1/companies/{id}/approvals        pending approvals
 POST   /api/v1/companies/{id}/approvals/{aid}  { "verdict": "approve"|"deny", "note": "…" }
-POST   /api/v1/companies/{id}/feedback         file feedback (see feedback-loop/)
+POST   /api/v1/companies/{id}/feedback         submit feedback (see feedback-loop/)
+GET    /api/v1/companies/{id}/feedback         past reports (no operator words)
 GET    /api/v1/companies/{id}/memory/traces    inspect working memory (debug)
 POST   /api/v1/companies/{id}/export           export bundle (tar)
 POST   /api/v1/companies/{id}/pause            pause / resume lifecycle transitions

--- a/docs/spec/runtime/config.md
+++ b/docs/spec/runtime/config.md
@@ -10,7 +10,11 @@ runtime to the TinyHumans backend (api.tinyhumans.ai) and from it derive:
 - access to the model catalog for TinyAgents-backed fallbacks (tiers map to
   SKUs server-side; the runtime never names models),
 - observability: TinyAgents' Langfuse exporter can proxy traces through the
-  backend's telemetry ingestion using the same credential.
+  backend's telemetry ingestion using the same credential,
+- feedback forwarding: an instance holding a credential sends operator reports
+  to the backend hub, recorded on behalf of the credential's **owner**, instead
+  of filing its own GitHub issues
+  ([feedback-loop](../feedback-loop/README.md)).
 
 **Credential reality vs contract.** Today the backend authenticates
 `/orchestration/v1` with a session JWT (magic-link / OAuth / login-token
@@ -20,10 +24,14 @@ an opaque *TinyHumans credential*: the runtime accepts either a session JWT
 hosts — a tracked upstream workstream, [roadmap.md](../roadmap.md)). The env
 var name `TINYHUMANS_API_KEY` is the stable product contract either way.
 
+Because a forwarded report is attributed to whoever the credential resolves to,
+the same pass-through works for either credential form: the backend identifies
+the owner, and the runtime never needs to know who that is.
+
 Without a credential the runtime still builds, validates manifests, runs
 `opencompany check`/`spec`, and serves the inspection routes — matching the
 README promise that you can build/inspect/explore keyless. Cycles require the
-credential.
+credential; feedback falls back to the local GitHub/manual-link path.
 
 ## Precedence
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -10,6 +10,7 @@ import type { ConsoleConfig } from "../config";
 import {
   ApiError,
   type ApiErrorBody,
+  type AppSpec,
   type ApprovalSummary,
   type ChatResponse,
   type CompanyStatus,
@@ -17,6 +18,7 @@ import {
   type ConnectionState,
   type FeedbackInput,
   type FeedbackResponse,
+  type FeedbackSummary,
   type TeamMemberDto,
   type Verdict,
 } from "./types";
@@ -157,6 +159,20 @@ export class OpenCompanyClient {
   /** Capture feedback (optionally preview the exact issue body first). */
   feedback(input: FeedbackInput, company?: string | null): Promise<FeedbackResponse> {
     return this.request<FeedbackResponse>("POST", `${this.scope(company)}/feedback`, input);
+  }
+
+  /** This company's past reports, newest first. */
+  listFeedback(company?: string | null): Promise<FeedbackSummary[]> {
+    return this.request<FeedbackSummary[]>("GET", `${this.scope(company)}/feedback`);
+  }
+
+  /**
+   * The host's runtime spec. Unauthenticated and company-agnostic, so it sits
+   * outside `scope()`; the console reads `cycles_available` from it to tell
+   * whether this instance is provisioned with a TinyHumans credential.
+   */
+  spec(): Promise<AppSpec> {
+    return this.request<AppSpec>("GET", "/spec");
   }
 
   /**

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -48,9 +48,17 @@ export interface FeedbackInput {
   preview?: boolean;
 }
 
+/**
+ * Where a submitted report ended up. `tinyhumans` means the instance is
+ * provisioned with a credential and the report was recorded against its owner;
+ * `github` is the unprovisioned filing path; `local` means it never left.
+ */
+export type FeedbackDestination = "local" | "tinyhumans" | "github";
+
 /** Response of `/feedback`. */
 export interface FeedbackResponse {
   item_id: string;
+  destination: FeedbackDestination;
   filed: boolean;
   blocked: boolean;
   reason?: string;
@@ -58,6 +66,35 @@ export interface FeedbackResponse {
   prefilled_url?: string;
   issue_url?: string;
   deduped: boolean;
+}
+
+/**
+ * One past report from `GET .../feedback`. Deliberately omits the operator's
+ * own words, which never leave the host that captured them.
+ */
+export interface FeedbackSummary {
+  id: string;
+  category: FeedbackCategory;
+  work_item: string | null;
+  at_millis: number;
+  filed_issue_url: string | null;
+  issue_status: string | null;
+}
+
+/**
+ * `GET /spec` — the host's runtime specification. Unauthenticated, so the
+ * console can read it before (and regardless of) a session.
+ */
+export interface AppSpec {
+  name: string;
+  version: string;
+  api_url: string;
+  /**
+   * Whether hosted cognition can run, which is true exactly when this instance
+   * has a TinyHumans credential and a hosted brain. The console uses it as the
+   * "is this instance provisioned" signal. No secret bytes are surfaced.
+   */
+  cycles_available: boolean;
 }
 
 /**

--- a/frontend/src/components/feedback-form.tsx
+++ b/frontend/src/components/feedback-form.tsx
@@ -171,20 +171,14 @@ function FeedbackResult({
     );
   }
 
+  const { title, description } = outcomeCopy(result);
+
   return (
     <div className="space-y-4">
       <Alert>
         <CheckCircle2 className="size-4" />
-        <AlertTitle>
-          {result.filed
-            ? result.deduped
-              ? "Added to an existing report"
-              : "Shared — thanks!"
-            : "Captured locally"}
-        </AlertTitle>
-        <AlertDescription>
-          {result.filed ? "You'll hear back if it ships." : "Your note is saved on this machine."}
-        </AlertDescription>
+        <AlertTitle>{title}</AlertTitle>
+        <AlertDescription>{description}</AlertDescription>
       </Alert>
       {result.issue_url && (
         <a
@@ -196,7 +190,12 @@ function FeedbackResult({
           View the report <ExternalLink className="size-3" />
         </a>
       )}
-      {!result.filed && result.prefilled_url && (
+      {/*
+        The prefilled link is a GitHub fallback. On a provisioned instance the
+        report went to TinyHumans and there is no issue for the operator to file
+        themselves, so offering the link would only cause a duplicate.
+      */}
+      {!result.filed && result.destination !== "tinyhumans" && result.prefilled_url && (
         <a
           className="inline-flex items-center gap-1 text-sm font-medium underline underline-offset-4"
           href={result.prefilled_url}
@@ -211,4 +210,33 @@ function FeedbackResult({
       </div>
     </div>
   );
+}
+
+/** What to tell the operator, based on where the report actually went. */
+function outcomeCopy(result: FeedbackResponse): { title: string; description: string } {
+  if (result.destination === "tinyhumans") {
+    // Not filed here means the hub took it but its moderation declined.
+    if (!result.filed) {
+      return {
+        title: "Not added",
+        description: result.reason ?? "It wasn't accepted. Your note is saved on this machine.",
+      };
+    }
+    return {
+      title: "Sent — thanks!",
+      description: "It's on your TinyHumans account. You'll hear back if it ships.",
+    };
+  }
+
+  if (result.filed) {
+    return {
+      title: result.deduped ? "Added to an existing report" : "Shared — thanks!",
+      description: "You'll hear back if it ships.",
+    };
+  }
+
+  return {
+    title: "Captured locally",
+    description: result.reason ?? "Your note is saved on this machine.",
+  };
 }

--- a/frontend/src/views/FeedbackView.tsx
+++ b/frontend/src/views/FeedbackView.tsx
@@ -1,6 +1,8 @@
-import { MessageCircleHeart } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { ExternalLink, MessageCircleHeart } from "lucide-react";
 
 import type { OpenCompanyClient } from "@/api/client";
+import type { FeedbackCategory, FeedbackSummary } from "@/api/types";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -11,15 +13,60 @@ import {
 } from "@/components/ui/card";
 import { FeedbackForm } from "@/components/feedback-form";
 import { DiscordIcon } from "@/components/discord-icon";
+import { FEEDBACK_CATEGORIES, timeAgo } from "@/lib/language";
 import { DISCORD_INVITE_URL } from "@/lib/links";
+
+const CATEGORY_LABELS = Object.fromEntries(
+  FEEDBACK_CATEGORIES.map((c) => [c.value, c.label]),
+) as Record<FeedbackCategory, string>;
+
+/** Plain-language wording for the statuses the store records. */
+const STATUS_LABELS: Record<string, string> = {
+  open: "reported",
+  duplicate: "merged with an existing report",
+  forwarded: "sent to TinyHumans",
+};
 
 interface Props {
   client: OpenCompanyClient;
   company: string | null;
 }
 
-/** A standalone feedback surface, plus a nudge to the community. */
+/** A standalone feedback surface: report something, see past reports, get help. */
 export function FeedbackView({ client, company }: Props) {
+  // Stays null until /spec answers, so the copy below never flickers between
+  // the provisioned and unprovisioned wordings.
+  const [provisioned, setProvisioned] = useState<boolean | null>(null);
+  const [reports, setReports] = useState<FeedbackSummary[] | null>(null);
+  // Bumped on Done, which both clears the form and refetches the list.
+  const [round, setRound] = useState(0);
+
+  useEffect(() => {
+    let live = true;
+    client
+      .spec()
+      .then((spec) => live && setProvisioned(spec.cycles_available))
+      // A host that cannot answer /spec is treated as unprovisioned.
+      .catch(() => live && setProvisioned(false));
+    return () => {
+      live = false;
+    };
+  }, [client]);
+
+  useEffect(() => {
+    let live = true;
+    client
+      .listFeedback(company)
+      .then((items) => live && setReports(items))
+      // A host without the list route yet shows the form and nothing else.
+      .catch(() => live && setReports([]));
+    return () => {
+      live = false;
+    };
+  }, [client, company, round]);
+
+  const onDone = useCallback(() => setRound((n) => n + 1), []);
+
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="mx-auto w-full max-w-2xl space-y-6 px-4 py-6">
@@ -35,12 +82,39 @@ export function FeedbackView({ client, company }: Props) {
             <CardTitle className="text-base">Flag something</CardTitle>
             <CardDescription>
               You&apos;ll preview exactly what gets shared before it leaves your machine.
+              {provisioned === true && " Reports go to your TinyHumans account."}
+              {provisioned === false && " Reports stay here until you choose to file them."}
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <FeedbackForm client={client} company={company} onDone={() => {}} showCancel={false} />
+            {/* Remounting on `round` resets the form after a submission. */}
+            <FeedbackForm
+              key={round}
+              client={client}
+              company={company}
+              onDone={onDone}
+              showCancel={false}
+            />
           </CardContent>
         </Card>
+
+        {reports !== null && reports.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Your reports</CardTitle>
+              <CardDescription>
+                What you&apos;ve flagged from this company, newest first.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="p-0">
+              <ul className="divide-y">
+                {reports.map((report) => (
+                  <ReportRow key={report.id} report={report} />
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        )}
 
         <Card className="overflow-hidden">
           <CardContent className="flex flex-col items-start gap-4 py-6 sm:flex-row sm:items-center sm:justify-between">
@@ -67,5 +141,32 @@ export function FeedbackView({ client, company }: Props) {
         </Card>
       </div>
     </div>
+  );
+}
+
+function ReportRow({ report }: { report: FeedbackSummary }) {
+  return (
+    <li className="flex items-start justify-between gap-4 px-6 py-3">
+      <div className="min-w-0 space-y-0.5">
+        <p className="truncate text-sm font-medium">
+          {CATEGORY_LABELS[report.category] ?? report.category}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {timeAgo(report.at_millis, Date.now())}
+          {report.work_item && ` · ${report.work_item}`}
+          {report.issue_status && ` · ${STATUS_LABELS[report.issue_status] ?? report.issue_status}`}
+        </p>
+      </div>
+      {report.filed_issue_url && (
+        <a
+          className="inline-flex shrink-0 items-center gap-1 text-xs font-medium underline underline-offset-4"
+          href={report.filed_issue_url}
+          target="_blank"
+          rel="noreferrer"
+        >
+          View <ExternalLink className="size-3" />
+        </a>
+      )}
+    </li>
   );
 }

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -182,10 +182,13 @@ async fn register_company(
     // The company's on-disk source directory (`companies/<name>`) seeds the
     // workspace tree on first boot and lets read resolvers find its committed
     // skills/workflows content.
-    let mut builder = attach_harness(attach_openhuman(RuntimeBuilder::new(
-        home.to_path_buf(),
-        manifest,
-    )))
+    let mut builder = attach_tinyhumans_feedback(
+        attach_harness(attach_openhuman(RuntimeBuilder::new(
+            home.to_path_buf(),
+            manifest,
+        ))),
+        state.config(),
+    )
     .with_seed_dir(company_source_dir(dir))
     .with_tinyplace_api_url(state.config().tinyplace_api_url.clone())
     .with_host_base_url(state.config().host_base_url());
@@ -276,6 +279,31 @@ fn attach_harness(builder: RuntimeBuilder) -> RuntimeBuilder {
         Some((config, model)) => builder
             .with_harness(Arc::new(HarnessPool::new()))
             .with_harness_inference(config, model),
+        None => builder,
+    }
+}
+
+/// Routes feedback to the TinyHumans hub when this instance is provisioned with
+/// a credential, so reports are recorded on behalf of the credential's owner
+/// instead of being filed as issues from here.
+///
+/// Without the feature this is the identity function, so the default build stays
+/// network-free and keeps the local capture → GitHub/manual-link path.
+#[cfg(not(feature = "tinyhumans"))]
+fn attach_tinyhumans_feedback(builder: RuntimeBuilder, _config: &AppConfig) -> RuntimeBuilder {
+    builder
+}
+
+#[cfg(feature = "tinyhumans")]
+fn attach_tinyhumans_feedback(builder: RuntimeBuilder, config: &AppConfig) -> RuntimeBuilder {
+    use opencompany::feedback::HttpTinyHumansClient;
+
+    match &config.tinyhumans_credential {
+        Some(credential) => builder.with_tinyhumans_feedback(Arc::new(HttpTinyHumansClient::new(
+            config.api_url.clone(),
+            credential.clone(),
+        ))),
+        // Unprovisioned: keep the local path rather than dropping reports.
         None => builder,
     }
 }

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -19,7 +19,7 @@ use crate::Result;
 use crate::error::OpenCompanyError;
 use crate::feedback::service::{FeedbackFiler, FeedbackResponse};
 use crate::feedback::store::FeedbackStore;
-use crate::feedback::types::{FeedbackInput, FeedbackItem};
+use crate::feedback::types::{FeedbackInput, FeedbackItem, FeedbackSummary};
 use crate::policy::ManifestApprovalGate;
 use crate::ports::now_millis;
 use crate::ports::types::{Actor, ApprovalId, CompanyEvent, CompanyId, Verdict};
@@ -350,6 +350,18 @@ impl CompanyRuntime {
             preview,
         )
         .await
+    }
+
+    /// Lists this company's captured feedback, newest first, as the
+    /// HTTP-safe [`FeedbackSummary`] projection.
+    ///
+    /// The operator's raw words never appear: they are local-only by
+    /// construction (see [`FeedbackItem::operator_words`]), so the reports list
+    /// shows what was reported and where it went, not what was typed.
+    pub async fn list_feedback(&self) -> Result<Vec<FeedbackSummary>> {
+        let mut items = self.feedback.list().await?;
+        items.sort_by_key(|item| std::cmp::Reverse(item.at_millis));
+        Ok(items.iter().map(FeedbackSummary::from_item).collect())
     }
 
     /// A status snapshot, loading the company record for name and lifecycle.

--- a/src/error.rs
+++ b/src/error.rs
@@ -157,6 +157,17 @@ pub enum OpenCompanyError {
         message: String,
     },
 
+    /// A TinyHumans backend transport or protocol failure. `code` is a stable
+    /// machine-readable token (e.g. `unreachable`, `http_502`); `message` is the
+    /// human-readable detail.
+    #[error("tinyhumans error ({code}): {message}")]
+    TinyHumans {
+        /// A stable, machine-readable failure token.
+        code: String,
+        /// A human-readable description of the failure.
+        message: String,
+    },
+
     /// A port method has no implementation in the current build.
     #[error("port not implemented: {0}")]
     Unimplemented(&'static str),
@@ -218,6 +229,7 @@ impl OpenCompanyError {
             Self::Config(_) => "config_error".to_string(),
             Self::Orchestration { code, .. } => code.clone(),
             Self::Tinyplace { code, .. } => format!("tinyplace_{code}"),
+            Self::TinyHumans { code, .. } => format!("tinyhumans_{code}"),
             Self::Unimplemented(_) => "unimplemented".to_string(),
             #[cfg(feature = "openhuman")]
             Self::Harness(_) => "harness_error".to_string(),

--- a/src/feedback/mod.rs
+++ b/src/feedback/mod.rs
@@ -17,6 +17,7 @@ pub mod labels;
 pub mod scrub;
 pub mod service;
 pub mod store;
+pub mod tinyhumans;
 pub mod tool;
 pub mod triage;
 pub mod types;
@@ -26,8 +27,9 @@ pub use github::{
     file_feedback, manual_issue_url, sign_body,
 };
 pub use scrub::{CharterTerm, ScrubOutcome, scrub};
-pub use service::{FeedbackFiler, FeedbackResponse};
+pub use service::{FeedbackDestination, FeedbackFiler, FeedbackResponse};
 pub use store::FeedbackStore;
+pub use tinyhumans::{IngestOutcome, IngestRequest, MockTinyHumansClient, TinyHumansClient};
 pub use tool::BuiltinToolProvider;
 pub use triage::{
     ClusterPlan, DedupePlan, EscalationPlan, FeedbackSource, QualityLedger, Severity, TriageAgent,
@@ -37,6 +39,9 @@ pub use types::{ConsentMode, FeedbackCategory, FeedbackInput, FeedbackItem, dete
 
 #[cfg(feature = "github")]
 pub use github::HttpGitHubClient;
+
+#[cfg(feature = "tinyhumans")]
+pub use tinyhumans::HttpTinyHumansClient;
 
 /// The public issue tracker feedback is filed against.
 pub const DEFAULT_REPO: &str = "tinyhumansai/opencompany";

--- a/src/feedback/mod.rs
+++ b/src/feedback/mod.rs
@@ -35,7 +35,9 @@ pub use triage::{
     ClusterPlan, DedupePlan, EscalationPlan, FeedbackSource, QualityLedger, Severity, TriageAgent,
     classify_labels, cluster_plans, escalation_for, map_fixed_issues, process_bug_check,
 };
-pub use types::{ConsentMode, FeedbackCategory, FeedbackInput, FeedbackItem, detect_chat_intent};
+pub use types::{
+    ConsentMode, FeedbackCategory, FeedbackInput, FeedbackItem, FeedbackSummary, detect_chat_intent,
+};
 
 #[cfg(feature = "github")]
 pub use github::HttpGitHubClient;

--- a/src/feedback/service.rs
+++ b/src/feedback/service.rs
@@ -1,9 +1,21 @@
 //! The feedback filing flow: capture → scrub → preview → file.
 //!
 //! [`finalize`] runs the scrub-then-preview gate over an already-captured
-//! [`FeedbackItem`] and either previews the exact final body or files it. It is
+//! [`FeedbackItem`] and either previews the exact final body or sends it. It is
 //! driven by the HTTP `POST .../feedback` handler through
 //! [`CompanyRuntime::submit_feedback`](crate::company::runtime::CompanyRuntime::submit_feedback).
+//!
+//! Where a report goes depends on how the instance is provisioned:
+//!
+//! * **With a TinyHumans credential** — forwarded to the hub
+//!   ([`crate::feedback::tinyhumans`]) and recorded on behalf of the credential's
+//!   owner. The hub's enrichment pipeline decides whether an issue is filed, so
+//!   this runtime does not also file one.
+//! * **Without one** — the original path: file a GitHub issue, or degrade to a
+//!   prefilled manual link.
+//!
+//! Both destinations receive the identical scrubbed body, so the scrub-then-
+//! preview gate remains the single exit for operator words.
 
 use std::sync::Arc;
 
@@ -16,6 +28,7 @@ use crate::feedback::github::{
 };
 use crate::feedback::scrub::{CharterTerm, ScrubOutcome, scrub};
 use crate::feedback::store::FeedbackStore;
+use crate::feedback::tinyhumans::{IngestOutcome, IngestRequest, TinyHumansClient};
 use crate::feedback::triage::{FeedbackSource, QualityLedger, Severity, classify_labels};
 use crate::feedback::types::{ConsentMode, FeedbackItem};
 use crate::ports::SecretStore;
@@ -26,6 +39,10 @@ use crate::ports::types::CompanyId;
 pub struct FeedbackFiler {
     /// The GitHub client, or `None` to always degrade to a manual link.
     pub client: Option<Arc<dyn GitHubClient>>,
+    /// The TinyHumans hub client, set only when the instance is provisioned with
+    /// a credential. Its presence *is* the "forward instead of file" signal —
+    /// the credential itself stays in the client and never reaches [`finalize`].
+    pub tinyhumans: Option<Arc<dyn TinyHumansClient>>,
     /// The `owner/repo` issues are filed against.
     pub repo: String,
     /// The standing consent mode.
@@ -41,6 +58,7 @@ impl Default for FeedbackFiler {
     fn default() -> Self {
         Self {
             client: None,
+            tinyhumans: None,
             repo: crate::feedback::DEFAULT_REPO.to_string(),
             consent: ConsentMode::default(),
             limiter: RateLimiter::default(),
@@ -55,8 +73,25 @@ impl std::fmt::Debug for FeedbackFiler {
             .field("repo", &self.repo)
             .field("consent", &self.consent)
             .field("has_client", &self.client.is_some())
+            .field("has_tinyhumans", &self.tinyhumans.is_some())
             .finish_non_exhaustive()
     }
+}
+
+/// Where a submitted report ended up.
+///
+/// The console branches its wording on this rather than inferring a destination
+/// from which optional fields happen to be set.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FeedbackDestination {
+    /// Held on this machine only — a preview, a block, or a failed send.
+    #[default]
+    Local,
+    /// Forwarded to the TinyHumans hub, recorded as the credential's owner.
+    Tinyhumans,
+    /// Filed as (or commented onto) a GitHub issue.
+    Github,
 }
 
 /// The response body for a feedback submission, mirroring the api.md envelope.
@@ -64,6 +99,8 @@ impl std::fmt::Debug for FeedbackFiler {
 pub struct FeedbackResponse {
     /// The captured item's id (it persists regardless of filing).
     pub item_id: String,
+    /// Where the report went.
+    pub destination: FeedbackDestination,
     /// Whether an issue was filed (created or commented).
     pub filed: bool,
     /// Whether filing was blocked by the scrubber (fail-closed).
@@ -85,24 +122,38 @@ pub struct FeedbackResponse {
 }
 
 impl FeedbackResponse {
-    fn blocked(item_id: &str, reason: String) -> Self {
+    /// A nothing-happened response for `item_id`: kept local, not filed, not
+    /// blocked. Every other constructor below builds on it with struct-update
+    /// syntax so a new field cannot be silently forgotten on one path.
+    fn local(item_id: &str) -> Self {
         Self {
             item_id: item_id.to_string(),
+            destination: FeedbackDestination::Local,
             filed: false,
-            blocked: true,
-            reason: Some(reason),
+            blocked: false,
+            reason: None,
             preview_body: None,
             prefilled_url: None,
             issue_url: None,
             deduped: false,
         }
     }
+
+    fn blocked(item_id: &str, reason: String) -> Self {
+        Self {
+            blocked: true,
+            reason: Some(reason),
+            ..Self::local(item_id)
+        }
+    }
 }
 
-/// Runs the scrub-then-preview gate for `item` and either previews or files.
+/// Runs the scrub-then-preview gate for `item` and either previews or sends it.
 ///
 /// * A scrub abort → a `blocked` response that never leaks the offending value.
 /// * `preview` → the byte-exact final body plus a prefilled link.
+/// * A configured TinyHumans credential → forward to the hub, recorded as the
+///   credential's owner; no issue is filed from here.
 /// * Otherwise → file through the [`FeedbackFiler`], updating the stored item's
 ///   status on success.
 #[allow(clippy::too_many_arguments)]
@@ -133,15 +184,18 @@ pub async fn finalize(
 
     if preview {
         return Ok(FeedbackResponse {
-            item_id: item.id.clone(),
-            filed: false,
-            blocked: false,
-            reason: None,
             prefilled_url: Some(manual_issue_url(&filer.repo, &title, &scrubbed, &labels)),
             preview_body: Some(scrubbed),
-            issue_url: None,
-            deduped: false,
+            ..FeedbackResponse::local(&item.id)
         });
+    }
+
+    // A provisioned instance forwards to the hub instead of filing its own
+    // issue: the report is attributed to the credential's owner and the hub's
+    // pipeline decides whether it becomes an issue. Note this consumes the same
+    // `scrubbed` body the preview above would have shown.
+    if let Some(hub) = filer.tinyhumans.as_deref() {
+        return forward_to_hub(store, hub, item, &handle, title, scrubbed).await;
     }
 
     // A throttled handle (too many low-quality filings) has its standing Auto
@@ -166,14 +220,10 @@ pub async fn finalize(
             filer.quality.record_filed(&handle);
             store.update_status(&item.id, &url, "open").await?;
             FeedbackResponse {
-                item_id: item.id.clone(),
+                destination: FeedbackDestination::Github,
                 filed: true,
-                blocked: false,
-                reason: None,
-                preview_body: None,
-                prefilled_url: None,
                 issue_url: Some(url),
-                deduped: false,
+                ..FeedbackResponse::local(&item.id)
             }
         }
         FilingOutcome::Deduped { url } => {
@@ -183,37 +233,78 @@ pub async fn finalize(
             filer.quality.record_low_quality(&handle);
             store.update_status(&item.id, &url, "duplicate").await?;
             FeedbackResponse {
-                item_id: item.id.clone(),
+                destination: FeedbackDestination::Github,
                 filed: true,
-                blocked: false,
-                reason: None,
-                preview_body: None,
-                prefilled_url: None,
                 issue_url: Some(url),
                 deduped: true,
+                ..FeedbackResponse::local(&item.id)
             }
         }
         FilingOutcome::RateLimited => FeedbackResponse {
-            item_id: item.id.clone(),
-            filed: false,
-            blocked: false,
             reason: Some("rate limit reached; try later or file manually".to_string()),
-            preview_body: None,
-            prefilled_url: None,
-            issue_url: None,
-            deduped: false,
+            ..FeedbackResponse::local(&item.id)
         },
         FilingOutcome::ManualLink { url } => FeedbackResponse {
-            item_id: item.id.clone(),
-            filed: false,
-            blocked: false,
-            reason: None,
-            preview_body: None,
             prefilled_url: Some(url),
-            issue_url: None,
-            deduped: false,
+            ..FeedbackResponse::local(&item.id)
         },
     })
+}
+
+/// Forwards an already-scrubbed report to the TinyHumans hub.
+///
+/// The item is already persisted locally, so a hub that refuses or cannot be
+/// reached is a degraded success, not a failed request: the operator keeps their
+/// note and gets a plain reason. That mirrors how a GitHub rate-limit behaves.
+async fn forward_to_hub(
+    store: &FeedbackStore,
+    hub: &dyn TinyHumansClient,
+    item: &FeedbackItem,
+    handle: &str,
+    title: String,
+    scrubbed: String,
+) -> Result<FeedbackResponse> {
+    let request = IngestRequest {
+        category: item.category,
+        title,
+        body: scrubbed,
+        origin: handle.to_string(),
+        external_ref: item.id.clone(),
+    };
+
+    match hub.ingest(&request).await {
+        Ok(IngestOutcome::Accepted { remote_id }) => {
+            // The hub decides whether this becomes an issue, so there is no
+            // issue URL to record yet — only that it left this machine.
+            let remote = remote_id.unwrap_or_default();
+            store.update_status(&item.id, &remote, "forwarded").await?;
+            Ok(FeedbackResponse {
+                destination: FeedbackDestination::Tinyhumans,
+                filed: true,
+                ..FeedbackResponse::local(&item.id)
+            })
+        }
+        Ok(IngestOutcome::Rejected { reason }) => Ok(FeedbackResponse {
+            destination: FeedbackDestination::Tinyhumans,
+            reason: Some(reason),
+            ..FeedbackResponse::local(&item.id)
+        }),
+        Ok(IngestOutcome::RateLimited { reason }) => Ok(FeedbackResponse {
+            reason: Some(reason),
+            ..FeedbackResponse::local(&item.id)
+        }),
+        Err(err) => {
+            tracing::warn!(
+                item = %item.id,
+                error = %err,
+                "could not forward feedback to tinyhumans; it stays on this machine"
+            );
+            Ok(FeedbackResponse {
+                reason: Some("could not reach TinyHumans; your note is saved here".to_string()),
+                ..FeedbackResponse::local(&item.id)
+            })
+        }
+    }
 }
 
 /// The roster names/handles to redact (agent ids plus the company `@handle`

--- a/src/feedback/tinyhumans.rs
+++ b/src/feedback/tinyhumans.rs
@@ -1,0 +1,363 @@
+//! Forwarding feedback to the TinyHumans hub behind a mockable client.
+//!
+//! A provisioned instance — one configured with a TinyHumans credential — sends
+//! its feedback to the backend enrichment hub instead of filing a GitHub issue
+//! itself, so the report is recorded on behalf of the credential's owner and
+//! the hub decides whether an issue is ultimately filed.
+//!
+//! The [`TinyHumansClient`] trait and its offline [`MockTinyHumansClient`]
+//! compile in the default build so the whole routing decision is exercised
+//! without linking a network crate. Only the real HTTP client
+//! [`HttpTinyHumansClient`] is gated behind the `tinyhumans` feature.
+//!
+//! Two invariants this module must not break:
+//!
+//! * **Only scrubbed text leaves.** The body handed to [`TinyHumansClient::ingest`]
+//!   is the same one the scrub-then-preview gate produced, byte for byte, so
+//!   forwarding is not a second path around [`crate::feedback::scrub`].
+//! * **The credential never appears in a body.** It travels only as the
+//!   `Authorization` header, held by the HTTP client and never by a request.
+
+use std::sync::Mutex as StdMutex;
+
+use async_trait::async_trait;
+
+use crate::Result;
+use crate::feedback::types::FeedbackCategory;
+
+/// The product discriminator the hub routes on. Feedback from this runtime is
+/// always attributed to opencompany, whichever company reported it.
+pub const PRODUCT: &str = "opencompany";
+
+/// One feedback report to forward.
+///
+/// `title` and `body` are the byte-exact strings the preview showed; `origin`
+/// and `external_ref` let an operator trace a hub item back to the local one
+/// without carrying anything private across.
+#[derive(Clone, Debug, PartialEq)]
+pub struct IngestRequest {
+    /// The reported category, mapped to the hub's coarser type on the wire.
+    pub category: FeedbackCategory,
+    /// The issue title.
+    pub title: String,
+    /// The scrubbed, signed body.
+    pub body: String,
+    /// The reporting company's `@handle`.
+    pub origin: String,
+    /// The local [`FeedbackItem`](crate::feedback::FeedbackItem) id.
+    pub external_ref: String,
+}
+
+impl IngestRequest {
+    /// The hub's `type` for this report.
+    ///
+    /// The hub accepts only `feature | bug`, a coarser split than the local
+    /// taxonomy. Nothing is lost: the precise category is the first line of
+    /// every body (`**Category:** …`), and it also travels as `external_ref`'s
+    /// companion in the local store.
+    pub fn wire_type(&self) -> &'static str {
+        match self.category {
+            // Something the product did wrong.
+            FeedbackCategory::Bug | FeedbackCategory::WrongOutput => "bug",
+            // Something the product does not do (well enough) yet.
+            FeedbackCategory::MissingCapability
+            | FeedbackCategory::TemplateGap
+            | FeedbackCategory::ApprovalFriction
+            | FeedbackCategory::Docs => "feature",
+        }
+    }
+}
+
+/// What the hub did with a forwarded report.
+#[derive(Clone, Debug, PartialEq)]
+pub enum IngestOutcome {
+    /// The hub accepted the report into the enrichment pipeline.
+    Accepted {
+        /// The hub's id for the report, when it returned one.
+        remote_id: Option<String>,
+    },
+    /// The hub received the report but its moderation rejected it.
+    Rejected {
+        /// The human-safe moderation reason.
+        reason: String,
+    },
+    /// The owner's daily feedback limit was reached; nothing was recorded.
+    RateLimited {
+        /// The human-safe limit message.
+        reason: String,
+    },
+}
+
+/// The TinyHumans backend, scoped to feedback ingestion.
+#[async_trait]
+pub trait TinyHumansClient: Send + Sync {
+    /// Forwards one report to the hub, recorded as the credential's owner.
+    async fn ingest(&self, request: &IngestRequest) -> Result<IngestOutcome>;
+}
+
+/// An in-memory [`TinyHumansClient`] for offline tests.
+///
+/// Every forwarded request is recorded so a test can assert the *scrubbed* body
+/// crossed the boundary. Seed a non-accepting outcome with
+/// [`with_outcome`](Self::with_outcome) or a transport failure with
+/// [`with_failure`](Self::with_failure).
+#[derive(Debug)]
+pub struct MockTinyHumansClient {
+    forwarded: StdMutex<Vec<IngestRequest>>,
+    outcome: IngestOutcome,
+    failure: Option<String>,
+}
+
+impl Default for MockTinyHumansClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MockTinyHumansClient {
+    /// A mock that accepts everything.
+    pub fn new() -> Self {
+        Self {
+            forwarded: StdMutex::new(Vec::new()),
+            outcome: IngestOutcome::Accepted {
+                remote_id: Some("hub-1".to_string()),
+            },
+            failure: None,
+        }
+    }
+
+    /// Returns `outcome` instead of accepting.
+    pub fn with_outcome(mut self, outcome: IngestOutcome) -> Self {
+        self.outcome = outcome;
+        self
+    }
+
+    /// Fails every forward with `message`, simulating an unreachable hub.
+    pub fn with_failure(mut self, message: &str) -> Self {
+        self.failure = Some(message.to_string());
+        self
+    }
+
+    /// A snapshot of every request forwarded through this mock.
+    pub fn forwarded(&self) -> Vec<IngestRequest> {
+        self.forwarded.lock().expect("mock poisoned").clone()
+    }
+}
+
+#[async_trait]
+impl TinyHumansClient for MockTinyHumansClient {
+    async fn ingest(&self, request: &IngestRequest) -> Result<IngestOutcome> {
+        // Record before failing: a test asserting "we tried to send X" still
+        // sees the attempt on the failure path.
+        self.forwarded
+            .lock()
+            .expect("mock poisoned")
+            .push(request.clone());
+        if let Some(message) = &self.failure {
+            return Err(crate::error::OpenCompanyError::TinyHumans {
+                code: "unreachable".to_string(),
+                message: message.clone(),
+            });
+        }
+        Ok(self.outcome.clone())
+    }
+}
+
+/// The real HTTP TinyHumans client, compiled only under the `tinyhumans` feature.
+#[cfg(feature = "tinyhumans")]
+pub use http::HttpTinyHumansClient;
+
+#[cfg(feature = "tinyhumans")]
+mod http {
+    use super::{IngestOutcome, IngestRequest, PRODUCT, TinyHumansClient};
+    use crate::Result;
+    use crate::error::OpenCompanyError;
+    use crate::ports::types::SecretValue;
+    use async_trait::async_trait;
+
+    /// A [`TinyHumansClient`] backed by `POST {api_url}/feedback/ingest`.
+    ///
+    /// The credential authenticates the call; the backend resolves it to the
+    /// owning account, which is what makes a forwarded report "recorded on
+    /// behalf of the key owner".
+    pub struct HttpTinyHumansClient {
+        api_url: String,
+        credential: SecretValue,
+        http: reqwest::Client,
+    }
+
+    impl HttpTinyHumansClient {
+        /// Builds a client posting to `api_url` as `credential`'s owner.
+        pub fn new(api_url: impl Into<String>, credential: SecretValue) -> Self {
+            Self {
+                // Trailing slashes would produce `//feedback/ingest`.
+                api_url: api_url.into().trim_end_matches('/').to_string(),
+                credential,
+                http: reqwest::Client::new(),
+            }
+        }
+
+        fn err(context: &str, e: impl std::fmt::Display) -> OpenCompanyError {
+            OpenCompanyError::TinyHumans {
+                code: context.to_string(),
+                message: e.to_string(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl TinyHumansClient for HttpTinyHumansClient {
+        async fn ingest(&self, request: &IngestRequest) -> Result<IngestOutcome> {
+            let url = format!("{}/feedback/ingest", self.api_url);
+            let body = serde_json::json!({
+                "type": request.wire_type(),
+                "title": request.title,
+                "body": request.body,
+                "product": PRODUCT,
+                "origin": request.origin,
+                "externalRef": request.external_ref,
+            });
+            let resp = self
+                .http
+                .post(&url)
+                // The credential rides the header and only the header.
+                .bearer_auth(self.credential.expose())
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| Self::err("unreachable", e))?;
+
+            let status = resp.status();
+            let value: serde_json::Value = resp.json().await.map_err(|e| Self::err("decode", e))?;
+
+            // The daily-limit refusal is a normal outcome for a busy operator,
+            // not a transport failure: report it rather than erroring.
+            if status.as_u16() == 429 {
+                return Ok(IngestOutcome::RateLimited {
+                    reason: wire_error(&value)
+                        .unwrap_or_else(|| "daily feedback limit reached".to_string()),
+                });
+            }
+            if !status.is_success() {
+                return Err(OpenCompanyError::TinyHumans {
+                    code: format!("http_{}", status.as_u16()),
+                    message: wire_error(&value).unwrap_or_else(|| status.to_string()),
+                });
+            }
+
+            // { success, data: { accepted, reason, feedback } } — a 200 with
+            // `accepted: false` is a moderation rejection, not an error.
+            let data = value.get("data").unwrap_or(&serde_json::Value::Null);
+            let accepted = data
+                .get("accepted")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if !accepted {
+                return Ok(IngestOutcome::Rejected {
+                    reason: data
+                        .get("reason")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("rejected by moderation")
+                        .to_string(),
+                });
+            }
+            Ok(IngestOutcome::Accepted {
+                remote_id: data
+                    .get("feedback")
+                    .and_then(|f| f.get("id"))
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string),
+            })
+        }
+    }
+
+    /// The `error` string from a failure envelope, when present.
+    fn wire_error(value: &serde_json::Value) -> Option<String> {
+        value
+            .get("error")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn request(category: FeedbackCategory) -> IngestRequest {
+        IngestRequest {
+            category,
+            title: "[bug] it broke".to_string(),
+            body: "**Category:** bug\n\nit broke\n\n— filed by @acme".to_string(),
+            origin: "acme".to_string(),
+            external_ref: "item-1".to_string(),
+        }
+    }
+
+    #[test]
+    fn maps_categories_onto_the_hub_type_pair() {
+        // Something the product did wrong.
+        for category in [FeedbackCategory::Bug, FeedbackCategory::WrongOutput] {
+            assert_eq!(request(category).wire_type(), "bug", "{category:?}");
+        }
+        // Something the product does not do yet.
+        for category in [
+            FeedbackCategory::MissingCapability,
+            FeedbackCategory::TemplateGap,
+            FeedbackCategory::ApprovalFriction,
+            FeedbackCategory::Docs,
+        ] {
+            assert_eq!(request(category).wire_type(), "feature", "{category:?}");
+        }
+    }
+
+    #[test]
+    fn product_is_always_opencompany() {
+        assert_eq!(PRODUCT, "opencompany");
+    }
+
+    #[tokio::test]
+    async fn mock_records_the_forwarded_request() {
+        let client = MockTinyHumansClient::new();
+        let outcome = client
+            .ingest(&request(FeedbackCategory::Bug))
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome,
+            IngestOutcome::Accepted {
+                remote_id: Some("hub-1".to_string())
+            }
+        );
+        let forwarded = client.forwarded();
+        assert_eq!(forwarded.len(), 1);
+        assert_eq!(forwarded[0].external_ref, "item-1");
+        assert_eq!(forwarded[0].origin, "acme");
+    }
+
+    #[tokio::test]
+    async fn mock_can_reject_and_fail() {
+        let rejected = MockTinyHumansClient::new().with_outcome(IngestOutcome::Rejected {
+            reason: "spam".to_string(),
+        });
+        assert_eq!(
+            rejected
+                .ingest(&request(FeedbackCategory::Bug))
+                .await
+                .unwrap(),
+            IngestOutcome::Rejected {
+                reason: "spam".to_string()
+            }
+        );
+
+        let failing = MockTinyHumansClient::new().with_failure("connection refused");
+        assert!(
+            failing
+                .ingest(&request(FeedbackCategory::Bug))
+                .await
+                .is_err()
+        );
+        // The attempt is still recorded, so a test can assert what we tried to send.
+        assert_eq!(failing.forwarded().len(), 1);
+    }
+}

--- a/src/feedback/types.rs
+++ b/src/feedback/types.rs
@@ -115,6 +115,49 @@ pub struct FeedbackItem {
     pub consent_mode: ConsentMode,
 }
 
+/// The HTTP-safe projection of a [`FeedbackItem`] for the console's reports
+/// list.
+///
+/// Deliberately *not* a serialization of the whole item: `operator_words` and
+/// `context_excerpt` are local-only and are the two fields this type exists to
+/// leave behind. An operator sees what they reported and where it went, and
+/// re-reads their own words in the client that captured them.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct FeedbackSummary {
+    /// The item's id.
+    pub id: String,
+    /// The reported category.
+    pub category: FeedbackCategory,
+    /// The work item the feedback concerns, if any.
+    pub work_item: Option<String>,
+    /// Epoch-millis the item was captured.
+    pub at_millis: u64,
+    /// The filed issue URL, once filed.
+    pub filed_issue_url: Option<String>,
+    /// The last-observed status (`open`, `duplicate`, `forwarded`, …).
+    pub issue_status: Option<String>,
+}
+
+impl FeedbackSummary {
+    /// Projects an item, dropping every local-only field.
+    pub fn from_item(item: &FeedbackItem) -> Self {
+        Self {
+            id: item.id.clone(),
+            category: item.category,
+            work_item: item.work_item.clone(),
+            at_millis: item.at_millis,
+            // A forwarded item stores the hub's id here, which is not a URL;
+            // only surface this when it is one so the console can link it.
+            filed_issue_url: item
+                .filed_issue_url
+                .as_ref()
+                .filter(|url| url.starts_with("http"))
+                .cloned(),
+            issue_status: item.issue_status.clone(),
+        }
+    }
+}
+
 /// The maximum length of a captured context excerpt, in bytes. Data
 /// minimization: issues carry the minimum needed to reproduce.
 pub const CONTEXT_EXCERPT_CAP: usize = 2000;

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -22,6 +22,7 @@ use crate::company::runtime::{CompanyRuntime, OpsStores};
 use crate::feedback::github::{GitHubClient, RateLimiter};
 use crate::feedback::service::FeedbackFiler;
 use crate::feedback::store::FeedbackStore;
+use crate::feedback::tinyhumans::TinyHumansClient;
 use crate::feedback::tool::BuiltinToolProvider;
 use crate::feedback::types::ConsentMode;
 #[cfg(feature = "openhuman")]
@@ -146,6 +147,7 @@ pub struct RuntimeBuilder {
     seed_dir: Option<PathBuf>,
     feedback: Option<Arc<FeedbackStore>>,
     github: Option<Arc<dyn GitHubClient>>,
+    tinyhumans_feedback: Option<Arc<dyn TinyHumansClient>>,
     consent: ConsentMode,
     /// WS4: the embedded openhuman harness pool. Feature-gated so the default
     /// build is unaffected; wired through to [`CompanyRuntime`] when present.
@@ -199,6 +201,7 @@ impl RuntimeBuilder {
             seed_dir: None,
             feedback: None,
             github: None,
+            tinyhumans_feedback: None,
             consent: ConsentMode::default(),
             #[cfg(feature = "openhuman")]
             harness: None,
@@ -470,6 +473,17 @@ impl RuntimeBuilder {
         self
     }
 
+    /// Wires the TinyHumans hub for feedback forwarding (default: none → file
+    /// to GitHub instead).
+    ///
+    /// Set this only on a provisioned instance — one with a TinyHumans
+    /// credential. Its presence redirects feedback to the hub, where it is
+    /// recorded on behalf of the credential's owner.
+    pub fn with_tinyhumans_feedback(mut self, client: Arc<dyn TinyHumansClient>) -> Self {
+        self.tinyhumans_feedback = Some(client);
+        self
+    }
+
     /// Sets the standing feedback consent mode (default: `manual`).
     pub fn with_feedback_consent(mut self, consent: ConsentMode) -> Self {
         self.consent = consent;
@@ -545,6 +559,7 @@ impl RuntimeBuilder {
         let consent = self.consent;
         let filer = Arc::new(FeedbackFiler {
             client: self.github,
+            tinyhumans: self.tinyhumans_feedback,
             repo: crate::feedback::DEFAULT_REPO.to_string(),
             consent,
             limiter: RateLimiter::default(),

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -49,6 +49,13 @@ impl ApiError {
                 StatusCode::SERVICE_UNAVAILABLE
             }
             OpenCompanyError::Tinyplace { .. } => StatusCode::BAD_GATEWAY,
+            // The TinyHumans hub degrades the same way. In practice feedback
+            // forwarding swallows these (the report is already stored locally),
+            // so this mapping only applies if a future caller propagates one.
+            OpenCompanyError::TinyHumans { code, .. } if code == "unreachable" => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
+            OpenCompanyError::TinyHumans { .. } => StatusCode::BAD_GATEWAY,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/src/server/feedback.rs
+++ b/src/server/feedback.rs
@@ -5,7 +5,12 @@
 //! scrub-then-preview gate. The response never leaks a blocked value: a scrub
 //! abort returns `{ blocked: true, reason }`, a `preview` returns the byte-exact
 //! final body, and a satisfied consent returns the filed issue URL (or a
-//! prefilled manual link when no token is configured).
+//! prefilled manual link when no token is configured). `destination` reports
+//! where the report actually went.
+//!
+//! The matching `GET` routes list this company's reports for the console, as
+//! the [`FeedbackSummary`] projection — never the raw item, whose
+//! `operator_words` are local-only.
 
 use std::sync::Arc;
 
@@ -19,7 +24,7 @@ use crate::AppState;
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
 use crate::feedback::service::FeedbackResponse;
-use crate::feedback::types::FeedbackInput;
+use crate::feedback::types::{FeedbackInput, FeedbackSummary};
 use crate::ports::types::CompanyId;
 use crate::server::error::ApiError;
 use crate::server::platform_auth::{CompanyAuth, authorize_address, refuse_until_password_changed};
@@ -27,8 +32,11 @@ use crate::server::platform_auth::{CompanyAuth, authorize_address, refuse_until_
 /// Builds the feedback route fragment, merged into the main router.
 pub fn router() -> Router<AppState> {
     Router::new()
-        .route("/api/v1/companies/{id}/feedback", post(submit))
-        .route("/api/v1/company/feedback", post(submit_single))
+        .route("/api/v1/companies/{id}/feedback", post(submit).get(list))
+        .route(
+            "/api/v1/company/feedback",
+            post(submit_single).get(list_single),
+        )
 }
 
 /// The feedback submission body: the capture input plus a `preview` flag.
@@ -107,6 +115,43 @@ async fn submit_single(
         .map_err(IntoResponse::into_response)
 }
 
+/// `GET /api/v1/companies/{id}/feedback` — this company's reports, newest first.
+///
+/// Returns the [`FeedbackSummary`] projection, never the raw item: the
+/// operator's own words are local-only and must not cross this boundary.
+async fn list(
+    CompanyAuth(auth): CompanyAuth,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<Vec<FeedbackSummary>>, Response> {
+    let company = CompanyId::new(&id);
+    if let Some(resp) = authorize_address(&state, &auth, &company) {
+        return Err(resp);
+    }
+    let runtime = lookup(&state, &id).map_err(IntoResponse::into_response)?;
+    runtime
+        .list_feedback()
+        .await
+        .map(Json)
+        .map_err(|e| ApiError(e).into_response())
+}
+
+/// `GET /api/v1/company/feedback` (single-company alias).
+async fn list_single(
+    CompanyAuth(auth): CompanyAuth,
+    State(state): State<AppState>,
+) -> Result<Json<Vec<FeedbackSummary>>, Response> {
+    let runtime = sole(&state).map_err(IntoResponse::into_response)?;
+    if let Some(resp) = authorize_address(&state, &auth, runtime.id()) {
+        return Err(resp);
+    }
+    runtime
+        .list_feedback()
+        .await
+        .map(Json)
+        .map_err(|e| ApiError(e).into_response())
+}
+
 #[cfg(test)]
 mod test {
     use axum::body::{Body, to_bytes};
@@ -181,6 +226,25 @@ mod test {
         state.registry().insert(id, Arc::new(runtime));
         crate::server::test_support::seed_fixed_admin(&state, "acme").await;
         state
+    }
+
+    async fn get_json(app: &Router, uri: &str) -> (StatusCode, serde_json::Value) {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(uri)
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+        (status, value)
     }
 
     async fn post_json(app: &Router, uri: &str, body: &str) -> (StatusCode, serde_json::Value) {
@@ -415,6 +479,66 @@ mod test {
         assert_eq!(value["filed"], true);
         assert_eq!(value["destination"], "github");
         assert_eq!(github.created().len(), 1);
+
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    // The reports list shows what was reported and where it went, and never the
+    // operator's own words.
+    #[tokio::test]
+    async fn list_returns_summaries_without_operator_words() {
+        let home = home();
+        let github = Arc::new(MockGitHubClient::new());
+        let state = state_with_company(&home, github).await;
+        let app = router(state);
+
+        post_json(
+            &app,
+            "/api/v1/company/feedback",
+            r#"{"category":"bug","note":"the payroll run crashed","work_ref":"payroll.run"}"#,
+        )
+        .await;
+
+        let (status, value) = get_json(&app, "/api/v1/company/feedback").await;
+        assert_eq!(status, StatusCode::OK);
+        let items = value.as_array().expect("an array");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0]["category"], "bug");
+        assert_eq!(items[0]["work_item"], "payroll.run");
+        assert!(items[0]["id"].is_string());
+        assert!(items[0]["at_millis"].is_number());
+
+        // The local-only fields must not be in the payload at all.
+        let raw = value.to_string();
+        assert!(!raw.contains("payroll run crashed"), "got {raw}");
+        assert!(!raw.contains("operator_words"), "got {raw}");
+        assert!(!raw.contains("context_excerpt"), "got {raw}");
+
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    // A forwarded report stores the hub's id, which is not a URL — the list must
+    // not offer it as a link.
+    #[tokio::test]
+    async fn list_omits_a_non_url_reference_for_forwarded_reports() {
+        let home = home();
+        let github = Arc::new(MockGitHubClient::new());
+        let hub = Arc::new(MockTinyHumansClient::new());
+        let state = state_with_clients(&home, github, Some(hub)).await;
+        let app = router(state);
+
+        post_json(
+            &app,
+            "/api/v1/company/feedback",
+            r#"{"category":"bug","note":"the payroll run crashed"}"#,
+        )
+        .await;
+
+        let (_, value) = get_json(&app, "/api/v1/company/feedback").await;
+        let items = value.as_array().expect("an array");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0]["issue_status"], "forwarded");
+        assert!(items[0]["filed_issue_url"].is_null());
 
         tokio::fs::remove_dir_all(&home).await.ok();
     }

--- a/src/server/feedback.rs
+++ b/src/server/feedback.rs
@@ -115,8 +115,9 @@ mod test {
 
     use super::*;
     use crate::company::CompanyManifest;
-    use crate::feedback::MockGitHubClient;
+    use crate::feedback::tinyhumans::IngestOutcome;
     use crate::feedback::types::ConsentMode;
+    use crate::feedback::{MockGitHubClient, MockTinyHumansClient};
     use crate::ports::SecretStore;
     use crate::ports::types::SecretValue;
     use crate::runtime::RuntimeBuilder;
@@ -150,6 +151,16 @@ mod test {
     /// Builds state with a company wired for `auto` consent and a mock GitHub
     /// client, plus a seeded secret to exercise the scrub-abort path.
     async fn state_with_company(home: &std::path::Path, github: Arc<MockGitHubClient>) -> AppState {
+        state_with_clients(home, github, None).await
+    }
+
+    /// As [`state_with_company`], but optionally provisioned with a TinyHumans
+    /// hub — the "instance has a credential" case.
+    async fn state_with_clients(
+        home: &std::path::Path,
+        github: Arc<MockGitHubClient>,
+        hub: Option<Arc<MockTinyHumansClient>>,
+    ) -> AppState {
         let id = CompanyId::new("acme");
         // Seed a secret whose value the scrubber must abort on if it appears.
         let secrets = FsSecretStore::new(home.to_path_buf());
@@ -158,13 +169,14 @@ mod test {
             .await
             .unwrap();
 
-        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest())
+        let mut builder = RuntimeBuilder::new(home.to_path_buf(), manifest())
             .with_id(id.clone())
             .with_github(github)
-            .with_feedback_consent(ConsentMode::Auto)
-            .build()
-            .await
-            .unwrap();
+            .with_feedback_consent(ConsentMode::Auto);
+        if let Some(hub) = hub {
+            builder = builder.with_tinyhumans_feedback(hub);
+        }
+        let runtime = builder.build().await.unwrap();
         let state = AppState::new(AppConfig::default());
         state.registry().insert(id, Arc::new(runtime));
         crate::server::test_support::seed_fixed_admin(&state, "acme").await;
@@ -262,6 +274,147 @@ mod test {
         assert_eq!(value["deduped"], true);
         assert_eq!(github.created().len(), 1);
         assert_eq!(github.comments().len(), 1);
+
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    // A provisioned instance forwards to the hub instead of filing, and what
+    // crosses the boundary is the scrubbed body — not the operator's raw words.
+    #[tokio::test]
+    async fn provisioned_instance_forwards_scrubbed_body_and_files_nothing() {
+        let home = home();
+        let github = Arc::new(MockGitHubClient::new());
+        let hub = Arc::new(MockTinyHumansClient::new());
+        let state = state_with_clients(&home, github.clone(), Some(hub.clone())).await;
+        let app = router(state);
+
+        let (status, value) = post_json(
+            &app,
+            "/api/v1/company/feedback",
+            r#"{"category":"wrong-output","note":"email dana@acme.co bounced"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(value["filed"], true);
+        assert_eq!(value["destination"], "tinyhumans");
+        // The hub decides whether an issue exists, so we report no URL.
+        assert!(value["issue_url"].is_null());
+
+        // Nothing was filed from here.
+        assert!(github.created().is_empty());
+        assert!(github.comments().is_empty());
+
+        let forwarded = hub.forwarded();
+        assert_eq!(forwarded.len(), 1);
+        let sent = &forwarded[0];
+        assert!(sent.body.contains("⟨redacted:email⟩"), "got {}", sent.body);
+        assert!(!sent.body.contains("dana@acme.co"));
+        assert!(sent.body.contains("— filed by @acme"));
+        assert_eq!(sent.origin, "acme");
+        assert_eq!(sent.wire_type(), "bug");
+        assert!(!sent.external_ref.is_empty());
+
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    // The scrub gate runs before the destination choice, so a secret is blocked
+    // rather than forwarded.
+    #[tokio::test]
+    async fn scrub_abort_blocks_before_forwarding() {
+        let home = home();
+        let github = Arc::new(MockGitHubClient::new());
+        let hub = Arc::new(MockTinyHumansClient::new());
+        let state = state_with_clients(&home, github, Some(hub.clone())).await;
+        let app = router(state);
+
+        let (status, value) = post_json(
+            &app,
+            "/api/v1/company/feedback",
+            r#"{"category":"bug","note":"token ghp_LEAKEDSECRET broke the run"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(value["blocked"], true);
+        assert_eq!(value["destination"], "local");
+        assert!(
+            hub.forwarded().is_empty(),
+            "a blocked report must not leave"
+        );
+
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    // An unreachable hub is a degraded success: the note is already stored, so
+    // the operator gets a reason rather than a failed request.
+    #[tokio::test]
+    async fn unreachable_hub_degrades_to_local() {
+        let home = home();
+        let github = Arc::new(MockGitHubClient::new());
+        let hub = Arc::new(MockTinyHumansClient::new().with_failure("connection refused"));
+        let state = state_with_clients(&home, github.clone(), Some(hub)).await;
+        let app = router(state);
+
+        let (status, value) = post_json(
+            &app,
+            "/api/v1/company/feedback",
+            r#"{"category":"bug","note":"the run crashed"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(value["filed"], false);
+        assert_eq!(value["destination"], "local");
+        assert!(value["reason"].is_string());
+        // It must not silently fall back to filing an issue instead.
+        assert!(github.created().is_empty());
+
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    // Moderation rejection is reported as such, not as a transport failure.
+    #[tokio::test]
+    async fn hub_moderation_rejection_is_reported() {
+        let home = home();
+        let github = Arc::new(MockGitHubClient::new());
+        let hub = Arc::new(
+            MockTinyHumansClient::new().with_outcome(IngestOutcome::Rejected {
+                reason: "off-topic".to_string(),
+            }),
+        );
+        let state = state_with_clients(&home, github, Some(hub)).await;
+        let app = router(state);
+
+        let (status, value) = post_json(
+            &app,
+            "/api/v1/company/feedback",
+            r#"{"category":"docs","note":"the docs are thin"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(value["filed"], false);
+        assert_eq!(value["destination"], "tinyhumans");
+        assert_eq!(value["reason"], "off-topic");
+
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    // Without a credential the original GitHub path is untouched.
+    #[tokio::test]
+    async fn unprovisioned_instance_still_files_to_github() {
+        let home = home();
+        let github = Arc::new(MockGitHubClient::new());
+        let state = state_with_company(&home, github.clone()).await;
+        let app = router(state);
+
+        let (status, value) = post_json(
+            &app,
+            "/api/v1/company/feedback",
+            r#"{"category":"bug","note":"the run crashed"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(value["filed"], true);
+        assert_eq!(value["destination"], "github");
+        assert_eq!(github.created().len(), 1);
 
         tokio::fs::remove_dir_all(&home).await.ok();
     }


### PR DESCRIPTION
## Overview

On an instance provisioned with a TinyHumans credential, operator feedback is now forwarded to the backend enrichment hub and **recorded on behalf of the credential's owner**, instead of the runtime filing its own GitHub issue. Without a credential, behavior is unchanged.

This is the product-side half of the follow-up named in [backend#1104](https://github.com/tinyhumansai/backend/pull/1104) ("product-side forwarding from openhuman/opencompany — the backend contract is ready"). It needs **no backend change**: a literal API key does not exist server-side yet, so the credential — a session JWT today, per `docs/spec/runtime/config.md` — is passed through as `Authorization: Bearer` and `authenticateJWT` resolves the owner. The env var name stays the stable contract if/when a real API-key path ships.

## Changes

### Runtime

- **`src/feedback/tinyhumans.rs`** (new) — follows the existing `GitHubClient` shape: `TinyHumansClient` trait + `MockTinyHumansClient` in the default build, `HttpTinyHumansClient` behind a new optional `tinyhumans` feature. This matters because `reqwest` is optional here and the default build deliberately links no network crates. Posts to `{api_url}/feedback/ingest` with `product: opencompany`, the company `@handle` as `origin`, and the local item id as `externalRef`. The hub's coarser `feature | bug` type is mapped from the local category; nothing is lost, since the precise category is the first line of every body.
- **`src/feedback/service.rs`** — `finalize` branches after the scrub gate: credential present → forward and file nothing; absent → today's GitHub path, untouched. New `destination` field (`tinyhumans` | `github` | `local`) on `FeedbackResponse`.
- **`src/server/feedback.rs`** — `GET /api/v1/companies/{id}/feedback` (+ single-company alias). `FeedbackStore::list()` already existed with no route.
- Wiring via `RuntimeBuilder::with_tinyhumans_feedback`, attached in `bin/opencompany.rs` only when `tinyhumans_credential` is set, cfg-gated with an identity fallback.

### Console

`FeedbackView` reads `cycles_available` from the already-existing `GET /spec` to say where reports go, and gains a **"Your reports"** section. Success copy branches on `destination` rather than inferring one from which optional fields happen to be set; the "file it yourself" link is suppressed when the report went to the hub, since there is no issue to file and offering it would only cause a duplicate.

## Invariants held

- **Only scrubbed text leaves.** Both destinations receive the byte-identical body the preview showed — forwarding is not a second exit around the fail-closed scrubber.
- **The credential never appears in a body**, log line, or stored item; it travels only as a header.
- **No silent fallback to a public issue.** The item is stored before the send, so an unreachable or refusing hub is a degraded success — the operator keeps their note and gets a plain reason.
- **`operator_words` never crosses the HTTP boundary.** The new `GET` returns a `FeedbackSummary` projection that drops it and `context_excerpt`.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --features tinyhumans --all-targets -- -D warnings`
- [x] `cargo test` — 471 passing on the **default** build, which is the load-bearing check that the trait+mock path works with no network feature enabled
- [x] `npm run build` (runs `tsc -b`)

Seven new tests: category→type mapping and the mock's record/reject/fail paths; and end-to-end through the router — the hub receives the *scrubbed* body while GitHub is never called, a scrub abort blocks *before* forwarding, an unreachable hub degrades without falling back to filing, moderation rejection is reported as such, the unprovisioned path still files to GitHub, and the list route omits operator words and non-URL references.

## Notes

**Not exercised against a live backend** — that needs a real credential:

```bash
TINYHUMANS_API_KEY=<session-jwt> cargo run --features tinyhumans -- serve --company companies/<name>
```

Then confirm `destination: "tinyhumans"` and that the item appears under the backend's `/feedback/admin/triage` attributed to the credential owner. Worth doing before enabling the feature anywhere real.

Out of scope: the dashboard admin triage UI (#1104's other follow-up), real API-key auth in the backend (`docs/spec/roadmap.md`), and openhuman forwarding.
