### PR TITLE
feat(harness): retrieve→inject→store memory loop (#36)

### DIFF
--- a/src/harness/memory_loop.rs
+++ b/src/harness/memory_loop.rs
@@ -1,0 +1,93 @@
+//! The retrieve→inject→store memory loop for embedded company agents.
+//!
+//! openhuman's own turn recalls the agent's *learned context* (preferences,
+//! observations, reflections) from memory. This module adds the
+//! OpenCompany-orchestrator layer the memory spec calls for: before a turn it
+//! retrieves the top-K prior task outcomes relevant to the incoming message and
+//! injects them as context, and after the turn it stores the outcome so it
+//! compounds into later turns.
+//!
+//! The **store** half is the load-bearing part: the harness wires no
+//! memory-store tool, so without this nothing persists a completed task — the
+//! compounding loop stays open and every turn starts cold. Retrieval reads and
+//! storage writes go through the same [`ContextStore`](crate::ports::ContextStore)
+//! the agent's own recall uses, so an `OPENCOMPANY_MEMORY=tinycortex` overlay
+//! (or any base backend) applies uniformly.
+//!
+//! The helpers here are pure so they unit-test without a live agent;
+//! [`HarnessPool::run`](super::HarnessPool::run) wires them around the turn.
+
+use crate::ports::types::{ChunkHit, ContextChunk};
+
+/// How many prior-outcome chunks to inject before a turn.
+pub const RETRIEVE_TOP_K: usize = 5;
+
+/// Label prefix for stored task outcomes, so they are listable by prefix and
+/// never collide with the agent's namespaced learned-context entries.
+pub const OUTCOME_LABEL_PREFIX: &str = "task-outcome";
+
+/// Builds the message actually handed to the agent: the original message,
+/// prefixed with a compact "relevant prior work" preamble when retrieval
+/// returned anything.
+///
+/// With no hits the message is returned unchanged, so a cold-start turn (empty
+/// memory) is byte-identical to the pre-loop behaviour.
+pub fn inject(message: &str, hits: &[ChunkHit]) -> String {
+    if hits.is_empty() {
+        return message.to_string();
+    }
+    let mut out = String::from("## Relevant prior work\n");
+    for hit in hits {
+        out.push_str("- ");
+        out.push_str(hit.snippet.trim());
+        out.push('\n');
+    }
+    out.push_str("\n## Task\n");
+    out.push_str(message);
+    out
+}
+
+/// The context chunk recording one completed turn's outcome, labelled under
+/// [`OUTCOME_LABEL_PREFIX`] and carrying both the task and the answer so a later
+/// `search` matches on either side.
+pub fn outcome_chunk(agent_id: &str, message: &str, reply: &str) -> ContextChunk {
+    ContextChunk {
+        label: format!("{OUTCOME_LABEL_PREFIX}/{agent_id}"),
+        body: format!("Task: {message}\nOutcome: {reply}"),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ports::types::ChunkAddr;
+
+    fn hit(snippet: &str) -> ChunkHit {
+        ChunkHit {
+            addr: ChunkAddr::new("addr"),
+            snippet: snippet.to_string(),
+            score: 1.0,
+        }
+    }
+
+    #[test]
+    fn inject_with_no_hits_is_unchanged() {
+        assert_eq!(inject("do the thing", &[]), "do the thing");
+    }
+
+    #[test]
+    fn inject_prepends_a_preamble_and_keeps_the_task() {
+        let out = inject("ship it", &[hit("Task: plan\nOutcome: drafted plan")]);
+        assert!(out.starts_with("## Relevant prior work\n"));
+        assert!(out.contains("drafted plan"));
+        assert!(out.trim_end().ends_with("ship it"));
+    }
+
+    #[test]
+    fn outcome_chunk_labels_and_carries_both_sides() {
+        let chunk = outcome_chunk("ceo", "plan the launch", "here is the plan");
+        assert_eq!(chunk.label, "task-outcome/ceo");
+        assert!(chunk.body.contains("plan the launch"));
+        assert!(chunk.body.contains("here is the plan"));
+    }
+}

--- a/src/harness/memory_loop.rs
+++ b/src/harness/memory_loop.rs
@@ -22,6 +22,15 @@ use crate::ports::types::{ChunkHit, ContextChunk};
 /// How many prior-outcome chunks to inject before a turn.
 pub const RETRIEVE_TOP_K: usize = 5;
 
+/// Max characters of any single retrieved snippet injected as prior work; longer
+/// snippets are truncated with an ellipsis.
+pub const MAX_SNIPPET_CHARS: usize = 500;
+
+/// Max total characters of the injected "relevant prior work" preamble. Once
+/// reached, remaining hits are dropped so a few large stored replies can't blow
+/// the model's context window or inflate cost.
+pub const MAX_HISTORY_CHARS: usize = 2000;
+
 /// Label prefix for stored task outcomes, so they are listable by prefix and
 /// never collide with the agent's namespaced learned-context entries.
 pub const OUTCOME_LABEL_PREFIX: &str = "task-outcome";
@@ -37,14 +46,40 @@ pub fn inject(message: &str, hits: &[ChunkHit]) -> String {
         return message.to_string();
     }
     let mut out = String::from("## Relevant prior work\n");
+    // Bound both each snippet and the total preamble so a few large stored
+    // replies can't blow the context window (see MAX_* constants).
+    let mut remaining = MAX_HISTORY_CHARS;
+    let mut injected = false;
     for hit in hits {
+        let snippet = truncate_chars(hit.snippet.trim(), MAX_SNIPPET_CHARS);
+        let cost = snippet.chars().count() + 3; // "- " + "\n"
+        if cost > remaining {
+            break;
+        }
         out.push_str("- ");
-        out.push_str(hit.snippet.trim());
+        out.push_str(&snippet);
         out.push('\n');
+        remaining -= cost;
+        injected = true;
+    }
+    // Every hit was empty or over budget — fall back to the bare message so a
+    // cold-equivalent turn stays unchanged.
+    if !injected {
+        return message.to_string();
     }
     out.push_str("\n## Task\n");
     out.push_str(message);
     out
+}
+
+/// Truncates `s` to at most `max` characters (on a char boundary), appending an
+/// ellipsis when anything was dropped.
+fn truncate_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(max).collect();
+    format!("{head}…")
 }
 
 /// The context chunk recording one completed turn's outcome, labelled under
