### PR TITLE
feat(harness): add run_workflow orchestrator tool (#67)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,7 +657,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "shlex 1.3.0",
  "syn 2.0.118",
 ]
@@ -2022,6 +2022,22 @@ dependencies = [
  "rustc_version",
  "syn 2.0.118",
  "unicode-xid",
+]
+
+[[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
 ]
 
 [[package]]
@@ -4583,6 +4599,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5418,6 +5440,7 @@ dependencies = [
  "cron",
  "crossterm",
  "curve25519-dalek",
+ "dhat",
  "directories",
  "dirs 5.0.1",
  "docx-rs",
@@ -6278,7 +6301,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -6300,7 +6323,7 @@ dependencies = [
  "rand 0.10.2",
  "rand_pcg",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -6878,6 +6901,12 @@ name = "rustc-demangle"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -8134,6 +8163,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -106,6 +106,7 @@ async fn main() -> anyhow::Result<()> {
         facts: None,
         events: None,
         delegations: opencompany::harness::orchestrator::DelegationQueue::default(),
+        workflow_runner: opencompany::harness::orchestrator::WorkflowRunnerHandle::default(),
         mcp_failures: opencompany::harness::mcp_probe::McpFailureQueue::default(),
         secrets: None,
     };

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -409,6 +409,7 @@ description = "Runs Acme."
             facts: None,
             events: None,
             delegations: orchestrator::DelegationQueue::default(),
+            workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             secrets: None,
         };
@@ -540,6 +541,7 @@ description = "Builds it."
             facts: None,
             events: None,
             delegations: orchestrator::DelegationQueue::default(),
+            workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             secrets: None,
         };
@@ -735,6 +737,7 @@ members = ["engineer"]
             facts: None,
             events: None,
             delegations: orchestrator::DelegationQueue::default(),
+            workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             secrets: None,
         };
@@ -856,6 +859,7 @@ members = ["engineer"]
             facts: None,
             events: Some(events.clone()),
             delegations: orchestrator::DelegationQueue::default(),
+            workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: failures.clone(),
             secrets: None,
         };

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -45,7 +45,7 @@ use crate::harness::mcp::{
     OcMcpCallTool, OcMcpListServersTool, capability_brief, granted_secrets, registry_for_agent,
 };
 use crate::harness::memory::OcMemory;
-use crate::harness::orchestrator::{self, QueryCompanyTool};
+use crate::harness::orchestrator;
 use crate::harness::policy::ApprovalPolicy;
 use crate::harness::skills::EffectiveSkills;
 use crate::ports::skills_state::SkillState;
@@ -203,19 +203,25 @@ pub fn build_agent(
         persona.push_str(&capability_brief());
     }
 
