### PR TITLE
feat(harness): author workflows from company chat via create_workflow (#112)

### DIFF
--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -75,7 +75,10 @@ pub trait EventLog: Send + Sync {
 
 `CompanyEvent` variants: `OperatorMessage`, `WebhookReceived`,
 `ScheduleFired`, `A2aTaskReceived`, `ApprovalResolved`, `FeedbackFiled`,
-`PaymentReceived`.
+`PaymentReceived`, `LifecycleChanged`, `AgentReply`, `MemoryFactDeleted`,
+`TaskDispatched`, `McpCallFailed`, `WorkflowCreated` (a new saved workflow
+graph was authored + enabled via the console `POST …/workflows` route or the
+orchestrator's `create_workflow` tool; journaled best-effort after persist).
 
 ## MemoryStore
 

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -119,6 +119,14 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("MCP call to {server}/{tool} failed ({status}): {message}"),
             "mcp.call_failed",
         ),
+        CompanyEvent::WorkflowCreated {
+            workflow_id, name, ..
+        } => (
+            Role::System,
+            "workflow".to_string(),
+            format!("Created workflow {name} ({workflow_id})"),
+            "workflow.created",
+        ),
     };
     WireEvent {
         seq,

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -20,6 +20,7 @@ pub mod runtime;
 mod skill_file;
 pub mod telegram;
 mod types;
+mod workflow_create;
 mod workflow_file;
 pub mod workspace_seed;
 
@@ -41,6 +42,9 @@ pub use workflow_file::{
 // from its request body, renders it to TOML, and re-parses it through
 // `parse_workflow` above for validation before writing to disk.
 pub(crate) use workflow_file::{RawEdge, RawNode, RawWorkflow, render_workflow};
+// Crate-internal only: the shared validated-persist core (issue #112) both the
+// REST `POST …/workflows` route and the orchestrator `create_workflow` tool run.
+pub(crate) use workflow_create::create_company_workflow;
 pub use workspace_seed::{NodeKind, SeedNode, extract_wikilinks, walk_workspace};
 
 use crate::{Result, VERSION};

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -1,0 +1,796 @@
+//! Feature-free core for authoring a new workflow graph (issue #112).
+//!
+//! [`create_company_workflow`] is the single validated-persist sequence for
+//! creating a `workflows/<id>.toml`, lifted out of the REST handler so **both**
+//! the console's `POST …/workflows` route and the orchestrator's
+//! `create_workflow` tool run exactly the same checks and land the exact same
+//! artifact — no create-vs-run drift, one place to reason about safety.
+//!
+//! The sequence, in order, each step an actionable error before anything is
+//! written:
+//!
+//! 1. the id is a safe filename (no slashes / `..`) and within length caps;
+//! 2. the graph is within the node/edge size caps (a runaway graph can't be
+//!    persisted);
+//! 3. it names exactly one `trigger` (a freshly authored graph must say what
+//!    starts it — stricter than [`parse_workflow`], which allows many);
+//! 4. every `agent` node names a real roster teammate (manifest ∪ overlay);
+//! 5. its display name is unique (case-insensitive) against the company's
+//!    existing on-disk + manifest-enabled workflows;
+//! 6. the rendered TOML re-parses through [`parse_workflow`] (the same
+//!    structural validation a hand-authored file passes) and is within the
+//!    byte cap;
+//! 7. the file is written atomically (`create_new(true)` → a duplicate id is a
+//!    [`Conflict`](OpenCompanyError::Conflict), closing the TOCTOU gap);
+//! 8. the id is recorded as enabled on the operator's live record (the
+//!    version-controlled manifest is never rewritten — the team-overlay
+//!    convention); a store-save failure rolls the file back so the id isn't
+//!    orphaned;
+//! 9. a best-effort [`WorkflowCreated`](CompanyEvent::WorkflowCreated) audit
+//!    event is journaled — never rolling the create back if the journal fails.
+//!
+//! Steps 4–8 run under the per-company [`company_write_lock`] so a concurrent
+//! `create_workflow` (tool) and `POST …/workflows` (REST) can never clobber
+//! each other's `overlay`/`enabled` write, the same primitive `add_agent` uses.
+//!
+//! Compiled in the default build (no harness imports) so the REST route reaches
+//! it without any feature gate.
+
+use std::collections::HashSet;
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::company::{
+    RawWorkflow, WorkflowFile, load_company_workflows, parse_workflow, render_workflow,
+};
+use crate::error::{OpenCompanyError, Result};
+use crate::ports::CompanyStore;
+use crate::ports::events::EventLog;
+use crate::ports::store::company_write_lock;
+use crate::ports::types::{CompanyEvent, CompanyId};
+use crate::server::ops::language;
+
+/// Max nodes a freshly authored graph may declare. A larger graph is refused
+/// before anything is rendered or written.
+pub(crate) const MAX_WORKFLOW_NODES: usize = 50;
+/// Max edges a freshly authored graph may declare.
+pub(crate) const MAX_WORKFLOW_EDGES: usize = 100;
+/// Max size of the rendered `workflows/<id>.toml`, checked after render and
+/// before the file is written.
+pub(crate) const MAX_WORKFLOW_TOML_BYTES: usize = 64 * 1024;
+/// Max length of a workflow id (also the on-disk filename stem).
+pub(crate) const MAX_WORKFLOW_ID_LEN: usize = 64;
+/// Max length of a workflow display name.
+pub(crate) const MAX_WORKFLOW_NAME_LEN: usize = 200;
+
+/// Authors and persists a new workflow graph for `company`, returning the
+/// parsed [`WorkflowFile`] exactly as [`load_company_workflows`] would hand it
+/// to the runner (so what a caller reads back and what runs are identical).
+///
+/// `source_dir` is the company source directory (`companies/<name>`) whose
+/// `workflows/` subtree the graph lands in — the caller supplies it (both
+/// surfaces refuse a deployment with no source directory before calling here,
+/// with [`language::WORKFLOW_NEEDS_SOURCE_DIR`]). `events` is the company event
+/// log for the best-effort audit journal; pass `None` to skip journaling.
+///
+/// Errors map to the same HTTP statuses the REST route always returned:
+/// [`InvalidRequest`](OpenCompanyError::InvalidRequest) → 400,
+/// [`Conflict`](OpenCompanyError::Conflict) → 409.
+pub(crate) async fn create_company_workflow(
+    company: &CompanyId,
+    source_dir: &Path,
+    store: &Arc<dyn CompanyStore>,
+    events: Option<&Arc<dyn EventLog>>,
+    draft: RawWorkflow,
+) -> Result<WorkflowFile> {
+    // --- Input validation (no lock; pure function of the draft) -------------
+
+    if !is_safe_workflow_id(&draft.id) {
+        return Err(OpenCompanyError::InvalidRequest(
+            language::WORKFLOW_ID_INVALID.to_string(),
+        ));
+    }
+    if draft.id.len() > MAX_WORKFLOW_ID_LEN {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "a workflow id can be at most {MAX_WORKFLOW_ID_LEN} characters."
+        )));
+    }
+    if draft.name.trim().len() > MAX_WORKFLOW_NAME_LEN {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "a workflow name can be at most {MAX_WORKFLOW_NAME_LEN} characters."
+        )));
+    }
+    if draft.nodes.len() > MAX_WORKFLOW_NODES {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "a workflow can have at most {MAX_WORKFLOW_NODES} nodes (this one has {}).",
+            draft.nodes.len()
+        )));
+    }
+    if draft.edges.len() > MAX_WORKFLOW_EDGES {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "a workflow can have at most {MAX_WORKFLOW_EDGES} edges (this one has {}).",
+            draft.edges.len()
+        )));
+    }
+
+    // `parse_workflow` only rejects zero triggers (a saved graph may legally
+    // have more than one entry point); the creator is stricter — a freshly
+    // authored graph must name exactly one starting point.
+    let trigger_count = draft.nodes.iter().filter(|n| n.kind == "trigger").count();
+    if trigger_count != 1 {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "a workflow needs exactly one `trigger` node to say what starts it (found {trigger_count})."
+        )));
+    }
+
+    // --- Serialized write section -------------------------------------------
+    // Load record → roster check → name uniqueness → file write → save record
+    // all under the per-company write lock, so a concurrent create/add_agent
+    // can never clobber the record's `enabled`/`overlay` write.
+    let write_lock = company_write_lock(company);
+    let _lock = write_lock.lock().await;
+
+    let mut record = store
+        .load(company)
+        .await?
+        .ok_or_else(|| OpenCompanyError::CompanyNotFound(company.to_string()))?;
+
+    // Cross-check every `agent` node against the company's effective roster
+    // (manifest agents ∪ operator overlay teammates). `parse_workflow` checks
+    // the graph's own shape but has no roster to validate names against.
+    let roster: HashSet<&str> = record
+        .manifest
+        .agents
+        .iter()
+        .map(|a| a.id.as_str())
+        .chain(record.overlay_agents.iter().map(|a| a.id.as_str()))
+        .collect();
+    for node in &draft.nodes {
+        if node.kind != "agent" {
+            continue;
+        }
+        match node.agent.as_deref() {
+            Some(agent_id) if roster.contains(agent_id) => {}
+            Some(agent_id) => {
+                return Err(OpenCompanyError::InvalidRequest(format!(
+                    "node `{}` names teammate `{agent_id}`, which is not on this company's roster.",
+                    node.id
+                )));
+            }
+            None => {
+                return Err(OpenCompanyError::InvalidRequest(format!(
+                    "node `{}` is an agent node but names no teammate.",
+                    node.id
+                )));
+            }
+        }
+    }
+
+    // Case-insensitive display-name uniqueness against the company's existing
+    // workflows (on-disk ∪ manifest-enabled). Id uniqueness stays atomic via
+    // `create_new(true)` below — this only guards two *differently-id'd*
+    // workflows sharing one indistinguishable name in the picker.
+    let existing_names = existing_workflow_names(source_dir, &record.manifest.workflows.enabled);
+    if existing_names.contains(&draft.name.trim().to_ascii_lowercase()) {
+        return Err(OpenCompanyError::Conflict(format!(
+            "A workflow named `{}` already exists. Pick a different name.",
+            draft.name.trim()
+        )));
+    }
+
+    // Render the candidate to TOML and re-parse it through `parse_workflow`,
+    // the same structural validation a hand-authored file passes. Any problem
+    // becomes an `InvalidRequest` (400), never the 500 a malformed on-disk file
+    // gets from the read routes.
+    let toml_src = render_workflow(&draft)?;
+    if toml_src.len() > MAX_WORKFLOW_TOML_BYTES {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "the rendered workflow is {} bytes, over the {MAX_WORKFLOW_TOML_BYTES}-byte limit.",
+            toml_src.len()
+        )));
+    }
+    let file = parse_workflow(&toml_src).map_err(|err| match err {
+        OpenCompanyError::DataInvalid { problems, .. } => {
+            OpenCompanyError::InvalidRequest(problems.join(" "))
+        }
+        OpenCompanyError::DataParse { message, .. } => OpenCompanyError::InvalidRequest(message),
+        other => other,
+    })?;
+
+    let workflows_dir = source_dir.join("workflows");
+    let path = workflows_dir.join(format!("{}.toml", file.id));
+    std::fs::create_dir_all(&workflows_dir).map_err(|source| OpenCompanyError::StoreIo {
+        path: workflows_dir.clone(),
+        source,
+    })?;
+
+    // Write atomically: `create_new(true)` fails if the path already exists,
+    // closing the TOCTOU gap between a separate existence check and the write —
+    // a duplicate id is a clean `Conflict` (409). Clean the empty file up on a
+    // write failure so the id isn't permanently blocked.
+    let mut wf_file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .map_err(|e| match e.kind() {
+            std::io::ErrorKind::AlreadyExists => OpenCompanyError::Conflict(format!(
+                "A workflow named `{}` already exists.",
+                file.id
+            )),
+            _ => OpenCompanyError::StoreIo {
+                path: path.clone(),
+                source: e,
+            },
+        })?;
+    wf_file.write_all(toml_src.as_bytes()).map_err(|source| {
+        let _ = std::fs::remove_file(&path);
+        OpenCompanyError::StoreIo {
+            path: path.clone(),
+            source,
+        }
+    })?;
+    drop(wf_file);
+
+    // Record the id as enabled on the live record — mirrors the team overlay:
+    // the version-controlled `company.toml` on disk is never rewritten. Save
+    // **after** the file lands; on a save failure remove the file we wrote so a
+    // retry can succeed without admin intervention.
+    let save_result = if record
+        .manifest
+        .workflows
+        .enabled
+        .iter()
+        .any(|e| e == &file.id)
+    {
+        Ok(())
+    } else {
+        record.manifest.workflows.enabled.push(file.id.clone());
+        store.save(&record).await
+    };
+    if let Err(e) = save_result {
+        let _ = std::fs::remove_file(&path);
+        return Err(e);
+    }
+
+    // Drop the write lock before journaling: the audit event is best-effort and
+    // never gates the create, so it needn't hold the serialization lock.
+    drop(_lock);
+
+    // Best-effort audit journal. A journal failure never rolls the create back
+    // (the workflow is already persisted + enabled) — we only log it.
+    if let Some(log) = events
+        && let Err(err) = log
+            .append(
+                company,
+                CompanyEvent::WorkflowCreated {
+                    workflow_id: file.id.clone(),
+                    name: file.name.clone(),
+                    by: None,
+                },
+            )
+            .await
+    {
+        tracing::warn!(
+            company = %company,
+            workflow = %file.id,
+            error = %err,
+            "workflow created but audit journal append failed"
+        );
+    }
+
+    Ok(file)
+}
+
+/// The set of existing workflow display names (trimmed, lowercased) for
+/// `source_dir`'s company: every successfully-loaded on-disk `workflows/*.toml`
+/// name, unioned with the id-as-name fallback for each manifest-`enabled` id
+/// that has no loadable file — mirroring how `list_workflows` names the same
+/// set. A malformed on-disk file contributes no name (it's skipped, same as the
+/// picker), so it can't false-positive a conflict.
+fn existing_workflow_names(source_dir: &Path, enabled: &[String]) -> HashSet<String> {
+    let mut names = HashSet::new();
+    let mut seen_ids = HashSet::new();
+
+    if let Ok(entries) = std::fs::read_dir(source_dir.join("workflows")) {
+        let ids: Vec<String> = entries
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("toml"))
+            .filter_map(|path| {
+                path.file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .map(str::to_string)
+            })
+            .collect();
+        for id in ids {
+            match load_company_workflows(source_dir, std::slice::from_ref(&id)) {
+                Ok(mut files) => {
+                    if let Some(file) = files.pop() {
+                        names.insert(file.name.trim().to_ascii_lowercase());
+                        seen_ids.insert(file.id);
+                    }
+                }
+                // A malformed file skips only its own name (same tolerance the
+                // picker has); still mark the id seen so the enabled-fallback
+                // below doesn't re-add it as an id-named entry.
+                Err(_) => {
+                    seen_ids.insert(id);
+                }
+            }
+        }
+    }
+
+    // Manifest-enabled ids with no loadable on-disk file fall back to the id as
+    // their display name (what `list_workflows` shows), so a new workflow can't
+    // collide with that fallback name either.
+    for id in enabled {
+        if !seen_ids.contains(id) {
+            names.insert(id.trim().to_ascii_lowercase());
+        }
+    }
+
+    names
+}
+
+/// Whether `wid` is a single safe on-disk filename stem — no path separators, no
+/// `..`, not empty — so it can't escape the `workflows/` directory.
+fn is_safe_workflow_id(wid: &str) -> bool {
+    use std::path::Component;
+    let mut comps = Path::new(wid).components();
+    matches!(comps.next(), Some(Component::Normal(_))) && comps.next().is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    use crate::company::{CompanyManifest, RawEdge, RawNode};
+    use crate::ports::types::{CompanyRecord, CompanySummary, EventSeq, LedgerEntry, StoredEvent};
+    use async_trait::async_trait;
+    use futures::stream::{self, BoxStream};
+
+    // --- test doubles --------------------------------------------------------
+
+    /// An in-memory `CompanyStore` seeded with one record; `save` can be told to
+    /// fail so the file-rollback path is exercised.
+    #[derive(Default)]
+    struct MemStore {
+        record: StdMutex<Option<CompanyRecord>>,
+        fail_save: bool,
+    }
+
+    impl MemStore {
+        fn seeded(record: CompanyRecord) -> Self {
+            Self {
+                record: StdMutex::new(Some(record)),
+                fail_save: false,
+            }
+        }
+        fn failing(record: CompanyRecord) -> Self {
+            Self {
+                record: StdMutex::new(Some(record)),
+                fail_save: true,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl CompanyStore for MemStore {
+        async fn load(&self, _id: &CompanyId) -> Result<Option<CompanyRecord>> {
+            Ok(self.record.lock().unwrap().clone())
+        }
+        async fn save(&self, record: &CompanyRecord) -> Result<()> {
+            if self.fail_save {
+                return Err(OpenCompanyError::InvalidRequest("save boom".into()));
+            }
+            *self.record.lock().unwrap() = Some(record.clone());
+            Ok(())
+        }
+        async fn list(&self) -> Result<Vec<CompanySummary>> {
+            Ok(Vec::new())
+        }
+        async fn append_ledger(&self, _id: &CompanyId, _entry: LedgerEntry) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    /// An in-memory `EventLog` that records appended events so the audit journal
+    /// can be asserted.
+    #[derive(Default)]
+    struct MemLog {
+        events: StdMutex<Vec<CompanyEvent>>,
+    }
+
+    #[async_trait]
+    impl EventLog for MemLog {
+        async fn append(&self, _id: &CompanyId, event: CompanyEvent) -> Result<EventSeq> {
+            let mut guard = self.events.lock().unwrap();
+            guard.push(event);
+            Ok(EventSeq::new(guard.len() as u64))
+        }
+        async fn read_from(
+            &self,
+            _id: &CompanyId,
+            _seq: EventSeq,
+            _limit: usize,
+        ) -> Result<Vec<StoredEvent>> {
+            Ok(Vec::new())
+        }
+        fn subscribe(&self, _id: &CompanyId) -> BoxStream<'static, StoredEvent> {
+            Box::pin(stream::empty())
+        }
+    }
+
+    // --- fixtures ------------------------------------------------------------
+
+    /// A manifest with an `assistant` roster agent so `agent`-node graphs pass
+    /// the roster check.
+    fn manifest_with_assistant() -> CompanyManifest {
+        toml::from_str(
+            "[company]\nname = \"Acme\"\n[[agent]]\nid = \"assistant\"\nrole = \"Assistant\"\n",
+        )
+        .expect("valid manifest")
+    }
+
+    fn record(id: &CompanyId, manifest: CompanyManifest) -> CompanyRecord {
+        CompanyRecord {
+            id: id.clone(),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+        }
+    }
+
+    /// A valid trigger → agent → output draft naming the `assistant` teammate.
+    fn valid_draft(id: &str, name: &str) -> RawWorkflow {
+        RawWorkflow {
+            id: id.to_string(),
+            name: name.to_string(),
+            description: Some("A tiny graph.".to_string()),
+            nodes: vec![
+                RawNode {
+                    id: "start".to_string(),
+                    kind: "trigger".to_string(),
+                    name: "Start".to_string(),
+                    summary: None,
+                    agent: None,
+                },
+                RawNode {
+                    id: "worker".to_string(),
+                    kind: "agent".to_string(),
+                    name: "Worker".to_string(),
+                    summary: None,
+                    agent: Some("assistant".to_string()),
+                },
+                RawNode {
+                    id: "done".to_string(),
+                    kind: "output".to_string(),
+                    name: "Report".to_string(),
+                    summary: None,
+                    agent: None,
+                },
+            ],
+            edges: vec![
+                RawEdge {
+                    from: "start".to_string(),
+                    to: "worker".to_string(),
+                    label: None,
+                },
+                RawEdge {
+                    from: "worker".to_string(),
+                    to: "done".to_string(),
+                    label: Some("ok".to_string()),
+                },
+            ],
+        }
+    }
+
+    fn store_of(store: MemStore) -> Arc<dyn CompanyStore> {
+        Arc::new(store)
+    }
+
+    // --- happy path ----------------------------------------------------------
+
+    #[tokio::test]
+    async fn creates_enables_and_journals() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let log = Arc::new(MemLog::default());
+        let log_dyn: Arc<dyn EventLog> = log.clone();
+
+        let file = create_company_workflow(
+            &company,
+            dir.path(),
+            &store,
+            Some(&log_dyn),
+            valid_draft("greeter", "Greeter"),
+        )
+        .await
+        .expect("creates");
+
+        assert_eq!(file.id, "greeter");
+        assert_eq!(file.nodes.len(), 3);
+
+        // File landed and re-loads to exactly what we returned (contract).
+        let reloaded = load_company_workflows(dir.path(), std::slice::from_ref(&file.id))
+            .expect("reloads")
+            .into_iter()
+            .next()
+            .expect("one file");
+        assert_eq!(
+            reloaded, file,
+            "returned WorkflowFile must equal the on-disk load"
+        );
+
+        // Enabled on the record.
+        let record = store.load(&company).await.unwrap().unwrap();
+        assert!(
+            record
+                .manifest
+                .workflows
+                .enabled
+                .contains(&"greeter".to_string())
+        );
+
+        // Journaled a WorkflowCreated audit event.
+        let events = log.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            CompanyEvent::WorkflowCreated {
+                workflow_id,
+                name,
+                by,
+            } => {
+                assert_eq!(workflow_id, "greeter");
+                assert_eq!(name, "Greeter");
+                assert!(by.is_none());
+            }
+            other => panic!("expected WorkflowCreated, got {other:?}"),
+        }
+    }
+
+    // --- guardrail failures --------------------------------------------------
+
+    #[tokio::test]
+    async fn duplicate_id_is_conflict() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        create_company_workflow(
+            &company,
+            dir.path(),
+            &store,
+            None,
+            valid_draft("dup", "First"),
+        )
+        .await
+        .expect("first create");
+        let err = create_company_workflow(
+            &company,
+            dir.path(),
+            &store,
+            None,
+            valid_draft("dup", "Second name"),
+        )
+        .await
+        .expect_err("second create with same id");
+        assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn duplicate_name_case_insensitive_is_conflict() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        create_company_workflow(
+            &company,
+            dir.path(),
+            &store,
+            None,
+            valid_draft("one", "Greeter"),
+        )
+        .await
+        .expect("first");
+        let err = create_company_workflow(
+            &company,
+            dir.path(),
+            &store,
+            None,
+            valid_draft("two", "  GREETER  "),
+        )
+        .await
+        .expect_err("name collides case-insensitively");
+        assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn unknown_roster_teammate_is_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let mut draft = valid_draft("wf", "WF");
+        draft.nodes[1].agent = Some("ghost".to_string());
+
+        let err = create_company_workflow(&company, dir.path(), &store, None, draft)
+            .await
+            .expect_err("unknown teammate");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+        assert!(err.to_string().contains("ghost"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn missing_agent_on_agent_node_is_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let mut draft = valid_draft("wf", "WF");
+        draft.nodes[1].agent = None;
+
+        let err = create_company_workflow(&company, dir.path(), &store, None, draft)
+            .await
+            .expect_err("agent node with no teammate");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn zero_or_two_triggers_is_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        // Zero triggers.
+        let mut zero = valid_draft("z", "Z");
+        zero.nodes[0].kind = "output".to_string();
+        let err = create_company_workflow(&company, dir.path(), &store, None, zero)
+            .await
+            .expect_err("no trigger");
+        assert!(err.to_string().contains("exactly one `trigger`"), "{err}");
+
+        // Two triggers.
+        let mut two = valid_draft("t", "T");
+        two.nodes[2].kind = "trigger".to_string();
+        let err = create_company_workflow(&company, dir.path(), &store, None, two)
+            .await
+            .expect_err("two triggers");
+        assert!(err.to_string().contains("exactly one `trigger`"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn traversal_id_is_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let err = create_company_workflow(
+            &company,
+            dir.path(),
+            &store,
+            None,
+            valid_draft("../secrets", "Escape"),
+        )
+        .await
+        .expect_err("traversal id");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn oversized_node_count_is_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let mut draft = valid_draft("big", "Big");
+        for i in 0..MAX_WORKFLOW_NODES {
+            draft.nodes.push(RawNode {
+                id: format!("n{i}"),
+                kind: "output".to_string(),
+                name: format!("N{i}"),
+                summary: None,
+                agent: None,
+            });
+        }
+        assert!(draft.nodes.len() > MAX_WORKFLOW_NODES);
+        let err = create_company_workflow(&company, dir.path(), &store, None, draft)
+            .await
+            .expect_err("too many nodes");
+        assert!(err.to_string().contains("at most"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn oversized_toml_bytes_is_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        // Stay within the node cap but blow the byte cap with a huge summary.
+        let mut draft = valid_draft("fat", "Fat");
+        draft.nodes[0].summary = Some("x".repeat(MAX_WORKFLOW_TOML_BYTES + 10));
+        let err = create_company_workflow(&company, dir.path(), &store, None, draft)
+            .await
+            .expect_err("too many bytes");
+        assert!(err.to_string().contains("byte"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn store_save_failure_rolls_the_file_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::failing(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        let err = create_company_workflow(
+            &company,
+            dir.path(),
+            &store,
+            None,
+            valid_draft("rollback", "Rollback"),
+        )
+        .await
+        .expect_err("save fails");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+
+        // The file must have been removed so a retry can succeed.
+        let path = dir.path().join("workflows").join("rollback.toml");
+        assert!(!path.exists(), "the orphaned file must be cleaned up");
+    }
+
+    #[tokio::test]
+    async fn no_company_record_is_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("ghost");
+        let store: Arc<dyn CompanyStore> = Arc::new(MemStore::default());
+        let err =
+            create_company_workflow(&company, dir.path(), &store, None, valid_draft("wf", "WF"))
+                .await
+                .expect_err("no record");
+        assert!(
+            matches!(err, OpenCompanyError::CompanyNotFound(_)),
+            "{err:?}"
+        );
+    }
+}

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -9,7 +9,7 @@
 //! first agent when none is tagged (so a company without an orchestrator behaves
 //! exactly as before).
 //!
-//! It reaches five tools, all wired only onto the orchestrator agent:
+//! It reaches six tools, all wired only onto the orchestrator agent:
 //!
 //! * [`QueryCompanyTool`] — a read surface over the company's [`FactStore`] and
 //!   recent [`EventLog`] history.
@@ -25,6 +25,11 @@
 //!   task waiting on a workflow can actually be run to completion. Unlike the
 //!   delegation tools it runs the graph inline and returns a concise summary of
 //!   the run rather than enqueuing deferred work.
+//! * [`CreateWorkflowTool`] (issue #112) — authors and saves a brand-new
+//!   workflow graph through the same validated-persist core the console
+//!   `POST .../workflows` route runs, so the orchestrator can capture a
+//!   repeatable process mid-chat; it lands enabled and runnable by
+//!   [`RunWorkflowTool`] the same turn.
 //! * [`AddAgentTool`] (issue #71) — writes a new [`OverlayAgent`] through the
 //!   same store path the console `POST .../team` route uses, so the
 //!   orchestrator can bring on a teammate mid-chat.
@@ -43,7 +48,10 @@ use openhuman_core::openhuman as oh;
 
 use oh::tools::traits::{PermissionLevel, Tool, ToolResult};
 
-use crate::company::{Agent as ManifestAgent, WorkflowFile, load_company_workflows};
+use crate::company::{
+    Agent as ManifestAgent, RawEdge, RawNode, RawWorkflow, WorkflowFile, create_company_workflow,
+    load_company_workflows,
+};
 use crate::error::OpenCompanyError;
 use crate::ports::events::EventLog;
 use crate::ports::facts::FactStore;
@@ -73,6 +81,8 @@ pub const DELEGATE_TO_DESK_TOOL: &str = "delegate_to_desk";
 pub const RUN_WORKFLOW_TOOL: &str = "run_workflow";
 /// The `add_agent` tool name (issue #71 — Active Runtime Teammates).
 pub const ADD_AGENT_TOOL: &str = "add_agent";
+/// The `create_workflow` tool name (issue #112 — author a saved workflow graph).
+pub const CREATE_WORKFLOW_TOOL: &str = "create_workflow";
 
 /// The id of the orchestrator agent for a roster: the first agent tagged
 /// `tier = "orchestrator"`, else the first roster agent, else `None` (empty
@@ -95,7 +105,10 @@ pub fn orchestrator_id(agents: &[ManifestAgent]) -> Option<String> {
 /// [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy) classifies them as
 /// internal — never an external effect to park or deny.
 pub fn is_delegation_tool(tool: &str) -> bool {
-    tool == SPAWN_TASK_TOOL || tool == DELEGATE_TO_DESK_TOOL || tool == ADD_AGENT_TOOL
+    tool == SPAWN_TASK_TOOL
+        || tool == DELEGATE_TO_DESK_TOOL
+        || tool == ADD_AGENT_TOOL
+        || tool == CREATE_WORKFLOW_TOOL
 }
 
 /// The orchestrator persona brief, appended to the orchestrator agent's persona.
@@ -107,10 +120,13 @@ company's durable facts and recent activity, `delegate_to_desk` to hand a turn t
 member, `spawn_task` to open a tracked task card, `run_workflow` to execute one of the \
 company's saved workflows by id (for example to advance or finish a task that is waiting on a \
 workflow run) — you can run workflows yourself; never claim the run_workflow tool is unavailable — \
-and `add_agent` to bring on a new teammate (a name, role, and optional mandate) when the company \
-genuinely needs one — it becomes a real, addressable member of the team starting next turn. \
-Delegate, run a workflow, or add a teammate only when it genuinely helps — otherwise answer \
-directly and concisely."
+`create_workflow` to author and save a brand-new workflow graph (a trigger plus agent / tool / \
+condition / output steps) when a repeatable process is worth capturing — it's enabled immediately \
+and runnable with run_workflow — and `add_agent` to bring on a new teammate (a name, role, and \
+optional mandate) when the company genuinely needs one — it becomes a real, addressable member of \
+the team starting next turn. \
+Delegate, run or create a workflow, or add a teammate only when it genuinely helps — otherwise \
+answer directly and concisely."
         .to_string()
 }
 
@@ -317,6 +333,9 @@ fn summarize_event(event: &CompanyEvent) -> String {
         CompanyEvent::McpCallFailed { server, tool, .. } => {
             format!("MCP call failed: {server}/{tool}")
         }
+        CompanyEvent::WorkflowCreated {
+            workflow_id, name, ..
+        } => format!("workflow created: {name} ({workflow_id})"),
     }
 }
 
@@ -605,9 +624,10 @@ impl Tool for AddAgentTool {
 // ---------------------------------------------------------------------------
 
 /// The complete tool set wired onto the company's orchestrator agent (issues
-/// #53, #67, and #71), in order: the `query_company` read surface, the
+/// #53, #67, #71, and #112), in order: the `query_company` read surface, the
 /// `spawn_task` and `delegate_to_desk` delegation tools, the `run_workflow`
-/// execution tool, and the `add_agent` roster-write tool.
+/// execution tool, the `create_workflow` authoring tool, and the `add_agent`
+/// roster-write tool.
 ///
 /// [`build_agent`](crate::harness::build::build_agent) extends the orchestrator
 /// agent's tools with exactly this vector, so a test over this function is the
@@ -628,13 +648,22 @@ pub fn orchestrator_tools(
     let mut tools: Vec<Box<dyn Tool>> = vec![Box::new(QueryCompanyTool::new(
         company.clone(),
         facts,
-        events,
+        events.clone(),
     ))];
     tools.extend(delegation_tools(queue));
     tools.push(Box::new(RunWorkflowTool::new(
         company.clone(),
-        workflow_source_dir,
+        workflow_source_dir.clone(),
         workflow_runner,
+    )));
+    // `create_workflow` (issue #112) shares the same source dir the run tool
+    // reads graphs from, plus the store it enables the new id on and the event
+    // log it journals the audit event to.
+    tools.push(Box::new(CreateWorkflowTool::new(
+        company.clone(),
+        workflow_source_dir,
+        store.clone(),
+        events,
     )));
     tools.push(Box::new(AddAgentTool::new(company, store)));
     tools
@@ -917,6 +946,254 @@ fn preview_item(item: &Value) -> String {
     }
 }
 
+// ---------------------------------------------------------------------------
+// create_workflow (issue #112)
+// ---------------------------------------------------------------------------
+
+/// The camelCase request shape the `create_workflow` tool accepts — the same
+/// graph shape the console's creator posts to `POST …/workflows` and the read
+/// routes return (`id`/`name`/`description?`/`nodes`/`edges`), so a graph the
+/// orchestrator authors is indistinguishable from one authored in the console.
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateWorkflowArgs {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    nodes: Vec<CreateWorkflowArgNode>,
+    #[serde(default)]
+    edges: Vec<CreateWorkflowArgEdge>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateWorkflowArgNode {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    kind: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    agent: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateWorkflowArgEdge {
+    #[serde(default)]
+    from: String,
+    #[serde(default)]
+    to: String,
+    #[serde(default)]
+    label: Option<String>,
+}
+
+impl From<CreateWorkflowArgs> for RawWorkflow {
+    fn from(args: CreateWorkflowArgs) -> Self {
+        Self {
+            id: args.id,
+            name: args.name,
+            description: args.description,
+            nodes: args
+                .nodes
+                .into_iter()
+                .map(|n| RawNode {
+                    id: n.id,
+                    kind: n.kind,
+                    name: n.name,
+                    summary: n.summary,
+                    agent: n.agent,
+                })
+                .collect(),
+            edges: args
+                .edges
+                .into_iter()
+                .map(|e| RawEdge {
+                    from: e.from,
+                    to: e.to,
+                    label: e.label,
+                })
+                .collect(),
+        }
+    }
+}
+
+/// A tool that lets the orchestrator author and save a brand-new workflow graph
+/// mid-chat (issue #112).
+///
+/// It runs the exact same validated-persist core the console's
+/// `POST …/workflows` route runs
+/// ([`create_company_workflow`](crate::company::create_company_workflow)): safe
+/// id + size caps, exactly one trigger, roster cross-check, case-insensitive
+/// name uniqueness, [`parse_workflow`](crate::company::parse_workflow)
+/// revalidation, atomic write, enable-on-record, best-effort audit event. So a
+/// workflow the orchestrator creates is byte-identical to one created in the
+/// console, immediately enabled, and runnable via `run_workflow` the same turn.
+///
+/// Every failure mode — no source directory, an invalid graph, a duplicate id
+/// or name, a store write error — is an agent-actionable [`ToolResult::error`]
+/// (the [`RunWorkflowTool`] convention), never a panic, so the orchestrator can
+/// reason about and report exactly what to fix.
+pub struct CreateWorkflowTool {
+    company: CompanyId,
+    source_dir: Option<PathBuf>,
+    store: Arc<dyn CompanyStore>,
+    events: Option<Arc<dyn EventLog>>,
+}
+
+impl CreateWorkflowTool {
+    /// Builds the tool over the company id, its on-disk source directory
+    /// (`companies/<name>`, whose `workflows/` subtree the graph lands in), the
+    /// company store (to enable the new id), and the event log (to journal the
+    /// audit event).
+    pub fn new(
+        company: CompanyId,
+        source_dir: Option<PathBuf>,
+        store: Arc<dyn CompanyStore>,
+        events: Option<Arc<dyn EventLog>>,
+    ) -> Self {
+        Self {
+            company,
+            source_dir,
+            store,
+            events,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for CreateWorkflowTool {
+    fn name(&self) -> &str {
+        CREATE_WORKFLOW_TOOL
+    }
+
+    fn description(&self) -> &str {
+        "Author and save a new workflow graph for the company, then enable it so it can be run with run_workflow. A workflow is a directed graph: exactly one `trigger` node (what starts it) plus any of `agent` (a roster teammate does a step — set `agent` to that teammate's id), `tool_call`, `http_request`, `condition`, and `output` nodes, joined by `edges` ({from, to, optional label}). Node ids must be unique; every `agent` node must name a real teammate. Use this to capture a repeatable process; then run it with run_workflow."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "A short unique id (the on-disk filename stem): no spaces, slashes, or `..`."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "A human-readable name, unique among the company's workflows (case-insensitive)."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "An optional one-line description of what the workflow does."
+                },
+                "nodes": {
+                    "type": "array",
+                    "description": "The graph's nodes. Exactly one must be a `trigger`.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": { "type": "string", "description": "Node id, unique within the graph." },
+                            "kind": {
+                                "type": "string",
+                                "enum": ["trigger", "agent", "tool_call", "http_request", "condition", "output"],
+                                "description": "One of the six node kinds."
+                            },
+                            "name": { "type": "string", "description": "Human-readable node name." },
+                            "summary": { "type": "string", "description": "Optional short description of the step." },
+                            "agent": { "type": "string", "description": "On an `agent` node only: the roster teammate id that performs the step." }
+                        },
+                        "required": ["id", "kind", "name"],
+                        "additionalProperties": false
+                    }
+                },
+                "edges": {
+                    "type": "array",
+                    "description": "Directed edges between node ids.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "from": { "type": "string", "description": "Source node id." },
+                            "to": { "type": "string", "description": "Destination node id." },
+                            "label": { "type": "string", "description": "Optional branch label (e.g. `yes`/`no` off a condition)." }
+                        },
+                        "required": ["from", "to"],
+                        "additionalProperties": false
+                    }
+                }
+            },
+            "required": ["id", "name", "nodes"],
+            "additionalProperties": false
+        })
+    }
+
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Write
+    }
+
+    fn supports_markdown(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let draft: RawWorkflow = match serde_json::from_value::<CreateWorkflowArgs>(args) {
+            Ok(args) => args.into(),
+            Err(err) => {
+                tracing::debug!(company = %self.company, error = %err, "create_workflow: unreadable args");
+                return Ok(ToolResult::error(format!(
+                    "Couldn't read the workflow definition: {err}. Provide `id`, `name`, and `nodes` (with an `edges` list)."
+                )));
+            }
+        };
+
+        // A deployment with no source directory has nowhere to write the graph.
+        let Some(source_dir) = self.source_dir.as_deref() else {
+            tracing::debug!(company = %self.company, "create_workflow: no source dir");
+            return Ok(ToolResult::error(
+                "This company has no on-disk workflow definitions on this deployment, so there's nowhere to save a new workflow.",
+            ));
+        };
+
+        tracing::debug!(company = %self.company, workflow = %draft.id, "create_workflow: authoring");
+        match create_company_workflow(
+            &self.company,
+            source_dir,
+            &self.store,
+            self.events.as_ref(),
+            draft,
+        )
+        .await
+        {
+            Ok(file) => {
+                tracing::debug!(company = %self.company, workflow = %file.id, "create_workflow: created");
+                let md = format!(
+                    "Created workflow **{}** (`{}`). It's enabled and ready to run — use `run_workflow` with id `{}` to execute it.",
+                    file.name.trim(),
+                    file.id,
+                    file.id
+                );
+                Ok(ToolResult::success_with_markdown(
+                    json!({ "workflow": file.id }),
+                    md,
+                ))
+            }
+            Err(err) => {
+                tracing::debug!(company = %self.company, error = %err, "create_workflow: rejected");
+                Ok(ToolResult::error(format!(
+                    "Couldn't create the workflow: {err}"
+                )))
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -961,6 +1238,7 @@ mod tests {
         assert!(is_delegation_tool(SPAWN_TASK_TOOL));
         assert!(is_delegation_tool(DELEGATE_TO_DESK_TOOL));
         assert!(is_delegation_tool(ADD_AGENT_TOOL));
+        assert!(is_delegation_tool(CREATE_WORKFLOW_TOOL));
         // The read tool is NOT a delegation tool.
         assert!(!is_delegation_tool(QUERY_COMPANY_TOOL));
         assert!(!is_delegation_tool("send_email"));
@@ -1270,7 +1548,7 @@ mod tests {
     }
 
     #[test]
-    fn orchestrator_tools_includes_all_five() {
+    fn orchestrator_tools_includes_all_six() {
         let queue = DelegationQueue::default();
         let tools = orchestrator_tools(
             CompanyId::new("acme"),
@@ -1282,7 +1560,9 @@ mod tests {
             Arc::new(MemStore::default()),
         );
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert_eq!(names.len(), 6, "got {names:?}");
         assert!(names.contains(&RUN_WORKFLOW_TOOL), "got {names:?}");
+        assert!(names.contains(&CREATE_WORKFLOW_TOOL), "got {names:?}");
         assert!(names.contains(&ADD_AGENT_TOOL), "got {names:?}");
         assert!(names.contains(&QUERY_COMPANY_TOOL), "got {names:?}");
         assert!(names.contains(&SPAWN_TASK_TOOL), "got {names:?}");
@@ -1423,5 +1703,151 @@ mod tests {
             .await
             .expect("execute");
         assert!(result.is_error);
+    }
+
+    // ---- create_workflow (issue #112) ----
+
+    /// A record with an `assistant` roster agent so an `agent`-node graph passes
+    /// the roster cross-check inside the create core.
+    fn record_with_assistant(company: &CompanyId) -> CompanyRecord {
+        let manifest: crate::company::CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n[[agent]]\nid = \"assistant\"\nrole = \"Assistant\"\n",
+        )
+        .expect("valid manifest");
+        CompanyRecord {
+            id: company.clone(),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+        }
+    }
+
+    /// The canonical happy graph the create tool accepts (camelCase body).
+    fn greeter_body() -> Value {
+        json!({
+            "id": "greeter",
+            "name": "Greeter",
+            "description": "Says hi.",
+            "nodes": [
+                { "id": "start", "kind": "trigger", "name": "Start" },
+                { "id": "worker", "kind": "agent", "name": "Worker", "agent": "assistant" },
+                { "id": "done", "kind": "output", "name": "Report" }
+            ],
+            "edges": [
+                { "from": "start", "to": "worker" },
+                { "from": "worker", "to": "done", "label": "ok" }
+            ]
+        })
+    }
+
+    #[tokio::test]
+    async fn create_workflow_tool_then_run_workflow_tool() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store: Arc<dyn CompanyStore> =
+            Arc::new(MemStore::seeded(record_with_assistant(&company)));
+
+        // Author the graph.
+        let create = CreateWorkflowTool::new(
+            company.clone(),
+            Some(dir.path().to_path_buf()),
+            store.clone(),
+            None,
+        );
+        let created = create.execute(greeter_body()).await.expect("execute");
+        assert!(!created.is_error, "create should succeed: {created:?}");
+        assert!(
+            created.output_for_llm(true).contains("run_workflow"),
+            "{created:?}"
+        );
+
+        // It's enabled on the record.
+        let record = store.load(&company).await.unwrap().unwrap();
+        assert!(
+            record
+                .manifest
+                .workflows
+                .enabled
+                .contains(&"greeter".to_string())
+        );
+
+        // And immediately runnable via the run tool over the same source dir.
+        let runner: Arc<dyn WorkflowRunner> = Arc::new(StubRunner::new(WorkflowRun {
+            output: json!({ "nodes": { "worker": { "items": ["hi"] } } }),
+            pending_approvals: Vec::new(),
+        }));
+        let handle = WorkflowRunnerHandle::default();
+        handle.set(&runner);
+        let run = RunWorkflowTool::new(company.clone(), Some(dir.path().to_path_buf()), handle);
+        let result = run
+            .execute(json!({ "id": "greeter" }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error, "run should succeed: {result:?}");
+        assert!(
+            result.output_for_llm(true).contains("Greeter"),
+            "{result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_workflow_tool_guardrail_failure_is_error_result() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store: Arc<dyn CompanyStore> =
+            Arc::new(MemStore::seeded(record_with_assistant(&company)));
+        let tool = CreateWorkflowTool::new(company, Some(dir.path().to_path_buf()), store, None);
+        // Zero triggers — a guardrail failure must be an is_error ToolResult, not
+        // a raised anyhow error.
+        let result = tool
+            .execute(json!({
+                "id": "bad",
+                "name": "Bad",
+                "nodes": [ { "id": "a", "kind": "output", "name": "A" } ],
+                "edges": []
+            }))
+            .await
+            .expect("execute returns a result, not an error");
+        assert!(result.is_error, "{result:?}");
+        assert!(
+            result.output_for_llm(false).contains("trigger"),
+            "{result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_workflow_tool_errors_without_source_dir() {
+        let store: Arc<dyn CompanyStore> = Arc::new(MemStore::default());
+        let tool = CreateWorkflowTool::new(CompanyId::new("acme"), None, store, None);
+        let result = tool
+            .execute(json!({ "id": "x", "name": "X", "nodes": [] }))
+            .await
+            .expect("execute");
+        assert!(result.is_error);
+        assert!(
+            result.output_for_llm(false).contains("nowhere to save"),
+            "{result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_workflow_tool_errors_on_unreadable_args() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn CompanyStore> = Arc::new(MemStore::default());
+        let tool = CreateWorkflowTool::new(
+            CompanyId::new("acme"),
+            Some(dir.path().to_path_buf()),
+            store,
+            None,
+        );
+        // A non-object payload can't deserialize into the create body.
+        let result = tool.execute(json!(42)).await.expect("execute");
+        assert!(result.is_error);
+        assert!(
+            result.output_for_llm(false).contains("Couldn't read"),
+            "{result:?}"
+        );
     }
 }

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -333,6 +333,24 @@ pub enum CompanyEvent {
         /// A short, scrubbed, operator-facing message.
         message: String,
     },
+    /// A new workflow graph was authored and enabled (issue #112), from either
+    /// the console `POST …/workflows` route or the orchestrator's
+    /// `create_workflow` tool. Journaled best-effort **after** the graph is
+    /// persisted and enabled, so it records a completed create — a journal
+    /// failure never rolls the create back. Additive: old logs never carry it,
+    /// and its presence doesn't change how any existing variant serializes.
+    WorkflowCreated {
+        /// The new workflow's id (its `workflows/<id>.toml` stem).
+        workflow_id: String,
+        /// The new workflow's display name.
+        name: String,
+        /// Who authored it, when known. `None` when created by a surface that
+        /// carries no attributed actor (the current create paths); kept as an
+        /// `Option` so a future attributed create needs no migration, mirroring
+        /// [`OperatorMessage`](Self::OperatorMessage)'s `by`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        by: Option<Actor>,
+    },
 }
 
 /// A `CompanyEvent` durably appended to the log with its sequence and time.

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -381,6 +381,18 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             o["memo"] = json!(memo);
             o
         }
+        // Issue #112: surface a newly authored workflow so the console can react
+        // live (e.g. refresh the Workflows tab). Only the id + display name go on
+        // the wire — the actor (`by`) is omitted, matching the deny-by-default
+        // projection of the other attributed events.
+        CompanyEvent::WorkflowCreated {
+            workflow_id, name, ..
+        } => {
+            let mut o = envelope("workflow_created");
+            o["workflowId"] = json!(workflow_id);
+            o["name"] = json!(name);
+            o
+        }
         // Not an attention signal, or carries a raw payload we never put on the
         // wire — dropped.
         _ => return None,

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -37,7 +37,6 @@
 //! even on a build that cannot execute them.
 
 use std::collections::HashSet;
-use std::io::Write;
 use std::path::Path as FsPath;
 
 use axum::extract::Path;
@@ -50,7 +49,7 @@ use serde_json::Value;
 use crate::AppState;
 use crate::company::{
     RawEdge, RawNode, RawWorkflow, WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef,
-    load_company_workflows, parse_workflow, render_workflow,
+    create_company_workflow, load_company_workflows,
 };
 use crate::error::OpenCompanyError;
 use crate::server::error::ApiError;
@@ -307,156 +306,39 @@ impl From<CreateWorkflowBody> for RawWorkflow {
 /// form creator, or any direct API caller, posts the graph shape and it lands
 /// as a new `workflows/<id>.toml` in the company's source directory.
 ///
-/// Order of checks, each returning an actionable 4xx before anything is
-/// written: the id must be a safe filename, the deployment must have a source
-/// directory to write into, the id must not already be taken (409), every
-/// `agent` node must name a real roster teammate, and the graph must pass the
-/// same structural validation ([`parse_workflow`]) a hand-authored file would
-/// (at least one trigger, unique node ids, edges that reference real nodes, no
-/// stray `agent` field on a non-agent node).
+/// A thin shim over [`create_company_workflow`] (issue #112), the shared
+/// validated-persist core the orchestrator's `create_workflow` tool also runs —
+/// so both surfaces enforce the same checks (safe id + length/size caps,
+/// exactly one trigger, roster cross-check, case-insensitive name uniqueness,
+/// [`parse_workflow`](crate::company::parse_workflow) revalidation, atomic
+/// write, enable, best-effort audit event) and land the identical artifact.
+///
+/// The only work left at this layer is the two request-shaped concerns: refuse
+/// a deployment with no writable source directory (a hosted tenant with nothing
+/// seeded) before calling the core, and map the core's error variants to HTTP
+/// statuses — [`InvalidRequest`](OpenCompanyError::InvalidRequest) → 400,
+/// [`Conflict`](OpenCompanyError::Conflict) → 409 — via [`ApiError`].
 async fn create_workflow(
     company: ScopedCompany,
     Json(body): Json<CreateWorkflowBody>,
 ) -> Result<Json<WorkflowGraph>, ApiError> {
-    if !safe_wid(&body.id) {
-        return Err(ApiError(OpenCompanyError::InvalidRequest(
-            language::WORKFLOW_ID_INVALID.to_string(),
-        )));
-    }
-
+    // A deployment with no source directory (platform-provisioned mode with
+    // nothing seeded on disk yet) has nowhere to write the graph file.
     let source_dir = company.runtime.source_dir().ok_or_else(|| {
         ApiError(OpenCompanyError::InvalidRequest(
             language::WORKFLOW_NEEDS_SOURCE_DIR.to_string(),
         ))
     })?;
 
-    let workflows_dir = source_dir.join("workflows");
-    let path = workflows_dir.join(format!("{}.toml", body.id));
-
-    std::fs::create_dir_all(&workflows_dir).map_err(|source| {
-        ApiError(OpenCompanyError::StoreIo {
-            path: workflows_dir.clone(),
-            source,
-        })
-    })?;
-
-    // `parse_workflow` only rejects zero triggers (a saved graph may legally
-    // have more, e.g. multiple entry points); the creator is stricter — a
-    // freshly authored graph must name exactly one starting point.
-    let trigger_count = body.nodes.iter().filter(|n| n.kind == "trigger").count();
-    if trigger_count != 1 {
-        return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
-            "a workflow needs exactly one `trigger` node to say what starts it (found {trigger_count})."
-        ))));
-    }
-
-    // Cross-check every `agent` node against the company's effective roster
-    // (manifest agents + operator overlay teammates) before writing anything.
-    // `parse_workflow` validates the graph's own shape but has no roster to
-    // check names against.
-    let mut record = company
-        .runtime
-        .store()
-        .load(company.id())
-        .await?
-        .ok_or_else(|| OpenCompanyError::CompanyNotFound(company.id().to_string()))?;
-    let roster: HashSet<&str> = record
-        .manifest
-        .agents
-        .iter()
-        .map(|a| a.id.as_str())
-        .chain(record.overlay_agents.iter().map(|a| a.id.as_str()))
-        .collect();
-    for node in &body.nodes {
-        if node.kind != "agent" {
-            continue;
-        }
-        match node.agent.as_deref() {
-            Some(agent_id) if roster.contains(agent_id) => {}
-            Some(agent_id) => {
-                return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
-                    "node `{}` names teammate `{agent_id}`, which is not on this company's roster.",
-                    node.id
-                ))));
-            }
-            None => {
-                return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
-                    "node `{}` is an agent node but names no teammate.",
-                    node.id
-                ))));
-            }
-        }
-    }
-
-    // Save `body.id` before `body` is consumed by `Into<RawWorkflow>` below.
-    let body_id = body.id.clone();
-
-    // Render the candidate graph to TOML and reuse `parse_workflow` to
-    // validate its structure end to end — the same rules a hand-authored
-    // `workflows/<id>.toml` must satisfy. Any problem becomes a 400, never the
-    // 500 a malformed on-disk file gets from the read routes.
-    let toml_src = render_workflow(&body.into())?;
-    let file = parse_workflow(&toml_src).map_err(|err| match err {
-        OpenCompanyError::DataInvalid { problems, .. } => {
-            ApiError(OpenCompanyError::InvalidRequest(problems.join(" ")))
-        }
-        OpenCompanyError::DataParse { message, .. } => {
-            ApiError(OpenCompanyError::InvalidRequest(message))
-        }
-        other => ApiError(other),
-    })?;
-
-    // Write the file atomically: `create_new(true)` fails if the path already
-    // exists, closing the TOCTOU gap between a separate `is_file()` check and
-    // `fs::write`. If `write_all` fails, clean up the empty file so the id is
-    // not permanently blocked. Also, save the store record **after** the file
-    // lands so a store failure doesn't orphan a file — if the save fails the
-    // file is cleaned up and the caller can retry.
-    let mut wf_file = std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&path)
-        .map_err(|e| match e.kind() {
-            std::io::ErrorKind::AlreadyExists => ApiError(OpenCompanyError::Conflict(format!(
-                "A workflow named `{}` already exists.",
-                body_id
-            ))),
-            _ => ApiError(OpenCompanyError::StoreIo {
-                path: path.clone(),
-                source: e,
-            }),
-        })?;
-    wf_file.write_all(toml_src.as_bytes()).map_err(|source| {
-        let _ = std::fs::remove_file(&path);
-        ApiError(OpenCompanyError::StoreIo {
-            path: path.clone(),
-            source,
-        })
-    })?;
-    drop(wf_file);
-
-    // Record the id as enabled on the operator's live copy of the manifest —
-    // mirrors the team overlay: the version-controlled `company.toml` on disk
-    // is never rewritten (see `crate::server::ops::team`).
-    let save_result = if !record
-        .manifest
-        .workflows
-        .enabled
-        .iter()
-        .any(|e| e == &file.id)
-    {
-        record.manifest.workflows.enabled.push(file.id.clone());
-        company.runtime.store().save(&record).await
-    } else {
-        Ok(())
-    };
-
-    // If the store save failed, remove the file we just wrote so a retry can
-    // succeed without admin intervention.
-    if let Err(e) = save_result {
-        let _ = std::fs::remove_file(&path);
-        return Err(ApiError(e));
-    }
+    let file = create_company_workflow(
+        company.id(),
+        source_dir,
+        company.runtime.store(),
+        Some(company.runtime.events()),
+        body.into(),
+    )
+    .await
+    .map_err(ApiError)?;
 
     Ok(Json(WorkflowGraph::from(file)))
 }


