### PR TITLE
feat(harness): wire OpenHuman coding + web toolbelt into company agents (#107)

### DIFF
--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -110,6 +110,8 @@ async fn main() -> anyhow::Result<()> {
         workflow_runner: opencompany::harness::orchestrator::WorkflowRunnerHandle::default(),
         mcp_failures: opencompany::harness::mcp_probe::McpFailureQueue::default(),
         secrets: None,
+        web_allowed_domains: Vec::new(),
+        capabilities: opencompany::harness::toolbelt::CapabilityFilter::AllowAll,
     };
 
     let pool = HarnessPool::new();

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -362,6 +362,13 @@ pub struct Tools {
     /// Company-wide grant globs; agents intersect with this.
     #[serde(default)]
     pub allow: Vec<String>,
+    /// SSRF allowlist for the `web` tool namespace (Cell A). Empty (default) is
+    /// *open mode* — all public hosts allowed — while private/loopback/
+    /// link-local/metadata IPs are always rejected by OpenHuman's `url_guard`.
+    /// A non-empty list is strict (only those hosts + subdomains); `"*"` is an
+    /// explicit allow-all-public wildcard.
+    #[serde(default)]
+    pub web_allowed_domains: Vec<String>,
 }
 
 impl Default for Tools {
@@ -369,6 +376,7 @@ impl Default for Tools {
         Self {
             provider: default_tool_provider(),
             allow: Vec::new(),
+            web_allowed_domains: Vec::new(),
         }
     }
 }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -423,6 +423,8 @@ description = "Runs Acme."
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
         HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record())
     }
@@ -556,6 +558,8 @@ description = "Builds it."
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record_two()),
@@ -753,6 +757,8 @@ members = ["engineer"]
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record),
@@ -928,6 +934,8 @@ name = "Design"
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: failures.clone(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record());
 

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -6,13 +6,18 @@
 //!
 //! * **Tools**: every agent gets the intrinsic [`memory_tools`] (`memory_store`
 //!   + `memory_recall`) over its own company memory. **File tools** (read,
-//!   write, edit, list, grep, glob) are granted per-agent when the effective
-//!   `tools ∩ agent.tools` grants cover the `files`/`docs` namespace, and are
-//!   sandboxed to the agent's own workspace via a `workspace_only`
-//!   [`SecurityPolicy`] ([`file_tools`]). Network (`web.*`) and shell (`shell.*`)
-//!   tools are a tracked follow-up — they need an HTTP domain-allowlist config
-//!   and a runtime/audit sandbox respectively; the builder extends the same
-//!   vector, so they slot in beside the file tools.
+//!     write, edit, list, grep, glob) are granted per-agent when the effective
+//!     `tools ∩ agent.tools` grants cover the `files`/`docs` namespace, and are
+//!     sandboxed to the agent's own workspace via a `workspace_only`
+//!     [`SecurityPolicy`] ([`file_tools`]). **Exec-grade tools** (Cell A) now
+//!     slot in beside them via [`toolbelt`](crate::harness::toolbelt): `shell`
+//!     (shell + `read_workspace_state`) and `code` (`apply_patch`,
+//!     `git_operations`, `csv_export`) behind a strict [`toolbelt::exec_security`]
+//!     policy + native runtime + per-workspace audit; `web` (`web_fetch`,
+//!     `http_request`, `curl`, `image_info`) behind the same policy plus a
+//!     per-company SSRF domain allowlist. The `subagent` namespace is reserved
+//!     but empty in v1. Still deferred: browser automation (needs a backend),
+//!     search (needs engine keys), and Node/NPM exec (need a managed bootstrap).
 //! * **Workflows/skills** start empty. Parsing enabled `SKILL.md` bodies via
 //!   `openhuman::skills::ops_parse` depends on WS1's skill parsing; the seam is
 //!   the `.workflows(...)` setter.
@@ -48,6 +53,7 @@ use crate::harness::memory::OcMemory;
 use crate::harness::orchestrator;
 use crate::harness::policy::ApprovalPolicy;
 use crate::harness::skills::EffectiveSkills;
+use crate::harness::toolbelt;
 use crate::ports::skills_state::SkillState;
 use crate::ports::types::CompanyId;
 
@@ -146,6 +152,49 @@ pub fn build_agent(
         tools.extend(file_tools(&workspace));
     }
 
+    // Exec-grade coding + web tools (Cell A), each behind its own grant
+    // namespace and sandboxed to this agent's workspace by ONE strict
+    // `exec_security` policy shared across the shell/code/web tool constructors.
+    // Unlike the MCP bridge (which hands OpenHuman a permissive Supervised
+    // policy), shell/code/web receive the strict policy directly — the company's
+    // own `ApprovalPolicy` (`tool_policy` below) stays the authoritative
+    // per-call park/deny gate on top of it. The autonomy tier is mapped 1:1 from
+    // the manifest `[policy].mode`.
+    let wants_shell = grants_cover(grants, "shell");
+    let wants_code = grants_cover(grants, "code");
+    let wants_web = grants_cover(grants, "web");
+    if wants_shell || wants_code || wants_web {
+        let exec_security = Arc::new(toolbelt::exec_security(&workspace, policy.mode()));
+        // The shell + code bundle needs a host runtime and a per-workspace audit
+        // logger (tenant-isolated); build them only when granted.
+        if wants_shell || wants_code {
+            let runtime = toolbelt::native_runtime();
+            let audit = toolbelt::workspace_audit(&workspace);
+            tools.extend(toolbelt::coding_tools(
+                exec_security.clone(),
+                runtime,
+                audit,
+                &workspace,
+            ));
+        }
+        // Web tools reuse OpenHuman's upstream SSRF `url_guard` internally; the
+        // per-company allowlist comes from the manifest `[tools].web_allowed_domains`
+        // (empty = allow-public with private/metadata IPs always rejected).
+        if wants_web {
+            tools.extend(toolbelt::web_tools(
+                exec_security,
+                deps.web_allowed_domains.clone(),
+                &workspace,
+            ));
+        }
+    }
+    // The `subagent` namespace is reserved but intentionally wires no tools in
+    // v1 — OpenHuman's spawn tools use a process-global registry + budget bypass
+    // unsafe under multi-tenancy. Reserved so a grant can land without effect.
+    if grants_cover(grants, "subagent") {
+        tools.extend(toolbelt::subagent_tools());
+    }
+
     // Persona over openhuman's own identity: `omit_identity = true` drops the
     // "you are OpenHuman" preamble so the agent speaks as its company role.
     let mut persona = persona_prompt(company_name, manifest_agent);