-    // Orchestrator seam (issue #53): the company's orchestrator agent additionally
-    // gets the delegating-orchestrator persona + tools. `query_company` reads the
-    // company's facts + recent events; `spawn_task` / `delegate_to_desk` push onto
-    // the shared delegation queue the brain drains after the turn. Additive beside
-    // the MCP block above.
+    // Orchestrator seam (issues #53 + #67): the company's orchestrator agent
+    // additionally gets the delegating-orchestrator persona + tools. `query_company`
+    // reads the company's facts + recent events; `spawn_task` / `delegate_to_desk`
+    // push onto the shared delegation queue the brain drains after the turn;
+    // `run_workflow` executes one of the company's saved workflows by id through
+    // the shared runner handle (so a task waiting on a workflow can be run to
+    // completion). Additive beside the MCP block above.
     if is_orchestrator {
         persona.push_str(&orchestrator::orchestrator_brief());
-        tools.push(Box::new(QueryCompanyTool::new(
+        tools.extend(orchestrator::orchestrator_tools(
             company.clone(),
             deps.facts.clone(),
             deps.events.clone(),
-        )));
-        tools.extend(orchestrator::delegation_tools(&deps.delegations));
+            &deps.delegations,
+            // The company source dir (`companies/<name>`) also houses `workflows/`,
+            // which the `run_workflow` tool loads graphs from.
+            deps.skills_source_dir.clone(),
+            deps.workflow_runner.clone(),
+        ));
     }
 
     let prompt_builder = SystemPromptBuilder::for_subagent(

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -553,12 +553,19 @@ pub(crate) fn build_roster(
         .map(|manifest_agent| {
             let agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily);
             let is_orchestrator = orchestrator.as_deref() == Some(manifest_agent.id.as_str());
+            // This agent's effective tool grants: its own `tools` narrowed by the
+            // company `[tools].allow`-list (full allow-list when it lists none).
+            let grants = crate::runtime::builder::agent_effective_grants(
+                &company.manifest.tools.allow,
+                &manifest_agent.tools,
+            );
             let agent = build::build_agent(
                 &company.id,
                 company_name,
                 manifest_agent,
                 agent_policy,
                 deps,
+                &grants,
                 skill_deltas,
                 is_orchestrator,
             )?;

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -136,6 +136,16 @@ pub struct HarnessDeps {
     /// handle; cloning `HarnessDeps` shares one queue between the tools built
     /// into the agent and the brain that drains it. Default is an empty queue.
     pub delegations: DelegationQueue,
+    /// The shared handle to the company's [`WorkflowRunner`](crate::ports::WorkflowRunner),
+    /// so the orchestrator's `run_workflow` tool can reach the runner that is
+    /// itself built *from* these deps (issue #67). The runtime builder threads an
+    /// empty handle here, builds the [`HarnessWorkflowRunner`](crate::workflows::HarnessWorkflowRunner)
+    /// from a deps clone, then fills the shared cell — so the orchestrator agent
+    /// (built later from a clone of these deps) reaches it at turn time. The cell
+    /// holds a [`Weak`](std::sync::Weak), so deps↔runner is not a strong cycle.
+    /// Default (and any build with no runner) leaves it empty and the tool
+    /// reports workflow execution is not wired.
+    pub workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle,
     /// The shared MCP failure queue the `OcMcpCallTool` decorator pushes onto and
     /// the [`HarnessBrain`] drains after a turn (the error-hardening cell). Same
     /// cheap-shared-handle pattern as [`Self::delegations`]; every string it
@@ -755,6 +765,7 @@ description = "Builds the product."
                 facts: None,
                 events: None,
                 delegations: DelegationQueue::default(),
+                workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
                 mcp_failures: McpFailureQueue::default(),
                 secrets: None,
             },
@@ -804,6 +815,7 @@ description = "Builds the product."
             facts: None,
             events: None,
             delegations: DelegationQueue::default(),
+            workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             secrets: None,
         };
@@ -1027,6 +1039,7 @@ description = "Builds the product."
             facts: None,
             events: None,
             delegations: DelegationQueue::default(),
+            workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             secrets: None,
         };
@@ -1144,6 +1157,7 @@ description = "Builds the product."
             facts: None,
             events: None,
             delegations: DelegationQueue::default(),
+            workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             secrets: Some(secrets.clone()),
         };

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -9,7 +9,7 @@
 //! first agent when none is tagged (so a company without an orchestrator behaves
 //! exactly as before).
 //!
-//! It reaches three tools, all wired only onto the orchestrator agent:
+//! It reaches four tools, all wired only onto the orchestrator agent:
 //!
 //! * [`QueryCompanyTool`] — a read surface over the company's [`FactStore`] and
 //!   recent [`EventLog`] history.
@@ -18,10 +18,18 @@
 //!   themselves; the [`HarnessBrain`](crate::harness::HarnessBrain) drains the
 //!   queue after the orchestrator's turn (v1: synchronous, in-cycle, capped at
 //!   [`MAX_DELEGATIONS_PER_TURN`], no sub-agent re-delegation).
+//! * [`RunWorkflowTool`] — executes one of the company's saved workflow graphs
+//!   by id via the [`WorkflowRunner`] port (issue #67). It loads the graph from
+//!   the company source directory (the same loader the REST run route uses) and
+//!   invokes the runner reached through a shared [`WorkflowRunnerHandle`], so a
+//!   task waiting on a workflow can actually be run to completion. Unlike the
+//!   delegation tools it runs the graph inline and returns a concise summary of
+//!   the run rather than enqueuing deferred work.
 //!
 //! Compiled only under `feature = "openhuman"` (the whole `harness` module is).
 
-use std::sync::{Arc, Mutex};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, OnceLock, Weak};
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
@@ -30,10 +38,11 @@ use openhuman_core::openhuman as oh;
 
 use oh::tools::traits::{PermissionLevel, Tool, ToolResult};
 
-use crate::company::Agent as ManifestAgent;
+use crate::company::{Agent as ManifestAgent, WorkflowFile, load_company_workflows};
 use crate::ports::events::EventLog;
 use crate::ports::facts::FactStore;
 use crate::ports::types::{CompanyEvent, CompanyId, EventSeq};
+use crate::ports::{WorkflowRun, WorkflowRunner};
 
 /// The manifest cognition-tier that marks the orchestrator agent.
 pub const ORCHESTRATOR_TIER: &str = "orchestrator";
