### PR TITLE
feat(workspace): soft disk-quota config + boot usage alert (#36 Part 2)

### DIFF
--- a/docs/spec/runtime/storage.md
+++ b/docs/spec/runtime/storage.md
@@ -70,10 +70,18 @@ The `[workspace]` section of `config.toml` (in the data dir) tunes the lifecycle
 ```toml
 [workspace]
 clear_tmp_on_startup = true   # default; set false to preserve tmp/ across restarts
+storage_quota_gb = 5          # soft whole-workspace quota; omit or <= 0 = unlimited
+tmp_quota_gb = 1              # soft tmp/ quota; omit or <= 0 = unlimited
 ```
 
-Disk-quota enforcement and large-file S3 offload are infrastructure concerns of
-the hosting layer (`opencompany-microservice` + `k8s`), not the workload binary.
+**Quotas are soft/advisory in the binary.** At boot `serve` measures the
+workspace (and `tmp/`) and emits an operator-visible `tracing::warn` when either
+exceeds its configured quota. **Hard enforcement** — blocking writes at the
+limit — is the container/StorageClass layer's job (an EFS access point cap or a
+k8s `ResourceQuota`), which is where the deploy manifests wire it; the binary
+surfaces the condition rather than intercepting every write.
+
+Large-file S3 offload remains a follow-up (needs an S3 client + credentials).
 
 ## Memory engine overlay (`OPENCOMPANY_MEMORY`)
 

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -218,6 +218,14 @@ pub struct ConfigFile {
 pub struct WorkspaceSection {
     /// Empty the ephemeral `tmp/` scratch directory on startup. Default: true.
     pub clear_tmp_on_startup: Option<bool>,
+    /// Soft quota on the whole workspace, in gibibytes. Absent or `<= 0` means
+    /// unlimited. Surfaced as an operator alert when exceeded; hard enforcement
+    /// is the container/StorageClass layer's job (EFS access point / k8s
+    /// `ResourceQuota`).
+    pub storage_quota_gb: Option<f64>,
+    /// Soft quota on the `tmp/` scratch directory, in gibibytes. Absent or
+    /// `<= 0` means unlimited.
+    pub tmp_quota_gb: Option<f64>,
 }
 
 impl WorkspaceSection {
@@ -225,8 +233,17 @@ impl WorkspaceSection {
     pub fn resolve(&self) -> WorkspaceConfig {
         WorkspaceConfig {
             clear_tmp_on_startup: self.clear_tmp_on_startup.unwrap_or(true),
+            storage_quota_bytes: gib_to_bytes(self.storage_quota_gb),
+            tmp_quota_bytes: gib_to_bytes(self.tmp_quota_gb),
         }
     }
+}
+
+/// Converts an optional gibibyte quota to bytes, treating absent / non-positive
+/// values as "unlimited" (`None`).
+fn gib_to_bytes(gb: Option<f64>) -> Option<u64> {
+    gb.filter(|g| *g > 0.0)
+        .map(|g| (g * 1024.0 * 1024.0 * 1024.0) as u64)
 }
 
 /// Resolved `[workspace]` configuration.
@@ -234,12 +251,18 @@ impl WorkspaceSection {
 pub struct WorkspaceConfig {
     /// Whether the ephemeral `tmp/` scratch is cleared on startup.
     pub clear_tmp_on_startup: bool,
+    /// Soft whole-workspace quota in bytes; `None` is unlimited.
+    pub storage_quota_bytes: Option<u64>,
+    /// Soft `tmp/` quota in bytes; `None` is unlimited.
+    pub tmp_quota_bytes: Option<u64>,
 }
 
 impl Default for WorkspaceConfig {
     fn default() -> Self {
         Self {
             clear_tmp_on_startup: true,
+            storage_quota_bytes: None,
+            tmp_quota_bytes: None,
         }
     }
 }
@@ -585,6 +608,7 @@ mod test {
         let file = ConfigFile {
             workspace: WorkspaceSection {
                 clear_tmp_on_startup: Some(false),
+                ..WorkspaceSection::default()
             },
             ..ConfigFile::default()
         };
@@ -756,8 +780,26 @@ mod test {
         // An explicit opt-out is honored.
         let section = WorkspaceSection {
             clear_tmp_on_startup: Some(false),
+            ..WorkspaceSection::default()
         };
         assert!(!section.resolve().clear_tmp_on_startup);
+    }
+
+    #[test]
+    fn workspace_section_parses_quotas() {
+        let section = WorkspaceSection {
+            storage_quota_gb: Some(2.0),
+            tmp_quota_gb: Some(0.0), // non-positive → unlimited
+            ..WorkspaceSection::default()
+        };
+        let cfg = section.resolve();
+        assert_eq!(cfg.storage_quota_bytes, Some(2 * 1024 * 1024 * 1024));
+        assert_eq!(cfg.tmp_quota_bytes, None);
+        // Absent → unlimited.
+        assert_eq!(
+            WorkspaceSection::default().resolve().storage_quota_bytes,
+            None
+        );
     }
 
     #[test]

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -555,9 +555,33 @@ async fn main() -> Result<()> {
             let workspace_cfg = ConfigFile::load(&data_root)?
                 .map(|c| c.workspace.resolve())
                 .unwrap_or_default();
-            opencompany::store::DataLayout::new(&data_root)
-                .ensure(workspace_cfg.clear_tmp_on_startup)
-                .await?;
+            let layout = opencompany::store::DataLayout::new(&data_root);
+            layout.ensure(workspace_cfg.clear_tmp_on_startup).await?;
+            // Soft disk-quota alerting. Hard enforcement is the container /
+            // StorageClass layer's job (EFS access point, k8s ResourceQuota);
+            // here we surface an operator-visible warning when a workspace
+            // exceeds its configured `[workspace]` quota.
+            if let Some(limit) = workspace_cfg.storage_quota_bytes {
+                let used = layout.usage_bytes().await?;
+                if used > limit {
+                    tracing::warn!(
+                        used_bytes = used,
+                        quota_bytes = limit,
+                        data_dir = %data_root.display(),
+                        "workspace storage over quota — enforce hard limits at the container/StorageClass layer",
+                    );
+                }
+            }
+            if let Some(limit) = workspace_cfg.tmp_quota_bytes {
+                let used = layout.tmp_bytes().await?;
+                if used > limit {
+                    tracing::warn!(
+                        used_bytes = used,
+                        quota_bytes = limit,
+                        "workspace tmp/ scratch over quota",
+                    );
+                }
+            }
             // tiny.place economy + public-card configuration resolved from the
             // environment (with built-in defaults); the a2a routes and boot
             // going-public flow read these off `AppConfig`.

--- a/src/store/layout.rs
+++ b/src/store/layout.rs
@@ -106,6 +106,52 @@ impl DataLayout {
         }
         Ok(())
     }
+
+    /// Total size in bytes of everything under the workspace root, for the
+    /// soft-quota check. Used by `serve` to alert when a workspace exceeds its
+    /// configured `[workspace].storage_quota_gb`.
+    pub async fn usage_bytes(&self) -> Result<u64> {
+        dir_bytes(self.root.clone()).await
+    }
+
+    /// Size in bytes of the ephemeral `tmp/` scratch directory.
+    pub async fn tmp_bytes(&self) -> Result<u64> {
+        dir_bytes(self.tmp_dir()).await
+    }
+}
+
+/// Recursively sums the byte size of regular files under `dir`. A missing
+/// directory is `0`, not an error. Symlinks are not followed (an iterative
+/// stack walk, so no recursion depth limit and no symlink loops).
+async fn dir_bytes(dir: PathBuf) -> Result<u64> {
+    let read_err = |p: &Path, e: std::io::Error| {
+        OpenCompanyError::Store(format!("measuring {}: {e}", p.display()))
+    };
+    let mut total = 0u64;
+    let mut stack = vec![dir];
+    while let Some(path) = stack.pop() {
+        let mut entries = match tokio::fs::read_dir(&path).await {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(read_err(&path, e)),
+        };
+        while let Some(entry) = entries.next_entry().await.map_err(|e| read_err(&path, e))? {
+            // `DirEntry::metadata` does not follow symlinks, so a symlink is
+            // neither dir nor file here and is simply skipped.
+            let meta = match entry.metadata().await {
+                Ok(meta) => meta,
+                // A file removed mid-walk (e.g. tmp churn) just isn't counted.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => return Err(read_err(&entry.path(), e)),
+            };
+            if meta.is_dir() {
+                stack.push(entry.path());
+            } else if meta.is_file() {
+                total += meta.len();
+            }
+        }
+    }
+    Ok(total)
 }
 
 #[cfg(test)]
@@ -156,6 +202,32 @@ mod test {
             layout.tmp_dir().is_dir(),
             "tmp/ is recreated after clearing"
         );
+
+        tokio::fs::remove_dir_all(&root).await.ok();
+    }
+
+    #[tokio::test]
+    async fn usage_bytes_sums_files_recursively() {
+        let root = scratch_root("usage");
+        let layout = DataLayout::new(&root);
+        layout.ensure(true).await.unwrap();
+        tokio::fs::write(layout.files_dir().join("a.bin"), vec![0u8; 1000])
+            .await
+            .unwrap();
+        tokio::fs::write(layout.tmp_dir().join("scratch.bin"), vec![0u8; 500])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            layout.usage_bytes().await.unwrap(),
+            1500,
+            "root sums all files"
+        );
+        assert_eq!(layout.tmp_bytes().await.unwrap(), 500, "tmp/ subtree only");
+
+        // A missing workspace measures zero, not an error.
+        let absent = DataLayout::new(scratch_root("absent"));
+        assert_eq!(absent.usage_bytes().await.unwrap(), 0);
 
         tokio::fs::remove_dir_all(&root).await.ok();
     }


### PR DESCRIPTION
## Summary

Part of #36's **Workspace + Docker** checklist — the in-binary half of "disk quota enforced: write attempts beyond quota blocked and operator alerted".

- New `[workspace]` config: `storage_quota_gb` and `tmp_quota_gb` (gibibytes; omit or `<= 0` = unlimited).
- `serve` measures the workspace (`DataLayout::usage_bytes`) and `tmp/` (`tmp_bytes`) at boot and emits an operator-visible `tracing::warn` when either exceeds its quota.

### Why soft/advisory (honest scope)
Per #36's own architecture, **hard** enforcement is the container/StorageClass layer (EFS access-point cap, k8s `ResourceQuota`). Agent file writes flow through openhuman's file tools, not an OpenCompany hook, so intercepting every write in the binary isn't clean. The binary therefore **declares** the quota and **surfaces** the breach; the deploy manifests (follow-up PR) wire the hard cap. Large-file **S3 offload** is deferred (needs an S3 client + credentials).

## API Or Behavior Changes

- New config fields `WorkspaceSection.{storage_quota_gb,tmp_quota_gb}` → resolved `WorkspaceConfig.{storage_quota_bytes,tmp_quota_bytes}`.
- New `DataLayout::{usage_bytes, tmp_bytes}`.
- `serve` logs a quota warning at boot when over. No behavior change when quotas are unset (the default).

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — new: `usage_bytes_sums_files_recursively` (recursive size, missing dir = 0, symlink-safe) and `workspace_section_parses_quotas` (gib→bytes, non-positive → unlimited).

## Documentation

`docs/spec/runtime/storage.md`: `[workspace]` quota fields + the soft-vs-hard-enforcement boundary.