### PR TITLE
docs(readme): add cover image and GitHub chips

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/tinyhumansai/opencompany/refs/heads/main/gitbooks/.gitbook/assets/opencompany.png" alt="OpenCompany" />
+</p>
+
 <h1 align="center">OpenCompany</h1>
 
 <p align="center">
@@ -11,6 +15,11 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/tinyhumansai/opencompany/blob/main/LICENSE"><img src="https://img.shields.io/github/license/tinyhumansai/opencompany?style=flat-square" alt="License: GPL-3.0" /></a>
+  <a href="https://github.com/tinyhumansai/opencompany/stargazers"><img src="https://img.shields.io/github/stars/tinyhumansai/opencompany?style=flat-square" alt="GitHub stars" /></a>
+  <a href="https://github.com/tinyhumansai/opencompany/issues"><img src="https://img.shields.io/github/issues/tinyhumansai/opencompany?style=flat-square" alt="Open issues" /></a>
+  <a href="https://github.com/tinyhumansai/opencompany/pulls"><img src="https://img.shields.io/github/issues-pr/tinyhumansai/opencompany?style=flat-square" alt="Open pull requests" /></a>
+  <a href="https://github.com/tinyhumansai/opencompany/commits/main"><img src="https://img.shields.io/github/last-commit/tinyhumansai/opencompany?style=flat-square" alt="Last commit" /></a>
   <img src="https://img.shields.io/badge/status-work%20in%20progress-orange?style=flat-square" alt="Work in progress" />
 </p>
 


### PR DESCRIPTION
## Summary

- Adds the OpenCompany cover image to the top of the README (hosted at `gitbooks/.gitbook/assets/opencompany.png`).
- Replaces the lone status badge with a row of GitHub chips: license, stars, open issues, open PRs, last commit — plus the existing work-in-progress badge.

All badges are `shields.io` and link to the relevant GitHub pages. No prose changed; README stays marketing-focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a centered project logo to the README.
  - Added GitHub status badges for license, stars, open issues, open pull requests, and last commit.
  - Badges link directly to their corresponding project pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->