### PR TITLE
feat(harness): promote overlay teammates into the runtime + add_agent tool (#71)

### DIFF
--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -216,6 +216,14 @@ pub fn build_agent(
             deps.events.clone(),
         )));
         tools.extend(orchestrator::delegation_tools(&deps.delegations));
+        // Issue #71 — Active Runtime Teammates (minimal slice): the orchestrator
+        // can bring on a new teammate mid-chat. Writes through the same
+        // `CompanyStore` the console `POST .../team` route uses; the addition
+        // reaches the roster on the next `HarnessPool::ensure` call.
+        tools.push(Box::new(orchestrator::AddAgentTool::new(
+            company.clone(),
+            deps.store.clone(),
+        )));
     }
 
     let prompt_builder = SystemPromptBuilder::for_subagent(

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -756,6 +756,7 @@ fn overlay_agent_to_manifest(overlay: &OverlayAgent) -> ManifestAgent {
         tools: Vec::new(),
         budget_usd_daily: None,
     }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -50,7 +50,7 @@ pub mod steps;
 
 pub use brain::HarnessBrain;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -60,6 +60,7 @@ use tokio::sync::{Mutex, RwLock};
 use oh::agent::Agent;
 use oh::inference::provider::Provider;
 
+use crate::company::Agent as ManifestAgent;
 use crate::company::Policy;
 use crate::company::mcp::McpServerDecl;
 use crate::error::OpenCompanyError;
@@ -68,10 +69,11 @@ use crate::harness::mcp_probe::McpFailureQueue;
 use crate::harness::orchestrator::DelegationQueue;
 use crate::harness::policy::ApprovalPolicy;
 use crate::ports::skills_state::{SkillState, SkillStateStore};
-use crate::ports::types::{CompanyId, CompanyRecord, TurnStep};
+use crate::ports::types::{CompanyId, CompanyRecord, OverlayAgent, TurnStep};
 use crate::ports::{
     CompanyStore, ContextStore, EventLog, FactStore, SecretStore, TaskStore, UsageMeter,
 };
+use crate::runtime::builder::agent_effective_grants;
 
 /// Shared dependencies every harness-built agent draws on.
 #[derive(Clone)]
@@ -318,6 +320,12 @@ pub struct HarnessPool {
     /// from, keyed by company. Drives MCP-freshness: [`ensure`](Self::ensure)
     /// rebuilds the roster whenever the fingerprint changes.
     mcp_fingerprints: RwLock<HashMap<CompanyId, u64>>,
+    /// Fingerprint of the overlay-agent set (issue #71 — Active Runtime
+    /// Teammates) the cached roster was built from, keyed by company. Drives
+    /// overlay-agent freshness: [`ensure`](Self::ensure) rebuilds the roster
+    /// whenever an operator- or orchestrator-added teammate is added/removed,
+    /// mirroring the MCP-freshness fingerprint above.
+    overlay_fingerprints: RwLock<HashMap<CompanyId, u64>>,
 }
 
 impl Default for HarnessPool {
@@ -332,6 +340,7 @@ impl HarnessPool {
         Self {
             agents: RwLock::new(HashMap::new()),
             mcp_fingerprints: RwLock::new(HashMap::new()),
+            overlay_fingerprints: RwLock::new(HashMap::new()),
         }
     }
 
@@ -346,16 +355,29 @@ impl HarnessPool {
     /// company restart (the "Parallel Search / BrowserBase" bug). When nothing
     /// changed, the cached roster is reused (the common fast path), exactly as
     /// before.
+    ///
+    /// **Overlay-agent freshness (issue #71)**: the live overlay-agent set is
+    /// re-resolved and fingerprinted the same way, from [`HarnessDeps::store`]
+    /// rather than the (possibly stale) `company` snapshot passed in — so a
+    /// teammate added through the console `POST .../team` route or the
+    /// orchestrator's `add_agent` tool becomes a real, addressable roster agent
+    /// on the company's **next** `ensure` call, with no restart.
     pub async fn ensure(&self, company: &CompanyRecord, deps: &HarnessDeps) -> crate::Result<()> {
         // Re-resolve + fingerprint the effective MCP set (cheap; no rebuild yet).
         let effective_mcp = self.resolve_effective_mcp(company, deps).await;
-        let fingerprint = mcp_fingerprint(&effective_mcp);
+        let mcp_fp = mcp_fingerprint(&effective_mcp);
+
+        // Re-resolve + fingerprint the live overlay-agent set the same way.
+        let overlay_agents = self.resolve_effective_overlay(company, deps).await;
+        let overlay_fp = overlay_fingerprint(&overlay_agents);
 
         {
             let agents = self.agents.read().await;
-            let fingerprints = self.mcp_fingerprints.read().await;
+            let mcp_fingerprints = self.mcp_fingerprints.read().await;
+            let overlay_fingerprints = self.overlay_fingerprints.read().await;
             if agents.contains_key(&company.id)
-                && fingerprints.get(&company.id) == Some(&fingerprint)
+                && mcp_fingerprints.get(&company.id) == Some(&mcp_fp)
+                && overlay_fingerprints.get(&company.id) == Some(&overlay_fp)
             {
                 return Ok(());
             }
@@ -373,14 +395,23 @@ impl HarnessPool {
         // shares every Arc / queue handle — only `mcp_servers` is overridden.
         let mut fresh_deps = deps.clone();
         fresh_deps.mcp_servers = effective_mcp;
-        let roster = build_roster(company, &fresh_deps, &skill_deltas)?;
+        // Same treatment for the overlay-agent set: `company` may be a stale
+        // boot-time snapshot (e.g. `HarnessBrain::record`), so the roster is
+        // built from the live-resolved overlay set, not `company.overlay_agents`.
+        let mut fresh_company = company.clone();
+        fresh_company.overlay_agents = overlay_agents;
+        let roster = build_roster(&fresh_company, &fresh_deps, &skill_deltas)?;
 
         let mut agents = self.agents.write().await;
         agents.insert(company.id.clone(), roster);
         self.mcp_fingerprints
             .write()
             .await
-            .insert(company.id.clone(), fingerprint);
+            .insert(company.id.clone(), mcp_fp);
+        self.overlay_fingerprints
+            .write()
+            .await
+            .insert(company.id.clone(), overlay_fp);
         Ok(())
     }
 
@@ -405,11 +436,36 @@ impl HarnessPool {
         }
     }
 
+    /// Re-resolves the company's live overlay-agent set (issue #71): reloads the
+    /// [`CompanyRecord`] from [`HarnessDeps::store`] so a teammate added through
+    /// the console `POST .../team` route or the orchestrator's `add_agent` tool
+    /// reaches the roster on the company's next `ensure` call — the same
+    /// live-re-resolution pattern as [`Self::resolve_effective_mcp`]. A missing
+    /// record or a store error degrades to the `company` snapshot passed in
+    /// (never worse than the pre-#71 always-static behaviour).
+    async fn resolve_effective_overlay(
+        &self,
+        company: &CompanyRecord,
+        deps: &HarnessDeps,
+    ) -> Vec<OverlayAgent> {
+        match deps.store.load(&company.id).await {
+            Ok(Some(record)) => record.overlay_agents,
+            _ => company.overlay_agents.clone(),
+        }
+    }
+
     /// The current MCP fingerprint for a company (test-only), so a freshness test
     /// can assert a rebuild happened without introspecting agent internals.
     #[cfg(test)]
     pub async fn mcp_fingerprint_of(&self, company: &CompanyId) -> Option<u64> {
         self.mcp_fingerprints.read().await.get(company).copied()
+    }
+
+    /// The current overlay-agent fingerprint for a company (test-only), mirroring
+    /// [`Self::mcp_fingerprint_of`].
+    #[cfg(test)]
+    pub async fn overlay_fingerprint_of(&self, company: &CompanyId) -> Option<u64> {
+        self.overlay_fingerprints.read().await.get(company).copied()
     }
 
     /// Routes a message to one agent and returns its reply, recording the turn's
@@ -532,7 +588,37 @@ fn auth_kind(material: &crate::company::mcp::AuthMaterial) -> u8 {
     }
 }
 
-/// Build every roster agent for a company from its manifest.
+/// A stable fingerprint of an overlay-agent set (issue #71), used to detect a
+/// teammate add/remove/edit between [`HarnessPool::ensure`] calls. Mirrors
+/// [`mcp_fingerprint`]'s shape; no secrets are involved here so there is
+/// nothing to scrub — an [`OverlayAgent`] is display data.
+fn overlay_fingerprint(agents: &[OverlayAgent]) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    agents.len().hash(&mut hasher);
+    for agent in agents {
+        agent.id.hash(&mut hasher);
+        agent.name.hash(&mut hasher);
+        agent.role.hash(&mut hasher);
+        agent.description.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+/// Build every roster agent for a company: every manifest `[[agent]]`, plus
+/// every operator- or orchestrator-added [`OverlayAgent`] (issue #71 — Active
+/// Runtime Teammates) that does not collide with a manifest agent id.
+///
+/// Overlay teammates were presentation-only before this cell (listed in the
+/// console Team tab but never addressable); this promotes each one into a real
+/// [`CompanyAgent`] with the same shape [`build::build_agent`] gives a manifest
+/// agent — a standard (company-wide) tool grant, no cognition tier (the
+/// default `chat-v1` model), and never the orchestrator. A manifest agent
+/// always wins an id collision: the version-controlled roster is authoritative,
+/// and [`orchestrator::orchestrator_id`] only ever looks at `manifest.agents`,
+/// so an overlay teammate can never become the orchestrator.
 ///
 /// `skill_deltas` are the company's operator skill overrides (fetched once by
 /// the async caller); every agent folds them into its effective skill set.
@@ -543,32 +629,91 @@ pub(crate) fn build_roster(
 ) -> crate::Result<Vec<Arc<CompanyAgent>>> {
     let policy: &Policy = &company.manifest.policy;
     let company_name = &company.manifest.company.name;
+    let allow = &company.manifest.tools.allow;
     // The orchestrator agent (tier `orchestrator`, else the first agent) receives
     // the delegating-orchestrator persona + tools (issue #53).
     let orchestrator = orchestrator::orchestrator_id(&company.manifest.agents);
-    company
+
+    let mut roster =
+        Vec::with_capacity(company.manifest.agents.len() + company.overlay_agents.len());
+
+    for manifest_agent in &company.manifest.agents {
+        let agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily);
+        let is_orchestrator = orchestrator.as_deref() == Some(manifest_agent.id.as_str());
+        let grants = agent_effective_grants(allow, &manifest_agent.tools);
+        let agent = build::build_agent(
+            &company.id,
+            company_name,
+            manifest_agent,
+            agent_policy,
+            deps,
+            &grants,
+            skill_deltas,
+            is_orchestrator,
+        )?;
+        roster.push(Arc::new(CompanyAgent {
+            agent_id: manifest_agent.id.clone(),
+            role: manifest_agent.role.clone(),
+            agent: Mutex::new(agent),
+        }));
+    }
+
+    // Issue #71 — Active Runtime Teammates (minimal slice): promote every
+    // operator/orchestrator-added overlay teammate into a real roster agent
+    // too, skipping any id already claimed by a manifest agent.
+    let manifest_ids: HashSet<&str> = company
         .manifest
         .agents
         .iter()
-        .map(|manifest_agent| {
-            let agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily);
-            let is_orchestrator = orchestrator.as_deref() == Some(manifest_agent.id.as_str());
-            let agent = build::build_agent(
-                &company.id,
-                company_name,
-                manifest_agent,
-                agent_policy,
-                deps,
-                skill_deltas,
-                is_orchestrator,
-            )?;
-            Ok(Arc::new(CompanyAgent {
-                agent_id: manifest_agent.id.clone(),
-                role: manifest_agent.role.clone(),
-                agent: Mutex::new(agent),
-            }))
-        })
-        .collect()
+        .map(|a| a.id.as_str())
+        .collect();
+    for overlay in &company.overlay_agents {
+        if manifest_ids.contains(overlay.id.as_str()) {
+            continue;
+        }
+        let manifest_agent = overlay_agent_to_manifest(overlay);
+        // No per-teammate budget cap or cognition-tier hint in v1 — see
+        // `overlay_agent_to_manifest`.
+        let agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily);
+        let grants = agent_effective_grants(allow, &manifest_agent.tools);
+        let agent = build::build_agent(
+            &company.id,
+            company_name,
+            &manifest_agent,
+            agent_policy,
+            deps,
+            &grants,
+            skill_deltas,
+            /* is_orchestrator */ false,
+        )?;
+        roster.push(Arc::new(CompanyAgent {
+            agent_id: manifest_agent.id.clone(),
+            role: manifest_agent.role.clone(),
+            agent: Mutex::new(agent),
+        }));
+    }
+
+    Ok(roster)
+}
+
+/// Converts an operator-added [`OverlayAgent`] into the manifest agent shape
+/// [`build::build_agent`] consumes: an empty `tools` list (so
+/// [`agent_effective_grants`] falls back to the full company `[tools].allow`
+/// — the "standard tool grant"), no cognition tier (→ the default `chat-v1`
+/// model), and no per-agent budget cap. The overlay's `name` is a display
+/// label only — already surfaced through
+/// [`crate::metering::roster_display_names`] — so the persona is framed from
+/// `role`/`description` alone, exactly like a manifest teammate
+/// ([`build::persona_prompt`]).
+fn overlay_agent_to_manifest(overlay: &OverlayAgent) -> ManifestAgent {
+    ManifestAgent {
+        id: overlay.id.clone(),
+        role: overlay.role.clone(),
+        description: overlay.description.clone(),
+        tier: None,
+        tools: Vec::new(),
+        budget_usd_daily: None,
+    }
 }
 
 #[cfg(test)]
@@ -814,6 +959,55 @@ description = "Builds the product."
                 .join("SKILL.md")
                 .is_file(),
             "the effective skill bundle should be materialized under the agent workspace"
+        );
+    }
+
+    /// Issue #71 — an operator/orchestrator-added overlay teammate is promoted
+    /// into a real, addressable roster agent (not just a console row).
+    #[tokio::test]
+    async fn overlay_agent_is_built_as_a_real_roster_agent() {
+        let fx = fixture();
+        let mut rec = record();
+        rec.overlay_agents.push(OverlayAgent {
+            id: "growth".into(),
+            name: "Jamie".into(),
+            role: "Growth Lead".into(),
+            description: Some("Owns acquisition experiments.".into()),
+        });
+
+        let roster = build_roster(&rec, &fx.deps, &[]).expect("roster builds");
+        let ids: Vec<_> = roster.iter().map(|a| a.agent_id.as_str()).collect();
+        assert_eq!(ids, vec!["ceo", "engineer", "growth"], "got {ids:?}");
+        let overlay_agent = roster
+            .iter()
+            .find(|a| a.agent_id == "growth")
+            .expect("overlay teammate present in roster");
+        assert_eq!(overlay_agent.role, "Growth Lead");
+    }
+
+    /// A manifest agent always wins an id collision with an overlay teammate —
+    /// the version-controlled roster is authoritative.
+    #[tokio::test]
+    async fn overlay_agent_id_colliding_with_manifest_agent_is_skipped() {
+        let fx = fixture();
+        let mut rec = record();
+        rec.overlay_agents.push(OverlayAgent {
+            id: "ceo".into(),
+            name: "Impostor".into(),
+            role: "Shadow CEO".into(),
+            description: None,
+        });
+
+        let roster = build_roster(&rec, &fx.deps, &[]).expect("roster builds");
+        let ids: Vec<_> = roster.iter().map(|a| a.agent_id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["ceo", "engineer"],
+            "the manifest agent wins the id collision, not a duplicate"
+        );
+        assert_eq!(
+            roster[0].role, "Chief Executive",
+            "the manifest role survives, not the overlay's"
         );
     }
 
