### PR TITLE
deploy(workspace): persist /data via EFS on Fargate + document layout (#36 Part 2)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -78,14 +78,29 @@ aws ecs create-service --cluster <cluster> --service-name opencompany \
 Change the company by editing `OPENCOMPANY_COMPANY` in the task definition and
 re-registering.
 
+**Workspace persistence.** The container's data dir is `/data`
+(`OPENCOMPANY_DATA_DIR`, set in the image) — the per-instance workspace root
+(`companies/`, `memory/`, `store/`, `files/`, `logs/`, `tmp/`; see
+[`storage.md`](../docs/spec/runtime/storage.md)). On Fargate this is ephemeral
+unless backed by a volume, so the task definition mounts an **EFS** volume at
+`/data`: fill `fileSystemId` (`fs-…`) and `accessPointId` (`fsap-…`) in the
+`volumes` block. Give each tenant its **own EFS access point with a storage
+cap** — that access-point quota is the *hard* enforcement of
+`[workspace].storage_quota_gb` (the workload only alerts when over).
+
 ### EC2
 
 Same as any Docker host — run the Compose file on an EC2 instance with Docker.
 
 ## Kubernetes / other
 
-The images are plain and stateless except the host's `/data` volume (the
-company bundle). Any orchestrator works: run the host with `OPENCOMPANY_COMPANY`
-set and a persistent volume at `/data`, and the console with `OC_UPSTREAM`
-pointed at the host. The host also honours `TINYHUMANS_API_KEY` (live cognition)
-and `OPENCOMPANY_DISCOVERABLE=true` (tiny.place, needs the `tinyplace` feature).
+The images are plain and stateless except the host's `/data` volume — the
+per-instance workspace root (`companies/`, `memory/`, `store/`, `files/`,
+`logs/`, `tmp/`; see [`storage.md`](../docs/spec/runtime/storage.md)). Any
+orchestrator works: run the host with `OPENCOMPANY_COMPANY` set and a persistent
+volume at `/data`, and the console with `OC_UPSTREAM` pointed at the host. On
+Kubernetes, back `/data` with a PVC (one tenant per pod, or a shared PVC with a
+`subPath` per tenant) and cap it with a `ResourceQuota` / StorageClass quota —
+that quota is the hard enforcement of `[workspace].storage_quota_gb`. The host
+also honours `TINYHUMANS_API_KEY` (live cognition) and
+`OPENCOMPANY_DISCOVERABLE=true` (tiny.place, needs the `tinyplace` feature).

--- a/deploy/aws-ecs-task-definition.json
+++ b/deploy/aws-ecs-task-definition.json
@@ -15,6 +15,9 @@
         { "name": "OPENCOMPANY_COMPANY", "value": "agentic_marketing_agency" },
         { "name": "OPENCOMPANY_DISCOVERABLE", "value": "false" }
       ],
+      "mountPoints": [
+        { "sourceVolume": "workspace", "containerPath": "/data", "readOnly": false }
+      ],
       "healthCheck": {
         "command": ["CMD-SHELL", "curl -fsS http://localhost:8080/healthz || exit 1"],
         "interval": 15,
@@ -45,6 +48,17 @@
           "awslogs-region": "REGION",
           "awslogs-stream-prefix": "console"
         }
+      }
+    }
+  ],
+  "volumes": [
+    {
+      "name": "workspace",
+      "efsVolumeConfiguration": {
+        "fileSystemId": "fs-CHANGEME",
+        "rootDirectory": "/",
+        "transitEncryption": "ENABLED",
+        "authorizationConfig": { "accessPointId": "fsap-CHANGEME", "iam": "ENABLED" }
       }
     }
   ]


### PR DESCRIPTION
## Summary

Part of #36's **Workspace + Docker** checklist — the deploy/persistence half.

- **ECS task definition:** added an **EFS volume mounted at `/data`** (`mountPoints` on the workload container + a top-level `volumes` block). Previously the Fargate task had no volume, so the workspace (`companies/`, `memory/`, `store/`, `files/`, `logs/`, `tmp/`) was **ephemeral** across task restarts. Fill `fileSystemId`/`accessPointId` to wire a real EFS filesystem.
- **`deploy/README`:** documents the canonical workspace layout, the EFS mount for Fargate, and the k8s PVC/`subPath` pattern — and that a **per-tenant EFS access-point cap / k8s `ResourceQuota`** is the *hard* enforcement of `[workspace].storage_quota_gb` (the workload only alerts; PR #57).

> docker-compose already persists `/data` (the `opencompany-data` named volume + the Dockerfile's `OPENCOMPANY_DATA_DIR=/data`), so no change there — this closes the ECS gap.

## API Or Behavior Changes

None — deploy manifests + docs only. Pairs with #57 (quota config).

## Tests

- ECS task definition validated as well-formed JSON.
- Docs only; no code paths changed.

## Related
- #57 — soft disk-quota config + boot alert (the binary half).
- Deferred: k8s manifests live in the `k8s` repo; S3 offload needs an S3 client.