### PR TITLE
feat(workflows): add a workflow creator to the console (#69)

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -75,3 +75,33 @@ export function runWorkflow(
     { input: input ?? {} },
   );
 }
+
+/**
+ * Authors a new workflow graph (issue #69): the console's form creator posts
+ * the same shape `getWorkflow` returns, and the host writes it to
+ * `workflows/{id}.toml`. Rejections carry a prosumer-language `ApiError`
+ * message (bad id, duplicate id, an edge or `agent` node the graph can't
+ * support, no writable source directory on this deployment).
+ */
+export function createWorkflow(
+  client: OpenCompanyClient,
+  company: string | null,
+  graph: WorkflowGraph,
+): Promise<WorkflowGraph> {
+  return client.post<WorkflowGraph>(`${client.scopeFor(company)}/workflows`, graph);
+}
+
+/**
+ * The node kinds the form creator's palette offers. `tool_call` and
+ * `http_request` are real graph kinds the engine stores and the canvas
+ * renders, but the runtime only executes `trigger`/`agent`/`condition`/
+ * `output` today — the other two are `Unwired*` stubs that error at run time
+ * (see `src/workflows/caps.rs`). Creating one from scratch would silently
+ * produce a workflow that can never finish, so the creator doesn't offer them.
+ */
+export const CREATABLE_NODE_KINDS: { value: string; label: string }[] = [
+  { value: "trigger", label: "Trigger — starts the workflow" },
+  { value: "agent", label: "Agent — a teammate performs a step" },
+  { value: "condition", label: "Condition — branches on something" },
+  { value: "output", label: "Output — reports the result back" },
+];

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -1,0 +1,482 @@
+// The workflow creator (issue #69): a plain form editor — not a drag canvas —
+// that builds a `WorkflowGraph` and posts it via `createWorkflow`. Node kinds
+// are restricted to the ones the engine actually executes today
+// (`CREATABLE_NODE_KINDS`); `tool_call`/`http_request` stay off the palette
+// until they're wired (see `src/workflows/caps.rs`).
+
+import { useEffect, useId, useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
+
+import {
+  CREATABLE_NODE_KINDS,
+  createWorkflow,
+  type WorkflowEdge,
+  type WorkflowGraph,
+  type WorkflowNode,
+} from "@/api/workflows";
+import type { OpenCompanyClient } from "@/api/client";
+import type { TeamMemberDto } from "@/api/types";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+/** A node row being edited. `key` is a stable React key, independent of the
+ * user-editable `id` field (which can be blank or duplicated mid-edit). */
+interface DraftNode {
+  key: string;
+  id: string;
+  kind: string;
+  name: string;
+  summary: string;
+  agent: string;
+}
+
+interface DraftEdge {
+  key: string;
+  from: string;
+  to: string;
+  label: string;
+}
+
+let seq = 0;
+function nextKey(): string {
+  seq += 1;
+  return `row-${seq}`;
+}
+
+function starterNodes(): DraftNode[] {
+  return [{ key: nextKey(), id: "start", kind: "trigger", name: "Start", summary: "", agent: "" }];
+}
+
+/** A safe on-disk id: no slashes, no `..`, not empty — mirrors the host's
+ * `safe_wid` check so a bad id fails fast in the form instead of round-tripping
+ * to the server first. */
+function isSafeId(id: string): boolean {
+  return /^[A-Za-z0-9_-]+$/.test(id);
+}
+
+export function WorkflowCreateDialog({
+  client,
+  company,
+  open,
+  onOpenChange,
+  onCreated,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (graph: WorkflowGraph) => void;
+}) {
+  const [id, setId] = useState("");
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [nodes, setNodes] = useState<DraftNode[]>(starterNodes());
+  const [edges, setEdges] = useState<DraftEdge[]>([]);
+  const [roster, setRoster] = useState<TeamMemberDto[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const formId = useId();
+
+  // Reload the roster (for the agent-node picker) and reset the draft each
+  // time the dialog opens, so a prior attempt never leaks into the next one.
+  useEffect(() => {
+    if (!open) return;
+    setId("");
+    setName("");
+    setDescription("");
+    setNodes(starterNodes());
+    setEdges([]);
+    setError(null);
+    let live = true;
+    (async () => {
+      try {
+        const team = await client.listTeam(company);
+        if (live) setRoster(team);
+      } catch {
+        // No roster surface on this host — agent nodes fall back to a free-text
+        // teammate id below.
+        if (live) setRoster([]);
+      }
+    })();
+    return () => {
+      live = false;
+    };
+  }, [open, client, company]);
+
+  function addNode() {
+    setNodes((rows) => [
+      ...rows,
+      { key: nextKey(), id: "", kind: "agent", name: "", summary: "", agent: "" },
+    ]);
+  }
+
+  function updateNode(key: string, fields: Partial<DraftNode>) {
+    setNodes((rows) => rows.map((r) => (r.key === key ? { ...r, ...fields } : r)));
+  }
+
+  function removeNode(key: string) {
+    const removed = nodes.find((n) => n.key === key);
+    setNodes((rows) => rows.filter((r) => r.key !== key));
+    // Drop any edge that pointed at the removed node's id — a dangling
+    // reference would just bounce back from the server as a 400.
+    if (removed?.id) {
+      setEdges((rows) => rows.filter((e) => e.from !== removed.id && e.to !== removed.id));
+    }
+  }
+
+  function addEdge() {
+    setEdges((rows) => [...rows, { key: nextKey(), from: "", to: "", label: "" }]);
+  }
+
+  function updateEdge(key: string, fields: Partial<DraftEdge>) {
+    setEdges((rows) => rows.map((r) => (r.key === key ? { ...r, ...fields } : r)));
+  }
+
+  function removeEdge(key: string) {
+    setEdges((rows) => rows.filter((r) => r.key !== key));
+  }
+
+  /** Client-side validation, mirroring the host's checks so most mistakes
+   * surface here instead of round-tripping to the server first. Returns the
+   * first problem found, or `null` when the draft is postable. */
+  function validate(): string | null {
+    if (!id.trim()) return "Give the workflow an id.";
+    if (!isSafeId(id.trim())) return "The id can only use letters, numbers, `_`, and `-`.";
+    if (!name.trim()) return "Give the workflow a name.";
+    if (nodes.length === 0) return "Add at least one node.";
+    const ids = new Set<string>();
+    for (const n of nodes) {
+      if (!n.id.trim()) return "Every node needs an id.";
+      if (ids.has(n.id.trim())) return `Node id \`${n.id}\` is used more than once.`;
+      ids.add(n.id.trim());
+      if (!n.name.trim()) return `Node \`${n.id}\` needs a name.`;
+      if (n.kind === "agent" && !n.agent.trim()) {
+        return `Node \`${n.id}\` is an agent node — pick who does it.`;
+      }
+    }
+    const triggerCount = nodes.filter((n) => n.kind === "trigger").length;
+    if (triggerCount !== 1) {
+      return "A workflow needs exactly one trigger node to say what starts it.";
+    }
+    for (const e of edges) {
+      if (!e.from || !e.to) return "Every edge needs a from-node and a to-node.";
+      if (!ids.has(e.from)) return `Edge starts at \`${e.from}\`, which isn't one of the nodes.`;
+      if (!ids.has(e.to)) return `Edge points to \`${e.to}\`, which isn't one of the nodes.`;
+      if (e.from === e.to) return "An edge can't loop a node back to itself.";
+    }
+    return null;
+  }
+
+  async function submit() {
+    const problem = validate();
+    if (problem) {
+      setError(problem);
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    const graph: WorkflowGraph = {
+      id: id.trim(),
+      name: name.trim(),
+      description: description.trim() || undefined,
+      nodes: nodes.map(
+        (n): WorkflowNode => ({
+          id: n.id.trim(),
+          kind: n.kind,
+          name: n.name.trim(),
+          summary: n.summary.trim() || undefined,
+          agent: n.kind === "agent" ? n.agent.trim() : undefined,
+        }),
+      ),
+      edges: edges.map(
+        (e): WorkflowEdge => ({
+          from: e.from,
+          to: e.to,
+          label: e.label.trim() || undefined,
+        }),
+      ),
+    };
+    try {
+      const created = await createWorkflow(client, company, graph);
+      onCreated(created);
+      onOpenChange(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "could not create the workflow");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !submitting && onOpenChange(o)}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>New workflow</DialogTitle>
+          <DialogDescription>
+            Define the graph by hand — nodes, then how they connect.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid gap-2">
+            <Label htmlFor={`${formId}-id`}>Id</Label>
+            <Input
+              id={`${formId}-id`}
+              value={id}
+              onChange={(e) => setId(e.target.value)}
+              placeholder="e.g. campaign_pipeline"
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor={`${formId}-name`}>Name</Label>
+            <Input
+              id={`${formId}-name`}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Campaign pipeline"
+            />
+          </div>
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor={`${formId}-desc`}>Description</Label>
+          <Textarea
+            id={`${formId}-desc`}
+            rows={2}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="What does this workflow do?"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label>Nodes</Label>
+            <Button type="button" variant="outline" size="sm" onClick={addNode}>
+              <Plus className="size-3.5" /> Add node
+            </Button>
+          </div>
+          <div className="space-y-2">
+            {nodes.map((n) => (
+              <NodeRow
+                key={n.key}
+                node={n}
+                roster={roster}
+                onChange={(fields) => updateNode(n.key, fields)}
+                onRemove={() => removeNode(n.key)}
+              />
+            ))}
+            {nodes.length === 0 && (
+              <p className="rounded-lg border border-dashed p-3 text-center text-xs text-muted-foreground">
+                No nodes yet.
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label>Edges</Label>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={addEdge}
+              disabled={nodes.length < 2}
+            >
+              <Plus className="size-3.5" /> Add edge
+            </Button>
+          </div>
+          <div className="space-y-2">
+            {edges.map((e) => (
+              <EdgeRow
+                key={e.key}
+                edge={e}
+                nodeIds={nodes.map((n) => n.id).filter(Boolean)}
+                onChange={(fields) => updateEdge(e.key, fields)}
+                onRemove={() => removeEdge(e.key)}
+              />
+            ))}
+            {edges.length === 0 && (
+              <p className="rounded-lg border border-dashed p-3 text-center text-xs text-muted-foreground">
+                No edges yet — nodes won&apos;t be connected.
+              </p>
+            )}
+          </div>
+        </div>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={() => void submit()} disabled={submitting}>
+            {submitting ? "Creating…" : "Create workflow"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function NodeRow({
+  node,
+  roster,
+  onChange,
+  onRemove,
+}: {
+  node: DraftNode;
+  roster: TeamMemberDto[];
+  onChange: (fields: Partial<DraftNode>) => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="grid gap-2 rounded-lg border p-2 sm:grid-cols-[1fr_1fr_1.4fr_auto] sm:items-start">
+      <div className="grid gap-1">
+        <Input
+          value={node.id}
+          onChange={(e) => onChange({ id: e.target.value })}
+          placeholder="node id"
+          aria-label="Node id"
+        />
+        <Select value={node.kind} onValueChange={(v) => onChange({ kind: v ?? "" })}>
+          <SelectTrigger className="h-8" aria-label="Node kind">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {CREATABLE_NODE_KINDS.map((k) => (
+              <SelectItem key={k.value} value={k.value}>
+                {k.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1">
+        <Input
+          value={node.name}
+          onChange={(e) => onChange({ name: e.target.value })}
+          placeholder="display name"
+          aria-label="Node name"
+        />
+        {node.kind === "agent" &&
+          (roster.length > 0 ? (
+            <Select value={node.agent} onValueChange={(v) => onChange({ agent: v ?? "" })}>
+              <SelectTrigger className="h-8" aria-label="Teammate">
+                <SelectValue placeholder="Pick a teammate" />
+              </SelectTrigger>
+              <SelectContent>
+                {roster.map((m) => (
+                  <SelectItem key={m.id} value={m.id}>
+                    {m.name ?? m.role}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <Input
+              value={node.agent}
+              onChange={(e) => onChange({ agent: e.target.value })}
+              placeholder="teammate id"
+              aria-label="Teammate id"
+            />
+          ))}
+      </div>
+      <Input
+        value={node.summary}
+        onChange={(e) => onChange({ summary: e.target.value })}
+        placeholder="summary (optional)"
+        aria-label="Node summary"
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        onClick={onRemove}
+        aria-label="Remove node"
+        className="justify-self-end"
+      >
+        <Trash2 className="size-4" />
+      </Button>
+    </div>
+  );
+}
+
+function EdgeRow({
+  edge,
+  nodeIds,
+  onChange,
+  onRemove,
+}: {
+  edge: DraftEdge;
+  nodeIds: string[];
+  onChange: (fields: Partial<DraftEdge>) => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="grid grid-cols-[1fr_auto_1fr_1fr_auto] items-center gap-2 rounded-lg border p-2">
+      <Select value={edge.from} onValueChange={(v) => onChange({ from: v ?? "" })}>
+        <SelectTrigger className="h-8" aria-label="Edge from">
+          <SelectValue placeholder="from" />
+        </SelectTrigger>
+        <SelectContent>
+          {nodeIds.map((nid) => (
+            <SelectItem key={nid} value={nid}>
+              {nid}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <span className="text-xs text-muted-foreground">→</span>
+      <Select value={edge.to} onValueChange={(v) => onChange({ to: v ?? "" })}>
+        <SelectTrigger className="h-8" aria-label="Edge to">
+          <SelectValue placeholder="to" />
+        </SelectTrigger>
+        <SelectContent>
+          {nodeIds.map((nid) => (
+            <SelectItem key={nid} value={nid}>
+              {nid}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Input
+        value={edge.label}
+        onChange={(e) => onChange({ label: e.target.value })}
+        placeholder="label (optional)"
+        aria-label="Edge label"
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        onClick={onRemove}
+        aria-label="Remove edge"
+      >
+        <Trash2 className="size-4" />
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -65,9 +65,9 @@ function starterNodes(): DraftNode[] {
   return [{ key: nextKey(), id: "start", kind: "trigger", name: "Start", summary: "", agent: "" }];
 }
 
-/** A safe on-disk id: no slashes, no `..`, not empty — mirrors the host's
- * `safe_wid` check so a bad id fails fast in the form instead of round-tripping
- * to the server first. */
+/** A safe on-disk id: only letters, digits, `_`, and `-` — a subset of what the
+ * host's `safe_wid` accepts (any single path component), chosen to keep ids
+ * simple and unambiguous without a round-trip to the server first. */
 function isSafeId(id: string): boolean {
   return /^[A-Za-z0-9_-]+$/.test(id);
 }

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -208,8 +208,8 @@ export function WorkflowCreateDialog({
       ),
       edges: edges.map(
         (e): WorkflowEdge => ({
-          from: e.from,
-          to: e.to,
+          from: e.from.trim(),
+          to: e.to.trim(),
           label: e.label.trim() || undefined,
         }),
       ),
@@ -309,7 +309,7 @@ export function WorkflowCreateDialog({
               <EdgeRow
                 key={e.key}
                 edge={e}
-                nodeIds={nodes.map((n) => n.id).filter(Boolean)}
+                nodeIds={nodes.map((n) => n.id.trim()).filter(Boolean)}
                 onChange={(fields) => updateEdge(e.key, fields)}
                 onRemove={() => removeEdge(e.key)}
               />

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -10,7 +10,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useTheme } from "next-themes";
-import { Loader2, Play } from "lucide-react";
+import { Loader2, Play, Plus } from "lucide-react";
 import { toast } from "sonner";
 
 import {
@@ -34,6 +34,7 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { WorkflowNode } from "@/components/workflow-node";
+import { WorkflowCreateDialog } from "@/views/WorkflowCreateDialog";
 import { nodeKindMeta, type WorkflowNodeData } from "@/lib/workflow-sample";
 
 const NODE_TYPES = { oc: WorkflowNode };
@@ -65,6 +66,7 @@ export function WorkflowsView({
   const [running, setRunning] = useState(false);
   const [result, setResult] = useState<WorkflowRunResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
 
   // Load the workflow list once, and auto-select the first entry.
   useEffect(() => {
@@ -135,6 +137,19 @@ export function WorkflowsView({
     }
   }, [client, company, selectedId]);
 
+  // The creator posts the full graph back, so the new entry can be spliced
+  // straight into the list and selected — no extra round trip to re-list.
+  const handleCreated = useCallback((created: WorkflowGraph) => {
+    setWorkflows((prev) => {
+      const rest = prev.filter((w) => w.id !== created.id);
+      return [...rest, { id: created.id, name: created.name, description: created.description }].sort(
+        (a, b) => a.name.localeCompare(b.name),
+      );
+    });
+    setSelectedId(created.id);
+    toast.success("Workflow created.");
+  }, []);
+
   const { nodes, edges } = useMemo(() => (graph ? layout(graph) : { nodes: [], edges: [] }), [graph]);
 
   const selected = workflows.find((w) => w.id === selectedId) ?? null;
@@ -176,6 +191,10 @@ export function WorkflowsView({
             )}
             Run
           </Button>
+          <Button size="sm" variant="outline" onClick={() => setCreateOpen(true)}>
+            <Plus className="mr-1.5 size-4" />
+            New workflow
+          </Button>
         </div>
       </div>
 
@@ -193,8 +212,12 @@ export function WorkflowsView({
             <Skeleton className="h-full w-full rounded-xl" />
           </div>
         ) : !selectedId ? (
-          <div className="flex h-full items-center justify-center px-4 text-center text-sm text-muted-foreground">
-            This company has no saved workflows yet.
+          <div className="flex h-full flex-col items-center justify-center gap-3 px-4 text-center text-sm text-muted-foreground">
+            <p>This company has no saved workflows yet.</p>
+            <Button size="sm" variant="outline" onClick={() => setCreateOpen(true)}>
+              <Plus className="mr-1.5 size-4" />
+              New workflow
+            </Button>
           </div>
         ) : (
           <ReactFlow
@@ -217,6 +240,14 @@ export function WorkflowsView({
       </div>
 
       {result && <RunResultPanel result={result} onClose={() => setResult(null)} />}
+
+      <WorkflowCreateDialog
+        client={client}
+        company={company}
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreated={handleCreated}
+      />
     </div>
   );
 }

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -30,6 +30,10 @@ pub use workflow_file::{
     WORKFLOW_NODE_KINDS, WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef, WorkflowNodeKind,
     load_company_workflows, parse_workflow,
 };
+// Crate-internal only: the workflow creator (issue #69) builds a `RawWorkflow`
+// from its request body, renders it to TOML, and re-parses it through
+// `parse_workflow` above for validation before writing to disk.
+pub(crate) use workflow_file::{RawEdge, RawNode, RawWorkflow, render_workflow};
 pub use workspace_seed::{NodeKind, SeedNode, extract_wikilinks, walk_workspace};
 
 use crate::{Result, VERSION};

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -7,7 +7,7 @@
 
 use std::path::{Path, PathBuf};
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::error::{OpenCompanyError, Result};
 
@@ -108,42 +108,61 @@ pub struct WorkflowEdgeDef {
 
 /// Serde-facing shape of the workflow TOML. Enum-like `kind` is read as a plain
 /// string and validated so errors read in prosumer language, not serde traces.
-#[derive(Deserialize)]
-struct RawWorkflow {
+///
+/// Also carries `Serialize` (`pub(crate)` fields) so the workflow creator
+/// (issue #69) can render a candidate graph straight back to this same shape
+/// and re-parse it through [`parse_workflow`] for validation before writing
+/// anything to disk — see [`render_workflow`].
+#[derive(Deserialize, Serialize)]
+pub(crate) struct RawWorkflow {
     #[serde(default)]
-    id: String,
+    pub(crate) id: String,
     #[serde(default)]
-    name: String,
-    #[serde(default)]
-    description: Option<String>,
+    pub(crate) name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) description: Option<String>,
     #[serde(default, rename = "node")]
-    nodes: Vec<RawNode>,
+    pub(crate) nodes: Vec<RawNode>,
     #[serde(default, rename = "edge")]
-    edges: Vec<RawEdge>,
+    pub(crate) edges: Vec<RawEdge>,
 }
 
-#[derive(Deserialize)]
-struct RawNode {
+#[derive(Deserialize, Serialize)]
+pub(crate) struct RawNode {
     #[serde(default)]
-    id: String,
+    pub(crate) id: String,
     #[serde(default)]
-    kind: String,
+    pub(crate) kind: String,
     #[serde(default)]
-    name: String,
-    #[serde(default)]
-    summary: Option<String>,
-    #[serde(default)]
-    agent: Option<String>,
+    pub(crate) name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) agent: Option<String>,
 }
 
-#[derive(Deserialize)]
-struct RawEdge {
+#[derive(Deserialize, Serialize)]
+pub(crate) struct RawEdge {
     #[serde(default)]
-    from: String,
+    pub(crate) from: String,
     #[serde(default)]
-    to: String,
-    #[serde(default)]
-    label: Option<String>,
+    pub(crate) to: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) label: Option<String>,
+}
+
+/// Renders a candidate graph as on-disk workflow TOML — the inverse of
+/// [`parse_workflow`]. Used by the console's workflow creator (issue #69): the
+/// caller builds a [`RawWorkflow`] from the create-workflow request body,
+/// renders it here, then re-parses the result through [`parse_workflow`] to
+/// get the exact same structural validation (trigger count, duplicate/dangling
+/// node ids, unknown kinds, stray `agent` fields) a hand-authored
+/// `workflows/<id>.toml` must pass — before anything is written to disk.
+pub(crate) fn render_workflow(raw: &RawWorkflow) -> Result<String> {
+    toml::to_string(raw).map_err(|err| OpenCompanyError::DataParse {
+        path: PathBuf::from(format!("{}.toml", raw.id)),
+        message: err.to_string(),
+    })
 }
 
 /// Parses one workflow graph from TOML source, validating it in full.
@@ -311,6 +330,67 @@ fn validate(raw: &RawWorkflow) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn render_workflow_round_trips_through_parse_workflow() {
+        let raw = RawWorkflow {
+            id: "wf".to_string(),
+            name: "WF".to_string(),
+            description: Some("A test graph.".to_string()),
+            nodes: vec![
+                RawNode {
+                    id: "start".to_string(),
+                    kind: "trigger".to_string(),
+                    name: "Start".to_string(),
+                    summary: None,
+                    agent: None,
+                },
+                RawNode {
+                    id: "worker".to_string(),
+                    kind: "agent".to_string(),
+                    name: "Worker".to_string(),
+                    summary: Some("Does the thing.".to_string()),
+                    agent: Some("ceo".to_string()),
+                },
+            ],
+            edges: vec![RawEdge {
+                from: "start".to_string(),
+                to: "worker".to_string(),
+                label: Some("ok".to_string()),
+            }],
+        };
+        let toml_src = render_workflow(&raw).expect("renders");
+        let file = parse_workflow(&toml_src).expect("re-parses the rendered graph");
+        assert_eq!(file.id, "wf");
+        assert_eq!(file.nodes.len(), 2);
+        assert_eq!(file.edges.len(), 1);
+        let worker = file.nodes.iter().find(|n| n.id == "worker").unwrap();
+        assert_eq!(worker.agent.as_deref(), Some("ceo"));
+        assert_eq!(file.edges[0].label.as_deref(), Some("ok"));
+    }
+
+    /// A rendered graph that fails structural validation (no trigger) surfaces
+    /// the same prosumer-language problem `parse_workflow` gives a hand-authored
+    /// file — the create endpoint relies on this to turn a bad graph into a 4xx.
+    #[test]
+    fn render_workflow_of_an_invalid_graph_fails_reparse() {
+        let raw = RawWorkflow {
+            id: "wf".to_string(),
+            name: "WF".to_string(),
+            description: None,
+            nodes: vec![RawNode {
+                id: "only".to_string(),
+                kind: "output".to_string(),
+                name: "Only".to_string(),
+                summary: None,
+                agent: None,
+            }],
+            edges: vec![],
+        };
+        let toml_src = render_workflow(&raw).expect("renders even though invalid");
+        let err = parse_workflow(&toml_src).unwrap_err();
+        assert!(err.to_string().contains("trigger"), "{err}");
+    }
 
     const CAMPAIGN: &str = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),

--- a/src/server/ops/language.rs
+++ b/src/server/ops/language.rs
@@ -26,3 +26,12 @@ pub const WORKSPACE_CYCLE: &str = "You can't move a folder into itself.";
 
 /// Error shown when a custom skill is missing its required fields.
 pub const SKILL_FIELDS_REQUIRED: &str = "A skill needs a name and a description.";
+
+/// Error shown when creating a workflow on a deployment with no writable
+/// company source directory (hosted/platform mode without one provisioned).
+pub const WORKFLOW_NEEDS_SOURCE_DIR: &str =
+    "Workflow creation needs a company source directory, and this deployment doesn't have one yet.";
+
+/// Error shown when a workflow id is not safe to use as a filename.
+pub const WORKFLOW_ID_INVALID: &str =
+    "A workflow id can't be empty or contain slashes or `..` — use a plain name.";

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -408,9 +408,10 @@ async fn create_workflow(
 
     // Write the file atomically: `create_new(true)` fails if the path already
     // exists, closing the TOCTOU gap between a separate `is_file()` check and
-    // `fs::write`. Also, save the store record **after** the file lands so a
-    // store failure doesn't orphan a file — if the save fails the file is
-    // cleaned up and the caller can retry.
+    // `fs::write`. If `write_all` fails, clean up the empty file so the id is
+    // not permanently blocked. Also, save the store record **after** the file
+    // lands so a store failure doesn't orphan a file — if the save fails the
+    // file is cleaned up and the caller can retry.
     let mut wf_file = std::fs::OpenOptions::new()
         .write(true)
         .create_new(true)
@@ -426,6 +427,7 @@ async fn create_workflow(
             }),
         })?;
     wf_file.write_all(toml_src.as_bytes()).map_err(|source| {
+        let _ = std::fs::remove_file(&path);
         ApiError(OpenCompanyError::StoreIo {
             path: path.clone(),
             source,

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1,12 +1,22 @@
-//! Workflow surfaces: read the company's saved graphs (`GET /workflows`,
-//! `GET /workflows/{wid}`) and run one (`POST /workflows/{wid}/run`) under both
-//! scope forms.
+//! Workflow surfaces: create a graph (`POST /workflows`), read the company's
+//! saved graphs (`GET /workflows`, `GET /workflows/{wid}`), and run one
+//! (`POST /workflows/{wid}/run`) — under both scope forms.
 //!
 //! Graphs are loaded from the company's on-disk source directory
 //! (`companies/<name>/workflows/<wid>.toml`) via
 //! [`load_company_workflows`](crate::company::load_company_workflows), which
 //! takes an explicit id list (it never scans) — so `list_workflows` enumerates
 //! the `workflows/` directory itself to build that list.
+//!
+//! Creation (issue #69) writes a new `workflows/<id>.toml` into that same
+//! source directory — reusing [`parse_workflow`](crate::company::parse_workflow)
+//! to validate the graph a caller posts before anything touches disk — and
+//! records the id as enabled on the operator's live [`CompanyRecord`], mirroring
+//! the team overlay convention: the version-controlled `company.toml` is never
+//! rewritten (see `crate::server::ops::team`). A deployment with no source
+//! directory (platform-provisioned mode with nothing seeded on disk yet) has
+//! nowhere to write the graph file, so creation is refused with a 4xx rather
+//! than crashing.
 //!
 //! Execution is dependency-inverted behind the [`WorkflowRunner`] port: when no
 //! runner is wired (the default build, or a runtime built without a harness) the
@@ -15,6 +25,7 @@
 //! parse the committed graph files, so the console can list and render workflows
 //! even on a build that cannot execute them.
 
+use std::collections::HashSet;
 use std::path::Path as FsPath;
 
 use axum::extract::Path;
@@ -25,14 +36,19 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::AppState;
-use crate::company::{WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef, load_company_workflows};
+use crate::company::{
+    RawEdge, RawNode, RawWorkflow, WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef,
+    load_company_workflows, parse_workflow, render_workflow,
+};
 use crate::error::OpenCompanyError;
 use crate::server::error::ApiError;
+use crate::server::ops::language;
 use crate::server::ops::{ScopedCompany, scoped};
 
-/// Builds the workflow route fragment: list + graph reads and the run write.
+/// Builds the workflow route fragment: create + list, one graph read, and the
+/// run write.
 pub fn router() -> Router<AppState> {
-    scoped("/workflows", get(list_workflows))
+    scoped("/workflows", post(create_workflow).get(list_workflows))
         .merge(scoped("/workflows/{wid}", get(get_workflow)))
         .merge(scoped("/workflows/{wid}/run", post(run_workflow)))
 }
@@ -171,6 +187,198 @@ async fn get_workflow(
         .into_iter()
         .next()
         .ok_or_else(|| ApiError(OpenCompanyError::CompanyNotFound(format!("workflow {wid}"))))?;
+    Ok(Json(WorkflowGraph::from(file)))
+}
+
+/// The create-workflow body — the same camelCase graph shape the GET routes
+/// return (`id`/`name`/`description?`/`nodes`/`edges`), so the console's
+/// creator can post exactly what it would otherwise read back.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateWorkflowBody {
+    id: String,
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    nodes: Vec<CreateNode>,
+    #[serde(default)]
+    edges: Vec<CreateEdge>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateNode {
+    id: String,
+    kind: String,
+    name: String,
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    agent: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateEdge {
+    from: String,
+    to: String,
+    #[serde(default)]
+    label: Option<String>,
+}
+
+impl From<CreateWorkflowBody> for RawWorkflow {
+    fn from(body: CreateWorkflowBody) -> Self {
+        Self {
+            id: body.id,
+            name: body.name,
+            description: body.description,
+            nodes: body
+                .nodes
+                .into_iter()
+                .map(|n| RawNode {
+                    id: n.id,
+                    kind: n.kind,
+                    name: n.name,
+                    summary: n.summary,
+                    agent: n.agent,
+                })
+                .collect(),
+            edges: body
+                .edges
+                .into_iter()
+                .map(|e| RawEdge {
+                    from: e.from,
+                    to: e.to,
+                    label: e.label,
+                })
+                .collect(),
+        }
+    }
+}
+
+/// `POST …/workflows` — authors a new workflow graph (issue #69): the console's
+/// form creator, or any direct API caller, posts the graph shape and it lands
+/// as a new `workflows/<id>.toml` in the company's source directory.
+///
+/// Order of checks, each returning an actionable 4xx before anything is
+/// written: the id must be a safe filename, the deployment must have a source
+/// directory to write into, the id must not already be taken (409), every
+/// `agent` node must name a real roster teammate, and the graph must pass the
+/// same structural validation ([`parse_workflow`]) a hand-authored file would
+/// (at least one trigger, unique node ids, edges that reference real nodes, no
+/// stray `agent` field on a non-agent node).
+async fn create_workflow(
+    company: ScopedCompany,
+    Json(body): Json<CreateWorkflowBody>,
+) -> Result<Json<WorkflowGraph>, ApiError> {
+    if !safe_wid(&body.id) {
+        return Err(ApiError(OpenCompanyError::InvalidRequest(
+            language::WORKFLOW_ID_INVALID.to_string(),
+        )));
+    }
+
+    let source_dir = company.runtime.source_dir().ok_or_else(|| {
+        ApiError(OpenCompanyError::InvalidRequest(
+            language::WORKFLOW_NEEDS_SOURCE_DIR.to_string(),
+        ))
+    })?;
+
+    let workflows_dir = source_dir.join("workflows");
+    let path = workflows_dir.join(format!("{}.toml", body.id));
+    if path.is_file() {
+        return Err(ApiError(OpenCompanyError::Conflict(format!(
+            "A workflow named `{}` already exists.",
+            body.id
+        ))));
+    }
+
+    // `parse_workflow` only rejects zero triggers (a saved graph may legally
+    // have more, e.g. multiple entry points); the creator is stricter — a
+    // freshly authored graph must name exactly one starting point.
+    let trigger_count = body.nodes.iter().filter(|n| n.kind == "trigger").count();
+    if trigger_count != 1 {
+        return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
+            "a workflow needs exactly one `trigger` node to say what starts it (found {trigger_count})."
+        ))));
+    }
+
+    // Cross-check every `agent` node against the company's effective roster
+    // (manifest agents + operator overlay teammates) before writing anything.
+    // `parse_workflow` validates the graph's own shape but has no roster to
+    // check names against.
+    let mut record = company
+        .runtime
+        .store()
+        .load(company.id())
+        .await?
+        .ok_or_else(|| OpenCompanyError::CompanyNotFound(company.id().to_string()))?;
+    let roster: HashSet<&str> = record
+        .manifest
+        .agents
+        .iter()
+        .map(|a| a.id.as_str())
+        .chain(record.overlay_agents.iter().map(|a| a.id.as_str()))
+        .collect();
+    for node in &body.nodes {
+        if node.kind != "agent" {
+            continue;
+        }
+        match node.agent.as_deref() {
+            Some(agent_id) if roster.contains(agent_id) => {}
+            Some(agent_id) => {
+                return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
+                    "node `{}` names teammate `{agent_id}`, which is not on this company's roster.",
+                    node.id
+                ))));
+            }
+            None => {
+                return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
+                    "node `{}` is an agent node but names no teammate.",
+                    node.id
+                ))));
+            }
+        }
+    }
+
+    // Render the candidate graph to TOML and reuse `parse_workflow` to
+    // validate its structure end to end — the same rules a hand-authored
+    // `workflows/<id>.toml` must satisfy. Any problem becomes a 400, never the
+    // 500 a malformed on-disk file gets from the read routes.
+    let toml_src = render_workflow(&body.into())?;
+    let file = parse_workflow(&toml_src).map_err(|err| match err {
+        OpenCompanyError::DataInvalid { problems, .. } => {
+            ApiError(OpenCompanyError::InvalidRequest(problems.join(" ")))
+        }
+        OpenCompanyError::DataParse { message, .. } => {
+            ApiError(OpenCompanyError::InvalidRequest(message))
+        }
+        other => ApiError(other),
+    })?;
+
+    std::fs::create_dir_all(&workflows_dir).map_err(|source| {
+        ApiError(OpenCompanyError::StoreIo {
+            path: workflows_dir.clone(),
+            source,
+        })
+    })?;
+    std::fs::write(&path, &toml_src)
+        .map_err(|source| ApiError(OpenCompanyError::StoreIo { path, source }))?;
+
+    // Record the id as enabled on the operator's live copy of the manifest —
+    // mirrors the team overlay: the version-controlled `company.toml` on disk
+    // is never rewritten (see `crate::server::ops::team`).
+    if !record
+        .manifest
+        .workflows
+        .enabled
+        .iter()
+        .any(|e| e == &file.id)
+    {
+        record.manifest.workflows.enabled.push(file.id.clone());
+        company.runtime.store().save(&record).await?;
+    }
+
     Ok(Json(WorkflowGraph::from(file)))
 }
 

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -1214,10 +1214,7 @@ async fn workflow_create_rejects_bad_edges_missing_agent_and_no_trigger() {
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(body["code"], "invalid_request");
-    assert!(
-        body["error"].as_str().unwrap().contains("roster"),
-        "{body}"
-    );
+    assert!(body["error"].as_str().unwrap().contains("roster"), "{body}");
 
     // No trigger node at all.
     let (status, body) = send(
@@ -1236,11 +1233,13 @@ async fn workflow_create_rejects_bad_edges_missing_agent_and_no_trigger() {
     assert_eq!(body["code"], "invalid_request");
 
     // None of the rejected attempts left a file behind.
-    assert!(!seed_dir.join("workflows").is_dir() || {
-        std::fs::read_dir(seed_dir.join("workflows"))
-            .map(|mut d| d.next().is_none())
-            .unwrap_or(true)
-    });
+    assert!(
+        !seed_dir.join("workflows").is_dir() || {
+            std::fs::read_dir(seed_dir.join("workflows"))
+                .map(|mut d| d.next().is_none())
+                .unwrap_or(true)
+        }
+    );
 
     tokio::fs::remove_dir_all(&home).await.ok();
 }

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -1013,6 +1013,232 @@ async fn mcp_query_param_auth_round_trips_write_only_with_advisory() {
     tokio::fs::remove_dir_all(&home).await.ok();
 }
 
+// ---------------------------------------------------------------------------
+// Workflow creator (issue #69)
+// ---------------------------------------------------------------------------
+
+/// Boots an fs-backed company with a writable source directory (a `seed_dir`)
+/// — the workflow creator writes `workflows/<id>.toml` under it, mirroring how
+/// a real `companies/<name>` checkout is wired via `--company`.
+async fn state_with_source_dir(
+    home: &std::path::Path,
+    seed_dir: &std::path::Path,
+    manifest: CompanyManifest,
+) -> AppState {
+    use crate::ports::CompanyStore;
+    let store = FsCompanyStore::new(home.to_path_buf());
+    let id = CompanyId::new("acme");
+    store
+        .save(&CompanyRecord {
+            id: id.clone(),
+            manifest: manifest.clone(),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+        .with_id(id.clone())
+        .with_seed_dir(seed_dir.to_path_buf())
+        .build()
+        .await
+        .unwrap();
+    let state = AppState::new(AppConfig::default());
+    state.registry().insert(id, std::sync::Arc::new(runtime));
+    crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+    state
+}
+
+/// A valid graph body: a trigger → an agent node naming the roster's `ceo` →
+/// an output. `$id` becomes both the workflow id and its display name.
+fn workflow_body(id: &str) -> Value {
+    json!({
+        "id": id,
+        "name": id,
+        "description": "A tiny test graph.",
+        "nodes": [
+            {"id": "start", "kind": "trigger", "name": "Start"},
+            {"id": "worker", "kind": "agent", "name": "Worker", "agent": "ceo"},
+            {"id": "done", "kind": "output", "name": "Done"},
+        ],
+        "edges": [
+            {"from": "start", "to": "worker"},
+            {"from": "worker", "to": "done", "label": "ok"},
+        ],
+    })
+}
+
+#[tokio::test]
+async fn workflow_create_writes_file_appends_enabled_and_is_listed() {
+    let home = home();
+    let seed_dir = home.join("seed");
+    std::fs::create_dir_all(&seed_dir).unwrap();
+    let state = state_with_source_dir(&home, &seed_dir, manifest()).await;
+
+    let (status, created) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workflows",
+        Some(workflow_body("greet")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(created["id"], "greet");
+    assert_eq!(created["nodes"].as_array().unwrap().len(), 3);
+    assert_eq!(created["edges"].as_array().unwrap().len(), 2);
+
+    // The graph landed on disk as TOML under the seed dir.
+    let path = seed_dir.join("workflows").join("greet.toml");
+    assert!(path.is_file(), "workflow file was written to {path:?}");
+    let on_disk = std::fs::read_to_string(&path).unwrap();
+    assert!(on_disk.contains("id = \"greet\""));
+    assert!(on_disk.contains("agent = \"ceo\""));
+
+    // The operator's live manifest record gained the id in `[workflows].enabled`
+    // — the version-controlled seed dir's own `company.toml` was never touched
+    // (there isn't one here; only the store's copy is checked).
+    use crate::ports::CompanyStore;
+    let store = FsCompanyStore::new(home.to_path_buf());
+    let record = store.load(&CompanyId::new("acme")).await.unwrap().unwrap();
+    assert_eq!(record.manifest.workflows.enabled, vec!["greet".to_string()]);
+
+    // `GET …/workflows` (which scans the seed dir) now lists it.
+    let (status, list) = send(&state, "GET", "/api/v1/company/workflows", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let rows = list.as_array().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], "greet");
+
+    // `GET …/workflows/{wid}` round-trips the full graph too.
+    let (status, graph) = send(&state, "GET", "/api/v1/company/workflows/greet", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(graph["name"], "greet");
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+#[tokio::test]
+async fn workflow_create_duplicate_id_is_conflict() {
+    let home = home();
+    let seed_dir = home.join("seed");
+    std::fs::create_dir_all(&seed_dir).unwrap();
+    let state = state_with_source_dir(&home, &seed_dir, manifest()).await;
+
+    let (status, _) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workflows",
+        Some(workflow_body("greet")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, body) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workflows",
+        Some(workflow_body("greet")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(body["code"], "conflict");
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+#[tokio::test]
+async fn workflow_create_rejects_bad_edges_missing_agent_and_no_trigger() {
+    let home = home();
+    let seed_dir = home.join("seed");
+    std::fs::create_dir_all(&seed_dir).unwrap();
+    let state = state_with_source_dir(&home, &seed_dir, manifest()).await;
+
+    // An edge referencing a node id that doesn't exist.
+    let (status, body) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workflows",
+        Some(json!({
+            "id": "bad-edge",
+            "name": "Bad edge",
+            "nodes": [{"id": "start", "kind": "trigger", "name": "Start"}],
+            "edges": [{"from": "start", "to": "ghost"}],
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["code"], "invalid_request");
+
+    // An agent node naming a teammate not on the roster.
+    let (status, body) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workflows",
+        Some(json!({
+            "id": "bad-agent",
+            "name": "Bad agent",
+            "nodes": [
+                {"id": "start", "kind": "trigger", "name": "Start"},
+                {"id": "worker", "kind": "agent", "name": "Worker", "agent": "ghost"},
+            ],
+            "edges": [{"from": "start", "to": "worker"}],
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["code"], "invalid_request");
+    assert!(
+        body["error"].as_str().unwrap().contains("roster"),
+        "{body}"
+    );
+
+    // No trigger node at all.
+    let (status, body) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workflows",
+        Some(json!({
+            "id": "no-trigger",
+            "name": "No trigger",
+            "nodes": [{"id": "only", "kind": "output", "name": "Only"}],
+            "edges": [],
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["code"], "invalid_request");
+
+    // None of the rejected attempts left a file behind.
+    assert!(!seed_dir.join("workflows").is_dir() || {
+        std::fs::read_dir(seed_dir.join("workflows"))
+            .map(|mut d| d.next().is_none())
+            .unwrap_or(true)
+    });
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+#[tokio::test]
+async fn workflow_create_without_source_dir_is_bad_request() {
+    let home = home();
+    // `state_with_company` boots with no `seed_dir`, so the company has no
+    // writable source directory — the platform-provisioned-mode case.
+    let state = state_with_company(&home).await;
+
+    let (status, body) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workflows",
+        Some(workflow_body("greet")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["code"], "invalid_request");
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
 /// Without the `openhuman` feature the on-demand Test route is "not wired".
 #[cfg(not(feature = "openhuman"))]
 #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #69. The console had no way to create a workflow — `src/server/ops/workflows.rs` only had read (`GET /workflows`, `GET /workflows/{wid}`) and run (`POST /workflows/{wid}/run`). This adds a minimal, faithful creator: a backend write path plus a form-based UI in the console.

**Backend** — `POST /workflows` (both scope forms) takes the same camelCase graph shape the GET routes already return. It:
- validates the id (safe filename), rejects a duplicate id (409)
- checks every `agent` node names a real roster teammate (manifest agents + operator overlay)
- requires exactly one `trigger` node
- reuses `parse_workflow` (via a new `render_workflow` TOML round-trip) to apply the same structural validation a hand-authored `workflows/<id>.toml` must pass — duplicate/dangling node ids, unknown kinds, stray `agent` fields
- writes `workflows/<id>.toml` into the company's source directory
- records the id as `enabled` on the operator's **live manifest record** via the `CompanyStore` — mirroring the existing team-overlay convention (`src/server/ops/team.rs`): the version-controlled `company.toml` on disk is never rewritten
- returns a clean 4xx (not a crash) when the deployment has no source directory (hosted mode with nothing seeded)

**Frontend** — `WorkflowsView` gets a "New workflow" button (toolbar + empty state) that opens a plain **form** editor (not a drag canvas): id/name/description, a node list (id/kind/name/summary, plus a roster-teammate picker for `agent` nodes via `client.listTeam`), and an edge list (from/to/label, populated from the node ids just entered). The node-kind palette is restricted to `trigger`/`agent`/`condition`/`output` — the runtime doesn't execute `tool_call`/`http_request` yet (`Unwired*` stubs in `src/workflows/caps.rs`), so the creator doesn't offer them. Client-side validation mirrors the host's checks. On success the returned graph is spliced into the list and selected.

**Deferred (not built here, noted per the issue's MVP scope)**: PUT/DELETE edit of an existing workflow, the chat/copilot builder (OpenHuman's primary authoring UX), ReactFlow drag-to-connect editing, per-node `config`/params, and a proper hosted `WorkflowStore` (creation needs a company source directory today).

## API Or Behavior Changes

- New route: `POST /api/v1/company/workflows` and `POST /api/v1/companies/{id}/workflows`.
- `RawWorkflow`/`RawNode`/`RawEdge` in `src/company/workflow_file.rs` gained `Serialize` (crate-internal only, `pub(crate)`) and a new `render_workflow` function — the inverse of `parse_workflow`. No change to existing read/parse behavior.
- Frontend: new `createWorkflow` export in `frontend/src/api/workflows.ts`; no changes to existing exports.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` (566 passed, default features — no `openhuman`/`tiny` feature pulled in)
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run build`

New coverage: 2 unit tests for `render_workflow` (round-trips through `parse_workflow`; an invalid graph still fails re-parse), 4 end-to-end HTTP tests in `src/server/ops/write_test.rs` (writes file + appends enabled + GET lists/reads it back; duplicate id → 409; bad edge / unknown roster agent / missing trigger → 400; no source directory → 400).

## Documentation

Doc comments updated on the touched modules (`workflow_file.rs`, `server/ops/workflows.rs`) explaining the new write path and its relationship to the existing team-overlay convention. No user-facing docs existed for the (nonexistent) creator, so none needed updating.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-place workflow creation from the Workflows view, including a guided dialog to define id, name, description, nodes, edges, triggers, and agent assignments.
  * Added a company-scoped API to create workflows from the editor and return the created workflow.
  * Newly created workflows are persisted, enabled in the company manifest, and selected automatically.

* **Bug Fixes**
  * Improved validation with clear errors for invalid workflow ids, missing/invalid trigger configuration, malformed graphs, unknown agents, and duplicate workflow ids.
  * Ensures failed requests don’t leave behind partial workflow artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->