### PR TITLE
feat(media): image/video generation tools, grant-gated + approval-parked (#109)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,6 +190,15 @@ openhuman = ["dep:openhuman_core", "dep:reqwest", "dep:anyhow", "dep:log", "dep:
 # Enabling it necessarily enables the embedded harness and OpenHuman MCP
 # domain, while the default build remains unchanged.
 mcp = ["openhuman", "openhuman_core/mcp", "dep:uuid", "dep:base64", "dep:url"]
+# Image/video generation tools (issue #109, epic #26 Cell B). Bridges
+# OpenHuman's `media_generation` tools (`media_generate_image`,
+# `media_generate_video`, `media_list_models`) into a company agent's toolbelt
+# behind the opt-in `media` grant namespace and a MANAGED platform credential.
+# Enabling it necessarily enables the embedded harness and OpenHuman's own
+# `media` domain; the default build links none of it. Real money moves through
+# these tools, so they are wired only when a company explicitly grants `media`
+# (never via the `*` wildcard) AND a managed credential is configured.
+media = ["openhuman", "openhuman_core/media"]
 # Real HTTP transport to openhuman-core. The trait + offline mock + providers
 # compile without this; only `HttpOpenHumanRpc` is gated behind it.
 openhuman-rpc = ["dep:reqwest"]

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -81,6 +81,11 @@ skills = [
 [budget]
 monthly_usd = 200.0                # hard cap: inference + x402 combined
 
+[plan]                             # capability tier gating (issue #108)
+name = "starter"                   # free | starter | pro | unlimited (optional)
+period = "daily"                   # daily (default) | monthly
+token_budgets = { web = 500000 }   # override/extend the named tier per namespace
+
 [[schedule]]
 cron = "0 9 * * MON"
 prompt = "Weekly review and operator digest"
@@ -120,6 +125,23 @@ prompt = "Weekly review and operator digest"
 - **`[budget].monthly_usd`** is a hard ceiling enforced by the kernel across
   inference usage and x402 spend; reaching it pauses the company with an
   operator notification rather than silently degrading.
+- **`[plan]`** (issue #108) gates the exec tool families (`shell`, `code`,
+  `web`, `subagent`) by the company's **token spend this period**, a distinct
+  axis from `[policy].mode` (autonomy) and an agent's `tier` (cognition). A
+  built-in `name` (`free` / `starter` / `pro` / `unlimited`) supplies a base
+  budget map; `token_budgets` overrides/extends it per namespace. The map's key
+  set **is** the capability set — a gateable namespace absent from it is denied
+  outright. Each budget is a **threshold over total period token spend**, not a
+  per-namespace meter (usage samples carry no per-tool attribution): when spend
+  reaches a tier's budget, that tier's tools switch off for the rest of the
+  period; different budgets give **graduated degradation**. `period` is `daily`
+  (default) or `monthly`, aligned to UTC calendar boundaries. Gating is
+  **fail-closed** — if the usage meter can't be read, every gateable family is
+  denied (the turn still runs on its intrinsic memory/file/MCP tools). The gate
+  re-resolves before every turn, so a tier that crosses its budget mid-session
+  switches off on the **next** turn (a turn already in flight finishes). An
+  absent `[plan]` leaves gating off entirely. The console's Usage view shows a
+  live per-tier budget card (`GET …/capabilities`).
 - **`[[schedule]]`** entries become `ScheduleFired` events; cron syntax is
   standard 5-field.
 

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -142,6 +142,21 @@ prompt = "Weekly review and operator digest"
   switches off on the **next** turn (a turn already in flight finishes). An
   absent `[plan]` leaves gating off entirely. The console's Usage view shows a
   live per-tier budget card (`GET …/capabilities`).
+  - **`media`** (issue #109) is a fifth gateable namespace covering the
+    image/video generation tools (`media_generate_image`,
+    `media_generate_video`, `media_list_models`), but it is **real-money and
+    opt-in**: it is granted only by an **explicit** `media` / `media.*` entry in
+    `[tools].allow` — the `*` wildcard deliberately does **not** grant it — and
+    it runs exclusively on a **managed platform credential** (resolved from the
+    environment, never a tenant BYOK key or secret). It is absent from the
+    `free` / `starter` / `pro` tiers (denied there) and uncapped only under
+    `unlimited`; a company opts in per-namespace with
+    `token_budgets = { media = N }`. Every generation additionally **parks for
+    operator approval** before the backend bills it, and the whole family is
+    compiled out unless the build enables the `media` feature. With no managed
+    credential configured, a `media` grant wires no tools (fail-closed). The
+    Usage view surfaces a dedicated media status row (active / awaiting
+    credential / not granted / not in this build).
 - **`[[schedule]]`** entries become `ScheduleFired` events; cron syntax is
   standard 5-field.
 

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -113,6 +113,7 @@ async fn main() -> anyhow::Result<()> {
         web_allowed_domains: Vec::new(),
         capabilities: opencompany::harness::toolbelt::CapabilityFilter::AllowAll,
         plan: None,
+        media: None,
     };
 
     let pool = HarnessPool::new();

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -110,6 +110,8 @@ async fn main() -> anyhow::Result<()> {
         workflow_runner: opencompany::harness::orchestrator::WorkflowRunnerHandle::default(),
         mcp_failures: opencompany::harness::mcp_probe::McpFailureQueue::default(),
         secrets: None,
+        web_allowed_domains: Vec::new(),
+        capabilities: opencompany::harness::toolbelt::CapabilityFilter::AllowAll,
     };
 
     let pool = HarnessPool::new();

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -112,6 +112,7 @@ async fn main() -> anyhow::Result<()> {
         secrets: None,
         web_allowed_domains: Vec::new(),
         capabilities: opencompany::harness::toolbelt::CapabilityFilter::AllowAll,
+        plan: None,
     };
 
     let pool = HarnessPool::new();

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -18,6 +18,7 @@ import {
   type ApiErrorBody,
   type AppSpec,
   type ApprovalSummary,
+  type CapabilityStatusDto,
   type ChatHistoryMessageDto,
   type ChatResponse,
   type CompanyStatus,
@@ -141,6 +142,15 @@ export class OpenCompanyClient {
   /** One company's status. Uses the single-company alias when unscoped. */
   status(company?: string | null): Promise<CompanyStatus> {
     return this.request<CompanyStatus>("GET", `${this.scope(company)}`);
+  }
+
+  /**
+   * The company's capability-budget status (issue #108): the effective tier plan
+   * and per-tier token spend. Hosts without the surface (or with no `[plan]`)
+   * return `{ configured: false }`; callers render a "no plan configured" note.
+   */
+  capabilityStatus(company?: string | null): Promise<CapabilityStatusDto> {
+    return this.request<CapabilityStatusDto>("GET", `${this.scope(company)}/capabilities`);
   }
 
   /**

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -272,6 +272,38 @@ export interface McpToolInfo {
   inputSchema: unknown;
 }
 
+/** One capability tier's budget status (issue #108). */
+export interface CapabilityTierDto {
+  /** The exec tool namespace this tier gates (`shell` / `code` / `web` / `subagent`). */
+  namespace: string;
+  /** Tokens allowed this period. */
+  budgetTokens: number;
+  /** Tokens spent this period (company-wide — no per-tier attribution). */
+  spentTokens: number;
+  /** `budget - spent`, floored at zero. */
+  remainingTokens: number;
+  /** Whether spend has reached the threshold — the tier's tools are disabled. */
+  exhausted: boolean;
+}
+
+/**
+ * The company's capability-budget status. When no `[plan]` is configured only
+ * `configured: false` is present; the other fields accompany a configured plan.
+ */
+export interface CapabilityStatusDto {
+  configured: boolean;
+  /** The configured built-in tier name, or absent for a bare `token_budgets` plan. */
+  plan?: string | null;
+  /** Budget window (`daily` / `monthly`). */
+  period?: string;
+  /** Epoch-millis start of the current budget period. */
+  periodStartMillis?: number;
+  /** Total inference tokens spent this period. */
+  spentTokens?: number;
+  /** One row per configured tier, namespace-sorted. */
+  tiers?: CapabilityTierDto[];
+}
+
 /** Error envelope shape: `{ error, code }`. */
 export interface ApiErrorBody {
   error: string;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -302,6 +302,16 @@ export interface CapabilityStatusDto {
   spentTokens?: number;
   /** One row per configured tier, namespace-sorted. */
   tiers?: CapabilityTierDto[];
+  /**
+   * Media generation (issue #109): whether the company **explicitly** grants the
+   * real-money `media` namespace (a `*` wildcard does not count). Present
+   * regardless of whether a `[plan]` is configured.
+   */
+  mediaGranted?: boolean;
+  /** Whether the `media` feature is compiled into this build at all. */
+  mediaInBuild?: boolean;
+  /** Whether a managed media credential is configured on this build (env-only). */
+  mediaCredentialConfigured?: boolean;
 }
 
 /** Error envelope shape: `{ error, code }`. */

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -434,7 +434,7 @@ export function AppShell({
                 </div>
               }
             >
-              <UsageView />
+              <UsageView client={client} company={company} />
             </Suspense>
           )}
           {view === "finances" && (

--- a/frontend/src/views/UsageView.tsx
+++ b/frontend/src/views/UsageView.tsx
@@ -200,7 +200,7 @@ export function UsageView({ client, company }: Props) {
               switch off until the next period.
             </CardDescription>
           </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-4">
             {capsLoaded && caps?.configured && caps.tiers && caps.tiers.length > 0 ? (
               <div className="space-y-4">
                 {caps.tiers.map((tier) => (
@@ -212,6 +212,9 @@ export function UsageView({ client, company }: Props) {
                 {capsLoaded ? "No token plan configured." : "Loading budgets…"}
               </p>
             )}
+            {/* Media generation (issue #109): opt-in, managed-credential-gated —
+                its own status row, separate from the token-budget bars. */}
+            {capsLoaded && caps ? <MediaStatusRow caps={caps} /> : null}
           </CardContent>
         </Card>
       </div>
@@ -225,7 +228,44 @@ const NAMESPACE_LABELS: Record<string, string> = {
   code: "Code & patches",
   web: "Web & HTTP",
   subagent: "Sub-agents",
+  media: "Media generation",
 };
+
+// Badge variant subset the media status row uses.
+type BadgeVariant = "default" | "secondary" | "destructive" | "outline";
+
+/**
+ * The media-generation capability (issue #109) is opt-in per tool grant and
+ * gated on a managed platform credential, so it gets its own status row rather
+ * than a token-budget bar. Four states: not compiled into this build, not
+ * granted, granted-but-awaiting-credential, and active. A `media` token budget,
+ * if set, still surfaces as its own bar above via the tiers loop.
+ */
+function MediaStatusRow({ caps }: { caps: CapabilityStatusDto }) {
+  const { label, variant } = mediaStatus(caps);
+  return (
+    <div className="flex items-center justify-between gap-3 border-t pt-4 text-sm">
+      <div className="space-y-0.5">
+        <span className="font-medium">Media generation</span>
+        <p className="text-xs text-muted-foreground">
+          Image &amp; video generation — opt-in, runs on the managed platform credential, and
+          every generation is approved before it bills.
+        </p>
+      </div>
+      <Badge variant={variant} className="shrink-0">
+        {label}
+      </Badge>
+    </div>
+  );
+}
+
+function mediaStatus(caps: CapabilityStatusDto): { label: string; variant: BadgeVariant } {
+  if (caps.mediaInBuild === false) return { label: "Not in this build", variant: "outline" };
+  if (!caps.mediaGranted) return { label: "Not granted", variant: "secondary" };
+  if (!caps.mediaCredentialConfigured)
+    return { label: "Awaiting credential", variant: "destructive" };
+  return { label: "Active", variant: "default" };
+}
 
 // A budget large enough that we treat it as effectively unlimited (the backend
 // sends u64::MAX for the `unlimited` tier, which arrives as a huge float).

--- a/frontend/src/views/UsageView.tsx
+++ b/frontend/src/views/UsageView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Area,
   AreaChart,
@@ -9,8 +9,11 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { Coins, CreditCard, Plug, Zap } from "lucide-react";
+import { Coins, CreditCard, Gauge, Plug, Zap } from "lucide-react";
 
+import type { OpenCompanyClient } from "@/api/client";
+import type { CapabilityStatusDto } from "@/api/types";
+import { Badge } from "@/components/ui/badge";
 import {
   Card,
   CardContent,
@@ -34,6 +37,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { buildUsage, compact, usd } from "@/lib/usage-sample";
+import { cn } from "@/lib/utils";
 
 const RANGES: Record<string, number> = { "7d": 7, "30d": 30, "90d": 90 };
 const RANGE_LABELS: Record<string, string> = { "7d": "Last 7 days", "30d": "Last 30 days", "90d": "Last 90 days" };
@@ -48,11 +52,38 @@ const chartConfig = {
 // A stable "today" so the seeded series don't shift between renders.
 const TODAY_MS = Date.now();
 
+interface Props {
+  client: OpenCompanyClient;
+  company: string | null;
+}
+
 /** In-depth usage: token burn over time, by agent, and OAuth calls by provider. */
-export function UsageView() {
+export function UsageView({ client, company }: Props) {
   const [range, setRange] = useState("30d");
   const data = useMemo(() => buildUsage(RANGES[range], TODAY_MS), [range]);
   const { totals } = data;
+
+  // Capability budgets (issue #108) — the one live-wired card on this view.
+  const [caps, setCaps] = useState<CapabilityStatusDto | null>(null);
+  const [capsLoaded, setCapsLoaded] = useState(false);
+  useEffect(() => {
+    let alive = true;
+    client
+      .capabilityStatus(company)
+      .then((status) => {
+        if (alive) setCaps(status);
+      })
+      // Hosts without the surface (older builds) 404 — treat as unconfigured.
+      .catch(() => {
+        if (alive) setCaps({ configured: false });
+      })
+      .finally(() => {
+        if (alive) setCapsLoaded(true);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [client, company]);
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -105,7 +136,7 @@ export function UsageView() {
                   tickFormatter={(d: string) => new Date(d).toLocaleDateString(undefined, { month: "short", day: "numeric" })}
                 />
                 <YAxis tickLine={false} axisLine={false} width={40} tickFormatter={(v: number) => compact(v)} />
-                <ChartTooltip content={<ChartTooltipContent labelFormatter={(l) => new Date(l).toLocaleDateString(undefined, { month: "short", day: "numeric" })} />} />
+                <ChartTooltip content={<ChartTooltipContent labelFormatter={(l) => new Date(l as string).toLocaleDateString(undefined, { month: "short", day: "numeric" })} />} />
                 <ChartLegend content={<ChartLegendContent />} />
                 <Area dataKey="inputTokens" name="Input" type="monotone" stackId="t" stroke="var(--color-inputTokens)" fill="var(--color-inputTokens)" fillOpacity={0.2} strokeWidth={2} />
                 <Area dataKey="outputTokens" name="Output" type="monotone" stackId="t" stroke="var(--color-outputTokens)" fill="var(--color-outputTokens)" fillOpacity={0.2} strokeWidth={2} />
@@ -155,6 +186,84 @@ export function UsageView() {
             </CardContent>
           </Card>
         </div>
+
+        {/* Capability budgets (issue #108) */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Gauge className="size-4 text-muted-foreground" />
+              <CardTitle className="text-base">Capability budgets</CardTitle>
+            </div>
+            <CardDescription>
+              Token budgets that gate each exec tool family this{" "}
+              {caps?.period ?? "period"}. When spend crosses a tier&apos;s budget, its tools
+              switch off until the next period.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {capsLoaded && caps?.configured && caps.tiers && caps.tiers.length > 0 ? (
+              <div className="space-y-4">
+                {caps.tiers.map((tier) => (
+                  <CapabilityRow key={tier.namespace} tier={tier} />
+                ))}
+              </div>
+            ) : (
+              <p className="py-2 text-sm text-muted-foreground">
+                {capsLoaded ? "No token plan configured." : "Loading budgets…"}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+// Friendly labels for the exec tool namespaces a plan can budget.
+const NAMESPACE_LABELS: Record<string, string> = {
+  shell: "Shell & commands",
+  code: "Code & patches",
+  web: "Web & HTTP",
+  subagent: "Sub-agents",
+};
+
+// A budget large enough that we treat it as effectively unlimited (the backend
+// sends u64::MAX for the `unlimited` tier, which arrives as a huge float).
+const UNLIMITED_THRESHOLD = 1e15;
+
+function CapabilityRow({ tier }: { tier: NonNullable<CapabilityStatusDto["tiers"]>[number] }) {
+  const label = NAMESPACE_LABELS[tier.namespace] ?? tier.namespace;
+  const unlimited = tier.budgetTokens >= UNLIMITED_THRESHOLD;
+  const pct = unlimited
+    ? Math.min(100, tier.spentTokens > 0 ? 2 : 0)
+    : tier.budgetTokens > 0
+      ? Math.min(100, (tier.spentTokens / tier.budgetTokens) * 100)
+      : 100;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between gap-2 text-sm">
+        <span className="font-medium">{label}</span>
+        {tier.exhausted ? (
+          <Badge variant="destructive">Tools disabled</Badge>
+        ) : (
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {compact(tier.remainingTokens)} left
+          </span>
+        )}
+      </div>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className={cn(
+            "h-full rounded-full transition-all",
+            tier.exhausted ? "bg-destructive" : "bg-primary",
+          )}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div className="flex items-center justify-between text-xs text-muted-foreground tabular-nums">
+        <span>{compact(tier.spentTokens)} spent</span>
+        <span>{unlimited ? "Unlimited" : `${compact(tier.budgetTokens)} budget`}</span>
       </div>
     </div>
   );

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -300,9 +300,16 @@ fn attach_harness(builder: RuntimeBuilder) -> RuntimeBuilder {
 fn attach_harness(builder: RuntimeBuilder) -> RuntimeBuilder {
     use opencompany::app::config::ProcessEnv;
     use opencompany::harness::HarnessPool;
-    use opencompany::harness::provider::harness_inference_from_env;
+    use opencompany::harness::provider::{harness_inference_from_env, media_backend_from_env};
 
     let builder = builder.with_harness(Arc::new(HarnessPool::new()));
+    // Issue #109: the MANAGED media-generation backend, resolved from the
+    // environment only (never a tenant secret). Absent ⇒ media tools stay unwired
+    // even for a company that grants `media` (fail-closed).
+    let builder = match media_backend_from_env(&ProcessEnv) {
+        Some(media_backend) => builder.with_media_backend(media_backend),
+        None => builder,
+    };
     // The managed env default is an *optional*, lowest-precedence source; a
     // BYOK-only tenant supplies none and still gets a harness brain from its
     // manifest/runtime config.

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -11,8 +11,8 @@ use std::path::{Path, PathBuf};
 use crate::error::{OpenCompanyError, Result};
 
 use super::types::{
-    BRAIN_MODES, CONNECTION_PRIORITIES, CompanyManifest, KNOWN_CHANNELS, POLICY_MODES, TIERS,
-    TOOL_PROVIDERS,
+    BRAIN_MODES, CONNECTION_PRIORITIES, CompanyManifest, GATEABLE_NAMESPACES, KNOWN_CHANNELS,
+    PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, TIERS, TOOL_PROVIDERS,
 };
 
 /// Preferred manifest filename.
@@ -274,6 +274,28 @@ impl CompanyManifest {
             ));
         }
 
+        // `[plan]` — capability tier gating (issue #108). Only checked when the
+        // section is set; an absent `[plan]` leaves gating off and is always ok.
+        if self.plan.is_set() {
+            if let Some(name) = self.plan.name.as_deref().map(str::trim)
+                && !name.is_empty()
+                && !PLAN_NAMES.contains(&name)
+            {
+                problems.push(one_of("`[plan].name`", &PLAN_NAMES, name));
+            }
+            if !PLAN_PERIODS.contains(&self.plan.period.as_str()) {
+                problems.push(one_of("`[plan].period`", &PLAN_PERIODS, &self.plan.period));
+            }
+            for namespace in self.plan.token_budgets.keys() {
+                if !GATEABLE_NAMESPACES.contains(&namespace.as_str()) {
+                    problems.push(format!(
+                        "`[plan].token_budgets` has an unknown tool namespace `{namespace}` — budget one of {}.",
+                        join_backticked(&GATEABLE_NAMESPACES)
+                    ));
+                }
+            }
+        }
+
         for (index, schedule) in self.schedules.iter().enumerate() {
             let fields = schedule.cron.split_whitespace().count();
             if fields != 5 {
@@ -425,6 +447,60 @@ mod tests {
         assert_eq!(
             manifest.policy.always_approve,
             vec!["payment.send", "filing.submit", "external.publish"]
+        );
+    }
+
+    #[test]
+    fn valid_plan_section_passes() {
+        let manifest = parse(
+            "[company]\nname = \"X\"\n[plan]\nname = \"starter\"\nperiod = \"monthly\"\n[plan.token_budgets]\nweb = 500000\n",
+        );
+        assert!(manifest.validate().is_empty(), "{:?}", manifest.validate());
+    }
+
+    #[test]
+    fn absent_plan_is_valid() {
+        // No `[plan]` → gating off; the default section must not trip validation.
+        let manifest = parse("[company]\nname = \"X\"\n");
+        assert!(manifest.validate().is_empty(), "{:?}", manifest.validate());
+    }
+
+    #[test]
+    fn rejects_unknown_plan_name_in_prosumer_language() {
+        let manifest = parse("[company]\nname = \"X\"\n[plan]\nname = \"enterprise\"\n");
+        let problems = manifest.validate();
+        assert!(
+            problems.iter().any(|p| p.contains("`[plan].name`")
+                && p.contains("free, starter, pro, unlimited")
+                && p.contains("enterprise")),
+            "{problems:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_bad_plan_period() {
+        let manifest =
+            parse("[company]\nname = \"X\"\n[plan]\nname = \"free\"\nperiod = \"hourly\"\n");
+        let problems = manifest.validate();
+        assert!(
+            problems
+                .iter()
+                .any(|p| p.contains("`[plan].period`") && p.contains("hourly")),
+            "{problems:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_non_gateable_budget_namespace() {
+        let manifest = parse(
+            "[company]\nname = \"X\"\n[plan]\nname = \"pro\"\n[plan.token_budgets]\ntelepathy = 100\n",
+        );
+        let problems = manifest.validate();
+        assert!(
+            problems
+                .iter()
+                .any(|p| p.contains("telepathy") && p.contains("token_budgets")),
+            "{problems:?}"
         );
     }
 

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -29,8 +29,9 @@ pub use manifest::{LEGACY_MANIFEST_FILE, Located, MANIFEST_FILE, discover};
 pub use skill_file::{SkillDoc, load_dir_skills, parse_skill_md};
 pub use types::{
     Agent, BRAIN_MODES, Brain, Budget, ChannelConfig, Company, CompanyManifest, Connection,
-    DEFAULT_ALWAYS_APPROVE, INFERENCE_PROVIDERS, INFERENCE_TIERS, Inference, KNOWN_CHANNELS,
-    McpServer, POLICY_MODES, Place, Policy, Schedule, Skill, TIERS, TOOL_PROVIDERS, Tools,
+    DEFAULT_ALWAYS_APPROVE, GATEABLE_NAMESPACES, INFERENCE_PROVIDERS, INFERENCE_TIERS, Inference,
+    KNOWN_CHANNELS, McpServer, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, Place, Plan, Policy,
+    Schedule, Skill, TIERS, TOOL_PROVIDERS, Tools,
 };
 pub use workflow_file::{
     WORKFLOW_NODE_KINDS, WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef, WorkflowNodeKind,

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -31,7 +31,7 @@ pub use types::{
     Agent, BRAIN_MODES, Brain, Budget, ChannelConfig, Company, CompanyManifest, Connection,
     DEFAULT_ALWAYS_APPROVE, GATEABLE_NAMESPACES, INFERENCE_PROVIDERS, INFERENCE_TIERS, Inference,
     KNOWN_CHANNELS, McpServer, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, Place, Plan, Policy,
-    Schedule, Skill, TIERS, TOOL_PROVIDERS, Tools,
+    Schedule, Skill, TIERS, TOOL_PROVIDERS, Tools, grants_media_explicit,
 };
 pub use workflow_file::{
     WORKFLOW_NODE_KINDS, WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef, WorkflowNodeKind,

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -362,6 +362,13 @@ pub struct Tools {
     /// Company-wide grant globs; agents intersect with this.
     #[serde(default)]
     pub allow: Vec<String>,
+    /// SSRF allowlist for the `web` tool namespace (Cell A). Empty (default) is
+    /// *open mode* — all public hosts allowed — while private/loopback/
+    /// link-local/metadata IPs are always rejected by OpenHuman's `url_guard`.
+    /// A non-empty list is strict (only those hosts + subdomains); `"*"` is an
+    /// explicit allow-all-public wildcard.
+    #[serde(default)]
+    pub web_allowed_domains: Vec<String>,
 }
 
 impl Default for Tools {
@@ -369,6 +376,7 @@ impl Default for Tools {
         Self {
             provider: default_tool_provider(),
             allow: Vec::new(),
+            web_allowed_domains: Vec::new(),
         }
     }
 }

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -54,6 +54,25 @@ pub const DEFAULT_ALWAYS_APPROVE: &[&str] = &["payment.send", "filing.submit", "
 /// Priorities a company may assign to a prioritized `[[connection]]`.
 pub const CONNECTION_PRIORITIES: &[&str] = &["low", "medium", "high"];
 
+/// The exec tool-grant namespaces a capability [`Plan`] can budget (issue #108).
+///
+/// This is the canonical, always-compiled source of truth for "which tool
+/// families are gateable"; the harness re-exports it as
+/// [`GATEABLE_NAMESPACES`](crate::harness::toolbelt::GATEABLE_NAMESPACES) and
+/// maps individual tools onto these namespaces. A `[plan].token_budgets` key
+/// outside this set is a manifest error. Lives here (not the feature-gated
+/// harness) so manifest validation can see it in the default build.
+pub const GATEABLE_NAMESPACES: [&str; 4] = ["shell", "code", "web", "subagent"];
+
+/// Built-in capability tier names selectable in `[plan].name` (issue #108). The
+/// name → budget-map table lives in
+/// [`plan_named`](crate::harness::capability_budget::plan_named); this list is
+/// what manifest validation checks a name against.
+pub const PLAN_NAMES: [&str; 4] = ["free", "starter", "pro", "unlimited"];
+
+/// Budget windows selectable in `[plan].period` (issue #108).
+pub const PLAN_PERIODS: [&str; 2] = ["daily", "monthly"];
+
 /// The on-disk definition of a Company.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CompanyManifest {
@@ -108,6 +127,13 @@ pub struct CompanyManifest {
     /// Hard spend ceiling.
     #[serde(default)]
     pub budget: Budget,
+    /// Per-tenant capability tier plan (issue #108) — a token budget per exec
+    /// tool namespace, gating the `shell`/`code`/`web`/`subagent` families by the
+    /// company's period token spend. Absent (the default) leaves gating off. This
+    /// is a distinct axis from `[policy].mode` (autonomy) and an agent's `tier`
+    /// (cognition) — a plan bounds *cost of capability*, not trust or model.
+    #[serde(default)]
+    pub plan: Plan,
     /// Cron-driven prompts. Renamed from the `[[schedule]]` array-of-tables.
     #[serde(default, rename = "schedule")]
     pub schedules: Vec<Schedule>,
@@ -451,6 +477,62 @@ pub struct Budget {
     pub monthly_usd: Option<f64>,
 }
 
+/// `[plan]` — the company's capability tier plan (issue #108).
+///
+/// Declarative intent shaped like the other manifest sections: an optional
+/// built-in tier `name` (`free` / `starter` / `pro` / `unlimited`), the budget
+/// `period` (`daily` — the default — or `monthly`), and an explicit
+/// `token_budgets` table mapping an exec tool namespace (`shell` / `code` /
+/// `web` / `subagent`) to the tokens it may burn per period. The named tier
+/// supplies a base map; `token_budgets` overrides/extends it. A namespace absent
+/// from the effective map is denied outright — the map's key set *is* the
+/// company's capability set. An absent `[plan]` leaves gating off entirely.
+///
+/// The budget is a **threshold over the company's total period token spend**, not
+/// a per-namespace meter (usage samples carry no per-tool attribution): when
+/// spend reaches a tier's budget, that tier's tools switch off. See
+/// [`CapabilityPlan`](crate::harness::capability_budget::CapabilityPlan).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Plan {
+    /// Built-in tier name, or `None` for a bare `token_budgets`-only plan.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Budget window — `daily` (default) or `monthly`.
+    #[serde(default = "default_plan_period")]
+    pub period: String,
+    /// Exec-namespace → tokens allowed per period. Overrides/extends the named
+    /// tier's map; a gateable namespace absent here is denied.
+    #[serde(default)]
+    pub token_budgets: BTreeMap<String, u64>,
+}
+
+impl Default for Plan {
+    fn default() -> Self {
+        // A manual impl (not `#[derive(Default)]`) so an absent `[plan]` section —
+        // which `#[serde(default)]` fills via `Plan::default()`, NOT the per-field
+        // `default_plan_period` — still carries the `daily` window, matching the
+        // key-present-but-missing case. `is_set()` stays false regardless.
+        Self {
+            name: None,
+            period: default_plan_period(),
+            token_budgets: BTreeMap::new(),
+        }
+    }
+}
+
+impl Plan {
+    /// Whether this section meaningfully configures a plan — a named tier or an
+    /// explicit budget. An absent `[plan]` deserializes to the default (period
+    /// only), which is *not* set, so gating stays off.
+    pub fn is_set(&self) -> bool {
+        self.name.as_deref().is_some_and(|n| !n.trim().is_empty()) || !self.token_budgets.is_empty()
+    }
+}
+
+fn default_plan_period() -> String {
+    "daily".to_string()
+}
+
 /// A `[[schedule]]` entry; becomes a `ScheduleFired` event.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Schedule {
@@ -503,5 +585,38 @@ mod test {
         let value = serde_json::to_value(&manifest).unwrap();
         assert!(value.get("agent").is_some());
         assert!(value.get("schedule").is_some());
+    }
+
+    /// The `[plan]` section (issue #108) survives a TOML → struct → JSON → struct
+    /// round-trip, and an absent section deserializes to the not-set default.
+    #[test]
+    fn plan_section_round_trips_and_defaults() {
+        let toml_src = r#"
+            [company]
+            name = "Acme"
+
+            [plan]
+            name = "starter"
+            period = "monthly"
+
+            [plan.token_budgets]
+            web = 500000
+        "#;
+        let manifest: CompanyManifest = toml::from_str(toml_src).expect("parse toml");
+        assert!(manifest.plan.is_set());
+        assert_eq!(manifest.plan.name.as_deref(), Some("starter"));
+        assert_eq!(manifest.plan.period, "monthly");
+        assert_eq!(manifest.plan.token_budgets.get("web"), Some(&500_000));
+
+        let json = serde_json::to_string(&manifest).expect("serialize");
+        let back: CompanyManifest = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.plan.name.as_deref(), Some("starter"));
+        assert_eq!(back.plan.period, "monthly");
+        assert_eq!(back.plan.token_budgets.get("web"), Some(&500_000));
+
+        // An absent `[plan]` defaults to period-only, which is NOT set.
+        let bare: CompanyManifest = toml::from_str("[company]\nname = \"Bare\"\n").unwrap();
+        assert!(!bare.plan.is_set());
+        assert_eq!(bare.plan.period, "daily");
     }
 }

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -62,7 +62,22 @@ pub const CONNECTION_PRIORITIES: &[&str] = &["low", "medium", "high"];
 /// maps individual tools onto these namespaces. A `[plan].token_budgets` key
 /// outside this set is a manifest error. Lives here (not the feature-gated
 /// harness) so manifest validation can see it in the default build.
-pub const GATEABLE_NAMESPACES: [&str; 4] = ["shell", "code", "web", "subagent"];
+pub const GATEABLE_NAMESPACES: [&str; 5] = ["shell", "code", "web", "subagent", "media"];
+
+/// Whether a tool-grant list **explicitly** grants the real-money `media`
+/// namespace (issue #109).
+///
+/// Unlike the ordinary namespace match, the catch-all `*` does **not** grant
+/// `media`: a capability that spends real money on image/video generation must
+/// be opted into by name, never ridden in on a wildcard. Matches the bare
+/// `media` grant or any `media.*` sub-grant. Lives here (always compiled) so
+/// both the feature-gated harness wiring (`build::build_agent`) and the
+/// always-compiled console capability route key off one source of truth.
+pub fn grants_media_explicit(grants: &[String]) -> bool {
+    grants
+        .iter()
+        .any(|grant| grant == "media" || grant.starts_with("media."))
+}
 
 /// Built-in capability tier names selectable in `[plan].name` (issue #108). The
 /// name → budget-map table lives in
@@ -545,6 +560,23 @@ pub struct Schedule {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    /// Real-money `media` (issue #109) is granted ONLY by an explicit `media` /
+    /// `media.*` grant — never by the catch-all `*`. This wildcard exclusion is
+    /// the security property that keeps a broadly-permissioned company from
+    /// accidentally handing its agents a paid image/video generator.
+    #[test]
+    fn media_grant_requires_explicit_namespace_not_wildcard() {
+        assert!(grants_media_explicit(&["media".into()]));
+        assert!(grants_media_explicit(&["media.image".into()]));
+        assert!(grants_media_explicit(&["web.*".into(), "media".into()]));
+        // The catch-all `*` must NOT grant media.
+        assert!(!grants_media_explicit(&["*".into()]));
+        assert!(!grants_media_explicit(&["web.*".into()]));
+        assert!(!grants_media_explicit(&[]));
+        // A substring match ("mediation") must not count as the media namespace.
+        assert!(!grants_media_explicit(&["mediation".into()]));
+    }
 
     // Guards the newly-added `Serialize` derive: a manifest with renamed
     // `[[agent]]`/`[[schedule]]` arrays must survive a serialize→deserialize

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -423,6 +423,8 @@ description = "Runs Acme."
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
         HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record())
     }
@@ -556,6 +558,8 @@ description = "Builds it."
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record_two()),
@@ -753,6 +757,8 @@ members = ["engineer"]
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record),
@@ -928,6 +934,8 @@ name = "Design"
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: failures.clone(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record());
 

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -425,6 +425,7 @@ description = "Runs Acme."
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            plan: None,
         };
         HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record())
     }
@@ -560,6 +561,7 @@ description = "Builds it."
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            plan: None,
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record_two()),
@@ -759,6 +761,7 @@ members = ["engineer"]
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            plan: None,
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record),
@@ -936,6 +939,7 @@ name = "Design"
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            plan: None,
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record());
 

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -426,6 +426,7 @@ description = "Runs Acme."
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
+            media: None,
         };
         HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record())
     }
@@ -562,6 +563,7 @@ description = "Builds it."
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
+            media: None,
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record_two()),
@@ -762,6 +764,7 @@ members = ["engineer"]
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
+            media: None,
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record),
@@ -940,6 +943,7 @@ name = "Design"
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
+            media: None,
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record());
 

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -202,6 +202,32 @@ pub fn build_agent(
         tools.extend(toolbelt::subagent_tools());
     }
 
+    // Media generation (issue #109) — image/video tools that spend REAL MONEY
+    // (the backend charges on submit). Two hard gates before any tool is wired:
+    //
+    //  1. an **EXPLICIT** `media` grant (`grants_media_explicit`) — unlike every
+    //     other namespace, the catch-all `*` does NOT grant media, so a company
+    //     never accidentally hands its agents a paid generator via a broad
+    //     wildcard; it must opt in by name.
+    //  2. a MANAGED backend credential on the deps (`deps.media`), resolved
+    //     env-only by the runtime builder — never a tenant secret.
+    //
+    // Granted-but-uncredentialed wires nothing and warns (fail-closed). The
+    // generate tools additionally park for operator approval via the
+    // `ApprovalPolicy`. Gated on the `media` feature; the default/`openhuman`
+    // build never compiles this.
+    #[cfg(feature = "media")]
+    if crate::company::grants_media_explicit(grants) {
+        match &deps.media {
+            Some(backend) => tools.extend(toolbelt::media_tools(backend, &workspace)),
+            None => tracing::warn!(
+                company = %company,
+                agent = %manifest_agent.id,
+                "[build] agent explicitly grants `media` but no managed media backend is configured; media tools NOT wired (fail-closed)"
+            ),
+        }
+    }
+
     // Persona over openhuman's own identity: `omit_identity = true` drops the
     // "you are OpenHuman" preamble so the agent speaks as its company role.
     let mut persona = persona_prompt(company_name, manifest_agent);

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -6,13 +6,18 @@
 //!
 //! * **Tools**: every agent gets the intrinsic [`memory_tools`] (`memory_store`
 //!   + `memory_recall`) over its own company memory. **File tools** (read,
-//!   write, edit, list, grep, glob) are granted per-agent when the effective
-//!   `tools ∩ agent.tools` grants cover the `files`/`docs` namespace, and are
-//!   sandboxed to the agent's own workspace via a `workspace_only`
-//!   [`SecurityPolicy`] ([`file_tools`]). Network (`web.*`) and shell (`shell.*`)
-//!   tools are a tracked follow-up — they need an HTTP domain-allowlist config
-//!   and a runtime/audit sandbox respectively; the builder extends the same
-//!   vector, so they slot in beside the file tools.
+//!     write, edit, list, grep, glob) are granted per-agent when the effective
+//!     `tools ∩ agent.tools` grants cover the `files`/`docs` namespace, and are
+//!     sandboxed to the agent's own workspace via a `workspace_only`
+//!     [`SecurityPolicy`] ([`file_tools`]). **Exec-grade tools** (Cell A) now
+//!     slot in beside them via [`toolbelt`](crate::harness::toolbelt): `shell`
+//!     (shell + `read_workspace_state`) and `code` (`apply_patch`,
+//!     `git_operations`, `csv_export`) behind a strict [`toolbelt::exec_security`]
+//!     policy + native runtime + per-workspace audit; `web` (`web_fetch`,
+//!     `http_request`, `curl`, `image_info`) behind the same policy plus a
+//!     per-company SSRF domain allowlist. The `subagent` namespace is reserved
+//!     but empty in v1. Still deferred: browser automation (needs a backend),
+//!     search (needs engine keys), and Node/NPM exec (need a managed bootstrap).
 //! * **Workflows/skills** start empty. Parsing enabled `SKILL.md` bodies via
 //!   `openhuman::skills::ops_parse` depends on WS1's skill parsing; the seam is
 //!   the `.workflows(...)` setter.
@@ -48,6 +53,7 @@ use crate::harness::memory::OcMemory;
 use crate::harness::orchestrator;
 use crate::harness::policy::ApprovalPolicy;
 use crate::harness::skills::EffectiveSkills;
+use crate::harness::toolbelt;
 use crate::ports::skills_state::SkillState;
 use crate::ports::types::CompanyId;
 
@@ -146,6 +152,49 @@ pub fn build_agent(
         tools.extend(file_tools(&workspace));
     }
 
+    // Exec-grade coding + web tools (Cell A), each behind its own grant
+    // namespace and sandboxed to this agent's workspace by ONE strict
+    // `exec_security` policy shared across the shell/code/web tool constructors.
+    // Unlike the MCP bridge (which hands OpenHuman a permissive Supervised
+    // policy), shell/code/web receive the strict policy directly — the company's
+    // own `ApprovalPolicy` (`tool_policy` below) stays the authoritative
+    // per-call park/deny gate on top of it. The autonomy tier is mapped 1:1 from
+    // the manifest `[policy].mode`.
+    let wants_shell = grants_cover(grants, "shell");
+    let wants_code = grants_cover(grants, "code");
+    let wants_web = grants_cover(grants, "web");
+    if wants_shell || wants_code || wants_web {
+        let exec_security = Arc::new(toolbelt::exec_security(&workspace, policy.mode()));
+        // The shell + code bundle needs a host runtime and a per-workspace audit
+        // logger (tenant-isolated); build them only when granted.
+        if wants_shell || wants_code {
+            let runtime = toolbelt::native_runtime();
+            let audit = toolbelt::workspace_audit(&workspace);
+            tools.extend(toolbelt::coding_tools(
+                exec_security.clone(),
+                runtime,
+                audit,
+                &workspace,
+            ));
+        }
+        // Web tools reuse OpenHuman's upstream SSRF `url_guard` internally; the
+        // per-company allowlist comes from the manifest `[tools].web_allowed_domains`
+        // (empty = allow-public with private/metadata IPs always rejected).
+        if wants_web {
+            tools.extend(toolbelt::web_tools(
+                exec_security,
+                deps.web_allowed_domains.clone(),
+                &workspace,
+            ));
+        }
+    }
+    // The `subagent` namespace is reserved but intentionally wires no tools in
+    // v1 — OpenHuman's spawn tools use a process-global registry + budget bypass
+    // unsafe under multi-tenancy. Reserved so a grant can land without effect.
+    if grants_cover(grants, "subagent") {
+        tools.extend(toolbelt::subagent_tools());
+    }
+
     // Persona over openhuman's own identity: `omit_identity = true` drops the
     // "you are OpenHuman" preamble so the agent speaks as its company role.
     let mut persona = persona_prompt(company_name, manifest_agent);
@@ -237,6 +286,14 @@ pub fn build_agent(
         .model_override
         .clone()
         .unwrap_or_else(|| model_for_tier(manifest_agent.tier.as_deref()));
+
+    // Capability-tier seam (Cell A): one filtering pass over the fully assembled
+    // tool vector, just before it is handed to the builder. Today `AllowAll` is
+    // the only production variant (identity); a future capability-tier cell only
+    // swaps how `deps.capabilities` is constructed. Intrinsic tools
+    // (memory/MCP/orchestrator/file/skill) have no mapped namespace and are
+    // always kept.
+    let tools = toolbelt::filter_by_capabilities(tools, &deps.capabilities);
 
     AgentBuilder::default()
         .provider_arc(deps.provider.clone())

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -165,17 +165,24 @@ pub fn build_agent(
     let wants_web = grants_cover(grants, "web");
     if wants_shell || wants_code || wants_web {
         let exec_security = Arc::new(toolbelt::exec_security(&workspace, policy.mode()));
-        // The shell + code bundle needs a host runtime and a per-workspace audit
-        // logger (tenant-isolated); build them only when granted.
-        if wants_shell || wants_code {
+        // `shell` and `code` are separate grant namespaces and are wired from
+        // separate tool vectors — a company granting only one MUST NOT receive
+        // the other's tools (the production `CapabilityFilter` is identity and
+        // does not re-trim namespaces after construction). Only the `shell`
+        // tools need a host runtime + per-workspace audit logger (tenant-
+        // isolated), so those handles are built only under `wants_shell`.
+        if wants_shell {
             let runtime = toolbelt::native_runtime();
             let audit = toolbelt::workspace_audit(&workspace);
-            tools.extend(toolbelt::coding_tools(
+            tools.extend(toolbelt::shell_tools(
                 exec_security.clone(),
                 runtime,
                 audit,
                 &workspace,
             ));
+        }
+        if wants_code {
+            tools.extend(toolbelt::code_tools(exec_security.clone(), &workspace));
         }
         // Web tools reuse OpenHuman's upstream SSRF `url_guard` internally; the
         // per-company allowlist comes from the manifest `[tools].web_allowed_domains`

--- a/src/harness/capability_budget.rs
+++ b/src/harness/capability_budget.rs
@@ -1,0 +1,259 @@
+//! Per-tenant, per-period, fail-closed capability gating (issue #108).
+//!
+//! Cell A wired the exec-grade tool families (`shell`, `code`, `web`, and the
+//! reserved `subagent`) behind grant namespaces, but its
+//! [`CapabilityFilter`](crate::harness::toolbelt::CapabilityFilter) is a
+//! process-wide static — a granted tier stays cost-unbounded forever because
+//! nothing consults the [`UsageMeter`] before a turn. This module closes that
+//! gap: it reads a tenant's token spend for the current budget period and
+//! resolves the filter that gates the tenant's next turn.
+//!
+//! The **pure budget math** (plan resolution, period boundaries, spend summing,
+//! exhaustion) lives in always-compiled
+//! [`crate::metering::capability`] so the console read surface can share it; this
+//! module re-exports those types and adds the `CapabilityFilter` wiring —
+//! [`resolve_filter`] and [`filter_fingerprint`] — on top.
+//!
+//! ## Fail-closed
+//!
+//! Metering is a spend guard, so it defaults **closed**: a plan with no reachable
+//! meter, or a meter whose query errors, denies **every** gateable namespace
+//! (the turn still runs — intrinsic memory / file / MCP tools survive — it just
+//! runs without exec tools). A gateable namespace absent from the plan's budget
+//! map is likewise always denied: the map's key set *is* the capability set.
+//!
+//! ## Turn-boundary
+//!
+//! The gate resolves at [`HarnessPool::ensure`](crate::harness::HarnessPool),
+//! which runs before every turn. A turn that starts under budget may finish over
+//! it; the next `ensure` observes the new spend and flips the tier off. The
+//! window is one turn — acceptable for a token budget, and documented so.
+
+use crate::harness::toolbelt::{CapabilityFilter, GATEABLE_NAMESPACES};
+use crate::ports::UsageMeter;
+use crate::ports::types::CompanyId;
+
+// Re-export the pure math so harness call sites keep addressing it as
+// `capability_budget::{CapabilityPlan, BudgetPeriod, tokens_in, ...}`.
+pub use crate::metering::capability::{
+    BudgetPeriod, CapabilityPlan, TierBudgetStatus, plan_named, tokens_in,
+};
+
+/// Resolves the per-tenant [`CapabilityFilter`] for the turn about to run.
+///
+/// **Fail-closed**: with no meter, or a meter whose query errors, every gateable
+/// namespace is denied (a `tracing::warn` records the error — it is *not*
+/// propagated as a turn failure, so the turn still runs on its intrinsic tools).
+/// Otherwise the tenant's period spend is summed and the plan's exhausted (and
+/// unmapped) namespaces are denied; an empty deny set collapses to
+/// [`CapabilityFilter::AllowAll`] (the identity fast path).
+pub async fn resolve_filter(
+    plan: &CapabilityPlan,
+    meter: Option<&dyn UsageMeter>,
+    company: &CompanyId,
+    now: u64,
+) -> CapabilityFilter {
+    let Some(meter) = meter else {
+        tracing::warn!(
+            company = %company,
+            "[capability-budget] no usage meter available; denying all gateable tools (fail-closed)"
+        );
+        return deny_all_gateable();
+    };
+
+    let since = plan.period.period_start_millis(now);
+    let spent = match meter.query(company, since).await {
+        Ok(samples) => tokens_in(&samples),
+        Err(error) => {
+            tracing::warn!(
+                company = %company,
+                %error,
+                "[capability-budget] usage query failed; denying all gateable tools (fail-closed)"
+            );
+            return deny_all_gateable();
+        }
+    };
+
+    let denied = plan.denied_namespaces(spent);
+    if denied.is_empty() {
+        CapabilityFilter::AllowAll
+    } else {
+        CapabilityFilter::DenyNamespaces(denied)
+    }
+}
+
+/// The fail-closed filter: deny every gateable namespace.
+fn deny_all_gateable() -> CapabilityFilter {
+    CapabilityFilter::DenyNamespaces(GATEABLE_NAMESPACES.iter().copied().collect())
+}
+
+/// A stable fingerprint of a resolved filter's denied set, so
+/// [`HarnessPool::ensure`](crate::harness::HarnessPool) can detect a capability
+/// change between turns the same way it fingerprints the MCP and overlay-agent
+/// sets. [`CapabilityFilter::AllowAll`] fingerprints as the empty set; two
+/// `DenyNamespaces` filters with the same members fingerprint equal regardless
+/// of insertion order.
+pub fn filter_fingerprint(filter: &CapabilityFilter) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut denied: Vec<&str> = match filter {
+        CapabilityFilter::AllowAll => Vec::new(),
+        CapabilityFilter::DenyNamespaces(set) => set.iter().copied().collect(),
+    };
+    denied.sort_unstable();
+
+    let mut hasher = DefaultHasher::new();
+    denied.len().hash(&mut hasher);
+    for namespace in denied {
+        namespace.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::{SampleKind, UsageSample};
+    use async_trait::async_trait;
+    use std::collections::HashSet;
+
+    fn inference_sample(input: u64, output: u64) -> UsageSample {
+        UsageSample {
+            at_millis: 0,
+            agent: "ceo".into(),
+            provider: "managed".into(),
+            input_tokens: input,
+            output_tokens: output,
+            cached_input_tokens: 0,
+            cost_usd: 0.0,
+            kind: SampleKind::Inference,
+        }
+    }
+
+    /// A meter whose `query` always errors — proves the fail-closed path.
+    struct FailingMeter;
+
+    #[async_trait]
+    impl UsageMeter for FailingMeter {
+        async fn record(&self, _c: &CompanyId, _s: &UsageSample) -> crate::Result<()> {
+            Ok(())
+        }
+        async fn query(&self, _c: &CompanyId, _since: u64) -> crate::Result<Vec<UsageSample>> {
+            Err(crate::error::OpenCompanyError::Harness("boom".into()))
+        }
+    }
+
+    /// A meter serving a fixed sample set.
+    struct FixedMeter(Vec<UsageSample>);
+
+    #[async_trait]
+    impl UsageMeter for FixedMeter {
+        async fn record(&self, _c: &CompanyId, _s: &UsageSample) -> crate::Result<()> {
+            Ok(())
+        }
+        async fn query(&self, _c: &CompanyId, _since: u64) -> crate::Result<Vec<UsageSample>> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_filter_no_meter_denies_all() {
+        let plan = plan_named("pro").unwrap();
+        let filter = resolve_filter(&plan, None, &CompanyId::new("acme"), 0).await;
+        match filter {
+            CapabilityFilter::DenyNamespaces(set) => {
+                for ns in GATEABLE_NAMESPACES {
+                    assert!(set.contains(ns), "fail-closed must deny {ns}");
+                }
+            }
+            other => panic!("expected DenyNamespaces, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_filter_query_error_denies_all() {
+        let plan = plan_named("pro").unwrap();
+        let meter = FailingMeter;
+        let filter = resolve_filter(&plan, Some(&meter), &CompanyId::new("acme"), 0).await;
+        match filter {
+            CapabilityFilter::DenyNamespaces(set) => {
+                assert_eq!(set.len(), GATEABLE_NAMESPACES.len());
+            }
+            other => panic!("expected DenyNamespaces, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_filter_under_budget_allows_all_when_plan_covers_all() {
+        let plan = plan_named("unlimited").unwrap();
+        let meter = FixedMeter(vec![inference_sample(100, 100)]);
+        let filter = resolve_filter(&plan, Some(&meter), &CompanyId::new("acme"), 10).await;
+        assert!(
+            matches!(filter, CapabilityFilter::AllowAll),
+            "unlimited under budget is identity"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_filter_partial_plan_denies_uncovered_even_under_budget() {
+        let plan = plan_named("starter").unwrap();
+        let meter = FixedMeter(vec![inference_sample(10, 10)]);
+        let filter = resolve_filter(&plan, Some(&meter), &CompanyId::new("acme"), 10).await;
+        match filter {
+            CapabilityFilter::DenyNamespaces(set) => {
+                assert!(set.contains("web") && set.contains("subagent"));
+                assert!(!set.contains("shell") && !set.contains("code"));
+            }
+            other => panic!("expected DenyNamespaces, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_filter_over_budget_denies_exhausted_tier() {
+        let plan = plan_named("starter").unwrap();
+        // 150k + 150k = 300k > 200k → shell + code exhausted.
+        let meter = FixedMeter(vec![inference_sample(150_000, 150_000)]);
+        let filter = resolve_filter(&plan, Some(&meter), &CompanyId::new("acme"), 10).await;
+        match filter {
+            CapabilityFilter::DenyNamespaces(set) => {
+                for ns in GATEABLE_NAMESPACES {
+                    assert!(set.contains(ns), "everything denied once exhausted: {ns}");
+                }
+            }
+            other => panic!("expected DenyNamespaces, got {other:?}"),
+        }
+    }
+
+    // --- fingerprint --------------------------------------------------------
+
+    #[test]
+    fn fingerprint_is_order_independent_and_stable() {
+        let a: HashSet<&'static str> = ["shell", "web"].into_iter().collect();
+        let b: HashSet<&'static str> = ["web", "shell"].into_iter().collect();
+        assert_eq!(
+            filter_fingerprint(&CapabilityFilter::DenyNamespaces(a)),
+            filter_fingerprint(&CapabilityFilter::DenyNamespaces(b)),
+        );
+    }
+
+    #[test]
+    fn fingerprint_diverges_on_different_denied_sets() {
+        let allow = filter_fingerprint(&CapabilityFilter::AllowAll);
+        let deny_shell = filter_fingerprint(&CapabilityFilter::DenyNamespaces(
+            ["shell"].into_iter().collect(),
+        ));
+        let deny_web = filter_fingerprint(&CapabilityFilter::DenyNamespaces(
+            ["web"].into_iter().collect(),
+        ));
+        assert_ne!(allow, deny_shell);
+        assert_ne!(deny_shell, deny_web);
+    }
+
+    #[test]
+    fn allow_all_fingerprints_as_empty_deny() {
+        let allow = filter_fingerprint(&CapabilityFilter::AllowAll);
+        let empty = filter_fingerprint(&CapabilityFilter::DenyNamespaces(HashSet::new()));
+        assert_eq!(allow, empty);
+    }
+}

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -184,6 +184,15 @@ pub struct HarnessDeps {
     /// from the [`UsageMeter`] before each turn and installs it on the roster it
     /// builds. Resolved from the manifest `[plan]` section by the runtime builder.
     pub plan: Option<capability_budget::CapabilityPlan>,
+    /// The MANAGED media-generation backend (issue #109). `None` (the default at
+    /// every construction site) fails closed — no image/video tools are wired.
+    /// Only the production runtime builder sets it, from
+    /// [`media_backend_from_env`](crate::harness::provider::media_backend_from_env)
+    /// (env-only — never a tenant secret). When `Some` **and** a company
+    /// explicitly grants `media`, [`build::build_agent`] wires the
+    /// [`toolbelt::media_tools`]; a grant with no credential wires nothing and
+    /// warns.
+    pub media: Option<toolbelt::MediaBackend>,
 }
 
 /// One live openhuman agent, keyed by its manifest id.
@@ -1048,6 +1057,7 @@ description = "Builds the product."
                 web_allowed_domains: Vec::new(),
                 capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
                 plan: None,
+                media: None,
             },
             store,
             meter,
@@ -1101,6 +1111,7 @@ description = "Builds the product."
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
+            media: None,
         };
 
         let roster = build_roster(&record(), &deps, &[]).expect("roster builds with skills");
@@ -1377,6 +1388,7 @@ description = "Builds the product."
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
+            media: None,
         };
         let roster = build_roster(&record(), &deps, &[]).expect("roster");
         // Keep the tempdir alive for the agent's workspace by leaking it into the
@@ -1498,6 +1510,7 @@ description = "Builds the product."
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
+            media: None,
         };
         let pool = HarnessPool::new();
         let rec = record();
@@ -1606,6 +1619,7 @@ description = "Builds the product."
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
+            media: None,
         };
         let pool = HarnessPool::new();
 
@@ -1745,6 +1759,7 @@ description = "Sets direction."
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: Some(plan),
+            media: None,
         };
         let pool = HarnessPool::new();
         let rec = granting_record();

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -47,6 +47,7 @@ pub mod policy;
 pub mod provider;
 pub mod skills;
 pub mod steps;
+pub mod toolbelt;
 
 pub use brain::HarnessBrain;
 
@@ -160,6 +161,18 @@ pub struct HarnessDeps {
     /// `None` (default/tests) keeps the boot-resolved [`Self::mcp_servers`]
     /// static, exactly as before.
     pub secrets: Option<Arc<dyn SecretStore>>,
+    /// The per-company SSRF allowlist for the `web` toolbelt (Cell A), from the
+    /// manifest `[tools].web_allowed_domains`. Empty (the default) is *open
+    /// mode* — all public hosts allowed — while OpenHuman's upstream `url_guard`
+    /// still rejects private/loopback/link-local/metadata IPs regardless. A
+    /// non-empty list is strict (only those hosts + subdomains); `"*"` is an
+    /// explicit allow-all-public wildcard. Threaded verbatim into
+    /// [`toolbelt::web_tools`](crate::harness::toolbelt::web_tools).
+    pub web_allowed_domains: Vec<String>,
+    /// The capability-tier filter applied to each agent's assembled tool vector
+    /// (Cell A seam). [`AllowAll`](crate::harness::toolbelt::CapabilityFilter::AllowAll)
+    /// (the default) is identity; a future tier cell swaps this construction.
+    pub capabilities: toolbelt::CapabilityFilter,
 }
 
 /// One live openhuman agent, keyed by its manifest id.
@@ -955,6 +968,8 @@ description = "Builds the product."
                 workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
                 mcp_failures: McpFailureQueue::default(),
                 secrets: None,
+                web_allowed_domains: Vec::new(),
+                capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             },
             store,
             meter,
@@ -1005,6 +1020,8 @@ description = "Builds the product."
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
 
         let roster = build_roster(&record(), &deps, &[]).expect("roster builds with skills");
@@ -1278,6 +1295,8 @@ description = "Builds the product."
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
         let roster = build_roster(&record(), &deps, &[]).expect("roster");
         // Keep the tempdir alive for the agent's workspace by leaking it into the
@@ -1396,6 +1415,8 @@ description = "Builds the product."
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             secrets: Some(secrets.clone()),
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
         let pool = HarnessPool::new();
         let rec = record();
@@ -1501,6 +1522,8 @@ description = "Builds the product."
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
         let pool = HarnessPool::new();
 

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -37,6 +37,7 @@
 
 pub mod brain;
 pub mod build;
+pub mod capability_budget;
 pub mod cost;
 pub mod mcp;
 pub mod mcp_probe;
@@ -171,8 +172,18 @@ pub struct HarnessDeps {
     pub web_allowed_domains: Vec<String>,
     /// The capability-tier filter applied to each agent's assembled tool vector
     /// (Cell A seam). [`AllowAll`](crate::harness::toolbelt::CapabilityFilter::AllowAll)
-    /// (the default) is identity; a future tier cell swaps this construction.
+    /// (the default) is identity. When [`Self::plan`] is set,
+    /// [`HarnessPool::ensure`] overwrites this per turn with the tenant's
+    /// resolved filter; when the plan is `None` this stays the no-plan
+    /// fallback/test override.
     pub capabilities: toolbelt::CapabilityFilter,
+    /// The tenant's capability tier plan (issue #108). `None` (the default)
+    /// leaves gating **off** — byte-identical to Cell A, [`Self::capabilities`]
+    /// is used verbatim. When set, [`HarnessPool::ensure`] resolves a per-tenant,
+    /// per-period, fail-closed [`CapabilityFilter`](toolbelt::CapabilityFilter)
+    /// from the [`UsageMeter`] before each turn and installs it on the roster it
+    /// builds. Resolved from the manifest `[plan]` section by the runtime builder.
+    pub plan: Option<capability_budget::CapabilityPlan>,
 }
 
 /// One live openhuman agent, keyed by its manifest id.
@@ -349,6 +360,16 @@ pub struct HarnessPool {
     /// whenever an operator- or orchestrator-added teammate is added/removed,
     /// mirroring the MCP-freshness fingerprint above.
     overlay_fingerprints: RwLock<HashMap<CompanyId, u64>>,
+    /// Fingerprint of the resolved [`CapabilityFilter`](toolbelt::CapabilityFilter)
+    /// the cached roster was built from, keyed by company (issue #108). Drives
+    /// capability-budget freshness: [`ensure`](Self::ensure) re-resolves the
+    /// tenant's filter from the [`UsageMeter`] on every call and rebuilds the
+    /// roster whenever the denied-namespace set changes — so a tier that crosses
+    /// its token budget switches off on the company's **next** turn. With no
+    /// plan ([`HarnessDeps::plan`] `None`) the filter is the static
+    /// [`HarnessDeps::capabilities`], whose fingerprint never moves — no rebuild,
+    /// byte-identical to Cell A.
+    capability_fingerprints: RwLock<HashMap<CompanyId, u64>>,
 }
 
 impl Default for HarnessPool {
@@ -364,6 +385,7 @@ impl HarnessPool {
             agents: RwLock::new(HashMap::new()),
             mcp_fingerprints: RwLock::new(HashMap::new()),
             overlay_fingerprints: RwLock::new(HashMap::new()),
+            capability_fingerprints: RwLock::new(HashMap::new()),
         }
     }
 
@@ -394,13 +416,22 @@ impl HarnessPool {
         let overlay_agents = self.resolve_effective_overlay(company, deps).await;
         let overlay_fp = overlay_fingerprint(&overlay_agents);
 
+        // Re-resolve + fingerprint the tenant's capability filter (issue #108):
+        // a per-tenant, per-period, fail-closed budget read from the meter. With
+        // no plan this is the static `deps.capabilities`, whose fingerprint is
+        // stable — so a no-plan company never rebuilds on this axis.
+        let capability_filter = self.resolve_capability_filter(company, deps).await;
+        let capability_fp = capability_budget::filter_fingerprint(&capability_filter);
+
         {
             let agents = self.agents.read().await;
             let mcp_fingerprints = self.mcp_fingerprints.read().await;
             let overlay_fingerprints = self.overlay_fingerprints.read().await;
+            let capability_fingerprints = self.capability_fingerprints.read().await;
             if agents.contains_key(&company.id)
                 && mcp_fingerprints.get(&company.id) == Some(&mcp_fp)
                 && overlay_fingerprints.get(&company.id) == Some(&overlay_fp)
+                && capability_fingerprints.get(&company.id) == Some(&capability_fp)
             {
                 return Ok(());
             }
@@ -418,6 +449,11 @@ impl HarnessPool {
         // shares every Arc / queue handle — only `mcp_servers` is overridden.
         let mut fresh_deps = deps.clone();
         fresh_deps.mcp_servers = effective_mcp;
+        // Install the freshly-resolved capability filter on the deps the roster
+        // is built from, the same pattern as `mcp_servers` — so a tenant that
+        // crossed a tier budget gets a roster whose exec tools are actually
+        // trimmed. With no plan this is just `deps.capabilities` unchanged.
+        fresh_deps.capabilities = capability_filter;
         // Same treatment for the overlay-agent set: `company` may be a stale
         // boot-time snapshot (e.g. `HarnessBrain::record`), so the roster is
         // built from the live-resolved overlay set, not `company.overlay_agents`.
@@ -435,7 +471,37 @@ impl HarnessPool {
             .write()
             .await
             .insert(company.id.clone(), overlay_fp);
+        self.capability_fingerprints
+            .write()
+            .await
+            .insert(company.id.clone(), capability_fp);
         Ok(())
+    }
+
+    /// Re-resolves the company's capability filter (issue #108): with a plan
+    /// wired ([`HarnessDeps::plan`]), a per-tenant, per-period, fail-closed
+    /// budget read from the [`UsageMeter`] via
+    /// [`capability_budget::resolve_filter`]; without one, the static
+    /// [`HarnessDeps::capabilities`] verbatim (gating off). Never a boot
+    /// snapshot — resolved on every `ensure` so a tier switches off the turn
+    /// after its budget is crossed.
+    async fn resolve_capability_filter(
+        &self,
+        company: &CompanyRecord,
+        deps: &HarnessDeps,
+    ) -> toolbelt::CapabilityFilter {
+        match &deps.plan {
+            Some(plan) => {
+                capability_budget::resolve_filter(
+                    plan,
+                    deps.meter.as_deref(),
+                    &company.id,
+                    crate::ports::now_millis(),
+                )
+                .await
+            }
+            None => deps.capabilities.clone(),
+        }
     }
 
     /// Re-resolves the company's effective MCP server set: from the secret store
@@ -495,6 +561,17 @@ impl HarnessPool {
     #[cfg(test)]
     pub async fn overlay_fingerprint_of(&self, company: &CompanyId) -> Option<u64> {
         self.overlay_fingerprints.read().await.get(company).copied()
+    }
+
+    /// The current capability-filter fingerprint for a company (test-only), so a
+    /// budget-freshness test can assert a rebuild happened (issue #108).
+    #[cfg(test)]
+    pub async fn capability_fingerprint_of(&self, company: &CompanyId) -> Option<u64> {
+        self.capability_fingerprints
+            .read()
+            .await
+            .get(company)
+            .copied()
     }
 
     /// Routes a message to one agent and returns its reply, recording the turn's
@@ -970,6 +1047,7 @@ description = "Builds the product."
                 secrets: None,
                 web_allowed_domains: Vec::new(),
                 capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+                plan: None,
             },
             store,
             meter,
@@ -1022,6 +1100,7 @@ description = "Builds the product."
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            plan: None,
         };
 
         let roster = build_roster(&record(), &deps, &[]).expect("roster builds with skills");
@@ -1297,6 +1376,7 @@ description = "Builds the product."
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            plan: None,
         };
         let roster = build_roster(&record(), &deps, &[]).expect("roster");
         // Keep the tempdir alive for the agent's workspace by leaking it into the
@@ -1417,6 +1497,7 @@ description = "Builds the product."
             secrets: Some(secrets.clone()),
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            plan: None,
         };
         let pool = HarnessPool::new();
         let rec = record();
@@ -1524,6 +1605,7 @@ description = "Builds the product."
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            plan: None,
         };
         let pool = HarnessPool::new();
 
@@ -1577,5 +1659,190 @@ description = "Builds the product."
         // A third ensure with no further change is a no-op (fingerprint stable).
         pool.ensure(&rec, &deps).await.expect("third ensure");
         assert_eq!(pool.overlay_fingerprint_of(&rec.id).await, Some(after));
+    }
+
+    // --- Capability-budget freshness (issue #108) ---------------------------
+
+    /// A manifest that grants every tool namespace, so the roster actually builds
+    /// the exec tools the capability filter then trims. (The default `manifest()`
+    /// grants nothing, so no exec tools would be present to gate.)
+    fn granting_manifest() -> CompanyManifest {
+        toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+
+[tools]
+allow = ["shell", "code", "web", "files"]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+description = "Sets direction."
+"#,
+        )
+        .expect("valid manifest")
+    }
+
+    fn granting_record() -> CompanyRecord {
+        CompanyRecord {
+            id: CompanyId::new("acme"),
+            manifest: granting_manifest(),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+        }
+    }
+
+    /// The `ceo` roster agent's live tool names (test introspection via the
+    /// public `Agent::tools()` accessor).
+    async fn ceo_tool_names(pool: &HarnessPool, id: &CompanyId) -> Vec<String> {
+        let guard = pool.agents.read().await;
+        let roster = guard.get(id).expect("roster present");
+        let ceo = roster
+            .iter()
+            .find(|a| a.agent_id == "ceo")
+            .expect("ceo present");
+        let agent = ceo.agent.lock().await;
+        agent.tools().iter().map(|t| t.name().to_string()).collect()
+    }
+
+    /// End-to-end capability gating: a plan budgeting `shell` at 100 tokens grants
+    /// the shell tools while spend is under budget; once a recorded turn pushes
+    /// period spend past the threshold, the very next `ensure` rebuilds the roster
+    /// with the shell namespace dropped — while intrinsic tools (memory) and the
+    /// ungated `files` namespace survive. Mirrors the MCP-freshness test shape.
+    #[tokio::test]
+    async fn ensure_gates_shell_tools_once_the_token_budget_is_crossed() {
+        let dir = tempfile::tempdir().unwrap();
+        let meter = Arc::new(RecordingMeter::default());
+        let plan = crate::harness::capability_budget::CapabilityPlan {
+            period: crate::harness::capability_budget::BudgetPeriod::Daily,
+            budgets: std::collections::BTreeMap::from([("shell".to_string(), 100u64)]),
+        };
+        let deps = HarnessDeps {
+            provider: Arc::new(MockProvider::new("mock: ")),
+            provider_slug: "mock".to_string(),
+            context: Arc::new(MockContext::default()),
+            store: Arc::new(RecordingStore::default()),
+            meter: Some(meter.clone()),
+            workspace_root: dir.path().to_path_buf(),
+            model_override: None,
+            tasks: None,
+            skills: None,
+            skills_source_dir: None,
+            mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: DelegationQueue::default(),
+            workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
+            mcp_failures: McpFailureQueue::default(),
+            secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            plan: Some(plan),
+        };
+        let pool = HarnessPool::new();
+        let rec = granting_record();
+
+        // First ensure: 0 spend < 100 → shell granted.
+        pool.ensure(&rec, &deps).await.expect("first ensure");
+        let before_fp = pool
+            .capability_fingerprint_of(&rec.id)
+            .await
+            .expect("fingerprinted");
+        let before = ceo_tool_names(&pool, &rec.id).await;
+        assert!(before.contains(&"shell".to_string()), "got {before:?}");
+        assert!(
+            before.contains(&"read_workspace_state".to_string()),
+            "got {before:?}"
+        );
+        assert!(
+            before.contains(&"memory_store".to_string()),
+            "intrinsic memory tool must be present: {before:?}"
+        );
+        assert!(
+            before.contains(&"file_read".to_string()),
+            "ungated files namespace must be present: {before:?}"
+        );
+
+        // Record a turn that burns 150 inference tokens — past the 100 budget.
+        meter
+            .record(
+                &rec.id,
+                &UsageSample {
+                    at_millis: crate::ports::now_millis(),
+                    agent: "ceo".into(),
+                    provider: "managed".into(),
+                    input_tokens: 100,
+                    output_tokens: 50,
+                    cached_input_tokens: 0,
+                    cost_usd: 0.0,
+                    kind: crate::ports::SampleKind::Inference,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Second ensure: 150 >= 100 → shell exhausted → roster rebuilt without it.
+        pool.ensure(&rec, &deps).await.expect("second ensure");
+        let after_fp = pool
+            .capability_fingerprint_of(&rec.id)
+            .await
+            .expect("fingerprinted");
+        assert_ne!(
+            before_fp, after_fp,
+            "crossing the budget must change the capability fingerprint"
+        );
+        assert_eq!(pool.resident_companies().await, 1, "rebuilt in place");
+
+        let after = ceo_tool_names(&pool, &rec.id).await;
+        assert!(
+            !after.contains(&"shell".to_string()),
+            "shell must be gated off once exhausted: {after:?}"
+        );
+        assert!(
+            !after.contains(&"read_workspace_state".to_string()),
+            "the whole shell namespace drops: {after:?}"
+        );
+        assert!(
+            after.contains(&"memory_store".to_string()),
+            "intrinsic memory tool survives gating: {after:?}"
+        );
+        assert!(
+            after.contains(&"file_read".to_string()),
+            "ungated files namespace survives gating: {after:?}"
+        );
+
+        // Third ensure with no new spend → no rebuild (fingerprint stable).
+        pool.ensure(&rec, &deps).await.expect("third ensure");
+        assert_eq!(
+            pool.capability_fingerprint_of(&rec.id).await,
+            Some(after_fp)
+        );
+    }
+
+    /// With no plan wired, the capability fingerprint is stable across ensures —
+    /// gating stays off, byte-identical to Cell A (no rebuild on this axis).
+    #[tokio::test]
+    async fn ensure_without_a_plan_never_gates() {
+        let fx = fixture();
+        let pool = HarnessPool::new();
+        let rec = record();
+        pool.ensure(&rec, &fx.deps).await.expect("first ensure");
+        let fp = pool
+            .capability_fingerprint_of(&rec.id)
+            .await
+            .expect("fingerprinted");
+        pool.ensure(&rec, &fx.deps).await.expect("second ensure");
+        assert_eq!(
+            pool.capability_fingerprint_of(&rec.id).await,
+            Some(fp),
+            "no plan → stable fingerprint → no capability-driven rebuild"
+        );
     }
 }

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -193,6 +193,14 @@ fn is_external_effect(tool_name: &str) -> bool {
     if tool_name.eq_ignore_ascii_case("mcp_registry_tool_call") {
         return true;
     }
+    // The media catalog is a read-only GET (issue #109): listing models spends
+    // nothing and must never park for approval, even though its name does not
+    // start with a read-only prefix. The `media_generate_*` tools are NOT listed
+    // here — they spend real money and fall through to the external-effect
+    // default, so they park under supervised / deny under readonly.
+    if tool_name.eq_ignore_ascii_case("media_list_models") {
+        return false;
+    }
     const READ_ONLY_PREFIXES: &[&str] = &[
         "read",
         "list",
@@ -215,6 +223,11 @@ fn classify_group(tool_name: &str) -> EffectGroup {
     let name = tool_name.to_ascii_lowercase();
     if name == "mcp_registry_tool_call" {
         EffectGroup::Other
+    } else if name.starts_with("media_generate") {
+        // Image/video generation is billed by the backend on submit (issue
+        // #109), so it is a spend effect — parked for approval before money
+        // moves. (`media_list_models` is read-only and never reaches here.)
+        EffectGroup::Spend
     } else if name.contains("pay") || name.contains("transfer") || name.starts_with("spend") {
         EffectGroup::Spend
     } else if name.contains("email") || name.contains("send") || name.contains("message") {
@@ -344,6 +357,66 @@ mod tests {
             .await,
             ToolPolicyDecision::RequireApproval { .. }
         ));
+    }
+
+    /// Media generation (issue #109): the paid `media_generate_*` tools park
+    /// under supervised and deny under readonly (external spend effect), while
+    /// the read-only `media_list_models` catalog GET is always allowed.
+    #[tokio::test]
+    async fn media_generate_parks_supervised_and_denies_readonly_but_list_is_read_only() {
+        let supervised = policy("supervised", &[], None);
+        for tool in ["media_generate_image", "media_generate_video"] {
+            assert!(
+                matches!(
+                    supervised
+                        .check(&request(tool, serde_json::json!({})))
+                        .await,
+                    ToolPolicyDecision::RequireApproval { .. }
+                ),
+                "{tool} must park under supervised"
+            );
+        }
+        // The catalog GET is read-only — allowed even under supervised.
+        assert_eq!(
+            supervised
+                .check(&request("media_list_models", serde_json::json!({})))
+                .await,
+            ToolPolicyDecision::Allow
+        );
+
+        let readonly = policy("readonly", &[], None);
+        assert!(
+            matches!(
+                readonly
+                    .check(&request("media_generate_image", serde_json::json!({})))
+                    .await,
+                ToolPolicyDecision::Deny { .. }
+            ),
+            "media_generate must be denied under readonly"
+        );
+        // Even a read-only desk can list the model catalog.
+        assert_eq!(
+            readonly
+                .check(&request("media_list_models", serde_json::json!({})))
+                .await,
+            ToolPolicyDecision::Allow
+        );
+    }
+
+    /// Paid generation classifies as a spend effect (issue #109).
+    #[test]
+    fn media_generate_classifies_as_spend() {
+        let p = policy("supervised", &[], None);
+        assert_eq!(
+            p.effect_for("media_generate_image", &serde_json::json!({}))
+                .group,
+            EffectGroup::Spend
+        );
+        assert_eq!(
+            p.effect_for("media_generate_video", &serde_json::json!({}))
+                .group,
+            EffectGroup::Spend
+        );
     }
 
     #[test]

--- a/src/harness/provider.rs
+++ b/src/harness/provider.rs
@@ -78,6 +78,42 @@ pub fn harness_inference_from_env(
     ))
 }
 
+/// Default media-generation backend base URL when only a bare
+/// `TINYHUMANS_API_KEY` is supplied — the OpenHuman backend that owns the GMI
+/// provider keys, billing, and rate limiting for image/video generation.
+pub const DEFAULT_TINYHUMANS_MEDIA_BACKEND_URL: &str = "https://api.tinyhumans.ai";
+
+/// Resolve the MANAGED media-generation backend (issue #109) from the
+/// environment, or `None` when no managed credential is present (fail-closed —
+/// no credential ⇒ no media tools are ever wired).
+///
+/// Precedence, most specific first:
+///
+/// * token — `OPENCOMPANY_MEDIA_KEY`, else `TINYHUMANS_API_KEY`. **No token ⇒
+///   `None`.** This is the platform's own managed credential; the tenant
+///   identity the backend bills is derived server-side from it.
+/// * url — `OPENCOMPANY_MEDIA_BACKEND_URL`, else
+///   [`DEFAULT_TINYHUMANS_MEDIA_BACKEND_URL`].
+///
+/// **Security**: this deliberately consults ONLY the environment — never a
+/// tenant secret store — so media generation can only ever run on the managed
+/// platform credential, never a company-controlled BYOK key. Mirrors
+/// [`harness_inference_from_env`]'s two-name precedence so a per-platform media
+/// override (`OPENCOMPANY_MEDIA_KEY`) stays distinct from the shared
+/// `TINYHUMANS_API_KEY`.
+pub fn media_backend_from_env(env: &dyn EnvSource) -> Option<super::toolbelt::MediaBackend> {
+    let auth_token = env
+        .get("OPENCOMPANY_MEDIA_KEY")
+        .or_else(|| env.get("TINYHUMANS_API_KEY"))?;
+    let backend_url = env
+        .get("OPENCOMPANY_MEDIA_BACKEND_URL")
+        .unwrap_or_else(|| DEFAULT_TINYHUMANS_MEDIA_BACKEND_URL.to_string());
+    Some(super::toolbelt::MediaBackend {
+        backend_url,
+        auth_token,
+    })
+}
+
 /// Deterministic offline [`Provider`] for tests and offline harness wiring.
 ///
 /// Every call returns a canned reply built from a fixed prefix and the last
@@ -634,6 +670,38 @@ mod tests {
     fn env_config_is_none_without_any_key() {
         let env = MapEnv::new([("OPENCOMPANY_INFERENCE_URL", "https://x/v1")]);
         assert!(harness_inference_from_env(&env).is_none());
+    }
+
+    // ---- media backend (issue #109) ---------------------------------------
+
+    #[test]
+    fn media_backend_prefers_specific_key_and_defaults_url() {
+        let env = MapEnv::new([("OPENCOMPANY_MEDIA_KEY", "media-specific")]);
+        let backend = media_backend_from_env(&env).expect("configured");
+        assert_eq!(backend.auth_token, "media-specific");
+        assert_eq!(backend.backend_url, DEFAULT_TINYHUMANS_MEDIA_BACKEND_URL);
+    }
+
+    #[test]
+    fn media_backend_falls_back_to_tinyhumans_key_and_honors_url_override() {
+        let env = MapEnv::new([
+            ("TINYHUMANS_API_KEY", "platform-key"),
+            (
+                "OPENCOMPANY_MEDIA_BACKEND_URL",
+                "https://staging-api.tinyhumans.ai",
+            ),
+        ]);
+        let backend = media_backend_from_env(&env).expect("configured");
+        assert_eq!(backend.auth_token, "platform-key");
+        assert_eq!(backend.backend_url, "https://staging-api.tinyhumans.ai");
+    }
+
+    /// Fail-closed: no managed credential ⇒ no media backend, even when a URL is
+    /// set. A tenant BYOK inference key must never stand in for the media token.
+    #[test]
+    fn media_backend_is_none_without_managed_key() {
+        let env = MapEnv::new([("OPENCOMPANY_MEDIA_BACKEND_URL", "https://api.tinyhumans.ai")]);
+        assert!(media_backend_from_env(&env).is_none());
     }
 
     #[tokio::test]

--- a/src/harness/toolbelt.rs
+++ b/src/harness/toolbelt.rs
@@ -143,25 +143,40 @@ pub fn workspace_audit(workspace: &Path) -> Arc<AuditLogger> {
     }
 }
 
-/// The `shell` + `code` tools, all sharing the exec-grade `security` policy and
+/// The `shell` namespace tools, sharing the exec-grade `security` policy and
 /// pinned to the agent's `workspace`. Mirrors
 /// [`file_tools`](crate::harness::build): a flat vector the builder extends.
+///
+/// Kept **disjoint** from [`code_tools`] so the builder can gate each grant
+/// namespace independently — a company granting only `code` must never receive
+/// a live [`ShellTool`], and vice versa (the production [`CapabilityFilter`] is
+/// `AllowAll`/identity and does not re-trim namespaces post-construction).
 ///
 /// * `shell` — run commands (needs `runtime` + `audit`; plain constructor, no
 ///   Node/Python bootstrap in v1).
 /// * `read_workspace_state` — read-only git/tree overview.
-/// * `apply_patch` — structured multi-edit patches.
-/// * `git_operations` — status/diff/log/commit within the workspace.
-/// * `csv_export` — write a CSV into the workspace's `exports/` dir.
-pub fn coding_tools(
+pub fn shell_tools(
     security: Arc<SecurityPolicy>,
     runtime: Arc<dyn RuntimeAdapter>,
     audit: Arc<AuditLogger>,
     workspace: &Path,
 ) -> Vec<Box<dyn Tool>> {
     vec![
-        Box::new(ShellTool::new(security.clone(), runtime, audit)),
+        Box::new(ShellTool::new(security, runtime, audit)),
         Box::new(WorkspaceStateTool::new(workspace.to_path_buf())),
+    ]
+}
+
+/// The `code` namespace tools, sharing the exec-grade `security` policy and
+/// pinned to the agent's `workspace`. Disjoint from [`shell_tools`] (see there
+/// for why the split is a security boundary, not just cosmetics). Unlike shell,
+/// these need neither a host runtime nor an audit logger.
+///
+/// * `apply_patch` — structured multi-edit patches.
+/// * `git_operations` — status/diff/log/commit within the workspace.
+/// * `csv_export` — write a CSV into the workspace's `exports/` dir.
+pub fn code_tools(security: Arc<SecurityPolicy>, workspace: &Path) -> Vec<Box<dyn Tool>> {
+    vec![
         Box::new(ApplyPatchTool::new(security.clone())),
         Box::new(GitOperationsTool::new(
             security.clone(),
@@ -283,21 +298,72 @@ mod tests {
     }
 
     #[test]
-    fn coding_tools_expose_expected_names() {
-        let ws = Path::new("/tmp/oc-toolbelt-coding");
+    fn shell_tools_expose_expected_names() {
+        let ws = Path::new("/tmp/oc-toolbelt-shell");
         let security = test_security(ws, PolicyMode::Supervised);
-        let tools = coding_tools(security, native_runtime(), AuditLogger::disabled(), ws);
+        let tools = shell_tools(security, native_runtime(), AuditLogger::disabled(), ws);
         let got = names(&tools);
-        for expected in [
-            "shell",
-            "read_workspace_state",
-            "apply_patch",
-            "git_operations",
-            "csv_export",
-        ] {
+        for expected in ["shell", "read_workspace_state"] {
             assert!(got.contains(&expected), "missing {expected}: {got:?}");
         }
-        assert_eq!(got.len(), 5, "coding tools drifted: {got:?}");
+        assert_eq!(got.len(), 2, "shell tools drifted: {got:?}");
+    }
+
+    #[test]
+    fn code_tools_expose_expected_names() {
+        let ws = Path::new("/tmp/oc-toolbelt-code");
+        let security = test_security(ws, PolicyMode::Supervised);
+        let tools = code_tools(security, ws);
+        let got = names(&tools);
+        for expected in ["apply_patch", "git_operations", "csv_export"] {
+            assert!(got.contains(&expected), "missing {expected}: {got:?}");
+        }
+        assert_eq!(got.len(), 3, "code tools drifted: {got:?}");
+    }
+
+    /// The `shell` and `code` grant namespaces must build from **disjoint** tool
+    /// vectors: granting `code` alone must never hand an agent a live `ShellTool`
+    /// (and vice versa). The production `CapabilityFilter` is identity, so this
+    /// tool-vector split is the only thing enforcing the boundary — pin it.
+    #[test]
+    fn shell_and_code_tool_sets_are_disjoint_and_correctly_namespaced() {
+        let ws = Path::new("/tmp/oc-toolbelt-isolation");
+        let security = test_security(ws, PolicyMode::Supervised);
+
+        let shell = shell_tools(
+            security.clone(),
+            native_runtime(),
+            AuditLogger::disabled(),
+            ws,
+        );
+        let code = code_tools(security, ws);
+
+        // Every shell tool maps to the `shell` namespace and none to `code`.
+        for tool in &shell {
+            assert_eq!(
+                namespace_of(tool.name()),
+                Some("shell"),
+                "shell_tools leaked a non-shell tool: {}",
+                tool.name()
+            );
+        }
+        // Every code tool maps to the `code` namespace and none to `shell`.
+        for tool in &code {
+            assert_eq!(
+                namespace_of(tool.name()),
+                Some("code"),
+                "code_tools leaked a non-code tool: {}",
+                tool.name()
+            );
+        }
+
+        // No tool name appears in both vectors.
+        let shell_names: HashSet<&str> = names(&shell).into_iter().collect();
+        let code_names: HashSet<&str> = names(&code).into_iter().collect();
+        assert!(
+            shell_names.is_disjoint(&code_names),
+            "shell/code tool sets overlap: {shell_names:?} ∩ {code_names:?}"
+        );
     }
 
     #[test]
@@ -466,7 +532,13 @@ mod tests {
     fn filter_allow_all_is_identity() {
         let ws = Path::new("/tmp/oc-toolbelt-filter");
         let security = test_security(ws, PolicyMode::Supervised);
-        let tools = coding_tools(security, native_runtime(), AuditLogger::disabled(), ws);
+        let mut tools = shell_tools(
+            security.clone(),
+            native_runtime(),
+            AuditLogger::disabled(),
+            ws,
+        );
+        tools.extend(code_tools(security, ws));
         // Own the names before `tools` moves into the filter.
         let before: Vec<String> = tools.iter().map(|t| t.name().to_string()).collect();
         let after_tools = filter_by_capabilities(tools, &CapabilityFilter::AllowAll);
@@ -480,12 +552,13 @@ mod tests {
         // tools; a full namespace deny must keep only the intrinsic one.
         let ws = Path::new("/tmp/oc-toolbelt-deny");
         let security = test_security(ws, PolicyMode::Supervised);
-        let mut tools: Vec<Box<dyn Tool>> = coding_tools(
+        let mut tools: Vec<Box<dyn Tool>> = shell_tools(
             security.clone(),
             native_runtime(),
             AuditLogger::disabled(),
             ws,
         );
+        tools.extend(code_tools(security.clone(), ws));
         tools.extend(web_tools(security.clone(), Vec::new(), ws));
         // `file_read` has no mapped namespace → intrinsic → always kept.
         tools.push(Box::new(oh::tools::FileReadTool::new(security)));

--- a/src/harness/toolbelt.rs
+++ b/src/harness/toolbelt.rs
@@ -1,0 +1,502 @@
+//! Coding + web tool wiring for embedded company agents (Cell A).
+//!
+//! This module bridges a curated slice of OpenHuman's tool surface into the
+//! harness's per-agent [`AgentBuilder`](openhuman_core::openhuman::agent::AgentBuilder)
+//! wiring in [`build`](crate::harness::build). Where [`file_tools`] grants an
+//! agent read/write inside its own workspace, this module adds the **exec-grade**
+//! families behind their own grant namespaces:
+//!
+//! * **`shell`** → `shell` (run commands) + `read_workspace_state`.
+//! * **`code`** → `apply_patch`, `git_operations`, `csv_export`.
+//! * **`web`** → `web_fetch`, `http_request`, `curl`, `image_info`.
+//! * **`subagent`** → reserved, **empty in v1** (see [`subagent_tools`]).
+//!
+//! Everything here is scoped **per company/agent workspace** — no
+//! process-global state — so parallel tenants stay isolated:
+//!
+//! * Shell + code tools share one [`SecurityPolicy`] built by [`exec_security`],
+//!   pinned to the agent's workspace with `workspace_only`, high-risk commands
+//!   blocked, tool-install denied, and an autonomy level mapped 1:1 from the
+//!   company's [`PolicyMode`]. This is the *strict* policy — opencompany's own
+//!   [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy) tool policy stays
+//!   the real fail-closed approval gate on top of it.
+//! * Shell command audit is keyed on the agent's own workspace dir
+//!   ([`workspace_audit`]) so audit trails never cross tenants.
+//! * Web tools reuse OpenHuman's upstream SSRF guard (`url_guard`): every
+//!   request is validated against the per-company allowlist AND has
+//!   private/loopback/link-local/metadata IPs rejected — even in the default
+//!   "allow all public hosts" mode (an empty allowlist). The guard is applied
+//!   inside the tool constructors; it is not re-implemented here.
+//!
+//! A single [`filter_by_capabilities`] pass runs just before the tool vector is
+//! handed to the builder. Today the only [`CapabilityFilter`] is
+//! [`CapabilityFilter::AllowAll`] (identity); a future capability-tier cell only
+//! swaps how the filter is constructed. Tools with no mapped namespace
+//! (memory, MCP, orchestrator, skills) are **intrinsic** and always kept.
+//!
+//! **Deferred** (need infrastructure not present in v1): browser automation
+//! (needs a backend), search tools (need engine keys), Node/NPM exec (need a
+//! managed-runtime bootstrap), and OpenHuman's sub-agent spawn tools (global
+//! registry + budget bypass — unsafe under multi-tenancy).
+
+use std::path::Path;
+use std::sync::Arc;
+
+use openhuman_core::openhuman as oh;
+
+use oh::agent::host_runtime::{NativeRuntime, RuntimeAdapter};
+use oh::config::{AuditConfig, HttpRequestConfig};
+use oh::security::{
+    AuditLogger, AutonomyLevel, SecurityPolicy, get_or_create_workspace_audit_logger,
+};
+use oh::tools::{
+    ApplyPatchTool, CsvExportTool, CurlTool, GitOperationsTool, HttpRequestTool, ImageInfoTool,
+    ShellTool, Tool, WebFetchTool, WorkspaceStateTool,
+};
+
+use crate::harness::policy::PolicyMode;
+
+/// Subdirectory under the agent workspace that `curl` downloads land in.
+const CURL_DEST_SUBDIR: &str = "downloads";
+
+/// Map a tool's runtime `name()` onto its grant namespace, or `None` when the
+/// tool is **intrinsic** (memory / MCP / orchestrator / file / skill tools),
+/// which are always kept regardless of the capability filter.
+///
+/// This is the single source of truth coupling a wired tool to the namespace
+/// that gates it — [`filter_by_capabilities`] and any future capability-tier
+/// logic key off it, so a new exec tool is added here and nowhere else.
+pub fn namespace_of(tool_name: &str) -> Option<&'static str> {
+    match tool_name {
+        "shell" | "read_workspace_state" => Some("shell"),
+        "apply_patch" | "git_operations" | "csv_export" => Some("code"),
+        "web_fetch" | "http_request" | "curl" | "image_info" => Some("web"),
+        _ => None,
+    }
+}
+
+/// Build the exec-grade [`SecurityPolicy`] shared by an agent's shell + code +
+/// web tools, sandboxed to `workspace`.
+///
+/// Extends the same `workspace_only` shape [`file_tools`](crate::harness::build)
+/// uses with the exec-relevant knobs:
+///
+/// * `autonomy` is mapped **1:1** from the company [`PolicyMode`]
+///   (readonly/supervised/full → [`AutonomyLevel`] ReadOnly/Supervised/Full).
+/// * `block_high_risk_commands` is always on — destructive shell commands are
+///   refused before they spawn.
+/// * `require_approval_for_medium_risk` mirrors Supervised mode.
+/// * `allow_tool_install` and `auto_approve_all` are always off — an embedded
+///   company agent never installs OS packages nor blanket-approves itself.
+///
+/// This policy is *advisory-strict*: opencompany's own
+/// [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy) tool policy is the
+/// authoritative park/deny gate layered above it (unlike the MCP bridge, which
+/// passes a permissive OpenHuman policy).
+pub fn exec_security(workspace: &Path, mode: PolicyMode) -> SecurityPolicy {
+    let dir = workspace.to_path_buf();
+    SecurityPolicy {
+        autonomy: autonomy_for(mode),
+        workspace_dir: dir.clone(),
+        action_dir: dir,
+        workspace_only: true,
+        block_high_risk_commands: true,
+        require_approval_for_medium_risk: mode == PolicyMode::Supervised,
+        allow_tool_install: false,
+        auto_approve_all: false,
+        ..SecurityPolicy::default()
+    }
+}
+
+/// The OpenHuman [`AutonomyLevel`] a company [`PolicyMode`] maps to (1:1).
+fn autonomy_for(mode: PolicyMode) -> AutonomyLevel {
+    match mode {
+        PolicyMode::Readonly => AutonomyLevel::ReadOnly,
+        PolicyMode::Supervised => AutonomyLevel::Supervised,
+        PolicyMode::Full => AutonomyLevel::Full,
+    }
+}
+
+/// A native (host-process) [`RuntimeAdapter`] for the shell tool. Stateless and
+/// cheap — a fresh handle per agent keeps tenants from sharing runtime state.
+pub fn native_runtime() -> Arc<dyn RuntimeAdapter> {
+    Arc::new(NativeRuntime::new())
+}
+
+/// A workspace-scoped [`AuditLogger`] for shell command execution, built the way
+/// OpenHuman's `runtime_node::build_runtime_tools` does. Keyed on the agent's
+/// own workspace dir so audit trails are tenant-isolated.
+///
+/// Audit must never block agent construction, so a logger-init failure degrades
+/// to [`AuditLogger::disabled`] with a warning rather than propagating.
+pub fn workspace_audit(workspace: &Path) -> Arc<AuditLogger> {
+    match get_or_create_workspace_audit_logger(AuditConfig::default(), workspace.to_path_buf()) {
+        Ok(logger) => logger,
+        Err(error) => {
+            tracing::warn!(
+                workspace = %workspace.display(),
+                %error,
+                "[toolbelt] workspace audit logger init failed; shell audit disabled for this agent"
+            );
+            AuditLogger::disabled()
+        }
+    }
+}
+
+/// The `shell` + `code` tools, all sharing the exec-grade `security` policy and
+/// pinned to the agent's `workspace`. Mirrors
+/// [`file_tools`](crate::harness::build): a flat vector the builder extends.
+///
+/// * `shell` — run commands (needs `runtime` + `audit`; plain constructor, no
+///   Node/Python bootstrap in v1).
+/// * `read_workspace_state` — read-only git/tree overview.
+/// * `apply_patch` — structured multi-edit patches.
+/// * `git_operations` — status/diff/log/commit within the workspace.
+/// * `csv_export` — write a CSV into the workspace's `exports/` dir.
+pub fn coding_tools(
+    security: Arc<SecurityPolicy>,
+    runtime: Arc<dyn RuntimeAdapter>,
+    audit: Arc<AuditLogger>,
+    workspace: &Path,
+) -> Vec<Box<dyn Tool>> {
+    vec![
+        Box::new(ShellTool::new(security.clone(), runtime, audit)),
+        Box::new(WorkspaceStateTool::new(workspace.to_path_buf())),
+        Box::new(ApplyPatchTool::new(security.clone())),
+        Box::new(GitOperationsTool::new(
+            security.clone(),
+            workspace.to_path_buf(),
+        )),
+        Box::new(CsvExportTool::new(security)),
+    ]
+}
+
+/// The `web` tools, sharing the exec-grade `security` policy and the
+/// per-company `allowed_domains` SSRF allowlist.
+///
+/// `allowed_domains` semantics (OpenHuman's `url_guard`, applied inside each
+/// constructor): an **empty** list is *open mode* — all public hosts allowed —
+/// while private/loopback/link-local/multicast/metadata IPs are **always**
+/// rejected regardless. A non-empty list is strict (only those hosts +
+/// subdomains); `"*"` is an explicit allow-all-public wildcard.
+///
+/// * `web_fetch` — fetch + return page text (size/timeout defaults).
+/// * `http_request` — arbitrary HTTP method/headers/body.
+/// * `curl` — download a URL into the workspace `downloads/` dir.
+/// * `image_info` — inspect a workspace image's dimensions/format.
+pub fn web_tools(
+    security: Arc<SecurityPolicy>,
+    allowed_domains: Vec<String>,
+    workspace: &Path,
+) -> Vec<Box<dyn Tool>> {
+    // Source size/timeout defaults from OpenHuman's own config so there is one
+    // source of truth (and no `0 → coerced-with-warning` noise on each build).
+    let http_defaults = HttpRequestConfig::default();
+    vec![
+        Box::new(WebFetchTool::new(
+            security.clone(),
+            allowed_domains.clone(),
+            None,
+            None,
+        )),
+        Box::new(HttpRequestTool::new(
+            security.clone(),
+            allowed_domains.clone(),
+            http_defaults.max_response_size,
+            http_defaults.timeout_secs,
+        )),
+        Box::new(CurlTool::new(
+            security.clone(),
+            allowed_domains,
+            workspace.to_path_buf(),
+            CURL_DEST_SUBDIR.to_string(),
+            http_defaults.max_response_size as u64,
+            http_defaults.timeout_secs,
+        )),
+        Box::new(ImageInfoTool::new(security)),
+    ]
+}
+
+/// The `subagent` namespace — **reserved and empty in v1**.
+///
+/// OpenHuman's sub-agent spawn tools (`SpawnSubagentTool` et al.) reach a
+/// process-global agent registry and can bypass per-agent budget accounting —
+/// both unsafe under opencompany's multi-tenant isolation model. The namespace
+/// is reserved so a company can grant `subagent` today without effect, and a
+/// future cell can wire a tenant-safe delegation surface without a grant change.
+pub fn subagent_tools() -> Vec<Box<dyn Tool>> {
+    Vec::new()
+}
+
+/// Which tools an agent may keep after its grants have already admitted them —
+/// the seam a future capability-tier cell swaps.
+///
+/// Today the production build only ever constructs [`CapabilityFilter::AllowAll`]
+/// (identity). The deny variant exists for tests exercising the filter seam.
+#[derive(Clone, Debug, Default)]
+pub enum CapabilityFilter {
+    /// Keep every tool the grants admitted (identity).
+    #[default]
+    AllowAll,
+    /// Drop every tool whose [`namespace_of`] is in this set; intrinsic tools
+    /// (namespace `None`) are always kept. Test-only for now.
+    #[cfg(test)]
+    DenyNamespaces(std::collections::HashSet<&'static str>),
+}
+
+/// Apply a [`CapabilityFilter`] to a built tool vector, just before it is handed
+/// to the [`AgentBuilder`](openhuman_core::openhuman::agent::AgentBuilder).
+///
+/// Intrinsic tools (memory / MCP / orchestrator / file / skill — any tool whose
+/// [`namespace_of`] is `None`) are always kept; only namespaced exec tools can
+/// be dropped. [`CapabilityFilter::AllowAll`] is the identity pass.
+pub fn filter_by_capabilities(
+    tools: Vec<Box<dyn Tool>>,
+    filter: &CapabilityFilter,
+) -> Vec<Box<dyn Tool>> {
+    match filter {
+        CapabilityFilter::AllowAll => tools,
+        #[cfg(test)]
+        CapabilityFilter::DenyNamespaces(denied) => tools
+            .into_iter()
+            .filter(|tool| match namespace_of(tool.name()) {
+                Some(namespace) => !denied.contains(namespace),
+                // Intrinsic tools have no namespace and are never dropped.
+                None => true,
+            })
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashSet;
+
+    fn names(tools: &[Box<dyn Tool>]) -> Vec<&str> {
+        tools.iter().map(|t| t.name()).collect()
+    }
+
+    fn test_security(workspace: &Path, mode: PolicyMode) -> Arc<SecurityPolicy> {
+        Arc::new(exec_security(workspace, mode))
+    }
+
+    #[test]
+    fn coding_tools_expose_expected_names() {
+        let ws = Path::new("/tmp/oc-toolbelt-coding");
+        let security = test_security(ws, PolicyMode::Supervised);
+        let tools = coding_tools(security, native_runtime(), AuditLogger::disabled(), ws);
+        let got = names(&tools);
+        for expected in [
+            "shell",
+            "read_workspace_state",
+            "apply_patch",
+            "git_operations",
+            "csv_export",
+        ] {
+            assert!(got.contains(&expected), "missing {expected}: {got:?}");
+        }
+        assert_eq!(got.len(), 5, "coding tools drifted: {got:?}");
+    }
+
+    #[test]
+    fn web_tools_expose_expected_names() {
+        let ws = Path::new("/tmp/oc-toolbelt-web");
+        let security = test_security(ws, PolicyMode::Supervised);
+        // Empty allowlist = open-public mode; the SSRF IP guard still applies.
+        let tools = web_tools(security, Vec::new(), ws);
+        let got = names(&tools);
+        for expected in ["web_fetch", "http_request", "curl", "image_info"] {
+            assert!(got.contains(&expected), "missing {expected}: {got:?}");
+        }
+        assert_eq!(got.len(), 4, "web tools drifted: {got:?}");
+    }
+
+    #[test]
+    fn subagent_tools_are_reserved_empty() {
+        assert!(
+            subagent_tools().is_empty(),
+            "subagent namespace is v1-reserved"
+        );
+    }
+
+    #[test]
+    fn namespace_table_maps_exec_tools_and_leaves_intrinsic_unmapped() {
+        assert_eq!(namespace_of("shell"), Some("shell"));
+        assert_eq!(namespace_of("read_workspace_state"), Some("shell"));
+        assert_eq!(namespace_of("apply_patch"), Some("code"));
+        assert_eq!(namespace_of("git_operations"), Some("code"));
+        assert_eq!(namespace_of("csv_export"), Some("code"));
+        assert_eq!(namespace_of("web_fetch"), Some("web"));
+        assert_eq!(namespace_of("http_request"), Some("web"));
+        assert_eq!(namespace_of("curl"), Some("web"));
+        assert_eq!(namespace_of("image_info"), Some("web"));
+        // Intrinsic tools are unmapped (always kept by the filter).
+        assert_eq!(namespace_of("memory_store"), None);
+        assert_eq!(namespace_of("memory_recall"), None);
+        assert_eq!(namespace_of("file_read"), None);
+        assert_eq!(namespace_of("mcp_registry_tool_call"), None);
+    }
+
+    #[test]
+    fn exec_security_shape_is_workspace_scoped_and_hardened() {
+        let ws = Path::new("/tmp/oc-toolbelt-policy");
+
+        let supervised = exec_security(ws, PolicyMode::Supervised);
+        assert!(supervised.workspace_only, "must be workspace-only");
+        assert_eq!(supervised.workspace_dir, ws);
+        assert_eq!(supervised.action_dir, ws);
+        assert!(
+            supervised.block_high_risk_commands,
+            "high-risk must be blocked"
+        );
+        assert!(
+            !supervised.allow_tool_install,
+            "tool install must be denied"
+        );
+        assert!(
+            !supervised.auto_approve_all,
+            "blanket auto-approve must be off"
+        );
+        assert_eq!(supervised.autonomy, AutonomyLevel::Supervised);
+        assert!(
+            supervised.require_approval_for_medium_risk,
+            "supervised must approve medium-risk"
+        );
+
+        // Autonomy tracks the mode 1:1; medium-risk approval is Supervised-only.
+        let readonly = exec_security(ws, PolicyMode::Readonly);
+        assert_eq!(readonly.autonomy, AutonomyLevel::ReadOnly);
+        assert!(!readonly.require_approval_for_medium_risk);
+
+        let full = exec_security(ws, PolicyMode::Full);
+        assert_eq!(full.autonomy, AutonomyLevel::Full);
+        assert!(!full.require_approval_for_medium_risk);
+    }
+
+    #[tokio::test]
+    async fn shell_rm_rf_denied_under_readonly_parked_under_supervised() {
+        use oh::security::GateDecision;
+        let ws = std::env::temp_dir();
+
+        // Readonly: a destructive command is hard-blocked by the policy — proven
+        // both at the decision layer and end-to-end (the tool refuses before it
+        // spawns; the harmless nonexistent path is a belt-and-braces target).
+        let readonly = test_security(&ws, PolicyMode::Readonly);
+        assert_eq!(
+            readonly.gate_decision(readonly.classify_command("rm -rf /")),
+            GateDecision::Block,
+            "readonly must hard-block destructive commands"
+        );
+        let tool = ShellTool::new(readonly, native_runtime(), AuditLogger::disabled());
+        let result = tool
+            .execute(json!({ "command": "rm -rf /tmp/oc-toolbelt-nonexistent-xyz" }))
+            .await
+            .unwrap();
+        assert!(
+            result.is_error,
+            "readonly rm -rf must error: {}",
+            result.output()
+        );
+        assert!(result.output().to_lowercase().contains("read-only"));
+
+        // Supervised: the destructive command is *parked* (requires approval),
+        // never auto-allowed. The park→resolve step is opencompany's own
+        // `ApprovalPolicy` gate layered above; here we prove OpenHuman's policy
+        // classifies it as approval-required rather than allowed.
+        let supervised = test_security(&ws, PolicyMode::Supervised);
+        assert_eq!(
+            supervised.gate_decision(supervised.classify_command("rm -rf /")),
+            GateDecision::Prompt,
+            "supervised must park (require approval for) destructive commands"
+        );
+    }
+
+    #[tokio::test]
+    async fn web_tools_reject_ssrf_ip_literals() {
+        let ws = std::env::temp_dir();
+        let security = test_security(&ws, PolicyMode::Full);
+        // Open-public allowlist: proves the IP guard fires independently of the
+        // domain allowlist. Both are IP literals, so rejection short-circuits
+        // before any DNS lookup or network I/O.
+        let tools = web_tools(security, Vec::new(), &ws);
+        for tool in &tools {
+            // Only web_fetch / http_request take a plain `url` arg.
+            if !matches!(tool.name(), "web_fetch" | "http_request") {
+                continue;
+            }
+            for url in ["http://169.254.169.254/", "http://127.0.0.1:1/"] {
+                let result = tool.execute(json!({ "url": url })).await.unwrap();
+                assert!(
+                    result.is_error,
+                    "{} must reject SSRF target {url}: {}",
+                    tool.name(),
+                    result.output()
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_patch_denied_outside_workspace() {
+        let ws = std::env::temp_dir().join("oc-toolbelt-escape");
+        let _ = tokio::fs::remove_dir_all(&ws).await;
+        tokio::fs::create_dir_all(&ws).await.unwrap();
+        let security = test_security(&ws, PolicyMode::Full);
+        let tool = ApplyPatchTool::new(security);
+        // A path escaping the workspace root must be refused by the policy.
+        let result = tool
+            .execute(json!({
+                "edits": [
+                    { "path": "../outside.txt", "old_string": "x", "new_string": "y" }
+                ]
+            }))
+            .await
+            .unwrap();
+        assert!(
+            result.is_error,
+            "workspace escape must be denied: {}",
+            result.output()
+        );
+        let _ = tokio::fs::remove_dir_all(&ws).await;
+    }
+
+    #[test]
+    fn filter_allow_all_is_identity() {
+        let ws = Path::new("/tmp/oc-toolbelt-filter");
+        let security = test_security(ws, PolicyMode::Supervised);
+        let tools = coding_tools(security, native_runtime(), AuditLogger::disabled(), ws);
+        // Own the names before `tools` moves into the filter.
+        let before: Vec<String> = tools.iter().map(|t| t.name().to_string()).collect();
+        let after_tools = filter_by_capabilities(tools, &CapabilityFilter::AllowAll);
+        let after: Vec<String> = after_tools.iter().map(|t| t.name().to_string()).collect();
+        assert_eq!(before, after, "AllowAll must be identity");
+    }
+
+    #[test]
+    fn filter_deny_drops_mapped_but_keeps_intrinsic() {
+        // Mix a real intrinsic tool (`file_read`, unmapped) with mapped exec
+        // tools; a full namespace deny must keep only the intrinsic one.
+        let ws = Path::new("/tmp/oc-toolbelt-deny");
+        let security = test_security(ws, PolicyMode::Supervised);
+        let mut tools: Vec<Box<dyn Tool>> = coding_tools(
+            security.clone(),
+            native_runtime(),
+            AuditLogger::disabled(),
+            ws,
+        );
+        tools.extend(web_tools(security.clone(), Vec::new(), ws));
+        // `file_read` has no mapped namespace → intrinsic → always kept.
+        tools.push(Box::new(oh::tools::FileReadTool::new(security)));
+
+        let deny: HashSet<&'static str> = ["shell", "code", "web"].into_iter().collect();
+        let kept = filter_by_capabilities(tools, &CapabilityFilter::DenyNamespaces(deny));
+        let kept_names = names(&kept);
+        assert_eq!(
+            kept_names,
+            vec!["file_read"],
+            "only the intrinsic tool must survive a full deny: {kept_names:?}"
+        );
+    }
+}

--- a/src/harness/toolbelt.rs
+++ b/src/harness/toolbelt.rs
@@ -128,15 +128,18 @@ pub fn native_runtime() -> Arc<dyn RuntimeAdapter> {
 /// own workspace dir so audit trails are tenant-isolated.
 ///
 /// Audit must never block agent construction, so a logger-init failure degrades
-/// to [`AuditLogger::disabled`] with a warning rather than propagating.
+/// to [`AuditLogger::disabled`] rather than propagating. The failure is logged
+/// at `error!` (not `warn!`): a consistent init failure means every subsequent
+/// shell command for this agent runs with **no audit record**, so the event
+/// must surface in production error telemetry rather than blend into warnings.
 pub fn workspace_audit(workspace: &Path) -> Arc<AuditLogger> {
     match get_or_create_workspace_audit_logger(AuditConfig::default(), workspace.to_path_buf()) {
         Ok(logger) => logger,
         Err(error) => {
-            tracing::warn!(
+            tracing::error!(
                 workspace = %workspace.display(),
                 %error,
-                "[toolbelt] workspace audit logger init failed; shell audit disabled for this agent"
+                "[toolbelt] workspace audit logger init failed; shell commands for this agent will run UNAUDITED"
             );
             AuditLogger::disabled()
         }

--- a/src/harness/toolbelt.rs
+++ b/src/harness/toolbelt.rs
@@ -73,7 +73,7 @@ const CURL_DEST_SUBDIR: &str = "downloads";
 /// The canonical list lives in [`crate::company::GATEABLE_NAMESPACES`] (always
 /// compiled, so manifest validation can see it in the default build); this is a
 /// re-export for the harness call sites that key off it.
-pub const GATEABLE_NAMESPACES: [&str; 4] = crate::company::GATEABLE_NAMESPACES;
+pub const GATEABLE_NAMESPACES: [&str; 5] = crate::company::GATEABLE_NAMESPACES;
 
 /// Map a tool's runtime `name()` onto its grant namespace, or `None` when the
 /// tool is **intrinsic** (memory / MCP / orchestrator / file / skill tools),
@@ -87,6 +87,11 @@ pub fn namespace_of(tool_name: &str) -> Option<&'static str> {
         "shell" | "read_workspace_state" => Some("shell"),
         "apply_patch" | "git_operations" | "csv_export" => Some("code"),
         "web_fetch" | "http_request" | "curl" | "image_info" => Some("web"),
+        // Media generation (issue #109). Mapped unconditionally — the arm is
+        // inert without the `media` feature (the tools are never built), but the
+        // namespace mapping is a pure string match so the capability filter and
+        // the gateable-coverage invariant see `media` in every build.
+        "media_generate_image" | "media_generate_video" | "media_list_models" => Some("media"),
         _ => None,
     }
 }
@@ -248,6 +253,84 @@ pub fn web_tools(
             http_defaults.timeout_secs,
         )),
         Box::new(ImageInfoTool::new(security)),
+    ]
+}
+
+/// The managed platform credential for the media-generation backend (issue
+/// #109) — the OpenHuman backend URL + the platform's own bearer token.
+///
+/// **Security invariant**: this holds ONLY the managed platform credential,
+/// never a tenant BYOK key. The tenant identity that the backend bills is
+/// derived server-side from this managed credential, so a company can never
+/// point media generation at a key it controls. Threaded onto
+/// [`HarnessDeps`](crate::harness::HarnessDeps) and consumed by [`media_tools`].
+///
+/// Always compiled (so the deps field exists in every `openhuman` build and
+/// every construction site fails closed with `None`); the live tool
+/// constructors in [`media_tools`] are gated behind the `media` feature.
+#[derive(Clone)]
+pub struct MediaBackend {
+    /// The media-generation backend base URL (e.g. `https://api.tinyhumans.ai`).
+    pub backend_url: String,
+    /// The managed platform bearer credential. Never a tenant key.
+    pub auth_token: String,
+}
+
+impl std::fmt::Debug for MediaBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never let the managed credential land in a trace.
+        f.debug_struct("MediaBackend")
+            .field("backend_url", &self.backend_url)
+            .field(
+                "auth_token",
+                &if self.auth_token.is_empty() {
+                    "<unset>"
+                } else {
+                    "<redacted>"
+                },
+            )
+            .finish()
+    }
+}
+
+/// The `media` namespace tools (issue #109): image + video generation plus the
+/// model catalog, built over the MANAGED platform credential in `backend` with
+/// generated artifacts pinned to the agent's `workspace` (the tools' persistence
+/// `action_dir`, so nothing escapes the sandbox).
+///
+/// These spend real money — the backend charges on submit — so
+/// [`build_agent`](crate::harness::build::build_agent) only calls this when the
+/// company **explicitly** grants `media` (never via the `*` wildcard) AND a
+/// managed credential is present; the generate tools additionally park for
+/// operator approval through the [`ApprovalPolicy`](crate::harness::policy).
+///
+/// * `media_generate_image` / `media_generate_video` — submit → poll → persist,
+///   billed by the backend.
+/// * `media_list_models` — read-only catalog GET (needs no `action_dir`).
+///
+/// Gated on the `media` feature; enabling it necessarily enables
+/// `openhuman_core/media`, so the upstream tool types are in scope.
+#[cfg(feature = "media")]
+pub fn media_tools(backend: &MediaBackend, workspace: &Path) -> Vec<Box<dyn Tool>> {
+    use oh::integrations::IntegrationClient;
+    use oh::media_generation::{
+        MediaGenerateImageTool, MediaGenerateVideoTool, MediaListModelsTool,
+    };
+
+    // The Config-free seam: `IntegrationClient::new(backend_url, auth_token)`
+    // takes the managed credential directly, with no OpenHuman global `Config`.
+    let client = Arc::new(IntegrationClient::new(
+        backend.backend_url.clone(),
+        backend.auth_token.clone(),
+    ));
+    let action_dir = workspace.to_path_buf();
+    vec![
+        Box::new(MediaGenerateImageTool::new(
+            Arc::clone(&client),
+            action_dir.clone(),
+        )),
+        Box::new(MediaGenerateVideoTool::new(Arc::clone(&client), action_dir)),
+        Box::new(MediaListModelsTool::new(client)),
     ]
 }
 
@@ -419,6 +502,10 @@ mod tests {
         assert_eq!(namespace_of("http_request"), Some("web"));
         assert_eq!(namespace_of("curl"), Some("web"));
         assert_eq!(namespace_of("image_info"), Some("web"));
+        // Media generation (issue #109) maps to the `media` namespace.
+        assert_eq!(namespace_of("media_generate_image"), Some("media"));
+        assert_eq!(namespace_of("media_generate_video"), Some("media"));
+        assert_eq!(namespace_of("media_list_models"), Some("media"));
         // Intrinsic tools are unmapped (always kept by the filter).
         assert_eq!(namespace_of("memory_store"), None);
         assert_eq!(namespace_of("memory_recall"), None);
@@ -441,6 +528,9 @@ mod tests {
             "http_request",
             "curl",
             "image_info",
+            "media_generate_image",
+            "media_generate_video",
+            "media_list_models",
         ];
         for tool in mapped {
             let ns = namespace_of(tool).expect("mapped tool has a namespace");
@@ -452,6 +542,10 @@ mod tests {
         assert!(
             GATEABLE_NAMESPACES.contains(&"subagent"),
             "the reserved subagent namespace must be gateable"
+        );
+        assert!(
+            GATEABLE_NAMESPACES.contains(&"media"),
+            "the real-money media namespace must be gateable"
         );
     }
 
@@ -594,6 +688,50 @@ mod tests {
         let after_tools = filter_by_capabilities(tools, &CapabilityFilter::AllowAll);
         let after: Vec<String> = after_tools.iter().map(|t| t.name().to_string()).collect();
         assert_eq!(before, after, "AllowAll must be identity");
+    }
+
+    /// The `media` toolbelt (issue #109) exposes exactly the three OpenHuman
+    /// media tools, each mapped to the `media` namespace so the capability filter
+    /// gates them as one real-money family. Only built under the `media` feature.
+    #[cfg(feature = "media")]
+    #[test]
+    fn media_tools_expose_expected_names_and_namespace() {
+        let ws = Path::new("/tmp/oc-toolbelt-media");
+        let backend = MediaBackend {
+            backend_url: "https://api.tinyhumans.ai".to_string(),
+            auth_token: "managed-token".to_string(),
+        };
+        let tools = media_tools(&backend, ws);
+        let got = names(&tools);
+        for expected in [
+            "media_generate_image",
+            "media_generate_video",
+            "media_list_models",
+        ] {
+            assert!(got.contains(&expected), "missing {expected}: {got:?}");
+        }
+        assert_eq!(got.len(), 3, "media tools drifted: {got:?}");
+        for tool in &tools {
+            assert_eq!(
+                namespace_of(tool.name()),
+                Some("media"),
+                "media_tools leaked a non-media tool: {}",
+                tool.name()
+            );
+        }
+    }
+
+    /// The managed credential never lands in a `MediaBackend` debug trace.
+    #[test]
+    fn media_backend_debug_redacts_the_token() {
+        let backend = MediaBackend {
+            backend_url: "https://api.tinyhumans.ai".to_string(),
+            auth_token: "super-secret".to_string(),
+        };
+        let shown = format!("{backend:?}");
+        assert!(!shown.contains("super-secret"), "token leaked: {shown}");
+        assert!(shown.contains("<redacted>"), "{shown}");
+        assert!(shown.contains("api.tinyhumans.ai"), "{shown}");
     }
 
     #[test]

--- a/src/harness/toolbelt.rs
+++ b/src/harness/toolbelt.rs
@@ -59,6 +59,22 @@ use crate::harness::policy::PolicyMode;
 /// Subdirectory under the agent workspace that `curl` downloads land in.
 const CURL_DEST_SUBDIR: &str = "downloads";
 
+/// Every grant namespace a [`CapabilityFilter`] can gate — "which tool families
+/// are budgeted".
+///
+/// This is the exec-grade surface [`namespace_of`] maps tools onto (`shell`,
+/// `code`, `web`) plus the reserved `subagent` namespace. A capability plan's
+/// budget map keys are validated against this set (a key outside it is a
+/// manifest error), and it is the universe the fail-closed
+/// [`capability_budget`](crate::harness::capability_budget) denies from when no
+/// meter is available. Intrinsic tools (namespace `None`) are never listed here
+/// — they are always kept regardless of the filter.
+///
+/// The canonical list lives in [`crate::company::GATEABLE_NAMESPACES`] (always
+/// compiled, so manifest validation can see it in the default build); this is a
+/// re-export for the harness call sites that key off it.
+pub const GATEABLE_NAMESPACES: [&str; 4] = crate::company::GATEABLE_NAMESPACES;
+
 /// Map a tool's runtime `name()` onto its grant namespace, or `None` when the
 /// tool is **intrinsic** (memory / MCP / orchestrator / file / skill tools),
 /// which are always kept regardless of the capability filter.
@@ -247,18 +263,21 @@ pub fn subagent_tools() -> Vec<Box<dyn Tool>> {
 }
 
 /// Which tools an agent may keep after its grants have already admitted them —
-/// the seam a future capability-tier cell swaps.
+/// the seam the capability-tier gate ([`capability_budget`](crate::harness::capability_budget))
+/// constructs per tenant, per turn.
 ///
-/// Today the production build only ever constructs [`CapabilityFilter::AllowAll`]
-/// (identity). The deny variant exists for tests exercising the filter seam.
+/// [`AllowAll`](Self::AllowAll) is the identity pass (no plan configured, or a
+/// tenant under every tier's budget); [`DenyNamespaces`](Self::DenyNamespaces)
+/// drops the exec families whose per-period token budget the tenant has spent
+/// through — or, fail-closed, every gateable family when the meter can't be
+/// read.
 #[derive(Clone, Debug, Default)]
 pub enum CapabilityFilter {
     /// Keep every tool the grants admitted (identity).
     #[default]
     AllowAll,
     /// Drop every tool whose [`namespace_of`] is in this set; intrinsic tools
-    /// (namespace `None`) are always kept. Test-only for now.
-    #[cfg(test)]
+    /// (namespace `None`) are always kept.
     DenyNamespaces(std::collections::HashSet<&'static str>),
 }
 
@@ -274,7 +293,6 @@ pub fn filter_by_capabilities(
 ) -> Vec<Box<dyn Tool>> {
     match filter {
         CapabilityFilter::AllowAll => tools,
-        #[cfg(test)]
         CapabilityFilter::DenyNamespaces(denied) => tools
             .into_iter()
             .filter(|tool| match namespace_of(tool.name()) {
@@ -406,6 +424,35 @@ mod tests {
         assert_eq!(namespace_of("memory_recall"), None);
         assert_eq!(namespace_of("file_read"), None);
         assert_eq!(namespace_of("mcp_registry_tool_call"), None);
+    }
+
+    /// `GATEABLE_NAMESPACES` must be a superset of every namespace `namespace_of`
+    /// can emit — otherwise an exec family would be ungateable (silently always
+    /// granted). `subagent` is additionally present as the reserved namespace.
+    #[test]
+    fn gateable_namespaces_cover_every_mapped_namespace() {
+        let mapped = [
+            "shell",
+            "read_workspace_state",
+            "apply_patch",
+            "git_operations",
+            "csv_export",
+            "web_fetch",
+            "http_request",
+            "curl",
+            "image_info",
+        ];
+        for tool in mapped {
+            let ns = namespace_of(tool).expect("mapped tool has a namespace");
+            assert!(
+                GATEABLE_NAMESPACES.contains(&ns),
+                "namespace `{ns}` (from `{tool}`) is not gateable"
+            );
+        }
+        assert!(
+            GATEABLE_NAMESPACES.contains(&"subagent"),
+            "the reserved subagent namespace must be gateable"
+        );
     }
 
     #[test]

--- a/src/metering/capability.rs
+++ b/src/metering/capability.rs
@@ -1,0 +1,424 @@
+//! Pure capability-budget math (issue #108): resolve a manifest `[plan]` into a
+//! per-namespace token budget, sum a tenant's period spend, and decide which
+//! exec tool families that spend has exhausted.
+//!
+//! This is the I/O-free half of the capability-tier gate — it lives in
+//! `metering` (always compiled, beside [`usage`](super::usage) /
+//! [`finances`](super::finances)) so both the console read surface and the
+//! feature-gated harness can share it. The harness half
+//! ([`capability_budget`](crate::harness::capability_budget)) adds the
+//! `CapabilityFilter` wiring on top and re-exports these types.
+//!
+//! ## Threshold semantics (important)
+//!
+//! [`UsageSample`]s are **per-turn totals** — the meter records the tokens a turn
+//! burned, with **no per-tool-namespace attribution**. So each tier's budget is a
+//! **threshold over the tenant's total token spend this period**: when cumulative
+//! spend reaches a tier's budget, that tier's tools are disabled. Different
+//! budgets per tier give **graduated degradation** (the cheapest tier drops
+//! first). Per-tier *attribution* is out of scope; if it ever lands, the sample
+//! shape — not this module — is what must change first.
+
+use std::collections::{BTreeMap, HashSet};
+
+use crate::company::{GATEABLE_NAMESPACES, Plan};
+use crate::ports::{SampleKind, UsageSample};
+
+use super::calendar;
+
+/// The window a [`CapabilityPlan`]'s budgets are measured over.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BudgetPeriod {
+    /// The current UTC calendar day (`00:00Z`-aligned).
+    Daily,
+    /// The current UTC calendar month (the 1st, `00:00Z`).
+    Monthly,
+}
+
+impl BudgetPeriod {
+    /// Parses the manifest `[plan].period` string; `None` for an unknown value
+    /// (the manifest validator rejects those before a company boots).
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "daily" | "day" => Some(BudgetPeriod::Daily),
+            "monthly" | "month" => Some(BudgetPeriod::Monthly),
+            _ => None,
+        }
+    }
+
+    /// The console-facing label.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BudgetPeriod::Daily => "daily",
+            BudgetPeriod::Monthly => "monthly",
+        }
+    }
+
+    /// The epoch-millis start of the period `now` falls in — the `since` a spend
+    /// query is anchored to.
+    pub fn period_start_millis(self, now: u64) -> u64 {
+        match self {
+            BudgetPeriod::Daily => {
+                (calendar::epoch_day(now).max(0) as u64) * calendar::MILLIS_PER_DAY
+            }
+            BudgetPeriod::Monthly => calendar::month_start_millis(now),
+        }
+    }
+}
+
+/// A tenant's capability plan: a budget window plus a per-namespace token
+/// threshold map.
+///
+/// The `budgets` **key set is the capability set** — a gateable namespace
+/// (`shell` / `code` / `web` / `subagent`) present in the map is granted until
+/// the tenant's period spend reaches its value; a gateable namespace *absent*
+/// from the map is always denied. The value is a token count per
+/// [`BudgetPeriod`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CapabilityPlan {
+    /// The window `budgets` are measured over.
+    pub period: BudgetPeriod,
+    /// Gateable namespace → tokens allowed per period. `u64::MAX` is effectively
+    /// unlimited.
+    pub budgets: BTreeMap<String, u64>,
+}
+
+impl CapabilityPlan {
+    /// Resolves the manifest `[plan]` section into a runtime plan, or `None` when
+    /// no plan is configured (gating stays off — byte-identical to Cell A).
+    ///
+    /// A built-in tier name (`plan.name`) supplies the base budget map; the
+    /// explicit `token_budgets` table then overrides/extends it, and the `period`
+    /// field selects the window. The manifest validator has already rejected an
+    /// unknown name / period / non-gateable budget key, so this is infallible in
+    /// a booted company; an unknown name still degrades to `None` (gating off)
+    /// rather than panicking.
+    pub fn from_manifest(plan: &Plan) -> Option<Self> {
+        if !plan.is_set() {
+            return None;
+        }
+        let mut resolved = match plan.name.as_deref() {
+            Some(name) => plan_named(name)?,
+            None => CapabilityPlan {
+                period: BudgetPeriod::Daily,
+                budgets: BTreeMap::new(),
+            },
+        };
+        // The manifest `period` field is authoritative for the window (defaults
+        // to daily, which is also every built-in tier's window).
+        resolved.period = BudgetPeriod::parse(&plan.period).unwrap_or(BudgetPeriod::Daily);
+        // Explicit budgets override a named tier's entry and extend it with new
+        // namespaces.
+        for (namespace, tokens) in &plan.token_budgets {
+            resolved.budgets.insert(namespace.clone(), *tokens);
+        }
+        Some(resolved)
+    }
+
+    /// The gateable namespaces this plan denies at `spent` tokens: every gateable
+    /// namespace absent from the budget map, plus every mapped namespace whose
+    /// budget the spend has **reached or passed** (`spent >= budget`).
+    pub fn denied_namespaces(&self, spent: u64) -> HashSet<&'static str> {
+        GATEABLE_NAMESPACES
+            .iter()
+            .copied()
+            .filter(|namespace| match self.budgets.get(*namespace) {
+                Some(budget) => spent >= *budget,
+                None => true,
+            })
+            .collect()
+    }
+
+    /// The per-tier status rows the console renders: one per configured budget,
+    /// in stable (namespace-sorted, via [`BTreeMap`]) order. Because spend is a
+    /// per-turn total with no per-namespace attribution, every row's `spent` is
+    /// the same tenant-wide figure compared against that tier's own threshold.
+    pub fn status(&self, spent: u64) -> Vec<TierBudgetStatus> {
+        self.budgets
+            .iter()
+            .map(|(namespace, &budget)| TierBudgetStatus {
+                namespace: namespace.clone(),
+                budget,
+                spent,
+                remaining: budget.saturating_sub(spent),
+                exhausted: spent >= budget,
+            })
+            .collect()
+    }
+}
+
+/// A built-in plan tier, or `None` for an unknown name.
+///
+/// * `free` — no exec tiers (every gateable namespace denied).
+/// * `starter` — `shell` + `code` at 200k tokens/day.
+/// * `pro` — `shell` + `code` + `web` at 1M tokens/day.
+/// * `unlimited` — every gateable namespace at `u64::MAX` (effectively uncapped).
+///
+/// Every built-in is daily; the manifest `[plan].period` can widen the window.
+pub fn plan_named(name: &str) -> Option<CapabilityPlan> {
+    let budgets: &[(&str, u64)] = match name.trim().to_ascii_lowercase().as_str() {
+        "free" => &[],
+        "starter" => &[("shell", 200_000), ("code", 200_000)],
+        "pro" => &[
+            ("shell", 1_000_000),
+            ("code", 1_000_000),
+            ("web", 1_000_000),
+        ],
+        "unlimited" => &[
+            ("shell", u64::MAX),
+            ("code", u64::MAX),
+            ("web", u64::MAX),
+            ("subagent", u64::MAX),
+        ],
+        _ => return None,
+    };
+    Some(CapabilityPlan {
+        period: BudgetPeriod::Daily,
+        budgets: budgets
+            .iter()
+            .map(|(ns, tokens)| ((*ns).to_string(), *tokens))
+            .collect(),
+    })
+}
+
+/// Total inference tokens (input + output) across a sample window. OAuth-call
+/// samples carry no token spend and are ignored, so a tool-heavy turn never
+/// inflates the token budget.
+pub fn tokens_in(samples: &[UsageSample]) -> u64 {
+    samples
+        .iter()
+        .filter(|s| s.kind == SampleKind::Inference)
+        .map(|s| s.input_tokens.saturating_add(s.output_tokens))
+        .fold(0u64, |acc, t| acc.saturating_add(t))
+}
+
+/// One tier's budget status for the console read surface.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TierBudgetStatus {
+    /// The gateable namespace this tier gates (`shell` / `code` / `web` /
+    /// `subagent`).
+    pub namespace: String,
+    /// The token threshold for the period.
+    pub budget: u64,
+    /// The tenant's total period spend (same across rows — no per-tier
+    /// attribution).
+    pub spent: u64,
+    /// `budget - spent`, saturating at zero.
+    pub remaining: u64,
+    /// Whether spend has reached the threshold (`spent >= budget`) — the tier's
+    /// tools are disabled.
+    pub exhausted: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metering::calendar::{MILLIS_PER_DAY, days_from_civil};
+
+    fn inference_sample(input: u64, output: u64) -> UsageSample {
+        UsageSample {
+            at_millis: 0,
+            agent: "ceo".into(),
+            provider: "managed".into(),
+            input_tokens: input,
+            output_tokens: output,
+            cached_input_tokens: 0,
+            cost_usd: 0.0,
+            kind: SampleKind::Inference,
+        }
+    }
+
+    fn oauth_sample() -> UsageSample {
+        UsageSample {
+            at_millis: 0,
+            agent: "ceo".into(),
+            provider: "github".into(),
+            input_tokens: 999,
+            output_tokens: 999,
+            cached_input_tokens: 0,
+            cost_usd: 0.0,
+            kind: SampleKind::OauthCall,
+        }
+    }
+
+    // --- period boundaries --------------------------------------------------
+
+    #[test]
+    fn daily_period_start_snaps_to_midnight_utc() {
+        let day = days_from_civil(2026, 7, 16) as u64;
+        let noon = day * MILLIS_PER_DAY + 12 * 3_600_000;
+        assert_eq!(
+            BudgetPeriod::Daily.period_start_millis(noon),
+            day * MILLIS_PER_DAY
+        );
+        assert_eq!(
+            BudgetPeriod::Daily.period_start_millis(day * MILLIS_PER_DAY),
+            day * MILLIS_PER_DAY
+        );
+    }
+
+    #[test]
+    fn monthly_period_start_snaps_to_the_first() {
+        let mid = (days_from_civil(2026, 7, 16) as u64) * MILLIS_PER_DAY + 12 * 3_600_000;
+        let first = (days_from_civil(2026, 7, 1) as u64) * MILLIS_PER_DAY;
+        assert_eq!(BudgetPeriod::Monthly.period_start_millis(mid), first);
+    }
+
+    #[test]
+    fn period_parse_round_trips_and_rejects_unknown() {
+        assert_eq!(BudgetPeriod::parse("daily"), Some(BudgetPeriod::Daily));
+        assert_eq!(BudgetPeriod::parse("Monthly"), Some(BudgetPeriod::Monthly));
+        assert_eq!(BudgetPeriod::parse("hourly"), None);
+    }
+
+    // --- tokens_in ----------------------------------------------------------
+
+    #[test]
+    fn tokens_in_sums_inference_and_ignores_oauth() {
+        let samples = vec![
+            inference_sample(100, 50),
+            oauth_sample(),
+            inference_sample(20, 5),
+        ];
+        assert_eq!(tokens_in(&samples), 175);
+    }
+
+    #[test]
+    fn tokens_in_empty_is_zero() {
+        assert_eq!(tokens_in(&[]), 0);
+    }
+
+    // --- exhaustion / denial ------------------------------------------------
+
+    #[test]
+    fn ge_boundary_exhausts_the_tier() {
+        let plan = plan_named("starter").unwrap();
+        // Under budget, the *mapped* tiers (shell/code) are granted. web/subagent
+        // are absent from starter's map, so they are always denied — assert on the
+        // mapped tiers specifically, not on emptiness.
+        let under = plan.denied_namespaces(199_999);
+        assert!(!under.contains("shell") && !under.contains("code"));
+        // Exactly at budget: both mapped tiers exhausted (>= boundary).
+        let at = plan.denied_namespaces(200_000);
+        assert!(at.contains("shell") && at.contains("code"));
+        // Over budget: still denied.
+        assert!(plan.denied_namespaces(200_001).contains("shell"));
+    }
+
+    #[test]
+    fn absent_namespace_is_always_denied() {
+        let plan = plan_named("starter").unwrap();
+        let denied = plan.denied_namespaces(0);
+        assert!(denied.contains("web"), "web absent from map → denied");
+        assert!(denied.contains("subagent"), "subagent absent → denied");
+        assert!(!denied.contains("shell"), "shell granted under budget");
+    }
+
+    #[test]
+    fn zero_budget_namespace_is_denied_from_the_first_token() {
+        let mut plan = plan_named("free").unwrap();
+        plan.budgets.insert("shell".into(), 0);
+        assert!(plan.denied_namespaces(0).contains("shell"));
+    }
+
+    #[test]
+    fn free_plan_denies_every_gateable_namespace() {
+        let plan = plan_named("free").unwrap();
+        let denied = plan.denied_namespaces(0);
+        for ns in GATEABLE_NAMESPACES {
+            assert!(denied.contains(ns), "free must deny {ns}");
+        }
+    }
+
+    #[test]
+    fn unlimited_plan_grants_everything() {
+        let plan = plan_named("unlimited").unwrap();
+        assert!(plan.denied_namespaces(u64::MAX - 1).is_empty());
+    }
+
+    #[test]
+    fn unknown_plan_name_is_none() {
+        assert!(plan_named("enterprise").is_none());
+    }
+
+    // --- status -------------------------------------------------------------
+
+    #[test]
+    fn status_reports_per_tier_rows_against_shared_spend() {
+        let plan = plan_named("starter").unwrap();
+        let rows = plan.status(200_000);
+        assert_eq!(rows.len(), 2, "one row per configured budget");
+        for row in &rows {
+            assert_eq!(row.spent, 200_000);
+            assert_eq!(row.budget, 200_000);
+            assert_eq!(row.remaining, 0);
+            assert!(row.exhausted);
+        }
+        // Sorted namespace order (BTreeMap): code before shell.
+        assert_eq!(rows[0].namespace, "code");
+        assert_eq!(rows[1].namespace, "shell");
+    }
+
+    #[test]
+    fn status_remaining_saturates_and_tracks_exhaustion() {
+        let plan = plan_named("pro").unwrap();
+        let rows = plan.status(600_000);
+        for row in rows {
+            assert_eq!(row.remaining, 400_000);
+            assert!(!row.exhausted);
+        }
+    }
+
+    // --- from_manifest ------------------------------------------------------
+
+    #[test]
+    fn from_manifest_none_when_unset() {
+        let plan = Plan::default();
+        assert!(CapabilityPlan::from_manifest(&plan).is_none());
+    }
+
+    #[test]
+    fn from_manifest_named_tier_resolves_budgets() {
+        let plan = Plan {
+            name: Some("starter".into()),
+            period: "daily".into(),
+            token_budgets: BTreeMap::new(),
+        };
+        let resolved = CapabilityPlan::from_manifest(&plan).unwrap();
+        assert_eq!(resolved.period, BudgetPeriod::Daily);
+        assert_eq!(resolved.budgets.get("shell"), Some(&200_000));
+        assert_eq!(resolved.budgets.get("code"), Some(&200_000));
+        assert!(!resolved.budgets.contains_key("web"));
+    }
+
+    #[test]
+    fn from_manifest_token_budgets_override_and_extend_named() {
+        let mut token_budgets = BTreeMap::new();
+        token_budgets.insert("shell".to_string(), 42);
+        token_budgets.insert("web".to_string(), 7);
+        let plan = Plan {
+            name: Some("starter".into()),
+            period: "monthly".into(),
+            token_budgets,
+        };
+        let resolved = CapabilityPlan::from_manifest(&plan).unwrap();
+        assert_eq!(resolved.period, BudgetPeriod::Monthly, "period field wins");
+        assert_eq!(resolved.budgets.get("shell"), Some(&42), "override");
+        assert_eq!(resolved.budgets.get("code"), Some(&200_000), "kept");
+        assert_eq!(resolved.budgets.get("web"), Some(&7), "extended");
+    }
+
+    #[test]
+    fn from_manifest_bare_token_budgets_without_name() {
+        let mut token_budgets = BTreeMap::new();
+        token_budgets.insert("shell".to_string(), 500);
+        let plan = Plan {
+            name: None,
+            period: "daily".into(),
+            token_budgets,
+        };
+        let resolved = CapabilityPlan::from_manifest(&plan).unwrap();
+        assert_eq!(resolved.budgets.len(), 1);
+        assert_eq!(resolved.budgets.get("shell"), Some(&500));
+    }
+}

--- a/src/metering/capability.rs
+++ b/src/metering/capability.rs
@@ -152,7 +152,10 @@ impl CapabilityPlan {
 /// * `free` — no exec tiers (every gateable namespace denied).
 /// * `starter` — `shell` + `code` at 200k tokens/day.
 /// * `pro` — `shell` + `code` + `web` at 1M tokens/day.
-/// * `unlimited` — every gateable namespace at `u64::MAX` (effectively uncapped).
+/// * `unlimited` — every gateable namespace at `u64::MAX` (effectively
+///   uncapped), including the real-money `media` tier (issue #109). `media` is
+///   absent from `free` / `starter` / `pro`, so those tiers deny it outright
+///   unless the manifest opts in with an explicit `token_budgets = { media = N }`.
 ///
 /// Every built-in is daily; the manifest `[plan].period` can widen the window.
 pub fn plan_named(name: &str) -> Option<CapabilityPlan> {
@@ -169,6 +172,7 @@ pub fn plan_named(name: &str) -> Option<CapabilityPlan> {
             ("code", u64::MAX),
             ("web", u64::MAX),
             ("subagent", u64::MAX),
+            ("media", u64::MAX),
         ],
         _ => return None,
     };
@@ -334,6 +338,29 @@ mod tests {
     fn unlimited_plan_grants_everything() {
         let plan = plan_named("unlimited").unwrap();
         assert!(plan.denied_namespaces(u64::MAX - 1).is_empty());
+    }
+
+    /// The real-money `media` tier (issue #109) is uncapped under `unlimited`
+    /// but denied by every other built-in tier — a company must opt into it via
+    /// an explicit `token_budgets = { media = N }`, never a wildcard.
+    #[test]
+    fn media_tier_is_unlimited_only_and_denied_elsewhere() {
+        assert!(
+            !plan_named("unlimited")
+                .unwrap()
+                .denied_namespaces(0)
+                .contains("media"),
+            "unlimited grants media"
+        );
+        for tier in ["free", "starter", "pro"] {
+            assert!(
+                plan_named(tier)
+                    .unwrap()
+                    .denied_namespaces(0)
+                    .contains("media"),
+                "{tier} must deny the real-money media tier by default"
+            );
+        }
     }
 
     #[test]

--- a/src/metering/mod.rs
+++ b/src/metering/mod.rs
@@ -21,10 +21,12 @@ use crate::company::Agent;
 use crate::ports::types::OverlayAgent;
 
 mod calendar;
+pub mod capability;
 mod finances;
 mod types;
 mod usage;
 
+pub use capability::{BudgetPeriod, CapabilityPlan, TierBudgetStatus, plan_named, tokens_in};
 pub use finances::{category_label, finances_from};
 pub use types::{
     AgentTokens, CategorySpend, Direction, Finances, ProviderCalls, Transaction, Usage, UsagePoint,

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -818,6 +818,16 @@ impl RuntimeBuilder {
                                 // snapshot frozen here at boot.
                                 mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
                                 secrets: Some(secrets.clone()),
+                                // Cell A: the `web` toolbelt SSRF allowlist +
+                                // capability-tier filter. Domains come straight
+                                // from the manifest; the filter is `AllowAll`
+                                // until the capability-tier cell lands.
+                                web_allowed_domains: self
+                                    .manifest
+                                    .tools
+                                    .web_allowed_domains
+                                    .clone(),
+                                capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
                             };
                             let record = CompanyRecord {
                                 id: id.clone(),

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -188,6 +188,12 @@ pub struct RuntimeBuilder {
     /// per-tenant [`TenantProvider`](crate::harness::provider::TenantProvider).
     #[cfg(feature = "openhuman")]
     harness_inference: Option<(HostedProviderConfig, Option<String>)>,
+    /// Issue #109: the MANAGED media-generation backend (env-resolved platform
+    /// credential + URL). `None` fails closed — no image/video tools are wired.
+    /// Threaded onto every harness-built agent's [`HarnessDeps`], but only
+    /// consumed when a company **explicitly** grants the `media` namespace.
+    #[cfg(feature = "openhuman")]
+    media_backend: Option<crate::harness::toolbelt::MediaBackend>,
 }
 
 impl RuntimeBuilder {
@@ -237,6 +243,8 @@ impl RuntimeBuilder {
             harness: None,
             #[cfg(feature = "openhuman")]
             harness_inference: None,
+            #[cfg(feature = "openhuman")]
+            media_backend: None,
         }
     }
 
@@ -486,6 +494,22 @@ impl RuntimeBuilder {
         model_override: Option<String>,
     ) -> Self {
         self.harness_inference = Some((config, model_override));
+        self
+    }
+
+    /// Issue #109: sets the MANAGED media-generation backend (platform
+    /// credential + URL, resolved from the environment via
+    /// [`media_backend_from_env`](crate::harness::provider::media_backend_from_env)).
+    /// This is the ONLY path media generation is ever fed a credential — never a
+    /// tenant secret — so a company can generate media only on the managed
+    /// platform account. Absent (the default), media tools are never wired even
+    /// for a company that grants `media`. Feature-gated.
+    #[cfg(feature = "openhuman")]
+    pub fn with_media_backend(
+        mut self,
+        media_backend: crate::harness::toolbelt::MediaBackend,
+    ) -> Self {
+        self.media_backend = Some(media_backend);
         self
     }
 
@@ -835,6 +859,13 @@ impl RuntimeBuilder {
                                     crate::harness::capability_budget::CapabilityPlan::from_manifest(
                                         &self.manifest.plan,
                                     ),
+                                // Issue #109: the MANAGED media-generation
+                                // backend, resolved from the environment by the
+                                // CLI (`attach_harness` → `media_backend_from_env`)
+                                // and never from a tenant secret. `None` fails
+                                // closed — `build_agent` wires no media tools even
+                                // for a company that grants `media`.
+                                media: self.media_backend.clone(),
                             };
                             let record = CompanyRecord {
                                 id: id.clone(),

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -818,16 +818,23 @@ impl RuntimeBuilder {
                                 // snapshot frozen here at boot.
                                 mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
                                 secrets: Some(secrets.clone()),
-                                // Cell A: the `web` toolbelt SSRF allowlist +
-                                // capability-tier filter. Domains come straight
-                                // from the manifest; the filter is `AllowAll`
-                                // until the capability-tier cell lands.
+                                // Cell A: the `web` toolbelt SSRF allowlist.
+                                // Domains come straight from the manifest.
                                 web_allowed_domains: self
                                     .manifest
                                     .tools
                                     .web_allowed_domains
                                     .clone(),
+                                // Issue #108: `capabilities` is the no-plan
+                                // fallback (identity). When `[plan]` is set,
+                                // `HarnessPool::ensure` resolves the per-tenant
+                                // filter from the meter each turn and overwrites
+                                // it; `plan` carries the resolved budget so it can.
                                 capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+                                plan:
+                                    crate::harness::capability_budget::CapabilityPlan::from_manifest(
+                                        &self.manifest.plan,
+                                    ),
                             };
                             let record = CompanyRecord {
                                 id: id.clone(),

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1005,6 +1005,8 @@ mod test {
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record);
 

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1007,6 +1007,7 @@ mod test {
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            plan: None,
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record);
 

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1008,6 +1008,7 @@ mod test {
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
+            media: None,
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record);
 

--- a/src/server/ops/capabilities.rs
+++ b/src/server/ops/capabilities.rs
@@ -51,6 +51,18 @@ struct CapabilityStatusDto {
     /// One row per configured tier, namespace-sorted. Omitted when unconfigured.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tiers: Vec<TierDto>,
+    /// Media generation (issue #109): whether this company **explicitly** grants
+    /// the real-money `media` namespace (a `*` wildcard does NOT count). Sent
+    /// regardless of whether a `[plan]` is configured, since media is opt-in per
+    /// tool grant, not per plan.
+    media_granted: bool,
+    /// Whether the `media` feature is compiled into this build at all (the tools
+    /// only exist under it). `false` lets the console show a "not in this build"
+    /// state rather than implying a missing credential.
+    media_in_build: bool,
+    /// Whether a MANAGED media credential is resolvable from the environment on
+    /// this build (feature on + env present). Never reflects a tenant secret.
+    media_credential_configured: bool,
 }
 
 /// One tier's budget row.
@@ -70,8 +82,9 @@ struct TierDto {
     exhausted: bool,
 }
 
-/// The unconfigured response: `{ configured: false }`.
-fn unconfigured() -> CapabilityStatusDto {
+/// The unconfigured response: `{ configured: false }` plus the media-status
+/// flags (media is opt-in per tool grant, independent of a `[plan]`).
+fn unconfigured(media_granted: bool) -> CapabilityStatusDto {
     CapabilityStatusDto {
         configured: false,
         plan: None,
@@ -79,6 +92,25 @@ fn unconfigured() -> CapabilityStatusDto {
         period_start_millis: None,
         spent_tokens: None,
         tiers: Vec::new(),
+        media_granted,
+        media_in_build: cfg!(feature = "media"),
+        media_credential_configured: media_credential_configured(),
+    }
+}
+
+/// Whether a MANAGED media credential (issue #109) is resolvable from the
+/// environment on this build. `true` only under the `media` feature with a
+/// credential present — env-only, never a tenant secret, matching the harness's
+/// fail-closed resolution. Off the feature this is always `false`.
+fn media_credential_configured() -> bool {
+    #[cfg(feature = "media")]
+    {
+        use crate::app::config::ProcessEnv;
+        crate::harness::provider::media_backend_from_env(&ProcessEnv).is_some()
+    }
+    #[cfg(not(feature = "media"))]
+    {
+        false
     }
 }
 
@@ -86,11 +118,14 @@ fn unconfigured() -> CapabilityStatusDto {
 async fn effective_status(runtime: &CompanyRuntime) -> Result<CapabilityStatusDto, ApiError> {
     let record = runtime.store().load(runtime.id()).await.map_err(ApiError)?;
     let Some(record) = record else {
-        return Ok(unconfigured());
+        return Ok(unconfigured(false));
     };
+    // Media is opt-in per tool grant (explicit `media`, never `*`) and lives on
+    // the manifest regardless of whether a capability `[plan]` is configured.
+    let media_granted = crate::company::grants_media_explicit(&record.manifest.tools.allow);
     let manifest_plan = &record.manifest.plan;
     let Some(plan) = CapabilityPlan::from_manifest(manifest_plan) else {
-        return Ok(unconfigured());
+        return Ok(unconfigured(media_granted));
     };
 
     let now = now_millis();
@@ -121,6 +156,9 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<CapabilityStatusDt
         period_start_millis: Some(since),
         spent_tokens: Some(spent),
         tiers,
+        media_granted,
+        media_in_build: cfg!(feature = "media"),
+        media_credential_configured: media_credential_configured(),
     })
 }
 
@@ -212,6 +250,41 @@ mod tests {
         assert!(dto.get("plan").is_none());
 
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Media generation (issue #109): the route surfaces `mediaGranted` from the
+    /// manifest tool grants (explicit `media`, never `*`), even with no `[plan]`.
+    #[tokio::test]
+    async fn reports_media_granted_from_explicit_grant_only() {
+        // Explicit `media` grant, no `[plan]` → unconfigured but mediaGranted.
+        let home_a = home();
+        let state = state_with_manifest(
+            &home_a,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"media\"]\n",
+        )
+        .await;
+        let (status, dto) = get_capabilities(&state).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(dto["configured"], false);
+        assert_eq!(dto["mediaGranted"], true, "{dto}");
+        // The flags are always present so the console can render every state.
+        assert!(dto.get("mediaInBuild").is_some(), "{dto}");
+        assert!(dto.get("mediaCredentialConfigured").is_some(), "{dto}");
+        std::fs::remove_dir_all(&home_a).ok();
+
+        // A `*` wildcard grant must NOT count as a media grant.
+        let home_b = home();
+        let state2 = state_with_manifest(
+            &home_b,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"*\"]\n",
+        )
+        .await;
+        let (_, dto2) = get_capabilities(&state2).await;
+        assert_eq!(
+            dto2["mediaGranted"], false,
+            "the `*` wildcard must not grant the real-money media family: {dto2}"
+        );
+        std::fs::remove_dir_all(&home_b).ok();
     }
 
     #[tokio::test]

--- a/src/server/ops/capabilities.rs
+++ b/src/server/ops/capabilities.rs
@@ -1,0 +1,265 @@
+//! Capability-budget read surface (issue #108): the company's effective tier
+//! plan and how much of each tier's token budget the current period has spent.
+//!
+//! A read-only companion to the harness gate — the console renders one row per
+//! configured tier (budget, spend, remaining, whether its tools are disabled).
+//! With no `[plan]` configured the response is `{ configured: false }` and the
+//! console shows a "no token plan configured" note. The heavy lifting is the
+//! pure math in [`crate::metering::capability`]; this handler only queries the
+//! [`UsageMeter`](crate::ports::UsageMeter) for the period and projects it.
+
+use axum::Json;
+use axum::Router;
+use axum::routing::get;
+use serde::Serialize;
+
+use crate::AppState;
+use crate::company::runtime::CompanyRuntime;
+use crate::metering::capability::{CapabilityPlan, tokens_in};
+use crate::ports::now_millis;
+use crate::server::error::ApiError;
+use crate::server::ops::{ScopedCompany, scoped};
+
+/// Builds the capability-budget route fragment.
+pub fn router() -> Router<AppState> {
+    scoped("/capabilities", get(get_status))
+}
+
+/// The company's capability-budget status as the console renders it.
+///
+/// When no `[plan]` is configured only `configured: false` is sent; the extra
+/// fields are omitted so the console can branch on presence.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CapabilityStatusDto {
+    /// Whether the company has a capability plan at all.
+    configured: bool,
+    /// The configured built-in tier name, if any (`null` for a bare
+    /// `token_budgets` plan).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    plan: Option<String>,
+    /// The budget window (`daily` / `monthly`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    period: Option<String>,
+    /// Epoch-millis start of the current budget period (the spend window).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    period_start_millis: Option<u64>,
+    /// Total inference tokens spent by the company this period (the figure every
+    /// tier threshold is compared against).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    spent_tokens: Option<u64>,
+    /// One row per configured tier, namespace-sorted. Omitted when unconfigured.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tiers: Vec<TierDto>,
+}
+
+/// One tier's budget row.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TierDto {
+    /// The exec tool namespace this tier gates.
+    namespace: String,
+    /// Tokens allowed this period.
+    budget_tokens: u64,
+    /// Tokens spent this period (company-wide — spend has no per-tier
+    /// attribution, so this is the same across rows).
+    spent_tokens: u64,
+    /// `budget - spent`, saturating at zero.
+    remaining_tokens: u64,
+    /// Whether spend has reached the threshold — the tier's tools are disabled.
+    exhausted: bool,
+}
+
+/// The unconfigured response: `{ configured: false }`.
+fn unconfigured() -> CapabilityStatusDto {
+    CapabilityStatusDto {
+        configured: false,
+        plan: None,
+        period: None,
+        period_start_millis: None,
+        spent_tokens: None,
+        tiers: Vec::new(),
+    }
+}
+
+/// Resolves the capability-budget status DTO for a company.
+async fn effective_status(runtime: &CompanyRuntime) -> Result<CapabilityStatusDto, ApiError> {
+    let record = runtime.store().load(runtime.id()).await.map_err(ApiError)?;
+    let Some(record) = record else {
+        return Ok(unconfigured());
+    };
+    let manifest_plan = &record.manifest.plan;
+    let Some(plan) = CapabilityPlan::from_manifest(manifest_plan) else {
+        return Ok(unconfigured());
+    };
+
+    let now = now_millis();
+    let since = plan.period.period_start_millis(now);
+    let samples = runtime
+        .usage()
+        .query(runtime.id(), since)
+        .await
+        .map_err(ApiError)?;
+    let spent = tokens_in(&samples);
+
+    let tiers = plan
+        .status(spent)
+        .into_iter()
+        .map(|tier| TierDto {
+            namespace: tier.namespace,
+            budget_tokens: tier.budget,
+            spent_tokens: tier.spent,
+            remaining_tokens: tier.remaining,
+            exhausted: tier.exhausted,
+        })
+        .collect();
+
+    Ok(CapabilityStatusDto {
+        configured: true,
+        plan: manifest_plan.name.clone(),
+        period: Some(plan.period.as_str().to_string()),
+        period_start_millis: Some(since),
+        spent_tokens: Some(spent),
+        tiers,
+    })
+}
+
+/// `GET …/capabilities` — the company's capability-budget status.
+async fn get_status(company: ScopedCompany) -> Result<Json<CapabilityStatusDto>, ApiError> {
+    Ok(Json(effective_status(company.runtime.as_ref()).await?))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use serde_json::Value;
+    use tower::ServiceExt;
+
+    use crate::company::CompanyManifest;
+    use crate::ports::types::{CompanyId, CompanyRecord};
+    use crate::ports::usage::{SampleKind, UsageSample};
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+    use crate::store::FsCompanyStore;
+    use crate::{AppConfig, AppState};
+
+    fn home() -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("oc-capabilities-{}", crate::ports::generate_id()))
+    }
+
+    async fn state_with_manifest(home: &std::path::Path, manifest_toml: &str) -> AppState {
+        use crate::ports::CompanyStore;
+        let manifest: CompanyManifest = toml::from_str(manifest_toml).unwrap();
+        let store = FsCompanyStore::new(home.to_path_buf());
+        let id = CompanyId::new("acme");
+        store
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        state
+    }
+
+    async fn get_capabilities(state: &AppState) -> (StatusCode, Value) {
+        let request = Request::builder()
+            .method("GET")
+            .uri("/api/v1/company/capabilities")
+            .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+            .body(Body::empty())
+            .unwrap();
+        let response = router(state.clone()).oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value = if bytes.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+        };
+        (status, value)
+    }
+
+    #[tokio::test]
+    async fn reports_unconfigured_without_a_plan() {
+        let home = home();
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n",
+        )
+        .await;
+
+        let (status, dto) = get_capabilities(&state).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(dto["configured"], false);
+        assert!(
+            dto.get("tiers").is_none(),
+            "no tiers when unconfigured: {dto}"
+        );
+        assert!(dto.get("plan").is_none());
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[tokio::test]
+    async fn reports_tiers_and_exhaustion_for_a_configured_plan() {
+        let home = home();
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[plan]\nname = \"starter\"\n",
+        )
+        .await;
+
+        // Seed 250k inference tokens into the company meter — past starter's 200k.
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+        runtime
+            .usage()
+            .record(
+                &id,
+                &UsageSample {
+                    at_millis: crate::ports::now_millis(),
+                    agent: "ceo".into(),
+                    provider: "managed".into(),
+                    input_tokens: 200_000,
+                    output_tokens: 50_000,
+                    cached_input_tokens: 0,
+                    cost_usd: 0.0,
+                    kind: SampleKind::Inference,
+                },
+            )
+            .await
+            .unwrap();
+
+        let (status, dto) = get_capabilities(&state).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(dto["configured"], true);
+        assert_eq!(dto["plan"], "starter");
+        assert_eq!(dto["period"], "daily");
+        assert_eq!(dto["spentTokens"], 250_000);
+
+        let tiers = dto["tiers"].as_array().expect("tiers present");
+        assert_eq!(tiers.len(), 2, "starter budgets shell + code: {dto}");
+        for tier in tiers {
+            assert_eq!(tier["budgetTokens"], 200_000);
+            assert_eq!(tier["spentTokens"], 250_000);
+            assert_eq!(tier["remainingTokens"], 0);
+            assert_eq!(tier["exhausted"], true);
+        }
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -15,6 +15,7 @@
 //! mocks in tests, real impls when a feature is on); the OAuth write routes are
 //! compiled only under the `oauth` feature and 404 otherwise.
 
+pub mod capabilities;
 pub mod channels;
 pub mod domain;
 pub mod inbox;
@@ -135,6 +136,7 @@ impl std::fmt::Debug for ConnectionsRuntime {
 /// Builds the `ops` route fragment, merged into the main router.
 pub fn router() -> Router<AppState> {
     let router = Router::new()
+        .merge(capabilities::router())
         .merge(channels::router())
         .merge(domain::router())
         .merge(smtp::router())

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -152,6 +152,7 @@ description = "Runs Acme."
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            plan: None,
         }
     }
 

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -153,6 +153,7 @@ description = "Runs Acme."
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
+            media: None,
         }
     }
 

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -150,6 +150,8 @@ description = "Runs Acme."
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
         }
     }
 


### PR DESCRIPTION
## Summary

Cell B of Epic #26: company agents can generate **images and video**. Wraps OpenHuman's existing media-generation tools (`media_generate_image`, `media_generate_video`, `media_list_models`) for the embedded harness behind a new `media` grant namespace, folded into #107's toolbelt and #108's per-plan token-tier gate.

Real-money guardrails throughout:
- **Managed platform credential only** — resolved from env (`OPENCOMPANY_MEDIA_KEY` → `TINYHUMANS_API_KEY`), never a tenant BYOK key. Tenant identity is derived server-side from the platform credential. Fail-closed: no credential ⇒ no tools.
- **Explicit opt-in grant** — `media` is *not* covered by a `*` wildcard grant; a company must name it. Regression-tested.
- **Per-call approval** — every `media_generate_*` call parks on a Supervised desk (`EffectGroup::Spend`) before money moves; `media_list_models` (catalog GET) does not park.
- **Workspace-sandboxed** — artifacts land only under the agent's `action_dir`.
- **Plan-tiered** — `media` is unlimited-plan-only by default; other plans deny by absence unless the tenant sets `token_budgets = { media = N }`.

Console is wired end-to-end: the Usage view shows a "Media generation" status row (active / granted-awaiting-credential / not-granted / not-in-build) via new `capabilities` DTO fields.

Compiled out by default (`media` Cargo feature); upstream `media = []` adds no dependencies.

> **Stacked on #117 (#108).** Per the cross-fork PR-base limit this PR bases on `main`, so the diff currently includes #108's token-tier commits; it self-cleans once #108 merges. Review the `feat(media): …` commits.

## API Or Behavior Changes

- New `media` capability namespace (grant + `token_budgets` key).
- New `media` Cargo feature (`media = ["openhuman", "openhuman_core/media"]`).
- `HarnessDeps` gains a `media: Option<MediaBackend>` field.
- `GET /{scope}/capabilities` DTO gains `mediaGranted` / `mediaInBuild` / `mediaCredentialConfigured`.
- Prod wiring: `RuntimeBuilder::with_media_backend` from `media_backend_from_env` at boot.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (with `--features openhuman,mcp,telegram,media`)
- [x] `cargo build --all-targets` (full union: `--features openhuman,mcp,telegram,media`)
- [x] `cargo test` — 837 lib tests pass under the full feature union; default build 635 pass

Added: toolbelt media names/namespace coverage, `*`-grant does **not** wire media (regression), granted-without-credential wires nothing, provider env-precedence + fail-closed `None`, plan-tier grant/deny, policy (supervised parks generate / allows list / `Spend` classification), capabilities-route DTO. Frontend: `npm run typecheck` + `npm run build` clean.

> CI never builds the `media` feature combo (known repo gap) — the full union was built + tested locally.

## Documentation

`docs/spec/runtime/manifest.md` `[plan]` section documents the `media` namespace, opt-in/real-money semantics, and plan-tier behavior.

Closes #109


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional capability plans with daily or monthly token budgets for controlling access to execution tools.
  * Added a Usage view showing budget spend, remaining tokens, exhaustion status, and media-generation availability.
  * Added capability status reporting through the company API.
  * Added opt-in managed image and video generation with credential and approval safeguards.
  * Added workspace-scoped shell, code, and web tool access with capability-based filtering.

* **Documentation**
  * Documented plan configuration, budget behavior, media access requirements, and fail-closed safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->