@@ -237,6 +286,14 @@ pub fn build_agent(
         .model_override
         .clone()
         .unwrap_or_else(|| model_for_tier(manifest_agent.tier.as_deref()));
+
+    // Capability-tier seam (Cell A): one filtering pass over the fully assembled
+    // tool vector, just before it is handed to the builder. Today `AllowAll` is
+    // the only production variant (identity); a future capability-tier cell only
+    // swaps how `deps.capabilities` is constructed. Intrinsic tools
+    // (memory/MCP/orchestrator/file/skill) have no mapped namespace and are
+    // always kept.
+    let tools = toolbelt::filter_by_capabilities(tools, &deps.capabilities);
 
     AgentBuilder::default()
         .provider_arc(deps.provider.clone())

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -173,6 +173,11 @@ pub fn build_agent(
         // isolated), so those handles are built only under `wants_shell`.
         if wants_shell {
             let runtime = toolbelt::native_runtime();
+            // Fail closed: `workspace_audit` returns `None` if the per-workspace
+            // audit logger cannot be initialized, and `shell_tools` then withholds
+            // the shell namespace entirely rather than register an unaudited
+            // `ShellTool`. A granted agent silently loses shell here — the
+            // error-level log in `workspace_audit` surfaces why.
             let audit = toolbelt::workspace_audit(&workspace);
             tools.extend(toolbelt::shell_tools(
                 exec_security.clone(),

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -165,17 +165,24 @@ pub fn build_agent(
     let wants_web = grants_cover(grants, "web");
     if wants_shell || wants_code || wants_web {
         let exec_security = Arc::new(toolbelt::exec_security(&workspace, policy.mode()));
-        // The shell + code bundle needs a host runtime and a per-workspace audit
-        // logger (tenant-isolated); build them only when granted.
-        if wants_shell || wants_code {
+        // `shell` and `code` are separate grant namespaces and are wired from
+        // separate tool vectors — a company granting only one MUST NOT receive
+        // the other's tools (the production `CapabilityFilter` is identity and
+        // does not re-trim namespaces after construction). Only the `shell`
+        // tools need a host runtime + per-workspace audit logger (tenant-
+        // isolated), so those handles are built only under `wants_shell`.
+        if wants_shell {
             let runtime = toolbelt::native_runtime();
             let audit = toolbelt::workspace_audit(&workspace);
-            tools.extend(toolbelt::coding_tools(
+            tools.extend(toolbelt::shell_tools(
                 exec_security.clone(),
                 runtime,
                 audit,
                 &workspace,
             ));
+        }
+        if wants_code {
+            tools.extend(toolbelt::code_tools(exec_security.clone(), &workspace));
         }
         // Web tools reuse OpenHuman's upstream SSRF `url_guard` internally; the
         // per-company allowlist comes from the manifest `[tools].web_allowed_domains`

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -47,6 +47,7 @@ pub mod policy;
 pub mod provider;
 pub mod skills;
 pub mod steps;
+pub mod toolbelt;
 
 pub use brain::HarnessBrain;
 
@@ -160,6 +161,18 @@ pub struct HarnessDeps {
     /// `None` (default/tests) keeps the boot-resolved [`Self::mcp_servers`]
     /// static, exactly as before.
     pub secrets: Option<Arc<dyn SecretStore>>,
+    /// The per-company SSRF allowlist for the `web` toolbelt (Cell A), from the
+    /// manifest `[tools].web_allowed_domains`. Empty (the default) is *open
+    /// mode* — all public hosts allowed — while OpenHuman's upstream `url_guard`
+    /// still rejects private/loopback/link-local/metadata IPs regardless. A
+    /// non-empty list is strict (only those hosts + subdomains); `"*"` is an
+    /// explicit allow-all-public wildcard. Threaded verbatim into
+    /// [`toolbelt::web_tools`](crate::harness::toolbelt::web_tools).
+    pub web_allowed_domains: Vec<String>,
+    /// The capability-tier filter applied to each agent's assembled tool vector
+    /// (Cell A seam). [`AllowAll`](crate::harness::toolbelt::CapabilityFilter::AllowAll)
+    /// (the default) is identity; a future tier cell swaps this construction.
+    pub capabilities: toolbelt::CapabilityFilter,
 }
 
 /// One live openhuman agent, keyed by its manifest id.
@@ -955,6 +968,8 @@ description = "Builds the product."
                 workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
                 mcp_failures: McpFailureQueue::default(),
                 secrets: None,
+                web_allowed_domains: Vec::new(),
+                capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             },
             store,
             meter,
@@ -1005,6 +1020,8 @@ description = "Builds the product."
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
 
         let roster = build_roster(&record(), &deps, &[]).expect("roster builds with skills");
@@ -1278,6 +1295,8 @@ description = "Builds the product."
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
         let roster = build_roster(&record(), &deps, &[]).expect("roster");
         // Keep the tempdir alive for the agent's workspace by leaking it into the
@@ -1396,6 +1415,8 @@ description = "Builds the product."
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             secrets: Some(secrets.clone()),
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
         let pool = HarnessPool::new();
         let rec = record();
@@ -1501,6 +1522,8 @@ description = "Builds the product."
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
         let pool = HarnessPool::new();
 

--- a/src/harness/toolbelt.rs
+++ b/src/harness/toolbelt.rs
@@ -127,21 +127,21 @@ pub fn native_runtime() -> Arc<dyn RuntimeAdapter> {
 /// OpenHuman's `runtime_node::build_runtime_tools` does. Keyed on the agent's
 /// own workspace dir so audit trails are tenant-isolated.
 ///
-/// Audit must never block agent construction, so a logger-init failure degrades
-/// to [`AuditLogger::disabled`] rather than propagating. The failure is logged
-/// at `error!` (not `warn!`): a consistent init failure means every subsequent
-/// shell command for this agent runs with **no audit record**, so the event
-/// must surface in production error telemetry rather than blend into warnings.
-pub fn workspace_audit(workspace: &Path) -> Arc<AuditLogger> {
+/// Returns `None` when the logger cannot be initialized. Callers **must** treat
+/// `None` as fail-closed: [`shell_tools`] withholds the `ShellTool` entirely
+/// rather than register it unaudited (see there). The failure is logged at
+/// `error!` (not `warn!`): losing the audit logger drops shell capability for
+/// the agent, so the event must surface in production error telemetry.
+pub fn workspace_audit(workspace: &Path) -> Option<Arc<AuditLogger>> {
     match get_or_create_workspace_audit_logger(AuditConfig::default(), workspace.to_path_buf()) {
-        Ok(logger) => logger,
+        Ok(logger) => Some(logger),
         Err(error) => {
             tracing::error!(
                 workspace = %workspace.display(),
                 %error,
-                "[toolbelt] workspace audit logger init failed; shell commands for this agent will run UNAUDITED"
+                "[toolbelt] workspace audit logger init failed; withholding shell capability (fail-closed) — this agent gets NO shell tool"
             );
-            AuditLogger::disabled()
+            None
         }
     }
 }
@@ -158,12 +158,21 @@ pub fn workspace_audit(workspace: &Path) -> Arc<AuditLogger> {
 /// * `shell` — run commands (needs `runtime` + `audit`; plain constructor, no
 ///   Node/Python bootstrap in v1).
 /// * `read_workspace_state` — read-only git/tree overview.
+///
+/// **Fail closed on audit:** `audit` is `None` only when the per-workspace audit
+/// logger could not be initialized (see [`workspace_audit`]). In that case the
+/// whole `shell` namespace is withheld — an empty vector — so a `ShellTool` can
+/// never run commands with no audit record. Dropping the capability is the safe
+/// failure mode; registering an unaudited shell is not.
 pub fn shell_tools(
     security: Arc<SecurityPolicy>,
     runtime: Arc<dyn RuntimeAdapter>,
-    audit: Arc<AuditLogger>,
+    audit: Option<Arc<AuditLogger>>,
     workspace: &Path,
 ) -> Vec<Box<dyn Tool>> {
+    let Some(audit) = audit else {
+        return Vec::new();
+    };
     vec![
         Box::new(ShellTool::new(security, runtime, audit)),
         Box::new(WorkspaceStateTool::new(workspace.to_path_buf())),
@@ -304,12 +313,33 @@ mod tests {
     fn shell_tools_expose_expected_names() {
         let ws = Path::new("/tmp/oc-toolbelt-shell");
         let security = test_security(ws, PolicyMode::Supervised);
-        let tools = shell_tools(security, native_runtime(), AuditLogger::disabled(), ws);
+        let tools = shell_tools(
+            security,
+            native_runtime(),
+            Some(AuditLogger::disabled()),
+            ws,
+        );
         let got = names(&tools);
         for expected in ["shell", "read_workspace_state"] {
             assert!(got.contains(&expected), "missing {expected}: {got:?}");
         }
         assert_eq!(got.len(), 2, "shell tools drifted: {got:?}");
+    }
+
+    /// Fail-closed guard: when the workspace audit logger cannot be built
+    /// (`workspace_audit` → `None`), `shell_tools` MUST withhold the entire
+    /// `shell` namespace rather than register a `ShellTool` that would execute
+    /// commands with no audit record. This is the security boundary — pin it.
+    #[test]
+    fn shell_tools_absent_when_audit_init_fails() {
+        let ws = Path::new("/tmp/oc-toolbelt-shell-noaudit");
+        let security = test_security(ws, PolicyMode::Supervised);
+        let tools = shell_tools(security, native_runtime(), None, ws);
+        assert!(
+            tools.is_empty(),
+            "shell namespace must be withheld when audit init fails, got: {:?}",
+            names(&tools)
+        );
     }
 
     #[test]
@@ -336,7 +366,7 @@ mod tests {
         let shell = shell_tools(
             security.clone(),
             native_runtime(),
-            AuditLogger::disabled(),
+            Some(AuditLogger::disabled()),
             ws,
         );
         let code = code_tools(security, ws);
@@ -538,7 +568,7 @@ mod tests {
         let mut tools = shell_tools(
             security.clone(),
             native_runtime(),
-            AuditLogger::disabled(),
+            Some(AuditLogger::disabled()),
             ws,
         );
         tools.extend(code_tools(security, ws));
@@ -558,7 +588,7 @@ mod tests {
         let mut tools: Vec<Box<dyn Tool>> = shell_tools(
             security.clone(),
             native_runtime(),
-            AuditLogger::disabled(),
+            Some(AuditLogger::disabled()),
             ws,
         );
         tools.extend(code_tools(security.clone(), ws));

--- a/src/harness/toolbelt.rs
+++ b/src/harness/toolbelt.rs
@@ -143,25 +143,40 @@ pub fn workspace_audit(workspace: &Path) -> Arc<AuditLogger> {
     }
 }
 
-/// The `shell` + `code` tools, all sharing the exec-grade `security` policy and
+/// The `shell` namespace tools, sharing the exec-grade `security` policy and
 /// pinned to the agent's `workspace`. Mirrors
 /// [`file_tools`](crate::harness::build): a flat vector the builder extends.
+///
+/// Kept **disjoint** from [`code_tools`] so the builder can gate each grant
+/// namespace independently — a company granting only `code` must never receive
+/// a live [`ShellTool`], and vice versa (the production [`CapabilityFilter`] is
+/// `AllowAll`/identity and does not re-trim namespaces post-construction).
 ///
 /// * `shell` — run commands (needs `runtime` + `audit`; plain constructor, no
 ///   Node/Python bootstrap in v1).
 /// * `read_workspace_state` — read-only git/tree overview.
-/// * `apply_patch` — structured multi-edit patches.
-/// * `git_operations` — status/diff/log/commit within the workspace.
-/// * `csv_export` — write a CSV into the workspace's `exports/` dir.
-pub fn coding_tools(
+pub fn shell_tools(
     security: Arc<SecurityPolicy>,
     runtime: Arc<dyn RuntimeAdapter>,
     audit: Arc<AuditLogger>,
     workspace: &Path,
 ) -> Vec<Box<dyn Tool>> {
     vec![
-        Box::new(ShellTool::new(security.clone(), runtime, audit)),
+        Box::new(ShellTool::new(security, runtime, audit)),
         Box::new(WorkspaceStateTool::new(workspace.to_path_buf())),
+    ]
+}
+
+/// The `code` namespace tools, sharing the exec-grade `security` policy and
+/// pinned to the agent's `workspace`. Disjoint from [`shell_tools`] (see there
+/// for why the split is a security boundary, not just cosmetics). Unlike shell,
+/// these need neither a host runtime nor an audit logger.
+///
+/// * `apply_patch` — structured multi-edit patches.
+/// * `git_operations` — status/diff/log/commit within the workspace.
+/// * `csv_export` — write a CSV into the workspace's `exports/` dir.
+pub fn code_tools(security: Arc<SecurityPolicy>, workspace: &Path) -> Vec<Box<dyn Tool>> {
+    vec![
         Box::new(ApplyPatchTool::new(security.clone())),
         Box::new(GitOperationsTool::new(
             security.clone(),
@@ -283,21 +298,72 @@ mod tests {
     }
 
     #[test]
-    fn coding_tools_expose_expected_names() {
-        let ws = Path::new("/tmp/oc-toolbelt-coding");
+    fn shell_tools_expose_expected_names() {
+        let ws = Path::new("/tmp/oc-toolbelt-shell");
         let security = test_security(ws, PolicyMode::Supervised);
-        let tools = coding_tools(security, native_runtime(), AuditLogger::disabled(), ws);
+        let tools = shell_tools(security, native_runtime(), AuditLogger::disabled(), ws);
         let got = names(&tools);
-        for expected in [
-            "shell",
-            "read_workspace_state",
-            "apply_patch",
-            "git_operations",
-            "csv_export",
-        ] {
+        for expected in ["shell", "read_workspace_state"] {
             assert!(got.contains(&expected), "missing {expected}: {got:?}");
         }
-        assert_eq!(got.len(), 5, "coding tools drifted: {got:?}");
+        assert_eq!(got.len(), 2, "shell tools drifted: {got:?}");
+    }
+
+    #[test]
+    fn code_tools_expose_expected_names() {
+        let ws = Path::new("/tmp/oc-toolbelt-code");
+        let security = test_security(ws, PolicyMode::Supervised);
+        let tools = code_tools(security, ws);
+        let got = names(&tools);
+        for expected in ["apply_patch", "git_operations", "csv_export"] {
+            assert!(got.contains(&expected), "missing {expected}: {got:?}");
+        }
+        assert_eq!(got.len(), 3, "code tools drifted: {got:?}");
+    }
+
+    /// The `shell` and `code` grant namespaces must build from **disjoint** tool
+    /// vectors: granting `code` alone must never hand an agent a live `ShellTool`
+    /// (and vice versa). The production `CapabilityFilter` is identity, so this
+    /// tool-vector split is the only thing enforcing the boundary — pin it.
+    #[test]
+    fn shell_and_code_tool_sets_are_disjoint_and_correctly_namespaced() {
+        let ws = Path::new("/tmp/oc-toolbelt-isolation");
+        let security = test_security(ws, PolicyMode::Supervised);
+
+        let shell = shell_tools(
+            security.clone(),
+            native_runtime(),
+            AuditLogger::disabled(),
+            ws,
+        );
+        let code = code_tools(security, ws);
+
+        // Every shell tool maps to the `shell` namespace and none to `code`.
+        for tool in &shell {
+            assert_eq!(
+                namespace_of(tool.name()),
+                Some("shell"),
+                "shell_tools leaked a non-shell tool: {}",
+                tool.name()
+            );
+        }
+        // Every code tool maps to the `code` namespace and none to `shell`.
+        for tool in &code {
+            assert_eq!(
+                namespace_of(tool.name()),
+                Some("code"),
+                "code_tools leaked a non-code tool: {}",
+                tool.name()
+            );
+        }
+
+        // No tool name appears in both vectors.
+        let shell_names: HashSet<&str> = names(&shell).into_iter().collect();
+        let code_names: HashSet<&str> = names(&code).into_iter().collect();
+        assert!(
+            shell_names.is_disjoint(&code_names),
+            "shell/code tool sets overlap: {shell_names:?} ∩ {code_names:?}"
+        );
     }
 
     #[test]
@@ -466,7 +532,13 @@ mod tests {
     fn filter_allow_all_is_identity() {
         let ws = Path::new("/tmp/oc-toolbelt-filter");
         let security = test_security(ws, PolicyMode::Supervised);
-        let tools = coding_tools(security, native_runtime(), AuditLogger::disabled(), ws);
+        let mut tools = shell_tools(
+            security.clone(),
+            native_runtime(),
+            AuditLogger::disabled(),
+            ws,
+        );
+        tools.extend(code_tools(security, ws));
         // Own the names before `tools` moves into the filter.
         let before: Vec<String> = tools.iter().map(|t| t.name().to_string()).collect();
         let after_tools = filter_by_capabilities(tools, &CapabilityFilter::AllowAll);
@@ -480,12 +552,13 @@ mod tests {
         // tools; a full namespace deny must keep only the intrinsic one.
         let ws = Path::new("/tmp/oc-toolbelt-deny");
         let security = test_security(ws, PolicyMode::Supervised);
-        let mut tools: Vec<Box<dyn Tool>> = coding_tools(
+        let mut tools: Vec<Box<dyn Tool>> = shell_tools(
             security.clone(),
             native_runtime(),
             AuditLogger::disabled(),
             ws,
         );
+        tools.extend(code_tools(security.clone(), ws));
         tools.extend(web_tools(security.clone(), Vec::new(), ws));
         // `file_read` has no mapped namespace → intrinsic → always kept.
         tools.push(Box::new(oh::tools::FileReadTool::new(security)));

--- a/src/harness/toolbelt.rs
+++ b/src/harness/toolbelt.rs
@@ -1,0 +1,502 @@
+//! Coding + web tool wiring for embedded company agents (Cell A).
+//!
+//! This module bridges a curated slice of OpenHuman's tool surface into the
+//! harness's per-agent [`AgentBuilder`](openhuman_core::openhuman::agent::AgentBuilder)
+//! wiring in [`build`](crate::harness::build). Where [`file_tools`] grants an
+//! agent read/write inside its own workspace, this module adds the **exec-grade**
+//! families behind their own grant namespaces:
+//!
+//! * **`shell`** → `shell` (run commands) + `read_workspace_state`.
+//! * **`code`** → `apply_patch`, `git_operations`, `csv_export`.
+//! * **`web`** → `web_fetch`, `http_request`, `curl`, `image_info`.
+//! * **`subagent`** → reserved, **empty in v1** (see [`subagent_tools`]).
+//!
+//! Everything here is scoped **per company/agent workspace** — no
+//! process-global state — so parallel tenants stay isolated:
+//!
+//! * Shell + code tools share one [`SecurityPolicy`] built by [`exec_security`],
+//!   pinned to the agent's workspace with `workspace_only`, high-risk commands
+//!   blocked, tool-install denied, and an autonomy level mapped 1:1 from the
+//!   company's [`PolicyMode`]. This is the *strict* policy — opencompany's own
+//!   [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy) tool policy stays
+//!   the real fail-closed approval gate on top of it.
+//! * Shell command audit is keyed on the agent's own workspace dir
+//!   ([`workspace_audit`]) so audit trails never cross tenants.
+//! * Web tools reuse OpenHuman's upstream SSRF guard (`url_guard`): every
+//!   request is validated against the per-company allowlist AND has
+//!   private/loopback/link-local/metadata IPs rejected — even in the default
+//!   "allow all public hosts" mode (an empty allowlist). The guard is applied
+//!   inside the tool constructors; it is not re-implemented here.
+//!
+//! A single [`filter_by_capabilities`] pass runs just before the tool vector is
+//! handed to the builder. Today the only [`CapabilityFilter`] is
+//! [`CapabilityFilter::AllowAll`] (identity); a future capability-tier cell only
+//! swaps how the filter is constructed. Tools with no mapped namespace
+//! (memory, MCP, orchestrator, skills) are **intrinsic** and always kept.
+//!
+//! **Deferred** (need infrastructure not present in v1): browser automation
+//! (needs a backend), search tools (need engine keys), Node/NPM exec (need a
+//! managed-runtime bootstrap), and OpenHuman's sub-agent spawn tools (global
+//! registry + budget bypass — unsafe under multi-tenancy).
+
+use std::path::Path;
+use std::sync::Arc;
+
+use openhuman_core::openhuman as oh;
+
+use oh::agent::host_runtime::{NativeRuntime, RuntimeAdapter};
+use oh::config::{AuditConfig, HttpRequestConfig};
+use oh::security::{
+    AuditLogger, AutonomyLevel, SecurityPolicy, get_or_create_workspace_audit_logger,
+};
+use oh::tools::{
+    ApplyPatchTool, CsvExportTool, CurlTool, GitOperationsTool, HttpRequestTool, ImageInfoTool,
+    ShellTool, Tool, WebFetchTool, WorkspaceStateTool,
+};
+
+use crate::harness::policy::PolicyMode;
+
+/// Subdirectory under the agent workspace that `curl` downloads land in.
+const CURL_DEST_SUBDIR: &str = "downloads";
+
+/// Map a tool's runtime `name()` onto its grant namespace, or `None` when the
+/// tool is **intrinsic** (memory / MCP / orchestrator / file / skill tools),
+/// which are always kept regardless of the capability filter.
+///
+/// This is the single source of truth coupling a wired tool to the namespace
+/// that gates it — [`filter_by_capabilities`] and any future capability-tier
+/// logic key off it, so a new exec tool is added here and nowhere else.
+pub fn namespace_of(tool_name: &str) -> Option<&'static str> {
+    match tool_name {
+        "shell" | "read_workspace_state" => Some("shell"),
+        "apply_patch" | "git_operations" | "csv_export" => Some("code"),
+        "web_fetch" | "http_request" | "curl" | "image_info" => Some("web"),
+        _ => None,
+    }
+}
+
+/// Build the exec-grade [`SecurityPolicy`] shared by an agent's shell + code +
+/// web tools, sandboxed to `workspace`.
+///
+/// Extends the same `workspace_only` shape [`file_tools`](crate::harness::build)
+/// uses with the exec-relevant knobs:
+///
+/// * `autonomy` is mapped **1:1** from the company [`PolicyMode`]
+///   (readonly/supervised/full → [`AutonomyLevel`] ReadOnly/Supervised/Full).
+/// * `block_high_risk_commands` is always on — destructive shell commands are
+///   refused before they spawn.
+/// * `require_approval_for_medium_risk` mirrors Supervised mode.
+/// * `allow_tool_install` and `auto_approve_all` are always off — an embedded
+///   company agent never installs OS packages nor blanket-approves itself.
+///
+/// This policy is *advisory-strict*: opencompany's own
+/// [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy) tool policy is the
+/// authoritative park/deny gate layered above it (unlike the MCP bridge, which
+/// passes a permissive OpenHuman policy).
+pub fn exec_security(workspace: &Path, mode: PolicyMode) -> SecurityPolicy {
+    let dir = workspace.to_path_buf();
+    SecurityPolicy {
+        autonomy: autonomy_for(mode),
+        workspace_dir: dir.clone(),
+        action_dir: dir,
+        workspace_only: true,
+        block_high_risk_commands: true,
+        require_approval_for_medium_risk: mode == PolicyMode::Supervised,
+        allow_tool_install: false,
+        auto_approve_all: false,
+        ..SecurityPolicy::default()
+    }
+}
+
+/// The OpenHuman [`AutonomyLevel`] a company [`PolicyMode`] maps to (1:1).
+fn autonomy_for(mode: PolicyMode) -> AutonomyLevel {
+    match mode {
+        PolicyMode::Readonly => AutonomyLevel::ReadOnly,
+        PolicyMode::Supervised => AutonomyLevel::Supervised,
+        PolicyMode::Full => AutonomyLevel::Full,
+    }
+}
+
+/// A native (host-process) [`RuntimeAdapter`] for the shell tool. Stateless and
+/// cheap — a fresh handle per agent keeps tenants from sharing runtime state.
+pub fn native_runtime() -> Arc<dyn RuntimeAdapter> {
+    Arc::new(NativeRuntime::new())
+}
+
+/// A workspace-scoped [`AuditLogger`] for shell command execution, built the way
+/// OpenHuman's `runtime_node::build_runtime_tools` does. Keyed on the agent's
+/// own workspace dir so audit trails are tenant-isolated.
+///
+/// Audit must never block agent construction, so a logger-init failure degrades
+/// to [`AuditLogger::disabled`] with a warning rather than propagating.
+pub fn workspace_audit(workspace: &Path) -> Arc<AuditLogger> {
+    match get_or_create_workspace_audit_logger(AuditConfig::default(), workspace.to_path_buf()) {
+        Ok(logger) => logger,
+        Err(error) => {
+            tracing::warn!(
+                workspace = %workspace.display(),
+                %error,
+                "[toolbelt] workspace audit logger init failed; shell audit disabled for this agent"
+            );
+            AuditLogger::disabled()
+        }
+    }
+}
+
+/// The `shell` + `code` tools, all sharing the exec-grade `security` policy and
+/// pinned to the agent's `workspace`. Mirrors
+/// [`file_tools`](crate::harness::build): a flat vector the builder extends.
+///
+/// * `shell` — run commands (needs `runtime` + `audit`; plain constructor, no
+///   Node/Python bootstrap in v1).
+/// * `read_workspace_state` — read-only git/tree overview.
+/// * `apply_patch` — structured multi-edit patches.
+/// * `git_operations` — status/diff/log/commit within the workspace.
+/// * `csv_export` — write a CSV into the workspace's `exports/` dir.
+pub fn coding_tools(
+    security: Arc<SecurityPolicy>,
+    runtime: Arc<dyn RuntimeAdapter>,
+    audit: Arc<AuditLogger>,
+    workspace: &Path,
+) -> Vec<Box<dyn Tool>> {
+    vec![
+        Box::new(ShellTool::new(security.clone(), runtime, audit)),
+        Box::new(WorkspaceStateTool::new(workspace.to_path_buf())),
+        Box::new(ApplyPatchTool::new(security.clone())),
+        Box::new(GitOperationsTool::new(
+            security.clone(),
+            workspace.to_path_buf(),
+        )),
+        Box::new(CsvExportTool::new(security)),
+    ]
+}
+
+/// The `web` tools, sharing the exec-grade `security` policy and the
+/// per-company `allowed_domains` SSRF allowlist.
+///
+/// `allowed_domains` semantics (OpenHuman's `url_guard`, applied inside each
+/// constructor): an **empty** list is *open mode* — all public hosts allowed —
+/// while private/loopback/link-local/multicast/metadata IPs are **always**
+/// rejected regardless. A non-empty list is strict (only those hosts +
+/// subdomains); `"*"` is an explicit allow-all-public wildcard.
+///
+/// * `web_fetch` — fetch + return page text (size/timeout defaults).
+/// * `http_request` — arbitrary HTTP method/headers/body.
+/// * `curl` — download a URL into the workspace `downloads/` dir.
+/// * `image_info` — inspect a workspace image's dimensions/format.
+pub fn web_tools(
+    security: Arc<SecurityPolicy>,
+    allowed_domains: Vec<String>,
+    workspace: &Path,
+) -> Vec<Box<dyn Tool>> {
+    // Source size/timeout defaults from OpenHuman's own config so there is one
+    // source of truth (and no `0 → coerced-with-warning` noise on each build).
+    let http_defaults = HttpRequestConfig::default();
+    vec![
+        Box::new(WebFetchTool::new(
+            security.clone(),
+            allowed_domains.clone(),
+            None,
+            None,
+        )),
+        Box::new(HttpRequestTool::new(
+            security.clone(),
+            allowed_domains.clone(),
+            http_defaults.max_response_size,
+            http_defaults.timeout_secs,
+        )),
+        Box::new(CurlTool::new(
+            security.clone(),
+            allowed_domains,
+            workspace.to_path_buf(),
+            CURL_DEST_SUBDIR.to_string(),
+            http_defaults.max_response_size as u64,
+            http_defaults.timeout_secs,
+        )),
+        Box::new(ImageInfoTool::new(security)),
+    ]
+}
+
+/// The `subagent` namespace — **reserved and empty in v1**.
+///
+/// OpenHuman's sub-agent spawn tools (`SpawnSubagentTool` et al.) reach a
+/// process-global agent registry and can bypass per-agent budget accounting —
+/// both unsafe under opencompany's multi-tenant isolation model. The namespace
+/// is reserved so a company can grant `subagent` today without effect, and a
+/// future cell can wire a tenant-safe delegation surface without a grant change.
+pub fn subagent_tools() -> Vec<Box<dyn Tool>> {
+    Vec::new()
+}
+
+/// Which tools an agent may keep after its grants have already admitted them —
+/// the seam a future capability-tier cell swaps.
+///
+/// Today the production build only ever constructs [`CapabilityFilter::AllowAll`]
+/// (identity). The deny variant exists for tests exercising the filter seam.
+#[derive(Clone, Debug, Default)]
+pub enum CapabilityFilter {
+    /// Keep every tool the grants admitted (identity).
+    #[default]
+    AllowAll,
+    /// Drop every tool whose [`namespace_of`] is in this set; intrinsic tools
+    /// (namespace `None`) are always kept. Test-only for now.
+    #[cfg(test)]
+    DenyNamespaces(std::collections::HashSet<&'static str>),
+}
+
+/// Apply a [`CapabilityFilter`] to a built tool vector, just before it is handed
+/// to the [`AgentBuilder`](openhuman_core::openhuman::agent::AgentBuilder).
+///
+/// Intrinsic tools (memory / MCP / orchestrator / file / skill — any tool whose
+/// [`namespace_of`] is `None`) are always kept; only namespaced exec tools can
+/// be dropped. [`CapabilityFilter::AllowAll`] is the identity pass.
+pub fn filter_by_capabilities(
+    tools: Vec<Box<dyn Tool>>,
+    filter: &CapabilityFilter,
+) -> Vec<Box<dyn Tool>> {
+    match filter {
+        CapabilityFilter::AllowAll => tools,
+        #[cfg(test)]
+        CapabilityFilter::DenyNamespaces(denied) => tools
+            .into_iter()
+            .filter(|tool| match namespace_of(tool.name()) {
+                Some(namespace) => !denied.contains(namespace),
+                // Intrinsic tools have no namespace and are never dropped.
+                None => true,
+            })
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashSet;
+
+    fn names(tools: &[Box<dyn Tool>]) -> Vec<&str> {
+        tools.iter().map(|t| t.name()).collect()
+    }
+
+    fn test_security(workspace: &Path, mode: PolicyMode) -> Arc<SecurityPolicy> {
+        Arc::new(exec_security(workspace, mode))
+    }
+
+    #[test]
+    fn coding_tools_expose_expected_names() {
+        let ws = Path::new("/tmp/oc-toolbelt-coding");
+        let security = test_security(ws, PolicyMode::Supervised);
+        let tools = coding_tools(security, native_runtime(), AuditLogger::disabled(), ws);
+        let got = names(&tools);
+        for expected in [
+            "shell",
+            "read_workspace_state",
+            "apply_patch",
+            "git_operations",
+            "csv_export",
+        ] {
+            assert!(got.contains(&expected), "missing {expected}: {got:?}");
+        }
+        assert_eq!(got.len(), 5, "coding tools drifted: {got:?}");
+    }
+
+    #[test]
+    fn web_tools_expose_expected_names() {
+        let ws = Path::new("/tmp/oc-toolbelt-web");
+        let security = test_security(ws, PolicyMode::Supervised);
+        // Empty allowlist = open-public mode; the SSRF IP guard still applies.
+        let tools = web_tools(security, Vec::new(), ws);
+        let got = names(&tools);
+        for expected in ["web_fetch", "http_request", "curl", "image_info"] {
+            assert!(got.contains(&expected), "missing {expected}: {got:?}");
+        }
+        assert_eq!(got.len(), 4, "web tools drifted: {got:?}");
+    }
+
+    #[test]
+    fn subagent_tools_are_reserved_empty() {
+        assert!(
+            subagent_tools().is_empty(),
+            "subagent namespace is v1-reserved"
+        );
+    }
+
+    #[test]
+    fn namespace_table_maps_exec_tools_and_leaves_intrinsic_unmapped() {
+        assert_eq!(namespace_of("shell"), Some("shell"));
+        assert_eq!(namespace_of("read_workspace_state"), Some("shell"));
+        assert_eq!(namespace_of("apply_patch"), Some("code"));
+        assert_eq!(namespace_of("git_operations"), Some("code"));
+        assert_eq!(namespace_of("csv_export"), Some("code"));
+        assert_eq!(namespace_of("web_fetch"), Some("web"));
+        assert_eq!(namespace_of("http_request"), Some("web"));
+        assert_eq!(namespace_of("curl"), Some("web"));
+        assert_eq!(namespace_of("image_info"), Some("web"));
+        // Intrinsic tools are unmapped (always kept by the filter).
+        assert_eq!(namespace_of("memory_store"), None);
+        assert_eq!(namespace_of("memory_recall"), None);
+        assert_eq!(namespace_of("file_read"), None);
+        assert_eq!(namespace_of("mcp_registry_tool_call"), None);
+    }
+
+    #[test]
+    fn exec_security_shape_is_workspace_scoped_and_hardened() {
+        let ws = Path::new("/tmp/oc-toolbelt-policy");
+
+        let supervised = exec_security(ws, PolicyMode::Supervised);
+        assert!(supervised.workspace_only, "must be workspace-only");
+        assert_eq!(supervised.workspace_dir, ws);
+        assert_eq!(supervised.action_dir, ws);
+        assert!(
+            supervised.block_high_risk_commands,
+            "high-risk must be blocked"
+        );
+        assert!(
+            !supervised.allow_tool_install,
+            "tool install must be denied"
+        );
+        assert!(
+            !supervised.auto_approve_all,
+            "blanket auto-approve must be off"
+        );
+        assert_eq!(supervised.autonomy, AutonomyLevel::Supervised);
+        assert!(
+            supervised.require_approval_for_medium_risk,
+            "supervised must approve medium-risk"
+        );
+
+        // Autonomy tracks the mode 1:1; medium-risk approval is Supervised-only.
+        let readonly = exec_security(ws, PolicyMode::Readonly);
+        assert_eq!(readonly.autonomy, AutonomyLevel::ReadOnly);
+        assert!(!readonly.require_approval_for_medium_risk);
+
+        let full = exec_security(ws, PolicyMode::Full);
+        assert_eq!(full.autonomy, AutonomyLevel::Full);
+        assert!(!full.require_approval_for_medium_risk);
+    }
+
+    #[tokio::test]
+    async fn shell_rm_rf_denied_under_readonly_parked_under_supervised() {
+        use oh::security::GateDecision;
+        let ws = std::env::temp_dir();
+
+        // Readonly: a destructive command is hard-blocked by the policy — proven
+        // both at the decision layer and end-to-end (the tool refuses before it
+        // spawns; the harmless nonexistent path is a belt-and-braces target).
+        let readonly = test_security(&ws, PolicyMode::Readonly);
+        assert_eq!(
+            readonly.gate_decision(readonly.classify_command("rm -rf /")),
+            GateDecision::Block,
+            "readonly must hard-block destructive commands"
+        );
+        let tool = ShellTool::new(readonly, native_runtime(), AuditLogger::disabled());
+        let result = tool
+            .execute(json!({ "command": "rm -rf /tmp/oc-toolbelt-nonexistent-xyz" }))
+            .await
+            .unwrap();
+        assert!(
+            result.is_error,
+            "readonly rm -rf must error: {}",
+            result.output()
+        );
+        assert!(result.output().to_lowercase().contains("read-only"));
+
+        // Supervised: the destructive command is *parked* (requires approval),
+        // never auto-allowed. The park→resolve step is opencompany's own
+        // `ApprovalPolicy` gate layered above; here we prove OpenHuman's policy
+        // classifies it as approval-required rather than allowed.
+        let supervised = test_security(&ws, PolicyMode::Supervised);
+        assert_eq!(
+            supervised.gate_decision(supervised.classify_command("rm -rf /")),
+            GateDecision::Prompt,
+            "supervised must park (require approval for) destructive commands"
+        );
+    }
+
+    #[tokio::test]
+    async fn web_tools_reject_ssrf_ip_literals() {
+        let ws = std::env::temp_dir();
+        let security = test_security(&ws, PolicyMode::Full);
+        // Open-public allowlist: proves the IP guard fires independently of the
+        // domain allowlist. Both are IP literals, so rejection short-circuits
+        // before any DNS lookup or network I/O.
+        let tools = web_tools(security, Vec::new(), &ws);
+        for tool in &tools {
+            // Only web_fetch / http_request take a plain `url` arg.
+            if !matches!(tool.name(), "web_fetch" | "http_request") {
+                continue;
+            }
+            for url in ["http://169.254.169.254/", "http://127.0.0.1:1/"] {
+                let result = tool.execute(json!({ "url": url })).await.unwrap();
+                assert!(
+                    result.is_error,
+                    "{} must reject SSRF target {url}: {}",
+                    tool.name(),
+                    result.output()
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_patch_denied_outside_workspace() {
+        let ws = std::env::temp_dir().join("oc-toolbelt-escape");
+        let _ = tokio::fs::remove_dir_all(&ws).await;
+        tokio::fs::create_dir_all(&ws).await.unwrap();
+        let security = test_security(&ws, PolicyMode::Full);
+        let tool = ApplyPatchTool::new(security);
+        // A path escaping the workspace root must be refused by the policy.
+        let result = tool
+            .execute(json!({
+                "edits": [
+                    { "path": "../outside.txt", "old_string": "x", "new_string": "y" }
+                ]
+            }))
+            .await
+            .unwrap();
+        assert!(
+            result.is_error,
+            "workspace escape must be denied: {}",
+            result.output()
+        );
+        let _ = tokio::fs::remove_dir_all(&ws).await;
+    }
+
+    #[test]
+    fn filter_allow_all_is_identity() {
+        let ws = Path::new("/tmp/oc-toolbelt-filter");
+        let security = test_security(ws, PolicyMode::Supervised);
+        let tools = coding_tools(security, native_runtime(), AuditLogger::disabled(), ws);
+        // Own the names before `tools` moves into the filter.
+        let before: Vec<String> = tools.iter().map(|t| t.name().to_string()).collect();
+        let after_tools = filter_by_capabilities(tools, &CapabilityFilter::AllowAll);
+        let after: Vec<String> = after_tools.iter().map(|t| t.name().to_string()).collect();
+        assert_eq!(before, after, "AllowAll must be identity");
+    }
+
+    #[test]
+    fn filter_deny_drops_mapped_but_keeps_intrinsic() {
+        // Mix a real intrinsic tool (`file_read`, unmapped) with mapped exec
+        // tools; a full namespace deny must keep only the intrinsic one.
+        let ws = Path::new("/tmp/oc-toolbelt-deny");
+        let security = test_security(ws, PolicyMode::Supervised);
+        let mut tools: Vec<Box<dyn Tool>> = coding_tools(
+            security.clone(),
+            native_runtime(),
+            AuditLogger::disabled(),
+            ws,
+        );
+        tools.extend(web_tools(security.clone(), Vec::new(), ws));
+        // `file_read` has no mapped namespace → intrinsic → always kept.
+        tools.push(Box::new(oh::tools::FileReadTool::new(security)));
+
+        let deny: HashSet<&'static str> = ["shell", "code", "web"].into_iter().collect();
+        let kept = filter_by_capabilities(tools, &CapabilityFilter::DenyNamespaces(deny));
+        let kept_names = names(&kept);
+        assert_eq!(
+            kept_names,
+            vec!["file_read"],
+            "only the intrinsic tool must survive a full deny: {kept_names:?}"
+        );
+    }
+}

--- a/src/harness/toolbelt.rs
+++ b/src/harness/toolbelt.rs
@@ -128,15 +128,18 @@ pub fn native_runtime() -> Arc<dyn RuntimeAdapter> {
 /// own workspace dir so audit trails are tenant-isolated.
 ///
 /// Audit must never block agent construction, so a logger-init failure degrades
-/// to [`AuditLogger::disabled`] with a warning rather than propagating.
+/// to [`AuditLogger::disabled`] rather than propagating. The failure is logged
+/// at `error!` (not `warn!`): a consistent init failure means every subsequent
+/// shell command for this agent runs with **no audit record**, so the event
+/// must surface in production error telemetry rather than blend into warnings.
 pub fn workspace_audit(workspace: &Path) -> Arc<AuditLogger> {
     match get_or_create_workspace_audit_logger(AuditConfig::default(), workspace.to_path_buf()) {
         Ok(logger) => logger,
         Err(error) => {
-            tracing::warn!(
+            tracing::error!(
                 workspace = %workspace.display(),
                 %error,
-                "[toolbelt] workspace audit logger init failed; shell audit disabled for this agent"
+                "[toolbelt] workspace audit logger init failed; shell commands for this agent will run UNAUDITED"
             );
             AuditLogger::disabled()
         }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -818,6 +818,16 @@ impl RuntimeBuilder {
                                 // snapshot frozen here at boot.
                                 mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
                                 secrets: Some(secrets.clone()),
+                                // Cell A: the `web` toolbelt SSRF allowlist +
+                                // capability-tier filter. Domains come straight
+                                // from the manifest; the filter is `AllowAll`
+                                // until the capability-tier cell lands.
+                                web_allowed_domains: self
+                                    .manifest
+                                    .tools
+                                    .web_allowed_domains
+                                    .clone(),
+                                capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
                             };
                             let record = CompanyRecord {
                                 id: id.clone(),

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1005,6 +1005,8 @@ mod test {
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record);
 

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -150,6 +150,8 @@ description = "Runs Acme."
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         }
     }
 


### PR DESCRIPTION
## Summary

Wires OpenHuman's already-compiled-in **coding** (shell, apply_patch, git, csv_export, workspace_state) and **web** (web_fetch, http_request, curl, image_info) tools into embedded company agents. These tools ship in `openhuman_core` (`oh::tools::*`) but `build_agent` never handed them to the roster. New `src/harness/toolbelt.rs` exposes `coding_tools()` / `web_tools()`, grant namespaces (shell/code/web), and a `CapabilityFilter` (`filter_by_capabilities`) so each company only gets what it's granted.

Foundation for Cells B/C/D (#109/#108/#110).

Closes #107. Part of #26.

## API Or Behavior Changes

- Granted company agents now expose coding + web tools in their tool vector (previously only intrinsic memory/MCP tools).
- All new tools are **grant-gated per company**, **workspace-sandboxed**, and fail-closed:
  - shell/apply_patch honor `ApprovalPolicy` — `rm -rf` denied under read-only, parked under supervised.
  - apply_patch denied outside the company workspace root.
  - web tools reject SSRF IP-literals / private ranges behind the domain allowlist.
- No change for companies without the grants — tool vector is unchanged.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets` (via `cargo check --features openhuman,mcp,telegram` — green)
- [x] `cargo test` — 10 toolbelt tests pass (SSRF reject, rm -rf policy, sandbox-deny, capability filter); full suite green

## Documentation

Tool surface documented inline in `src/harness/toolbelt.rs` module docs. No external doc surface changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an exec-grade toolbelt that conditionally enables shell, code, and web tools (with reserved subagent support) for eligible agents.
  * Introduced capability-tier filtering to control which tools are exposed.
  * Added `web_allowed_domains` to tool manifests and wired it through the harness to restrict web access via SSRF allowlisting (defaults to empty).
* **Bug Fixes**
  * Improved workspace-scoped hardened security, auditing, and safer handling for destructive commands and unsafe web requests.
* **Tests**
  * Added coverage for tool namespace mapping, tool exposure, capability filtering semantics, and web/command security expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->