### PR TITLE
feat(workflows): live-wire the Workflows console — list, graph, run (#35)

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -1,0 +1,77 @@
+// The live workflow API: the console's Workflows canvas reads the company's
+// saved graphs through the host's `…/workflows` routes (REST, camelCase over
+// the wire) and runs one via `…/workflows/{wid}/run`. Replaces the client-side
+// `workflow-sample` illustrative data.
+
+import type { OpenCompanyClient } from "./client";
+
+/** A one-line workflow entry, as the picker lists it. */
+export interface WorkflowSummary {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+/** A single graph node. `kind` is one of the tinyflows node kinds. */
+export interface WorkflowNode {
+  id: string;
+  /** `trigger` | `agent` | `tool_call` | `http_request` | `condition` | `output`. */
+  kind: string;
+  name: string;
+  summary?: string;
+  /** The roster agent id — only present on `agent` nodes. */
+  agent?: string;
+}
+
+/** A directed edge between two node ids, with an optional branch label. */
+export interface WorkflowEdge {
+  from: string;
+  to: string;
+  label?: string;
+}
+
+/** The full graph the canvas renders. */
+export interface WorkflowGraph {
+  id: string;
+  name: string;
+  description?: string;
+  nodes: WorkflowNode[];
+  edges: WorkflowEdge[];
+}
+
+/** The result of a run: the engine's final state and any pending approvals. */
+export interface WorkflowRunResult {
+  /** The engine's final run state — a nested JSON payload. */
+  output: unknown;
+  /** Node ids left waiting on a human approval, if any. */
+  pendingApprovals: string[];
+}
+
+export function listWorkflows(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<WorkflowSummary[]> {
+  return client.get<WorkflowSummary[]>(`${client.scopeFor(company)}/workflows`);
+}
+
+export function getWorkflow(
+  client: OpenCompanyClient,
+  company: string | null,
+  wid: string,
+): Promise<WorkflowGraph> {
+  return client.get<WorkflowGraph>(
+    `${client.scopeFor(company)}/workflows/${encodeURIComponent(wid)}`,
+  );
+}
+
+export function runWorkflow(
+  client: OpenCompanyClient,
+  company: string | null,
+  wid: string,
+  input?: unknown,
+): Promise<WorkflowRunResult> {
+  return client.post<WorkflowRunResult>(
+    `${client.scopeFor(company)}/workflows/${encodeURIComponent(wid)}/run`,
+    { input: input ?? {} },
+  );
+}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -324,7 +324,7 @@ export function AppShell({
                 </div>
               }
             >
-              <WorkflowsView />
+              <WorkflowsView client={client} company={company} />
             </Suspense>
           )}
           {view === "usage" && (

--- a/frontend/src/lib/workflow-sample.ts
+++ b/frontend/src/lib/workflow-sample.ts
@@ -1,8 +1,7 @@
-// A dummy workflow graph for the canvas, in the spirit of OpenHuman's tinyflows
-// node kinds (trigger / agent / tool_call / http_request / condition / output).
-// This is illustrative sample data — the console has no live flow API yet.
-
-import type { Edge, Node } from "@xyflow/react";
+// Presentation metadata for the workflow canvas, keyed by the tinyflows node
+// kinds (trigger / agent / tool_call / http_request / condition / output). The
+// live graph comes from the host (`@/api/workflows`); this module only maps each
+// kind to its emoji + accent so `WorkflowsView` and `WorkflowNode` render it.
 
 export type NodeColor = "primary" | "sage" | "amber" | "coral" | "neutral";
 
@@ -33,52 +32,7 @@ export const COLOR_CLASSES: Record<NodeColor, { border: string; chip: string }> 
   neutral: { border: "border-border", chip: "bg-muted" },
 };
 
-function node(
-  id: string,
-  kind: string,
-  name: string,
-  summary: string,
-  position: { x: number; y: number },
-): Node<WorkflowNodeData> {
-  const meta = NODE_KIND_META[kind] ?? { emoji: "•", color: "neutral" as const };
-  return {
-    id,
-    type: "oc",
-    position,
-    data: { kind, name, summary, emoji: meta.emoji, color: meta.color },
-  };
-}
-
-/** The sample "campaign brief → published post" flow shown on the canvas. */
-export const SAMPLE_WORKFLOW: { nodes: Node<WorkflowNodeData>[]; edges: Edge[] } = {
-  nodes: [
-    node("brief", "trigger", "New campaign brief", "Client drops a brief in the inbox", { x: 0, y: 120 }),
-    node("strategist", "agent", "Strategist", "Turns the brief into an angle + outline", { x: 280, y: 120 }),
-    node("gate", "condition", "Needs research?", "Branch on topic familiarity", { x: 560, y: 120 }),
-    node("research", "tool_call", "Web research", "Pulls sources and competitor takes", { x: 840, y: 20 }),
-    node("copy", "agent", "Copywriter", "Drafts the post from the outline", { x: 840, y: 220 }),
-    node("design", "agent", "Designer", "Generates the hero image", { x: 1120, y: 220 }),
-    node("publish", "http_request", "Publish to CMS", "POST the approved draft", { x: 1400, y: 120 }),
-    node("done", "output", "Report back", "Summarize what shipped", { x: 1680, y: 120 }),
-  ],
-  edges: [
-    edge("brief", "strategist"),
-    edge("strategist", "gate"),
-    edge("gate", "research", "yes"),
-    edge("gate", "copy", "no"),
-    edge("research", "copy"),
-    edge("copy", "design"),
-    edge("design", "publish"),
-    edge("publish", "done"),
-  ],
-};
-
-function edge(source: string, target: string, label?: string): Edge {
-  return {
-    id: `${source}-${target}`,
-    source,
-    target,
-    label,
-    animated: true,
-  };
+/** Emoji + accent for a node kind, falling back for an unknown kind. */
+export function nodeKindMeta(kind: string): { emoji: string; color: NodeColor } {
+  return NODE_KIND_META[kind] ?? { emoji: "•", color: "neutral" };
 }

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -249,9 +249,19 @@ function RunResultPanel({
             Waiting on: {result.pendingApprovals.join(", ")}
           </p>
         )}
-        <pre className="rounded-lg border bg-muted/40 p-2 font-mono text-[11px] leading-snug">
-          {JSON.stringify(result.output, null, 2)}
-        </pre>
+        {!text && (
+          <p className="mb-2 text-xs text-muted-foreground">
+            The run finished; no final text node — see the raw output below.
+          </p>
+        )}
+        <details open={!text}>
+          <summary className="cursor-pointer text-xs text-muted-foreground">
+            Raw engine output
+          </summary>
+          <pre className="mt-1 rounded-lg border bg-muted/40 p-2 font-mono text-[11px] leading-snug">
+            {JSON.stringify(result.output, null, 2)}
+          </pre>
+        </details>
       </div>
     </div>
   );

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1,54 +1,330 @@
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Background,
   BackgroundVariant,
   Controls,
+  type Edge,
   MiniMap,
+  type Node,
   ReactFlow,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useTheme } from "next-themes";
+import { Loader2, Play } from "lucide-react";
+import { toast } from "sonner";
 
+import {
+  getWorkflow,
+  listWorkflows,
+  runWorkflow,
+  type WorkflowGraph,
+  type WorkflowRunResult,
+  type WorkflowSummary,
+} from "@/api/workflows";
+import type { OpenCompanyClient } from "@/api/client";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
 import { WorkflowNode } from "@/components/workflow-node";
-import { SAMPLE_WORKFLOW } from "@/lib/workflow-sample";
+import { nodeKindMeta, type WorkflowNodeData } from "@/lib/workflow-sample";
 
 const NODE_TYPES = { oc: WorkflowNode };
 
-/** A read-only canvas of how a company routes work, React Flow-powered. */
-export function WorkflowsView() {
+/** Horizontal gap between layers and vertical gap between nodes in a layer. */
+const COL_GAP = 300;
+const ROW_GAP = 150;
+
+/**
+ * The live Workflows canvas. Reads the company's saved graphs from the host's
+ * `…/workflows` routes, lets the operator pick one, renders its real nodes and
+ * edges (auto-laid-out left→right by longest-path depth, since saved graphs
+ * carry no coordinates), and runs it via `…/workflows/{wid}/run` — surfacing the
+ * engine's final output and any nodes left pending approval.
+ */
+export function WorkflowsView({
+  client,
+  company,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+}) {
   const { resolvedTheme } = useTheme();
-  const { nodes, edges } = useMemo(() => SAMPLE_WORKFLOW, []);
+  const [workflows, setWorkflows] = useState<WorkflowSummary[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [graph, setGraph] = useState<WorkflowGraph | null>(null);
+  const [loadingList, setLoadingList] = useState(true);
+  const [loadingGraph, setLoadingGraph] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<WorkflowRunResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Load the workflow list once, and auto-select the first entry.
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      try {
+        const rows = await listWorkflows(client, company);
+        if (!live) return;
+        setWorkflows(rows);
+        setSelectedId((prev) => prev ?? rows[0]?.id ?? null);
+        setError(null);
+      } catch (e) {
+        if (!live) return;
+        setError(e instanceof Error ? e.message : "could not load workflows");
+      } finally {
+        if (live) setLoadingList(false);
+      }
+    })();
+    return () => {
+      live = false;
+    };
+  }, [client, company]);
+
+  // Fetch the selected workflow's full graph.
+  useEffect(() => {
+    if (!selectedId) {
+      setGraph(null);
+      return;
+    }
+    let live = true;
+    setLoadingGraph(true);
+    setResult(null);
+    (async () => {
+      try {
+        const g = await getWorkflow(client, company, selectedId);
+        if (!live) return;
+        setGraph(g);
+        setError(null);
+      } catch (e) {
+        if (!live) return;
+        setGraph(null);
+        setError(e instanceof Error ? e.message : "could not load the workflow graph");
+      } finally {
+        if (live) setLoadingGraph(false);
+      }
+    })();
+    return () => {
+      live = false;
+    };
+  }, [client, company, selectedId]);
+
+  const run = useCallback(async () => {
+    if (!selectedId) return;
+    setRunning(true);
+    try {
+      const res = await runWorkflow(client, company, selectedId);
+      setResult(res);
+      toast.success("Workflow ran.");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "could not run the workflow");
+    } finally {
+      setRunning(false);
+    }
+  }, [client, company, selectedId]);
+
+  const { nodes, edges } = useMemo(() => (graph ? layout(graph) : { nodes: [], edges: [] }), [graph]);
+
+  const selected = workflows.find((w) => w.id === selectedId) ?? null;
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       <div className="flex flex-wrap items-center justify-between gap-2 border-b px-4 py-3">
-        <div className="flex items-center gap-2">
-          <h2 className="text-sm font-semibold">Campaign pipeline</h2>
-          <Badge variant="secondary">Sample</Badge>
+        <div className="flex min-w-0 items-center gap-2">
+          <h2 className="text-sm font-semibold">Workflows</h2>
+          <Badge variant="secondary">{workflows.length}</Badge>
+          {selected?.description && (
+            <p className="hidden truncate text-xs text-muted-foreground sm:block">
+              {selected.description}
+            </p>
+          )}
         </div>
