### PR TITLE
feat(harness): grant-gated workspace-sandboxed file tools (#36 Phase 2b)

### DIFF
--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -5,10 +5,14 @@
 //! [`ApprovalPolicy`] tool policy, and a workspace directory.
 //!
 //! * **Tools**: every agent gets the intrinsic [`memory_tools`] (`memory_store`
-//!   + `memory_recall`) over its own company memory. External/integration tools
-//!   gated on the manifest `tools ∩ agent.tools` allow-list (`web.*`/`docs.*`
-//!   etc.) still need the grant→tool bridge + a security/runtime sandbox — a
-//!   tracked follow-up; the builder accepts the vector so they extend it here.
+//!   + `memory_recall`) over its own company memory. **File tools** (read,
+//!   write, edit, list, grep, glob) are granted per-agent when the effective
+//!   `tools ∩ agent.tools` grants cover the `files`/`docs` namespace, and are
+//!   sandboxed to the agent's own workspace via a `workspace_only`
+//!   [`SecurityPolicy`] ([`file_tools`]). Network (`web.*`) and shell (`shell.*`)
+//!   tools are a tracked follow-up — they need an HTTP domain-allowlist config
+//!   and a runtime/audit sandbox respectively; the builder extends the same
+//!   vector, so they slot in beside the file tools.
 //! * **Workflows/skills** start empty. Parsing enabled `SKILL.md` bodies via
 //!   `openhuman::skills::ops_parse` depends on WS1's skill parsing; the seam is
 //!   the `.workflows(...)` setter.
@@ -16,6 +20,7 @@
 //! The tool dispatcher is the text-based [`XmlToolDispatcher`], which needs no
 //! global tool registry — the harness stays self-contained.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use openhuman_core::openhuman as oh;
@@ -26,7 +31,9 @@ use oh::context::prompt::SystemPromptBuilder;
 use oh::memory::tools::{MemoryRecallTool, MemoryStoreTool};
 use oh::memory::traits::Memory;
 use oh::security::SecurityPolicy;
-use oh::tools::Tool;
+use oh::tools::{
+    EditFileTool, FileReadTool, FileWriteTool, GlobTool, GrepTool, ListFilesTool, Tool,
+};
 
 use crate::company::Agent as ManifestAgent;
 use crate::error::OpenCompanyError;
@@ -86,6 +93,7 @@ pub fn build_agent(
     manifest_agent: &ManifestAgent,
     policy: ApprovalPolicy,
     deps: &HarnessDeps,
+    grants: &[String],
     skill_deltas: &[SkillState],
 ) -> crate::Result<Agent> {
     let memory: Arc<dyn Memory> = Arc::new(OcMemory::new(
@@ -103,10 +111,18 @@ pub fn build_agent(
     // Intrinsic memory tools: every agent can deliberately store and recall over
     // its own company memory, complementing the automatic retrieve→inject→store
     // loop. They are tenant-isolated (an agent's memory is its company's
-    // `ContextStore`) and granted to every agent — unlike the manifest
-    // `[tools]` allow-list, which scopes external/integration tools (the
-    // grant→tool bridge for `web.*`/`docs.*` etc. is a follow-up seam).
+    // `ContextStore`) and granted to every agent — unlike the external tools
+    // below, which are scoped by the manifest `[tools]` allow-list.
     let mut tools: Vec<Box<dyn Tool>> = memory_tools(memory.clone());
+
+    // Granted file tools, sandboxed to this agent's own workspace directory. An
+    // agent gets them only when its effective grants cover the `files`/`docs`
+    // namespace (`docs.*`, `files.*`, or `*`). The security policy is
+    // `workspace_only`, so a granted agent can read and write within its
+    // workspace and nowhere else on the host.
+    if grants_cover(grants, "files") || grants_cover(grants, "docs") {
+        tools.extend(file_tools(&workspace));
+    }
 
     // Persona over openhuman's own identity: `omit_identity = true` drops the
     // "you are OpenHuman" preamble so the agent speaks as its company role.
@@ -173,6 +189,44 @@ fn memory_tools(memory: Arc<dyn Memory>) -> Vec<Box<dyn Tool>> {
     ]
 }
 
+/// Whether an agent's effective `grants` cover a tool `namespace`.
+///
+/// Matches the bare namespace (`docs`), any glob under it (`docs.*`,
+/// `docs.read`), or the catch-all `*`.
+fn grants_cover(grants: &[String], namespace: &str) -> bool {
+    grants.iter().any(|grant| {
+        grant == "*" || grant == namespace || grant.starts_with(&format!("{namespace}."))
+    })
+}
+
+/// A [`SecurityPolicy`] that sandboxes an agent's file tools to `workspace` and
+/// nowhere else: `workspace_only` with both the workspace and the tool action
+/// root pinned to the agent's own directory.
+fn workspace_security(workspace: &Path) -> SecurityPolicy {
+    let dir: PathBuf = workspace.to_path_buf();
+    SecurityPolicy {
+        workspace_dir: dir.clone(),
+        action_dir: dir,
+        workspace_only: true,
+        ..SecurityPolicy::default()
+    }
+}
+
+/// The file tools granted under the `files`/`docs` namespace, each sandboxed to
+/// the agent's `workspace` by a shared [`workspace_security`] policy: read,
+/// write, edit, list, grep, and glob within the workspace only.
+fn file_tools(workspace: &Path) -> Vec<Box<dyn Tool>> {
+    let security = Arc::new(workspace_security(workspace));
+    vec![
+        Box::new(FileReadTool::new(security.clone())),
+        Box::new(FileWriteTool::new(security.clone())),
+        Box::new(EditFileTool::new(security.clone())),
+        Box::new(ListFilesTool::new(security.clone())),
+        Box::new(GrepTool::new(security.clone())),
+        Box::new(GlobTool::new(security)),
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -220,6 +274,33 @@ mod tests {
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(names.contains(&"memory_store"), "got {names:?}");
         assert!(names.contains(&"memory_recall"), "got {names:?}");
+    }
+
+    #[test]
+    fn grants_cover_matches_namespace_glob_and_star() {
+        assert!(grants_cover(&["docs.*".into()], "docs"));
+        assert!(grants_cover(&["docs".into()], "docs"));
+        assert!(grants_cover(&["docs.read".into()], "docs"));
+        assert!(grants_cover(&["*".into()], "docs"));
+        assert!(!grants_cover(&["web.*".into()], "docs"));
+        assert!(!grants_cover(&[], "docs"));
+        // A prefix must end on a namespace boundary, not a substring.
+        assert!(!grants_cover(&["documentation.*".into()], "docs"));
+    }
+
+    #[test]
+    fn file_tools_are_sandboxed_to_the_workspace() {
+        let ws = Path::new("/tmp/agent-ws");
+        let policy = workspace_security(ws);
+        assert!(policy.workspace_only, "file tools must be workspace-only");
+        assert_eq!(policy.workspace_dir, ws);
+        assert_eq!(policy.action_dir, ws);
+
+        let tools = file_tools(ws);
+        assert_eq!(tools.len(), 6, "read/write/edit/list/grep/glob");
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"file_read"), "got {names:?}");
+        assert!(names.contains(&"file_write"), "got {names:?}");
     }
 
     #[test]

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -253,12 +253,17 @@ pub(crate) fn build_roster(
         .iter()
         .map(|manifest_agent| {
             let agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily);
+            let grants = crate::runtime::builder::agent_effective_grants(
+                &company.manifest.tools.allow,
+                &manifest_agent.tools,
+            );
             let agent = build::build_agent(
                 &company.id,
                 company_name,
                 manifest_agent,
                 agent_policy,
                 deps,
+                &grants,
                 skill_deltas,
             )?;
             Ok(Arc::new(CompanyAgent {

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -101,6 +101,23 @@ pub fn effective_grants(manifest: &CompanyManifest) -> Vec<String> {
     dedup(grants)
 }
 
+/// One agent's effective tool grants: its own `tools` narrowed by the company
+/// `allow`-list, or the full allow-list when the agent lists none. This is the
+/// per-agent slice of [`effective_grants`], used by the harness to decide which
+/// tool families an individual agent receives.
+pub(crate) fn agent_effective_grants(allow: &[String], agent_tools: &[String]) -> Vec<String> {
+    let grants: Vec<String> = if agent_tools.is_empty() {
+        allow.to_vec()
+    } else {
+        agent_tools
+            .iter()
+            .filter(|tool| allow_covers(allow, tool))
+            .cloned()
+            .collect()
+    };
+    dedup(grants)
+}
+
 /// Whether the company allow-list covers an agent-requested grant glob.
 fn allow_covers(allow: &[String], tool: &str) -> bool {
     let literal = tool.strip_suffix('*').unwrap_or(tool);

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -105,6 +105,10 @@ pub fn effective_grants(manifest: &CompanyManifest) -> Vec<String> {
 /// `allow`-list, or the full allow-list when the agent lists none. This is the
 /// per-agent slice of [`effective_grants`], used by the harness to decide which
 /// tool families an individual agent receives.
+///
+/// Gated to the `openhuman` feature: its only caller is `build_roster`, which is
+/// itself feature-gated, so the default build would otherwise flag it dead.
+#[cfg(feature = "openhuman")]
 pub(crate) fn agent_effective_grants(allow: &[String], agent_tools: &[String]) -> Vec<String> {
     let grants: Vec<String> = if agent_tools.is_empty() {
         allow.to_vec()


### PR DESCRIPTION
## Summary

Phase 2b of the tool surface — external tools, starting with **file tools** (stacked on #44). An agent now receives `file_read`/`file_write`/`edit`/`list`/`grep`/`glob` when its effective grants cover the `files`/`docs` namespace (`docs.*`, `files.*`, or `*`).

**Safety (the core of this PR):** the file tools share one `workspace_only` `SecurityPolicy` whose `workspace_dir`/`action_dir` are pinned to the agent's own workspace — a granted agent can read/write within its workspace and **nowhere else on the host**. Per-agent grants come from the manifest `[tools]` allow-list narrowed by each agent's `tools` (new `agent_effective_grants`, the per-agent slice of `effective_grants`), threaded `build_roster` → `build_agent`.

### Deferred (documented, follow-up)
- **Network (`web.*`)**: `WebFetchTool` needs an HTTP domain-allowlist config not yet in `HarnessDeps`.
- **Shell (`shell.*`)**: needs a runtime adapter + audit logger + is the highest-risk surface; wants a real OS sandbox.
The builder extends the same vector, so both slot in beside the file tools.

> Stacked on #44 (memory tools). Base will retarget to `main` once #44 merges.

## API Or Behavior Changes

- Behavior: agents granted `files.*`/`docs.*` gain workspace-sandboxed file tools. Feature-gated to `openhuman`; default build unchanged.
- New `pub(crate)` `runtime::builder::agent_effective_grants`; `build_agent` gains a `grants` parameter.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --features openhuman` — **551 passed**, incl. new tests for the grant-namespace matcher and the workspace-sandbox policy (`workspace_only`, dirs pinned to the agent workspace).

## Documentation

Module docs on `build_agent`/`file_tools`/`workspace_security` explain the grant gating and the sandbox.