### PR TITLE
feat(mcp): harden MCP — query-param auth, health, scrubbed errors, freshness, empty-response retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,7 +657,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "shlex 1.3.0",
  "syn 2.0.118",
 ]
@@ -2022,22 +2022,6 @@ dependencies = [
  "rustc_version",
  "syn 2.0.118",
  "unicode-xid",
-]
-
-[[package]]
-name = "dhat"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
-dependencies = [
- "backtrace",
- "lazy_static",
- "mintex",
- "parking_lot",
- "rustc-hash 1.1.0",
- "serde",
- "serde_json",
- "thousands",
 ]
 
 [[package]]
@@ -4599,12 +4583,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mintex"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
-
-[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5440,7 +5418,6 @@ dependencies = [
  "cron",
  "crossterm",
  "curve25519-dalek",
- "dhat",
  "directories",
  "dirs 5.0.1",
  "docx-rs",
@@ -6301,7 +6278,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -6323,7 +6300,7 @@ dependencies = [
  "rand 0.10.2",
  "rand_pcg",
  "ring",
- "rustc-hash 2.1.3",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -6901,12 +6878,6 @@ name = "rustc-demangle"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -8163,12 +8134,6 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
-
-[[package]]
-name = "thousands"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -105,6 +105,8 @@ async fn main() -> anyhow::Result<()> {
         facts: None,
         events: None,
         delegations: opencompany::harness::orchestrator::DelegationQueue::default(),
+        mcp_failures: opencompany::harness::mcp_probe::McpFailureQueue::default(),
+        secrets: None,
     };
 
     let pool = HarnessPool::new();

--- a/frontend/src/api/mcp.ts
+++ b/frontend/src/api/mcp.ts
@@ -10,7 +10,10 @@
 // the shared client), so no change to `OpenCompanyClient` is needed.
 
 import type { OpenCompanyClient } from "./client";
-import type { McpMutationResponse, McpServer, McpToolInfo } from "./types";
+import type { McpHealth, McpMutationResponse, McpServer, McpToolInfo } from "./types";
+
+/** The auth scheme a write-only credential is stored under. */
+export type McpAuthKind = "bearer" | "header" | "query_param";
 
 /** The company's effective MCP servers. */
 export function listMcpServers(
@@ -20,7 +23,11 @@ export function listMcpServers(
   return client.get<McpServer[]>(`${client.scopeFor(company)}/mcp/servers`);
 }
 
-/** The add-a-runtime-server body. `token` is write-only (never returned). */
+/**
+ * The add-a-runtime-server body. `token` is write-only (never returned).
+ * `authKind` selects how it's stored: `bearer` (default), a custom `header`
+ * (with `headerName`), or a `query_param` (with `paramName`).
+ */
 export interface AddMcpServer {
   name: string;
   endpoint: string;
@@ -29,6 +36,9 @@ export interface AddMcpServer {
   disallowedTools?: string[];
   timeoutSecs?: number;
   token?: string;
+  authKind?: McpAuthKind;
+  headerName?: string;
+  paramName?: string;
 }
 
 /** Add a runtime MCP server (optionally with an outbound token). */
@@ -48,8 +58,11 @@ export interface UpdateMcpServer {
   allowedTools?: string[];
   disallowedTools?: string[];
   timeoutSecs?: number;
-  /** Rotate the outbound token (write-only). Omit to leave it unchanged. */
+  /** Rotate the outbound credential (write-only). Omit to leave it unchanged. */
   token?: string;
+  authKind?: McpAuthKind;
+  headerName?: string;
+  paramName?: string;
 }
 
 /** Update a server (enable/disable, tool lists, endpoint, or rotate token). */
@@ -84,5 +97,20 @@ export function discoverMcpTools(
 ): Promise<McpToolInfo[]> {
   return client.get<McpToolInfo[]>(
     `${client.scopeFor(company)}/mcp/servers/${encodeURIComponent(name)}/tools`,
+  );
+}
+
+/**
+ * Probe a server on demand and return its (scrubbed) health. 404 `not_wired`
+ * when the harness is off.
+ */
+export function testMcpServer(
+  client: OpenCompanyClient,
+  company: string | null,
+  name: string,
+): Promise<McpHealth> {
+  return client.post<McpHealth>(
+    `${client.scopeFor(company)}/mcp/servers/${encodeURIComponent(name)}/test`,
+    {},
   );
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -141,9 +141,27 @@ export interface ConnectionStart {
   url: string;
 }
 
+/** The coarse health tier of an MCP server, from a probe. */
+export type McpStatus = "ok" | "needs_config" | "error" | "unknown";
+
+/**
+ * The last (scrubbed) probe outcome for an MCP server. `message` is always
+ * scrubbed on the host — it can never carry a credential, response body, or URL
+ * query string.
+ */
+export interface McpHealth {
+  status: McpStatus;
+  message: string;
+  toolCount: number;
+  checkedAtMillis: number;
+  /** A stable auth-failure reason code, when the status is a credential problem. */
+  authHint?: string;
+}
+
 /**
  * One effective MCP tool server (issue #50), as `.../mcp/servers` returns it.
- * The credential is never present — only the non-secret `authConfigured` flag.
+ * The credential is never present — only the non-secret `authConfigured` flag
+ * and the last (scrubbed) probe `health`.
  */
 export interface McpServer {
   name: string;
@@ -157,12 +175,22 @@ export interface McpServer {
   timeoutSecs: number;
   /** Whether an outbound credential is stored — never the credential itself. */
   authConfigured: boolean;
+  /** The last recorded (scrubbed) probe outcome, when the server has been probed. */
+  health?: McpHealth;
 }
 
-/** A mutating MCP response: the resulting server plus a rebuild reminder. */
+/**
+ * A mutating MCP response: the resulting server, a rebuild reminder, the live
+ * probe result (absent on a non-`openhuman` host), and any non-blocking
+ * endpoint advisory.
+ */
 export interface McpMutationResponse {
   server: McpServer;
   note: string;
+  /** The probe result from right after the mutation (the server is never rolled back). */
+  test?: McpHealth;
+  /** A non-blocking advisory (e.g. a secret-looking query string in the URL). */
+  warning?: string;
 }
 
 /** One remote tool advertised by an MCP server (live discovery). */

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -1,5 +1,15 @@
 import { useCallback, useEffect, useState } from "react";
-import { Check, ChevronDown, Info, Loader2, Plug, Plus, Server, Trash2 } from "lucide-react";
+import {
+  AlertTriangle,
+  Check,
+  ChevronDown,
+  Info,
+  Loader2,
+  Plug,
+  Plus,
+  Server,
+  Trash2,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
@@ -7,10 +17,18 @@ import {
   addMcpServer,
   discoverMcpTools,
   listMcpServers,
+  type McpAuthKind,
   removeMcpServer,
+  testMcpServer,
   updateMcpServer,
 } from "@/api/mcp";
-import { ApiError, type ConnectionState, type McpServer, type McpToolInfo } from "@/api/types";
+import {
+  ApiError,
+  type ConnectionState,
+  type McpHealth,
+  type McpServer,
+  type McpToolInfo,
+} from "@/api/types";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -245,11 +263,18 @@ function McpServersSection({
   const [servers, setServers] = useState<McpServer[]>([]);
   const [busy, setBusy] = useState<string | null>(null);
   const [tools, setTools] = useState<Record<string, ToolsState>>({});
+  // Live health from an on-demand Test, overriding the persisted badge per row.
+  const [tested, setTested] = useState<Record<string, McpHealth>>({});
 
   // Add-server form.
   const [name, setName] = useState("");
   const [endpoint, setEndpoint] = useState("");
   const [token, setToken] = useState("");
+  const [authKind, setAuthKind] = useState<McpAuthKind>("bearer");
+  const [authFieldName, setAuthFieldName] = useState("");
+  // The add flow's failure is a PERSISTENT inline alert (not a transient toast):
+  // a silent-fail auth error is exactly the bug this cell fixes.
+  const [addError, setAddError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -267,24 +292,63 @@ function McpServersSection({
 
   async function add() {
     if (busy) return;
+    setAddError(null);
     if (!name.trim() || !endpoint.trim()) {
-      toast.error("A server needs a name and an https endpoint.");
+      setAddError("A server needs a name and an https endpoint.");
+      return;
+    }
+    if (authKind !== "bearer" && token.trim() && !authFieldName.trim()) {
+      setAddError(
+        authKind === "header"
+          ? "A custom-header credential needs a header name."
+          : "A query-parameter credential needs a parameter name.",
+      );
       return;
     }
     setBusy("add");
     try {
-      await addMcpServer(client, company, {
+      const res = await addMcpServer(client, company, {
         name: name.trim(),
         endpoint: endpoint.trim(),
         token: token.trim() || undefined,
+        authKind,
+        headerName: authKind === "header" ? authFieldName.trim() || undefined : undefined,
+        paramName: authKind === "query_param" ? authFieldName.trim() || undefined : undefined,
       });
-      toast.success(`Added ${name.trim()}. Agents pick it up on the next rebuild.`);
+      // A probe that lands "needs config" or "error" is NOT a rollback — the
+      // server is added — but surface it inline so the operator acts on it.
+      if (res.test && res.test.status !== "ok") {
+        setAddError(res.test.message);
+      } else if (res.warning) {
+        setAddError(res.warning);
+      } else {
+        toast.success(`Added ${name.trim()}. Agents pick it up on the next rebuild.`);
+      }
       setName("");
       setEndpoint("");
       setToken("");
+      setAuthFieldName("");
       await refresh();
     } catch (err) {
-      toast.error(err instanceof ApiError ? err.message : "Couldn't add the server.");
+      // Persistent, not a toast: the operator must see why the add failed.
+      setAddError(err instanceof ApiError ? err.message : "Couldn't add the server.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function test(server: McpServer) {
+    if (busy) return;
+    setBusy(server.name);
+    try {
+      const health = await testMcpServer(client, company, server.name);
+      setTested((t) => ({ ...t, [server.name]: health }));
+    } catch (err) {
+      if (err instanceof ApiError && err.code === "not_wired") {
+        toast.message("Live testing isn't enabled in this build (the agent harness is off).");
+      } else {
+        toast.error(err instanceof ApiError ? err.message : "Couldn't test the server.");
+      }
     } finally {
       setBusy(null);
     }
@@ -366,99 +430,202 @@ function McpServersSection({
               <p className="text-sm text-muted-foreground">No MCP servers yet.</p>
             ) : (
               <ul className="divide-y divide-border">
-                {servers.map((server) => (
-                  <li key={server.name} className="space-y-2 py-3 first:pt-0 last:pb-0">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="font-medium">{server.name}</span>
-                      <Badge variant={server.source === "manifest" ? "secondary" : "outline"}>
-                        {server.source}
-                      </Badge>
-                      {server.authConfigured && (
-                        <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
-                          <Check className="size-3" /> auth set
-                        </span>
-                      )}
-                      <span className="ml-auto flex items-center gap-2">
-                        <Switch
-                          checked={server.enabled}
-                          disabled={busy === server.name}
-                          onCheckedChange={(v) => void toggle(server, v)}
-                          aria-label={`Enable ${server.name}`}
-                        />
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          disabled={busy === server.name}
-                          onClick={() => void discover(server)}
-                        >
-                          <ChevronDown className="size-4" /> Tools
-                        </Button>
-                        {server.source === "runtime" && (
+                {servers.map((server) => {
+                  const health = tested[server.name] ?? server.health;
+                  return (
+                    <li key={server.name} className="space-y-2 py-3 first:pt-0 last:pb-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-medium">{server.name}</span>
+                        <Badge variant={server.source === "manifest" ? "secondary" : "outline"}>
+                          {server.source}
+                        </Badge>
+                        <McpHealthBadge health={health} authConfigured={server.authConfigured} />
+                        <span className="ml-auto flex items-center gap-2">
+                          <Switch
+                            checked={server.enabled}
+                            disabled={busy === server.name}
+                            onCheckedChange={(v) => void toggle(server, v)}
+                            aria-label={`Enable ${server.name}`}
+                          />
                           <Button
                             variant="ghost"
                             size="sm"
                             disabled={busy === server.name}
-                            onClick={() => void remove(server)}
-                            aria-label={`Remove ${server.name}`}
+                            onClick={() => void test(server)}
                           >
-                            <Trash2 className="size-4" />
+                            {busy === server.name ? (
+                              <Loader2 className="size-4 animate-spin" />
+                            ) : (
+                              <Plug className="size-4" />
+                            )}{" "}
+                            Test
                           </Button>
-                        )}
-                      </span>
-                    </div>
-                    <p className="truncate text-xs text-muted-foreground">{server.endpoint}</p>
-                    <McpToolsList state={tools[server.name] ?? { kind: "idle" }} />
-                  </li>
-                ))}
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            disabled={busy === server.name}
+                            onClick={() => void discover(server)}
+                          >
+                            <ChevronDown className="size-4" /> Tools
+                          </Button>
+                          {server.source === "runtime" && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              disabled={busy === server.name}
+                              onClick={() => void remove(server)}
+                              aria-label={`Remove ${server.name}`}
+                            >
+                              <Trash2 className="size-4" />
+                            </Button>
+                          )}
+                        </span>
+                      </div>
+                      <p className="truncate text-xs text-muted-foreground">{server.endpoint}</p>
+                      {health && health.status !== "ok" && health.message && (
+                        <p className="text-xs text-muted-foreground">{health.message}</p>
+                      )}
+                      <McpToolsList state={tools[server.name] ?? { kind: "idle" }} />
+                    </li>
+                  );
+                })}
               </ul>
             )}
 
-            <div className="grid gap-2 border-t border-border pt-3 sm:grid-cols-[1fr_1.5fr_1fr_auto] sm:items-end">
-              <div className="space-y-1">
-                <Label htmlFor="mcp-name" className="text-xs">
-                  Name
-                </Label>
-                <Input
-                  id="mcp-name"
-                  value={name}
-                  placeholder="notion"
-                  onChange={(e) => setName(e.target.value)}
-                />
+            <div className="space-y-2 border-t border-border pt-3">
+              {addError && (
+                <Alert variant="destructive">
+                  <AlertTriangle className="size-4" />
+                  <AlertTitle>Couldn&apos;t add the server</AlertTitle>
+                  <AlertDescription>{addError}</AlertDescription>
+                </Alert>
+              )}
+              <div className="grid gap-2 sm:grid-cols-2 sm:items-end">
+                <div className="space-y-1">
+                  <Label htmlFor="mcp-name" className="text-xs">
+                    Name
+                  </Label>
+                  <Input
+                    id="mcp-name"
+                    value={name}
+                    placeholder="notion"
+                    onChange={(e) => setName(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="mcp-endpoint" className="text-xs">
+                    Endpoint
+                  </Label>
+                  <Input
+                    id="mcp-endpoint"
+                    value={endpoint}
+                    placeholder="https://host/mcp"
+                    onChange={(e) => setEndpoint(e.target.value)}
+                  />
+                </div>
               </div>
-              <div className="space-y-1">
-                <Label htmlFor="mcp-endpoint" className="text-xs">
-                  Endpoint
-                </Label>
-                <Input
-                  id="mcp-endpoint"
-                  value={endpoint}
-                  placeholder="https://host/mcp"
-                  onChange={(e) => setEndpoint(e.target.value)}
-                />
+              <div className="grid gap-2 sm:grid-cols-[auto_1fr_1fr_auto] sm:items-end">
+                <div className="space-y-1">
+                  <Label htmlFor="mcp-auth-kind" className="text-xs">
+                    Auth
+                  </Label>
+                  <select
+                    id="mcp-auth-kind"
+                    value={authKind}
+                    onChange={(e) => setAuthKind(e.target.value as McpAuthKind)}
+                    className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-xs"
+                  >
+                    <option value="bearer">Bearer token</option>
+                    <option value="header">Custom header</option>
+                    <option value="query_param">Query parameter</option>
+                  </select>
+                </div>
+                {authKind !== "bearer" && (
+                  <div className="space-y-1">
+                    <Label htmlFor="mcp-auth-field" className="text-xs">
+                      {authKind === "header" ? "Header name" : "Parameter name"}
+                    </Label>
+                    <Input
+                      id="mcp-auth-field"
+                      value={authFieldName}
+                      placeholder={authKind === "header" ? "X-Api-Key" : "apiKey"}
+                      autoComplete="off"
+                      onChange={(e) => setAuthFieldName(e.target.value)}
+                    />
+                  </div>
+                )}
+                <div className="space-y-1">
+                  <Label htmlFor="mcp-token" className="text-xs">
+                    {authKind === "bearer" ? "Token (optional)" : "Credential value"}
+                  </Label>
+                  <Input
+                    id="mcp-token"
+                    type="password"
+                    value={token}
+                    placeholder="write-only"
+                    autoComplete="off"
+                    onChange={(e) => setToken(e.target.value)}
+                  />
+                </div>
+                <Button disabled={busy === "add"} onClick={() => void add()}>
+                  {busy === "add" ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Plus className="size-4" />
+                  )}
+                  Add
+                </Button>
               </div>
-              <div className="space-y-1">
-                <Label htmlFor="mcp-token" className="text-xs">
-                  Token (optional)
-                </Label>
-                <Input
-                  id="mcp-token"
-                  type="password"
-                  value={token}
-                  placeholder="write-only"
-                  autoComplete="off"
-                  onChange={(e) => setToken(e.target.value)}
-                />
-              </div>
-              <Button disabled={busy === "add"} onClick={() => void add()}>
-                {busy === "add" ? <Loader2 className="size-4 animate-spin" /> : <Plus className="size-4" />}
-                Add
-              </Button>
             </div>
           </CardContent>
         </Card>
       )}
     </section>
   );
+}
+
+/**
+ * The per-server health badge: green `ok · N tools`, amber `needs config`, red
+ * `error`. Falls back to a plain "auth set" hint when the server has never been
+ * probed (no `health`).
+ */
+function McpHealthBadge({
+  health,
+  authConfigured,
+}: {
+  health?: McpHealth;
+  authConfigured: boolean;
+}) {
+  if (!health) {
+    // Never probed — show only the non-secret auth hint (unchanged behavior).
+    return authConfigured ? (
+      <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+        <Check className="size-3" /> auth set
+      </span>
+    ) : null;
+  }
+  if (health.status === "ok") {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+        <Check className="size-3" /> ok · {health.toolCount} tool{health.toolCount === 1 ? "" : "s"}
+      </span>
+    );
+  }
+  if (health.status === "needs_config") {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400">
+        <AlertTriangle className="size-3" /> needs config
+      </span>
+    );
+  }
+  if (health.status === "error") {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs text-destructive">
+        <AlertTriangle className="size-3" /> error
+      </span>
+    );
+  }
+  return null;
 }
 
 /** Renders the live-discovered tool list for one server. */

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -108,6 +108,17 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("Dispatched task {task_id}"),
             "task.dispatched",
         ),
+        CompanyEvent::McpCallFailed {
+            server,
+            tool,
+            status,
+            message,
+        } => (
+            Role::System,
+            "mcp".to_string(),
+            format!("MCP call to {server}/{tool} failed ({status}): {message}"),
+            "mcp.call_failed",
+        ),
     };
     WireEvent {
         seq,

--- a/src/company/mcp.rs
+++ b/src/company/mcp.rs
@@ -39,6 +39,15 @@ pub fn auth_key(name: &str) -> String {
     format!("mcp/{name}/auth")
 }
 
+/// The per-server health key. Holds the last probe outcome as a JSON
+/// [`McpHealth`]. **Invariant**: the value written here is always scrubbed — it
+/// is a non-secret status record and MUST NEVER carry a credential (see
+/// [`save_health`]). Distinct from [`auth_key`], which holds the write-only
+/// credential and is never read back out.
+pub fn health_key(name: &str) -> String {
+    format!("mcp/{name}/health")
+}
+
 /// Where an effective server declaration came from — drives the console's source
 /// badge and the delete-guard (a manifest server cannot be deleted, only
 /// disabled/overridden).
@@ -66,6 +75,14 @@ pub enum AuthMaterial {
     Bearer(String),
     /// A single custom request header.
     Header { name: String, value: String },
+    /// A credential carried as a URL query parameter (`?<name>=<value>`), the
+    /// BrowserBase / Parallel-Search style. The upstream transport already
+    /// applies this via `request.query()` (`mcp_client/client.rs`), so wiring it
+    /// needs zero vendor changes — but it means the credential ends up in the
+    /// request URL, which is exactly why the error-surfacing seams strip query
+    /// strings before persisting or emitting anything (see
+    /// [`crate::harness::mcp_probe::scrub`]).
+    QueryParam { name: String, value: String },
 }
 
 impl AuthMaterial {
@@ -73,6 +90,18 @@ impl AuthMaterial {
     /// `auth_configured` status field). Never reveals the value.
     pub fn is_configured(&self) -> bool {
         !matches!(self, AuthMaterial::None)
+    }
+
+    /// The concrete credential substrings this material carries, for the
+    /// scrubber's known-secret set. Never surfaced to any caller that
+    /// serializes — used only to feed [`crate::harness::mcp_probe::scrub`].
+    pub fn secret_values(&self) -> Vec<String> {
+        match self {
+            AuthMaterial::None => Vec::new(),
+            AuthMaterial::Bearer(token) => vec![token.clone()],
+            AuthMaterial::Header { value, .. } => vec![value.clone()],
+            AuthMaterial::QueryParam { value, .. } => vec![value.clone()],
+        }
     }
 }
 
@@ -83,6 +112,7 @@ impl AuthMaterial {
 enum StoredAuth {
     Bearer { token: String },
     Header { name: String, value: String },
+    QueryParam { name: String, value: String },
 }
 
 impl From<StoredAuth> for AuthMaterial {
@@ -90,6 +120,7 @@ impl From<StoredAuth> for AuthMaterial {
         match stored {
             StoredAuth::Bearer { token } => AuthMaterial::Bearer(token),
             StoredAuth::Header { name, value } => AuthMaterial::Header { name, value },
+            StoredAuth::QueryParam { name, value } => AuthMaterial::QueryParam { name, value },
         }
     }
 }
@@ -258,20 +289,55 @@ pub async fn auth_configured(
     Ok(material.is_configured())
 }
 
-/// Writes a server's bearer token (write-only intake).
+/// Writes a server's outbound credential (write-only intake). The credential is
+/// serialized to the canonical [`auth_key`] and never read back out over any
+/// API — only [`load_auth`] (harness-build + probe) crosses that boundary.
+pub async fn store_auth(
+    company: &CompanyId,
+    name: &str,
+    material: &AuthMaterial,
+    secrets: &dyn SecretStore,
+) -> Result<()> {
+    let stored = match material {
+        AuthMaterial::None => {
+            // Nothing to store — clear instead so the read-back is "unset".
+            return clear_auth(company, name, secrets).await;
+        }
+        AuthMaterial::Bearer(token) => StoredAuth::Bearer {
+            token: token.clone(),
+        },
+        AuthMaterial::Header { name, value } => StoredAuth::Header {
+            name: name.clone(),
+            value: value.clone(),
+        },
+        AuthMaterial::QueryParam { name, value } => StoredAuth::QueryParam {
+            name: name.clone(),
+            value: value.clone(),
+        },
+    };
+    let raw = serde_json::to_string(&stored)
+        .map_err(|e| OpenCompanyError::Store(format!("serializing mcp auth: {e}")))?;
+    secrets
+        .set(company, &auth_key(name), SecretValue(raw))
+        .await
+}
+
+/// Writes a server's bearer token (write-only intake). Thin back-compat wrapper
+/// over [`store_auth`]; new callers should build an [`AuthMaterial`] and use
+/// [`store_auth`] directly so custom-header / query-param intake share one path.
 pub async fn store_bearer(
     company: &CompanyId,
     name: &str,
     token: &str,
     secrets: &dyn SecretStore,
 ) -> Result<()> {
-    let raw = serde_json::to_string(&StoredAuth::Bearer {
-        token: token.to_string(),
-    })
-    .map_err(|e| OpenCompanyError::Store(format!("serializing mcp auth: {e}")))?;
-    secrets
-        .set(company, &auth_key(name), SecretValue(raw))
-        .await
+    store_auth(
+        company,
+        name,
+        &AuthMaterial::Bearer(token.to_string()),
+        secrets,
+    )
+    .await
 }
 
 /// Clears a server's stored credential (best-effort — the store has no delete,
@@ -279,6 +345,111 @@ pub async fn store_bearer(
 pub async fn clear_auth(company: &CompanyId, name: &str, secrets: &dyn SecretStore) -> Result<()> {
     secrets
         .set(company, &auth_key(name), SecretValue(String::new()))
+        .await
+}
+
+/// Clears a server's stored health (best-effort — an empty value reads back as
+/// "never probed"). Called when a runtime server is deleted so a later server of
+/// the same name never inherits a stale badge.
+pub async fn clear_health(
+    company: &CompanyId,
+    name: &str,
+    secrets: &dyn SecretStore,
+) -> Result<()> {
+    secrets
+        .set(company, &health_key(name), SecretValue(String::new()))
+        .await
+}
+
+/// The coarse health status of an MCP server, shown as the console badge.
+///
+/// Serialized `snake_case`; the frontend maps it to a green/amber/red tier. Kept
+/// deliberately small — a single actionable status plus an operator-facing
+/// (scrubbed) message.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpStatus {
+    /// Reached the server and listed its tools — fully working.
+    Ok,
+    /// The server is reachable but needs a credential the operator hasn't
+    /// supplied (401 with no/rejected credential, or an OAuth challenge). A
+    /// valid, expected resting state for a just-added server — never a rollback.
+    NeedsConfig,
+    /// The server could not be used: unreachable, wrong URL, not an MCP
+    /// endpoint, a 5xx, a TLS failure, or a rejected call.
+    Error,
+    /// The probe did not run (non-`openhuman` build, or never attempted).
+    Unknown,
+}
+
+impl McpStatus {
+    /// The stable wire string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            McpStatus::Ok => "ok",
+            McpStatus::NeedsConfig => "needs_config",
+            McpStatus::Error => "error",
+            McpStatus::Unknown => "unknown",
+        }
+    }
+}
+
+/// The last probe outcome for one MCP server.
+///
+/// **Security invariant**: `message` is always scrubbed before it reaches this
+/// struct (via [`crate::harness::mcp_probe::scrub`]) and this struct is the only
+/// thing [`save_health`] persists — so a credential can never land in the health
+/// key, the console, or an API response. `auth_hint` is a stable reason code
+/// (`oauth_required` / `token_rejected` / `credential_required`), never a URL or
+/// raw challenge.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpHealth {
+    /// The coarse status tier.
+    pub status: McpStatus,
+    /// A short, scrubbed, operator-facing message.
+    pub message: String,
+    /// How many tools the server advertised on a successful probe.
+    pub tool_count: u32,
+    /// Epoch-millis timestamp of the probe.
+    pub checked_at_millis: u64,
+    /// Stable auth-failure reason code, when the status is a credential problem.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_hint: Option<String>,
+}
+
+/// Loads a server's last recorded health, or `None` when it has never been
+/// probed (missing/empty key). A malformed record degrades to `None` rather than
+/// erroring — a stale badge is never worth bricking a status read.
+pub async fn load_health(
+    company: &CompanyId,
+    name: &str,
+    secrets: &dyn SecretStore,
+) -> Result<Option<McpHealth>> {
+    let Some(SecretValue(raw)) = secrets.get(company, &health_key(name)).await? else {
+        return Ok(None);
+    };
+    if raw.trim().is_empty() {
+        return Ok(None);
+    }
+    Ok(serde_json::from_str(&raw).ok())
+}
+
+/// Persists a server's probe outcome under [`health_key`].
+///
+/// The caller is responsible for having scrubbed `health.message` first; this
+/// function does not re-scrub (the scrubber needs the known-secret set, which
+/// lives at the probe seam). Nothing secret should ever reach here.
+pub async fn save_health(
+    company: &CompanyId,
+    name: &str,
+    health: &McpHealth,
+    secrets: &dyn SecretStore,
+) -> Result<()> {
+    let raw = serde_json::to_string(health)
+        .map_err(|e| OpenCompanyError::Store(format!("serializing mcp health: {e}")))?;
+    secrets
+        .set(company, &health_key(name), SecretValue(raw))
         .await
 }
 
@@ -359,6 +530,14 @@ pub fn validate_one(label: &str, server: &McpServer) -> Vec<String> {
         problems.push(format!(
             "{label} `endpoint` must be an `http://` or `https://` URL — you wrote `{endpoint}`."
         ));
+    } else if has_userinfo(endpoint) {
+        // A `user:pass@host` endpoint smuggles a credential into the URL, which
+        // then leaks into every log line and transport error. Reject it — the
+        // operator should use a token / custom-header / query-parameter
+        // credential (stored write-only) instead.
+        problems.push(format!(
+            "{label} `endpoint` must not embed credentials in the URL (the `user:pass@host` form) — leave the endpoint credential-free and set a token or query-parameter credential instead."
+        ));
     }
 
     problems
@@ -368,6 +547,44 @@ pub fn validate_one(label: &str, server: &McpServer) -> Vec<String> {
 fn is_http_url(url: &str) -> bool {
     let lower = url.trim().to_ascii_lowercase();
     lower.starts_with("http://") || lower.starts_with("https://")
+}
+
+/// Whether an endpoint's authority carries a `user[:pass]@` userinfo section.
+/// Uses the same cheap authority-splitting as [`crate::harness::mcp_probe::scrub`]
+/// so a `?email=a@b` query never trips it.
+fn has_userinfo(url: &str) -> bool {
+    let after_scheme = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
+    let authority = after_scheme
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or(after_scheme);
+    authority.contains('@')
+}
+
+/// A **non-blocking** advisory when an endpoint's query string carries a
+/// key-ish parameter (`apiKey` / `token` / `secret` / …).
+///
+/// This is not an error: some providers legitimately put a *non-secret* id in
+/// the URL (BrowserBase's `projectId`). But a real secret in the endpoint URL
+/// leaks into logs and transport errors, so the ops layer surfaces this as a
+/// gentle nudge toward the write-only query-parameter credential intake. Returns
+/// `None` when nothing key-ish is present.
+pub fn endpoint_secret_advisory(endpoint: &str) -> Option<String> {
+    let (_, query) = endpoint.split_once('?')?;
+    const KEYISH: [&str; 8] = [
+        "apikey", "token", "secret", "password", "passwd", "access", "auth", "key",
+    ];
+    let hit = query
+        .split(['&', ';'])
+        .filter_map(|kv| kv.split('=').next())
+        .any(|param| {
+            let param = param.trim().to_ascii_lowercase();
+            KEYISH.iter().any(|needle| param.contains(needle))
+        });
+    hit.then(|| {
+        "the endpoint URL looks like it carries a secret in its query string — a credential in the URL can leak into logs and errors, so prefer the write-only query-parameter credential (only a non-secret id like a project id belongs in the URL)."
+            .to_string()
+    })
 }
 
 /// De-dupes and trims a tool-name list, dropping blanks.
@@ -544,5 +761,127 @@ mod tests {
         clear_auth(&company, "notion", &secrets).await.unwrap();
         let material = load_auth(&company, "notion", &secrets, None).await.unwrap();
         assert_eq!(material, AuthMaterial::None);
+    }
+
+    // ---- query-param auth (BrowserBase style) -----------------------------
+
+    #[tokio::test]
+    async fn store_and_resolve_query_param_auth_round_trips() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        save_runtime_index(
+            &company,
+            &secrets,
+            &[server(
+                "browserbase",
+                "https://api.browserbase.com/mcp?projectId=pid",
+            )],
+        )
+        .await
+        .unwrap();
+        store_auth(
+            &company,
+            "browserbase",
+            &AuthMaterial::QueryParam {
+                name: "apiKey".into(),
+                value: "qp-secret".into(),
+            },
+            &secrets,
+        )
+        .await
+        .unwrap();
+
+        let decls = resolve_effective(&company, &[], &secrets).await.unwrap();
+        assert_eq!(
+            decls[0].auth,
+            AuthMaterial::QueryParam {
+                name: "apiKey".into(),
+                value: "qp-secret".into(),
+            }
+        );
+        // The non-secret project id stays in the endpoint URL, unchanged.
+        assert!(decls[0].endpoint.contains("projectId=pid"));
+    }
+
+    #[test]
+    fn secret_values_lists_the_credential_for_scrubbing() {
+        assert_eq!(
+            AuthMaterial::Bearer("tok".into()).secret_values(),
+            vec!["tok".to_string()]
+        );
+        assert_eq!(
+            AuthMaterial::QueryParam {
+                name: "apiKey".into(),
+                value: "qp".into(),
+            }
+            .secret_values(),
+            vec!["qp".to_string()]
+        );
+        assert!(AuthMaterial::None.secret_values().is_empty());
+    }
+
+    // ---- health persistence -----------------------------------------------
+
+    #[tokio::test]
+    async fn health_round_trips_and_clears() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        assert_eq!(
+            load_health(&company, "notion", &secrets).await.unwrap(),
+            None
+        );
+
+        let health = McpHealth {
+            status: McpStatus::Ok,
+            message: "8 tools available".into(),
+            tool_count: 8,
+            checked_at_millis: 123,
+            auth_hint: None,
+        };
+        save_health(&company, "notion", &health, &secrets)
+            .await
+            .unwrap();
+        assert_eq!(
+            load_health(&company, "notion", &secrets).await.unwrap(),
+            Some(health)
+        );
+
+        clear_health(&company, "notion", &secrets).await.unwrap();
+        assert_eq!(
+            load_health(&company, "notion", &secrets).await.unwrap(),
+            None
+        );
+    }
+
+    // ---- endpoint validation ----------------------------------------------
+
+    #[test]
+    fn userinfo_endpoint_is_rejected() {
+        let problems = validate_servers(&[server("creds", "https://user:pass@host/mcp")]);
+        assert!(
+            problems
+                .iter()
+                .any(|p| p.contains("must not embed credentials")),
+            "{problems:?}"
+        );
+    }
+
+    #[test]
+    fn email_in_query_is_not_mistaken_for_userinfo() {
+        // The '@' lives in the query, not the authority — must stay valid.
+        assert!(validate_servers(&[server("ok", "https://host/mcp?to=a@b.com")]).is_empty());
+    }
+
+    #[test]
+    fn secret_in_query_is_a_non_blocking_advisory() {
+        // A key-ish query param yields an advisory but NOT a validation error.
+        assert!(endpoint_secret_advisory("https://host/mcp?apiKey=sk-123").is_some());
+        assert!(
+            validate_servers(&[server("browserbase", "https://host/mcp?apiKey=sk-123")]).is_empty()
+        );
+        // A non-secret id (BrowserBase's projectId) is fine — no advisory.
+        assert!(endpoint_secret_advisory("https://host/mcp?projectId=pid").is_none());
+        // No query string at all — no advisory.
+        assert!(endpoint_secret_advisory("https://host/mcp").is_none());
     }
 }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -140,6 +140,37 @@ impl HarnessBrain {
             .cloned()
     }
 
+    /// Drains the MCP failure queue and surfaces each failure: an
+    /// operator-visible warning bubble (the Activity-trace cell will re-skin it
+    /// as a warning step later), plus a scrubbed
+    /// [`CompanyEvent::McpCallFailed`] audit event when the event log is wired.
+    /// Every string was already scrubbed at the source (`OcMcpCallTool`).
+    async fn surface_mcp_failures(&self, responses: &mut Vec<OutboundMessage>) -> Result<()> {
+        for failure in self.deps.mcp_failures.drain() {
+            responses.push(OutboundMessage {
+                channel: "operator".to_string(),
+                text: format!(
+                    "⚠️ MCP tool issue on '{}': {}",
+                    failure.server, failure.scrubbed_message
+                ),
+            });
+            if let Some(events) = self.deps.events.as_ref() {
+                events
+                    .append(
+                        &self.record.id,
+                        CompanyEvent::McpCallFailed {
+                            server: failure.server,
+                            tool: failure.tool,
+                            status: failure.status,
+                            message: failure.scrubbed_message,
+                        },
+                    )
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
     /// Executes one drained delegation from the orchestrator's turn.
     ///
     /// `spawn_task` opens a backlog card through the same
@@ -221,10 +252,12 @@ impl Brain for HarnessBrain {
                 CompanyEvent::OperatorMessage { text, chat, .. } => {
                     // Route to the addressed desk's lead, else the orchestrator.
                     let responder = self.responder_for(chat.as_deref());
-                    // Clear stale delegations so nothing leaks from a prior turn,
-                    // run the turn (metered through `deps`), then drain whatever
-                    // the orchestrator queued (capped; discarded past the cap).
+                    // Clear stale delegations + MCP failures so nothing leaks from
+                    // a prior turn, run the turn (metered through `deps`), then
+                    // drain whatever the orchestrator queued (capped; discarded
+                    // past the cap).
                     self.deps.delegations.clear();
+                    self.deps.mcp_failures.clear();
                     let reply = self
                         .pool
                         .run(&self.record.id, &responder, text, &self.deps)
@@ -242,6 +275,9 @@ impl Brain for HarnessBrain {
                             channel_responses.push(message);
                         }
                     }
+                    // Surface any MCP tool-call failures the turn (or a delegated
+                    // desk turn) recorded.
+                    self.surface_mcp_failures(&mut channel_responses).await?;
                 }
                 CompanyEvent::TaskDispatched { task_id } => {
                     self.run_task(task_id).await?;
@@ -348,6 +384,8 @@ description = "Runs Acme."
             facts: None,
             events: None,
             delegations: orchestrator::DelegationQueue::default(),
+            mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            secrets: None,
         };
         HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record())
     }
@@ -469,6 +507,8 @@ description = "Builds it."
             facts: None,
             events: None,
             delegations: orchestrator::DelegationQueue::default(),
+            mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            secrets: None,
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record_two()),
@@ -662,6 +702,8 @@ members = ["engineer"]
             facts: None,
             events: None,
             delegations: orchestrator::DelegationQueue::default(),
+            mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            secrets: None,
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record_with_desk()),
@@ -749,5 +791,80 @@ members = ["engineer"]
             .await
             .expect("delegation runs");
         assert!(none.is_none(), "an unknown desk is a silent no-op");
+    }
+
+    // --- MCP failure drain --------------------------------------------------
+
+    /// A recorded MCP failure surfaces as an operator bubble AND a scrubbed
+    /// `McpCallFailed` audit event when the event log is wired.
+    #[tokio::test]
+    async fn mcp_failures_surface_as_bubble_and_event() {
+        use crate::harness::mcp_probe::McpFailure;
+        use crate::ports::EventLog;
+        use crate::ports::types::EventSeq;
+        use crate::store::FsEventLog;
+
+        let dir = tempfile::tempdir().unwrap();
+        let events: Arc<dyn EventLog> = Arc::new(FsEventLog::new(dir.path()));
+        let failures = crate::harness::mcp_probe::McpFailureQueue::default();
+        let deps = HarnessDeps {
+            provider: Arc::new(MockProvider::new("mock: ")),
+            provider_slug: "mock".to_string(),
+            context: Arc::new(FsContextStore::new(dir.path())),
+            store: Arc::new(FsCompanyStore::new(dir.path())),
+            meter: None,
+            workspace_root: dir.path().to_path_buf(),
+            model_override: None,
+            tasks: None,
+            skills: None,
+            skills_source_dir: None,
+            mcp_servers: Vec::new(),
+            facts: None,
+            events: Some(events.clone()),
+            delegations: orchestrator::DelegationQueue::default(),
+            mcp_failures: failures.clone(),
+            secrets: None,
+        };
+        let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record());
+
+        // A failure recorded during the turn (its message already scrubbed).
+        failures.push(McpFailure {
+            server: "browserbase".into(),
+            tool: "browse".into(),
+            status: "tool_call_rejected".into(),
+            hint: None,
+            scrubbed_message: "server rejected the call".into(),
+        });
+
+        let mut responses = Vec::new();
+        brain
+            .surface_mcp_failures(&mut responses)
+            .await
+            .expect("drain surfaces failures");
+
+        assert_eq!(responses.len(), 1, "one warning bubble");
+        assert!(
+            responses[0].text.contains("browserbase"),
+            "{:?}",
+            responses[0].text
+        );
+        assert!(
+            responses[0].text.contains("rejected the call"),
+            "{:?}",
+            responses[0].text
+        );
+
+        let logged = events
+            .read_from(&CompanyId::new("acme"), EventSeq::new(0), usize::MAX)
+            .await
+            .expect("read events");
+        assert!(
+            logged.iter().any(|e| matches!(
+                &e.event,
+                CompanyEvent::McpCallFailed { server, status, .. }
+                    if server == "browserbase" && status == "tool_call_rejected"
+            )),
+            "an McpCallFailed audit event was journaled"
+        );
     }
 }

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -41,7 +41,9 @@ use crate::company::Agent as ManifestAgent;
 use crate::error::OpenCompanyError;
 use crate::harness::HarnessDeps;
 #[cfg(feature = "mcp")]
-use crate::harness::mcp::{OcMcpListServersTool, registry_for_agent};
+use crate::harness::mcp::{
+    OcMcpCallTool, OcMcpListServersTool, capability_brief, granted_secrets, registry_for_agent,
+};
 use crate::harness::memory::OcMemory;
 use crate::harness::orchestrator::{self, QueryCompanyTool};
 use crate::harness::policy::ApprovalPolicy;
@@ -181,9 +183,24 @@ pub fn build_agent(
     #[cfg(feature = "mcp")]
     if let Some(registry) = registry_for_agent(&deps.mcp_servers, grants) {
         let mcp_security = Arc::new(SecurityPolicy::default());
+        // The known-secret set for the scrubber: every credential the agent's
+        // granted servers carry, so no configured token can leak into an
+        // agent-visible MCP error (the error-hardening cell).
+        let secrets = granted_secrets(&deps.mcp_servers, manifest_agent);
         tools.push(Box::new(OcMcpListServersTool::new(registry.clone())));
         tools.push(Box::new(McpListToolsTool::new(registry.clone())));
-        tools.push(Box::new(McpCallTool::new(registry, mcp_security)));
+        // `OcMcpCallTool` replaces upstream's `McpCallTool`: same name/schema,
+        // but it classifies + scrubs failures, rewrites the agent-facing text,
+        // and records each failure on the shared queue the brain drains.
+        tools.push(Box::new(OcMcpCallTool::new(
+            registry,
+            mcp_security,
+            secrets,
+            deps.mcp_failures.clone(),
+        )));
+        // Stale-memory mitigation: direct the agent to answer capability
+        // questions from a live `mcp_list_servers` call, never from memory.
+        persona.push_str(&capability_brief());
     }
 
     // Orchestrator seam (issue #53): the company's orchestrator agent additionally

--- a/src/harness/mcp.rs
+++ b/src/harness/mcp.rs
@@ -1,7 +1,5 @@
 //! Per-agent MCP registry assembly + a credential-redacting list-servers tool
-//! (issue #50), and company-scoped MCP server lifecycle management.
-//!
-//! ## Agent bridge
+//! (issue #50).
 //!
 //! [`registry_for_agent`] folds a company's effective [`McpServerDecl`]s into an
 //! OpenHuman [`McpServerRegistry`](oh::mcp_client::McpServerRegistry) scoped to
@@ -15,16 +13,8 @@
 //! output. [`OcMcpListServersTool`] is a drop-in replacement that emits the same
 //! shape **minus** any credential (only a non-secret `auth_configured` bool).
 //!
-//! ## Company-scoped lifecycle
-//!
-//! [`McpRuntime`] owns a company-home-scoped OpenHuman config and provides
-//! durable install/connect/disconnect/uninstall operations over the live
-//! registry, plus tool discovery and tool calls.
-//!
 //! Compiled only under `feature = "openhuman"` (the whole `harness` module is).
 
-use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -34,16 +24,15 @@ use openhuman_core::openhuman as oh;
 
 use oh::config::{Config, McpAuthConfig, McpServerConfig};
 use oh::mcp_client::{McpRegistrySource, McpServerRegistry};
-use oh::mcp_registry::types::{ConnStatus, InstalledServer, McpTool};
-use oh::tools::traits::{PermissionLevel, Tool, ToolResult};
+use oh::security::{SecurityPolicy, ToolOperation};
+use oh::tools::traits::{PermissionLevel, Tool, ToolCallOptions, ToolResult};
 
+use crate::company::Agent as ManifestAgent;
 use crate::company::mcp::{AuthMaterial, McpServerDecl};
-use crate::error::OpenCompanyError;
+use crate::harness::mcp_probe::{
+    McpFailure, McpFailureQueue, classify_mcp_error, operator_message, scrub, strip_endpoint,
+};
 use crate::runtime::tools::grant_matches;
-
-// ---------------------------------------------------------------------------
-// Agent bridge: per-agent registry + credential-redacting tools
-// ---------------------------------------------------------------------------
 
 /// Builds a registry from a set of decls, keeping only the enabled ones.
 ///
@@ -68,20 +57,17 @@ pub fn registry_from_decls(decls: &[McpServerDecl]) -> McpServerRegistry {
 /// The MCP registry scoped to one agent, or `None` when the agent is granted no
 /// (enabled) MCP servers.
 ///
-/// An agent reaches a server named `<slug>` only when its effective `grants`
-/// (already narrowed by [`agent_effective_grants`]) match `mcp:<slug>` (a bare
-/// `mcp:*` grants all). Disabled servers are excluded. Returns `None` (not an
-/// empty registry) so the caller can skip pushing the MCP bridge tools entirely
-/// for an agent with no MCP surface.
-///
-/// [`agent_effective_grants`]: crate::runtime::builder::agent_effective_grants
+/// An agent reaches a server named `<slug>` only when its manifest `tools`
+/// grants match `mcp:<slug>` (a bare `mcp:*` grants all). Disabled servers are
+/// excluded. Returns `None` (not an empty registry) so the caller can skip
+/// pushing the MCP bridge tools entirely for an agent with no MCP surface.
 pub fn registry_for_agent(
     decls: &[McpServerDecl],
-    grants: &[String],
+    agent: &ManifestAgent,
 ) -> Option<Arc<McpServerRegistry>> {
     let granted: Vec<McpServerDecl> = decls
         .iter()
-        .filter(|decl| decl.enabled && grants_cover_server(grants, &decl.name))
+        .filter(|decl| decl.enabled && agent_grants_server(agent, &decl.name))
         .cloned()
         .collect();
     if granted.is_empty() {
@@ -95,12 +81,33 @@ pub fn registry_for_agent(
     }
 }
 
-/// Whether an agent's effective `grants` cover the MCP server named `name`,
-/// using the same glob semantics as every other tool grant (`mcp:*` = all,
-/// `mcp:notion` = exact).
-fn grants_cover_server(grants: &[String], name: &str) -> bool {
+/// Whether `agent`'s tool grants reach the MCP server named `name`, using the
+/// same glob semantics as every other tool grant (`mcp:*` = all, `mcp:notion` =
+/// exact).
+fn agent_grants_server(agent: &ManifestAgent, name: &str) -> bool {
     let want = format!("mcp:{name}");
-    grants.iter().any(|grant| grant_matches(grant, &want))
+    agent.tools.iter().any(|grant| grant_matches(grant, &want))
+}
+
+/// The credential substrings from the (enabled, grant-matched) servers this
+/// agent reaches — the known-secret set fed to
+/// [`scrub`](crate::harness::mcp_probe::scrub) so no configured credential can
+/// survive into an agent-visible error. Never serialized anywhere.
+pub fn granted_secrets(decls: &[McpServerDecl], agent: &ManifestAgent) -> Vec<String> {
+    decls
+        .iter()
+        .filter(|decl| decl.enabled && agent_grants_server(agent, &decl.name))
+        .flat_map(|decl| decl.auth.secret_values())
+        .collect()
+}
+
+/// A persona brief appended when an agent is granted MCP tools: a stale-memory
+/// mitigation directing the agent to answer capability questions from a **live**
+/// `mcp_list_servers` / `mcp_list_tools` call, never from memory (the effective
+/// server set can change between turns — the MCP-freshness path). The root fix
+/// for stale answers lives in the Memory cell; this is the mitigation.
+pub fn capability_brief() -> String {
+    " When you are asked what tools, integrations, or MCP servers you have — or whether you can do something that would use one — ALWAYS call `mcp_list_servers` (and `mcp_list_tools` for a specific server) to check what is available right now. Never answer such questions from memory: your available servers and tools can change between turns.".to_string()
 }
 
 /// Projects a [`McpServerDecl`] onto an OpenHuman [`McpServerConfig`], mapping
@@ -128,6 +135,13 @@ fn auth_config(material: &AuthMaterial) -> McpAuthConfig {
             token: token.clone(),
         },
         AuthMaterial::Header { name, value } => McpAuthConfig::Header {
+            name: name.clone(),
+            value: value.clone(),
+        },
+        // The upstream HTTP transport already applies this via `request.query()`
+        // (`mcp_client/client.rs`), so BrowserBase-style URL auth needs zero
+        // vendor changes — just this mapping.
+        AuthMaterial::QueryParam { name, value } => McpAuthConfig::QueryParam {
             name: name.clone(),
             value: value.clone(),
         },
@@ -217,7 +231,10 @@ impl Tool for OcMcpListServersTool {
             .map(|server| {
                 json!({
                     "name": server.name,
-                    "endpoint": server.endpoint,
+                    // Strip the query string: a query-parameter credential rides
+                    // in the endpoint URL, so the agent-visible endpoint must
+                    // never carry it.
+                    "endpoint": strip_endpoint(&server.endpoint),
                     "description": server.description,
                     "timeout_secs": server.timeout_secs,
                     "allowed_tools": server.allowed_tools,
@@ -244,7 +261,8 @@ impl Tool for OcMcpListServersTool {
                 };
                 md.push_str(&format!(
                     "\n- **{}** ({source})\n  - endpoint: `{}`\n  - auth: {auth}",
-                    server.name, server.endpoint,
+                    server.name,
+                    strip_endpoint(&server.endpoint),
                 ));
                 if let Some(description) = server.description.as_deref() {
                     md.push_str(&format!("\n  - {description}"));
@@ -272,128 +290,169 @@ impl Tool for OcMcpListServersTool {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Company-scoped MCP lifecycle (McpRuntime)
-// ---------------------------------------------------------------------------
-
-/// Company-home-scoped persistence and access to OpenHuman's live MCP registry.
-pub struct McpRuntime {
-    config: oh::config::Config,
+/// A hardening decorator around upstream's [`McpCallTool`](oh::tools::McpCallTool)
+/// that keeps the same tool name + schema but turns a raw transport failure into
+/// a **scrubbed, actionable** result and records it on a shared
+/// [`McpFailureQueue`] the brain drains after the turn.
+///
+/// Upstream's tool surfaces `mcp_call_tool failed: {err}` verbatim — which can
+/// carry a response body or (with query-parameter auth) the full request URL
+/// including the credential. This decorator classifies the error, scrubs it
+/// against the granted servers' known credentials, rewrites the agent-facing
+/// text into a "don't retry blindly, tell the operator" directive, and pushes an
+/// [`McpFailure`] so the operator sees a warning after the turn.
+pub struct OcMcpCallTool {
+    registry: Arc<McpServerRegistry>,
+    security: Arc<SecurityPolicy>,
+    /// Known credential substrings from the agent's granted servers, fed to
+    /// [`scrub`] so no configured secret can survive into agent-visible output.
+    secrets: Vec<String>,
+    /// The shared failure queue the brain drains after the turn.
+    failures: McpFailureQueue,
 }
 
-impl McpRuntime {
-    /// Creates a runtime whose MCP SQLite store lives beneath `workspace_dir`.
-    pub fn new(workspace_dir: PathBuf) -> Self {
-        let config = oh::config::Config {
-            workspace_dir,
-            ..Default::default()
-        };
-        Self { config }
-    }
-
-    /// Reconnects enabled installed servers. Failures are logged by OpenHuman
-    /// per server and never prevent the company runtime from booting.
-    pub async fn boot(&self) {
-        oh::mcp_registry::boot::spawn_installed_servers(&self.config).await;
-    }
-
-    /// Returns every persisted install without loading secret environment values.
-    pub fn list(&self) -> crate::Result<Vec<InstalledServer>> {
-        oh::mcp_registry::store::list_servers(&self.config).map_err(store_error)
-    }
-
-    /// Persists an install and its write-only environment values.
-    pub fn install(
-        &self,
-        server: &InstalledServer,
-        env: &HashMap<String, String>,
-    ) -> crate::Result<()> {
-        oh::mcp_registry::store::insert_server(&self.config, server).map_err(store_error)?;
-        if let Err(error) =
-            oh::mcp_registry::store::set_env_values(&self.config, &server.server_id, env)
-        {
-            let _ = oh::mcp_registry::store::delete_server(&self.config, &server.server_id);
-            return Err(store_error(error));
+impl OcMcpCallTool {
+    /// Builds the decorator over the agent's registry, the (permissive) MCP
+    /// security policy, the granted servers' credential substrings, and the
+    /// shared failure queue.
+    pub fn new(
+        registry: Arc<McpServerRegistry>,
+        security: Arc<SecurityPolicy>,
+        secrets: Vec<String>,
+        failures: McpFailureQueue,
+    ) -> Self {
+        Self {
+            registry,
+            security,
+            secrets,
+            failures,
         }
-        Ok(())
     }
 
-    /// Loads an installed server, establishing the company-store membership
-    /// check before touching OpenHuman's process-global connection registry.
-    pub fn get(&self, server_id: &str) -> crate::Result<InstalledServer> {
-        oh::mcp_registry::store::get_server(&self.config, server_id)
-            .map_err(|_| OpenCompanyError::McpServerNotFound(server_id.to_string()))
+    /// Whether the named server has a credential configured (drives the
+    /// 401-vs-rejected classification without reading the credential).
+    fn auth_configured(&self, server: &str) -> bool {
+        self.registry
+            .get(server)
+            .map(|s| !matches!(s.auth, McpAuthConfig::None))
+            .unwrap_or(false)
     }
 
-    /// Connects an installed server and returns its advertised tools.
-    pub async fn connect(&self, server_id: &str) -> crate::Result<Vec<McpTool>> {
-        let server = self.get(server_id)?;
-        oh::mcp_registry::connections::connect(&self.config, &server)
-            .await
-            .map_err(harness_error)
+    /// Classify + scrub + record a failed call, returning the agent-facing error
+    /// result. The pushed [`McpFailure`] and the returned text are both scrubbed.
+    fn handle_failure(&self, server: &str, tool: &str, err: &anyhow::Error) -> ToolResult {
+        let class = classify_mcp_error(err, self.auth_configured(server), true);
+        let scrubbed = scrub(&operator_message(server, &class, err), &self.secrets);
+        self.failures.push(McpFailure {
+            server: server.to_string(),
+            tool: tool.to_string(),
+            status: class.code(),
+            hint: class.auth_hint.clone(),
+            scrubbed_message: scrubbed.clone(),
+        });
+        // The agent-facing directive: don't retry blindly, surface to operator.
+        let agent_text = scrub(
+            &format!(
+                "The MCP call to '{server}' (tool '{tool}') did not succeed. {scrubbed} Do not retry blindly — surface this to the operator."
+            ),
+            &self.secrets,
+        );
+        ToolResult::error(agent_text)
+    }
+}
+
+#[async_trait]
+impl Tool for OcMcpCallTool {
+    fn name(&self) -> &str {
+        "mcp_call_tool"
     }
 
-    /// Disconnects an installed server after verifying it belongs to this store.
-    pub async fn disconnect(&self, server_id: &str) -> crate::Result<bool> {
-        self.get(server_id)?;
-        Ok(oh::mcp_registry::connections::disconnect(server_id).await)
+    fn description(&self) -> &str {
+        "Call a tool on a named remote MCP server. First inspect available tools with `mcp_list_tools`, then pass the remote tool name and its JSON arguments here."
     }
 
-    /// Disconnects and deletes an installed server and its environment values.
-    pub async fn uninstall(&self, server_id: &str) -> crate::Result<bool> {
-        self.get(server_id)?;
-        oh::mcp_registry::connections::disconnect(server_id).await;
-        oh::mcp_registry::store::delete_server(&self.config, server_id).map_err(store_error)
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "server": {
+                    "type": "string",
+                    "description": "Registered MCP server name from `mcp_list_servers`."
+                },
+                "tool": {
+                    "type": "string",
+                    "description": "Remote MCP tool name from `mcp_list_tools`."
+                },
+                "arguments": {
+                    "type": "object",
+                    "description": "Arguments object passed through to the remote MCP tool."
+                }
+            },
+            "required": ["server", "tool", "arguments"],
+            "additionalProperties": false
+        })
     }
 
-    /// Returns connection state joined by OpenHuman against this runtime's store.
-    pub async fn status(&self) -> Vec<ConnStatus> {
-        oh::mcp_registry::connections::all_status(&self.config).await
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Execute
     }
 
-    /// Returns the cached tool list for a connected installed server.
-    pub async fn tools(&self, server_id: &str) -> crate::Result<Vec<McpTool>> {
-        self.get(server_id)?;
-        oh::mcp_registry::connections::tools_for(server_id)
-            .await
-            .ok_or_else(|| {
-                OpenCompanyError::InvalidRequest(format!(
-                    "MCP server '{server_id}' is not connected"
-                ))
-            })
+    fn supports_markdown(&self) -> bool {
+        true
     }
 
-    /// Calls one tool after verifying the server belongs to this runtime's store.
-    pub async fn call_tool(
+    async fn execute_with_options(
         &self,
-        server_id: &str,
-        tool_name: &str,
-        arguments: Value,
-    ) -> crate::Result<Value> {
-        self.get(server_id)?;
-        oh::mcp_registry::connections::call_tool(server_id, tool_name, arguments)
+        args: Value,
+        options: ToolCallOptions,
+    ) -> anyhow::Result<ToolResult> {
+        self.security
+            .enforce_tool_operation(ToolOperation::Act, self.name())
+            .map_err(|err| anyhow::anyhow!(err))?;
+
+        let server = required_string_arg(&args, "server")?;
+        let tool = required_string_arg(&args, "tool")?;
+        let arguments = args
+            .get("arguments")
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("missing required `arguments` object"))?;
+        if !arguments.is_object() {
+            return Ok(ToolResult::error("`arguments` must be an object"));
+        }
+
+        match self.registry.call_tool(&server, &tool, arguments).await {
+            Ok(result) => {
+                let mut result = result.rendered;
+                if options.prefer_markdown && result.markdown_formatted.is_none() {
+                    result.markdown_formatted = Some(result.output());
+                }
+                Ok(result)
+            }
+            Err(err) => Ok(self.handle_failure(&server, &tool, &err)),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        self.execute_with_options(args, ToolCallOptions::default())
             .await
-            .map_err(harness_error)
     }
 }
 
-fn store_error(error: anyhow::Error) -> OpenCompanyError {
-    OpenCompanyError::Store(format!("MCP registry: {error}"))
+/// Pulls a required, non-empty string argument (mirrors upstream's private
+/// helper of the same name).
+fn required_string_arg(args: &Value, key: &str) -> anyhow::Result<String> {
+    let value = args
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("missing required `{key}`"))?;
+    Ok(value.to_string())
 }
-
-fn harness_error(error: impl std::fmt::Display) -> OpenCompanyError {
-    OpenCompanyError::Harness(format!("MCP registry: {error}"))
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // -- Agent-bridge tests (HEAD) --
 
     fn decl(name: &str, endpoint: &str) -> McpServerDecl {
         McpServerDecl {
@@ -409,20 +468,27 @@ mod tests {
         }
     }
 
-    fn grants(g: &[&str]) -> Vec<String> {
-        g.iter().map(|s| s.to_string()).collect()
+    fn agent(grants: &[&str]) -> ManifestAgent {
+        ManifestAgent {
+            id: "ceo".into(),
+            role: "Chief".into(),
+            description: None,
+            tier: None,
+            tools: grants.iter().map(|g| g.to_string()).collect(),
+            budget_usd_daily: None,
+        }
     }
 
     #[test]
     fn empty_decls_yield_no_registry() {
-        assert!(registry_for_agent(&[], &grants(&["mcp:*"])).is_none());
+        assert!(registry_for_agent(&[], &agent(&["mcp:*"])).is_none());
     }
 
     #[test]
     fn ungranted_agent_gets_no_registry() {
         let decls = vec![decl("notion", "https://notion.example/mcp")];
         // No mcp grant at all.
-        assert!(registry_for_agent(&decls, &grants(&["email.send"])).is_none());
+        assert!(registry_for_agent(&decls, &agent(&["email.send"])).is_none());
     }
 
     #[test]
@@ -431,7 +497,7 @@ mod tests {
             decl("notion", "https://notion.example/mcp"),
             decl("linear", "https://linear.example/mcp"),
         ];
-        let reg = registry_for_agent(&decls, &grants(&["mcp:*"])).expect("registry");
+        let reg = registry_for_agent(&decls, &agent(&["mcp:*"])).expect("registry");
         let mut names: Vec<&str> = reg.list().iter().map(|s| s.name.as_str()).collect();
         names.sort_unstable();
         assert_eq!(names, vec!["linear", "notion"]);
@@ -443,7 +509,7 @@ mod tests {
             decl("notion", "https://notion.example/mcp"),
             decl("linear", "https://linear.example/mcp"),
         ];
-        let reg = registry_for_agent(&decls, &grants(&["mcp:notion"])).expect("registry");
+        let reg = registry_for_agent(&decls, &agent(&["mcp:notion"])).expect("registry");
         let names: Vec<&str> = reg.list().iter().map(|s| s.name.as_str()).collect();
         assert_eq!(names, vec!["notion"]);
     }
@@ -452,7 +518,7 @@ mod tests {
     fn disabled_server_is_excluded() {
         let mut d = decl("notion", "https://notion.example/mcp");
         d.enabled = false;
-        assert!(registry_for_agent(&[d], &grants(&["mcp:*"])).is_none());
+        assert!(registry_for_agent(&[d], &agent(&["mcp:*"])).is_none());
     }
 
     #[test]
@@ -460,7 +526,7 @@ mod tests {
         // OpenHuman's Config::default seeds a `gitbooks` server; the registry we
         // build for a tenant agent must NOT contain it.
         let decls = vec![decl("notion", "https://notion.example/mcp")];
-        let reg = registry_for_agent(&decls, &grants(&["mcp:*"])).expect("registry");
+        let reg = registry_for_agent(&decls, &agent(&["mcp:*"])).expect("registry");
         assert!(reg.get("gitbooks").is_none(), "gitbooks must not leak in");
     }
 
@@ -473,6 +539,11 @@ mod tests {
             value: "v".into(),
         });
         assert!(matches!(header, McpAuthConfig::Header { .. }));
+        let query = auth_config(&AuthMaterial::QueryParam {
+            name: "apiKey".into(),
+            value: "qp".into(),
+        });
+        assert!(matches!(query, McpAuthConfig::QueryParam { .. }));
         assert!(matches!(
             auth_config(&AuthMaterial::None),
             McpAuthConfig::None
@@ -483,7 +554,7 @@ mod tests {
     async fn list_servers_tool_never_emits_a_credential() {
         let mut d = decl("notion", "https://notion.example/mcp");
         d.auth = AuthMaterial::Bearer("sk-super-secret-token".into());
-        let reg = registry_for_agent(&[d], &grants(&["mcp:*"])).expect("registry");
+        let reg = registry_for_agent(&[d], &agent(&["mcp:*"])).expect("registry");
         let tool = OcMcpListServersTool::new(reg);
         let result = tool.execute(json!({})).await.expect("execute");
 
@@ -565,7 +636,7 @@ mod tests {
         let endpoint = format!("http://{addr}/mcp");
         let mut d = decl("fixture", &endpoint);
         d.auth = AuthMaterial::Bearer("sk-super-secret-xyz".into());
-        let registry = registry_for_agent(&[d], &grants(&["mcp:*"])).expect("registry");
+        let registry = registry_for_agent(&[d], &agent(&["mcp:*"])).expect("registry");
         let tool = McpCallTool::new(registry, Arc::new(SecurityPolicy::default()));
 
         let result = tool
@@ -588,84 +659,185 @@ mod tests {
         assert!(result.output().contains("remote ran ok"));
     }
 
-    // -- McpRuntime tests (origin/main) --
-
-    use std::process::Command;
-
-    use oh::mcp_registry::types::{CommandKind, Transport};
-
-    const NODE_STUB: &str = r#"
-const readline = require('node:readline');
-const rl = readline.createInterface({ input: process.stdin });
-const send = (value) => process.stdout.write(JSON.stringify(value) + '\n');
-rl.on('line', (line) => {
-  const request = JSON.parse(line);
-  if (!request.id) return;
-  if (request.method === 'initialize') {
-    send({ jsonrpc: '2.0', id: request.id, result: { protocolVersion: '2024-11-05', capabilities: { tools: {} }, serverInfo: { name: 'test', version: '1' } } });
-  } else if (request.method === 'tools/list') {
-    send({ jsonrpc: '2.0', id: request.id, result: { tools: [{ name: 'echo', description: 'Echo text', inputSchema: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] } }] } });
-  } else if (request.method === 'tools/call') {
-    send({ jsonrpc: '2.0', id: request.id, result: { content: [{ type: 'text', text: 'echo: ' + request.params.arguments.text }] } });
-  }
-});
-"#;
-
+    /// SECURITY CANARY: a server that **reflects the submitted credential** in a
+    /// non-401 error body must not leak it anywhere the `OcMcpCallTool` decorator
+    /// surfaces — not the agent-visible result, and not the drained failure. This
+    /// is the regression guard for leak vector #1 (upstream `MCP HTTP {status} —
+    /// {body}` echoing the body) driven through the REAL vendored transport.
     #[tokio::test]
-    async fn install_connect_call_disconnect_round_trip() {
-        if Command::new("node").arg("--version").output().is_err() {
-            eprintln!("skipping MCP runtime test because node is unavailable");
-            return;
+    async fn oc_call_tool_scrubs_reflected_credential() {
+        use axum::extract::State;
+        use axum::http::HeaderMap;
+        use axum::routing::post;
+        use axum::{Json, Router};
+        use oh::security::SecurityPolicy;
+
+        // On tools/call, reflect the Authorization header back in a 500 body — the
+        // exact hostile shape that would leak the token through upstream's
+        // `MCP HTTP 500 — {body}` surfacing.
+        async fn handler(
+            State(()): State<()>,
+            headers: HeaderMap,
+            Json(body): Json<Value>,
+        ) -> axum::response::Response {
+            use axum::response::IntoResponse;
+            let id = body.get("id").cloned().unwrap_or(Value::Null);
+            let method = body.get("method").and_then(Value::as_str).unwrap_or("");
+            match method {
+                "initialize" => Json(json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "result": { "protocolVersion": "2025-11-25", "capabilities": {},
+                                "serverInfo": { "name": "fixture", "version": "0" } }
+                }))
+                .into_response(),
+                "tools/list" => Json(json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "result": { "tools": [{ "name": "echo", "description": "e",
+                                            "inputSchema": { "type": "object" } }] }
+                }))
+                .into_response(),
+                "tools/call" => {
+                    let auth = headers
+                        .get("authorization")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or("")
+                        .to_string();
+                    (
+                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("boom — received {auth}"),
+                    )
+                        .into_response()
+                }
+                _ => Json(json!({ "jsonrpc": "2.0" })).into_response(),
+            }
         }
 
-        let temp = tempfile::tempdir().expect("tempdir");
-        let script = temp.path().join("mcp-stub.cjs");
-        std::fs::write(&script, NODE_STUB).expect("write node stub");
-        let runtime = McpRuntime::new(temp.path().join("workspace"));
-        let server = InstalledServer {
-            server_id: uuid::Uuid::new_v4().to_string(),
-            qualified_name: "test-node-echo".to_string(),
-            display_name: "Test Node Echo".to_string(),
-            description: None,
-            icon_url: None,
-            command_kind: CommandKind::Binary,
-            command: "node".to_string(),
-            args: vec![script.to_string_lossy().into_owned()],
-            env_keys: vec![],
-            config: None,
-            installed_at: 0,
-            last_connected_at: None,
-            transport: Transport::Stdio,
-            enabled: true,
-        };
+        let app = Router::new().route("/mcp", post(handler)).with_state(());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
 
-        runtime.install(&server, &HashMap::new()).expect("install");
-        let tools = runtime.connect(&server.server_id).await.expect("connect");
-        assert_eq!(tools.len(), 1);
-        assert_eq!(tools[0].name, "echo");
+        const CANARY: &str = "sk-canary-REFLECTED-9999";
+        let endpoint = format!("http://{addr}/mcp");
+        let mut d = decl("fixture", &endpoint);
+        d.auth = AuthMaterial::Bearer(CANARY.into());
+        let agent = agent(&["mcp:*"]);
+        let secrets = granted_secrets(std::slice::from_ref(&d), &agent);
+        let registry = registry_for_agent(&[d], &agent).expect("registry");
 
-        let result = runtime
-            .call_tool(
-                &server.server_id,
-                "echo",
-                serde_json::json!({"text": "hello"}),
-            )
+        let queue = McpFailureQueue::default();
+        let tool = OcMcpCallTool::new(
+            registry,
+            Arc::new(SecurityPolicy::default()),
+            secrets,
+            queue.clone(),
+        );
+
+        let result = tool
+            .execute(json!({ "server": "fixture", "tool": "echo", "arguments": {} }))
             .await
-            .expect("call");
-        assert_eq!(result["content"][0]["text"], "echo: hello");
+            .expect("mcp_call_tool");
 
+        // The agent-visible result is an error, but carries NO canary.
+        assert!(result.is_error, "a failed call must be an error result");
+        let out = serde_json::to_string(&result).unwrap();
         assert!(
-            runtime
-                .disconnect(&server.server_id)
-                .await
-                .expect("disconnect")
+            !out.contains(CANARY),
+            "OcMcpCallTool result leaked the reflected credential: {out}"
+        );
+
+        // The drained failure is recorded, classified, and scrubbed.
+        let failures = queue.drain();
+        assert_eq!(failures.len(), 1, "the failure was queued");
+        assert_eq!(failures[0].server, "fixture");
+        assert_eq!(failures[0].status, "server_error");
+        let serialized = format!("{:?}", failures[0]);
+        assert!(
+            !serialized.contains(CANARY),
+            "the drained failure leaked the reflected credential: {serialized}"
+        );
+    }
+
+    /// The query-parameter credential is **appended** to an endpoint that already
+    /// carries a (non-secret) query string, reaching the server on the wire —
+    /// the BrowserBase shape (`?projectId=…` in the URL, `apiKey` as the
+    /// credential). Proves the upstream `request.query()` path composes rather
+    /// than replaces, and that our mapping wires it.
+    #[tokio::test]
+    async fn query_param_auth_appends_to_existing_query_on_the_wire() {
+        use std::sync::Mutex as StdMutex;
+
+        use axum::extract::State;
+        use axum::http::Uri;
+        use axum::routing::post;
+        use axum::{Json, Router};
+
+        #[derive(Default)]
+        struct Seen {
+            query: StdMutex<Option<String>>,
+        }
+
+        async fn handler(
+            State(seen): State<Arc<Seen>>,
+            uri: Uri,
+            Json(body): Json<Value>,
+        ) -> Json<Value> {
+            if let Some(q) = uri.query() {
+                *seen.query.lock().unwrap() = Some(q.to_string());
+            }
+            let id = body.get("id").cloned().unwrap_or(Value::Null);
+            let method = body.get("method").and_then(Value::as_str).unwrap_or("");
+            let result = match method {
+                "initialize" => json!({
+                    "protocolVersion": "2025-11-25", "capabilities": {},
+                    "serverInfo": { "name": "fixture", "version": "0" }
+                }),
+                "tools/list" => json!({ "tools": [] }),
+                _ => return Json(json!({ "jsonrpc": "2.0" })),
+            };
+            Json(json!({ "jsonrpc": "2.0", "id": id, "result": result }))
+        }
+
+        let seen = Arc::new(Seen::default());
+        let app = Router::new()
+            .route("/mcp", post(handler))
+            .with_state(seen.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        // The non-secret project id stays in the endpoint; the secret rides as a
+        // query-parameter credential.
+        let endpoint = format!("http://{addr}/mcp?projectId=pid-123");
+        let mut d = decl("browserbase", &endpoint);
+        d.auth = AuthMaterial::QueryParam {
+            name: "apiKey".into(),
+            value: "qp-secret-abc".into(),
+        };
+        let registry = registry_for_agent(&[d], &agent(&["mcp:*"])).expect("registry");
+        // list_tools drives initialize + tools/list over the wire.
+        let _ = registry
+            .list_tools("browserbase")
+            .await
+            .expect("list_tools");
+
+        let query = seen
+            .query
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("server saw a query");
+        assert!(
+            query.contains("projectId=pid-123"),
+            "kept the existing id: {query}"
         );
         assert!(
-            runtime
-                .uninstall(&server.server_id)
-                .await
-                .expect("uninstall")
+            query.contains("apiKey=qp-secret-abc"),
+            "appended the credential: {query}"
         );
-        assert!(runtime.list().expect("list").is_empty());
     }
 }

--- a/src/harness/mcp_probe.rs
+++ b/src/harness/mcp_probe.rs
@@ -1,0 +1,600 @@
+//! MCP probing, error classification, and credential scrubbing (the
+//! error-hardening cell).
+//!
+//! This is the one place that turns a raw MCP transport failure into an
+//! operator-facing [`McpHealth`] the console can render, and it is the security
+//! choke point for the "a credential must NEVER appear in any error/health/
+//! response/agent-output" invariant.
+//!
+//! Three leak vectors are closed by [`scrub`]:
+//!
+//! 1. Upstream's `MCP HTTP {status} — {text}` embeds the raw response *body*.
+//! 2. A `reqwest::Error`'s `Display` embeds the **full request URL including the
+//!    query string** — lethal with [`AuthMaterial::QueryParam`], where the
+//!    credential lives in the URL.
+//!
+//! [`AuthMaterial::QueryParam`]: crate::company::mcp::AuthMaterial::QueryParam
+//! 3. Agent-visible endpoints could echo a URL query.
+//!
+//! [`scrub`] therefore (a) replaces every known credential substring with
+//! `•••`, (b) strips the query string off any embedded URL, and (c)
+//! UTF-8-safely truncates — and it is applied at **every** surfacing seam.
+//!
+//! Compiled only under `feature = "openhuman"` (the whole `harness` module is).
+
+use std::sync::{Arc, Mutex};
+
+use openhuman_core::openhuman as oh;
+
+use crate::company::mcp::{McpHealth, McpServerDecl, McpStatus};
+use crate::harness::mcp::registry_from_decls;
+use crate::ports::now_millis;
+
+/// The maximum byte length of any scrubbed, surfaced message.
+pub const SCRUB_MAX_BYTES: usize = 300;
+
+/// The shape of an MCP failure, driving both the status tier and the operator
+/// message. Derived by [`classify_mcp_error`] from the typed error (downcast)
+/// and the upstream bail-string arms.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FailureKind {
+    /// 401 with no/unknown credential — the operator hasn't supplied auth yet.
+    CredentialRequired,
+    /// The server advertises an OAuth challenge (browser sign-in), unsupported.
+    OauthRequired,
+    /// A credential WAS sent but the server refused it (wrong/expired, or 403).
+    TokenRejected,
+    /// The request did not complete within the timeout.
+    Timeout,
+    /// The host was unreachable (DNS failure, connection refused, no route).
+    Unreachable,
+    /// The TLS handshake failed (bad/self-signed cert, protocol mismatch).
+    Tls,
+    /// Reachable, but not an MCP endpoint (404 wrong path, HTML/JSON that
+    /// doesn't parse as an MCP reply).
+    NotMcp,
+    /// The server returned a 5xx.
+    ServerError,
+    /// A tool call was rejected by the server (JSON-RPC error in call context).
+    ToolCallRejected,
+    /// Anything not otherwise recognised.
+    Unknown,
+}
+
+/// The classification of one MCP failure: the coarse [`McpStatus`] tier, the
+/// stable auth-hint code (when it's a credential problem), and the internal
+/// [`FailureKind`] that selects the operator message.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProbeClass {
+    /// The coarse badge tier.
+    pub status: McpStatus,
+    /// A stable auth-failure reason code, when applicable.
+    pub auth_hint: Option<String>,
+    kind: FailureKind,
+}
+
+impl FailureKind {
+    /// A stable machine code for this failure, used as the [`McpFailure`] and
+    /// [`CompanyEvent::McpCallFailed`](crate::ports::types::CompanyEvent) status
+    /// string.
+    fn code(self) -> &'static str {
+        match self {
+            FailureKind::CredentialRequired => "credential_required",
+            FailureKind::OauthRequired => "oauth_required",
+            FailureKind::TokenRejected => "token_rejected",
+            FailureKind::Timeout => "timeout",
+            FailureKind::Unreachable => "unreachable",
+            FailureKind::Tls => "tls",
+            FailureKind::NotMcp => "not_mcp",
+            FailureKind::ServerError => "server_error",
+            FailureKind::ToolCallRejected => "tool_call_rejected",
+            FailureKind::Unknown => "error",
+        }
+    }
+
+    /// The badge tier this failure maps to. Auth problems are `NeedsConfig` (a
+    /// valid resting state the operator can fix), everything else is `Error`.
+    fn status(self) -> McpStatus {
+        match self {
+            FailureKind::CredentialRequired
+            | FailureKind::OauthRequired
+            | FailureKind::TokenRejected => McpStatus::NeedsConfig,
+            _ => McpStatus::Error,
+        }
+    }
+
+    /// The stable auth-hint wire code, when this is a credential problem.
+    fn auth_hint(self) -> Option<String> {
+        match self {
+            FailureKind::CredentialRequired => Some("credential_required".to_string()),
+            FailureKind::OauthRequired => Some("oauth_required".to_string()),
+            FailureKind::TokenRejected => Some("token_rejected".to_string()),
+            _ => None,
+        }
+    }
+}
+
+impl ProbeClass {
+    /// The stable machine code for this classification (mirrors the internal
+    /// [`FailureKind`]) — the status string carried on an [`McpFailure`] and the
+    /// `McpCallFailed` event.
+    pub fn code(&self) -> String {
+        self.kind.code().to_string()
+    }
+}
+
+/// One MCP tool-call failure observed during an agent turn, pushed onto the
+/// [`McpFailureQueue`] by [`crate::harness::mcp::OcMcpCallTool`] and drained by
+/// the [`HarnessBrain`](crate::harness::HarnessBrain) after the turn. Every
+/// string field is already scrubbed at construction — this is safe to persist,
+/// return, or show an operator.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct McpFailure {
+    /// The MCP server the failing call targeted.
+    pub server: String,
+    /// The remote tool the agent tried to call.
+    pub tool: String,
+    /// A stable status code (from [`ProbeClass::code`]).
+    pub status: String,
+    /// The auth-failure reason code, when the failure was a credential problem.
+    pub hint: Option<String>,
+    /// A short, scrubbed, operator-facing message.
+    pub scrubbed_message: String,
+}
+
+/// A shared, in-memory queue of MCP tool-call failures — the exact
+/// [`DelegationQueue`](crate::harness::orchestrator::DelegationQueue) pattern.
+/// Cheap to [`Clone`] (a shared handle); the tool built into the agent and the
+/// brain that drains it see the same queue because
+/// [`HarnessDeps`](crate::harness::HarnessDeps) clones share this handle.
+#[derive(Clone, Default)]
+pub struct McpFailureQueue {
+    inner: Arc<Mutex<Vec<McpFailure>>>,
+}
+
+impl McpFailureQueue {
+    /// Records a failure.
+    pub fn push(&self, failure: McpFailure) {
+        self.inner.lock().expect("mcp failure queue").push(failure);
+    }
+
+    /// Empties the queue (called before an orchestrator turn so a prior turn's
+    /// failures never leak into this one — mirrors `DelegationQueue::clear`).
+    pub fn clear(&self) {
+        self.inner.lock().expect("mcp failure queue").clear();
+    }
+
+    /// Drains every queued failure (FIFO), emptying the queue.
+    pub fn drain(&self) -> Vec<McpFailure> {
+        let mut guard = self.inner.lock().expect("mcp failure queue");
+        std::mem::take(&mut *guard)
+    }
+
+    /// The number of queued failures (test/observability).
+    #[cfg(test)]
+    pub fn queued(&self) -> usize {
+        self.inner.lock().expect("mcp failure queue").len()
+    }
+}
+
+/// Classify a raw MCP transport error into a [`ProbeClass`].
+///
+/// `auth_configured` is whether the server has a stored credential — it
+/// disambiguates a bare 401 (credential required) from a rejected one (token
+/// rejected). `in_call_context` is true when the error came from a *tool call*
+/// (via [`crate::harness::mcp`]'s `OcMcpCallTool`) rather than a connect/probe;
+/// only then is a JSON-RPC `MCP error:` treated as a tool-call rejection.
+///
+/// Order matters: the **typed** downcasts (401, reqwest) win over string arms so
+/// classification survives `?`/`.context()` wrapping and never depends on
+/// fragile prose for the security-relevant cases.
+pub fn classify_mcp_error(
+    err: &anyhow::Error,
+    auth_configured: bool,
+    in_call_context: bool,
+) -> ProbeClass {
+    let kind = classify_kind(err, auth_configured, in_call_context);
+    ProbeClass {
+        status: kind.status(),
+        auth_hint: kind.auth_hint(),
+        kind,
+    }
+}
+
+fn classify_kind(err: &anyhow::Error, auth_configured: bool, in_call_context: bool) -> FailureKind {
+    // 1. Typed 401 — the security-critical case. Read the typed
+    //    `resource_metadata` (not the message) to decide OAuth vs static auth.
+    if let Some(unauthorized) = err
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<oh::mcp_client::McpUnauthorizedError>())
+    {
+        return if unauthorized.resource_metadata.is_some() {
+            FailureKind::OauthRequired
+        } else if auth_configured {
+            FailureKind::TokenRejected
+        } else {
+            FailureKind::CredentialRequired
+        };
+    }
+
+    // 2. Typed transport error — timeout / connect / TLS. reqwest's `Display`
+    //    leaks the full URL, but we only read its typed predicates here; the
+    //    message is scrubbed before it ever surfaces.
+    if let Some(req) = err
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<reqwest::Error>())
+    {
+        if req.is_timeout() {
+            return FailureKind::Timeout;
+        }
+        if looks_like_tls(err) {
+            return FailureKind::Tls;
+        }
+        if req.is_connect() {
+            return FailureKind::Unreachable;
+        }
+        return FailureKind::Unreachable;
+    }
+
+    // 3. String arms over the upstream bail! messages (whole chain).
+    let full = format!("{err:#}");
+    if let Some(code) = http_status_in(&full) {
+        return match code {
+            401 => {
+                if auth_configured {
+                    FailureKind::TokenRejected
+                } else {
+                    FailureKind::CredentialRequired
+                }
+            }
+            403 => FailureKind::TokenRejected,
+            404 => FailureKind::NotMcp,
+            500..=599 => FailureKind::ServerError,
+            _ => FailureKind::Unknown,
+        };
+    }
+    if full.contains("Failed to parse MCP JSON response") {
+        return FailureKind::NotMcp;
+    }
+    if in_call_context && full.contains("MCP error:") {
+        return FailureKind::ToolCallRejected;
+    }
+    if looks_like_tls(err) {
+        return FailureKind::Tls;
+    }
+    FailureKind::Unknown
+}
+
+/// The HTTP status code embedded in an upstream `MCP HTTP {status} — …` message,
+/// if present.
+fn http_status_in(text: &str) -> Option<u16> {
+    let after = text.split("MCP HTTP ").nth(1)?;
+    let digits: String = after.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().ok()
+}
+
+/// Whether the error chain smells like a TLS/certificate failure.
+fn looks_like_tls(err: &anyhow::Error) -> bool {
+    let full = format!("{err:#}").to_ascii_lowercase();
+    [
+        "tls",
+        "certificate",
+        "handshake",
+        "ssl",
+        "self-signed",
+        "self signed",
+    ]
+    .iter()
+    .any(|needle| full.contains(needle))
+}
+
+/// A short, actionable, operator-facing message for a classified failure. The
+/// caller MUST pass the result through [`scrub`] before persisting or surfacing
+/// it — `err` may embed a body or URL.
+pub fn operator_message(server: &str, class: &ProbeClass, err: &anyhow::Error) -> String {
+    match class.kind {
+        FailureKind::CredentialRequired => format!(
+            "MCP server '{server}' needs a credential. Add its API token (or query-parameter key) in Connections, then Test again."
+        ),
+        FailureKind::OauthRequired => format!(
+            "MCP server '{server}' uses OAuth sign-in, which isn't supported yet — a pasted token won't be accepted."
+        ),
+        FailureKind::TokenRejected => format!(
+            "MCP server '{server}' rejected the credential — it's wrong or expired. Update it and Test again."
+        ),
+        FailureKind::Timeout => format!(
+            "MCP server '{server}' didn't respond in time. Check the endpoint is reachable, or raise its timeout."
+        ),
+        FailureKind::Unreachable => format!(
+            "Couldn't reach MCP server '{server}'. Check the endpoint URL is correct and the host is online."
+        ),
+        FailureKind::Tls => format!(
+            "MCP server '{server}' has a TLS/certificate problem — the secure connection couldn't be established."
+        ),
+        FailureKind::NotMcp => format!(
+            "MCP server '{server}' didn't respond as an MCP endpoint. Check the URL points at the server's MCP path."
+        ),
+        FailureKind::ServerError => format!(
+            "MCP server '{server}' returned a server error. It's likely down — try again later."
+        ),
+        FailureKind::ToolCallRejected => format!(
+            "MCP server '{server}' rejected the call: {err}. It may need different arguments or credentials — tell the operator, don't retry blindly."
+        ),
+        FailureKind::Unknown => format!("MCP server '{server}' couldn't be used: {err}."),
+    }
+}
+
+/// Probe a single server end-to-end: build a one-server registry (auth
+/// **included** — unlike upstream's no-auth test probe), list its tools
+/// (inheriting the injection-safety filter), and classify the outcome into a
+/// **scrubbed** [`McpHealth`].
+///
+/// A disabled decl is probed as if enabled (the caller decides whether to probe;
+/// probing must reflect the configured auth regardless of the exposed flag).
+pub async fn probe_server(decl: &McpServerDecl) -> McpHealth {
+    let secrets = decl.auth.secret_values();
+    let auth_configured = decl.auth.is_configured();
+
+    let mut probe = decl.clone();
+    probe.enabled = true; // the probe reflects config, not the exposed flag
+    let registry = registry_from_decls(std::slice::from_ref(&probe));
+
+    match registry.list_tools(&decl.name).await {
+        Ok(tools) => {
+            let count = tools.len() as u32;
+            McpHealth {
+                status: McpStatus::Ok,
+                message: format!(
+                    "{count} tool{} available.",
+                    if count == 1 { "" } else { "s" }
+                ),
+                tool_count: count,
+                checked_at_millis: now_millis(),
+                auth_hint: None,
+            }
+        }
+        Err(err) => {
+            let class = classify_mcp_error(&err, auth_configured, false);
+            let message = scrub(&operator_message(&decl.name, &class, &err), &secrets);
+            McpHealth {
+                status: class.status,
+                message,
+                tool_count: 0,
+                checked_at_millis: now_millis(),
+                auth_hint: class.auth_hint,
+            }
+        }
+    }
+}
+
+/// Scrub a message so it can be safely persisted, returned, or shown to an agent.
+///
+/// Three passes, in order:
+/// 1. Replace every known credential substring (from `secrets`) with `•••`.
+/// 2. Strip the query string (and fragment) off **every** embedded URL — this is
+///    what kills the `reqwest` full-URL leak when the credential rides in a
+///    query parameter.
+/// 3. UTF-8-safely truncate to [`SCRUB_MAX_BYTES`].
+pub fn scrub(text: &str, secrets: &[String]) -> String {
+    let mut out = text.to_string();
+    for secret in secrets {
+        if !secret.is_empty() {
+            out = out.replace(secret.as_str(), "•••");
+        }
+    }
+    out = strip_url_queries(&out);
+    utf8_truncate(&out, SCRUB_MAX_BYTES)
+}
+
+/// Remove the entire endpoint credential surface from an agent-visible endpoint
+/// string: strip its query + fragment. Kept separate so [`crate::harness::mcp`]'s
+/// list-servers tool can sanitize endpoints without the full [`scrub`] pipeline.
+pub fn strip_endpoint(endpoint: &str) -> String {
+    let cut = endpoint.find(['?', '#']).unwrap_or(endpoint.len());
+    endpoint[..cut].to_string()
+}
+
+/// Cut the query/fragment off any `http(s)://…` URL embedded anywhere in `text`.
+fn strip_url_queries(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(pos) = find_url_start(rest) {
+        out.push_str(&rest[..pos]);
+        let tail = &rest[pos..];
+        // The URL token runs until the next whitespace.
+        let url_end = tail.find(char::is_whitespace).unwrap_or(tail.len());
+        let url = &tail[..url_end];
+        let cut = url.find(['?', '#']).unwrap_or(url.len());
+        out.push_str(&url[..cut]);
+        rest = &tail[url_end..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// The byte offset of the earliest `http://` or `https://` in `s`.
+fn find_url_start(s: &str) -> Option<usize> {
+    match (s.find("http://"), s.find("https://")) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
+/// Truncate `s` to at most `max_bytes` on a char boundary, appending `…` when it
+/// was cut. Never panics mid-codepoint.
+fn utf8_truncate(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut truncated = s[..end].to_string();
+    truncated.push('…');
+    truncated
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn anyhow_str(msg: &str) -> anyhow::Error {
+        anyhow::anyhow!("{}", msg.to_string())
+    }
+
+    // ---- scrub -------------------------------------------------------------
+
+    #[test]
+    fn scrub_replaces_known_secret() {
+        let out = scrub(
+            "token was sk-canary-123 here",
+            &["sk-canary-123".to_string()],
+        );
+        assert!(!out.contains("sk-canary-123"), "{out}");
+        assert!(out.contains("•••"), "{out}");
+    }
+
+    #[test]
+    fn scrub_strips_url_query_string() {
+        // The lethal case: a reqwest error with the credential in the URL query.
+        let msg = "error sending request for url (https://api.browserbase.com/mcp?projectId=pid&apiKey=qp-canary) failed";
+        let out = scrub(msg, &[]);
+        assert!(
+            !out.contains("qp-canary"),
+            "query-carried secret leaked: {out}"
+        );
+        assert!(!out.contains("projectId"), "{out}");
+        assert!(out.contains("https://api.browserbase.com/mcp"), "{out}");
+    }
+
+    #[test]
+    fn scrub_strips_query_and_replaces_secret_together() {
+        let msg = "url https://host/mcp?apiKey=qp-canary and bearer sk-canary";
+        let out = scrub(msg, &["qp-canary".to_string(), "sk-canary".to_string()]);
+        assert!(!out.contains("qp-canary"), "{out}");
+        assert!(!out.contains("sk-canary"), "{out}");
+    }
+
+    #[test]
+    fn scrub_truncates_utf8_safely() {
+        let long = "é".repeat(400); // 800 bytes
+        let out = scrub(&long, &[]);
+        assert!(out.len() <= SCRUB_MAX_BYTES + "…".len());
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn strip_endpoint_drops_query() {
+        assert_eq!(
+            strip_endpoint("https://host/mcp?apiKey=secret&projectId=pid"),
+            "https://host/mcp"
+        );
+        assert_eq!(strip_endpoint("https://host/mcp"), "https://host/mcp");
+    }
+
+    // ---- classify (string arms — no live dial) -----------------------------
+
+    #[test]
+    fn classify_403_is_token_rejected() {
+        let class = classify_mcp_error(&anyhow_str("MCP HTTP 403 — Forbidden"), true, false);
+        assert_eq!(class.status, McpStatus::NeedsConfig);
+        assert_eq!(class.auth_hint.as_deref(), Some("token_rejected"));
+    }
+
+    #[test]
+    fn classify_404_is_not_mcp() {
+        let class = classify_mcp_error(&anyhow_str("MCP HTTP 404 — Not Found"), false, false);
+        assert_eq!(class.status, McpStatus::Error);
+        assert_eq!(class.auth_hint, None);
+    }
+
+    #[test]
+    fn classify_5xx_is_server_error() {
+        let class = classify_mcp_error(
+            &anyhow_str("MCP HTTP 503 — Service Unavailable"),
+            false,
+            false,
+        );
+        assert_eq!(class.status, McpStatus::Error);
+    }
+
+    #[test]
+    fn classify_bare_401_string_needs_credential_when_none() {
+        let class = classify_mcp_error(&anyhow_str("MCP HTTP 401 — Unauthorized"), false, false);
+        assert_eq!(class.auth_hint.as_deref(), Some("credential_required"));
+        let class = classify_mcp_error(&anyhow_str("MCP HTTP 401 — Unauthorized"), true, false);
+        assert_eq!(class.auth_hint.as_deref(), Some("token_rejected"));
+    }
+
+    #[test]
+    fn classify_parse_failure_is_not_mcp() {
+        let class = classify_mcp_error(
+            &anyhow_str("Failed to parse MCP JSON response: expected value — body: <html>"),
+            false,
+            false,
+        );
+        assert_eq!(class.status, McpStatus::Error);
+        assert_eq!(class.auth_hint, None);
+    }
+
+    #[test]
+    fn classify_json_rpc_error_only_in_call_context() {
+        let msg = "MCP error: {\"code\":-32000,\"message\":\"bad args\"}";
+        assert_eq!(
+            classify_mcp_error(&anyhow_str(msg), false, true).status,
+            McpStatus::Error
+        );
+        // Both are Error tier, but the message routing differs — assert the kind.
+        assert_eq!(
+            classify_mcp_error(&anyhow_str(msg), false, true).kind,
+            FailureKind::ToolCallRejected
+        );
+        assert_eq!(
+            classify_mcp_error(&anyhow_str(msg), false, false).kind,
+            FailureKind::Unknown
+        );
+    }
+
+    #[test]
+    fn classify_typed_401_dominates_string() {
+        // A typed McpUnauthorizedError with OAuth metadata → oauth_required,
+        // even though the message string would otherwise be generic.
+        let err = anyhow::Error::new(oh::mcp_client::McpUnauthorizedError {
+            endpoint: "host".into(),
+            resource_metadata: Some("https://host/.well-known/oauth".into()),
+        });
+        let class = classify_mcp_error(&err, false, false);
+        assert_eq!(class.auth_hint.as_deref(), Some("oauth_required"));
+        assert_eq!(class.status, McpStatus::NeedsConfig);
+    }
+
+    #[test]
+    fn classify_typed_401_without_metadata_respects_credential_state() {
+        let err = anyhow::Error::new(oh::mcp_client::McpUnauthorizedError {
+            endpoint: "host".into(),
+            resource_metadata: None,
+        });
+        assert_eq!(
+            classify_mcp_error(&err, false, false).auth_hint.as_deref(),
+            Some("credential_required")
+        );
+        assert_eq!(
+            classify_mcp_error(&err, true, false).auth_hint.as_deref(),
+            Some("token_rejected")
+        );
+    }
+
+    #[test]
+    fn operator_message_is_actionable_and_scrubbed() {
+        let class = classify_mcp_error(&anyhow_str("MCP HTTP 401 — Unauthorized"), false, false);
+        let msg = scrub(
+            &operator_message("browserbase", &class, &anyhow_str("x")),
+            &[],
+        );
+        assert!(msg.contains("browserbase"), "{msg}");
+        assert!(msg.to_lowercase().contains("credential"), "{msg}");
+    }
+}

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -38,8 +38,8 @@
 pub mod brain;
 pub mod build;
 pub mod cost;
-#[cfg(feature = "mcp")]
 pub mod mcp;
+pub mod mcp_probe;
 pub mod memory;
 pub mod memory_loop;
 pub mod orchestrator;
@@ -63,11 +63,14 @@ use crate::company::Policy;
 use crate::company::mcp::McpServerDecl;
 use crate::error::OpenCompanyError;
 use crate::harness::cost::{TurnUsage, record_turn_cost};
+use crate::harness::mcp_probe::McpFailureQueue;
 use crate::harness::orchestrator::DelegationQueue;
 use crate::harness::policy::ApprovalPolicy;
 use crate::ports::skills_state::{SkillState, SkillStateStore};
 use crate::ports::types::{CompanyId, CompanyRecord};
-use crate::ports::{CompanyStore, ContextStore, EventLog, FactStore, TaskStore, UsageMeter};
+use crate::ports::{
+    CompanyStore, ContextStore, EventLog, FactStore, SecretStore, TaskStore, UsageMeter,
+};
 
 /// Shared dependencies every harness-built agent draws on.
 #[derive(Clone)]
@@ -132,6 +135,18 @@ pub struct HarnessDeps {
     /// handle; cloning `HarnessDeps` shares one queue between the tools built
     /// into the agent and the brain that drains it. Default is an empty queue.
     pub delegations: DelegationQueue,
+    /// The shared MCP failure queue the `OcMcpCallTool` decorator pushes onto and
+    /// the [`HarnessBrain`] drains after a turn (the error-hardening cell). Same
+    /// cheap-shared-handle pattern as [`Self::delegations`]; every string it
+    /// carries is scrubbed at the source. Default is an empty queue.
+    pub mcp_failures: McpFailureQueue,
+    /// The company's [`SecretStore`], so [`HarnessPool::ensure`] can **re-resolve**
+    /// the effective MCP server set on each call and rebuild the roster when a
+    /// console add/remove/enable-toggle changes it — the MCP-freshness fix (a
+    /// runtime-added server reaches the agent on its next turn, no restart).
+    /// `None` (default/tests) keeps the boot-resolved [`Self::mcp_servers`]
+    /// static, exactly as before.
+    pub secrets: Option<Arc<dyn SecretStore>>,
 }
 
 /// One live openhuman agent, keyed by its manifest id.
@@ -145,53 +160,110 @@ pub struct CompanyAgent {
     agent: Mutex<Agent>,
 }
 
+/// The graceful reply returned when a turn yields the transient empty-response
+/// class twice — so chat never shows a bare "Couldn't send" for a model hiccup.
+const GRACEFUL_EMPTY_REPLY: &str = "Sorry — I hit a temporary model hiccup and couldn't produce a reply. Please resend your message.";
+
+/// The outcome of a single `agent.turn`, classified for the retry wrapper.
+enum TurnOutcome {
+    /// A non-empty reply.
+    Reply(String),
+    /// The transient empty-response class (an empty/blank reply, or the model's
+    /// "empty response" error) — retryable.
+    Empty,
+    /// A hard error (budget/auth/build/etc.) — propagated loudly, never swallowed.
+    Hard(OpenCompanyError),
+}
+
 impl CompanyAgent {
-    /// Runs one turn against this agent, returning its reply text and the turn's
-    /// token/cost totals.
+    /// Runs one turn against this agent, returning its reply text and the
+    /// per-attempt token/cost totals.
     ///
-    /// The usage is read from the just-completed turn via openhuman's public
+    /// **Empty-response hardening (the error-hardening cell)**: the hosted brain
+    /// occasionally returns a transient empty completion, which openhuman
+    /// surfaces as an error. Rather than letting the operator see a bare
+    /// "Couldn't send", this wrapper retries **once**; if the second attempt is
+    /// still empty it returns a graceful, scrubbed message instead of an `Err`.
+    /// **Non-transient** errors (budget, auth, build) still propagate loudly — no
+    /// blanket swallow. Every attempt's usage is returned so the cost hook meters
+    /// what the model actually consumed (a burnt empty attempt still costs
+    /// tokens).
+    ///
+    /// The usage is read from each just-completed turn via openhuman's public
     /// [`Agent::last_turn_usage`](oh::agent::Agent::last_turn_usage) accessor
-    /// while the agent lock is still held (so a concurrent turn can't overwrite
-    /// it). An offline provider that reports no usage yields a zero
-    /// [`TurnUsage`], which the cost hook treats as inert.
-    pub async fn run(&self, message: &str) -> crate::Result<(String, TurnUsage)> {
+    /// while the agent lock is still held. An offline provider that reports no
+    /// usage yields a zero [`TurnUsage`], which the cost hook treats as inert.
+    pub async fn run(&self, message: &str) -> crate::Result<(String, Vec<TurnUsage>)> {
         let mut agent = self.agent.lock().await;
-        let reply = agent
-            .turn(message)
-            .await
-            .map_err(|e| OpenCompanyError::Harness(format!("turn for '{}': {e}", self.agent_id)))?;
-        let usage = agent
-            .last_turn_usage()
-            .map(|u| TurnUsage {
-                input_tokens: u.input_tokens,
-                output_tokens: u.output_tokens,
-                cached_input_tokens: u.cached_input_tokens,
-                cost_usd: u.cost_usd,
-            })
-            .unwrap_or_default();
-        Ok((reply, usage))
+        let mut usages: Vec<TurnUsage> = Vec::new();
+
+        // Attempt 1.
+        let first = agent.turn(message).await;
+        usages.push(read_turn_usage(&agent));
+        match self.classify_turn(first) {
+            TurnOutcome::Reply(reply) => return Ok((reply, usages)),
+            TurnOutcome::Hard(err) => return Err(err),
+            TurnOutcome::Empty => {} // fall through to a single retry
+        }
+
+        // Attempt 2 (retry once).
+        let second = agent.turn(message).await;
+        usages.push(read_turn_usage(&agent));
+        match self.classify_turn(second) {
+            TurnOutcome::Reply(reply) => Ok((reply, usages)),
+            // Still empty → graceful, scrubbed text (never an `Err`).
+            TurnOutcome::Empty => Ok((
+                crate::harness::mcp_probe::scrub(GRACEFUL_EMPTY_REPLY, &[]),
+                usages,
+            )),
+            TurnOutcome::Hard(err) => Err(err),
+        }
+    }
+
+    /// Classify one `agent.turn` result for the retry wrapper.
+    fn classify_turn(&self, result: anyhow::Result<String>) -> TurnOutcome {
+        match result {
+            Ok(reply) if reply.trim().is_empty() => TurnOutcome::Empty,
+            Ok(reply) => TurnOutcome::Reply(reply),
+            Err(err) if is_transient_empty_response(&err) => TurnOutcome::Empty,
+            Err(err) => TurnOutcome::Hard(OpenCompanyError::Harness(format!(
+                "turn for '{}': {err}",
+                self.agent_id
+            ))),
+        }
     }
 }
 
-/// A company's cached roster together with the skill deltas it was built from.
-///
-/// Caching the deltas is what lets [`HarnessPool::ensure`] tell whether the
-/// operator's effective skill set has moved (a skill authored, enabled, or
-/// disabled in the console *after* the roster was first built) and rebuild only
-/// then — so a fresh skill reaches every agent on the next cycle without a
-/// process restart, and an unchanged set leaves the live agents (and their
-/// conversation state) untouched.
-struct CompanyRoster {
-    /// The live agents, one per manifest `[[agent]]`.
-    agents: Vec<Arc<CompanyAgent>>,
-    /// The skill deltas the agents were built from, sorted by slug so the
-    /// freshness comparison is store-order-agnostic.
-    skill_deltas: Vec<SkillState>,
+/// Reads the just-completed turn's usage (zero when the provider reported none).
+fn read_turn_usage(agent: &Agent) -> TurnUsage {
+    agent
+        .last_turn_usage()
+        .map(|u| TurnUsage {
+            input_tokens: u.input_tokens,
+            output_tokens: u.output_tokens,
+            cached_input_tokens: u.cached_input_tokens,
+            cost_usd: u.cost_usd,
+        })
+        .unwrap_or_default()
+}
+
+/// Whether a turn error is the transient empty-response class openhuman raises
+/// instead of a silent blank reply. Matched on the error chain's message
+/// (`turn` returns `anyhow::Result`, so the typed `AgentError` is erased):
+/// "The model returned an empty response…".
+fn is_transient_empty_response(err: &anyhow::Error) -> bool {
+    format!("{err:#}")
+        .to_ascii_lowercase()
+        .contains("empty response")
 }
 
 /// A pool of live agents, one roster per company.
 pub struct HarnessPool {
-    rosters: RwLock<HashMap<CompanyId, CompanyRoster>>,
+    agents: RwLock<HashMap<CompanyId, Vec<Arc<CompanyAgent>>>>,
+    /// Fingerprint of the effective MCP server set the cached roster was built
+    /// from, keyed by company. Drives MCP-freshness: [`ensure`](Self::ensure)
+    /// rebuilds the roster whenever the fingerprint changes.
+    mcp_fingerprints: RwLock<HashMap<CompanyId, u64>>,
 }
 
 impl Default for HarnessPool {
@@ -204,68 +276,86 @@ impl HarnessPool {
     /// Builds an empty pool.
     pub fn new() -> Self {
         Self {
-            rosters: RwLock::new(HashMap::new()),
+            agents: RwLock::new(HashMap::new()),
+            mcp_fingerprints: RwLock::new(HashMap::new()),
         }
     }
 
-    /// Ensures a company's roster is built, cached, and **current with the
-    /// operator's skill deltas**.
+    /// Ensures a company's roster is built and cached.
     ///
-    /// On every call the current deltas are fetched once (a cheap store `list`,
-    /// sorted by slug so the compare is store-order-agnostic) and matched against
-    /// the deltas the cached roster was built from:
-    ///
-    /// * no cached roster, or the deltas moved → (re)build the roster and cache
-    ///   it alongside the deltas it was built from;
-    /// * deltas unchanged → the cached roster is still current; return it
-    ///   untouched (no rebuild, so each agent's conversation history survives).
-    ///
-    /// This is what makes a skill authored / enabled / disabled in the console
-    /// reach every agent on the **next** cycle — [`HarnessBrain`] calls `ensure`
-    /// at the top of each cycle — rather than only on the first build (the prior
-    /// behaviour cached the roster forever and never re-read the deltas, so a
-    /// skill written after the operator's first turn was invisible until
-    /// restart). A company with no skills store (`deps.skills == None`) compares
-    /// empty-to-empty, so it still builds exactly once.
+    /// **MCP-freshness (the error-hardening cell)**: on every call, the effective
+    /// MCP server set is re-resolved (from the [`SecretStore`] when
+    /// [`HarnessDeps::secrets`] is wired, else the boot-resolved
+    /// [`HarnessDeps::mcp_servers`]) and fingerprinted. The roster is rebuilt when
+    /// it is absent **or** the fingerprint changed — so a console MCP
+    /// add/remove/enable-toggle reaches the agent on its **next turn**, with no
+    /// company restart (the "Parallel Search / BrowserBase" bug). When nothing
+    /// changed, the cached roster is reused (the common fast path), exactly as
+    /// before.
     pub async fn ensure(&self, company: &CompanyRecord, deps: &HarnessDeps) -> crate::Result<()> {
-        // Current operator skill deltas, sorted by slug for a store-agnostic
-        // compare. `build_roster`/`build_agent` stay synchronous and fold these
-        // into each agent's effective skill set.
-        let mut skill_deltas = match &deps.skills {
-            Some(store) => store.list(&company.id).await?,
-            None => Vec::new(),
-        };
-        skill_deltas.sort_by(|a, b| a.slug.cmp(&b.slug));
+        // Re-resolve + fingerprint the effective MCP set (cheap; no rebuild yet).
+        let effective_mcp = self.resolve_effective_mcp(company, deps).await;
+        let fingerprint = mcp_fingerprint(&effective_mcp);
 
-        // Fast path: a cached roster built from the same deltas is still current.
         {
-            let guard = self.rosters.read().await;
-            if let Some(roster) = guard.get(&company.id)
-                && roster.skill_deltas == skill_deltas
+            let agents = self.agents.read().await;
+            let fingerprints = self.mcp_fingerprints.read().await;
+            if agents.contains_key(&company.id)
+                && fingerprints.get(&company.id) == Some(&fingerprint)
             {
                 return Ok(());
             }
         }
 
-        // The deltas moved (or there is no roster yet): rebuild. Build outside
-        // the write lock (synchronous but non-trivial), then install under a
-        // double-check so a racing `ensure` that already rebuilt from the same
-        // deltas wins and this build is dropped.
-        let agents = build_roster(company, deps, &skill_deltas)?;
-        let mut guard = self.rosters.write().await;
-        if let Some(existing) = guard.get(&company.id)
-            && existing.skill_deltas == skill_deltas
-        {
-            return Ok(());
-        }
-        guard.insert(
-            company.id.clone(),
-            CompanyRoster {
-                agents,
-                skill_deltas,
-            },
-        );
+        // Fetch the operator skill deltas once (async) before building the
+        // roster; `build_roster`/`build_agent` stay synchronous and fold the
+        // deltas into each agent's effective skill set.
+        let skill_deltas = match &deps.skills {
+            Some(store) => store.list(&company.id).await?,
+            None => Vec::new(),
+        };
+        // Fold the freshly-resolved MCP set into the deps the roster is built
+        // from, so a changed set actually reaches the rebuilt agents. The clone
+        // shares every Arc / queue handle — only `mcp_servers` is overridden.
+        let mut fresh_deps = deps.clone();
+        fresh_deps.mcp_servers = effective_mcp;
+        let roster = build_roster(company, &fresh_deps, &skill_deltas)?;
+
+        let mut agents = self.agents.write().await;
+        agents.insert(company.id.clone(), roster);
+        self.mcp_fingerprints
+            .write()
+            .await
+            .insert(company.id.clone(), fingerprint);
         Ok(())
+    }
+
+    /// Re-resolves the company's effective MCP server set: from the secret store
+    /// when [`HarnessDeps::secrets`] is wired (picking up console changes), else
+    /// the boot-resolved [`HarnessDeps::mcp_servers`] unchanged. A resolution
+    /// error degrades to the boot-resolved set rather than dropping MCP tools.
+    async fn resolve_effective_mcp(
+        &self,
+        company: &CompanyRecord,
+        deps: &HarnessDeps,
+    ) -> Vec<McpServerDecl> {
+        match &deps.secrets {
+            Some(secrets) => crate::company::mcp::resolve_effective(
+                &company.id,
+                &company.manifest.mcp_servers,
+                secrets.as_ref(),
+            )
+            .await
+            .unwrap_or_else(|_| deps.mcp_servers.clone()),
+            None => deps.mcp_servers.clone(),
+        }
+    }
+
+    /// The current MCP fingerprint for a company (test-only), so a freshness test
+    /// can assert a rebuild happened without introspecting agent internals.
+    #[cfg(test)]
+    pub async fn mcp_fingerprint_of(&self, company: &CompanyId) -> Option<u64> {
+        self.mcp_fingerprints.read().await.get(company).copied()
     }
 
     /// Routes a message to one agent and returns its reply, recording the turn's
@@ -281,12 +371,11 @@ impl HarnessPool {
         deps: &HarnessDeps,
     ) -> crate::Result<String> {
         let agent = {
-            let guard = self.rosters.read().await;
+            let guard = self.agents.read().await;
             let roster = guard
                 .get(company)
                 .ok_or_else(|| OpenCompanyError::CompanyNotFound(company.to_string()))?;
             roster
-                .agents
                 .iter()
                 .find(|a| a.agent_id == agent_id)
                 .cloned()
@@ -306,19 +395,23 @@ impl HarnessPool {
             .await?;
         let augmented = memory_loop::inject(message, &hits);
 
-        // Run the turn and record its real cost. `CompanyAgent::run` reads the
-        // turn's token/cost totals from openhuman's public `last_turn_usage()`
-        // accessor; a zero-usage turn (offline provider) writes nothing.
-        let (reply, turn_cost) = agent.run(&augmented).await?;
-        record_turn_cost(
-            &turn_cost,
-            agent_id,
-            &deps.provider_slug,
-            company,
-            deps.store.as_ref(),
-            deps.meter.as_deref(),
-        )
-        .await?;
+        // Run the turn and record its real cost. `CompanyAgent::run` reads each
+        // attempt's token/cost totals from openhuman's public `last_turn_usage()`
+        // accessor and returns one entry per attempt (two when the empty-response
+        // wrapper retried once). A zero-usage attempt (offline provider) writes
+        // nothing, so the inert-metering contract holds.
+        let (reply, turn_costs) = agent.run(&augmented).await?;
+        for turn_cost in &turn_costs {
+            record_turn_cost(
+                turn_cost,
+                agent_id,
+                &deps.provider_slug,
+                company,
+                deps.store.as_ref(),
+                deps.meter.as_deref(),
+            )
+            .await?;
+        }
 
         // Store: persist the outcome (original task + reply) so it compounds
         // into later turns. Without this the harness never writes memory back.
@@ -334,7 +427,46 @@ impl HarnessPool {
 
     /// Number of companies currently resident in the pool (test/observability).
     pub async fn resident_companies(&self) -> usize {
-        self.rosters.read().await.len()
+        self.agents.read().await.len()
+    }
+}
+
+/// A stable fingerprint of an effective MCP server set, used to detect a console
+/// change (add / remove / enable-toggle / token rotation) between
+/// [`HarnessPool::ensure`] calls. Hashes only non-secret configuration plus the
+/// credential substrings — the resulting `u64` is non-reversible and never
+/// surfaces anywhere, so it is not a credential leak, and hashing the credential
+/// substrings means a rotate-token also invalidates the cached roster.
+fn mcp_fingerprint(decls: &[McpServerDecl]) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    decls.len().hash(&mut hasher);
+    for decl in decls {
+        decl.name.hash(&mut hasher);
+        decl.endpoint.hash(&mut hasher);
+        decl.enabled.hash(&mut hasher);
+        decl.description.hash(&mut hasher);
+        decl.allowed_tools.hash(&mut hasher);
+        decl.disallowed_tools.hash(&mut hasher);
+        decl.timeout_secs.hash(&mut hasher);
+        auth_kind(&decl.auth).hash(&mut hasher);
+        for secret in decl.auth.secret_values() {
+            secret.hash(&mut hasher);
+        }
+    }
+    hasher.finish()
+}
+
+/// A small discriminant for an [`AuthMaterial`] variant, for the fingerprint.
+fn auth_kind(material: &crate::company::mcp::AuthMaterial) -> u8 {
+    use crate::company::mcp::AuthMaterial::*;
+    match material {
+        None => 0,
+        Bearer(_) => 1,
+        Header { .. } => 2,
+        QueryParam { .. } => 3,
     }
 }
 
@@ -359,17 +491,12 @@ pub(crate) fn build_roster(
         .map(|manifest_agent| {
             let agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily);
             let is_orchestrator = orchestrator.as_deref() == Some(manifest_agent.id.as_str());
-            let grants = crate::runtime::builder::agent_effective_grants(
-                &company.manifest.tools.allow,
-                &manifest_agent.tools,
-            );
             let agent = build::build_agent(
                 &company.id,
                 company_name,
                 manifest_agent,
                 agent_policy,
                 deps,
-                &grants,
                 skill_deltas,
                 is_orchestrator,
             )?;
@@ -388,8 +515,6 @@ mod tests {
     use std::sync::Mutex as StdMutex;
 
     use async_trait::async_trait;
-    #[cfg(feature = "mcp")]
-    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use crate::company::CompanyManifest;
     use crate::harness::provider::MockProvider;
@@ -501,52 +626,6 @@ mod tests {
         }
     }
 
-    /// In-memory [`SkillStateStore`] so a test can author/enable/disable skills
-    /// between `ensure` calls and assert the roster refreshes (or doesn't).
-    #[derive(Default)]
-    struct MockSkillStore {
-        deltas: StdMutex<Vec<SkillState>>,
-    }
-
-    #[async_trait]
-    impl SkillStateStore for MockSkillStore {
-        async fn list(&self, _company: &CompanyId) -> crate::Result<Vec<SkillState>> {
-            Ok(self.deltas.lock().unwrap().clone())
-        }
-        async fn set(&self, _company: &CompanyId, state: &SkillState) -> crate::Result<()> {
-            let mut g = self.deltas.lock().unwrap();
-            g.retain(|d| d.slug != state.slug);
-            g.push(state.clone());
-            Ok(())
-        }
-        async fn remove(&self, _company: &CompanyId, slug: &str) -> crate::Result<bool> {
-            let mut g = self.deltas.lock().unwrap();
-            let before = g.len();
-            g.retain(|d| d.slug != slug);
-            Ok(g.len() != before)
-        }
-    }
-
-    /// A console-authored custom skill delta: a full `SKILL.md` carried inline in
-    /// `custom_doc`, with `body_marker` embedded in the body so a `describe_workflow`
-    /// assertion can prove the *content* (not just the slug) reached the agent.
-    fn custom_skill_delta(
-        slug: &str,
-        name: &str,
-        description: &str,
-        body_marker: &str,
-    ) -> SkillState {
-        use crate::ports::skills_state::SkillSource;
-        SkillState {
-            slug: slug.to_string(),
-            enabled: true,
-            source: SkillSource::Custom,
-            custom_doc: Some(format!(
-                "---\nname: {name}\ndescription: {description}\n---\n\n# {name}\n\n{body_marker}\n"
-            )),
-        }
-    }
-
     fn manifest() -> CompanyManifest {
         toml::from_str(
             r#"
@@ -607,106 +686,13 @@ description = "Builds the product."
                 facts: None,
                 events: None,
                 delegations: DelegationQueue::default(),
+                mcp_failures: McpFailureQueue::default(),
+                secrets: None,
             },
             store,
             meter,
             _dir: dir,
         }
-    }
-
-    #[cfg(feature = "mcp")]
-    struct McpToolCallProvider {
-        server_id: String,
-        calls: AtomicUsize,
-    }
-
-    #[cfg(feature = "mcp")]
-    #[async_trait]
-    impl Provider for McpToolCallProvider {
-        async fn chat_with_system(
-            &self,
-            _system_prompt: Option<&str>,
-            message: &str,
-            _model: &str,
-            _temperature: f64,
-        ) -> anyhow::Result<String> {
-            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
-                Ok(format!(
-                    "<tool_call>{{\"name\":\"mcp_registry_tool_call\",\"arguments\":{{\"server_id\":\"{}\",\"tool_name\":\"echo\",\"arguments\":{{\"text\":\"agent-mcp\"}}}}}}</tool_call>",
-                    self.server_id
-                ))
-            } else {
-                Ok(format!("__MOCK_LLM__ {message}"))
-            }
-        }
-    }
-
-    #[cfg(feature = "mcp")]
-    #[tokio::test]
-    async fn agent_executes_connected_mcp_tool() {
-        use std::collections::HashMap;
-        use std::process::Command;
-
-        use oh::mcp_registry::types::{CommandKind, InstalledServer, Transport};
-
-        if Command::new("node").arg("--version").output().is_err() {
-            eprintln!("skipping MCP agent test because node is unavailable");
-            return;
-        }
-        let dir = tempfile::tempdir().expect("tempdir");
-        let script = dir.path().join("agent-mcp-stub.cjs");
-        std::fs::write(
-            &script,
-            r#"
-const readline = require('node:readline');
-const rl = readline.createInterface({ input: process.stdin });
-const send = (v) => process.stdout.write(JSON.stringify(v) + '\n');
-rl.on('line', (line) => {
-  const r = JSON.parse(line); if (!r.id) return;
-  if (r.method === 'initialize') send({jsonrpc:'2.0',id:r.id,result:{protocolVersion:'2024-11-05',capabilities:{tools:{}},serverInfo:{name:'agent-test',version:'1'}}});
-  else if (r.method === 'tools/list') send({jsonrpc:'2.0',id:r.id,result:{tools:[{name:'echo',description:'Echo text',inputSchema:{type:'object'}}]}});
-  else if (r.method === 'tools/call') send({jsonrpc:'2.0',id:r.id,result:{content:[{type:'text',text:'echo: ' + r.params.arguments.text}]}});
-});
-"#,
-        )
-        .expect("write stub");
-
-        let mcp = crate::harness::mcp::McpRuntime::new(dir.path().join("mcp"));
-        let server = InstalledServer {
-            server_id: uuid::Uuid::new_v4().to_string(),
-            qualified_name: "agent-test".to_string(),
-            display_name: "Agent Test".to_string(),
-            description: None,
-            icon_url: None,
-            command_kind: CommandKind::Binary,
-            command: "node".to_string(),
-            args: vec![script.to_string_lossy().into_owned()],
-            env_keys: vec![],
-            config: None,
-            installed_at: 0,
-            last_connected_at: None,
-            transport: Transport::Stdio,
-            enabled: true,
-        };
-        mcp.install(&server, &HashMap::new()).expect("install");
-        mcp.connect(&server.server_id).await.expect("connect");
-
-        let mut fx = fixture();
-        fx.deps.provider = Arc::new(McpToolCallProvider {
-            server_id: server.server_id.clone(),
-            calls: AtomicUsize::new(0),
-        });
-        let pool = HarnessPool::new();
-        let rec = record();
-        pool.ensure(&rec, &fx.deps).await.expect("ensure");
-        let reply = pool
-            .run(&rec.id, "ceo", "use the MCP echo tool", &fx.deps)
-            .await
-            .expect("agent turn");
-        assert!(reply.contains("__MOCK_LLM__"), "{reply}");
-        assert!(reply.contains("echo: agent-mcp"), "{reply}");
-
-        mcp.disconnect(&server.server_id).await.expect("disconnect");
     }
 
     #[tokio::test]
@@ -749,6 +735,8 @@ rl.on('line', (line) => {
             facts: None,
             events: None,
             delegations: DelegationQueue::default(),
+            mcp_failures: McpFailureQueue::default(),
+            secrets: None,
         };
 
         let roster = build_roster(&record(), &deps, &[]).expect("roster builds with skills");
@@ -841,188 +829,6 @@ rl.on('line', (line) => {
         assert_eq!(pool.resident_companies().await, 1);
     }
 
-    // --- Skill freshness (issue #41) ---------------------------------------
-
-    /// Deps wired to an in-memory [`MockSkillStore`] (no company-dir source, so
-    /// only operator deltas drive the effective set) plus the store handle and
-    /// the workspace tempdir so a test can author skills and read back the
-    /// per-agent materialized catalogue.
-    fn skill_fixture() -> (HarnessDeps, Arc<MockSkillStore>, tempfile::TempDir) {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let skills = Arc::new(MockSkillStore::default());
-        let deps = HarnessDeps {
-            provider: Arc::new(MockProvider::new("mock: ")),
-            provider_slug: "mock".to_string(),
-            context: Arc::new(MockContext::default()),
-            store: Arc::new(RecordingStore::default()),
-            meter: None,
-            workspace_root: dir.path().to_path_buf(),
-            model_override: None,
-            tasks: None,
-            skills: Some(skills.clone()),
-            skills_source_dir: None,
-            mcp_servers: Vec::new(),
-        };
-        (deps, skills, dir)
-    }
-
-    /// The first cached agent for `agent_id`, cloned out of the pool so two
-    /// snapshots across `ensure` calls can be compared with [`Arc::ptr_eq`].
-    async fn cached_agent(pool: &HarnessPool, id: &CompanyId, agent_id: &str) -> Arc<CompanyAgent> {
-        let guard = pool.rosters.read().await;
-        guard
-            .get(id)
-            .expect("roster resident")
-            .agents
-            .iter()
-            .find(|a| a.agent_id == agent_id)
-            .expect("agent on roster")
-            .clone()
-    }
-
-    /// A skill the operator authors in the console *after* the roster is already
-    /// live must reach the agent on the next `ensure` — with its BODY, not just
-    /// its name. This is the core #41 regression: the pool used to cache the
-    /// roster on the first build and never re-read the deltas.
-    #[tokio::test]
-    async fn late_authored_skill_reaches_agent_on_next_ensure() {
-        use oh::config::Config;
-        use oh::skills::tools::WorkflowDescribeTool;
-        use oh::tools::Tool;
-        use serde_json::json;
-
-        let (deps, skills, dir) = skill_fixture();
-        let pool = HarnessPool::new();
-        let rec = record();
-
-        // First cycle: roster built with no skills yet.
-        pool.ensure(&rec, &deps).await.expect("first ensure");
-
-        // Operator authors a custom skill AFTER the roster exists.
-        skills
-            .set(
-                &rec.id,
-                &custom_skill_delta(
-                    "invoicing",
-                    "Invoicing",
-                    "Draft an invoice for a client",
-                    "STEP-MARKER-total-due",
-                ),
-            )
-            .await
-            .unwrap();
-
-        // Next cycle rebuilds the roster from the moved deltas.
-        pool.ensure(&rec, &deps).await.expect("second ensure");
-
-        // `describe_workflow` over the responder's materialized catalogue returns
-        // the skill's inline body — proving the CONTENT reached the agent, not
-        // merely that a same-named entry exists.
-        let catalog = dir.path().join("acme").join("ceo").join("skill-catalog");
-        let config = Arc::new(Config {
-            workspace_dir: catalog,
-            ..Default::default()
-        });
-        let tool = WorkflowDescribeTool::new(config);
-        let out = tool
-            .execute(json!({ "workflow_id": "invoicing" }))
-            .await
-            .expect("describe the fresh skill");
-        let text = out.output_for_llm(false);
-        assert!(
-            text.contains("STEP-MARKER-total-due"),
-            "the skill body must reach the agent: {text}"
-        );
-        assert!(
-            text.contains("Draft an invoice for a client"),
-            "the skill description must surface: {text}"
-        );
-    }
-
-    /// When the deltas have not moved, a second `ensure` must NOT rebuild — the
-    /// same `Arc<CompanyAgent>` is handed back, so live conversation state is
-    /// preserved and no work is wasted.
-    #[tokio::test]
-    async fn unchanged_deltas_reuse_the_same_roster() {
-        let (deps, skills, _dir) = skill_fixture();
-        let pool = HarnessPool::new();
-        let rec = record();
-
-        skills
-            .set(
-                &rec.id,
-                &custom_skill_delta("invoicing", "Invoicing", "Draft an invoice", "BODY-A"),
-            )
-            .await
-            .unwrap();
-        pool.ensure(&rec, &deps).await.expect("first ensure");
-        let before = cached_agent(&pool, &rec.id, "ceo").await;
-
-        // No delta change between the two calls.
-        pool.ensure(&rec, &deps).await.expect("second ensure");
-        let after = cached_agent(&pool, &rec.id, "ceo").await;
-
-        assert!(
-            Arc::ptr_eq(&before, &after),
-            "an unchanged skill set must not rebuild the roster"
-        );
-    }
-
-    /// Disabling a skill drops it from the effective set on the next `ensure`:
-    /// the roster rebuilds (a new agent instance) and the skill is gone from the
-    /// materialized catalogue.
-    #[tokio::test]
-    async fn disabling_a_skill_drops_it_on_next_ensure() {
-        use crate::ports::skills_state::{SkillSource, SkillState};
-
-        let (deps, skills, dir) = skill_fixture();
-        let pool = HarnessPool::new();
-        let rec = record();
-
-        skills
-            .set(
-                &rec.id,
-                &custom_skill_delta("invoicing", "Invoicing", "Draft an invoice", "BODY-A"),
-            )
-            .await
-            .unwrap();
-        pool.ensure(&rec, &deps).await.expect("first ensure");
-        let before = cached_agent(&pool, &rec.id, "ceo").await;
-        let materialized = dir
-            .path()
-            .join("acme")
-            .join("ceo")
-            .join("skill-catalog")
-            .join("skills")
-            .join("invoicing");
-        assert!(materialized.is_dir(), "skill materialized on first build");
-
-        // Operator disables the skill (a custom skill, disabled, drops entirely).
-        skills
-            .set(
-                &rec.id,
-                &SkillState {
-                    slug: "invoicing".to_string(),
-                    enabled: false,
-                    source: SkillSource::Custom,
-                    custom_doc: None,
-                },
-            )
-            .await
-            .unwrap();
-        pool.ensure(&rec, &deps).await.expect("second ensure");
-        let after = cached_agent(&pool, &rec.id, "ceo").await;
-
-        assert!(
-            !Arc::ptr_eq(&before, &after),
-            "a moved skill set must rebuild the roster"
-        );
-        assert!(
-            !materialized.exists(),
-            "the disabled skill must be gone from the materialized catalogue"
-        );
-    }
-
     #[tokio::test]
     async fn turns_are_serialised_and_history_survives() {
         let fx = fixture();
@@ -1086,5 +892,224 @@ rl.on('line', (line) => {
 
         assert!(fx.store.ledger.lock().unwrap().is_empty());
         assert!(fx.meter.samples.lock().unwrap().is_empty());
+    }
+
+    // --- Empty-response turn wrapper ----------------------------------------
+
+    /// A provider that plays back a scripted sequence of outcomes, one per
+    /// `chat_with_system` call, so the empty-response retry wrapper can be driven
+    /// deterministically. `Ok("")` is the transient empty class; `Err(_)` is a
+    /// hard error.
+    struct ScriptedProvider {
+        script: StdMutex<std::collections::VecDeque<Result<String, String>>>,
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl ScriptedProvider {
+        fn new(outcomes: Vec<Result<String, String>>) -> Self {
+            Self {
+                script: StdMutex::new(outcomes.into_iter().collect()),
+                calls: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl oh::inference::provider::Provider for ScriptedProvider {
+        fn telemetry_provider_id(&self) -> String {
+            "scripted".to_string()
+        }
+        async fn chat_with_system(
+            &self,
+            _system: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<String> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            match self.script.lock().unwrap().pop_front() {
+                Some(Ok(reply)) => Ok(reply),
+                Some(Err(err)) => Err(anyhow::anyhow!("{err}")),
+                None => Ok("exhausted".to_string()),
+            }
+        }
+    }
+
+    /// Build a single [`CompanyAgent`] over a scripted provider so the wrapper can
+    /// be exercised directly (its retry logic is the unit under test).
+    fn scripted_agent(outcomes: Vec<Result<String, String>>) -> (Arc<CompanyAgent>, HarnessDeps) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let deps = HarnessDeps {
+            provider: Arc::new(ScriptedProvider::new(outcomes)),
+            provider_slug: "scripted".to_string(),
+            context: Arc::new(MockContext::default()),
+            store: Arc::new(RecordingStore::default()),
+            meter: None,
+            workspace_root: dir.path().to_path_buf(),
+            model_override: None,
+            tasks: None,
+            skills: None,
+            skills_source_dir: None,
+            mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: DelegationQueue::default(),
+            mcp_failures: McpFailureQueue::default(),
+            secrets: None,
+        };
+        let roster = build_roster(&record(), &deps, &[]).expect("roster");
+        // Keep the tempdir alive for the agent's workspace by leaking it into the
+        // test's lifetime — the process ends the test anyway.
+        std::mem::forget(dir);
+        (roster.into_iter().next().expect("one agent"), deps)
+    }
+
+    /// Empty first, real reply on retry → the wrapper returns the recovered reply
+    /// and reports two attempts' usage (so both burnt attempts can be metered).
+    #[tokio::test]
+    async fn turn_wrapper_retries_empty_then_recovers() {
+        let (agent, _deps) = scripted_agent(vec![Ok(String::new()), Ok("recovered".into())]);
+        let (reply, usages) = agent.run("hi").await.expect("wrapper recovers");
+        assert!(reply.contains("recovered"), "got {reply:?}");
+        assert_eq!(usages.len(), 2, "both attempts' usage is returned");
+    }
+
+    /// Empty twice → a graceful, non-error reply (chat never shows "Couldn't
+    /// send" for a transient hiccup), still two attempts.
+    #[tokio::test]
+    async fn turn_wrapper_empty_twice_is_graceful() {
+        let (agent, _deps) = scripted_agent(vec![Ok(String::new()), Ok(String::new())]);
+        let (reply, usages) = agent.run("hi").await.expect("graceful, not an Err");
+        assert!(
+            reply.to_lowercase().contains("temporary model hiccup"),
+            "got {reply:?}"
+        );
+        assert_eq!(usages.len(), 2);
+    }
+
+    /// The Empty-vs-Hard split: only the transient empty-response class is
+    /// retried/softened; every other error is `Hard` and propagates loudly (no
+    /// blanket swallow). Driven at the classifier so it's deterministic — the
+    /// live agent internally retries provider errors, which would make a scripted
+    /// "hard error" non-deterministic.
+    #[test]
+    fn transient_empty_response_is_recognised_but_hard_errors_are_not() {
+        let empty = anyhow::anyhow!("The model returned an empty response. Please try again.");
+        assert!(
+            is_transient_empty_response(&empty),
+            "empty-response is transient"
+        );
+
+        let hard = anyhow::anyhow!("daily budget exceeded for agent 'ceo'");
+        assert!(
+            !is_transient_empty_response(&hard),
+            "a budget error is NOT the transient empty class — it must propagate"
+        );
+    }
+
+    // --- MCP-freshness ------------------------------------------------------
+
+    /// In-memory secret store so `ensure` can re-resolve the runtime MCP index.
+    #[derive(Default)]
+    struct MemSecrets {
+        map: StdMutex<std::collections::HashMap<String, String>>,
+    }
+
+    #[async_trait]
+    impl SecretStore for MemSecrets {
+        async fn get(
+            &self,
+            _c: &CompanyId,
+            key: &str,
+        ) -> crate::Result<Option<crate::ports::types::SecretValue>> {
+            Ok(self
+                .map
+                .lock()
+                .unwrap()
+                .get(key)
+                .map(|v| crate::ports::types::SecretValue(v.clone())))
+        }
+        async fn set(
+            &self,
+            _c: &CompanyId,
+            key: &str,
+            value: crate::ports::types::SecretValue,
+        ) -> crate::Result<()> {
+            self.map.lock().unwrap().insert(key.to_string(), value.0);
+            Ok(())
+        }
+    }
+
+    /// A console-added MCP server reaches the agent on the NEXT `ensure` — the
+    /// roster is rebuilt because the effective set re-resolved from the LIVE
+    /// secret store (not the boot snapshot) changed its fingerprint. This is the
+    /// Parallel-Search / BrowserBase freshness bug, proven end-to-end.
+    #[tokio::test]
+    async fn ensure_rebuilds_when_a_runtime_mcp_server_is_added() {
+        let secrets: Arc<dyn SecretStore> = Arc::new(MemSecrets::default());
+        let dir = tempfile::tempdir().unwrap();
+        let deps = HarnessDeps {
+            provider: Arc::new(MockProvider::new("mock: ")),
+            provider_slug: "mock".to_string(),
+            context: Arc::new(MockContext::default()),
+            store: Arc::new(RecordingStore::default()),
+            meter: None,
+            workspace_root: dir.path().to_path_buf(),
+            model_override: None,
+            tasks: None,
+            skills: None,
+            skills_source_dir: None,
+            mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: DelegationQueue::default(),
+            mcp_failures: McpFailureQueue::default(),
+            secrets: Some(secrets.clone()),
+        };
+        let pool = HarnessPool::new();
+        let rec = record();
+
+        pool.ensure(&rec, &deps).await.expect("first ensure");
+        let before = pool
+            .mcp_fingerprint_of(&rec.id)
+            .await
+            .expect("fingerprinted");
+
+        // Console-add a runtime MCP server directly into the live secret store.
+        crate::company::mcp::save_runtime_index(
+            &rec.id,
+            secrets.as_ref(),
+            &[crate::company::McpServer {
+                name: "browserbase".into(),
+                endpoint: "https://api.browserbase.com/mcp".into(),
+                description: None,
+                command: None,
+                allowed_tools: Vec::new(),
+                disallowed_tools: Vec::new(),
+                timeout_secs: 30,
+                enabled: true,
+                auth_secret: None,
+            }],
+        )
+        .await
+        .unwrap();
+
+        // Next ensure re-resolves from the live store → fingerprint changes →
+        // roster rebuilt, so the new server reaches the agent without a restart.
+        pool.ensure(&rec, &deps).await.expect("second ensure");
+        let after = pool
+            .mcp_fingerprint_of(&rec.id)
+            .await
+            .expect("fingerprinted");
+        assert_ne!(before, after, "adding a server must change the fingerprint");
+        assert_eq!(
+            pool.resident_companies().await,
+            1,
+            "same company, rebuilt in place"
+        );
+
+        // A third ensure with no change is a no-op (fingerprint stable).
+        pool.ensure(&rec, &deps).await.expect("third ensure");
+        assert_eq!(pool.mcp_fingerprint_of(&rec.id).await, Some(after));
     }
 }

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -288,6 +288,9 @@ fn summarize_event(event: &CompanyEvent) -> String {
         CompanyEvent::PaymentReceived { amount_usd, .. } => format!("payment ${amount_usd:.2}"),
         CompanyEvent::LifecycleChanged { from, to, .. } => format!("lifecycle {from} → {to}"),
         CompanyEvent::MemoryFactDeleted { .. } => "memory fact deleted".to_string(),
+        CompanyEvent::McpCallFailed { server, tool, .. } => {
+            format!("MCP call failed: {server}/{tool}")
+        }
     }
 }
 

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -316,6 +316,23 @@ pub enum CompanyEvent {
         /// The id of the dispatched task card.
         task_id: String,
     },
+    /// An agent's MCP tool call failed during a turn, journaled by the harness
+    /// so the operator has an audit trail of which server/tool broke and why.
+    /// The `message` is always **scrubbed** at the source (the
+    /// `OcMcpCallTool` → `HarnessBrain` drain path), so this record can never
+    /// carry a credential, response body, or URL query string. Additive: old
+    /// logs never contain it, and its presence doesn't change how any existing
+    /// variant serializes (same `by`/`chat` precedent).
+    McpCallFailed {
+        /// The MCP server the failing call targeted.
+        server: String,
+        /// The remote tool the agent tried to call.
+        tool: String,
+        /// A stable status code (e.g. `credential_required`, `tool_call_rejected`).
+        status: String,
+        /// A short, scrubbed, operator-facing message.
+        message: String,
+    },
 }
 
 /// A `CompanyEvent` durably appended to the log with its sequence and time.
@@ -973,6 +990,23 @@ mod test {
         let json = serde_json::to_value(&events[0]).unwrap();
         assert_eq!(json["kind"], "OperatorMessage");
         assert_eq!(json["text"], "hi");
+    }
+
+    #[test]
+    fn mcp_call_failed_round_trips_and_is_byte_stable() {
+        let event = CompanyEvent::McpCallFailed {
+            server: "browserbase".into(),
+            tool: "browse".into(),
+            status: "tool_call_rejected".into(),
+            message: "server rejected the call".into(),
+        };
+        assert_eq!(round_trip(&event), event);
+        // The tag is emitted under `kind`, and the field set is fixed — a byte
+        // guard so a later field addition is a deliberate, tested change.
+        assert_eq!(
+            serde_json::to_string(&event).unwrap(),
+            r#"{"kind":"McpCallFailed","server":"browserbase","tool":"browse","status":"tool_call_rejected","message":"server rejected the call"}"#
+        );
     }
 
     #[test]

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -747,6 +747,14 @@ impl RuntimeBuilder {
                                 events: Some(events.clone()),
                                 delegations: crate::harness::orchestrator::DelegationQueue::default(
                                 ),
+                                // Error-hardening cell: a fresh MCP-failure queue
+                                // the `OcMcpCallTool` decorator fills and the brain
+                                // drains; and a LIVE secret-store handle so
+                                // `HarnessPool::ensure` can re-resolve the effective
+                                // MCP set each turn (MCP-freshness) rather than the
+                                // snapshot frozen here at boot.
+                                mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+                                secrets: Some(secrets.clone()),
                             };
                             let record = CompanyRecord {
                                 id: id.clone(),

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -564,6 +564,8 @@ mod test {
             facts: None,
             events: None,
             delegations: crate::harness::orchestrator::DelegationQueue::default(),
+            mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            secrets: None,
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record);
 

--- a/src/server/ops/mcp.rs
+++ b/src/server/ops/mcp.rs
@@ -23,8 +23,9 @@ use serde::{Deserialize, Serialize};
 use crate::AppState;
 use crate::company::McpServer;
 use crate::company::mcp::{
-    self, McpSource, clear_auth, load_runtime_index, resolve_effective, save_runtime_index,
-    store_bearer, validate_one,
+    self, AuthMaterial, McpHealth, McpSource, clear_auth, clear_health, endpoint_secret_advisory,
+    load_health, load_runtime_index, resolve_effective, save_runtime_index, store_auth,
+    validate_one,
 };
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
@@ -44,10 +45,12 @@ pub fn router() -> Router<AppState> {
             put(update_server).delete(delete_server),
         ))
         .merge(scoped("/mcp/servers/{name}/tools", get(discover_tools)))
+        .merge(scoped("/mcp/servers/{name}/test", post(test_server)))
 }
 
 /// One effective MCP server as the console renders it. **Never** carries a
-/// credential — only a non-secret `authConfigured` flag.
+/// credential — only a non-secret `authConfigured` flag and the last (scrubbed)
+/// probe `health`.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct McpServerDto {
@@ -62,17 +65,42 @@ struct McpServerDto {
     timeout_secs: u64,
     /// Whether an outbound credential is stored — never the credential itself.
     auth_configured: bool,
+    /// The last recorded probe outcome (scrubbed), or `None` when never probed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    health: Option<McpHealth>,
 }
 
-/// A mutating response: the resulting server plus the rebuild reminder.
+/// A mutating response: the resulting server, the rebuild reminder, the live
+/// probe result (`None` on a non-`openhuman` build), and any non-blocking
+/// endpoint advisory.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct MutationResponse {
     server: McpServerDto,
     note: String,
+    /// The result of probing the server right after the mutation. `None` when
+    /// probing isn't wired (default build). The server is **never** rolled back
+    /// on a failed probe — a needs-config result is a valid resting state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    test: Option<McpHealth>,
+    /// A non-blocking advisory (e.g. a secret-looking query string in the URL).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    warning: Option<String>,
 }
 
-/// Add-server body. `token` is write-only intake.
+/// The auth scheme an intake body selects. `bearer` (default) uses `token` as
+/// an `Authorization: Bearer`; `header` uses `headerName` + `token`;
+/// `query_param` uses `paramName` + `token` (the BrowserBase style).
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum AuthKind {
+    #[default]
+    Bearer,
+    Header,
+    QueryParam,
+}
+
+/// Add-server body. Credential fields are write-only intake.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct AddServer {
@@ -86,9 +114,20 @@ struct AddServer {
     disallowed_tools: Vec<String>,
     #[serde(default)]
     timeout_secs: Option<u64>,
-    /// The outbound bearer token, stored write-only. Omit to leave auth unset.
+    /// The outbound credential value, stored write-only. Omit to leave auth
+    /// unset. Interpreted per [`AuthKind`].
     #[serde(default)]
     token: Option<String>,
+    /// The auth scheme; defaults to `bearer` (back-compat — a bare `token` is a
+    /// bearer token exactly as before).
+    #[serde(default)]
+    auth_kind: AuthKind,
+    /// The header name, when `authKind == header`.
+    #[serde(default)]
+    header_name: Option<String>,
+    /// The query-parameter name, when `authKind == query_param`.
+    #[serde(default)]
+    param_name: Option<String>,
 }
 
 /// Update-server body — every field optional (only set fields are applied).
@@ -107,9 +146,59 @@ struct UpdateServer {
     disallowed_tools: Option<Vec<String>>,
     #[serde(default)]
     timeout_secs: Option<u64>,
-    /// Rotate the outbound token (write-only). Omit to leave it unchanged.
+    /// Rotate the outbound credential (write-only). Omit to leave it unchanged.
     #[serde(default)]
     token: Option<String>,
+    /// The auth scheme for a rotated credential; defaults to `bearer`.
+    #[serde(default)]
+    auth_kind: AuthKind,
+    /// The header name, when `authKind == header`.
+    #[serde(default)]
+    header_name: Option<String>,
+    /// The query-parameter name, when `authKind == query_param`.
+    #[serde(default)]
+    param_name: Option<String>,
+}
+
+/// Builds the [`AuthMaterial`] a write-only intake describes, or `None` when no
+/// credential value was supplied (leave auth unchanged). Returns a 400 when a
+/// scheme is missing its companion field.
+fn auth_material_from(
+    token: Option<&str>,
+    kind: AuthKind,
+    header_name: Option<&str>,
+    param_name: Option<&str>,
+) -> Result<Option<AuthMaterial>, ApiError> {
+    let Some(value) = non_empty(token) else {
+        return Ok(None);
+    };
+    let value = value.to_string();
+    let material = match kind {
+        AuthKind::Bearer => AuthMaterial::Bearer(value),
+        AuthKind::Header => {
+            let name = non_empty(header_name).ok_or_else(|| {
+                ApiError(OpenCompanyError::InvalidRequest(
+                    "a custom-header credential needs a `headerName`.".to_string(),
+                ))
+            })?;
+            AuthMaterial::Header {
+                name: name.to_string(),
+                value,
+            }
+        }
+        AuthKind::QueryParam => {
+            let name = non_empty(param_name).ok_or_else(|| {
+                ApiError(OpenCompanyError::InvalidRequest(
+                    "a query-parameter credential needs a `paramName`.".to_string(),
+                ))
+            })?;
+            AuthMaterial::QueryParam {
+                name: name.to_string(),
+                value,
+            }
+        }
+    };
+    Ok(Some(material))
 }
 
 /// The sub-resource path (`name`).
@@ -125,8 +214,9 @@ async fn manifest_servers(runtime: &CompanyRuntime) -> Result<Vec<McpServer>, Ap
 }
 
 /// Projects an effective decl (already merged + auth-resolved) to the console
-/// DTO, reducing the resolved credential to a boolean.
-fn dto_from_decl(decl: &mcp::McpServerDecl) -> McpServerDto {
+/// DTO, reducing the resolved credential to a boolean and attaching the last
+/// (scrubbed) probe health.
+fn dto_from_decl(decl: &mcp::McpServerDecl, health: Option<McpHealth>) -> McpServerDto {
     McpServerDto {
         name: decl.name.clone(),
         endpoint: decl.endpoint.clone(),
@@ -137,17 +227,26 @@ fn dto_from_decl(decl: &mcp::McpServerDecl) -> McpServerDto {
         disallowed_tools: decl.disallowed_tools.clone(),
         timeout_secs: decl.timeout_secs,
         auth_configured: decl.auth.is_configured(),
+        health,
     }
 }
 
-/// `GET …/mcp/servers` — the company's effective MCP servers.
+/// `GET …/mcp/servers` — the company's effective MCP servers, each with its last
+/// recorded (scrubbed) probe health.
 async fn list_servers(company: ScopedCompany) -> Result<Json<Vec<McpServerDto>>, ApiError> {
     let runtime = company.runtime.as_ref();
     let manifest = manifest_servers(runtime).await?;
     let decls = resolve_effective(runtime.id(), &manifest, runtime.secrets().as_ref())
         .await
         .map_err(ApiError)?;
-    Ok(Json(decls.iter().map(dto_from_decl).collect()))
+    let mut out = Vec::with_capacity(decls.len());
+    for decl in &decls {
+        let health = load_health(runtime.id(), &decl.name, runtime.secrets().as_ref())
+            .await
+            .map_err(ApiError)?;
+        out.push(dto_from_decl(decl, health));
+    }
+    Ok(Json(out))
 }
 
 /// `POST …/mcp/servers` — add a runtime MCP server (+ optional token).
@@ -192,14 +291,20 @@ async fn add_server(
         .await
         .map_err(ApiError)?;
 
-    // Persist the token write-only, if supplied.
-    if let Some(token) = non_empty(body.token.as_deref()) {
-        store_bearer(runtime.id(), &name, token, runtime.secrets().as_ref())
+    // Persist the credential write-only, if supplied (bearer / header / query).
+    if let Some(material) = auth_material_from(
+        body.token.as_deref(),
+        body.auth_kind,
+        body.header_name.as_deref(),
+        body.param_name.as_deref(),
+    )? {
+        store_auth(runtime.id(), &name, &material, runtime.secrets().as_ref())
             .await
             .map_err(ApiError)?;
     }
 
-    mutation_response(runtime, &name).await
+    let warning = endpoint_secret_advisory(&server.endpoint);
+    mutation_response(runtime, &name, warning).await
 }
 
 /// `PUT …/mcp/servers/{name}` — update a server (enable/disable, tool lists,
@@ -255,6 +360,8 @@ async fn update_server(
     server.command = None;
     server.auth_secret = None;
     reject_invalid(&format!("mcp server `{name}`"), &server)?;
+    // Capture the advisory before the value moves into the index.
+    let warning = endpoint_secret_advisory(&server.endpoint);
 
     match position {
         Some(i) => index[i] = server,
@@ -264,13 +371,18 @@ async fn update_server(
         .await
         .map_err(ApiError)?;
 
-    if let Some(token) = non_empty(patch.token.as_deref()) {
-        store_bearer(runtime.id(), &name, token, runtime.secrets().as_ref())
+    if let Some(material) = auth_material_from(
+        patch.token.as_deref(),
+        patch.auth_kind,
+        patch.header_name.as_deref(),
+        patch.param_name.as_deref(),
+    )? {
+        store_auth(runtime.id(), &name, &material, runtime.secrets().as_ref())
             .await
             .map_err(ApiError)?;
     }
 
-    mutation_response(runtime, &name).await
+    mutation_response(runtime, &name, warning).await
 }
 
 /// `DELETE …/mcp/servers/{name}` — remove a runtime server (409 for a manifest
@@ -302,19 +414,32 @@ async fn delete_server(
     save_runtime_index(runtime.id(), runtime.secrets().as_ref(), &index)
         .await
         .map_err(ApiError)?;
-    // Best-effort credential wipe (the store has no delete; empty reads as unset).
+    // Best-effort credential + health wipe (the store has no delete; an empty
+    // value reads as unset, so a later server of the same name never inherits a
+    // stale credential or badge).
     clear_auth(runtime.id(), &name, runtime.secrets().as_ref())
+        .await
+        .map_err(ApiError)?;
+    clear_health(runtime.id(), &name, runtime.secrets().as_ref())
         .await
         .map_err(ApiError)?;
     Ok(StatusCode::NO_CONTENT)
 }
 
 /// Builds the mutation response by re-resolving the named server's effective
-/// projection (so the response reflects manifest/runtime merge + auth status).
+/// projection (so the response reflects manifest/runtime merge + auth status),
+/// then probing it once. The probe **never** rolls the mutation back — a
+/// needs-config result is a valid resting state; the outcome is persisted as
+/// (scrubbed) health and echoed as `test`.
 async fn mutation_response(
     runtime: &CompanyRuntime,
     name: &str,
+    warning: Option<String>,
 ) -> Result<Json<MutationResponse>, ApiError> {
+    // Probe first (persists scrubbed health), then read the health back into the
+    // DTO so the response and a later `GET` agree.
+    let test = probe_and_persist(runtime, name).await;
+
     let manifest = manifest_servers(runtime).await?;
     let decls = resolve_effective(runtime.id(), &manifest, runtime.secrets().as_ref())
         .await
@@ -324,10 +449,40 @@ async fn mutation_response(
             "`{name}` not found"
         )))
     })?;
+    let health = load_health(runtime.id(), name, runtime.secrets().as_ref())
+        .await
+        .map_err(ApiError)?;
     Ok(Json(MutationResponse {
-        server: dto_from_decl(decl),
+        server: dto_from_decl(decl, health),
         note: REBUILD_NOTE.to_string(),
+        test,
+        warning,
     }))
+}
+
+/// Probe the named server and persist the (scrubbed) outcome as health, returning
+/// it. Under the `openhuman` feature this dials the server through the same
+/// registry the agent uses (auth INCLUDED); without it there is no MCP transport,
+/// so no probe runs and the console falls back to the declared shape.
+#[cfg(feature = "openhuman")]
+async fn probe_and_persist(runtime: &CompanyRuntime, name: &str) -> Option<McpHealth> {
+    let manifest = manifest_servers(runtime).await.ok()?;
+    let decls = resolve_effective(runtime.id(), &manifest, runtime.secrets().as_ref())
+        .await
+        .ok()?;
+    let decl = decls.iter().find(|d| d.name == name)?;
+    // `probe_server` already scrubs its message; persist that scrubbed health.
+    let health = crate::harness::mcp_probe::probe_server(decl).await;
+    let _ = mcp::save_health(runtime.id(), name, &health, runtime.secrets().as_ref()).await;
+    Some(health)
+}
+
+/// Without the `openhuman` feature there is no MCP transport, so probing is a
+/// no-op (the console falls back gracefully — same `not_wired` posture as
+/// discovery).
+#[cfg(not(feature = "openhuman"))]
+async fn probe_and_persist(_runtime: &CompanyRuntime, _name: &str) -> Option<McpHealth> {
+    None
 }
 
 /// Rejects an invalid server declaration as a `400`.
@@ -385,29 +540,80 @@ async fn discover_tools(
             })),
         )
             .into_response(),
-        Some(_) => {
-            #[cfg(feature = "mcp")]
-            {
-                match crate::harness::mcp::discover_tools(&decls, &name).await {
-                    Ok(tools) => return Json(tools).into_response(),
-                    Err(err) => {
-                        return (
-                            StatusCode::BAD_GATEWAY,
-                            Json(serde_json::json!({
-                                "error": format!("MCP discovery failed: {err}"),
-                                "code": "discovery_failed",
-                            })),
-                        )
-                            .into_response();
-                    }
-                }
+        Some(decl) => match crate::harness::mcp::discover_tools(&decls, &name).await {
+            Ok(tools) => Json(tools).into_response(),
+            Err(err) => {
+                // NEVER surface the raw error — it can carry a response body or a
+                // full request URL (with a query-parameter credential). Classify,
+                // scrub against this server's known secrets, and persist the
+                // scrubbed outcome as health.
+                use crate::harness::mcp_probe;
+                let secrets = decl.auth.secret_values();
+                let class = mcp_probe::classify_mcp_error(&err, decl.auth.is_configured(), false);
+                let message =
+                    mcp_probe::scrub(&mcp_probe::operator_message(&name, &class, &err), &secrets);
+                let health = McpHealth {
+                    status: class.status,
+                    message: message.clone(),
+                    tool_count: 0,
+                    checked_at_millis: crate::ports::now_millis(),
+                    auth_hint: class.auth_hint.clone(),
+                };
+                let _ = mcp::save_health(runtime.id(), &name, &health, runtime.secrets().as_ref())
+                    .await;
+                (
+                    StatusCode::BAD_GATEWAY,
+                    Json(serde_json::json!({
+                        "error": message,
+                        "code": class.code(),
+                    })),
+                )
+                    .into_response()
             }
-            #[cfg(not(feature = "mcp"))]
-            {
-                return crate::server::ops::not_wired("mcp tool discovery");
-            }
-        }
+        },
     }
+}
+
+/// `POST …/mcp/servers/{name}/test` — probe a server on demand and return its
+/// (scrubbed) health. Gated on the `openhuman` feature; without it the route
+/// reports `not_wired` so the console's Test button degrades gracefully.
+#[cfg(feature = "openhuman")]
+async fn test_server(company: ScopedCompany, Path(NamePath { name }): Path<NamePath>) -> Response {
+    use axum::response::IntoResponse;
+
+    let runtime = company.runtime.as_ref();
+    let name = name.trim().to_string();
+    // A server that doesn't exist can't be tested.
+    let manifest = match manifest_servers(runtime).await {
+        Ok(m) => m,
+        Err(err) => return err.into_response(),
+    };
+    let decls = match resolve_effective(runtime.id(), &manifest, runtime.secrets().as_ref()).await {
+        Ok(d) => d,
+        Err(err) => return ApiError(err).into_response(),
+    };
+    if !decls.iter().any(|d| d.name == name) {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": format!("no MCP server named `{name}`"),
+                "code": "not_found",
+            })),
+        )
+            .into_response();
+    }
+    match probe_and_persist(runtime, &name).await {
+        Some(health) => Json(health).into_response(),
+        None => crate::server::ops::not_wired("mcp probe"),
+    }
+}
+
+/// Without the `openhuman` feature there is no MCP transport, so on-demand
+/// testing is "not wired" (the console falls back to the declared shape).
+#[cfg(not(feature = "openhuman"))]
+async fn test_server(company: ScopedCompany, Path(NamePath { name }): Path<NamePath>) -> Response {
+    let _ = (company, name);
+    crate::server::ops::not_wired("mcp probe")
 }
 
 /// Without the `openhuman` feature there is no MCP transport, so discovery is

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -942,3 +942,149 @@ async fn mcp_discovery_is_not_wired_without_the_feature() {
     assert_eq!(body["code"], "not_wired");
     tokio::fs::remove_dir_all(&home).await.ok();
 }
+
+/// A `user:pass@host` endpoint smuggles a credential into the URL — rejected as
+/// a 400 (the error-hardening cell's validate-on-add).
+#[tokio::test]
+async fn mcp_userinfo_endpoint_is_rejected() {
+    let home = home();
+    let state = state_with_company(&home).await;
+    let (status, _) = send(
+        &state,
+        "POST",
+        "/api/v1/company/mcp/servers",
+        Some(json!({ "name": "creds", "endpoint": "https://user:pass@host/mcp" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+/// A query-parameter credential (BrowserBase style) round-trips write-only:
+/// `authConfigured` flips true, the value never appears in the response, and a
+/// non-secret id left in the endpoint URL raises the non-blocking advisory.
+#[tokio::test]
+async fn mcp_query_param_auth_round_trips_write_only_with_advisory() {
+    let home = home();
+    let state = state_with_company(&home).await;
+
+    let (status, added) = send(
+        &state,
+        "POST",
+        "/api/v1/company/mcp/servers",
+        Some(json!({
+            "name": "browserbase",
+            // A secret-looking query param triggers the advisory; the real
+            // credential rides write-only as a query-parameter auth.
+            "endpoint": "https://api.browserbase.com/mcp?apiKey=leftover",
+            "authKind": "query_param",
+            "paramName": "apiKey",
+            "token": "qp-secret-xyz"
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(added["server"]["authConfigured"], true);
+    assert!(
+        added["warning"].as_str().is_some(),
+        "a secret-looking endpoint query raises the advisory: {added}"
+    );
+    assert!(
+        !serde_json::to_string(&added)
+            .unwrap()
+            .contains("qp-secret-xyz"),
+        "the query-parameter credential leaked into the response"
+    );
+
+    // A query_param auth WITHOUT a paramName is a 400.
+    let (status, _) = send(
+        &state,
+        "POST",
+        "/api/v1/company/mcp/servers",
+        Some(json!({
+            "name": "noparam",
+            "endpoint": "https://host/mcp",
+            "authKind": "query_param",
+            "token": "x"
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+/// Without the `openhuman` feature the on-demand Test route is "not wired".
+#[cfg(not(feature = "openhuman"))]
+#[tokio::test]
+async fn mcp_test_route_is_not_wired_without_the_feature() {
+    let home = home();
+    let state = state_with_company(&home).await;
+    send(
+        &state,
+        "POST",
+        "/api/v1/company/mcp/servers",
+        Some(json!({ "name": "notion", "endpoint": "https://notion.example/mcp" })),
+    )
+    .await;
+    let (status, body) = send(
+        &state,
+        "POST",
+        "/api/v1/company/mcp/servers/notion/test",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(body["code"], "not_wired");
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+/// Under the `openhuman` feature, adding a server probes it — and a probe that
+/// fails (dead endpoint) is **never** rolled back: the server stays added, and
+/// its scrubbed health is returned as `test` and persisted onto the GET shape.
+#[cfg(feature = "openhuman")]
+#[tokio::test]
+async fn mcp_add_probes_without_rollback_and_persists_health() {
+    let home = home();
+    let state = state_with_company(&home).await;
+
+    // A syntactically valid but unreachable endpoint (nothing listening).
+    let (status, added) = send(
+        &state,
+        "POST",
+        "/api/v1/company/mcp/servers",
+        Some(json!({ "name": "dead", "endpoint": "http://127.0.0.1:1/mcp" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    // No rollback — the server is present despite the failed probe.
+    assert_eq!(added["server"]["name"], "dead");
+    // The probe result is echoed and the status is a non-ok tier.
+    assert!(added["test"].is_object(), "probe result echoed: {added}");
+    assert_ne!(added["test"]["status"], "ok");
+
+    // The health is persisted onto the GET shape too.
+    let (_, list) = send(&state, "GET", "/api/v1/company/mcp/servers", None).await;
+    let server = list
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["name"] == "dead")
+        .expect("server present");
+    assert!(server["health"].is_object(), "health persisted: {server}");
+
+    // On-demand Test re-probes and returns health.
+    let (status, health) = send(
+        &state,
+        "POST",
+        "/api/v1/company/mcp/servers/dead/test",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        health["status"].is_string(),
+        "test returns health: {health}"
+    );
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -146,6 +146,8 @@ description = "Runs Acme."
             facts: None,
             events: None,
             delegations: crate::harness::orchestrator::DelegationQueue::default(),
+            mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            secrets: None,
         }
     }
 


### PR DESCRIPTION
## Summary

The single home for all MCP work. This branch hardens the MCP integration end-to-end — auth intake, health, freshness to the agent, error handling, and token safety.

Adds:

- **BrowserBase-style query-param auth** — `AuthMaterial::QueryParam` for servers that authenticate via URL query string; userinfo `user:pass@` endpoints are rejected at intake.
- **Validate-on-add** + per-server **health** + a Test button — a server is probed when added/mutated, exposes per-server health, and the console gets a `/test` route + Test button to re-probe on demand.
- **MCP-freshness** — added `HarnessDeps.secrets: Arc<dyn SecretStore>` as a live handle; `HarnessPool::ensure` re-resolves the effective MCP set from the live store every turn and fingerprint-gates a rebuild. A console MCP add reaches the agent on the **next turn** — no restart required.
- **Empty-response retry-once** — when the model returns an empty response, we retry once and fall back to a scrubbed graceful message. Chat never surfaces a bare "Couldn't send".
- **Stale-memory persona brief** — capability questions ("which tools do you have?") are answered from a live `mcp_list_servers` call, not from stale memory.

**Security** — token scrubbing at all three leak vectors (upstream body echo, reqwest URL-with-query, agent-visible endpoints) via `mcp_probe::scrub`: credentials collapse to `•••`, URL query-strings are stripped, and truncation is UTF-8-safe.

**Stacking note**: this branch is stacked on #55 (`feat/53`, the orchestrator branch). Fork branches can't be a PR base, so this PR targets `main` and the diff is **cumulative** — it currently includes #55's orchestrator commits. Once #55 merges, rebasing this branch onto `main` shrinks the diff to the MCP-hardening changes only.

## API Or Behavior Changes

- New MCP auth schemes at intake, including `AuthMaterial::QueryParam`; `user:pass@` userinfo endpoints are now rejected.
- Per-server MCP **health** surface + a `/test` route to re-probe a server on demand.
- New audit event `CompanyEvent::McpCallFailed` (scrubbed).
- `HarnessDeps` gained two fields: `mcp_failures` (failure queue drained into operator warnings) and `secrets: Arc<dyn SecretStore>` (live handle enabling per-turn MCP re-resolution).

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo build --all-targets`
- [x] `cargo test` — 514 passed + 4 (integration)

Additional verification:

- `cargo test --features openhuman` — 629 passed + 4.
- `cargo check --features openhuman` — **compiles**. This PR fixes the pre-existing `server/ops/mcp.rs:388` gating error that the other cells hit.
- Leak test `oc_call_tool_scrubs_reflected_credential` drives a credential-reflecting server through the real vendored transport and asserts the credential never reaches agent-visible output.
- Frontend `typecheck` + `build` clean.

## Documentation

- `mcp_probe` module docs (scrubber, probe, error classifier).
- Connections auth-scheme docs updated for the new intake schemes.
