### PR TITLE
feat(orchestrator): make the company chat a delegating orchestrator (#53)

### DIFF
--- a/companies/e2e_harness/company.toml
+++ b/companies/e2e_harness/company.toml
@@ -29,13 +29,34 @@ admins = ["harness-e2e@tinyhumans.ai"]
 id = "ceo"
 role = "Chief Executive"
 description = "Sets direction, answers about the company, and delegates the work."
+tier = "orchestrator"
+tools = ["mcp:*"]
 
 [[agent]]
 id = "engineer"
 role = "Engineer"
 description = "Explains how things are built and proposes technical plans."
+tools = ["mcp:*"]
 
 [[agent]]
 id = "writer"
 role = "Writer"
 description = "Turns rough notes into short, clear written drafts."
+tools = ["mcp:*"]
+
+[[group_chat]]
+id = "engineering"
+name = "Engineering desk"
+description = "How things are built and technical plans."
+members = ["engineer"]
+
+[[group_chat]]
+id = "content"
+name = "Content desk"
+description = "Written drafts and copy."
+members = ["writer"]
+
+[[mcp_server]]
+name = "deepwiki"
+endpoint = "https://mcp.deepwiki.com/mcp"
+description = "AI-generated documentation and Q&A for public GitHub repositories."

--- a/companies/openhuman_demo/company.toml
+++ b/companies/openhuman_demo/company.toml
@@ -27,13 +27,43 @@ mode = "full"
 id = "ceo"
 role = "Chief Executive"
 description = "Sets direction, answers about the company, and delegates the work."
+# The operator↔company chat responder. `orchestrator` makes the CEO answer from
+# whole-company context and delegate to the desks below. `mcp:*` grants the
+# remote MCP tool servers declared in `[[mcp_server]]`.
+tier = "orchestrator"
+tools = ["mcp:*"]
 
 [[agent]]
 id = "engineer"
 role = "Engineer"
 description = "Explains how things are built and proposes technical plans."
+tools = ["mcp:*"]
 
 [[agent]]
 id = "writer"
 role = "Writer"
 description = "Turns rough notes into short, clear written drafts."
+tools = ["mcp:*"]
+
+# Desks (group chats) the orchestrator can hand a turn to. Each desk's first
+# member is its lead; `delegate_to_desk` runs that member's turn.
+[[group_chat]]
+id = "engineering"
+name = "Engineering desk"
+description = "How things are built and technical plans."
+members = ["engineer"]
+
+[[group_chat]]
+id = "content"
+name = "Content desk"
+description = "Written drafts and copy."
+members = ["writer"]
+
+# A real, public, no-auth MCP tool server (DeepWiki — AI docs for GitHub
+# repositories). Its tools (read_wiki_structure / read_wiki_contents /
+# ask_question) reach every agent granted `mcp:*` above. Add credentialed
+# servers at runtime from the console's Connections tab.
+[[mcp_server]]
+name = "deepwiki"
+endpoint = "https://mcp.deepwiki.com/mcp"
+description = "AI-generated documentation and Q&A for public GitHub repositories."

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -102,6 +102,9 @@ async fn main() -> anyhow::Result<()> {
         skills: None,
         skills_source_dir: None,
         mcp_servers: Vec::new(),
+        facts: None,
+        events: None,
+        delegations: opencompany::harness::orchestrator::DelegationQueue::default(),
     };
 
     let pool = HarnessPool::new();

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -16,6 +16,7 @@ import {
   type CompanyStatus,
   type ConnectionStart,
   type ConnectionState,
+  type DeskDto,
   type FeedbackInput,
   type FeedbackResponse,
   type FeedbackSummary,
@@ -135,9 +136,25 @@ export class OpenCompanyClient {
     return this.request<CompanyStatus>("GET", `${this.scope(company)}`);
   }
 
-  /** Send the operator's message and return the company's reply. */
-  chat(text: string, company?: string | null): Promise<ChatResponse> {
-    return this.request<ChatResponse>("POST", `${this.scope(company)}/chat`, { text });
+  /**
+   * Send the operator's message and return the company's reply. `chat` is the
+   * addressed desk / thread id (issue #53): the orchestrator routes an addressed
+   * message to that desk's lead, and an unaddressed one answers itself. Omitted /
+   * unknown ids fall to the orchestrator, so callers can always pass the active
+   * thread id safely.
+   */
+  chat(text: string, company?: string | null, chat?: string | null): Promise<ChatResponse> {
+    const body: { text: string; chat?: string } = { text };
+    if (chat) body.chat = chat;
+    return this.request<ChatResponse>("POST", `${this.scope(company)}/chat`, body);
+  }
+
+  /**
+   * The company's desks (group chats). Hosts that don't expose `.../desks` yet
+   * return 404 — callers fall back to the static default threads.
+   */
+  listDesks(company?: string | null): Promise<DeskDto[]> {
+    return this.request<DeskDto[]>("GET", `${this.scope(company)}/desks`);
   }
 
   /** The approvals awaiting the operator. */

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -17,6 +17,18 @@ export interface OutboundMessage {
   text: string;
 }
 
+/**
+ * `GET {scope}/desks` — one desk (group chat). Mirrors `DeskDto` in
+ * `src/server/operator.rs`. The `id` doubles as the chat thread id; `members[0]`
+ * is the desk's lead.
+ */
+export interface DeskDto {
+  id: string;
+  name: string;
+  description?: string;
+  members: string[];
+}
+
 /** Response of `/chat` and approval-resolution routes. */
 export interface ChatResponse {
   responses: OutboundMessage[];

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import {
   Brain,
   ChartColumnBig,
@@ -49,7 +49,7 @@ import { useCompany } from "@/hooks/use-company";
 import { useHashView } from "@/hooks/use-hash-view";
 import { type ChatMessage, makeMessage } from "@/lib/chat";
 import { DISCORD_INVITE_URL } from "@/lib/links";
-import { defaultThreads } from "@/lib/threads";
+import { defaultThreads, threadsFromDesks } from "@/lib/threads";
 import { Overview } from "@/views/Overview";
 import { Conversation } from "@/views/Conversation";
 import { ApprovalsView } from "@/views/ApprovalsView";
@@ -185,6 +185,31 @@ export function AppShell({
   const feed = useCompany(client, company, initialStatus);
 
   const pending = feed.status.pending_approvals;
+
+  // Build the chat threads from the company's real desks (issue #53); keep the
+  // static defaults when the host doesn't expose `/desks` (404) or defines none.
+  // Merges by id so a transcript typed before desks load survives.
+  useEffect(() => {
+    let cancelled = false;
+    client
+      .listDesks(company)
+      .then((desks) => {
+        if (cancelled) return;
+        setThreads((prev) => {
+          const byId = new Map(prev.map((t) => [t.id, t]));
+          return threadsFromDesks(desks).map((t) => {
+            const existing = byId.get(t.id);
+            return existing ? { ...t, messages: existing.messages } : t;
+          });
+        });
+      })
+      .catch(() => {
+        /* host without `/desks`, or offline — keep the current threads */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client, company]);
 
   const setThreadMessages = (
     threadId: string,

--- a/frontend/src/lib/threads.ts
+++ b/frontend/src/lib/threads.ts
@@ -2,6 +2,7 @@
 // talks to the same company chat endpoint; a thread just scopes a transcript
 // and gives the company side a consistent identity (a "desk" you're talking to).
 
+import type { DeskDto } from "../api/types";
 import type { ChatMessage } from "./chat";
 
 export interface ThreadContact {
@@ -19,15 +20,23 @@ export interface Thread {
   messages: ChatMessage[];
 }
 
+/** Avatar tones rotated across desk threads. */
+const DESK_TONES = ["sky", "violet", "amber", "emerald", "rose", "cyan"];
+
+/** The company's main line — the orchestrator you talk to for anything. */
+function mainThread(): Thread {
+  return {
+    id: "main",
+    contact: { name: "Your company", kind: "company" },
+    blurb: "The main line — ask for anything",
+    messages: [],
+  };
+}
+
 /** The default chat list: the company's main line plus a few focused desks. */
 export function defaultThreads(): Thread[] {
   return [
-    {
-      id: "main",
-      contact: { name: "Your company", kind: "company" },
-      blurb: "The main line — ask for anything",
-      messages: [],
-    },
+    mainThread(),
     {
       id: "strategy",
       contact: { name: "Strategy desk", kind: "agent", tone: "sky" },
@@ -47,4 +56,25 @@ export function defaultThreads(): Thread[] {
       messages: [],
     },
   ];
+}
+
+/**
+ * Build the chat list from the company's real desks (issue #53): the main line
+ * (the orchestrator) first, then one thread per desk keyed by its id. Falls back
+ * to {@link defaultThreads} when the company defines no desks (or the fetch
+ * failed and returned an empty list), so the console always renders something.
+ */
+export function threadsFromDesks(desks: DeskDto[]): Thread[] {
+  if (desks.length === 0) return defaultThreads();
+  const deskThreads: Thread[] = desks.map((desk, i) => ({
+    id: desk.id,
+    contact: {
+      name: desk.name,
+      kind: "agent",
+      tone: DESK_TONES[i % DESK_TONES.length],
+    },
+    blurb: desk.description ?? "A desk of your company",
+    messages: [],
+  }));
+  return [mainThread(), ...deskThreads];
 }

--- a/frontend/src/views/Conversation.tsx
+++ b/frontend/src/views/Conversation.tsx
@@ -145,7 +145,9 @@ function ChatPane({
     setMessages(thread.id, (m) => [...m, makeMessage("you", text)]);
     setSending(true);
     try {
-      const reply = await client.chat(text, company);
+      // Address the active desk thread (issue #53). "main" and any id the
+      // company doesn't define fall to the orchestrator on the backend.
+      const reply = await client.chat(text, company, thread.id);
       const replies = reply.responses.length
         ? reply.responses.map((r) => makeMessage("company", r.text, { channel: r.channel }))
         : [makeMessage("system", "(no reply)")];

--- a/src/brain/echo.rs
+++ b/src/brain/echo.rs
@@ -128,6 +128,7 @@ mod test {
                 request(vec![CompanyEvent::OperatorMessage {
                     text: "hi".into(),
                     by: None,
+                    chat: None,
                 }]),
                 &host,
             )

--- a/src/brain/hosted/test.rs
+++ b/src/brain/hosted/test.rs
@@ -103,6 +103,7 @@ fn operator_request() -> CycleRequest {
         events: vec![CompanyEvent::OperatorMessage {
             text: "hi".into(),
             by: None,
+            chat: None,
         }],
         event_seqs: Vec::new(),
         compressed_history: Vec::new(),
@@ -409,6 +410,7 @@ async fn e2e_operator_message_drives_tool_call_and_gated_send_dm() {
         .run_cycle(vec![CompanyEvent::OperatorMessage {
             text: "how are we doing".into(),
             by: None,
+            chat: None,
         }])
         .await
         .unwrap();
@@ -458,6 +460,7 @@ async fn e2e_supervised_effect_parks_and_acks_not_ok() {
         .run_cycle(vec![CompanyEvent::OperatorMessage {
             text: "file it".into(),
             by: None,
+            chat: None,
         }])
         .await
         .unwrap();

--- a/src/brain/sidecar/test.rs
+++ b/src/brain/sidecar/test.rs
@@ -104,6 +104,7 @@ fn operator_request() -> CycleRequest {
         events: vec![CompanyEvent::OperatorMessage {
             text: "hi".into(),
             by: None,
+            chat: None,
         }],
         event_seqs: Vec::new(),
         compressed_history: Vec::new(),
@@ -442,6 +443,7 @@ async fn e2e_inference_then_gated_send_dm_drives_a_channel_response() {
         .run_cycle(vec![CompanyEvent::OperatorMessage {
             text: "how are we doing".into(),
             by: None,
+            chat: None,
         }])
         .await
         .unwrap();
@@ -487,6 +489,7 @@ async fn e2e_supervised_effect_parks_through_the_real_gate() {
         .run_cycle(vec![CompanyEvent::OperatorMessage {
             text: "file it".into(),
             by: None,
+            chat: None,
         }])
         .await
         .unwrap();

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -7,10 +7,13 @@
 //! [`HarnessPool`], so the reply comes from the hosted brain and the turn's
 //! token/cost usage is metered into the company ledger.
 //!
-//! v1 is **single-responder**: one agent (the first on the roster, or the id
-//! given to [`HarnessBrain::with_responder`]) answers every operator message.
-//! Desk routing — resolving which roster member owns a given group chat — is the
-//! WS3 chat handler's job and lands separately.
+//! The default chat responder is the company **orchestrator** (issue #53): the
+//! roster agent tagged `tier = "orchestrator"`, or the first agent when none is
+//! (so a company without an orchestrator behaves exactly as before). An operator
+//! message addressed to a desk (its `chat` field) is answered by that desk's
+//! lead member; an unaddressed message goes to the orchestrator, which may
+//! delegate — the queue its tools fill is drained here after its turn (v1:
+//! synchronous, in-cycle, capped, no sub-agent re-delegation).
 //!
 //! Compiled only under `feature = "openhuman"`.
 
@@ -19,13 +22,14 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::Result;
+use crate::harness::orchestrator::{self, Delegation};
 use crate::harness::{HarnessDeps, HarnessPool};
 use crate::ports::brain::{Brain, CycleHost};
 use crate::ports::types::{
     CompanyEvent, CompanyRecord, CompressedTrace, CycleRequest, CycleResult, OutboundMessage,
     TokenUsage,
 };
-use crate::ports::{TaskRecord, now_millis};
+use crate::ports::{TaskRecord, generate_id, now_millis};
 
 /// A [`Brain`] that answers with a live openhuman agent turn.
 pub struct HarnessBrain {
@@ -36,16 +40,12 @@ pub struct HarnessBrain {
 }
 
 impl HarnessBrain {
-    /// Builds a harness brain for `record`, answering with the first roster
-    /// agent. The pool is shared so the roster is built once and reused across
-    /// cycles.
+    /// Builds a harness brain for `record`, answering unaddressed operator
+    /// messages with the company orchestrator (the `tier = "orchestrator"` agent,
+    /// else the first roster agent). The pool is shared so the roster is built
+    /// once and reused across cycles.
     pub fn new(pool: Arc<HarnessPool>, deps: HarnessDeps, record: CompanyRecord) -> Self {
-        let responder = record
-            .manifest
-            .agents
-            .first()
-            .map(|a| a.id.clone())
-            .unwrap_or_default();
+        let responder = orchestrator::orchestrator_id(&record.manifest.agents).unwrap_or_default();
         Self {
             pool,
             deps,
@@ -112,6 +112,81 @@ impl HarnessBrain {
             self.responder.clone()
         }
     }
+
+    /// Resolves which agent answers an operator message. A message addressed to a
+    /// desk (its `chat` field naming a group chat with a lead member) is answered
+    /// by that desk's lead; everything else — including the "General" desk and
+    /// unaddressed messages — goes to the orchestrator (the default responder).
+    fn responder_for(&self, chat: Option<&str>) -> String {
+        match chat.and_then(|desk| self.desk_lead(desk)) {
+            Some(member) => member,
+            None => self.responder.clone(),
+        }
+    }
+
+    /// The lead member of a desk: the first member of the matching group chat
+    /// (by id, or by case-insensitive name) that is a real roster agent. `None`
+    /// when no desk matches or none of its members are on the roster.
+    fn desk_lead(&self, desk: &str) -> Option<String> {
+        let chat = self
+            .record
+            .manifest
+            .group_chats
+            .iter()
+            .find(|c| c.id == desk || c.name.eq_ignore_ascii_case(desk))?;
+        chat.members
+            .iter()
+            .find(|m| self.record.manifest.agents.iter().any(|a| &a.id == *m))
+            .cloned()
+    }
+
+    /// Executes one drained delegation from the orchestrator's turn.
+    ///
+    /// `spawn_task` opens a backlog card through the same
+    /// [`TaskStore::upsert`](crate::ports::TaskStore) path the console uses and
+    /// surfaces nothing extra (a missing task store is a silent no-op).
+    /// `delegate_to_desk` runs a single turn on the desk's lead member and
+    /// returns its reply as its own chat bubble — `channel = <member id>`, the
+    /// distinct-bubble path the console already renders. An unknown desk (no
+    /// roster-backed lead) is a silent no-op. No sub-agent re-delegation in v1:
+    /// desk members carry no delegation tools, so their turns queue nothing.
+    async fn run_delegation(&self, delegation: Delegation) -> Result<Option<OutboundMessage>> {
+        match delegation {
+            Delegation::SpawnTask {
+                title,
+                note,
+                assignee,
+            } => {
+                let Some(tasks) = self.deps.tasks.as_ref() else {
+                    return Ok(None);
+                };
+                let card = TaskRecord {
+                    id: generate_id(),
+                    title,
+                    note,
+                    column: "backlog".to_string(),
+                    priority: "medium".to_string(),
+                    assignee: assignee.unwrap_or_default(),
+                    updated_at_millis: now_millis(),
+                };
+                tasks.upsert(&self.record.id, &card).await?;
+                Ok(None)
+            }
+            Delegation::DelegateToDesk { desk, instruction } => {
+                let Some(member) = self.desk_lead(&desk) else {
+                    return Ok(None);
+                };
+                let reply = self
+                    .pool
+                    .run(&self.record.id, &member, &instruction, &self.deps)
+                    .await?;
+                Ok(Some(OutboundMessage {
+                    channel: member,
+                    text: reply,
+                }))
+            }
+        }
+    }
 }
 
 /// The turn instruction for a dispatched card: its title, plus its note when it
@@ -143,18 +218,30 @@ impl Brain for HarnessBrain {
         let mut channel_responses = Vec::new();
         for event in &req.events {
             match event {
-                CompanyEvent::OperatorMessage { text, .. } => {
-                    // `run` executes the turn on the openhuman runtime and meters
-                    // its usage into the ledger/meter through `deps`. The reply is
-                    // the agent's own text.
+                CompanyEvent::OperatorMessage { text, chat, .. } => {
+                    // Route to the addressed desk's lead, else the orchestrator.
+                    let responder = self.responder_for(chat.as_deref());
+                    // Clear stale delegations so nothing leaks from a prior turn,
+                    // run the turn (metered through `deps`), then drain whatever
+                    // the orchestrator queued (capped; discarded past the cap).
+                    self.deps.delegations.clear();
                     let reply = self
                         .pool
-                        .run(&self.record.id, &self.responder, text, &self.deps)
+                        .run(&self.record.id, &responder, text, &self.deps)
                         .await?;
                     channel_responses.push(OutboundMessage {
                         channel: "operator".to_string(),
                         text: reply,
                     });
+                    for delegation in self
+                        .deps
+                        .delegations
+                        .drain(orchestrator::MAX_DELEGATIONS_PER_TURN)
+                    {
+                        if let Some(message) = self.run_delegation(delegation).await? {
+                            channel_responses.push(message);
+                        }
+                    }
                 }
                 CompanyEvent::TaskDispatched { task_id } => {
                     self.run_task(task_id).await?;
@@ -258,6 +345,9 @@ description = "Runs Acme."
             skills: None,
             skills_source_dir: None,
             mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: orchestrator::DelegationQueue::default(),
         };
         HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record())
     }
@@ -283,6 +373,7 @@ description = "Runs Acme."
                 request(vec![CompanyEvent::OperatorMessage {
                     text: "status?".into(),
                     by: None,
+                    chat: None,
                 }]),
                 &NoopHost,
             )
@@ -375,6 +466,9 @@ description = "Builds it."
             skills: None,
             skills_source_dir: None,
             mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: orchestrator::DelegationQueue::default(),
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record_two()),
@@ -504,5 +598,156 @@ description = "Builds it."
                 .unwrap()
                 .is_empty()
         );
+    }
+
+    // --- Orchestrator routing + delegation ----------------------------------
+
+    /// A roster with an `orchestrator`-tier agent (not first) and a desk.
+    fn record_with_desk() -> CompanyRecord {
+        let manifest = toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+description = "Runs Acme."
+
+[[agent]]
+id = "chief"
+role = "Chief of Staff"
+tier = "orchestrator"
+description = "Coordinates the company."
+
+[[agent]]
+id = "engineer"
+role = "Engineer"
+description = "Builds it."
+
+[[group_chat]]
+id = "eng_desk"
+name = "Engineering"
+members = ["engineer"]
+"#,
+        )
+        .expect("valid manifest");
+        CompanyRecord {
+            id: CompanyId::new("acme"),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+        }
+    }
+
+    /// A brain over the desk-bearing record, wired to a real task store.
+    fn brain_with_desk(dir: &std::path::Path) -> (HarnessBrain, Arc<FsOps>) {
+        let tasks = Arc::new(FsOps::new(dir));
+        let deps = HarnessDeps {
+            provider: Arc::new(MockProvider::new("mock: ")),
+            provider_slug: "mock".to_string(),
+            context: Arc::new(FsContextStore::new(dir)),
+            store: Arc::new(FsCompanyStore::new(dir)),
+            meter: Some(Arc::new(FsOps::new(dir))),
+            workspace_root: dir.to_path_buf(),
+            model_override: None,
+            tasks: Some(tasks.clone()),
+            skills: None,
+            skills_source_dir: None,
+            mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: orchestrator::DelegationQueue::default(),
+        };
+        (
+            HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record_with_desk()),
+            tasks,
+        )
+    }
+
+    /// The default responder is the `orchestrator`-tier agent, even when it is
+    /// not first on the roster.
+    #[test]
+    fn default_responder_is_the_orchestrator() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, _tasks) = brain_with_desk(dir.path());
+        assert_eq!(brain.responder, "chief");
+    }
+
+    /// An addressed desk routes to its lead member (by id or name); anything else
+    /// — the "General" desk, an unknown id, or no address — falls to the
+    /// orchestrator.
+    #[test]
+    fn responder_for_routes_desk_to_lead_else_orchestrator() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, _tasks) = brain_with_desk(dir.path());
+        assert_eq!(brain.responder_for(Some("eng_desk")), "engineer");
+        assert_eq!(brain.responder_for(Some("Engineering")), "engineer");
+        assert_eq!(brain.responder_for(Some("General")), "chief");
+        assert_eq!(brain.responder_for(Some("nope")), "chief");
+        assert_eq!(brain.responder_for(None), "chief");
+    }
+
+    /// A `spawn_task` delegation opens a backlog card and surfaces no bubble.
+    #[tokio::test]
+    async fn spawn_task_delegation_opens_a_backlog_card() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks) = brain_with_desk(dir.path());
+        let out = brain
+            .run_delegation(Delegation::SpawnTask {
+                title: "Draft the plan".to_string(),
+                note: Some("by friday".to_string()),
+                assignee: Some("engineer".to_string()),
+            })
+            .await
+            .expect("delegation runs");
+        assert!(out.is_none(), "spawn_task surfaces no chat bubble");
+
+        let cards = tasks.list(&CompanyId::new("acme")).await.unwrap();
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].title, "Draft the plan");
+        assert_eq!(cards[0].column, "backlog");
+        assert_eq!(cards[0].assignee, "engineer");
+    }
+
+    /// A `delegate_to_desk` delegation runs the desk lead and surfaces its reply
+    /// as its own bubble (`channel = <member id>`); an unknown desk is a no-op.
+    #[tokio::test]
+    async fn delegate_to_desk_delegation_answers_as_the_desk_lead() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, _tasks) = brain_with_desk(dir.path());
+        // The pool must have the roster before a member turn can run.
+        brain
+            .pool
+            .ensure(&brain.record, &brain.deps)
+            .await
+            .expect("roster");
+
+        let out = brain
+            .run_delegation(Delegation::DelegateToDesk {
+                desk: "eng_desk".to_string(),
+                instruction: "ship-marker".to_string(),
+            })
+            .await
+            .expect("delegation runs")
+            .expect("desk lead replies");
+        // The reply is its own bubble attributed to the desk lead, and the mock
+        // provider echoes the instruction, proving the member's turn ran.
+        assert_eq!(out.channel, "engineer");
+        assert!(out.text.contains("ship-marker"), "{:?}", out.text);
+
+        // An unknown desk delegates to nobody.
+        let none = brain
+            .run_delegation(Delegation::DelegateToDesk {
+                desk: "ghost".to_string(),
+                instruction: "hello".to_string(),
+            })
+            .await
+            .expect("delegation runs");
+        assert!(none.is_none(), "an unknown desk is a silent no-op");
     }
 }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -209,49 +209,6 @@ fn append_result(prev: Option<&str>, responder: &str, body: &str) -> String {
     }
 }
 
-/// Desk-routes an operator message to the roster member it addresses.
-///
-/// A leading `@mention` matching a roster member's id or role (case- and
-/// separator-insensitive — `@Creative-Director`, `@creative_director`, and the
-/// role "Creative Director" all match) routes to that member, and the mention is
-/// stripped from the message. Anything else — no mention, or a mention that
-/// names no roster member — falls back to `responder` with the message intact.
-///
-/// Returns `(agent_id, message)` ready for [`HarnessPool::run`].
-fn resolve_address(agents: &[ManifestAgent], responder: &str, text: &str) -> (String, String) {
-    if let Some(rest) = text.trim_start().strip_prefix('@') {
-        let (mention, remainder) = match rest.split_once(char::is_whitespace) {
-            Some((m, r)) => (m, r.trim_start()),
-            None => (rest, ""),
-        };
-        let target = normalize_mention(mention);
-        if !target.is_empty()
-            && let Some(agent) = agents.iter().find(|a| {
-                normalize_mention(&a.id) == target || normalize_mention(&a.role) == target
-            })
-        {
-            // Strip the mention; keep the original text if nothing else remains
-            // (a bare "@creative_director" still addresses that agent).
-            let message = if remainder.is_empty() {
-                text.to_string()
-            } else {
-                remainder.to_string()
-            };
-            return (agent.id.clone(), message);
-        }
-    }
-    (responder.to_string(), text.to_string())
-}
-
-/// Normalizes a mention / agent id / role for matching: lowercased, ASCII
-/// alphanumerics only, so separators (`-`, `_`, spaces) are ignored.
-fn normalize_mention(s: &str) -> String {
-    s.chars()
-        .filter(char::is_ascii_alphanumeric)
-        .map(|c| c.to_ascii_lowercase())
-        .collect()
-}
-
 #[async_trait]
 impl Brain for HarnessBrain {
     async fn run_cycle(&self, req: CycleRequest, _host: &dyn CycleHost) -> Result<CycleResult> {
@@ -328,49 +285,6 @@ mod tests {
         CompanyId, ContextOp, ContextOpResult, Effect, EffectDisposition, ToolCall, ToolResult,
     };
     use crate::store::{FsCompanyStore, FsContextStore, FsOps};
-
-    fn agent(id: &str, role: &str) -> ManifestAgent {
-        ManifestAgent {
-            id: id.to_string(),
-            role: role.to_string(),
-            description: None,
-            tier: None,
-            tools: Vec::new(),
-            budget_usd_daily: None,
-        }
-    }
-
-    #[test]
-    fn resolve_address_routes_mentions_and_falls_back() {
-        let roster = [
-            agent("creative_director", "Creative Director"),
-            agent("ceo", "Chief Executive"),
-        ];
-
-        // @id — separator/case-insensitive, mention stripped from the message.
-        let (who, msg) = resolve_address(&roster, "ceo", "@Creative-Director draft the copy");
-        assert_eq!(who, "creative_director");
-        assert_eq!(msg, "draft the copy");
-
-        // @role — "Creative Director" normalizes to "creativedirector".
-        let (who, _) = resolve_address(&roster, "ceo", "@creativedirector hi");
-        assert_eq!(who, "creative_director");
-
-        // No mention → default responder, message untouched.
-        let (who, msg) = resolve_address(&roster, "ceo", "just do it");
-        assert_eq!(who, "ceo");
-        assert_eq!(msg, "just do it");
-
-        // Unknown mention → default responder, message left intact (not stripped).
-        let (who, msg) = resolve_address(&roster, "ceo", "@nobody hello");
-        assert_eq!(who, "ceo");
-        assert_eq!(msg, "@nobody hello");
-
-        // Bare mention with no remainder → routes, keeps the original text.
-        let (who, msg) = resolve_address(&roster, "ceo", "@creative_director");
-        assert_eq!(who, "creative_director");
-        assert_eq!(msg, "@creative_director");
-    }
 
     /// A `CycleHost` that auto-executes anything the brain asks for; the harness
     /// brain v1 makes no host calls, so it stays inert.

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -33,6 +33,7 @@ use crate::error::OpenCompanyError;
 use crate::harness::HarnessDeps;
 use crate::harness::mcp::{OcMcpListServersTool, registry_for_agent};
 use crate::harness::memory::OcMemory;
+use crate::harness::orchestrator::{self, QueryCompanyTool};
 use crate::harness::policy::ApprovalPolicy;
 use crate::harness::skills::EffectiveSkills;
 use crate::ports::skills_state::SkillState;
@@ -45,6 +46,9 @@ use crate::ports::types::CompanyId;
 /// resolves. Unknown / absent tiers fall back to the conversational `chat-v1`.
 pub fn model_for_tier(tier: Option<&str>) -> String {
     match tier.map(|t| t.trim().to_ascii_lowercase()).as_deref() {
+        // The orchestrator answers from whole-company context and drives tool
+        // use (query/delegate), so it maps to the capable agentic workload.
+        Some("orchestrator") => "agentic-v1",
         Some("reasoning") => "reasoning-v1",
         Some("agentic") => "agentic-v1",
         Some("vision") => "vision-v1",
@@ -81,6 +85,10 @@ pub fn persona_prompt(company_name: &str, agent: &ManifestAgent) -> String {
 /// is wired to a skills source (a [`SkillStateStore`](crate::ports::SkillStateStore)
 /// and/or a source directory), the agent's effective skill set is materialized
 /// and surfaced as three read tools plus a persona-prompt catalogue.
+///
+/// `is_orchestrator` marks the company's orchestrator agent (issue #53): it
+/// additionally receives the delegating-orchestrator persona brief and the
+/// `query_company` / `spawn_task` / `delegate_to_desk` tools.
 pub fn build_agent(
     company: &CompanyId,
     company_name: &str,
@@ -88,6 +96,7 @@ pub fn build_agent(
     policy: ApprovalPolicy,
     deps: &HarnessDeps,
     skill_deltas: &[SkillState],
+    is_orchestrator: bool,
 ) -> crate::Result<Agent> {
     let memory: Arc<dyn Memory> = Arc::new(OcMemory::new(
         company.clone(),
@@ -148,6 +157,21 @@ pub fn build_agent(
         tools.push(Box::new(OcMcpListServersTool::new(registry.clone())));
         tools.push(Box::new(McpListToolsTool::new(registry.clone())));
         tools.push(Box::new(McpCallTool::new(registry, mcp_security)));
+    }
+
+    // Orchestrator seam (issue #53): the company's orchestrator agent additionally
+    // gets the delegating-orchestrator persona + tools. `query_company` reads the
+    // company's facts + recent events; `spawn_task` / `delegate_to_desk` push onto
+    // the shared delegation queue the brain drains after the turn. Additive beside
+    // the MCP block above.
+    if is_orchestrator {
+        persona.push_str(&orchestrator::orchestrator_brief());
+        tools.push(Box::new(QueryCompanyTool::new(
+            company.clone(),
+            deps.facts.clone(),
+            deps.events.clone(),
+        )));
+        tools.extend(orchestrator::delegation_tools(&deps.delegations));
     }
 
     let prompt_builder = SystemPromptBuilder::for_subagent(

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -41,6 +41,7 @@ pub mod cost;
 pub mod mcp;
 pub mod memory;
 pub mod memory_loop;
+pub mod orchestrator;
 pub mod policy;
 pub mod provider;
 pub mod skills;
@@ -61,10 +62,11 @@ use crate::company::Policy;
 use crate::company::mcp::McpServerDecl;
 use crate::error::OpenCompanyError;
 use crate::harness::cost::{TurnUsage, record_turn_cost};
+use crate::harness::orchestrator::DelegationQueue;
 use crate::harness::policy::ApprovalPolicy;
 use crate::ports::skills_state::{SkillState, SkillStateStore};
 use crate::ports::types::{CompanyId, CompanyRecord};
-use crate::ports::{CompanyStore, ContextStore, TaskStore, UsageMeter};
+use crate::ports::{CompanyStore, ContextStore, EventLog, FactStore, TaskStore, UsageMeter};
 
 /// Shared dependencies every harness-built agent draws on.
 #[derive(Clone)]
@@ -114,6 +116,21 @@ pub struct HarnessDeps {
     /// builder resolves these ahead of time; each agent then filters the set by
     /// its `mcp:*` tool grants. Empty leaves the agent with no MCP bridge tools.
     pub mcp_servers: Vec<McpServerDecl>,
+    /// The company's durable [`FactStore`], surfaced to the orchestrator agent
+    /// through the `query_company` read tool (issue #53). `None` leaves the
+    /// orchestrator without the facts half of its insight surface (the chat path
+    /// off the orchestrator seam wires nothing).
+    pub facts: Option<Arc<dyn FactStore>>,
+    /// The company's [`EventLog`], surfaced to the orchestrator agent through
+    /// the `query_company` read tool for recent-activity context (issue #53).
+    /// `None` leaves the orchestrator without the recent-events half.
+    pub events: Option<Arc<dyn EventLog>>,
+    /// The shared delegation queue the orchestrator's `spawn_task` /
+    /// `delegate_to_desk` tools push onto and the [`HarnessBrain`] drains after
+    /// an orchestrator turn (issue #53). A [`DelegationQueue`] is a cheap shared
+    /// handle; cloning `HarnessDeps` shares one queue between the tools built
+    /// into the agent and the brain that drains it. Default is an empty queue.
+    pub delegations: DelegationQueue,
 }
 
 /// One live openhuman agent, keyed by its manifest id.
@@ -277,12 +294,16 @@ pub(crate) fn build_roster(
 ) -> crate::Result<Vec<Arc<CompanyAgent>>> {
     let policy: &Policy = &company.manifest.policy;
     let company_name = &company.manifest.company.name;
+    // The orchestrator agent (tier `orchestrator`, else the first agent) receives
+    // the delegating-orchestrator persona + tools (issue #53).
+    let orchestrator = orchestrator::orchestrator_id(&company.manifest.agents);
     company
         .manifest
         .agents
         .iter()
         .map(|manifest_agent| {
             let agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily);
+            let is_orchestrator = orchestrator.as_deref() == Some(manifest_agent.id.as_str());
             let agent = build::build_agent(
                 &company.id,
                 company_name,
@@ -290,6 +311,7 @@ pub(crate) fn build_roster(
                 agent_policy,
                 deps,
                 skill_deltas,
+                is_orchestrator,
             )?;
             Ok(Arc::new(CompanyAgent {
                 agent_id: manifest_agent.id.clone(),
@@ -474,6 +496,9 @@ description = "Builds the product."
                 skills: None,
                 skills_source_dir: None,
                 mcp_servers: Vec::new(),
+                facts: None,
+                events: None,
+                delegations: DelegationQueue::default(),
             },
             store,
             meter,
@@ -518,6 +543,9 @@ description = "Builds the product."
             skills: None,
             skills_source_dir: Some(source.path().to_path_buf()),
             mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: DelegationQueue::default(),
         };
 
         let roster = build_roster(&record(), &deps, &[]).expect("roster builds with skills");

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -1,0 +1,575 @@
+//! The company **orchestrator**: the operator↔company chat as a first-class
+//! delegating agent.
+//!
+//! Where the harness brain's default chat responder is just the first roster
+//! agent, the orchestrator is the one place the operator asks anything and it
+//! answers from whole-company context — grounding replies in the company's
+//! durable facts and recent activity, and delegating work it should not do
+//! itself. It is the roster agent whose manifest `tier = "orchestrator"`, or the
+//! first agent when none is tagged (so a company without an orchestrator behaves
+//! exactly as before).
+//!
+//! It reaches three tools, all wired only onto the orchestrator agent:
+//!
+//! * [`QueryCompanyTool`] — a read surface over the company's [`FactStore`] and
+//!   recent [`EventLog`] history.
+//! * [`SpawnTaskTool`] / [`DelegateToDeskTool`] — delegation tools that push a
+//!   [`Delegation`] onto a shared [`DelegationQueue`]. They perform no work
+//!   themselves; the [`HarnessBrain`](crate::harness::HarnessBrain) drains the
+//!   queue after the orchestrator's turn (v1: synchronous, in-cycle, capped at
+//!   [`MAX_DELEGATIONS_PER_TURN`], no sub-agent re-delegation).
+//!
+//! Compiled only under `feature = "openhuman"` (the whole `harness` module is).
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use openhuman_core::openhuman as oh;
+
+use oh::tools::traits::{PermissionLevel, Tool, ToolResult};
+
+use crate::company::Agent as ManifestAgent;
+use crate::ports::events::EventLog;
+use crate::ports::facts::FactStore;
+use crate::ports::types::{CompanyEvent, CompanyId, EventSeq};
+
+/// The manifest cognition-tier that marks the orchestrator agent.
+pub const ORCHESTRATOR_TIER: &str = "orchestrator";
+
+/// Max delegations drained from a single orchestrator turn (v1 cap). Anything an
+/// over-eager turn queues beyond this is discarded — delegation is bounded so a
+/// runaway turn can't fan out unboundedly.
+pub const MAX_DELEGATIONS_PER_TURN: usize = 3;
+
+/// How many recent events [`QueryCompanyTool`] surfaces.
+const RECENT_EVENTS: usize = 10;
+/// How many facts [`QueryCompanyTool`] surfaces.
+const FACT_LIMIT: usize = 20;
+
+/// The `query_company` tool name.
+pub const QUERY_COMPANY_TOOL: &str = "query_company";
+/// The `spawn_task` tool name.
+pub const SPAWN_TASK_TOOL: &str = "spawn_task";
+/// The `delegate_to_desk` tool name.
+pub const DELEGATE_TO_DESK_TOOL: &str = "delegate_to_desk";
+
+/// The id of the orchestrator agent for a roster: the first agent tagged
+/// `tier = "orchestrator"`, else the first roster agent, else `None` (empty
+/// roster). The fallback is what keeps a company with no tagged orchestrator
+/// answering exactly as it did before this cell.
+pub fn orchestrator_id(agents: &[ManifestAgent]) -> Option<String> {
+    agents
+        .iter()
+        .find(|a| a.tier.as_deref() == Some(ORCHESTRATOR_TIER))
+        .or_else(|| agents.first())
+        .map(|a| a.id.clone())
+}
+
+/// Whether `tool` is one of the orchestrator's in-cycle delegation tools.
+///
+/// These enqueue internal work drained by the harness brain (a task card, or a
+/// hand-off to a desk's lead member) rather than reaching an external
+/// counterparty, so the [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy)
+/// classifies them as internal — never an external effect to park or deny.
+pub fn is_delegation_tool(tool: &str) -> bool {
+    tool == SPAWN_TASK_TOOL || tool == DELEGATE_TO_DESK_TOOL
+}
+
+/// The orchestrator persona brief, appended to the orchestrator agent's persona.
+pub fn orchestrator_brief() -> String {
+    " You are also this company's orchestrator: the single point of contact for the operator. \
+Answer from whole-company context, and when a request belongs to a specialist desk or should be \
+tracked as work, delegate instead of guessing. Use `query_company` to ground answers in the \
+company's durable facts and recent activity, `delegate_to_desk` to hand a turn to a desk's lead \
+member, and `spawn_task` to open a tracked task card. Delegate only when it genuinely helps — \
+otherwise answer directly and concisely."
+        .to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Delegation queue
+// ---------------------------------------------------------------------------
+
+/// One unit of work the orchestrator hands off during a turn, drained by the
+/// harness brain after the turn completes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Delegation {
+    /// Open a tracked task card on the company's board.
+    SpawnTask {
+        /// The task title.
+        title: String,
+        /// An optional longer note / brief.
+        note: Option<String>,
+        /// An optional assignee (a roster/desk id); empty when unassigned.
+        assignee: Option<String>,
+    },
+    /// Hand a turn to a desk's lead member.
+    DelegateToDesk {
+        /// The desk id or name to delegate to.
+        desk: String,
+        /// The instruction handed to the desk's lead member.
+        instruction: String,
+    },
+}
+
+/// A shared, in-memory queue the delegation tools push onto and the harness
+/// brain drains. Cheap to [`Clone`] (a shared handle); the same underlying
+/// queue is seen by the tools captured into the orchestrator agent and by the
+/// brain that drains it, because [`HarnessDeps`](crate::harness::HarnessDeps)
+/// clones share this handle.
+#[derive(Clone, Default)]
+pub struct DelegationQueue {
+    inner: Arc<Mutex<Vec<Delegation>>>,
+}
+
+impl DelegationQueue {
+    /// Enqueues a delegation.
+    pub fn push(&self, delegation: Delegation) {
+        self.inner
+            .lock()
+            .expect("delegation queue")
+            .push(delegation);
+    }
+
+    /// Empties the queue (called before an orchestrator turn so stale
+    /// delegations from a prior turn never leak into this one).
+    pub fn clear(&self) {
+        self.inner.lock().expect("delegation queue").clear();
+    }
+
+    /// Drains up to `cap` queued delegations (FIFO) and discards the rest, so a
+    /// single turn can never fan out past the cap.
+    pub fn drain(&self, cap: usize) -> Vec<Delegation> {
+        let mut guard = self.inner.lock().expect("delegation queue");
+        let take = guard.len().min(cap);
+        let drained: Vec<Delegation> = guard.drain(..take).collect();
+        guard.clear();
+        drained
+    }
+
+    /// The number of queued delegations (test/observability).
+    #[cfg(test)]
+    pub fn queued(&self) -> usize {
+        self.inner.lock().expect("delegation queue").len()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tools
+// ---------------------------------------------------------------------------
+
+/// A read surface over the company's durable facts and recent event history, so
+/// the orchestrator can ground its answers in whole-company context.
+pub struct QueryCompanyTool {
+    company: CompanyId,
+    facts: Option<Arc<dyn FactStore>>,
+    events: Option<Arc<dyn EventLog>>,
+}
+
+impl QueryCompanyTool {
+    /// Builds the tool over the company's read ports. Either handle may be
+    /// `None`; the tool reports whatever surface is wired.
+    pub fn new(
+        company: CompanyId,
+        facts: Option<Arc<dyn FactStore>>,
+        events: Option<Arc<dyn EventLog>>,
+    ) -> Self {
+        Self {
+            company,
+            facts,
+            events,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for QueryCompanyTool {
+    fn name(&self) -> &str {
+        QUERY_COMPANY_TOOL
+    }
+
+    fn description(&self) -> &str {
+        "Read the company's durable facts and recent activity to ground an answer in whole-company context. Optionally pass a `query` to filter facts by a case-insensitive substring."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Optional case-insensitive substring to filter facts by."
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::ReadOnly
+    }
+
+    fn supports_markdown(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let query = args.get("query").and_then(Value::as_str).map(str::trim);
+        let query = query.filter(|q| !q.is_empty());
+
+        let facts = match &self.facts {
+            Some(store) => store
+                .list(&self.company, query, None)
+                .await
+                .unwrap_or_default(),
+            None => Vec::new(),
+        };
+
+        // Recent events: read the log and keep the tail. Mirrors the GraphQL
+        // history resolver's read-then-tail pattern (`read_from(0, MAX)`).
+        let mut recent: Vec<String> = match &self.events {
+            Some(log) => log
+                .read_from(&self.company, EventSeq::new(0), usize::MAX)
+                .await
+                .unwrap_or_default()
+                .iter()
+                .rev()
+                .take(RECENT_EVENTS)
+                .map(|stored| format!("- #{} {}", stored.seq, summarize_event(&stored.event)))
+                .collect(),
+            None => Vec::new(),
+        };
+        recent.reverse(); // back to chronological order
+
+        let mut md = String::from("# Company insight\n");
+        md.push_str("\n## Facts\n");
+        if facts.is_empty() {
+            md.push_str("_No durable facts recorded._\n");
+        } else {
+            for fact in facts.iter().take(FACT_LIMIT) {
+                md.push_str(&format!(
+                    "- **{}**: {}\n",
+                    fact.title.trim(),
+                    fact.body.trim()
+                ));
+            }
+        }
+        md.push_str("\n## Recent activity\n");
+        if recent.is_empty() {
+            md.push_str("_No recent activity._\n");
+        } else {
+            md.push_str(&recent.join("\n"));
+            md.push('\n');
+        }
+
+        Ok(ToolResult::success_with_markdown(
+            json!({
+                "facts": facts.len(),
+                "recent_events": recent.len(),
+            }),
+            md,
+        ))
+    }
+}
+
+/// A short, non-sensitive one-line summary of an event for the insight surface.
+fn summarize_event(event: &CompanyEvent) -> String {
+    match event {
+        CompanyEvent::OperatorMessage { .. } => "operator message".to_string(),
+        CompanyEvent::AgentReply { agent_id, .. } => format!("reply from {agent_id}"),
+        CompanyEvent::TaskDispatched { task_id } => format!("task dispatched: {task_id}"),
+        CompanyEvent::ScheduleFired { cron, .. } => format!("schedule fired: {cron}"),
+        CompanyEvent::WebhookReceived { channel, .. } => format!("webhook on {channel}"),
+        CompanyEvent::A2aTaskReceived { from, .. } => format!("A2A task from {from}"),
+        CompanyEvent::ApprovalResolved { verdict, .. } => format!("approval {verdict:?}"),
+        CompanyEvent::FeedbackFiled { .. } => "feedback filed".to_string(),
+        CompanyEvent::PaymentReceived { amount_usd, .. } => format!("payment ${amount_usd:.2}"),
+        CompanyEvent::LifecycleChanged { from, to, .. } => format!("lifecycle {from} → {to}"),
+        CompanyEvent::MemoryFactDeleted { .. } => "memory fact deleted".to_string(),
+    }
+}
+
+/// A delegation tool that opens a tracked task card. Enqueues a
+/// [`Delegation::SpawnTask`]; the harness brain writes the card on drain.
+pub struct SpawnTaskTool {
+    queue: DelegationQueue,
+}
+
+impl SpawnTaskTool {
+    /// Builds the tool over the shared delegation queue.
+    pub fn new(queue: DelegationQueue) -> Self {
+        Self { queue }
+    }
+}
+
+#[async_trait]
+impl Tool for SpawnTaskTool {
+    fn name(&self) -> &str {
+        SPAWN_TASK_TOOL
+    }
+
+    fn description(&self) -> &str {
+        "Open a tracked task card on the company's board for work that should be followed up. Provide a `title`, an optional `note` brief, and an optional `assignee` (a desk or teammate id)."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "title": { "type": "string", "description": "The task title." },
+                "note": { "type": "string", "description": "An optional longer brief." },
+                "assignee": { "type": "string", "description": "An optional desk/teammate id to own it." }
+            },
+            "required": ["title"],
+            "additionalProperties": false
+        })
+    }
+
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Write
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let title = args
+            .get("title")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("`title` is required"))?
+            .to_string();
+        let note = args
+            .get("note")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|n| !n.is_empty())
+            .map(str::to_string);
+        let assignee = args
+            .get("assignee")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|a| !a.is_empty())
+            .map(str::to_string);
+
+        self.queue.push(Delegation::SpawnTask {
+            title: title.clone(),
+            note,
+            assignee,
+        });
+        Ok(ToolResult::success(format!(
+            "Queued a task card: \"{title}\". It will be opened on the board this turn."
+        )))
+    }
+}
+
+/// A delegation tool that hands a turn to a desk's lead member. Enqueues a
+/// [`Delegation::DelegateToDesk`]; the harness brain runs the desk turn on
+/// drain and surfaces its reply as its own chat bubble.
+pub struct DelegateToDeskTool {
+    queue: DelegationQueue,
+}
+
+impl DelegateToDeskTool {
+    /// Builds the tool over the shared delegation queue.
+    pub fn new(queue: DelegationQueue) -> Self {
+        Self { queue }
+    }
+}
+
+#[async_trait]
+impl Tool for DelegateToDeskTool {
+    fn name(&self) -> &str {
+        DELEGATE_TO_DESK_TOOL
+    }
+
+    fn description(&self) -> &str {
+        "Hand a turn to a desk's lead member so a specialist answers. Provide the `desk` (its id or name) and the `instruction` to carry out."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "desk": { "type": "string", "description": "The desk id or name to delegate to." },
+                "instruction": { "type": "string", "description": "The instruction for the desk's lead member." }
+            },
+            "required": ["desk", "instruction"],
+            "additionalProperties": false
+        })
+    }
+
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Write
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let desk = args
+            .get("desk")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|d| !d.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("`desk` is required"))?
+            .to_string();
+        let instruction = args
+            .get("instruction")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|i| !i.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("`instruction` is required"))?
+            .to_string();
+
+        self.queue.push(Delegation::DelegateToDesk {
+            desk: desk.clone(),
+            instruction,
+        });
+        Ok(ToolResult::success(format!(
+            "Delegated to the {desk} desk. Its lead will answer this turn."
+        )))
+    }
+}
+
+/// The orchestrator's delegation tools over a shared queue: `spawn_task` and
+/// `delegate_to_desk`. `query_company` is built separately because it needs the
+/// read ports, not the queue.
+pub fn delegation_tools(queue: &DelegationQueue) -> Vec<Box<dyn Tool>> {
+    vec![
+        Box::new(SpawnTaskTool::new(queue.clone())),
+        Box::new(DelegateToDeskTool::new(queue.clone())),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agent(id: &str, tier: Option<&str>) -> ManifestAgent {
+        ManifestAgent {
+            id: id.to_string(),
+            role: "Role".to_string(),
+            description: None,
+            tier: tier.map(str::to_string),
+            tools: Vec::new(),
+            budget_usd_daily: None,
+        }
+    }
+
+    #[test]
+    fn orchestrator_id_prefers_the_tagged_agent() {
+        let roster = vec![
+            agent("ceo", None),
+            agent("chief", Some("orchestrator")),
+            agent("eng", Some("reasoning")),
+        ];
+        assert_eq!(orchestrator_id(&roster).as_deref(), Some("chief"));
+    }
+
+    #[test]
+    fn orchestrator_id_falls_back_to_first_agent() {
+        let roster = vec![agent("ceo", None), agent("eng", None)];
+        assert_eq!(orchestrator_id(&roster).as_deref(), Some("ceo"));
+    }
+
+    #[test]
+    fn orchestrator_id_is_none_for_an_empty_roster() {
+        assert_eq!(orchestrator_id(&[]), None);
+    }
+
+    #[test]
+    fn delegation_tool_names_are_classified_internal() {
+        assert!(is_delegation_tool(SPAWN_TASK_TOOL));
+        assert!(is_delegation_tool(DELEGATE_TO_DESK_TOOL));
+        // The read tool is NOT a delegation tool.
+        assert!(!is_delegation_tool(QUERY_COMPANY_TOOL));
+        assert!(!is_delegation_tool("send_email"));
+    }
+
+    #[test]
+    fn queue_drains_fifo_up_to_cap_and_discards_the_rest() {
+        let queue = DelegationQueue::default();
+        for i in 0..5 {
+            queue.push(Delegation::SpawnTask {
+                title: format!("t{i}"),
+                note: None,
+                assignee: None,
+            });
+        }
+        assert_eq!(queue.queued(), 5);
+        let drained = queue.drain(MAX_DELEGATIONS_PER_TURN);
+        assert_eq!(drained.len(), 3);
+        // The first three (FIFO) survive; the queue is emptied.
+        assert_eq!(
+            drained[0],
+            Delegation::SpawnTask {
+                title: "t0".to_string(),
+                note: None,
+                assignee: None,
+            }
+        );
+        assert_eq!(queue.queued(), 0);
+    }
+
+    #[test]
+    fn clear_empties_the_queue() {
+        let queue = DelegationQueue::default();
+        queue.push(Delegation::DelegateToDesk {
+            desk: "strategy".to_string(),
+            instruction: "plan".to_string(),
+        });
+        queue.clear();
+        assert_eq!(queue.queued(), 0);
+    }
+
+    #[tokio::test]
+    async fn spawn_task_tool_enqueues_a_task() {
+        let queue = DelegationQueue::default();
+        let tool = SpawnTaskTool::new(queue.clone());
+        tool.execute(json!({ "title": "Ship it", "note": "soon", "assignee": "eng" }))
+            .await
+            .expect("execute");
+        let drained = queue.drain(MAX_DELEGATIONS_PER_TURN);
+        assert_eq!(
+            drained,
+            vec![Delegation::SpawnTask {
+                title: "Ship it".to_string(),
+                note: Some("soon".to_string()),
+                assignee: Some("eng".to_string()),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_task_tool_requires_a_title() {
+        let queue = DelegationQueue::default();
+        let tool = SpawnTaskTool::new(queue.clone());
+        assert!(tool.execute(json!({ "note": "no title" })).await.is_err());
+        assert_eq!(queue.queued(), 0);
+    }
+
+    #[tokio::test]
+    async fn delegate_to_desk_tool_enqueues_a_hand_off() {
+        let queue = DelegationQueue::default();
+        let tool = DelegateToDeskTool::new(queue.clone());
+        tool.execute(json!({ "desk": "strategy", "instruction": "draft a plan" }))
+            .await
+            .expect("execute");
+        let drained = queue.drain(MAX_DELEGATIONS_PER_TURN);
+        assert_eq!(
+            drained,
+            vec![Delegation::DelegateToDesk {
+                desk: "strategy".to_string(),
+                instruction: "draft a plan".to_string(),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn query_company_tool_reports_no_data_when_unwired() {
+        let tool = QueryCompanyTool::new(CompanyId::new("acme"), None, None);
+        let result = tool.execute(json!({})).await.expect("execute");
+        // The insight surface lives in the markdown; `output()` is the summary.
+        let out = result.output_for_llm(true);
+        assert!(out.contains("No durable facts recorded"), "{out}");
+        assert!(out.contains("No recent activity"), "{out}");
+    }
+}

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -180,6 +180,14 @@ impl ToolPolicy for ApprovalPolicy {
 /// the bridge only the tool name and arguments, not the tool's own
 /// external-effect flag. Unknown tools are treated as external (fail-safe).
 fn is_external_effect(tool_name: &str) -> bool {
+    // The orchestrator's in-cycle delegation tools (`spawn_task`,
+    // `delegate_to_desk`) enqueue internal work the harness brain drains this
+    // turn — a task card or a hand-off to a desk's lead — never an external
+    // effect. Without this, the default `supervised` policy would park them and
+    // `readonly` would deny them, breaking in-cycle delegation. (Issue #53.)
+    if crate::harness::orchestrator::is_delegation_tool(tool_name) {
+        return false;
+    }
     const READ_ONLY_PREFIXES: &[&str] = &[
         "read",
         "list",

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -228,6 +228,15 @@ pub enum CompanyEvent {
         /// export/import and the cross-backend round-trip need no migration.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         by: Option<Actor>,
+        /// The desk / chat thread the message targets (issue #53), so the
+        /// orchestrator brain can route an addressed message to that desk's lead
+        /// member and journal replies against it. `None` on an unaddressed
+        /// message (routed to the orchestrator) and on every event journaled
+        /// before this field existed. Like `by`, `skip_serializing_if` keeps a
+        /// pre-existing event byte-identical, so no stored record needs
+        /// migrating.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        chat: Option<String>,
     },
     /// An inbound webhook fired.
     WebhookReceived {
@@ -872,6 +881,7 @@ mod test {
             CompanyEvent::OperatorMessage {
                 text: "hi".into(),
                 by: None,
+                chat: None,
             }
         );
     }
@@ -884,6 +894,7 @@ mod test {
         let event = CompanyEvent::OperatorMessage {
             text: "hi".into(),
             by: None,
+            chat: None,
         };
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
@@ -899,6 +910,7 @@ mod test {
                 kind: ActorKind::User,
                 id: "u1".into(),
             }),
+            chat: None,
         };
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["by"]["kind"], "user");
@@ -923,6 +935,7 @@ mod test {
             CompanyEvent::OperatorMessage {
                 text: "hi".into(),
                 by: None,
+                chat: None,
             },
             CompanyEvent::WebhookReceived {
                 channel: "email".into(),

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -718,6 +718,14 @@ impl RuntimeBuilder {
                                 skills: Some(ops.skills.clone()),
                                 skills_source_dir: self.seed_dir.clone(),
                                 mcp_servers,
+                                // Orchestrator read surface + delegation queue
+                                // (#53): the company's facts + event log ground
+                                // `query_company`; a fresh queue per company backs
+                                // the delegation tools the brain drains.
+                                facts: Some(ops.facts.clone()),
+                                events: Some(events.clone()),
+                                delegations: crate::harness::orchestrator::DelegationQueue::default(
+                                ),
                             };
                             let record = CompanyRecord {
                                 id: id.clone(),

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -449,6 +449,7 @@ mod test {
             .run_cycle(vec![CompanyEvent::OperatorMessage {
                 text: "hi".into(),
                 by: None,
+                chat: None,
             }])
             .await
             .unwrap();
@@ -469,7 +470,8 @@ mod test {
             stored[0].event,
             CompanyEvent::OperatorMessage {
                 text: "hi".into(),
-                by: None
+                by: None,
+                chat: None
             }
         );
 
@@ -537,6 +539,7 @@ mod test {
             .run_cycle(vec![CompanyEvent::OperatorMessage {
                 text: "file it".into(),
                 by: None,
+                chat: None,
             }])
             .await
             .unwrap();
@@ -579,6 +582,7 @@ mod test {
                 .run_cycle(vec![CompanyEvent::OperatorMessage {
                     text: "file it".into(),
                     by: None,
+                    chat: None,
                 }])
                 .await
                 .unwrap();
@@ -631,6 +635,7 @@ mod test {
             .run_cycle(vec![CompanyEvent::OperatorMessage {
                 text: "file it".into(),
                 by: None,
+                chat: None,
             }])
             .await
             .unwrap();
@@ -695,6 +700,7 @@ mod test {
             .run_cycle(vec![CompanyEvent::OperatorMessage {
                 text: "file it".into(),
                 by: None,
+                chat: None,
             }])
             .await
             .unwrap();
@@ -784,11 +790,13 @@ mod test {
         let (ra, rb) = tokio::join!(
             one.run_cycle(vec![CompanyEvent::OperatorMessage {
                 text: "a".into(),
-                by: None
+                by: None,
+                chat: None
             }]),
             two.run_cycle(vec![CompanyEvent::OperatorMessage {
                 text: "b".into(),
-                by: None
+                by: None,
+                chat: None
             }]),
         );
         assert_eq!(ra.unwrap().responses.len(), 1);

--- a/src/server/graphql/company.rs
+++ b/src/server/graphql/company.rs
@@ -466,7 +466,7 @@ impl MessageGql {
                 at_millis,
                 mine: false,
             },
-            CompanyEvent::OperatorMessage { text, by } => {
+            CompanyEvent::OperatorMessage { text, by, .. } => {
                 let (author, mine) = match &by {
                     // Sent by a signed-in human.
                     Some(actor) if actor.kind == ActorKind::User => {

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -29,6 +29,7 @@ use crate::ports::types::{
 };
 use crate::runtime::types::{ApprovalSummary, CompanyStatus, CycleReport};
 use crate::server::error::ApiError;
+use crate::server::ops::{ScopedCompany, scoped};
 use crate::server::platform_auth::{CompanyAuth, authorize_address, refuse_until_password_changed};
 use crate::server::provision::{emit_cycle_webhooks, emit_feedback_webhook};
 
@@ -50,6 +51,53 @@ pub fn router() -> Router<AppState> {
             "/api/v1/company/approvals/{aid}",
             post(resolve_approval_single),
         )
+        // The company's desks (group chats), under both scope forms — the
+        // console builds its chat threads from these (issue #53).
+        .merge(scoped("/desks", get(list_desks)))
+}
+
+/// One desk (group chat) as the console renders it. Mirrors `DeskDto` in
+/// `frontend/src/api/types.ts`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DeskDto {
+    /// The desk id (the group-chat id; used as the chat thread id).
+    id: String,
+    /// The desk's display name.
+    name: String,
+    /// An optional description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    /// The teammate ids on this desk; the first is its lead.
+    members: Vec<String>,
+}
+
+/// `GET {scope}/desks` — the company's desks, built from its manifest group
+/// chats. Empty when the company defines none (the console then falls back to
+/// its static default threads).
+async fn list_desks(scope: ScopedCompany) -> Result<Json<Vec<DeskDto>>, Response> {
+    let record = scope
+        .runtime
+        .store()
+        .load(scope.id())
+        .await
+        .map_err(|e| ApiError(e).into_response())?;
+    let desks = record
+        .map(|record| {
+            record
+                .manifest
+                .group_chats
+                .iter()
+                .map(|chat| DeskDto {
+                    id: chat.id.clone(),
+                    name: chat.name.clone(),
+                    description: chat.description.clone(),
+                    members: chat.members.clone(),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(Json(desks))
 }
 
 fn lookup(state: &AppState, id: &str) -> Result<Arc<CompanyRuntime>, ApiError> {
@@ -158,6 +206,9 @@ async fn run_chat(
         .run_cycle(vec![CompanyEvent::OperatorMessage {
             text: message.text,
             by,
+            // Thread the addressed desk through so the orchestrator brain can
+            // route to that desk's lead member (issue #53).
+            chat: message.chat,
         }])
         .await?;
     Ok((report, feedback_note))
@@ -510,6 +561,9 @@ mod test {
             skills: None,
             skills_source_dir: None,
             mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: crate::harness::orchestrator::DelegationQueue::default(),
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record);
 
@@ -552,6 +606,31 @@ mod test {
         );
         assert_ne!(text, "You said: hi", "still routing through the echo brain");
         assert_eq!(value["responses"][0]["channel"], "operator");
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    #[tokio::test]
+    async fn desks_route_returns_the_company_desks() {
+        // The default test manifest defines no group chats, so the route answers
+        // 200 with an empty list (the console then falls back to its defaults).
+        let home = home();
+        let state = state_with_company(&home, "running").await;
+        let app = router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/company/desks")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value.as_array().unwrap().len(), 0);
         tokio::fs::remove_dir_all(&home).await.ok();
     }
 

--- a/src/server/ops/mcp.rs
+++ b/src/server/ops/mcp.rs
@@ -385,17 +385,28 @@ async fn discover_tools(
             })),
         )
             .into_response(),
-        Some(_) => match crate::harness::mcp::discover_tools(&decls, &name).await {
-            Ok(tools) => Json(tools).into_response(),
-            Err(err) => (
-                StatusCode::BAD_GATEWAY,
-                Json(serde_json::json!({
-                    "error": format!("MCP discovery failed: {err}"),
-                    "code": "discovery_failed",
-                })),
-            )
-                .into_response(),
-        },
+        Some(_) => {
+            #[cfg(feature = "mcp")]
+            {
+                match crate::harness::mcp::discover_tools(&decls, &name).await {
+                    Ok(tools) => return Json(tools).into_response(),
+                    Err(err) => {
+                        return (
+                            StatusCode::BAD_GATEWAY,
+                            Json(serde_json::json!({
+                                "error": format!("MCP discovery failed: {err}"),
+                                "code": "discovery_failed",
+                            })),
+                        )
+                            .into_response();
+                    }
+                }
+            }
+            #[cfg(not(feature = "mcp"))]
+            {
+                return crate::server::ops::not_wired("mcp tool discovery");
+            }
+        }
     }
 }
 

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -92,6 +92,7 @@ pub async fn assert_isolation_by_company(
             CompanyEvent::OperatorMessage {
                 text: "a".into(),
                 by: None,
+                chat: None,
             },
         )
         .await
@@ -185,6 +186,7 @@ pub async fn assert_append_only_event_and_ledger(
             CompanyEvent::OperatorMessage {
                 text: "e0".into(),
                 by: None,
+                chat: None,
             },
         )
         .await
@@ -195,6 +197,7 @@ pub async fn assert_append_only_event_and_ledger(
             CompanyEvent::OperatorMessage {
                 text: "e1".into(),
                 by: None,
+                chat: None,
             },
         )
         .await
@@ -211,6 +214,7 @@ pub async fn assert_append_only_event_and_ledger(
             CompanyEvent::OperatorMessage {
                 text: "e2".into(),
                 by: None,
+                chat: None,
             },
         )
         .await
@@ -243,6 +247,7 @@ pub async fn assert_monotonic_event_seq(events: Arc<dyn EventLog>) {
                 CompanyEvent::OperatorMessage {
                     text: format!("a{expected}"),
                     by: None,
+                    chat: None,
                 },
             )
             .await
@@ -257,6 +262,7 @@ pub async fn assert_monotonic_event_seq(events: Arc<dyn EventLog>) {
             CompanyEvent::OperatorMessage {
                 text: "b0".into(),
                 by: None,
+                chat: None,
             },
         )
         .await
@@ -308,6 +314,7 @@ pub async fn assert_export_totality(
         let ev = CompanyEvent::OperatorMessage {
             text: format!("event {i}"),
             by: None,
+            chat: None,
         };
         events.append(&id, ev.clone()).await.unwrap();
         appended.push(ev);

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -543,6 +543,7 @@ mod test {
             .run_cycle(vec![CompanyEvent::OperatorMessage {
                 text: "kick off".into(),
                 by: None,
+                chat: None,
             }])
             .await
             .expect("cycle");
@@ -779,6 +780,7 @@ mod test {
             .run_cycle(vec![CompanyEvent::OperatorMessage {
                 text: "hi".into(),
                 by: None,
+                chat: None,
             }])
             .await
             .unwrap();

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -892,6 +892,7 @@ mod test {
                 CompanyEvent::OperatorMessage {
                     text: "a".into(),
                     by: None,
+                    chat: None,
                 },
             )
             .await
@@ -902,6 +903,7 @@ mod test {
                 CompanyEvent::OperatorMessage {
                     text: "b".into(),
                     by: None,
+                    chat: None,
                 },
             )
             .await
@@ -929,6 +931,7 @@ mod test {
             CompanyEvent::OperatorMessage {
                 text: "hi".into(),
                 by: None,
+                chat: None,
             },
         )
         .await
@@ -938,7 +941,8 @@ mod test {
             received.event,
             CompanyEvent::OperatorMessage {
                 text: "hi".into(),
-                by: None
+                by: None,
+                chat: None
             }
         );
         tokio::fs::remove_dir_all(&root).await.ok();

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1835,6 +1835,7 @@ mod test {
                 CompanyEvent::OperatorMessage {
                     text: "hi".into(),
                     by: None,
+                    chat: None,
                 },
             )
             .await
@@ -1885,6 +1886,7 @@ mod test {
             CompanyEvent::OperatorMessage {
                 text: "hi".into(),
                 by: None,
+                chat: None,
             },
         )
         .await
@@ -1894,7 +1896,8 @@ mod test {
             received.event,
             CompanyEvent::OperatorMessage {
                 text: "hi".into(),
-                by: None
+                by: None,
+                chat: None
             }
         );
     }
@@ -1979,6 +1982,7 @@ mod test {
                 CompanyEvent::OperatorMessage {
                     text: "persist".into(),
                     by: None,
+                    chat: None,
                 },
             )
             .await
@@ -1993,6 +1997,7 @@ mod test {
             CompanyEvent::OperatorMessage {
                 text: "persist".into(),
                 by: None,
+                chat: None,
             }
         );
     }

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -143,6 +143,9 @@ description = "Runs Acme."
             skills: None,
             skills_source_dir: None,
             mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: crate::harness::orchestrator::DelegationQueue::default(),
         }
     }
 


### PR DESCRIPTION
## Summary

Part of #26 (feature 1 — orchestration / Medulla). Turns the operator↔company chat into a single delegating **orchestrator** agent: one place the operator asks anything ("where are we on the launch?", "get X shipped") and it answers from whole-company context, delegating to desks or opening tracked work as needed.

Before this, the chat responder was just `agents.first()` with no company-wide view and no ability to act.

- The chat responder is now the **orchestrator**: the roster agent tagged `tier = "orchestrator"`, falling back to `agents.first()` (so a company with no tagged orchestrator behaves exactly as before).
- It reaches three tools, wired only onto it:
  - `query_company` — read-only grounding over the company's `FactStore` + recent `EventLog` activity.
  - `spawn_task` — opens a tracked backlog card via the same `TaskStore` path the console uses.
  - `delegate_to_desk` — hands a turn to a desk's lead member; the reply surfaces as its own chat bubble.
- Delegation is **synchronous, in-cycle, and bounded**: the queue is cleared before the turn, drained after (cap 3/turn, overflow discarded), no sub-agent re-delegation (desk members carry no delegation tools).
- The console's chat threads are now the company's **real desks** (`GET …/desks`), with the previous static defaults as fallback.

The delegation tools are classified **internal** by the approval policy (they enqueue in-company work, never an external effect); any external effect a delegated agent later attempts still passes through the policy gate on that agent's own calls.

> **Stacked on #50 (MCP).** This branch is cut from `feat/50-mcp` because it edits the same harness seam (`build.rs` / `HarnessDeps` / `brain.rs`); the tool injection is additive beside MCP's. **Until #50 merges, this PR's diff includes #50's commits** — it will be rebased onto `main` (shrinking to orchestrator-only) once #50 lands. Draft until then.

## API Or Behavior Changes

- New route: `GET …/desks` — the company's desks (group chats) with their lead member.
- `CompanyEvent::OperatorMessage` gains an optional `chat` field (which desk/thread a message targets); `#[serde(default, skip_serializing_if = "Option::is_none")]` keeps existing serialization round-trips byte-identical.
- Chat responder selection changes from "first agent" to "orchestrator (fallback first agent)".
- `HarnessDeps` gains `facts` / `events` / `delegations` handles.
- Approval policy treats `spawn_task` / `delegate_to_desk` as internal (documented carve-out).
- Console chat threads come from real desks; `chat(text, company, chat)` threads the active desk id.

## Tests

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean (default features)
- [x] `cargo build --all-targets`
- [x] `cargo test` — 508 passed, 0 failed
- Feature build (CI does not build it):
  - `cargo check --features openhuman` — clean
  - `cargo test --features openhuman` — 602 passed, 0 failed (incl. #50's, since this is stacked)
  - Frontend `npm run typecheck` + `npm run build` — clean

`cargo clippy --features openhuman` surfaces only pre-existing vendored-`tinyagents` lints; the new files produce zero clippy findings.

## Documentation

- Module/persona docs describe the orchestrator responder, the three tools, and the v1 delegation bounds (sync, in-cycle, cap 3, no re-delegation).

Closes #53