-        <p className="text-xs text-muted-foreground">
-          How this company routes a brief from intake to a published post.
-        </p>
+        <div className="flex items-center gap-2">
+          <Select
+            value={selectedId ?? undefined}
+            onValueChange={(v) => setSelectedId(v)}
+            disabled={loadingList || workflows.length === 0}
+          >
+            <SelectTrigger className="h-8 w-56">
+              <SelectValue placeholder={loadingList ? "Loading…" : "Pick a workflow"} />
+            </SelectTrigger>
+            <SelectContent>
+              {workflows.map((w) => (
+                <SelectItem key={w.id} value={w.id}>
+                  {w.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button size="sm" onClick={() => void run()} disabled={!selectedId || running || loadingGraph}>
+            {running ? (
+              <Loader2 className="mr-1.5 size-4 animate-spin" />
+            ) : (
+              <Play className="mr-1.5 size-4" />
+            )}
+            Run
+          </Button>
+        </div>
       </div>
+
+      {error && (
+        <div className="px-4 pt-3">
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        </div>
+      )}
+
       <div className="relative flex-1">
-        <ReactFlow
-          nodes={nodes}
-          edges={edges}
-          nodeTypes={NODE_TYPES}
-          colorMode={resolvedTheme === "dark" ? "dark" : "light"}
-          fitView
-          fitViewOptions={{ padding: 0.2 }}
-          nodesDraggable={false}
-          nodesConnectable={false}
-          elementsSelectable
-          proOptions={{ hideAttribution: true }}
-        >
-          <Background variant={BackgroundVariant.Dots} gap={20} size={1} />
-          <Controls showInteractive={false} />
-          <MiniMap pannable zoomable className="!hidden sm:!block" />
-        </ReactFlow>
+        {loadingList || loadingGraph ? (
+          <div className="absolute inset-0 p-4">
+            <Skeleton className="h-full w-full rounded-xl" />
+          </div>
+        ) : !selectedId ? (
+          <div className="flex h-full items-center justify-center px-4 text-center text-sm text-muted-foreground">
+            This company has no saved workflows yet.
+          </div>
+        ) : (
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            nodeTypes={NODE_TYPES}
+            colorMode={resolvedTheme === "dark" ? "dark" : "light"}
+            fitView
+            fitViewOptions={{ padding: 0.2 }}
+            nodesDraggable={false}
+            nodesConnectable={false}
+            elementsSelectable
+            proOptions={{ hideAttribution: true }}
+          >
+            <Background variant={BackgroundVariant.Dots} gap={20} size={1} />
+            <Controls showInteractive={false} />
+            <MiniMap pannable zoomable className="!hidden sm:!block" />
+          </ReactFlow>
+        )}
+      </div>
+
+      {result && <RunResultPanel result={result} onClose={() => setResult(null)} />}
+    </div>
+  );
+}
+
+/** The run-output drawer: the final text (when we can find one) plus the raw
+ * engine state and any nodes left pending approval. */
+function RunResultPanel({
+  result,
+  onClose,
+}: {
+  result: WorkflowRunResult;
+  onClose: () => void;
+}) {
+  const text = finalText(result.output);
+  return (
+    <div className="border-t bg-card/60">
+      <div className="flex items-center justify-between px-4 py-2">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">Run result</span>
+          {result.pendingApprovals.length > 0 && (
+            <Badge variant="outline" className="border-amber-500/40 bg-amber-500/10">
+              {result.pendingApprovals.length} pending approval
+              {result.pendingApprovals.length === 1 ? "" : "s"}
+            </Badge>
+          )}
+        </div>
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          Dismiss
+        </Button>
+      </div>
+      <div className="max-h-56 overflow-auto px-4 pb-3">
+        {text && <p className="mb-2 whitespace-pre-wrap text-sm">{text}</p>}
+        {result.pendingApprovals.length > 0 && (
+          <p className="mb-2 text-xs text-muted-foreground">
+            Waiting on: {result.pendingApprovals.join(", ")}
+          </p>
+        )}
+        <pre className="rounded-lg border bg-muted/40 p-2 font-mono text-[11px] leading-snug">
+          {JSON.stringify(result.output, null, 2)}
+        </pre>
       </div>
     </div>
   );
+}
+
+/** Lays a saved graph out left→right by longest-path depth, stacking siblings
+ * vertically within each layer. Cycles are bounded by an iteration cap, so a
+ * back edge never loops forever. */
+function layout(graph: WorkflowGraph): { nodes: Node<WorkflowNodeData>[]; edges: Edge[] } {
+  const depth = new Map<string, number>(graph.nodes.map((n) => [n.id, 0]));
+  for (let i = 0; i < graph.nodes.length; i++) {
+    let changed = false;
+    for (const e of graph.edges) {
+      const d = (depth.get(e.from) ?? 0) + 1;
+      if (d > (depth.get(e.to) ?? 0)) {
+        depth.set(e.to, d);
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+
+  const rowInLayer = new Map<number, number>();
+  const nodes: Node<WorkflowNodeData>[] = graph.nodes.map((n) => {
+    const layer = depth.get(n.id) ?? 0;
+    const row = rowInLayer.get(layer) ?? 0;
+    rowInLayer.set(layer, row + 1);
+    const meta = nodeKindMeta(n.kind);
+    return {
+      id: n.id,
+      type: "oc",
+      position: { x: layer * COL_GAP, y: row * ROW_GAP },
+      data: {
+        kind: n.kind,
+        name: n.name,
+        // Agent nodes surface their roster id; otherwise the node's summary.
+        summary: n.summary ?? (n.agent ? `Agent: ${n.agent}` : ""),
+        emoji: meta.emoji,
+        color: meta.color,
+      },
+    };
+  });
+
+  const edges: Edge[] = graph.edges.map((e, i) => ({
+    id: `${e.from}-${e.to}-${i}`,
+    source: e.from,
+    target: e.to,
+    label: e.label,
+    animated: true,
+  }));
+
+  return { nodes, edges };
+}
+
+/** Best-effort pull of a human-readable final string from the nested run state,
+ * checking the keys the engine is likely to carry. Returns `null` when none is
+ * found, in which case the raw JSON is shown instead. */
+function finalText(output: unknown): string | null {
+  const KEYS = ["text", "output", "final", "reply", "message", "content", "result"];
+  const seen = new Set<unknown>();
+  function walk(value: unknown, depth: number): string | null {
+    if (typeof value === "string") return value.trim() || null;
+    if (depth > 6 || value === null || typeof value !== "object") return null;
+    if (seen.has(value)) return null;
+    seen.add(value);
+    const obj = value as Record<string, unknown>;
+    for (const key of KEYS) {
+      if (key in obj) {
+        const found = walk(obj[key], depth + 1);
+        if (found) return found;
+      }
+    }
+    return null;
+  }
+  return walk(output, 0);
 }

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -74,7 +74,12 @@ export function WorkflowsView({
         const rows = await listWorkflows(client, company);
         if (!live) return;
         setWorkflows(rows);
-        setSelectedId((prev) => prev ?? rows[0]?.id ?? null);
+        // Keep the selection only if it still exists in the freshly loaded list
+        // (this effect also reruns on company change) — otherwise a stale id
+        // from the previous company would fetch the wrong/nonexistent graph.
+        setSelectedId((prev) =>
+          prev && rows.some((r) => r.id === prev) ? prev : (rows[0]?.id ?? null),
+        );
         setError(null);
       } catch (e) {
         if (!live) return;

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -148,6 +148,12 @@ async fn get_workflow(
     company: ScopedCompany,
     Path(WorkflowPath { wid }): Path<WorkflowPath>,
 ) -> Result<Json<WorkflowGraph>, ApiError> {
+    // `wid` becomes a filename — reject anything that could escape `workflows/`.
+    if !safe_wid(&wid) {
+        return Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
+            "workflow {wid}"
+        ))));
+    }
     let source_dir = company
         .runtime
         .source_dir()
@@ -189,7 +195,24 @@ fn load_source_workflows(source_dir: Option<&FsPath>) -> Result<Vec<WorkflowFile
         .collect();
     // Stable, deterministic order for the picker.
     ids.sort();
-    load_company_workflows(source_dir, &ids).map_err(ApiError)
+    // Load each id on its own so one malformed `workflows/*.toml` skips only
+    // itself instead of 500-ing the whole picker.
+    let mut files = Vec::with_capacity(ids.len());
+    for id in &ids {
+        match load_company_workflows(source_dir, std::slice::from_ref(id)) {
+            Ok(loaded) => files.extend(loaded),
+            Err(err) => tracing::warn!(workflow = %id, error = %err, "skipping malformed workflow"),
+        }
+    }
+    Ok(files)
+}
+
+/// Whether `wid` is a single safe on-disk filename stem — no path separators,
+/// no `..`, not empty — so it can't escape the `workflows/` directory.
+fn safe_wid(wid: &str) -> bool {
+    use std::path::Component;
+    let mut comps = FsPath::new(wid).components();
+    matches!(comps.next(), Some(Component::Normal(_))) && comps.next().is_none()
 }
 
 /// The sub-resource path (`wid`); the scope `id` is consumed by the extractor.
@@ -226,6 +249,13 @@ async fn run_workflow(
     let Some(runner) = company.runtime.workflow_runner() else {
         return Err(super::not_wired("workflow execution"));
     };
+
+    // `wid` becomes a filename — reject anything that could escape `workflows/`.
+    if !safe_wid(&wid) {
+        return Err(
+            ApiError(OpenCompanyError::CompanyNotFound(format!("workflow {wid}"))).into_response(),
+        );
+    }
 
     // Load the saved graph from the company's on-disk source directory. Without
     // one (platform-provisioned mode) there is nothing to run.
@@ -368,5 +398,32 @@ mod tests {
         assert!(done.get("agent").is_none());
         assert!(done.get("summary").is_none());
         assert_eq!(done["kind"], "output");
+    }
+
+    #[test]
+    fn safe_wid_rejects_traversal() {
+        assert!(safe_wid("demo"));
+        assert!(safe_wid("my-workflow_2"));
+        assert!(!safe_wid(""));
+        assert!(!safe_wid(".."));
+        assert!(!safe_wid("."));
+        assert!(!safe_wid("../secrets"));
+        assert!(!safe_wid("a/b"));
+        assert!(!safe_wid("/etc/passwd"));
+        assert!(!safe_wid("foo/../bar"));
+    }
+
+    #[test]
+    fn one_malformed_workflow_does_not_break_the_list() {
+        let dir = seed_demo();
+        // A second, broken workflow file must not 500 the whole picker.
+        std::fs::write(
+            dir.path().join("workflows").join("broken.toml"),
+            "id = \"broken\"\nname = \n[[node]] oops",
+        )
+        .unwrap();
+        let files = load_source_workflows(Some(dir.path())).expect("lists despite a bad file");
+        let ids: Vec<_> = files.iter().map(|f| f.id.as_str()).collect();
+        assert_eq!(ids, vec!["demo"]);
     }
 }

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1,31 +1,195 @@
-//! Workflow execution: `POST /workflows/{wid}/run` under both scope forms.
+//! Workflow surfaces: read the company's saved graphs (`GET /workflows`,
+//! `GET /workflows/{wid}`) and run one (`POST /workflows/{wid}/run`) under both
+//! scope forms.
 //!
-//! Runs the company's saved workflow graph `wid` on the embedded `tinyflows`
-//! engine, with agent nodes executing on the harness pool (see
-//! [`crate::ports::WorkflowRunner`]). The graph is loaded from the company's
-//! on-disk source directory (`companies/<name>/workflows/<wid>.toml`).
+//! Graphs are loaded from the company's on-disk source directory
+//! (`companies/<name>/workflows/<wid>.toml`) via
+//! [`load_company_workflows`](crate::company::load_company_workflows), which
+//! takes an explicit id list (it never scans) — so `list_workflows` enumerates
+//! the `workflows/` directory itself to build that list.
 //!
 //! Execution is dependency-inverted behind the [`WorkflowRunner`] port: when no
 //! runner is wired (the default build, or a runtime built without a harness) the
-//! route reports `not_wired` — the same 404 seam the DNS/SMTP surfaces use — so
-//! the default build stays inert.
+//! run route reports `not_wired` — the same 404 seam the DNS/SMTP surfaces use —
+//! so the default build stays inert. The read routes need no runner: they only
+//! parse the committed graph files, so the console can list and render workflows
+//! even on a build that cannot execute them.
+
+use std::path::Path as FsPath;
 
 use axum::extract::Path;
 use axum::response::{IntoResponse, Response};
-use axum::routing::post;
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::AppState;
-use crate::company::load_company_workflows;
+use crate::company::{WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef, load_company_workflows};
 use crate::error::OpenCompanyError;
 use crate::server::error::ApiError;
 use crate::server::ops::{ScopedCompany, scoped};
 
-/// Builds the workflow-run route fragment.
+/// Builds the workflow route fragment: list + graph reads and the run write.
 pub fn router() -> Router<AppState> {
-    scoped("/workflows/{wid}/run", post(run_workflow))
+    scoped("/workflows", get(list_workflows))
+        .merge(scoped("/workflows/{wid}", get(get_workflow)))
+        .merge(scoped("/workflows/{wid}/run", post(run_workflow)))
+}
+
+/// A one-line workflow entry as the console's picker renders it.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowSummary {
+    id: String,
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+}
+
+impl From<WorkflowFile> for WorkflowSummary {
+    fn from(f: WorkflowFile) -> Self {
+        Self {
+            id: f.id,
+            name: f.name,
+            description: f.description,
+        }
+    }
+}
+
+/// The full graph the canvas renders — nodes and directed edges, camelCase.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowGraph {
+    id: String,
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    nodes: Vec<WorkflowNode>,
+    edges: Vec<WorkflowEdge>,
+}
+
+impl From<WorkflowFile> for WorkflowGraph {
+    fn from(f: WorkflowFile) -> Self {
+        Self {
+            id: f.id,
+            name: f.name,
+            description: f.description,
+            nodes: f.nodes.into_iter().map(WorkflowNode::from).collect(),
+            edges: f.edges.into_iter().map(WorkflowEdge::from).collect(),
+        }
+    }
+}
+
+/// A single graph node. `kind` is the on-disk string
+/// (`trigger`/`agent`/`tool_call`/`http_request`/`condition`/`output`); `agent`
+/// is only meaningful on `agent` nodes.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowNode {
+    id: String,
+    kind: String,
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    summary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agent: Option<String>,
+}
+
+impl From<WorkflowNodeDef> for WorkflowNode {
+    fn from(n: WorkflowNodeDef) -> Self {
+        Self {
+            id: n.id,
+            kind: n.kind.as_str().to_string(),
+            name: n.name,
+            summary: n.summary,
+            agent: n.agent,
+        }
+    }
+}
+
+/// A directed edge between two node ids, with an optional branch label.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowEdge {
+    from: String,
+    to: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    label: Option<String>,
+}
+
+impl From<WorkflowEdgeDef> for WorkflowEdge {
+    fn from(e: WorkflowEdgeDef) -> Self {
+        Self {
+            from: e.from,
+            to: e.to,
+            label: e.label,
+        }
+    }
+}
+
+/// `GET …/workflows` — the company's saved workflows as picker summaries.
+///
+/// The loader takes an explicit id list rather than scanning, so this reads the
+/// company's `workflows/` directory to collect the `*.toml` file stems as ids,
+/// then loads and summarizes them. No source directory (platform-provisioned
+/// mode) or no `workflows/` directory yields an empty list — a `200`, not an
+/// error, so the console renders "no workflows yet" rather than a failure.
+async fn list_workflows(company: ScopedCompany) -> Result<Json<Vec<WorkflowSummary>>, ApiError> {
+    let files = load_source_workflows(company.runtime.source_dir())?;
+    Ok(Json(files.into_iter().map(WorkflowSummary::from).collect()))
+}
+
+/// `GET …/workflows/{wid}` — the full graph for one workflow.
+///
+/// An unknown `wid` (or a deployment with no source directory) is a `404`,
+/// mirroring the sub-resource-not-found shape the task routes use.
+async fn get_workflow(
+    company: ScopedCompany,
+    Path(WorkflowPath { wid }): Path<WorkflowPath>,
+) -> Result<Json<WorkflowGraph>, ApiError> {
+    let source_dir = company
+        .runtime
+        .source_dir()
+        .ok_or_else(|| ApiError(OpenCompanyError::CompanyNotFound(format!("workflow {wid}"))))?;
+    // Only try to load ids that exist on disk, so a missing file is a clean 404
+    // rather than the loader's `DataRead` (a 500).
+    let path = source_dir.join("workflows").join(format!("{wid}.toml"));
+    if !path.is_file() {
+        return Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
+            "workflow {wid}"
+        ))));
+    }
+    let file = load_company_workflows(source_dir, std::slice::from_ref(&wid))
+        .map_err(ApiError)?
+        .into_iter()
+        .next()
+        .ok_or_else(|| ApiError(OpenCompanyError::CompanyNotFound(format!("workflow {wid}"))))?;
+    Ok(Json(WorkflowGraph::from(file)))
+}
+
+/// Loads every saved workflow under `source_dir/workflows/`, or an empty list
+/// when there is no source directory or no `workflows/` directory.
+fn load_source_workflows(source_dir: Option<&FsPath>) -> Result<Vec<WorkflowFile>, ApiError> {
+    let Some(source_dir) = source_dir else {
+        return Ok(Vec::new());
+    };
+    let Ok(entries) = std::fs::read_dir(source_dir.join("workflows")) else {
+        return Ok(Vec::new());
+    };
+    let mut ids: Vec<String> = entries
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("toml"))
+        .filter_map(|path| {
+            path.file_stem()
+                .and_then(|stem| stem.to_str())
+                .map(str::to_string)
+        })
+        .collect();
+    // Stable, deterministic order for the picker.
+    ids.sort();
+    load_company_workflows(source_dir, &ids).map_err(ApiError)
 }
 
 /// The sub-resource path (`wid`); the scope `id` is consumed by the extractor.
