### PR TITLE
feat(skills): live-wire the Skills console + make registry installs agent-usable (#34, #42)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -105,6 +105,11 @@ export class OpenCompanyClient {
     return this.request<T>("PATCH", path, body);
   }
 
+  /** A typed PUT, for surfaces that live outside this class (e.g. skills). */
+  put<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>("PUT", path, body);
+  }
+
   /** A typed DELETE, for surfaces that live outside this class (e.g. auth). */
   del<T>(path: string): Promise<T> {
     return this.request<T>("DELETE", path);

--- a/frontend/src/api/skills.ts
+++ b/frontend/src/api/skills.ts
@@ -31,14 +31,24 @@ export function listSkills(client: OpenCompanyClient, company: string | null): P
   return client.get<Skill[]>(`${client.scopeFor(company)}/skills`);
 }
 
-/** Install a skill from the shared registry by slug. */
+/** The registry entry's metadata, sent on install so the host can persist a
+ * real `SKILL.md` the agent can act on (not just a content-less slug). */
+export interface InstallSkillMeta {
+  name: string;
+  description: string;
+  category?: string;
+}
+
+/** Install a skill from the shared registry by slug, carrying its metadata. */
 export function installSkill(
   client: OpenCompanyClient,
   company: string | null,
   slug: string,
+  meta: InstallSkillMeta,
 ): Promise<Skill> {
   return client.post<Skill>(
     `${client.scopeFor(company)}/skills/${encodeURIComponent(slug)}/install`,
+    meta,
   );
 }
 

