### PR TITLE
feat(harness): surface company skills to embedded OpenHuman agents (#28)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,13 +73,18 @@ tinyagents = { path = "vendor/tinyagents", optional = true, features = ["sqlite"
 # WS4: openhuman embedded as a library (the harness). Only links under the
 # `openhuman` feature; the default build pulls none of this enormous native
 # dependency tree. `default-features = false` sheds openhuman's whole default
-# set — `tokenjuice-treesitter`, `voice`, `web3`, `media`, `meet`, `skills`,
+# set — `tokenjuice-treesitter`, `voice`, `web3`, `media`, `meet`,
 # `flows`, `mcp` — none of which a company agent needs; it wants the agent
-# loop, memory, and an inference provider. Keep `vendor/tinyagents` on the
+# loop, memory, and an inference provider. `skills` is re-enabled: cell #28
+# surfaces a company's effective skill set to its harness agents through
+# OpenHuman's own skill *read* tools (`list_workflows` / `describe_workflow` /
+# `read_workflow_resource`), which live in the gated `openhuman::skills`
+# domain. The feature carries no extra deps (`skills = []` upstream) — it only
+# recompiles the skills domain modules. Keep `vendor/tinyagents` on the
 # same commit openhuman's own `vendor/tinyagents` pins: the two are a
 # lockstep pair, and a skew fails to compile (only under this feature, which
 # CI does not build).
-openhuman_core = { package = "openhuman", path = "vendor/openhuman", optional = true, default-features = false }
+openhuman_core = { package = "openhuman", path = "vendor/openhuman", optional = true, default-features = false, features = ["skills"] }
 # The openhuman `Provider`/`Memory` traits return `anyhow::Result` and log via
 # the `log` facade; both only link under the `openhuman` feature.
 anyhow = { version = "1", optional = true }

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -98,6 +98,7 @@ async fn main() -> anyhow::Result<()> {
         meter: Some(meter.clone()),
         workspace_root: dir.path().to_path_buf(),
         model_override: Some(default_model.clone()),
+        tasks: None,
     };
 
     let pool = HarnessPool::new();

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -99,6 +99,8 @@ async fn main() -> anyhow::Result<()> {
         workspace_root: dir.path().to_path_buf(),
         model_override: Some(default_model.clone()),
         tasks: None,
+        skills: None,
+        skills_source_dir: None,
     };
 
     let pool = HarnessPool::new();

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -1,0 +1,64 @@
+// The live task-board API: the console's Kanban reads and writes real cards
+// through the host's `…/tasks` routes (REST, camelCase over the wire). Replaces
+// the client-side `tasks-sample` illustrative data.
+
+import type { OpenCompanyClient } from "./client";
+
+/** A board card as the host returns it. */
+export interface Task {
+  id: string;
+  title: string;
+  note?: string;
+  column: string;
+  priority: string;
+  /** The desk/teammate label that owns it (a roster agent id routes a turn). */
+  assignee: string;
+  updatedAt: number;
+}
+
+/** The create body; the host defaults column→`backlog`, priority→`medium`. */
+export interface CreateTask {
+  title: string;
+  note?: string;
+  column?: string;
+  priority?: string;
+  assignee?: string;
+}
+
+/** A partial update; any omitted field is left as-is. A drag sends `{column}`. */
+export interface PatchTask {
+  title?: string;
+  note?: string;
+  column?: string;
+  priority?: string;
+  assignee?: string;
+}
+
+export function listTasks(client: OpenCompanyClient, company: string | null): Promise<Task[]> {
+  return client.get<Task[]>(`${client.scopeFor(company)}/tasks`);
+}
+
+export function createTask(
+  client: OpenCompanyClient,
+  company: string | null,
+  body: CreateTask,
+): Promise<Task> {
+  return client.post<Task>(`${client.scopeFor(company)}/tasks`, body);
+}
+
+export function patchTask(
+  client: OpenCompanyClient,
+  company: string | null,
+  id: string,
+  body: PatchTask,
+): Promise<Task> {
+  return client.patch<Task>(`${client.scopeFor(company)}/tasks/${encodeURIComponent(id)}`, body);
+}
+
+export function deleteTask(
+  client: OpenCompanyClient,
+  company: string | null,
+  id: string,
+): Promise<void> {
+  return client.del<void>(`${client.scopeFor(company)}/tasks/${encodeURIComponent(id)}`);
+}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -291,7 +291,7 @@ export function AppShell({
             />
           )}
           {view === "inbox" && <InboxView company={company} />}
-          {view === "tasks" && <TasksView />}
+          {view === "tasks" && <TasksView client={client} company={company} />}
           {view === "team" && <TeamView client={client} company={company} />}
           {view === "people" && <PeopleView client={client} company={company} />}
           {view === "skills" && <SkillsView company={company} />}

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -1,33 +1,129 @@
-import { useState } from "react";
-import { Plus } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Loader2, Plus, Trash2 } from "lucide-react";
 
-import { Badge } from "@/components/ui/badge";
-import { cn } from "@/lib/utils";
 import {
-  PRIORITY_STYLES,
-  sampleTasks,
-  TASK_COLUMNS,
-  type TaskCard,
-} from "@/lib/tasks-sample";
+  createTask,
+  deleteTask,
+  listTasks,
+  patchTask,
+  type PatchTask,
+  type Task,
+} from "@/api/tasks";
+import type { OpenCompanyClient } from "@/api/client";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { PRIORITY_STYLES, TASK_COLUMNS } from "@/lib/tasks-sample";
+import { toast } from "sonner";
 
-const TONES: Record<string, string> = {
-  sky: "bg-sky-500/15 text-sky-600 dark:text-sky-400",
-  violet: "bg-violet-500/15 text-violet-600 dark:text-violet-400",
-  amber: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
-  emerald: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
-};
+const PRIORITIES = ["low", "medium", "high"] as const;
 
