### PR TITLE
chore(ci): unblock main CI — clippy unnecessary_sort_by + builder fmt drift

### DIFF
--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -29,13 +29,11 @@ use crate::feedback::types::ConsentMode;
 use crate::harness::provider::{HostedProvider, HostedProviderConfig};
 #[cfg(feature = "openhuman")]
 use crate::harness::{HarnessBrain, HarnessDeps};
-#[cfg(feature = "openhuman")]
-use crate::ports::WorkflowRunner;
-#[cfg(feature = "openhuman")]
-use crate::workflows::HarnessWorkflowRunner;
 use crate::openhuman::rpc::OpenHumanRpc;
 use crate::openhuman::{OpenHumanChannelAdapter, OpenHumanToolProvider};
 use crate::policy::ManifestApprovalGate;
+#[cfg(feature = "openhuman")]
+use crate::ports::WorkflowRunner;
 use crate::ports::types::{CompanyId, CompanyRecord, SecretValue};
 use crate::ports::{
     AgentEconomy, Brain, ChannelAdapter, CompanyStore, ContextStore, EventLog, FactStore,
@@ -49,6 +47,8 @@ use crate::store::paths::Bundle;
 use crate::store::{
     FsCompanyStore, FsContextStore, FsEventLog, FsInboxStore, FsMemoryStore, FsOps, FsSecretStore,
 };
+#[cfg(feature = "openhuman")]
+use crate::workflows::HarnessWorkflowRunner;
 
 /// Derives a filesystem-and-URL-safe company id from a display name.
 ///

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -95,7 +95,7 @@ struct TaskPath {
 /// this to render the Kanban columns and each card's detail (note, assignee).
 async fn list_tasks(company: ScopedCompany) -> Result<Json<Vec<TaskCard>>, ApiError> {
     let mut rows = company.runtime.tasks().list(company.id()).await?;
-    rows.sort_by(|a, b| b.updated_at_millis.cmp(&a.updated_at_millis));
+    rows.sort_by_key(|t| std::cmp::Reverse(t.updated_at_millis));
     Ok(Json(rows.into_iter().map(TaskCard::from).collect()))
 }
 


### PR DESCRIPTION
## Summary

Unblocks main's CI, which went red after the epic #26 merges (#27/#28/#29) under the current floating `stable` toolchain (clippy 1.95.0). Two pre-existing gate failures, both verified to reproduce on pristine `main` @ 8a32dcf:

- `clippy -D warnings` on `src/server/ops/tasks.rs:98` — `unnecessary_sort_by` (the `list_tasks` descending sort) → now `sort_by_key(|t| Reverse(t.updated_at_millis))`.
- `cargo fmt --all -- --check` on `src/runtime/builder.rs` — import-ordering drift → reformatted.

No behavior change. Merge first — it clears the clippy/fmt lanes for the stacked console PRs (#34/#35).

## API Or Behavior Changes

None.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Task lists consistently display the most recently updated tasks first.
  * Runtime components continue to load correctly across supported configurations.

* **Maintenance**
  * Improved internal organization and reliability without changing the user-facing workflow experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->