@@ -1185,5 +1379,116 @@ description = "Builds the product."
         // A third ensure with no change is a no-op (fingerprint stable).
         pool.ensure(&rec, &deps).await.expect("third ensure");
         assert_eq!(pool.mcp_fingerprint_of(&rec.id).await, Some(after));
+    }
+
+    // --- Overlay-agent freshness (issue #71) --------------------------------
+
+    /// A `CompanyStore` backed by a live, mutable record — so a test can mutate
+    /// it between two `ensure` calls the same way the console `POST .../team`
+    /// route or the orchestrator's `add_agent` tool would, and observe the
+    /// freshness gate react.
+    #[derive(Default)]
+    struct LiveStore {
+        record: StdMutex<Option<CompanyRecord>>,
+    }
+
+    #[async_trait]
+    impl CompanyStore for LiveStore {
+        async fn load(&self, _id: &CompanyId) -> crate::Result<Option<CompanyRecord>> {
+            Ok(self.record.lock().unwrap().clone())
+        }
+        async fn save(&self, record: &CompanyRecord) -> crate::Result<()> {
+            *self.record.lock().unwrap() = Some(record.clone());
+            Ok(())
+        }
+        async fn list(&self) -> crate::Result<Vec<CompanySummary>> {
+            Ok(Vec::new())
+        }
+        async fn append_ledger(&self, _id: &CompanyId, _entry: LedgerEntry) -> crate::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// An overlay teammate added through the live company store (the same path
+    /// the console `POST .../team` route and the orchestrator's `add_agent` tool
+    /// both write through) reaches the roster on the company's NEXT `ensure` —
+    /// no restart — mirroring `ensure_rebuilds_when_a_runtime_mcp_server_is_added`.
+    #[tokio::test]
+    async fn ensure_rebuilds_when_an_overlay_agent_is_added() {
+        let live_store = Arc::new(LiveStore::default());
+        let rec = record();
+        live_store.save(&rec).await.unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let deps = HarnessDeps {
+            provider: Arc::new(MockProvider::new("mock: ")),
+            provider_slug: "mock".to_string(),
+            context: Arc::new(MockContext::default()),
+            store: live_store.clone(),
+            meter: None,
+            workspace_root: dir.path().to_path_buf(),
+            model_override: None,
+            tasks: None,
+            skills: None,
+            skills_source_dir: None,
+            mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: DelegationQueue::default(),
+            mcp_failures: McpFailureQueue::default(),
+            secrets: None,
+        };
+        let pool = HarnessPool::new();
+
+        pool.ensure(&rec, &deps).await.expect("first ensure");
+        let before = pool
+            .overlay_fingerprint_of(&rec.id)
+            .await
+            .expect("fingerprinted");
+        assert_eq!(pool.resident_companies().await, 1);
+        // The roster is not addressable under "growth" yet.
+        assert!(
+            pool.run(&rec.id, "growth", "hi", &deps).await.is_err(),
+            "the overlay teammate must not exist before it is added"
+        );
+
+        // Add a teammate directly through the live store — the same write path
+        // `AddAgentTool` and the console `POST .../team` route both use.
+        let mut updated = rec.clone();
+        updated.overlay_agents.push(OverlayAgent {
+            id: "growth".into(),
+            name: "Jamie".into(),
+            role: "Growth Lead".into(),
+            description: None,
+        });
+        live_store.save(&updated).await.unwrap();
+
+        // Next ensure re-resolves the live store → fingerprint changes → roster
+        // rebuilt, so the new teammate reaches the company without a restart.
+        pool.ensure(&rec, &deps).await.expect("second ensure");
+        let after = pool
+            .overlay_fingerprint_of(&rec.id)
+            .await
+            .expect("fingerprinted");
+        assert_ne!(
+            before, after,
+            "adding a teammate must change the overlay fingerprint"
+        );
+        assert_eq!(
+            pool.resident_companies().await,
+            1,
+            "same company, rebuilt in place"
+        );
+
+        let reply = pool
+            .run(&rec.id, "growth", "hello-marker", &deps)
+            .await
+            .expect("the new teammate is addressable on the very next turn")
+            .reply;
+        assert!(reply.contains("hello-marker"), "got {reply:?}");
+
+        // A third ensure with no further change is a no-op (fingerprint stable).
+        pool.ensure(&rec, &deps).await.expect("third ensure");
+        assert_eq!(pool.overlay_fingerprint_of(&rec.id).await, Some(after));
     }
 }

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -9,7 +9,7 @@
 //! first agent when none is tagged (so a company without an orchestrator behaves
 //! exactly as before).
 //!