@@ -86,4 +250,123 @@ async fn run_workflow(
         output: run.output,
         pending_approvals: run.pending_approvals,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DEMO: &str = r#"
+        id = "demo"
+        name = "Demo flow"
+        description = "A tiny trigger → agent → output graph."
+        [[node]]
+        id = "start"
+        kind = "trigger"
+        name = "Start"
+        summary = "Kicks it off."
+        [[node]]
+        id = "worker"
+        kind = "agent"
+        name = "Worker"
+        summary = "Does the thing."
+        agent = "assistant"
+        [[node]]
+        id = "done"
+        kind = "output"
+        name = "Report"
+        [[edge]]
+        from = "start"
+        to = "worker"
+        [[edge]]
+        from = "worker"
+        to = "done"
+        label = "ok"
+    "#;
+
+    /// Writes `DEMO` to `<dir>/workflows/demo.toml` and returns `dir`.
+    fn seed_demo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let workflows = dir.path().join("workflows");
+        std::fs::create_dir_all(&workflows).unwrap();
+        std::fs::write(workflows.join("demo.toml"), DEMO).unwrap();
+        dir
+    }
+
+    #[test]
+    fn list_returns_a_summary_per_saved_workflow() {
+        let dir = seed_demo();
+        let files = load_source_workflows(Some(dir.path())).expect("lists");
+        let summaries: Vec<WorkflowSummary> =
+            files.into_iter().map(WorkflowSummary::from).collect();
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].id, "demo");
+        assert_eq!(summaries[0].name, "Demo flow");
+        assert_eq!(
+            summaries[0].description.as_deref(),
+            Some("A tiny trigger → agent → output graph.")
+        );
+    }
+
+    #[test]
+    fn get_returns_the_full_graph_with_nodes_and_edges() {
+        let dir = seed_demo();
+        let ids = ["demo".to_string()];
+        let file = load_company_workflows(dir.path(), &ids)
+            .expect("loads")
+            .into_iter()
+            .next()
+            .expect("one file");
+        let graph = WorkflowGraph::from(file);
+
+        assert_eq!(graph.id, "demo");
+        assert_eq!(graph.nodes.len(), 3);
+        assert_eq!(graph.edges.len(), 2);
+
+        // The `kind` field is the on-disk string via `as_str()`.
+        let worker = graph.nodes.iter().find(|n| n.id == "worker").unwrap();
+        assert_eq!(worker.kind, "agent");
+        assert_eq!(worker.agent.as_deref(), Some("assistant"));
+
+        let trigger = graph.nodes.iter().find(|n| n.id == "start").unwrap();
+        assert_eq!(trigger.kind, "trigger");
+        assert!(trigger.agent.is_none());
+
+        let labeled = graph.edges.iter().find(|e| e.to == "done").unwrap();
+        assert_eq!(labeled.from, "worker");
+        assert_eq!(labeled.label.as_deref(), Some("ok"));
+    }
+
+    #[test]
+    fn no_source_dir_lists_empty() {
+        assert!(load_source_workflows(None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn no_workflows_dir_lists_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load_source_workflows(Some(dir.path())).unwrap().is_empty());
+    }
+
+    #[test]
+    fn json_serializes_camelcase_and_omits_empty_options() {
+        let dir = seed_demo();
+        let ids = ["demo".to_string()];
+        let file = load_company_workflows(dir.path(), &ids)
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+        let json = serde_json::to_value(WorkflowGraph::from(file)).unwrap();
+        // A node with no summary/agent omits those keys entirely.
+        let done = json["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|n| n["id"] == "done")
+            .unwrap();
+        assert!(done.get("agent").is_none());
+        assert!(done.get("summary").is_none());
+        assert_eq!(done["kind"], "output");
+    }
 }


### PR DESCRIPTION
## Summary

Wires the operator console **Workflows** tab to the live workflow API (follow-on to the merged #29 cell). Replaces the hardcoded `SAMPLE_WORKFLOW` canvas with the company's real workflows.

- Backend `GET …/workflows` (list: id/name/description) + `GET …/workflows/{wid}` (full graph: nodes/edges) via the existing `load_company_workflows`.
- `WorkflowsView` lists workflows, renders the **real** graph (nodes/edges → React Flow, auto-laid-out), and a **Run** button → `POST …/workflows/{wid}/run`, rendering the final text prominently with the raw engine output collapsed behind a details toggle.

Closes #35.

## API Or Behavior Changes

- New `GET /api/v1/companies/{id}/workflows` and `GET …/workflows/{wid}` (+ single-company aliases), camelCase.
- Default build unchanged.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (own code clean; see stacking note)
- [x] `cargo build --all-targets`
- [x] `cargo test` — `cargo test --lib workflows` 7 passed (list/graph read routes + camelCase serialization)
- [x] Frontend `pnpm typecheck` + `pnpm build`
- [x] Manual (staging): pick workflow → real graph → Run → engineer agent output rendered

## Documentation

Route contract + translation notes in `src/server/ops/workflows.rs` module docs.

---

Stacked on `chore/ci-green` — merge that first (pre-existing main clippy/fmt failure otherwise reddens this PR's lanes).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a data-driven workflow browser that lists available workflows and renders their connected graph.
  * Added workflow execution directly from the canvas, including a results panel with final text, engine output, and any pending approvals.
  * Added server support for listing workflows, fetching a workflow graph by id, and running a workflow.
* **Bug Fixes**
  * Updated the workflows screen to correctly receive the required client and company context for loading and running workflows.
  * Improved behavior when no workflows are available or workflow data is missing/invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->