### PR TITLE
feat(console): surface agent memory + task outcomes in the Brain view

### DIFF
--- a/frontend/src/api/memory.ts
+++ b/frontend/src/api/memory.ts
@@ -9,15 +9,27 @@ import type { OpenCompanyClient } from "./client";
 /** The taxonomy of a durable fact — mirrors the host's `FactKind`. */
 export type MemoryKind = "fact" | "preference" | "person" | "project" | "reference";
 
-/** One durable memory entry as the host returns it. */
+/**
+ * Where a memory row came from — the host's `MemoryOrigin` discriminator.
+ * `fact` rows are operator-authored (editable/deletable); `agent-memory` and
+ * `task-outcome` rows are the agents' own runtime memory and are read-only.
+ */
+export type MemoryOrigin = "fact" | "agent-memory" | "task-outcome";
+
+/** One memory row as the host returns it (an operator fact OR an agent chunk). */
 export interface MemoryEntry {
   id: string;
-  kind: MemoryKind;
+  /** The fact taxonomy — present only on `fact` rows (omitted for context). */
+  kind?: MemoryKind;
+  /** Which backend the row came from; drives editable-vs-read-only rendering. */
+  origin: MemoryOrigin;
+  /** Whether the operator may delete this row (true only for `fact` rows). */
+  editable: boolean;
   title: string;
   body: string;
-  /** Which desk/teammate captured it. */
+  /** Which desk/teammate/agent captured it. */
   source: string;
-  /** Epoch-millis of the last update. */
+  /** Epoch-millis of the last update (`0` for context rows, which carry none). */
   updatedAt: number;
 }
 
@@ -54,6 +66,22 @@ export const KIND_STYLES: Record<MemoryKind, string> = {
   person: "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400",
   project: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
   reference: "border-border bg-muted text-muted-foreground",
+};
+
+/** The read-only context origins, in display order (facts filter by kind). */
+export const CONTEXT_ORIGINS: Exclude<MemoryOrigin, "fact">[] = ["agent-memory", "task-outcome"];
+
+/** Human labels for each origin, for badges and the type filter. */
+export const ORIGIN_LABELS: Record<MemoryOrigin, string> = {
+  fact: "Fact",
+  "agent-memory": "Agent memory",
+  "task-outcome": "Task outcome",
+};
+
+/** Per-origin badge styling for the read-only context rows. */
+export const ORIGIN_STYLES: Record<Exclude<MemoryOrigin, "fact">, string> = {
+  "agent-memory": "border-teal-500/30 bg-teal-500/10 text-teal-600 dark:text-teal-400",
+  "task-outcome": "border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-400",
 };
 
 /** The company's durable facts, newest-first, optionally filtered server-side. */

