### PR TITLE
feat(inference): per-tenant BYOK inference with live provider re-resolution (#56)

### DIFF
--- a/companies/README.md
+++ b/companies/README.md
@@ -74,3 +74,24 @@ Initialize the vendored runtime before using deeper integrations:
 ```sh
 git submodule update --init --recursive
 ```
+
+## Bring your own inference (BYOK)
+
+By default a company thinks with the managed TinyHumans brain. To route its
+agents through your own provider — OpenRouter, any OpenAI-compatible endpoint,
+or a local Ollama server — add an `[inference]` section to `company.toml` (see
+[`openhuman_demo`](openhuman_demo/company.toml) for a commented example), or
+switch live from the operator console under **Connections → Inference**:
+
+```toml
+[inference]
+provider = "openrouter"            # managed | openrouter | openai_compatible | ollama
+
+[inference.models]                 # abstract tier → concrete provider model id
+"chat-v1" = "deepseek/deepseek-chat"
+"reasoning-v1" = "deepseek/deepseek-r1"
+```
+
+The credential is **never** written in the manifest — set it write-only from
+the console, or name a secret-store key with `api_key_secret`. Switching
+providers takes effect on the agents' next turn with no restart.

--- a/companies/e2e_harness/company.toml
+++ b/companies/e2e_harness/company.toml
@@ -60,3 +60,15 @@ members = ["writer"]
 name = "deepwiki"
 endpoint = "https://mcp.deepwiki.com/mcp"
 description = "AI-generated documentation and Q&A for public GitHub repositories."
+
+# Bring-Your-Own-Key inference — commented so the harness keeps the
+# managed/echo brain. Uncomment + set a key from the console to route agents
+# through your own provider. Switching is live (no restart) via the per-tenant
+# provider that re-resolves this config each turn.
+#
+# [inference]
+# provider = "ollama"
+# base_url = "http://localhost:11434/v1"
+#
+# [inference.models]
+# "chat-v1" = "llama3.1"

--- a/companies/openhuman_demo/company.toml
+++ b/companies/openhuman_demo/company.toml
@@ -67,3 +67,18 @@ members = ["writer"]
 name = "deepwiki"
 endpoint = "https://mcp.deepwiki.com/mcp"
 description = "AI-generated documentation and Q&A for public GitHub repositories."
+
+# Bring-Your-Own-Key inference. Uncomment to route this company's
+# agents through your own provider instead of the managed TinyHumans brain.
+# Omitting the section (the default) keeps the managed brain. The credential is
+# NEVER written here — set it write-only from the console's Connections tab, or
+# name a secret-store key with `api_key_secret`. You can also switch providers
+# live from the console (Connections → Inference) with no restart.
+#
+# [inference]
+# provider = "openrouter"          # managed | openrouter | openai_compatible | ollama
+# # base_url = "https://openrouter.ai/api/v1"   # defaulted for openrouter/managed
+#
+# [inference.models]               # abstract tier → concrete provider model id
+# "chat-v1" = "deepseek/deepseek-chat"
+# "reasoning-v1" = "deepseek/deepseek-r1"

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -48,6 +48,15 @@ admins = ["ada@example.com"]
 mode = "hosted"                    # hosted (default) | sidecar
 max_passes = 12                    # passed through to Medulla
 
+[inference]                        # NEW: per-tenant Bring-Your-Own-Key (#56)
+provider = "openrouter"            # managed (default) | openrouter | openai_compatible | ollama
+# base_url = "https://openrouter.ai/api/v1"  # required for ollama/openai_compatible; defaulted otherwise
+# api_key_secret = "byo/openrouter"          # names a secret-store KEY — never the token itself
+
+[inference.models]                 # abstract tier → concrete provider model id
+"chat-v1" = "deepseek/deepseek-chat"
+"reasoning-v1" = "deepseek/deepseek-r1"
+
 [channels.operator]
 enabled = true                     # built-in chat; default true
 
@@ -87,6 +96,17 @@ prompt = "Weekly review and operator digest"
   `[tools].allow` and `[budget]` — the most restrictive wins.
 - **`[brain]`** selects the `Brain` implementation. `hosted` requires a
   TinyHumans credential at runtime; `sidecar` requires the `sidecar` feature.
+- **`[inference]`** (issue #56 — BYOK) routes the company's agents through a
+  chosen model provider. Absent (the default) keeps the managed TinyHumans
+  brain. `provider` is one of `managed` / `openrouter` / `openai_compatible` /
+  `ollama`; `base_url` is required for the latter two. `api_key_secret` names a
+  **secret-store key** — never the token, which is written write-only through
+  the console (Connections → Inference). `[inference.models]` maps an abstract
+  cognition tier (`chat-v1`, `reasoning-v1`, `agentic-v1`, `vision-v1`) to a
+  concrete provider model id; an unmapped tier passes through verbatim.
+  Precedence is **runtime console override > manifest `[inference]` > managed
+  default**, and a per-tenant provider re-resolves it every turn — so a console
+  switch takes effect on the agents' next turn with **no restart**.
 - **`[channels.*]`** enables `ChannelAdapter`s. Unknown channels are a
   validation error; disabled OpenHuman means non-operator channels degrade
   with a boot warning, never a failure.

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -68,15 +68,16 @@ async fn main() -> anyhow::Result<()> {
         .nth(1)
         .unwrap_or_else(|| "Introduce yourself in one sentence.".to_string());
 
-    let (cfg, default_model) = harness_inference_from_env(&ProcessEnv).ok_or_else(|| {
+    let (cfg, model_override) = harness_inference_from_env(&ProcessEnv).ok_or_else(|| {
         anyhow::anyhow!(
             "no inference credential — set TINYHUMANS_API_KEY (or OPENCOMPANY_INFERENCE_KEY), \
              optionally OPENCOMPANY_INFERENCE_URL / _MODEL"
         )
     })?;
     eprintln!(
-        "[live] endpoint={}  default_model={}",
-        cfg.base_url, default_model
+        "[live] endpoint={}  model_override={}",
+        cfg.base_url,
+        model_override.as_deref().unwrap_or("<per-agent tier>")
     );
 
     let manifest: CompanyManifest = toml::from_str(MANIFEST)?;
@@ -97,7 +98,7 @@ async fn main() -> anyhow::Result<()> {
         store: Arc::new(FsCompanyStore::new(dir.path())),
         meter: Some(meter.clone()),
         workspace_root: dir.path().to_path_buf(),
-        model_override: Some(default_model.clone()),
+        model_override,
         tasks: None,
         skills: None,
         skills_source_dir: None,

--- a/frontend/src/api/inference.ts
+++ b/frontend/src/api/inference.ts
@@ -1,0 +1,92 @@
+// The live inference API (issue #56 — BYOK): the console reads and writes the
+// company's effective inference provider through the host's `.../inference`
+// routes (REST, camelCase over the wire). The effective config is the
+// highest-precedence of a runtime console override, the committed manifest
+// `[inference]`, and the platform managed default.
+//
+// The outbound credential is WRITE-ONLY: a `key` is sent on set and stored in
+// the host's secret store; it is never returned. The read shape carries only a
+// `keyConfigured` boolean. Standalone functions over the shared client (mirrors
+// `api/skills.ts` / `api/mcp.ts`), so no change to `OpenCompanyClient` or the
+// shared `api/types.ts` is needed.
+
+import type { OpenCompanyClient } from "./client";
+
+/** Provider kinds the console offers. */
+export type InferenceProvider = "managed" | "openrouter" | "openai_compatible" | "ollama";
+
+/** Where the effective config came from — drives the source badge. */
+export type InferenceSource = "managed" | "default" | "manifest" | "runtime";
+
+/** The company's effective inference status. Never carries the credential. */
+export interface InferenceStatus {
+  /** Provider kind. */
+  provider: string;
+  /** Telemetry slug: `managed` | `openrouter` | `byok` | `ollama`. */
+  slug: string;
+  /** Resolved OpenAI-compatible base URL. */
+  baseUrl: string;
+  /** Abstract-tier → concrete model id. */
+  models: Record<string, string>;
+  /** Provenance badge. */
+  source: InferenceSource;
+  /** Whether an outbound key is stored — never the key itself. */
+  keyConfigured: boolean;
+}
+
+/** The set-provider body. `key` is write-only (never returned). */
+export interface SetInferenceInput {
+  provider: InferenceProvider;
+  baseUrl?: string;
+  models?: Record<string, string>;
+  /** The outbound credential. Omit to leave unchanged; "" to clear. */
+  key?: string;
+}
+
+/** A mutating response: the resulting status plus a plain-language note. */
+export interface InferenceMutation {
+  status: InferenceStatus;
+  note: string;
+}
+
+/** The live-probe result. */
+export interface InferenceTestResult {
+  ok: boolean;
+  provider?: string;
+  note?: string;
+  error?: string;
+  code?: string;
+}
+
+/** The company's effective inference status. */
+export function getInferenceStatus(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<InferenceStatus> {
+  return client.get<InferenceStatus>(`${client.scopeFor(company)}/inference`);
+}
+
+/** Set (or replace) the runtime provider override, optionally rotating the key. */
+export function setInference(
+  client: OpenCompanyClient,
+  company: string | null,
+  body: SetInferenceInput,
+): Promise<InferenceMutation> {
+  return client.put<InferenceMutation>(`${client.scopeFor(company)}/inference`, body);
+}
+
+/** Clear the runtime override, reverting to the manifest (or managed) config. */
+export function revertInference(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<InferenceMutation> {
+  return client.del<InferenceMutation>(`${client.scopeFor(company)}/inference`);
+}
+
+/** Live-probe the resolved provider (one `ping` turn). */
+export function testInference(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<InferenceTestResult> {
+  return client.post<InferenceTestResult>(`${client.scopeFor(company)}/inference/test`, {});
+}

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -43,6 +43,7 @@ import {
   type ConnectionProvider,
 } from "@/lib/connections";
 import { cn } from "@/lib/utils";
+import { InferenceSection } from "@/views/connections/InferenceSection";
 
 interface Props {
   client: OpenCompanyClient;
@@ -128,6 +129,8 @@ export function ConnectionsView({ client, company }: Props) {
         )}
 
         <McpServersSection client={client} company={company} />
+
+        <InferenceSection client={client} company={company} />
 
         {load === "loading" ? (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -1,0 +1,350 @@
+import { useCallback, useEffect, useState } from "react";
+import { BrainCircuit, Check, Loader2, RotateCcw, Save, Zap } from "lucide-react";
+import { toast } from "sonner";
+
+import type { OpenCompanyClient } from "@/api/client";
+import {
+  getInferenceStatus,
+  revertInference,
+  setInference,
+  testInference,
+  type InferenceProvider,
+  type InferenceStatus,
+} from "@/api/inference";
+import { ApiError } from "@/api/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/** The abstract cognition tiers the tenant model table maps. */
+const TIERS = ["chat-v1", "reasoning-v1", "agentic-v1", "vision-v1"] as const;
+type Tier = (typeof TIERS)[number];
+
+const PROVIDER_LABELS: Record<InferenceProvider, string> = {
+  managed: "Managed (TinyHumans)",
+  openrouter: "OpenRouter",
+  ollama: "Ollama (local)",
+  openai_compatible: "Custom (OpenAI-compatible)",
+};
+
+/** Per-provider form defaults applied when the operator picks a provider. */
+function presetFor(provider: InferenceProvider): {
+  baseUrl: string;
+  models: Partial<Record<Tier, string>>;
+} {
+  switch (provider) {
+    case "openrouter":
+      return {
+        baseUrl: "",
+        // OpenRouter's recommended DeepSeek pairing, prefilled.
+        models: { "chat-v1": "deepseek/deepseek-chat", "reasoning-v1": "deepseek/deepseek-r1" },
+      };
+    case "ollama":
+      return { baseUrl: "http://localhost:11434/v1", models: { "chat-v1": "llama3.1" } };
+    case "openai_compatible":
+      return { baseUrl: "", models: {} };
+    case "managed":
+      return { baseUrl: "", models: {} };
+  }
+}
+
+type Load = "loading" | "ready" | "unavailable";
+type TestState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ok"; note: string }
+  | { kind: "error"; message: string };
+
+/**
+ * Bring-Your-Own-Key inference (issue #56). Shows the company's effective
+ * provider (with a source badge + tier→model rows + a "key set" indicator), a
+ * live "Test" probe, and a switch form with per-provider presets. The key input
+ * is **write-only** — it is sent on Save, stored server-side, and never read
+ * back. A switch takes effect on the agents' next turn with no restart.
+ */
+export function InferenceSection({
+  client,
+  company,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+}) {
+  const [load, setLoad] = useState<Load>("loading");
+  const [status, setStatus] = useState<InferenceStatus | null>(null);
+  const [busy, setBusy] = useState<"save" | "reset" | "test" | null>(null);
+  const [test, setTest] = useState<TestState>({ kind: "idle" });
+
+  // Switch form.
+  const [provider, setProvider] = useState<InferenceProvider>("managed");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [models, setModels] = useState<Partial<Record<Tier, string>>>({});
+  const [key, setKey] = useState("");
+
+  const refresh = useCallback(async () => {
+    try {
+      setStatus(await getInferenceStatus(client, company));
+      setLoad("ready");
+    } catch {
+      setLoad("unavailable");
+    }
+  }, [client, company]);
+
+  useEffect(() => {
+    setLoad("loading");
+    void refresh();
+  }, [refresh]);
+
+  function pickProvider(next: InferenceProvider) {
+    setProvider(next);
+    const preset = presetFor(next);
+    setBaseUrl(preset.baseUrl);
+    setModels(preset.models);
+    setTest({ kind: "idle" });
+  }
+
+  function setModel(tier: Tier, value: string) {
+    setModels((m) => ({ ...m, [tier]: value }));
+  }
+
+  async function save() {
+    if (busy) return;
+    setBusy("save");
+    try {
+      // "Managed" means "use the platform default" — that's a revert, not a
+      // runtime override with an empty credential.
+      if (provider === "managed") {
+        await revertInference(client, company);
+      } else {
+        const cleanModels = Object.fromEntries(
+          Object.entries(models)
+            .map(([t, v]) => [t, (v ?? "").trim()])
+            .filter(([, v]) => v.length > 0),
+        );
+        await setInference(client, company, {
+          provider,
+          baseUrl: baseUrl.trim() || undefined,
+          models: Object.keys(cleanModels).length ? cleanModels : undefined,
+          key: key.trim() || undefined,
+        });
+      }
+      toast.success("Inference updated. Agents use it on their next turn.");
+      setKey("");
+      setTest({ kind: "idle" });
+      await refresh();
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Couldn't update inference.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function reset() {
+    if (busy) return;
+    setBusy("reset");
+    try {
+      await revertInference(client, company);
+      toast.success("Reverted to the managed configuration.");
+      pickProvider("managed");
+      setKey("");
+      await refresh();
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Couldn't revert inference.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function probe() {
+    if (busy) return;
+    setBusy("test");
+    setTest({ kind: "loading" });
+    try {
+      const result = await testInference(client, company);
+      if (result.ok) {
+        setTest({ kind: "ok", note: result.note ?? "Reached the provider." });
+      } else {
+        setTest({ kind: "error", message: result.error ?? "The provider did not respond." });
+      }
+    } catch (err) {
+      setTest({
+        kind: "error",
+        message: err instanceof ApiError ? err.message : "The probe failed.",
+      });
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (load === "unavailable") return null;
+
+  const modelRows = status ? Object.entries(status.models) : [];
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2">
+        <BrainCircuit className="size-4 text-muted-foreground" />
+        <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          Inference (BYOK)
+        </h3>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Choose which model provider your agents think with. Bring your own key for OpenRouter, a
+        custom OpenAI-compatible endpoint, or a local Ollama server — the key is stored securely and
+        never shown again. A switch takes effect on the next turn, no restart.
+      </p>
+
+      {load === "loading" ? (
+        <Skeleton className="h-40 rounded-xl" />
+      ) : (
+        <Card>
+          <CardContent className="space-y-4 py-4">
+            {/* Status card. */}
+            {status && (
+              <div className="space-y-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-medium">{PROVIDER_LABELS[status.provider as InferenceProvider] ?? status.provider}</span>
+                  <Badge variant={status.source === "runtime" ? "outline" : "secondary"}>
+                    {status.source}
+                  </Badge>
+                  {status.keyConfigured && (
+                    <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+                      <Check className="size-3" /> key set
+                    </span>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="ml-auto"
+                    disabled={busy !== null}
+                    onClick={() => void probe()}
+                  >
+                    {busy === "test" ? <Loader2 className="size-4 animate-spin" /> : <Zap className="size-4" />}
+                    Test
+                  </Button>
+                </div>
+                <p className="truncate text-xs text-muted-foreground">{status.baseUrl}</p>
+                {modelRows.length > 0 && (
+                  <ul className="space-y-1 rounded-md bg-muted/40 p-2">
+                    {modelRows.map(([tier, model]) => (
+                      <li key={tier} className="text-xs">
+                        <span className="font-mono font-medium">{tier}</span>
+                        <span className="text-muted-foreground"> → {model}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                {test.kind === "ok" && (
+                  <p className="flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+                    <Check className="size-3" /> {test.note}
+                  </p>
+                )}
+                {test.kind === "error" && <p className="text-xs text-destructive">{test.message}</p>}
+                {test.kind === "loading" && (
+                  <p className="flex items-center gap-1 text-xs text-muted-foreground">
+                    <Loader2 className="size-3 animate-spin" /> Probing the provider…
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Switch form. */}
+            <div className="space-y-3 border-t border-border pt-3">
+              <div className="grid gap-2 sm:grid-cols-2 sm:items-end">
+                <div className="space-y-1">
+                  <Label htmlFor="inference-provider" className="text-xs">
+                    Provider
+                  </Label>
+                  <Select
+                    value={provider}
+                    onValueChange={(v) => pickProvider(v as InferenceProvider)}
+                    items={PROVIDER_LABELS}
+                  >
+                    <SelectTrigger id="inference-provider" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {(Object.keys(PROVIDER_LABELS) as InferenceProvider[]).map((p) => (
+                        <SelectItem key={p} value={p}>
+                          {PROVIDER_LABELS[p]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                {(provider === "ollama" || provider === "openai_compatible") && (
+                  <div className="space-y-1">
+                    <Label htmlFor="inference-base-url" className="text-xs">
+                      Base URL
+                    </Label>
+                    <Input
+                      id="inference-base-url"
+                      value={baseUrl}
+                      placeholder="https://host/v1"
+                      onChange={(e) => setBaseUrl(e.target.value)}
+                    />
+                  </div>
+                )}
+              </div>
+
+              {provider !== "managed" && (
+                <>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    {TIERS.map((tier) => (
+                      <div key={tier} className="space-y-1">
+                        <Label htmlFor={`inference-model-${tier}`} className="text-xs">
+                          {tier}
+                        </Label>
+                        <Input
+                          id={`inference-model-${tier}`}
+                          value={models[tier] ?? ""}
+                          placeholder="provider model id"
+                          onChange={(e) => setModel(tier, e.target.value)}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                  {provider !== "ollama" && (
+                    <div className="space-y-1">
+                      <Label htmlFor="inference-key" className="text-xs">
+                        API key {status?.keyConfigured ? "(leave blank to keep)" : ""}
+                      </Label>
+                      <Input
+                        id="inference-key"
+                        type="password"
+                        value={key}
+                        placeholder="write-only"
+                        autoComplete="off"
+                        onChange={(e) => setKey(e.target.value)}
+                      />
+                    </div>
+                  )}
+                </>
+              )}
+
+              <div className="flex items-center gap-2">
+                <Button disabled={busy !== null} onClick={() => void save()}>
+                  {busy === "save" ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+                  Save
+                </Button>
+                <Button variant="outline" disabled={busy !== null} onClick={() => void reset()}>
+                  {busy === "reset" ? <Loader2 className="size-4 animate-spin" /> : <RotateCcw className="size-4" />}
+                  Reset to managed
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </section>
+  );
+}

--- a/gitbooks/developers/configuration.md
+++ b/gitbooks/developers/configuration.md
@@ -32,6 +32,27 @@ live cognition is gated.
 
 The CLI mirrors several of these as flags — see the [CLI reference](cli.md).
 
+## Inference: managed or bring-your-own (BYOK)
+
+By default agents think with the managed TinyHumans brain, keyed by
+`TINYHUMANS_API_KEY`. The managed default is also tunable by env:
+
+| Variable | Purpose |
+| --- | --- |
+| `OPENCOMPANY_INFERENCE_KEY` | Per-tenant override for `TINYHUMANS_API_KEY`. |
+| `OPENCOMPANY_INFERENCE_URL` | Managed base URL override. |
+| `OPENCOMPANY_INFERENCE_MODEL` | Pins the **whole roster** to one workload; unset keeps each agent's tier. |
+
+A company can instead **bring its own key** (issue #56) — OpenRouter, any
+OpenAI-compatible endpoint, or a local Ollama server — via a manifest
+`[inference]` section (see [manifest spec](../../docs/spec/runtime/manifest.md))
+or, live from the operator console under **Connections → Inference**. The
+outbound key is **write-only**: it is stored server-side and never returned in
+any status/API response. Precedence is **console override > manifest
+`[inference]` > managed default**, and a switch takes effect on the agents'
+next turn with no restart. A BYOK-only tenant needs no `TINYHUMANS_API_KEY` at
+all.
+
 ## Storage backends
 
 Storage is DB-agnostic behind ports. The default is **file-based** (a folder —

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -278,11 +278,16 @@ fn attach_openhuman(builder: RuntimeBuilder) -> RuntimeBuilder {
     }
 }
 
-/// Attaches the embedded OpenHuman harness brain when the `openhuman` feature
-/// is enabled and a hosted-inference credential is present in the environment
-/// (`TINYHUMANS_API_KEY` / `OPENCOMPANY_INFERENCE_*`). With it, `/company/chat`
-/// routes each operator message through a live company agent on the hosted
-/// brain; without a credential the runtime keeps its hosted/echo brain.
+/// Attaches the embedded OpenHuman harness under the `openhuman` feature.
+///
+/// The harness pool is **always** attached, so cognition routes through a live
+/// company agent whenever *any* inference source is configured — the managed
+/// env default (`TINYHUMANS_API_KEY` / `OPENCOMPANY_INFERENCE_*`), a manifest
+/// `[inference]` section, or a runtime console override (issue #56 — BYOK).
+/// Attaching the pool unconditionally is what unblocks a BYOK-only tenant that
+/// has no platform credential: the builder still constructs the harness brain
+/// from its manifest/runtime config. Without any source, the runtime keeps its
+/// hosted/echo brain.
 ///
 /// Without the feature this is the identity function, so the default build is
 /// unaffected.
@@ -297,10 +302,12 @@ fn attach_harness(builder: RuntimeBuilder) -> RuntimeBuilder {
     use opencompany::harness::HarnessPool;
     use opencompany::harness::provider::harness_inference_from_env;
 
+    let builder = builder.with_harness(Arc::new(HarnessPool::new()));
+    // The managed env default is an *optional*, lowest-precedence source; a
+    // BYOK-only tenant supplies none and still gets a harness brain from its
+    // manifest/runtime config.
     match harness_inference_from_env(&ProcessEnv) {
-        Some((config, model)) => builder
-            .with_harness(Arc::new(HarnessPool::new()))
-            .with_harness_inference(config, model),
+        Some((config, model_override)) => builder.with_harness_inference(config, model_override),
         None => builder,
     }
 }

--- a/src/company/inference.rs
+++ b/src/company/inference.rs
@@ -1,0 +1,800 @@
+//! Per-tenant Bring-Your-Own-Key inference (issue #56): the inert data model
+//! plus the async secret-resolution used to materialize a company's *effective*
+//! inference configuration.
+//!
+//! A company's effective inference config is the highest-precedence of three
+//! sources:
+//!
+//! 1. **Runtime** — a config the operator sets through the console, persisted as
+//!    a single JSON blob in the [`SecretStore`](crate::ports::SecretStore) under
+//!    [`RUNTIME_CONFIG_KEY`]. Highest precedence, so a console switch takes
+//!    effect on the agents' next turn with no rebuild.
+//! 2. **Manifest** — the `[inference]` section committed in `company.toml`
+//!    ([`Inference`]). Declarative intent; never a credential.
+//! 3. **Default** — the platform-injected managed brain
+//!    (`TINYHUMANS_API_KEY` / `OPENCOMPANY_INFERENCE_*`), passed in as an
+//!    [`EnvDefault`]. Lowest precedence.
+//!
+//! Credentials live apart from the declarations. The outbound key is written to
+//! its own [`KEY_KEY`] secret (write-only via the console) — never inline in the
+//! runtime config blob or the manifest — and is resolved into the
+//! [`InferenceDecl`]'s private field only at build/turn time by
+//! [`resolve_effective`]. Nothing here ever serializes a credential into an API
+//! response, log line, or agent-visible output: [`InferenceDecl`] derives no
+//! `Serialize` and its `Debug` redacts the key.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::Result;
+use crate::company::types::{INFERENCE_PROVIDERS, Inference};
+use crate::error::OpenCompanyError;
+use crate::ports::SecretStore;
+use crate::ports::types::{CompanyId, SecretValue};
+
+/// The [`SecretStore`](crate::ports::SecretStore) key holding the JSON runtime
+/// inference override (a [`RuntimeInference`] the console writes).
+pub const RUNTIME_CONFIG_KEY: &str = "inference/config";
+
+/// The canonical per-company inference credential key. The outbound token is
+/// stored here (write-only via the console); the value is the raw token string.
+pub const KEY_KEY: &str = "inference/key";
+
+/// Default managed base URL (the hosted TinyHumans / Medulla OpenAI-compatible
+/// surface) when the managed provider names no `base_url`.
+pub const MANAGED_BASE_URL: &str = "https://api.tinyhumans.ai/openai/v1";
+
+/// OpenRouter's OpenAI-compatible base URL — used when the `openrouter`
+/// provider names no explicit `base_url`.
+pub const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
+
+/// A local Ollama server's OpenAI-compatible surface — the convenience default
+/// for the `ollama` provider (validation still requires an explicit `base_url`
+/// in the manifest; this only backstops an empty resolved value).
+pub const OLLAMA_DEFAULT_BASE_URL: &str = "http://localhost:11434/v1";
+
+/// Where an effective inference config came from — drives the console's source
+/// badge.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InferenceSource {
+    /// The platform-injected managed default (`env`).
+    Default,
+    /// Declared in `company.toml`'s `[inference]`.
+    Manifest,
+    /// Set at runtime through the console.
+    Runtime,
+}
+
+/// The platform-injected managed default (from `harness_inference_from_env`):
+/// the base URL + credential the manager supplies. Passed to
+/// [`resolve_effective`] as the lowest-precedence source. Carries no `Debug`
+/// derive so the credential never lands in a trace.
+#[derive(Clone)]
+pub struct EnvDefault {
+    /// Managed base URL (env `OPENCOMPANY_INFERENCE_URL` or the default).
+    pub base_url: String,
+    /// Managed credential (`OPENCOMPANY_INFERENCE_KEY` / `TINYHUMANS_API_KEY`).
+    pub api_key: String,
+}
+
+impl std::fmt::Debug for EnvDefault {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EnvDefault")
+            .field("base_url", &self.base_url)
+            .field(
+                "api_key",
+                &if self.api_key.is_empty() {
+                    "<unset>"
+                } else {
+                    "<redacted>"
+                },
+            )
+            .finish()
+    }
+}
+
+/// The on-disk runtime inference override stored under [`RUNTIME_CONFIG_KEY`].
+/// Carries no credential — the token lives apart under [`KEY_KEY`].
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct RuntimeInference {
+    /// Provider kind — one of [`INFERENCE_PROVIDERS`].
+    pub provider: String,
+    /// Optional OpenAI-compatible base URL override.
+    #[serde(default)]
+    pub base_url: Option<String>,
+    /// Abstract-tier → concrete model id.
+    #[serde(default)]
+    pub models: BTreeMap<String, String>,
+}
+
+/// One company's *effective* inference configuration — the highest-precedence
+/// of runtime / manifest / env, with the credential resolved to a private field
+/// at build/turn time.
+///
+/// Derives **no** `Serialize` (the key must never cross a wire) and its `Debug`
+/// redacts the key.
+#[derive(Clone)]
+pub struct InferenceDecl {
+    /// Provider slug — one of [`INFERENCE_PROVIDERS`].
+    pub provider: String,
+    /// Resolved OpenAI-compatible base URL (never empty for a valid config).
+    pub base_url: String,
+    /// Abstract-tier → concrete model id. Empty means every tier passes
+    /// through to the provider verbatim.
+    pub models: BTreeMap<String, String>,
+    /// Provenance badge for the console.
+    pub source: InferenceSource,
+    /// Resolved outbound credential. Empty means "no bearer" (e.g. Ollama).
+    /// Private — read only through [`api_key`](Self::api_key); never serialized.
+    api_key: String,
+}
+
+impl InferenceDecl {
+    /// The resolved outbound credential (empty = omit the bearer header). Kept
+    /// crate-internal so the request builder can read it; never serialized.
+    pub fn api_key(&self) -> &str {
+        &self.api_key
+    }
+
+    /// Whether an outbound credential is configured — the non-secret status the
+    /// read APIs surface. Never returns the value.
+    pub fn key_configured(&self) -> bool {
+        !self.api_key.trim().is_empty()
+    }
+
+    /// The stable telemetry slug for this provider (`managed` / `openrouter` /
+    /// `byok` / `ollama`).
+    pub fn telemetry_slug(&self) -> &'static str {
+        provider_slug(&self.provider)
+    }
+}
+
+impl std::fmt::Debug for InferenceDecl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InferenceDecl")
+            .field("provider", &self.provider)
+            .field("base_url", &self.base_url)
+            .field("models", &self.models)
+            .field("source", &self.source)
+            .field(
+                "api_key",
+                &if self.api_key.is_empty() {
+                    "<unset>"
+                } else {
+                    "<redacted>"
+                },
+            )
+            .finish()
+    }
+}
+
+/// The stable telemetry slug for a provider kind. Unknown kinds fall back to
+/// `managed` (the safe default attribution).
+pub fn provider_slug(provider: &str) -> &'static str {
+    match provider.trim() {
+        "openrouter" => "openrouter",
+        "ollama" => "ollama",
+        "openai_compatible" => "byok",
+        _ => "managed",
+    }
+}
+
+/// Resolves the effective `(base_url, api_key)` for a provider.
+///
+/// The `managed` kind is special: it is the *platform* brain, so it inherits the
+/// env default's base URL and credential when a source (manifest/runtime) names
+/// `managed` without supplying its own — otherwise a hand-written
+/// `provider = "managed"` would drop the platform key and 401. Every other kind
+/// uses its own configured base URL + key verbatim.
+fn resolve_endpoint(
+    provider: &str,
+    base_url_override: Option<&str>,
+    key: String,
+    env_default: Option<&EnvDefault>,
+) -> (String, String) {
+    let base_url_override = base_url_override.map(str::trim).filter(|s| !s.is_empty());
+    if provider.trim() == "managed" {
+        let base_url = base_url_override
+            .map(str::to_string)
+            .or_else(|| env_default.map(|e| e.base_url.clone()))
+            .unwrap_or_else(|| MANAGED_BASE_URL.to_string());
+        let api_key = if !key.trim().is_empty() {
+            key
+        } else {
+            env_default.map(|e| e.api_key.clone()).unwrap_or_default()
+        };
+        (base_url, api_key)
+    } else {
+        (effective_base_url(provider, base_url_override), key)
+    }
+}
+
+/// The effective base URL for a provider kind, given an optional override.
+///
+/// `managed`/`openrouter` default to their well-known endpoints; `ollama`
+/// backstops to a local default; `openai_compatible` has no default (validation
+/// requires an explicit URL).
+pub fn effective_base_url(provider: &str, override_url: Option<&str>) -> String {
+    let override_url = override_url.map(str::trim).filter(|s| !s.is_empty());
+    match provider.trim() {
+        "openrouter" => override_url.unwrap_or(OPENROUTER_BASE_URL).to_string(),
+        "ollama" => override_url.unwrap_or(OLLAMA_DEFAULT_BASE_URL).to_string(),
+        "openai_compatible" => override_url.unwrap_or_default().to_string(),
+        // managed (and any unknown kind, which validation rejects separately).
+        _ => override_url.unwrap_or(MANAGED_BASE_URL).to_string(),
+    }
+}
+
+/// Loads the runtime inference override, or `None` when unset/blank. A malformed
+/// blob is a store error (surfaced, not silently dropped).
+pub async fn load_runtime_config(
+    company: &CompanyId,
+    secrets: &dyn SecretStore,
+) -> Result<Option<RuntimeInference>> {
+    let Some(SecretValue(raw)) = secrets.get(company, RUNTIME_CONFIG_KEY).await? else {
+        return Ok(None);
+    };
+    if raw.trim().is_empty() {
+        return Ok(None);
+    }
+    let config: RuntimeInference = serde_json::from_str(&raw).map_err(|e| {
+        OpenCompanyError::Store(format!("inference runtime config is not valid JSON: {e}"))
+    })?;
+    if config.provider.trim().is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(config))
+}
+
+/// Persists the runtime inference override (console `PUT`).
+pub async fn save_runtime_config(
+    company: &CompanyId,
+    secrets: &dyn SecretStore,
+    config: &RuntimeInference,
+) -> Result<()> {
+    let raw = serde_json::to_string(config)
+        .map_err(|e| OpenCompanyError::Store(format!("serializing inference config: {e}")))?;
+    secrets
+        .set(company, RUNTIME_CONFIG_KEY, SecretValue(raw))
+        .await
+}
+
+/// Clears the runtime inference override (console `DELETE` → revert to
+/// manifest/managed). Best-effort — the store has no delete, so an empty value
+/// reads back as unset.
+pub async fn clear_runtime_config(company: &CompanyId, secrets: &dyn SecretStore) -> Result<()> {
+    secrets
+        .set(company, RUNTIME_CONFIG_KEY, SecretValue(String::new()))
+        .await
+}
+
+/// Reads the effective outbound credential.
+///
+/// The canonical [`KEY_KEY`] (`inference/key`) is tried first — the console
+/// writes rotated tokens there. When it is empty/missing, `override_key` (a
+/// manifest section's `api_key_secret`) is the fallback for a commit-time key.
+/// Returns an empty string when neither holds a value.
+pub async fn load_key(
+    company: &CompanyId,
+    secrets: &dyn SecretStore,
+    override_key: Option<&str>,
+) -> Result<String> {
+    if let Some(SecretValue(raw)) = secrets.get(company, KEY_KEY).await?
+        && !raw.trim().is_empty()
+    {
+        return Ok(raw);
+    }
+    if let Some(key) = override_key.map(str::trim).filter(|s| !s.is_empty())
+        && let Some(SecretValue(raw)) = secrets.get(company, key).await?
+        && !raw.trim().is_empty()
+    {
+        return Ok(raw);
+    }
+    Ok(String::new())
+}
+
+/// Writes the company's outbound inference credential (write-only intake).
+pub async fn store_key(company: &CompanyId, secrets: &dyn SecretStore, key: &str) -> Result<()> {
+    secrets
+        .set(company, KEY_KEY, SecretValue(key.to_string()))
+        .await
+}
+
+/// Clears the stored credential (best-effort — the store has no delete, so an
+/// empty value reads back as "not configured").
+pub async fn clear_key(company: &CompanyId, secrets: &dyn SecretStore) -> Result<()> {
+    secrets
+        .set(company, KEY_KEY, SecretValue(String::new()))
+        .await
+}
+
+/// Whether the company currently has an outbound inference credential — the
+/// non-secret status surfaced by the read APIs. Never returns the value.
+pub async fn key_configured(
+    company: &CompanyId,
+    secrets: &dyn SecretStore,
+    override_key: Option<&str>,
+) -> Result<bool> {
+    Ok(!load_key(company, secrets, override_key)
+        .await?
+        .trim()
+        .is_empty())
+}
+
+/// Resolves a company's *effective* inference configuration.
+///
+/// Precedence is **runtime > manifest > env-default**. Returns `None` when no
+/// source configures inference at all — the caller then keeps the managed/echo
+/// brain. The single seam the harness builder and the ops route both use so the
+/// agent-facing resolution and the console's status view stay identical.
+///
+/// This re-reads the secret store on every call, which is what makes a console
+/// switch take effect on the agents' next turn with no rebuild.
+pub async fn resolve_effective(
+    company: &CompanyId,
+    manifest: &Inference,
+    env_default: Option<&EnvDefault>,
+    secrets: &dyn SecretStore,
+) -> Result<Option<InferenceDecl>> {
+    // 1. Runtime override (console) wins.
+    if let Some(runtime) = load_runtime_config(company, secrets).await? {
+        let provider = runtime.provider.trim().to_string();
+        let key = load_key(company, secrets, None).await?;
+        let (base_url, api_key) =
+            resolve_endpoint(&provider, runtime.base_url.as_deref(), key, env_default);
+        return Ok(Some(InferenceDecl {
+            provider,
+            base_url,
+            models: runtime.models,
+            source: InferenceSource::Runtime,
+            api_key,
+        }));
+    }
+
+    // 2. Manifest `[inference]`.
+    if manifest.is_set() {
+        let provider = manifest
+            .provider
+            .as_deref()
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        let key = load_key(company, secrets, manifest.api_key_secret.as_deref()).await?;
+        let (base_url, api_key) =
+            resolve_endpoint(&provider, manifest.base_url.as_deref(), key, env_default);
+        return Ok(Some(InferenceDecl {
+            provider,
+            base_url,
+            models: manifest.models.clone(),
+            source: InferenceSource::Manifest,
+            api_key,
+        }));
+    }
+
+    // 3. Platform-injected managed default.
+    if let Some(env) = env_default {
+        return Ok(Some(InferenceDecl {
+            provider: "managed".to_string(),
+            base_url: env.base_url.clone(),
+            models: BTreeMap::new(),
+            source: InferenceSource::Default,
+            api_key: env.api_key.clone(),
+        }));
+    }
+
+    Ok(None)
+}
+
+/// Validates the manifest `[inference]` section, returning every problem in
+/// prosumer language. An absent section (`provider = None`) is inert. Shared by
+/// manifest validation and the ops `PUT` route (via [`validate_runtime`]).
+pub fn validate_inference(inference: &Inference) -> Vec<String> {
+    let Some(provider_raw) = inference.provider.as_deref() else {
+        return Vec::new();
+    };
+    let provider = provider_raw.trim();
+    if provider.is_empty() {
+        return Vec::new();
+    }
+    validate_parts(
+        provider,
+        inference.base_url.as_deref(),
+        inference.api_key_secret.as_deref(),
+    )
+}
+
+/// Validates a runtime override (console `PUT`) — same rules as the manifest,
+/// but a runtime override never names a secret key (the console writes the
+/// canonical `inference/key`), so `api_key_secret` is not part of the shape.
+pub fn validate_runtime(config: &RuntimeInference) -> Vec<String> {
+    validate_parts(config.provider.trim(), config.base_url.as_deref(), None)
+}
+
+/// The shared validation rules for an inference declaration.
+fn validate_parts(
+    provider: &str,
+    base_url: Option<&str>,
+    api_key_secret: Option<&str>,
+) -> Vec<String> {
+    let mut problems = Vec::new();
+
+    if !INFERENCE_PROVIDERS.contains(&provider) {
+        problems.push(format!(
+            "`[inference].provider` must be one of {} — you wrote `{provider}`.",
+            INFERENCE_PROVIDERS.join(", ")
+        ));
+    }
+
+    let base_url = base_url.map(str::trim).filter(|s| !s.is_empty());
+    match provider {
+        "ollama" | "openai_compatible" => match base_url {
+            None => problems.push(format!(
+                "`[inference].base_url` is required for provider `{provider}` — give the OpenAI-compatible endpoint URL."
+            )),
+            Some(url) if !is_http_url(url) => problems.push(format!(
+                "`[inference].base_url` must be an `http://` or `https://` URL — you wrote `{url}`."
+            )),
+            _ => {}
+        },
+        _ => {
+            if let Some(url) = base_url
+                && !is_http_url(url)
+            {
+                problems.push(format!(
+                    "`[inference].base_url` must be an `http://` or `https://` URL — you wrote `{url}`."
+                ));
+            }
+        }
+    }
+
+    // The credential must be a *key name*, not the token itself. Reject values
+    // that look like a pasted credential so a secret never lands in the manifest.
+    if let Some(secret) = api_key_secret.map(str::trim).filter(|s| !s.is_empty())
+        && looks_like_inline_credential(secret)
+    {
+        problems.push(
+            "`[inference].api_key_secret` names a secret-store key, not the secret itself — you appear to have pasted a credential. Set the token through the console instead.".to_string(),
+        );
+    }
+
+    problems
+}
+
+/// True when `url` is an absolute `http://` or `https://` URL.
+fn is_http_url(url: &str) -> bool {
+    let lower = url.trim().to_ascii_lowercase();
+    lower.starts_with("http://") || lower.starts_with("https://")
+}
+
+/// Heuristic: does this string look like a pasted credential rather than a
+/// secret-store *key name*? Catches the common provider token prefixes and any
+/// long, opaque, single-token value.
+fn looks_like_inline_credential(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    const PREFIXES: &[&str] = &[
+        "sk-", "sk_", "pk-", "pk_", "rk-", "or-v1-", "xai-", "gsk_", "bearer ",
+    ];
+    if PREFIXES.iter().any(|p| lower.starts_with(p)) {
+        return true;
+    }
+    // A long, opaque token with no path separator or whitespace — key names are
+    // short and structured (`inference/openrouter`), tokens are long and dense.
+    value.len() >= 40 && !value.contains('/') && !value.contains(char::is_whitespace)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+
+    fn inference(provider: &str) -> Inference {
+        Inference {
+            provider: Some(provider.to_string()),
+            base_url: None,
+            api_key_secret: None,
+            models: BTreeMap::new(),
+        }
+    }
+
+    #[derive(Default)]
+    struct MemSecrets {
+        map: Mutex<HashMap<String, String>>,
+    }
+
+    #[async_trait]
+    impl SecretStore for MemSecrets {
+        async fn get(&self, _c: &CompanyId, key: &str) -> Result<Option<SecretValue>> {
+            Ok(self
+                .map
+                .lock()
+                .unwrap()
+                .get(key)
+                .map(|v| SecretValue(v.clone())))
+        }
+        async fn set(&self, _c: &CompanyId, key: &str, value: SecretValue) -> Result<()> {
+            self.map.lock().unwrap().insert(key.to_string(), value.0);
+            Ok(())
+        }
+    }
+
+    // ---- precedence matrix -------------------------------------------------
+
+    #[tokio::test]
+    async fn runtime_beats_manifest_beats_env() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        let env = EnvDefault {
+            base_url: "https://env.example/v1".into(),
+            api_key: "env-key".into(),
+        };
+        let mut manifest = inference("openai_compatible");
+        manifest.base_url = Some("https://manifest.example/v1".into());
+
+        // Env only.
+        let decl = resolve_effective(&company, &Inference::default(), Some(&env), &secrets)
+            .await
+            .unwrap()
+            .expect("env default resolves");
+        assert_eq!(decl.source, InferenceSource::Default);
+        assert_eq!(decl.provider, "managed");
+        assert_eq!(decl.api_key(), "env-key");
+
+        // Manifest beats env.
+        let decl = resolve_effective(&company, &manifest, Some(&env), &secrets)
+            .await
+            .unwrap()
+            .expect("manifest resolves");
+        assert_eq!(decl.source, InferenceSource::Manifest);
+        assert_eq!(decl.provider, "openai_compatible");
+        assert_eq!(decl.base_url, "https://manifest.example/v1");
+
+        // Runtime beats manifest.
+        save_runtime_config(
+            &company,
+            &secrets,
+            &RuntimeInference {
+                provider: "openrouter".into(),
+                base_url: None,
+                models: BTreeMap::new(),
+            },
+        )
+        .await
+        .unwrap();
+        store_key(&company, &secrets, "or-secret").await.unwrap();
+        let decl = resolve_effective(&company, &manifest, Some(&env), &secrets)
+            .await
+            .unwrap()
+            .expect("runtime resolves");
+        assert_eq!(decl.source, InferenceSource::Runtime);
+        assert_eq!(decl.provider, "openrouter");
+        assert_eq!(decl.base_url, OPENROUTER_BASE_URL);
+        assert_eq!(decl.api_key(), "or-secret");
+        assert!(decl.key_configured());
+    }
+
+    #[tokio::test]
+    async fn manifest_managed_inherits_env_credential() {
+        // A hand-written `provider = "managed"` must still use the platform
+        // env key + base URL rather than dropping the credential.
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        let env = EnvDefault {
+            base_url: "https://env.example/openai/v1".into(),
+            api_key: "platform-key".into(),
+        };
+        let decl = resolve_effective(&company, &inference("managed"), Some(&env), &secrets)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(decl.source, InferenceSource::Manifest);
+        assert_eq!(decl.provider, "managed");
+        assert_eq!(decl.base_url, "https://env.example/openai/v1");
+        assert_eq!(decl.api_key(), "platform-key");
+    }
+
+    #[tokio::test]
+    async fn no_source_resolves_to_none() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        let decl = resolve_effective(&company, &Inference::default(), None, &secrets)
+            .await
+            .unwrap();
+        assert!(
+            decl.is_none(),
+            "no source means the managed/echo brain stays"
+        );
+    }
+
+    #[tokio::test]
+    async fn clearing_runtime_reverts_to_manifest() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        let manifest = inference("openrouter");
+        save_runtime_config(
+            &company,
+            &secrets,
+            &RuntimeInference {
+                provider: "ollama".into(),
+                base_url: Some("http://localhost:11434/v1".into()),
+                models: BTreeMap::new(),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            resolve_effective(&company, &manifest, None, &secrets)
+                .await
+                .unwrap()
+                .unwrap()
+                .provider,
+            "ollama"
+        );
+        clear_runtime_config(&company, &secrets).await.unwrap();
+        assert_eq!(
+            resolve_effective(&company, &manifest, None, &secrets)
+                .await
+                .unwrap()
+                .unwrap()
+                .provider,
+            "openrouter"
+        );
+    }
+
+    // ---- write-only key ----------------------------------------------------
+
+    #[tokio::test]
+    async fn key_is_write_only_and_never_serialized() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        store_key(&company, &secrets, "sk-super-secret")
+            .await
+            .unwrap();
+        let decl = resolve_effective(&company, &inference("openrouter"), None, &secrets)
+            .await
+            .unwrap()
+            .unwrap();
+        // The key resolves for request building…
+        assert_eq!(decl.api_key(), "sk-super-secret");
+        // …but never appears in the Debug rendering.
+        let debug = format!("{decl:?}");
+        assert!(!debug.contains("sk-super-secret"), "{debug}");
+        assert!(debug.contains("<redacted>"), "{debug}");
+    }
+
+    #[tokio::test]
+    async fn cleared_key_reads_back_unconfigured() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        store_key(&company, &secrets, "tok").await.unwrap();
+        assert!(key_configured(&company, &secrets, None).await.unwrap());
+        clear_key(&company, &secrets).await.unwrap();
+        assert!(!key_configured(&company, &secrets, None).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn manifest_api_key_secret_is_the_fallback_key() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        // Only the manifest-named key holds a token; canonical key is cold.
+        secrets
+            .set(
+                &company,
+                "byo/openrouter",
+                SecretValue("named-secret".into()),
+            )
+            .await
+            .unwrap();
+        let mut manifest = inference("openrouter");
+        manifest.api_key_secret = Some("byo/openrouter".into());
+        let decl = resolve_effective(&company, &manifest, None, &secrets)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(decl.api_key(), "named-secret");
+    }
+
+    // ---- validation --------------------------------------------------------
+
+    #[test]
+    fn absent_section_is_inert() {
+        assert!(validate_inference(&Inference::default()).is_empty());
+    }
+
+    #[test]
+    fn valid_configs_pass() {
+        assert!(validate_inference(&inference("managed")).is_empty());
+        assert!(validate_inference(&inference("openrouter")).is_empty());
+        let mut ollama = inference("ollama");
+        ollama.base_url = Some("http://localhost:11434/v1".into());
+        assert!(
+            validate_inference(&ollama).is_empty(),
+            "{:?}",
+            validate_inference(&ollama)
+        );
+    }
+
+    #[test]
+    fn unknown_provider_is_rejected() {
+        let problems = validate_inference(&inference("gpt5"));
+        assert!(
+            problems.iter().any(|p| p.contains("provider")),
+            "{problems:?}"
+        );
+    }
+
+    #[test]
+    fn ollama_and_openai_compatible_require_base_url() {
+        let ollama = validate_inference(&inference("ollama"));
+        assert!(
+            ollama
+                .iter()
+                .any(|p| p.contains("base_url") && p.contains("required"))
+        );
+        let compat = validate_inference(&inference("openai_compatible"));
+        assert!(
+            compat
+                .iter()
+                .any(|p| p.contains("base_url") && p.contains("required"))
+        );
+    }
+
+    #[test]
+    fn non_http_base_url_is_rejected() {
+        let mut m = inference("openai_compatible");
+        m.base_url = Some("ftp://x/v1".into());
+        let problems = validate_inference(&m);
+        assert!(problems.iter().any(|p| p.contains("http")), "{problems:?}");
+    }
+
+    #[test]
+    fn inline_credential_in_key_name_is_rejected() {
+        let mut m = inference("openrouter");
+        m.api_key_secret = Some("sk-or-v1-abcdef0123456789".into());
+        let problems = validate_inference(&m);
+        assert!(
+            problems
+                .iter()
+                .any(|p| p.contains("names a secret-store key")),
+            "{problems:?}"
+        );
+
+        // A long opaque token with no separators is also caught.
+        let mut m2 = inference("openrouter");
+        m2.api_key_secret = Some("abcdefghijklmnopqrstuvwxyz0123456789ABCDEF".into());
+        assert!(!validate_inference(&m2).is_empty());
+
+        // A structured key name is accepted.
+        let mut ok = inference("openrouter");
+        ok.api_key_secret = Some("byo/openrouter".into());
+        assert!(
+            validate_inference(&ok).is_empty(),
+            "{:?}",
+            validate_inference(&ok)
+        );
+    }
+
+    #[test]
+    fn provider_slugs_map_as_documented() {
+        assert_eq!(provider_slug("managed"), "managed");
+        assert_eq!(provider_slug("openrouter"), "openrouter");
+        assert_eq!(provider_slug("openai_compatible"), "byok");
+        assert_eq!(provider_slug("ollama"), "ollama");
+        assert_eq!(provider_slug("mystery"), "managed");
+    }
+
+    #[test]
+    fn effective_base_url_defaults_per_provider() {
+        assert_eq!(effective_base_url("managed", None), MANAGED_BASE_URL);
+        assert_eq!(effective_base_url("openrouter", None), OPENROUTER_BASE_URL);
+        assert_eq!(effective_base_url("ollama", None), OLLAMA_DEFAULT_BASE_URL);
+        assert_eq!(
+            effective_base_url("openrouter", Some("https://proxy/v1")),
+            "https://proxy/v1"
+        );
+    }
+}

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -204,6 +204,11 @@ impl CompanyManifest {
         // MCP servers: unique names, an `http(s)://` endpoint, no stdio in v1.
         problems.extend(super::mcp::validate_servers(&self.mcp_servers));
 
+        // Inference (issue #56 — BYOK): provider kind, base_url rules, and a
+        // key *name* (never an inline credential). Inert when the section is
+        // absent.
+        problems.extend(super::inference::validate_inference(&self.inference));
+
         // Enabled workflows reference `workflows/<id>.toml`; ids must be sane.
         for id in &self.workflows.enabled {
             if !is_snake_case(id) {
@@ -614,6 +619,43 @@ mod tests {
                 .iter()
                 .any(|p| p.contains("stdio") && p.contains("hosted v1")),
             "{problems:?}"
+        );
+    }
+
+    #[test]
+    fn accepts_byok_inference_and_rejects_bad_provider() {
+        let ok = parse(
+            r#"
+            [company]
+            name = "X"
+            [inference]
+            provider = "openrouter"
+            [inference.models]
+            "chat-v1" = "deepseek/deepseek-chat"
+            "#,
+        );
+        assert!(ok.validate().is_empty(), "{:?}", ok.validate());
+        assert_eq!(ok.inference.provider.as_deref(), Some("openrouter"));
+        assert_eq!(
+            ok.inference.models.get("chat-v1").map(String::as_str),
+            Some("deepseek/deepseek-chat")
+        );
+
+        let bad = parse(
+            r#"
+            [company]
+            name = "X"
+            [inference]
+            provider = "ollama"
+            "#,
+        );
+        // Ollama needs a base_url.
+        assert!(
+            bad.validate()
+                .iter()
+                .any(|p| p.contains("base_url") && p.contains("required")),
+            "{:?}",
+            bad.validate()
         );
     }
 

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -8,6 +8,7 @@
 #[cfg(test)]
 mod content_test;
 pub mod dns;
+pub mod inference;
 mod manifest;
 pub mod mcp;
 pub mod runtime;
@@ -22,8 +23,8 @@ pub use manifest::{LEGACY_MANIFEST_FILE, Located, MANIFEST_FILE, discover};
 pub use skill_file::{SkillDoc, load_dir_skills, parse_skill_md};
 pub use types::{
     Agent, BRAIN_MODES, Brain, Budget, ChannelConfig, Company, CompanyManifest, Connection,
-    DEFAULT_ALWAYS_APPROVE, KNOWN_CHANNELS, McpServer, POLICY_MODES, Place, Policy, Schedule,
-    Skill, TIERS, TOOL_PROVIDERS, Tools,
+    DEFAULT_ALWAYS_APPROVE, INFERENCE_PROVIDERS, INFERENCE_TIERS, Inference, KNOWN_CHANNELS,
+    McpServer, POLICY_MODES, Place, Policy, Schedule, Skill, TIERS, TOOL_PROVIDERS, Tools,
 };
 pub use workflow_file::{
     WORKFLOW_NODE_KINDS, WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef, WorkflowNodeKind,

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -22,6 +22,22 @@ pub const TIERS: &[&str] = &[
 /// Brain implementations selectable in `[brain].mode`.
 pub const BRAIN_MODES: &[&str] = &["hosted", "sidecar"];
 
+/// Inference providers selectable in `[inference].provider` (issue #56 — BYOK).
+///
+/// * `managed` — the hosted TinyHumans / Medulla brain (the default path).
+/// * `openrouter` — OpenRouter's OpenAI-compatible aggregator (needs a key +
+///   the `HTTP-Referer` / `X-Title` attribution headers).
+/// * `openai_compatible` — any OpenAI-compatible endpoint the tenant runs
+///   (needs a `base_url`, usually a key).
+/// * `ollama` — a local Ollama server's OpenAI-compatible surface (needs a
+///   `base_url`; no key).
+pub const INFERENCE_PROVIDERS: &[&str] = &["managed", "openrouter", "openai_compatible", "ollama"];
+
+/// The abstract cognition tiers the tenant `[inference].models` table maps to
+/// concrete provider model ids. These are the workload names the harness
+/// addresses; an unmapped tier passes through to the provider verbatim.
+pub const INFERENCE_TIERS: &[&str] = &["chat-v1", "reasoning-v1", "agentic-v1", "vision-v1"];
+
 /// Tool providers selectable in `[tools].provider`.
 pub const TOOL_PROVIDERS: &[&str] = &["openhuman", "builtin"];
 
@@ -70,6 +86,13 @@ pub struct CompanyManifest {
     /// Brain selection.
     #[serde(default)]
     pub brain: Brain,
+    /// Per-tenant Bring-Your-Own-Key inference routing (issue #56). Declarative
+    /// intent — a provider kind, an OpenAI-compatible `base_url`, an optional
+    /// *named* secret key (`api_key_secret`), and an abstract-tier → model map.
+    /// **Never** an inline credential. Absent (the default) keeps the managed
+    /// hosted brain. An anchor of its own, kept append-only.
+    #[serde(default)]
+    pub inference: Inference,
     /// Channel adapters, keyed by channel name.
     #[serde(default)]
     pub channels: BTreeMap<String, ChannelConfig>,
@@ -272,6 +295,51 @@ impl Default for Brain {
 
 fn default_brain_mode() -> String {
     "hosted".to_string()
+}
+
+/// `[inference]` — per-tenant Bring-Your-Own-Key inference routing (issue #56).
+///
+/// This is declarative intent, shaped like [`McpServer`]: it names a provider
+/// kind, an OpenAI-compatible `base_url`, and (optionally) which
+/// [`SecretStore`](crate::ports::SecretStore) key holds the outbound
+/// credential, but it **never** carries a token. When a provider needs auth,
+/// `api_key_secret` names a key holding it, which the operator writes through
+/// the console (write-only). An absent section (`provider = None`) keeps the
+/// managed hosted brain.
+///
+/// The `models` table maps an abstract cognition tier (`chat-v1`,
+/// `reasoning-v1`, `agentic-v1`, `vision-v1`) to a concrete provider model id
+/// (e.g. `deepseek/deepseek-chat`). An unmapped tier passes through verbatim.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Inference {
+    /// Provider kind — one of [`INFERENCE_PROVIDERS`]. `None` (absent section)
+    /// keeps the managed hosted brain.
+    #[serde(default)]
+    pub provider: Option<String>,
+    /// Base URL of the OpenAI-compatible chat-completions API. Required for
+    /// `openai_compatible` and `ollama`; defaulted for `managed`/`openrouter`.
+    #[serde(default)]
+    pub base_url: Option<String>,
+    /// The name of the [`SecretStore`](crate::ports::SecretStore) key holding
+    /// this provider's outbound credential. Names a key — **never** the token.
+    /// When unset, the runtime resolves the canonical key (`inference/key`)
+    /// written by the console.
+    #[serde(default)]
+    pub api_key_secret: Option<String>,
+    /// Abstract-tier → concrete provider model id. An unmapped tier passes
+    /// through to the provider unchanged.
+    #[serde(default)]
+    pub models: BTreeMap<String, String>,
+}
+
+impl Inference {
+    /// Whether this manifest section names a provider — i.e. it meaningfully
+    /// configures inference (an absent `[inference]` leaves `provider` `None`).
+    pub fn is_set(&self) -> bool {
+        self.provider
+            .as_deref()
+            .is_some_and(|p| !p.trim().is_empty())
+    }
 }
 
 /// A `[channels.*]` entry.

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -401,11 +401,16 @@ impl HarnessPool {
         // wrapper retried once). A zero-usage attempt (offline provider) writes
         // nothing, so the inert-metering contract holds.
         let (reply, turn_costs) = agent.run(&augmented).await?;
+        // Attribute cost to the provider this turn actually resolved to. With a
+        // per-tenant [`TenantProvider`](crate::harness::provider::TenantProvider)
+        // a console BYOK switch changes the slug between turns, so read it live
+        // rather than trusting the static `deps.provider_slug` baked at build.
+        let provider_slug = deps.provider.telemetry_provider_id();
         for turn_cost in &turn_costs {
             record_turn_cost(
                 turn_cost,
                 agent_id,
-                &deps.provider_slug,
+                &provider_slug,
                 company,
                 deps.store.as_ref(),
                 deps.meter.as_deref(),

--- a/src/harness/provider.rs
+++ b/src/harness/provider.rs
@@ -13,12 +13,18 @@
 //! `BrainMode` continues to select hosted vs echo at the runtime layer; the old
 //! out-of-process `sidecar` mode is subsumed by this in-process harness.
 
+use std::sync::{Arc, RwLock};
+
 use async_trait::async_trait;
 use openhuman_core::openhuman as oh;
 
 use oh::inference::provider::{ChatRequest, ChatResponse, Provider, UsageInfo};
 
 use crate::app::config::EnvSource;
+use crate::company::Inference;
+use crate::company::inference::{self, EnvDefault, InferenceDecl};
+use crate::ports::SecretStore;
+use crate::ports::types::CompanyId;
 
 /// Default hosted inference endpoint when only a bare `TINYHUMANS_API_KEY` is
 /// supplied — the OpenAI-compatible surface a company agent's `chat-v1` /
@@ -27,6 +33,13 @@ pub const DEFAULT_TINYHUMANS_INFERENCE_URL: &str = "https://api.tinyhumans.ai/op
 
 /// Default hosted model/tier when none is configured.
 pub const DEFAULT_HOSTED_MODEL: &str = "chat-v1";
+
+/// The `HTTP-Referer` attribution header OpenRouter asks BYOK callers to send —
+/// it identifies the app in OpenRouter's dashboard/rankings.
+pub const OPENROUTER_REFERER: &str = "https://opencompany.tinyhumans.ai";
+
+/// The `X-Title` attribution header OpenRouter asks BYOK callers to send.
+pub const OPENROUTER_TITLE: &str = "OpenCompany";
 
 /// Resolve a [`HostedProvider`] configuration (and its default model) from the
 /// environment, or `None` when no credential is present.
@@ -41,17 +54,28 @@ pub const DEFAULT_HOSTED_MODEL: &str = "chat-v1";
 /// The two-name key precedence keeps a per-tenant override
 /// (`OPENCOMPANY_INFERENCE_KEY`) distinct from the platform-wide TinyHumans
 /// credential the manager injects (`TINYHUMANS_API_KEY`).
-pub fn harness_inference_from_env(env: &dyn EnvSource) -> Option<(HostedProviderConfig, String)> {
+pub fn harness_inference_from_env(
+    env: &dyn EnvSource,
+) -> Option<(HostedProviderConfig, Option<String>)> {
     let api_key = env
         .get("OPENCOMPANY_INFERENCE_KEY")
         .or_else(|| env.get("TINYHUMANS_API_KEY"))?;
     let base_url = env
         .get("OPENCOMPANY_INFERENCE_URL")
         .unwrap_or_else(|| DEFAULT_TINYHUMANS_INFERENCE_URL.to_string());
-    let model = env
-        .get("OPENCOMPANY_INFERENCE_MODEL")
-        .unwrap_or_else(|| DEFAULT_HOSTED_MODEL.to_string());
-    Some((HostedProviderConfig { base_url, api_key }, model))
+    // The model is a per-roster **override** now: only an explicit
+    // `OPENCOMPANY_INFERENCE_MODEL` flattens every agent to one workload. When
+    // unset, each agent keeps its tier-derived model, which the tenant
+    // `[inference].models` table then maps. `None` = no override.
+    let model_override = env.get("OPENCOMPANY_INFERENCE_MODEL");
+    Some((
+        HostedProviderConfig {
+            base_url,
+            api_key,
+            extra_headers: Vec::new(),
+        },
+        model_override,
+    ))
 }
 
 /// Deterministic offline [`Provider`] for tests and offline harness wiring.
@@ -101,7 +125,7 @@ impl Provider for MockProvider {
 }
 
 /// Configuration for the hosted inference [`Provider`].
-#[derive(Debug, Clone)]
+#[derive(Clone, Default)]
 pub struct HostedProviderConfig {
     /// Base URL of the OpenAI-compatible chat-completions API, e.g.
     /// `https://api.tinyhumans.ai/v1`. The provider POSTs to
@@ -109,6 +133,27 @@ pub struct HostedProviderConfig {
     pub base_url: String,
     /// Bearer credential for the hosted brain. Empty string omits the header.
     pub api_key: String,
+    /// Extra request headers to attach on every call (e.g. OpenRouter's
+    /// `HTTP-Referer` / `X-Title` attribution headers).
+    pub extra_headers: Vec<(String, String)>,
+}
+
+impl std::fmt::Debug for HostedProviderConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never let the credential land in a trace.
+        f.debug_struct("HostedProviderConfig")
+            .field("base_url", &self.base_url)
+            .field(
+                "api_key",
+                &if self.api_key.is_empty() {
+                    "<unset>"
+                } else {
+                    "<redacted>"
+                },
+            )
+            .field("extra_headers", &self.extra_headers)
+            .finish()
+    }
 }
 
 /// Hosted TinyHumans / Medulla inference [`Provider`].
@@ -164,6 +209,9 @@ impl Provider for HostedProvider {
         let mut request = self.client.post(&url).json(&body);
         if !self.config.api_key.is_empty() {
             request = request.bearer_auth(&self.config.api_key);
+        }
+        for (name, value) in &self.config.extra_headers {
+            request = request.header(name, value);
         }
 
         let response = request
@@ -233,6 +281,9 @@ impl Provider for HostedProvider {
         if !self.config.api_key.is_empty() {
             http = http.bearer_auth(&self.config.api_key);
         }
+        for (name, value) in &self.config.extra_headers {
+            http = http.header(name, value);
+        }
 
         let response = http
             .send()
@@ -252,6 +303,236 @@ impl Provider for HostedProvider {
             .map_err(|e| anyhow::anyhow!("hosted inference response was not JSON: {e}"))?;
         chat_response_from_payload(&payload)
     }
+}
+
+/// A pure request plan — everything needed to issue one chat-completion call,
+/// derived from a resolved [`InferenceDecl`] with no I/O. Split out so the tier
+/// mapping, header injection, and empty-key handling are unit-testable without
+/// a live backend.
+#[derive(Debug)]
+pub struct RequestPlan {
+    /// The full POST URL (`{base_url}/chat/completions`).
+    pub url: String,
+    /// The concrete provider model id after tier mapping.
+    pub model: String,
+    /// The bearer credential, or `None` to omit the header (e.g. Ollama).
+    pub bearer: Option<String>,
+    /// Extra request headers (OpenRouter attribution) to attach.
+    pub headers: Vec<(&'static str, String)>,
+    /// The JSON request body.
+    pub body: serde_json::Value,
+}
+
+/// Builds the [`RequestPlan`] for one turn against a tenant provider.
+///
+/// * The abstract tier (`chat-v1`, …) is mapped through the tenant
+///   `[inference].models` table; an unmapped tier passes through verbatim.
+/// * OpenRouter gets its mandatory `HTTP-Referer` / `X-Title` attribution
+///   headers; other providers get none.
+/// * An empty resolved key omits the bearer (the Ollama / keyless case).
+pub fn request_plan(
+    decl: &InferenceDecl,
+    abstract_model: &str,
+    messages: Vec<serde_json::Value>,
+    temperature: f64,
+    max_tokens: Option<u32>,
+) -> RequestPlan {
+    let model = decl
+        .models
+        .get(abstract_model)
+        .cloned()
+        .unwrap_or_else(|| abstract_model.to_string());
+    let url = format!("{}/chat/completions", decl.base_url.trim_end_matches('/'));
+    let key = decl.api_key().trim();
+    let bearer = if key.is_empty() {
+        None
+    } else {
+        Some(key.to_string())
+    };
+    let headers = if decl.provider == "openrouter" {
+        vec![
+            ("HTTP-Referer", OPENROUTER_REFERER.to_string()),
+            ("X-Title", OPENROUTER_TITLE.to_string()),
+        ]
+    } else {
+        Vec::new()
+    };
+    let mut body = serde_json::json!({
+        "model": model,
+        "temperature": temperature,
+        "messages": messages,
+    });
+    if let Some(cap) = max_tokens {
+        body["max_tokens"] = serde_json::json!(cap);
+    }
+    RequestPlan {
+        url,
+        model,
+        bearer,
+        headers,
+        body,
+    }
+}
+
+/// Issues a prepared [`RequestPlan`] against `client`, returning the raw JSON
+/// payload. Every error string is scrubbed of the bearer, so a credential can
+/// never leak into a log line or an operator-visible message.
+async fn send_plan(
+    client: &reqwest::Client,
+    plan: &RequestPlan,
+) -> anyhow::Result<serde_json::Value> {
+    let mut request = client.post(&plan.url).json(&plan.body);
+    if let Some(bearer) = &plan.bearer {
+        request = request.bearer_auth(bearer);
+    }
+    for (name, value) in &plan.headers {
+        request = request.header(*name, value);
+    }
+    let scrub = |text: String| match &plan.bearer {
+        Some(bearer) if !bearer.is_empty() => text.replace(bearer.as_str(), "<redacted>"),
+        _ => text,
+    };
+    let response = request
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("inference request failed: {}", scrub(e.to_string())))?;
+    let status = response.status();
+    if !status.is_success() {
+        let text = response.text().await.unwrap_or_default();
+        return Err(anyhow::anyhow!(
+            "inference returned {status}: {}",
+            scrub(text)
+        ));
+    }
+    response
+        .json()
+        .await
+        .map_err(|e| anyhow::anyhow!("inference response was not JSON: {}", scrub(e.to_string())))
+}
+
+/// The per-tenant inference [`Provider`] (issue #56 — BYOK).
+///
+/// Holds no baked configuration: on **every** `chat` / `chat_with_system` it
+/// re-resolves the company's effective [`InferenceDecl`] from the secret store
+/// (runtime override > manifest `[inference]` > managed env default). That
+/// re-resolution is what makes a console provider switch take effect on the
+/// agents' *next turn* with **no rebuild** — the roster and history survive; only
+/// the outbound endpoint/model/credential change. Each turn maps the incoming
+/// abstract tier through the tenant model table, injects OpenRouter's
+/// attribution headers, and omits the bearer when the key is empty (Ollama).
+pub struct TenantProvider {
+    company: CompanyId,
+    secrets: Arc<dyn SecretStore>,
+    manifest: Inference,
+    env_default: Option<EnvDefault>,
+    client: reqwest::Client,
+    /// The slug of the most recently resolved provider, so the synchronous
+    /// [`telemetry_provider_id`](Provider::telemetry_provider_id) reflects the
+    /// config the last turn actually used (cost attribution follows the switch).
+    slug: RwLock<&'static str>,
+}
+
+impl TenantProvider {
+    /// Builds a tenant provider over `secrets`, the manifest `[inference]`
+    /// section, and the optional managed env default.
+    pub fn new(
+        company: CompanyId,
+        secrets: Arc<dyn SecretStore>,
+        manifest: Inference,
+        env_default: Option<EnvDefault>,
+    ) -> Self {
+        Self {
+            company,
+            secrets,
+            manifest,
+            env_default,
+            client: reqwest::Client::new(),
+            slug: RwLock::new("managed"),
+        }
+    }
+
+    /// Re-resolves the effective config from the secret store and updates the
+    /// cached telemetry slug. Errors when no provider is configured at all.
+    async fn resolve(&self) -> anyhow::Result<InferenceDecl> {
+        let decl = inference::resolve_effective(
+            &self.company,
+            &self.manifest,
+            self.env_default.as_ref(),
+            self.secrets.as_ref(),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("resolving inference config: {e}"))?
+        .ok_or_else(|| anyhow::anyhow!("no inference provider is configured for this company"))?;
+        *self.slug.write().unwrap() = decl.telemetry_slug();
+        Ok(decl)
+    }
+}
+
+#[async_trait]
+impl Provider for TenantProvider {
+    fn telemetry_provider_id(&self) -> String {
+        (*self.slug.read().unwrap()).to_string()
+    }
+
+    async fn chat_with_system(
+        &self,
+        system_prompt: Option<&str>,
+        message: &str,
+        model: &str,
+        temperature: f64,
+    ) -> anyhow::Result<String> {
+        let decl = self.resolve().await?;
+        let mut messages: Vec<serde_json::Value> = Vec::with_capacity(2);
+        if let Some(system) = system_prompt {
+            messages.push(serde_json::json!({ "role": "system", "content": system }));
+        }
+        messages.push(serde_json::json!({ "role": "user", "content": message }));
+
+        let plan = request_plan(&decl, model, messages, temperature, None);
+        let payload = send_plan(&self.client, &plan).await?;
+        let content = payload
+            .pointer("/choices/0/message/content")
+            .and_then(|c| c.as_str())
+            .ok_or_else(|| {
+                anyhow::anyhow!("inference response missing choices[0].message.content")
+            })?;
+        Ok(content.to_string())
+    }
+
+    /// Structured multi-turn chat — the path [`Agent::turn`](oh::agent::Agent)
+    /// calls. Mirrors [`HostedProvider::chat`]: full history reaches the backend
+    /// and token/cost usage is parsed back out.
+    async fn chat(
+        &self,
+        request: ChatRequest<'_>,
+        model: &str,
+        temperature: f64,
+    ) -> anyhow::Result<ChatResponse> {
+        let decl = self.resolve().await?;
+        let messages: Vec<serde_json::Value> = request
+            .messages
+            .iter()
+            .map(|m| serde_json::json!({ "role": m.role, "content": m.content }))
+            .collect();
+        let plan = request_plan(&decl, model, messages, temperature, request.max_tokens);
+        let payload = send_plan(&self.client, &plan).await?;
+        chat_response_from_payload(&payload)
+    }
+}
+
+/// A minimal live probe: one `ping` turn against the resolved config, used by
+/// the console's "Test" button. The error is scrubbed of the credential by
+/// [`send_plan`].
+pub async fn probe(decl: &InferenceDecl) -> anyhow::Result<()> {
+    let client = reqwest::Client::new();
+    let messages = vec![serde_json::json!({ "role": "user", "content": "ping" })];
+    let plan = request_plan(decl, DEFAULT_HOSTED_MODEL, messages, 0.0, Some(16));
+    let payload = send_plan(&client, &plan).await?;
+    payload
+        .pointer("/choices/0/message/content")
+        .and_then(|c| c.as_str())
+        .ok_or_else(|| anyhow::anyhow!("probe response missing choices[0].message.content"))?;
+    Ok(())
 }
 
 /// Parse an OpenAI-compatible chat-completion payload into a [`ChatResponse`],
@@ -329,7 +610,8 @@ mod tests {
         let (cfg, model) = harness_inference_from_env(&env).expect("configured");
         assert_eq!(cfg.api_key, "sk-specific");
         assert_eq!(cfg.base_url, DEFAULT_TINYHUMANS_INFERENCE_URL);
-        assert_eq!(model, "chat-v1");
+        // No explicit model → no roster-wide override (each agent keeps its tier).
+        assert_eq!(model, None);
     }
 
     #[test]
@@ -345,7 +627,7 @@ mod tests {
         let (cfg, model) = harness_inference_from_env(&env).expect("configured");
         assert_eq!(cfg.api_key, "sk-platform");
         assert_eq!(cfg.base_url, "https://staging-api.tinyhumans.ai/openai/v1");
-        assert_eq!(model, "reasoning-v1");
+        assert_eq!(model.as_deref(), Some("reasoning-v1"));
     }
 
     #[test]
@@ -380,6 +662,7 @@ mod tests {
         let provider = HostedProvider::new(HostedProviderConfig {
             base_url: "https://example.test/v1".to_string(),
             api_key: String::new(),
+            extra_headers: Vec::new(),
         });
         assert_eq!(provider.telemetry_provider_id(), "managed");
     }
@@ -447,5 +730,177 @@ mod tests {
         });
         let resp = chat_response_from_payload(&no_usage).expect("parses");
         assert!(resp.usage.is_none());
+    }
+
+    // ---- TenantProvider (issue #56 — BYOK) --------------------------------
+
+    use std::collections::BTreeMap;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    use crate::company::Inference;
+    use crate::ports::types::SecretValue;
+
+    #[derive(Default)]
+    struct MemSecrets {
+        map: Mutex<HashMap<String, String>>,
+    }
+
+    #[async_trait]
+    impl SecretStore for MemSecrets {
+        async fn get(&self, _c: &CompanyId, key: &str) -> crate::Result<Option<SecretValue>> {
+            Ok(self
+                .map
+                .lock()
+                .unwrap()
+                .get(key)
+                .map(|v| SecretValue(v.clone())))
+        }
+        async fn set(&self, _c: &CompanyId, key: &str, value: SecretValue) -> crate::Result<()> {
+            self.map.lock().unwrap().insert(key.to_string(), value.0);
+            Ok(())
+        }
+    }
+
+    fn manifest_inference(provider: &str) -> Inference {
+        Inference {
+            provider: Some(provider.to_string()),
+            base_url: None,
+            api_key_secret: None,
+            models: BTreeMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn request_plan_maps_tier_and_injects_openrouter_headers() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        let mut manifest = manifest_inference("openrouter");
+        manifest.models =
+            BTreeMap::from([("chat-v1".to_string(), "deepseek/deepseek-chat".to_string())]);
+        inference::store_key(&company, &secrets, "or-key")
+            .await
+            .unwrap();
+        let decl = inference::resolve_effective(&company, &manifest, None, &secrets)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let plan = request_plan(&decl, "chat-v1", Vec::new(), 0.2, None);
+        assert_eq!(
+            plan.model, "deepseek/deepseek-chat",
+            "tier maps through table"
+        );
+        assert_eq!(plan.bearer.as_deref(), Some("or-key"));
+        assert!(plan.url.ends_with("/chat/completions"), "{}", plan.url);
+        assert!(
+            plan.headers
+                .contains(&("HTTP-Referer", OPENROUTER_REFERER.to_string()))
+        );
+        assert!(
+            plan.headers
+                .contains(&("X-Title", OPENROUTER_TITLE.to_string()))
+        );
+
+        // An unmapped tier passes through unchanged.
+        let passthrough = request_plan(&decl, "reasoning-v1", Vec::new(), 0.2, None);
+        assert_eq!(passthrough.model, "reasoning-v1");
+    }
+
+    #[tokio::test]
+    async fn request_plan_omits_bearer_for_keyless_ollama() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        let mut manifest = manifest_inference("ollama");
+        manifest.base_url = Some("http://localhost:11434/v1".into());
+        let decl = inference::resolve_effective(&company, &manifest, None, &secrets)
+            .await
+            .unwrap()
+            .unwrap();
+        let plan = request_plan(&decl, "chat-v1", Vec::new(), 0.0, None);
+        assert!(plan.bearer.is_none(), "keyless Ollama sends no bearer");
+        assert!(plan.headers.is_empty(), "no OpenRouter headers for Ollama");
+    }
+
+    /// Spawns an in-process OpenAI-compatible stub that echoes `marker` as the
+    /// completion content. The listener is bound before the task spawns, so the
+    /// OS accepts connections into the backlog immediately.
+    async fn spawn_stub(marker: &'static str) -> String {
+        use axum::routing::post;
+        use axum::{Json, Router};
+
+        let app = Router::new().route(
+            "/chat/completions",
+            post(move || async move {
+                Json(serde_json::json!({
+                    "choices": [{ "message": { "role": "assistant", "content": marker } }],
+                    "usage": { "prompt_tokens": 1, "completion_tokens": 1 }
+                }))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        format!("http://{addr}")
+    }
+
+    /// The live-switch contract: the same `TenantProvider` instance routes turn
+    /// 1 to stub A, then — after the operator flips the runtime override in the
+    /// secret store — routes turn 2 to stub B, with **no rebuild** of the
+    /// provider or the agent. This is what makes a console switch take effect on
+    /// the next turn.
+    #[tokio::test]
+    async fn tenant_provider_live_switches_between_turns_without_rebuild() {
+        let url_a = spawn_stub("reply-from-A").await;
+        let url_b = spawn_stub("reply-from-B").await;
+
+        let company = CompanyId::new("acme");
+        let secrets: Arc<dyn SecretStore> = Arc::new(MemSecrets::default());
+        let mut manifest = manifest_inference("openai_compatible");
+        manifest.base_url = Some(url_a.clone());
+        let provider = TenantProvider::new(company.clone(), secrets.clone(), manifest, None);
+
+        // Turn 1 → stub A.
+        let first = provider
+            .chat_with_system(None, "hi", "chat-v1", 0.0)
+            .await
+            .expect("turn 1");
+        assert_eq!(first, "reply-from-A");
+        assert_eq!(provider.telemetry_provider_id(), "byok");
+
+        // Operator flips the provider to stub B via a runtime override — no
+        // rebuild, just a secret-store write.
+        inference::save_runtime_config(
+            &company,
+            secrets.as_ref(),
+            &inference::RuntimeInference {
+                provider: "openai_compatible".into(),
+                base_url: Some(url_b.clone()),
+                models: BTreeMap::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Turn 2 → stub B, same provider instance.
+        let second = provider
+            .chat_with_system(None, "hi", "chat-v1", 0.0)
+            .await
+            .expect("turn 2");
+        assert_eq!(second, "reply-from-B", "the switch took effect next turn");
+    }
+
+    #[tokio::test]
+    async fn tenant_provider_errors_when_nothing_is_configured() {
+        let company = CompanyId::new("acme");
+        let secrets: Arc<dyn SecretStore> = Arc::new(MemSecrets::default());
+        let provider = TenantProvider::new(company, secrets, Inference::default(), None);
+        let err = provider
+            .chat_with_system(None, "hi", "chat-v1", 0.0)
+            .await
+            .expect_err("no provider configured");
+        assert!(err.to_string().contains("no inference provider"), "{err}");
     }
 }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -18,6 +18,8 @@ use crate::brain::medulla::MedullaTransport;
 use crate::brain::medulla::wire::ToolManifestEntry;
 use crate::brain::{EchoBrain, HostedMedullaBrain};
 use crate::company::CompanyManifest;
+#[cfg(feature = "openhuman")]
+use crate::company::inference::{self, EnvDefault};
 use crate::company::runtime::{CompanyRuntime, OpsStores};
 use crate::feedback::github::{GitHubClient, RateLimiter};
 use crate::feedback::service::FeedbackFiler;
@@ -26,7 +28,7 @@ use crate::feedback::tinyhumans::TinyHumansClient;
 use crate::feedback::tool::BuiltinToolProvider;
 use crate::feedback::types::ConsentMode;
 #[cfg(feature = "openhuman")]
-use crate::harness::provider::{HostedProvider, HostedProviderConfig};
+use crate::harness::provider::{HostedProviderConfig, TenantProvider};
 #[cfg(feature = "openhuman")]
 use crate::harness::{HarnessBrain, HarnessDeps};
 use crate::openhuman::rpc::OpenHumanRpc;
@@ -178,11 +180,14 @@ pub struct RuntimeBuilder {
     /// build is unaffected; wired through to [`CompanyRuntime`] when present.
     #[cfg(feature = "openhuman")]
     harness: Option<Arc<crate::harness::HarnessPool>>,
-    /// WS4: hosted-inference config (endpoint + default model) for the harness
-    /// brain. With both this and [`harness`](Self::harness) set — and no
-    /// explicit brain — cognition routes through the embedded openhuman runtime.
+    /// WS4/#56: the platform-injected managed inference default (endpoint +
+    /// credential) and an optional roster-wide model override. This is the
+    /// *lowest-precedence* inference source — a manifest `[inference]` section
+    /// or a runtime console override outranks it. With [`harness`](Self::harness)
+    /// set and any inference source configured, cognition routes through a
+    /// per-tenant [`TenantProvider`](crate::harness::provider::TenantProvider).
     #[cfg(feature = "openhuman")]
-    harness_inference: Option<(HostedProviderConfig, String)>,
+    harness_inference: Option<(HostedProviderConfig, Option<String>)>,
 }
 
 impl RuntimeBuilder {
@@ -467,18 +472,20 @@ impl RuntimeBuilder {
         self
     }
 
-    /// WS4: sets the hosted-inference config (endpoint + default model) the
-    /// harness brain drives. Combined with [`with_harness`](Self::with_harness)
-    /// and no explicit brain, cognition routes through the embedded openhuman
-    /// runtime; without it the harness pool stays wired but unused and the
-    /// runtime keeps its hosted/echo brain. Feature-gated.
+    /// WS4/#56: sets the platform-injected managed inference default (endpoint +
+    /// credential) and an optional roster-wide model override
+    /// (`OPENCOMPANY_INFERENCE_MODEL`). This is the lowest-precedence inference
+    /// source; a manifest `[inference]` section or a runtime console override
+    /// wins over it. Combined with [`with_harness`](Self::with_harness) and any
+    /// configured inference source, cognition routes through a per-tenant
+    /// [`TenantProvider`](crate::harness::provider::TenantProvider). Feature-gated.
     #[cfg(feature = "openhuman")]
     pub fn with_harness_inference(
         mut self,
         config: HostedProviderConfig,
-        default_model: impl Into<String>,
+        model_override: Option<String>,
     ) -> Self {
-        self.harness_inference = Some((config, default_model.into()));
+        self.harness_inference = Some((config, model_override));
         self
     }
 
@@ -701,14 +708,53 @@ impl RuntimeBuilder {
                 // `CompanyRuntime::harness` wiring — the brain and the runtime
                 // deliberately share one pool.
                 #[cfg(feature = "openhuman")]
-                let harness_brain: Option<Arc<dyn Brain>> =
-                    match (self.harness.clone(), self.harness_inference.clone()) {
-                        (Some(pool), Some((provider_config, model))) => {
-                            // Resolve the company's effective MCP servers to
-                            // data (manifest ∪ runtime index, credentials
-                            // materialized) before building sync deps. A corrupt
-                            // runtime index degrades to no MCP servers rather
-                            // than bricking the company boot.
+                let harness_brain: Option<Arc<dyn Brain>> = match self.harness.clone() {
+                    Some(pool) => {
+                        // The platform-injected managed default (endpoint +
+                        // credential) is the lowest-precedence inference source.
+                        let env_default =
+                            self.harness_inference
+                                .as_ref()
+                                .map(|(config, _)| EnvDefault {
+                                    base_url: config.base_url.clone(),
+                                    api_key: config.api_key.clone(),
+                                });
+                        // An explicit `OPENCOMPANY_INFERENCE_MODEL` flattens the
+                        // whole roster to one workload; otherwise each agent keeps
+                        // its tier-derived model and the tenant
+                        // `[inference].models` table maps it (`None` = no override).
+                        let model_override = self
+                            .harness_inference
+                            .as_ref()
+                            .and_then(|(_, model)| model.clone());
+
+                        // Is any inference source configured — a runtime console
+                        // override, a manifest `[inference]` section, or the
+                        // managed env default? A corrupt runtime config degrades
+                        // to "unconfigured" (managed/echo brain) rather than
+                        // bricking boot.
+                        let configured = inference::resolve_effective(
+                            &id,
+                            &self.manifest.inference,
+                            env_default.as_ref(),
+                            secrets.as_ref(),
+                        )
+                        .await
+                        .unwrap_or_else(|err| {
+                            tracing::warn!(
+                                company = %id,
+                                error = %err,
+                                "resolving inference config failed; keeping the managed/echo brain"
+                            );
+                            None
+                        })
+                        .is_some();
+
+                        if configured {
+                            // Resolve the company's effective MCP servers to data
+                            // (manifest ∪ runtime index, credentials materialized)
+                            // before building sync deps. A corrupt index degrades
+                            // to no MCP servers rather than bricking boot.
                             let mcp_servers = crate::company::mcp::resolve_effective(
                                 &id,
                                 &self.manifest.mcp_servers,
@@ -724,13 +770,24 @@ impl RuntimeBuilder {
                                 Vec::new()
                             });
                             let deps = HarnessDeps {
-                                provider: Arc::new(HostedProvider::new(provider_config)),
+                                // A per-tenant provider that re-resolves the
+                                // effective inference config on every turn, so a
+                                // console BYOK switch takes effect next turn with
+                                // no rebuild.
+                                provider: Arc::new(TenantProvider::new(
+                                    id.clone(),
+                                    secrets.clone(),
+                                    self.manifest.inference.clone(),
+                                    env_default,
+                                )),
+                                // Static fallback only; `HarnessPool::run` reads
+                                // the live slug from the provider per turn.
                                 provider_slug: "managed".to_string(),
                                 context: context.clone(),
                                 store: store.clone(),
                                 meter: Some(fs_ops.clone()),
                                 workspace_root: home.join("harness"),
-                                model_override: Some(model),
+                                model_override,
                                 tasks: Some(ops.tasks.clone()),
                                 // Skill read surface (#28): the operator delta
                                 // store + the company source dir (`companies/<name>`,
@@ -772,9 +829,12 @@ impl RuntimeBuilder {
                             ))
                                 as Arc<dyn WorkflowRunner>);
                             Some(Arc::new(HarnessBrain::new(pool, deps, record)) as Arc<dyn Brain>)
+                        } else {
+                            None
                         }
-                        _ => None,
-                    };
+                    }
+                    None => None,
+                };
                 #[cfg(not(feature = "openhuman"))]
                 let harness_brain: Option<Arc<dyn Brain>> = None;
 

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -1,0 +1,447 @@
+//! Per-tenant Bring-Your-Own-Key inference management (issue #56): read the
+//! company's effective inference status, set a runtime provider override, revert
+//! it, and live-probe the configured provider.
+//!
+//! The effective config is the highest-precedence of a runtime override (a JSON
+//! blob the console writes under `inference/config`), the committed manifest
+//! `[inference]` section, and the platform managed default. The outbound
+//! credential lives apart under `inference/key` and is **write-only** over the
+//! API: it is set through the `key` field, stored in the secret store, and never
+//! echoed — the read shape carries only a `keyConfigured` bool.
+//!
+//! A runtime switch takes effect on the agents' **next turn** with no restart:
+//! the per-tenant provider re-resolves this config every turn.
+
+use std::collections::BTreeMap;
+
+use axum::Router;
+use axum::routing::{get, post};
+use axum::{Json, response::Response};
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+use crate::company::Inference;
+use crate::company::inference::{
+    self, InferenceSource, RuntimeInference, clear_runtime_config, resolve_effective,
+    save_runtime_config, store_key, validate_runtime,
+};
+use crate::company::runtime::CompanyRuntime;
+use crate::error::OpenCompanyError;
+use crate::server::error::ApiError;
+use crate::server::ops::{ScopedCompany, scoped};
+
+/// The reminder attached to every mutating response: a per-tenant provider
+/// re-resolves its config each turn, so a switch reaches agents on the next
+/// turn with no restart.
+const SWITCH_NOTE: &str =
+    "Agents use the new inference provider on their next turn — no restart needed.";
+
+/// Builds the inference management route fragment.
+pub fn router() -> Router<AppState> {
+    scoped(
+        "/inference",
+        get(get_status).put(set_config).delete(revert_config),
+    )
+    .merge(scoped("/inference/test", post(test_config)))
+}
+
+/// The company's effective inference status as the console renders it. **Never**
+/// carries a credential — only a non-secret `keyConfigured` flag.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InferenceStatusDto {
+    /// Provider kind (`managed` / `openrouter` / `openai_compatible` / `ollama`).
+    provider: String,
+    /// The stable telemetry slug (`managed` / `openrouter` / `byok` / `ollama`).
+    slug: String,
+    /// Resolved OpenAI-compatible base URL.
+    base_url: String,
+    /// Abstract-tier → concrete model id.
+    models: BTreeMap<String, String>,
+    /// Where the effective config came from: `default` / `manifest` / `runtime`,
+    /// or `managed` when nothing tenant-specific is configured.
+    source: String,
+    /// Whether an outbound credential is stored — never the credential itself.
+    key_configured: bool,
+}
+
+/// A mutating response: the resulting status plus the switch reminder.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MutationResponse {
+    status: InferenceStatusDto,
+    note: String,
+}
+
+/// Set-config body. `key` is write-only intake (never returned).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetInference {
+    provider: String,
+    #[serde(default)]
+    base_url: Option<String>,
+    #[serde(default)]
+    models: Option<BTreeMap<String, String>>,
+    /// The outbound credential, stored write-only. Omit to leave it unchanged;
+    /// send an empty string to clear it.
+    #[serde(default)]
+    key: Option<String>,
+}
+
+/// Loads the company's committed `[inference]` section from its record.
+async fn manifest_inference(runtime: &CompanyRuntime) -> Result<Inference, ApiError> {
+    let record = runtime.store().load(runtime.id()).await.map_err(ApiError)?;
+    Ok(record.map(|r| r.manifest.inference).unwrap_or_default())
+}
+
+/// The console-facing source label for a resolved source badge.
+fn source_label(source: InferenceSource) -> &'static str {
+    match source {
+        InferenceSource::Default => "default",
+        InferenceSource::Manifest => "manifest",
+        InferenceSource::Runtime => "runtime",
+    }
+}
+
+/// Resolves the effective status DTO. The ops layer resolves *tenant* config
+/// only (no env default), so a company with nothing configured reports the
+/// managed default rather than a synthesized env decl.
+async fn effective_status(runtime: &CompanyRuntime) -> Result<InferenceStatusDto, ApiError> {
+    let manifest = manifest_inference(runtime).await?;
+    let decl = resolve_effective(runtime.id(), &manifest, None, runtime.secrets().as_ref())
+        .await
+        .map_err(ApiError)?;
+    Ok(match decl {
+        Some(d) => InferenceStatusDto {
+            provider: d.provider.clone(),
+            slug: d.telemetry_slug().to_string(),
+            base_url: d.base_url.clone(),
+            models: d.models.clone(),
+            source: source_label(d.source).to_string(),
+            key_configured: d.key_configured(),
+        },
+        None => InferenceStatusDto {
+            provider: "managed".to_string(),
+            slug: "managed".to_string(),
+            base_url: inference::MANAGED_BASE_URL.to_string(),
+            models: BTreeMap::new(),
+            source: "managed".to_string(),
+            key_configured: false,
+        },
+    })
+}
+
+/// `GET …/inference` — the company's effective inference status.
+async fn get_status(company: ScopedCompany) -> Result<Json<InferenceStatusDto>, ApiError> {
+    Ok(Json(effective_status(company.runtime.as_ref()).await?))
+}
+
+/// `PUT …/inference` — set (or replace) the runtime provider override, and
+/// optionally rotate the write-only outbound credential.
+async fn set_config(
+    company: ScopedCompany,
+    Json(body): Json<SetInference>,
+) -> Result<Json<MutationResponse>, ApiError> {
+    let runtime = company.runtime.as_ref();
+
+    let config = RuntimeInference {
+        provider: body.provider.trim().to_string(),
+        base_url: body
+            .base_url
+            .map(|u| u.trim().to_string())
+            .filter(|u| !u.is_empty()),
+        models: body.models.unwrap_or_default(),
+    };
+    let problems = validate_runtime(&config);
+    if !problems.is_empty() {
+        return Err(ApiError(OpenCompanyError::InvalidRequest(
+            problems.join(" "),
+        )));
+    }
+
+    save_runtime_config(runtime.id(), runtime.secrets().as_ref(), &config)
+        .await
+        .map_err(ApiError)?;
+
+    // The key is write-only: a non-empty value rotates it, an explicit empty
+    // string clears it, and an omitted field leaves it untouched.
+    if let Some(key) = body.key {
+        store_key(runtime.id(), runtime.secrets().as_ref(), key.trim())
+            .await
+            .map_err(ApiError)?;
+    }
+
+    Ok(Json(MutationResponse {
+        status: effective_status(runtime).await?,
+        note: SWITCH_NOTE.to_string(),
+    }))
+}
+
+/// `DELETE …/inference` — clear the runtime override, reverting to the committed
+/// manifest `[inference]` (or the managed default). The stored credential is
+/// left in place (harmless for the managed default; still resolves for a
+/// manifest provider) — clear it explicitly with `PUT { key: "" }`.
+async fn revert_config(company: ScopedCompany) -> Result<Json<MutationResponse>, ApiError> {
+    let runtime = company.runtime.as_ref();
+    clear_runtime_config(runtime.id(), runtime.secrets().as_ref())
+        .await
+        .map_err(ApiError)?;
+    Ok(Json(MutationResponse {
+        status: effective_status(runtime).await?,
+        note: "Reverted to the committed manifest (or managed) configuration.".to_string(),
+    }))
+}
+
+/// `POST …/inference/test` — a live one-message probe of the resolved provider.
+///
+/// Gated on the `openhuman` feature (the HTTP provider lives there); without it
+/// the route reports `not_wired` so the console falls back gracefully. The probe
+/// error is scrubbed of the credential by the provider layer.
+#[cfg(feature = "openhuman")]
+async fn test_config(company: ScopedCompany) -> Response {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+
+    let runtime = company.runtime.as_ref();
+    let manifest = match manifest_inference(runtime).await {
+        Ok(m) => m,
+        Err(err) => return err.into_response(),
+    };
+    let decl =
+        match resolve_effective(runtime.id(), &manifest, None, runtime.secrets().as_ref()).await {
+            Ok(d) => d,
+            Err(err) => return ApiError(err).into_response(),
+        };
+    match decl {
+        None => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "ok": false,
+                "error": "No custom inference is configured — this company is on the managed brain.",
+                "code": "not_configured",
+            })),
+        )
+            .into_response(),
+        Some(decl) => match crate::harness::provider::probe(&decl).await {
+            Ok(()) => Json(serde_json::json!({
+                "ok": true,
+                "provider": decl.provider,
+                "note": "Reached the provider and got a reply.",
+            }))
+            .into_response(),
+            Err(err) => (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({
+                    "ok": false,
+                    "error": format!("Inference probe failed: {err}"),
+                    "code": "probe_failed",
+                })),
+            )
+                .into_response(),
+        },
+    }
+}
+
+/// Without the `openhuman` feature there is no HTTP provider, so the live probe
+/// is "not wired" (the console falls back to the stored status).
+#[cfg(not(feature = "openhuman"))]
+async fn test_config(company: ScopedCompany) -> Response {
+    let _ = company;
+    crate::server::ops::not_wired("inference test")
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+
+    use crate::company::CompanyManifest;
+    use crate::ports::types::{CompanyId, CompanyRecord};
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+    use crate::store::FsCompanyStore;
+    use crate::{AppConfig, AppState};
+
+    const TOKEN: &str = "sk-super-secret-inference-token-XYZ";
+
+    fn home() -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("oc-inference-{}", crate::ports::generate_id()))
+    }
+
+    fn manifest() -> CompanyManifest {
+        toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n").unwrap()
+    }
+
+    async fn state_with_company(home: &std::path::Path) -> AppState {
+        use crate::ports::CompanyStore;
+        let store = FsCompanyStore::new(home.to_path_buf());
+        let id = CompanyId::new("acme");
+        store
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: manifest(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest())
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        state
+    }
+
+    async fn send(
+        state: &AppState,
+        method: &str,
+        uri: &str,
+        body: Option<Value>,
+    ) -> (StatusCode, Value, String) {
+        let request = Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("cookie", crate::server::test_support::fixed_cookie("acme"));
+        let request = match body {
+            Some(body) => request
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+            None => request.body(Body::empty()).unwrap(),
+        };
+        let response = router(state.clone()).oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let raw = String::from_utf8_lossy(&bytes).to_string();
+        let value = if bytes.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+        };
+        (status, value, raw)
+    }
+
+    #[tokio::test]
+    async fn status_defaults_to_managed_then_switches_to_runtime() {
+        let home = home();
+        let state = state_with_company(&home).await;
+
+        // A company with no manifest/runtime inference reports the managed default.
+        let (status, dto, _) = send(&state, "GET", "/api/v1/company/inference", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(dto["provider"], "managed");
+        assert_eq!(dto["source"], "managed");
+        assert_eq!(dto["keyConfigured"], false);
+        assert!(dto.get("key").is_none(), "status DTO must not carry a key");
+
+        // Switch to OpenRouter with a write-only key + a tier→model map.
+        let (status, resp, raw) = send(
+            &state,
+            "PUT",
+            "/api/v1/company/inference",
+            Some(json!({
+                "provider": "openrouter",
+                "models": { "chat-v1": "deepseek/deepseek-chat", "reasoning-v1": "deepseek/deepseek-r1" },
+                "key": TOKEN,
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_eq!(resp["status"]["provider"], "openrouter");
+        assert_eq!(resp["status"]["slug"], "openrouter");
+        assert_eq!(resp["status"]["source"], "runtime");
+        assert_eq!(resp["status"]["keyConfigured"], true);
+        assert_eq!(
+            resp["status"]["models"]["chat-v1"],
+            "deepseek/deepseek-chat"
+        );
+        // The token must NEVER appear in the mutation response body.
+        assert!(!raw.contains(TOKEN), "PUT response leaked the token: {raw}");
+
+        // GET reflects the switch and still never carries the token.
+        let (_, dto, raw) = send(&state, "GET", "/api/v1/company/inference", None).await;
+        assert_eq!(dto["provider"], "openrouter");
+        assert_eq!(dto["source"], "runtime");
+        assert_eq!(dto["keyConfigured"], true);
+        assert!(!raw.contains(TOKEN), "GET status leaked the token: {raw}");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[tokio::test]
+    async fn revert_clears_the_runtime_override() {
+        let home = home();
+        let state = state_with_company(&home).await;
+
+        send(
+            &state,
+            "PUT",
+            "/api/v1/company/inference",
+            Some(json!({ "provider": "openrouter", "key": TOKEN })),
+        )
+        .await;
+
+        let (status, resp, _) = send(&state, "DELETE", "/api/v1/company/inference", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(resp["status"]["provider"], "managed");
+        assert_eq!(resp["status"]["source"], "managed");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[tokio::test]
+    async fn invalid_provider_config_is_rejected() {
+        let home = home();
+        let state = state_with_company(&home).await;
+
+        // Ollama requires a base_url.
+        let (status, err, _) = send(
+            &state,
+            "PUT",
+            "/api/v1/company/inference",
+            Some(json!({ "provider": "ollama" })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(
+            err["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("base_url"),
+            "{err}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[tokio::test]
+    async fn key_never_leaks_across_any_response() {
+        let home = home();
+        let state = state_with_company(&home).await;
+
+        let (_, _, put_raw) = send(
+            &state,
+            "PUT",
+            "/api/v1/company/inference",
+            Some(json!({ "provider": "openai_compatible", "baseUrl": "https://byo.example/v1", "key": TOKEN })),
+        )
+        .await;
+        let (_, _, get_raw) = send(&state, "GET", "/api/v1/company/inference", None).await;
+        // The live probe path returns an error (unreachable host) — assert the
+        // scrubbed error body still never contains the token.
+        let (_, _, test_raw) = send(&state, "POST", "/api/v1/company/inference/test", None).await;
+
+        for raw in [put_raw, get_raw, test_raw] {
+            assert!(!raw.contains(TOKEN), "a response leaked the token: {raw}");
+        }
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod domain;
 pub mod inbox;
+pub mod inference;
 pub mod language;
 pub mod mail;
 pub mod mailer;
@@ -125,6 +126,7 @@ pub fn router() -> Router<AppState> {
         .merge(workspace::router())
         .merge(skills::router())
         .merge(mcp::router())
+        .merge(inference::router())
         .merge(team::router())
         .merge(workflows::router())
         .merge(mail::router());

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -12,7 +12,6 @@ use std::sync::{Arc, Mutex as StdMutex};
 
 use async_trait::async_trait;
 use futures::stream::BoxStream;
-use tokio::io::AsyncWriteExt;
 use tokio::sync::{Mutex as TokioMutex, broadcast};
 
 use crate::Result;
@@ -59,25 +58,30 @@ impl PathLocks {
 
 /// Appends one line (a `\n` is added) to `path`, creating the file if absent.
 ///
-/// The line and its terminating newline are written in a **single** `write_all`
-/// so the whole record lands as one `O_APPEND` write. Splitting it into two
-/// writes let concurrent appends to the same JSONL file interleave as
-/// `{a}{b}\n\n` — two JSON objects on one physical line — which surfaces later as
-/// a `serde_json` "trailing characters" parse error in [`read_jsonl`].
+/// The line and its terminating newline are written in a **single** blocking
+/// `write_all` inside `spawn_blocking` (via `std::fs::OpenOptions` with
+/// `O_APPEND`), so the whole record lands as one atomic OS-level write.
+/// Tokio's async `File` buffers internally and can return before the kernel
+/// write completes, which makes concurrent-appends tests unreliable; this
+/// version always waits for the write syscall to finish before returning.
 pub(crate) async fn append_line(path: &Path, line: &str) -> Result<()> {
-    let mut file = tokio::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .await
-        .map_err(|e| io_err(path, e))?;
+    let owned_path = path.to_path_buf();
     let mut record = String::with_capacity(line.len() + 1);
     record.push_str(line);
     record.push('\n');
-    file.write_all(record.as_bytes())
-        .await
-        .map_err(|e| io_err(path, e))?;
-    Ok(())
+    tokio::task::spawn_blocking(move || {
+        use std::io::Write;
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&owned_path)
+            .map_err(|e| io_err(&owned_path, e))?;
+        file.write_all(record.as_bytes())
+            .map_err(|e| io_err(&owned_path, e))?;
+        Ok::<_, OpenCompanyError>(())
+    })
+    .await
+    .map_err(|e| OpenCompanyError::Store(format!("spawn_blocking failed: {e}")))?
 }
 
 /// Reads a file to a string, returning an empty string if it does not exist.


### PR DESCRIPTION
## Summary

Adds bring-your-own-key (BYOK) inference per company. A new `TenantProvider` re-resolves the effective `(base_url, key, model)` on every turn with precedence **console-override > manifest `[inference]` > managed env default**, so a console key change takes effect on the very next turn with no rebuild. Adds new `GET/PUT/DELETE /inference` routes (plus a feature-gated `POST /inference/test`), a console Inference section (provider presets including OpenRouter), and `[inference]` manifest support. Also flips `bin/opencompany.rs` to always attach the `HarnessPool`, so a BYOK-only tenant with no platform key can still run.

`Closes #56`.

> Note: Touches the same `HarnessPool::run` cost-slug span as #41 (skills-freshness) — expect a ~2-line conflict; whichever merges second rebases (keep #41's `CompanyRoster` body + this PR's live-slug binding).

## API Or Behavior Changes

- New `/inference` routes: `GET` (status), `PUT` (set), `DELETE` (revert), plus feature-gated `POST /inference/test`.
- Status DTO carries only `keyConfigured` — never the key itself.
- Manifest gains an `[inference]` section.
- `HarnessPool` is now always attached, so a BYOK-only tenant with no platform key can run.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo build --all-targets`
- [x] `cargo test` — 538 passed

Also ran `cargo test --features mcp` — 628 passed, including `tenant_provider_live_switches_between_turns_without_rebuild`, `key_never_leaks_across_any_response`, and the precedence matrix. Frontend `npm run typecheck` + `npm run build` clean.

**Security note**: the inference key is write-only — `InferenceDecl` derives no `Serialize`, keeps `api_key` private, and has a redacting `Debug`; this is asserted by `key_never_leaks_across_any_response`. Same pre-existing base caveat re `cargo check --features openhuman`.

## Documentation

- `docs/spec/runtime/manifest.md` — `[inference]` manifest section
- GitBook configuration page
- `companies/README.md`
- Commented `[inference]` block in both demo tomls