@@ -54,6 +63,8 @@ pub const QUERY_COMPANY_TOOL: &str = "query_company";
 pub const SPAWN_TASK_TOOL: &str = "spawn_task";
 /// The `delegate_to_desk` tool name.
 pub const DELEGATE_TO_DESK_TOOL: &str = "delegate_to_desk";
+/// The `run_workflow` tool name.
+pub const RUN_WORKFLOW_TOOL: &str = "run_workflow";
 
 /// The id of the orchestrator agent for a roster: the first agent tagged
 /// `tier = "orchestrator"`, else the first roster agent, else `None` (empty
@@ -83,8 +94,10 @@ pub fn orchestrator_brief() -> String {
 Answer from whole-company context, and when a request belongs to a specialist desk or should be \
 tracked as work, delegate instead of guessing. Use `query_company` to ground answers in the \
 company's durable facts and recent activity, `delegate_to_desk` to hand a turn to a desk's lead \
-member, and `spawn_task` to open a tracked task card. Delegate only when it genuinely helps — \
-otherwise answer directly and concisely."
+member, `spawn_task` to open a tracked task card, and `run_workflow` to execute one of the \
+company's saved workflows by id (for example to advance or finish a task that is waiting on a \
+workflow run) — you can run workflows yourself; never claim the run_workflow tool is unavailable. \
+Delegate only when it genuinely helps — otherwise answer directly and concisely."
         .to_string()
 }
 
@@ -442,6 +455,316 @@ pub fn delegation_tools(queue: &DelegationQueue) -> Vec<Box<dyn Tool>> {
     ]
 }
 
