### PR TITLE
fix: restore green CI after #29/#33 (fmt + clippy)

### DIFF
--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -29,13 +29,11 @@ use crate::feedback::types::ConsentMode;
 use crate::harness::provider::{HostedProvider, HostedProviderConfig};
 #[cfg(feature = "openhuman")]
 use crate::harness::{HarnessBrain, HarnessDeps};
-#[cfg(feature = "openhuman")]
-use crate::ports::WorkflowRunner;
-#[cfg(feature = "openhuman")]
-use crate::workflows::HarnessWorkflowRunner;
 use crate::openhuman::rpc::OpenHumanRpc;
 use crate::openhuman::{OpenHumanChannelAdapter, OpenHumanToolProvider};
 use crate::policy::ManifestApprovalGate;
+#[cfg(feature = "openhuman")]
+use crate::ports::WorkflowRunner;
 use crate::ports::types::{CompanyId, CompanyRecord, SecretValue};
 use crate::ports::{
     AgentEconomy, Brain, ChannelAdapter, CompanyStore, ContextStore, EventLog, FactStore,
@@ -49,6 +47,8 @@ use crate::store::paths::Bundle;
 use crate::store::{
     FsCompanyStore, FsContextStore, FsEventLog, FsInboxStore, FsMemoryStore, FsOps, FsSecretStore,
 };
+#[cfg(feature = "openhuman")]
+use crate::workflows::HarnessWorkflowRunner;
 
 /// Derives a filesystem-and-URL-safe company id from a display name.
 ///

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -95,7 +95,7 @@ struct TaskPath {
 /// this to render the Kanban columns and each card's detail (note, assignee).
 async fn list_tasks(company: ScopedCompany) -> Result<Json<Vec<TaskCard>>, ApiError> {
     let mut rows = company.runtime.tasks().list(company.id()).await?;
-    rows.sort_by(|a, b| b.updated_at_millis.cmp(&a.updated_at_millis));
+    rows.sort_by_key(|row| std::cmp::Reverse(row.updated_at_millis));
     Ok(Json(rows.into_iter().map(TaskCard::from).collect()))
 }
 


### PR DESCRIPTION
## Summary

`main` is currently red on two checks, both from yesterday's workflow merges — neither related to any in-flight feature:

- **`cargo fmt --all -- --check`** — `src/runtime/builder.rs` imports added by #29 (`5b16d09`) were not rustfmt-ordered.
- **`cargo clippy --all-targets -- -D warnings`** — `src/server/ops/tasks.rs:98` `sort_by` reverse comparator trips `clippy::unnecessary_sort_by` (#33, `082190ce`).

Both fixes are mechanical and **behavior-preserving** (the task list stays sorted descending by `updated_at_millis`).

## API Or Behavior Changes

None.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` (487 passed)

## Documentation

None needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task-board sorting so tasks are consistently ordered by most recent update, making recently changed tasks easier to find.
  * Preserved existing task listing behavior and response details while improving ordering reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->