### PR TITLE
feat: add embedded MCP runtime and console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5411,6 +5411,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "uuid 1.23.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ openhuman_core = { package = "openhuman", path = "vendor/openhuman", optional = 
 # the `log` facade; both only link under the `openhuman` feature.
 anyhow = { version = "1", optional = true }
 log = { version = "0.4", optional = true }
+uuid = { version = "1", features = ["v4"], optional = true }
 
 # Issue #29 (epic #26): the tinyflows workflow engine, embedded directly. It is
 # host-agnostic and Config-free — `Capabilities` is a plain struct of trait
@@ -178,7 +179,7 @@ openhuman = ["dep:openhuman_core", "dep:reqwest", "dep:anyhow", "dep:log", "dep:
 # MCP server management and agent tools share OpenHuman's in-process registry.
 # Enabling it necessarily enables the embedded harness and OpenHuman MCP
 # domain, while the default build remains unchanged.
-mcp = ["openhuman", "openhuman_core/mcp"]
+mcp = ["openhuman", "openhuman_core/mcp", "dep:uuid"]
 # Real HTTP transport to openhuman-core. The trait + offline mock + providers
 # compile without this; only `HttpOpenHumanRpc` is gated behind it.
 openhuman-rpc = ["dep:reqwest"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,8 +74,9 @@ tinyagents = { path = "vendor/tinyagents", optional = true, features = ["sqlite"
 # `openhuman` feature; the default build pulls none of this enormous native
 # dependency tree. `default-features = false` sheds openhuman's whole default
 # set — `tokenjuice-treesitter`, `voice`, `web3`, `media`, `meet`,
-# `flows`, `mcp` — none of which a company agent needs; it wants the agent
-# loop, memory, and an inference provider. `skills` is re-enabled: cell #28
+# `flows`, and `mcp`. A company agent wants the agent loop, memory, and an
+# inference provider by default; MCP is re-enabled separately through the
+# opt-in OpenCompany `mcp` feature below. `skills` is re-enabled: cell #28
 # surfaces a company's effective skill set to its harness agents through
 # OpenHuman's own skill *read* tools (`list_workflows` / `describe_workflow` /
 # `read_workflow_resource`), which live in the gated `openhuman::skills`
@@ -174,6 +175,10 @@ tiny = ["tinyagents"]
 # `reqwest` is pulled in for the hosted Medulla inference `Provider`; the
 # `MockProvider` and every adapter compile without touching the network.
 openhuman = ["dep:openhuman_core", "dep:reqwest", "dep:anyhow", "dep:log", "dep:tinyflows"]
+# MCP server management and agent tools share OpenHuman's in-process registry.
+# Enabling it necessarily enables the embedded harness and OpenHuman MCP
+# domain, while the default build remains unchanged.
+mcp = ["openhuman", "openhuman_core/mcp"]
 # Real HTTP transport to openhuman-core. The trait + offline mock + providers
 # compile without this; only `HttpOpenHumanRpc` is gated behind it.
 openhuman-rpc = ["dep:reqwest"]

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,4 +1,6 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig } from "@playwright/test";
+
+const storageState = process.env.PW_STORAGE_STATE;
 
 /**
  * Playwright config for the operator-console end-to-end suite.
@@ -10,14 +12,16 @@ import { defineConfig } from '@playwright/test';
  * `webServer` is declared here.
  */
 export default defineConfig({
-  testDir: './test/e2e',
+  testDir: "./test/e2e",
+  globalSetup: storageState ? "./test/e2e/global-setup.ts" : undefined,
   fullyParallel: false,
   workers: 1,
   timeout: 60_000,
-  reporter: [['list']],
+  reporter: [["list"]],
   use: {
-    baseURL: process.env.PW_BASE_URL || 'http://127.0.0.1:8080',
-    trace: 'on-first-retry',
-    screenshot: 'only-on-failure',
+    baseURL: process.env.PW_BASE_URL || "http://127.0.0.1:8080",
+    storageState,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
   },
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -7,6 +7,12 @@
 //     and calls use `/api/v1/companies/{id}/*`.
 
 import type { ConsoleConfig } from "../config";
+import type {
+  InstallMcpServerInput,
+  McpCallResult,
+  McpServer,
+  McpTool,
+} from "../lib/mcp";
 import {
   ApiError,
   type ApiErrorBody,
@@ -204,6 +210,68 @@ export class OpenCompanyClient {
     return this.request<void>(
       "POST",
       `${this.scope(company)}/connections/${encodeURIComponent(provider)}/disconnect`,
+    );
+  }
+
+  /** Installed MCP servers plus their live connection state. */
+  listMcpServers(company?: string | null): Promise<{ servers: McpServer[] }> {
+    return this.request<{ servers: McpServer[] }>("GET", `${this.scope(company)}/mcp/servers`);
+  }
+
+  /** Persist a manual stdio or streamable-HTTP MCP server install. */
+  installMcpServer(
+    input: InstallMcpServerInput,
+    company?: string | null,
+  ): Promise<{ server_id: string }> {
+    return this.request<{ server_id: string }>("POST", `${this.scope(company)}/mcp/servers`, input);
+  }
+
+  /** Connect an installed server and return its advertised tools. */
+  connectMcpServer(serverId: string, company?: string | null): Promise<{ tools: McpTool[] }> {
+    return this.request<{ tools: McpTool[] }>(
+      "POST",
+      `${this.scope(company)}/mcp/servers/${encodeURIComponent(serverId)}/connect`,
+    );
+  }
+
+  /** Stop an installed server's live connection. */
+  disconnectMcpServer(
+    serverId: string,
+    company?: string | null,
+  ): Promise<{ disconnected: boolean }> {
+    return this.request<{ disconnected: boolean }>(
+      "POST",
+      `${this.scope(company)}/mcp/servers/${encodeURIComponent(serverId)}/disconnect`,
+    );
+  }
+
+  /** Disconnect and remove an MCP install. */
+  uninstallMcpServer(serverId: string, company?: string | null): Promise<void> {
+    return this.request<void>(
+      "DELETE",
+      `${this.scope(company)}/mcp/servers/${encodeURIComponent(serverId)}`,
+    );
+  }
+
+  /** Cached tools advertised by a connected MCP server. */
+  listMcpTools(serverId: string, company?: string | null): Promise<{ tools: McpTool[] }> {
+    return this.request<{ tools: McpTool[] }>(
+      "GET",
+      `${this.scope(company)}/mcp/servers/${encodeURIComponent(serverId)}/tools`,
+    );
+  }
+
+  /** Invoke one tool through a connected MCP server. */
+  callMcpTool(
+    serverId: string,
+    tool: string,
+    arguments_: Record<string, unknown>,
+    company?: string | null,
+  ): Promise<McpCallResult> {
+    return this.request<McpCallResult>(
+      "POST",
+      `${this.scope(company)}/mcp/servers/${encodeURIComponent(serverId)}/tools/${encodeURIComponent(tool)}/call`,
+      { arguments: arguments_ },
     );
   }
 

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -14,6 +14,7 @@ import {
   ShieldCheck,
   Sparkles,
   SquareKanban,
+  Blocks,
   UserCog,
   Users,
   Wallet,
@@ -60,6 +61,7 @@ import { SkillsView } from "@/views/SkillsView";
 import { InboxView } from "@/views/InboxView";
 import { MemoryView } from "@/views/MemoryView";
 import { ConnectionsView } from "@/views/ConnectionsView";
+import { McpServersView } from "@/views/McpServersView";
 import { SettingsView } from "@/views/SettingsView";
 import { FeedbackView } from "@/views/FeedbackView";
 
@@ -93,6 +95,7 @@ export type View =
   | "usage"
   | "finances"
   | "connections"
+  | "mcp"
   | "settings"
   | "feedback";
 
@@ -129,6 +132,7 @@ const NAV: NavGroup[] = [
       { view: "usage", label: "Usage", icon: ChartColumnBig },
       { view: "finances", label: "Finances", icon: Wallet },
       { view: "connections", label: "Connections", icon: Plug },
+      { view: "mcp", label: "MCP Servers", icon: Blocks },
       { view: "people", label: "People", icon: UserCog },
       { view: "settings", label: "Settings", icon: Settings2 },
     ],
@@ -153,6 +157,7 @@ const TITLES: Record<View, string> = {
   usage: "Usage",
   finances: "Finances",
   connections: "Connections",
+  mcp: "MCP Servers",
   people: "People",
   settings: "Settings",
   feedback: "Feedback",
@@ -350,6 +355,7 @@ export function AppShell({
             </Suspense>
           )}
           {view === "connections" && <ConnectionsView client={client} company={company} />}
+          {view === "mcp" && <McpServersView client={client} company={company} />}
           {view === "settings" && (
             <SettingsView client={client} company={company} feed={feed} onFlag={() => setFeedbackOpen(true)} />
           )}

--- a/frontend/src/lib/mcp.ts
+++ b/frontend/src/lib/mcp.ts
@@ -1,0 +1,34 @@
+export type McpTransport = "stdio" | "http";
+
+export interface McpTool {
+  name: string;
+  description?: string | null;
+  input_schema: Record<string, unknown>;
+}
+
+export interface McpServer {
+  server_id: string;
+  name: string;
+  transport: McpTransport;
+  command: string;
+  args: string[];
+  url?: string;
+  env_keys: string[];
+  enabled: boolean;
+  status: "connected" | "connecting" | "disconnected" | "unauthorized" | "error" | "disabled";
+  tool_count: number;
+  last_error?: string;
+}
+
+export interface InstallMcpServerInput {
+  name: string;
+  transport: McpTransport;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+}
+
+export interface McpCallResult {
+  result: unknown;
+}

--- a/frontend/src/views/McpServersView.tsx
+++ b/frontend/src/views/McpServersView.tsx
@@ -1,0 +1,402 @@
+import { type FormEvent, useCallback, useEffect, useState } from "react";
+import { ChevronDown, ChevronRight, Info, Loader2, Play, Plug, Trash2, Unplug } from "lucide-react";
+import { toast } from "sonner";
+
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import type { McpServer, McpTool, McpTransport } from "@/lib/mcp";
+
+interface Props {
+  client: OpenCompanyClient;
+  company: string | null;
+}
+
+type Load = "loading" | "ready" | "unavailable";
+
+export function McpServersView({ client, company }: Props) {
+  const [load, setLoad] = useState<Load>("loading");
+  const [servers, setServers] = useState<McpServer[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [name, setName] = useState("");
+  const [transport, setTransport] = useState<McpTransport>("stdio");
+  const [command, setCommand] = useState("");
+  const [args, setArgs] = useState("");
+  const [url, setUrl] = useState("");
+  const [env, setEnv] = useState("{}");
+
+  const refresh = useCallback(async () => {
+    try {
+      const response = await client.listMcpServers(company);
+      setServers(response.servers);
+      setLoad("ready");
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 404) setLoad("unavailable");
+      else {
+        setLoad("ready");
+        toast.error("Couldn't load MCP servers.");
+      }
+    }
+  }, [client, company]);
+
+  useEffect(() => {
+    setLoad("loading");
+    void refresh();
+  }, [refresh]);
+
+  async function install(event: FormEvent) {
+    event.preventDefault();
+    if (busy) return;
+    let envValues: Record<string, string>;
+    try {
+      const parsed: unknown = JSON.parse(env || "{}");
+      if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") throw new Error();
+      envValues = Object.fromEntries(
+        Object.entries(parsed).map(([key, value]) => {
+          if (typeof value !== "string") throw new Error();
+          return [key, value];
+        }),
+      );
+    } catch {
+      toast.error("Environment must be a JSON object with string values.");
+      return;
+    }
+
+    setBusy("install");
+    try {
+      await client.installMcpServer(
+        {
+          name,
+          transport,
+          command: transport === "stdio" ? command : undefined,
+          args: transport === "stdio" ? splitArgs(args) : undefined,
+          env: envValues,
+          url: transport === "http" ? url : undefined,
+        },
+        company,
+      );
+      setName("");
+      setCommand("");
+      setArgs("");
+      setUrl("");
+      setEnv("{}");
+      toast.success("MCP server installed.");
+      await refresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Couldn't install MCP server.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function lifecycle(server: McpServer, action: "connect" | "disconnect" | "uninstall") {
+    if (busy) return;
+    setBusy(`${action}:${server.server_id}`);
+    try {
+      if (action === "connect") await client.connectMcpServer(server.server_id, company);
+      else if (action === "disconnect") await client.disconnectMcpServer(server.server_id, company);
+      else await client.uninstallMcpServer(server.server_id, company);
+      await refresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : `Couldn't ${action} MCP server.`);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="mx-auto w-full max-w-5xl space-y-6 px-4 py-6">
+        <div className="space-y-1">
+          <h2 className="text-2xl font-semibold tracking-tight">MCP Servers</h2>
+          <p className="text-sm text-muted-foreground">
+            Install tool servers for operators and company agents to use through the embedded runtime.
+          </p>
+        </div>
+
+        {load === "unavailable" ? (
+          <Alert>
+            <Info className="size-4" />
+            <AlertTitle>MCP is not enabled on this host</AlertTitle>
+            <AlertDescription>
+              Rebuild the OpenCompany host with the MCP feature to install and call tool servers.
+            </AlertDescription>
+          </Alert>
+        ) : (
+          <>
+            <Card>
+              <CardHeader>
+                <CardTitle>Install a server</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <form className="grid gap-4 md:grid-cols-2" onSubmit={install}>
+                  <Field label="Name">
+                    <Input
+                      data-testid="mcp-install-name"
+                      value={name}
+                      onChange={(event) => setName(event.target.value)}
+                      required
+                    />
+                  </Field>
+                  <Field label="Transport">
+                    <select
+                      className="h-8 rounded-lg border border-input bg-background px-2.5 text-sm"
+                      value={transport}
+                      onChange={(event) => setTransport(event.target.value as McpTransport)}
+                    >
+                      <option value="stdio">Local command (stdio)</option>
+                      <option value="http">Remote HTTP</option>
+                    </select>
+                  </Field>
+                  {transport === "stdio" ? (
+                    <>
+                      <Field label="Command">
+                        <Input
+                          data-testid="mcp-install-command"
+                          value={command}
+                          onChange={(event) => setCommand(event.target.value)}
+                          placeholder="node"
+                          required
+                        />
+                      </Field>
+                      <Field label="Arguments">
+                        <Input
+                          data-testid="mcp-install-args"
+                          value={args}
+                          onChange={(event) => setArgs(event.target.value)}
+                          placeholder="/path/to/server.mjs"
+                        />
+                      </Field>
+                    </>
+                  ) : (
+                    <Field label="URL">
+                      <Input
+                        value={url}
+                        onChange={(event) => setUrl(event.target.value)}
+                        placeholder="https://example.com/mcp"
+                        required
+                      />
+                    </Field>
+                  )}
+                  <Field label="Environment JSON" className="md:col-span-2">
+                    <Textarea
+                      value={env}
+                      onChange={(event) => setEnv(event.target.value)}
+                      placeholder='{"API_KEY":"…"}'
+                      rows={3}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Values are write-only and never returned by the API.
+                    </p>
+                  </Field>
+                  <div className="md:col-span-2">
+                    <Button data-testid="mcp-install-submit" type="submit" disabled={busy === "install"}>
+                      {busy === "install" && <Loader2 className="size-4 animate-spin" />}
+                      Install server
+                    </Button>
+                  </div>
+                </form>
+              </CardContent>
+            </Card>
+
+            <section className="space-y-3">
+              <h3 className="font-medium">Installed servers</h3>
+              {load === "loading" ? (
+                <p className="text-sm text-muted-foreground">Loading MCP servers…</p>
+              ) : servers.length === 0 ? (
+                <p className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+                  No MCP servers installed yet.
+                </p>
+              ) : (
+                servers.map((server) => (
+                  <ServerCard
+                    key={server.server_id}
+                    server={server}
+                    client={client}
+                    company={company}
+                    busy={busy}
+                    onLifecycle={(action) => void lifecycle(server, action)}
+                  />
+                ))
+              )}
+            </section>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ServerCard({
+  server,
+  client,
+  company,
+  busy,
+  onLifecycle,
+}: {
+  server: McpServer;
+  client: OpenCompanyClient;
+  company: string | null;
+  busy: string | null;
+  onLifecycle: (action: "connect" | "disconnect" | "uninstall") => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [tools, setTools] = useState<McpTool[]>([]);
+  const [toolName, setToolName] = useState("");
+  const [argumentsText, setArgumentsText] = useState("{}");
+  const [result, setResult] = useState("");
+  const [calling, setCalling] = useState(false);
+
+  async function toggleTools() {
+    const next = !expanded;
+    setExpanded(next);
+    if (!next || tools.length > 0 || server.status !== "connected") return;
+    try {
+      const response = await client.listMcpTools(server.server_id, company);
+      setTools(response.tools);
+      setToolName(response.tools[0]?.name ?? "");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Couldn't load MCP tools.");
+    }
+  }
+
+  async function callTool() {
+    let arguments_: Record<string, unknown>;
+    try {
+      const parsed: unknown = JSON.parse(argumentsText);
+      if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") throw new Error();
+      arguments_ = parsed as Record<string, unknown>;
+    } catch {
+      toast.error("Tool arguments must be a JSON object.");
+      return;
+    }
+    setCalling(true);
+    try {
+      const response = await client.callMcpTool(server.server_id, toolName, arguments_, company);
+      setResult(JSON.stringify(response.result, null, 2));
+    } catch (error) {
+      setResult(error instanceof Error ? error.message : "Tool call failed.");
+    } finally {
+      setCalling(false);
+    }
+  }
+
+  return (
+    <Card data-testid="mcp-server-row">
+      <CardContent className="space-y-4 py-4">
+        <div className="flex flex-wrap items-center gap-3">
+          <Button variant="ghost" size="icon-sm" onClick={() => void toggleTools()} aria-label={`Show ${server.name} tools`}>
+            {expanded ? <ChevronDown /> : <ChevronRight />}
+          </Button>
+          <div className="min-w-0 flex-1">
+            <p className="font-medium">{server.name}</p>
+            <p className="truncate text-xs text-muted-foreground">
+              {server.transport === "stdio" ? [server.command, ...server.args].join(" ") : server.url}
+            </p>
+          </div>
+          <Badge variant={server.status === "connected" ? "default" : "secondary"}>
+            {titleCase(server.status)}
+          </Badge>
+          <span className="text-xs text-muted-foreground">{server.tool_count} tools</span>
+          {server.status === "connected" ? (
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={busy !== null}
+              onClick={() => onLifecycle("disconnect")}
+            >
+              <Unplug /> Disconnect
+            </Button>
+          ) : (
+            <Button size="sm" disabled={busy !== null} onClick={() => onLifecycle("connect")}>
+              <Plug /> Connect
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            disabled={busy !== null}
+            onClick={() => onLifecycle("uninstall")}
+            aria-label={`Uninstall ${server.name}`}
+          >
+            <Trash2 />
+          </Button>
+        </div>
+        {server.last_error && <p className="text-sm text-destructive">{server.last_error}</p>}
+        {expanded && server.status === "connected" && (
+          <div className="grid gap-4 border-t pt-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Tool</Label>
+              <select
+                className="h-8 w-full rounded-lg border border-input bg-background px-2.5 text-sm"
+                value={toolName}
+                onChange={(event) => setToolName(event.target.value)}
+              >
+                {tools.map((tool) => (
+                  <option key={tool.name} value={tool.name}>
+                    {tool.name}
+                  </option>
+                ))}
+              </select>
+              <Textarea
+                data-testid="mcp-tool-call-args"
+                value={argumentsText}
+                onChange={(event) => setArgumentsText(event.target.value)}
+                rows={6}
+              />
+              <Button
+                data-testid="mcp-tool-call-run"
+                size="sm"
+                disabled={!toolName || calling}
+                onClick={() => void callTool()}
+              >
+                {calling ? <Loader2 className="animate-spin" /> : <Play />}
+                Run tool
+              </Button>
+            </div>
+            <div className="space-y-2">
+              <Label>Result</Label>
+              <pre
+                data-testid="mcp-tool-call-result"
+                className="min-h-36 overflow-auto rounded-lg bg-muted p-3 text-xs whitespace-pre-wrap"
+              >
+                {result || "Run a tool to see its raw MCP result."}
+              </pre>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Field({
+  label,
+  className,
+  children,
+}: {
+  label: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={`space-y-2 ${className ?? ""}`}>
+      <Label>{label}</Label>
+      {children}
+    </div>
+  );
+}
+
+function splitArgs(value: string): string[] {
+  return value.match(/(?:[^\s"]+|"[^"]*")+/g)?.map((part) => part.replace(/^"|"$/g, "")) ?? [];
+}
+
+function titleCase(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}

--- a/frontend/test/e2e/global-setup.ts
+++ b/frontend/test/e2e/global-setup.ts
@@ -1,0 +1,34 @@
+import { expect, request, type FullConfig } from "@playwright/test";
+
+const ADMIN_EMAIL = "harness-e2e@tinyhumans.ai";
+
+export default async function globalSetup(config: FullConfig) {
+  const storageState = process.env.PW_STORAGE_STATE;
+  if (!storageState) return;
+
+  const baseURL = config.projects[0]?.use.baseURL as string | undefined;
+  const context = await request.newContext({ baseURL });
+  try {
+    const requested = await context.post("/api/v1/company/auth/request", {
+      data: { email: ADMIN_EMAIL },
+    });
+    expect(requested.ok()).toBeTruthy();
+    const requestedBody = await requested.json();
+    const devCode = requestedBody.dev_code as string | undefined;
+    expect(
+      devCode,
+      "auth/request must echo dev_code on a loopback bind",
+    ).toBeTruthy();
+
+    const verified = await context.post("/api/v1/company/auth/verify", {
+      data: { code: devCode },
+    });
+    expect(
+      verified.ok(),
+      "auth/verify must accept the dev_code and set a session",
+    ).toBeTruthy();
+    await context.storageState({ path: storageState });
+  } finally {
+    await context.dispose();
+  }
+}

--- a/frontend/test/e2e/mcp.spec.ts
+++ b/frontend/test/e2e/mcp.spec.ts
@@ -1,61 +1,60 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-const ADMIN_EMAIL = 'harness-e2e@tinyhumans.ai';
-
-test('operator installs and calls an MCP server from the console and an agent', async ({ page }) => {
+test("operator installs and calls an MCP server from the console and an agent", async ({
+  page,
+}) => {
   const serverScript = process.env.PW_MCP_SERVER;
-  expect(serverScript, 'PW_MCP_SERVER must point at the simple MCP server').toBeTruthy();
+  expect(
+    serverScript,
+    "PW_MCP_SERVER must point at the simple MCP server",
+  ).toBeTruthy();
 
-  const requested = await page.request.post('/api/v1/company/auth/request', {
-    data: { email: ADMIN_EMAIL },
-  });
-  expect(requested.ok()).toBeTruthy();
-  const requestedBody = await requested.json();
-  const devCode = requestedBody.dev_code as string | undefined;
-  expect(devCode, 'auth/request must echo dev_code on a loopback bind').toBeTruthy();
+  await page.goto("/#/mcp");
+  await page.getByTestId("mcp-install-name").fill("simple");
+  await page.getByTestId("mcp-install-command").fill("node");
+  await page.getByTestId("mcp-install-args").fill(serverScript!);
+  await page.getByTestId("mcp-install-submit").click();
 
-  const verified = await page.request.post('/api/v1/company/auth/verify', {
-    data: { code: devCode },
-  });
-  expect(verified.ok()).toBeTruthy();
+  const row = page.getByTestId("mcp-server-row").filter({ hasText: "simple" });
+  await expect(row).toContainText("Connected", { timeout: 30_000 });
+  await expect(row).toContainText("2 tools");
 
-  await page.goto('/#/mcp');
-  await page.getByTestId('mcp-install-name').fill('simple');
-  await page.getByTestId('mcp-install-command').fill('node');
-  await page.getByTestId('mcp-install-args').fill(serverScript!);
-  await page.getByTestId('mcp-install-submit').click();
-
-  const row = page.getByTestId('mcp-server-row').filter({ hasText: 'simple' });
-  await expect(row).toContainText('Connected', { timeout: 30_000 });
-  await expect(row).toContainText('2 tools');
-
-  const listed = await page.request.get('/api/v1/company/mcp/servers');
+  const listed = await page.request.get("/api/v1/company/mcp/servers");
   expect(listed.ok()).toBeTruthy();
   const listedBody = await listed.json();
-  const serverId = listedBody.servers.find((server: { name: string }) => server.name === 'simple')
-    ?.server_id as string | undefined;
+  const serverId = listedBody.servers.find(
+    (server: { name: string }) => server.name === "simple",
+  )?.server_id as string | undefined;
   expect(serverId).toBeTruthy();
 
-  await row.getByRole('button', { name: 'Show simple tools' }).click();
+  await row.getByRole("button", { name: "Show simple tools" }).click();
   const marker = `pw-${Date.now()}`;
-  await row.getByTestId('mcp-tool-call-args').fill(JSON.stringify({ text: marker }));
-  await row.getByTestId('mcp-tool-call-run').click();
-  await expect(row.getByTestId('mcp-tool-call-result')).toContainText(`echo: ${marker}`);
+  await row
+    .getByTestId("mcp-tool-call-args")
+    .fill(JSON.stringify({ text: marker }));
+  await row.getByTestId("mcp-tool-call-run").click();
+  await expect(row.getByTestId("mcp-tool-call-result")).toContainText(
+    `echo: ${marker}`,
+  );
 
-  await page.goto('/#/conversation');
+  await page.goto("/#/conversation");
   const agentMarker = `agent-mcp-${Date.now()}`;
   const directive = `__MOCK_TOOL_CALL__ ${JSON.stringify({
-    name: 'mcp_registry_tool_call',
+    name: "mcp_registry_tool_call",
     arguments: {
       server_id: serverId,
-      tool_name: 'echo',
+      tool_name: "echo",
       arguments: { text: agentMarker },
     },
   })}`;
   await page.getByPlaceholder(/^Message /).fill(directive);
-  await page.getByRole('button', { name: 'Send' }).click();
+  await page.getByRole("button", { name: "Send" }).click();
 
-  await expect(page.getByText(/__MOCK_LLM__/).last()).toBeVisible({ timeout: 60_000 });
-  await expect(page.getByText(new RegExp(`echo: ${agentMarker}`)).last()).toBeVisible();
+  await expect(page.getByText(/__MOCK_LLM__/).last()).toBeVisible({
+    timeout: 60_000,
+  });
+  await expect(
+    page.getByText(new RegExp(`echo: ${agentMarker}`)).last(),
+  ).toBeVisible();
   await expect(page.getByText(/^Couldn't send/)).toHaveCount(0);
 });

--- a/frontend/test/e2e/mcp.spec.ts
+++ b/frontend/test/e2e/mcp.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test';
+
+const ADMIN_EMAIL = 'harness-e2e@tinyhumans.ai';
+
+test('operator installs and calls an MCP server from the console and an agent', async ({ page }) => {
+  const serverScript = process.env.PW_MCP_SERVER;
+  expect(serverScript, 'PW_MCP_SERVER must point at the simple MCP server').toBeTruthy();
+
+  const requested = await page.request.post('/api/v1/company/auth/request', {
+    data: { email: ADMIN_EMAIL },
+  });
+  expect(requested.ok()).toBeTruthy();
+  const requestedBody = await requested.json();
+  const devCode = requestedBody.dev_code as string | undefined;
+  expect(devCode, 'auth/request must echo dev_code on a loopback bind').toBeTruthy();
+
+  const verified = await page.request.post('/api/v1/company/auth/verify', {
+    data: { code: devCode },
+  });
+  expect(verified.ok()).toBeTruthy();
+
+  await page.goto('/#/mcp');
+  await page.getByTestId('mcp-install-name').fill('simple');
+  await page.getByTestId('mcp-install-command').fill('node');
+  await page.getByTestId('mcp-install-args').fill(serverScript!);
+  await page.getByTestId('mcp-install-submit').click();
+
+  const row = page.getByTestId('mcp-server-row').filter({ hasText: 'simple' });
+  await expect(row).toContainText('Connected', { timeout: 30_000 });
+  await expect(row).toContainText('2 tools');
+
+  const listed = await page.request.get('/api/v1/company/mcp/servers');
+  expect(listed.ok()).toBeTruthy();
+  const listedBody = await listed.json();
+  const serverId = listedBody.servers.find((server: { name: string }) => server.name === 'simple')
+    ?.server_id as string | undefined;
+  expect(serverId).toBeTruthy();
+
+  await row.getByRole('button', { name: 'Show simple tools' }).click();
+  const marker = `pw-${Date.now()}`;
+  await row.getByTestId('mcp-tool-call-args').fill(JSON.stringify({ text: marker }));
+  await row.getByTestId('mcp-tool-call-run').click();
+  await expect(row.getByTestId('mcp-tool-call-result')).toContainText(`echo: ${marker}`);
+
+  await page.goto('/#/conversation');
+  const agentMarker = `agent-mcp-${Date.now()}`;
+  const directive = `__MOCK_TOOL_CALL__ ${JSON.stringify({
+    name: 'mcp_registry_tool_call',
+    arguments: {
+      server_id: serverId,
+      tool_name: 'echo',
+      arguments: { text: agentMarker },
+    },
+  })}`;
+  await page.getByPlaceholder(/^Message /).fill(directive);
+  await page.getByRole('button', { name: 'Send' }).click();
+
+  await expect(page.getByText(/__MOCK_LLM__/).last()).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByText(new RegExp(`echo: ${agentMarker}`)).last()).toBeVisible();
+  await expect(page.getByText(/^Couldn't send/)).toHaveCount(0);
+});

--- a/frontend/test/e2e/wiring.spec.ts
+++ b/frontend/test/e2e/wiring.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
 /**
  * End-to-end wiring proof for the operator console.
@@ -17,38 +17,24 @@ import { expect, test } from '@playwright/test';
  * `[users] admins`, which is what makes the login flow succeed.
  */
 
-const ADMIN_EMAIL = 'harness-e2e@tinyhumans.ai';
-
-test('operator console renders a mocked backend reply end to end', async ({ page }) => {
-  // 1. Authenticate through the real magic-link flow. `page.request` shares
-  //    the page's browser-context cookie jar (the standalone `request` fixture
-  //    does NOT), so the session cookie set here is carried by the subsequent
-  //    navigation. On a loopback bind with no mail transport, auth/request
-  //    echoes the login code as `dev_code`.
-  const requested = await page.request.post('/api/v1/company/auth/request', {
-    data: { email: ADMIN_EMAIL },
-  });
-  expect(requested.ok()).toBeTruthy();
-  const requestedBody = await requested.json();
-  const devCode = requestedBody.dev_code as string | undefined;
-  expect(devCode, 'auth/request must echo dev_code on a loopback bind').toBeTruthy();
-
-  const verified = await page.request.post('/api/v1/company/auth/verify', {
-    data: { code: devCode },
-  });
-  expect(verified.ok(), 'auth/verify must accept the dev_code and set a session').toBeTruthy();
-
-  // 2. Open the conversation view. The default "Your company" thread is
+test("operator console renders a mocked backend reply end to end", async ({
+  page,
+}) => {
+  // Authentication is performed once by global-setup.ts and shared through
+  // Playwright storage state so multiple specs do not trip the resend throttle.
+  // Open the conversation view. The default "Your company" thread is
   //    pre-selected.
-  await page.goto('/#/conversation');
+  await page.goto("/#/conversation");
 
-  // 3. Send a unique prompt through the operator chat input.
+  // Send a unique prompt through the operator chat input.
   const prompt = `e2e wiring ping ${Date.now()}`;
   await page.getByPlaceholder(/^Message /).fill(prompt);
-  await page.getByRole('button', { name: 'Send' }).click();
+  await page.getByRole("button", { name: "Send" }).click();
 
-  // 4. The mocked backend reply must render as a company bubble, and no send
+  // The mocked backend reply must render as a company bubble, and no send
   //    error may appear.
-  await expect(page.getByText('__MOCK_LLM__').first()).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByText("__MOCK_LLM__").first()).toBeVisible({
+    timeout: 60_000,
+  });
   await expect(page.getByText(/^Couldn't send/)).toHaveCount(0);
 });

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -112,6 +112,11 @@ pub struct CompanyRuntime {
     /// Feature-gated so the default build is unaffected.
     #[cfg(feature = "openhuman")]
     pub(crate) harness: Option<Arc<crate::harness::HarnessPool>>,
+    /// MCP installs and live connections for this runtime. The wrapper owns a
+    /// company-home-scoped OpenHuman config while the live registry remains
+    /// shared in-process with harness agents.
+    #[cfg(feature = "mcp")]
+    pub(crate) mcp: Option<Arc<crate::harness::mcp::McpRuntime>>,
 }
 
 impl CompanyRuntime {
@@ -160,6 +165,8 @@ impl CompanyRuntime {
             serial: TokioMutex::new(()),
             #[cfg(feature = "openhuman")]
             harness: None,
+            #[cfg(feature = "mcp")]
+            mcp: None,
         }
     }
 
@@ -201,6 +208,18 @@ impl CompanyRuntime {
     #[cfg(feature = "openhuman")]
     pub fn harness(&self) -> Option<&Arc<crate::harness::HarnessPool>> {
         self.harness.as_ref()
+    }
+
+    /// Attaches the embedded MCP runtime used by REST and harness agents.
+    #[cfg(feature = "mcp")]
+    pub fn set_mcp(&mut self, mcp: Arc<crate::harness::mcp::McpRuntime>) {
+        self.mcp = Some(mcp);
+    }
+
+    /// Returns this company's embedded MCP runtime when the feature is enabled.
+    #[cfg(feature = "mcp")]
+    pub fn mcp(&self) -> Option<&Arc<crate::harness::mcp::McpRuntime>> {
+        self.mcp.as_ref()
     }
 
     /// This company's id.

--- a/src/error.rs
+++ b/src/error.rs
@@ -107,6 +107,11 @@ pub enum OpenCompanyError {
     #[error("company not found: {0}")]
     CompanyNotFound(String),
 
+    /// No MCP install exists in the addressed company's registry store.
+    #[cfg(feature = "mcp")]
+    #[error("MCP server not found: {0}")]
+    McpServerNotFound(String),
+
     /// A tool was invoked outside the manifest grant.
     #[error("tool not granted: {0}")]
     ToolNotGranted(String),
@@ -221,6 +226,8 @@ impl OpenCompanyError {
             Self::StoreIo { .. } => "store_io".to_string(),
             Self::Serde(_) => "serialization_error".to_string(),
             Self::CompanyNotFound(_) => "company_not_found".to_string(),
+            #[cfg(feature = "mcp")]
+            Self::McpServerNotFound(_) => "mcp_server_not_found".to_string(),
             Self::ToolNotGranted(_) => "tool_not_granted".to_string(),
             Self::BudgetExceeded(_) => "budget_exceeded".to_string(),
             Self::LifecycleConflict(_) => "lifecycle_conflict".to_string(),

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -100,6 +100,13 @@ pub fn build_agent(
     // v1: no manifest tools yet (see module docs — WS4 tool-surface seam). The
     // manifest `tools ∩ agent.tools` intersection lands here.
     let mut tools: Vec<Box<dyn Tool>> = Vec::new();
+    #[cfg(feature = "mcp")]
+    {
+        // These config-free tools read OpenHuman's live process registry, so
+        // installs and lifecycle changes are visible without rebuilding agents.
+        tools.push(Box::new(oh::mcp_registry::tools::McpRegistryListToolsTool));
+        tools.push(Box::new(oh::mcp_registry::tools::McpRegistryToolCallTool));
+    }
 
     // Persona over openhuman's own identity: `omit_identity = true` drops the
     // "you are OpenHuman" preamble so the agent speaks as its company role.

--- a/src/harness/mcp.rs
+++ b/src/harness/mcp.rs
@@ -1,0 +1,203 @@
+//! OpenHuman MCP registry wrapper for the embedded company runtime.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use openhuman_core::openhuman as oh;
+use serde_json::Value;
+
+use oh::mcp_registry::types::{ConnStatus, InstalledServer, McpTool};
+
+use crate::error::OpenCompanyError;
+
+/// Company-home-scoped persistence and access to OpenHuman's live MCP registry.
+pub struct McpRuntime {
+    config: oh::config::Config,
+}
+
+impl McpRuntime {
+    /// Creates a runtime whose MCP SQLite store lives beneath `workspace_dir`.
+    pub fn new(workspace_dir: PathBuf) -> Self {
+        let mut config = oh::config::Config::default();
+        config.workspace_dir = workspace_dir;
+        Self { config }
+    }
+
+    /// Reconnects enabled installed servers. Failures are logged by OpenHuman
+    /// per server and never prevent the company runtime from booting.
+    pub async fn boot(&self) {
+        oh::mcp_registry::boot::spawn_installed_servers(&self.config).await;
+    }
+
+    /// Returns every persisted install without loading secret environment values.
+    pub fn list(&self) -> crate::Result<Vec<InstalledServer>> {
+        oh::mcp_registry::store::list_servers(&self.config).map_err(store_error)
+    }
+
+    /// Persists an install and its write-only environment values.
+    pub fn install(
+        &self,
+        server: &InstalledServer,
+        env: &HashMap<String, String>,
+    ) -> crate::Result<()> {
+        oh::mcp_registry::store::insert_server(&self.config, server).map_err(store_error)?;
+        if let Err(error) =
+            oh::mcp_registry::store::set_env_values(&self.config, &server.server_id, env)
+        {
+            let _ = oh::mcp_registry::store::delete_server(&self.config, &server.server_id);
+            return Err(store_error(error));
+        }
+        Ok(())
+    }
+
+    /// Loads an installed server, establishing the company-store membership
+    /// check before touching OpenHuman's process-global connection registry.
+    pub fn get(&self, server_id: &str) -> crate::Result<InstalledServer> {
+        oh::mcp_registry::store::get_server(&self.config, server_id).map_err(|_| {
+            OpenCompanyError::InvalidRequest(format!("MCP server '{server_id}' not found"))
+        })
+    }
+
+    /// Connects an installed server and returns its advertised tools.
+    pub async fn connect(&self, server_id: &str) -> crate::Result<Vec<McpTool>> {
+        let server = self.get(server_id)?;
+        oh::mcp_registry::connections::connect(&self.config, &server)
+            .await
+            .map_err(harness_error)
+    }
+
+    /// Disconnects an installed server after verifying it belongs to this store.
+    pub async fn disconnect(&self, server_id: &str) -> crate::Result<bool> {
+        self.get(server_id)?;
+        Ok(oh::mcp_registry::connections::disconnect(server_id).await)
+    }
+
+    /// Disconnects and deletes an installed server and its environment values.
+    pub async fn uninstall(&self, server_id: &str) -> crate::Result<bool> {
+        self.get(server_id)?;
+        oh::mcp_registry::connections::disconnect(server_id).await;
+        oh::mcp_registry::store::delete_server(&self.config, server_id).map_err(store_error)
+    }
+
+    /// Returns connection state joined by OpenHuman against this runtime's store.
+    pub async fn status(&self) -> Vec<ConnStatus> {
+        oh::mcp_registry::connections::all_status(&self.config).await
+    }
+
+    /// Returns the cached tool list for a connected installed server.
+    pub async fn tools(&self, server_id: &str) -> crate::Result<Vec<McpTool>> {
+        self.get(server_id)?;
+        oh::mcp_registry::connections::tools_for(server_id)
+            .await
+            .ok_or_else(|| {
+                OpenCompanyError::InvalidRequest(format!(
+                    "MCP server '{server_id}' is not connected"
+                ))
+            })
+    }
+
+    /// Calls one tool after verifying the server belongs to this runtime's store.
+    pub async fn call_tool(
+        &self,
+        server_id: &str,
+        tool_name: &str,
+        arguments: Value,
+    ) -> crate::Result<Value> {
+        self.get(server_id)?;
+        oh::mcp_registry::connections::call_tool(server_id, tool_name, arguments)
+            .await
+            .map_err(harness_error)
+    }
+}
+
+fn store_error(error: anyhow::Error) -> OpenCompanyError {
+    OpenCompanyError::Store(format!("MCP registry: {error}"))
+}
+
+fn harness_error(error: impl std::fmt::Display) -> OpenCompanyError {
+    OpenCompanyError::Harness(format!("MCP registry: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use oh::mcp_registry::types::{CommandKind, Transport};
+
+    use super::*;
+
+    const NODE_STUB: &str = r#"
+const readline = require('node:readline');
+const rl = readline.createInterface({ input: process.stdin });
+const send = (value) => process.stdout.write(JSON.stringify(value) + '\n');
+rl.on('line', (line) => {
+  const request = JSON.parse(line);
+  if (!request.id) return;
+  if (request.method === 'initialize') {
+    send({ jsonrpc: '2.0', id: request.id, result: { protocolVersion: '2024-11-05', capabilities: { tools: {} }, serverInfo: { name: 'test', version: '1' } } });
+  } else if (request.method === 'tools/list') {
+    send({ jsonrpc: '2.0', id: request.id, result: { tools: [{ name: 'echo', description: 'Echo text', inputSchema: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] } }] } });
+  } else if (request.method === 'tools/call') {
+    send({ jsonrpc: '2.0', id: request.id, result: { content: [{ type: 'text', text: 'echo: ' + request.params.arguments.text }] } });
+  }
+});
+"#;
+
+    #[tokio::test]
+    async fn install_connect_call_disconnect_round_trip() {
+        if Command::new("node").arg("--version").output().is_err() {
+            eprintln!("skipping MCP runtime test because node is unavailable");
+            return;
+        }
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let script = temp.path().join("mcp-stub.cjs");
+        std::fs::write(&script, NODE_STUB).expect("write node stub");
+        let runtime = McpRuntime::new(temp.path().join("workspace"));
+        let server = InstalledServer {
+            server_id: uuid::Uuid::new_v4().to_string(),
+            qualified_name: "test-node-echo".to_string(),
+            display_name: "Test Node Echo".to_string(),
+            description: None,
+            icon_url: None,
+            command_kind: CommandKind::Binary,
+            command: "node".to_string(),
+            args: vec![script.to_string_lossy().into_owned()],
+            env_keys: vec![],
+            config: None,
+            installed_at: 0,
+            last_connected_at: None,
+            transport: Transport::Stdio,
+            enabled: true,
+        };
+
+        runtime.install(&server, &HashMap::new()).expect("install");
+        let tools = runtime.connect(&server.server_id).await.expect("connect");
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "echo");
+
+        let result = runtime
+            .call_tool(
+                &server.server_id,
+                "echo",
+                serde_json::json!({"text": "hello"}),
+            )
+            .await
+            .expect("call");
+        assert_eq!(result["content"][0]["text"], "echo: hello");
+
+        assert!(
+            runtime
+                .disconnect(&server.server_id)
+                .await
+                .expect("disconnect")
+        );
+        assert!(
+            runtime
+                .uninstall(&server.server_id)
+                .await
+                .expect("uninstall")
+        );
+        assert!(runtime.list().expect("list").is_empty());
+    }
+}

--- a/src/harness/mcp.rs
+++ b/src/harness/mcp.rs
@@ -53,9 +53,8 @@ impl McpRuntime {
     /// Loads an installed server, establishing the company-store membership
     /// check before touching OpenHuman's process-global connection registry.
     pub fn get(&self, server_id: &str) -> crate::Result<InstalledServer> {
-        oh::mcp_registry::store::get_server(&self.config, server_id).map_err(|_| {
-            OpenCompanyError::InvalidRequest(format!("MCP server '{server_id}' not found"))
-        })
+        oh::mcp_registry::store::get_server(&self.config, server_id)
+            .map_err(|_| OpenCompanyError::McpServerNotFound(server_id.to_string()))
     }
 
     /// Connects an installed server and returns its advertised tools.

--- a/src/harness/mcp.rs
+++ b/src/harness/mcp.rs
@@ -18,8 +18,10 @@ pub struct McpRuntime {
 impl McpRuntime {
     /// Creates a runtime whose MCP SQLite store lives beneath `workspace_dir`.
     pub fn new(workspace_dir: PathBuf) -> Self {
-        let mut config = oh::config::Config::default();
-        config.workspace_dir = workspace_dir;
+        let config = oh::config::Config {
+            workspace_dir,
+            ..Default::default()
+        };
         Self { config }
     }
 

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -278,6 +278,8 @@ mod tests {
     use std::sync::Mutex as StdMutex;
 
     use async_trait::async_trait;
+    #[cfg(feature = "mcp")]
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use crate::company::CompanyManifest;
     use crate::harness::provider::MockProvider;
@@ -450,6 +452,101 @@ description = "Builds the product."
             meter,
             _dir: dir,
         }
+    }
+
+    #[cfg(feature = "mcp")]
+    struct McpToolCallProvider {
+        server_id: String,
+        calls: AtomicUsize,
+    }
+
+    #[cfg(feature = "mcp")]
+    #[async_trait]
+    impl Provider for McpToolCallProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<String> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                Ok(format!(
+                    "<tool_call>{{\"name\":\"mcp_registry_tool_call\",\"arguments\":{{\"server_id\":\"{}\",\"tool_name\":\"echo\",\"arguments\":{{\"text\":\"agent-mcp\"}}}}}}</tool_call>",
+                    self.server_id
+                ))
+            } else {
+                Ok(format!("__MOCK_LLM__ {message}"))
+            }
+        }
+    }
+
+    #[cfg(feature = "mcp")]
+    #[tokio::test]
+    async fn agent_executes_connected_mcp_tool() {
+        use std::collections::HashMap;
+        use std::process::Command;
+
+        use oh::mcp_registry::types::{CommandKind, InstalledServer, Transport};
+
+        if Command::new("node").arg("--version").output().is_err() {
+            eprintln!("skipping MCP agent test because node is unavailable");
+            return;
+        }
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("agent-mcp-stub.cjs");
+        std::fs::write(
+            &script,
+            r#"
+const readline = require('node:readline');
+const rl = readline.createInterface({ input: process.stdin });
+const send = (v) => process.stdout.write(JSON.stringify(v) + '\n');
+rl.on('line', (line) => {
+  const r = JSON.parse(line); if (!r.id) return;
+  if (r.method === 'initialize') send({jsonrpc:'2.0',id:r.id,result:{protocolVersion:'2024-11-05',capabilities:{tools:{}},serverInfo:{name:'agent-test',version:'1'}}});
+  else if (r.method === 'tools/list') send({jsonrpc:'2.0',id:r.id,result:{tools:[{name:'echo',description:'Echo text',inputSchema:{type:'object'}}]}});
+  else if (r.method === 'tools/call') send({jsonrpc:'2.0',id:r.id,result:{content:[{type:'text',text:'echo: ' + r.params.arguments.text}]}});
+});
+"#,
+        )
+        .expect("write stub");
+
+        let mcp = crate::harness::mcp::McpRuntime::new(dir.path().join("mcp"));
+        let server = InstalledServer {
+            server_id: uuid::Uuid::new_v4().to_string(),
+            qualified_name: "agent-test".to_string(),
+            display_name: "Agent Test".to_string(),
+            description: None,
+            icon_url: None,
+            command_kind: CommandKind::Binary,
+            command: "node".to_string(),
+            args: vec![script.to_string_lossy().into_owned()],
+            env_keys: vec![],
+            config: None,
+            installed_at: 0,
+            last_connected_at: None,
+            transport: Transport::Stdio,
+            enabled: true,
+        };
+        mcp.install(&server, &HashMap::new()).expect("install");
+        mcp.connect(&server.server_id).await.expect("connect");
+
+        let mut fx = fixture();
+        fx.deps.provider = Arc::new(McpToolCallProvider {
+            server_id: server.server_id.clone(),
+            calls: AtomicUsize::new(0),
+        });
+        let pool = HarnessPool::new();
+        let rec = record();
+        pool.ensure(&rec, &fx.deps).await.expect("ensure");
+        let reply = pool
+            .run(&rec.id, "ceo", "use the MCP echo tool", &fx.deps)
+            .await
+            .expect("agent turn");
+        assert!(reply.contains("__MOCK_LLM__"), "{reply}");
+        assert!(reply.contains("echo: agent-mcp"), "{reply}");
+
+        mcp.disconnect(&server.server_id).await.expect("disconnect");
     }
 
     #[tokio::test]

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -38,6 +38,8 @@
 pub mod brain;
 pub mod build;
 pub mod cost;
+#[cfg(feature = "mcp")]
+pub mod mcp;
 pub mod memory;
 pub mod policy;
 pub mod provider;

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -180,6 +180,11 @@ impl ToolPolicy for ApprovalPolicy {
 /// the bridge only the tool name and arguments, not the tool's own
 /// external-effect flag. Unknown tools are treated as external (fail-safe).
 fn is_external_effect(tool_name: &str) -> bool {
+    // An MCP tool call can perform any effect advertised by a third-party
+    // server. Treat it as external even if future prefix rules become broader.
+    if tool_name.eq_ignore_ascii_case("mcp_registry_tool_call") {
+        return true;
+    }
     const READ_ONLY_PREFIXES: &[&str] = &[
         "read",
         "list",
@@ -200,7 +205,9 @@ fn is_external_effect(tool_name: &str) -> bool {
 /// Map a tool name onto the supervised [`EffectGroup`] taxonomy.
 fn classify_group(tool_name: &str) -> EffectGroup {
     let name = tool_name.to_ascii_lowercase();
-    if name.contains("pay") || name.contains("transfer") || name.starts_with("spend") {
+    if name == "mcp_registry_tool_call" {
+        EffectGroup::Other
+    } else if name.contains("pay") || name.contains("transfer") || name.starts_with("spend") {
         EffectGroup::Spend
     } else if name.contains("email") || name.contains("send") || name.contains("message") {
         EffectGroup::Send
@@ -272,6 +279,25 @@ mod tests {
         assert_eq!(
             p.check(&request("read_file", serde_json::json!({}))).await,
             ToolPolicyDecision::Allow
+        );
+    }
+
+    #[tokio::test]
+    async fn supervised_parks_mcp_tool_calls_as_external_other_effects() {
+        let p = policy("supervised", &[], None);
+        let args = serde_json::json!({
+            "server_id": "server-1",
+            "tool_name": "echo",
+            "arguments": {"text": "hello"}
+        });
+        assert!(matches!(
+            p.check(&request("mcp_registry_tool_call", args.clone()))
+                .await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
+        assert_eq!(
+            p.effect_for("mcp_registry_tool_call", &args).group,
+            EffectGroup::Other
         );
     }
 

--- a/src/harness/skills.rs
+++ b/src/harness/skills.rs
@@ -171,8 +171,10 @@ impl EffectiveSkills {
     pub fn read_tools(&self) -> Vec<Box<dyn Tool>> {
         // `Config` has private fields, so build from `Default` and set the one
         // field the read tools read rather than a struct literal.
-        let mut config = Config::default();
-        config.workspace_dir = self.workspace_dir.clone();
+        let config = Config {
+            workspace_dir: self.workspace_dir.clone(),
+            ..Default::default()
+        };
         let config = Arc::new(config);
         vec![
             Box::new(WorkflowListTool::new(config.clone())),

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -821,6 +821,17 @@ impl RuntimeBuilder {
         // skills/workflows content on the serve path.
         runtime.set_source_dir(self.seed_dir.clone());
 
+        // MCP uses OpenHuman's process-global live connection registry. Keep a
+        // runtime-owned config for this OpenCompany home so REST and agents see
+        // the same installed servers, and reconnect persisted installs without
+        // delaying company boot.
+        #[cfg(feature = "mcp")]
+        {
+            let mcp = Arc::new(crate::harness::mcp::McpRuntime::new(home.join("mcp")));
+            runtime.set_mcp(mcp.clone());
+            tokio::spawn(async move { mcp.boot().await });
+        }
+
         // WS4: attach the embedded harness pool when one was provided.
         #[cfg(feature = "openhuman")]
         if let Some(harness) = self.harness.clone() {

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -34,6 +34,8 @@ impl ApiError {
     pub fn status(&self) -> StatusCode {
         match &self.0 {
             OpenCompanyError::CompanyNotFound(_) => StatusCode::NOT_FOUND,
+            #[cfg(feature = "mcp")]
+            OpenCompanyError::McpServerNotFound(_) => StatusCode::NOT_FOUND,
             OpenCompanyError::ManifestInvalid { .. }
             | OpenCompanyError::ManifestParse(_, _)
             | OpenCompanyError::MissingManifest(_)

--- a/src/server/ops/mcp.rs
+++ b/src/server/ops/mcp.rs
@@ -148,7 +148,7 @@ fn empty_object() -> Value {
 }
 
 fn runtime(company: &ScopedCompany) -> Result<&McpRuntime, ApiError> {
-    company.runtime.mcp().map(AsRef::as_ref).ok_or_else(|| {
+    company.runtime.mcp().map(AsRef::as_ref).ok_or({
         ApiError(OpenCompanyError::Unimplemented(
             "MCP is not enabled on this host",
         ))

--- a/src/server/ops/mcp.rs
+++ b/src/server/ops/mcp.rs
@@ -1,0 +1,475 @@
+//! Company-scoped MCP server installation, lifecycle, and tool calls.
+
+use std::collections::HashMap;
+
+use axum::extract::Path;
+use axum::http::StatusCode;
+use axum::routing::{delete, get, post};
+use axum::{Json, Router};
+use openhuman_core::openhuman::mcp_registry::types::{
+    CommandKind, ConnStatus, InstalledServer, McpTool, Transport,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::AppState;
+use crate::error::OpenCompanyError;
+use crate::harness::mcp::McpRuntime;
+use crate::ports::now_millis;
+use crate::server::error::ApiError;
+use crate::server::ops::{ScopedCompany, scoped};
+
+/// Builds the MCP route fragment under both company scope forms.
+pub fn router() -> Router<AppState> {
+    scoped("/mcp/servers", get(list_servers).post(install_server))
+        .merge(scoped(
+            "/mcp/servers/{server_id}/connect",
+            post(connect_server),
+        ))
+        .merge(scoped(
+            "/mcp/servers/{server_id}/disconnect",
+            post(disconnect_server),
+        ))
+        .merge(scoped("/mcp/servers/{server_id}", delete(uninstall_server)))
+        .merge(scoped("/mcp/servers/{server_id}/tools", get(list_tools)))
+        .merge(scoped(
+            "/mcp/servers/{server_id}/tools/{tool}/call",
+            post(call_tool),
+        ))
+}
+
+#[derive(Debug, Serialize)]
+struct ServersResponse {
+    servers: Vec<ServerResponse>,
+}
+
+#[derive(Debug, Serialize)]
+struct ServerResponse {
+    server_id: String,
+    name: String,
+    transport: &'static str,
+    command: String,
+    args: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    url: Option<String>,
+    env_keys: Vec<String>,
+    enabled: bool,
+    status: String,
+    tool_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_error: Option<String>,
+}
+
+impl ServerResponse {
+    fn from_install(server: InstalledServer, status: Option<&ConnStatus>) -> Self {
+        let (transport, url) = match &server.transport {
+            Transport::Stdio => ("stdio", None),
+            Transport::HttpRemote { url } => ("http", Some(url.clone())),
+        };
+        Self {
+            server_id: server.server_id,
+            name: server.display_name,
+            transport,
+            command: server.command,
+            args: server.args,
+            url,
+            env_keys: server.env_keys,
+            enabled: server.enabled,
+            status: status
+                .map(|entry| entry.status.as_str())
+                .unwrap_or("disconnected")
+                .to_string(),
+            tool_count: status.map_or(0, |entry| entry.tool_count),
+            last_error: status.and_then(|entry| entry.last_error.clone()),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum InstallTransport {
+    Stdio,
+    Http,
+}
+
+#[derive(Debug, Deserialize)]
+struct InstallRequest {
+    name: String,
+    transport: InstallTransport,
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: HashMap<String, String>,
+    #[serde(default)]
+    url: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct InstallResponse {
+    server_id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ToolsResponse {
+    tools: Vec<McpTool>,
+}
+
+#[derive(Debug, Serialize)]
+struct DisconnectResponse {
+    disconnected: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ServerPath {
+    server_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolPath {
+    server_id: String,
+    tool: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CallRequest {
+    #[serde(default = "empty_object")]
+    arguments: Value,
+}
+
+#[derive(Debug, Serialize)]
+struct CallResponse {
+    result: Value,
+}
+
+fn empty_object() -> Value {
+    serde_json::json!({})
+}
+
+fn runtime(company: &ScopedCompany) -> Result<&McpRuntime, ApiError> {
+    company.runtime.mcp().map(AsRef::as_ref).ok_or_else(|| {
+        ApiError(OpenCompanyError::Unimplemented(
+            "MCP is not enabled on this host",
+        ))
+    })
+}
+
+async fn list_servers(company: ScopedCompany) -> Result<Json<ServersResponse>, ApiError> {
+    let mcp = runtime(&company)?;
+    let statuses = mcp.status().await;
+    let servers = mcp
+        .list()?
+        .into_iter()
+        .map(|server| {
+            let status = statuses
+                .iter()
+                .find(|entry| entry.server_id == server.server_id);
+            ServerResponse::from_install(server, status)
+        })
+        .collect();
+    Ok(Json(ServersResponse { servers }))
+}
+
+async fn install_server(
+    company: ScopedCompany,
+    Json(request): Json<InstallRequest>,
+) -> Result<(StatusCode, Json<InstallResponse>), ApiError> {
+    let mcp = runtime(&company)?;
+    let name = request.name.trim();
+    if name.is_empty() {
+        return Err(ApiError(OpenCompanyError::InvalidRequest(
+            "MCP server name is required".to_string(),
+        )));
+    }
+
+    let (transport, command, args) = match request.transport {
+        InstallTransport::Stdio => {
+            let command = request
+                .command
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    ApiError(OpenCompanyError::InvalidRequest(
+                        "stdio MCP servers require a command".to_string(),
+                    ))
+                })?;
+            (Transport::Stdio, command.to_string(), request.args)
+        }
+        InstallTransport::Http => {
+            let url = request
+                .url
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    ApiError(OpenCompanyError::InvalidRequest(
+                        "HTTP MCP servers require a URL".to_string(),
+                    ))
+                })?;
+            if !(url.starts_with("http://") || url.starts_with("https://")) {
+                return Err(ApiError(OpenCompanyError::InvalidRequest(
+                    "HTTP MCP server URL must use http:// or https://".to_string(),
+                )));
+            }
+            (
+                Transport::HttpRemote {
+                    url: url.to_string(),
+                },
+                String::new(),
+                Vec::new(),
+            )
+        }
+    };
+
+    let server_id = uuid::Uuid::new_v4().to_string();
+    let mut env_keys: Vec<String> = request.env.keys().cloned().collect();
+    env_keys.sort();
+    let server = InstalledServer {
+        server_id: server_id.clone(),
+        qualified_name: format!("manual/{server_id}"),
+        display_name: name.to_string(),
+        description: None,
+        icon_url: None,
+        command_kind: CommandKind::Binary,
+        command,
+        args,
+        env_keys,
+        config: None,
+        installed_at: now_millis() as i64,
+        last_connected_at: None,
+        transport,
+        enabled: true,
+    };
+    mcp.install(&server, &request.env)?;
+
+    // Installation is durable even when the process or endpoint is currently
+    // unavailable. The failure is recorded by OpenHuman and appears in status.
+    let _ = mcp.connect(&server_id).await;
+
+    Ok((StatusCode::CREATED, Json(InstallResponse { server_id })))
+}
+
+async fn connect_server(
+    company: ScopedCompany,
+    Path(ServerPath { server_id }): Path<ServerPath>,
+) -> Result<Json<ToolsResponse>, ApiError> {
+    let tools = runtime(&company)?.connect(&server_id).await?;
+    Ok(Json(ToolsResponse { tools }))
+}
+
+async fn disconnect_server(
+    company: ScopedCompany,
+    Path(ServerPath { server_id }): Path<ServerPath>,
+) -> Result<Json<DisconnectResponse>, ApiError> {
+    let disconnected = runtime(&company)?.disconnect(&server_id).await?;
+    Ok(Json(DisconnectResponse { disconnected }))
+}
+
+async fn uninstall_server(
+    company: ScopedCompany,
+    Path(ServerPath { server_id }): Path<ServerPath>,
+) -> Result<StatusCode, ApiError> {
+    runtime(&company)?.uninstall(&server_id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn list_tools(
+    company: ScopedCompany,
+    Path(ServerPath { server_id }): Path<ServerPath>,
+) -> Result<Json<ToolsResponse>, ApiError> {
+    let tools = runtime(&company)?.tools(&server_id).await?;
+    Ok(Json(ToolsResponse { tools }))
+}
+
+async fn call_tool(
+    company: ScopedCompany,
+    Path(ToolPath { server_id, tool }): Path<ToolPath>,
+    Json(request): Json<CallRequest>,
+) -> Result<Json<CallResponse>, ApiError> {
+    let result = runtime(&company)?
+        .call_tool(&server_id, &tool, request.arguments)
+        .await?;
+    Ok(Json(CallResponse { result }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use axum::body::{Body, to_bytes};
+    use axum::http::Request;
+    use serde_json::json;
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::company::CompanyManifest;
+    use crate::ports::types::CompanyId;
+    use crate::runtime::RuntimeBuilder;
+    use crate::server;
+    use crate::{AppConfig, AppState};
+
+    const NODE_STUB: &str = r#"
+const readline = require('node:readline');
+const rl = readline.createInterface({ input: process.stdin });
+const send = (value) => process.stdout.write(JSON.stringify(value) + '\n');
+rl.on('line', (line) => {
+  const r = JSON.parse(line);
+  if (!r.id) return;
+  if (r.method === 'initialize') send({jsonrpc:'2.0',id:r.id,result:{protocolVersion:'2024-11-05',capabilities:{tools:{}},serverInfo:{name:'api-test',version:'1'}}});
+  else if (r.method === 'tools/list') send({jsonrpc:'2.0',id:r.id,result:{tools:[{name:'echo',description:'Echo text',inputSchema:{type:'object'}},{name:'add',description:'Add values',inputSchema:{type:'object'}}]}});
+  else if (r.method === 'tools/call') send({jsonrpc:'2.0',id:r.id,result:{content:[{type:'text',text:r.params.name === 'echo' ? 'echo: ' + r.params.arguments.text : String(r.params.arguments.a + r.params.arguments.b)}]}});
+});
+"#;
+
+    fn manifest() -> CompanyManifest {
+        toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n").unwrap()
+    }
+
+    async fn test_state(home: &std::path::Path) -> AppState {
+        let runtime = RuntimeBuilder::new(home, manifest())
+            .with_id(CompanyId::new("acme"))
+            .build()
+            .await
+            .expect("runtime");
+        let state = AppState::new(AppConfig::default());
+        state
+            .registry()
+            .insert(CompanyId::new("acme"), std::sync::Arc::new(runtime));
+        server::test_support::seed_fixed_admin(&state, "acme").await;
+        state
+    }
+
+    async fn send(
+        state: &AppState,
+        method: &str,
+        uri: &str,
+        body: Option<Value>,
+    ) -> (StatusCode, Value) {
+        let mut request = Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("cookie", server::test_support::fixed_cookie("acme"));
+        if body.is_some() {
+            request = request.header("content-type", "application/json");
+        }
+        let response = server::router(state.clone())
+            .oneshot(
+                request
+                    .body(Body::from(body.map_or_else(String::new, |v| v.to_string())))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value = if bytes.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&bytes).unwrap()
+        };
+        (status, value)
+    }
+
+    #[tokio::test]
+    async fn lifecycle_and_tool_call_round_trip_without_leaking_env_values() {
+        if Command::new("node").arg("--version").output().is_err() {
+            eprintln!("skipping MCP API test because node is unavailable");
+            return;
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let script = temp.path().join("mcp-api-stub.cjs");
+        std::fs::write(&script, NODE_STUB).unwrap();
+        let state = test_state(temp.path()).await;
+
+        let (status, installed) = send(
+            &state,
+            "POST",
+            "/api/v1/company/mcp/servers",
+            Some(json!({
+                "name": "simple",
+                "transport": "stdio",
+                "command": "node",
+                "args": [script],
+                "env": {"API_TOKEN": "never-return-this"}
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED, "{installed}");
+        let server_id = installed["server_id"].as_str().unwrap();
+
+        let (status, listed) = send(&state, "GET", "/api/v1/company/mcp/servers", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(listed["servers"][0]["status"], "connected");
+        assert_eq!(listed["servers"][0]["tool_count"], 2);
+        assert_eq!(listed["servers"][0]["env_keys"][0], "API_TOKEN");
+        assert!(!listed.to_string().contains("never-return-this"));
+
+        let (status, called) = send(
+            &state,
+            "POST",
+            &format!("/api/v1/company/mcp/servers/{server_id}/tools/echo/call"),
+            Some(json!({"arguments": {"text": "api"}})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{called}");
+        assert_eq!(called["result"]["content"][0]["text"], "echo: api");
+
+        let (status, disconnected) = send(
+            &state,
+            "POST",
+            &format!("/api/v1/company/mcp/servers/{server_id}/disconnect"),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(disconnected["disconnected"], true);
+
+        let (status, _) = send(
+            &state,
+            "DELETE",
+            &format!("/api/v1/company/mcp/servers/{server_id}"),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn rejects_server_id_from_another_registry_store() {
+        let temp = tempfile::tempdir().unwrap();
+        let state = test_state(&temp.path().join("company-a")).await;
+        let foreign = McpRuntime::new(temp.path().join("company-b/mcp"));
+        let server = InstalledServer {
+            server_id: uuid::Uuid::new_v4().to_string(),
+            qualified_name: "foreign".to_string(),
+            display_name: "Foreign".to_string(),
+            description: None,
+            icon_url: None,
+            command_kind: CommandKind::Binary,
+            command: "node".to_string(),
+            args: vec![],
+            env_keys: vec![],
+            config: None,
+            installed_at: 0,
+            last_connected_at: None,
+            transport: Transport::Stdio,
+            enabled: true,
+        };
+        foreign.install(&server, &HashMap::new()).unwrap();
+
+        let (status, body) = send(
+            &state,
+            "POST",
+            &format!(
+                "/api/v1/company/mcp/servers/{}/disconnect",
+                server.server_id
+            ),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+        assert_eq!(body["code"], "mcp_server_not_found");
+    }
+}

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -31,6 +31,8 @@ pub mod workspace;
 
 #[cfg(feature = "oauth")]
 pub mod connections;
+#[cfg(feature = "mcp")]
+pub mod mcp;
 
 pub(crate) use scope::{ScopedCompany, scoped};
 
@@ -128,6 +130,8 @@ pub fn router() -> Router<AppState> {
         .merge(mail::router());
     #[cfg(feature = "oauth")]
     let router = router.merge(connections::router());
+    #[cfg(feature = "mcp")]
+    let router = router.merge(mcp::router());
     router
 }
 


### PR DESCRIPTION
## What changed

- add an opt-in embedded MCP runtime backed by OpenHuman
- expose company-scoped MCP server lifecycle, tool discovery, and tool-call APIs
- surface MCP tools to harness agents with explicit external-effect policy
- add an operator-console MCP servers view and tool playground
- cover the UI and runtime paths with unit, integration, subprocess-agent, and Playwright tests

## Why

OpenCompany needs a company-scoped way to install and operate MCP servers, expose their tools to agents, and verify the complete console-to-runtime flow.

## Impact

The behavior is feature-gated behind `openhuman,mcp`; default builds remain unchanged. MCP server environment values are stored in the existing local config model and should be treated as sensitive.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `GGML_NATIVE=OFF cargo test --features openhuman,mcp`
- `GGML_NATIVE=OFF cargo clippy --all-targets --features openhuman,mcp --no-deps -- -D warnings`
- `npm run build` in `frontend/`
- umbrella MCP E2E: backend smoke, two Playwright specs, and MCP REST smoke all passed

The exact feature clippy command without `--no-deps` still reports two pre-existing `large_enum_variant` warnings in vendored TinyAgents; the project audit records this upstream gap.