@@ -73,6 +108,31 @@ mod test {
     #[test]
     fn inject_with_no_hits_is_unchanged() {
         assert_eq!(inject("do the thing", &[]), "do the thing");
+    }
+
+    #[test]
+    fn inject_truncates_an_oversized_snippet() {
+        let big = "x".repeat(10_000);
+        let out = inject("do it", &[hit(&big)]);
+        // The 10k snippet is capped to MAX_SNIPPET_CHARS, not injected whole.
+        assert!(
+            out.chars().count() < 10_000,
+            "oversized snippet must truncate"
+        );
+        assert!(out.contains('…'), "truncation is marked with an ellipsis");
+        assert!(out.trim_end().ends_with("do it"));
+    }
+
+    #[test]
+    fn inject_stops_at_the_total_history_budget() {
+        // Many mid-size snippets: the injected preamble stays within budget.
+        let hits: Vec<ChunkHit> = (0..50).map(|_| hit(&"y".repeat(400))).collect();
+        let out = inject("go", &hits);
+        let injected = out.chars().count() - "go".chars().count();
+        assert!(
+            injected <= MAX_HISTORY_CHARS + MAX_SNIPPET_CHARS,
+            "history is budget-capped, got {injected} injected chars"
+        );
     }
 
     #[test]

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -39,6 +39,7 @@ pub mod brain;
 pub mod build;
 pub mod cost;
 pub mod memory;
+pub mod memory_loop;
 pub mod policy;
 pub mod provider;
 pub mod skills;
@@ -213,10 +214,19 @@ impl HarnessPool {
                 })?
         };
 
+        // Retrieve→inject: pull the top-K prior task outcomes relevant to this
+        // message and prepend them as context. On a cold store this yields no
+        // hits and the message is passed through unchanged.
+        let hits = deps
+            .context
+            .search(company, message, memory_loop::RETRIEVE_TOP_K)
+            .await?;
+        let augmented = memory_loop::inject(message, &hits);
+
         // Run the turn and record its real cost. `CompanyAgent::run` reads the
         // turn's token/cost totals from openhuman's public `last_turn_usage()`
         // accessor; a zero-usage turn (offline provider) writes nothing.