-//! It reaches three tools, all wired only onto the orchestrator agent:
+//! It reaches four tools, all wired only onto the orchestrator agent:
 //!
 //! * [`QueryCompanyTool`] — a read surface over the company's [`FactStore`] and
 //!   recent [`EventLog`] history.
@@ -18,6 +18,9 @@
 //!   themselves; the [`HarnessBrain`](crate::harness::HarnessBrain) drains the
 //!   queue after the orchestrator's turn (v1: synchronous, in-cycle, capped at
 //!   [`MAX_DELEGATIONS_PER_TURN`], no sub-agent re-delegation).
+//! * [`AddAgentTool`] (issue #71) — writes a new [`OverlayAgent`] through the
+//!   same store path the console `POST .../team` route uses, so the
+//!   orchestrator can bring on a teammate mid-chat.
 //!
 //! Compiled only under `feature = "openhuman"` (the whole `harness` module is).
 
@@ -31,9 +34,11 @@ use openhuman_core::openhuman as oh;
 use oh::tools::traits::{PermissionLevel, Tool, ToolResult};
 
 use crate::company::Agent as ManifestAgent;
+use crate::error::OpenCompanyError;
 use crate::ports::events::EventLog;
 use crate::ports::facts::FactStore;
-use crate::ports::types::{CompanyEvent, CompanyId, EventSeq};
+use crate::ports::types::{CompanyEvent, CompanyId, EventSeq, OverlayAgent};
+use crate::ports::{CompanyStore, generate_id};
 
 /// The manifest cognition-tier that marks the orchestrator agent.
 pub const ORCHESTRATOR_TIER: &str = "orchestrator";
