### PR TITLE
feat(chat): surface scrubbed tool-call/thinking steps in the operator chat

### DIFF
--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -124,6 +124,44 @@ pub trait ChannelAdapter: Send + Sync {
 }
 ```
 
+### OutboundMessage steps (activity trace)
+
+An `OutboundMessage` carries an additive, scrubbed `steps: Vec<TurnStep>` — the
+visible processing behind that bubble (tool calls, thinking runs, surfaced MCP
+failures), folded from the harness turn's progress stream:
+
+```rust
+// src/ports/types.rs
+pub struct OutboundMessage {
+    pub channel: String,
+    pub text: String,
+    // Omitted on the wire when empty (serde skip_serializing_if).
+    pub steps: Vec<TurnStep>,
+}
+
+pub struct TurnStep {
+    pub kind: TurnStepKind,      // tool_call | thinking | note
+    pub status: TurnStepStatus,  // ok | error | running
+    pub label: String,           // display_label, else the tool name
+    pub detail: Option<String>,  // whitelisted enrichment, or a scrubbed cause
+    pub elapsed_ms: Option<u64>,
+}
+```
+
+Per-bubble ownership: the operator bubble carries the orchestrator's steps; a
+delegated desk bubble carries that desk lead's steps. **Zero steps is
+meaningful** — a memory-served or tool-less answer runs none, which is how the
+console distinguishes it from a tool-backed one, and how a silently-failed MCP
+call becomes visible (surfaced as an `error` step on the operator bubble rather
+than a vague acknowledgement).
+
+Security: `steps` never carry raw tool arguments, tool output, or call ids —
+only a safe label, a whitelisted/scrubbed detail, and an elapsed time. They are
+never written to the memory store (`memory_loop::outcome_chunk` stays
+text-only), so a step detail can never be retrieved and re-injected into a later
+turn. The fold + scrub lives in `src/harness/steps.rs` (compiled under the
+`openhuman` feature). Non-harness brains (echo, medulla) emit no steps.
+
 ## ToolProvider
 
 Tool catalog + invocation, scoped per company. Backed by OpenHuman JSON-RPC

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -114,8 +114,16 @@ async fn main() -> anyhow::Result<()> {
     pool.ensure(&record, &deps).await?;
 
     println!("── prompt → ceo ──\n{prompt}\n");
-    let reply = pool.run(&record.id, "ceo", &prompt, &deps).await?;
+    let outcome = pool.run(&record.id, "ceo", &prompt, &deps).await?;
+    let reply = outcome.reply;
     println!("── ceo reply ──\n{reply}\n");
+    if !outcome.steps.is_empty() {
+        println!("── steps ({}) ──", outcome.steps.len());
+        for step in &outcome.steps {
+            println!("  · {:?} {} [{:?}]", step.status, step.label, step.kind);
+        }
+        println!();
+    }
 
     // An empty reply means the turn ran but produced nothing — broken wiring,
     // not a valid answer. Fail loudly so this smoke never passes silently.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -11,10 +11,39 @@ export interface CompanyStatus {
   pending_approvals: number;
 }
 
+/** What kind of processing step this is (drives the timeline icon). */
+export type TurnStepKind = "tool_call" | "thinking" | "note";
+
+/** How a processing step ended. */
+export type TurnStepStatus = "ok" | "error" | "running";
+
+/**
+ * One visible step in an agent turn's processing timeline. Mirrors `TurnStep`
+ * in `src/ports/types.rs`. The host folds and scrubs these from the turn's
+ * progress stream: `label`/`detail` never carry raw tool arguments, tool
+ * output, or call ids — only a safe label and an optional scrubbed detail.
+ */
+export interface TurnStep {
+  kind: TurnStepKind;
+  status: TurnStepStatus;
+  label: string;
+  /** A muted, scrubbed detail (e.g. an MCP `server · tool`, a failure cause). */
+  detail?: string;
+  /** How long a tool call took, in milliseconds, when known. */
+  elapsedMs?: number;
+}
+
 /** One channel reply from a cycle. */
 export interface OutboundMessage {
   channel: string;
   text: string;
+  /**
+   * The visible processing steps behind this reply (tool calls, thinking runs,
+   * surfaced MCP failures). Omitted by the host when empty — a memory-served or
+   * tool-less answer carries no steps, which is the tell that distinguishes it
+   * from a tool-backed one.
+   */
+  steps?: TurnStep[];
 }
 
 /**

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -1,3 +1,5 @@
+import type { TurnStep } from "@/api/types";
+
 /** One line in the conversation with the company. */
 export interface ChatMessage {
   id: string;
@@ -10,6 +12,12 @@ export interface ChatMessage {
    * side by sender: a distinct channel reads as its own agent in the chat.
    */
   channel?: string;
+  /**
+   * The scrubbed processing steps behind a company reply (tool calls, thinking,
+   * surfaced failures), rendered as a timeline above the bubble. Absent/empty
+   * on your own messages and on tool-less replies.
+   */
+  steps?: TurnStep[];
 }
 
 let seq = 0;
@@ -19,7 +27,14 @@ const nextId = () => `m${seq++}`;
 export function makeMessage(
   from: ChatMessage["from"],
   text: string,
-  opts: { channel?: string; at?: number } = {},
+  opts: { channel?: string; at?: number; steps?: TurnStep[] } = {},
 ): ChatMessage {
-  return { id: nextId(), from, text, at: opts.at ?? Date.now(), channel: opts.channel };
+  return {
+    id: nextId(),
+    from,
+    text,
+    at: opts.at ?? Date.now(),
+    channel: opts.channel,
+    steps: opts.steps,
+  };
 }

--- a/frontend/src/views/Conversation.tsx
+++ b/frontend/src/views/Conversation.tsx
@@ -1,8 +1,18 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { ArrowLeft, ArrowUp, Building2, PenSquare } from "lucide-react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowUp,
+  Brain,
+  Building2,
+  ChevronDown,
+  ChevronRight,
+  PenSquare,
+  Wrench,
+} from "lucide-react";
 
 import type { OpenCompanyClient } from "@/api/client";
-import { ApiError } from "@/api/types";
+import { ApiError, type TurnStep, type TurnStepKind } from "@/api/types";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
@@ -149,7 +159,9 @@ function ChatPane({
       // company doesn't define fall to the orchestrator on the backend.
       const reply = await client.chat(text, company, thread.id);
       const replies = reply.responses.length
-        ? reply.responses.map((r) => makeMessage("company", r.text, { channel: r.channel }))
+        ? reply.responses.map((r) =>
+            makeMessage("company", r.text, { channel: r.channel, steps: r.steps }),
+          )
         : [makeMessage("system", "(no reply)")];
       setMessages(thread.id, (m) => [...m, ...replies]);
       onReply?.();
@@ -288,7 +300,10 @@ function MessageGroup({ group, prev }: { group: Group; prev?: Group }) {
             </div>
           )}
           {group.messages.map((m, i) => (
-            <Bubble key={m.id} message={m} mine={mine} last={i === group.messages.length - 1} />
+            <Fragment key={m.id}>
+              {!mine && m.steps && m.steps.length > 0 && <StepTimeline steps={m.steps} />}
+              <Bubble message={m} mine={mine} last={i === group.messages.length - 1} />
+            </Fragment>
           ))}
         </div>
       </div>
@@ -316,6 +331,88 @@ function Bubble({ message, mine, last }: { message: ChatMessage; mine: boolean; 
       </span>
     </div>
   );
+}
+
+/* ---- processing-step timeline (Activity-trace) ---- */
+
+/**
+ * The scrubbed processing steps behind a company reply, rendered above its
+ * bubble. Collapsed by default to a one-line "N steps · M failed" summary; auto
+ * expands when any step failed so a silent MCP failure is visible, not buried.
+ * Renders nothing when there are no steps (a memory-served / tool-less reply).
+ */
+function StepTimeline({ steps }: { steps: TurnStep[] }) {
+  const failed = steps.filter((s) => s.status === "error").length;
+  const hasError = failed > 0;
+  const [open, setOpen] = useState(hasError);
+
+  if (steps.length === 0) return null;
+
+  return (
+    <div className="w-full max-w-[85%] sm:max-w-[75%]">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className={cn(
+          "flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] font-medium transition-colors hover:bg-accent/60",
+          hasError ? "text-destructive" : "text-muted-foreground",
+        )}
+      >
+        {open ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+        <span>
+          {steps.length} step{steps.length === 1 ? "" : "s"}
+          {failed > 0 && ` · ${failed} failed`}
+        </span>
+      </button>
+      {open && (
+        <ol className="mt-0.5 flex flex-col gap-1 rounded-lg border bg-card/60 px-2.5 py-1.5">
+          {steps.map((step, i) => (
+            <StepRow key={i} step={step} />
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+function StepRow({ step }: { step: TurnStep }) {
+  const error = step.status === "error";
+  const Icon = stepIcon(step.kind);
+  return (
+    <li
+      className={cn(
+        "flex items-center gap-1.5 text-[11px] leading-relaxed",
+        error ? "text-destructive" : "text-muted-foreground",
+      )}
+    >
+      <Icon className={cn("size-3 shrink-0", step.status === "running" && "animate-pulse")} />
+      <span className={cn("font-medium", !error && "text-foreground/80")}>{step.label}</span>
+      {step.detail && <span className="min-w-0 truncate">— {step.detail}</span>}
+      {typeof step.elapsedMs === "number" && (
+        <span className="ml-auto shrink-0 tabular-nums opacity-70">
+          {formatElapsed(step.elapsedMs)}
+        </span>
+      )}
+    </li>
+  );
+}
+
+function stepIcon(kind: TurnStepKind) {
+  switch (kind) {
+    case "tool_call":
+      return Wrench;
+    case "thinking":
+      return Brain;
+    case "note":
+      return AlertTriangle;
+    default:
+      return Wrench;
+  }
+}
+
+function formatElapsed(ms: number): string {
+  return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`;
 }
 
 function SenderAvatar({ sender }: { sender: Sender }) {

--- a/src/brain/echo.rs
+++ b/src/brain/echo.rs
@@ -47,6 +47,7 @@ impl Brain for EchoBrain {
                 channel_responses.push(OutboundMessage {
                     channel: "operator".to_string(),
                     text: format!("You said: {text}"),
+                    steps: Vec::new(),
                 });
             }
         }