-/** A built-in Kanban board. Drag cards between columns to move work along. */
-export function TasksView() {
-  const [tasks, setTasks] = useState<TaskCard[]>(sampleTasks);
+/** How often to re-poll the board, so a dispatched card's result appears. */
+const POLL_MS = 4000;
+
+function priorityStyle(priority: string): string {
+  return PRIORITY_STYLES[priority as keyof typeof PRIORITY_STYLES] ?? PRIORITY_STYLES.low;
+}
+
+/**
+ * The live Kanban board. Cards are read from and written to the host's
+ * `…/tasks` routes; dragging a card into a column PATCHes it (moving one into
+ * "In progress" is what dispatches it to its assignee on the embedded runtime),
+ * and clicking a card opens its detail — where the agent's result shows up in
+ * the note once the turn completes.
+ */
+export function TasksView({
+  client,
+  company,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+}) {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [dragId, setDragId] = useState<string | null>(null);
   const [overCol, setOverCol] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Task | null>(null);
+  const [creatingIn, setCreatingIn] = useState<string | null>(null);
+  const mounted = useRef(true);
+  // A real HTML5 drag fires a trailing click; suppress it so a drag never also
+  // opens the detail dialog.
+  const dragged = useRef(false);
 
-  function moveTo(column: string) {
-    if (!dragId) return;
-    setTasks((ts) => ts.map((t) => (t.id === dragId ? { ...t, column } : t)));
+  const refresh = useCallback(async () => {
+    try {
+      const rows = await listTasks(client, company);
+      if (!mounted.current) return;
+      setTasks(rows);
+      setError(null);
+    } catch (e) {
+      if (!mounted.current) return;
+      setError(e instanceof Error ? e.message : "could not load the board");
+    } finally {
+      if (mounted.current) setLoading(false);
+    }
+  }, [client, company]);
+
+  useEffect(() => {
+    mounted.current = true;
+    void refresh();
+    const timer = setInterval(() => void refresh(), POLL_MS);
+    return () => {
+      mounted.current = false;
+      clearInterval(timer);
+    };
+  }, [refresh]);
+
+  async function moveTo(column: string) {
+    const id = dragId;
     setDragId(null);
     setOverCol(null);
+    if (!id) return;
+    const current = tasks.find((t) => t.id === id);
+    if (!current || current.column === column) return;
+    // Optimistic move; reconcile with the server's echo (and revert on error).
+    setTasks((ts) => ts.map((t) => (t.id === id ? { ...t, column } : t)));
+    try {
+      const saved = await patchTask(client, company, id, { column });
+      setTasks((ts) => ts.map((t) => (t.id === id ? saved : t)));
+      if (column === "in_progress") {
+        toast.success("Dispatched — the assignee is working on it.");
+        // The turn runs server-side; poll a touch sooner so the result shows.
+        setTimeout(() => void refresh(), 1500);
+      }
+    } catch (e) {
+      setTasks((ts) => ts.map((t) => (t.id === id ? { ...t, column: current.column } : t)));
+      toast.error(e instanceof Error ? e.message : "could not move the card");
+    }
+  }
+
+  function openCard(task: Task) {
+    if (dragged.current) {
+      dragged.current = false;
+      return;
+    }
+    setSelected(task);
   }
 
   return (
@@ -38,9 +134,17 @@ export function TasksView() {
           <Badge variant="secondary">{tasks.length}</Badge>
         </div>
         <p className="hidden text-xs text-muted-foreground sm:block">
-          Drag a card to move it between columns.
+          Drag a card to move it; drop into “In progress” to hand it to its assignee.
         </p>
       </div>
+
+      {error && (
+        <div className="px-4 pt-3">
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        </div>
+      )}
 
       <div className="flex flex-1 gap-4 overflow-x-auto p-4">
         {TASK_COLUMNS.map((col) => {
@@ -53,7 +157,7 @@ export function TasksView() {
                 setOverCol(col.id);
               }}
               onDragLeave={() => setOverCol((c) => (c === col.id ? null : c))}
-              onDrop={() => moveTo(col.id)}
+              onDrop={() => void moveTo(col.id)}
               className={cn(
                 "flex w-72 shrink-0 flex-col rounded-xl border bg-card/40 transition-colors",
                 overCol === col.id && "border-primary/40 bg-accent/40",
@@ -64,24 +168,39 @@ export function TasksView() {
                   <span className="text-sm font-medium">{col.label}</span>
                   <span className="text-xs text-muted-foreground">{items.length}</span>
                 </div>
-                <button className="text-muted-foreground hover:text-foreground" aria-label="Add task" disabled>
+                <button
+                  className="text-muted-foreground hover:text-foreground"
+                  aria-label={`Add task to ${col.label}`}
+                  onClick={() => setCreatingIn(col.id)}
+                >
                   <Plus className="size-4" />
                 </button>
               </div>
               <div className="flex flex-1 flex-col gap-2 overflow-y-auto px-2 pb-2">
-                {items.map((t) => (
-                  <TaskItem
-                    key={t.id}
-                    task={t}
-                    dragging={dragId === t.id}
-                    onDragStart={() => setDragId(t.id)}
-                    onDragEnd={() => {
-                      setDragId(null);
-                      setOverCol(null);
-                    }}
-                  />
-                ))}
-                {items.length === 0 && (
+                {loading && items.length === 0 ? (
+                  <Skeleton className="h-20 rounded-lg" />
+                ) : (
+                  items.map((t) => (
+                    <TaskItem
+                      key={t.id}
+                      task={t}
+                      dragging={dragId === t.id}
+                      onOpen={() => openCard(t)}
+                      onDragStart={() => {
+                        dragged.current = true;
+                        setDragId(t.id);
+                      }}
+                      onDragEnd={() => {
+                        setDragId(null);
+                        setOverCol(null);
+                        // Clear the drag-suppression shortly after, so a genuine
+                        // click that follows is honored.
+                        setTimeout(() => (dragged.current = false), 0);
+                      }}
+                    />
+                  ))
+                )}
+                {!loading && items.length === 0 && (
                   <div className="rounded-lg border border-dashed py-6 text-center text-xs text-muted-foreground">
                     Drop tasks here
                   </div>
@@ -91,6 +210,32 @@ export function TasksView() {
           );
         })}
       </div>
+
+      <TaskDetailDialog
+        task={selected}
+        onClose={() => setSelected(null)}
+        onSaved={(saved) => {
+          setTasks((ts) => ts.map((t) => (t.id === saved.id ? saved : t)));
+          setSelected(null);
+        }}
+        onDeleted={(id) => {
+          setTasks((ts) => ts.filter((t) => t.id !== id));
+          setSelected(null);
+        }}
+        client={client}
+        company={company}
+      />
+
+      <CreateTaskDialog
+        column={creatingIn}
+        onClose={() => setCreatingIn(null)}
+        onCreated={(created) => {
+          setTasks((ts) => [created, ...ts]);
+          setCreatingIn(null);
+        }}
+        client={client}
+        company={company}
+      />
     </div>
   );
 }
@@ -98,11 +243,13 @@ export function TasksView() {
 function TaskItem({
   task,
   dragging,
+  onOpen,
   onDragStart,
   onDragEnd,
 }: {
-  task: TaskCard;
+  task: Task;
   dragging: boolean;
+  onOpen: () => void;
   onDragStart: () => void;
   onDragEnd: () => void;
 }) {
@@ -111,6 +258,15 @@ function TaskItem({
       draggable
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
+      onClick={onOpen}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
       className={cn(
         "cursor-grab rounded-lg border bg-card p-3 shadow-sm transition-shadow hover:shadow active:cursor-grabbing",
         dragging && "opacity-50",
@@ -118,24 +274,310 @@ function TaskItem({
     >
       <div className="flex items-start justify-between gap-2">
         <p className="text-sm font-medium leading-snug">{task.title}</p>
-        <Badge variant="outline" className={cn("shrink-0 capitalize", PRIORITY_STYLES[task.priority])}>
+        <Badge variant="outline" className={cn("shrink-0 capitalize", priorityStyle(task.priority))}>
           {task.priority}
         </Badge>
       </div>
-      {task.note && <p className="mt-1 text-xs text-muted-foreground">{task.note}</p>}
-      <div className="mt-3 flex items-center gap-2">
-        <span
-          className={cn(
-            "flex size-6 items-center justify-center rounded-full text-[10px] font-semibold",
-            TONES[task.assignee.tone] ?? "bg-muted text-muted-foreground",
-          )}
-          aria-hidden
-        >
-          {initials(task.assignee.name)}
-        </span>
-        <span className="truncate text-xs text-muted-foreground">{task.assignee.name}</span>
-      </div>
+      {task.note && (
+        <p className="mt-1 line-clamp-2 whitespace-pre-wrap text-xs text-muted-foreground">
+          {task.note}
+        </p>
+      )}
+      {task.assignee && (
+        <div className="mt-3 flex items-center gap-2">
+          <span
+            className="flex size-6 items-center justify-center rounded-full bg-muted text-[10px] font-semibold text-muted-foreground"
+            aria-hidden
+          >
+            {initials(task.assignee)}
+          </span>
+          <span className="truncate text-xs text-muted-foreground">{task.assignee}</span>
+        </div>
+      )}
     </div>
+  );
+}
+
+function TaskDetailDialog({
+  task,
+  onClose,
+  onSaved,
+  onDeleted,
+  client,
+  company,
+}: {
+  task: Task | null;
+  onClose: () => void;
+  onSaved: (t: Task) => void;
+  onDeleted: (id: string) => void;
+  client: OpenCompanyClient;
+  company: string | null;
+}) {
+  const [draft, setDraft] = useState<PatchTask>({});
+  const [busy, setBusy] = useState(false);
+
+  // Reset the edit draft each time a different card is opened.
+  useEffect(() => {
+    if (task) {
+      setDraft({
+        title: task.title,
+        note: task.note ?? "",
+        column: task.column,
+        priority: task.priority,
+        assignee: task.assignee,
+      });
+    }
+  }, [task]);
+
+  if (!task) return null;
+
+  async function save() {
+    if (!task) return;
+    setBusy(true);
+    try {
+      const saved = await patchTask(client, company, task.id, draft);
+      onSaved(saved);
+      toast.success("Saved.");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "could not save");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove() {
+    if (!task) return;
+    setBusy(true);
+    try {
+      await deleteTask(client, company, task.id);
+      onDeleted(task.id);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "could not delete");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Dialog open={!!task} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Task detail</DialogTitle>
+          <DialogDescription>
+            Edit the card, or drop it into “In progress” on the board to dispatch it.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3">
+          <div className="grid gap-1.5">
+            <Label htmlFor="task-title">Title</Label>
+            <Input
+              id="task-title"
+              value={draft.title ?? ""}
+              onChange={(e) => setDraft((d) => ({ ...d, title: e.target.value }))}
+            />
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label htmlFor="task-note">Note / result</Label>
+            <Textarea
+              id="task-note"
+              rows={8}
+              className="font-mono text-xs"
+              value={draft.note ?? ""}
+              onChange={(e) => setDraft((d) => ({ ...d, note: e.target.value }))}
+            />
+          </div>
+
+          <div className="grid grid-cols-3 gap-3">
+            <div className="grid gap-1.5">
+              <Label>Column</Label>
+              <Select
+                value={draft.column}
+                onValueChange={(v) => setDraft((d) => ({ ...d, column: v ?? undefined }))}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {TASK_COLUMNS.map((c) => (
+                    <SelectItem key={c.id} value={c.id}>
+                      {c.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid gap-1.5">
+              <Label>Priority</Label>
+              <Select
+                value={draft.priority}
+                onValueChange={(v) => setDraft((d) => ({ ...d, priority: v ?? undefined }))}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {PRIORITIES.map((p) => (
+                    <SelectItem key={p} value={p} className="capitalize">
+                      {p}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid gap-1.5">
+              <Label htmlFor="task-assignee">Assignee</Label>
+              <Input
+                id="task-assignee"
+                value={draft.assignee ?? ""}
+                placeholder="agent id"
+                onChange={(e) => setDraft((d) => ({ ...d, assignee: e.target.value }))}
+              />
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter className="justify-between sm:justify-between">
+          <Button variant="ghost" size="sm" onClick={() => void remove()} disabled={busy}>
+            <Trash2 className="mr-1.5 size-4" />
+            Delete
+          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={onClose} disabled={busy}>
+              Cancel
+            </Button>
+            <Button onClick={() => void save()} disabled={busy}>
+              {busy && <Loader2 className="mr-1.5 size-4 animate-spin" />}
+              Save
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CreateTaskDialog({
+  column,
+  onClose,
+  onCreated,
+  client,
+  company,
+}: {
+  column: string | null;
+  onClose: () => void;
+  onCreated: (t: Task) => void;
+  client: OpenCompanyClient;
+  company: string | null;
+}) {
+  const [title, setTitle] = useState("");
+  const [note, setNote] = useState("");
+  const [priority, setPriority] = useState("medium");
+  const [assignee, setAssignee] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (column) {
+      setTitle("");
+      setNote("");
+      setPriority("medium");
+      setAssignee("");
+    }
+  }, [column]);
+
+  if (!column) return null;
+
+  async function create() {
+    if (!title.trim()) return;
+    setBusy(true);
+    try {
+      const created = await createTask(client, company, {
+        title: title.trim(),
+        note: note.trim() || undefined,
+        column: column ?? undefined,
+        priority,
+        assignee: assignee.trim() || undefined,
+      });
+      onCreated(created);
+      toast.success("Task created.");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "could not create the task");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const columnLabel = TASK_COLUMNS.find((c) => c.id === column)?.label ?? column;
+
+  return (
+    <Dialog open={!!column} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>New task</DialogTitle>
+          <DialogDescription>Added to “{columnLabel}”.</DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3">
+          <div className="grid gap-1.5">
+            <Label htmlFor="new-title">Title</Label>
+            <Input
+              id="new-title"
+              autoFocus
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="What needs doing?"
+            />
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor="new-note">Note</Label>
+            <Textarea
+              id="new-note"
+              rows={4}
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Any detail the assignee should act on."
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="grid gap-1.5">
+              <Label>Priority</Label>
+              <Select value={priority} onValueChange={(v) => setPriority(v ?? "medium")}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {PRIORITIES.map((p) => (
+                    <SelectItem key={p} value={p} className="capitalize">
+                      {p}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid gap-1.5">
+              <Label htmlFor="new-assignee">Assignee</Label>
+              <Input
+                id="new-assignee"
+                value={assignee}
+                placeholder="agent id"
+                onChange={(e) => setAssignee(e.target.value)}
+              />
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={busy}>
+            Cancel
+          </Button>
+          <Button onClick={() => void create()} disabled={busy || !title.trim()}>
+            {busy && <Loader2 className="mr-1.5 size-4 animate-spin" />}
+            Create
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -102,6 +102,12 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("Deleted memory fact {fact_id}"),
             "memory.fact_deleted",
         ),
+        CompanyEvent::TaskDispatched { task_id } => (
+            Role::System,
+            "board".to_string(),
+            format!("Dispatched task {task_id}"),
+            "task.dispatched",
+        ),
     };
     WireEvent {
         seq,

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -26,8 +26,17 @@ use crate::ports::types::{Actor, ApprovalId, CompanyEvent, CompanyId, Verdict};
 use crate::ports::{
     AgentEconomy, ApprovalGate, Brain, ChannelAdapter, CompanyStore, ContextStore, EventLog,
     FactStore, InboxStore, LoginCodeStore, MemoryStore, SecretStore, SessionStore, SkillStateStore,
-    TaskStore, ToolProvider, UsageMeter, UserStore, WorkspaceStore,
+    TaskRecord, TaskStore, ToolProvider, UsageMeter, UserStore, WorkspaceStore,
 };
+
+/// The board column a task must enter to be dispatched to its assignee.
+const IN_PROGRESS: &str = "in_progress";
+
+/// Whether an upsert moves a card **into** `in_progress` (the dispatch edge).
+/// A card already in `in_progress` re-saved is not a fresh dispatch.
+fn task_enters_in_progress(prev_column: Option<&str>, next_column: &str) -> bool {
+    next_column == IN_PROGRESS && prev_column != Some(IN_PROGRESS)
+}
 use crate::runtime::CycleRunner;
 use crate::runtime::journal::RuntimeJournal;
 use crate::runtime::types::{ApprovalSummary, CompanyStatus, CycleReport};
@@ -201,6 +210,64 @@ impl CompanyRuntime {
     /// This company's task board.
     pub fn tasks(&self) -> &Arc<dyn TaskStore> {
         &self.ops.tasks
+    }
+
+    /// Upserts a board task and edge-fires a dispatch when the write moves the
+    /// card **into** `in_progress` — the drag into `in_progress` is the human
+    /// approval gate. The single write site for REST task mutations, so the
+    /// trigger cannot be bypassed by writing straight to the store.
+    ///
+    /// The dispatch is detached (see [`dispatch_task`](Self::dispatch_task)), so
+    /// the HTTP write returns immediately; the agent turn's result lands back on
+    /// the card asynchronously. Without an attached harness the board stays inert
+    /// — the card simply rests in `in_progress`.
+    pub async fn upsert_task(self: &Arc<Self>, task: &TaskRecord) -> Result<()> {
+        let prev_column = self
+            .ops
+            .tasks
+            .list(&self.id)
+            .await?
+            .into_iter()
+            .find(|t| t.id == task.id)
+            .map(|t| t.column);
+        let dispatch = task_enters_in_progress(prev_column.as_deref(), &task.column);
+        self.ops.tasks.upsert(&self.id, task).await?;
+        if dispatch {
+            self.dispatch_task(task.id.clone());
+        }
+        Ok(())
+    }
+
+    /// Fires the detached [`TaskDispatched`] cycle for a task when a harness is
+    /// attached. Detached (`tokio::spawn`) so the board write returns at once;
+    /// the cycle writes its outcome back onto the card. In the default build (no
+    /// harness) this is a no-op, keeping the board inert.
+    ///
+    /// [`TaskDispatched`]: crate::ports::types::CompanyEvent::TaskDispatched
+    fn dispatch_task(self: &Arc<Self>, task_id: String) {
+        #[cfg(feature = "openhuman")]
+        if self.harness.is_some() {
+            let runtime = Arc::clone(self);
+            tokio::spawn(async move {
+                if let Err(err) = runtime
+                    .run_cycle(vec![CompanyEvent::TaskDispatched {
+                        task_id: task_id.clone(),
+                    }])
+                    .await
+                {
+                    tracing::warn!(
+                        company = %runtime.id,
+                        task = %task_id,
+                        error = %err,
+                        "task dispatch cycle failed"
+                    );
+                }
+            });
+            return;
+        }
+        // Default build / no harness: the board stays inert. The card rests in
+        // `in_progress` until a harness cycle (or a human) advances it.
+        let _ = task_id;
     }
 
     /// This company's workspace file tree.
@@ -429,5 +496,24 @@ impl std::fmt::Debug for CompanyRuntime {
             .field("channels", &self.channels.len())
             .field("has_economy", &self.economy.is_some())
             .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::task_enters_in_progress;
+
+    #[test]
+    fn dispatch_only_on_entering_in_progress() {
+        // Fresh card created straight into `in_progress` → dispatch.
+        assert!(task_enters_in_progress(None, "in_progress"));
+        // The drag: backlog → in_progress → dispatch.
+        assert!(task_enters_in_progress(Some("backlog"), "in_progress"));
+        // Already in_progress, re-saved (e.g. an edit) → no re-dispatch.
+        assert!(!task_enters_in_progress(Some("in_progress"), "in_progress"));
+        // Any non-in_progress target → no dispatch.
+        assert!(!task_enters_in_progress(Some("in_progress"), "in_review"));
+        assert!(!task_enters_in_progress(None, "backlog"));
+        assert!(!task_enters_in_progress(Some("in_review"), "done"));
     }
 }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -255,6 +255,8 @@ description = "Runs Acme."
             workspace_root: dir.to_path_buf(),
             model_override: None,
             tasks: None,
+            skills: None,
+            skills_source_dir: None,
         };
         HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record())
     }
@@ -369,6 +371,8 @@ description = "Builds it."
             workspace_root: dir.to_path_buf(),
             model_override: None,
             tasks: Some(tasks.clone()),
+            skills: None,
+            skills_source_dir: None,
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record_two()),

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -25,6 +25,7 @@ use crate::ports::types::{
     CompanyEvent, CompanyRecord, CompressedTrace, CycleRequest, CycleResult, OutboundMessage,
     TokenUsage,
 };
+use crate::ports::{TaskRecord, now_millis};
 
 /// A [`Brain`] that answers with a live openhuman agent turn.
 pub struct HarnessBrain {
@@ -58,6 +59,79 @@ impl HarnessBrain {
         self.responder = agent_id.into();
         self
     }
+
+    /// Runs one dispatched board task: load the card, route it to its assignee
+    /// (or the default responder) for a single turn, and write the outcome back
+    /// onto the board — moved to `in_review` on success, back to `backlog` with
+    /// the error noted on failure. A missing task store or a card that has since
+    /// vanished is a silent no-op.
+    async fn run_task(&self, task_id: &str) -> Result<()> {
+        let Some(tasks) = self.deps.tasks.as_ref() else {
+            return Ok(());
+        };
+        let Some(mut card) = tasks
+            .list(&self.record.id)
+            .await?
+            .into_iter()
+            .find(|t| t.id == task_id)
+        else {
+            return Ok(());
+        };
+
+        let responder = self.task_responder(&card.assignee);
+        let instruction = task_instruction(&card);
+        match self
+            .pool
+            .run(&self.record.id, &responder, &instruction, &self.deps)
+            .await
+        {
+            Ok(reply) => {
+                card.note = Some(append_result(card.note.as_deref(), &responder, &reply));
+                card.column = "in_review".to_string();
+            }
+            Err(err) => {
+                card.note = Some(append_result(
+                    card.note.as_deref(),
+                    &responder,
+                    &format!("dispatch failed: {err}"),
+                ));
+                card.column = "backlog".to_string();
+            }
+        }
+        card.updated_at_millis = now_millis();
+        tasks.upsert(&self.record.id, &card).await?;
+        Ok(())
+    }
+
+    /// Resolves which roster agent runs a task: its `assignee` when that names a
+    /// roster member, else the brain's default responder.
+    fn task_responder(&self, assignee: &str) -> String {
+        if !assignee.is_empty() && self.record.manifest.agents.iter().any(|a| a.id == assignee) {
+            assignee.to_string()
+        } else {
+            self.responder.clone()
+        }
+    }
+}
+
+/// The turn instruction for a dispatched card: its title, plus its note when it
+/// carries one, framed as a work item to act on.
+fn task_instruction(card: &TaskRecord) -> String {
+    match card.note.as_deref().filter(|n| !n.is_empty()) {
+        Some(note) => format!("Task: {}\n\n{}", card.title, note),
+        None => format!("Task: {}", card.title),
+    }
+}
+
+/// Appends a responder-attributed result block to a card's note, preserving any
+/// prior note above it. Slice 1 has no first-class `TaskRecord.result` field, so
+/// the outcome lives in the note.
+fn append_result(prev: Option<&str>, responder: &str, body: &str) -> String {
+    let block = format!("[{responder}] {body}");
+    match prev.filter(|p| !p.is_empty()) {
+        Some(p) => format!("{p}\n\n{block}"),
+        None => block,
+    }
 }
 
 #[async_trait]
@@ -68,18 +142,24 @@ impl Brain for HarnessBrain {
 
         let mut channel_responses = Vec::new();
         for event in &req.events {
-            if let CompanyEvent::OperatorMessage { text, .. } = event {
-                // `run` executes the turn on the openhuman runtime and meters
-                // its usage into the ledger/meter through `deps`. The reply is
-                // the agent's own text.
-                let reply = self
-                    .pool
-                    .run(&self.record.id, &self.responder, text, &self.deps)
-                    .await?;
-                channel_responses.push(OutboundMessage {
-                    channel: "operator".to_string(),
-                    text: reply,
-                });
+            match event {
+                CompanyEvent::OperatorMessage { text, .. } => {
+                    // `run` executes the turn on the openhuman runtime and meters
+                    // its usage into the ledger/meter through `deps`. The reply is
+                    // the agent's own text.
+                    let reply = self
+                        .pool
+                        .run(&self.record.id, &self.responder, text, &self.deps)
+                        .await?;
+                    channel_responses.push(OutboundMessage {
+                        channel: "operator".to_string(),
+                        text: reply,
+                    });
+                }
+                CompanyEvent::TaskDispatched { task_id } => {
+                    self.run_task(task_id).await?;
+                }
+                _ => {}
             }
         }
         // The runtime requires at least one channel response per cycle.
@@ -174,6 +254,7 @@ description = "Runs Acme."
             meter: Some(Arc::new(FsOps::new(dir))),
             workspace_root: dir.to_path_buf(),
             model_override: None,
+            tasks: None,
         };
         HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record())
     }
@@ -238,5 +319,184 @@ description = "Runs Acme."
         assert_eq!(brain.responder, "ceo");
         let brain = brain.with_responder("cfo");
         assert_eq!(brain.responder, "cfo");
+    }
+
+    // --- Task dispatch ------------------------------------------------------
+
+    use crate::ports::TaskStore;
+
+    /// A two-agent record so assignee routing has somewhere to route.
+    fn record_two() -> CompanyRecord {
+        let manifest = toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+description = "Runs Acme."
+
+[[agent]]
+id = "engineer"
+role = "Engineer"
+description = "Builds it."
+"#,
+        )
+        .expect("valid manifest");
+        CompanyRecord {
+            id: CompanyId::new("acme"),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+        }
+    }
+
+    /// A brain wired to a real task store (shared handle returned for seeding /
+    /// asserting), over the offline mock provider.
+    fn brain_with_tasks(dir: &std::path::Path) -> (HarnessBrain, Arc<FsOps>) {
+        let tasks = Arc::new(FsOps::new(dir));
+        let deps = HarnessDeps {
+            provider: Arc::new(MockProvider::new("mock: ")),
+            provider_slug: "mock".to_string(),
+            context: Arc::new(FsContextStore::new(dir)),
+            store: Arc::new(FsCompanyStore::new(dir)),
+            meter: Some(Arc::new(FsOps::new(dir))),
+            workspace_root: dir.to_path_buf(),
+            model_override: None,
+            tasks: Some(tasks.clone()),
+        };
+        (
+            HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record_two()),
+            tasks,
+        )
+    }
+
+    fn card(id: &str, assignee: &str) -> TaskRecord {
+        TaskRecord {
+            id: id.to_string(),
+            title: "Ship the thing".to_string(),
+            note: None,
+            column: "in_progress".to_string(),
+            priority: "high".to_string(),
+            assignee: assignee.to_string(),
+            updated_at_millis: 0,
+        }
+    }
+
+    async fn only_card(tasks: &Arc<FsOps>) -> TaskRecord {
+        tasks
+            .list(&CompanyId::new("acme"))
+            .await
+            .expect("list")
+            .into_iter()
+            .next()
+            .expect("one card")
+    }
+
+    /// A dispatched task runs a turn and moves to `in_review`, its result folded
+    /// into the note under the responder that ran it.
+    #[tokio::test]
+    async fn task_dispatch_runs_and_moves_to_in_review() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks) = brain_with_tasks(dir.path());
+        tasks
+            .upsert(&CompanyId::new("acme"), &card("t1", ""))
+            .await
+            .unwrap();
+
+        brain
+            .run_cycle(
+                request(vec![CompanyEvent::TaskDispatched {
+                    task_id: "t1".into(),
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        let moved = only_card(&tasks).await;
+        assert_eq!(moved.column, "in_review");
+        let note = moved.note.expect("result written to note");
+        // Default responder (first roster agent) ran it, and the mock provider
+        // echoes the instruction (the card title) back into the reply.
+        assert!(note.contains("[ceo]"), "{note:?}");
+        assert!(note.contains("Ship the thing"), "{note:?}");
+    }
+
+    /// An `assignee` that names a roster member routes the turn to that member.
+    #[tokio::test]
+    async fn task_dispatch_routes_to_assignee() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks) = brain_with_tasks(dir.path());
+        tasks
+            .upsert(&CompanyId::new("acme"), &card("t1", "engineer"))
+            .await
+            .unwrap();
+
+        brain
+            .run_cycle(
+                request(vec![CompanyEvent::TaskDispatched {
+                    task_id: "t1".into(),
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        let note = only_card(&tasks).await.note.expect("note");
+        assert!(note.contains("[engineer]"), "{note:?}");
+    }
+
+    /// An assignee that is not on the roster falls back to the default responder.
+    #[tokio::test]
+    async fn task_dispatch_unknown_assignee_falls_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks) = brain_with_tasks(dir.path());
+        tasks
+            .upsert(&CompanyId::new("acme"), &card("t1", "ghost"))
+            .await
+            .unwrap();
+
+        brain
+            .run_cycle(
+                request(vec![CompanyEvent::TaskDispatched {
+                    task_id: "t1".into(),
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        let note = only_card(&tasks).await.note.expect("note");
+        assert!(note.contains("[ceo]"), "{note:?}");
+    }
+
+    /// A dispatch for a card that no longer exists is a silent no-op, not an
+    /// error.
+    #[tokio::test]
+    async fn task_dispatch_missing_card_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks) = brain_with_tasks(dir.path());
+        brain
+            .run_cycle(
+                request(vec![CompanyEvent::TaskDispatched {
+                    task_id: "nope".into(),
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs without a card");
+        assert!(
+            tasks
+                .list(&CompanyId::new("acme"))
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 }

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -30,6 +30,8 @@ use crate::error::OpenCompanyError;
 use crate::harness::HarnessDeps;
 use crate::harness::memory::OcMemory;
 use crate::harness::policy::ApprovalPolicy;
+use crate::harness::skills::EffectiveSkills;
+use crate::ports::skills_state::SkillState;
 use crate::ports::types::CompanyId;
 
 /// Map a manifest cognition-tier hint to a hosted model/tier name.
@@ -70,12 +72,18 @@ pub fn persona_prompt(company_name: &str, agent: &ManifestAgent) -> String {
 }
 
 /// Build one openhuman [`Agent`] for `manifest_agent` within `company`.
+///
+/// `skill_deltas` are the company's operator skill overrides. When the harness
+/// is wired to a skills source (a [`SkillStateStore`](crate::ports::SkillStateStore)
+/// and/or a source directory), the agent's effective skill set is materialized
+/// and surfaced as three read tools plus a persona-prompt catalogue.
 pub fn build_agent(
     company: &CompanyId,
     company_name: &str,
     manifest_agent: &ManifestAgent,
     policy: ApprovalPolicy,
     deps: &HarnessDeps,
+    skill_deltas: &[SkillState],
 ) -> crate::Result<Agent> {
     let memory = OcMemory::new(
         company.clone(),
@@ -83,19 +91,41 @@ pub fn build_agent(
         deps.context.clone(),
     );
 
-    // v1: no tools yet (see module docs — WS4 tool-surface seam). The manifest
-    // `tools ∩ agent.tools` intersection lands here.
-    let tools: Vec<Box<dyn Tool>> = Vec::new();
-
     let workspace = deps
         .workspace_root
         .join(company.as_ref())
         .join(&manifest_agent.id)
         .join("workspace");
 
+    // v1: no manifest tools yet (see module docs — WS4 tool-surface seam). The
+    // manifest `tools ∩ agent.tools` intersection lands here.
+    let mut tools: Vec<Box<dyn Tool>> = Vec::new();
+
     // Persona over openhuman's own identity: `omit_identity = true` drops the
     // "you are OpenHuman" preamble so the agent speaks as its company role.
-    let persona = persona_prompt(company_name, manifest_agent);
+    let mut persona = persona_prompt(company_name, manifest_agent);
+
+    // Skill read surface (read-only catalogue slice). Only materializes when the
+    // harness is wired to a skills source; otherwise the agent stays skill-less
+    // and the default path is untouched. The catalogue is folded into the
+    // persona body because `omit_skills_catalog` is inert upstream.
+    if deps.skills_source_dir.is_some() || !skill_deltas.is_empty() {
+        let skill_ws = deps
+            .workspace_root
+            .join(company.as_ref())
+            .join(&manifest_agent.id)
+            .join("skill-catalog");
+        let effective = EffectiveSkills::materialize(
+            skill_ws,
+            deps.skills_source_dir.as_deref(),
+            skill_deltas,
+        )?;
+        if !effective.is_empty() {
+            tools.extend(effective.read_tools());
+            persona.push_str(&effective.catalogue());
+        }
+    }
+
     let prompt_builder = SystemPromptBuilder::for_subagent(
         persona, /* omit_identity */ true, /* omit_safety_preamble */ false,
         /* omit_skills_catalog */ true,

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -41,6 +41,7 @@ pub mod cost;
 pub mod memory;
 pub mod policy;
 pub mod provider;
+pub mod skills;
 
 pub use brain::HarnessBrain;
 
@@ -58,6 +59,7 @@ use crate::company::Policy;
 use crate::error::OpenCompanyError;
 use crate::harness::cost::{TurnUsage, record_turn_cost};
 use crate::harness::policy::ApprovalPolicy;
+use crate::ports::skills_state::{SkillState, SkillStateStore};
 use crate::ports::types::{CompanyId, CompanyRecord};
 use crate::ports::{CompanyStore, ContextStore, TaskStore, UsageMeter};
 
@@ -88,6 +90,18 @@ pub struct HarnessDeps {
     ///
     /// [`TaskDispatched`]: crate::ports::types::CompanyEvent::TaskDispatched
     pub tasks: Option<Arc<dyn TaskStore>>,
+    /// The company's skill-delta store, so a built agent can see its effective
+    /// skill set (company-dir skills ∪ operator deltas ∪ custom docs) as read
+    /// tools + a prompt catalogue. `None` leaves the agent skill-less (the chat
+    /// path off the skills seam builds no skill surface).
+    ///
+    /// See [`skills`](crate::harness::skills) — this is the read-only catalogue
+    /// slice; skill *execution* is deferred.
+    pub skills: Option<Arc<dyn SkillStateStore>>,
+    /// The company's source directory (`companies/<name>`), whose `skills/`
+    /// subtree supplies the committed skill bundles unioned into the effective
+    /// set. `None` surfaces only the operator deltas.
+    pub skills_source_dir: Option<PathBuf>,
 }
 
 /// One live openhuman agent, keyed by its manifest id.
@@ -158,7 +172,14 @@ impl HarnessPool {
                 return Ok(());
             }
         }
-        let roster = build_roster(company, deps)?;
+        // Fetch the operator skill deltas once (async) before building the
+        // roster; `build_roster`/`build_agent` stay synchronous and fold the
+        // deltas into each agent's effective skill set.
+        let skill_deltas = match &deps.skills {
+            Some(store) => store.list(&company.id).await?,
+            None => Vec::new(),
+        };
+        let roster = build_roster(company, deps, &skill_deltas)?;
         let mut guard = self.agents.write().await;
         guard.entry(company.id.clone()).or_insert(roster);
         Ok(())
@@ -216,9 +237,13 @@ impl HarnessPool {
 }
 
 /// Build every roster agent for a company from its manifest.
+///
+/// `skill_deltas` are the company's operator skill overrides (fetched once by
+/// the async caller); every agent folds them into its effective skill set.
 pub(crate) fn build_roster(
     company: &CompanyRecord,
     deps: &HarnessDeps,
+    skill_deltas: &[SkillState],
 ) -> crate::Result<Vec<Arc<CompanyAgent>>> {
     let policy: &Policy = &company.manifest.policy;
     let company_name = &company.manifest.company.name;
@@ -234,6 +259,7 @@ pub(crate) fn build_roster(
                 manifest_agent,
                 agent_policy,
                 deps,
+                skill_deltas,
             )?;
             Ok(Arc::new(CompanyAgent {
                 agent_id: manifest_agent.id.clone(),
@@ -415,6 +441,8 @@ description = "Builds the product."
                 workspace_root: dir.path().to_path_buf(),
                 model_override: None,
                 tasks: None,
+                skills: None,
+                skills_source_dir: None,
             },
             store,
             meter,
@@ -425,10 +453,55 @@ description = "Builds the product."
     #[tokio::test]
     async fn roster_builds_every_manifest_agent() {
         let fx = fixture();
-        let roster = build_roster(&record(), &fx.deps).expect("roster builds");
+        let roster = build_roster(&record(), &fx.deps, &[]).expect("roster builds");
         let ids: Vec<_> = roster.iter().map(|a| a.agent_id.as_str()).collect();
         assert_eq!(ids, vec!["ceo", "engineer"]);
         assert_eq!(roster[0].role, "Chief Executive");
+    }
+
+    /// The roster builds end-to-end with the skill read surface wired: the
+    /// effective set materializes, the read tools build, and the catalogue folds
+    /// into the persona — all without error — and the scratch tree lands under
+    /// the agent's workspace root.
+    #[tokio::test]
+    async fn roster_builds_with_skill_surface_wired() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source = tempfile::tempdir().expect("source");
+        let skill_dir = source.path().join("skills").join("web-research");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: Web Research\ndescription: Answer a question\n---\n\n# Web Research\n",
+        )
+        .unwrap();
+
+        let deps = HarnessDeps {
+            provider: Arc::new(MockProvider::new("mock: ")),
+            provider_slug: "mock".to_string(),
+            context: Arc::new(MockContext::default()),
+            store: Arc::new(RecordingStore::default()),
+            meter: None,
+            workspace_root: dir.path().to_path_buf(),
+            model_override: None,
+            tasks: None,
+            skills: None,
+            skills_source_dir: Some(source.path().to_path_buf()),
+        };
+
+        let roster = build_roster(&record(), &deps, &[]).expect("roster builds with skills");
+        assert_eq!(roster.len(), 2);
+        // The scratch skill tree was materialized for the first roster agent.
+        assert!(
+            dir.path()
+                .join("acme")
+                .join("ceo")
+                .join("skill-catalog")
+                .join("skills")
+                .join("web-research")
+                .join("SKILL.md")
+                .is_file(),
+            "the effective skill bundle should be materialized under the agent workspace"
+        );
     }
 
     #[tokio::test]

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -59,7 +59,7 @@ use crate::error::OpenCompanyError;
 use crate::harness::cost::{TurnUsage, record_turn_cost};
 use crate::harness::policy::ApprovalPolicy;
 use crate::ports::types::{CompanyId, CompanyRecord};
-use crate::ports::{CompanyStore, ContextStore, UsageMeter};
+use crate::ports::{CompanyStore, ContextStore, TaskStore, UsageMeter};
 
 /// Shared dependencies every harness-built agent draws on.
 #[derive(Clone)]
@@ -82,6 +82,12 @@ pub struct HarnessDeps {
     /// the whole roster addresses the configured workload (e.g. `chat-v1`).
     /// `None` keeps each agent's tier-derived default.
     pub model_override: Option<String>,
+    /// The company's task board, so a [`TaskDispatched`] cycle can load the
+    /// dispatched card and write its result back. `None` off the task path (the
+    /// chat brain leaves the board untouched).
+    ///
+    /// [`TaskDispatched`]: crate::ports::types::CompanyEvent::TaskDispatched
+    pub tasks: Option<Arc<dyn TaskStore>>,
 }
 
 /// One live openhuman agent, keyed by its manifest id.
@@ -408,6 +414,7 @@ description = "Builds the product."
                 meter: Some(meter.clone()),
                 workspace_root: dir.path().to_path_buf(),
                 model_override: None,
+                tasks: None,
             },
             store,
             meter,

--- a/src/harness/skills.rs
+++ b/src/harness/skills.rs
@@ -1,0 +1,438 @@
+//! The effective skill set → OpenHuman skill *read* tools + a prompt catalogue.
+//!
+//! A company's effective skills are the union of three sources:
+//!
+//! 1. **Company-dir skills** — the `SKILL.md` bundles committed under the
+//!    company's source directory (`companies/<name>/skills/**`), parsed by
+//!    [`load_dir_skills`](crate::company::load_dir_skills).
+//! 2. **Operator deltas** — the [`SkillState`] rows the console writes through
+//!    the [`SkillStateStore`](crate::ports::SkillStateStore): enable/disable
+//!    overrides over a built-in, and custom skills authored in-app.
+//! 3. **Custom docs** — a delta's `custom_doc` carries the full `SKILL.md` for
+//!    a console-authored skill.
+//!
+//! [`EffectiveSkills::materialize`] folds those into one set, resolves
+//! enable/disable overrides, and writes the surviving bundles into a scratch
+//! `skills/<slug>/` tree under a per-agent directory. OpenHuman's three skill
+//! read tools then scan that tree (its `skills/` root is the legacy skill root,
+//! scanned without a trust marker) so an agent can **see and read** its skills.
+//!
+//! This is deliberately **read-only**: skill *execution* (`run_workflow`) is not
+//! wired here. `RunWorkflowTool` reaches for the global `Config::load_or_init()`
+//! and bypasses the harness's metering, so it needs an upstream injection seam
+//! that does not exist yet — it is out of scope for this slice.
+//!
+//! Compiled only under `feature = "openhuman"` (the whole `harness` module is).
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use openhuman_core::openhuman as oh;
+
+use oh::config::Config;
+use oh::skills::tools::{WorkflowDescribeTool, WorkflowListTool, WorkflowReadResourceTool};
+use oh::tools::Tool;
+
+use crate::company::{SkillDoc, load_dir_skills, parse_skill_md};
+use crate::error::OpenCompanyError;
+use crate::ports::skills_state::SkillState;
+
+/// One agent's effective, enabled skill set, materialized on disk so OpenHuman's
+/// skill read tools can scan it.
+pub struct EffectiveSkills {
+    /// The read-tools' workspace dir. Its `skills/<slug>/SKILL.md` tree holds the
+    /// materialized effective set; a synthesized [`Config`] points OpenHuman's
+    /// read tools at it.
+    workspace_dir: PathBuf,
+    /// The enabled effective skill docs, ordered by slug.
+    docs: Vec<SkillDoc>,
+}
+
+impl EffectiveSkills {
+    /// Materializes the effective skill set for one agent under `workspace_dir`.
+    ///
+    /// `source_dir` is the company's source directory (`companies/<name>`); its
+    /// `skills/` subtree supplies the committed bundles. `deltas` are the
+    /// operator overrides from the [`SkillStateStore`](crate::ports::SkillStateStore).
+    ///
+    /// Resolution rules:
+    /// * a company-dir skill is included unless a delta disables it;
+    /// * an enabled delta carrying a `custom_doc` supersedes any same-slug
+    ///   company-dir body (and installs a console-authored skill outright);
+    /// * a disabled delta drops the skill from the effective set;
+    /// * a malformed `custom_doc` is skipped (never fails the build).
+    ///
+    /// The `workspace_dir/skills/` tree is rebuilt from scratch on every call so
+    /// a rebuild reflects the current deltas (removed skills disappear).
+    pub fn materialize(
+        workspace_dir: PathBuf,
+        source_dir: Option<&Path>,
+        deltas: &[SkillState],
+    ) -> crate::Result<Self> {
+        // Parsed effective docs, and where an on-disk bundle can be copied from
+        // (company-dir skills only). Custom docs carry their SKILL.md inline.
+        let mut docs: BTreeMap<String, SkillDoc> = BTreeMap::new();
+        let mut source_paths: BTreeMap<String, PathBuf> = BTreeMap::new();
+        let mut custom_docs: BTreeMap<String, String> = BTreeMap::new();
+
+        // 1. Company-dir skills (verbatim on-disk bundles, resources included).
+        if let Some(dir) = source_dir {
+            let skills_root = dir.join("skills");
+            for doc in load_dir_skills(&skills_root)? {
+                source_paths.insert(doc.slug.clone(), skills_root.join(&doc.slug));
+                docs.insert(doc.slug.clone(), doc);
+            }
+        }
+
+        // 2. Apply operator deltas: disables drop, enabled custom docs supersede.
+        let mut disabled: HashSet<String> = HashSet::new();
+        for delta in deltas {
+            if !delta.enabled {
+                disabled.insert(delta.slug.clone());
+                continue;
+            }
+            let Some(body) = delta.custom_doc.as_deref() else {
+                // An enable-only delta over a built-in: nothing to materialize
+                // beyond what the company dir already supplies.
+                continue;
+            };
+            match parse_skill_md(&delta.slug, body) {
+                Ok(doc) => {
+                    // A custom body supersedes any same-slug company-dir bundle.
+                    source_paths.remove(&delta.slug);
+                    custom_docs.insert(delta.slug.clone(), body.to_string());
+                    docs.insert(delta.slug.clone(), doc);
+                }
+                Err(err) => {
+                    log::warn!(
+                        "[harness][skills] skipping malformed custom skill '{}': {err}",
+                        delta.slug
+                    );
+                }
+            }
+        }
+
+        // 3. Drop disabled skills from every source.
+        for slug in &disabled {
+            docs.remove(slug);
+            source_paths.remove(slug);
+            custom_docs.remove(slug);
+        }
+
+        // 4. Rebuild the scratch tree from the surviving set.
+        let skills_out = workspace_dir.join("skills");
+        if skills_out.exists() {
+            std::fs::remove_dir_all(&skills_out).map_err(|e| {
+                OpenCompanyError::Harness(format!(
+                    "clearing skill scratch {}: {e}",
+                    skills_out.display()
+                ))
+            })?;
+        }
+        std::fs::create_dir_all(&skills_out).map_err(|e| {
+            OpenCompanyError::Harness(format!(
+                "creating skill scratch {}: {e}",
+                skills_out.display()
+            ))
+        })?;
+
+        for slug in docs.keys() {
+            let dest = skills_out.join(slug);
+            if let Some(src) = source_paths.get(slug) {
+                copy_dir_recursive(src, &dest)?;
+            } else if let Some(body) = custom_docs.get(slug) {
+                std::fs::create_dir_all(&dest).map_err(|e| {
+                    OpenCompanyError::Harness(format!("creating skill dir {}: {e}", dest.display()))
+                })?;
+                std::fs::write(dest.join("SKILL.md"), body).map_err(|e| {
+                    OpenCompanyError::Harness(format!("writing SKILL.md for '{slug}': {e}"))
+                })?;
+            }
+        }
+
+        Ok(Self {
+            workspace_dir,
+            docs: docs.into_values().collect(),
+        })
+    }
+
+    /// Whether the effective set is empty (no skills to surface).
+    pub fn is_empty(&self) -> bool {
+        self.docs.is_empty()
+    }
+
+    /// The three OpenHuman skill **read** tools, scoped to this agent's
+    /// materialized skill tree.
+    ///
+    /// Each tool consumes only `config.workspace_dir` (verified upstream), so a
+    /// throwaway [`Config`] with just that field set is enough — the global
+    /// `Config::load_or_init()` and its registry are never booted.
+    pub fn read_tools(&self) -> Vec<Box<dyn Tool>> {
+        // `Config` has private fields, so build from `Default` and set the one
+        // field the read tools read rather than a struct literal.
+        let mut config = Config::default();
+        config.workspace_dir = self.workspace_dir.clone();
+        let config = Arc::new(config);
+        vec![
+            Box::new(WorkflowListTool::new(config.clone())),
+            Box::new(WorkflowDescribeTool::new(config.clone())),
+            Box::new(WorkflowReadResourceTool::new(config)),
+        ]
+    }
+
+    /// A plain-text catalogue of the effective skills for the persona prompt.
+    ///
+    /// Returns an empty string when the set is empty so an agent with no skills
+    /// gets no catalogue (and the persona is left untouched). The catalogue is
+    /// folded into the persona body — `SystemPromptBuilder::for_subagent`'s
+    /// `omit_skills_catalog` flag is inert upstream, so it cannot be relied on.
+    pub fn catalogue(&self) -> String {
+        if self.docs.is_empty() {
+            return String::new();
+        }
+        let mut out = String::from(
+            "\n\nSkills available to you (read-only). Each is a packaged, reusable \
+             procedure:\n",
+        );
+        for doc in &self.docs {
+            out.push_str(&format!(
+                "- {} (`{}`): {}\n",
+                doc.name, doc.slug, doc.description
+            ));
+        }
+        out.push_str(
+            "Use `list_workflows` to enumerate them, `describe_workflow` to inspect one, \
+             and `read_workflow_resource` to read a skill's bundled files.\n",
+        );
+        out
+    }
+
+    /// The materialized skill tree's workspace dir (test/observability).
+    pub fn workspace_dir(&self) -> &Path {
+        &self.workspace_dir
+    }
+}
+
+/// Recursively copies a skill bundle directory (SKILL.md plus any bundled
+/// resource files) into `dest`. Regular files and directories only — symlinks
+/// are skipped so a bundle can't smuggle out-of-tree content into the scratch.
+fn copy_dir_recursive(src: &Path, dest: &Path) -> crate::Result<()> {
+    std::fs::create_dir_all(dest)
+        .map_err(|e| OpenCompanyError::Harness(format!("creating {}: {e}", dest.display())))?;
+    let entries = std::fs::read_dir(src)
+        .map_err(|e| OpenCompanyError::Harness(format!("reading {}: {e}", src.display())))?;
+    for entry in entries {
+        let entry = entry
+            .map_err(|e| OpenCompanyError::Harness(format!("reading {}: {e}", src.display())))?;
+        let file_type = entry.file_type().map_err(|e| {
+            OpenCompanyError::Harness(format!("stat {}: {e}", entry.path().display()))
+        })?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        let from = entry.path();
+        let to = dest.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else if file_type.is_file() {
+            std::fs::copy(&from, &to).map_err(|e| {
+                OpenCompanyError::Harness(format!(
+                    "copying {} -> {}: {e}",
+                    from.display(),
+                    to.display()
+                ))
+            })?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::ports::skills_state::SkillSource;
+
+    /// Writes a company-dir `skills/<slug>/SKILL.md` (plus an optional resource).
+    fn seed_company_skill(source_dir: &Path, slug: &str, name: &str, resource: Option<&str>) {
+        let dir = source_dir.join("skills").join(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: {slug} does things\n---\n\n# {name}\n"),
+        )
+        .unwrap();
+        if let Some(body) = resource {
+            std::fs::create_dir_all(dir.join("references")).unwrap();
+            std::fs::write(dir.join("references").join("spec.md"), body).unwrap();
+        }
+    }
+
+    fn delta(slug: &str, enabled: bool, custom_doc: Option<&str>) -> SkillState {
+        SkillState {
+            slug: slug.to_string(),
+            enabled,
+            source: if custom_doc.is_some() {
+                SkillSource::Custom
+            } else {
+                SkillSource::Company
+            },
+            custom_doc: custom_doc.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn company_dir_skills_materialize_with_resources() {
+        let src = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        seed_company_skill(src.path(), "web-research", "Web Research", Some("# spec"));
+
+        let eff =
+            EffectiveSkills::materialize(ws.path().to_path_buf(), Some(src.path()), &[]).unwrap();
+
+        // The parsed doc surfaces in the catalogue.
+        assert_eq!(eff.docs.len(), 1);
+        let cat = eff.catalogue();
+        assert!(cat.contains("Web Research"), "{cat}");
+        assert!(cat.contains("`web-research`"), "{cat}");
+
+        // The bundle (SKILL.md + resource) is copied verbatim into the scratch.
+        let out = ws.path().join("skills").join("web-research");
+        assert!(out.join("SKILL.md").is_file());
+        assert_eq!(
+            std::fs::read_to_string(out.join("references").join("spec.md")).unwrap(),
+            "# spec"
+        );
+    }
+
+    #[test]
+    fn disabled_delta_drops_a_company_skill() {
+        let src = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        seed_company_skill(src.path(), "keep", "Keep", None);
+        seed_company_skill(src.path(), "drop", "Drop", None);
+
+        let eff = EffectiveSkills::materialize(
+            ws.path().to_path_buf(),
+            Some(src.path()),
+            &[delta("drop", false, None)],
+        )
+        .unwrap();
+
+        let slugs: Vec<&str> = eff.docs.iter().map(|d| d.slug.as_str()).collect();
+        assert_eq!(slugs, vec!["keep"]);
+        assert!(!ws.path().join("skills").join("drop").exists());
+        assert!(ws.path().join("skills").join("keep").exists());
+    }
+
+    #[test]
+    fn custom_doc_installs_a_new_skill() {
+        let ws = tempfile::tempdir().unwrap();
+        let body = "---\nname: Invoicing\ndescription: Draft an invoice\n---\n\n# Invoicing\n";
+
+        let eff = EffectiveSkills::materialize(
+            ws.path().to_path_buf(),
+            None,
+            &[delta("invoicing", true, Some(body))],
+        )
+        .unwrap();
+
+        assert_eq!(eff.docs.len(), 1);
+        assert_eq!(eff.docs[0].name, "Invoicing");
+        let written =
+            std::fs::read_to_string(ws.path().join("skills").join("invoicing").join("SKILL.md"))
+                .unwrap();
+        assert_eq!(written, body);
+    }
+
+    #[test]
+    fn custom_doc_supersedes_company_body() {
+        let src = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        seed_company_skill(src.path(), "report", "Old Report", None);
+        let body = "---\nname: New Report\ndescription: Updated\n---\n\n# New\n";
+
+        let eff = EffectiveSkills::materialize(
+            ws.path().to_path_buf(),
+            Some(src.path()),
+            &[delta("report", true, Some(body))],
+        )
+        .unwrap();
+
+        assert_eq!(eff.docs.len(), 1);
+        assert_eq!(eff.docs[0].name, "New Report");
+        let written =
+            std::fs::read_to_string(ws.path().join("skills").join("report").join("SKILL.md"))
+                .unwrap();
+        assert_eq!(written, body);
+    }
+
+    #[test]
+    fn malformed_custom_doc_is_skipped_not_fatal() {
+        let ws = tempfile::tempdir().unwrap();
+        let eff = EffectiveSkills::materialize(
+            ws.path().to_path_buf(),
+            None,
+            &[delta("broken", true, Some("no frontmatter here"))],
+        )
+        .expect("malformed custom doc must not fail the build");
+        assert!(eff.is_empty());
+        assert!(eff.catalogue().is_empty());
+    }
+
+    #[test]
+    fn empty_set_yields_no_tools_catalogue() {
+        let ws = tempfile::tempdir().unwrap();
+        let eff = EffectiveSkills::materialize(ws.path().to_path_buf(), None, &[]).unwrap();
+        assert!(eff.is_empty());
+        assert!(eff.catalogue().is_empty());
+    }
+
+    #[test]
+    fn read_tools_expose_three_named_tools() {
+        let src = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        seed_company_skill(src.path(), "web-research", "Web Research", None);
+        let eff =
+            EffectiveSkills::materialize(ws.path().to_path_buf(), Some(src.path()), &[]).unwrap();
+
+        let tools = eff.read_tools();
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "list_workflows",
+                "describe_workflow",
+                "read_workflow_resource"
+            ]
+        );
+        // The tools point at the materialized scratch dir.
+        assert_eq!(eff.workspace_dir(), ws.path());
+    }
+
+    #[tokio::test]
+    async fn list_workflows_tool_sees_the_materialized_skill() {
+        use serde_json::json;
+
+        let src = tempfile::tempdir().unwrap();
+        let ws = tempfile::tempdir().unwrap();
+        seed_company_skill(src.path(), "web-research", "Web Research", None);
+        let eff =
+            EffectiveSkills::materialize(ws.path().to_path_buf(), Some(src.path()), &[]).unwrap();
+
+        let tools = eff.read_tools();
+        let list = tools
+            .iter()
+            .find(|t| t.name() == "list_workflows")
+            .expect("list tool");
+        let result = list.execute(json!({})).await.expect("execute");
+        let text = result.output_for_llm(false);
+        // The legacy `<workspace>/skills/` root is scanned without a trust
+        // marker, so the materialized bundle shows up in the tool's output.
+        assert!(
+            text.contains("web-research") || text.contains("Web Research"),
+            "{text}"
+        );
+    }
+}

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -298,6 +298,15 @@ pub enum CompanyEvent {
         /// The id of the deleted fact.
         fact_id: String,
     },
+    /// A board task was moved into `in_progress` and dispatched to its assignee
+    /// for one agent turn on the embedded runtime. Journaled so the dispatch is
+    /// auditable and replayable. Only the `openhuman` `HarnessBrain` acts on it;
+    /// the default build's `EchoBrain` ignores it, so the board stays inert
+    /// without the harness.
+    TaskDispatched {
+        /// The id of the dispatched task card.
+        task_id: String,
+    },
 }
 
 /// A `CompanyEvent` durably appended to the log with its sequence and time.

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -672,6 +672,7 @@ impl RuntimeBuilder {
                                 meter: Some(fs_ops.clone()),
                                 workspace_root: home.join("harness"),
                                 model_override: Some(model),
+                                tasks: Some(ops.tasks.clone()),
                             };
                             let record = CompanyRecord {
                                 id: id.clone(),

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -673,6 +673,12 @@ impl RuntimeBuilder {
                                 workspace_root: home.join("harness"),
                                 model_override: Some(model),
                                 tasks: Some(ops.tasks.clone()),
+                                // Skill read surface (#28): the operator delta
+                                // store + the company source dir (`companies/<name>`,
+                                // held as `seed_dir`) whose `skills/` subtree
+                                // supplies the committed bundles.
+                                skills: Some(ops.skills.clone()),
+                                skills_source_dir: self.seed_dir.clone(),
                             };
                             let record = CompanyRecord {
                                 id: id.clone(),

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -507,6 +507,8 @@ mod test {
             workspace_root: home.to_path_buf(),
             model_override: None,
             tasks: None,
+            skills: None,
+            skills_source_dir: None,
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record);
 

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -506,6 +506,7 @@ mod test {
             meter: Some(Arc::new(FsOps::new(home.to_path_buf()))),
             workspace_root: home.to_path_buf(),
             model_override: None,
+            tasks: None,
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record);
 

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -104,11 +104,7 @@ async fn create_task(
         assignee: body.assignee.unwrap_or_default(),
         updated_at_millis: now_millis(),
     };
-    company
-        .runtime
-        .tasks()
-        .upsert(company.id(), &record)
-        .await?;
+    company.runtime.upsert_task(&record).await?;
     Ok(Json(record.into()))
 }
 
@@ -141,11 +137,7 @@ async fn patch_task(
         record.assignee = assignee;
     }
     record.updated_at_millis = now_millis();
-    company
-        .runtime
-        .tasks()
-        .upsert(company.id(), &record)
-        .await?;
+    company.runtime.upsert_task(&record).await?;
     Ok(Json(record.into()))
 }
 

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -7,7 +7,7 @@
 
 use axum::extract::Path;
 use axum::http::StatusCode;
-use axum::routing::{patch, post};
+use axum::routing::{get, patch, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
@@ -20,7 +20,7 @@ use crate::server::ops::{ScopedCompany, scoped};
 
 /// Builds the task route fragment.
 pub fn router() -> Router<AppState> {
-    scoped("/tasks", post(create_task)).merge(scoped(
+    scoped("/tasks", post(create_task).get(list_tasks)).merge(scoped(
         "/tasks/{task_id}",
         patch(patch_task).delete(delete_task),
     ))
@@ -89,6 +89,14 @@ struct PatchTask {
 #[derive(Debug, Deserialize)]
 struct TaskPath {
     task_id: String,
+}
+
+/// `GET …/tasks` — the whole board, newest-updated first. The console reads
+/// this to render the Kanban columns and each card's detail (note, assignee).
+async fn list_tasks(company: ScopedCompany) -> Result<Json<Vec<TaskCard>>, ApiError> {
+    let mut rows = company.runtime.tasks().list(company.id()).await?;
+    rows.sort_by(|a, b| b.updated_at_millis.cmp(&a.updated_at_millis));
+    Ok(Json(rows.into_iter().map(TaskCard::from).collect()))
 }
 
 async fn create_task(

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -7,7 +7,7 @@
 
 use axum::extract::Path;
 use axum::http::StatusCode;
-use axum::routing::{get, patch, post};
+use axum::routing::{patch, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -124,6 +124,14 @@ async fn tasks_crud_round_trips_under_both_scopes() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(moved["column"], "done");
 
+    // List (GET) reflects the write — the board the console reads.
+    let (status, board) = send(&state, "GET", "/api/v1/company/tasks", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let rows = board.as_array().expect("array of cards");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], id);
+    assert_eq!(rows[0]["column"], "done");
+
     // Delete.
     let (status, _) = send(
         &state,


### PR DESCRIPTION
## Summary

Cell #28 of the OpenHuman-as-library epic (#26): surface a company's **effective skill set** to its embedded OpenHuman harness agents — read-only. Company-dir skills ∪ operator `SkillStateStore` deltas ∪ custom docs are materialized into a scratch tree; each harness agent gains OpenHuman's three real skill **read** tools (`list_workflows` / `describe` / `read_resource`) plus a prompt catalogue of what's available.

Fills the capability from OpenCompany's own ports — no OpenHuman global `Config::load_or_init()`, no global registry. A throwaway `oh::Config { workspace_dir, .. }` is synthesized only for the read tools (they consume `workspace_dir` alone).

Skill **execution** (`run_workflow`) is deliberately out of scope — OpenHuman's `RunWorkflowTool` uses the global config + bypasses harness metering; it needs an upstream injection seam that doesn't exist yet. Only the three read tools are wired.

Closes #28.

## API Or Behavior Changes

- `HarnessDeps` gains two append-only fields: `skills: Option<Arc<dyn SkillStateStore>>`, `skills_source_dir: Option<PathBuf>` (both `None` off the harness path — default build inert).
- `build_roster` / `build_agent` take an added `skill_deltas: &[SkillState]` param.
- `openhuman_core` dep now compiled with `features = ["skills"]` (no extra deps upstream — `skills = []`; recompiles the skills domain only, does **not** pull rhai/builder tools).
- Harness agent personas now include a skills catalogue + three read tools when a skills source is wired. No HTTP/route change.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default)
- [x] `cargo build --all-targets`
- [x] `cargo test` (default) + `cargo test --features openhuman --lib -- harness::` → **52 passed / 0 failed** (8 new `harness::skills::` tests incl. a live `list_workflows` exec)
- `cargo check --features openhuman` green (2 pre-existing vendored-openhuman warnings only).

## Documentation

Module-level doc comments on `src/harness/skills.rs` (materialization + read-tool wiring). Execution-deferral rationale captured above. No spec-doc change — the read surface is internal to the harness.

---

**Stacked on #30 (#27).** Branched off the #27 tasks slice, which lands the `HarnessDeps` seam this builds on. Review/merge after #30. The diff will show #27's commits until it merges.
