### PR TITLE
fix(chat): rehydrate the console transcript from persisted history (#65)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -18,6 +18,7 @@ import {
   type ApiErrorBody,
   type AppSpec,
   type ApprovalSummary,
+  type ChatHistoryMessageDto,
   type ChatResponse,
   type CompanyStatus,
   type ConnectionStart,
@@ -161,6 +162,21 @@ export class OpenCompanyClient {
    */
   listDesks(company?: string | null): Promise<DeskDto[]> {
     return this.request<DeskDto[]>("GET", `${this.scope(company)}/desks`);
+  }
+
+  /**
+   * A desk's persisted transcript (issue #65), so the console can rehydrate a
+   * thread on login/reload instead of always starting empty. `desk` is the
+   * thread id (as passed to {@link chat}); omitted reads the operator/General
+   * line. Hosts that don't expose `.../chat/history` yet return 404 — callers
+   * fall back to an empty transcript.
+   */
+  getChatHistory(desk?: string | null, company?: string | null): Promise<ChatHistoryMessageDto[]> {
+    const qs = desk ? `?desk=${encodeURIComponent(desk)}` : "";
+    return this.request<ChatHistoryMessageDto[]>(
+      "GET",
+      `${this.scope(company)}/chat/history${qs}`,
+    );
   }
 
   /** The approvals awaiting the operator. */

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -58,6 +58,21 @@ export interface DeskDto {
   members: string[];
 }
 
+/**
+ * `GET {scope}/chat/history` — one persisted transcript message. Mirrors
+ * `ChatHistoryMessageDto` in `src/server/operator.rs`. Shares its filter +
+ * projection logic with the GraphQL `Chat.history` resolver, so the two can
+ * never disagree about a desk's history (issue #65).
+ */
+export interface ChatHistoryMessageDto {
+  id: string;
+  channel: string;
+  author: string;
+  text: string;
+  atMillis: number;
+  mine: boolean;
+}
+
 /** Response of `/chat` and approval-resolution routes. */
 export interface ChatResponse {
   responses: OutboundMessage[];

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -48,7 +48,7 @@ import { ThemeToggle } from "@/components/theme-toggle";
 import { DiscordIcon } from "@/components/discord-icon";
 import { useCompany } from "@/hooks/use-company";
 import { useHashView } from "@/hooks/use-hash-view";
-import { type ChatMessage, makeMessage } from "@/lib/chat";
+import { type ChatMessage, fromHistory, makeMessage } from "@/lib/chat";
 import { DISCORD_INVITE_URL } from "@/lib/links";
 import { defaultThreads, threadsFromDesks } from "@/lib/threads";
 import { Overview } from "@/views/Overview";
@@ -194,23 +194,57 @@ export function AppShell({
   // Build the chat threads from the company's real desks (issue #53); keep the
   // static defaults when the host doesn't expose `/desks` (404) or defines none.
   // Merges by id so a transcript typed before desks load survives.
+  //
+  // Once the thread list is known, rehydrate each thread's transcript from the
+  // backend's persisted history (issue #65): the server journals every
+  // operator message and agent reply to the EventLog, but the console used to
+  // always start every thread empty. Merges by message id so a line typed
+  // locally before its thread's history lands isn't lost — hydration can race
+  // the operator's first message on a fresh page load.
   useEffect(() => {
     let cancelled = false;
+
+    const hydrate = (threadId: string) => {
+      client
+        .getChatHistory(threadId, company)
+        .then((entries) => {
+          if (cancelled || entries.length === 0) return;
+          const hydrated = fromHistory(entries);
+          setThreads((ts) =>
+            ts.map((t) => {
+              if (t.id !== threadId) return t;
+              const known = new Set(t.messages.map((m) => m.id));
+              const fresh = hydrated.filter((m) => !known.has(m.id));
+              return fresh.length === 0 ? t : { ...t, messages: [...fresh, ...t.messages] };
+            }),
+          );
+        })
+        .catch(() => {
+          /* host without `/chat/history`, or offline — thread stays empty */
+        });
+    };
+
     client
       .listDesks(company)
       .then((desks) => {
         if (cancelled) return;
+        const resolved = threadsFromDesks(desks);
         setThreads((prev) => {
           const byId = new Map(prev.map((t) => [t.id, t]));
-          return threadsFromDesks(desks).map((t) => {
+          return resolved.map((t) => {
             const existing = byId.get(t.id);
             return existing ? { ...t, messages: existing.messages } : t;
           });
         });
+        resolved.forEach((t) => hydrate(t.id));
       })
       .catch(() => {
-        /* host without `/desks`, or offline — keep the current threads */
+        // Host without `/desks`, or offline — keep the static default
+        // threads, but the operator/General line still deserves a
+        // rehydration attempt (it's the one every deployment has).
+        defaultThreads().forEach((t) => hydrate(t.id));
       });
+
     return () => {
       cancelled = true;
     };

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -1,4 +1,4 @@
-import type { TurnStep } from "@/api/types";
+import type { ChatHistoryMessageDto, TurnStep } from "@/api/types";
 
 /** One line in the conversation with the company. */
 export interface ChatMessage {
@@ -37,4 +37,26 @@ export function makeMessage(
     channel: opts.channel,
     steps: opts.steps,
   };
+}
+
+/**
+ * Maps a desk's persisted transcript (`GET .../chat/history`, issue #65) to
+ * the console's chat lines, preserving `mine`/author/text and ordering — the
+ * backend already returns messages oldest-first. `id`s are namespaced with an
+ * `h` prefix so a rehydrated line can never collide with one built locally by
+ * {@link makeMessage} (`m<seq>`).
+ */
+export function fromHistory(entries: ChatHistoryMessageDto[]): ChatMessage[] {
+  return entries.map((entry) => {
+    const from: ChatMessage["from"] = entry.mine ? "you" : "company";
+    return {
+      id: `h${entry.id}`,
+      from,
+      text: entry.text,
+      at: entry.atMillis,
+      // A sent message never carries a channel; only attribute one when the
+      // line came from someone/something else, mirroring `ChatPane.send`.
+      channel: from === "company" ? entry.channel : undefined,
+    };
+  });
 }

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -1,0 +1,260 @@
+//! Shared desk-history read logic (issue #65).
+//!
+//! Both the GraphQL `Chat.history` resolver
+//! ([`crate::server::graphql::company`]) and the REST `GET .../chat/history`
+//! route ([`crate::server::operator`]) need to answer the same question — "what
+//! messages belong to this desk, as seen by this viewer?" — and they must never
+//! be allowed to disagree about it. This module is the one place that answers
+//! it; both surfaces call through it instead of each keeping their own copy of
+//! the filter + projection logic.
+
+use std::collections::HashMap;
+
+use crate::company::runtime::CompanyRuntime;
+use crate::error::OpenCompanyError;
+use crate::ports::types::{ActorKind, CompanyEvent, EventSeq, StoredEvent};
+use crate::server::ops::language::DEFAULT_DESK as GENERAL_DESK;
+
+/// The console's default/orchestrator thread id
+/// (`frontend/src/lib/threads.ts` `mainThread()`). The console addresses every
+/// send on that thread with `chat: "main"`, so `AgentReply`s answering it are
+/// journaled with `chat_id == "main"` rather than [`GENERAL_DESK`]. `owns`
+/// admits both spellings for the General desk so a transcript is never split
+/// across the two ids depending on which one happened to write it (issue #65).
+pub const MAIN_THREAD_ID: &str = "main";
+
+/// Whether a stored event belongs to the desk identified by `desk_id` /
+/// `desk_name`.
+///
+/// `AgentReply`s match on the desk id or name verbatim, plus — only for the
+/// General/operator desk — the console's `"main"` thread id and an empty chat
+/// id, so no historical reply is orphaned by the id it happened to be
+/// journaled under (issue #65). Pre-threading `OperatorMessage`s carry no chat
+/// id at all and have always belonged to the General desk unconditionally.
+pub fn owns(desk_id: &str, desk_name: &str, event: &CompanyEvent) -> bool {
+    let is_general_desk =
+        desk_id.eq_ignore_ascii_case(GENERAL_DESK) || desk_name.eq_ignore_ascii_case(GENERAL_DESK);
+    match event {
+        CompanyEvent::AgentReply { chat_id, .. } => {
+            chat_id == desk_id
+                || chat_id == desk_name
+                || (is_general_desk
+                    && (chat_id.is_empty() || chat_id.eq_ignore_ascii_case(MAIN_THREAD_ID)))
+        }
+        CompanyEvent::OperatorMessage { .. } => is_general_desk,
+        _ => false,
+    }
+}
+
+/// Who is reading a desk history. `mine` is relative to this.
+///
+/// There is no `From<StoredEvent> for MessageView`, and there cannot be:
+/// `mine` depends on who is asking. With one operator it was safe to hardcode
+/// `true`; with several users it would mark everyone's messages as everyone
+/// else's.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Viewer {
+    /// An operator or platform credential. Legacy unattributed messages are
+    /// theirs, because that is who sent them before users existed.
+    Operator,
+    /// A human collaborator, by user id.
+    User(String),
+}
+
+/// One message in a desk history, independent of transport. Mirrors
+/// `frontend/src/lib/chat.ts`. The GraphQL `Message` type and the REST
+/// `chat/history` JSON shape both project from this.
+#[derive(Clone, Debug)]
+pub struct MessageView {
+    /// The message id (its EventLog sequence position).
+    pub id: String,
+    /// The channel the message came in on.
+    pub channel: String,
+    /// The author label.
+    pub author: String,
+    /// The message text.
+    pub text: String,
+    /// When it was journaled, epoch millis.
+    pub at_millis: f64,
+    /// Whether it is the operator's own message.
+    pub mine: bool,
+}
+
+impl MessageView {
+    /// Projects a stored event for one viewer.
+    ///
+    /// `authors` maps user id → display label, resolved once per history
+    /// rather than per message.
+    pub fn project(
+        stored: StoredEvent,
+        viewer: &Viewer,
+        authors: &HashMap<String, String>,
+    ) -> Self {
+        let id = stored.seq.value().to_string();
+        let at_millis = stored.at_millis as f64;
+        match stored.event {
+            CompanyEvent::AgentReply { agent_id, text, .. } => MessageView {
+                id,
+                channel: agent_id.clone(),
+                author: agent_id,
+                text,
+                at_millis,
+                mine: false,
+            },
+            CompanyEvent::OperatorMessage { text, by, .. } => {
+                let (author, mine) = match &by {
+                    // Sent by a signed-in human.
+                    Some(actor) if actor.kind == ActorKind::User => {
+                        let label = authors
+                            .get(&actor.id)
+                            .cloned()
+                            .unwrap_or_else(|| "someone".to_string());
+                        (label, *viewer == Viewer::User(actor.id.clone()))
+                    }
+                    // Sent with a machine credential, or journaled before
+                    // attribution existed. Either way there is no person to
+                    // name, and it belongs to whoever holds that credential.
+                    _ => ("operator".to_string(), matches!(viewer, Viewer::Operator)),
+                };
+                MessageView {
+                    id,
+                    channel: "operator".to_string(),
+                    author,
+                    text,
+                    at_millis,
+                    mine,
+                }
+            }
+            // `owns` never admits other variants into a history.
+            other => MessageView {
+                id,
+                channel: "system".to_string(),
+                author: "system".to_string(),
+                text: format!("{other:?}"),
+                at_millis,
+                mine: false,
+            },
+        }
+    }
+}
+
+/// Loads roster display labels for a company: user id → label.
+///
+/// Prefers a display name, and falls back to the email's *local part* rather
+/// than the whole address: a desk history is read by every member, and it
+/// should not hand each of them everyone else's email.
+pub async fn author_labels(
+    runtime: &CompanyRuntime,
+) -> Result<HashMap<String, String>, OpenCompanyError> {
+    let users = runtime.users().list_users(runtime.id()).await?;
+    Ok(users
+        .into_iter()
+        .map(|user| {
+            let label = user.display_name.unwrap_or_else(|| {
+                user.email
+                    .split('@')
+                    .next()
+                    .unwrap_or("someone")
+                    .to_string()
+            });
+            (user.id, label)
+        })
+        .collect())
+}
+
+/// One desk's message history for one viewer, most-recent last.
+///
+/// `before_seq` is an opaque EventLog cursor (a sequence position); only
+/// messages before it are considered. `first` caps how many of the remaining,
+/// most-recent messages come back. Returns the page plus the total count of
+/// matching messages (before the `first` cap, after the `before_seq` cut).
+///
+/// Shared by the GraphQL `Chat.history` resolver and the REST
+/// `GET .../chat/history` route so the two can never disagree about what a
+/// desk's history contains (issue #65).
+pub async fn history_for_desk(
+    runtime: &CompanyRuntime,
+    desk_id: &str,
+    desk_name: &str,
+    viewer: &Viewer,
+    before_seq: Option<u64>,
+    first: usize,
+) -> Result<(Vec<MessageView>, i32), OpenCompanyError> {
+    let stored = runtime
+        .events()
+        .read_from(runtime.id(), EventSeq::new(0), usize::MAX)
+        .await?;
+    // One roster read per history, not one per message: the scan above is
+    // already O(log), and an N+1 on top of it would be worse.
+    let authors = author_labels(runtime).await?;
+
+    let mut messages: Vec<MessageView> = stored
+        .into_iter()
+        .filter(|event| owns(desk_id, desk_name, &event.event))
+        .filter(|event| before_seq.is_none_or(|before| event.seq.value() < before))
+        .map(|event| MessageView::project(event, viewer, &authors))
+        .collect();
+
+    let total = messages.len() as i32;
+    // Keep the most recent `first`, still in chronological order.
+    if messages.len() > first {
+        messages.drain(0..messages.len() - first);
+    }
+    Ok((messages, total))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ports::types::Actor;
+
+    fn agent_reply(chat_id: &str) -> CompanyEvent {
+        CompanyEvent::AgentReply {
+            chat_id: chat_id.to_string(),
+            agent_id: "ceo".to_string(),
+            text: "hi".to_string(),
+        }
+    }
+
+    #[test]
+    fn general_desk_owns_agent_replies_under_general_and_main() {
+        assert!(owns(GENERAL_DESK, GENERAL_DESK, &agent_reply(GENERAL_DESK)));
+        assert!(owns(
+            GENERAL_DESK,
+            GENERAL_DESK,
+            &agent_reply(MAIN_THREAD_ID)
+        ));
+        assert!(owns(GENERAL_DESK, GENERAL_DESK, &agent_reply("")));
+        assert!(!owns(GENERAL_DESK, GENERAL_DESK, &agent_reply("strategy")));
+    }
+
+    #[test]
+    fn non_general_desk_only_owns_its_own_id_or_name() {
+        assert!(owns("strategy", "Strategy desk", &agent_reply("strategy")));
+        assert!(owns(
+            "strategy",
+            "Strategy desk",
+            &agent_reply("Strategy desk")
+        ));
+        assert!(!owns(
+            "strategy",
+            "Strategy desk",
+            &agent_reply(MAIN_THREAD_ID)
+        ));
+        assert!(!owns("strategy", "Strategy desk", &agent_reply("")));
+    }
+
+    #[test]
+    fn general_desk_owns_every_operator_message() {
+        let event = CompanyEvent::OperatorMessage {
+            text: "hi".to_string(),
+            by: Some(Actor {
+                kind: ActorKind::User,
+                id: "u1".to_string(),
+            }),
+            chat: Some(MAIN_THREAD_ID.to_string()),
+        };
+        assert!(owns(GENERAL_DESK, GENERAL_DESK, &event));
+        assert!(!owns("strategy", "Strategy desk", &event));
+    }
+}

--- a/src/server/graphql/company.rs
+++ b/src/server/graphql/company.rs
@@ -25,10 +25,8 @@ use super::{
     connections, finances, inbox, memory_facts, skills, tasks, usage, workflows, workspace,
 };
 use crate::company::runtime::CompanyRuntime;
-use crate::ports::types::{ActorKind, CompanyEvent, CompanyId, EventSeq, StoredEvent};
-
-/// The synthetic desk pre-threading operator messages are attributed to.
-const GENERAL_DESK: &str = "General";
+use crate::ports::types::CompanyId;
+use crate::server::chat_history::{self, MessageView, Viewer};
 
 /// The aggregation-root handle over one company. See the module docs.
 pub struct CompanyGql {
@@ -303,22 +301,6 @@ impl ChatGql {
     fn new(runtime: Arc<CompanyRuntime>, desk: Desk) -> Self {
         Self { runtime, desk }
     }
-
-    /// Whether a stored event belongs to this desk. `AgentReply`s match on the
-    /// desk id or name; pre-threading `OperatorMessage`s fall to the synthetic
-    /// "General" desk.
-    fn owns(&self, event: &CompanyEvent) -> bool {
-        match event {
-            CompanyEvent::AgentReply { chat_id, .. } => {
-                chat_id == &self.desk.id || chat_id == &self.desk.name
-            }
-            CompanyEvent::OperatorMessage { .. } => {
-                self.desk.id.eq_ignore_ascii_case(GENERAL_DESK)
-                    || self.desk.name.eq_ignore_ascii_case(GENERAL_DESK)
-            }
-            _ => false,
-        }
-    }
 }
 
 #[Object(name = "Chat")]
@@ -343,34 +325,13 @@ impl ChatGql {
         self.desk.members.iter().cloned().map(ID).collect()
     }
 
-    /// User id → the label their messages are attributed to.
-    ///
-    /// Prefers a display name, and falls back to the email's *local part*
-    /// rather than the whole address: a desk history is read by every member,
-    /// and it should not hand each of them everyone else's email.
-    #[graphql(skip)]
-    async fn author_labels(
-        &self,
-    ) -> async_graphql::Result<std::collections::HashMap<String, String>> {
-        let users = self.runtime.users().list_users(self.runtime.id()).await?;
-        Ok(users
-            .into_iter()
-            .map(|user| {
-                let label = user.display_name.unwrap_or_else(|| {
-                    user.email
-                        .split('@')
-                        .next()
-                        .unwrap_or("someone")
-                        .to_string()
-                });
-                (user.id, label)
-            })
-            .collect())
-    }
-
     /// The desk's message history, most-recent last. `before` is an opaque
     /// EventLog cursor (a stringified sequence position); only messages before
     /// it are returned.
+    ///
+    /// Filtering + projection is shared with the REST `GET .../chat/history`
+    /// route via [`chat_history::history_for_desk`] (issue #65) so the two
+    /// surfaces can never disagree about a desk's transcript.
     async fn history(
         &self,
         ctx: &Context<'_>,
@@ -378,35 +339,22 @@ impl ChatGql {
         before: Option<String>,
     ) -> async_graphql::Result<Page<MessageGql>> {
         let before_seq = before.as_deref().and_then(|c| c.parse::<u64>().ok());
-        let stored = self
-            .runtime
-            .events()
-            .read_from(self.runtime.id(), EventSeq::new(0), usize::MAX)
-            .await?;
-
         let viewer = match ctx.data::<GqlAuth>() {
             Ok(GqlAuth::User(user)) => Viewer::User(user.user_id.clone()),
             _ => Viewer::Operator,
         };
-        // One roster read per history, not one per message: the scan above is
-        // already O(log), and an N+1 on top of it would be worse.
-        let authors = self.author_labels().await?;
-
-        let mut messages: Vec<MessageGql> = stored
-            .into_iter()
-            .filter(|event| self.owns(&event.event))
-            .filter(|event| before_seq.is_none_or(|before| event.seq.value() < before))
-            .map(|event| MessageGql::project(event, &viewer, &authors))
-            .collect();
-
-        let total = messages.len() as i32;
-        // Keep the most recent `first`, still in chronological order.
         let first = first.max(0) as usize;
-        if messages.len() > first {
-            messages.drain(0..messages.len() - first);
-        }
+        let (messages, total) = chat_history::history_for_desk(
+            &self.runtime,
+            &self.desk.id,
+            &self.desk.name,
+            &viewer,
+            before_seq,
+            first,
+        )
+        .await?;
         Ok(Page {
-            items: messages,
+            items: messages.into_iter().map(MessageGql::from).collect(),
             total,
         })
     }
@@ -430,75 +378,17 @@ pub struct MessageGql {
     pub mine: bool,
 }
 
-/// Who is reading a desk history. `mine` is relative to this.
-///
-/// There is no `From<StoredEvent> for MessageGql` any more, and there cannot
-/// be: `mine` depends on who is asking, and a `From` has no way to know. With
-/// one operator it was safe to hardcode `true`; with several users it would
-/// mark everyone's messages as everyone else's.
-#[derive(Clone, Debug, PartialEq)]
-pub enum Viewer {
-    /// An operator or platform credential. Legacy unattributed messages are
-    /// theirs, because that is who sent them before users existed.
-    Operator,
-    /// A human collaborator, by user id.
-    User(String),
-}
-
-impl MessageGql {
-    /// Projects a stored event for one viewer.
-    ///
-    /// `authors` maps user id → display label, resolved once per history rather
-    /// than per message.
-    pub fn project(
-        stored: StoredEvent,
-        viewer: &Viewer,
-        authors: &std::collections::HashMap<String, String>,
-    ) -> Self {
-        let id = ID(stored.seq.value().to_string());
-        let at_millis = stored.at_millis as f64;
-        match stored.event {
-            CompanyEvent::AgentReply { agent_id, text, .. } => MessageGql {
-                id,
-                channel: agent_id.clone(),
-                author: agent_id,
-                text,
-                at_millis,
-                mine: false,
-            },
-            CompanyEvent::OperatorMessage { text, by, .. } => {
-                let (author, mine) = match &by {
-                    // Sent by a signed-in human.
-                    Some(actor) if actor.kind == ActorKind::User => {
-                        let label = authors
-                            .get(&actor.id)
-                            .cloned()
-                            .unwrap_or_else(|| "someone".to_string());
-                        (label, *viewer == Viewer::User(actor.id.clone()))
-                    }
-                    // Sent with a machine credential, or journaled before
-                    // attribution existed. Either way there is no person to
-                    // name, and it belongs to whoever holds that credential.
-                    _ => ("operator".to_string(), matches!(viewer, Viewer::Operator)),
-                };
-                MessageGql {
-                    id,
-                    channel: "operator".to_string(),
-                    author,
-                    text,
-                    at_millis,
-                    mine,
-                }
-            }
-            // `owns` never admits other variants into a history.
-            other => MessageGql {
-                id,
-                channel: "system".to_string(),
-                author: "system".to_string(),
-                text: format!("{other:?}"),
-                at_millis,
-                mine: false,
-            },
+/// Wraps a viewer-agnostic [`MessageView`] (shared with the REST
+/// `chat/history` route, issue #65) as the GraphQL `Message` type.
+impl From<MessageView> for MessageGql {
+    fn from(view: MessageView) -> Self {
+        MessageGql {
+            id: ID(view.id),
+            channel: view.channel,
+            author: view.author,
+            text: view.text,
+            at_millis: view.at_millis,
+            mine: view.mine,
         }
     }
 }

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -71,6 +71,10 @@ type Chat {
 	The desk's message history, most-recent last. `before` is an opaque
 	EventLog cursor (a stringified sequence position); only messages before
 	it are returned.
+	
+	Filtering + projection is shared with the REST `GET .../chat/history`
+	route via [`chat_history::history_for_desk`] (issue #65) so the two
+	surfaces can never disagree about a desk's transcript.
 	"""
 	history(first: Int! = 50, before: String): MessagePage!
 }

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -219,6 +219,61 @@ async fn chats_list_the_manifest_desks() {
     tokio::fs::remove_dir_all(&home).await.ok();
 }
 
+/// Issue #65: `AgentReply`s answering the console's default thread are
+/// journaled with `chat_id == "main"` (the frontend's thread id), not
+/// `"General"`. The General desk's `Chat.history` must still find them
+/// alongside a reply journaled the "canonical" way, so the operator
+/// transcript is never split by which id a given turn happened to use.
+#[tokio::test]
+async fn chat_history_finds_agent_replies_under_general_and_main() {
+    let home = home();
+    let state = state_with_rich_company(&home).await;
+    let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+    runtime
+        .events()
+        .append(
+            runtime.id(),
+            crate::ports::types::CompanyEvent::AgentReply {
+                chat_id: "General".to_string(),
+                agent_id: "maya".to_string(),
+                text: "canonical id".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    runtime
+        .events()
+        .append(
+            runtime.id(),
+            crate::ports::types::CompanyEvent::AgentReply {
+                chat_id: "main".to_string(),
+                agent_id: "maya".to_string(),
+                text: "console default-thread id".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let app = router(state);
+    let value = query(
+        app,
+        r#"{"query":"{ company(id:\"acme\"){ chat(id:\"general\"){ history(first: 10) { items { text } } } } }"}"#,
+    )
+    .await;
+    let texts: Vec<&str> = value["data"]["company"]["chat"]["history"]["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| m["text"].as_str().unwrap())
+        .collect();
+    assert!(texts.contains(&"canonical id"), "missing: {texts:?}");
+    assert!(
+        texts.contains(&"console default-thread id"),
+        "missing: {texts:?}"
+    );
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
 #[tokio::test]
 async fn connections_reflect_manifest_intent_disconnected() {
     let home = home();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "tinyplace")]
 pub mod a2a;
+pub mod chat_history;
 pub mod cors;
 mod error;
 pub mod feedback;

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -28,7 +28,9 @@ use crate::ports::types::{
     Actor, ActorKind, ApprovalId, CompanyEvent, CompanyId, OutboundMessage, Verdict,
 };
 use crate::runtime::types::{ApprovalSummary, CompanyStatus, CycleReport};
+use crate::server::chat_history::{MessageView, Viewer, history_for_desk};
 use crate::server::error::ApiError;
+use crate::server::ops::language::DEFAULT_DESK;
 use crate::server::ops::{ScopedCompany, scoped};
 use crate::server::platform_auth::{CompanyAuth, authorize_address, refuse_until_password_changed};
 use crate::server::provision::{emit_cycle_webhooks, emit_feedback_webhook};
@@ -39,6 +41,7 @@ pub fn router() -> Router<AppState> {
         .route("/api/v1/companies", get(list_companies))
         .route("/api/v1/companies/{id}", get(company_status))
         .route("/api/v1/companies/{id}/chat", post(operator_chat))
+        .route("/api/v1/companies/{id}/chat/history", get(chat_history))
         .route("/api/v1/companies/{id}/approvals", get(list_approvals))
         .route(
             "/api/v1/companies/{id}/approvals/{aid}",
@@ -46,6 +49,7 @@ pub fn router() -> Router<AppState> {
         )
         // Single-company aliases (no id; resolved via the sole registered company).
         .route("/api/v1/company/chat", post(operator_chat_single))
+        .route("/api/v1/company/chat/history", get(chat_history_single))
         .route("/api/v1/company/approvals", get(list_approvals_single))
         .route(
             "/api/v1/company/approvals/{aid}",
@@ -318,6 +322,154 @@ async fn operator_chat_single(
     chat_and_emit(&state, &id, runtime, message, by)
         .await
         .map_err(IntoResponse::into_response)
+}
+
+/// Query params for `GET .../chat/history`.
+#[derive(Debug, Deserialize)]
+struct ChatHistoryQuery {
+    /// The desk to read, by id or name. Omitted defaults to the operator's
+    /// General/"main" line — the console's default thread (issue #65).
+    #[serde(default)]
+    desk: Option<String>,
+}
+
+/// One desk-history message, as the console renders it. Mirrors `ChatMessage`
+/// in `frontend/src/lib/chat.ts`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ChatHistoryMessageDto {
+    /// The message id (its EventLog sequence position).
+    id: String,
+    /// The channel the message came in on.
+    channel: String,
+    /// The author label.
+    author: String,
+    /// The message text.
+    text: String,
+    /// When it was journaled, epoch millis.
+    at_millis: f64,
+    /// Whether it is the operator's own message.
+    mine: bool,
+}
+
+impl From<MessageView> for ChatHistoryMessageDto {
+    fn from(view: MessageView) -> Self {
+        Self {
+            id: view.id,
+            channel: view.channel,
+            author: view.author,
+            text: view.text,
+            at_millis: view.at_millis,
+            mine: view.mine,
+        }
+    }
+}
+
+/// How many messages `GET .../chat/history` returns. Generous enough to
+/// hydrate a console thread on load (issue #65) while still bounding the
+/// response on a very long transcript; pagination is a GraphQL `Chat.history`
+/// concern, not this REST convenience route's.
+const CHAT_HISTORY_LIMIT: usize = 200;
+
+/// Resolves a `?desk=` selector to the `(id, name)` pair `history_for_desk`
+/// filters on.
+///
+/// A selector matching a manifest group chat (by id or name,
+/// case-insensitive) resolves to that desk's real id/name pair — same as the
+/// GraphQL `chat(id:)` lookup. An unmatched selector (an ad hoc thread id the
+/// console addresses with no backing manifest entry, e.g. a static default
+/// thread) passes through as both id and name, so history still finds
+/// whatever was journaled under that exact string. Omitted resolves to the
+/// synthetic General/operator desk.
+async fn resolve_desk(
+    runtime: &CompanyRuntime,
+    desk: Option<&str>,
+) -> Result<(String, String), OpenCompanyError> {
+    let Some(desk) = desk else {
+        return Ok((DEFAULT_DESK.to_string(), DEFAULT_DESK.to_string()));
+    };
+    let record = runtime.store().load(runtime.id()).await?;
+    let matched =
+        record.and_then(|record| {
+            record.manifest.group_chats.into_iter().find(|chat| {
+                chat.id.eq_ignore_ascii_case(desk) || chat.name.eq_ignore_ascii_case(desk)
+            })
+        });
+    Ok(match matched {
+        Some(chat) => (chat.id, chat.name),
+        None => (desk.to_string(), desk.to_string()),
+    })
+}
+
+/// Resolves who is reading a desk's history, for the `mine` flag. Reuses
+/// [`chat_actor`]'s auth (session cookie or platform credential, tenant
+/// address-authorization, temporary-password gate) so a history read can
+/// never see more than a matching chat send could.
+async fn history_viewer(
+    headers: &HeaderMap,
+    state: &AppState,
+    company: &CompanyId,
+) -> Result<Viewer, Response> {
+    let actor = chat_actor(headers, state, company).await?;
+    Ok(match actor {
+        Some(actor) if actor.kind == ActorKind::User => Viewer::User(actor.id),
+        _ => Viewer::Operator,
+    })
+}
+
+/// Shared body for both scope forms of `GET .../chat/history`.
+async fn chat_history_response(
+    state: &AppState,
+    company: &CompanyId,
+    runtime: Arc<CompanyRuntime>,
+    headers: &HeaderMap,
+    query: ChatHistoryQuery,
+) -> Result<Json<Vec<ChatHistoryMessageDto>>, Response> {
+    let viewer = history_viewer(headers, state, company).await?;
+    let (desk_id, desk_name) = resolve_desk(&runtime, query.desk.as_deref())
+        .await
+        .map_err(|e| ApiError(e).into_response())?;
+    let (messages, _total) = history_for_desk(
+        &runtime,
+        &desk_id,
+        &desk_name,
+        &viewer,
+        None,
+        CHAT_HISTORY_LIMIT,
+    )
+    .await
+    .map_err(|e| ApiError(e).into_response())?;
+    Ok(Json(
+        messages
+            .into_iter()
+            .map(ChatHistoryMessageDto::from)
+            .collect(),
+    ))
+}
+
+/// `GET /api/v1/companies/{id}/chat/history` — a desk's transcript (issue
+/// #65), reusing the same filter + projection as GraphQL `Chat.history` via
+/// [`history_for_desk`].
+async fn chat_history(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    headers: HeaderMap,
+    Query(query): Query<ChatHistoryQuery>,
+) -> Result<Json<Vec<ChatHistoryMessageDto>>, Response> {
+    let company = CompanyId::new(&id);
+    let runtime = lookup(&state, &id).map_err(IntoResponse::into_response)?;
+    chat_history_response(&state, &company, runtime, &headers, query).await
+}
+
+/// `GET /api/v1/company/chat/history` (single-company alias).
+async fn chat_history_single(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Query(query): Query<ChatHistoryQuery>,
+) -> Result<Json<Vec<ChatHistoryMessageDto>>, Response> {
+    let runtime = sole(&state).map_err(IntoResponse::into_response)?;
+    let id = runtime.id().clone();
+    chat_history_response(&state, &id, runtime, &headers, query).await
 }
 
 /// `GET /api/v1/companies/{id}/approvals`.
@@ -623,6 +775,98 @@ mod test {
             .oneshot(
                 Request::builder()
                     .uri("/api/v1/company/desks")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value.as_array().unwrap().len(), 0);
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    /// Issue #65: the console's default thread addresses sends with
+    /// `chat: "main"`, but pre-threading history and the synthetic operator
+    /// desk are keyed on `"General"`. A transcript spanning both ids — one
+    /// operator turn journaled under each — must read back as one history via
+    /// the REST route with no `?desk=` selector (the console's default read).
+    #[tokio::test]
+    async fn chat_history_route_reunifies_general_and_main_transcripts() {
+        let home = home();
+        let state = state_with_company(&home, "running").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+
+        runtime
+            .events()
+            .append(
+                runtime.id(),
+                CompanyEvent::AgentReply {
+                    chat_id: "General".to_string(),
+                    agent_id: "ceo".to_string(),
+                    text: "reply under General".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        runtime
+            .events()
+            .append(
+                runtime.id(),
+                CompanyEvent::AgentReply {
+                    chat_id: "main".to_string(),
+                    agent_id: "ceo".to_string(),
+                    text: "reply under main".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let app = router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/company/chat/history")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let messages = value.as_array().unwrap();
+        let texts: Vec<&str> = messages
+            .iter()
+            .map(|m| m["text"].as_str().unwrap())
+            .collect();
+        assert!(
+            texts.contains(&"reply under General"),
+            "missing General-id reply: {texts:?}"
+        );
+        assert!(
+            texts.contains(&"reply under main"),
+            "missing main-id reply: {texts:?}"
+        );
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    /// A desk id with no `?desk=` selector defaults to the operator/General
+    /// thread; an unaddressed thread id that neither matches a manifest desk
+    /// nor the General desk reads back empty rather than erroring.
+    #[tokio::test]
+    async fn chat_history_route_unknown_desk_is_empty_not_an_error() {
+        let home = home();
+        let state = state_with_company(&home, "running").await;
+        let app = router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/company/chat/history?desk=strategy")
                     .header("cookie", crate::server::test_support::fixed_cookie("acme"))
                     .body(Body::empty())
                     .unwrap(),


### PR DESCRIPTION
## Summary

The console chat transcript never rehydrated — every login/reload showed an empty chat even though the backend persists the full transcript (every operator message + agent reply) to the `EventLog`. The only working read was GraphQL's `Chat.history`, and the console is REST-only, so it never called it; `listDesks` only ever fetched desk *metadata* and always seeded `thread.messages` empty.

This adds a REST `GET .../chat/history` route (both scope forms) and wires the console to call it after its thread list resolves. The filter + projection logic (`owns` / message projection) is extracted out of the GraphQL resolver into a shared `src/server/chat_history.rs` module that both surfaces now call through — so REST and GraphQL can never disagree about what a desk's history contains.

Separately, the operator/General thread had a data wrinkle: the console's default thread addresses sends with `chat: "main"`, but the backend's synthetic default desk is keyed on `"General"`, so an `AgentReply` answering that thread journals with `chat_id == "main"` while the read side only recognized `"General"`. Fixed on the read side — `owns()` now admits `"main"` (and an empty chat id) for the General/operator desk, so no historical reply is orphaned by which id it happened to be journaled under. The write path already defaults to `"General"` and is untouched.

`Closes #65`.

## API Or Behavior Changes

- New routes: `GET /api/v1/companies/{id}/chat/history` and `GET /api/v1/company/chat/history`, both accepting an optional `?desk=<id-or-name>` query param (case-insensitive match against a manifest group chat; unmatched selectors pass through as a raw chat id so an ad hoc thread with no manifest entry still reads back whatever was journaled under it). Omitted `desk` reads the operator/General line. Returns a JSON array of `{id, channel, author, text, atMillis, mine}`, most-recent last, capped at 200 messages.
- `GraphQL Chat.history` behavior change: the General desk's history now also matches `AgentReply`s journaled under the console's `"main"` thread id (previously only `"General"`/desk id/desk name). No schema shape change — only the doc comment on `history` changed (regenerated `schema.graphql`).
- Console: `OpenCompanyClient.getChatHistory(desk, company)` added; `AppShell` now fetches and merges each thread's history after desks resolve (or after the static default threads are chosen, if `/desks` 404s).

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets` (via `cargo check --lib` + `cargo test`, which builds all targets)
- [x] `cargo test` — 562 passed (lib) + 4 passed (bin), 0 failed, 1 ignored (`regenerate_sdl_snapshot`, an explicit-only snapshot-writer test)
- [x] `cd frontend && npm run typecheck` — clean
- [x] `cd frontend && npm run build` — clean

New tests: a `chat_history` unit-test suite for `owns()`; a REST-level test (`chat_history_route_reunifies_general_and_main_transcripts`) proving a transcript spanning both the `"General"` and `"main"` `chat_id`s reads back as one history through the default (no `?desk=`) read; a GraphQL-level test (`chat_history_finds_agent_replies_under_general_and_main`) proving the same at the `Chat.history` resolver.

## Documentation

None needed — this closes a gap in existing behavior (`Chat.history`, `#53`) rather than introducing a new documented surface; the new REST route mirrors the already-documented `GET .../desks` convenience route.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chat history endpoints for retrieving persisted desk conversations.
  * Chat transcripts now reload automatically when opening the application.
  * Added support for selecting specific desks and returning author, channel, timestamp, and ownership details.
  * Unified transcript behavior across REST and GraphQL, including General desk conversations.

* **Bug Fixes**
  * Improved handling of messages recorded under alternate default thread identifiers.
  * History loading failures no longer prevent conversations from opening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->