### PR TITLE
fix(console): bound app shell to viewport so panes scroll independently

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -297,7 +297,7 @@ export function AppShell({
   });
 
   return (
-    <SidebarProvider>
+    <SidebarProvider className="h-svh overflow-hidden">
       <Sidebar collapsible="icon">
         <SidebarHeader>
           <CompanySwitcher
@@ -347,7 +347,7 @@ export function AppShell({
         <SidebarRail />
       </Sidebar>
 
-      <SidebarInset>
+      <SidebarInset className="min-h-0">
         <header className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
           <SidebarTrigger className="-ml-1" />
           <Separator orientation="vertical" className="mr-1 h-4" />
@@ -367,7 +367,7 @@ export function AppShell({
           </div>
         </header>
 
-        <main className="flex flex-1 flex-col overflow-hidden">
+        <main className="flex min-h-0 flex-1 flex-col overflow-hidden">
           {view === "overview" && (
             <Overview
               feed={feed}


### PR DESCRIPTION
## Summary

The console's company-chat two-pane view scrolled both panes (thread list + transcript) together, and every view page-scrolled instead of keeping the shell/header fixed.

Root cause: the app-shell sidebar wrapper was `min-h-svh` (grows with content) with no `min-h-0` chain below it, so nothing in the shell was height-bounded. Because the outer container could grow past the viewport, each view's inner `flex-1 overflow-y-auto` scroller never engaged — the whole page scrolled instead, and the two chat panes moved as one.

The fix bounds the shell to the viewport and threads `min-h-0` down through the layout so each view's existing scroller takes over. Three className changes in `frontend/src/components/app-shell.tsx`:

- `SidebarProvider` → `h-svh overflow-hidden`
- `SidebarInset` → `min-h-0`
- `main` → add `min-h-0`

No edits to the shared `sidebar.tsx` primitive.

## API Or Behavior Changes

No API changes. Behavior: chat panes now scroll independently and the shell/header stay fixed; each view scrolls within its own region instead of the whole page moving.

## Tests

Frontend-only change — the Rust CI checklist below is not applicable. Ran the console checks locally:

- [x] `npm run typecheck` (tsc -b --noEmit) — pass
- [x] `npm run build` (tsc -b && vite build) — pass
- [x] Manual: chat two-pane view — thread list and transcript scroll independently; shell no longer page-scrolls
- [x] N/A: `cargo fmt --all -- --check` (no Rust changes)
- [x] N/A: `cargo clippy --all-targets -- -D warnings` (no Rust changes)
- [x] N/A: `cargo build --all-targets` (no Rust changes)
- [x] N/A: `cargo test` (no Rust changes)

## Documentation

N/A — internal layout fix, no user-facing docs affected.

## Related

Closes #96


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application layout behavior to prevent unwanted overflow and ensure content fits correctly within the visible screen area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->