### PR TITLE
feat(events): company->operator attention SSE feed (#66)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import {
   Brain,
   ChartColumnBig,
@@ -47,6 +47,7 @@ import { StatusPill } from "@/components/status-pill";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { DiscordIcon } from "@/components/discord-icon";
 import { useCompany } from "@/hooks/use-company";
+import { type AgentReplyEvent, useEvents } from "@/hooks/use-events";
 import { useHashView } from "@/hooks/use-hash-view";
 import { type ChatMessage, makeMessage } from "@/lib/chat";
 import { DISCORD_INVITE_URL } from "@/lib/links";
@@ -227,6 +228,39 @@ export function AppShell({
   // Approval decisions and other events land in the active thread's transcript.
   const noteSystem = (line: string) =>
     setThreadMessages(activeThreadId, (m) => [...m, makeMessage("system", line)]);
+
+  // Inject an `AgentReply` pushed over the SSE feed (issue #66) into its desk
+  // thread's transcript. Dedupe against our own optimistic echo: the backend
+  // journals an `AgentReply` for the operator's own chat turn too, and
+  // Conversation already rendered that reply locally. Local message ids are
+  // ephemeral counters (not content-addressed), so we key the dedupe on an
+  // identical company line already present in the thread's recent tail. Only
+  // desks that exist as a thread receive an injection; an unmatched chatId is a
+  // no-op rather than polluting the wrong thread.
+  const injectAgentReply = useCallback((event: AgentReplyEvent) => {
+    setThreads((ts) =>
+      ts.map((t) => {
+        if (t.id !== event.chatId) return t;
+        const dup = t.messages
+          .slice(-8)
+          .some((m) => m.from === "company" && m.text === event.text);
+        if (dup) return t;
+        return {
+          ...t,
+          messages: [...t.messages, makeMessage("company", event.text, { channel: event.agentId })],
+        };
+      }),
+    );
+  }, []);
+
+  // The active push half of the attention surface: SSE-driven toasts + chat
+  // injection, plus a rising-edge "needs a sign-off" toast off the poll's
+  // pending count. Degrades silently to the `useCompany` poll when the host has
+  // no `/events` route.
+  useEvents(client, company, {
+    pendingApprovals: pending,
+    onAgentReply: injectAgentReply,
+  });
 
   return (
     <SidebarProvider>

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -1,0 +1,172 @@
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+
+import type { OpenCompanyClient } from "@/api/client";
+
+/**
+ * One attention item off the company → operator SSE feed (issue #66). Mirrors
+ * the safe projection emitted by `project_event` in `src/server/operator.rs`:
+ * every field here already exists on a `CompanyEvent`, and no token, secret, or
+ * raw third-party payload is ever on the wire.
+ */
+export type CompanyStreamEvent =
+  | { type: "agent_reply"; seq: number; atMillis: number; chatId: string; agentId: string; text: string }
+  | { type: "task_dispatched"; seq: number; atMillis: number; taskId: string }
+  | {
+      type: "mcp_call_failed";
+      seq: number;
+      atMillis: number;
+      server: string;
+      tool: string;
+      status: string;
+      message: string;
+    }
+  | { type: "approval_resolved"; seq: number; atMillis: number; approvalId: string; verdict: string }
+  | { type: "lifecycle_changed"; seq: number; atMillis: number; from: string; to: string }
+  | { type: "payment_received"; seq: number; atMillis: number; amountUsd: number; memo: string };
+
+/** An `AgentReply` the hook hands back for injection into a chat transcript. */
+export interface AgentReplyEvent {
+  chatId: string;
+  agentId: string;
+  text: string;
+}
+
+interface Options {
+  /**
+   * The number of approvals currently awaiting the operator, from the existing
+   * status poll. A rising edge fires the "needs a sign-off" push — approvals have
+   * no `CompanyEvent`, so this is the one attention signal that rides the poll
+   * rather than the SSE stream.
+   */
+  pendingApprovals: number;
+  /**
+   * Called for each `AgentReply` so the shell can inject it into the active
+   * chat's transcript. The shell dedupes against its own optimistic echo.
+   */
+  onAgentReply?: (event: AgentReplyEvent) => void;
+}
+
+/**
+ * Opens an `EventSource` on `{scope}/events` for the active company and turns
+ * incoming attention events into `sonner` toasts (and, for agent replies, a
+ * transcript injection via {@link Options.onAgentReply}). This is the active
+ * push half of the attention surface; the passive 5s status/approvals poll in
+ * {@link useCompany} stays as the fallback — if the host doesn't expose
+ * `/events` (404) or the connection drops, this hook degrades silently and the
+ * poll keeps the console current.
+ */
+export function useEvents(
+  client: OpenCompanyClient,
+  company: string | null,
+  { pendingApprovals, onAgentReply }: Options,
+): void {
+  // Keep the latest callback without re-opening the stream when it changes.
+  const onAgentReplyRef = useRef(onAgentReply);
+  useEffect(() => {
+    onAgentReplyRef.current = onAgentReply;
+  }, [onAgentReply]);
+
+  // The rising-edge detector for pending approvals. Seeded with the current
+  // value so we only toast on an *increase* observed while mounted, never on the
+  // first read or when the count falls after a resolution.
+  const prevPending = useRef(pendingApprovals);
+  useEffect(() => {
+    if (pendingApprovals > prevPending.current) {
+      toast.warning("Your company needs a sign-off", {
+        description:
+          pendingApprovals === 1
+            ? "An action is waiting for your approval."
+            : `${pendingApprovals} actions are waiting for your approval.`,
+      });
+    }
+    prevPending.current = pendingApprovals;
+  }, [pendingApprovals]);
+
+  // The SSE subscription. Re-opens when the company (or client) changes.
+  useEffect(() => {
+    // EventSource can only speak same-origin cookies; the URL is built from the
+    // client's base + scope so it lands on the right company under either
+    // deployment shape.
+    const url = `${client.baseUrl}${client.scopeFor(company)}/events`;
+    let source: EventSource;
+    try {
+      source = new EventSource(url, { withCredentials: true });
+    } catch (err) {
+      // A malformed URL or an environment without EventSource: nothing to do,
+      // the poll remains the source of truth.
+      console.debug("[events] EventSource unavailable, falling back to poll", err);
+      return;
+    }
+    console.debug("[events] connecting", { url });
+
+    source.onopen = () => {
+      console.debug("[events] connected", { url });
+    };
+
+    source.onmessage = (msg) => {
+      let event: CompanyStreamEvent;
+      try {
+        event = JSON.parse(msg.data) as CompanyStreamEvent;
+      } catch (err) {
+        console.debug("[events] dropping unparseable event", err);
+        return;
+      }
+      handleEvent(event, onAgentReplyRef.current);
+    };
+
+    source.onerror = () => {
+      // On a 404 / wrong content-type the browser closes the stream and does not
+      // reconnect (readyState === CLOSED); on a transient drop it reconnects on
+      // its own. Either way we log and lean on the poll — no manual retry loop.
+      const closed = source.readyState === EventSource.CLOSED;
+      console.debug("[events] stream error", {
+        url,
+        reconnecting: !closed,
+      });
+      if (closed) source.close();
+    };
+
+    return () => {
+      console.debug("[events] disconnecting", { url });
+      source.close();
+    };
+  }, [client, company]);
+}
+
+/** Routes one parsed event to its toast / transcript side effect. */
+function handleEvent(event: CompanyStreamEvent, onAgentReply?: (e: AgentReplyEvent) => void): void {
+  switch (event.type) {
+    case "mcp_call_failed":
+      toast.error(`MCP ${event.server} failed`, {
+        description: event.message || `${event.tool} · ${event.status}`,
+      });
+      break;
+    case "task_dispatched":
+      toast("A task is on the move", {
+        description: "Your company picked up a task.",
+      });
+      break;
+    case "agent_reply":
+      onAgentReply?.({ chatId: event.chatId, agentId: event.agentId, text: event.text });
+      break;
+    case "approval_resolved":
+      toast(event.verdict === "approve" ? "Approval granted" : "Approval denied", {
+        description: "An approval was just resolved.",
+      });
+      break;
+    case "lifecycle_changed":
+      toast(`Company is now ${event.to}`, {
+        description: `Changed from ${event.from}.`,
+      });
+      break;
+    case "payment_received":
+      toast.success("Payment received", {
+        description: `$${event.amountUsd.toFixed(2)} — ${event.memo}`,
+      });
+      break;
+    default:
+      // An unknown/forward event kind: ignore rather than surface noise.
+      break;
+  }
+}

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -12,20 +12,25 @@
 //! Auth is a platform token (hosting layer) or a human's session cookie; there
 //! is no unauthenticated path. See [`server::users`](crate::server::users).
 
+use std::convert::Infallible;
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::extract::{Path, State};
 use axum::http::{HeaderMap, StatusCode};
+use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
+use futures::StreamExt;
+use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
 use crate::ports::types::{
-    Actor, ActorKind, ApprovalId, CompanyEvent, CompanyId, OutboundMessage, Verdict,
+    Actor, ActorKind, ApprovalId, CompanyEvent, CompanyId, OutboundMessage, StoredEvent, Verdict,
 };
 use crate::runtime::types::{ApprovalSummary, CompanyStatus, CycleReport};
 use crate::server::error::ApiError;
@@ -54,6 +59,10 @@ pub fn router() -> Router<AppState> {
         // The company's desks (group chats), under both scope forms — the
         // console builds its chat threads from these (issue #53).
         .merge(scoped("/desks", get(list_desks)))
+        // The company → operator attention feed (issue #66): a live SSE stream of
+        // the attention-worthy events already on the company's event log, under
+        // both scope forms.
+        .merge(scoped("/events", get(company_events)))
 }
 
 /// One desk (group chat) as the console renders it. Mirrors `DeskDto` in
@@ -98,6 +107,134 @@ async fn list_desks(scope: ScopedCompany) -> Result<Json<Vec<DeskDto>>, Response
         })
         .unwrap_or_default();
     Ok(Json(desks))
+}
+
+/// Logs SSE stream teardown when the subscriber disconnects. Held inside the
+/// projection closure so it drops exactly when the response body is dropped.
+struct SseStreamGuard(CompanyId);
+
+impl Drop for SseStreamGuard {
+    fn drop(&mut self) {
+        tracing::debug!(company = %self.0, "operator SSE stream closed");
+    }
+}
+
+/// `GET {scope}/events` — the company → operator attention feed (issue #66).
+///
+/// Subscribes to the company's [`EventLog`](crate::ports::EventLog) and streams a
+/// **safe projection** of each attention-worthy [`CompanyEvent`] to the console
+/// as Server-Sent Events. Only domain fields already present on the event reach
+/// the wire — never a token, secret, credential, or raw webhook/tool payload —
+/// and events that carry no attention signal (or that carry raw internal state)
+/// are dropped entirely (see [`project_event`]). Auth rides the same
+/// [`ScopedCompany`] guard as every other company-scoped route: the browser's
+/// `EventSource` sends the session cookie same-origin, so no new auth path is
+/// introduced.
+async fn company_events(
+    scope: ScopedCompany,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let company = scope.id().clone();
+    tracing::debug!(company = %company, "operator SSE stream opening");
+    let guard = SseStreamGuard(company.clone());
+    let stream = scope
+        .runtime
+        .events()
+        .subscribe(&company)
+        .filter_map(move |stored| {
+            // Keep the teardown guard alive for the life of the stream.
+            let _ = &guard;
+            let event =
+                project_event(&stored).map(|value| Ok(Event::default().data(value.to_string())));
+            std::future::ready(event)
+        });
+    Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(15))
+            .text("keep-alive"),
+    )
+}
+
+/// Projects a stored event into the safe SSE wire shape, or `None` to drop it.
+///
+/// The projection is deny-by-default: every emitted object carries only
+/// domain fields that already exist on the [`CompanyEvent`], and any variant not
+/// explicitly listed — `OperatorMessage` (the operator's own echo),
+/// `WebhookReceived` / `A2aTaskReceived` (raw third-party payloads),
+/// `ScheduleFired`, `FeedbackFiled`, `MemoryFactDeleted` — is dropped so nothing
+/// unexpected (or secret-bearing) ever reaches the console. The actor (`by`) on
+/// `ApprovalResolved` / `LifecycleChanged` is intentionally omitted: the console
+/// renders the attention item without it, and it can carry a user id.
+fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
+    use serde_json::json;
+
+    let envelope = |ty: &str| {
+        json!({
+            "type": ty,
+            "seq": stored.seq.value(),
+            "atMillis": stored.at_millis,
+        })
+    };
+
+    let value = match &stored.event {
+        CompanyEvent::AgentReply {
+            chat_id,
+            agent_id,
+            text,
+        } => {
+            let mut o = envelope("agent_reply");
+            o["chatId"] = json!(chat_id);
+            o["agentId"] = json!(agent_id);
+            o["text"] = json!(text);
+            o
+        }
+        CompanyEvent::TaskDispatched { task_id } => {
+            let mut o = envelope("task_dispatched");
+            o["taskId"] = json!(task_id);
+            o
+        }
+        // `message` is scrubbed at the source (`OcMcpCallTool` → `HarnessBrain`
+        // drain), so it can never carry a credential, response body, or URL query
+        // string — safe to forward verbatim. See `CompanyEvent::McpCallFailed`.
+        CompanyEvent::McpCallFailed {
+            server,
+            tool,
+            status,
+            message,
+        } => {
+            let mut o = envelope("mcp_call_failed");
+            o["server"] = json!(server);
+            o["tool"] = json!(tool);
+            o["status"] = json!(status);
+            o["message"] = json!(message);
+            o
+        }
+        CompanyEvent::ApprovalResolved {
+            approval_id,
+            verdict,
+            ..
+        } => {
+            let mut o = envelope("approval_resolved");
+            o["approvalId"] = json!(approval_id.as_ref());
+            o["verdict"] = json!(verdict);
+            o
+        }
+        CompanyEvent::LifecycleChanged { from, to, .. } => {
+            let mut o = envelope("lifecycle_changed");
+            o["from"] = json!(from);
+            o["to"] = json!(to);
+            o
+        }
+        CompanyEvent::PaymentReceived { amount_usd, memo } => {
+            let mut o = envelope("payment_received");
+            o["amountUsd"] = json!(amount_usd);
+            o["memo"] = json!(memo);
+            o
+        }
+        // Not an attention signal, or carries a raw payload we never put on the
+        // wire — dropped.
+        _ => return None,
+    };
+    Some(value)
 }
 
 fn lookup(state: &AppState, id: &str) -> Result<Arc<CompanyRuntime>, ApiError> {
@@ -874,6 +1011,201 @@ mod test {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    // ---- issue #66: the operator attention SSE feed ----
+
+    use crate::ports::types::{EventSeq, StoredEvent};
+
+    fn stored(event: CompanyEvent) -> StoredEvent {
+        StoredEvent {
+            seq: EventSeq::new(7),
+            company: CompanyId::new("acme"),
+            event,
+            at_millis: 1_700_000_000_000,
+        }
+    }
+
+    #[test]
+    fn projects_agent_reply_with_only_chat_fields() {
+        let v = super::project_event(&stored(CompanyEvent::AgentReply {
+            chat_id: "General".into(),
+            agent_id: "ceo".into(),
+            text: "shipped it".into(),
+        }))
+        .expect("agent_reply is an attention signal");
+        assert_eq!(v["type"], "agent_reply");
+        assert_eq!(v["seq"], 7);
+        assert_eq!(v["atMillis"], 1_700_000_000_000_u64);
+        assert_eq!(v["chatId"], "General");
+        assert_eq!(v["agentId"], "ceo");
+        assert_eq!(v["text"], "shipped it");
+    }
+
+    #[test]
+    fn projects_task_dispatched() {
+        let v = super::project_event(&stored(CompanyEvent::TaskDispatched {
+            task_id: "t-42".into(),
+        }))
+        .expect("task_dispatched is an attention signal");
+        assert_eq!(v["type"], "task_dispatched");
+        assert_eq!(v["taskId"], "t-42");
+    }
+
+    #[test]
+    fn projects_mcp_call_failed_with_scrubbed_message() {
+        let v = super::project_event(&stored(CompanyEvent::McpCallFailed {
+            server: "browserbase".into(),
+            tool: "browse".into(),
+            status: "tool_call_rejected".into(),
+            message: "server rejected the call".into(),
+        }))
+        .expect("mcp_call_failed is an attention signal");
+        assert_eq!(v["type"], "mcp_call_failed");
+        assert_eq!(v["server"], "browserbase");
+        assert_eq!(v["tool"], "browse");
+        assert_eq!(v["status"], "tool_call_rejected");
+        // The message is already scrubbed at the source; we forward exactly it.
+        assert_eq!(v["message"], "server rejected the call");
+    }
+
+    #[test]
+    fn projects_approval_resolved_without_the_actor() {
+        let v = super::project_event(&stored(CompanyEvent::ApprovalResolved {
+            approval_id: ApprovalId::new("ap-1"),
+            verdict: Verdict::Approve,
+            by: Actor {
+                kind: ActorKind::User,
+                // A user id must never reach the wire via the attention feed.
+                id: "secret-user-id".into(),
+            },
+        }))
+        .expect("approval_resolved is an attention signal");
+        assert_eq!(v["type"], "approval_resolved");
+        assert_eq!(v["approvalId"], "ap-1");
+        assert_eq!(v["verdict"], "approve");
+        // The actor is intentionally dropped — the projection carries no `by`,
+        // and the serialized bytes never mention the user id.
+        assert!(v.get("by").is_none(), "actor must not be projected");
+        assert!(
+            !v.to_string().contains("secret-user-id"),
+            "user id leaked onto the wire"
+        );
+    }
+
+    #[test]
+    fn projects_lifecycle_changed_without_the_actor() {
+        let v = super::project_event(&stored(CompanyEvent::LifecycleChanged {
+            from: "running".into(),
+            to: "paused".into(),
+            by: Actor {
+                kind: ActorKind::Operator,
+                id: "operator".into(),
+            },
+        }))
+        .expect("lifecycle_changed is an attention signal");
+        assert_eq!(v["type"], "lifecycle_changed");
+        assert_eq!(v["from"], "running");
+        assert_eq!(v["to"], "paused");
+        assert!(v.get("by").is_none(), "actor must not be projected");
+    }
+
+    #[test]
+    fn projects_payment_received() {
+        let v = super::project_event(&stored(CompanyEvent::PaymentReceived {
+            amount_usd: 25.0,
+            memo: "invoice #1".into(),
+        }))
+        .expect("payment_received is an attention signal");
+        assert_eq!(v["type"], "payment_received");
+        assert_eq!(v["amountUsd"], 25.0);
+        assert_eq!(v["memo"], "invoice #1");
+    }
+
+    #[test]
+    fn drops_non_attention_and_raw_payload_events() {
+        // The operator's own message, and every variant that carries a raw
+        // third-party payload or is audit-only, is dropped so nothing unexpected
+        // (or secret-bearing) ever reaches the console.
+        let dropped = [
+            CompanyEvent::OperatorMessage {
+                text: "hi".into(),
+                by: None,
+                chat: None,
+            },
+            CompanyEvent::WebhookReceived {
+                channel: "email".into(),
+                body: serde_json::json!({"authorization": "Bearer sk-secret"}),
+            },
+            CompanyEvent::A2aTaskReceived {
+                from: "@peer".into(),
+                task: serde_json::json!({"token": "sk-secret"}),
+            },
+            CompanyEvent::ScheduleFired {
+                cron: "0 9 * * *".into(),
+                prompt: "daily standup".into(),
+            },
+            CompanyEvent::FeedbackFiled {
+                note: "too slow".into(),
+            },
+            CompanyEvent::MemoryFactDeleted {
+                fact_id: "f-1".into(),
+            },
+        ];
+        for event in dropped {
+            assert!(
+                super::project_event(&stored(event.clone())).is_none(),
+                "event should be dropped from the SSE feed: {event:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn events_route_streams_text_event_stream() {
+        let home = home();
+        let state = state_with_company(&home, "running").await;
+        let app = router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/company/events")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // The SSE head is returned immediately; the body streams indefinitely, so
+        // we assert the status + content-type without draining it.
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some("text/event-stream")
+        );
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    #[tokio::test]
+    async fn events_route_requires_a_session() {
+        let home = home();
+        let state = state_with_company(&home, "running").await;
+        let app = router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/company/events")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
         tokio::fs::remove_dir_all(&home).await.ok();
     }
 }


### PR DESCRIPTION
## Summary

The company chat was one-directional — nothing proactively poked the operator when something needed attention (task dispatched, approval pending, MCP call failed, agent reply). This adds a company → operator attention signal end-to-end:

- **Backend**: a new `GET {scope}/events` SSE route (`/api/v1/companies/{id}/events` and `/api/v1/company/events`) that subscribes to the company's existing `EventLog` and streams a safe, deny-by-default projection of attention-worthy `CompanyEvent`s (`AgentReply`, `TaskDispatched`, `McpCallFailed`, `ApprovalResolved`, `LifecycleChanged`, `PaymentReceived`). Auth rides the existing `ScopedCompany` guard (same session cookie as every other company-scoped route) — no new auth path. A 15s keep-alive is included.
- **Frontend**: a new `useEvents` hook opens an `EventSource` on the feed and turns incoming events into `sonner` toasts ("MCP `<server>` failed", task-moved notices, lifecycle/payment notices) and a rising-edge "your company needs a sign-off" toast off the existing approvals poll. `AgentReply` events are injected directly into the matching desk thread's transcript (reusing the existing `makeMessage`/`setThreads` helpers in `app-shell.tsx`), deduped against the operator's own optimistic echo of the same turn.
- If the host has no `/events` route or the SSE connection drops, the hook degrades silently — the existing 5s status/approvals poll in `use-company.ts` remains the fallback, untouched.

Closes #66

## API Or Behavior Changes

- New route: `GET {scope}/events` (SSE, `text/event-stream`), company-scoped, cookie-authed. No existing routes changed.
- Wire projection is deny-by-default — every field on the JSON payload already exists on the corresponding `CompanyEvent`; actor identities (`Actor.id`) and raw third-party payloads (`WebhookReceived`, `A2aTaskReceived` bodies) are never projected. See the `project_event` doc comment in `src/server/operator.rs` for the full mapping and rationale.
- Frontend behavior change: desk chat threads and the approvals badge can now update live via push, in addition to the existing poll.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 565 passed / 0 failed / 1 ignored (lib) + 4 passed (bin), including 9 new tests covering the projection (one per emitted event kind, one asserting non-attention/raw-payload events and a planted secret string never reach the wire) and the new route (SSE content-type + 401-without-session).
- [x] `cd frontend && npm run typecheck` — pass
- [x] `cd frontend && npm run build` — pass

## Documentation

None needed — the route and its safety contract are documented inline via doc comments on `company_events` / `project_event` in `src/server/operator.rs`.

## Related

Overlaps with #65 (chat injection / `app-shell.tsx`), which is a separate in-flight branch. The `app-shell.tsx` edit here is kept minimal and localized (one hook call + one callback) to avoid conflicting; the two should union cleanly at consolidation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time event updates for agent replies, approval activity, task progress, payment notifications, and other important account events.
  * Agent replies now appear automatically in the relevant conversation.
  * Added notifications when pending approvals increase, with tailored messaging for one or multiple approvals.

* **Bug Fixes**
  * Prevented duplicate agent messages when locally displayed replies are also received through real-time updates.
  * Preserved existing polling behavior when real-time event updates are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->