### PR TITLE
fix(chat): rehydrate operator messages by honoring stored chat id (#92)

### DIFF
--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -26,11 +26,13 @@ pub const MAIN_THREAD_ID: &str = "main";
 /// Whether a stored event belongs to the desk identified by `desk_id` /
 /// `desk_name`.
 ///
-/// `AgentReply`s match on the desk id or name verbatim, plus — only for the
-/// General/operator desk — the console's `"main"` thread id and an empty chat
-/// id, so no historical reply is orphaned by the id it happened to be
-/// journaled under (issue #65). Pre-threading `OperatorMessage`s carry no chat
-/// id at all and have always belonged to the General desk unconditionally.
+/// Both `AgentReply`s and `OperatorMessage`s match on the desk id or name
+/// verbatim, plus — only for the General/operator desk — the console's `"main"`
+/// thread id and an empty chat id, so no historical message is orphaned by the
+/// id it happened to be journaled under (issue #65). An operator message routes
+/// by its stored `chat` id symmetrically with an agent reply's `chat_id`; only
+/// a legacy operator message with no stored chat id (empty/`None`) falls back
+/// to belonging to the General desk.
 pub fn owns(desk_id: &str, desk_name: &str, event: &CompanyEvent) -> bool {
     let is_general_desk =
         desk_id.eq_ignore_ascii_case(GENERAL_DESK) || desk_name.eq_ignore_ascii_case(GENERAL_DESK);
@@ -41,7 +43,13 @@ pub fn owns(desk_id: &str, desk_name: &str, event: &CompanyEvent) -> bool {
                 || (is_general_desk
                     && (chat_id.is_empty() || chat_id.eq_ignore_ascii_case(MAIN_THREAD_ID)))
         }
-        CompanyEvent::OperatorMessage { .. } => is_general_desk,
+        CompanyEvent::OperatorMessage { chat, .. } => {
+            let chat = chat.as_deref().unwrap_or_default();
+            chat == desk_id
+                || chat == desk_name
+                || (is_general_desk
+                    && (chat.is_empty() || chat.eq_ignore_ascii_case(MAIN_THREAD_ID)))
+        }
         _ => false,
     }
 }
@@ -253,6 +261,45 @@ mod test {
                 id: "u1".to_string(),
             }),
             chat: Some(MAIN_THREAD_ID.to_string()),
+        };
+        assert!(owns(GENERAL_DESK, GENERAL_DESK, &event));
+        assert!(!owns("strategy", "Strategy desk", &event));
+    }
+
+    // Regression: issue — operator messages vanished on reload because the read
+    // filter ignored the stored chat id.
+    #[test]
+    fn main_thread_owns_operator_messages_it_stored() {
+        let event = CompanyEvent::OperatorMessage {
+            text: "hi".to_string(),
+            by: None,
+            chat: Some(MAIN_THREAD_ID.to_string()),
+        };
+        // The console queries the main thread with desk = ("main", "main").
+        assert!(owns(MAIN_THREAD_ID, MAIN_THREAD_ID, &event));
+        // And it is still owned when read under the General desk's own id/name.
+        assert!(owns(GENERAL_DESK, GENERAL_DESK, &event));
+        // But it must not leak into an unrelated desk.
+        assert!(!owns("strategy", "Strategy desk", &event));
+    }
+
+    #[test]
+    fn desk_addressed_operator_message_belongs_to_that_desk() {
+        let event = CompanyEvent::OperatorMessage {
+            text: "hi".to_string(),
+            by: None,
+            chat: Some("strategy".to_string()),
+        };
+        assert!(owns("strategy", "Strategy desk", &event));
+        assert!(!owns(MAIN_THREAD_ID, MAIN_THREAD_ID, &event));
+    }
+
+    #[test]
+    fn legacy_operator_message_without_chat_stays_on_general() {
+        let event = CompanyEvent::OperatorMessage {
+            text: "hi".to_string(),
+            by: None,
+            chat: None,
         };
         assert!(owns(GENERAL_DESK, GENERAL_DESK, &event));
         assert!(!owns("strategy", "Strategy desk", &event));


### PR DESCRIPTION
## Summary

An operator's own chat messages vanished from the console on reload. Reopening a thread rehydrated the agent's replies but silently dropped the operator's own messages.

Root cause: in `owns()` (`src/server/chat_history.rs`), the `OperatorMessage` arm discarded the stored `chat` field and never matched the queried chat id, so operator messages were filtered out on read. This was asymmetric with the `AgentReply` arm, which correctly honors its stored `chat`. Since the console queries `desk=main`, the operator's messages — persisted under their real chat id — were excluded from rehydration.

Fix: honor the stored `chat` field symmetrically in the `OperatorMessage` arm, matching the `AgentReply` behavior. Read-side only — the messages were always persisted correctly; only the retrieval filter was wrong.

Closes #92

## API Or Behavior Changes

Behavior fix only. Operator messages now rehydrate on reload, matching agent replies. No public API change, no write-path change, no schema change — the persisted data is unchanged and byte-stable; only the read-side ownership filter is corrected.

## Tests

Default gate green: `cargo fmt` clean, `cargo clippy --all-targets -- -D warnings` clean, `cargo test` 601 passed. Added 3 regression tests covering operator-message ownership across chat ids.

Also verified the full feature combo `cargo check --features openhuman,mcp,telegram` compiles cleanly (only pre-existing unused-import warnings in vendored `openhuman` crates, none in `chat_history.rs`) — covering the known full-feature CI gap.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test`

## Documentation

N/A: internal read-side ownership fix with no user-facing API or config surface to document.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected chat history ownership for operator messages associated with specific desks.
  * Improved handling of messages stored under the `"main"` thread, including legacy messages without a chat identifier.
  * Prevented operator messages from appearing in the wrong desk’s history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->