### PR TITLE
fix(server): list manifest-enabled workflows without a source dir (#70)

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -242,6 +242,22 @@ impl CompanyRuntime {
         &self.store
     }
 
+    /// The workflow ids declared in this company's manifest
+    /// (`[workflows].enabled`), read from the persisted record. Empty when the
+    /// record hasn't been saved yet.
+    ///
+    /// This is the source of truth for *which* workflows exist on a
+    /// platform-provisioned tenant (no `source_dir`, so nothing to scan on
+    /// disk) — see [`Self::source_dir`]. Both the REST `list_workflows` route
+    /// and the GraphQL `Company.workflows` resolver read it so the two
+    /// surfaces agree on what the company has enabled.
+    pub async fn enabled_workflow_ids(&self) -> Result<Vec<String>> {
+        let record = self.store.load(&self.id).await?;
+        Ok(record
+            .map(|record| record.manifest.workflows.enabled)
+            .unwrap_or_default())
+    }
+
     /// This company's inbox store (inbound + outbound email).
     pub fn inbox(&self) -> &Arc<dyn InboxStore> {
         &self.inbox

--- a/src/server/graphql/workflows.rs
+++ b/src/server/graphql/workflows.rs
@@ -101,10 +101,7 @@ fn load_one(dir: Option<&Path>, id: &str) -> Option<WorkflowFile> {
 
 /// The enabled workflow ids from the company manifest.
 async fn enabled_ids(runtime: &Arc<CompanyRuntime>) -> async_graphql::Result<Vec<String>> {
-    let record = runtime.store().load(runtime.id()).await?;
-    Ok(record
-        .map(|record| record.manifest.workflows.enabled)
-        .unwrap_or_default())
+    Ok(runtime.enabled_workflow_ids().await?)
 }
 
 /// Resolves `Company.workflows`.

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -8,6 +8,17 @@
 //! takes an explicit id list (it never scans) — so `list_workflows` enumerates
 //! the `workflows/` directory itself to build that list.
 //!
+//! A platform-provisioned tenant has no source directory, so there is nothing
+//! to scan — but it can still declare `[workflows].enabled` ids in its
+//! manifest. `list_workflows` unions those manifest-enabled ids in (deduped by
+//! id) so the console's picker isn't empty just because the deployment has no
+//! `workflows/*.toml` files on disk, mirroring the `Company.workflows`
+//! GraphQL resolver. Where the definition body isn't available to load (no
+//! source directory, or the id has no matching file), the summary falls back
+//! to the id as its name — the same fallback the GraphQL resolver uses. Full
+//! graphs (`GET …/workflows/{wid}`) still require a source directory, since
+//! there is currently no other place a graph body can come from.
+//!
 //! Execution is dependency-inverted behind the [`WorkflowRunner`] port: when no
 //! runner is wired (the default build, or a runtime built without a harness) the
 //! run route reports `not_wired` — the same 404 seam the DNS/SMTP surfaces use —
@@ -15,6 +26,7 @@
 //! parse the committed graph files, so the console can list and render workflows
 //! even on a build that cannot execute them.
 
+use std::collections::HashSet;
 use std::path::Path as FsPath;
 
 use axum::extract::Path;
@@ -133,11 +145,45 @@ impl From<WorkflowEdgeDef> for WorkflowEdge {
 /// The loader takes an explicit id list rather than scanning, so this reads the
 /// company's `workflows/` directory to collect the `*.toml` file stems as ids,
 /// then loads and summarizes them. No source directory (platform-provisioned
-/// mode) or no `workflows/` directory yields an empty list — a `200`, not an
-/// error, so the console renders "no workflows yet" rather than a failure.
+/// mode) or no `workflows/` directory yields an empty filesystem scan — but not
+/// necessarily an empty response: the manifest's `[workflows].enabled` ids are
+/// unioned in (deduped against the filesystem scan by id), falling back to the
+/// id as the name when there's no file to load a real name from. Only when
+/// both the scan and the manifest are empty does this return `200 []`, so the
+/// console renders "no workflows yet" rather than a failure.
 async fn list_workflows(company: ScopedCompany) -> Result<Json<Vec<WorkflowSummary>>, ApiError> {
-    let files = load_source_workflows(company.runtime.source_dir())?;
-    Ok(Json(files.into_iter().map(WorkflowSummary::from).collect()))
+    let source_dir = company.runtime.source_dir();
+    let files = load_source_workflows(source_dir)?;
+    let mut seen: HashSet<String> = files.iter().map(|f| f.id.clone()).collect();
+    let mut summaries: Vec<WorkflowSummary> =
+        files.into_iter().map(WorkflowSummary::from).collect();
+
+    let enabled_ids = company
+        .runtime
+        .enabled_workflow_ids()
+        .await
+        .map_err(ApiError)?;
+    for id in enabled_ids {
+        // Already present from the filesystem scan — skip so hosted mode
+        // (source dir present, manifest also lists the same ids) doesn't
+        // double-list.
+        if !seen.insert(id.clone()) {
+            continue;
+        }
+        let loaded = source_dir
+            .and_then(|dir| load_company_workflows(dir, std::slice::from_ref(&id)).ok())
+            .and_then(|mut files| files.pop());
+        summaries.push(match loaded {
+            Some(file) => WorkflowSummary::from(file),
+            None => WorkflowSummary {
+                id: id.clone(),
+                name: id,
+                description: None,
+            },
+        });
+    }
+
+    Ok(Json(summaries))
 }
 
 /// `GET …/workflows/{wid}` — the full graph for one workflow.
@@ -425,5 +471,104 @@ mod tests {
         let files = load_source_workflows(Some(dir.path())).expect("lists despite a bad file");
         let ids: Vec<_> = files.iter().map(|f| f.id.as_str()).collect();
         assert_eq!(ids, vec!["demo"]);
+    }
+
+    // HTTP-level: a hosted tenant has no source directory to scan, so these
+    // exercise the manifest-enabled union path end to end via the router.
+    mod hosted_mode {
+        use axum::body::{Body, to_bytes};
+        use axum::http::{Request, StatusCode};
+        use tower::ServiceExt;
+
+        use crate::company::CompanyManifest;
+        use crate::ports::CompanyStore;
+        use crate::ports::types::{CompanyId, CompanyRecord};
+        use crate::runtime::RuntimeBuilder;
+        use crate::server::router;
+        use crate::store::FsCompanyStore;
+        use crate::{AppConfig, AppState};
+
+        fn home() -> std::path::PathBuf {
+            std::env::temp_dir().join(format!(
+                "oc-workflows-hosted-{}",
+                crate::ports::generate_id()
+            ))
+        }
+
+        /// A manifest declaring one enabled workflow — mirrors what a
+        /// platform tenant provisions with, minus any `workflows/` directory
+        /// on disk (there isn't one: hosted tenants have no source dir).
+        fn manifest_with_enabled() -> CompanyManifest {
+            toml::from_str(
+                "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[workflows]\nenabled = [\"demo\"]\n",
+            )
+            .unwrap()
+        }
+
+        /// Builds a running company whose runtime has **no source directory**
+        /// (built without `with_seed_dir`, matching how the platform builds a
+        /// provisioned tenant) but whose persisted record declares an enabled
+        /// workflow — the exact hosted-mode gap #70 reports.
+        async fn state_with_hosted_company(home: &std::path::Path) -> AppState {
+            let store = FsCompanyStore::new(home.to_path_buf());
+            let id = CompanyId::new("acme");
+            store
+                .save(&CompanyRecord {
+                    id: id.clone(),
+                    manifest: manifest_with_enabled(),
+                    ledger: Vec::new(),
+                    lifecycle: "running".to_string(),
+                    overlay_agents: Vec::new(),
+                })
+                .await
+                .unwrap();
+            let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest_with_enabled())
+                .with_id(id.clone())
+                .build()
+                .await
+                .unwrap();
+            assert!(
+                runtime.source_dir().is_none(),
+                "test setup must simulate hosted mode: no source dir"
+            );
+            let state = AppState::new(AppConfig::default());
+            state.registry().insert(id, std::sync::Arc::new(runtime));
+            crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+            state
+        }
+
+        #[tokio::test]
+        async fn manifest_enabled_workflow_lists_with_no_source_dir() {
+            let home = home();
+            let state = state_with_hosted_company(&home).await;
+
+            let response = router(state)
+                .oneshot(
+                    Request::builder()
+                        .method("GET")
+                        .uri("/api/v1/company/workflows")
+                        .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+            // Regression for #70: the REST list used to scan the filesystem
+            // only, so a hosted tenant with no source dir always got `[]`
+            // here even though its manifest declared an enabled workflow.
+            let items = body.as_array().expect("array response");
+            assert_eq!(items.len(), 1, "body: {body}");
+            assert_eq!(items[0]["id"], "demo");
+            // No file to load a real name from, so the id is the fallback
+            // name — same fallback the GraphQL `Company.workflows` resolver
+            // uses for the same case.
+            assert_eq!(items[0]["name"], "demo");
+
+            std::fs::remove_dir_all(&home).ok();
+        }
     }
 }


### PR DESCRIPTION
## Summary

The Workflows tab was empty in hosted/platform mode even when the tenant
manifest declared `[workflows] enabled = [...]`. `GET …/workflows` only
scanned the company's on-disk `workflows/` directory for `*.toml` files;
platform-provisioned tenants have no source directory at all, so the scan
always returned `[]` — even though the GraphQL `Company.workflows` resolver
already listed the manifest's enabled ids for the same company.

`list_workflows` now unions the manifest's `[workflows].enabled` ids into the
filesystem scan (deduped by id), falling back to the id as the display name
when there is no `workflows/<id>.toml` to load a real name/description from
— the same fallback the GraphQL resolver already used. The manifest read
itself was pulled out of the GraphQL resolver into a new
`CompanyRuntime::enabled_workflow_ids()` method so both surfaces share one
source of truth instead of two copies of the same store read.

**Known limitation, called out explicitly rather than left silent:** a
platform-provisioned tenant has no `workflows/*.toml` files anywhere, so
there is currently no way to load a *full graph body* (nodes/edges) for a
manifest-enabled workflow that has no source directory. `GET
…/workflows/{wid}` is unchanged — it still 404s without a source dir, which
matches `Company.workflow(id)` returning `null` in the same case on the
GraphQL side. The list now at least surfaces `id` + a name (falling back to
the id) so the tab isn't silently blank; opening one of these to view/run the
graph is a separate follow-up (loading workflow definitions from somewhere
other than the on-disk source dir in hosted mode).

## API Or Behavior Changes

- `GET /api/v1/company/workflows` and `GET
  /api/v1/companies/{id}/workflows`: now also includes workflows the
  manifest's `[workflows].enabled` list references, even when the deployment
  has no on-disk source directory (or the id has no matching file). No change
  when the filesystem scan already covers everything (typical local `--company`
  runs).
- `GET …/workflows/{wid}`: unchanged (still requires a source directory to
  load the full graph body).
- Added `CompanyRuntime::enabled_workflow_ids()`; the GraphQL
  `Company.workflows` resolver now delegates to it instead of duplicating the
  manifest read.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` (557 lib tests + 4 bin tests passed, 1 ignored, 0 failed)

New test: `server::ops::workflows::tests::hosted_mode::manifest_enabled_workflow_lists_with_no_source_dir`
— builds a company runtime with no source directory (`with_seed_dir` not
called, matching how a platform tenant is provisioned) but a manifest
declaring one enabled workflow, and asserts `GET …/workflows` returns that
workflow (falling back to the id as the name) instead of `[]`.

## Documentation

None needed — this is an internal consistency fix between the REST and
GraphQL workflow-listing resolvers; no public API surface changed shape,
only what data populates it.

Closes #70


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow listings now include workflows enabled through a company manifest, even when no source directory is available.
  * Hosted workflows without source files display their workflow ID as the name.

* **Bug Fixes**
  * Removed duplicate workflow entries from listings.
  * Improved workflow discovery for hosted environments.
  * Added coverage for hosted workflow listing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->