@@ -54,6 +59,8 @@ pub const QUERY_COMPANY_TOOL: &str = "query_company";
 pub const SPAWN_TASK_TOOL: &str = "spawn_task";
 /// The `delegate_to_desk` tool name.
 pub const DELEGATE_TO_DESK_TOOL: &str = "delegate_to_desk";
+/// The `add_agent` tool name (issue #71 — Active Runtime Teammates).
+pub const ADD_AGENT_TOOL: &str = "add_agent";
 
 /// The id of the orchestrator agent for a roster: the first agent tagged
 /// `tier = "orchestrator"`, else the first roster agent, else `None` (empty
@@ -83,8 +90,10 @@ pub fn orchestrator_brief() -> String {
 Answer from whole-company context, and when a request belongs to a specialist desk or should be \
 tracked as work, delegate instead of guessing. Use `query_company` to ground answers in the \
 company's durable facts and recent activity, `delegate_to_desk` to hand a turn to a desk's lead \
-member, and `spawn_task` to open a tracked task card. Delegate only when it genuinely helps — \
-otherwise answer directly and concisely."
+member, `spawn_task` to open a tracked task card, and `add_agent` to bring on a new teammate \
+(a name, role, and optional mandate) when the company genuinely needs one — it becomes a real, \
+addressable member of the team starting next turn. Delegate or add a teammate only when it \
+genuinely helps — otherwise answer directly and concisely."
         .to_string()
 }
 
