### PR TITLE
docs(gitbook): marketing site with a walled-off developer section

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,14 @@ loop), **`server`** (Axum router), **`openhuman`** (launcher seams),
 See [docs/spec/README.md](docs/spec/README.md) for the architecture reference
 and [companies/README.md](companies/README.md) for the full company catalog.
 
+## Documentation
+
+The full docs live in [`gitbooks/`](gitbooks/README.md): what OpenCompany is,
+what one person can run, how [Medulla](gitbooks/overview/medulla.md) drives it,
+and the [tiny.place economy](gitbooks/overview/tiny-place.md). Builders should
+start with the [developer section](gitbooks/developers/README.md) — build,
+CLI, architecture, authoring companies, deployment, and configuration.
+
 ## License
 
 OpenCompany is licensed under the GNU General Public License v3. See

--- a/gitbooks/README.md
+++ b/gitbooks/README.md
@@ -1,2 +1,52 @@
-# Hello World
+---
+description: Run an entire company with a headcount of one.
+---
 
+# Welcome to OpenCompany
+
+**OpenCompany is the operating layer for one-person businesses powered by
+agents.** You bring the vision and the judgment calls. Your agents do the
+work — every function, around the clock, at the speed of software.
+
+For a century, ambition meant headcount. Want to ship a product? Hire
+engineers. Want customers? Hire marketers, then sales, then support. Every new
+capability was a new payroll line, a new manager, a new quarter of ramp-up.
+
+That tax is gone. OpenCompany turns a single operator into a full org chart —
+opportunity scouts, founders, engineers, designers, marketers, lawyers,
+finance, support, recruiters — instantiated as agents, coordinated by one
+host, working while you sleep.
+
+You stay where humans are irreplaceable: **capital, taste, and the decisions
+that actually matter.** Everything else is delegated.
+
+{% hint style="warning" %}
+**🚧 Work in progress.** OpenCompany is under active development and moving
+fast. APIs, the CLI, the templates, and these docs will change without notice.
+Explore it, fork it, build on it — but don't depend on anything staying put
+yet. Not production-ready.
+{% endhint %}
+
+## What this isn't
+
+This isn't a chatbot with a to-do list. It's a **company runtime** — a durable
+host that stands up a roster of specialized agents, gives each one a clear
+mandate, and runs them as a coordinated business on top of the OpenHuman and
+TinyHumans runtimes.
+
+## Where to go next
+
+| If you want to… | Start here |
+| --- | --- |
+| Understand the idea | [The company of one](overview/company-of-one.md) |
+| See what you can run today | [What one person can run](overview/what-you-can-run.md) |
+| Understand why it holds together | [Why it works](overview/why-it-works.md) |
+| Meet the engine | [Medulla, the orchestrator](overview/medulla.md) |
+| Trade with other agents | [The tiny.place economy](overview/tiny-place.md) |
+| Launch your first company | [Quickstart](get-started/quickstart.md) |
+| Build on the runtime | [Developer docs](developers/README.md) |
+
+## Yours to own
+
+OpenCompany is licensed under the GNU General Public License v3 —
+self-hostable, inspectable, no lock-in.

--- a/gitbooks/SUMMARY.md
+++ b/gitbooks/SUMMARY.md
@@ -1,3 +1,27 @@
 # Table of contents
 
-* [Hello World](README.md)
+* [Welcome to OpenCompany](README.md)
+
+## Overview
+
+* [The company of one](overview/company-of-one.md)
+* [What one person can run](overview/what-you-can-run.md)
+* [Why it works](overview/why-it-works.md)
+* [Medulla, the orchestrator](overview/medulla.md)
+* [The tiny.place economy](overview/tiny-place.md)
+
+## Get started
+
+* [Quickstart](get-started/quickstart.md)
+* [Your first company](get-started/your-first-company.md)
+* [Pricing & your key](get-started/pricing.md)
+
+## For developers
+
+* [Developer overview](developers/README.md)
+* [Build & run locally](developers/quickstart.md)
+* [Architecture](developers/architecture.md)
+* [CLI reference](developers/cli.md)
+* [Authoring companies](developers/companies.md)
+* [Deployment](developers/deployment.md)
+* [Configuration](developers/configuration.md)

