### PR TITLE
feat(mcp): per-tenant OAuth sign-in for MCP servers in the console (#90)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5382,6 +5382,7 @@ dependencies = [
  "async-graphql-axum",
  "async-trait",
  "axum",
+ "base64 0.22.1",
  "bs58",
  "clap",
  "ed25519-dalek",
@@ -5411,6 +5412,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid 1.23.5",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,12 @@ openhuman_core = { package = "openhuman", path = "vendor/openhuman", optional = 
 anyhow = { version = "1", optional = true }
 log = { version = "0.4", optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }
+# Console MCP OAuth (issue #90): base64url for PKCE (S256 challenge + verifier
+# entropy) and URL building for the `/authorize` redirect. Both are already in
+# the tree via `openhuman_core` + `reqwest`, so pinning them as direct deps adds
+# no new Cargo.lock entries; they link only under the `mcp` feature.
+base64 = { version = "0.22", optional = true }
+url = { version = "2", optional = true }
 
 # Issue #29 (epic #26): the tinyflows workflow engine, embedded directly. It is
 # host-agnostic and Config-free — `Capabilities` is a plain struct of trait
@@ -183,7 +189,7 @@ openhuman = ["dep:openhuman_core", "dep:reqwest", "dep:anyhow", "dep:log", "dep:
 # MCP server management and agent tools share OpenHuman's in-process registry.
 # Enabling it necessarily enables the embedded harness and OpenHuman MCP
 # domain, while the default build remains unchanged.
-mcp = ["openhuman", "openhuman_core/mcp", "dep:uuid"]
+mcp = ["openhuman", "openhuman_core/mcp", "dep:uuid", "dep:base64", "dep:url"]
 # Real HTTP transport to openhuman-core. The trait + offline mock + providers
 # compile without this; only `HttpOpenHumanRpc` is gated behind it.
 openhuman-rpc = ["dep:reqwest"]

--- a/frontend/src/api/mcp.ts
+++ b/frontend/src/api/mcp.ts
@@ -100,6 +100,29 @@ export function discoverMcpTools(
   );
 }
 
+/** The `oauth/start` response: the authorization URL to open in a browser. */
+export interface McpOAuthStart {
+  authorizeUrl: string;
+}
+
+/**
+ * Begin a server's browser OAuth sign-in (issue #90). Returns the authorization
+ * URL the console opens in a new tab; the host completes the flow on its
+ * `/oauth/mcp/callback` route and stores the token write-only. 404 `not_wired`
+ * when the harness/OAuth path is off; 400 when the server can't do OAuth (paste
+ * a static token instead).
+ */
+export function startMcpOAuth(
+  client: OpenCompanyClient,
+  company: string | null,
+  name: string,
+): Promise<McpOAuthStart> {
+  return client.post<McpOAuthStart>(
+    `${client.scopeFor(company)}/mcp/servers/${encodeURIComponent(name)}/oauth/start`,
+    {},
+  );
+}
+
 /**
  * Probe a server on demand and return its (scrubbed) health. 404 `not_wired`
  * when the harness is off.

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   AlertTriangle,
   Check,
@@ -273,6 +273,11 @@ function McpServersSection({
   const [tools, setTools] = useState<Record<string, ToolsState>>({});
   // Live health from an on-demand Test, overriding the persisted badge per row.
   const [tested, setTested] = useState<Record<string, McpHealth>>({});
+  // In-flight OAuth sign-in poll timers, keyed by server name. A row with a live
+  // timer is still "signing in" even after its `busy` flag clears, so a repeat
+  // click can't spawn a second overlapping poll. Cleared on unmount so stale
+  // callbacks don't fire against a gone component.
+  const pollTimers = useRef<Record<string, number>>({});
 
   // Add-server form.
   const [name, setName] = useState("");
@@ -297,6 +302,15 @@ function McpServersSection({
     setLoad("loading");
     void refresh();
   }, [refresh]);
+
+  // Cancel any in-flight sign-in polls when the view unmounts so their timers
+  // don't fire against a torn-down component.
+  useEffect(() => {
+    const timers = pollTimers.current;
+    return () => {
+      for (const id of Object.values(timers)) window.clearTimeout(id);
+    };
+  }, []);
 
   async function add() {
     if (busy) return;
@@ -369,7 +383,10 @@ function McpServersSection({
   // then poll the server's health until it flips to `ok` (the host stores the
   // token on its callback route) so the amber badge turns green on its own.
   async function signIn(server: McpServer) {
-    if (busy) return;
+    // Guard both the shared `busy` flag and a per-server poll already in flight:
+    // the poll outlives `busy`, so without the second check a repeat click would
+    // spawn a second overlapping sign-in (duplicate token exchange + toasts).
+    if (busy || pollTimers.current[server.name] !== undefined) return;
     setBusy(server.name);
     try {
       const { authorizeUrl } = await startMcpOAuth(client, company, server.name);
@@ -378,7 +395,13 @@ function McpServersSection({
       // Poll for completion for up to ~2 minutes; stop as soon as it's healthy.
       const deadline = Date.now() + 120_000;
       const poll = async () => {
-        if (Date.now() > deadline) return;
+        delete pollTimers.current[server.name];
+        if (Date.now() > deadline) {
+          toast.message(
+            `Sign-in for ${server.name} timed out. Try again if it didn't complete.`,
+          );
+          return;
+        }
         try {
           const health = await testMcpServer(client, company, server.name);
           setTested((t) => ({ ...t, [server.name]: health }));
@@ -390,9 +413,9 @@ function McpServersSection({
         } catch {
           // Ignore transient probe errors while the operator finishes sign-in.
         }
-        window.setTimeout(() => void poll(), 2_000);
+        pollTimers.current[server.name] = window.setTimeout(() => void poll(), 2_000);
       };
-      window.setTimeout(() => void poll(), 2_000);
+      pollTimers.current[server.name] = window.setTimeout(() => void poll(), 2_000);
     } catch (err) {
       if (err instanceof ApiError && err.code === "not_wired") {
         toast.message("OAuth sign-in isn't enabled in this build (the agent harness is off).");

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDown,
   Info,
   Loader2,
+  LogIn,
   Plug,
   Plus,
   Server,
@@ -19,6 +20,7 @@ import {
   listMcpServers,
   type McpAuthKind,
   removeMcpServer,
+  startMcpOAuth,
   testMcpServer,
   updateMcpServer,
 } from "@/api/mcp";
@@ -323,7 +325,10 @@ function McpServersSection({
       });
       // A probe that lands "needs config" or "error" is NOT a rollback — the
       // server is added — but surface it inline so the operator acts on it.
-      if (res.test && res.test.status !== "ok") {
+      // Exception: an OAuth-required result is not an error to shout about — the
+      // amber "needs config" badge carries a Sign in button, so a red alert here
+      // would be redundant and misleading.
+      if (res.test && res.test.status !== "ok" && res.test.authHint !== "oauth_required") {
         setAddError(res.test.message);
       } else if (res.warning) {
         setAddError(res.warning);
@@ -354,6 +359,45 @@ function McpServersSection({
         toast.message("Live testing isn't enabled in this build (the agent harness is off).");
       } else {
         toast.error(err instanceof ApiError ? err.message : "Couldn't test the server.");
+      }
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  // Browser OAuth sign-in (issue #90): open the authorization URL in a new tab,
+  // then poll the server's health until it flips to `ok` (the host stores the
+  // token on its callback route) so the amber badge turns green on its own.
+  async function signIn(server: McpServer) {
+    if (busy) return;
+    setBusy(server.name);
+    try {
+      const { authorizeUrl } = await startMcpOAuth(client, company, server.name);
+      window.open(authorizeUrl, "_blank", "noopener,noreferrer");
+      toast.message(`Complete sign-in for ${server.name} in the new tab.`);
+      // Poll for completion for up to ~2 minutes; stop as soon as it's healthy.
+      const deadline = Date.now() + 120_000;
+      const poll = async () => {
+        if (Date.now() > deadline) return;
+        try {
+          const health = await testMcpServer(client, company, server.name);
+          setTested((t) => ({ ...t, [server.name]: health }));
+          if (health.status === "ok") {
+            toast.success(`Signed in to ${server.name}.`);
+            await refresh();
+            return;
+          }
+        } catch {
+          // Ignore transient probe errors while the operator finishes sign-in.
+        }
+        window.setTimeout(() => void poll(), 2_000);
+      };
+      window.setTimeout(() => void poll(), 2_000);
+    } catch (err) {
+      if (err instanceof ApiError && err.code === "not_wired") {
+        toast.message("OAuth sign-in isn't enabled in this build (the agent harness is off).");
+      } else {
+        toast.error(err instanceof ApiError ? err.message : "Couldn't start sign-in.");
       }
     } finally {
       setBusy(null);
@@ -453,6 +497,21 @@ function McpServersSection({
                             onCheckedChange={(v) => void toggle(server, v)}
                             aria-label={`Enable ${server.name}`}
                           />
+                          {health?.authHint === "oauth_required" && (
+                            <Button
+                              variant="default"
+                              size="sm"
+                              disabled={busy === server.name}
+                              onClick={() => void signIn(server)}
+                            >
+                              {busy === server.name ? (
+                                <Loader2 className="size-4 animate-spin" />
+                              ) : (
+                                <LogIn className="size-4" />
+                              )}{" "}
+                              Sign in
+                            </Button>
+                          )}
                           <Button
                             variant="ghost"
                             size="sm"

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -245,6 +245,13 @@ pub struct AppState {
     /// request. Gated behind `tinyplace` so the default build links no crypto.
     #[cfg(feature = "tinyplace")]
     nonce: std::sync::Arc<crate::economy::NonceCache>,
+    /// In-flight console MCP OAuth flows, keyed by the opaque `state` the browser
+    /// round-trips (issue #90). The `/mcp/servers/{name}/oauth/start` route parks
+    /// a [`PendingOAuth`](crate::company::mcp_oauth::PendingOAuth) here; the
+    /// unauthenticated `/oauth/mcp/callback` route takes it back out by `state`.
+    /// Gated behind `mcp` so the default build links none of the OAuth path.
+    #[cfg(feature = "mcp")]
+    oauth_pending: Arc<std::sync::Mutex<HashMap<String, crate::company::mcp_oauth::PendingOAuth>>>,
 }
 
 impl std::fmt::Debug for AppState {
@@ -276,6 +283,8 @@ impl AppState {
             cors: crate::server::cors::CorsConfig::default(),
             #[cfg(feature = "tinyplace")]
             nonce: std::sync::Arc::new(crate::economy::NonceCache::new()),
+            #[cfg(feature = "mcp")]
+            oauth_pending: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
     }
 
@@ -454,6 +463,27 @@ impl AppState {
     #[cfg(feature = "tinyplace")]
     pub fn nonce(&self) -> &std::sync::Arc<crate::economy::NonceCache> {
         &self.nonce
+    }
+
+    /// Parks an in-flight console MCP OAuth flow keyed by its opaque `state`, to
+    /// be reclaimed by the callback route. See issue #90.
+    #[cfg(feature = "mcp")]
+    pub fn park_oauth(&self, state: String, pending: crate::company::mcp_oauth::PendingOAuth) {
+        self.oauth_pending
+            .lock()
+            .expect("oauth pending poisoned")
+            .insert(state, pending);
+    }
+
+    /// Takes (removes) a parked console MCP OAuth flow by its `state`. `None` when
+    /// the state is unknown or already consumed (single-use, so a replayed
+    /// callback can't re-exchange).
+    #[cfg(feature = "mcp")]
+    pub fn take_oauth(&self, state: &str) -> Option<crate::company::mcp_oauth::PendingOAuth> {
+        self.oauth_pending
+            .lock()
+            .expect("oauth pending poisoned")
+            .remove(state)
     }
 
     /// Returns a serializable system specification snapshot.

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -250,8 +250,16 @@ pub struct AppState {
     /// a [`PendingOAuth`](crate::company::mcp_oauth::PendingOAuth) here; the
     /// unauthenticated `/oauth/mcp/callback` route takes it back out by `state`.
     /// Gated behind `mcp` so the default build links none of the OAuth path.
+    /// Each entry carries the [`Instant`](std::time::Instant) it was parked so
+    /// abandoned flows (closed tab, double-click, pre-callback error) can be
+    /// swept — they hold a `client_secret` + `code_verifier` that must not live
+    /// in memory forever.
     #[cfg(feature = "mcp")]
-    oauth_pending: Arc<std::sync::Mutex<HashMap<String, crate::company::mcp_oauth::PendingOAuth>>>,
+    oauth_pending: Arc<
+        std::sync::Mutex<
+            HashMap<String, (std::time::Instant, crate::company::mcp_oauth::PendingOAuth)>,
+        >,
+    >,
 }
 
 impl std::fmt::Debug for AppState {
@@ -465,25 +473,38 @@ impl AppState {
         &self.nonce
     }
 
+    /// How long a parked OAuth flow stays reclaimable before it's swept. Longer
+    /// than any realistic operator round-trip through the authorization server,
+    /// short enough that an abandoned flow's secrets don't linger.
+    #[cfg(feature = "mcp")]
+    const OAUTH_PENDING_TTL: std::time::Duration = std::time::Duration::from_secs(600);
+
     /// Parks an in-flight console MCP OAuth flow keyed by its opaque `state`, to
-    /// be reclaimed by the callback route. See issue #90.
+    /// be reclaimed by the callback route. See issue #90. Sweeps flows older than
+    /// [`OAUTH_PENDING_TTL`](Self::OAUTH_PENDING_TTL) on every park so an
+    /// abandoned sign-in (closed tab, double-click, pre-callback error) can't
+    /// retain its `client_secret`/`code_verifier` for the life of the process.
     #[cfg(feature = "mcp")]
     pub fn park_oauth(&self, state: String, pending: crate::company::mcp_oauth::PendingOAuth) {
-        self.oauth_pending
-            .lock()
-            .expect("oauth pending poisoned")
-            .insert(state, pending);
+        let mut guard = self.oauth_pending.lock().expect("oauth pending poisoned");
+        guard.retain(|_, (parked_at, _)| parked_at.elapsed() < Self::OAUTH_PENDING_TTL);
+        guard.insert(state, (std::time::Instant::now(), pending));
     }
 
     /// Takes (removes) a parked console MCP OAuth flow by its `state`. `None` when
-    /// the state is unknown or already consumed (single-use, so a replayed
-    /// callback can't re-exchange).
+    /// the state is unknown, already consumed (single-use, so a replayed
+    /// callback can't re-exchange), or swept as stale past
+    /// [`OAUTH_PENDING_TTL`](Self::OAUTH_PENDING_TTL).
     #[cfg(feature = "mcp")]
     pub fn take_oauth(&self, state: &str) -> Option<crate::company::mcp_oauth::PendingOAuth> {
-        self.oauth_pending
-            .lock()
-            .expect("oauth pending poisoned")
-            .remove(state)
+        let mut guard = self.oauth_pending.lock().expect("oauth pending poisoned");
+        let entry = guard.remove(state)?;
+        let (parked_at, pending) = entry;
+        // A flow that outlived its TTL is treated as expired, not reclaimable.
+        if parked_at.elapsed() >= Self::OAUTH_PENDING_TTL {
+            return None;
+        }
+        Some(pending)
     }
 
     /// Returns a serializable system specification snapshot.
@@ -603,6 +624,31 @@ mod tests {
 
         assert_eq!(spec.framework, "axum");
         assert!(spec.modules.contains(&"server"));
+    }
+
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn parked_oauth_flow_is_single_use() {
+        use crate::company::mcp_oauth::PendingOAuth;
+        use crate::ports::types::CompanyId;
+
+        let state = AppState::new(AppConfig::default());
+        let pending = PendingOAuth {
+            company_id: CompanyId::new("acme"),
+            server_name: "notion".into(),
+            code_verifier: "verifier".into(),
+            client_id: "cid".into(),
+            client_secret: Some("secret".into()),
+            token_endpoint: "https://as.example/token".into(),
+            redirect_uri: "https://acme.example/oauth/mcp/callback".into(),
+        };
+
+        state.park_oauth("state-1".into(), pending);
+        // First take reclaims it; a replayed callback finds nothing (single-use).
+        assert!(state.take_oauth("state-1").is_some());
+        assert!(state.take_oauth("state-1").is_none());
+        // An unknown state is always None.
+        assert!(state.take_oauth("never-parked").is_none());
     }
 
     #[test]

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -507,6 +507,21 @@ impl AppState {
         Some(pending)
     }
 
+    /// Test-only: park a flow with an explicit parked-at instant so the TTL
+    /// expiry + sweep paths can be exercised without waiting real time.
+    #[cfg(all(test, feature = "mcp"))]
+    fn park_oauth_at(
+        &self,
+        state: String,
+        pending: crate::company::mcp_oauth::PendingOAuth,
+        parked_at: std::time::Instant,
+    ) {
+        self.oauth_pending
+            .lock()
+            .expect("oauth pending poisoned")
+            .insert(state, (parked_at, pending));
+    }
+
     /// Returns a serializable system specification snapshot.
     pub fn spec(&self) -> AppSpec {
         AppSpec {
@@ -643,12 +658,43 @@ mod tests {
             redirect_uri: "https://acme.example/oauth/mcp/callback".into(),
         };
 
-        state.park_oauth("state-1".into(), pending);
+        state.park_oauth("state-1".into(), pending.clone());
         // First take reclaims it; a replayed callback finds nothing (single-use).
         assert!(state.take_oauth("state-1").is_some());
         assert!(state.take_oauth("state-1").is_none());
         // An unknown state is always None.
         assert!(state.take_oauth("never-parked").is_none());
+    }
+
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn parked_oauth_flow_expires_and_is_swept() {
+        use crate::company::mcp_oauth::PendingOAuth;
+        use crate::ports::types::CompanyId;
+        use std::time::{Duration, Instant};
+
+        let state = AppState::new(AppConfig::default());
+        let pending = |server: &str| PendingOAuth {
+            company_id: CompanyId::new("acme"),
+            server_name: server.into(),
+            code_verifier: "verifier".into(),
+            client_id: "cid".into(),
+            client_secret: Some("secret".into()),
+            token_endpoint: "https://as.example/token".into(),
+            redirect_uri: "https://acme.example/oauth/mcp/callback".into(),
+        };
+        let stale_at = Instant::now() - (AppState::OAUTH_PENDING_TTL + Duration::from_secs(1));
+
+        // Stale-on-read: an entry parked past its TTL is rejected (and removed).
+        state.park_oauth_at("expired".into(), pending("notion"), stale_at);
+        assert!(state.take_oauth("expired").is_none());
+
+        // Sweep-on-park: parking a fresh flow evicts any stale sibling first, so
+        // an abandoned flow's secrets can't outlive the TTL even if never taken.
+        state.park_oauth_at("stale".into(), pending("slack"), stale_at);
+        state.park_oauth("fresh".into(), pending("github"));
+        assert!(state.take_oauth("stale").is_none());
+        assert!(state.take_oauth("fresh").is_some());
     }
 
     #[test]

--- a/src/company/mcp.rs
+++ b/src/company/mcp.rs
@@ -83,6 +83,32 @@ pub enum AuthMaterial {
     /// strings before persisting or emitting anything (see
     /// [`crate::harness::mcp_probe::scrub`]).
     QueryParam { name: String, value: String },
+    /// An OAuth 2.0 (authorization-code + PKCE) credential obtained through the
+    /// console's browser sign-in flow ([`crate::company::mcp_oauth`]). The
+    /// resolved `access_token` is sent to the transport as an
+    /// `Authorization: Bearer` (the harness `auth_config` mapping); the
+    /// remaining fields are the bookkeeping the OAuth refresh path needs to mint
+    /// a fresh access token without another browser round-trip.
+    ///
+    /// **Security**: every token field is enumerated by [`Self::secret_values`],
+    /// so the access token, the refresh token, and any confidential
+    /// `client_secret` all feed the scrubber and can never survive into an
+    /// agent-visible error, health record, or API response.
+    OAuth {
+        /// The bearer access token sent to the server (short-lived, ≈1h).
+        access_token: String,
+        /// The refresh token, when the authorization server issued one. Absent
+        /// servers force a fresh browser sign-in once the access token expires.
+        refresh_token: Option<String>,
+        /// The dynamically-registered client id (RFC 7591).
+        client_id: String,
+        /// The confidential client secret, when the server issued one.
+        client_secret: Option<String>,
+        /// The token endpoint a refresh POSTs to.
+        token_endpoint: String,
+        /// Unix seconds when `access_token` expires (best-effort).
+        expires_at: u64,
+    },
 }
 
 impl AuthMaterial {
@@ -101,6 +127,25 @@ impl AuthMaterial {
             AuthMaterial::Bearer(token) => vec![token.clone()],
             AuthMaterial::Header { value, .. } => vec![value.clone()],
             AuthMaterial::QueryParam { value, .. } => vec![value.clone()],
+            // CRITICAL: every OAuth token substring must feed the scrubber —
+            // the access token (sent as the bearer), the refresh token, and any
+            // confidential client secret. Missing one would let it survive into
+            // an error/health/agent-visible surface.
+            AuthMaterial::OAuth {
+                access_token,
+                refresh_token,
+                client_secret,
+                ..
+            } => {
+                let mut out = vec![access_token.clone()];
+                if let Some(refresh) = refresh_token {
+                    out.push(refresh.clone());
+                }
+                if let Some(secret) = client_secret {
+                    out.push(secret.clone());
+                }
+                out
+            }
         }
     }
 }
@@ -110,9 +155,30 @@ impl AuthMaterial {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum StoredAuth {
-    Bearer { token: String },
-    Header { name: String, value: String },
-    QueryParam { name: String, value: String },
+    Bearer {
+        token: String,
+    },
+    Header {
+        name: String,
+        value: String,
+    },
+    QueryParam {
+        name: String,
+        value: String,
+    },
+    /// The persisted OAuth bundle: the access token plus everything a silent
+    /// refresh needs. Written by the callback exchange and the refresh path;
+    /// read only by [`load_auth`] at harness-build / probe time.
+    Oauth {
+        access_token: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        refresh_token: Option<String>,
+        client_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        client_secret: Option<String>,
+        token_endpoint: String,
+        expires_at: u64,
+    },
 }
 
 impl From<StoredAuth> for AuthMaterial {
@@ -121,6 +187,21 @@ impl From<StoredAuth> for AuthMaterial {
             StoredAuth::Bearer { token } => AuthMaterial::Bearer(token),
             StoredAuth::Header { name, value } => AuthMaterial::Header { name, value },
             StoredAuth::QueryParam { name, value } => AuthMaterial::QueryParam { name, value },
+            StoredAuth::Oauth {
+                access_token,
+                refresh_token,
+                client_id,
+                client_secret,
+                token_endpoint,
+                expires_at,
+            } => AuthMaterial::OAuth {
+                access_token,
+                refresh_token,
+                client_id,
+                client_secret,
+                token_endpoint,
+                expires_at,
+            },
         }
     }
 }
@@ -313,6 +394,21 @@ pub async fn store_auth(
         AuthMaterial::QueryParam { name, value } => StoredAuth::QueryParam {
             name: name.clone(),
             value: value.clone(),
+        },
+        AuthMaterial::OAuth {
+            access_token,
+            refresh_token,
+            client_id,
+            client_secret,
+            token_endpoint,
+            expires_at,
+        } => StoredAuth::Oauth {
+            access_token: access_token.clone(),
+            refresh_token: refresh_token.clone(),
+            client_id: client_id.clone(),
+            client_secret: client_secret.clone(),
+            token_endpoint: token_endpoint.clone(),
+            expires_at: *expires_at,
         },
     };
     let raw = serde_json::to_string(&stored)

--- a/src/company/mcp_oauth.rs
+++ b/src/company/mcp_oauth.rs
@@ -155,6 +155,91 @@ fn http() -> reqwest::Client {
         .expect("reqwest client must build")
 }
 
+/// SSRF guard for a **discovery-supplied** OAuth endpoint. The MCP server we're
+/// signing into advertises its own registration/token/authorize URLs, and
+/// `begin` / `complete` / `refresh` then POST to them **server-side** — so an
+/// unvalidated endpoint is a server-side request-forgery primitive a hostile
+/// server can aim at internal services or the cloud metadata endpoint
+/// (`169.254.169.254`). Reject anything that isn't `https` or whose host
+/// resolves to a loopback/private/link-local/unspecified address. Ported (kept
+/// decoupled from OpenHuman's `url_guard`, which is `pub(super)` and unreachable
+/// here) so the console path validates every outbound OAuth target itself.
+fn guard_endpoint(raw: &str, what: &str) -> Result<()> {
+    let url = url::Url::parse(raw).map_err(|e| {
+        OpenCompanyError::InvalidRequest(format!("{what} endpoint is not a valid URL: {e}"))
+    })?;
+    if url.scheme() != "https" {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "{what} endpoint must use https (got `{}`)",
+            url.scheme()
+        )));
+    }
+    let host = url
+        .host_str()
+        .ok_or_else(|| OpenCompanyError::InvalidRequest(format!("{what} endpoint has no host")))?;
+
+    // An IP-literal host is checked directly — no DNS round-trip needed.
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        return if is_blocked_ip(&ip) {
+            Err(OpenCompanyError::InvalidRequest(format!(
+                "{what} endpoint resolves to a disallowed address"
+            )))
+        } else {
+            Ok(())
+        };
+    }
+
+    // Resolve the hostname and reject if it fails to resolve or if ANY resolved
+    // address is in a blocked range (a single blocked A/AAAA record is enough —
+    // this also blunts DNS-rebinding to an internal address).
+    let port = url.port_or_known_default().unwrap_or(443);
+    let mut resolved = false;
+    for addr in std::net::ToSocketAddrs::to_socket_addrs(&(host, port)).map_err(|e| {
+        OpenCompanyError::InvalidRequest(format!("{what} endpoint host does not resolve: {e}"))
+    })? {
+        resolved = true;
+        if is_blocked_ip(&addr.ip()) {
+            return Err(OpenCompanyError::InvalidRequest(format!(
+                "{what} endpoint resolves to a disallowed address"
+            )));
+        }
+    }
+    if !resolved {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "{what} endpoint host does not resolve"
+        )));
+    }
+    Ok(())
+}
+
+/// Whether an IP is in a range we refuse to POST OAuth material to (loopback,
+/// RFC 1918 / unique-local, link-local incl. the `169.254.169.254` metadata
+/// address, unspecified, broadcast, documentation, multicast).
+fn is_blocked_ip(ip: &std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+                || v4.is_documentation()
+                || v4.is_multicast()
+                || v4.octets()[0] == 0
+        }
+        std::net::IpAddr::V6(v6) => {
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_blocked_ip(&std::net::IpAddr::V4(v4));
+            }
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.is_multicast()
+                || (v6.segments()[0] & 0xfe00) == 0xfc00 // unique-local fc00::/7
+                || (v6.segments()[0] & 0xffc0) == 0xfe80 // link-local fe80::/10
+        }
+    }
+}
+
 /// RFC 7591 dynamic client registration. Requests `client_secret_post`; servers
 /// that issue a confidential client return a `client_secret` we keep for the
 /// token exchange. Returns `(client_id, client_secret?)`.
@@ -162,6 +247,7 @@ async fn register_client(
     registration_endpoint: &str,
     redirect_uri: &str,
 ) -> Result<(String, Option<String>)> {
+    guard_endpoint(registration_endpoint, "registration")?;
     let body = json!({
         "client_name": "OpenCompany",
         "redirect_uris": [redirect_uri],
@@ -272,6 +358,12 @@ pub async fn begin(
         ))
     })?;
 
+    // Fail fast on unsafe discovery-supplied targets before any outbound call or
+    // before parking a pending flow whose stored `token_endpoint` refresh would
+    // later replay. `register_client` / `post_token_form` re-guard at call time.
+    guard_endpoint(&authorization_endpoint, "authorization")?;
+    guard_endpoint(&token_endpoint, "token")?;
+
     let (client_id, client_secret) = register_client(&registration_endpoint, redirect_uri).await?;
     let (code_verifier, code_challenge) = gen_pkce();
     let state = uuid::Uuid::new_v4().to_string();
@@ -316,6 +408,11 @@ struct TokenResponse {
 /// without echoing the raw body — a token endpoint's success body carries the
 /// access token, so we never surface it).
 async fn post_token_form(endpoint: &str, form: &[(&str, &str)]) -> Result<Value> {
+    // Every token exchange + refresh POST funnels through here, so validating the
+    // target at this choke point guards both `complete` and `refresh` — and
+    // re-checks at call time (not just at `begin`), blunting a rebind between
+    // discovery and exchange.
+    guard_endpoint(endpoint, "token")?;
     let resp = http()
         .post(endpoint)
         .form(form)
@@ -567,6 +664,37 @@ mod tests {
         assert!(needs_refresh(&stale, 60));
         // A non-OAuth material never needs refresh.
         assert!(!needs_refresh(&AuthMaterial::Bearer("t".into()), 60));
+    }
+
+    #[test]
+    fn guard_blocks_non_https_and_local_targets() {
+        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+        // Scheme: plain http is refused outright (SSRF loves cleartext localhost).
+        assert!(guard_endpoint("http://as.example/token", "token").is_err());
+        // IP-literal hosts in blocked ranges are rejected without DNS.
+        assert!(guard_endpoint("https://127.0.0.1/token", "token").is_err());
+        assert!(guard_endpoint("https://10.0.0.5/register", "registration").is_err());
+        assert!(guard_endpoint("https://192.168.1.1/token", "token").is_err());
+        // The cloud metadata endpoint — the canonical SSRF target — is link-local.
+        assert!(guard_endpoint("https://169.254.169.254/latest/meta-data", "token").is_err());
+        assert!(guard_endpoint("https://[::1]/token", "token").is_err());
+        // A syntactically bad URL is a clean rejection, not a panic.
+        assert!(guard_endpoint("not a url", "token").is_err());
+
+        // The IP-classification helper covers v4 + v6 ranges directly.
+        assert!(is_blocked_ip(&IpAddr::V4(Ipv4Addr::new(
+            169, 254, 169, 254
+        ))));
+        assert!(is_blocked_ip(&IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1))));
+        assert!(is_blocked_ip(&IpAddr::V6(Ipv6Addr::LOCALHOST)));
+        assert!(is_blocked_ip(&IpAddr::V6("fc00::1".parse().unwrap())));
+        assert!(is_blocked_ip(&IpAddr::V6("fe80::1".parse().unwrap())));
+        // A routable public address passes the classifier.
+        assert!(!is_blocked_ip(&IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))));
+        assert!(!is_blocked_ip(&IpAddr::V6(
+            "2606:2800:220:1::1".parse().unwrap()
+        )));
     }
 
     #[tokio::test]

--- a/src/company/mcp_oauth.rs
+++ b/src/company/mcp_oauth.rs
@@ -164,7 +164,11 @@ fn http() -> reqwest::Client {
 /// resolves to a loopback/private/link-local/unspecified address. Ported (kept
 /// decoupled from OpenHuman's `url_guard`, which is `pub(super)` and unreachable
 /// here) so the console path validates every outbound OAuth target itself.
-fn guard_endpoint(raw: &str, what: &str) -> Result<()> {
+///
+/// Async because hostname resolution goes through [`tokio::net::lookup_host`],
+/// which offloads the blocking `getaddrinfo` to Tokio's blocking pool — a
+/// slow/hostile discovery-supplied host must not stall the executor thread.
+async fn guard_endpoint(raw: &str, what: &str) -> Result<()> {
     let url = url::Url::parse(raw).map_err(|e| {
         OpenCompanyError::InvalidRequest(format!("{what} endpoint is not a valid URL: {e}"))
     })?;
@@ -191,12 +195,14 @@ fn guard_endpoint(raw: &str, what: &str) -> Result<()> {
 
     // Resolve the hostname and reject if it fails to resolve or if ANY resolved
     // address is in a blocked range (a single blocked A/AAAA record is enough —
-    // this also blunts DNS-rebinding to an internal address).
+    // this also blunts DNS-rebinding to an internal address). `lookup_host`
+    // keeps the blocking resolver call off the async executor thread.
     let port = url.port_or_known_default().unwrap_or(443);
     let mut resolved = false;
-    for addr in std::net::ToSocketAddrs::to_socket_addrs(&(host, port)).map_err(|e| {
+    let addrs = tokio::net::lookup_host((host, port)).await.map_err(|e| {
         OpenCompanyError::InvalidRequest(format!("{what} endpoint host does not resolve: {e}"))
-    })? {
+    })?;
+    for addr in addrs {
         resolved = true;
         if is_blocked_ip(&addr.ip()) {
             return Err(OpenCompanyError::InvalidRequest(format!(
@@ -247,7 +253,7 @@ async fn register_client(
     registration_endpoint: &str,
     redirect_uri: &str,
 ) -> Result<(String, Option<String>)> {
-    guard_endpoint(registration_endpoint, "registration")?;
+    guard_endpoint(registration_endpoint, "registration").await?;
     let body = json!({
         "client_name": "OpenCompany",
         "redirect_uris": [redirect_uri],
@@ -361,8 +367,8 @@ pub async fn begin(
     // Fail fast on unsafe discovery-supplied targets before any outbound call or
     // before parking a pending flow whose stored `token_endpoint` refresh would
     // later replay. `register_client` / `post_token_form` re-guard at call time.
-    guard_endpoint(&authorization_endpoint, "authorization")?;
-    guard_endpoint(&token_endpoint, "token")?;
+    guard_endpoint(&authorization_endpoint, "authorization").await?;
+    guard_endpoint(&token_endpoint, "token").await?;
 
     let (client_id, client_secret) = register_client(&registration_endpoint, redirect_uri).await?;
     let (code_verifier, code_challenge) = gen_pkce();
@@ -412,7 +418,7 @@ async fn post_token_form(endpoint: &str, form: &[(&str, &str)]) -> Result<Value>
     // target at this choke point guards both `complete` and `refresh` — and
     // re-checks at call time (not just at `begin`), blunting a rebind between
     // discovery and exchange.
-    guard_endpoint(endpoint, "token")?;
+    guard_endpoint(endpoint, "token").await?;
     let resp = http()
         .post(endpoint)
         .form(form)
@@ -666,21 +672,47 @@ mod tests {
         assert!(!needs_refresh(&AuthMaterial::Bearer("t".into()), 60));
     }
 
-    #[test]
-    fn guard_blocks_non_https_and_local_targets() {
+    #[tokio::test]
+    async fn guard_blocks_non_https_and_local_targets() {
         use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
+        // Every case here short-circuits before DNS (bad scheme, bad URL, or an
+        // IP-literal host), so the test never touches the network.
         // Scheme: plain http is refused outright (SSRF loves cleartext localhost).
-        assert!(guard_endpoint("http://as.example/token", "token").is_err());
+        assert!(
+            guard_endpoint("http://as.example/token", "token")
+                .await
+                .is_err()
+        );
         // IP-literal hosts in blocked ranges are rejected without DNS.
-        assert!(guard_endpoint("https://127.0.0.1/token", "token").is_err());
-        assert!(guard_endpoint("https://10.0.0.5/register", "registration").is_err());
-        assert!(guard_endpoint("https://192.168.1.1/token", "token").is_err());
+        assert!(
+            guard_endpoint("https://127.0.0.1/token", "token")
+                .await
+                .is_err()
+        );
+        assert!(
+            guard_endpoint("https://10.0.0.5/register", "registration")
+                .await
+                .is_err()
+        );
+        assert!(
+            guard_endpoint("https://192.168.1.1/token", "token")
+                .await
+                .is_err()
+        );
         // The cloud metadata endpoint — the canonical SSRF target — is link-local.
-        assert!(guard_endpoint("https://169.254.169.254/latest/meta-data", "token").is_err());
-        assert!(guard_endpoint("https://[::1]/token", "token").is_err());
+        assert!(
+            guard_endpoint("https://169.254.169.254/latest/meta-data", "token")
+                .await
+                .is_err()
+        );
+        assert!(
+            guard_endpoint("https://[::1]/token", "token")
+                .await
+                .is_err()
+        );
         // A syntactically bad URL is a clean rejection, not a panic.
-        assert!(guard_endpoint("not a url", "token").is_err());
+        assert!(guard_endpoint("not a url", "token").await.is_err());
 
         // The IP-classification helper covers v4 + v6 ranges directly.
         assert!(is_blocked_ip(&IpAddr::V4(Ipv4Addr::new(

--- a/src/company/mcp_oauth.rs
+++ b/src/company/mcp_oauth.rs
@@ -1,0 +1,586 @@
+//! Per-tenant browser OAuth for HTTP-remote MCP servers (issue #90).
+//!
+//! Many remote MCP servers gate access behind OAuth 2.0 (authorization-code +
+//! PKCE), advertised via a `401` challenge that points at an
+//! `oauth-protected-resource` document. This module runs that flow for the
+//! **console** path: the operator clicks *Sign in*, a browser tab opens the
+//! authorization server, and the redirect lands on the host's unauthenticated
+//! `/oauth/mcp/callback` route, which exchanges the code for a token and stores
+//! it write-only under the company's per-server credential key.
+//!
+//! **Why a bespoke module and not `oh::mcp_registry::oauth`.** OpenHuman's full
+//! flow (`vendor/openhuman/src/openhuman/mcp_registry/oauth.rs`) is coupled to
+//! its SQLite `mcp_registry` store and its desktop loopback callback
+//! (`http://127.0.0.1:<core_port>/…`). Our console path is multi-tenant and
+//! stores credentials in a per-tenant [`SecretStore`](crate::ports::SecretStore),
+//! so only the **discovery primitive** ([`oh::mcp_client::McpHttpClient`]) is
+//! reused; the small private helpers (PKCE, dynamic client registration, the
+//! authorize-URL builder, the token exchange + parse, and refresh) are **ported**
+//! here so they stay decoupled from OpenHuman's store and single-user callback.
+//!
+//! **Security.** Every token this module mints is returned as an
+//! [`AuthMaterial::OAuth`], whose [`AuthMaterial::secret_values`] enumerates the
+//! access token, refresh token, and any confidential `client_secret` — so all of
+//! them feed the existing scrubber and can never survive into an error, a health
+//! record, or agent-visible output. Nothing here serializes a token into any
+//! operator-visible response.
+//!
+//! Compiled only under `feature = "mcp"` (it needs the vendored discovery
+//! primitive plus `uuid` / `base64` / `url`).
+
+use base64::Engine as _;
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use openhuman_core::openhuman as oh;
+
+use oh::mcp_client::{AuthorizationServerMetadata, McpAuthorizationContext, McpHttpClient};
+
+use crate::Result;
+use crate::company::mcp::AuthMaterial;
+use crate::error::OpenCompanyError;
+use crate::ports::types::CompanyId;
+
+/// The discovery/registration/token HTTP timeout, in seconds.
+const HTTP_TIMEOUT_SECS: u64 = 20;
+
+/// base64url, no padding — the PKCE + entropy encoding.
+const B64: base64::engine::general_purpose::GeneralPurpose =
+    base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+/// Pending authorization parked between [`begin`] and the callback's
+/// [`complete`], keyed by the opaque `state` the console round-trips through the
+/// browser. Multi-tenant: unlike OpenHuman's single-user version it carries the
+/// `company_id` + `server_name` the callback must resolve, since the browser
+/// redirect carries no console session.
+#[derive(Clone, Debug)]
+pub struct PendingOAuth {
+    /// The company whose per-tenant secret store the token lands in.
+    pub company_id: CompanyId,
+    /// The MCP server (by slug) the token authenticates.
+    pub server_name: String,
+    /// The PKCE verifier proving this client began the flow.
+    pub code_verifier: String,
+    /// The dynamically-registered client id (RFC 7591).
+    pub client_id: String,
+    /// The confidential client secret, when the server issued one.
+    pub client_secret: Option<String>,
+    /// The token endpoint the code exchange POSTs to.
+    pub token_endpoint: String,
+    /// The exact redirect URI registered in DCR — must match on exchange.
+    pub redirect_uri: String,
+}
+
+/// The output of [`begin`]: the live `/authorize` URL for the browser plus the
+/// `state`/`PendingOAuth` the route parks until the callback fires.
+pub struct OAuthBegin {
+    /// The authorization-server URL to open in the operator's browser.
+    pub authorize_url: String,
+    /// The opaque CSRF/state token the callback matches against.
+    pub state: String,
+    /// The pending record the caller stores keyed by `state`.
+    pub pending: PendingOAuth,
+}
+
+/// Unix seconds now (best-effort; `0` if the clock is before the epoch).
+fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// The callback redirect URI: `<base>/oauth/mcp/callback`. `base` is the host's
+/// public URL (`OPENCOMPANY_PUBLIC_URL`) or `http://{bind}` — see
+/// [`AppConfig::host_base_url`](crate::app::AppConfig::host_base_url). This MUST
+/// be the exact string registered in DCR and replayed on the token exchange, or
+/// the authorization server rejects the redirect.
+pub fn callback_redirect_uri(base_url: &str) -> String {
+    format!("{}/oauth/mcp/callback", base_url.trim_end_matches('/'))
+}
+
+/// `n` v4 UUIDs of entropy, base64url-encoded (no `rand` dependency — mirrors
+/// the OpenHuman helper).
+fn random_b64(n_uuids: usize) -> String {
+    let mut bytes = Vec::with_capacity(n_uuids * 16);
+    for _ in 0..n_uuids {
+        bytes.extend_from_slice(uuid::Uuid::new_v4().as_bytes());
+    }
+    B64.encode(bytes)
+}
+
+/// A PKCE `(verifier, S256 challenge)` pair. The verifier is ~86 chars, inside
+/// the RFC 7636 43..128 range.
+fn gen_pkce() -> (String, String) {
+    let verifier = random_b64(4);
+    let challenge = B64.encode(Sha256::digest(verifier.as_bytes()));
+    (verifier, challenge)
+}
+
+/// Discover a server's OAuth authorization context via an unauthenticated MCP
+/// `initialize` probe. `Ok(None)` means the server did not 401 (open / static
+/// token). Errors surface a discovery failure.
+async fn discover(endpoint: &str) -> Result<Option<McpAuthorizationContext>> {
+    let client = McpHttpClient::new(endpoint.to_string(), HTTP_TIMEOUT_SECS);
+    client
+        .discover_authorization()
+        .await
+        .map_err(|e| OpenCompanyError::Harness(format!("oauth discovery failed: {e}")))
+}
+
+/// Pick the authorization server that advertises a **usable** configuration:
+/// authorize + token + dynamic client registration, and (when grant types are
+/// listed) `authorization_code`. Pick by capability, not position — the first
+/// advertised server may be incomplete while a later one is fully usable
+/// (mirrors OpenHuman's `begin`).
+fn select_auth_server(ctx: McpAuthorizationContext) -> Option<AuthorizationServerMetadata> {
+    ctx.authorization_server_metadata.into_iter().find(|asm| {
+        asm.authorization_endpoint.is_some()
+            && asm.token_endpoint.is_some()
+            && asm.registration_endpoint.is_some()
+            && (asm.grant_types_supported.is_empty()
+                || asm
+                    .grant_types_supported
+                    .iter()
+                    .any(|g| g == "authorization_code"))
+    })
+}
+
+/// A short-lived reqwest client for DCR + token calls. Separate from the MCP
+/// transport client (which speaks JSON-RPC), matching OpenHuman's split.
+fn http() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECS))
+        .build()
+        .expect("reqwest client must build")
+}
+
+/// RFC 7591 dynamic client registration. Requests `client_secret_post`; servers
+/// that issue a confidential client return a `client_secret` we keep for the
+/// token exchange. Returns `(client_id, client_secret?)`.
+async fn register_client(
+    registration_endpoint: &str,
+    redirect_uri: &str,
+) -> Result<(String, Option<String>)> {
+    let body = json!({
+        "client_name": "OpenCompany",
+        "redirect_uris": [redirect_uri],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "client_secret_post",
+    });
+    let resp = http()
+        .post(registration_endpoint)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| {
+            OpenCompanyError::Harness(format!("client registration request failed: {e}"))
+        })?;
+    let status = resp.status();
+    let json: Value = resp.json().await.map_err(|e| {
+        OpenCompanyError::Harness(format!("client registration returned non-JSON: {e}"))
+    })?;
+    if !status.is_success() {
+        // The error body carries `error`/`error_description`, never a secret (a
+        // client_secret is issued only on success), so surfacing the code is safe.
+        let code = json
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        return Err(OpenCompanyError::Harness(format!(
+            "dynamic client registration failed (HTTP {status}, {code})"
+        )));
+    }
+    let client_id = json
+        .get("client_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            OpenCompanyError::Harness("registration response missing client_id".to_string())
+        })?
+        .to_string();
+    let client_secret = json
+        .get("client_secret")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    Ok((client_id, client_secret))
+}
+
+/// Build the `/authorize` redirect URL (authorization-code + PKCE S256).
+/// `resource` is the MCP server URL, per the MCP authorization spec.
+fn build_authorize_url(
+    authorization_endpoint: &str,
+    client_id: &str,
+    redirect_uri: &str,
+    code_challenge: &str,
+    state: &str,
+    resource: &str,
+) -> Result<String> {
+    url::Url::parse_with_params(
+        authorization_endpoint,
+        &[
+            ("response_type", "code"),
+            ("client_id", client_id),
+            ("redirect_uri", redirect_uri),
+            ("code_challenge", code_challenge),
+            ("code_challenge_method", "S256"),
+            ("state", state),
+            ("resource", resource),
+        ],
+    )
+    .map(|u| u.to_string())
+    .map_err(|e| OpenCompanyError::Harness(format!("failed to build authorize url: {e}")))
+}
+
+/// Begin the browser-OAuth flow for `server_name` at `endpoint`: discover →
+/// dynamic client registration → PKCE, and return the live `/authorize` URL plus
+/// the [`PendingOAuth`] the caller parks (keyed by the returned `state`).
+///
+/// Returns [`OpenCompanyError::InvalidRequest`] (a clean operator-actionable
+/// error) when the server does not advertise dynamic client registration — the
+/// operator should paste a static token instead.
+pub async fn begin(
+    endpoint: &str,
+    company_id: &CompanyId,
+    server_name: &str,
+    redirect_uri: &str,
+) -> Result<OAuthBegin> {
+    let ctx = discover(endpoint)
+        .await?
+        .ok_or_else(|| OpenCompanyError::InvalidRequest(format!(
+            "MCP server `{server_name}` does not require authorization — no OAuth sign-in is needed."
+        )))?;
+
+    // No usable auth server → the server can't do dynamic client registration.
+    // Tell the operator to paste a static token instead (edge case).
+    let asm = select_auth_server(ctx).ok_or_else(|| {
+        OpenCompanyError::InvalidRequest(format!(
+            "MCP server `{server_name}` requires OAuth but does not advertise dynamic client \
+             registration — paste a static API token in its credential field instead."
+        ))
+    })?;
+    let authorization_endpoint = asm
+        .authorization_endpoint
+        .ok_or_else(|| OpenCompanyError::Harness("no authorization_endpoint".to_string()))?;
+    let token_endpoint = asm
+        .token_endpoint
+        .ok_or_else(|| OpenCompanyError::Harness("no token_endpoint".to_string()))?;
+    let registration_endpoint = asm.registration_endpoint.ok_or_else(|| {
+        OpenCompanyError::InvalidRequest(format!(
+            "MCP server `{server_name}` requires OAuth but does not support dynamic client \
+             registration — paste a static API token instead."
+        ))
+    })?;
+
+    let (client_id, client_secret) = register_client(&registration_endpoint, redirect_uri).await?;
+    let (code_verifier, code_challenge) = gen_pkce();
+    let state = uuid::Uuid::new_v4().to_string();
+
+    let authorize_url = build_authorize_url(
+        &authorization_endpoint,
+        &client_id,
+        redirect_uri,
+        &code_challenge,
+        &state,
+        endpoint,
+    )?;
+
+    log::info!(
+        "[mcp-oauth] begin company={} server={server_name} client_id={client_id}",
+        company_id.as_ref()
+    );
+
+    Ok(OAuthBegin {
+        authorize_url,
+        state,
+        pending: PendingOAuth {
+            company_id: company_id.clone(),
+            server_name: server_name.to_string(),
+            code_verifier,
+            client_id,
+            client_secret,
+            token_endpoint,
+            redirect_uri: redirect_uri.to_string(),
+        },
+    })
+}
+
+/// The parsed token-endpoint response.
+struct TokenResponse {
+    access_token: String,
+    refresh_token: Option<String>,
+    expires_in: Option<u64>,
+}
+
+/// POST a form to a token endpoint and return the JSON body (erroring on non-2xx
+/// without echoing the raw body — a token endpoint's success body carries the
+/// access token, so we never surface it).
+async fn post_token_form(endpoint: &str, form: &[(&str, &str)]) -> Result<Value> {
+    let resp = http()
+        .post(endpoint)
+        .form(form)
+        .send()
+        .await
+        .map_err(|e| OpenCompanyError::Harness(format!("token request failed: {e}")))?;
+    let status = resp.status();
+    let json: Value = resp
+        .json()
+        .await
+        .map_err(|e| OpenCompanyError::Harness(format!("token endpoint returned non-JSON: {e}")))?;
+    if !status.is_success() {
+        // Surface only the standard OAuth `error` code — never the whole body,
+        // which on some servers echoes back submitted material.
+        let code = json
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        return Err(OpenCompanyError::Harness(format!(
+            "token request rejected (HTTP {status}, {code})"
+        )));
+    }
+    Ok(json)
+}
+
+fn parse_token_response(json: &Value) -> Result<TokenResponse> {
+    let access_token = json
+        .get("access_token")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            OpenCompanyError::Harness("token response missing access_token".to_string())
+        })?
+        .to_string();
+    Ok(TokenResponse {
+        access_token,
+        refresh_token: json
+            .get("refresh_token")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        expires_in: json.get("expires_in").and_then(Value::as_u64),
+    })
+}
+
+/// Build an [`AuthMaterial::OAuth`] from a parsed token response + the client
+/// credentials it was minted with.
+fn material_from_tokens(
+    tokens: TokenResponse,
+    client_id: String,
+    client_secret: Option<String>,
+    token_endpoint: String,
+) -> AuthMaterial {
+    AuthMaterial::OAuth {
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+        client_id,
+        client_secret,
+        token_endpoint,
+        expires_at: now_unix() + tokens.expires_in.unwrap_or(3600),
+    }
+}
+
+/// Complete the flow: exchange `code` (with the PKCE verifier + client creds)
+/// for a token, returning the [`AuthMaterial::OAuth`] the caller stores
+/// write-only. The `pending` was parked by [`begin`] and looked up by `state`.
+pub async fn complete(pending: &PendingOAuth, code: &str) -> Result<AuthMaterial> {
+    let mut form: Vec<(&str, &str)> = vec![
+        ("grant_type", "authorization_code"),
+        ("code", code),
+        ("redirect_uri", pending.redirect_uri.as_str()),
+        ("client_id", pending.client_id.as_str()),
+        ("code_verifier", pending.code_verifier.as_str()),
+    ];
+    if let Some(secret) = pending.client_secret.as_deref() {
+        form.push(("client_secret", secret));
+    }
+    let tokens = parse_token_response(&post_token_form(&pending.token_endpoint, &form).await?)?;
+    log::info!(
+        "[mcp-oauth] complete company={} server={} — token minted",
+        pending.company_id.as_ref(),
+        pending.server_name
+    );
+    Ok(material_from_tokens(
+        tokens,
+        pending.client_id.clone(),
+        pending.client_secret.clone(),
+        pending.token_endpoint.clone(),
+    ))
+}
+
+/// Whether an OAuth credential's access token is expired or within `slack_secs`
+/// of expiring.
+pub fn needs_refresh(material: &AuthMaterial, slack_secs: u64) -> bool {
+    matches!(material, AuthMaterial::OAuth { expires_at, .. } if *expires_at <= now_unix() + slack_secs)
+}
+
+/// If `material` is an [`AuthMaterial::OAuth`] with a refresh token, mint a fresh
+/// access token via the refresh-token grant and return the updated material.
+///
+/// Returns `Ok(None)` when the material is not OAuth, has no refresh token, or
+/// the refresh request fails (the caller keeps the old material and lets the next
+/// 401 re-prompt sign-in — a failed refresh must never brick the harness build).
+pub async fn refresh(material: &AuthMaterial) -> Option<AuthMaterial> {
+    let AuthMaterial::OAuth {
+        refresh_token: Some(refresh_token),
+        client_id,
+        client_secret,
+        token_endpoint,
+        ..
+    } = material
+    else {
+        return None;
+    };
+    if refresh_token.is_empty() {
+        return None;
+    }
+
+    let mut form: Vec<(&str, &str)> = vec![
+        ("grant_type", "refresh_token"),
+        ("refresh_token", refresh_token.as_str()),
+        ("client_id", client_id.as_str()),
+    ];
+    if let Some(secret) = client_secret.as_deref() {
+        form.push(("client_secret", secret));
+    }
+
+    let json = match post_token_form(token_endpoint, &form).await {
+        Ok(json) => json,
+        Err(e) => {
+            log::warn!("[mcp-oauth] refresh failed, keeping existing token: {e}");
+            return None;
+        }
+    };
+    let mut tokens = parse_token_response(&json).ok()?;
+    // Some servers omit a rotated refresh token — keep the existing one.
+    if tokens.refresh_token.is_none() {
+        tokens.refresh_token = Some(refresh_token.clone());
+    }
+    log::info!("[mcp-oauth] refreshed access token");
+    Some(material_from_tokens(
+        tokens,
+        client_id.clone(),
+        client_secret.clone(),
+        token_endpoint.clone(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pkce_challenge_is_s256_of_verifier() {
+        let (verifier, challenge) = gen_pkce();
+        assert!(
+            (43..=128).contains(&verifier.len()),
+            "verifier in PKCE range: {}",
+            verifier.len()
+        );
+        let expected = B64.encode(Sha256::digest(verifier.as_bytes()));
+        assert_eq!(challenge, expected);
+    }
+
+    #[test]
+    fn callback_uri_appends_route_and_trims_trailing_slash() {
+        assert_eq!(
+            callback_redirect_uri("http://127.0.0.1:8080"),
+            "http://127.0.0.1:8080/oauth/mcp/callback"
+        );
+        assert_eq!(
+            callback_redirect_uri("https://acme.example/"),
+            "https://acme.example/oauth/mcp/callback"
+        );
+    }
+
+    #[test]
+    fn authorize_url_carries_pkce_and_resource() {
+        let url = build_authorize_url(
+            "https://as.example/authorize",
+            "client-123",
+            "http://127.0.0.1:8080/oauth/mcp/callback",
+            "challenge-abc",
+            "state-xyz",
+            "https://mcp.example/mcp",
+        )
+        .expect("url");
+        assert!(url.contains("response_type=code"));
+        assert!(url.contains("client_id=client-123"));
+        assert!(url.contains("code_challenge=challenge-abc"));
+        assert!(url.contains("code_challenge_method=S256"));
+        assert!(url.contains("state=state-xyz"));
+        // The MCP server URL is the `resource`, percent-encoded.
+        assert!(url.contains("resource=https%3A%2F%2Fmcp.example%2Fmcp"));
+    }
+
+    #[test]
+    fn parse_token_response_extracts_fields() {
+        let v = json!({"access_token":"a","refresh_token":"r","expires_in":3600});
+        let t = parse_token_response(&v).unwrap();
+        assert_eq!(t.access_token, "a");
+        assert_eq!(t.refresh_token.as_deref(), Some("r"));
+        assert_eq!(t.expires_in, Some(3600));
+        // refresh_token / expires_in are optional; access_token is required.
+        let minimal = parse_token_response(&json!({"access_token":"x"})).unwrap();
+        assert_eq!(minimal.access_token, "x");
+        assert!(minimal.refresh_token.is_none());
+        assert!(parse_token_response(&json!({"token_type":"bearer"})).is_err());
+    }
+
+    #[test]
+    fn oauth_material_secret_values_cover_every_token() {
+        // The security invariant: access token, refresh token, and client secret
+        // all reach the scrubber's known-secret set.
+        let material = AuthMaterial::OAuth {
+            access_token: "at-secret".into(),
+            refresh_token: Some("rt-secret".into()),
+            client_id: "cid".into(),
+            client_secret: Some("cs-secret".into()),
+            token_endpoint: "https://as/token".into(),
+            expires_at: 0,
+        };
+        let secrets = material.secret_values();
+        assert!(secrets.contains(&"at-secret".to_string()));
+        assert!(secrets.contains(&"rt-secret".to_string()));
+        assert!(secrets.contains(&"cs-secret".to_string()));
+        // The client id is NOT a secret and must not be in the set.
+        assert!(!secrets.contains(&"cid".to_string()));
+        assert!(material.is_configured());
+    }
+
+    #[test]
+    fn needs_refresh_only_fires_near_expiry() {
+        let fresh = AuthMaterial::OAuth {
+            access_token: "a".into(),
+            refresh_token: None,
+            client_id: "c".into(),
+            client_secret: None,
+            token_endpoint: "https://as/token".into(),
+            expires_at: now_unix() + 3600,
+        };
+        assert!(!needs_refresh(&fresh, 60));
+        let stale = AuthMaterial::OAuth {
+            access_token: "a".into(),
+            refresh_token: None,
+            client_id: "c".into(),
+            client_secret: None,
+            token_endpoint: "https://as/token".into(),
+            expires_at: now_unix() + 30,
+        };
+        assert!(needs_refresh(&stale, 60));
+        // A non-OAuth material never needs refresh.
+        assert!(!needs_refresh(&AuthMaterial::Bearer("t".into()), 60));
+    }
+
+    #[tokio::test]
+    async fn refresh_is_noop_without_refresh_token() {
+        let material = AuthMaterial::OAuth {
+            access_token: "a".into(),
+            refresh_token: None,
+            client_id: "c".into(),
+            client_secret: None,
+            token_endpoint: "https://as/token".into(),
+            expires_at: 0,
+        };
+        assert!(refresh(&material).await.is_none());
+        // A non-OAuth material is also a no-op.
+        assert!(refresh(&AuthMaterial::Bearer("t".into())).await.is_none());
+    }
+}

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -11,6 +11,11 @@ pub mod dns;
 pub mod inference;
 mod manifest;
 pub mod mcp;
+// Console MCP OAuth (issue #90): discovery + PKCE + DCR + token exchange for the
+// per-tenant browser sign-in flow. Needs the vendored `oh::mcp_client` discovery
+// primitive + `uuid`/`base64`/`url`, so it links only under the `mcp` feature.
+#[cfg(feature = "mcp")]
+pub mod mcp_oauth;
 pub mod runtime;
 mod skill_file;
 pub mod telegram;

--- a/src/harness/mcp.rs
+++ b/src/harness/mcp.rs
@@ -160,6 +160,14 @@ fn auth_config(material: &AuthMaterial) -> McpAuthConfig {
             name: name.clone(),
             value: value.clone(),
         },
+        // The whole trick behind console OAuth: an OAuth credential resolves to
+        // exactly the bearer path the static registry already knows how to send.
+        // The freshness of `access_token` is the caller's responsibility — the
+        // harness builder refreshes an expired token before this mapping runs
+        // (see `crate::company::mcp_oauth::refresh` + `resolve_effective`).
+        AuthMaterial::OAuth { access_token, .. } => McpAuthConfig::BearerToken {
+            token: access_token.clone(),
+        },
     }
 }
 

--- a/src/harness/mcp.rs
+++ b/src/harness/mcp.rs
@@ -674,6 +674,17 @@ mod tests {
     fn auth_material_maps_onto_transport_config() {
         let bearer = auth_config(&AuthMaterial::Bearer("tok".into()));
         assert!(matches!(bearer, McpAuthConfig::BearerToken { .. }));
+        // An OAuth credential resolves to the same bearer path, carrying exactly
+        // its (already-refreshed) access token and nothing else.
+        let oauth = auth_config(&AuthMaterial::OAuth {
+            access_token: "at".into(),
+            refresh_token: None,
+            client_id: "cid".into(),
+            client_secret: None,
+            token_endpoint: "https://as.example/token".into(),
+            expires_at: 0,
+        });
+        assert!(matches!(oauth, McpAuthConfig::BearerToken { token } if token == "at"));
         let header = auth_config(&AuthMaterial::Header {
             name: "X-Key".into(),
             value: "v".into(),

--- a/src/harness/mcp_probe.rs
+++ b/src/harness/mcp_probe.rs
@@ -297,7 +297,7 @@ pub fn operator_message(server: &str, class: &ProbeClass, err: &anyhow::Error) -
             "MCP server '{server}' needs a credential. Add its API token (or query-parameter key) in Connections, then Test again."
         ),
         FailureKind::OauthRequired => format!(
-            "MCP server '{server}' uses OAuth sign-in, which isn't supported yet — a pasted token won't be accepted."
+            "MCP server '{server}' needs OAuth sign-in — click Sign in on the server in Connections to authorize it."
         ),
         FailureKind::TokenRejected => format!(
             "MCP server '{server}' rejected the credential — it's wrong or expired. Update it and Test again."
@@ -440,9 +440,99 @@ fn utf8_truncate(s: &str, max_bytes: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::company::mcp::{AuthMaterial, McpServerDecl, McpSource};
 
     fn anyhow_str(msg: &str) -> anyhow::Error {
         anyhow::anyhow!("{}", msg.to_string())
+    }
+
+    fn oauth_decl(name: &str, endpoint: &str, access_token: &str) -> McpServerDecl {
+        McpServerDecl {
+            name: name.to_string(),
+            endpoint: endpoint.to_string(),
+            description: None,
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
+            timeout_secs: 30,
+            enabled: true,
+            source: McpSource::Runtime,
+            auth: AuthMaterial::OAuth {
+                access_token: access_token.to_string(),
+                refresh_token: Some("rt-oauth-secret".to_string()),
+                client_id: "client-abc".to_string(),
+                client_secret: Some("cs-oauth-secret".to_string()),
+                token_endpoint: "https://as.example/token".to_string(),
+                expires_at: u64::MAX,
+            },
+        }
+    }
+
+    /// SECURITY: an OAuth access token planted as the credential must NEVER
+    /// appear in a probed server's health message — even when the server
+    /// reflects the `Authorization` header back in an error body. This is the
+    /// regression guard for issue #90's "OAuth tokens are write-only, never in
+    /// any status/health/error response" invariant, driven through the REAL
+    /// vendored transport + the OAuth→bearer mapping.
+    #[tokio::test]
+    async fn oauth_token_never_leaks_into_probed_health() {
+        use axum::extract::State;
+        use axum::http::HeaderMap;
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use axum::{Json, Router};
+        use serde_json::Value;
+
+        // Reflect the Authorization header back in a 500 on `initialize` — the
+        // hostile shape that would leak the bearer through the raw error. `Json`
+        // is last so it consumes the body after the header read.
+        async fn handler(
+            State(()): State<()>,
+            headers: HeaderMap,
+            _body: Json<Value>,
+        ) -> axum::response::Response {
+            let auth = headers
+                .get("authorization")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("")
+                .to_string();
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("boom — received {auth}"),
+            )
+                .into_response()
+        }
+
+        let app = Router::new().route("/mcp", post(handler)).with_state(());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        const ACCESS: &str = "at-oauth-CANARY-9999";
+        let endpoint = format!("http://{addr}/mcp");
+        let decl = oauth_decl("oauthy", &endpoint, ACCESS);
+
+        let health = probe_server(&decl).await;
+
+        // The health message is surfaced to the operator — it must carry none of
+        // the OAuth secrets (access token reflected by the server, and neither
+        // the refresh token nor the client secret which feed the scrubber set).
+        assert!(
+            !health.message.contains(ACCESS),
+            "probed health leaked the OAuth access token: {}",
+            health.message
+        );
+        assert!(
+            !health.message.contains("rt-oauth-secret"),
+            "{}",
+            health.message
+        );
+        assert!(
+            !health.message.contains("cs-oauth-secret"),
+            "{}",
+            health.message
+        );
     }
 
     // ---- scrub -------------------------------------------------------------

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -435,13 +435,19 @@ impl HarnessPool {
         deps: &HarnessDeps,
     ) -> Vec<McpServerDecl> {
         match &deps.secrets {
-            Some(secrets) => crate::company::mcp::resolve_effective(
-                &company.id,
-                &company.manifest.mcp_servers,
-                secrets.as_ref(),
-            )
-            .await
-            .unwrap_or_else(|_| deps.mcp_servers.clone()),
+            Some(secrets) => {
+                let mut decls = crate::company::mcp::resolve_effective(
+                    &company.id,
+                    &company.manifest.mcp_servers,
+                    secrets.as_ref(),
+                )
+                .await
+                .unwrap_or_else(|_| deps.mcp_servers.clone());
+                // Refresh any near-expiry console-OAuth credential before the
+                // registry is built, so an agent never sends a stale bearer.
+                refresh_oauth_decls(&company.id, &mut decls, secrets.as_ref()).await;
+                decls
+            }
             None => deps.mcp_servers.clone(),
         }
     }
@@ -595,7 +601,49 @@ fn auth_kind(material: &crate::company::mcp::AuthMaterial) -> u8 {
         Bearer(_) => 1,
         Header { .. } => 2,
         QueryParam { .. } => 3,
+        OAuth { .. } => 4,
     }
+}
+
+/// Refreshes any near-expiry console-OAuth credential in `decls` before the
+/// registry is built, re-persisting the rotated token **write-only** so agents
+/// never send an expired bearer. Per-tenant analogue of OpenHuman's
+/// `mcp_registry::oauth::refresh_if_expired`. A refresh failure is non-fatal —
+/// the old token is kept and the next `401` re-prompts sign-in.
+#[cfg(feature = "mcp")]
+async fn refresh_oauth_decls(
+    company: &CompanyId,
+    decls: &mut [McpServerDecl],
+    secrets: &dyn SecretStore,
+) {
+    use crate::company::mcp_oauth;
+
+    for decl in decls.iter_mut() {
+        if !mcp_oauth::needs_refresh(&decl.auth, 60) {
+            continue;
+        }
+        let Some(new_material) = mcp_oauth::refresh(&decl.auth).await else {
+            continue;
+        };
+        match crate::company::mcp::store_auth(company, &decl.name, &new_material, secrets).await {
+            Ok(()) => decl.auth = new_material,
+            Err(err) => log::warn!(
+                "[mcp-oauth] failed to persist refreshed token for `{}`: {}",
+                decl.name,
+                err.code()
+            ),
+        }
+    }
+}
+
+/// Without the `mcp` feature there is no OAuth credential to refresh, so this is
+/// a no-op (keeps `resolve_effective_mcp` uniform across the two builds).
+#[cfg(not(feature = "mcp"))]
+async fn refresh_oauth_decls(
+    _company: &CompanyId,
+    _decls: &mut [McpServerDecl],
+    _secrets: &dyn SecretStore,
+) {
 }
 
 /// A stable fingerprint of an overlay-agent set (issue #71), used to detect a

--- a/src/server/mcp_oauth.rs
+++ b/src/server/mcp_oauth.rs
@@ -255,4 +255,92 @@ mod tests {
         assert_eq!(non_empty(Some("   ")), None);
         assert_eq!(non_empty(None), None);
     }
+
+    // Integration-style coverage of the unauthenticated callback route's guard
+    // branches, driven through a real axum app (mirrors
+    // `mcp_probe::oauth_token_never_leaks_into_probed_health`). These are the
+    // security-relevant early exits: none may exchange a code or reach a company.
+    use crate::AppConfig;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    async fn call(uri: &str) -> (StatusCode, String) {
+        let state = AppState::new(AppConfig::default());
+        let app = router().with_state(state);
+        let resp = app
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, String::from_utf8_lossy(&bytes).into_owned())
+    }
+
+    #[tokio::test]
+    async fn callback_denied_by_authorization_server_renders_error() {
+        let (status, body) = call("/oauth/mcp/callback?error=access_denied").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body.contains("Sign-in was declined"));
+    }
+
+    #[tokio::test]
+    async fn callback_missing_code_or_state_is_rejected() {
+        // No code, no state.
+        let (status, body) = call("/oauth/mcp/callback").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body.contains("Invalid sign-in response"));
+        // Code without state is equally malformed.
+        let (status, _) = call("/oauth/mcp/callback?code=abc").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn callback_with_unknown_state_is_expired() {
+        // A well-formed callback whose `state` was never parked (or already
+        // consumed) reclaims nothing — no token exchange happens.
+        let (status, body) = call("/oauth/mcp/callback?code=abc&state=never-parked").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body.contains("Sign-in expired"));
+    }
+
+    #[tokio::test]
+    async fn callback_for_unknown_company_stops_before_exchange() {
+        use crate::company::mcp_oauth::PendingOAuth;
+        use crate::ports::types::CompanyId;
+
+        let state = AppState::new(AppConfig::default());
+        // Park a flow pointing at a company the registry doesn't hold, then drive
+        // the callback: it must resolve the parked state, find no company, and
+        // return before ever attempting a token exchange.
+        state.park_oauth(
+            "s-1".into(),
+            PendingOAuth {
+                company_id: CompanyId::new("ghost"),
+                server_name: "notion".into(),
+                code_verifier: "v".into(),
+                client_id: "cid".into(),
+                client_secret: None,
+                token_endpoint: "https://as.example/token".into(),
+                redirect_uri: "https://acme.example/oauth/mcp/callback".into(),
+            },
+        );
+        let app = router().with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/oauth/mcp/callback?code=abc&state=s-1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(String::from_utf8_lossy(&bytes).contains("Company not found"));
+    }
 }

--- a/src/server/mcp_oauth.rs
+++ b/src/server/mcp_oauth.rs
@@ -1,0 +1,258 @@
+//! The unauthenticated console MCP OAuth callback (issue #90).
+//!
+//! `GET /oauth/mcp/callback?code=…&state=…` is where the operator's browser
+//! lands after approving an MCP server's OAuth sign-in. It is mounted at the
+//! **top level** (next to `/healthz`), **without** console auth: the browser
+//! redirect from the authorization server carries no console session cookie, so
+//! the route cannot require one. Its trust comes instead from the opaque `state`
+//! it round-trips — an unknown/expired/replayed `state` yields nothing.
+//!
+//! Flow: look up the parked [`PendingOAuth`](crate::company::mcp_oauth::PendingOAuth)
+//! by `state`, exchange the `code` for a token, store it **write-only** under the
+//! company's per-server credential key, probe-and-persist the server's health,
+//! and render a small self-contained success (or failure) HTML page for the tab.
+//!
+//! Compiled only under `feature = "mcp"`.
+
+use axum::Router;
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{Html, IntoResponse, Response};
+use axum::routing::get;
+use serde::Deserialize;
+
+use crate::AppState;
+use crate::company::mcp::{self, McpHealth};
+use crate::company::mcp_oauth;
+
+/// The OAuth callback query. All fields optional so a malformed/`error` redirect
+/// is handled with a clean page rather than a 422 extractor rejection.
+#[derive(Debug, Deserialize)]
+struct CallbackQuery {
+    #[serde(default)]
+    code: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+    /// The OAuth `error` code, when the authorization server denied the request.
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    error_description: Option<String>,
+}
+
+/// The top-level, unauthenticated callback route fragment (merged in
+/// [`crate::server::routes`]).
+pub fn router() -> Router<AppState> {
+    Router::new().route("/oauth/mcp/callback", get(callback))
+}
+
+async fn callback(State(state): State<AppState>, Query(query): Query<CallbackQuery>) -> Response {
+    // 1. The authorization server denied the request.
+    if let Some(err) = query.error.as_deref() {
+        let detail = query.error_description.as_deref().unwrap_or(err);
+        return failure_page(
+            StatusCode::BAD_REQUEST,
+            "Sign-in was declined",
+            &format!("The authorization server returned an error: {detail}"),
+        );
+    }
+
+    // 2. A well-formed callback must carry both a code and a state.
+    let (Some(code), Some(cb_state)) = (
+        non_empty(query.code.as_deref()),
+        non_empty(query.state.as_deref()),
+    ) else {
+        return failure_page(
+            StatusCode::BAD_REQUEST,
+            "Invalid sign-in response",
+            "The sign-in response was missing its authorization code or state. Start again from Connections.",
+        );
+    };
+
+    // 3. Reclaim the parked flow (single-use — a replayed callback finds nothing).
+    let Some(pending) = state.take_oauth(cb_state) else {
+        return failure_page(
+            StatusCode::BAD_REQUEST,
+            "Sign-in expired",
+            "This sign-in link is no longer valid (it may have already been used or expired). Start again from Connections.",
+        );
+    };
+
+    // 4. Resolve the company the pending flow targets.
+    let Some(runtime) = state.registry().get(&pending.company_id) else {
+        log::warn!(
+            "[mcp-oauth] callback for unknown company={}",
+            pending.company_id.as_ref()
+        );
+        return failure_page(
+            StatusCode::NOT_FOUND,
+            "Company not found",
+            "The company this sign-in belongs to is no longer available.",
+        );
+    };
+
+    // 5. Exchange the code for a token (PKCE verifier + client creds).
+    let material = match mcp_oauth::complete(&pending, code).await {
+        Ok(material) => material,
+        Err(err) => {
+            // `complete` never echoes a secret in its error, but scrub anyway
+            // against this flow's own known secrets as defence in depth.
+            let scrubbed =
+                crate::harness::mcp_probe::scrub(&err.to_string(), &pending_secret_hints(&pending));
+            log::warn!(
+                "[mcp-oauth] token exchange failed for company={} server={}: {scrubbed}",
+                pending.company_id.as_ref(),
+                pending.server_name
+            );
+            return failure_page(
+                StatusCode::BAD_GATEWAY,
+                "Couldn't complete sign-in",
+                &format!("The token exchange failed: {scrubbed}"),
+            );
+        }
+    };
+
+    // 6. Store the token WRITE-ONLY under the per-server credential key.
+    if let Err(err) = mcp::store_auth(
+        runtime.id(),
+        &pending.server_name,
+        &material,
+        runtime.secrets().as_ref(),
+    )
+    .await
+    {
+        log::error!(
+            "[mcp-oauth] failed to persist token for company={} server={}: {}",
+            pending.company_id.as_ref(),
+            pending.server_name,
+            err.code()
+        );
+        return failure_page(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Couldn't save the credential",
+            "The sign-in completed but the credential couldn't be stored. Try again.",
+        );
+    }
+
+    // 7. Probe-and-persist so the console badge flips to green (best-effort).
+    let health = probe_and_persist(&runtime, &pending.server_name).await;
+
+    log::info!(
+        "[mcp-oauth] callback stored token for company={} server={} (status={})",
+        pending.company_id.as_ref(),
+        pending.server_name,
+        health
+            .as_ref()
+            .map(|h| h.status.as_str())
+            .unwrap_or("unknown"),
+    );
+
+    success_page(&pending.server_name)
+}
+
+/// The known-secret set from a pending flow (client secret only — the tokens
+/// aren't known until after exchange). Feeds the scrubber on the error path.
+fn pending_secret_hints(pending: &mcp_oauth::PendingOAuth) -> Vec<String> {
+    pending.client_secret.iter().cloned().collect()
+}
+
+/// Probe the server through the same auth-included registry the agent uses, and
+/// persist the scrubbed outcome as the server's health. Best-effort — a probe
+/// failure never fails the callback.
+async fn probe_and_persist(
+    runtime: &crate::company::runtime::CompanyRuntime,
+    name: &str,
+) -> Option<McpHealth> {
+    let manifest = runtime
+        .store()
+        .load(runtime.id())
+        .await
+        .ok()
+        .flatten()
+        .map(|record| record.manifest.mcp_servers)
+        .unwrap_or_default();
+    let decls = mcp::resolve_effective(runtime.id(), &manifest, runtime.secrets().as_ref())
+        .await
+        .ok()?;
+    let decl = decls.iter().find(|d| d.name == name)?;
+    let health = crate::harness::mcp_probe::probe_server(decl).await;
+    let _ = mcp::save_health(runtime.id(), name, &health, runtime.secrets().as_ref()).await;
+    Some(health)
+}
+
+/// `Some(trimmed)` when a query value is present and non-blank.
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|s| !s.is_empty())
+}
+
+/// Minimal HTML-escaping for interpolated text (defence against a hostile
+/// `error_description` from the authorization server).
+fn escape(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// A self-contained success page telling the operator to return to the console.
+fn success_page(server: &str) -> Response {
+    Html(page(
+        "Signed in",
+        &format!(
+            "You're connected to <strong>{}</strong>. You can close this tab and return to OpenCompany.",
+            escape(server)
+        ),
+    ))
+    .into_response()
+}
+
+/// A self-contained failure page with a scrubbed, escaped message.
+fn failure_page(status: StatusCode, title: &str, message: &str) -> Response {
+    (status, Html(page(title, &escape(message)))).into_response()
+}
+
+/// One inline, dependency-free HTML document (no external assets — this page is
+/// served to a bare browser tab).
+fn page(title: &str, body: &str) -> String {
+    format!(
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">\
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\
+<title>{title}</title>\
+<style>body{{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;\
+background:#0b0f14;color:#e6edf3;display:flex;min-height:100vh;margin:0;\
+align-items:center;justify-content:center}}.card{{max-width:26rem;padding:2rem;\
+background:#111820;border:1px solid #1f2933;border-radius:12px;text-align:center}}\
+h1{{font-size:1.25rem;margin:0 0 .75rem}}p{{margin:0;color:#9fb0c0;line-height:1.5}}\
+</style></head><body><div class=\"card\"><h1>{title}</h1><p>{body}</p></div></body></html>",
+        title = escape(title),
+        body = body,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_neutralizes_html() {
+        let out = escape("<script>alert(1)</script>&\"");
+        assert!(!out.contains('<'));
+        assert!(!out.contains('>'));
+        assert!(out.contains("&lt;script&gt;"));
+        assert!(out.contains("&amp;"));
+        assert!(out.contains("&quot;"));
+    }
+
+    #[test]
+    fn success_page_names_the_server_escaped() {
+        let resp = success_page("no<tion");
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn non_empty_trims_and_rejects_blank() {
+        assert_eq!(non_empty(Some("  x ")), Some("x"));
+        assert_eq!(non_empty(Some("   ")), None);
+        assert_eq!(non_empty(None), None);
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6,6 +6,10 @@ mod error;
 pub mod feedback;
 pub mod graphql;
 pub mod hooks;
+// Console MCP OAuth callback (issue #90): the unauthenticated browser-redirect
+// landing route. Gated on `mcp` (it needs the OAuth token-exchange path).
+#[cfg(feature = "mcp")]
+pub mod mcp_oauth;
 pub mod operator;
 pub mod ops;
 pub mod platform_auth;

--- a/src/server/ops/mcp.rs
+++ b/src/server/ops/mcp.rs
@@ -46,6 +46,7 @@ pub fn router() -> Router<AppState> {
         ))
         .merge(scoped("/mcp/servers/{name}/tools", get(discover_tools)))
         .merge(scoped("/mcp/servers/{name}/test", post(test_server)))
+        .merge(scoped("/mcp/servers/{name}/oauth/start", post(start_oauth)))
 }
 
 /// One effective MCP server as the console renders it. **Never** carries a
@@ -614,6 +615,60 @@ async fn test_server(company: ScopedCompany, Path(NamePath { name }): Path<NameP
 async fn test_server(company: ScopedCompany, Path(NamePath { name }): Path<NamePath>) -> Response {
     let _ = (company, name);
     crate::server::ops::not_wired("mcp probe")
+}
+
+/// `POST …/mcp/servers/{name}/oauth/start` — begin the browser OAuth flow for a
+/// server that advertises OAuth sign-in (issue #90).
+///
+/// Resolves the server's effective endpoint, discovers its authorization server,
+/// dynamically registers a client (RFC 7591) + generates PKCE, parks the pending
+/// state on [`AppState`] keyed by the opaque `state`, and returns
+/// `{ "authorizeUrl": … }` for the console to open in a browser tab. The redirect
+/// URI is derived from the host's public URL (or bind) so it matches what DCR
+/// registered — see [`crate::company::mcp_oauth::callback_redirect_uri`].
+///
+/// A `400` with a clean operator message is returned when the server does not
+/// support dynamic client registration (it can't do console OAuth — the operator
+/// should paste a static token instead).
+#[cfg(feature = "mcp")]
+async fn start_oauth(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    company: ScopedCompany,
+    Path(NamePath { name }): Path<NamePath>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    use crate::company::mcp_oauth;
+
+    let runtime = company.runtime.as_ref();
+    let name = name.trim().to_string();
+
+    // Resolve the effective server so OAuth uses the same endpoint agents will.
+    let manifest = manifest_servers(runtime).await?;
+    let decls = resolve_effective(runtime.id(), &manifest, runtime.secrets().as_ref())
+        .await
+        .map_err(ApiError)?;
+    let decl = decls
+        .iter()
+        .find(|d| d.name == name)
+        .ok_or_else(|| ApiError(OpenCompanyError::McpServerNotFound(name.clone())))?;
+
+    let redirect_uri = mcp_oauth::callback_redirect_uri(&state.config().host_base_url());
+    let begun = mcp_oauth::begin(&decl.endpoint, runtime.id(), &name, &redirect_uri)
+        .await
+        .map_err(ApiError)?;
+
+    // Park the pending flow; the unauthenticated callback route reclaims it.
+    state.park_oauth(begun.state.clone(), begun.pending);
+    Ok(Json(
+        serde_json::json!({ "authorizeUrl": begun.authorize_url }),
+    ))
+}
+
+/// Without the `mcp` feature there is no OAuth transport, so starting a sign-in
+/// is "not wired" (the console's Sign in button degrades gracefully).
+#[cfg(not(feature = "mcp"))]
+async fn start_oauth(company: ScopedCompany, Path(NamePath { name }): Path<NamePath>) -> Response {
+    let _ = (company, name);
+    crate::server::ops::not_wired("mcp oauth")
 }
 
 /// Without the `openhuman` feature there is no MCP transport, so discovery is

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -17,8 +17,8 @@ use crate::{AppState, Result};
 /// build without that feature), and absent server routes must keep 404ing so
 /// API and external clients can detect an unwired surface instead of receiving
 /// the `index.html` shell with a `200`.
-const RESERVED_PREFIXES: [&str; 7] = [
-    "/api", "/graphql", "/healthz", "/spec", "/tiny", "/a2a", "/hooks",
+const RESERVED_PREFIXES: [&str; 8] = [
+    "/api", "/graphql", "/healthz", "/spec", "/tiny", "/a2a", "/hooks", "/oauth",
 ];
 
 /// True when `path` is server-owned and so must 404 rather than fall through to
@@ -77,6 +77,9 @@ fn router_with_console(state: AppState, console_dir: Option<PathBuf>) -> Router 
     // tiny.place A2A inbound + discovery routes, only when the feature is on.
     #[cfg(feature = "tinyplace")]
     let router = router.merge(crate::server::a2a::router());
+    // Unauthenticated console MCP OAuth callback (issue #90), only under `mcp`.
+    #[cfg(feature = "mcp")]
+    let router = router.merge(crate::server::mcp_oauth::router());
     let router = router.with_state(state.clone());
 
     // Operator console: the lowest-priority fallback. Every real route above —


### PR DESCRIPTION
## Summary

Adds per-tenant **OAuth sign-in for MCP servers** in the console, matching OpenHuman's browser-OAuth flow. Many remote MCP servers gate access behind OAuth 2.0 (authorization-code + PKCE) advertised via a 401 challenge; until now the console could only surface a dead-end "OAuth isn't supported" message. Now an operator clicks **Sign in**, approves in a browser tab, and the server's token is stored write-only per tenant.

**Approach (COPY, not vendor patch).** OpenHuman's full flow (`mcp_registry/oauth.rs`) is coupled to its SQLite store and desktop loopback callback, so it isn't reusable for our multi-tenant `SecretStore` console path. This PR reuses **only** the vendored discovery primitive (`McpHttpClient::discover_authorization`) and **ports** the small private helpers — PKCE, RFC 7591 dynamic client registration, the authorize-URL builder, token exchange + parse, and refresh — into a new `company::mcp_oauth` module (~330 LOC incl. tests). The vendor submodule is untouched.

**The whole trick:** a new `AuthMaterial::OAuth` resolves to the transport's existing `BearerToken` path, so the static agent registry sends the token with **zero** further changes. Only the credential *type* and the *flow to obtain it* are new.

Flow:
1. `POST …/mcp/servers/{name}/oauth/start` (authenticated) → discover → dynamic client registration + PKCE → park pending flow keyed by an opaque `state` → return `{ authorizeUrl }`.
2. `GET /oauth/mcp/callback?code&state` (top-level, **unauthenticated** — the browser redirect carries no console session; trust comes from the single-use `state`) → exchange code → store token write-only → probe-and-persist health → render a self-contained success page.
3. The console's **Sign in** button opens the URL, then polls health until the badge flips green.
4. The harness refreshes a near-expiry OAuth token before building the registry, so agents never send a stale bearer.

**Security (the whole point).** OAuth tokens are write-only per tenant, exactly like the BYOK inference pattern — never in any GET/status/log/error/agent-visible output. `AuthMaterial::OAuth::secret_values()` enumerates the access token, refresh token, **and** any confidential client secret, so all of them feed the existing scrubber. A regression test plants an OAuth token, drives a probe against a server that reflects the bearer back in an error body, and asserts none of the three secrets survive into the scrubbed health message. The callback page HTML-escapes and scrubs all interpolated text.

**Stacked PR.** This branch is stacked on `fix/mcp-build-restore-mcpruntime` (**PR #89**) and carries those `McpRuntime`/full-feature build-repair commits until #89 merges. **Rebase onto `main` after #89 lands.** Please do not merge before #89.

## API Or Behavior Changes

- **New route** `POST /api/v1/companies/{id}/mcp/servers/{name}/oauth/start` (+ single-company alias) → `{ authorizeUrl }`; 400 when the server can't do dynamic client registration (paste a static token instead); `not_wired` without the `mcp` feature.
- **New route** `GET /oauth/mcp/callback` (unauthenticated, top-level) — completes the flow, renders an HTML page. `/oauth` is now a reserved path prefix (unmatched `/oauth/*` 404s instead of serving the SPA).
- **New credential kind** `AuthMaterial::OAuth` / `StoredAuth` `oauth` variant, stored write-only under the existing per-server key. No read shape exposes it — the DTO still carries only `authConfigured`.
- MCP servers that require OAuth now report an actionable "click Sign in" message (auth hint `oauth_required` unchanged).
- Console: a per-server **Sign in** button for `oauth_required` servers.
- New optional deps `base64` / `url` wired to the `mcp` feature (already in the tree; no new lockfile crate entries).

## Tests

Run locally (feature set `openhuman,mcp,telegram`):

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --no-deps --all-targets --features openhuman,mcp,telegram -- -D warnings` — clean for this crate. (`--all-targets` without `--no-deps` fails on pre-existing `clippy::large_enum_variant` in the vendored `tinyagents` **path** dependency, which Cargo does not cap-lints; that failure predates this branch and is unrelated to #90.)
- [x] `cargo build --features openhuman,mcp,telegram`
- [x] `cargo test --features openhuman,mcp,telegram` — **763 passed, 0 failed, 1 ignored** (+ 4 integration). New tests: OAuth secret-values coverage, PKCE S256, authorize-URL shape, token-response parse, refresh no-op, callback HTML escaping, and the **no-leak** probe regression (`oauth_token_never_leaks_into_probed_health`).
- [x] `cd frontend && npm run typecheck && npm run build`

## Documentation

No dedicated doc file added — the module-level docs on `company::mcp_oauth`, `server::mcp_oauth`, and the new `AuthMaterial::OAuth` variant document the flow and the write-only security invariant inline.

Closes #90


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser-based OAuth sign-in for MCP servers that require authorization, including a new authorization-start endpoint and an unauthenticated OAuth callback surface.
  * Implemented secure OAuth (PKCE + dynamic client registration) with single-use state handling and server health probing after sign-in.
  * OAuth-authenticated MCP connections now use bearer-token auth automatically, with automatic refresh for near-expiry credentials.
  * Updated the MCP servers UI with a conditional “Sign in” button and in-progress polling.
* **Bug Fixes**
  * Prevented OAuth secrets from appearing in MCP probe/health messages and tightened UI error handling for OAuth-required probe results.
  * Improved routing coverage by expanding the reserved `/oauth` namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->