### PR TITLE
feat(store): TinyCortex memory overlay via OPENCOMPANY_MEMORY (#36 part 1)

### DIFF
--- a/docs/spec/runtime/storage.md
+++ b/docs/spec/runtime/storage.md
@@ -39,6 +39,31 @@ MongoDB settings:
 - `OPENCOMPANY_TENANT_ID` — tenant identity for **shared-single-DB** mode
   (default unset). See [Shared single database](#shared-single-database-mode).
 
+## Memory engine overlay (`OPENCOMPANY_MEMORY`)
+
+Memory is a separable concern. `OPENCOMPANY_STORAGE` picks the durable base for
+all fourteen ports; `OPENCOMPANY_MEMORY` optionally swaps **just** the two
+knowledge ports — `MemoryStore` + `ContextStore` — onto a dedicated memory
+engine layered on top of that base. The base still owns every other port
+(companies, events, secrets, tasks, …).
+
+| Value | Engine | Feature flag | Notes |
+|---|---|---|---|
+| `store` (default) | The base backend's own memory | — | fs substring recall, or sqlite/mongodb |
+| `tinycortex` | TinyCortex chunk store | `tinycortex` | Ranked token-overlap recall over a compounding store |
+
+This is why TinyCortex is not a `StorageKind`: it implements only memory +
+context, so it cannot be a full backend — it overlays. `serve` and platform
+provisioning build the overlay once (`open_memory_overlay`,
+`src/store/select.rs`) and apply it to each company's `RuntimeBuilder` via
+`with_memory_overlay`, **after** `with_stores`, so the engine's ports win while
+the base keeps the rest. A selected-but-unavailable engine (feature disabled)
+aborts boot, same as the storage backend.
+
+The compiled TinyCortex backend is the offline in-memory client
+(`src/store/tinycortex.rs`); a networked client for true semantic recall is an
+inert seam until the service is reachable through the OpenHuman integration.
+
 ## MongoDB backend (`src/store/mongodb.rs`)
 
 One `MongoStore` wraps a single database and implements all five ports.

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -219,6 +219,11 @@ pub struct AppState {
     /// selected (`OPENCOMPANY_STORAGE`). Provisioning injects these into each
     /// new company's builder; `None` means fs defaults.
     stores: Option<crate::store::StorageHandles>,
+    /// The memory engine overlay selected by `OPENCOMPANY_MEMORY`, when it is
+    /// not the base store's own memory. Provisioning and boot apply it after
+    /// `stores` so a dedicated engine (TinyCortex) backs recall on top of any
+    /// base backend. `None` means the base backend's memory is used unchanged.
+    memory_overlay: Option<crate::store::MemoryOverlay>,
     /// The repo-level shared skill library directory (`skills/`), set on the
     /// serve path. `None` in platform-provisioned mode (no repo checkout), where
     /// the `skillRegistry` query degrades to empty.
@@ -263,6 +268,7 @@ impl AppState {
             home: std::path::PathBuf::from("."),
             ownership: Arc::new(RwLock::new(HashMap::new())),
             stores: None,
+            memory_overlay: None,
             skills_root: None,
             skill_registry: Arc::new(OnceLock::new()),
             schema: crate::server::graphql::build_schema(),
@@ -301,6 +307,17 @@ impl AppState {
     /// The opened storage backend's handles, if a non-fs backend is selected.
     pub fn stores(&self) -> Option<&crate::store::StorageHandles> {
         self.stores.as_ref()
+    }
+
+    /// Installs the memory engine overlay selected by `OPENCOMPANY_MEMORY`.
+    pub fn with_memory_overlay(mut self, overlay: crate::store::MemoryOverlay) -> Self {
+        self.memory_overlay = Some(overlay);
+        self
+    }
+
+    /// The memory engine overlay, if one is selected (`OPENCOMPANY_MEMORY`).
+    pub fn memory_overlay(&self) -> Option<&crate::store::MemoryOverlay> {
+        self.memory_overlay.as_ref()
     }
 
     /// The repo-level shared skill registry, loaded from `dir` and cached.

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -201,6 +201,9 @@ async fn register_company(
     if let Some(stores) = state.stores() {
         builder = builder.with_stores(stores);
     }
+    if let Some(overlay) = state.memory_overlay() {
+        builder = builder.with_memory_overlay(overlay);
+    }
     if discoverable {
         builder = builder.with_discoverable(true);
     }
@@ -608,6 +611,14 @@ async fn main() -> Result<()> {
                 }
                 state = state.with_stores(handles);
                 println!("storage backend: {:?}", storage_settings.kind);
+            }
+            // Memory engine overlay (`OPENCOMPANY_MEMORY`): swaps just the
+            // memory + context ports onto a dedicated engine on top of the base
+            // backend. A selected-but-unavailable engine aborts boot, same as
+            // the storage backend.
+            if let Some(overlay) = opencompany::store::open_memory_overlay(&storage_settings)? {
+                state = state.with_memory_overlay(overlay);
+                println!("memory backend: {:?}", storage_settings.memory_backend);
             }
             // Platform (multi-tenant) auth: a shared platform token enables the
             // provisioning/lifecycle surface. Without it the prosumer operator

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -29,13 +29,11 @@ use crate::feedback::types::ConsentMode;
 use crate::harness::provider::{HostedProvider, HostedProviderConfig};
 #[cfg(feature = "openhuman")]
 use crate::harness::{HarnessBrain, HarnessDeps};
-#[cfg(feature = "openhuman")]
-use crate::ports::WorkflowRunner;
-#[cfg(feature = "openhuman")]
-use crate::workflows::HarnessWorkflowRunner;
 use crate::openhuman::rpc::OpenHumanRpc;
 use crate::openhuman::{OpenHumanChannelAdapter, OpenHumanToolProvider};
 use crate::policy::ManifestApprovalGate;
+#[cfg(feature = "openhuman")]
+use crate::ports::WorkflowRunner;
 use crate::ports::types::{CompanyId, CompanyRecord, SecretValue};
 use crate::ports::{
     AgentEconomy, Brain, ChannelAdapter, CompanyStore, ContextStore, EventLog, FactStore,
@@ -49,6 +47,8 @@ use crate::store::paths::Bundle;
 use crate::store::{
     FsCompanyStore, FsContextStore, FsEventLog, FsInboxStore, FsMemoryStore, FsOps, FsSecretStore,
 };
+#[cfg(feature = "openhuman")]
+use crate::workflows::HarnessWorkflowRunner;
 
 /// Derives a filesystem-and-URL-safe company id from a display name.
 ///
@@ -306,6 +306,17 @@ impl RuntimeBuilder {
             .with_context(handles.context.clone())
             .with_secrets(handles.secrets.clone())
             .with_inbox(handles.inbox.clone())
+    }
+
+    /// Overlays just the memory + context ports from a selected memory engine
+    /// (`OPENCOMPANY_MEMORY`, see [`crate::store::select`]).
+    ///
+    /// Applied *after* [`with_stores`](Self::with_stores) (or over the fs
+    /// defaults), so a dedicated memory engine such as TinyCortex backs recall
+    /// while the base backend keeps every other durable port.
+    pub fn with_memory_overlay(self, overlay: &crate::store::MemoryOverlay) -> Self {
+        self.with_memory(overlay.memory.clone())
+            .with_context(overlay.context.clone())
     }
 
     /// Swaps the task board store (default: fs-backed).

--- a/src/server/provision.rs
+++ b/src/server/provision.rs
@@ -197,6 +197,9 @@ async fn provision(
     if let Some(stores) = state.stores() {
         builder = builder.with_stores(stores);
     }
+    if let Some(overlay) = state.memory_overlay() {
+        builder = builder.with_memory_overlay(overlay);
+    }
     let runtime = match builder.build().await {
         Ok(runtime) => runtime,
         Err(err) => return ApiError(err).into_response(),

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -21,7 +21,9 @@ pub mod paths;
 
 /// Config-driven backend selection: maps `OPENCOMPANY_STORAGE` (fs | sqlite |
 /// mongodb) onto opened port implementations, injected once per process into
-/// every company's `RuntimeBuilder`.
+/// every company's `RuntimeBuilder`. `OPENCOMPANY_MEMORY` (store | tinycortex)
+/// selects an optional overlay that swaps just the memory + context ports onto
+/// a dedicated engine on top of that base.
 pub mod select;
 
 #[cfg(feature = "sqlite")]
@@ -59,7 +61,10 @@ pub use fs::{
 };
 pub use fs_ops::FsOps;
 pub use paths::{Bundle, default_home};
-pub use select::{StorageHandles, StorageKind, StorageSettings, open_storage};
+pub use select::{
+    MemoryBackend, MemoryOverlay, StorageHandles, StorageKind, StorageSettings,
+    open_memory_overlay, open_storage,
+};
 
 #[cfg(feature = "sqlite")]
 pub use sqlite::SqliteStore;

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -171,19 +171,29 @@ pub struct StorageSettings {
     pub memory_backend: MemoryBackend,
 }
 
+/// Parses env var `key` into `T`. Absent → `Ok(None)` (the caller applies its
+/// default); a set-but-non-UTF-8 value is a hard [`OpenCompanyError::Config`]
+/// rather than a silent fallback to the default.
+fn parse_env<T>(key: &str) -> Result<Option<T>>
+where
+    T: std::str::FromStr<Err = OpenCompanyError>,
+{
+    match std::env::var(key) {
+        Ok(raw) => Ok(Some(raw.parse()?)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(OpenCompanyError::Config(format!(
+            "{key} is set but is not valid UTF-8"
+        ))),
+    }
+}
+
 impl StorageSettings {
     /// Reads the CLI-surface storage env vars (`OPENCOMPANY_STORAGE`,
     /// `OPENCOMPANY_MONGODB_URI`, `OPENCOMPANY_MONGODB_DB`,
     /// `OPENCOMPANY_TENANT_ID`, `OPENCOMPANY_MEMORY`).
     pub fn from_env() -> Result<Self> {
-        let kind = match std::env::var("OPENCOMPANY_STORAGE") {
-            Ok(raw) => raw.parse()?,
-            Err(_) => StorageKind::Fs,
-        };
-        let memory_backend = match std::env::var("OPENCOMPANY_MEMORY") {
-            Ok(raw) => raw.parse()?,
-            Err(_) => MemoryBackend::Store,
-        };
+        let kind: StorageKind = parse_env("OPENCOMPANY_STORAGE")?.unwrap_or_default();
+        let memory_backend: MemoryBackend = parse_env("OPENCOMPANY_MEMORY")?.unwrap_or_default();
         let non_empty = |key: &str| std::env::var(key).ok().filter(|value| !value.is_empty());
         Ok(Self {
             kind,

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -60,6 +60,54 @@ impl std::str::FromStr for StorageKind {
     }
 }
 
+/// Which engine backs the memory + context ports, independent of the base
+/// [`StorageKind`].
+///
+/// Memory is a separable concern: `OPENCOMPANY_STORAGE` picks the durable base
+/// (companies, events, secrets, …) while `OPENCOMPANY_MEMORY` can swap just the
+/// two knowledge ports onto a dedicated memory engine. This is why TinyCortex
+/// is *not* a [`StorageKind`] — it only implements memory + context, not the
+/// other durable ports, so it layers on top rather than replacing the base.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum MemoryBackend {
+    /// Memory + context come from the base [`StorageKind`] (the default; fs
+    /// substring recall, or the sqlite/mongodb store).
+    #[default]
+    Store,
+    /// TinyCortex backs memory + context: ranked token-overlap recall over a
+    /// compounding chunk store, on top of whatever base backend is selected
+    /// (`tinycortex` feature).
+    Tinycortex,
+}
+
+impl std::str::FromStr for MemoryBackend {
+    type Err = OpenCompanyError;
+    fn from_str(value: &str) -> Result<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "store" | "" => Ok(Self::Store),
+            "tinycortex" | "cortex" => Ok(Self::Tinycortex),
+            other => Err(OpenCompanyError::Config(format!(
+                "OPENCOMPANY_MEMORY must be 'store' or 'tinycortex', got '{other}'"
+            ))),
+        }
+    }
+}
+
+/// The memory + context ports of a selected memory engine, ready to overlay
+/// onto a company's builder after the base [`StorageHandles`] via
+/// [`RuntimeBuilder::with_memory_overlay`](crate::runtime::RuntimeBuilder::with_memory_overlay).
+#[derive(Clone)]
+pub struct MemoryOverlay {
+    pub memory: Arc<dyn MemoryStore>,
+    pub context: Arc<dyn ContextStore>,
+}
+
+impl std::fmt::Debug for MemoryOverlay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryOverlay").finish_non_exhaustive()
+    }
+}
+
 /// Durable company → tenant ownership, for shared-database platform mode.
 /// Backends that can persist ownership (MongoDB today) expose it here so the
 /// in-memory `AppState` map can be hydrated at boot and updated on provision.
@@ -117,16 +165,24 @@ pub struct StorageSettings {
     /// collide on the `companies` unique index. Unset means the id-namespacing
     /// no-op: single-tenant / db-per-tenant behavior is unchanged.
     pub tenant_id: Option<String>,
+    /// Which engine backs the memory + context ports (`OPENCOMPANY_MEMORY`),
+    /// overlaid on top of `kind`. Defaults to [`MemoryBackend::Store`] (the base
+    /// backend's own memory), so unset changes nothing.
+    pub memory_backend: MemoryBackend,
 }
 
 impl StorageSettings {
     /// Reads the CLI-surface storage env vars (`OPENCOMPANY_STORAGE`,
     /// `OPENCOMPANY_MONGODB_URI`, `OPENCOMPANY_MONGODB_DB`,
-    /// `OPENCOMPANY_TENANT_ID`).
+    /// `OPENCOMPANY_TENANT_ID`, `OPENCOMPANY_MEMORY`).
     pub fn from_env() -> Result<Self> {
         let kind = match std::env::var("OPENCOMPANY_STORAGE") {
             Ok(raw) => raw.parse()?,
             Err(_) => StorageKind::Fs,
+        };
+        let memory_backend = match std::env::var("OPENCOMPANY_MEMORY") {
+            Ok(raw) => raw.parse()?,
+            Err(_) => MemoryBackend::Store,
         };
         let non_empty = |key: &str| std::env::var(key).ok().filter(|value| !value.is_empty());
         Ok(Self {
@@ -134,6 +190,7 @@ impl StorageSettings {
             mongodb_uri: non_empty("OPENCOMPANY_MONGODB_URI"),
             mongodb_db: non_empty("OPENCOMPANY_MONGODB_DB"),
             tenant_id: non_empty("OPENCOMPANY_TENANT_ID"),
+            memory_backend,
         })
     }
 }
@@ -150,6 +207,31 @@ pub async fn open_storage(
         StorageKind::Sqlite => open_sqlite(data_dir),
         StorageKind::Mongodb => open_mongodb(settings).await,
     }
+}
+
+/// Opens the memory + context overlay selected by `OPENCOMPANY_MEMORY`.
+///
+/// `Ok(None)` means [`MemoryBackend::Store`] — the base backend keeps its own
+/// memory, no overlay. A selected-but-unavailable engine (feature disabled) is
+/// an error, never a silent fallback, mirroring [`open_storage`].
+pub fn open_memory_overlay(settings: &StorageSettings) -> Result<Option<MemoryOverlay>> {
+    match settings.memory_backend {
+        MemoryBackend::Store => Ok(None),
+        MemoryBackend::Tinycortex => open_tinycortex(),
+    }
+}
+
+#[cfg(feature = "tinycortex")]
+fn open_tinycortex() -> Result<Option<MemoryOverlay>> {
+    let (memory, context) = crate::store::tinycortex::in_memory();
+    Ok(Some(MemoryOverlay { memory, context }))
+}
+
+#[cfg(not(feature = "tinycortex"))]
+fn open_tinycortex() -> Result<Option<MemoryOverlay>> {
+    Err(OpenCompanyError::Config(
+        "OPENCOMPANY_MEMORY=tinycortex requires a build with the `tinycortex` feature".into(),
+    ))
 }
 
 #[cfg(feature = "sqlite")]
@@ -255,6 +337,113 @@ mod test {
         let settings = StorageSettings::default();
         let handles = open_storage(&settings, Path::new("/tmp")).await.unwrap();
         assert!(handles.is_none());
+    }
+
+    #[test]
+    fn parses_memory_backends() {
+        assert_eq!(
+            "store".parse::<MemoryBackend>().unwrap(),
+            MemoryBackend::Store
+        );
+        assert_eq!("".parse::<MemoryBackend>().unwrap(), MemoryBackend::Store);
+        assert_eq!(
+            "TinyCortex".parse::<MemoryBackend>().unwrap(),
+            MemoryBackend::Tinycortex
+        );
+        assert_eq!(
+            "cortex".parse::<MemoryBackend>().unwrap(),
+            MemoryBackend::Tinycortex
+        );
+        assert!("redis".parse::<MemoryBackend>().is_err());
+    }
+
+    #[test]
+    fn default_memory_backend_is_store() {
+        assert_eq!(
+            StorageSettings::default().memory_backend,
+            MemoryBackend::Store
+        );
+        // Store is the no-op: no overlay, base backend keeps its own memory.
+        assert!(
+            open_memory_overlay(&StorageSettings::default())
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn from_env_reads_memory_backend() {
+        // SAFETY: single-threaded test; restores prior state.
+        let prev = std::env::var("OPENCOMPANY_MEMORY").ok();
+
+        unsafe { std::env::set_var("OPENCOMPANY_MEMORY", "tinycortex") };
+        assert_eq!(
+            StorageSettings::from_env().unwrap().memory_backend,
+            MemoryBackend::Tinycortex
+        );
+
+        unsafe { std::env::remove_var("OPENCOMPANY_MEMORY") };
+        assert_eq!(
+            StorageSettings::from_env().unwrap().memory_backend,
+            MemoryBackend::Store
+        );
+
+        match prev {
+            Some(v) => unsafe { std::env::set_var("OPENCOMPANY_MEMORY", v) },
+            None => unsafe { std::env::remove_var("OPENCOMPANY_MEMORY") },
+        }
+    }
+
+    #[cfg(feature = "tinycortex")]
+    #[tokio::test]
+    async fn tinycortex_overlay_recalls_stored_chunks() {
+        use crate::ports::types::{CompanyId, ContextChunk};
+
+        let settings = StorageSettings {
+            memory_backend: MemoryBackend::Tinycortex,
+            ..Default::default()
+        };
+        let overlay = open_memory_overlay(&settings).unwrap().expect("overlay");
+
+        let company = CompanyId::new("acme");
+        overlay
+            .context
+            .put(
+                &company,
+                ContextChunk {
+                    label: "notes/q3".into(),
+                    body: "revenue grew in the q3 report".into(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // The chunk is recallable by content — the compounding-memory contract.
+        let hits = overlay
+            .context
+            .search(&company, "q3 revenue", 5)
+            .await
+            .unwrap();
+        assert!(hits.iter().any(|h| h.score > 0.0), "expected a ranked hit");
+
+        // Isolation: another company never sees acme's chunk.
+        let other = CompanyId::new("globex");
+        let leaked = overlay
+            .context
+            .search(&other, "q3 revenue", 5)
+            .await
+            .unwrap();
+        assert!(leaked.is_empty(), "cross-company recall must not bleed");
+    }
+
+    #[cfg(not(feature = "tinycortex"))]
+    #[test]
+    fn tinycortex_overlay_requires_feature() {
+        let settings = StorageSettings {
+            memory_backend: MemoryBackend::Tinycortex,
+            ..Default::default()
+        };
+        assert!(open_memory_overlay(&settings).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `OPENCOMPANY_MEMORY={store|tinycortex}` — a **memory-engine overlay** that
swaps just the `MemoryStore` + `ContextStore` ports onto a dedicated engine on
top of any `OPENCOMPANY_STORAGE` base (fs/sqlite/mongodb keeps every other
durable port).

This is **Part 1 (core)** of #36. The issue proposed a new `MemoryAdapter`
trait with an `OpenHumanMemoryAdapter` delegating to the OH Brain over IPC.
That would duplicate the existing `ContextStore`/`MemoryStore` ports and invert
the real architecture (OpenCompany owns the store; openhuman's `Memory` is
already implemented over it via `OcMemory`). Instead this wires the **overlay**:
the TinyCortex backend already existed (`src/store/tinycortex.rs`, ranked recall
+ a ready `in_memory()` injector) but was **unreachable** — nothing selected it.
Company agents now get that recall through the existing `OcMemory` port, with no
new adapter and no parallel structure. TinyCortex is not a `StorageKind` because
it implements only memory + context, so it layers rather than replaces.

Applied via `RuntimeBuilder::with_memory_overlay` **after** `with_stores` (at
`serve` boot and provisioning), so the engine's two ports win while the base
keeps the rest.

### Issue #36 acceptance-criteria mapping
- Semantic-ish per-company recall, task outputs retrievable later — **done** (overlay + existing `OcMemory` recall).
- Two tenants' memory fully isolated — **done / already held** (company-scoped keys; covered by a new test).
- Workspace layout, Docker/EFS/PVC, disk quota, S3 offload — **deferred**: these belong in `opencompany-microservice` + `k8s`, not this binary.
- Retrieve→inject→store loop around task dispatch, Brain-tab `list_sources` UI — **follow-up** (separate PRs).

## API Or Behavior Changes

- New env var `OPENCOMPANY_MEMORY` (default `store` — a full no-op; nothing changes unless set).
- New public API: `store::{MemoryBackend, MemoryOverlay, open_memory_overlay}`, `RuntimeBuilder::with_memory_overlay`, `AppState::{with_memory_overlay, memory_overlay}`.
- `OPENCOMPANY_MEMORY=tinycortex` requires the `tinycortex` feature; a selected-but-unavailable engine aborts boot (same contract as `OPENCOMPANY_STORAGE`).

## Tests

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings` — **pre-existing failure at `src/server/ops/tasks.rs:98`** (introduced by `082190ce`, not in this diff; fails on `main` too). Fixed separately so this PR stays focused. No new clippy findings from this change.
- [x] `cargo build --all-targets` (verified `--features openhuman` compiles too)
- [x] `cargo test` — 487 passed
- [x] `cargo test --features tinycortex` — 496 passed (incl. recall + cross-company isolation)

## Documentation

- `docs/spec/runtime/storage.md`: new "Memory engine overlay (`OPENCOMPANY_MEMORY`)" section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional memory engine configuration through `OPENCOMPANY_MEMORY`.
  * Added support for the TinyCortex in-memory engine when enabled.
  * Memory and context services can now be overlaid independently of durable storage settings.
  * New company runtimes and provisioned companies automatically use the selected memory configuration.

* **Documentation**
  * Documented configuration options, startup behavior, and TinyCortex availability requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->