### PR TITLE
feat(server,console): persist team roster via GET/POST/DELETE .../team (#73)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -212,6 +212,27 @@ export class OpenCompanyClient {
   }
 
   /**
+   * Add an operator-defined teammate (a "team overlay" agent). Persists on the
+   * host and shows up in `listTeam` afterwards — never returned by the write
+   * itself, so callers should refetch. Hosts without the write plane 404;
+   * callers fall back to a local-only add.
+   */
+  addTeamMember(
+    input: { name: string; role: string; description?: string },
+    company?: string | null,
+  ): Promise<TeamMemberDto> {
+    return this.request<TeamMemberDto>("POST", `${this.scope(company)}/team`, input);
+  }
+
+  /** Remove an operator-added teammate. 409s for a manifest teammate (can't be removed here). */
+  removeTeamMember(agentId: string, company?: string | null): Promise<void> {
+    return this.request<void>(
+      "DELETE",
+      `${this.scope(company)}/team/${encodeURIComponent(agentId)}`,
+    );
+  }
+
+  /**
    * Third-party connections for a company (forward-looking surface). Hosts
    * that don't expose it yet return 404 — callers treat that as "unavailable".
    */

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { Mail, MoreHorizontal, Plus, Sparkles, UserPlus } from "lucide-react";
+import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
+import { ApiError } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -66,10 +68,12 @@ export function TeamView({ client, company }: Props) {
         setFromHost(true);
       } else {
         setMembers(starterTeam());
+        setFromHost(false);
       }
     } catch {
       // No roster surface on this host yet — start from an editable team.
       setMembers(starterTeam());
+      setFromHost(false);
     } finally {
       setLoad("ready");
     }
@@ -80,10 +84,42 @@ export function TeamView({ client, company }: Props) {
     void boot();
   }, [boot]);
 
-  function addMember(fields: { name: string; role: string; description: string; inbox?: boolean }) {
-    setMembers((m) => [...m, newMember(fields)]);
+  async function addMember(fields: { name: string; role: string; description: string; inbox?: boolean }) {
+    try {
+      await client.addTeamMember(
+        { name: fields.name, role: fields.role, description: fields.description || undefined },
+        company,
+      );
+      // Persisted on the host — refetch so the card reflects the real record
+      // (id, merge order) rather than a locally-guessed one.
+      await boot();
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 404) {
+        // No team write plane on this host — keep the edit local-only.
+        setMembers((m) => [...m, newMember(fields)]);
+      } else {
+        toast.error(error instanceof Error ? error.message : "Couldn't add teammate.");
+        return;
+      }
+    }
     if (fields.inbox) toggleMemberInbox(fields.name);
     setAddOpen(false);
+  }
+
+  async function removeMember(member: TeamMember) {
+    try {
+      await client.removeTeamMember(member.id, company);
+      await boot();
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 404) {
+        // No team write plane on this host — drop it from local state only.
+        setMembers((ms) => ms.filter((x) => x.id !== member.id));
+      } else if (error instanceof ApiError && error.status === 409) {
+        toast.error("This teammate is defined in the company manifest and can't be removed here.");
+      } else {
+        toast.error(error instanceof Error ? error.message : "Couldn't remove teammate.");
+      }
+    }
   }
 
   return (
@@ -115,7 +151,7 @@ export function TeamView({ client, company }: Props) {
                 member={m}
                 inboxOn={isInboxEnabled(inboxes, m.name)}
                 onToggleInbox={() => toggleMemberInbox(m.name)}
-                onRemove={() => setMembers((ms) => ms.filter((x) => x.id !== m.id))}
+                onRemove={() => void removeMember(m)}
               />
             ))}
             <button

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -10,7 +10,7 @@
 
 use axum::extract::Path;
 use axum::http::StatusCode;
-use axum::routing::{delete, post, put};
+use axum::routing::{delete, get, put};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
@@ -26,7 +26,7 @@ use crate::server::ops::{DOMAIN_KEY, ScopedCompany, scoped};
 
 /// Builds the team route fragment.
 pub fn router() -> Router<AppState> {
-    scoped("/team", post(add_member))
+    scoped("/team", get(list_team).post(add_member))
         .merge(scoped("/team/{agent_id}", delete(remove_member)))
         .merge(scoped("/team/{agent_id}/inbox", put(toggle_inbox)))
 }