-        let (reply, turn_cost) = agent.run(message).await?;
+        let (reply, turn_cost) = agent.run(&augmented).await?;
         record_turn_cost(
             &turn_cost,
             agent_id,
@@ -226,6 +236,15 @@ impl HarnessPool {
             deps.meter.as_deref(),
         )
         .await?;
+
+        // Store: persist the outcome (original task + reply) so it compounds
+        // into later turns. Without this the harness never writes memory back.
+        deps.context
+            .put(
+                company,
+                memory_loop::outcome_chunk(agent_id, message, &reply),
+            )
+            .await?;
 
         Ok(reply)
     }
@@ -520,6 +539,52 @@ description = "Builds the product."
             reply.contains("hello-marker"),
             "reply should echo the prompt through the agent: {reply:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn run_stores_outcomes_and_injects_them_into_later_turns() {
+        let fx = fixture();
+        let pool = HarnessPool::new();
+        let rec = record();
+        pool.ensure(&rec, &fx.deps).await.expect("ensure");
+
+        // Cold store: nothing to inject on the first turn.
+        let first = pool
+            .run(&rec.id, "ceo", "alpha task", &fx.deps)
+            .await
+            .expect("first turn");
+        assert!(
+            !first.contains("Relevant prior work"),
+            "a cold turn injects nothing: {first:?}"
+        );
+
+        // The outcome was written back under the task-outcome prefix.
+        let stored = fx
+            .deps
+            .context
+            .list(&rec.id, memory_loop::OUTCOME_LABEL_PREFIX)
+            .await
+            .unwrap();
+        assert_eq!(stored.len(), 1, "the first turn stores its outcome");
+
+        // Second turn: the prior outcome (its body contains "alpha") is
+        // retrieved and injected, so the agent sees the preamble.
+        let second = pool
+            .run(&rec.id, "ceo", "alpha", &fx.deps)
+            .await
+            .expect("second turn");
+        assert!(
+            second.contains("Relevant prior work"),
+            "the second turn injects the retrieved outcome: {second:?}"
+        );
+
+        let stored = fx
+            .deps
+            .context
+            .list(&rec.id, memory_loop::OUTCOME_LABEL_PREFIX)
+            .await
+            .unwrap();
+        assert_eq!(stored.len(), 2, "the second turn stores its outcome too");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes the compounding-memory loop for embedded company agents — **Part of #36** (the memory acceptance criteria: "retrieves relevant memory before a task and injects it", "task outputs stored as memory chunks after completion; retrievable in subsequent tasks").

The embedded openhuman agent already recalls its *learned context* each turn, but nothing writes a completed task back (the harness wires no memory-store tool), so the loop stayed open — every turn started cold. `HarnessPool::run` now wraps the turn:

- **retrieve** the top-K prior task outcomes relevant to the message (`ContextStore::search`),
- **inject** them as a compact "relevant prior work" preamble (a cold store injects nothing, so first turns are byte-identical to before),
- run the turn, then **store** the outcome (task + reply) under a `task-outcome/<agent>` label so it compounds into later turns.

Retrieval and storage go through the same `ContextStore` the agent's own recall uses, so an `OPENCOMPANY_MEMORY=tinycortex` overlay (#37) applies uniformly — the two PRs compound.

New `src/harness/memory_loop.rs` holds the pure `inject`/`outcome_chunk` helpers (unit-tested); an integration test proves an outcome is stored on turn 1 and retrieved+injected on turn 2.

## API Or Behavior Changes

- Behavior: an embedded agent's turn now retrieves+injects prior outcomes and persists the result. Feature-gated to `openhuman`; the default (echo) build is unaffected.
- No public API added beyond the `harness::memory_loop` helpers.

## Tests

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy` — pre-existing `main` failures (`builder.rs` fmt, `tasks.rs` clippy) fixed in the separate CI PR; no new findings here.
- [x] `cargo test --features openhuman` — 56 harness tests pass (incl. 3 memory_loop unit tests + the store/inject integration test)

## Documentation

Module-level docs in `memory_loop.rs` explain the retrieve/inject/store contract and why only the store half is new.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents can now retain relevant outcomes from previous tasks and use them as context in future turns.
  * Completed tasks and responses are automatically saved for later retrieval.
  * Prior work is included only when relevant, preserving the original message when no matching context is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->