### PR TITLE
feat(console): render a readable per-node workflow run result (#68)

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -267,7 +267,7 @@ function RunResultPanel({
           </p>
         )}
 
-        {nodeResults ? (
+        {nodeResults && nodeResults.length > 0 ? (
           <div className="mb-2 space-y-2">
             {nodeResults.map((n) => (
               <NodeResultCard key={n.id} node={n} />
@@ -280,7 +280,7 @@ function RunResultPanel({
           </p>
         )}
 
-        <details open={!nodeResults}>
+        <details open={!nodeResults || nodeResults.length === 0}>
           <summary className="cursor-pointer text-xs text-muted-foreground">
             Show raw engine output
           </summary>
@@ -297,7 +297,6 @@ function RunResultPanel({
  * (markdown-rendered). Falls back to a subtle placeholder / the branch it took
  * when it produced no text (e.g. a trigger or a condition node). */
 function NodeResultCard({ node }: { node: NodeResult }) {
-  const hasText = node.messages.some((m) => m.text);
   return (
     <div className="rounded-lg border bg-background/40 p-2">
       <div className="mb-1 flex items-center gap-2">
@@ -324,7 +323,7 @@ function NodeResultCard({ node }: { node: NodeResult }) {
           )}
         </div>
       ))}
-      {node.messages.length === 0 && !hasText && (
+      {node.messages.length === 0 && (
         <p className="text-sm text-muted-foreground">—</p>
       )}
     </div>

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -12,6 +12,8 @@ import "@xyflow/react/dist/style.css";
 import { useTheme } from "next-themes";
 import { Loader2, Play } from "lucide-react";
 import { toast } from "sonner";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 import {
   getWorkflow,
@@ -216,21 +218,32 @@ export function WorkflowsView({
         )}
       </div>
 
-      {result && <RunResultPanel result={result} onClose={() => setResult(null)} />}
+      {result && (
+        <RunResultPanel result={result} graph={graph} onClose={() => setResult(null)} />
+      )}
     </div>
   );
 }
 
-/** The run-output drawer: the final text (when we can find one) plus the raw
- * engine state and any nodes left pending approval. */
+/** The run-output drawer: one readable card per executed node (the producing
+ * agent and its reply, markdown-rendered) plus the branch each condition node
+ * took, any nodes left pending approval, and the raw engine state collapsed
+ * behind a toggle. Falls back to a raw JSON dump when the output doesn't match
+ * the expected per-node shape. */
 function RunResultPanel({
   result,
+  graph,
   onClose,
 }: {
   result: WorkflowRunResult;
+  graph: WorkflowGraph | null;
   onClose: () => void;
 }) {
-  const text = finalText(result.output);
+  const nodeResults = useMemo(
+    () => parseRunNodes(result.output, graph),
+    [result.output, graph],
+  );
+
   return (
     <div className="border-t bg-card/60">
       <div className="flex items-center justify-between px-4 py-2">
@@ -247,27 +260,73 @@ function RunResultPanel({
           Dismiss
         </Button>
       </div>
-      <div className="max-h-56 overflow-auto px-4 pb-3">
-        {text && <p className="mb-2 whitespace-pre-wrap text-sm">{text}</p>}
+      <div className="max-h-72 overflow-auto px-4 pb-3">
         {result.pendingApprovals.length > 0 && (
           <p className="mb-2 text-xs text-muted-foreground">
             Waiting on: {result.pendingApprovals.join(", ")}
           </p>
         )}
-        {!text && (
+
+        {nodeResults ? (
+          <div className="mb-2 space-y-2">
+            {nodeResults.map((n) => (
+              <NodeResultCard key={n.id} node={n} />
+            ))}
+          </div>
+        ) : (
           <p className="mb-2 text-xs text-muted-foreground">
-            The run finished; no final text node — see the raw output below.
+            The run finished, but its output didn't match the expected node
+            shape — see the raw output below.
           </p>
         )}
-        <details open={!text}>
+
+        <details open={!nodeResults}>
           <summary className="cursor-pointer text-xs text-muted-foreground">
-            Raw engine output
+            Show raw engine output
           </summary>
           <pre className="mt-1 rounded-lg border bg-muted/40 p-2 font-mono text-[11px] leading-snug">
             {JSON.stringify(result.output, null, 2)}
           </pre>
         </details>
       </div>
+    </div>
+  );
+}
+
+/** One node's readable result: its name, the producing agent, and its reply
+ * (markdown-rendered). Falls back to a subtle placeholder / the branch it took
+ * when it produced no text (e.g. a trigger or a condition node). */
+function NodeResultCard({ node }: { node: NodeResult }) {
+  const hasText = node.messages.some((m) => m.text);
+  return (
+    <div className="rounded-lg border bg-background/40 p-2">
+      <div className="mb-1 flex items-center gap-2">
+        <span className="truncate text-xs font-medium">{node.name}</span>
+        {node.port !== null && (
+          <Badge variant="outline" className="h-4 px-1.5 text-[10px] font-normal">
+            branch: {node.port}
+          </Badge>
+        )}
+      </div>
+      {node.messages.map((m, i) => (
+        <div key={i} className={i > 0 ? "mt-2 border-t pt-2" : undefined}>
+          {m.agentRef && (
+            <p className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+              {m.agentRef}
+            </p>
+          )}
+          {m.text ? (
+            <div className="prose prose-sm max-w-none dark:prose-invert">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{m.text}</ReactMarkdown>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">—</p>
+          )}
+        </div>
+      ))}
+      {node.messages.length === 0 && !hasText && (
+        <p className="text-sm text-muted-foreground">—</p>
+      )}
     </div>
   );
 }
@@ -321,25 +380,87 @@ function layout(graph: WorkflowGraph): { nodes: Node<WorkflowNodeData>[]; edges:
   return { nodes, edges };
 }
 
-/** Best-effort pull of a human-readable final string from the nested run state,
- * checking the keys the engine is likely to carry. Returns `null` when none is
- * found, in which case the raw JSON is shown instead. */
-function finalText(output: unknown): string | null {
-  const KEYS = ["text", "output", "final", "reply", "message", "content", "result"];
-  const seen = new Set<unknown>();
-  function walk(value: unknown, depth: number): string | null {
-    if (typeof value === "string") return value.trim() || null;
-    if (depth > 6 || value === null || typeof value !== "object") return null;
-    if (seen.has(value)) return null;
-    seen.add(value);
-    const obj = value as Record<string, unknown>;
-    for (const key of KEYS) {
-      if (key in obj) {
-        const found = walk(obj[key], depth + 1);
-        if (found) return found;
-      }
-    }
+/** A single agent reply extracted from a node's `items[].json`. */
+interface NodeMessage {
+  text: string | null;
+  agentRef: string | null;
+}
+
+/** One node's readable, shape-checked result, ready to render. */
+interface NodeResult {
+  id: string;
+  name: string;
+  /** The condition branch taken (`null` when the node isn't a branch point). */
+  port: string | null;
+  messages: NodeMessage[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** A non-empty trimmed string, else `null` (defensive against non-strings). */
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+/** Pull a field from an item's `json`, preferring the OUTERMOST value and
+ * falling back to the NESTED `json.json.<key>` the engine sometimes emits.
+ * Handles the observed shape where `json` carries both a top-level `text` and
+ * a nested `json.json.text` — the outer one wins. */
+function readNested(json: unknown, key: string): string | null {
+  if (!isRecord(json)) return null;
+  const outer = nonEmptyString(json[key]);
+  if (outer) return outer;
+  const inner = json.json;
+  if (isRecord(inner)) return nonEmptyString(inner[key]);
+  return null;
+}
+
+/** Safely parse the engine's run output into per-node results, ordered by the
+ * loaded graph when available (falling back to the map's insertion order).
+ * Returns `null` when `output` doesn't match the expected `{ nodes: {…} }`
+ * shape, signalling the caller to fall back to the raw JSON dump. Every access
+ * is guarded — `output` is typed `unknown` and older/edge runs may be a plain
+ * string, missing `nodes`, or carry malformed node values. */
+function parseRunNodes(
+  output: unknown,
+  graph: WorkflowGraph | null,
+): NodeResult[] | null {
+  if (!isRecord(output) || !isRecord(output.nodes)) {
+    console.debug(
+      "[WorkflowsView] run output missing a `nodes` map; showing raw JSON",
+      output,
+    );
     return null;
   }
-  return walk(output, 0);
+  const nodes = output.nodes;
+
+  // Order by the graph's node order when we have it, then append any node ids
+  // present in the output but not in the graph (in the map's insertion order).
+  const graphOrder = graph?.nodes.map((n) => n.id) ?? [];
+  const orderedIds = [
+    ...graphOrder.filter((id) => id in nodes),
+    ...Object.keys(nodes).filter((id) => !graphOrder.includes(id)),
+  ];
+
+  const nameById = new Map(graph?.nodes.map((n) => [n.id, n.name]) ?? []);
+
+  const results: NodeResult[] = orderedIds.map((id) => {
+    const raw = nodes[id];
+    const items = isRecord(raw) && Array.isArray(raw.items) ? raw.items : [];
+    const messages: NodeMessage[] = items
+      .map((item) => {
+        const json = isRecord(item) ? item.json : undefined;
+        return {
+          text: readNested(json, "text"),
+          agentRef: readNested(json, "agent_ref"),
+        };
+      })
+      .filter((m) => m.text || m.agentRef);
+    const port = isRecord(raw) ? nonEmptyString(raw.port) : null;
+    return { id, name: nameById.get(id) ?? id, port, messages };
+  });
+
+  return results;
 }


### PR DESCRIPTION
## Summary

Running a workflow rendered the raw TinyFlows execution JSON instead of a
readable result. `RunResultPanel` (`frontend/src/views/WorkflowsView.tsx`)
used a weak best-effort `finalText()` walk over `WorkflowRunResult.output`
that usually failed to find a string and fell back to dumping the whole raw
JSON blob at the user.

This PR rewrites the panel to read the engine's actual output shape —
`output.nodes[nodeId] = { items: [{ json: { text, agent_ref } }], port }` —
and renders one readable card per node: the producing agent, its
markdown-rendered reply text, and the branch a condition node took
(`port`). Nodes with no text (e.g. a trigger) show a subtle placeholder
instead of nothing. The raw JSON is still available, but now collapsed
behind a `Show raw engine output` toggle instead of being the default view.

Frontend-only change. No backend/Rust code touched.

Closes #68

## API Or Behavior Changes

No API changes. Behavior change is purely visual/UX: the workflow run
result drawer now shows structured per-node output instead of a JSON dump,
with the raw JSON demoted to a collapsed toggle. `pendingApprovals`
handling is unchanged.

The node/agent JSON shape can vary (a top-level `text`/`agent_ref` on
`item.json`, or nested one level deeper as `item.json.json.text`) — the
new `readNested()` helper prefers the outermost value and falls back to
the nested one, so both shapes render correctly. If `output` doesn't match
the expected `{ nodes: {...} }` shape at all (e.g. an older/edge run), the
panel safely falls back to the previous raw-JSON display rather than
crashing.

## Tests

- [ ] N/A: no Rust code changed (frontend-only fix; nothing for `cargo fmt` to check)
- [ ] N/A: no Rust code changed (frontend-only fix; nothing for `cargo clippy` to check)
- [ ] N/A: no Rust code changed (frontend-only fix; nothing for `cargo build` to check)
- [ ] N/A: no Rust code changed (frontend-only fix; nothing for `cargo test` to check)

Frontend checks run instead:
- `npm run typecheck` — pass
- `npm run build` — pass (vite build succeeds; only the pre-existing
  "chunks larger than 500 kB" advisory, unrelated to this change)
- No `lint` script/config exists in this frontend package to run.

## Documentation

No docs updates needed — this is an internal console rendering fix with
no new public API, config, or user-facing setup step to document.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Run results now display individual outputs for each workflow node.
  * Markdown formatting is supported within node result cards.
  * Results follow the workflow’s node order for easier review.
  * Pending approvals are shown clearly in the results panel.

* **Bug Fixes**
  * Improved handling of varied run-output formats.
  * Added a fallback view with raw engine data when results cannot be interpreted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->