--- a/frontend/src/api/skills.ts
+++ b/frontend/src/api/skills.ts
@@ -1,0 +1,75 @@
+// The live skills API: the console reads and writes the company's real
+// effective skills through the host's `…/skills` routes (REST, camelCase over
+// the wire). The effective set is the company's on-disk bundles unioned with
+// the operator's deltas. Replaces the client-side `lib/skills` localStorage
+// stub.
+
+import type { OpenCompanyClient } from "./client";
+
+/** An installed skill as the host returns it. */
+export interface Skill {
+  id: string;
+  name: string;
+  description: string;
+  /** Free-form category (e.g. `Marketing`, `Ops`) — from the skill's doc. */
+  category: string;
+  /** Provenance: `company` | `registry` | `custom`. */
+  source: string;
+  enabled: boolean;
+}
+
+/** The author-a-custom-skill body; the host slugs the name into the id. */
+export interface CreateSkill {
+  name: string;
+  description: string;
+  category?: string;
+  body?: string;
+}
+
+/** The company's effective skill set, sorted by slug. */
+export function listSkills(client: OpenCompanyClient, company: string | null): Promise<Skill[]> {
+  return client.get<Skill[]>(`${client.scopeFor(company)}/skills`);
+}
+
+/** Install a skill from the shared registry by slug. */
+export function installSkill(
+  client: OpenCompanyClient,
+  company: string | null,
+  slug: string,
+): Promise<Skill> {
+  return client.post<Skill>(
+    `${client.scopeFor(company)}/skills/${encodeURIComponent(slug)}/install`,
+  );
+}
+
+/** Uninstall a registry or custom skill by slug (a built-in cannot be removed). */
+export function uninstallSkill(
+  client: OpenCompanyClient,
+  company: string | null,
+  slug: string,
+): Promise<void> {
+  return client.post<void>(
+    `${client.scopeFor(company)}/skills/${encodeURIComponent(slug)}/uninstall`,
+  );
+}
+
+/** Toggle a skill on or off. */
+export function setSkillEnabled(
+  client: OpenCompanyClient,
+  company: string | null,
+  slug: string,
+  enabled: boolean,
+): Promise<Skill> {
+  return client.put<Skill>(`${client.scopeFor(company)}/skills/${encodeURIComponent(slug)}`, {
+    enabled,
+  });
+}
+
+/** Author a custom skill. */
+export function createSkill(
+  client: OpenCompanyClient,
+  company: string | null,
+  body: CreateSkill,
+): Promise<Skill> {
+  return client.post<Skill>(`${client.scopeFor(company)}/skills`, body);
+}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -294,7 +294,7 @@ export function AppShell({
           {view === "tasks" && <TasksView client={client} company={company} />}
           {view === "team" && <TeamView client={client} company={company} />}
           {view === "people" && <PeopleView client={client} company={company} />}
-          {view === "skills" && <SkillsView company={company} />}
+          {view === "skills" && <SkillsView client={client} company={company} />}
           {view === "memory" && <MemoryView company={company} />}
           {view === "workspace" && (
             <Suspense

--- a/frontend/src/lib/skills.ts
+++ b/frontend/src/lib/skills.ts
@@ -1,20 +1,9 @@
-// The company's skills: capability write-ups (SKILL.md files) the operator can
-// view, enable/disable, install from a registry, or add. Persisted per company
-// in localStorage; the console has no skills API yet, so this is a local store
-// seeded from the company's own skills plus a shared registry.
+// Static skill presentation data for the console: the shared registry the
+// operator can install from, plus per-category badge styling. The company's
+// live effective skills (installed/enabled state) come from the host over the
+// `…/skills` API (`@/api/skills`), not from here.
 
 export type SkillCategory = "Marketing" | "Research" | "Ops" | "Content" | "Finance";
-
-export type SkillSource = "company" | "registry" | "custom";
-
-export interface InstalledSkill {
-  id: string;
-  name: string;
-  description: string;
-  category: SkillCategory;
-  source: SkillSource;
-  enabled: boolean;
-}
 
 export interface RegistrySkill {
   id: string;
@@ -41,55 +30,3 @@ export const SKILL_REGISTRY: RegistrySkill[] = [
   { id: "meeting-notes", name: "Meeting Notes", description: "Turn a transcript into decisions and action items.", category: "Content", publisher: "OpenCompany" },
   { id: "invoice-drafting", name: "Invoice Drafting", description: "Draft invoices from a scope and rate card.", category: "Finance", publisher: "OpenCompany" },
 ];
-
-let n = 0;
-const genId = () => `skill-${Date.now().toString(36)}-${n++}`;
-
-export function fromRegistry(skill: RegistrySkill): InstalledSkill {
-  return { ...skill, source: "registry", enabled: true };
-}
-
-export function newSkill(fields: {
-  name: string;
-  description: string;
-  category: SkillCategory;
-}): InstalledSkill {
-  return {
-    id: genId(),
-    name: fields.name.trim(),
-    description: fields.description.trim(),
-    category: fields.category,
-    source: "custom",
-    enabled: true,
-  };
-}
-
-const KEY = (company: string | null) => `oc-skills:${company ?? "single"}`;
-
-export function loadSkills(company: string | null): InstalledSkill[] {
-  try {
-    const raw = localStorage.getItem(KEY(company));
-    if (raw) return JSON.parse(raw) as InstalledSkill[];
-  } catch {
-    /* fall through to seed */
-  }
-  return seedSkills();
-}
-
-export function saveSkills(company: string | null, skills: InstalledSkill[]): void {
-  try {
-    localStorage.setItem(KEY(company), JSON.stringify(skills));
-  } catch {
-    /* storage unavailable */
-  }
-}
-
-/** The company's own skills, from its `skills/` directory. */
-function seedSkills(): InstalledSkill[] {
-  return [
-    { id: "seo-audit", name: "SEO Audit", description: "Audit a site's organic-search health and produce prioritized fixes.", category: "Marketing", source: "company", enabled: true },
-    { id: "landing-page", name: "Landing Page", description: "Build and A/B test a conversion-focused landing page from a brief.", category: "Marketing", source: "company", enabled: true },
-    { id: "email-campaign", name: "Email Campaign", description: "Design and send a lifecycle or broadcast email program.", category: "Marketing", source: "company", enabled: true },
-    { id: "brand-positioning", name: "Brand Positioning", description: "Define a company's positioning on one page.", category: "Marketing", source: "company", enabled: false },
-  ];
-}

--- a/frontend/src/views/SkillsView.tsx
+++ b/frontend/src/views/SkillsView.tsx
@@ -71,28 +71,32 @@ export function SkillsView({ client, company }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [addOpen, setAddOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const mounted = useRef(true);
+  // A generation token so a response from a previous company scope (or after
+  // unmount) can't overwrite the current one.
+  const gen = useRef(0);
 
   const refresh = useCallback(async () => {
+    const mine = ++gen.current;
     try {
       const rows = await listSkills(client, company);
-      if (!mounted.current) return;
+      if (mine !== gen.current) return;
       setSkills(rows);
       setError(null);
     } catch (e) {
-      if (!mounted.current) return;
+      if (mine !== gen.current) return;
       setError(e instanceof Error ? e.message : "could not load skills");
     } finally {
-      if (mounted.current) setLoading(false);
+      if (mine === gen.current) setLoading(false);
     }
   }, [client, company]);
 
   useEffect(() => {
-    mounted.current = true;
     setLoading(true);
+    setSkills([]); // drop the previous scope's skills while the new set loads
     void refresh();
+    // Invalidate any in-flight request on scope change / unmount.
     return () => {
-      mounted.current = false;
+      gen.current++;
     };
   }, [refresh]);
 
@@ -100,25 +104,27 @@ export function SkillsView({ client, company }: Props) {
   const enabledCount = skills.filter((s) => s.enabled).length;
 
   async function toggle(skill: Skill) {
-    const previous = skills;
     const next = !skill.enabled;
     setSkills((all) => all.map((s) => (s.id === skill.id ? { ...s, enabled: next } : s)));
     try {
       const saved = await setSkillEnabled(client, company, skill.id, next);
       setSkills((all) => all.map((s) => (s.id === saved.id ? saved : s)));
     } catch (e) {
-      setSkills(previous);
+      // Revert only this skill, so a concurrent mutation isn't clobbered.
+      setSkills((all) =>
+        all.map((s) => (s.id === skill.id ? { ...s, enabled: skill.enabled } : s)),
+      );
       toast.error(e instanceof Error ? e.message : "could not update the skill");
     }
   }
 
   async function uninstall(skill: Skill) {
-    const previous = skills;
     setSkills((all) => all.filter((s) => s.id !== skill.id));
     try {
       await uninstallSkill(client, company, skill.id);
     } catch (e) {
-      setSkills(previous);
+      // Re-insert only this skill on failure (no whole-list rollback).
+      setSkills((all) => (all.some((s) => s.id === skill.id) ? all : [...all, skill]));
       toast.error(e instanceof Error ? e.message : "could not uninstall the skill");
     }
   }
@@ -347,7 +353,8 @@ function AddSkillDialog({
   }
 
   async function submit() {
-    if (!name.trim()) return;
+    // The host rejects a blank description, so gate on both here.
+    if (!name.trim() || !description.trim()) return;
     setBusy(true);
     try {
       await onAdd({ name, description, category });
@@ -402,7 +409,7 @@ function AddSkillDialog({
           <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
             Cancel
           </Button>
-          <Button disabled={!name.trim() || busy} onClick={() => void submit()}>
+          <Button disabled={!name.trim() || !description.trim() || busy} onClick={() => void submit()}>
             {busy && <Loader2 className="mr-1.5 size-4 animate-spin" />}
             Add skill
           </Button>

--- a/frontend/src/views/SkillsView.tsx
+++ b/frontend/src/views/SkillsView.tsx
@@ -126,7 +126,11 @@ export function SkillsView({ client, company }: Props) {
   async function install(skill: RegistrySkill) {
     if (installedIds.has(skill.id)) return;
     try {
-      const saved = await installSkill(client, company, skill.id);
+      const saved = await installSkill(client, company, skill.id, {
+        name: skill.name,
+        description: skill.description,
+        category: skill.category,
+      });
       setSkills((all) => [...all.filter((s) => s.id !== saved.id), saved]);
       toast.success(`Installed ${skill.name}.`);
     } catch (e) {

--- a/frontend/src/views/SkillsView.tsx
+++ b/frontend/src/views/SkillsView.tsx
@@ -1,7 +1,17 @@
-import { useEffect, useMemo, useState } from "react";
-import { Check, Download, Plus, Search, Sparkles, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Check, Download, Loader2, Plus, Search, Sparkles, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
+import {
+  createSkill,
+  installSkill,
+  listSkills,
+  setSkillEnabled,
+  uninstallSkill,
+  type Skill,
+} from "@/api/skills";
+import type { OpenCompanyClient } from "@/api/client";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -22,51 +32,106 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import {
   CATEGORY_STYLES,
-  fromRegistry,
-  type InstalledSkill,
-  loadSkills,
-  newSkill,
   type RegistrySkill,
-  saveSkills,
   SKILL_REGISTRY,
   type SkillCategory,
 } from "@/lib/skills";
 
 interface Props {
+  client: OpenCompanyClient;
   company: string | null;
 }
 
 const CATEGORIES: SkillCategory[] = ["Marketing", "Research", "Ops", "Content", "Finance"];
 
-/** The company's skills: view, enable/disable, install from a registry, or add. */
-export function SkillsView({ company }: Props) {
-  const [skills, setSkills] = useState<InstalledSkill[]>(() => loadSkills(company));
+/** Category badge styling, tolerating the host's free-form category strings. */
+function categoryStyle(category: string): string {
+  return (
+    CATEGORY_STYLES[category as SkillCategory] ??
+    "border-muted-foreground/30 bg-muted text-muted-foreground"
+  );
+}
+
+/**
+ * The company's skills: the real effective set read from the host (`…/skills`),
+ * which the operator can enable/disable, install from a registry, uninstall, or
+ * extend with a custom skill. Every mutation writes through the API and updates
+ * optimistically, reverting on error.
+ */
+export function SkillsView({ client, company }: Props) {
+  const [skills, setSkills] = useState<Skill[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [addOpen, setAddOpen] = useState(false);
   const [query, setQuery] = useState("");
+  const mounted = useRef(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const rows = await listSkills(client, company);
+      if (!mounted.current) return;
+      setSkills(rows);
+      setError(null);
+    } catch (e) {
+      if (!mounted.current) return;
+      setError(e instanceof Error ? e.message : "could not load skills");
+    } finally {
+      if (mounted.current) setLoading(false);
+    }
+  }, [client, company]);
 
   useEffect(() => {
-    saveSkills(company, skills);
-  }, [company, skills]);
+    mounted.current = true;
+    setLoading(true);
+    void refresh();
+    return () => {
+      mounted.current = false;
+    };
+  }, [refresh]);
 
   const installedIds = useMemo(() => new Set(skills.map((s) => s.id)), [skills]);
   const enabledCount = skills.filter((s) => s.enabled).length;
 
-  function toggle(id: string) {
-    setSkills((all) => all.map((s) => (s.id === id ? { ...s, enabled: !s.enabled } : s)));
+  async function toggle(skill: Skill) {
+    const previous = skills;
+    const next = !skill.enabled;
+    setSkills((all) => all.map((s) => (s.id === skill.id ? { ...s, enabled: next } : s)));
+    try {
+      const saved = await setSkillEnabled(client, company, skill.id, next);
+      setSkills((all) => all.map((s) => (s.id === saved.id ? saved : s)));
+    } catch (e) {
+      setSkills(previous);
+      toast.error(e instanceof Error ? e.message : "could not update the skill");
+    }
   }
-  function uninstall(id: string) {
-    setSkills((all) => all.filter((s) => s.id !== id));
+
+  async function uninstall(skill: Skill) {
+    const previous = skills;
+    setSkills((all) => all.filter((s) => s.id !== skill.id));
+    try {
+      await uninstallSkill(client, company, skill.id);
+    } catch (e) {
+      setSkills(previous);
+      toast.error(e instanceof Error ? e.message : "could not uninstall the skill");
+    }
   }
-  function install(skill: RegistrySkill) {
+
+  async function install(skill: RegistrySkill) {
     if (installedIds.has(skill.id)) return;
-    setSkills((all) => [...all, fromRegistry(skill)]);
-    toast.success(`Installed ${skill.name}.`);
+    try {
+      const saved = await installSkill(client, company, skill.id);
+      setSkills((all) => [...all.filter((s) => s.id !== saved.id), saved]);
+      toast.success(`Installed ${skill.name}.`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "could not install the skill");
+    }
   }
 
   const registry = useMemo(() => {
@@ -91,6 +156,12 @@ export function SkillsView({ company }: Props) {
           </Button>
         </div>
 
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
         <Tabs defaultValue="installed">
           <TabsList>
             <TabsTrigger value="installed">Installed ({skills.length})</TabsTrigger>
@@ -98,7 +169,12 @@ export function SkillsView({ company }: Props) {
           </TabsList>
 
           <TabsContent value="installed" className="mt-4">
-            {skills.length === 0 ? (
+            {loading ? (
+              <div className="grid gap-3 sm:grid-cols-2">
+                <Skeleton className="h-32 rounded-xl" />
+                <Skeleton className="h-32 rounded-xl" />
+              </div>
+            ) : skills.length === 0 ? (
               <Empty label="No skills installed yet." />
             ) : (
               <>
@@ -108,8 +184,8 @@ export function SkillsView({ company }: Props) {
                     <InstalledCard
                       key={s.id}
                       skill={s}
-                      onToggle={() => toggle(s.id)}
-                      onUninstall={() => uninstall(s.id)}
+                      onToggle={() => void toggle(s)}
+                      onUninstall={() => void uninstall(s)}
                     />
                   ))}
                 </div>
@@ -128,7 +204,7 @@ export function SkillsView({ company }: Props) {
                   key={s.id}
                   skill={s}
                   installed={installedIds.has(s.id)}
-                  onInstall={() => install(s)}
+                  onInstall={() => void install(s)}
                 />
               ))}
             </div>
@@ -139,9 +215,15 @@ export function SkillsView({ company }: Props) {
       <AddSkillDialog
         open={addOpen}
         onOpenChange={setAddOpen}
-        onAdd={(fields) => {
-          setSkills((all) => [newSkill(fields), ...all]);
+        onAdd={async (fields) => {
+          const saved = await createSkill(client, company, {
+            name: fields.name.trim(),
+            description: fields.description.trim(),
+            category: fields.category,
+          });
+          setSkills((all) => [saved, ...all.filter((s) => s.id !== saved.id)]);
           setAddOpen(false);
+          toast.success(`Added ${saved.name}.`);
         }}
       />
     </div>
@@ -153,7 +235,7 @@ function InstalledCard({
   onToggle,
   onUninstall,
 }: {
-  skill: InstalledSkill;
+  skill: Skill;
   onToggle: () => void;
   onUninstall: () => void;
 }) {
@@ -170,7 +252,7 @@ function InstalledCard({
         <p className="text-sm text-muted-foreground">{skill.description}</p>
         <div className="flex items-center justify-between pt-1">
           <div className="flex items-center gap-2">
-            <Badge variant="outline" className={cn("capitalize", CATEGORY_STYLES[skill.category])}>
+            <Badge variant="outline" className={cn("capitalize", categoryStyle(skill.category))}>
               {skill.category}
             </Badge>
             <span className="text-xs text-muted-foreground capitalize">{skill.source}</span>
@@ -211,7 +293,7 @@ function RegistryCard({
         <p className="text-sm text-muted-foreground">{skill.description}</p>
         <div className="flex items-center justify-between pt-1">
           <div className="flex items-center gap-2">
-            <Badge variant="outline" className={cn("capitalize", CATEGORY_STYLES[skill.category])}>
+            <Badge variant="outline" className={cn("capitalize", categoryStyle(skill.category))}>
               {skill.category}
             </Badge>
             <span className="text-xs text-muted-foreground">{skill.publisher}</span>
@@ -247,16 +329,29 @@ function AddSkillDialog({
 }: {
   open: boolean;
   onOpenChange: (o: boolean) => void;
-  onAdd: (fields: { name: string; description: string; category: SkillCategory }) => void;
+  onAdd: (fields: { name: string; description: string; category: SkillCategory }) => Promise<void>;
 }) {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [category, setCategory] = useState<SkillCategory>("Marketing");
+  const [busy, setBusy] = useState(false);
 
   function reset() {
     setName("");
     setDescription("");
     setCategory("Marketing");
+  }
+
+  async function submit() {
+    if (!name.trim()) return;
+    setBusy(true);
+    try {
+      await onAdd({ name, description, category });
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "could not add the skill");
+    } finally {
+      setBusy(false);
+    }
   }
 
   return (
@@ -300,10 +395,11 @@ function AddSkillDialog({
           <Textarea id="skill-desc" rows={3} value={description} onChange={(e) => setDescription(e.target.value)} placeholder="One line on when to use it and what it delivers." />
         </div>
         <DialogFooter>
-          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
             Cancel
           </Button>
-          <Button disabled={!name.trim()} onClick={() => onAdd({ name, description, category })}>
+          <Button disabled={!name.trim() || busy} onClick={() => void submit()}>
+            {busy && <Loader2 className="mr-1.5 size-4 animate-spin" />}
             Add skill
           </Button>
         </DialogFooter>

--- a/src/server/ops/skills.rs
+++ b/src/server/ops/skills.rs
@@ -8,6 +8,9 @@
 //! built-in skills the name/description are best-effort (the console enriches
 //! from its catalog), while a custom skill's fields come from its `SKILL.md`.
 
+use std::collections::HashMap;
+use std::path::Path as FsPath;
+
 use axum::extract::Path;
 use axum::http::StatusCode;
 use axum::routing::{post, put};
@@ -15,19 +18,22 @@ use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
-use crate::company::parse_skill_md;
+use crate::company::{SkillDoc, parse_skill_md};
 use crate::error::OpenCompanyError;
 use crate::ports::skills_state::{SkillSource, SkillState};
 use crate::server::error::ApiError;
 use crate::server::ops::language;
 use crate::server::ops::{ScopedCompany, scoped};
 
+/// The default category stamped on a skill whose doc carries none.
+const DEFAULT_CATEGORY: &str = "Ops";
+
 /// Builds the skills route fragment.
 pub fn router() -> Router<AppState> {
     scoped("/skills/{slug}/install", post(install))
         .merge(scoped("/skills/{slug}/uninstall", post(uninstall)))
         .merge(scoped("/skills/{slug}", put(set_enabled)))
-        .merge(scoped("/skills", post(create_custom)))
+        .merge(scoped("/skills", post(create_custom).get(list_skills)))
 }
 
 /// An installed skill as the console renders it.
@@ -52,11 +58,21 @@ impl InstalledSkill {
                 Ok(parsed) => (
                     parsed.name,
                     parsed.description,
-                    parsed.category.unwrap_or_else(|| "Ops".to_string()),
+                    parsed
+                        .category
+                        .unwrap_or_else(|| DEFAULT_CATEGORY.to_string()),
                 ),
-                Err(_) => (titleize(&state.slug), String::new(), "Ops".to_string()),
+                Err(_) => (
+                    titleize(&state.slug),
+                    String::new(),
+                    DEFAULT_CATEGORY.to_string(),
+                ),
             },
-            None => (titleize(&state.slug), String::new(), "Ops".to_string()),
+            None => (
+                titleize(&state.slug),
+                String::new(),
+                DEFAULT_CATEGORY.to_string(),
+            ),
         };
         Self {
             id: state.slug.clone(),
@@ -65,6 +81,23 @@ impl InstalledSkill {
             category,
             source: state.source,
             enabled: state.enabled,
+        }
+    }
+
+    /// Projects a company-bundle `SKILL.md` (`companies/<name>/skills/<slug>`)
+    /// to the console shape. These are [`SkillSource::Company`], enabled unless
+    /// a store delta later overrides the flag.
+    fn from_company_bundle(doc: &SkillDoc, enabled: bool) -> Self {
+        Self {
+            id: doc.slug.clone(),
+            name: doc.name.clone(),
+            description: doc.description.clone(),
+            category: doc
+                .category
+                .clone()
+                .unwrap_or_else(|| DEFAULT_CATEGORY.to_string()),
+            source: SkillSource::Company,
+            enabled,
         }
     }
 }
@@ -90,6 +123,83 @@ struct CreateSkill {
     category: Option<String>,
     #[serde(default)]
     body: Option<String>,
+}
+
+/// `GET …/skills` — the company's **effective** skill set: its on-disk bundles
+/// (`companies/<name>/skills/*/SKILL.md`) unioned with the operator's
+/// [`SkillStateStore`] deltas. The console renders this list; it mirrors the
+/// write-plane semantics (and the GraphQL `Company.skills` resolver).
+async fn list_skills(company: ScopedCompany) -> Result<Json<Vec<InstalledSkill>>, ApiError> {
+    let deltas = company.runtime.skills().list(company.id()).await?;
+    Ok(Json(merge_effective(company.runtime.source_dir(), deltas)))
+}
+
+/// Merges the company-dir bundles with the operator deltas: a delta over a
+/// same-slug bundle wins its `enabled` flag, source, and (if it carries one) its
+/// custom doc; a delta with no bundle appears on its own. Sorted by slug so the
+/// response is deterministic.
+fn merge_effective(source_dir: Option<&FsPath>, deltas: Vec<SkillState>) -> Vec<InstalledSkill> {
+    let mut by_slug: HashMap<String, InstalledSkill> = company_bundles(source_dir)
+        .into_iter()
+        .map(|skill| (skill.id.clone(), skill))
+        .collect();
+
+    for st in deltas {
+        match by_slug.get_mut(&st.slug) {
+            Some(existing) => {
+                existing.enabled = st.enabled;
+                existing.source = st.source;
+                // A delta that carries a doc (a custom override) refreshes the
+                // display fields; a plain enable/disable delta keeps the bundle's.
+                if let Some(doc) = st
+                    .custom_doc
+                    .as_deref()
+                    .and_then(|doc| parse_skill_md(&st.slug, doc).ok())
+                {
+                    existing.name = doc.name;
+                    existing.description = doc.description;
+                    existing.category =
+                        doc.category.unwrap_or_else(|| DEFAULT_CATEGORY.to_string());
+                }
+            }
+            None => {
+                by_slug.insert(st.slug.clone(), InstalledSkill::from_state(&st));
+            }
+        }
+    }
+
+    let mut out: Vec<InstalledSkill> = by_slug.into_values().collect();
+    out.sort_by(|a, b| a.id.cmp(&b.id));
+    out
+}
+
+/// Scans `<source_dir>/skills/*/SKILL.md` into console skills. A missing source
+/// dir (platform-provisioned mode) or unreadable directory yields an empty list,
+/// and a missing or malformed `SKILL.md` skips just that bundle — never fails.
+fn company_bundles(source_dir: Option<&FsPath>) -> Vec<InstalledSkill> {
+    let Some(dir) = source_dir.map(|dir| dir.join("skills")) else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(slug) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        let Ok(body) = std::fs::read_to_string(path.join("SKILL.md")) else {
+            continue;
+        };
+        if let Ok(doc) = parse_skill_md(slug, &body) {
+            out.push(InstalledSkill::from_company_bundle(&doc, true));
+        }
+    }
+    out
 }
 
 async fn install(
@@ -227,4 +337,93 @@ fn titleize(slug: &str) -> String {
         })
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_bundle(root: &FsPath, slug: &str, contents: &str) {
+        let dir = root.join("skills").join(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("SKILL.md"), contents).unwrap();
+    }
+
+    #[test]
+    fn merge_unions_bundles_with_deltas_and_skips_malformed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // A well-formed company bundle, plus one with no frontmatter that must be
+        // skipped rather than failing the whole scan.
+        write_bundle(
+            root,
+            "onboard",
+            "---\nname: Onboard\ndescription: Get set up\ncategory: Ops\n---\n# Onboard\n",
+        );
+        write_bundle(root, "broken", "no frontmatter here\n");
+
+        let deltas = vec![
+            // Disables the company bundle above (a plain enable/disable delta).
+            SkillState {
+                slug: "onboard".to_string(),
+                enabled: false,
+                source: SkillSource::Company,
+                custom_doc: None,
+            },
+            // A custom skill with no matching company bundle.
+            SkillState {
+                slug: "my-skill".to_string(),
+                enabled: true,
+                source: SkillSource::Custom,
+                custom_doc: Some(
+                    "---\nname: My Skill\ndescription: Does a thing\n---\n# body\n".to_string(),
+                ),
+            },
+        ];
+
+        let out = merge_effective(Some(root), deltas);
+
+        // The company bundle appears, keeps its parsed name, and the delta flips
+        // it disabled.
+        let onboard = out
+            .iter()
+            .find(|s| s.id == "onboard")
+            .expect("company bundle present");
+        assert_eq!(onboard.name, "Onboard");
+        assert_eq!(onboard.source, SkillSource::Company);
+        assert!(!onboard.enabled, "delta flips the bundle disabled");
+
+        // The custom delta appears on its own, enriched from its doc.
+        let custom = out
+            .iter()
+            .find(|s| s.id == "my-skill")
+            .expect("custom delta present");
+        assert_eq!(custom.source, SkillSource::Custom);
+        assert_eq!(custom.name, "My Skill");
+        assert!(custom.enabled);
+
+        // The malformed bundle is skipped, never surfaced.
+        assert!(
+            out.iter().all(|s| s.id != "broken"),
+            "malformed SKILL.md is skipped"
+        );
+
+        // Deterministic order (by slug): my-skill < onboard.
+        let ids: Vec<&str> = out.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(ids, vec!["my-skill", "onboard"]);
+    }
+
+    #[test]
+    fn merge_with_no_source_dir_returns_only_deltas() {
+        let deltas = vec![SkillState {
+            slug: "web-research".to_string(),
+            enabled: true,
+            source: SkillSource::Registry,
+            custom_doc: None,
+        }];
+        let out = merge_effective(None, deltas);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, "web-research");
+        assert_eq!(out[0].source, SkillSource::Registry);
+    }
 }

--- a/src/server/ops/skills.rs
+++ b/src/server/ops/skills.rs
@@ -114,6 +114,20 @@ struct SetEnabled {
     enabled: bool,
 }
 
+/// The install body — the registry entry's metadata, so the installed skill
+/// carries a real `SKILL.md` the embedded agent can act on (a bare slug has no
+/// content, so it would never reach the agent's effective set).
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct InstallSkill {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    category: Option<String>,
+}
+
 /// The custom-skill body.
 #[derive(Debug, Deserialize)]
 struct CreateSkill {
@@ -205,12 +219,23 @@ fn company_bundles(source_dir: Option<&FsPath>) -> Vec<InstalledSkill> {
 async fn install(
     company: ScopedCompany,
     Path(SlugPath { slug }): Path<SlugPath>,
+    body: Option<Json<InstallSkill>>,
 ) -> Result<Json<InstalledSkill>, ApiError> {
+    let meta = body.map(|Json(b)| b).unwrap_or_default();
+    let name = meta
+        .name
+        .filter(|n| !n.trim().is_empty())
+        .unwrap_or_else(|| titleize(&slug));
+    let description = meta.description.unwrap_or_default();
+    // The registry ships metadata only. Persist a real `SKILL.md` built from it
+    // (the description doubles as the body) so `EffectiveSkills::materialize`
+    // surfaces the skill to the agent instead of skipping a content-less delta.
+    let doc = skill_md(&name, &description, meta.category.as_deref(), &description);
     let state = SkillState {
         slug,
         enabled: true,
         source: SkillSource::Registry,
-        custom_doc: None,
+        custom_doc: Some(doc),
     };
     company.runtime.skills().set(company.id(), &state).await?;
     Ok(Json(InstalledSkill::from_state(&state)))
@@ -278,7 +303,12 @@ async fn create_custom(
         )));
     }
     let slug = slugify(&body.name);
-    let doc = build_skill_md(&body);
+    let doc = skill_md(
+        &body.name,
+        &body.description,
+        body.category.as_deref(),
+        body.body.as_deref().unwrap_or(""),
+    );
     let state = SkillState {
         slug,
         enabled: true,
@@ -289,18 +319,14 @@ async fn create_custom(
     Ok(Json(InstalledSkill::from_state(&state)))
 }
 
-/// Builds a `SKILL.md` document from the custom-skill fields.
-fn build_skill_md(body: &CreateSkill) -> String {
-    let category = body
-        .category
-        .as_deref()
+/// Builds a `SKILL.md` document from a name, description, optional category, and
+/// body. Shared by custom-skill authoring and registry install (which passes
+/// the description as the body).
+fn skill_md(name: &str, description: &str, category: Option<&str>, content: &str) -> String {
+    let category = category
         .map(|c| format!("category: {c}\n"))
         .unwrap_or_default();
-    let content = body.body.as_deref().unwrap_or("");
-    format!(
-        "---\nname: {}\ndescription: {}\n{category}---\n{content}\n",
-        body.name, body.description
-    )
+    format!("---\nname: {name}\ndescription: {description}\n{category}---\n{content}\n")
 }
 
 /// Turns a display name into a filesystem-and-URL-safe slug.

--- a/src/server/ops/skills.rs
+++ b/src/server/ops/skills.rs
@@ -322,11 +322,23 @@ async fn create_custom(
 /// Builds a `SKILL.md` document from a name, description, optional category, and
 /// body. Shared by custom-skill authoring and registry install (which passes
 /// the description as the body).
+///
+/// The frontmatter parser is line-based (`key: value`), so each scalar is
+/// collapsed to a single line: newlines become spaces. That prevents a
+/// name/description from injecting extra frontmatter fields or emitting a bare
+/// `---` line that would close the block early. (Colons within a value are
+/// safe — the parser splits only on the first one.)
 fn skill_md(name: &str, description: &str, category: Option<&str>, content: &str) -> String {
-    let category = category
-        .map(|c| format!("category: {c}\n"))
-        .unwrap_or_default();
-    format!("---\nname: {name}\ndescription: {description}\n{category}---\n{content}\n")
+    let one_line = |s: &str| s.replace(['\n', '\r'], " ");
+    let mut frontmatter = format!(
+        "name: {}\ndescription: {}\n",
+        one_line(name).trim(),
+        one_line(description).trim()
+    );
+    if let Some(category) = category {
+        frontmatter.push_str(&format!("category: {}\n", one_line(category).trim()));
+    }
+    format!("---\n{frontmatter}---\n{content}\n")
 }
 
 /// Turns a display name into a filesystem-and-URL-safe slug.
@@ -373,6 +385,25 @@ mod tests {
         let dir = root.join("skills").join(slug);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("SKILL.md"), contents).unwrap();
+    }
+
+    #[test]
+    fn skill_md_frontmatter_resists_injection() {
+        // A name carrying newlines, a stray `---`, and a fake field must not
+        // inject frontmatter or hijack another field: newlines collapse to
+        // spaces, so it all lands as the single `name` value.
+        let nasty_name = "Evil\n---\ninjected: true\nname: hijacked";
+        let doc = skill_md(nasty_name, "a real description", Some("Ops"), "body");
+        let parsed = parse_skill_md("evil", &doc).expect("frontmatter stays valid");
+        assert_eq!(parsed.name, "Evil --- injected: true name: hijacked");
+        // The description was NOT overwritten by the injected `name: hijacked`.
+        assert_eq!(parsed.description, "a real description");
+        // A colon inside a value is preserved (split only on the first colon).
+        let colon = skill_md("Name", "ratio 3:1 outcome", None, "body");
+        assert_eq!(
+            parse_skill_md("c", &colon).unwrap().description,
+            "ratio 3:1 outcome"
+        );
     }
 
     #[test]

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -324,6 +324,19 @@ async fn skills_install_toggle_custom_and_builtin_uninstall_conflict() {
     assert_eq!(status, StatusCode::OK);
     assert!(!toggled["enabled"].as_bool().unwrap());
 
+    // `GET …/skills` returns the effective set: here (no source dir) that's the
+    // deltas — the custom skill, now disabled.
+    let (status, list) = send(&state, "GET", "/api/v1/company/skills", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let rows = list.as_array().expect("a JSON array of skills");
+    let my_skill = rows
+        .iter()
+        .find(|s| s["id"] == "my-skill")
+        .expect("the custom skill is listed");
+    assert_eq!(my_skill["source"], "custom");
+    assert_eq!(my_skill["name"], "My Skill");
+    assert!(!my_skill["enabled"].as_bool().unwrap());
+
     tokio::fs::remove_dir_all(&home).await.ok();
 }
 

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -268,17 +268,30 @@ async fn skills_install_toggle_custom_and_builtin_uninstall_conflict() {
     let home = home();
     let state = state_with_company(&home).await;
 
-    // Install from registry.
+    // Install from registry, carrying the entry's metadata so the host persists
+    // a real SKILL.md the agent can act on (not a content-less slug).
     let (status, skill) = send(
         &state,
         "POST",
         "/api/v1/company/skills/web-research/install",
-        None,
+        Some(json!({
+            "name": "Web Research",
+            "description": "Answer a question from multiple sources with citations.",
+            "category": "Research"
+        })),
     )
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(skill["source"], "registry");
     assert!(skill["enabled"].as_bool().unwrap());
+    // The install response reflects the persisted custom_doc (parsed back), so a
+    // non-empty description proves content was stored — the fix for the agent
+    // never receiving registry skills.
+    assert_eq!(skill["name"], "Web Research");
+    assert_eq!(
+        skill["description"],
+        "Answer a question from multiple sources with citations."
+    );
 
     // Uninstall the registry skill: 204.
     let (status, _) = send(


### PR DESCRIPTION
## Summary

Wires the operator console **Skills** tab to a live backend (follow-on to the merged #28 cell), and makes registry installs actually usable by the embedded agent.

- Backend `GET …/skills` returns the company's **effective** skill set — committed company-dir `SKILL.md` bundles ∪ `SkillStateStore` deltas (slug/name/description/category/source/enabled).
- `SkillsView` reads that live (drops the localStorage stub); enable/disable → PUT, install/uninstall → POST, author custom → POST, all optimistic with revert.
- **Registry install now persists real content (Closes #42):** the console sends the registry entry's metadata on install, and the host builds a `SKILL.md` from it (stored as `custom_doc`). Previously a bare registry install had no body, so `EffectiveSkills::materialize` skipped it and the agent never received it. Verified end-to-end: after installing a registry skill, the engineer agent enumerates it alongside company-dir and custom skills.

Closes #34. Closes #42.

## API Or Behavior Changes

- New `GET /api/v1/companies/{id}/skills` (+ single-company alias) → effective skills, camelCase.
- `POST …/skills/{slug}/install` now accepts an optional `{name, description, category}` body and persists a `SKILL.md` (`custom_doc`) built from it; source stays `registry`.
- Console client gains a typed `put`.
- Default build unchanged.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (own code clean; see stacking note)
- [x] `cargo build --all-targets`
- [x] `cargo test` — `cargo test --lib skills` 6 passed (incl. merge-of-effective-set + install-persists-content)
- [x] Frontend `pnpm typecheck` + `pnpm build`
- [x] Manual (staging): install registry skill → dispatch task to agent → agent lists it

## Documentation

Module docs on `src/server/ops/skills.rs` (effective-set merge + install content). Known follow-up: skills only refresh on a fresh harness pool (mid-session changes need a restart to reach already-running agents).

---

Stacked on `chore/ci-green` — merge that first (it fixes a pre-existing main clippy/fmt failure that otherwise reddens this PR's lanes).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added live skills management backed by the company API, including viewing, installing, creating custom skills, enabling/disabling, and uninstalling.
  - SkillsView now loads from the server with improved loading/empty states and async optimistic updates with rollback on failure.
  - Installed and custom skills now retain provided metadata and custom skill content.

- **Bug Fixes**
  - Improved skill merging and deterministic ordering when combining company bundles with operator updates.
  - Better handling of missing or malformed skill definitions, including consistent category fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->