### PR TITLE
feat: serve the operator console from the host at /

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3268,6 +3268,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5135,7 +5141,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.17",
  "hickory-resolver 0.24.4",
- "hmac 0.13.0",
+ "hmac 0.12.1",
  "jsonwebtoken",
  "lettre",
  "log",
@@ -5154,6 +5160,7 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -8302,10 +8309,19 @@ checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.13.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.4.2",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,11 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 # directory, so the default build's behavior is byte-for-byte unchanged. Pure
 # Rust, no system libs, no network.
 tower-http = { version = "0.6", features = ["fs"] }
+# `ServiceExt::oneshot` lets the `/` SPA fallback hand a request off to
+# `ServeDir` from inside an axum handler, so reserved server prefixes can 404
+# before the static service ever sees them. Already in the tree via `tower-http`
+# and `axum`, so this is a direct-use declaration, not new compilation.
+tower = { version = "0.5", features = ["util"] }
 
 tinyagents = { path = "vendor/tinyagents", optional = true, features = ["sqlite", "repl"] }
 
@@ -238,4 +243,3 @@ whisper-rs-sys = { git = "https://github.com/tinyhumansai/whisper-rs-sys.git", b
 
 [dev-dependencies]
 tempfile = "3"
-tower = { version = "0.5", features = ["util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,14 @@ tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "process"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
+# Static file serving for the embedded operator console. `ServeDir`/`ServeFile`
+# back the `/` SPA fallback so a hosted tenant serves its own console
+# same-origin without a separate nginx container. Unconditional but inert: the
+# fallback is only mounted when `OPENCOMPANY_CONSOLE_DIR` points at a real
+# directory, so the default build's behavior is byte-for-byte unchanged. Pure
+# Rust, no system libs, no network.
+tower-http = { version = "0.6", features = ["fs"] }
+
 tinyagents = { path = "vendor/tinyagents", optional = true, features = ["sqlite", "repl"] }
 
 # WS4: openhuman embedded as a library (the harness). Only links under the

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,17 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     fi; \
     install -Dm755 target/release/opencompany /out/opencompany
 
+# ── console builder ────────────────────────────────────────────────────────
+# Builds the Vite/React operator console (frontend/) into a static bundle that
+# the runtime image serves at `/` (same-origin, no separate nginx container).
+# Matches the node version frontend/Dockerfile pins.
+FROM node:22-slim AS console
+WORKDIR /console
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ ./
+RUN npm run build
+
 # ── local development ─────────────────────────────────────────────────────
 # Used by docker-compose.dev.yml. The repository is bind-mounted over
 # /workspace; cargo-watch rebuilds and restarts the host after local edits.
@@ -44,14 +55,21 @@ WORKDIR /app
 COPY --from=builder /out/opencompany /usr/local/bin/opencompany
 # The company definitions the switch chooses from at runtime.
 COPY companies ./companies
+# The built operator console, served at `/` by the host. World-readable so the
+# unprivileged runtime user (uid 10001 under the platform's securityContext)
+# can read it even with a read-only root filesystem.
+COPY --from=console /console/dist /app/console
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh && mkdir -p /data
 
 # The switch: which example company this container runs. Override at deploy time.
+# `OPENCOMPANY_CONSOLE_DIR` points the host at the baked console bundle so a
+# hosted tenant serves its own UI at `/` instead of 404ing.
 ENV OPENCOMPANY_COMPANY=agentic_marketing_agency \
     OPENCOMPANY_BIND=0.0.0.0:8080 \
     OPENCOMPANY_DATA_DIR=/data \
-    OPENCOMPANY_DISCOVERABLE=false
+    OPENCOMPANY_DISCOVERABLE=false \
+    OPENCOMPANY_CONSOLE_DIR=/app/console
 
 EXPOSE 8080
 HEALTHCHECK --interval=15s --timeout=3s --start-period=8s --retries=5 \

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -1,13 +1,36 @@
+use std::path::PathBuf;
+
 use axum::extract::Request;
 use axum::response::{IntoResponse, Response};
 use axum::{Json, Router, extract::State, routing::get};
 use serde::Serialize;
 use tokio::net::TcpListener;
+use tower_http::services::{ServeDir, ServeFile};
 
 use crate::{AppState, Result};
 
-/// Builds the Axum router.
+/// The directory whose built operator console the host serves at `/`, read from
+/// `OPENCOMPANY_CONSOLE_DIR`. Returns `None` when the variable is unset, empty,
+/// or does not point at an existing directory — in which case the host keeps
+/// its historical behavior and 404s on unknown paths (no console fallback).
+fn console_dir_from_env() -> Option<PathBuf> {
+    let raw = std::env::var_os("OPENCOMPANY_CONSOLE_DIR")?;
+    if raw.is_empty() {
+        return None;
+    }
+    let dir = PathBuf::from(raw);
+    dir.is_dir().then_some(dir)
+}
+
+/// Builds the Axum router, mounting the operator console at `/` when
+/// `OPENCOMPANY_CONSOLE_DIR` is configured.
 pub fn router(state: AppState) -> Router {
+    router_with_console(state, console_dir_from_env())
+}
+
+/// Router builder with an explicit console directory, so tests can inject a
+/// temporary console tree without touching process environment.
+fn router_with_console(state: AppState, console_dir: Option<PathBuf>) -> Router {
     let router = Router::new()
         .route("/healthz", get(healthz))
         .route("/spec", get(spec))
@@ -23,6 +46,24 @@ pub fn router(state: AppState) -> Router {
     #[cfg(feature = "tinyplace")]
     let router = router.merge(crate::server::a2a::router());
     let router = router.with_state(state.clone());
+
+    // Operator console: the lowest-priority fallback. Every real route above —
+    // `/api`, `/graphql`, `/spec`, `/tiny`, `/healthz` — is matched first and
+    // always wins. Only when nothing else matches does `ServeDir` answer:
+    // asset paths (`/assets/app.js`, `/favicon.ico`) serve their file, and any
+    // other unknown path (a client-side SPA route) falls through to
+    // `index.html` so the React router can take over. When no console dir is
+    // configured this is skipped entirely and unknown paths keep 404ing.
+    let router = match console_dir {
+        Some(dir) => {
+            let index = dir.join("index.html");
+            let serve = ServeDir::new(dir)
+                .append_index_html_on_directories(true)
+                .fallback(ServeFile::new(index));
+            router.fallback_service(serve)
+        }
+        None => router,
+    };
 
     // CORS is off unless origins are configured, which is every same-origin
     // deployment. When it is on, `map_response` cannot see the request, so the
@@ -88,6 +129,88 @@ mod tests {
 
     use super::*;
     use crate::AppConfig;
+
+    /// Writes a minimal console tree (just `index.html`) into a temp dir.
+    fn console_fixture() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), "<!doctype html><title>console</title>")
+            .unwrap();
+        let path = dir.path().to_path_buf();
+        (dir, path)
+    }
+
+    async fn body_text(response: axum::response::Response) -> String {
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn console_serves_index_at_root() {
+        let (_guard, dir) = console_fixture();
+        let app = router_with_console(AppState::new(AppConfig::default()), Some(dir));
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(body_text(response).await.contains("<title>console</title>"));
+    }
+
+    #[tokio::test]
+    async fn console_falls_back_to_index_for_spa_routes() {
+        let (_guard, dir) = console_fixture();
+        let app = router_with_console(AppState::new(AppConfig::default()), Some(dir));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/some/spa/route")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(body_text(response).await.contains("<title>console</title>"));
+    }
+
+    #[tokio::test]
+    async fn console_does_not_shadow_api_routes() {
+        let (_guard, dir) = console_fixture();
+        let app = router_with_console(AppState::new(AppConfig::default()), Some(dir));
+
+        // A real API route still reaches the API and answers with its own auth
+        // status (401), never the SPA shell.
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/companies")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(!body_text(response).await.contains("<title>console</title>"));
+    }
+
+    #[tokio::test]
+    async fn root_404s_without_console_dir() {
+        let app = router_with_console(AppState::new(AppConfig::default()), None);
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
 
     #[tokio::test]
     async fn healthz_returns_ok() {

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -17,20 +17,19 @@ use crate::{AppState, Result};
 /// build without that feature), and absent server routes must keep 404ing so
 /// API and external clients can detect an unwired surface instead of receiving
 /// the `index.html` shell with a `200`.
-const RESERVED_PREFIXES: [&str; 7] = [
-    "/api",
-    "/graphql",
-    "/healthz",
-    "/spec",
-    "/tiny",
-    "/a2a",
-    "/.well-known",
-];
+const RESERVED_PREFIXES: [&str; 6] = ["/api", "/graphql", "/healthz", "/spec", "/tiny", "/a2a"];
 
-/// True when `path` falls under a reserved server prefix — either an exact
-/// match (`/spec`) or a sub-path (`/api/v1/...`) — so the SPA fallback should
-/// yield a 404 rather than the console shell.
+/// True when `path` is server-owned and so must 404 rather than fall through to
+/// the console shell. That is either a path under a reserved prefix — an exact
+/// match (`/spec`) or a sub-path (`/api/v1/...`) — or any `.well-known`
+/// discovery URI (RFC 8615). The latter is reserved wherever the segment
+/// appears, not just at the root: `/companies/{handle}/.well-known/agent-card.json`
+/// is a tiny.place Agent Card endpoint (feature-gated on `tinyplace`), and the
+/// SPA must never masquerade as one for a directory client probing it.
 fn is_reserved_path(path: &str) -> bool {
+    if path.split('/').any(|segment| segment == ".well-known") {
+        return true;
+    }
     RESERVED_PREFIXES.iter().any(|prefix| {
         path == *prefix
             || path
@@ -257,7 +256,11 @@ mod tests {
         // feature-gated route in a build without that feature) must 404, not
         // fall through to the SPA shell, so callers can still detect the
         // surface as unwired.
-        for path in ["/api/v1/does-not-exist", "/.well-known/agent-card.json"] {
+        for path in [
+            "/api/v1/does-not-exist",
+            "/.well-known/agent-card.json",
+            "/companies/acme/.well-known/agent-card.json",
+        ] {
             let response = app
                 .clone()
                 .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
@@ -275,9 +278,16 @@ mod tests {
         assert!(is_reserved_path("/api/v1/companies"));
         assert!(is_reserved_path("/.well-known/agent-card.json"));
         assert!(is_reserved_path("/a2a/handle"));
+        // A `.well-known` discovery URI is reserved wherever the segment sits,
+        // including under a company handle the SPA otherwise owns.
+        assert!(is_reserved_path(
+            "/companies/acme/.well-known/agent-card.json"
+        ));
         // A console route that merely shares a prefix substring is not reserved.
         assert!(!is_reserved_path("/apidocs"));
         assert!(!is_reserved_path("/tinyplace-console"));
+        // `/companies/{handle}` client-side console routes still fall through.
+        assert!(!is_reserved_path("/companies/acme"));
         assert!(!is_reserved_path("/"));
         assert!(!is_reserved_path("/some/spa/route"));
     }

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -133,8 +133,11 @@ mod tests {
     /// Writes a minimal console tree (just `index.html`) into a temp dir.
     fn console_fixture() -> (tempfile::TempDir, PathBuf) {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("index.html"), "<!doctype html><title>console</title>")
-            .unwrap();
+        std::fs::write(
+            dir.path().join("index.html"),
+            "<!doctype html><title>console</title>",
+        )
+        .unwrap();
         let path = dir.path().to_path_buf();
         (dir, path)
     }

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -17,7 +17,9 @@ use crate::{AppState, Result};
 /// build without that feature), and absent server routes must keep 404ing so
 /// API and external clients can detect an unwired surface instead of receiving
 /// the `index.html` shell with a `200`.
-const RESERVED_PREFIXES: [&str; 6] = ["/api", "/graphql", "/healthz", "/spec", "/tiny", "/a2a"];
+const RESERVED_PREFIXES: [&str; 7] = [
+    "/api", "/graphql", "/healthz", "/spec", "/tiny", "/a2a", "/hooks",
+];
 
 /// True when `path` is server-owned and so must 404 rather than fall through to
 /// the console shell. That is either a path under a reserved prefix — an exact
@@ -276,6 +278,9 @@ mod tests {
     fn reserved_path_matches_prefixes_and_subpaths_only() {
         assert!(is_reserved_path("/api"));
         assert!(is_reserved_path("/api/v1/companies"));
+        // `/hooks/{companyId}/{channel}` inbound webhooks (api.md) — a
+        // server-owned namespace, reserved even before the route is wired.
+        assert!(is_reserved_path("/hooks/acme/slack"));
         assert!(is_reserved_path("/.well-known/agent-card.json"));
         assert!(is_reserved_path("/a2a/handle"));
         // A `.well-known` discovery URI is reserved wherever the segment sits,

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -1,13 +1,43 @@
 use std::path::PathBuf;
 
 use axum::extract::Request;
+use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::{Json, Router, extract::State, routing::get};
 use serde::Serialize;
 use tokio::net::TcpListener;
+use tower::ServiceExt;
 use tower_http::services::{ServeDir, ServeFile};
 
 use crate::{AppState, Result};
+
+/// Path prefixes owned by the server's API and discovery surfaces. The console
+/// SPA fallback must never answer these: a request under one of them either
+/// hits a real handler or is genuinely absent (e.g. a feature-gated route in a
+/// build without that feature), and absent server routes must keep 404ing so
+/// API and external clients can detect an unwired surface instead of receiving
+/// the `index.html` shell with a `200`.
+const RESERVED_PREFIXES: [&str; 7] = [
+    "/api",
+    "/graphql",
+    "/healthz",
+    "/spec",
+    "/tiny",
+    "/a2a",
+    "/.well-known",
+];
+
+/// True when `path` falls under a reserved server prefix — either an exact
+/// match (`/spec`) or a sub-path (`/api/v1/...`) — so the SPA fallback should
+/// yield a 404 rather than the console shell.
+fn is_reserved_path(path: &str) -> bool {
+    RESERVED_PREFIXES.iter().any(|prefix| {
+        path == *prefix
+            || path
+                .strip_prefix(prefix)
+                .is_some_and(|rest| rest.starts_with('/'))
+    })
+}
 
 /// The directory whose built operator console the host serves at `/`, read from
 /// `OPENCOMPANY_CONSOLE_DIR`. Returns `None` when the variable is unset, empty,
@@ -52,15 +82,30 @@ fn router_with_console(state: AppState, console_dir: Option<PathBuf>) -> Router 
     // always wins. Only when nothing else matches does `ServeDir` answer:
     // asset paths (`/assets/app.js`, `/favicon.ico`) serve their file, and any
     // other unknown path (a client-side SPA route) falls through to
-    // `index.html` so the React router can take over. When no console dir is
-    // configured this is skipped entirely and unknown paths keep 404ing.
+    // `index.html` so the React router can take over. Unmatched paths under a
+    // reserved server prefix (`/api`, `/a2a`, `/.well-known`, ...) are the one
+    // exception: they 404 rather than serve the shell, so a feature-gated or
+    // otherwise absent API/discovery route stays detectable by its callers.
+    // When no console dir is configured this is skipped entirely and unknown
+    // paths keep 404ing.
     let router = match console_dir {
         Some(dir) => {
             let index = dir.join("index.html");
             let serve = ServeDir::new(dir)
                 .append_index_html_on_directories(true)
                 .fallback(ServeFile::new(index));
-            router.fallback_service(serve)
+            router.fallback(move |request: Request| {
+                let serve = serve.clone();
+                async move {
+                    if is_reserved_path(request.uri().path()) {
+                        return StatusCode::NOT_FOUND.into_response();
+                    }
+                    match serve.oneshot(request).await {
+                        Ok(response) => response.into_response(),
+                        Err(err) => match err {},
+                    }
+                }
+            })
         }
         None => router,
     };
@@ -201,6 +246,40 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
         assert!(!body_text(response).await.contains("<title>console</title>"));
+    }
+
+    #[tokio::test]
+    async fn console_does_not_shadow_unmatched_reserved_paths() {
+        let (_guard, dir) = console_fixture();
+        let app = router_with_console(AppState::new(AppConfig::default()), Some(dir));
+
+        // An unmatched path under a reserved API/discovery prefix (e.g. a
+        // feature-gated route in a build without that feature) must 404, not
+        // fall through to the SPA shell, so callers can still detect the
+        // surface as unwired.
+        for path in ["/api/v1/does-not-exist", "/.well-known/agent-card.json"] {
+            let response = app
+                .clone()
+                .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::NOT_FOUND, "path: {path}");
+            assert!(!body_text(response).await.contains("<title>console</title>"));
+        }
+    }
+
+    #[test]
+    fn reserved_path_matches_prefixes_and_subpaths_only() {
+        assert!(is_reserved_path("/api"));
+        assert!(is_reserved_path("/api/v1/companies"));
+        assert!(is_reserved_path("/.well-known/agent-card.json"));
+        assert!(is_reserved_path("/a2a/handle"));
+        // A console route that merely shares a prefix substring is not reserved.
+        assert!(!is_reserved_path("/apidocs"));
+        assert!(!is_reserved_path("/tinyplace-console"));
+        assert!(!is_reserved_path("/"));
+        assert!(!is_reserved_path("/some/spa/route"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation

Hosted tenant pods (e.g. https://smoke1.staging.opencompany.work) run the single
`runtime` image from the root `Dockerfile` and serve `/api/v1`, `/graphql`,
`/spec`, `/tiny`, and `/healthz` — but **404 at `/`**. The operator console is a
Vite/React SPA under `frontend/` that today ships as a *separate* nginx
container (`frontend/Dockerfile`, `OC_UPSTREAM` proxy) which hosted k8s tenants
never run. This makes the console reachable at the tenant root from the same
workload.

## How same-origin serving works

The SPA already talks to the API over **relative, same-origin paths**: its
`baseUrl` defaults to `""` (`frontend/src/config.ts`) and every call is
`fetch("/api/v1/...", { credentials: "include" })`. It needed the nginx proxy
only because it was served from a different container. Served from the host
itself, no proxy and no CORS is required — **no frontend code change was
needed.**

The Axum host now mounts a `tower-http` `ServeDir` (with a `ServeFile`
`index.html` fallback) as the router's **lowest-priority `fallback_service`**:

- Real routes (`/api`, `/graphql`, `/spec`, `/tiny`, `/healthz`) are matched
  first and always win — a valid API route still answers `401`, never the shell.
- Unknown asset paths (`/assets/*.js`) serve their file.
- Any other unknown path serves `index.html`, so the React client router takes
  over (SPA deep links work).

## Env contract

`OPENCOMPANY_CONSOLE_DIR` points the host at a built console bundle.

- **Unset, empty, or not a real directory → current behavior, no regression**
  (unknown paths keep 404ing). `router()` resolves it once via
  `console_dir_from_env()`.
- The runtime image bakes the bundle at `/app/console` and sets
  `OPENCOMPANY_CONSOLE_DIR=/app/console` by default. A new `console`
  Docker stage (`node:22-slim`, matching `frontend/Dockerfile`) runs
  `npm ci && npm run build` and the result is copied world-readable so the
  unprivileged runtime user (uid 10001, read-only root fs) can serve it.

`tower-http` is added as an unconditional dependency (`fs` feature; already in
the lockfile transitively at 0.6.11) — it's inert unless the console dir is
configured, so the default/offline build is byte-for-byte unchanged.

## Test evidence

New router tests in `src/server/routes.rs` (temp console dir injected, no env
dependence):

- `/` serves `index.html` (200 html)
- `/some/spa/route` falls back to `index.html`
- `/api/v1/companies` still hits the API → `401` (not the shell)
- without a console dir, `/` → `404`

Gates (all green):

- `cargo test --features mongodb,sqlite` → 516 + 4 + 6 passed
- `cargo fmt --all -- --check` → clean
- `cargo clippy --all-targets -- -D warnings` (plain **and** `--features
  mongodb,sqlite`) → clean

Local Docker validation:

- `docker build --build-arg FEATURES="sqlite,mongodb" -t oc-console-test .` →
  succeeds
- container run + curl: `/` → 200 text/html (`<title>OpenCompany Console</title>`),
  `/assets/index-*.js` → 200 text/javascript, `/spec` → 200 application/json,
  `/healthz` → 200 `{"status":"ok"}`, `/some/spa/route` → 200 html,
  `/api/v1/companies` → 401. Test image/container cleaned up.

## Rollout

Hosted tenant images pick this up automatically on their next `:staging`
build — no deploy is performed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an embedded operator console served directly from the application.
  * Added SPA routing support, including fallback to the console’s main page for client-side routes.
  * Added configurable console hosting through `OPENCOMPANY_CONSOLE_DIR`.
  * Added a container build stage to package the console automatically.

* **Bug Fixes**
  * Prevented console routing from overriding API, discovery, and reserved paths.
  * Preserved 404 responses when no console is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->