--- a/gitbooks/developers/README.md
+++ b/gitbooks/developers/README.md
@@ -1,0 +1,47 @@
+---
+description: Build on, extend, and deploy the OpenCompany runtime.
+---
+
+# Developer overview
+
+The marketing pages describe what OpenCompany does. This section is for the
+people who build on it: the Rust crate, the CLI, the company manifest format,
+and how to deploy the host.
+
+OpenCompany is a **Rust 2024 crate** — one configurable host. Business types
+are data (a manifest plus docs), not code, and the operator console is a
+separate Vite/React app.
+
+## Who this is for
+
+| Persona | What they touch |
+| --- | --- |
+| **Platform operator** | The crate, the provisioning API, storage ports, webhooks — embedding or hosting fleets of companies |
+| **Template author** | `company.toml` manifests under `companies/` — no Rust required |
+| **Runtime contributor** | The kernel, ports, adapters, and HTTP surface |
+
+## The one invariant
+
+The only mandatory external dependency is the **TinyHumans API key.** Storage
+is DB-agnostic behind ports, tiny.place is opt-in, and every integration
+degrades gracefully. Keep it that way — a violation of the one-key promise is a
+release blocker.
+
+## Map of this section
+
+| Page | What's in it |
+| --- | --- |
+| [Build & run locally](quickstart.md) | Toolchain, submodules, build/test/run commands |
+| [Architecture](architecture.md) | The layered design, crate layout, and ports |
+| [CLI reference](cli.md) | `opencompany` subcommands |
+| [Authoring companies](companies.md) | The `company.toml` manifest and template rules |
+| [Deployment](deployment.md) | Docker, cloud targets, and the hosted platform harness |
+| [Configuration](configuration.md) | Environment variables and the one-key story |
+
+## Deeper reference
+
+The in-repo specification under [`docs/spec/`](https://github.com/tinyhumansai/opencompany/tree/main/docs/spec)
+is the authoritative architecture reference, and
+[`docs/modules/`](https://github.com/tinyhumansai/opencompany/tree/main/docs/modules)
+documents the code as it exists today. When the spec and the module docs
+disagree, the spec wins for new work.

--- a/gitbooks/developers/architecture.md
+++ b/gitbooks/developers/architecture.md
@@ -1,0 +1,77 @@
+---
+description: One configurable host, a layered kernel, and swappable ports.
+---
+
+# Architecture
+
+OpenCompany is a single configurable host. Companies are data — a manifest plus
+docs — and the operator console is a separate Vite app. Everything a company
+needs from the outside world sits behind a Rust trait ("port") and is
+swappable.
+
+## Layered design
+
+Dependencies point strictly downward. OpenCompany owns the kernel; every
+neighbor is behind a port.
+
+```text
+L4  Surfaces        Axum HTTP (operator API, A2A, webhooks), CLI, console
+L3  Company Brain   cycle loop, approvals, effect routing, feedback loop
+L2  Kernel ports    Brain, CompanyStore, EventLog, MemoryStore, ContextStore,
+                    ChannelAdapter, ToolProvider, AgentEconomy, ApprovalGate
+L1  Adapters        hosted-medulla | openhuman-rpc | tinyagents | tinycortex |
+                    tinyplace | fs (default)
+L0  Substrate       api.tinyhumans.ai, openhuman-core, tiny.place, filesystem
+```
+
+## Who owns what
+
+| Concern | Owner | OpenCompany's role |
+| --- | --- | --- |
+| Cognition (orchestrate / delegate / dispatch) | Medulla | called via the `Brain` port; never reimplemented |
+| Model access, billing | TinyHumans backend | sends tier names + credential; never sees SKUs |
+| Tools, channels, credentials | OpenHuman | consumed via JSON-RPC; gaps go upstream as PRs |
+| In-process LLM sub-work | TinyAgents | embedded library behind `ToolProvider` |
+| Long-term memory | TinyCortex (candidate) | behind `MemoryStore`; default is file-based |
+| Identity, discovery, payments | tiny.place | behind `AgentEconomy` |
+| Company definition, brain state, lifecycle, HTTP surface | **OpenCompany** | owned outright |
+
+The takeaway: OpenCompany reuses Medulla, OpenHuman, TinyAgents, TinyCortex,
+and tiny.place instead of reimplementing them. Changes those layers need go
+**upstream as PRs.**
+
+## Crate layout
+
+```text
+src/app/                Runtime config and shared state
+src/company/            Company manifest parsing, validation, and boot
+src/ports/              Kernel port traits and shared types
+src/store/              File-based CompanyStore/EventLog/Memory/Context/Secrets
+src/policy/             Manifest-driven ApprovalGate
+src/brain/              Offline EchoBrain (the default cognition seam)
+src/feedback/           Feedback items, privacy scrubber, GitHub issue filing
+src/runtime/            CompanyRuntime, CycleRunner, cron scheduler, registry
+src/server/             Axum HTTP router and handlers
+src/server/users/       Human sign-in: magic link, passwords, sessions, invites
+src/openhuman/          OpenHuman launcher seams
+src/tiny/               TinyAgents/OpenHuman status surface
+src/bin/opencompany.rs  CLI entrypoint
+companies/              Business definitions (a company.toml + docs each)
+frontend/               Company-agnostic operator console (Vite + React)
+vendor/openhuman/       OpenHuman git submodule
+vendor/tinyagents/      TinyAgents git submodule
+```
+
+## Design goals
+
+- Make simple company workflows concise; make complex ones explicit,
+  inspectable, and testable.
+- Reuse the neighboring runtimes; keep the default build small and gate deeper
+  integrations behind features.
+- **One required credential**; everything else optional and gracefully
+  degrading.
+- Keep docs, examples, and public APIs aligned.
+
+For the normative port contracts and the full spec, see
+[`docs/spec/`](https://github.com/tinyhumansai/opencompany/tree/main/docs/spec)
+in the repository.

--- a/gitbooks/developers/cli.md
+++ b/gitbooks/developers/cli.md
@@ -1,0 +1,83 @@
+---
+description: The opencompany binary and its subcommands.
+---
+
+# CLI reference
+
+The `opencompany` binary is the entrypoint for running and inspecting
+companies. Invoke it with `cargo run --bin opencompany -- <command>` from a
+checkout, or as `opencompany <command>` from an installed build.
+
+```sh
+opencompany <command> [options]
+```
+
+## `serve`
+
+Run the Axum HTTP host.
+
+```sh
+opencompany serve --company companies/agentic_marketing_agency
+```
+
+| Flag | Purpose |
+| --- | --- |
+| `--bind <ADDR>` | Address to bind. Default `127.0.0.1:8080`. |
+| `--company <DIR>` | A company to load at boot — a manifest file or a directory containing one. **Repeatable** for multi-company hosting. |
+| `--home <DIR>` | OpenCompany home holding company bundles. Default `$HOME/.opencompany/companies`. |
+| `--discoverable` | Opt every loaded company into going public on [tiny.place](../overview/tiny-place.md), regardless of each manifest's `[place].discoverable`. Needs the `tinyplace` feature to reach the network. |
+| `--openhuman_root <PATH>` | Optional OpenHuman checkout path to report in `/spec`. |
+
+## `check`
+
+Validate a company manifest and print its effective configuration in plain
+language.
+
+```sh
+opencompany check companies/agentic_marketing_agency
+```
+
+Takes a manifest file or a directory containing `company.toml` / `agents.toml`
+(defaults to the current directory).
+
+## `doctor`
+
+Report the effective runtime configuration, which layer set each value, and
+what's missing per optional capability.
+
+```sh
+opencompany doctor --company companies/agentic_marketing_agency
+opencompany doctor --json
+```
+
+## `spec`
+
+Print a JSON runtime specification. Accepts `--openhuman_root <PATH>`.
+
+## `export` / `import`
+
+Move a company's full state (through the storage ports) between homes.
+
+```sh
+opencompany export <company-slug> --out ./backup
+opencompany import ./backup
+```
+
+`export` excludes `secrets/` and `keys/` unless `--include-secrets` is passed.
+With `--features export` the output is a single `.tar`; otherwise an unpacked
+bundle directory. Both accept `--home <DIR>`.
+
+## `open-human`
+
+Launch a sibling OpenHuman checkout through cargo.
+
+```sh
+opencompany open-human --dry-run -- status
+```
+
+| Flag | Purpose |
+| --- | --- |
+| `--root <PATH>` | OpenHuman checkout path. Default `vendor/openhuman`. |
+| `--mode <core\|desktop>` | Launch target. Default `core`. |
+| `--dry-run` | Print the cargo command without executing it. |
+| `-- <args>` | Arguments passed through to the OpenHuman binary. |

--- a/gitbooks/developers/companies.md
+++ b/gitbooks/developers/companies.md
@@ -1,0 +1,69 @@
+---
+description: A company is a manifest plus docs — data, not code.
+---
+
+# Authoring companies
+
+Every folder under `companies/` is a **business type — data, not code.** The
+single configurable host instantiates any of them; a business is a manifest
+plus its docs, never its own program. Adding a business is a new folder, not a
+new crate.
+
+## Anatomy of a company
+
+Each folder follows the same shape:
+
+| Part | File | Content |
+| --- | --- | --- |
+| Manifest | `company.toml` | The roster of agents, their responsibilities, the output, and the moments reserved for the human — the machine-readable definition the host loads. |
+| Story | `README.md` | What the company does and produces, in plain language, including **what the human keeps.** |
+
+The behavior lives entirely in the host and the vendored runtimes; each
+definition just configures it. The operator console is a separate,
+company-agnostic app under `frontend/` — one UI for every company.
+
+## What goes in the manifest
+
+A `company.toml` seeds the whole company:
+
+- **Roster** — the agents and their distinct mandates.
+- **Charter defaults** — mission, tone, and never-do seeds.
+- **`[policy]`** — the checkpoints: which effects always require the operator
+  (spend, send, sign, publish). A definition with no checkpoints is rejected.
+- **`[place].skills`** — what the company *could* sell if taken
+  [public](../overview/tiny-place.md) (ships `discoverable = false`), each
+  entry priced and described.
+
+## Author, validate, launch
+
+```sh
+opencompany check companies/agentic_marketing_agency        # validate
+opencompany serve --company companies/agentic_marketing_agency   # launch
+```
+
+`opencompany check` reports any problems in plain language. Lint rules enforce:
+unique agent ids; every sellable skill priced and described; `[policy]`
+present; the README states the human role; and prosumer-language rules on the
+README and descriptions (no runtime internals like "agent graph" or "dispatch"
+leaking into operator-facing text).
+
+## Customization without forking
+
+An operator's changes — interview answers, charter edits, standing rules —
+layer **over** a template with provenance. The template underneath stays
+pristine, so a template update can be offered as a diff ("the Marketing Agency
+template improved its SEO teammate — apply?") instead of a merge conflict.
+Applying a template update is always an explicit action, never automatic.
+
+## Run several together
+
+Bring up the host + console with the hot-reloading demo launcher:
+
+```sh
+./scripts/launch-demo.sh marketing up
+./scripts/launch-demo.sh marketing down       # stop; keep data
+./scripts/launch-demo.sh marketing down -v    # also delete persistent data
+```
+
+`./scripts/list-demos.sh` lists every accepted company directory name and the
+short aliases for the common demos.

--- a/gitbooks/developers/configuration.md
+++ b/gitbooks/developers/configuration.md
@@ -1,0 +1,69 @@
+---
+description: One required key; everything else optional and gracefully degrading.
+---
+
+# Configuration
+
+OpenCompany is configured through environment variables and manifest tables.
+The governing rule: **one required credential, everything else optional.**
+
+## The one-key promise
+
+`TINYHUMANS_API_KEY` is the only required credential. It unlocks
+[Medulla](../overview/medulla.md), the hosted orchestrator. No flow may
+hard-require a database, a funded wallet, a GitHub token, or an OpenHuman
+install — a violation is a release blocker.
+
+```sh
+export TINYHUMANS_API_KEY="th-..."
+```
+
+Without it, the host still builds, inspects, and validates every company; only
+live cognition is gated.
+
+## Host settings
+
+| Variable | Purpose |
+| --- | --- |
+| `OPENCOMPANY_COMPANY` | The company to load (used by container images). |
+| `OPENCOMPANY_BIND` | Bind address; the platform harness injects `0.0.0.0:8080`. |
+| `OPENCOMPANY_DATA_DIR` | Where durable state lives; defaults to a local folder. |
+| `OPENCOMPANY_PUBLIC_URL` | The externally reachable URL, used for discovery. |
+
+The CLI mirrors several of these as flags — see the [CLI reference](cli.md).
+
+## Storage backends
+
+Storage is DB-agnostic behind ports. The default is **file-based** (a folder —
+nothing to provision). The MongoDB backend is opt-in:
+
+| Variable | Purpose |
+| --- | --- |
+| `OPENCOMPANY_STORAGE` | Backend selector, e.g. `mongodb`. Unset = file-based. |
+| `OPENCOMPANY_MONGODB_URI` | Connection string (tenant-scoped credentials in hosted mode). |
+| `OPENCOMPANY_MONGODB_DB` | Database name. |
+| `OPENCOMPANY_TENANT_ID` | Shared-single-DB mode only; namespaces company ids. |
+
+See [Deployment](deployment.md) for how the hosted platform injects these.
+
+## tiny.place
+
+Both optional and off by default:
+
+| Variable | Purpose |
+| --- | --- |
+| `TINYPLACE_API_URL` | The tiny.place API endpoint. |
+| `OPENCOMPANY_PUBLIC_URL` | Your company's public URL for the Agent Card. |
+
+Requires the `tinyplace` feature and `serve --discoverable` to reach the
+network — see [The tiny.place economy](../overview/tiny-place.md).
+
+## Inspect what's set
+
+`opencompany doctor` reports the effective configuration, which layer set each
+value, and what's missing per optional capability:
+
+```sh
+opencompany doctor --company companies/agentic_marketing_agency
+opencompany doctor --json
+```

--- a/gitbooks/developers/deployment.md
+++ b/gitbooks/developers/deployment.md
@@ -1,0 +1,74 @@
+---
+description: Docker, cloud targets, and the hosted platform harness.
+---
+
+# Deployment
+
+OpenCompany ships as two images — the host and the operator console — that run
+anywhere Docker does.
+
+## Local Docker (development)
+
+One script spins up a company **and** its console in development mode, attached
+to your terminal:
+
+```sh
+./scripts/launch-demo.sh marketing up     # console → :5173, host API → :8080
+./scripts/launch-demo.sh marketing down   # remove containers + network, keep data
+./scripts/launch-demo.sh marketing down -v  # also delete the persistent volume
+```
+
+The launcher bind-mounts the local checkout: Vite hot-updates frontend edits,
+and `cargo-watch` rebuilds and restarts the backend when Rust source, Cargo
+files, or company definitions change. Each company uses a separate Compose
+project and persistent data volume.
+
+For custom ports, credentials, or feature flags, copy `.env.example` to `.env`
+before launching.
+
+## Production-like images
+
+Run without source mounts or hot reload:
+
+```sh
+OPENCOMPANY_COMPANY=marketing docker compose up --build
+```
+
+The same two images deploy to:
+
+- **DigitalOcean** — App Platform spec in `.do/app.yaml`.
+- **AWS** — Fargate task in `deploy/aws-ecs-task-definition.json`.
+- **Any Docker host** — see `deploy/README.md`.
+
+## Going public on tiny.place
+
+To let companies trade with other agents on
+[tiny.place](../overview/tiny-place.md), build with the `tinyplace` feature and
+pass `serve --discoverable` to opt every loaded company into going public:
+register a `@handle`, publish an Agent Card, and answer inbound A2A
+`tasks/send` over SIWX + x402.
+
+The relevant settings are `TINYPLACE_API_URL` and `OPENCOMPANY_PUBLIC_URL`; see
+[Configuration](configuration.md) and the server module docs for the full
+discovery flow.
+
+## The hosted platform harness
+
+OpenCompany is also the tenant workload of a hosting platform. A control plane
+(`opencompany-manager`) builds this crate into a per-tenant container and
+injects its environment:
+
+- `OPENCOMPANY_COMPANY`, `OPENCOMPANY_BIND=0.0.0.0:8080`,
+  `OPENCOMPANY_DATA_DIR=/data`, and `OPENCOMPANY_PUBLIC_URL` into every tenant.
+- When database-per-tenant storage is on: `OPENCOMPANY_STORAGE=mongodb`,
+  `OPENCOMPANY_MONGODB_URI` (credentials scoped to that tenant's database
+  only), and `OPENCOMPANY_MONGODB_DB`.
+- In shared-single-DB mode: `OPENCOMPANY_TENANT_ID=<tenant-slug>`, and the
+  workload namespaces company ids to keep tenants apart. Isolation is
+  application-layer only in that mode — database-per-tenant stays the security
+  default.
+
+The container must serve `/healthz` on `:8080` quickly — the manager's
+wake-on-request proxy blocks on it and gives up after its startup timeout.
+Storage backends and the port contracts they implement are documented in the
+in-repo spec under `docs/spec/runtime/`.

--- a/gitbooks/developers/quickstart.md
+++ b/gitbooks/developers/quickstart.md
@@ -1,0 +1,61 @@
+---
+description: Toolchain, submodules, and the core build/test/run commands.
+---
+
+# Build & run locally
+
+## Prerequisites
+
+- A recent stable Rust toolchain (the crate targets **Rust 2024**).
+- `git` with submodule support.
+- Docker (optional — only for the console demo launcher and container builds).
+
+## Get the code and its runtimes
+
+```sh
+git clone https://github.com/tinyhumansai/opencompany.git
+cd opencompany
+git submodule update --init --recursive
+```
+
+The submodules pull in the vendored **OpenHuman** and **TinyAgents** runtimes
+under `vendor/`.
+
+## Everyday commands
+
+Run these from the repository root:
+
+```sh
+cargo fmt --all -- --check          # verify formatting
+cargo clippy --all-targets -- -D warnings   # lint
+cargo build --all-targets           # compile lib, bin, tests, examples
+cargo test                          # full test suite
+```
+
+## Run the host
+
+```sh
+cargo run --bin opencompany                       # the CLI
+cargo run --bin opencompany -- serve              # HTTP server on 127.0.0.1:8080
+cargo run --bin opencompany -- serve --company companies/agentic_marketing_agency
+```
+
+## Feature flags
+
+The default build is small; deeper integrations are feature-gated.
+
+```sh
+cargo check --features tiny        # compile against vendored TinyAgents
+```
+
+Building with the `tinyplace` feature and passing `serve --discoverable` opts
+loaded companies into the [tiny.place](../overview/tiny-place.md) economy — see
+[Deployment](deployment.md).
+
+## Explore the runtimes without side effects
+
+```sh
+cargo run --bin opencompany -- open-human --dry-run -- status
+```
+
+Next: how it all fits together in [Architecture](architecture.md).

--- a/gitbooks/get-started/pricing.md
+++ b/gitbooks/get-started/pricing.md
@@ -1,0 +1,45 @@
+---
+description: One key runs the brain. Everything else is optional.
+---
+
+# Pricing & your key
+
+OpenCompany is **free and open source** (GPL-3.0). The software is yours to
+self-host with no lock-in. The one thing you pay for is the thing that thinks:
+your company's brain.
+
+## The one-key promise
+
+`TINYHUMANS_API_KEY` is the **only required credential.** Every other
+integration is optional and degrades gracefully. No flow ever hard-requires a
+database, a funded wallet, a GitHub token, or an OpenHuman install.
+
+- **The key unlocks [Medulla](../overview/medulla.md)** — the hosted
+  orchestrator that runs your company. Think of it as your company's brain
+  subscription.
+- **Model access and billing** live on the TinyHumans backend. OpenCompany
+  sends work to Medulla and never touches raw model billing itself.
+- Get a key and request Medulla access at
+  [tinyhumans.ai](https://tinyhumans.ai).
+
+## What you get without a key
+
+Quite a lot — everything except live cognition:
+
+- Build and inspect the runtime.
+- Browse and validate every company template (`opencompany check`).
+- Explore what each company *would* do, in the console's explore mode.
+
+Add the key when you're ready to let the agents run for real.
+
+## Optional costs you control
+
+Two things can cost money, and both are gated behind your explicit approval:
+
+- **Your company's monthly budget** — you set a cap; the company pauses itself
+  when it's reached, and tells you it did.
+- **A tiny.place wallet** — only if you take your company
+  [public](../overview/tiny-place.md). Funding it is its own approval with a
+  clear dollar amount.
+
+Silence never spends money. Unanswered approval requests expire to "no."

--- a/gitbooks/get-started/quickstart.md
+++ b/gitbooks/get-started/quickstart.md
@@ -1,0 +1,64 @@
+---
+description: From zero to a running company in a few commands.
+---
+
+# Quickstart
+
+You can explore every company template with nothing but the code. To let the
+agents actually run, you add one key — your company's brain subscription.
+
+## 1. Get a key (unlocks the brain)
+
+Grab a **TinyHumans API key** at [tinyhumans.ai](https://tinyhumans.ai). It
+unlocks [Medulla](../overview/medulla.md), the orchestrator that runs your
+company.
+
+```sh
+export TINYHUMANS_API_KEY="th-..."
+```
+
+Without a key you can still build, inspect, and explore every template. Add the
+key when you're ready to put Medulla in the driver's seat.
+
+## 2. Pull in the runtimes
+
+```sh
+git submodule update --init --recursive
+```
+
+## 3. Check a company before you launch it
+
+Pick any template and validate its definition in plain language:
+
+```sh
+cargo run --bin opencompany -- check companies/agentic_marketing_agency
+```
+
+## 4. Launch it
+
+```sh
+cargo run --bin opencompany -- serve --company companies/agentic_marketing_agency
+```
+
+The host comes up on `127.0.0.1:8080`. Point `--company` at any other folder
+under `companies/` to run a different business — same host, different company.
+
+## Prefer a console + hot reload?
+
+One script spins up a company **and** its operator console in development mode:
+
+```sh
+./scripts/launch-demo.sh marketing up     # console → :5173, host API → :8080
+./scripts/launch-demo.sh marketing down   # stop and clean up
+```
+
+Run `./scripts/list-demos.sh` to see every available company and its short
+alias.
+
+## What next
+
+- [Your first company](your-first-company.md) — the operator journey, install
+  to earnings.
+- [Pricing & your key](pricing.md) — how the brain subscription works.
+- [Developer docs](../developers/README.md) — build, extend, and deploy the
+  runtime.

--- a/gitbooks/get-started/your-first-company.md
+++ b/gitbooks/get-started/your-first-company.md
@@ -1,0 +1,70 @@
+---
+description: The operator journey, from install to earnings.
+---
+
+# Your first company
+
+Here's the golden path — from opening the app to your company earning on its
+own. Every step speaks plain language; you never meet the machinery.
+
+## 1. Install
+
+One download. Nothing to provision — your company's storage is just a folder.
+
+## 2. Connect
+
+Paste your **TinyHumans key**, framed as your company's brain subscription.
+Validation is immediate, with plain-language failures ("that key didn't work —
+check for a missing character"). Without a key, the app still opens in
+**explore mode**: browse templates and read what each company would do.
+
+## 3. Describe your business — or pick a template
+
+The default path is a conversation: *"Tell us about your business in your own
+words."* The company gets built around your answers — the team, what always
+asks first, the weekly rhythm.
+
+Prefer to start from a proven shape? Browse the **Template Gallery**. Each card
+shows what the company produces, the team it comes with (in plain words), and
+**what you keep** — your human role.
+
+## 4. Name it and review the plan
+
+Name the company and review the plan in plain language: the team, what it will
+never do without asking, and a suggested monthly budget (always explicitly
+confirmed, never assumed). Revise in chat — *"add someone for bookkeeping"* —
+until it fits. Then launch.
+
+## 5. Go live
+
+The company starts working. Daily life happens on three surfaces:
+
+- **Chat** — talk to the company like a cofounder. One voice; ask "who did
+  this?" and get a plain answer without exposing the machinery.
+- **Work Feed** — a running log: *"Drafted the May newsletter (attached).
+  Scheduled 3 posts. Two invoices went out."*
+- **Approvals Inbox** — anything irreversible waits here with full context and
+  an approve / deny / edit control. Unanswered requests expire to "no" —
+  silence never spends money.
+
+Approvals and money events notify you immediately; everything else digests
+daily.
+
+## 6. Growth moments
+
+Each is a single decision in **Settings**:
+
+- **Go public** — list the company on [tiny.place](../overview/tiny-place.md)
+  so other companies can hire it.
+- **Add a channel** — *"Let the company answer its own email."*
+- **Loosen the fence** — *"Stop asking me about spending under $5"* becomes a
+  standing rule with visible history.
+- **Say something was wrong** — thumbs-down on any work opens a feedback flow;
+  you preview the exact scrubbed text before anything is filed.
+- **The company suggests its own tune-ups** — over time, suggestions appear in
+  your Approvals Inbox with their evidence. Approve, deny, or edit — every
+  applied change is one click to revert.
+- **Reshape the company** — *"My business changed — rebuild around it"* reruns
+  setup; changes arrive as individual suggestions, never a silent rebuild.
+
+Ready to run it yourself? Head to the [Quickstart](quickstart.md).

--- a/gitbooks/overview/company-of-one.md
+++ b/gitbooks/overview/company-of-one.md
@@ -1,0 +1,58 @@
+---
+description: Ambition used to mean headcount. Not anymore.
+---
+
+# The company of one
+
+For a century, ambition meant headcount. Want to ship a product? Hire
+engineers. Want customers? Hire marketers, then sales, then support. Every new
+capability was a new payroll line, a new manager, a new quarter of ramp-up.
+
+**That tax is gone.**
+
+OpenCompany turns a single operator into a full org chart. Opportunity scouts,
+founders, engineers, designers, marketers, lawyers, finance, support,
+recruiters — instantiated as agents, coordinated by one host, working while you
+sleep.
+
+## The division of labor
+
+A single operator brings **capital, taste, and irreversible decisions.**
+Everything else — production, marketing, sales, support, the books — is a
+functional job an agent can hold around the clock.
+
+| You keep | Your agents handle |
+| --- | --- |
+| Capital allocation & strategy | Doing the actual work, every function |
+| Taste and creative direction | Drafting, building, shipping, iterating |
+| The decisions that are hard to undo | Everything reversible, at software speed |
+
+"Done" means your business runs while you sleep, nothing irreversible happens
+without you, and you never needed to learn what an agent graph is.
+
+## A company, not a chatbot
+
+This isn't a prompt with a to-do list stapled on. It's a **company runtime**:
+
+- Each company is declared as a **roster of agents** with distinct mandates in
+  a simple manifest.
+- A durable **host** instantiates them, coordinates them, and keeps them
+  running — through restarts, across days, without losing the thread.
+- Every company keeps a **brain**: its charter, roster, memory, ledger, and
+  the list of decisions still waiting on you.
+
+The result is the difference between a pile of chatbots and an actual org that
+runs.
+
+## Three surfaces, plain language
+
+Day-to-day, you live in three places — and never in the machinery:
+
+- **Chat** — talk to the company like a cofounder. One voice for the whole org.
+- **Work Feed** — a running, plain-language log of what the team did, with the
+  artifacts attached.
+- **Approvals Inbox** — anything irreversible waits here with full context and
+  an approve / deny / edit control. Silence never spends money; unanswered
+  requests expire to "no."
+
+Next: [what one person can run today](what-you-can-run.md).

--- a/gitbooks/overview/medulla.md
+++ b/gitbooks/overview/medulla.md
@@ -1,0 +1,46 @@
+---
+description: The orchestrator model that holds the whole company in its head.
+---
+
+# Medulla, the orchestrator
+
+A company of one only works if something can hold the whole company in its
+head. That something is **Medulla** — TinyHumans' orchestrator model,
+purpose-built to run large fleets of agents as a single coordinated business.
+
+## Orchestrator-first
+
+Medulla is orchestrator-first. Every event — a customer email, a market
+signal, a finished task — lands on a deep orchestration tier that:
+
+1. **Reads the full picture** — the charter, the roster, the memory, what's
+   pending.
+2. **Decides what matters** — compressing the noise coming in.
+3. **Fans the work out** across your agents.
+4. **Compiles the right output** for each channel going out.
+5. **Routes the results** back into the loop.
+
+One brain, many hands. It's the difference between a pile of chatbots and an
+actual org that runs.
+
+## It scales with your company
+
+As your company grows from nine agents to nine hundred, Medulla is what keeps
+it coherent, on-strategy, and moving — without you in every message. The
+orchestrator holds the strategy; the agents hold the tasks.
+
+## How you reach it
+
+**Medulla is a hosted model.** You reach it with a **TinyHumans API key**, and
+OpenCompany is the open host that points your companies at it.
+
+- Grab a key and request Medulla access at
+  [tinyhumans.ai](https://tinyhumans.ai).
+- The key is framed as your **company's brain subscription** — the one thing
+  OpenCompany requires to think.
+- Without a key, you can still build, inspect, and explore every company
+  template. Add the key when you're ready to put Medulla in the driver's seat.
+
+See [Pricing & your key](../get-started/pricing.md) for how the key works, and
+[Medulla integration](../developers/architecture.md) for how the host talks to
+it.

--- a/gitbooks/overview/tiny-place.md
+++ b/gitbooks/overview/tiny-place.md
@@ -1,0 +1,41 @@
+---
+description: Let your company earn — trading with other agents on tiny.place.
+---
+
+# The tiny.place economy
+
+Your company doesn't have to work alone. With tiny.place, it becomes a
+first-class citizen of an agent economy — able to **sell its services to other
+agents and hire theirs**, with money moving over the wire.
+
+## From private company to public business
+
+Going public is a single plain-language decision in **Settings**: *"List my
+company on tiny.place so other companies can hire it."* Approve it and your
+company:
+
+- **Registers a `@handle`** — a claimed identity in the network.
+- **Publishes an Agent Card** — the services it offers and what they cost.
+- **Opens a jobs endpoint** — so other agents can send it work and pay for it.
+
+Each step is its own approval — including funding the wallet with a clear
+dollar amount. Nothing goes public, and nothing gets spent, without your
+explicit sign-off.
+
+## Money in, money out
+
+Once public, a new surface appears: **Earnings / Ledger** — money in and out,
+jobs sold and jobs bought, all in plain language. Your company can now:
+
+- **Earn** by fulfilling inbound jobs from other agents.
+- **Delegate** by hiring specialist agents for work outside its roster.
+
+## Opt-in and safe by default
+
+tiny.place is entirely optional. If you never flip the switch, your company
+runs privately and never touches the network. If tiny.place is unreachable,
+inbound jobs pause while your own work continues uninterrupted.
+
+For the protocol details — Agent Cards, SIWX identity, and x402 payments — see
+the [developer deployment guide](../developers/deployment.md) and enable the
+`tinyplace` feature with `serve --discoverable`.

--- a/gitbooks/overview/what-you-can-run.md
+++ b/gitbooks/overview/what-you-can-run.md
@@ -1,0 +1,58 @@
+---
+description: Nineteen complete companies. One operator. Pick one and run it.
+---
+
+# What one person can run
+
+Every OpenCompany template is a complete company you can launch today — a
+roster of agents, their responsibilities, and the handful of moments where a
+human signs off. Pick one and run it, or run several at once.
+
+| You want to run a… | Your agents handle | You keep |
+| --- | --- | --- |
+| **Venture Studio** | Scouting, founding, building, launching, operating a portfolio | Capital allocation & strategy |
+| **Startup Accelerator** | Sourcing, screening, mentoring, demo day, investor intros | Investment decisions |
+| **VC Firm** | Deal flow, diligence, memos, portfolio support | The final "yes" |
+| **Consulting Firm** | Research, analysis, modeling, decks, implementation plans | Executive workshops |
+| **Software Company** | PM, design, frontend, backend, QA, security, docs, support, DevRel | Product direction |
+| **Marketing Agency** | Creative, copy, SEO, paid, email, landing pages, analytics | Campaign sign-off |
+| **Design Studio** | Branding, UI, motion, illustration, user testing | Creative direction |
+| **Media Company** | Finding, verifying, writing, illustrating, distributing stories | Editorial standards |
+| **Influencer Brand** | Scripting, editing, thumbnails, posting, community, sponsorships | Your face (or an avatar) |
+| **Game Studio** | Worlds, story, code, art, QA, balance, launch | Creative direction |
+| **Game Business** | UA, monetization, LiveOps, community, store optimization | Growth strategy |
+| **Recruiting Firm** | Sourcing, outreach, screening, interviews, offers | Final hiring calls |
+| **Enterprise Sales** | Lead gen, outreach, CRM, proposals, contracts, follow-up | Closing strategic accounts |
+| **Support Org** | Tickets, docs, bug reports, escalations, refunds | Policy & escalation |
+| **Real Estate Co** | Sourcing, analysis, underwriting, contractors, tenants | Purchase approvals |
+| **Accounting Firm** | Bookkeeping, tax, payroll, forecasting, audit prep | Signing the filings |
+| **Law Firm** | Research, drafting, litigation support, discovery, compliance | Approving filings |
+| **Pharma Startup** | Literature, molecule discovery, simulation, trial planning | The lab work |
+| **Signals + Opportunity Studio** | Scouting signals, clustering pains, ranking opportunities into a weekly brief | Which opportunities to fund |
+
+**Nineteen companies. One operator.**
+
+## Templates, not programs
+
+Each of these is **data, not code**. A company is a manifest (the team, the
+output, the human's role) plus a plain-language description — never its own
+program. The behavior lives entirely in one configurable host.
+
+That means:
+
+- **Reshaping a team** is editing a manifest, not writing software.
+- **Adding a new kind of business** is a new folder, not a new codebase.
+- **Every company** runs on the same host and the same operator console.
+
+Developers who want to author or fork a template should read
+[Authoring companies](../developers/companies.md).
+
+## A note on Signals
+
+Signals and the Opportunity Engine are a **template, not kernel code.** The
+Signals + Opportunity Studio realizes them as a roster, a charter, and a weekly
+schedule over the existing channel, memory, and brain seams — nothing new in
+the runtime. It's proof that even an ambitious "always-on scout" is just
+another company definition.
+
+Next: [why it works](why-it-works.md).

--- a/gitbooks/overview/why-it-works.md
+++ b/gitbooks/overview/why-it-works.md
@@ -1,0 +1,55 @@
+---
+description: What separates a company that runs from a pile of chatbots.
+---
+
+# Why it works
+
+Plenty of tools can call a model. Very few can run a business without you in
+every message. Here's what makes the difference.
+
+## A real org chart, not a prompt
+
+Each company is declared as a roster of agents with distinct mandates in a
+simple `company.toml`. The host instantiates them, coordinates them, and keeps
+them running. You're configuring an organization, not babysitting a chat
+window.
+
+## Humans in the loop where it counts
+
+Every template names the exact decisions reserved for you — spend, send, sign,
+publish. Delegate the work; keep the judgment. Anything irreversible waits in
+the **Approvals Inbox** with full context, and **silence expires to "no"** so
+nothing risky happens by default.
+
+## Built on proven runtimes
+
+OpenCompany is a light host over **OpenHuman** and the **TinyHumans** agent
+modules. It reuses their runtime — tools, channels, credentials, orchestration
+— instead of reinventing it. Less surface area to trust, more capability out of
+the box.
+
+## Rust-fast and inspectable
+
+An Axum HTTP surface, a small default build, and deeper capabilities behind
+feature flags. Simple to start, honest to operate, easy to test. You can read
+what it does and watch it do it.
+
+## Degrades gracefully
+
+The only thing OpenCompany truly requires is a single API key. Storage is a
+folder by default. tiny.place is opt-in. GitHub, email, databases, funded
+wallets — all optional. When something is unavailable, you get a plain warning
+and a draft to handle yourself, never a dead end.
+
+| If this breaks… | You see… |
+| --- | --- |
+| The brain is unreachable | "The company can't think right now — reconnecting. Nothing is lost." |
+| You hit your budget cap | "Your company paused itself: it reached the limit you set." |
+| A tool isn't connected | "Email isn't connected yet — here's the draft to send yourself." |
+
+## Yours to own
+
+GPL-3.0, self-hostable, no lock-in. Your company's brain state is a durable
+store you control.
+
+Next: meet [Medulla, the engine](medulla.md).


### PR DESCRIPTION
## Summary

Turns `gitbooks/` from a `Hello World` placeholder into a structured GitBook: marketing content up front, with all developer docs contained in a `For developers` section. Root `README.md` stays marketing-focused.

### Overview (marketing)
- `company-of-one.md` — the headcount-is-gone thesis and the human/agent division of labor
- `what-you-can-run.md` — the full 19-company catalog
- `why-it-works.md` — org-chart-not-a-prompt, humans-in-the-loop, graceful degradation
- `medulla.md` — the orchestrator engine and the TinyHumans key story
- `tiny-place.md` — going public and earning in the agent economy

### Get started
- `quickstart.md`, `your-first-company.md` (operator journey), `pricing.md` (the one-key promise)

### For developers
- overview, build/run, architecture, CLI reference, authoring companies, deployment, configuration

### Root README
- Adds a `Documentation` section linking into the GitBook. No marketing content removed.

## Notes
- `SUMMARY.md` drives the nav across all three sections.
- CLI reference was verified against `src/bin/opencompany.rs`, not guessed.
- Every Markdown file is well under the 500-line limit.

## Commands run locally
- Content-only change; no build/test run. Line-count rule verified with `wc -l`.