### PR TITLE
feat: tenant identity namespace for shared-database deployments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,13 @@ injects its environment. When developing hosted behavior, know the seams:
   tenant container, plus — when database-per-tenant storage is enabled —
   `OPENCOMPANY_STORAGE=mongodb`, `OPENCOMPANY_MONGODB_URI` (credentials
   scoped to that tenant's database only), and `OPENCOMPANY_MONGODB_DB`.
+- In the alternative **shared-single-DB** mode (all tenants on one logical
+  MongoDB), the manager also injects `OPENCOMPANY_TENANT_ID=<tenant-slug>`.
+  The workload then namespaces company ids with `<tenant>--` and records
+  `owners` rows so tenants stay apart in the shared database. Isolation is
+  application-layer only in this mode — a compromised container can reach
+  every tenant's documents; db-per-tenant stays the security default. See
+  `docs/spec/runtime/storage.md`. Unset (the default) is a full no-op.
 - Storage backend selection and the MongoDB backend are documented in
   `docs/spec/runtime/storage.md`; the port traits it implements are the
   entire persistence contract (`docs/spec/runtime/ports.md`).

--- a/docs/spec/runtime/storage.md
+++ b/docs/spec/runtime/storage.md
@@ -36,6 +36,8 @@ MongoDB settings:
 
 - `OPENCOMPANY_MONGODB_URI` — connection string (required for `mongodb`).
 - `OPENCOMPANY_MONGODB_DB` — database name (default `opencompany`).
+- `OPENCOMPANY_TENANT_ID` — tenant identity for **shared-single-DB** mode
+  (default unset). See [Shared single database](#shared-single-database-mode).
 
 ## MongoDB backend (`src/store/mongodb.rs`)
 
@@ -68,6 +70,44 @@ on each `record` (see [ports.md](ports.md), `UsageMeter`).
    collection makes the company → tenant map durable: `serve` hydrates the
    in-memory `AppState` ownership map from it at boot, and provisioning
    updates it — closing the previous restart-loses-ownership stub.
+
+### Shared single database (`OPENCOMPANY_TENANT_ID`) mode
+
+An operator may run every tenant workload against **one** logical MongoDB
+database instead of one database per tenant (e.g. to stay under a managed
+cluster's database/namespace limits). In this mode the manager injects
+`OPENCOMPANY_TENANT_ID=<tenant-slug>` (alongside `OPENCOMPANY_MONGODB_DB`
+pointing all tenants at the shared database name) so the workload can keep its
+records apart:
+
+- **Id namespacing.** Company ids are prefixed with `<tenant>--` before they
+  reach the store (`AppConfig::namespaced_company_id`). The boot path prefixes
+  with the workload's own `OPENCOMPANY_TENANT_ID`; the API provisioning path
+  prefixes with the acting tenant of the request. This keeps the same boot
+  template (`OPENCOMPANY_COMPANY=agentic_software_company` for every tenant)
+  from colliding on the `companies` collection's unique `company_id` index. The
+  prefix is idempotent — an already-prefixed id passes through unchanged.
+- **Ownership.** The boot company's `company_id -> tenant_id` mapping is written
+  to the `owners` collection (best-effort), so a shared-DB manager can enumerate
+  and purge a tenant's companies later. Owners hydration at boot filters to rows
+  whose `tenant_id` equals this workload's `OPENCOMPANY_TENANT_ID`, so the
+  in-memory ownership map never carries other tenants' companies.
+
+Everything is backwards compatible: with `OPENCOMPANY_TENANT_ID` unset, id
+derivation, ownership recording, and owners hydration behave exactly as before
+(the db-per-tenant and single-tenant paths are unchanged).
+
+#### Isolation tradeoff — read this before enabling shared-single-DB mode
+
+In shared-single-DB mode all tenant workloads hold credentials to the **same**
+logical database. Isolation is **application-layer only** — the `<tenant>--`
+id namespace, the `company_id` filter on every query, and the registry serving
+only locally-loaded companies. A compromised or malicious tenant container that
+reaches the database directly can read and write **every** tenant's documents;
+nothing at the MongoDB auth layer stops it. Database-per-tenant (layer 1 below)
+remains the security-recommended mode and stays the manager default; enable
+shared-single-DB mode only where the operational constraint outweighs this
+weaker isolation.
 
 ### Adding another backend (e.g. DynamoDB)
 

--- a/docs/spec/runtime/storage.md
+++ b/docs/spec/runtime/storage.md
@@ -81,17 +81,24 @@ pointing all tenants at the shared database name) so the workload can keep its
 records apart:
 
 - **Id namespacing.** Company ids are prefixed with `<tenant>--` before they
-  reach the store (`AppConfig::namespaced_company_id`). The boot path prefixes
-  with the workload's own `OPENCOMPANY_TENANT_ID`; the API provisioning path
-  prefixes with the acting tenant of the request. This keeps the same boot
-  template (`OPENCOMPANY_COMPANY=agentic_software_company` for every tenant)
-  from colliding on the `companies` collection's unique `company_id` index. The
+  reach the store (`AppConfig::namespaced_company_id`). Both the boot path and
+  the API provisioning path prefix with the workload's own
+  `OPENCOMPANY_TENANT_ID` — config, not the request's acting tenant, is
+  authoritative for this workload's data scope. So even a full-platform token
+  provisioning on behalf of another tenant yields a workload-local id rather
+  than one prefixed with a foreign tenant. This keeps the same boot template
+  (`OPENCOMPANY_COMPANY=agentic_software_company` for every tenant) from
+  colliding on the `companies` collection's unique `company_id` index. The
   prefix is idempotent — an already-prefixed id passes through unchanged.
-- **Ownership.** The boot company's `company_id -> tenant_id` mapping is written
-  to the `owners` collection (best-effort), so a shared-DB manager can enumerate
-  and purge a tenant's companies later. Owners hydration at boot filters to rows
-  whose `tenant_id` equals this workload's `OPENCOMPANY_TENANT_ID`, so the
-  in-memory ownership map never carries other tenants' companies.
+- **Ownership.** A provisioned or boot company's `company_id -> tenant_id`
+  mapping is written to the `owners` collection (best-effort) with the
+  workload's own `OPENCOMPANY_TENANT_ID`, so a shared-DB manager can enumerate
+  and purge a tenant's companies later. Recording the same value the id is
+  namespaced with is what lets owners hydration reload it: hydration at boot
+  filters to rows whose `tenant_id` equals this workload's
+  `OPENCOMPANY_TENANT_ID`, so the in-memory ownership map never carries other
+  tenants' companies and no API-provisioned company is orphaned across a
+  restart.
 
 Everything is backwards compatible: with `OPENCOMPANY_TENANT_ID` unset, id
 derivation, ownership recording, and owners hydration behave exactly as before

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,4 +4,4 @@ mod types;
 
 pub use config::{BrainMode, ConfigProvenance, RuntimeConfig, resolve};
 pub use doctor::{DoctorReport, report as doctor_report};
-pub use types::{AppConfig, AppSpec, AppState};
+pub use types::{AppConfig, AppSpec, AppState, namespace_company_id};

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -79,8 +79,9 @@ impl Default for AppConfig {
 ///
 /// Idempotent: an id already carrying the `<tenant>--` prefix is returned
 /// unchanged, so applying it more than once — or to an id read back from a
-/// shared DB — never double-prefixes. The boot path uses the workload's own
-/// [`AppConfig::tenant_namespace`]; API provisioning uses the acting tenant.
+/// shared DB — never double-prefixes. Both the boot path and API provisioning
+/// use the workload's own [`AppConfig::tenant_namespace`], so ids stay
+/// workload-local regardless of which tenant a provisioning request acts for.
 pub fn namespace_company_id(tenant: &str, id: CompanyId) -> CompanyId {
     let prefix = format!("{tenant}--");
     if id.as_ref().starts_with(&prefix) {

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -47,6 +47,13 @@ pub struct AppConfig {
     pub max_companies_per_tenant: Option<usize>,
     /// Outbound webhook delivery configuration. `None` disables webhooks.
     pub webhook: Option<WebhookConfig>,
+    /// Tenant namespace for shared-single-DB deployments
+    /// (`OPENCOMPANY_TENANT_ID`). When set, provisioned/booted company ids are
+    /// prefixed with `<tenant>--` via [`Self::namespaced_company_id`] so many
+    /// tenants sharing one logical database never collide on the `companies`
+    /// unique index. `None` (the default) is a no-op: db-per-tenant and
+    /// single-tenant deployments are unaffected.
+    pub tenant_namespace: Option<String>,
 }
 
 impl Default for AppConfig {
@@ -63,7 +70,23 @@ impl Default for AppConfig {
             max_companies: None,
             max_companies_per_tenant: None,
             webhook: None,
+            tenant_namespace: None,
         }
+    }
+}
+
+/// Prefixes `id` with `<tenant>--` for shared-single-DB namespacing.
+///
+/// Idempotent: an id already carrying the `<tenant>--` prefix is returned
+/// unchanged, so applying it more than once — or to an id read back from a
+/// shared DB — never double-prefixes. The boot path uses the workload's own
+/// [`AppConfig::tenant_namespace`]; API provisioning uses the acting tenant.
+pub fn namespace_company_id(tenant: &str, id: CompanyId) -> CompanyId {
+    let prefix = format!("{tenant}--");
+    if id.as_ref().starts_with(&prefix) {
+        id
+    } else {
+        CompanyId::new(format!("{prefix}{}", id.as_ref()))
     }
 }
 
@@ -71,6 +94,20 @@ impl AppConfig {
     /// True when hosted cognition can run: hosted mode plus a credential.
     pub fn cycles_available(&self) -> bool {
         self.brain_mode == BrainMode::Hosted && self.tinyhumans_credential.is_some()
+    }
+
+    /// Namespaces a company id for shared-single-DB mode.
+    ///
+    /// Returns `<tenant>--<id>` when [`Self::tenant_namespace`] is set and `id`
+    /// is not already prefixed; returns `id` unchanged when the namespace is
+    /// unset (the no-op that keeps db-per-tenant deployments identical).
+    /// Idempotent: an already-prefixed id passes through untouched, so applying
+    /// it twice — or to an id read back from a shared DB — never double-prefixes.
+    pub fn namespaced_company_id(&self, id: CompanyId) -> CompanyId {
+        match &self.tenant_namespace {
+            Some(tenant) => namespace_company_id(tenant, id),
+            None => id,
+        }
     }
 
     /// The host base URL to embed in published Agent Card endpoints: the
@@ -142,6 +179,7 @@ impl std::fmt::Debug for AppConfig {
             .field("max_companies", &self.max_companies)
             .field("max_companies_per_tenant", &self.max_companies_per_tenant)
             .field("webhook", &self.webhook)
+            .field("tenant_namespace", &self.tenant_namespace)
             .finish()
     }
 }
@@ -535,6 +573,38 @@ mod tests {
             .skill_registry(std::path::Path::new("/nonexistent"))
             .expect("cached registry");
         assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn namespaced_company_id_is_noop_when_unset() {
+        let config = AppConfig::default();
+        assert!(config.tenant_namespace.is_none());
+        let id = CompanyId::new("agentic-software-company");
+        assert_eq!(config.namespaced_company_id(id.clone()), id);
+    }
+
+    #[test]
+    fn namespaced_company_id_prefixes_when_set() {
+        let config = AppConfig {
+            tenant_namespace: Some("acme".into()),
+            ..AppConfig::default()
+        };
+        assert_eq!(
+            config.namespaced_company_id(CompanyId::new("agentic-software-company")),
+            CompanyId::new("acme--agentic-software-company")
+        );
+    }
+
+    #[test]
+    fn namespaced_company_id_is_idempotent() {
+        let config = AppConfig {
+            tenant_namespace: Some("acme".into()),
+            ..AppConfig::default()
+        };
+        let once = config.namespaced_company_id(CompanyId::new("agentic-software-company"));
+        let twice = config.namespaced_company_id(once.clone());
+        assert_eq!(once, twice);
+        assert_eq!(once, CompanyId::new("acme--agentic-software-company"));
     }
 
     #[test]

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -192,6 +192,12 @@ async fn register_company(
     .with_seed_dir(company_source_dir(dir))
     .with_tinyplace_api_url(state.config().tinyplace_api_url.clone())
     .with_host_base_url(state.config().host_base_url());
+    // Shared-single-DB mode: namespace the derived id with this tenant so the
+    // same boot template (`OPENCOMPANY_COMPANY`) does not collide across tenants
+    // in one logical database. A no-op when `tenant_namespace` is unset.
+    let derived = opencompany::runtime::company_id_from_name(&name);
+    let company_id = state.config().namespaced_company_id(derived);
+    builder = builder.with_id(company_id);
     if let Some(stores) = state.stores() {
         builder = builder.with_stores(stores);
     }
@@ -199,10 +205,20 @@ async fn register_company(
         builder = builder.with_discoverable(true);
     }
     let runtime = builder.build().await?;
-    let id = runtime.id().as_ref().to_string();
-    state
-        .registry()
-        .insert(runtime.id().clone(), Arc::new(runtime));
+    let company_id = runtime.id().clone();
+    let id = company_id.as_ref().to_string();
+    // Record boot-company ownership so a shared-DB manager can later purge by
+    // tenant. Only meaningful in tenant-namespace mode; otherwise skipped so
+    // db-per-tenant / self-hosted deployments keep their in-memory-only stub.
+    if let Some(tenant) = state.config().tenant_namespace.clone() {
+        state.set_owner(company_id.clone(), tenant.clone());
+        if let Some(ownership) = state.stores().and_then(|s| s.ownership.clone())
+            && let Err(err) = ownership.set_owner(&company_id, &tenant).await
+        {
+            eprintln!("failed to persist ownership for `{id}`: {err}");
+        }
+    }
+    state.registry().insert(company_id, Arc::new(runtime));
     Ok((id, name, schedules))
 }
 
@@ -535,11 +551,19 @@ async fn main() -> Result<()> {
             let public_url = std::env::var("OPENCOMPANY_PUBLIC_URL")
                 .ok()
                 .filter(|value| !value.trim().is_empty());
+            // Shared-single-DB tenant identity. When set, company ids are
+            // namespaced with this value so many tenants can share one logical
+            // database without colliding on the `companies` unique index. Unset
+            // (db-per-tenant / single-tenant) keeps every id derivation as-is.
+            let tenant_namespace = std::env::var("OPENCOMPANY_TENANT_ID")
+                .ok()
+                .filter(|value| !value.trim().is_empty());
             let mut state = AppState::new(AppConfig {
                 bind,
                 openhuman_root,
                 tinyplace_api_url,
                 public_url,
+                tenant_namespace,
                 ..AppConfig::default()
             })
             .with_cors(opencompany::server::cors::CorsConfig::from_env()?)
@@ -557,10 +581,18 @@ async fn main() -> Result<()> {
                 opencompany::store::open_storage(&storage_settings, &home).await?
             {
                 // Shared-database platform mode: restore the durable company →
-                // tenant map so ownership survives restarts.
+                // tenant map so ownership survives restarts. In shared-single-DB
+                // mode the `owners` collection holds every tenant's rows; hydrate
+                // only this tenant's own mappings so the in-memory map never
+                // leaks other tenants' companies (which are unaddressable here
+                // regardless, since the registry only holds locally-loaded ones).
                 if let Some(ownership) = &handles.ownership {
+                    let self_tenant = state.config().tenant_namespace.clone();
                     for (id, tenant) in ownership.owners().await? {
-                        state.set_owner(id, tenant);
+                        match &self_tenant {
+                            Some(me) if &tenant != me => continue,
+                            _ => state.set_owner(id, tenant),
+                        }
                     }
                 }
                 state = state.with_stores(handles);

--- a/src/server/provision.rs
+++ b/src/server/provision.rs
@@ -128,18 +128,30 @@ async fn provision(
         Some(raw) => CompanyId::new(raw),
         None => company_id_from_name(&manifest.company.name),
     };
-    // The tenant this request acts for; also the ownership record below.
-    let tenant = acting_tenant(&GqlAuth::Platform(claims.clone()));
-    // Shared-single-DB mode: namespace the id with the acting tenant so that
-    // API-provisioned companies are globally unique in one logical database
-    // (the same template name under two tenants no longer collides on the
-    // `companies` unique index). A no-op when the workload is not in
-    // tenant-namespace mode; idempotent for an already-prefixed explicit id.
-    let id = if state.config().tenant_namespace.is_some() {
-        crate::app::namespace_company_id(&tenant, id)
-    } else {
-        id
-    };
+    // The tenant that owns this company and namespaces its id.
+    //
+    // In shared-single-DB mode the workload's *configured* namespace
+    // (`OPENCOMPANY_TENANT_ID`) is authoritative for its own data scope: config,
+    // not the request's acting tenant, decides where this workload writes. Using
+    // it keeps the id and the ownership record workload-local even when a
+    // full-platform token provisions on behalf of another tenant, and it matches
+    // the filter boot hydration applies to the persisted `owners` rows (also
+    // `AppConfig::tenant_namespace`) — so an API-provisioned company survives a
+    // restart instead of being orphaned by a foreign-tenant prefix.
+    //
+    // Outside shared-single-DB mode the acting tenant is recorded, feeding
+    // per-tenant quota and db-per-tenant / self-hosted ownership as before.
+    let tenant = state
+        .config()
+        .tenant_namespace
+        .clone()
+        .unwrap_or_else(|| acting_tenant(&GqlAuth::Platform(claims.clone())));
+    // Namespace the id with the workload's tenant so API-provisioned companies
+    // are globally unique in one logical database (the same template name under
+    // two tenant workloads no longer collides on the `companies` unique index).
+    // A no-op when tenant-namespace mode is off; idempotent for an already-
+    // prefixed explicit id.
+    let id = state.config().namespaced_company_id(id);
 
     // Reject a duplicate id.
     if state.registry().get(&id).is_some() {

--- a/src/server/provision.rs
+++ b/src/server/provision.rs
@@ -128,6 +128,18 @@ async fn provision(
         Some(raw) => CompanyId::new(raw),
         None => company_id_from_name(&manifest.company.name),
     };
+    // The tenant this request acts for; also the ownership record below.
+    let tenant = acting_tenant(&GqlAuth::Platform(claims.clone()));
+    // Shared-single-DB mode: namespace the id with the acting tenant so that
+    // API-provisioned companies are globally unique in one logical database
+    // (the same template name under two tenants no longer collides on the
+    // `companies` unique index). A no-op when the workload is not in
+    // tenant-namespace mode; idempotent for an already-prefixed explicit id.
+    let id = if state.config().tenant_namespace.is_some() {
+        crate::app::namespace_company_id(&tenant, id)
+    } else {
+        id
+    };
 
     // Reject a duplicate id.
     if state.registry().get(&id).is_some() {
@@ -139,7 +151,6 @@ async fn provision(
     }
 
     // Quota: per-tenant then global.
-    let tenant = acting_tenant(&GqlAuth::Platform(claims.clone()));
     if let Some(max) = state.config().max_companies_per_tenant
         && state.tenant_company_count(&tenant) >= max
     {

--- a/src/server/provision/test.rs
+++ b/src/server/provision/test.rs
@@ -39,12 +39,15 @@ fn platform_state(home: &std::path::Path, max_per_tenant: Option<usize>) -> AppS
         .with_quota(None, max_per_tenant)
 }
 
-/// A platform state in shared-single-DB mode: `tenant_namespace` is set, which
-/// turns on id-namespacing by the acting tenant of each provisioning request.
-fn namespaced_state(home: &std::path::Path) -> AppState {
+/// A platform state in shared-single-DB mode for the workload tenant
+/// `namespace` (its `OPENCOMPANY_TENANT_ID`). The configured namespace — not the
+/// request's acting tenant — is authoritative for the id prefix and the
+/// ownership record, so ids and owners stay workload-local and survive boot
+/// hydration, which filters the `owners` rows by this same value.
+fn namespaced_state(home: &std::path::Path, namespace: &str) -> AppState {
     let verifier = Arc::new(StaticPlatformVerifier::new(PLATFORM_SECRET));
     AppState::new(AppConfig {
-        tenant_namespace: Some("shared".to_string()),
+        tenant_namespace: Some(namespace.to_string()),
         ..AppConfig::default()
     })
     .with_home(home.to_path_buf())
@@ -259,49 +262,61 @@ async fn duplicate_id_conflicts() {
 }
 
 #[tokio::test]
-async fn provision_namespaces_id_by_acting_tenant() {
+async fn provision_namespaces_id_by_workload_tenant() {
     let home = home();
-    let state = namespaced_state(&home);
+    // Workload tenant is `tenant-a`.
+    let state = namespaced_state(&home, "tenant-a");
+    // Keep a handle on the shared ownership map to inspect what boot hydration
+    // (which filters `owners` rows by the configured namespace) would reload.
+    let observed = state.clone();
     let app = router(state);
 
-    // A platform-scope token acting as `tenant-a` provisions the Acme template.
-    let token = tenant_token("tenant-a", &["platform", "operator"]);
+    // A *full-platform* token provisions the Acme template. Its acting tenant is
+    // `tenant:platform`, not `tenant-a` — yet the id and owner must be keyed to
+    // the workload tenant, or the company is orphaned at reboot.
     let response = app
-        .oneshot(provision_req(Some(&token), ACME_TOML))
+        .oneshot(provision_req(Some(PLATFORM_SECRET), ACME_TOML))
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::CREATED);
-    // The derived id `acme` is namespaced with the acting tenant.
+    // The derived id `acme` is namespaced with the workload tenant, not the
+    // acting `tenant:platform`.
     assert_eq!(json_body(response).await["id"], "tenant-a--acme");
+    // The ownership row records the workload tenant — exactly what boot
+    // hydration filters on — so the company survives a restart.
+    let id = CompanyId::new("tenant-a--acme");
+    assert_eq!(observed.owner_of(&id).as_deref(), Some("tenant-a"));
     std::fs::remove_dir_all(&home).ok();
 }
 
 #[tokio::test]
-async fn same_template_under_two_tenants_does_not_conflict() {
-    let home = home();
-    let state = namespaced_state(&home);
-    let app = router(state);
-
-    // Tenant A provisions the Acme template.
+async fn same_template_under_two_tenant_workloads_does_not_conflict() {
+    // Two tenants are two separate workloads (containers), each with its own
+    // `OPENCOMPANY_TENANT_ID`, writing to one shared logical database. In a
+    // shared DB the derived id `acme` used to collide; per-workload namespacing
+    // keeps them distinct.
+    let home_a = home();
+    let app_a = router(namespaced_state(&home_a, "tenant-a"));
     let a = tenant_token("tenant-a", &["platform", "operator"]);
-    let first = app
-        .clone()
+    let first = app_a
         .oneshot(provision_req(Some(&a), ACME_TOML))
         .await
         .unwrap();
     assert_eq!(first.status(), StatusCode::CREATED);
     assert_eq!(json_body(first).await["id"], "tenant-a--acme");
 
-    // Tenant B provisions the *same* template name — in a shared DB this used
-    // to collide on the derived id `acme`; namespacing keeps them distinct.
+    let home_b = home();
+    let app_b = router(namespaced_state(&home_b, "tenant-b"));
     let b = tenant_token("tenant-b", &["platform", "operator"]);
-    let second = app
+    let second = app_b
         .oneshot(provision_req(Some(&b), ACME_TOML))
         .await
         .unwrap();
     assert_eq!(second.status(), StatusCode::CREATED);
     assert_eq!(json_body(second).await["id"], "tenant-b--acme");
-    std::fs::remove_dir_all(&home).ok();
+
+    std::fs::remove_dir_all(&home_a).ok();
+    std::fs::remove_dir_all(&home_b).ok();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/provision/test.rs
+++ b/src/server/provision/test.rs
@@ -39,6 +39,18 @@ fn platform_state(home: &std::path::Path, max_per_tenant: Option<usize>) -> AppS
         .with_quota(None, max_per_tenant)
 }
 
+/// A platform state in shared-single-DB mode: `tenant_namespace` is set, which
+/// turns on id-namespacing by the acting tenant of each provisioning request.
+fn namespaced_state(home: &std::path::Path) -> AppState {
+    let verifier = Arc::new(StaticPlatformVerifier::new(PLATFORM_SECRET));
+    AppState::new(AppConfig {
+        tenant_namespace: Some("shared".to_string()),
+        ..AppConfig::default()
+    })
+    .with_home(home.to_path_buf())
+    .with_platform_auth(PlatformAuthConfig::new(verifier))
+}
+
 fn tenant_token(tenant: &str, scopes: &[&str]) -> String {
     StaticPlatformVerifier::tenant_token(&PlatformClaims {
         tenant: tenant.to_string(),
@@ -243,6 +255,52 @@ async fn duplicate_id_conflicts() {
         .unwrap();
     assert_eq!(dup.status(), StatusCode::CONFLICT);
     assert_eq!(json_body(dup).await["code"], "company_exists");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[tokio::test]
+async fn provision_namespaces_id_by_acting_tenant() {
+    let home = home();
+    let state = namespaced_state(&home);
+    let app = router(state);
+
+    // A platform-scope token acting as `tenant-a` provisions the Acme template.
+    let token = tenant_token("tenant-a", &["platform", "operator"]);
+    let response = app
+        .oneshot(provision_req(Some(&token), ACME_TOML))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    // The derived id `acme` is namespaced with the acting tenant.
+    assert_eq!(json_body(response).await["id"], "tenant-a--acme");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[tokio::test]
+async fn same_template_under_two_tenants_does_not_conflict() {
+    let home = home();
+    let state = namespaced_state(&home);
+    let app = router(state);
+
+    // Tenant A provisions the Acme template.
+    let a = tenant_token("tenant-a", &["platform", "operator"]);
+    let first = app
+        .clone()
+        .oneshot(provision_req(Some(&a), ACME_TOML))
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::CREATED);
+    assert_eq!(json_body(first).await["id"], "tenant-a--acme");
+
+    // Tenant B provisions the *same* template name — in a shared DB this used
+    // to collide on the derived id `acme`; namespacing keeps them distinct.
+    let b = tenant_token("tenant-b", &["platform", "operator"]);
+    let second = app
+        .oneshot(provision_req(Some(&b), ACME_TOML))
+        .await
+        .unwrap();
+    assert_eq!(second.status(), StatusCode::CREATED);
+    assert_eq!(json_body(second).await["id"], "tenant-b--acme");
     std::fs::remove_dir_all(&home).ok();
 }
 

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -1649,6 +1649,64 @@ mod test {
         let _ = store.db.drop().await;
     }
 
+    /// Shared-single-DB namespacing: two tenants registering the same template
+    /// name land distinct namespaced ids in one database, so the `companies`
+    /// unique index never conflicts, and the `owners` rows carry the right
+    /// tenant for each. Mirrors what the workload does when
+    /// `OPENCOMPANY_TENANT_ID` is set (see `AppConfig::namespaced_company_id`).
+    #[tokio::test]
+    async fn shared_db_namespaced_companies_do_not_conflict() {
+        let Some(s) = store().await else { return };
+
+        let manifest: CompanyManifest = toml::from_str("[company]\nname = \"Acme\"\n").unwrap();
+        let id_a = crate::app::namespace_company_id(
+            "tenant-a",
+            crate::runtime::company_id_from_name(&manifest.company.name),
+        );
+        let id_b = crate::app::namespace_company_id(
+            "tenant-b",
+            crate::runtime::company_id_from_name(&manifest.company.name),
+        );
+        assert_eq!(id_a.as_ref(), "tenant-a--acme");
+        assert_eq!(id_b.as_ref(), "tenant-b--acme");
+
+        for (id, tenant) in [(&id_a, "tenant-a"), (&id_b, "tenant-b")] {
+            let record = CompanyRecord {
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".into(),
+                overlay_agents: Vec::new(),
+            };
+            // Same template name under two tenants: distinct namespaced ids, no
+            // `companies` unique-index conflict.
+            s.save(&record).await.expect("save namespaced company");
+            s.set_owner(id, tenant).await.expect("record owner");
+        }
+
+        let mut owners = s.owners().await.unwrap();
+        owners.sort_by(|a, b| a.0.as_ref().cmp(b.0.as_ref()));
+        assert_eq!(
+            owners,
+            vec![
+                (id_a.clone(), "tenant-a".to_string()),
+                (id_b.clone(), "tenant-b".to_string()),
+            ]
+        );
+
+        // Both companies remain addressable and carry the shared template name.
+        assert_eq!(
+            s.load(&id_a).await.unwrap().unwrap().manifest.company.name,
+            "Acme"
+        );
+        assert_eq!(
+            s.load(&id_b).await.unwrap().unwrap().manifest.company.name,
+            "Acme"
+        );
+
+        drop_db(&s).await;
+    }
+
     #[tokio::test]
     async fn conformance_isolation_by_company() {
         let Some(s) = store().await else { return };

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -111,11 +111,18 @@ pub struct StorageSettings {
     /// MongoDB database name (`OPENCOMPANY_MONGODB_DB`); the hosting layer
     /// sets a per-tenant name (e.g. `oc-<tenant>`) on a shared cluster.
     pub mongodb_db: Option<String>,
+    /// Tenant identity for shared-single-DB deployments
+    /// (`OPENCOMPANY_TENANT_ID`). When set, company ids are namespaced with
+    /// this value so that many tenants sharing one logical database never
+    /// collide on the `companies` unique index. Unset means the id-namespacing
+    /// no-op: single-tenant / db-per-tenant behavior is unchanged.
+    pub tenant_id: Option<String>,
 }
 
 impl StorageSettings {
     /// Reads the CLI-surface storage env vars (`OPENCOMPANY_STORAGE`,
-    /// `OPENCOMPANY_MONGODB_URI`, `OPENCOMPANY_MONGODB_DB`).
+    /// `OPENCOMPANY_MONGODB_URI`, `OPENCOMPANY_MONGODB_DB`,
+    /// `OPENCOMPANY_TENANT_ID`).
     pub fn from_env() -> Result<Self> {
         let kind = match std::env::var("OPENCOMPANY_STORAGE") {
             Ok(raw) => raw.parse()?,
@@ -126,6 +133,7 @@ impl StorageSettings {
             kind,
             mongodb_uri: non_empty("OPENCOMPANY_MONGODB_URI"),
             mongodb_db: non_empty("OPENCOMPANY_MONGODB_DB"),
+            tenant_id: non_empty("OPENCOMPANY_TENANT_ID"),
         })
     }
 }
@@ -247,6 +255,31 @@ mod test {
         let settings = StorageSettings::default();
         let handles = open_storage(&settings, Path::new("/tmp")).await.unwrap();
         assert!(handles.is_none());
+    }
+
+    #[test]
+    fn from_env_reads_tenant_id() {
+        // SAFETY: single-threaded test; restores prior state.
+        let prev = std::env::var("OPENCOMPANY_TENANT_ID").ok();
+
+        unsafe { std::env::set_var("OPENCOMPANY_TENANT_ID", "acme") };
+        assert_eq!(
+            StorageSettings::from_env().unwrap().tenant_id.as_deref(),
+            Some("acme")
+        );
+
+        // An empty value is filtered out, same as the mongodb vars.
+        unsafe { std::env::set_var("OPENCOMPANY_TENANT_ID", "") };
+        assert_eq!(StorageSettings::from_env().unwrap().tenant_id, None);
+
+        // Unset leaves it `None` (the id-namespacing no-op).
+        unsafe { std::env::remove_var("OPENCOMPANY_TENANT_ID") };
+        assert_eq!(StorageSettings::from_env().unwrap().tenant_id, None);
+
+        match prev {
+            Some(v) => unsafe { std::env::set_var("OPENCOMPANY_TENANT_ID", v) },
+            None => unsafe { std::env::remove_var("OPENCOMPANY_TENANT_ID") },
+        }
     }
 
     #[cfg(feature = "mongodb")]


### PR DESCRIPTION
## Summary

Adds a tenant identity namespace for shared-database OpenCompany deployments so multiple tenants can safely share one database:

- **store**: read `OPENCOMPANY_TENANT_ID` into `StorageSettings`.
- **app**: `tenant_namespace` and a `namespaced_company_id` helper.
- **serve**: namespace boot company ids and filter owners by tenant.
- **provision**: namespace API-provisioned ids by the acting tenant.
- **tests/docs**: env-gated shared-db namespacing regression test; document the shared-single-DB tenant mode and its isolation tradeoff.

## Validation

- `cargo test --features mongodb,sqlite`: **509 passed**.
- `cargo fmt` + `cargo clippy -D warnings`: **clean**.
- Strict no-op unless `OPENCOMPANY_TENANT_ID` is set.
- Validated on staging shared Atlas DB: namespaced ids (`smoke1--*`), owner isolation, and purge leaving other tenants intact.

## Notes

- Base branch: `main`.
- First PR in a stack — the follow-up `fix/docker-vendor-build` PR is based on this branch.
