### PR TITLE
fix: land stacked remainder — docker vendor build + canonical tenant ids

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,34 @@
 # Build artifacts and heavy/irrelevant paths kept out of the build context.
 .git
+**/.git
 target/
+**/target/
 **/node_modules/
 **/dist/
-# The host binary build needs vendor/tinyagents (the [patch] source) but never
-# the 90 MB OpenHuman checkout.
-vendor/openhuman/
-docs/
-gitbooks/
+
+# vendor/openhuman (and its own nested vendored crates under vendor/openhuman/
+# vendor/*) back the root Cargo.toml's [patch.crates-io] table and the optional
+# `openhuman_core` path dependency. Cargo must read their Cargo.toml manifests
+# AND their lib sources during *resolution* — even for the default/offline and
+# mongodb/medulla builds where the `openhuman` feature is off — so the whole
+# tree cannot be excluded (that was the packaging bug: `cargo build` failed with
+# "failed to read vendor/openhuman/Cargo.toml"). We therefore keep every
+# Cargo.toml + src/ tree and strip only the documentation, generated books,
+# desktop app, and media that bloat the raw checkout to ~300 MB. openhuman's
+# build.rs is written to tolerate a source-only build (it emits an empty raw-
+# coverage module list when tests/ is absent), and every include_str!/-bytes! in
+# openhuman's sources resolves inside src/, so a `--features openhuman` compile
+# still works from this trimmed context.
+**/docs/
+**/gitbooks/
+**/website/
+**/paper/
+**/wiki/
+vendor/openhuman/app/
+vendor/openhuman/tests/
+vendor/openhuman/e2e/
+vendor/openhuman/fastlane/
+
 *.log
 .env
 .DS_Store

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,4 +4,4 @@ mod types;
 
 pub use config::{BrainMode, ConfigProvenance, RuntimeConfig, resolve};
 pub use doctor::{DoctorReport, report as doctor_report};
-pub use types::{AppConfig, AppSpec, AppState, namespace_company_id};
+pub use types::{AppConfig, AppSpec, AppState, canonical_tenant, namespace_company_id};

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -91,6 +91,22 @@ pub fn namespace_company_id(tenant: &str, id: CompanyId) -> CompanyId {
     }
 }
 