+/// The complete tool set wired onto the company's orchestrator agent (issues
+/// #53 and #67), in order: the `query_company` read surface, the `spawn_task`
+/// and `delegate_to_desk` delegation tools, and the `run_workflow` execution
+/// tool.
+///
+/// [`build_agent`](crate::harness::build::build_agent) extends the orchestrator
+/// agent's tools with exactly this vector, so a test over this function is the
+/// registration check for the orchestrator's tool list. `workflow_source_dir` is
+/// the company source directory (`companies/<name>`) whose `workflows/` subtree
+/// holds the graphs; `workflow_runner` is the shared handle the runtime builder
+/// fills once the runner is built.
+pub fn orchestrator_tools(
+    company: CompanyId,
+    facts: Option<Arc<dyn FactStore>>,
+    events: Option<Arc<dyn EventLog>>,
+    queue: &DelegationQueue,
+    workflow_source_dir: Option<PathBuf>,
+    workflow_runner: WorkflowRunnerHandle,
+) -> Vec<Box<dyn Tool>> {
+    let mut tools: Vec<Box<dyn Tool>> = vec![Box::new(QueryCompanyTool::new(
+        company.clone(),
+        facts,
+        events,
+    ))];
+    tools.extend(delegation_tools(queue));
+    tools.push(Box::new(RunWorkflowTool::new(
+        company,
+        workflow_source_dir,
+        workflow_runner,
+    )));
+    tools
+}
+
+// ---------------------------------------------------------------------------
+// run_workflow (issue #67)
+// ---------------------------------------------------------------------------
+
+/// A shared, fillable handle to the company's [`WorkflowRunner`].
+///
+/// The `run_workflow` tool must reach the runner, but the runner
+/// ([`HarnessWorkflowRunner`](crate::workflows::HarnessWorkflowRunner)) is built
+/// *from* [`HarnessDeps`](crate::harness::HarnessDeps) — so it cannot be a plain
+/// field on deps without a construction cycle. Instead the runtime builder puts
+/// an empty handle on deps, builds the runner from a deps clone (which shares
+/// this one cell), then fills the handle. Every clone — the deps the brain later
+/// builds the orchestrator agent from, and the tool captured into that agent —
+/// sees the same cell, so the fill is visible at turn time.
+///
+/// The cell holds a [`Weak`], so the deps→handle→runner→deps reference is **not**
+/// a strong cycle: the one strong reference lives on the
+/// [`CompanyRuntime`](crate::company::CompanyRuntime), and the tool upgrades the
+/// weak on demand. Empty until filled (and always empty on a build with no
+/// runner), in which case the tool reports that workflow execution is not wired.
+#[derive(Clone, Default)]
+pub struct WorkflowRunnerHandle {
+    inner: Arc<OnceLock<Weak<dyn WorkflowRunner>>>,
+}
+
+impl WorkflowRunnerHandle {
+    /// Fills the handle with a weak reference to the built runner. Idempotent —
+    /// a second fill is ignored (the runner is built once per company boot).
+    pub fn set(&self, runner: &Arc<dyn WorkflowRunner>) {
+        let _ = self.inner.set(Arc::downgrade(runner));
+    }
+
+    /// The wired runner, upgraded from the weak cell, or `None` when no runner
+    /// was attached (or the owning runtime has been dropped).
+    pub fn get(&self) -> Option<Arc<dyn WorkflowRunner>> {
+        self.inner.get().and_then(Weak::upgrade)
+    }
+}
+
+/// How many characters of a node item preview the run summary keeps.
+const ITEM_PREVIEW_CHARS: usize = 120;
+
+/// A tool that runs one of the company's saved workflows by id.
+///
+/// It mirrors the REST run route (`POST /workflows/{wid}/run`): load the graph
+/// from the company source directory, then invoke the [`WorkflowRunner`] reached
+/// through a shared [`WorkflowRunnerHandle`]. On success it returns a concise,
+/// natural-language summary of the run (per-node outcome + any nodes left
+/// pending approval) rather than the engine's raw JSON. Every failure mode — no
+/// runner wired, no source directory, an unknown id, a load or run error — is an
+/// agent-actionable [`ToolResult::error`], never a panic or a silent empty
+/// result, so the orchestrator can reason about and report what went wrong.
+pub struct RunWorkflowTool {
+    company: CompanyId,
+    source_dir: Option<PathBuf>,
+    runner: WorkflowRunnerHandle,
+}
+
+impl RunWorkflowTool {
+    /// Builds the tool over the company id, its on-disk source directory
+    /// (`companies/<name>`, whose `workflows/` subtree holds the graphs), and the
+    /// shared runner handle.
+    pub fn new(
+        company: CompanyId,
+        source_dir: Option<PathBuf>,
+        runner: WorkflowRunnerHandle,
+    ) -> Self {
+        Self {
+            company,
+            source_dir,
+            runner,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for RunWorkflowTool {
+    fn name(&self) -> &str {
+        RUN_WORKFLOW_TOOL
+    }
+
+    fn description(&self) -> &str {
+        "Run one of the company's saved workflows by id to completion — use this to advance or finish work that is waiting on a workflow run. Provide the workflow `id` and an optional `input` trigger payload. Returns a summary of each node's outcome and any steps left pending approval."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "The id of the workflow to run (its `workflows/<id>.toml` stem; see the workflows list)."
+                },
+                "input": {
+                    "description": "An optional trigger payload seeded as the workflow's trigger item. Any JSON value; omit to run with no input."
+                }
+            },
+            "required": ["id"],
+            "additionalProperties": false
+        })
+    }
+
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Write
+    }
+
+    fn supports_markdown(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        // Accept `id` (canonical) or `workflow` (a natural alias) for the id.
+        let wid = args
+            .get("id")
+            .or_else(|| args.get("workflow"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|w| !w.is_empty());
+        let Some(wid) = wid.map(str::to_string) else {
+            return Ok(ToolResult::error(
+                "`id` is required: pass the id of the workflow to run (see the workflows list).",
+            ));
+        };
+        let input = args.get("input").cloned().unwrap_or(Value::Null);
+
+        // `wid` becomes a filename — reject anything that could escape the
+        // `workflows/` directory (mirrors the REST route's guard).
+        if !is_safe_workflow_id(&wid) {
+            tracing::debug!(company = %self.company, workflow = %wid, "run_workflow: rejected unsafe id");
+            return Ok(ToolResult::error(format!(
+                "No workflow with id `{wid}` exists."
+            )));
+        }
+
+        // The runner is reached through the shared handle; an empty handle means
+        // no runner is wired (default build / no harness).
+        let Some(runner) = self.runner.get() else {
+            tracing::debug!(company = %self.company, workflow = %wid, runner = false, "run_workflow: no runner wired");
+            return Ok(ToolResult::error(
+                "Workflow execution isn't available on this deployment (no workflow runner is wired).",
+            ));
+        };
+
+        // Load the saved graph from the company's on-disk source directory.
+        let Some(source_dir) = self.source_dir.as_deref() else {
+            tracing::debug!(company = %self.company, workflow = %wid, "run_workflow: no source dir");
+            return Ok(ToolResult::error(
+                "This company has no on-disk workflow definitions on this deployment, so there is nothing to run.",
+            ));
+        };
+        // Mirror the REST run route: a missing file is a clean "unknown id"
+        // rather than a raw filesystem read error (which would also leak the
+        // on-disk path into agent-visible text).
+        let path = source_dir.join("workflows").join(format!("{wid}.toml"));
+        if !path.is_file() {
+            tracing::debug!(company = %self.company, workflow = %wid, "run_workflow: unknown id");
+            return Ok(ToolResult::error(format!(
+                "No workflow with id `{wid}` exists. Check the workflows list for valid ids."
+            )));
+        }
+        let file = match load_company_workflows(source_dir, std::slice::from_ref(&wid)) {
+            Ok(files) => files.into_iter().next(),
+            Err(err) => {
+                tracing::debug!(company = %self.company, workflow = %wid, error = %err, "run_workflow: load failed");
+                return Ok(ToolResult::error(format!(
+                    "Couldn't load workflow `{wid}`: {err}"
+                )));
+            }
+        };
+        let Some(file) = file else {
+            tracing::debug!(company = %self.company, workflow = %wid, "run_workflow: unknown id");
+            return Ok(ToolResult::error(format!(
+                "No workflow with id `{wid}` exists. Check the workflows list for valid ids."
+            )));
+        };
+
+        tracing::debug!(company = %self.company, workflow = %wid, runner = true, "run_workflow: invoking runner");
+        match runner.run(&self.company, &file, input).await {
+            Ok(run) => {
+                tracing::debug!(
+                    company = %self.company,
+                    workflow = %wid,
+                    pending = run.pending_approvals.len(),
+                    "run_workflow: run succeeded"
+                );
+                let md = summarize_run(&file, &run);
+                Ok(ToolResult::success_with_markdown(
+                    json!({
+                        "workflow": file.id,
+                        "pending_approvals": run.pending_approvals.len(),
+                    }),
+                    md,
+                ))
+            }
+            Err(err) => {
+                tracing::debug!(company = %self.company, workflow = %wid, error = %err, "run_workflow: run failed");
+                Ok(ToolResult::error(format!(
+                    "Workflow `{wid}` failed to run: {err}"
+                )))
+            }
+        }
+    }
+}
+
+/// Whether `wid` is a single safe on-disk filename stem — no path separators, no
+/// `..`, not empty — so it can't escape the `workflows/` directory.
+fn is_safe_workflow_id(wid: &str) -> bool {
+    use std::path::{Component, Path};
+    let mut comps = Path::new(wid).components();
+    matches!(comps.next(), Some(Component::Normal(_))) && comps.next().is_none()
+}
+
+/// A concise, natural-language summary of a completed workflow run: a per-node
+/// outcome line (in graph order) plus any nodes left pending approval. This is
+/// what the tool hands back to the turn — never the engine's raw
+/// `{ run, nodes }` JSON dumped verbatim.
+fn summarize_run(file: &WorkflowFile, run: &WorkflowRun) -> String {
+    let mut md = format!("Ran workflow **{}** (`{}`).\n\n", file.name.trim(), file.id);
+    md.push_str("## Per-node outcome\n");
+    let nodes = run.output.get("nodes").and_then(Value::as_object);
+    match nodes {
+        Some(nodes) if !file.nodes.is_empty() => {
+            for node in &file.nodes {
+                let name = node.name.trim();
+                let kind = node.kind.as_str();
+                match nodes.get(&node.id) {
+                    Some(state) => {
+                        let items = state.get("items").and_then(Value::as_array);
+                        let count = items.map(Vec::len).unwrap_or(0);
+                        let preview = items
+                            .and_then(|items| items.last())
+                            .map(preview_item)
+                            .filter(|p| !p.is_empty());
+                        match preview {
+                            Some(preview) => md.push_str(&format!(
+                                "- **{name}** ({kind}): {count} item(s) — {preview}\n"
+                            )),
+                            None => {
+                                md.push_str(&format!("- **{name}** ({kind}): {count} item(s)\n"))
+                            }
+                        }
+                    }
+                    None => md.push_str(&format!("- **{name}** ({kind}): not reached\n")),
+                }
+            }
+        }
+        _ => md.push_str("_No per-node output was produced._\n"),
+    }
+
+    if run.pending_approvals.is_empty() {
+        md.push_str("\nThe run reached its terminal node(s) without pausing for approval.\n");
+    } else {
+        md.push_str(&format!(
+            "\n**Paused for approval** at: {}. Resolve these for the run to continue.\n",
+            run.pending_approvals.join(", ")
+        ));
+    }
+    md
+}
+
+/// A short, single-line preview of one node output item: the raw string when the
+/// item is a string, else its compact JSON — truncated on a char boundary to
+/// [`ITEM_PREVIEW_CHARS`] so a large item can't blow up the summary.
+fn preview_item(item: &Value) -> String {
+    let raw = match item {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    };
+    let one_line = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+    if one_line.chars().count() <= ITEM_PREVIEW_CHARS {
+        one_line
+    } else {
+        let cut: String = one_line.chars().take(ITEM_PREVIEW_CHARS).collect();
+        format!("{cut}…")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -574,5 +897,255 @@ mod tests {
         let out = result.output_for_llm(true);
         assert!(out.contains("No durable facts recorded"), "{out}");
         assert!(out.contains("No recent activity"), "{out}");
+    }
+
+    // ---- run_workflow (issue #67) ----
+
+    /// A valid trigger → agent → output graph, mirroring the REST route's fixture.
+    const DEMO_WF: &str = r#"
+        id = "demo"
+        name = "Demo flow"
+        description = "A tiny trigger → agent → output graph."
+        [[node]]
+        id = "start"
+        kind = "trigger"
+        name = "Start"
+        [[node]]
+        id = "worker"
+        kind = "agent"
+        name = "Worker"
+        agent = "assistant"
+        [[node]]
+        id = "done"
+        kind = "output"
+        name = "Report"
+        [[edge]]
+        from = "start"
+        to = "worker"
+        [[edge]]
+        from = "worker"
+        to = "done"
+    "#;
+
+    /// A [`WorkflowRunner`] test double: records the ids it was asked to run and
+    /// returns a canned [`WorkflowRun`].
+    struct StubRunner {
+        calls: Arc<Mutex<Vec<String>>>,
+        run: WorkflowRun,
+    }
+
+    impl StubRunner {
+        fn new(run: WorkflowRun) -> Self {
+            Self {
+                calls: Arc::new(Mutex::new(Vec::new())),
+                run,
+            }
+        }
+
+        fn empty() -> Self {
+            Self::new(WorkflowRun {
+                output: Value::Null,
+                pending_approvals: Vec::new(),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl WorkflowRunner for StubRunner {
+        async fn run(
+            &self,
+            _company: &CompanyId,
+            workflow: &WorkflowFile,
+            _input: Value,
+        ) -> crate::Result<WorkflowRun> {
+            self.calls.lock().unwrap().push(workflow.id.clone());
+            Ok(self.run.clone())
+        }
+    }
+
+    /// Writes `DEMO_WF` to `<dir>/workflows/demo.toml`.
+    fn seed_demo_workflow(dir: &std::path::Path) {
+        let wf = dir.join("workflows");
+        std::fs::create_dir_all(&wf).unwrap();
+        std::fs::write(wf.join("demo.toml"), DEMO_WF).unwrap();
+    }
+
+    #[test]
+    fn workflow_runner_handle_is_empty_until_filled() {
+        let handle = WorkflowRunnerHandle::default();
+        assert!(handle.get().is_none());
+        let runner: Arc<dyn WorkflowRunner> = Arc::new(StubRunner::empty());
+        handle.set(&runner);
+        assert!(handle.get().is_some());
+    }
+
+    #[test]
+    fn workflow_runner_handle_holds_only_a_weak_reference() {
+        // Proves the deps↔runner cell is not a strong cycle: once the sole strong
+        // owner drops, the handle can no longer upgrade.
+        let handle = WorkflowRunnerHandle::default();
+        {
+            let runner: Arc<dyn WorkflowRunner> = Arc::new(StubRunner::empty());
+            handle.set(&runner);
+            assert!(handle.get().is_some());
+        }
+        assert!(
+            handle.get().is_none(),
+            "the handle must not keep the runner alive"
+        );
+    }
+
+    #[test]
+    fn orchestrator_tools_includes_run_workflow_and_the_rest() {
+        let queue = DelegationQueue::default();
+        let tools = orchestrator_tools(
+            CompanyId::new("acme"),
+            None,
+            None,
+            &queue,
+            None,
+            WorkflowRunnerHandle::default(),
+        );
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&RUN_WORKFLOW_TOOL), "got {names:?}");
+        assert!(names.contains(&QUERY_COMPANY_TOOL), "got {names:?}");
+        assert!(names.contains(&SPAWN_TASK_TOOL), "got {names:?}");
+        assert!(names.contains(&DELEGATE_TO_DESK_TOOL), "got {names:?}");
+    }
+
+    #[tokio::test]
+    async fn run_workflow_tool_loads_and_invokes_the_runner() {
+        let dir = tempfile::tempdir().unwrap();
+        seed_demo_workflow(dir.path());
+
+        let runner_impl = StubRunner::new(WorkflowRun {
+            output: json!({
+                "run": {},
+                "nodes": { "worker": { "items": ["did the thing"] }, "done": { "items": [] } }
+            }),
+            pending_approvals: Vec::new(),
+        });
+        let calls = runner_impl.calls.clone();
+        let runner: Arc<dyn WorkflowRunner> = Arc::new(runner_impl);
+        let handle = WorkflowRunnerHandle::default();
+        handle.set(&runner);
+
+        let tool = RunWorkflowTool::new(
+            CompanyId::new("acme"),
+            Some(dir.path().to_path_buf()),
+            handle,
+        );
+        let result = tool
+            .execute(json!({ "id": "demo", "input": { "seed": 1 } }))
+            .await
+            .expect("execute");
+
+        assert!(!result.is_error, "expected success, got {result:?}");
+        assert_eq!(calls.lock().unwrap().as_slice(), ["demo"]);
+        let out = result.output_for_llm(true);
+        assert!(out.contains("Demo flow"), "{out}");
+        assert!(out.contains("did the thing"), "{out}");
+        assert!(out.contains("without pausing for approval"), "{out}");
+    }
+
+    #[tokio::test]
+    async fn run_workflow_tool_surfaces_pending_approvals() {
+        let dir = tempfile::tempdir().unwrap();
+        seed_demo_workflow(dir.path());
+
+        let runner: Arc<dyn WorkflowRunner> = Arc::new(StubRunner::new(WorkflowRun {
+            output: json!({ "nodes": { "worker": { "items": [] } } }),
+            pending_approvals: vec!["worker".to_string()],
+        }));
+        let handle = WorkflowRunnerHandle::default();
+        handle.set(&runner);
+
+        let tool = RunWorkflowTool::new(
+            CompanyId::new("acme"),
+            Some(dir.path().to_path_buf()),
+            handle,
+        );
+        let result = tool
+            .execute(json!({ "id": "demo" }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error);
+        let out = result.output_for_llm(true);
+        assert!(out.contains("Paused for approval"), "{out}");
+        assert!(out.contains("worker"), "{out}");
+    }
+
+    #[tokio::test]
+    async fn run_workflow_tool_errors_when_no_runner_is_wired() {
+        let dir = tempfile::tempdir().unwrap();
+        seed_demo_workflow(dir.path());
+        // A valid workflow on disk, but an empty handle → not wired.
+        let tool = RunWorkflowTool::new(
+            CompanyId::new("acme"),
+            Some(dir.path().to_path_buf()),
+            WorkflowRunnerHandle::default(),
+        );
+        let result = tool
+            .execute(json!({ "id": "demo" }))
+            .await
+            .expect("execute");
+        assert!(result.is_error, "expected an error result");
+        assert!(result.output_for_llm(false).contains("wired"), "{result:?}");
+    }
+
+    #[tokio::test]
+    async fn run_workflow_tool_errors_on_unknown_id() {
+        let dir = tempfile::tempdir().unwrap();
+        seed_demo_workflow(dir.path());
+        let runner: Arc<dyn WorkflowRunner> = Arc::new(StubRunner::empty());
+        let handle = WorkflowRunnerHandle::default();
+        handle.set(&runner);
+
+        let tool = RunWorkflowTool::new(
+            CompanyId::new("acme"),
+            Some(dir.path().to_path_buf()),
+            handle,
+        );
+        let result = tool
+            .execute(json!({ "id": "nope" }))
+            .await
+            .expect("execute");
+        assert!(result.is_error);
+        assert!(
+            result.output_for_llm(false).contains("No workflow with id"),
+            "{result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_workflow_tool_requires_an_id() {
+        let tool = RunWorkflowTool::new(
+            CompanyId::new("acme"),
+            None,
+            WorkflowRunnerHandle::default(),
+        );
+        let result = tool.execute(json!({})).await.expect("execute");
+        assert!(result.is_error);
+        assert!(
+            result.output_for_llm(false).contains("`id` is required"),
+            "{result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_workflow_tool_rejects_traversal_ids() {
+        let runner: Arc<dyn WorkflowRunner> = Arc::new(StubRunner::empty());
+        let handle = WorkflowRunnerHandle::default();
+        handle.set(&runner);
+        let tool = RunWorkflowTool::new(
+            CompanyId::new("acme"),
+            Some(std::path::PathBuf::from("/tmp")),
+            handle,
+        );
+        let result = tool
+            .execute(json!({ "id": "../secrets" }))
+            .await
+            .expect("execute");
+        assert!(result.is_error);
     }
 }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -804,6 +804,12 @@ impl RuntimeBuilder {
                                 events: Some(events.clone()),
                                 delegations: crate::harness::orchestrator::DelegationQueue::default(
                                 ),
+                                // Issue #67: an empty runner handle, filled just
+                                // below once the `HarnessWorkflowRunner` is built,
+                                // so the orchestrator's `run_workflow` tool reaches
+                                // the runner without a construction cycle.
+                                workflow_runner:
+                                    crate::harness::orchestrator::WorkflowRunnerHandle::default(),
                                 // Error-hardening cell: a fresh MCP-failure queue
                                 // the `OcMcpCallTool` decorator fills and the brain
                                 // drains; and a LIVE secret-store handle so
@@ -822,12 +828,20 @@ impl RuntimeBuilder {
                             };
                             // Workflow agent nodes execute on the same pool as the
                             // brain — clone before both moves into `HarnessBrain`.
-                            wf_runner = Some(Arc::new(HarnessWorkflowRunner::new(
-                                pool.clone(),
-                                deps.clone(),
-                                record.clone(),
-                            ))
-                                as Arc<dyn WorkflowRunner>);
+                            let runner: Arc<dyn WorkflowRunner> =
+                                Arc::new(HarnessWorkflowRunner::new(
+                                    pool.clone(),
+                                    deps.clone(),
+                                    record.clone(),
+                                ));
+                            // Issue #67: fill the shared handle on `deps` (a clone
+                            // of which the runner holds, and which moves into the
+                            // brain below) so the orchestrator's `run_workflow` tool
+                            // reaches this runner. The handle stores a `Weak`; the
+                            // strong ref lives on the runtime via
+                            // `set_workflow_runner`, so this is not a strong cycle.
+                            deps.workflow_runner.set(&runner);
+                            wf_runner = Some(runner);
                             Some(Arc::new(HarnessBrain::new(pool, deps, record)) as Arc<dyn Brain>)
                         } else {
                             None

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -564,6 +564,7 @@ mod test {
             facts: None,
             events: None,
             delegations: crate::harness::orchestrator::DelegationQueue::default(),
+            workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             secrets: None,
         };

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -146,6 +146,7 @@ description = "Runs Acme."
             facts: None,
             events: None,
             delegations: crate::harness::orchestrator::DelegationQueue::default(),
+            workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             secrets: None,
         }


### PR DESCRIPTION
## Summary

The orchestrator could query company facts/events and delegate work (`spawn_task`, `delegate_to_desk`), but had no way to actually run a saved workflow — so a task waiting on a workflow run had no path to completion, and the orchestrator could only report the tool wasn't available.

Adds a `run_workflow` tool, wired only onto the orchestrator agent alongside the existing delegation tools (`src/harness/orchestrator.rs`). It loads a workflow graph by id from the company's source directory — the same loader/traversal guard the REST run route (`src/server/ops/workflows.rs`) uses — and invokes it through a new shared `WorkflowRunnerHandle`: a `Weak`-backed cell the runtime builder (`src/runtime/builder.rs`) fills once the `HarnessWorkflowRunner` is constructed, breaking the deps-builds-the-runner construction cycle without creating a strong reference cycle. Every failure mode (no runner wired, unknown id, load/run error, unsafe id) returns an agent-actionable tool error rather than a panic or an empty result. On success it returns a concise per-node-outcome markdown summary — never the engine's raw JSON — including any nodes left pending approval. The orchestrator persona brief is updated so it stops claiming the tool is unavailable.

Also fixes a pre-existing, unrelated compile break under `--features openhuman`: `build_agent` already required a `grants: &[String]` argument, but `build_roster` (its only caller) never supplied it, so the crate could not compile with the `openhuman` feature at all. Split into its own commit (`fix(harness): wire per-agent tool grants into build_roster`).

Closes #67

## API Or Behavior Changes

- New orchestrator-only tool `run_workflow` (input: `id` — the workflow id — plus optional `input` trigger payload). No changes to any existing tool's behavior or public API.
- No REST/HTTP surface changes.

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --features openhuman`
- `cargo test --features openhuman` — 702 passed / 0 failed / 1 ignored (lib) + 4 passed (bin)

9 new tests cover: the shared handle's empty/filled/weak-drop behavior (no strong reference cycle), `run_workflow` registration in the orchestrator's tool set, the load-and-invoke happy path, the pending-approvals summary, and every error path (no runner wired, unknown id, missing id, path-traversal rejection).

## Documentation

No user-facing docs changed — `run_workflow` is an internal orchestrator tool exposed only through the agent's own tool-calling surface, matching how `spawn_task`/`delegate_to_desk` (issue #53) were introduced without a separate doc update. The tool's own description/parameter schema (visible to the agent) documents its usage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability for the orchestrator to run saved workflows directly during a conversation.
  * Workflow execution now reports node results and pending approvals in a concise summary.
  * Added validation and clear error messages for missing, unknown, or unsafe workflow identifiers.

* **Improvements**
  * Orchestrator tools now respect effective agent tool permissions and support workflow execution when configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->