### PR TITLE
fix(console): cap dialog height + scroll + sticky footer so task actions stay reachable (#74)

### DIFF
--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -53,7 +53,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid max-h-[90vh] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}
@@ -102,7 +102,7 @@ function DialogFooter({
     <div
       data-slot="dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        "sticky bottom-[-1rem] -mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

The task detail dialog had no height cap or overflow handling. It's vertically
centered (`-translate-y-1/2`), so tall content — e.g. an "in review" task card
whose 8-row textarea holds a completed agent result — overflowed both the top
and bottom of the viewport, pushing the footer actions (Delete/Cancel/Save)
below the fold and out of reach.

Fix: cap `DialogContent` at `max-h-[90vh]` with `overflow-y-auto` so it scrolls
internally instead of overflowing, and make `DialogFooter` `sticky
bottom-[-1rem]` so the action buttons stay pinned and visible while the body
scrolls (the footer already has `bg-muted/50 border-t`, so it reads cleanly
over scrolled content).

Frontend-only change, scoped to `frontend/src/components/ui/dialog.tsx`.

Closes #74

## API Or Behavior Changes

No public API changes. Behavior change: the shared `Dialog` component (used by
every dialog in the console, including the task detail dialog) now caps its
height at 90% of the viewport and scrolls its content internally instead of
overflowing off-screen; the footer action row stays pinned to the bottom of
the visible dialog while scrolling.

## Tests

- [x] `npm run typecheck` (frontend)
- [x] `npm run build` (frontend)
- N/A: `cargo fmt --all -- --check` — frontend-only change, no Rust touched
- N/A: `cargo clippy --all-targets -- -D warnings` — frontend-only change, no Rust touched
- N/A: `cargo build --all-targets` — frontend-only change, no Rust touched
- N/A: `cargo test` — frontend-only change, no Rust touched

## Documentation

No docs impacted — this is a CSS-only layout fix to an existing shared UI
primitive; no new API or usage pattern to document.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dialog opening transitions and removed the default focus outline.
  * Kept dialog footers visible and accessible while scrolling through longer content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->