### PR TITLE
feat(harness): desk-route operator messages to the addressed agent (#36 Phase 4)

### DIFF
--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -7,10 +7,12 @@
 //! [`HarnessPool`], so the reply comes from the hosted brain and the turn's
 //! token/cost usage is metered into the company ledger.
 //!
-//! v1 is **single-responder**: one agent (the first on the roster, or the id
-//! given to [`HarnessBrain::with_responder`]) answers every operator message.
-//! Desk routing — resolving which roster member owns a given group chat — is the
-//! WS3 chat handler's job and lands separately.
+//! **Desk routing**: an operator message that opens with an `@member` mention
+//! is routed to that roster agent (matched on id or role); anything else goes to
+//! the default responder — the first roster agent, or the id given to
+//! [`HarnessBrain::with_responder`]. Dispatched board tasks route to their
+//! assignee. openhuman itself is single-agent, so this member-selection is
+//! opencompany's job (see [`resolve_address`]).
 //!
 //! Compiled only under `feature = "openhuman"`.
 
@@ -19,6 +21,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::Result;
+use crate::company::Agent as ManifestAgent;
 use crate::harness::{HarnessDeps, HarnessPool};
 use crate::ports::brain::{Brain, CycleHost};
 use crate::ports::types::{
@@ -134,6 +137,49 @@ fn append_result(prev: Option<&str>, responder: &str, body: &str) -> String {
     }
 }
 
+/// Desk-routes an operator message to the roster member it addresses.
+///
+/// A leading `@mention` matching a roster member's id or role (case- and
+/// separator-insensitive — `@Creative-Director`, `@creative_director`, and the
+/// role "Creative Director" all match) routes to that member, and the mention is
+/// stripped from the message. Anything else — no mention, or a mention that
+/// names no roster member — falls back to `responder` with the message intact.
+///
+/// Returns `(agent_id, message)` ready for [`HarnessPool::run`].
+fn resolve_address(agents: &[ManifestAgent], responder: &str, text: &str) -> (String, String) {
+    if let Some(rest) = text.trim_start().strip_prefix('@') {
+        let (mention, remainder) = match rest.split_once(char::is_whitespace) {
+            Some((m, r)) => (m, r.trim_start()),
+            None => (rest, ""),
+        };
+        let target = normalize_mention(mention);
+        if !target.is_empty()
+            && let Some(agent) = agents.iter().find(|a| {
+                normalize_mention(&a.id) == target || normalize_mention(&a.role) == target
+            })
+        {
+            // Strip the mention; keep the original text if nothing else remains
+            // (a bare "@creative_director" still addresses that agent).
+            let message = if remainder.is_empty() {
+                text.to_string()
+            } else {
+                remainder.to_string()
+            };
+            return (agent.id.clone(), message);
+        }
+    }
+    (responder.to_string(), text.to_string())
+}
+
+/// Normalizes a mention / agent id / role for matching: lowercased, ASCII
+/// alphanumerics only, so separators (`-`, `_`, spaces) are ignored.
+fn normalize_mention(s: &str) -> String {
+    s.chars()
+        .filter(char::is_ascii_alphanumeric)
+        .map(|c| c.to_ascii_lowercase())
+        .collect()
+}
+
 #[async_trait]
 impl Brain for HarnessBrain {
     async fn run_cycle(&self, req: CycleRequest, _host: &dyn CycleHost) -> Result<CycleResult> {
@@ -144,12 +190,15 @@ impl Brain for HarnessBrain {
         for event in &req.events {
             match event {
                 CompanyEvent::OperatorMessage { text, .. } => {
-                    // `run` executes the turn on the openhuman runtime and meters
-                    // its usage into the ledger/meter through `deps`. The reply is
-                    // the agent's own text.
+                    // Desk routing: a leading `@member` addresses a specific
+                    // roster agent (mention stripped); otherwise the default
+                    // responder answers. `run` then executes the turn on the
+                    // openhuman runtime and meters its usage through `deps`.
+                    let (responder, message) =
+                        resolve_address(&self.record.manifest.agents, &self.responder, text);
                     let reply = self
                         .pool
-                        .run(&self.record.id, &self.responder, text, &self.deps)
+                        .run(&self.record.id, &responder, &message, &self.deps)
                         .await?;
                     channel_responses.push(OutboundMessage {
                         channel: "operator".to_string(),
@@ -198,6 +247,49 @@ mod tests {
         CompanyId, ContextOp, ContextOpResult, Effect, EffectDisposition, ToolCall, ToolResult,
     };
     use crate::store::{FsCompanyStore, FsContextStore, FsOps};
+
+    fn agent(id: &str, role: &str) -> ManifestAgent {
+        ManifestAgent {
+            id: id.to_string(),
+            role: role.to_string(),
+            description: None,
+            tier: None,
+            tools: Vec::new(),
+            budget_usd_daily: None,
+        }
+    }
+
+    #[test]
+    fn resolve_address_routes_mentions_and_falls_back() {
+        let roster = [
+            agent("creative_director", "Creative Director"),
+            agent("ceo", "Chief Executive"),
+        ];
+
+        // @id — separator/case-insensitive, mention stripped from the message.
+        let (who, msg) = resolve_address(&roster, "ceo", "@Creative-Director draft the copy");
+        assert_eq!(who, "creative_director");
+        assert_eq!(msg, "draft the copy");
+
+        // @role — "Creative Director" normalizes to "creativedirector".
+        let (who, _) = resolve_address(&roster, "ceo", "@creativedirector hi");
+        assert_eq!(who, "creative_director");
+
+        // No mention → default responder, message untouched.
+        let (who, msg) = resolve_address(&roster, "ceo", "just do it");
+        assert_eq!(who, "ceo");
+        assert_eq!(msg, "just do it");
+
+        // Unknown mention → default responder, message left intact (not stripped).
+        let (who, msg) = resolve_address(&roster, "ceo", "@nobody hello");
+        assert_eq!(who, "ceo");
+        assert_eq!(msg, "@nobody hello");
+
+        // Bare mention with no remainder → routes, keeps the original text.
+        let (who, msg) = resolve_address(&roster, "ceo", "@creative_director");
+        assert_eq!(who, "creative_director");
+        assert_eq!(msg, "@creative_director");
+    }
 
     /// A `CycleHost` that auto-executes anything the brain asks for; the harness
     /// brain v1 makes no host calls, so it stays inert.


### PR DESCRIPTION
## Summary

Multi-agent **desk routing** (Phase 4). The harness answered every operator message with a single default responder; now a message opening with an `@member` mention is routed to that roster agent.

- Matched on **id or role**, case- and separator-insensitive: `@Creative-Director`, `@creative_director`, and the role "Creative Director" all resolve to the same agent.
- The mention is **stripped** from the message before the turn.
- **No recognized mention → the default responder answers, message unchanged** — so existing single-agent behavior is byte-for-byte intact.
- Board tasks already route to their `assignee`; this brings operator chat to parity. openhuman is single-agent, so member-selection is opencompany's job.

## API Or Behavior Changes

- Behavior: `@member`-prefixed operator messages now reach the addressed roster agent. Feature-gated to `openhuman`; default (echo) build unaffected.
- No public API change (internal `resolve_address` helper in `brain.rs`).

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default features = CI)
- [x] `cargo test --features openhuman` — **563 passed**, incl. a pure `resolve_address` test covering id-match, role-match, no-mention fallback, unknown-mention passthrough, and bare-mention.

## Documentation

Module docs on `HarnessBrain`/`resolve_address` describe the routing rules.