@@ -54,6 +55,7 @@ impl Brain for EchoBrain {
             channel_responses.push(OutboundMessage {
                 channel: "operator".to_string(),
                 text: "Acknowledged.".to_string(),
+                steps: Vec::new(),
             });
         }
 

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -201,7 +201,11 @@ pub(crate) fn channel_message_from_effect(effect: &Effect) -> Option<OutboundMes
         .or_else(|| payload_str(payload, "body"))
         .or_else(|| payload_str(payload, "message"))?
         .to_string();
-    Some(OutboundMessage { channel, text })
+    Some(OutboundMessage {
+        channel,
+        text,
+        steps: Vec::new(),
+    })
 }
 
 /// Records a ledger delta for an executed effect that moved money.

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -27,7 +27,7 @@ use crate::harness::{HarnessDeps, HarnessPool};
 use crate::ports::brain::{Brain, CycleHost};
 use crate::ports::types::{
     CompanyEvent, CompanyRecord, CompressedTrace, CycleRequest, CycleResult, OutboundMessage,
-    TokenUsage,
+    TokenUsage, TurnStep, TurnStepKind, TurnStepStatus,
 };
 use crate::ports::{TaskRecord, generate_id, now_millis};
 
@@ -85,8 +85,13 @@ impl HarnessBrain {
             .run(&self.record.id, &responder, &instruction, &self.deps)
             .await
         {
-            Ok(reply) => {
-                card.note = Some(append_result(card.note.as_deref(), &responder, &reply));
+            // A dispatched task discards its steps — the card note is text-only.
+            Ok(outcome) => {
+                card.note = Some(append_result(
+                    card.note.as_deref(),
+                    &responder,
+                    &outcome.reply,
+                ));
                 card.column = "in_review".to_string();
             }
             Err(err) => {
@@ -140,19 +145,25 @@ impl HarnessBrain {
             .cloned()
     }
 
-    /// Drains the MCP failure queue and surfaces each failure: an
-    /// operator-visible warning bubble (the Activity-trace cell will re-skin it
-    /// as a warning step later), plus a scrubbed
-    /// [`CompanyEvent::McpCallFailed`] audit event when the event log is wired.
-    /// Every string was already scrubbed at the source (`OcMcpCallTool`).
-    async fn surface_mcp_failures(&self, responses: &mut Vec<OutboundMessage>) -> Result<()> {
+    /// Drains the MCP failure queue **onto the operator bubble's step timeline**
+    /// as error steps (the Activity-trace re-skin of the error-hardening cell's
+    /// original fallback bubble), and journals a scrubbed
+    /// [`CompanyEvent::McpCallFailed`] audit event per failure when the event log
+    /// is wired.
+    ///
+    /// One surface, one renderer, one scrub discipline: a silently-failed MCP
+    /// call shows up as a red step in the same timeline as every other tool call
+    /// instead of a separate warning bubble. Every string was already scrubbed at
+    /// the source (`OcMcpCallTool`), so `scrubbed_message` is safe to show and to
+    /// persist.
+    async fn surface_mcp_failures(&self, steps: &mut Vec<TurnStep>) -> Result<()> {
         for failure in self.deps.mcp_failures.drain() {
-            responses.push(OutboundMessage {
-                channel: "operator".to_string(),
-                text: format!(
-                    "⚠️ MCP tool issue on '{}': {}",
-                    failure.server, failure.scrubbed_message
-                ),
+            steps.push(TurnStep {
+                kind: TurnStepKind::Note,
+                status: TurnStepStatus::Error,
+                label: format!("MCP: {} unavailable", failure.server),
+                detail: Some(failure.scrubbed_message.clone()),
+                elapsed_ms: None,
             });
             if let Some(events) = self.deps.events.as_ref() {
                 events
@@ -207,13 +218,15 @@ impl HarnessBrain {
                 let Some(member) = self.desk_lead(&desk) else {
                     return Ok(None);
                 };
-                let reply = self
+                let outcome = self
                     .pool
                     .run(&self.record.id, &member, &instruction, &self.deps)
                     .await?;
+                // The desk lead's own steps ride on its distinct bubble.
                 Ok(Some(OutboundMessage {
                     channel: member,
-                    text: reply,
+                    text: outcome.reply,
+                    steps: outcome.steps,
                 }))
             }
         }
@@ -258,26 +271,37 @@ impl Brain for HarnessBrain {
                     // past the cap).
                     self.deps.delegations.clear();
                     self.deps.mcp_failures.clear();
-                    let reply = self
+                    let outcome = self
                         .pool
                         .run(&self.record.id, &responder, text, &self.deps)
                         .await?;
-                    channel_responses.push(OutboundMessage {
-                        channel: "operator".to_string(),
-                        text: reply,
-                    });
+                    // The orchestrator's own steps ride on the operator bubble.
+                    let mut operator_steps = outcome.steps;
+                    // Run whatever the orchestrator queued; each delegated desk
+                    // bubble carries its own lead's steps. Collect them first so
+                    // the operator bubble can still be finalized before it is
+                    // pushed (any MCP failure a delegated turn recorded lands on
+                    // the operator timeline).
+                    let mut delegated = Vec::new();
                     for delegation in self
                         .deps
                         .delegations
                         .drain(orchestrator::MAX_DELEGATIONS_PER_TURN)
                     {
                         if let Some(message) = self.run_delegation(delegation).await? {
-                            channel_responses.push(message);
+                            delegated.push(message);
                         }
                     }
-                    // Surface any MCP tool-call failures the turn (or a delegated
-                    // desk turn) recorded.
-                    self.surface_mcp_failures(&mut channel_responses).await?;
+                    // Re-skin any MCP tool-call failures (from the orchestrator
+                    // turn or a delegated desk turn) as error steps on the
+                    // operator bubble — one surface, one renderer.
+                    self.surface_mcp_failures(&mut operator_steps).await?;
+                    channel_responses.push(OutboundMessage {
+                        channel: "operator".to_string(),
+                        text: outcome.reply,
+                        steps: operator_steps,
+                    });
+                    channel_responses.extend(delegated);
                 }
                 CompanyEvent::TaskDispatched { task_id } => {
                     self.run_task(task_id).await?;
@@ -290,6 +314,7 @@ impl Brain for HarnessBrain {
             channel_responses.push(OutboundMessage {
                 channel: "operator".to_string(),
                 text: "Acknowledged.".to_string(),
+                steps: Vec::new(),
             });
         }
 
@@ -426,6 +451,14 @@ description = "Runs Acme."
             result.channel_responses[0].text.contains("status?"),
             "{:?}",
             result.channel_responses[0].text
+        );
+        // The offline mock runs no tools and emits no progress, so the operator
+        // bubble carries zero steps — the tell that distinguishes a tool-less
+        // (here, memory/echo-style) answer from a tool-backed one.
+        assert!(
+            result.channel_responses[0].steps.is_empty(),
+            "a tool-less turn carries no steps: {:?}",
+            result.channel_responses[0].steps
         );
         assert_eq!(result.new_traces.len(), 1);
         // Single cost-accounting site: the cycle result carries no ledger delta.
@@ -795,10 +828,11 @@ members = ["engineer"]
 
     // --- MCP failure drain --------------------------------------------------
 
-    /// A recorded MCP failure surfaces as an operator bubble AND a scrubbed
-    /// `McpCallFailed` audit event when the event log is wired.
+    /// A recorded MCP failure re-skins into an **error step** on the operator
+    /// bubble's timeline AND a scrubbed `McpCallFailed` audit event when the
+    /// event log is wired (the Activity-trace re-skin of the old warning bubble).
     #[tokio::test]
-    async fn mcp_failures_surface_as_bubble_and_event() {
+    async fn mcp_failures_surface_as_error_steps_and_event() {
         use crate::harness::mcp_probe::McpFailure;
         use crate::ports::EventLog;
         use crate::ports::types::EventSeq;
@@ -836,23 +870,21 @@ members = ["engineer"]
             scrubbed_message: "server rejected the call".into(),
         });
 
-        let mut responses = Vec::new();
+        let mut steps: Vec<TurnStep> = Vec::new();
         brain
-            .surface_mcp_failures(&mut responses)
+            .surface_mcp_failures(&mut steps)
             .await
             .expect("drain surfaces failures");
 
-        assert_eq!(responses.len(), 1, "one warning bubble");
+        assert_eq!(steps.len(), 1, "one error step");
+        assert_eq!(steps[0].kind, TurnStepKind::Note);
+        assert_eq!(steps[0].status, TurnStepStatus::Error);
         assert!(
-            responses[0].text.contains("browserbase"),
+            steps[0].label.contains("browserbase"),
             "{:?}",
-            responses[0].text
+            steps[0].label
         );
-        assert!(
-            responses[0].text.contains("rejected the call"),
-            "{:?}",
-            responses[0].text
-        );
+        assert_eq!(steps[0].detail.as_deref(), Some("server rejected the call"));
 
         let logged = events
             .read_from(&CompanyId::new("acme"), EventSeq::new(0), usize::MAX)

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -46,6 +46,7 @@ pub mod orchestrator;
 pub mod policy;
 pub mod provider;
 pub mod skills;
+pub mod steps;
 
 pub use brain::HarnessBrain;
 
@@ -67,7 +68,7 @@ use crate::harness::mcp_probe::McpFailureQueue;
 use crate::harness::orchestrator::DelegationQueue;
 use crate::harness::policy::ApprovalPolicy;
 use crate::ports::skills_state::{SkillState, SkillStateStore};
-use crate::ports::types::{CompanyId, CompanyRecord};
+use crate::ports::types::{CompanyId, CompanyRecord, TurnStep};
 use crate::ports::{
     CompanyStore, ContextStore, EventLog, FactStore, SecretStore, TaskStore, UsageMeter,
 };
@@ -164,8 +165,8 @@ pub struct CompanyAgent {
 /// class twice — so chat never shows a bare "Couldn't send" for a model hiccup.
 const GRACEFUL_EMPTY_REPLY: &str = "Sorry — I hit a temporary model hiccup and couldn't produce a reply. Please resend your message.";
 
-/// The outcome of a single `agent.turn`, classified for the retry wrapper.
-enum TurnOutcome {
+/// The classification of a single `agent.turn` attempt, for the retry wrapper.
+enum AttemptOutcome {
     /// A non-empty reply.
     Reply(String),
     /// The transient empty-response class (an empty/blank reply, or the model's
@@ -173,6 +174,23 @@ enum TurnOutcome {
     Empty,
     /// A hard error (budget/auth/build/etc.) — propagated loudly, never swallowed.
     Hard(OpenCompanyError),
+}
+
+/// The result of a completed turn: the reply text plus the scrubbed
+/// [`TurnStep`] timeline folded from the turn's progress stream.
+///
+/// The steps are per-bubble: the operator bubble carries the orchestrator's
+/// steps, a delegated desk bubble carries that desk lead's steps. They ride the
+/// wire on [`OutboundMessage::steps`](crate::ports::types::OutboundMessage) and
+/// are **never** written to memory ([`HarnessPool::run`] persists
+/// `outcome.reply` only).
+#[derive(Debug, Clone)]
+pub struct TurnOutcome {
+    /// The agent's reply text.
+    pub reply: String,
+    /// The scrubbed, folded processing steps (empty for a memory-served or
+    /// tool-less turn — the zero-steps tell).
+    pub steps: Vec<TurnStep>,
 }
 
 impl CompanyAgent {
@@ -193,40 +211,76 @@ impl CompanyAgent {
     /// [`Agent::last_turn_usage`](oh::agent::Agent::last_turn_usage) accessor
     /// while the agent lock is still held. An offline provider that reports no
     /// usage yields a zero [`TurnUsage`], which the cost hook treats as inert.
-    pub async fn run(&self, message: &str) -> crate::Result<(String, Vec<TurnUsage>)> {
+    ///
+    /// **Activity-trace**: this is the one site holding `&mut Agent`, so it is
+    /// where the turn's [`AgentProgress`](oh::agent::progress::AgentProgress)
+    /// stream is captured. A per-turn `mpsc` channel is attached via
+    /// [`Agent::set_on_progress`](oh::agent::Agent::set_on_progress); an
+    /// always-draining collector task buffers every event so the turn loop never
+    /// blocks on a full channel; and after the turn (both attempts share the one
+    /// channel) the sink is detached, the collector joined, and the events folded
+    /// into the scrubbed [`TurnOutcome::steps`] by
+    /// [`steps::fold_steps`](crate::harness::steps::fold_steps). The sink is
+    /// per-turn *local* — deliberately not a [`HarnessDeps`] field — so parallel
+    /// turns never collide.
+    pub async fn run(&self, message: &str) -> crate::Result<(TurnOutcome, Vec<TurnUsage>)> {
+        // Per-turn progress sink + an always-draining collector, so a burst of
+        // events never blocks the turn loop on a full channel.
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<oh::agent::progress::AgentProgress>(1024);
+        let collector = tokio::spawn(async move {
+            let mut events = Vec::new();
+            while let Some(event) = rx.recv().await {
+                events.push(event);
+            }
+            events
+        });
+
         let mut agent = self.agent.lock().await;
+        agent.set_on_progress(Some(tx));
         let mut usages: Vec<TurnUsage> = Vec::new();
 
-        // Attempt 1.
+        // Attempt 1, falling through to a single retry only on the transient
+        // empty-response class. Both attempts feed the one progress channel.
         let first = agent.turn(message).await;
         usages.push(read_turn_usage(&agent));
-        match self.classify_turn(first) {
-            TurnOutcome::Reply(reply) => return Ok((reply, usages)),
-            TurnOutcome::Hard(err) => return Err(err),
-            TurnOutcome::Empty => {} // fall through to a single retry
-        }
+        let reply: crate::Result<String> = match self.classify_turn(first) {
+            AttemptOutcome::Reply(reply) => Ok(reply),
+            AttemptOutcome::Hard(err) => Err(err),
+            AttemptOutcome::Empty => {
+                // Attempt 2 (retry once).
+                let second = agent.turn(message).await;
+                usages.push(read_turn_usage(&agent));
+                match self.classify_turn(second) {
+                    AttemptOutcome::Reply(reply) => Ok(reply),
+                    // Still empty → graceful, scrubbed text (never an `Err`).
+                    AttemptOutcome::Empty => {
+                        Ok(crate::harness::mcp_probe::scrub(GRACEFUL_EMPTY_REPLY, &[]))
+                    }
+                    AttemptOutcome::Hard(err) => Err(err),
+                }
+            }
+        };
 
-        // Attempt 2 (retry once).
-        let second = agent.turn(message).await;
-        usages.push(read_turn_usage(&agent));
-        match self.classify_turn(second) {
-            TurnOutcome::Reply(reply) => Ok((reply, usages)),
-            // Still empty → graceful, scrubbed text (never an `Err`).
-            TurnOutcome::Empty => Ok((
-                crate::harness::mcp_probe::scrub(GRACEFUL_EMPTY_REPLY, &[]),
-                usages,
-            )),
-            TurnOutcome::Hard(err) => Err(err),
-        }
+        // Detach the sink (drops the only remaining `Sender`, closing the
+        // channel), release the agent lock, then drain + fold. A `Hard` error
+        // still runs this cleanup before propagating, so the collector never
+        // leaks.
+        agent.set_on_progress(None);
+        drop(agent);
+        let events = collector.await.unwrap_or_default();
+        let steps = steps::fold_steps(events);
+
+        let reply = reply?;
+        Ok((TurnOutcome { reply, steps }, usages))
     }
 
     /// Classify one `agent.turn` result for the retry wrapper.
-    fn classify_turn(&self, result: anyhow::Result<String>) -> TurnOutcome {
+    fn classify_turn(&self, result: anyhow::Result<String>) -> AttemptOutcome {
         match result {
-            Ok(reply) if reply.trim().is_empty() => TurnOutcome::Empty,
-            Ok(reply) => TurnOutcome::Reply(reply),
-            Err(err) if is_transient_empty_response(&err) => TurnOutcome::Empty,
-            Err(err) => TurnOutcome::Hard(OpenCompanyError::Harness(format!(
+            Ok(reply) if reply.trim().is_empty() => AttemptOutcome::Empty,
+            Ok(reply) => AttemptOutcome::Reply(reply),
+            Err(err) if is_transient_empty_response(&err) => AttemptOutcome::Empty,
+            Err(err) => AttemptOutcome::Hard(OpenCompanyError::Harness(format!(
                 "turn for '{}': {err}",
                 self.agent_id
             ))),
@@ -369,7 +423,7 @@ impl HarnessPool {
         agent_id: &str,
         message: &str,
         deps: &HarnessDeps,
-    ) -> crate::Result<String> {
+    ) -> crate::Result<TurnOutcome> {
         let agent = {
             let guard = self.agents.read().await;
             let roster = guard
@@ -400,7 +454,7 @@ impl HarnessPool {
         // accessor and returns one entry per attempt (two when the empty-response
         // wrapper retried once). A zero-usage attempt (offline provider) writes
         // nothing, so the inert-metering contract holds.
-        let (reply, turn_costs) = agent.run(&augmented).await?;
+        let (outcome, turn_costs) = agent.run(&augmented).await?;
         // Attribute cost to the provider this turn actually resolved to. With a
         // per-tenant [`TenantProvider`](crate::harness::provider::TenantProvider)
         // a console BYOK switch changes the slug between turns, so read it live
@@ -420,14 +474,17 @@ impl HarnessPool {
 
         // Store: persist the outcome (original task + reply) so it compounds
         // into later turns. Without this the harness never writes memory back.
+        // SECURITY: the reply **text only** — the scrubbed `outcome.steps` never
+        // enter the memory store, so a step detail can never be retrieved and
+        // re-injected into a later turn.
         deps.context
             .put(
                 company,
-                memory_loop::outcome_chunk(agent_id, message, &reply),
+                memory_loop::outcome_chunk(agent_id, message, &outcome.reply),
             )
             .await?;
 
-        Ok(reply)
+        Ok(outcome)
     }
 
     /// Number of companies currently resident in the pool (test/observability).
@@ -770,7 +827,8 @@ description = "Builds the product."
         let reply = pool
             .run(&rec.id, "ceo", "hello-marker", &fx.deps)
             .await
-            .expect("turn runs");
+            .expect("turn runs")
+            .reply;
 
         assert!(
             reply.contains("hello-marker"),
@@ -789,7 +847,8 @@ description = "Builds the product."
         let first = pool
             .run(&rec.id, "ceo", "alpha task", &fx.deps)
             .await
-            .expect("first turn");
+            .expect("first turn")
+            .reply;
         assert!(
             !first.contains("Relevant prior work"),
             "a cold turn injects nothing: {first:?}"
@@ -809,7 +868,8 @@ description = "Builds the product."
         let second = pool
             .run(&rec.id, "ceo", "alpha", &fx.deps)
             .await
-            .expect("second turn");
+            .expect("second turn")
+            .reply;
         assert!(
             second.contains("Relevant prior work"),
             "the second turn injects the retrieved outcome: {second:?}"
@@ -847,7 +907,8 @@ description = "Builds the product."
         let second = pool
             .run(&rec.id, "ceo", "second", &fx.deps)
             .await
-            .expect("second turn");
+            .expect("second turn")
+            .reply;
 
         assert!(second.contains("second"));
     }
@@ -974,8 +1035,12 @@ description = "Builds the product."
     #[tokio::test]
     async fn turn_wrapper_retries_empty_then_recovers() {
         let (agent, _deps) = scripted_agent(vec![Ok(String::new()), Ok("recovered".into())]);
-        let (reply, usages) = agent.run("hi").await.expect("wrapper recovers");
-        assert!(reply.contains("recovered"), "got {reply:?}");
+        let (outcome, usages) = agent.run("hi").await.expect("wrapper recovers");
+        assert!(
+            outcome.reply.contains("recovered"),
+            "got {:?}",
+            outcome.reply
+        );
         assert_eq!(usages.len(), 2, "both attempts' usage is returned");
     }
 
@@ -984,10 +1049,14 @@ description = "Builds the product."
     #[tokio::test]
     async fn turn_wrapper_empty_twice_is_graceful() {
         let (agent, _deps) = scripted_agent(vec![Ok(String::new()), Ok(String::new())]);
-        let (reply, usages) = agent.run("hi").await.expect("graceful, not an Err");
+        let (outcome, usages) = agent.run("hi").await.expect("graceful, not an Err");
         assert!(
-            reply.to_lowercase().contains("temporary model hiccup"),
-            "got {reply:?}"
+            outcome
+                .reply
+                .to_lowercase()
+                .contains("temporary model hiccup"),
+            "got {:?}",
+            outcome.reply
         );
         assert_eq!(usages.len(), 2);
     }

--- a/src/harness/steps.rs
+++ b/src/harness/steps.rs
@@ -1,0 +1,543 @@
+//! Fold the harness progress stream into the scrubbed [`TurnStep`] timeline
+//! surfaced in operator chat.
+//!
+//! During [`Agent::turn`](openhuman_core::openhuman::agent::Agent) the tinyagents
+//! observability bridge emits a stream of
+//! [`AgentProgress`](oh::agent::progress::AgentProgress) events — tool calls
+//! starting/completing, thinking/text deltas, cost updates, sub-agent lifecycle.
+//! [`CompanyAgent::run`](crate::harness::CompanyAgent) drains that stream into a
+//! `Vec<AgentProgress>` and hands it here; [`fold_steps`] turns it into the
+//! compact, **scrubbed** [`TurnStep`] list that rides back on the operator
+//! bubble.
+//!
+//! Compiled only under `feature = "openhuman"`.
+//!
+//! ## Security (the whole reason this is a separate, unit-tested module)
+//!
+//! The wire shape carries **no raw tool arguments, no tool output, and no call
+//! ids** — only a label, an optional scrubbed detail, and an elapsed time. Three
+//! rules enforce that:
+//!
+//! * **Label** comes from the tool's server-computed `display_label`, else its
+//!   tool *name* — never from arguments or output.
+//! * **Detail on success** is *whitelist-only* enrichment: a fixed per-tool set
+//!   of structural fields (`mcp_call_tool → server·tool`, `delegate_to_desk →
+//!   desk`, `spawn_task → title`). An unknown tool contributes nothing, and the
+//!   nested remote `arguments` of an MCP call are never read — that is exactly
+//!   the re-injection surface this avoids.
+//! * **Detail on failure** is the classifier's plain-language
+//!   [`cause_plain`](oh::tool_status::ClassifiedFailure::cause_plain) when
+//!   present, else the `sanitize_tool_output` **class** string (`"tool: failed
+//!   (timeout)"`) — never the remote error text.
+//!
+//! The unit test `planted_secret_never_reaches_serialized_steps` proves it end
+//! to end: a secret planted in a tool's output, its nested arguments, and its
+//! `display_detail` appears in **no** serialized step.
+//!
+//! Steps must also never enter the memory store — `memory_loop::outcome_chunk`
+//! stays text-only — so a scrubbed detail can never be re-retrieved and
+//! re-injected into a later turn.
+
+use openhuman_core::openhuman as oh;
+use serde_json::Value;
+
+use oh::agent::hooks::sanitize_tool_output;
+use oh::agent::progress::AgentProgress;
+use oh::tool_status::ClassifiedFailure;
+
+use crate::ports::types::{TurnStep, TurnStepKind, TurnStepStatus};
+
+/// Hard cap on the number of steps carried back to the operator. A runaway turn
+/// (a tight tool loop) is truncated to this many, plus one omission note.
+const MAX_STEPS: usize = 50;
+
+/// A `spawn_task` title is truncated to this many chars before it becomes a
+/// step detail — a title is agent-authored free text, so it is bounded even
+/// though it is whitelisted.
+const TITLE_MAX: usize = 80;
+
+/// Fold an ordered progress stream into the scrubbed [`TurnStep`] timeline.
+///
+/// * Pairs each `ToolCallStarted` with its `ToolCallCompleted` by `call_id` into
+///   one step; an unmatched start stays [`Running`](TurnStepStatus::Running).
+/// * Coalesces a run of consecutive `ThinkingDelta`s into one label-only
+///   "Thinking" step.
+/// * Ignores every other event (text deltas, iteration/cost updates, sub-agent
+///   lifecycle) — they carry nothing an operator-facing timeline needs and
+///   would only add noise.
+/// * Caps the result at [`MAX_STEPS`], appending a note when steps were dropped.
+pub fn fold_steps(events: Vec<AgentProgress>) -> Vec<TurnStep> {
+    let mut steps: Vec<TurnStep> = Vec::new();
+    // call_id → index of its (still-running) step in `steps`, so the matching
+    // `ToolCallCompleted` can finalize it in place. Removed on match so a reused
+    // id never double-folds.
+    let mut running: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    // Whether the most recently emitted step is the open "Thinking" run, so
+    // consecutive thinking deltas coalesce into it.
+    let mut thinking_open = false;
+
+    for event in events {
+        match event {
+            AgentProgress::ToolCallStarted {
+                call_id,
+                tool_name,
+                display_label,
+                ..
+            } => {
+                thinking_open = false;
+                // NOTE: `arguments` is `Null` on the tinyagents path here — real
+                // args arrive on `ToolCallCompleted`, so we do not enrich yet.
+                let step = TurnStep {
+                    kind: TurnStepKind::ToolCall,
+                    status: TurnStepStatus::Running,
+                    label: label_for(display_label, &tool_name),
+                    detail: None,
+                    elapsed_ms: None,
+                };
+                running.insert(call_id, steps.len());
+                steps.push(step);
+            }
+            AgentProgress::ToolCallCompleted {
+                call_id,
+                tool_name,
+                success,
+                output,
+                arguments,
+                elapsed_ms,
+                failure,
+                ..
+            } => {
+                thinking_open = false;
+                let status = if success {
+                    TurnStepStatus::Ok
+                } else {
+                    TurnStepStatus::Error
+                };
+                let detail = if success {
+                    enrich_detail(&tool_name, arguments.as_ref())
+                } else {
+                    error_detail(failure.as_ref(), &output, &tool_name)
+                };
+
+                if let Some(idx) = running.remove(&call_id) {
+                    // Finalize the paired start in place, keeping its label.
+                    let step = &mut steps[idx];
+                    step.status = status;
+                    step.elapsed_ms = Some(elapsed_ms);
+                    step.detail = detail;
+                } else {
+                    // A completion with no observed start — surface it standalone.
+                    steps.push(TurnStep {
+                        kind: TurnStepKind::ToolCall,
+                        status,
+                        label: humanize(&tool_name),
+                        detail,
+                        elapsed_ms: Some(elapsed_ms),
+                    });
+                }
+            }
+            // The first thinking delta of a run opens one label-only step.
+            // Consecutive deltas (the guard is already false) fall through to the
+            // catch-all below and fold into that same step.
+            AgentProgress::ThinkingDelta { .. } if !thinking_open => {
+                steps.push(TurnStep {
+                    kind: TurnStepKind::Thinking,
+                    status: TurnStepStatus::Ok,
+                    label: "Thinking".to_string(),
+                    detail: None,
+                    elapsed_ms: None,
+                });
+                thinking_open = true;
+            }
+            AgentProgress::TextDelta { .. } => {
+                // Visible assistant text breaks a thinking run without adding a
+                // step of its own (the reply text is the bubble body).
+                thinking_open = false;
+            }
+            // Everything else (iteration/cost updates, args-delta fragments,
+            // sub-agent lifecycle, task-board, turn-started) contributes no
+            // operator-facing step. It also does not break thinking coalescing.
+            _ => {}
+        }
+    }
+
+    if steps.len() > MAX_STEPS {
+        let omitted = steps.len() - MAX_STEPS;
+        steps.truncate(MAX_STEPS);
+        steps.push(TurnStep {
+            kind: TurnStepKind::Note,
+            status: TurnStepStatus::Ok,
+            label: format!(
+                "{omitted} more step{} omitted",
+                if omitted == 1 { "" } else { "s" }
+            ),
+            detail: None,
+            elapsed_ms: None,
+        });
+    }
+
+    steps
+}
+
+/// The label for a tool step: the server-computed `display_label` when it is a
+/// non-blank string, else a humanized form of the tool name. Never derived from
+/// arguments or output.
+fn label_for(display_label: Option<String>, tool_name: &str) -> String {
+    display_label
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| humanize(tool_name))
+}
+
+/// Turn a `snake_case` / `kebab-case` tool name into a short human label
+/// ("mcp_call_tool" → "Mcp call tool"). Structural only — the input is a tool
+/// identifier, never user/remote text.
+fn humanize(tool_name: &str) -> String {
+    let spaced = tool_name.replace(['_', '-'], " ");
+    let trimmed = spaced.trim();
+    if trimmed.is_empty() {
+        return "Tool".to_string();
+    }
+    let mut chars = trimmed.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => "Tool".to_string(),
+    }
+}
+
+/// Whitelist-only success enrichment. Reads a fixed set of structural fields per
+/// known tool from the arguments the crate captured on the *completed* event.
+/// Any other tool — or a missing field — yields `None`. The nested remote
+/// `arguments` of an MCP call are deliberately never read.
+fn enrich_detail(tool_name: &str, arguments: Option<&Value>) -> Option<String> {
+    let args = arguments?;
+    match tool_name {
+        "mcp_call_tool" => {
+            let server = args.get("server").and_then(Value::as_str)?;
+            let tool = args.get("tool").and_then(Value::as_str)?;
+            Some(format!("{server} · {tool}"))
+        }
+        "delegate_to_desk" => args.get("desk").and_then(Value::as_str).map(str::to_string),
+        "spawn_task" => args
+            .get("title")
+            .and_then(Value::as_str)
+            .map(|title| truncate(title, TITLE_MAX)),
+        _ => None,
+    }
+}
+
+/// The detail for a failed tool call: the classifier's plain-language cause when
+/// present, else the `sanitize_tool_output` **class** string. Never the raw
+/// remote error text.
+fn error_detail(
+    failure: Option<&ClassifiedFailure>,
+    output: &str,
+    tool_name: &str,
+) -> Option<String> {
+    match failure {
+        Some(f) if !f.cause_plain.trim().is_empty() => Some(f.cause_plain.clone()),
+        _ => {
+            let class = sanitize_tool_output(output, tool_name, false);
+            (!class.trim().is_empty()).then_some(class)
+        }
+    }
+}
+
+/// UTF-8-safe truncation to at most `max` chars, appending `…` when cut.
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oh::tool_status::{FailureCategory, ToolFailureClass};
+
+    fn started(call_id: &str, tool: &str, label: Option<&str>) -> AgentProgress {
+        AgentProgress::ToolCallStarted {
+            call_id: call_id.to_string(),
+            tool_name: tool.to_string(),
+            // The tinyagents path sends Null here; mirror that.
+            arguments: Value::Null,
+            iteration: 1,
+            display_label: label.map(str::to_string),
+            display_detail: None,
+        }
+    }
+
+    fn completed(
+        call_id: &str,
+        tool: &str,
+        success: bool,
+        output: &str,
+        arguments: Option<Value>,
+        failure: Option<ClassifiedFailure>,
+    ) -> AgentProgress {
+        AgentProgress::ToolCallCompleted {
+            call_id: call_id.to_string(),
+            tool_name: tool.to_string(),
+            success,
+            output_chars: output.chars().count(),
+            output: output.to_string(),
+            arguments,
+            elapsed_ms: 42,
+            iteration: 1,
+            failure,
+        }
+    }
+
+    fn thinking(delta: &str) -> AgentProgress {
+        AgentProgress::ThinkingDelta {
+            delta: delta.to_string(),
+            iteration: 1,
+        }
+    }
+
+    fn text(delta: &str) -> AgentProgress {
+        AgentProgress::TextDelta {
+            delta: delta.to_string(),
+            iteration: 1,
+        }
+    }
+
+    fn classified(class: ToolFailureClass, cause: &str) -> ClassifiedFailure {
+        ClassifiedFailure {
+            class,
+            category: FailureCategory::Recoverable,
+            cause_plain: cause.to_string(),
+            next_action: "try again".to_string(),
+            recoverable: true,
+        }
+    }
+
+    #[test]
+    fn pairs_started_and_completed_into_one_step() {
+        let steps = fold_steps(vec![
+            started("c1", "mcp_call_tool", Some("Searching the web")),
+            completed(
+                "c1",
+                "mcp_call_tool",
+                true,
+                "ok",
+                Some(serde_json::json!({"server": "brave", "tool": "search"})),
+                None,
+            ),
+        ]);
+        assert_eq!(steps.len(), 1, "one step for the pair: {steps:?}");
+        assert_eq!(steps[0].kind, TurnStepKind::ToolCall);
+        assert_eq!(steps[0].status, TurnStepStatus::Ok);
+        assert_eq!(steps[0].label, "Searching the web");
+        assert_eq!(steps[0].detail.as_deref(), Some("brave · search"));
+        assert_eq!(steps[0].elapsed_ms, Some(42));
+    }
+
+    #[test]
+    fn label_falls_back_to_humanized_tool_name() {
+        let steps = fold_steps(vec![
+            started("c1", "spawn_task", None),
+            completed("c1", "spawn_task", true, "ok", None, None),
+        ]);
+        assert_eq!(steps[0].label, "Spawn task");
+    }
+
+    #[test]
+    fn enriches_delegate_to_desk_and_spawn_task_from_whitelist() {
+        let steps = fold_steps(vec![
+            completed(
+                "d1",
+                "delegate_to_desk",
+                true,
+                "ok",
+                Some(serde_json::json!({"desk": "engineering", "instruction": "ship it"})),
+                None,
+            ),
+            completed(
+                "s1",
+                "spawn_task",
+                true,
+                "ok",
+                Some(serde_json::json!({"title": "Draft the Q3 plan", "note": "secret-in-note"})),
+                None,
+            ),
+        ]);
+        assert_eq!(steps[0].detail.as_deref(), Some("engineering"));
+        assert_eq!(steps[1].detail.as_deref(), Some("Draft the Q3 plan"));
+    }
+
+    #[test]
+    fn unknown_tool_gets_no_detail() {
+        let steps = fold_steps(vec![completed(
+            "c1",
+            "some_other_tool",
+            true,
+            "ok",
+            Some(serde_json::json!({"anything": "at all"})),
+            None,
+        )]);
+        assert_eq!(steps.len(), 1);
+        assert!(steps[0].detail.is_none(), "unknown tool enriches nothing");
+    }
+
+    #[test]
+    fn spawn_task_title_is_truncated() {
+        let long = "x".repeat(200);
+        let steps = fold_steps(vec![completed(
+            "s1",
+            "spawn_task",
+            true,
+            "ok",
+            Some(serde_json::json!({ "title": long })),
+            None,
+        )]);
+        let detail = steps[0].detail.as_deref().unwrap();
+        assert!(detail.ends_with('…'));
+        assert_eq!(detail.chars().count(), TITLE_MAX + 1);
+    }
+
+    #[test]
+    fn error_uses_cause_plain_when_present() {
+        let steps = fold_steps(vec![completed(
+            "c1",
+            "mcp_call_tool",
+            false,
+            "HTTP 503 upstream exploded at https://x.test?token=SECRET",
+            Some(serde_json::json!({"server": "brave", "tool": "search"})),
+            Some(classified(
+                ToolFailureClass::ServiceUnavailable,
+                "The search service was temporarily unavailable.",
+            )),
+        )]);
+        assert_eq!(steps[0].status, TurnStepStatus::Error);
+        assert_eq!(
+            steps[0].detail.as_deref(),
+            Some("The search service was temporarily unavailable.")
+        );
+    }
+
+    #[test]
+    fn error_without_failure_uses_sanitized_class_not_raw_output() {
+        let steps = fold_steps(vec![completed(
+            "c1",
+            "mcp_call_tool",
+            false,
+            "connection refused talking to 10.0.0.5 with token=SUPERSECRET",
+            None,
+            None,
+        )]);
+        let detail = steps[0].detail.as_deref().unwrap();
+        // A safe class string, never the raw remote text.
+        assert_eq!(detail, "mcp_call_tool: failed (connection_error)");
+        assert!(!detail.contains("SUPERSECRET"));
+        assert!(!detail.contains("10.0.0.5"));
+    }
+
+    #[test]
+    fn consecutive_thinking_coalesces_but_text_between_splits() {
+        let steps = fold_steps(vec![
+            thinking("let"),
+            thinking(" me"),
+            thinking(" think"),
+            text("Here"),
+            thinking("more"),
+            thinking(" thought"),
+        ]);
+        let thinking_steps: Vec<_> = steps
+            .iter()
+            .filter(|s| s.kind == TurnStepKind::Thinking)
+            .collect();
+        assert_eq!(
+            thinking_steps.len(),
+            2,
+            "two runs (split by the text delta): {steps:?}"
+        );
+        assert!(thinking_steps.iter().all(|s| s.label == "Thinking"));
+        assert!(thinking_steps.iter().all(|s| s.detail.is_none()));
+    }
+
+    #[test]
+    fn unmatched_started_stays_running() {
+        let steps = fold_steps(vec![started("c1", "mcp_call_tool", Some("Searching"))]);
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].status, TurnStepStatus::Running);
+        assert_eq!(steps[0].elapsed_ms, None);
+    }
+
+    #[test]
+    fn caps_at_fifty_with_omission_note() {
+        let mut events = Vec::new();
+        for i in 0..60 {
+            events.push(completed(
+                &format!("c{i}"),
+                "spawn_task",
+                true,
+                "ok",
+                None,
+                None,
+            ));
+        }
+        let steps = fold_steps(events);
+        assert_eq!(steps.len(), MAX_STEPS + 1, "50 steps + one omission note");
+        let note = steps.last().unwrap();
+        assert_eq!(note.kind, TurnStepKind::Note);
+        assert_eq!(note.label, "10 more steps omitted");
+    }
+
+    /// SECURITY: a secret planted in a tool's raw output, its nested remote
+    /// `arguments`, and its `display_detail` must appear in **no** serialized
+    /// step. This is the wire-level guarantee the whole module exists to keep.
+    #[test]
+    fn planted_secret_never_reaches_serialized_steps() {
+        const SECRET: &str = "sk-live-PLANTEDSECRET-abc123";
+        let events = vec![
+            // display_detail carries the secret; we never read it.
+            AgentProgress::ToolCallStarted {
+                call_id: "c1".to_string(),
+                tool_name: "mcp_call_tool".to_string(),
+                arguments: Value::Null,
+                iteration: 1,
+                display_label: Some("Calling a remote tool".to_string()),
+                display_detail: Some(format!("auth={SECRET}")),
+            },
+            // Success: nested remote arguments carry the secret; output carries it.
+            completed(
+                "c1",
+                "mcp_call_tool",
+                true,
+                &format!("remote said: {SECRET}"),
+                Some(serde_json::json!({
+                    "server": "brave",
+                    "tool": "search",
+                    "arguments": { "api_key": SECRET }
+                })),
+                None,
+            ),
+            // A failing call whose raw output also carries the secret.
+            completed(
+                "c2",
+                "mcp_call_tool",
+                false,
+                &format!("401 unauthorized token={SECRET}"),
+                Some(serde_json::json!({ "server": "brave", "tool": "search" })),
+                None,
+            ),
+        ];
+        let steps = fold_steps(events);
+        let json = serde_json::to_string(&steps).expect("steps serialize");
+        assert!(
+            !json.contains(SECRET),
+            "a planted secret leaked into the serialized steps: {json}"
+        );
+        assert!(!json.contains("api_key"), "nested arg keys must not leak");
+    }
+
+    /// A memory-served answer runs zero steps — the tell that distinguishes it
+    /// from a tool-backed one — so an empty stream folds to an empty timeline.
+    #[test]
+    fn empty_stream_folds_to_no_steps() {
+        assert!(fold_steps(Vec::new()).is_empty());
+    }
+}

--- a/src/openhuman/channel.rs
+++ b/src/openhuman/channel.rs
@@ -69,6 +69,7 @@ mod test {
             .send(OutboundMessage {
                 channel: "email".into(),
                 text: "hello".into(),
+                steps: Vec::new(),
             })
             .await
             .unwrap();
@@ -95,6 +96,7 @@ mod test {
             .send(OutboundMessage {
                 channel: "email".into(),
                 text: "hi".into(),
+                steps: Vec::new(),
             })
             .await
             .unwrap_err();

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -691,6 +691,78 @@ pub struct OutboundMessage {
     pub channel: String,
     /// The message text.
     pub text: String,
+    /// The visible processing steps behind this bubble — the agent's tool calls,
+    /// thinking runs, and any surfaced MCP failures — folded and scrubbed from
+    /// the turn's progress stream (see [`crate::harness::steps`] under the
+    /// `openhuman` feature). Per-bubble ownership: the operator bubble carries the
+    /// orchestrator's steps; a delegated desk bubble carries that desk lead's
+    /// steps.
+    ///
+    /// Additive and non-secret: the field is omitted on the wire when empty, so
+    /// every prior producer (and every non-harness brain, which emits none)
+    /// round-trips byte-identically. Never carries raw tool arguments, tool
+    /// output, or call ids — only the scrubbed [`TurnStep`] shape.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub steps: Vec<TurnStep>,
+}
+
+/// One visible step in an agent turn's processing timeline, surfaced in the
+/// operator chat.
+///
+/// The point of the timeline: a failed tool call becomes visible (instead of a
+/// vague acknowledgement), and a memory-served answer — which runs **zero**
+/// steps — is distinguishable from a tool-backed one. Folded from the harness
+/// progress stream by [`crate::harness::steps`] (compiled under the `openhuman`
+/// feature); every field is scrubbed there before it reaches this shape.
+///
+/// The wire form is additive and camelCase (`elapsedMs`).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TurnStep {
+    /// What kind of step this is (drives the icon in the UI).
+    pub kind: TurnStepKind,
+    /// How the step ended.
+    pub status: TurnStepStatus,
+    /// A short, human label (e.g. "Reading messages", "Thinking"). Derived from
+    /// the tool's server-computed `display_label`, else its tool name — never
+    /// from tool arguments or output.
+    pub label: String,
+    /// An optional muted detail: whitelisted, scrubbed enrichment (e.g. an MCP
+    /// `server · tool`, a delegated desk, a task title) or a plain-language
+    /// failure cause. **Never** raw tool output or arguments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    /// How long the step took in milliseconds, when known (tool calls report it;
+    /// thinking/note steps do not).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub elapsed_ms: Option<u64>,
+}
+
+/// The kind of a [`TurnStep`], driving its icon in the timeline. Serialized in
+/// `snake_case` (`tool_call` / `thinking` / `note`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnStepKind {
+    /// A tool call (a paired started/completed pair, or an unmatched one).
+    ToolCall,
+    /// A run of the model's reasoning, coalesced to a single "Thinking" step.
+    Thinking,
+    /// A standalone note — e.g. a surfaced MCP failure or the cap-omission
+    /// marker.
+    Note,
+}
+
+/// How a [`TurnStep`] ended. Serialized in `snake_case` (`ok` / `error` /
+/// `running`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnStepStatus {
+    /// Completed successfully (or an informational step).
+    Ok,
+    /// Failed — rendered in the destructive tone.
+    Error,
+    /// Started but no completion was observed by the end of the turn.
+    Running,
 }
 
 // ---------------------------------------------------------------------------
@@ -885,6 +957,82 @@ mod test {
     {
         let json = serde_json::to_string(value).expect("serialize");
         serde_json::from_str(&json).expect("deserialize")
+    }
+
+    /// The `TurnStep` wire shape is camelCase with snake_case enum values:
+    /// `{kind, status, label, detail?, elapsedMs?}`. Locks the contract the
+    /// console `TurnStep` mirror in `frontend/src/api/types.ts` depends on.
+    #[test]
+    fn turn_step_wire_shape_is_camel_case_with_snake_case_enums() {
+        let step = TurnStep {
+            kind: TurnStepKind::ToolCall,
+            status: TurnStepStatus::Error,
+            label: "Searching the web".to_string(),
+            detail: Some("brave · search".to_string()),
+            elapsed_ms: Some(1234),
+        };
+        let json = serde_json::to_value(&step).unwrap();
+        assert_eq!(json["kind"], "tool_call");
+        assert_eq!(json["status"], "error");
+        assert_eq!(json["label"], "Searching the web");
+        assert_eq!(json["detail"], "brave · search");
+        assert_eq!(json["elapsedMs"], 1234);
+        assert_eq!(round_trip(&step), step);
+    }
+
+    /// A step with no detail/elapsed omits both keys, and every kind/status
+    /// value serializes to its documented snake_case token.
+    #[test]
+    fn turn_step_omits_absent_fields_and_covers_every_variant() {
+        let bare = TurnStep {
+            kind: TurnStepKind::Thinking,
+            status: TurnStepStatus::Ok,
+            label: "Thinking".to_string(),
+            detail: None,
+            elapsed_ms: None,
+        };
+        let json = serde_json::to_value(&bare).unwrap();
+        assert_eq!(json["kind"], "thinking");
+        assert_eq!(json["status"], "ok");
+        assert!(json.get("detail").is_none(), "absent detail is omitted");
+        assert!(json.get("elapsedMs").is_none(), "absent elapsed is omitted");
+
+        assert_eq!(serde_json::to_value(TurnStepKind::Note).unwrap(), "note");
+        assert_eq!(
+            serde_json::to_value(TurnStepStatus::Running).unwrap(),
+            "running"
+        );
+    }
+
+    /// `OutboundMessage.steps` is additive: an empty timeline is omitted from
+    /// the wire entirely (so every prior producer round-trips byte-identically),
+    /// and a legacy `{channel, text}` payload still loads with an empty `steps`.
+    #[test]
+    fn outbound_message_steps_are_additive_and_omitted_when_empty() {
+        let no_steps = OutboundMessage {
+            channel: "operator".to_string(),
+            text: "hi".to_string(),
+            steps: Vec::new(),
+        };
+        let json = serde_json::to_string(&no_steps).unwrap();
+        assert_eq!(json, r#"{"channel":"operator","text":"hi"}"#);
+
+        let legacy: OutboundMessage =
+            serde_json::from_str(r#"{"channel":"operator","text":"hi"}"#).unwrap();
+        assert!(legacy.steps.is_empty());
+
+        let with_steps = OutboundMessage {
+            channel: "operator".to_string(),
+            text: "done".to_string(),
+            steps: vec![TurnStep {
+                kind: TurnStepKind::Note,
+                status: TurnStepStatus::Error,
+                label: "MCP: brave unavailable".to_string(),
+                detail: Some("server rejected the call".to_string()),
+                elapsed_ms: None,
+            }],
+        };
+        assert_eq!(round_trip(&with_steps), with_steps);
     }
 
     #[test]

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -75,6 +75,7 @@ mod test {
             .send(OutboundMessage {
                 channel: "operator".into(),
                 text: "hello".into(),
+                steps: Vec::new(),
             })
             .await
             .unwrap();

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -267,6 +267,7 @@ async fn perform_effect(rt: &CompanyRuntime, effect: &Effect) -> Result<()> {
                     .send(OutboundMessage {
                         channel: channel.to_string(),
                         text: text.to_string(),
+                        steps: Vec::new(),
                     })
                     .await?;
                 break;
@@ -426,6 +427,7 @@ mod test {
                     responses.push(OutboundMessage {
                         channel: "operator".into(),
                         text: format!("handled: {text}"),
+                        steps: Vec::new(),
                     });
                 }
             }

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -271,6 +271,7 @@ mod test {
                     responses.push(OutboundMessage {
                         channel: "operator".into(),
                         text: format!("scheduled: {prompt}"),
+                        steps: Vec::new(),
                     });
                 }
             }

--- a/src/server/provision/test.rs
+++ b/src/server/provision/test.rs
@@ -676,6 +676,7 @@ impl Brain for EffectBrain {
                 responses.push(OutboundMessage {
                     channel: "operator".into(),
                     text: format!("handled: {text}"),
+                    steps: Vec::new(),
                 });
             }
         }

--- a/src/workflows/caps.rs
+++ b/src/workflows/caps.rs
@@ -92,14 +92,16 @@ impl AgentRunner for HarnessAgentRunner {
             agent = agent_ref,
             "workflow agent node: routing to harness pool"
         );
-        let reply = self
+        let outcome = self
             .pool
             .run(&self.company, agent_ref, &message, &self.deps)
             .await
             .map_err(|e| EngineError::Capability(format!("harness agent '{agent_ref}': {e}")))?;
         // Mirror the engine's `{ json, text, raw }` envelope shape: expose the
-        // reply as `text` so a downstream `=item.text` binding resolves.
-        Ok(json!({ "text": reply, "agent_ref": agent_ref }))
+        // reply as `text` so a downstream `=item.text` binding resolves. A
+        // workflow node carries no chat bubble, so the turn's steps are dropped
+        // here (they surface only on operator/desk chat replies).
+        Ok(json!({ "text": outcome.reply, "agent_ref": agent_ref }))
     }
 }
 


### PR DESCRIPTION
## Summary

The operator chat returned only final text, so a failed MCP call looked like a vague ack and a memory-served answer was indistinguishable from a tool-backed one. This adds a scrubbed `steps[]` activity trace per turn: `Agent::set_on_progress` captures ToolCallStarted/Completed + ThinkingDelta during the turn; a new `harness/steps.rs` folds them into `TurnStep`s and a `StepTimeline` renders above each chat bubble (collapsed "N steps · M failed", auto-expand on error). **Zero steps is the tell** that an answer was memory-served. Also re-skins MCP-hardening's failure surface into the same `steps[]` renderer. Stacked on MCP-hardening + #55 — diff includes them until they merge.

> Note: Sibling of the channels-telegram PR — both append a field to `OutboundMessage` (no `Default`) across ~12 construction sites; whichever merges second rebases.

## API Or Behavior Changes

Additive `steps: Vec<TurnStep>` on `OutboundMessage` (serde default, skip-empty); `HarnessPool::run` now returns `TurnOutcome{reply, steps}`.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo build --all-targets`
- [x] `cargo test` (517 passing; `cargo test --features openhuman` = 644)

**Security**: the wire carries NO raw arguments/output/call_id — whitelist-only enrichment, errors are `cause_plain`/sanitize-class; `planted_secret_never_reaches_serialized_steps` asserts a planted secret (in output, nested args, error text) never survives serialization. Frontend typecheck + build clean.

## Documentation

`docs/spec/runtime/ports.md` documents `steps`.