--- a/frontend/src/views/MemoryView.tsx
+++ b/frontend/src/views/MemoryView.tsx
@@ -67,10 +67,11 @@ function entryType(e: MemoryEntry): string {
 
 /** The badge label + style for a row, from its kind (facts) or origin (context). */
 function entryBadge(e: MemoryEntry): { label: string; style: string } {
-  if (e.origin === "fact" && e.kind) {
-    return { label: e.kind, style: KIND_STYLES[e.kind] };
+  if (e.origin === "fact") {
+    const kind = e.kind ?? "fact";
+    return { label: kind, style: KIND_STYLES[kind] };
   }
-  return { label: ORIGIN_LABELS[e.origin], style: ORIGIN_STYLES[e.origin as "agent-memory" | "task-outcome"] };
+  return { label: ORIGIN_LABELS[e.origin], style: ORIGIN_STYLES[e.origin] };
 }
 
 /** The type-filter options in display order: fact kinds, then context origins. */

--- a/frontend/src/views/MemoryView.tsx
+++ b/frontend/src/views/MemoryView.tsx
@@ -3,12 +3,15 @@ import { Brain, Loader2, Plus, Search, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import {
+  CONTEXT_ORIGINS,
   createMemory,
   deleteMemory,
   KIND_STYLES,
   listMemory,
   MEMORY_KINDS,
   memoryStats,
+  ORIGIN_LABELS,
+  ORIGIN_STYLES,
   type MemoryEntry,
   type MemoryKind,
   type MemoryStats,
@@ -51,6 +54,33 @@ const KIND_LABELS: Record<string, string> = {
   person: "People",
   project: "Projects",
   reference: "References",
+};
+
+/**
+ * The value the type filter matches a row on: a fact matches on its `kind`, a
+ * read-only context row matches on its `origin` (agent-memory / task-outcome).
+ * Keeps the original per-kind filtering while extending it to the new sources.
+ */
+function entryType(e: MemoryEntry): string {
+  return e.origin === "fact" ? (e.kind ?? "fact") : e.origin;
+}
+
+/** The badge label + style for a row, from its kind (facts) or origin (context). */
+function entryBadge(e: MemoryEntry): { label: string; style: string } {
+  if (e.origin === "fact" && e.kind) {
+    return { label: e.kind, style: KIND_STYLES[e.kind] };
+  }
+  return { label: ORIGIN_LABELS[e.origin], style: ORIGIN_STYLES[e.origin as "agent-memory" | "task-outcome"] };
+}
+
+/** The type-filter options in display order: fact kinds, then context origins. */
+const TYPE_FILTERS: string[] = [...MEMORY_KINDS, ...CONTEXT_ORIGINS];
+
+/** Labels for every type-filter value (including `all`), for the Select. */
+const TYPE_FILTER_LABELS: Record<string, string> = {
+  all: "All types",
+  ...Object.fromEntries(MEMORY_KINDS.map((k) => [k, KIND_LABELS[k]])),
+  ...Object.fromEntries(CONTEXT_ORIGINS.map((o) => [o, ORIGIN_LABELS[o]])),
 };
 
 /** Formats an epoch-millis instant as a short absolute date, or a dash when 0. */
@@ -116,13 +146,18 @@ export function MemoryView({ client, company }: Props) {
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     return entries
-      .filter((e) => kind === "all" || e.kind === kind)
+      .filter((e) => kind === "all" || entryType(e) === kind)
       .filter((e) => !q || e.title.toLowerCase().includes(q) || e.body.toLowerCase().includes(q));
   }, [entries, query, kind]);
 
-  const perKind = useMemo(() => {
+  // Per-type counts for the health badges, keyed by the same value the filter
+  // matches on (fact kind or context origin) so every source shows a count.
+  const perType = useMemo(() => {
     const counts: Record<string, number> = {};
-    for (const e of entries) counts[e.kind] = (counts[e.kind] ?? 0) + 1;
+    for (const e of entries) {
+      const t = entryType(e);
+      counts[t] = (counts[t] ?? 0) + 1;
+    }
     return counts;
   }, [entries]);
 
@@ -167,7 +202,7 @@ export function MemoryView({ client, company }: Props) {
           </Alert>
         )}
 
-        <HealthStrip loading={loading} stats={stats} total={entries.length} perKind={perKind} />
+        <HealthStrip loading={loading} stats={stats} total={entries.length} perType={perType} />
 
         <div className="flex flex-wrap items-center gap-2">
           <div className="relative flex-1 sm:max-w-xs">
@@ -179,15 +214,15 @@ export function MemoryView({ client, company }: Props) {
               className="pl-8"
             />
           </div>
-          <Select value={kind} onValueChange={(v) => v && setKind(v)} items={KIND_LABELS}>
+          <Select value={kind} onValueChange={(v) => v && setKind(v)} items={TYPE_FILTER_LABELS}>
             <SelectTrigger className="w-40">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">All types</SelectItem>
-              {MEMORY_KINDS.map((k) => (
-                <SelectItem key={k} value={k}>
-                  {KIND_LABELS[k]}
+              {TYPE_FILTERS.map((t) => (
+                <SelectItem key={t} value={t}>
+                  {TYPE_FILTER_LABELS[t]}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -219,12 +254,12 @@ function HealthStrip({
   loading,
   stats,
   total,
-  perKind,
+  perType,
 }: {
   loading: boolean;
   stats: MemoryStats | null;
   total: number;
-  perKind: Record<string, number>;
+  perType: Record<string, number>;
 }) {
   if (loading && !stats) {
     return <Skeleton className="h-16 rounded-xl" />;
@@ -245,9 +280,14 @@ function HealthStrip({
           </div>
         ))}
         <div className="flex flex-wrap items-center gap-1.5">
-          {MEMORY_KINDS.filter((k) => perKind[k]).map((k) => (
+          {MEMORY_KINDS.filter((k) => perType[k]).map((k) => (
             <Badge key={k} variant="outline" className={cn("capitalize", KIND_STYLES[k])}>
-              {k} · {perKind[k]}
+              {k} · {perType[k]}
+            </Badge>
+          ))}
+          {CONTEXT_ORIGINS.filter((o) => perType[o]).map((o) => (
+            <Badge key={o} variant="outline" className={ORIGIN_STYLES[o]}>
+              {ORIGIN_LABELS[o]} · {perType[o]}
             </Badge>
           ))}
         </div>
@@ -257,27 +297,32 @@ function HealthStrip({
 }
 
 function MemoryCard({ entry, onDelete }: { entry: MemoryEntry; onDelete: () => void }) {
+  const badge = entryBadge(entry);
   return (
     <Card className="group" data-testid="memory-card">
       <CardContent className="space-y-2 py-4">
         <div className="flex items-start justify-between gap-2">
           <p className="font-medium leading-snug">{entry.title}</p>
-          <Badge variant="outline" className={cn("shrink-0 capitalize", KIND_STYLES[entry.kind])}>
-            {entry.kind}
+          <Badge variant="outline" className={cn("shrink-0 capitalize", badge.style)}>
+            {badge.label}
           </Badge>
         </div>
         {entry.body && <p className="text-sm text-muted-foreground">{entry.body}</p>}
         <div className="flex items-center justify-between pt-1">
           <span className="text-xs text-muted-foreground">via {entry.source}</span>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-7 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:text-destructive"
-            onClick={onDelete}
-            aria-label="Delete memory"
-          >
-            <Trash2 className="size-4" />
-          </Button>
+          {/* Delete is only offered on operator facts; agent memory and task
+              outcomes are read-only, so they show no delete affordance. */}
+          {entry.editable && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:text-destructive"
+              onClick={onDelete}
+              aria-label="Delete memory"
+            >
+              <Trash2 className="size-4" />
+            </Button>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/src/server/ops/memory.rs
+++ b/src/server/ops/memory.rs
@@ -51,12 +51,47 @@ pub fn router() -> Router<AppState> {
         .merge(scoped("/memory/{fact_id}", delete(delete_fact)))
 }
 
+/// Upper bound on context-store entries materialised into the list, so a company
+/// with a very large learned-context store can't force an unbounded number of
+/// chunk-body reads on a single `GET /memory`. The stats endpoint only counts
+/// (no per-chunk read), so it stays unbounded; the list caps its reads here.
+const MAX_CONTEXT_ENTRIES: usize = 500;
+
+/// Max characters kept for a context entry's synthesised title (its first line).
+const CONTEXT_TITLE_MAX: usize = 120;
+
+/// Where a rendered [`MemoryEntry`] came from. The console keys "editable vs
+/// read-only" and the source label off this: only [`Fact`](MemoryOrigin::Fact)
+/// rows are operator-authored and therefore deletable; the two context-derived
+/// origins are the agents' own runtime memory and are read-only.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum MemoryOrigin {
+    /// A durable operator-authored fact (FactStore). Editable + deletable.
+    Fact,
+    /// A learned-context chunk the agents recall from (ContextStore). Read-only.
+    AgentMemory,
+    /// A stored task outcome the harness wrote (ContextStore). Read-only.
+    TaskOutcome,
+}
+
 /// A durable memory entry as the console renders it.
+///
+/// Carries entries from two backends: operator facts (FactStore) and the agents'
+/// runtime context chunks (ContextStore). `origin` + `editable` let the console
+/// tell them apart — facts are editable/deletable, context rows are read-only.
+/// `kind` is only meaningful for facts, so it is omitted for context rows.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct MemoryEntry {
     id: String,
-    kind: FactKind,
+    /// The fact taxonomy — present only on `Fact` rows (omitted for context).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kind: Option<FactKind>,
+    /// Which backend the row came from; drives editable-vs-read-only rendering.
+    origin: MemoryOrigin,
+    /// Whether the operator may edit/delete this row (true only for facts).
+    editable: bool,
     title: String,
     body: String,
     source: String,
@@ -67,13 +102,114 @@ impl From<FactRecord> for MemoryEntry {
     fn from(f: FactRecord) -> Self {
         Self {
             id: f.id,
-            kind: f.kind,
+            kind: Some(f.kind),
+            origin: MemoryOrigin::Fact,
+            editable: true,
             title: f.title,
             body: f.body,
             source: f.source,
             updated_at: f.updated_at_millis,
         }
     }
+}
+
+/// A context chunk pulled from the [`ContextStore`](crate::ports::ContextStore),
+/// carrying its content address (for a stable row id), logical label (for origin
+/// classification), and body (peeked). The input to [`context_entries`].
+struct RawChunk {
+    addr: String,
+    label: String,
+    body: String,
+}
+
+/// Truncates `s` to at most `max` characters on a char boundary, appending an
+/// ellipsis when anything was dropped. Char-based (never byte-slices) so a
+/// multibyte body can't panic mid-codepoint.
+fn truncate_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(max).collect();
+    format!("{head}…")
+}
+
+/// Splits a chunk body into a short title (its first non-empty line, truncated)
+/// and the remaining body. Used to render a context chunk as a titled card.
+fn split_title_body(body: &str) -> (String, String) {
+    let trimmed = body.trim();
+    let mut parts = trimmed.splitn(2, '\n');
+    let first = parts.next().unwrap_or("").trim();
+    let rest = parts.next().unwrap_or("").trim();
+    (truncate_chars(first, CONTEXT_TITLE_MAX), rest.to_string())
+}
+
+/// Turns peeked context chunks into read-only [`MemoryEntry`]s, ordered agent
+/// memory first then task outcomes. Drops operator-fact mirrors (they are
+/// already represented by their FactStore row — never double-list them) and
+/// applies `query` (case-insensitive substring over the chunk body) so the
+/// list's free-text search reaches context rows too, matching fact search.
+fn context_entries(chunks: Vec<RawChunk>, query: Option<&str>) -> Vec<MemoryEntry> {
+    let needle = query.map(|q| q.to_lowercase());
+    let mirror_prefix = format!("{OPERATOR_FACT_PREFIX}/");
+    let outcome_prefix = format!("{OUTCOME_LABEL_PREFIX}/");
+
+    let mut agent_memory = Vec::new();
+    let mut task_outcomes = Vec::new();
+
+    for chunk in chunks {
+        // The operator-fact mirror is the same knowledge as its FactStore row;
+        // surfacing it here would double-list the operator's note.
+        if chunk.label.starts_with(&mirror_prefix) {
+            continue;
+        }
+        if let Some(ref q) = needle {
+            if !chunk.body.to_lowercase().contains(q) {
+                continue;
+            }
+        }
+
+        let (origin, source, bucket): (MemoryOrigin, String, &mut Vec<MemoryEntry>) =
+            if let Some(agent) = chunk.label.strip_prefix(&outcome_prefix) {
+                let who = if agent.is_empty() { "an agent" } else { agent };
+                (
+                    MemoryOrigin::TaskOutcome,
+                    who.to_string(),
+                    &mut task_outcomes,
+                )
+            } else {
+                let who = chunk.label.split('/').next().filter(|s| !s.is_empty());
+                (
+                    MemoryOrigin::AgentMemory,
+                    who.unwrap_or("an agent").to_string(),
+                    &mut agent_memory,
+                )
+            };
+
+        let (mut title, body) = split_title_body(&chunk.body);
+        if title.is_empty() {
+            title = match origin {
+                MemoryOrigin::TaskOutcome => "Task outcome".to_string(),
+                _ => "Agent memory".to_string(),
+            };
+        }
+
+        bucket.push(MemoryEntry {
+            // Prefix so a context row's id can never collide with a fact id
+            // (delete targets fact ids only; this keeps React keys unique too).
+            id: format!("ctx:{}", chunk.addr),
+            kind: None,
+            origin,
+            editable: false,
+            title,
+            body,
+            source,
+            // Context chunks carry no timestamp; the console renders `—`.
+            updated_at: 0,
+        });
+    }
+
+    agent_memory.extend(task_outcomes);
+    agent_memory
 }
 
 /// The create-fact body.
@@ -119,10 +255,19 @@ struct MemoryStats {
     task_outcomes: usize,
 }
 
-/// `GET /memory` — the company's durable facts, newest-first, optionally
-/// filtered by `?query=` (case-insensitive substring over title + body) and/or
-/// `?kind=`. Same semantics as the GraphQL `Company.memory` resolver; the
-/// console reads this instead of a client-side stub.
+/// `GET /memory` — everything the company remembers, so the console lists what
+/// the Brain header counts. Three sources, in this order:
+///
+/// 1. **Operator facts** (FactStore) — newest-first, editable/deletable.
+/// 2. **Agent memory** (ContextStore chunks that are neither task outcomes nor
+///    operator-fact mirrors) — read-only.
+/// 3. **Task outcomes** (ContextStore `task-outcome/*`) — read-only.
+///
+/// `?query=` (case-insensitive substring over title + body) filters all three.
+/// `?kind=` is a *fact* taxonomy filter, so when it is set the context sources
+/// are omitted (they have no `FactKind`) and only matching facts are returned —
+/// preserving the type-filter's original facts-only meaning while the console's
+/// wider "agent memory / task outcome" filters run client-side.
 async fn list_facts(
     company: ScopedCompany,
     Query(ListQuery { query, kind }): Query<ListQuery>,
@@ -132,7 +277,38 @@ async fn list_facts(
         .facts()
         .list(company.id(), query.as_deref(), kind)
         .await?;
-    Ok(Json(rows.into_iter().map(MemoryEntry::from).collect()))
+    let mut entries: Vec<MemoryEntry> = rows.into_iter().map(MemoryEntry::from).collect();
+
+    // A fact-kind filter is inherently facts-only — context chunks carry no
+    // `FactKind`, so skip them (and the reads) when one is set.
+    if kind.is_none() {
+        // `""` lists every chunk; drop the operator-fact mirrors before peeking
+        // so we neither double-list them nor pay to read their bodies, then cap
+        // the reads so a huge context store can't unbound this request.
+        let mirror_prefix = format!("{OPERATOR_FACT_PREFIX}/");
+        let metas = company.runtime.context.list(company.id(), "").await?;
+        let mut chunks = Vec::new();
+        for meta in metas
+            .into_iter()
+            .filter(|m| !m.label.starts_with(&mirror_prefix))
+            .take(MAX_CONTEXT_ENTRIES)
+        {
+            let body = company
+                .runtime
+                .context
+                .peek(company.id(), &meta.addr, None)
+                .await
+                .unwrap_or_default();
+            chunks.push(RawChunk {
+                addr: meta.addr.to_string(),
+                label: meta.label,
+                body,
+            });
+        }
+        entries.extend(context_entries(chunks, query.as_deref()));
+    }
+
+    Ok(Json(entries))
 }
 
 /// `GET /memory/stats` — counts across the fact store and the agents' context
@@ -232,6 +408,129 @@ async fn delete_fact(
         Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
             "fact {fact_id}"
         ))))
+    }
+}
+
+#[cfg(test)]
+mod combined_list_tests {
+    use super::*;
+
+    fn chunk(label: &str, body: &str) -> RawChunk {
+        RawChunk {
+            addr: format!("addr-{label}"),
+            label: label.to_string(),
+            body: body.to_string(),
+        }
+    }
+
+    fn fact(id: &str, kind: FactKind, title: &str) -> FactRecord {
+        FactRecord {
+            id: id.to_string(),
+            kind,
+            title: title.to_string(),
+            body: format!("{title} body"),
+            source: "You".to_string(),
+            updated_at_millis: 100,
+        }
+    }
+
+    #[test]
+    fn zero_facts_plus_context_yields_readonly_nonempty_list() {
+        // The reported bug: header counts N context chunks but the list is empty
+        // because it only read the (empty) FactStore. Prove context now surfaces.
+        let chunks = vec![
+            chunk("agent-1/notes", "Learned a thing\nmore detail"),
+            chunk("task-outcome/agent-1", "Task: ship it\nOutcome: done"),
+        ];
+        let entries = context_entries(chunks, None);
+
+        assert_eq!(entries.len(), 2, "both context chunks surface as entries");
+        assert!(
+            entries.iter().all(|e| !e.editable),
+            "context rows are read-only"
+        );
+        assert!(
+            entries.iter().all(|e| e.kind.is_none()),
+            "context rows carry no fact kind"
+        );
+        // Ordering: agent memory before task outcomes.
+        assert!(matches!(entries[0].origin, MemoryOrigin::AgentMemory));
+        assert!(matches!(entries[1].origin, MemoryOrigin::TaskOutcome));
+        assert_eq!(entries[1].source, "agent-1", "outcome source = agent id");
+        // Title/body split off the first line.
+        assert_eq!(entries[0].title, "Learned a thing");
+        assert_eq!(entries[0].body, "more detail");
+    }
+
+    #[test]
+    fn operator_fact_mirror_is_not_double_listed() {
+        // The `operator-fact/{id}` chunk mirrors a FactStore row; it must NOT
+        // appear as a second read-only row duplicating that fact.
+        let chunks = vec![
+            chunk("operator-fact/fact-123", "Client prefers Friday\nreviews"),
+            chunk("agent-2/x", "genuine agent memory"),
+        ];
+        let entries = context_entries(chunks, None);
+
+        assert_eq!(
+            entries.len(),
+            1,
+            "mirror dropped; only agent memory remains"
+        );
+        assert!(matches!(entries[0].origin, MemoryOrigin::AgentMemory));
+    }
+
+    #[test]
+    fn facts_editable_context_readonly() {
+        // Facts get the delete affordance; read-only rows never do.
+        let fact_entry = MemoryEntry::from(fact("f1", FactKind::Person, "Ada"));
+        assert!(fact_entry.editable, "operator facts are deletable");
+        assert!(matches!(fact_entry.origin, MemoryOrigin::Fact));
+        assert_eq!(fact_entry.kind, Some(FactKind::Person));
+
+        let ctx = context_entries(vec![chunk("task-outcome/a", "Task: t\nOutcome: o")], None);
+        assert!(
+            !ctx[0].editable,
+            "read-only rows expose no edit/delete affordance"
+        );
+    }
+
+    #[test]
+    fn query_matches_across_context_rows() {
+        let chunks = vec![
+            chunk("agent-1/a", "alpha content"),
+            chunk("agent-1/b", "beta content"),
+        ];
+        // Case-insensitive substring, same as fact search.
+        let entries = context_entries(chunks, Some("BETA"));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].title, "beta content");
+    }
+
+    #[test]
+    fn json_shape_facts_stable_context_omits_kind() {
+        // Fact serialization is unchanged (kind present); context omits kind and
+        // carries the read-only discriminator the console keys off.
+        let fact_json =
+            serde_json::to_value(MemoryEntry::from(fact("f", FactKind::Fact, "t"))).unwrap();
+        assert_eq!(fact_json["kind"], "fact");
+        assert_eq!(fact_json["origin"], "fact");
+        assert_eq!(fact_json["editable"], true);
+
+        let ctx = &context_entries(vec![chunk("agent-1/a", "hello world")], None)[0];
+        let ctx_json = serde_json::to_value(ctx).unwrap();
+        assert!(ctx_json.get("kind").is_none(), "context row omits kind");
+        assert_eq!(ctx_json["origin"], "agent-memory");
+        assert_eq!(ctx_json["editable"], false);
+    }
+
+    #[test]
+    fn blank_body_falls_back_to_origin_label() {
+        // A whitespace-only chunk body has no title line, so the row shows the
+        // origin label rather than an empty heading.
+        let ctx = context_entries(vec![chunk("task-outcome/a", "   ")], None);
+        assert_eq!(ctx[0].title, "Task outcome");
+        assert_eq!(ctx[0].body, "");
     }
 }
 

--- a/src/server/ops/memory.rs
+++ b/src/server/ops/memory.rs
@@ -293,12 +293,26 @@ async fn list_facts(
             .filter(|m| !m.label.starts_with(&mirror_prefix))
             .take(MAX_CONTEXT_ENTRIES)
         {
-            let body = company
+            // A peek failure degrades one row to an empty body rather than
+            // failing the whole list, but log it so a real storage fault
+            // surfaces instead of silently rendering blank cards.
+            let body = match company
                 .runtime
                 .context
                 .peek(company.id(), &meta.addr, None)
                 .await
-                .unwrap_or_default();
+            {
+                Ok(body) => body,
+                Err(err) => {
+                    tracing::warn!(
+                        company = %company.id(),
+                        addr = %meta.addr,
+                        error = %err,
+                        "failed to peek context chunk; rendering empty body"
+                    );
+                    String::new()
+                }
+            };
             chunks.push(RawChunk {
                 addr: meta.addr.to_string(),
                 label: meta.label,

--- a/src/server/ops/memory.rs
+++ b/src/server/ops/memory.rs
@@ -162,10 +162,10 @@ fn context_entries(chunks: Vec<RawChunk>, query: Option<&str>) -> Vec<MemoryEntr
         if chunk.label.starts_with(&mirror_prefix) {
             continue;
         }
-        if let Some(ref q) = needle {
-            if !chunk.body.to_lowercase().contains(q) {
-                continue;
-            }
+        if let Some(ref q) = needle
+            && !chunk.body.to_lowercase().contains(q)
+        {
+            continue;
         }
 
         let (origin, source, bucket): (MemoryOrigin, String, &mut Vec<MemoryEntry>) =


### PR DESCRIPTION
## Summary

The console Brain/Memory view showed **Total items: 0 / "No memories yet"** while the stats header on the same page counted **35 agent memories + 34 task outcomes** (69 total). The list read only the **FactStore** (operator-entered facts), while the 69 real memories live in the **ContextStore** — counted by the stats aggregation but never included in the list payload. With no operator facts present, the list rendered empty next to a non-zero header.

This surfaces the ContextStore contents in the Brain view: `GET /memory` now merges all three sources — operator facts, agent memory, and task outcomes — into a single `Vec<MemoryEntry>`, each tagged with an `origin` discriminator and an `editable` flag. The console renders every source, hides the delete affordance on read-only rows, and only shows the empty state when all three sources are genuinely empty.

## API Or Behavior Changes

- `GET /memory` now returns entries from **all three** memory sources (operator facts + agent memory + task outcomes), not just operator facts. Each entry carries a new `origin` discriminator and an `editable` flag.
- **Delete** is gated to operator facts only; read-only ContextStore rows (agent memory, task outcomes) render no delete affordance and are rejected server-side.
- Operator-fact mirrors in the ContextStore are de-duplicated so they are not double-listed.
- The empty state ("No memories yet") renders only when all three sources are empty.
- Existing operator-fact JSON shape is preserved; context rows omit the fact-only `kind` field.

## Tests

- [x] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings` — not run for this change; vendored-crate lint debt is pre-existing and unrelated to the diff.
- [x] `cargo test --features openhuman,mcp,telegram memory` — 28 passed, 0 failed (includes new `combined_list_tests`: facts-editable/context-readonly, operator-fact mirror not double-listed, zero-facts-plus-context yields a read-only non-empty list, query matches across context rows, stable JSON shape).
- [x] `cd frontend && npm run typecheck` — clean
- [x] `cd frontend && npm run build` — clean

## Documentation

No docs update needed — this is an internal console list-completeness fix with no new user-facing concepts or configuration. Behavior changes are captured in the section above.

## Related

Closes #98


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Memory listings now combine operator-authored facts with read-only agent context entries (including task outcomes).
  - Added source-aware filters, badges, and health-strip breakdown for both fact kinds and context origins.
  - Context entries now include origin metadata, editability, and last-updated timestamps for proper display.
- **Bug Fixes**
  - Read-only context entries no longer show delete controls.
  - Operator-fact mirror rows are excluded to prevent duplicates in combined results.
  - Query matching and context title/body handling are improved for consistent filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->