### PR DESCRIPTION
## Summary

Adds a `create_workflow` orchestrator tool so an operator can author a workflow from company chat — the agent could already `run_workflow` but had no way to create one, so "set up a weekly report workflow" dead-ended. The tool delegates to a new shared validated-persist core (`src/company/workflow_create.rs`) that the console's REST create route now also uses, so a chat-authored workflow is byte-identical to what the runner consumes — no create-vs-run schema drift.

Closes #112. Part of #26.

## API Or Behavior Changes

- New orchestrator tool `create_workflow` (PermissionLevel::Write, delegation-class): takes `id`, `name`, `description?`, `nodes[]`, `edges[]` (same camelCase shape as the REST body); returns the new workflow id, enabled and immediately runnable via `run_workflow`.
- The REST `POST …/workflows` create handler now shares the same core, gaining three guardrails it lacked: a per-company write lock (closes a lost-update race against team/agent writes), size caps (≤50 nodes, ≤100 edges, ≤64 KiB TOML, id/name length), and case-insensitive display-name uniqueness. Status codes unchanged (400 invalid / 409 conflict).
- Additive `CompanyEvent::WorkflowCreated { workflow_id, name, by }` audit event, journaled best-effort from both surfaces; never rolls back a created workflow on journal failure.
- New workflow appears in the console Workflows tab on next load (existing refetch) and runs from there — no frontend change needed.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 618 pass (default); `cargo test --features openhuman,mcp,telegram` — 28 harness/orchestrator pass incl. `create_workflow_tool_then_run_workflow_tool`
- Core unit tests (12): happy-path write+enable+journal; dup id → Conflict; case-insensitive dup name; unknown/missing roster teammate; zero/two triggers; traversal id; node-count + TOML-byte oversize; store-save failure rolls the file back; contract test that the returned file == `load_company_workflows` of what was written.
- Tool tests: create-then-run on the returned id (StubRunner); guardrail failures are `is_error` ToolResults; six-tool registration; delegation classification.

## Documentation

`docs/spec/runtime/ports.md` documents chat workflow authoring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflow creation via the orchestrator tool, console, and `POST /workflows`.
  * Newly created workflows are validated, enabled automatically, and become available to run immediately.
  * Emit and surface “workflow created” activity in the console and recent activity feed (via the SSE events stream).
* **Documentation**
  * Expanded runtime event documentation for additional `CompanyEvent` variants, including workflow creation and journaling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->