@@ -442,6 +451,102 @@ pub fn delegation_tools(queue: &DelegationQueue) -> Vec<Box<dyn Tool>> {
     ]
 }
 
+/// A tool that lets the orchestrator bring on a new teammate mid-chat (issue
+/// #71 — Active Runtime Teammates, the minimal slice): it writes an
+/// [`OverlayAgent`] through the exact same load → push → save path the console
+/// `POST .../team` route uses (`crate::server::ops::team::add_member`), so a
+/// teammate added from chat is persisted identically to one added from the
+/// operator's Team tab. The teammate becomes a real, addressable roster agent
+/// on the company's next [`HarnessPool::ensure`](crate::harness::HarnessPool::ensure)
+/// call (the overlay-agent freshness gate) — no restart needed.
+///
+/// No lifecycle states, budgets, or workspace/memory namespaces here — those
+/// stay future work per the design doc; this tool only ever appends a roster
+/// entry with the standard company-wide tool grant.
+pub struct AddAgentTool {
+    company: CompanyId,
+    store: Arc<dyn CompanyStore>,
+}
+
+impl AddAgentTool {
+    /// Builds the tool over the company id and its store handle
+    /// ([`HarnessDeps::store`](crate::harness::HarnessDeps::store)).
+    pub fn new(company: CompanyId, store: Arc<dyn CompanyStore>) -> Self {
+        Self { company, store }
+    }
+}
+
+#[async_trait]
+impl Tool for AddAgentTool {
+    fn name(&self) -> &str {
+        ADD_AGENT_TOOL
+    }
+
+    fn description(&self) -> &str {
+        "Add a new teammate to the company. Provide a `name`, a `role` (job title), and an optional `description` of their mandate. The teammate becomes a real, addressable member of the roster starting next turn."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string", "description": "The new teammate's display name." },
+                "role": { "type": "string", "description": "The new teammate's job title." },
+                "description": { "type": "string", "description": "An optional description of the teammate's mandate." }
+            },
+            "required": ["name", "role"],
+            "additionalProperties": false
+        })
+    }
+
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Write
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let name = args
+            .get("name")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|n| !n.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("`name` is required"))?
+            .to_string();
+        let role = args
+            .get("role")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|r| !r.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("`role` is required"))?
+            .to_string();
+        let description = args
+            .get("description")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|d| !d.is_empty())
+            .map(str::to_string);
+
+        // Same write path as the console `POST .../team` route: load, push the
+        // overlay entry, save. Never rewrites the version-controlled manifest.
+        let mut record = self
+            .store
+            .load(&self.company)
+            .await?
+            .ok_or_else(|| OpenCompanyError::CompanyNotFound(self.company.to_string()))?;
+        let agent = OverlayAgent {
+            id: generate_id(),
+            name: name.clone(),
+            role: role.clone(),
+            description,
+        };
+        record.overlay_agents.push(agent);
+        self.store.save(&record).await?;
+
+        Ok(ToolResult::success(format!(
+            "Added {name} as {role} to the team. They'll be reachable as a teammate starting next turn."
+        )))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -574,5 +679,126 @@ mod tests {
         let out = result.output_for_llm(true);
         assert!(out.contains("No durable facts recorded"), "{out}");
         assert!(out.contains("No recent activity"), "{out}");
+    }
+
+    // --- add_agent (issue #71) ----------------------------------------------
+
+    use std::sync::Mutex as StdMutex;
+
+    use crate::ports::types::{CompanyRecord, CompanySummary, LedgerEntry};
+
+    /// An in-memory `CompanyStore` so `AddAgentTool` can be exercised without a
+    /// filesystem, mirroring `crate::server::ops::team`'s `add_member` write
+    /// path (load → push overlay → save).
+    #[derive(Default)]
+    struct MemStore {
+        record: StdMutex<Option<CompanyRecord>>,
+    }
+
+    impl MemStore {
+        fn seeded(record: CompanyRecord) -> Self {
+            Self {
+                record: StdMutex::new(Some(record)),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl CompanyStore for MemStore {
+        async fn load(&self, _id: &CompanyId) -> crate::Result<Option<CompanyRecord>> {
+            Ok(self.record.lock().unwrap().clone())
+        }
+        async fn save(&self, record: &CompanyRecord) -> crate::Result<()> {
+            *self.record.lock().unwrap() = Some(record.clone());
+            Ok(())
+        }
+        async fn list(&self) -> crate::Result<Vec<CompanySummary>> {
+            Ok(Vec::new())
+        }
+        async fn append_ledger(&self, _id: &CompanyId, _entry: LedgerEntry) -> crate::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn empty_manifest() -> crate::company::CompanyManifest {
+        toml::from_str("[company]\nname = \"Acme\"\n").expect("valid manifest")
+    }
+
+    fn seeded_record(id: &CompanyId) -> CompanyRecord {
+        CompanyRecord {
+            id: id.clone(),
+            manifest: empty_manifest(),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn add_agent_tool_persists_an_overlay_teammate() {
+        let company = CompanyId::new("acme");
+        let store = Arc::new(MemStore::seeded(seeded_record(&company)));
+        let tool = AddAgentTool::new(company.clone(), store.clone());
+
+        let result = tool
+            .execute(json!({
+                "name": "Jamie",
+                "role": "Growth Lead",
+                "description": "Owns acquisition experiments."
+            }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error, "add_agent should succeed");
+
+        let record = store
+            .load(&company)
+            .await
+            .unwrap()
+            .expect("record persisted");
+        assert_eq!(record.overlay_agents.len(), 1);
+        let added = &record.overlay_agents[0];
+        assert_eq!(added.name, "Jamie");
+        assert_eq!(added.role, "Growth Lead");
+        assert_eq!(
+            added.description.as_deref(),
+            Some("Owns acquisition experiments.")
+        );
+        assert!(!added.id.is_empty(), "a stable id must be minted");
+    }
+
+    #[tokio::test]
+    async fn add_agent_tool_requires_name_and_role() {
+        let company = CompanyId::new("acme");
+        let store = Arc::new(MemStore::seeded(seeded_record(&company)));
+        let tool = AddAgentTool::new(company.clone(), store.clone());
+
+        assert!(
+            tool.execute(json!({ "role": "Growth Lead" }))
+                .await
+                .is_err(),
+            "missing `name` must be rejected"
+        );
+        assert!(
+            tool.execute(json!({ "name": "Jamie" })).await.is_err(),
+            "missing `role` must be rejected"
+        );
+        let record = store.load(&company).await.unwrap().expect("record");
+        assert!(
+            record.overlay_agents.is_empty(),
+            "a rejected call must not persist a half-formed teammate"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_agent_tool_reports_company_not_found() {
+        let company = CompanyId::new("ghost");
+        let store: Arc<dyn CompanyStore> = Arc::new(MemStore::default());
+        let tool = AddAgentTool::new(company, store);
+
+        let err = tool
+            .execute(json!({ "name": "Jamie", "role": "Growth Lead" }))
+            .await
+            .expect_err("no record for this company id");
+        assert!(err.to_string().contains("ghost"), "{err}");
     }
 }

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -111,7 +111,8 @@ async fn add_member(
 ) -> Result<Json<TeamMemberDto>, ApiError> {
     // Serialize per-company writes so concurrent console POST /team and
     // orchestrator add_agent calls can't clobber each other's overlay_agents.
-    let _lock = company_write_lock(company.id()).lock().await;
+    let write_lock = company_write_lock(company.id());
+    let _lock = write_lock.lock().await;
 
     let mut record = company
         .runtime
@@ -140,7 +141,8 @@ async fn remove_member(
     Path(AgentPath { agent_id }): Path<AgentPath>,
 ) -> Result<StatusCode, ApiError> {
     // Serialize so a concurrent add_agent / add_member doesn't clobber.
-    let _lock = company_write_lock(company.id()).lock().await;
+    let write_lock = company_write_lock(company.id());
+    let _lock = write_lock.lock().await;
 
     let mut record = company
         .runtime


### PR DESCRIPTION
## Summary

Implements a **deliberately minimal first slice** of #71 (Active Runtime Teammates). Today, a teammate added through the console Team tab (`POST .../team` → `record.overlay_agents`) is presentation-only — it shows up in the UI but never becomes an executable agent, and the orchestrator has no way to add one itself. This PR closes both gaps, without building the full lifecycle described in `docs/spec/feature-audit/02-active-runtime-teammates.md`.

Two things, and only these two:

1. **Overlay agents become real roster agents.** `build_roster` now also builds a `CompanyAgent` for every `record.overlay_agents` entry (standard company-wide tool grant, no cognition tier, never the orchestrator), skipping any id already claimed by a manifest agent. An overlay teammate added via the Team tab is now addressable and can receive `delegate_to_desk`.
2. **Orchestrator `add_agent` tool.** The orchestrator agent can now bring on a new teammate mid-chat. It writes an `OverlayAgent` through the exact same load → push → save path the console `POST .../team` route uses, so a chat-added teammate is persisted identically to a console-added one.

**Freshness**: `HarnessPool::ensure` gains an overlay-agent freshness gate mirroring the existing MCP-freshness one (issue #50) — it re-resolves the live overlay set from `HarnessDeps::store` on every call and rebuilds the cached roster when it changed. **A teammate added via either path is live on the company's next turn — no restart required.**

### Explicitly deferred (per the design doc, out of scope here)

- Lifecycle states (draft / active / suspended / retired)
- Per-teammate budgets
- Isolated workspace / memory namespaces
- Suspension / retirement / drain

### Incidental fix

Making `build_roster` compile against `build_agent`'s existing `grants: &[String]` parameter surfaced that the call site was missing that argument entirely — a dead compile path, since CI only checks the default feature set and never `--features openhuman`. Fixed by threading `agent_effective_grants` (already defined, previously uncalled) through both the manifest-agent and overlay-agent build paths.

## API Or Behavior Changes

- `build_roster` (private, `src/harness/mod.rs`) now also produces one `CompanyAgent` per `CompanyRecord::overlay_agents` entry.
- `HarnessPool` gains a second fingerprint map (`overlay_fingerprints`) and a `resolve_effective_overlay` re-resolution step in `ensure`, so overlay-agent changes trigger a roster rebuild the same way MCP changes do.
- New tool `add_agent`, wired onto the orchestrator agent only (alongside `query_company`, `spawn_task`, `delegate_to_desk`). Input: `name`, `role`, optional `description`. Writes through `HarnessDeps::store` (the same `CompanyStore` the console route uses).
- No manifest schema change, no new HTTP routes, no frontend change — the existing Team view already lists overlay agents.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default features — clean)
- [x] `cargo build --all-targets` (default features)
- [x] `cargo test` (default features — 556 passed)
- [x] `cargo build --features openhuman`
- [x] `cargo test --features openhuman` (699 passed, 1 ignored, 0 failed; 129 in `harness::*`)

`cargo clippy --features openhuman` was also attempted, but fails on a pre-existing `clippy::large_enum_variant` lint inside the vendored `vendor/tinyagents` submodule (unrelated to this diff, untouched by it) — this is why CI itself never runs clippy under `--features openhuman`. `cargo check --features openhuman` is clean.

New tests added:
- `harness::tests::overlay_agent_is_built_as_a_real_roster_agent`
- `harness::tests::overlay_agent_id_colliding_with_manifest_agent_is_skipped`
- `harness::tests::ensure_rebuilds_when_an_overlay_agent_is_added` (freshness, no-restart)
- `harness::orchestrator::tests::add_agent_tool_persists_an_overlay_teammate`
- `harness::orchestrator::tests::add_agent_tool_requires_name_and_role`
- `harness::orchestrator::tests::add_agent_tool_reports_company_not_found`

## Documentation

No doc changes — `docs/spec/feature-audit/02-active-runtime-teammates.md` already describes the full future lifecycle this PR intentionally does not build; nothing in it needed correcting for this slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Operators can add teammates during an active chat by providing a name, role, and optional description.
  * Newly added teammates become available in the current roster without restarting the conversation.
  * Orchestrator tools and guidance now include the option to add teammates dynamically.

* **Bug Fixes**
  * Roster updates now reflect changes to live overlay teammates, including additions and edits.
  * Existing manifest agents remain prioritized when identifier conflicts occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->