@@ -69,6 +69,39 @@ struct InboxAck {
 #[derive(Debug, Deserialize)]
 struct AgentPath {
     agent_id: String,
+}
+
+/// `GET {scope}/team` — the merged roster: manifest teammates (versioned in
+/// `company.toml`, `name: null` — the console falls back to the role) plus
+/// operator-added overlay teammates (`name` always set). Mirrors the GraphQL
+/// `resolve_team` merge (minus its `inbox_enabled` field, which has no REST
+/// consumer yet). Hosts with no persisted record yet return an empty roster,
+/// the same soft-fail the sibling `/desks` route uses, rather than 404ing.
+async fn list_team(company: ScopedCompany) -> Result<Json<Vec<TeamMemberDto>>, ApiError> {
+    let record = company.runtime.store().load(company.id()).await?;
+    let members = record
+        .map(|record| {
+            let mut members: Vec<TeamMemberDto> = record
+                .manifest
+                .agents
+                .iter()
+                .map(|agent| TeamMemberDto {
+                    id: agent.id.clone(),
+                    name: None,
+                    role: agent.role.clone(),
+                    description: agent.description.clone(),
+                })
+                .collect();
+            members.extend(record.overlay_agents.iter().map(|agent| TeamMemberDto {
+                id: agent.id.clone(),
+                name: Some(agent.name.clone()),
+                role: agent.role.clone(),
+                description: agent.description.clone(),
+            }));
+            members
+        })
+        .unwrap_or_default();
+    Ok(Json(members))
 }
 
 async fn add_member(

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -588,6 +588,16 @@ async fn team_overlay_add_delete_and_manifest_delete_conflict() {
     let home = home();
     let state = state_with_company(&home).await;
 
+    // The manifest teammate shows up on the read side before any overlay add,
+    // named `null` (the console falls back to the role).
+    let (status, roster) = send(&state, "GET", "/api/v1/company/team", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let roster = roster.as_array().unwrap();
+    assert_eq!(roster.len(), 1);
+    assert_eq!(roster[0]["id"], "ceo");
+    assert_eq!(roster[0]["role"], "Chief");
+    assert!(roster[0]["name"].is_null());
+
     // Add an overlay teammate.
     let (status, member) = send(
         &state,
@@ -599,6 +609,15 @@ async fn team_overlay_add_delete_and_manifest_delete_conflict() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(member["role"], "Designer");
     let id = member["id"].as_str().unwrap().to_string();
+
+    // The read side now merges in the overlay teammate, named this time.
+    let (status, roster) = send(&state, "GET", "/api/v1/company/team", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let roster = roster.as_array().unwrap();
+    assert_eq!(roster.len(), 2);
+    let dana = roster.iter().find(|m| m["id"] == id).unwrap();
+    assert_eq!(dana["name"], "Dana");
+    assert_eq!(dana["role"], "Designer");
 
     // Deleting a manifest teammate is a 409.
     let (status, body) = send(&state, "DELETE", "/api/v1/company/team/ceo", None).await;
@@ -614,6 +633,13 @@ async fn team_overlay_add_delete_and_manifest_delete_conflict() {
     )
     .await;
     assert_eq!(status, StatusCode::NO_CONTENT);
+
+    // The removed overlay teammate is gone from the read side too.
+    let (status, roster) = send(&state, "GET", "/api/v1/company/team", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let roster = roster.as_array().unwrap();
+    assert_eq!(roster.len(), 1);
+    assert_eq!(roster[0]["id"], "ceo");
 
     // Toggle an inbox on.
     let (status, ack) = send(


### PR DESCRIPTION
## Summary

Team add/remove in the console was local-only — `addMember` did a bare `setMembers([...])` React update that vanished on reload, because the server had no REST read for the roster (only writes: add/remove/toggle-inbox) and `client.listTeam` always 404'd. This adds the missing `GET .../team` route and wires the console's add/remove flows to actually persist through it, with a graceful local-only fallback preserved for hosts that don't expose the write plane yet.

- **Backend** (`src/server/ops/team.rs`): added `list_team` on `GET .../team`, reusing the exact manifest-agents + overlay-agents merge that GraphQL's `resolve_team` (`src/server/graphql/company.rs`) already uses, so both surfaces return the same shape. Soft-fails to an empty roster for a company with no persisted record yet (same pattern as the sibling `/desks` route) instead of 404ing.
- **Frontend** (`frontend/src/api/client.ts`, `frontend/src/views/TeamView.tsx`): added `client.addTeamMember`/`client.removeTeamMember`; `TeamView.addMember`/new `removeMember` now call the host and refetch `listTeam` on success, falling back to the old local-only behavior only on a 404 (no write plane), and surfacing a toast for a 409 (manifest teammate can't be removed) or any other error.

## API Or Behavior Changes

- New route: `GET {scope}/team` — returns the merged roster (`TeamMemberDto[]`), manifest teammates first (`name: null`) then overlay teammates (`name` set). No auth/scoping changes — same `ScopedCompany` extractor as the existing team routes.
- Console behavior change: adding or removing a teammate now persists on hosts that expose the route, and the card reflects the real host record (id, merge order) after a refetch instead of a locally-guessed one. Hosts that still 404 the team surface keep the previous local-only behavior unchanged.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo build --all-targets` — not run standalone; covered by `cargo test` build + clippy build above
- [x] `cargo test` (556 passed, 1 pre-existing ignored, 0 failed) — extended `team_overlay_add_delete_and_manifest_delete_conflict` to assert the GET roster before any overlay add (manifest teammate only, `name: null`), after an overlay add (both teammates merged), and after the overlay removal (back to manifest-only)
- [x] `cd frontend && npm run typecheck` — clean
- [x] `cd frontend && npm run build` — clean (pre-existing chunk-size warning only, unrelated to this change)

All gates run with default features — this route isn't `openhuman`-gated.

## Documentation

None needed — this is a new route on an existing, already-documented domain (`team`), following the same shape/merge contract GraphQL already documents via `resolve_team`.

Closes #73


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing the complete team roster.
  * Added the ability to add and remove team members with server synchronization.
  * Team rosters now combine manifest-defined and manually added members.

* **Bug Fixes**
  * Improved handling of unavailable team services with local fallback behavior.
  * Added clearer error messages for failed additions or removals, including manifest-defined members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->