+/// The canonical form of a tenant identifier for ownership: the bare slug, with
+/// any leading `tenant:` prefix stripped.
+///
+/// The two representations of the *same* tenant must compare equal. A verified
+/// token's [`PlatformClaims::tenant`](crate::server::platform_auth::PlatformClaims)
+/// carries the platform-issued `tenant:acme` form, while the workload's injected
+/// `OPENCOMPANY_TENANT_ID` (and thus [`AppConfig::tenant_namespace`], the id
+/// prefix, and shared-DB `owners` rows) is the bare slug `acme`. Recording
+/// ownership under one form and authorizing against the other would lock a
+/// tenant out of its own companies. Every site that stores, counts, hydrates, or
+/// compares an owning tenant funnels through this one helper so `acme` and
+/// `tenant:acme` are one identity end-to-end.
+pub fn canonical_tenant(tenant: &str) -> &str {
+    tenant.strip_prefix("tenant:").unwrap_or(tenant)
+}
+
 impl AppConfig {
     /// True when hosted cognition can run: hosted mode plus a credential.
     pub fn cycles_available(&self) -> bool {
@@ -357,11 +373,16 @@ impl AppState {
     }
 
     /// Records that `tenant` owns `id`.
+    ///
+    /// The tenant is stored in [`canonical_tenant`] form so the map always keys
+    /// ownership by the bare slug, whatever representation the caller passes
+    /// (a token's `tenant:acme` claim or the workload's bare `acme` namespace).
     pub fn set_owner(&self, id: CompanyId, tenant: impl Into<String>) {
+        let tenant = canonical_tenant(&tenant.into()).to_string();
         self.ownership
             .write()
             .expect("ownership poisoned")
-            .insert(id, tenant.into());
+            .insert(id, tenant);
     }
 
     /// Forgets the ownership record for `id` (used by archive).
@@ -373,7 +394,12 @@ impl AppState {
     }
 
     /// The number of companies owned by `tenant`.
+    ///
+    /// Both the stored owners and the query are compared in [`canonical_tenant`]
+    /// form, so a `tenant:acme` claim and a bare `acme` namespace count the same
+    /// tenant's companies.
     pub fn tenant_company_count(&self, tenant: &str) -> usize {
+        let tenant = canonical_tenant(tenant);
         self.ownership
             .read()
             .expect("ownership poisoned")
@@ -606,6 +632,33 @@ mod tests {
         let twice = config.namespaced_company_id(once.clone());
         assert_eq!(once, twice);
         assert_eq!(once, CompanyId::new("acme--agentic-software-company"));
+    }
+
+    #[test]
+    fn canonical_tenant_strips_prefix() {
+        assert_eq!(canonical_tenant("tenant:acme"), "acme");
+        assert_eq!(canonical_tenant("acme"), "acme");
+        // Only the leading `tenant:` is stripped, and only once.
+        assert_eq!(canonical_tenant("company:acme"), "company:acme");
+        assert_eq!(canonical_tenant("tenant:tenant:x"), "tenant:x");
+    }
+
+    #[test]
+    fn ownership_is_keyed_canonically_across_representations() {
+        let state = AppState::new(AppConfig::default());
+        let id = CompanyId::new("acme--acme");
+
+        // A row stored in the claim shape (as hydration would set it) is keyed by
+        // the bare slug, so a query in either representation finds it.
+        state.set_owner(id.clone(), "tenant:acme");
+        assert_eq!(state.owner_of(&id).as_deref(), Some("acme"));
+        assert_eq!(state.tenant_company_count("acme"), 1);
+        assert_eq!(state.tenant_company_count("tenant:acme"), 1);
+        assert_eq!(state.tenant_company_count("tenant:globex"), 0);
+
+        // Re-recording under the bare form is the same identity, not a second.
+        state.set_owner(id.clone(), "acme");
+        assert_eq!(state.tenant_company_count("tenant:acme"), 1);
     }
 
     #[test]

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -211,6 +211,9 @@ async fn register_company(
     // tenant. Only meaningful in tenant-namespace mode; otherwise skipped so
     // db-per-tenant / self-hosted deployments keep their in-memory-only stub.
     if let Some(tenant) = state.config().tenant_namespace.clone() {
+        // Canonical (bare-slug) form so the persisted `owners` row matches what
+        // tenant-scoped auth compares a `tenant:acme` claim against.
+        let tenant = opencompany::app::canonical_tenant(&tenant).to_string();
         state.set_owner(company_id.clone(), tenant.clone());
         if let Some(ownership) = state.stores().and_then(|s| s.ownership.clone())
             && let Err(err) = ownership.set_owner(&company_id, &tenant).await
@@ -590,7 +593,15 @@ async fn main() -> Result<()> {
                     let self_tenant = state.config().tenant_namespace.clone();
                     for (id, tenant) in ownership.owners().await? {
                         match &self_tenant {
-                            Some(me) if &tenant != me => continue,
+                            // Compare in canonical (bare-slug) form so a row
+                            // persisted as `tenant:acme` still hydrates under the
+                            // workload's bare `acme` namespace, and vice versa.
+                            Some(me)
+                                if opencompany::app::canonical_tenant(&tenant)
+                                    != opencompany::app::canonical_tenant(me) =>
+                            {
+                                continue;
+                            }
                             _ => state.set_owner(id, tenant),
                         }
                     }

--- a/src/server/graphql/auth.rs
+++ b/src/server/graphql/auth.rs
@@ -198,7 +198,9 @@ impl GqlAuth {
                     return Ok(());
                 }
                 let owner = state.owner_of(company);
-                if owner.as_deref() == Some(claims.tenant.as_str()) && claims.may_address(company) {
+                if owner.as_deref() == Some(crate::app::canonical_tenant(&claims.tenant))
+                    && claims.may_address(company)
+                {
                     Ok(())
                 } else {
                     Err(forbidden())
@@ -228,7 +230,8 @@ impl GqlAuth {
             GqlAuth::Platform(claims) => all
                 .into_iter()
                 .filter(|id| {
-                    state.owner_of(id).as_deref() == Some(claims.tenant.as_str())
+                    state.owner_of(id).as_deref()
+                        == Some(crate::app::canonical_tenant(&claims.tenant))
                         && claims.may_address(id)
                 })
                 .collect(),

--- a/src/server/platform_auth.rs
+++ b/src/server/platform_auth.rs
@@ -326,7 +326,9 @@ pub fn authorize_address(state: &AppState, auth: &GqlAuth, id: &CompanyId) -> Op
                 return None;
             }
             let owner = state.owner_of(id);
-            if owner.as_deref() == Some(claims.tenant.as_str()) && claims.may_address(id) {
+            if owner.as_deref() == Some(crate::app::canonical_tenant(&claims.tenant))
+                && claims.may_address(id)
+            {
                 None
             } else {
                 Some(forbidden())

--- a/src/server/provision.rs
+++ b/src/server/provision.rs
@@ -141,11 +141,17 @@ async fn provision(
     //
     // Outside shared-single-DB mode the acting tenant is recorded, feeding
     // per-tenant quota and db-per-tenant / self-hosted ownership as before.
-    let tenant = state
-        .config()
-        .tenant_namespace
-        .clone()
-        .unwrap_or_else(|| acting_tenant(&GqlAuth::Platform(claims.clone())));
+    // Canonicalized (bare-slug) so the recorded owner, the persisted `owners`
+    // row, and quota counting all key by the same identity that tenant-scoped
+    // auth compares a `tenant:acme` claim against.
+    let tenant = crate::app::canonical_tenant(
+        &state
+            .config()
+            .tenant_namespace
+            .clone()
+            .unwrap_or_else(|| acting_tenant(&GqlAuth::Platform(claims.clone()))),
+    )
+    .to_string();
     // Namespace the id with the workload's tenant so API-provisioned companies
     // are globally unique in one logical database (the same template name under
     // two tenant workloads no longer collides on the `companies` unique index).

--- a/src/server/provision/test.rs
+++ b/src/server/provision/test.rs
@@ -319,6 +319,60 @@ async fn same_template_under_two_tenant_workloads_does_not_conflict() {
     std::fs::remove_dir_all(&home_b).ok();
 }
 
+#[tokio::test]
+async fn claim_shaped_tenant_manages_namespaced_company() {
+    // Shared-single-DB workload for tenant slug `acme` (its bare
+    // `OPENCOMPANY_TENANT_ID`). A full-platform token provisions the company; it
+    // is namespaced `acme--acme` and its owner is recorded under the bare slug.
+    let home = home();
+    let state = namespaced_state(&home, "acme");
+    let observed = state.clone();
+    let app = router(state);
+
+    let created = app
+        .clone()
+        .oneshot(provision_req(Some(PLATFORM_SECRET), ACME_TOML))
+        .await
+        .unwrap();
+    assert_eq!(created.status(), StatusCode::CREATED);
+    assert_eq!(json_body(created).await["id"], "acme--acme");
+    // Ownership is recorded canonically (bare slug), matching the namespace.
+    let id = CompanyId::new("acme--acme");
+    assert_eq!(observed.owner_of(&id).as_deref(), Some("acme"));
+
+    // The tenant's own token carries the platform-issued *claim* shape
+    // `tenant:acme`, which differs textually from the bare `acme` owner. It must
+    // still be authorized to address and manage its own company.
+    let claim_shaped = tenant_token("tenant:acme", &["operator"]);
+    let status = app
+        .clone()
+        .oneshot(get_req("/api/v1/companies/acme--acme", Some(&claim_shaped)))
+        .await
+        .unwrap();
+    assert_eq!(status.status(), StatusCode::OK);
+    assert_eq!(json_body(status).await["id"], "acme--acme");
+
+    let paused = app
+        .clone()
+        .oneshot(post_req(
+            "/api/v1/companies/acme--acme/pause",
+            Some(&claim_shaped),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(paused.status(), StatusCode::OK);
+    assert_eq!(json_body(paused).await["lifecycle"], "paused");
+
+    // A different tenant — whatever its representation — is still denied.
+    let intruder = tenant_token("tenant:globex", &["operator"]);
+    let denied = app
+        .oneshot(get_req("/api/v1/companies/acme--acme", Some(&intruder)))
+        .await
+        .unwrap();
+    assert_eq!(denied.status(), StatusCode::FORBIDDEN);
+    std::fs::remove_dir_all(&home).ok();
+}
+
 // ---------------------------------------------------------------------------
 // Lifecycle
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Lands the content that missed \`main\` when the stacked PRs merged out of order, plus one review follow-up:

- **#18's fix** (\`fix(docker): stop dockerignoring vendored openhuman manifests\`) was merged into \`feat/tenant-namespace\` *after* #17 had merged, so it never reached \`main\`.
- **Canonical tenant-id normalization** (\`4e70f63\`) — follow-up to the Codex P2 on #17: \`PlatformClaims.tenant\` is prefixed (\`tenant:acme\`) while \`OPENCOMPANY_TENANT_ID\` is the bare slug; ownership is now stored/compared via one \`canonical_tenant\` helper across provision, boot hydration, REST/GraphQL auth, and quota counting, so tenant tokens can manage their own namespaced companies.

## Testing

- \`cargo test --features mongodb,sqlite\`: 512 passed
- \`cargo fmt --all -- --check\` clean; \`cargo clippy --all-targets -- -D warnings\` clean (plain and with features)
- New tests: claim-shaped token manages namespaced company (cross-tenant denied); ownership keyed canonically across representations; docker build validated in #18