### PR TITLE
feat(steer): pause/redirect/cancel in-flight tasks from chat (#111)

### DIFF
--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -75,7 +75,10 @@ pub trait EventLog: Send + Sync {
 
 `CompanyEvent` variants: `OperatorMessage`, `WebhookReceived`,
 `ScheduleFired`, `A2aTaskReceived`, `ApprovalResolved`, `FeedbackFiled`,
-`PaymentReceived`.
+`PaymentReceived`, `LifecycleChanged`, `AgentReply`, `MemoryFactDeleted`,
+`TaskDispatched`, `McpCallFailed`, `WorkflowCreated` (a new saved workflow
+graph was authored + enabled via the console `POST …/workflows` route or the
+orchestrator's `create_workflow` tool; journaled best-effort after persist).
 
 ## MemoryStore
 

--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -78,7 +78,9 @@ pub trait EventLog: Send + Sync {
 `PaymentReceived`, `LifecycleChanged`, `AgentReply`, `MemoryFactDeleted`,
 `TaskDispatched`, `McpCallFailed`, `WorkflowCreated` (a new saved workflow
 graph was authored + enabled via the console `POST …/workflows` route or the
-orchestrator's `create_workflow` tool; journaled best-effort after persist).
+orchestrator's `create_workflow` tool; journaled best-effort after persist),
+`TaskSteered` (an operator paused, cancelled, or redirected an in-flight task
+or delegation).
 
 ## MemoryStore
 

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -114,6 +114,7 @@ async fn main() -> anyhow::Result<()> {
         capabilities: opencompany::harness::toolbelt::CapabilityFilter::AllowAll,
         plan: None,
         media: None,
+        steer: opencompany::company::steer::InflightRegistry::default(),
     };
 
     let pool = HarnessPool::new();

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -62,3 +62,55 @@ export function deleteTask(
 ): Promise<void> {
   return client.del<void>(`${client.scopeFor(company)}/tasks/${encodeURIComponent(id)}`);
 }
+
+/** A steer verb the operator can apply to an in-flight run (issue #111). */
+export type SteerAction = "pause" | "cancel" | "redirect";
+
+/**
+ * One in-flight run the operator can steer (issue #111): a dispatched board
+ * task (`kind: "task"`) or a sub-agent delegation (`kind: "delegation"`).
+ * `key` is the steer identifier — for a board task it equals the task id.
+ * `pendingAction` is non-null while a steer of that verb is already in flight
+ * for this run, so the console can badge + disable its row.
+ */
+export interface InflightRun {
+  taskId: string | null;
+  key: string;
+  kind: "task" | "delegation";
+  title: string;
+  agentId: string;
+  startedAt: number;
+  pendingAction: string | null;
+}
+
+/** The steer body. `redirect` requires `instruction`; `cancel` requires `confirm`. */
+export interface SteerInput {
+  action: SteerAction;
+  instruction?: string;
+  confirm?: boolean;
+}
+
+/** The runs currently in flight for a company, steerable from company chat. */
+export function listInflight(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<InflightRun[]> {
+  return client.get<InflightRun[]>(`${client.scopeFor(company)}/tasks/inflight`);
+}
+
+/**
+ * Steer an in-flight run by its `key`: pause it, cancel it (requires
+ * `confirm: true`), or redirect it with a fresh `instruction`. The host answers
+ * 202 with no body; callers should refetch {@link listInflight} afterwards.
+ */
+export function steerTask(
+  client: OpenCompanyClient,
+  company: string | null,
+  key: string,
+  body: SteerInput,
+): Promise<void> {
+  return client.post<void>(
+    `${client.scopeFor(company)}/tasks/${encodeURIComponent(key)}/steer`,
+    body,
+  );
+}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -188,6 +188,9 @@ export function AppShell({
   const [threads, setThreads] = useState(defaultThreads);
   const [activeThreadId, setActiveThreadId] = useState("main");
   const [feedbackOpen, setFeedbackOpen] = useState(false);
+  // A monotonic nonce bumped on every task-lifecycle SSE event, so the
+  // company-chat in-flight steer strip (issue #111) refetches live.
+  const [taskEventTick, setTaskEventTick] = useState(0);
   const feed = useCompany(client, company, initialStatus);
 
   const pending = feed.status.pending_approvals;
@@ -294,6 +297,7 @@ export function AppShell({
   useEvents(client, company, {
     pendingApprovals: pending,
     onAgentReply: injectAgentReply,
+    onTaskEvent: useCallback(() => setTaskEventTick((n) => n + 1), []),
   });
 
   return (
@@ -386,6 +390,7 @@ export function AppShell({
               onSelect={setActiveThreadId}
               setMessages={setThreadMessages}
               onReply={() => void feed.refresh()}
+              taskEventTick={taskEventTick}
             />
           )}
           {view === "inbox" && <InboxView company={company} />}

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -12,6 +12,7 @@ import type { OpenCompanyClient } from "@/api/client";
 export type CompanyStreamEvent =
   | { type: "agent_reply"; seq: number; atMillis: number; chatId: string; agentId: string; text: string }
   | { type: "task_dispatched"; seq: number; atMillis: number; taskId: string }
+  | { type: "task_steered"; seq: number; atMillis: number; taskId: string; action: string }
   | {
       type: "mcp_call_failed";
       seq: number;
@@ -45,6 +46,12 @@ interface Options {
    * chat's transcript. The shell dedupes against its own optimistic echo.
    */
   onAgentReply?: (event: AgentReplyEvent) => void;
+  /**
+   * Called for each task-lifecycle event (`task_dispatched`, `task_steered`) so
+   * a surface showing in-flight runs — the company-chat steer strip (issue #111)
+   * — can refetch live off the existing SSE stream instead of only on a poll.
+   */
+  onTaskEvent?: (event: CompanyStreamEvent) => void;
 }
 
 /**
@@ -59,13 +66,17 @@ interface Options {
 export function useEvents(
   client: OpenCompanyClient,
   company: string | null,
-  { pendingApprovals, onAgentReply }: Options,
+  { pendingApprovals, onAgentReply, onTaskEvent }: Options,
 ): void {
-  // Keep the latest callback without re-opening the stream when it changes.
+  // Keep the latest callbacks without re-opening the stream when they change.
   const onAgentReplyRef = useRef(onAgentReply);
   useEffect(() => {
     onAgentReplyRef.current = onAgentReply;
   }, [onAgentReply]);
+  const onTaskEventRef = useRef(onTaskEvent);
+  useEffect(() => {
+    onTaskEventRef.current = onTaskEvent;
+  }, [onTaskEvent]);
 
   // The rising-edge detector for pending approvals. Seeded with the current
   // value so we only toast on an *increase* observed while mounted, never on the
@@ -112,7 +123,7 @@ export function useEvents(
         console.debug("[events] dropping unparseable event", err);
         return;
       }
-      handleEvent(event, onAgentReplyRef.current);
+      handleEvent(event, onAgentReplyRef.current, onTaskEventRef.current);
     };
 
     source.onerror = () => {
@@ -135,7 +146,11 @@ export function useEvents(
 }
 
 /** Routes one parsed event to its toast / transcript side effect. */
-function handleEvent(event: CompanyStreamEvent, onAgentReply?: (e: AgentReplyEvent) => void): void {
+function handleEvent(
+  event: CompanyStreamEvent,
+  onAgentReply?: (e: AgentReplyEvent) => void,
+  onTaskEvent?: (e: CompanyStreamEvent) => void,
+): void {
   switch (event.type) {
     case "mcp_call_failed":
       toast.error(`MCP ${event.server} failed`, {
@@ -146,6 +161,13 @@ function handleEvent(event: CompanyStreamEvent, onAgentReply?: (e: AgentReplyEve
       toast("A task is on the move", {
         description: "Your company picked up a task.",
       });
+      onTaskEvent?.(event);
+      break;
+    case "task_steered":
+      toast("A task was steered", {
+        description: `Your company ${steeredVerb(event.action)} a task.`,
+      });
+      onTaskEvent?.(event);
       break;
     case "agent_reply":
       onAgentReply?.({ chatId: event.chatId, agentId: event.agentId, text: event.text });
@@ -168,5 +190,19 @@ function handleEvent(event: CompanyStreamEvent, onAgentReply?: (e: AgentReplyEve
     default:
       // An unknown/forward event kind: ignore rather than surface noise.
       break;
+  }
+}
+
+/** Past-tense phrasing for a `task_steered` action, for the toast copy. */
+function steeredVerb(action: string): string {
+  switch (action) {
+    case "pause":
+      return "paused";
+    case "cancel":
+      return "cancelled";
+    case "redirect":
+      return "redirected";
+    default:
+      return "steered";
   }
 }

--- a/frontend/src/lib/tasks-sample.ts
+++ b/frontend/src/lib/tasks-sample.ts
@@ -21,6 +21,8 @@ export interface TaskColumn {
 export const TASK_COLUMNS: TaskColumn[] = [
   { id: "backlog", label: "Backlog" },
   { id: "in_progress", label: "In progress" },
+  // Where a steered-to-pause run parks (issue #111); a card here offers Resume.
+  { id: "paused", label: "Paused" },
   { id: "in_review", label: "In review" },
   { id: "done", label: "Done" },
 ];

--- a/frontend/src/views/Conversation.tsx
+++ b/frontend/src/views/Conversation.tsx
@@ -353,7 +353,7 @@ function InflightRow({
   const [instruction, setInstruction] = useState("");
 
   // A pending server-side steer, or an optimistic local one, freezes the row.
-  const pending = run.pendingAction;
+  const pending = run.pendingAction ?? null;
   const disabled = busy || pending !== null;
 
   async function steer(action: SteerAction, opts?: { instruction?: string; confirm?: boolean }) {
@@ -452,6 +452,7 @@ function InflightRow({
               }
             }}
             placeholder="New instruction for this task…"
+            aria-label={`New instruction for ${run.title}`}
             className="h-7 flex-1 text-xs"
             autoFocus
           />

--- a/frontend/src/views/Conversation.tsx
+++ b/frontend/src/views/Conversation.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   AlertTriangle,
   ArrowLeft,
@@ -7,13 +7,21 @@ import {
   Building2,
   ChevronDown,
   ChevronRight,
+  CornerUpRight,
+  Loader2,
+  Pause,
   PenSquare,
+  Send,
   Wrench,
+  X,
 } from "lucide-react";
+import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
 import { ApiError, type TurnStep, type TurnStepKind } from "@/api/types";
+import { listInflight, steerTask, type InflightRun, type SteerAction } from "@/api/tasks";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { type ChatMessage, makeMessage } from "@/lib/chat";
@@ -28,13 +36,15 @@ interface Props {
   setMessages: (threadId: string, updater: (m: ChatMessage[]) => ChatMessage[]) => void;
   /** Called after a reply lands, so the parent can refresh approvals/status. */
   onReply?: () => void;
+  /** Bumped on every task-lifecycle SSE event, so the in-flight strip refetches. */
+  taskEventTick?: number;
 }
 
 /** Consecutive messages from one sender within this window group together. */
 const GROUP_WINDOW_MS = 5 * 60 * 1000;
 
 /** WhatsApp-style two-pane chat: a thread list on the left, transcript right. */
-export function Conversation({ client, company, threads, activeId, onSelect, setMessages, onReply }: Props) {
+export function Conversation({ client, company, threads, activeId, onSelect, setMessages, onReply, taskEventTick }: Props) {
   const active = threads.find((t) => t.id === activeId) ?? threads[0];
   // On mobile, the list and the chat share the pane — track which is showing.
   const [mobilePane, setMobilePane] = useState<"list" | "chat">("chat");
@@ -57,6 +67,7 @@ export function Conversation({ client, company, threads, activeId, onSelect, set
         thread={active}
         setMessages={setMessages}
         onReply={onReply}
+        taskEventTick={taskEventTick}
         onOpenList={() => setMobilePane("list")}
         className={cn("md:flex", mobilePane === "chat" ? "flex" : "hidden")}
       />
@@ -126,6 +137,7 @@ function ChatPane({
   thread,
   setMessages,
   onReply,
+  taskEventTick,
   onOpenList,
   className,
 }: {
@@ -134,6 +146,7 @@ function ChatPane({
   thread: Thread;
   setMessages: (threadId: string, updater: (m: ChatMessage[]) => ChatMessage[]) => void;
   onReply?: () => void;
+  taskEventTick?: number;
   onOpenList: () => void;
   className?: string;
 }) {
@@ -219,6 +232,9 @@ function ChatPane({
         </div>
       </div>
 
+      {/* In-flight steer strip (issue #111) */}
+      <InflightStrip client={client} company={company} taskEventTick={taskEventTick} />
+
       {/* Composer */}
       <div className="border-t bg-background/80 backdrop-blur">
         <div className="mx-auto w-full max-w-3xl px-4 py-3">
@@ -247,6 +263,210 @@ function ChatPane({
         </div>
       </div>
     </section>
+  );
+}
+
+/* ---- in-flight steer strip (issue #111) ---- */
+
+/** Past-tense badge copy while a steer of the given verb is in flight. */
+const PENDING_LABEL: Record<string, string> = {
+  pause: "pausing…",
+  cancel: "cancelling…",
+  redirect: "redirecting…",
+};
+
+/**
+ * A strip above the composer listing the company's in-flight runs, so the
+ * operator can steer them (issue #111) without leaving company chat: pause,
+ * redirect, or cancel a dispatched task; cancel a sub-agent delegation. Reads
+ * {@link listInflight} on mount and refetches on any successful steer and on
+ * each task-lifecycle SSE tick. Renders nothing when nothing is in flight (or
+ * when the host has no inflight route), so it stays out of the way.
+ */
+function InflightStrip({
+  client,
+  company,
+  taskEventTick,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+  taskEventTick?: number;
+}) {
+  const [runs, setRuns] = useState<InflightRun[]>([]);
+  const mounted = useRef(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const rows = await listInflight(client, company);
+      if (mounted.current) setRuns(rows);
+    } catch {
+      // Best-effort surface: a host without the inflight route (404) just means
+      // no strip. Clear rather than surface an error into the chat.
+      if (mounted.current) setRuns([]);
+    }
+  }, [client, company]);
+
+  useEffect(() => {
+    mounted.current = true;
+    void refresh();
+    return () => {
+      mounted.current = false;
+    };
+  }, [refresh]);
+
+  // Live refetch when a task-lifecycle event rides the SSE stream.
+  useEffect(() => {
+    if (taskEventTick !== undefined) void refresh();
+  }, [taskEventTick, refresh]);
+
+  if (runs.length === 0) return null;
+
+  return (
+    <div className="border-t bg-muted/30">
+      <div className="mx-auto w-full max-w-3xl px-4 py-2">
+        <p className="mb-1.5 px-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          In flight · {runs.length}
+        </p>
+        <div className="flex flex-col gap-1.5">
+          {runs.map((run) => (
+            <InflightRow key={run.key} run={run} onSteer={refresh} client={client} company={company} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function InflightRow({
+  run,
+  onSteer,
+  client,
+  company,
+}: {
+  run: InflightRun;
+  onSteer: () => Promise<void> | void;
+  client: OpenCompanyClient;
+  company: string | null;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [redirecting, setRedirecting] = useState(false);
+  const [instruction, setInstruction] = useState("");
+
+  // A pending server-side steer, or an optimistic local one, freezes the row.
+  const pending = run.pendingAction;
+  const disabled = busy || pending !== null;
+
+  async function steer(action: SteerAction, opts?: { instruction?: string; confirm?: boolean }) {
+    setBusy(true);
+    try {
+      await steerTask(client, company, run.key, { action, ...opts });
+      setRedirecting(false);
+      setInstruction("");
+      await onSteer();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "could not steer the task");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function onCancel() {
+    // Cancel is destructive — the backend also requires `confirm: true`.
+    if (!window.confirm(`Cancel “${run.title}”? This stops the run.`)) return;
+    void steer("cancel", { confirm: true });
+  }
+
+  function onRedirect() {
+    const text = instruction.trim();
+    if (!text) return;
+    void steer("redirect", { instruction: text });
+  }
+
+  const isTask = run.kind === "task";
+
+  return (
+    <div className="rounded-lg border bg-card px-2.5 py-1.5">
+      <div className="flex items-center gap-2">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-xs font-medium">{run.title}</p>
+          <p className="truncate text-[11px] text-muted-foreground">
+            {run.kind === "delegation" ? "Delegation" : "Task"} · {run.agentId}
+          </p>
+        </div>
+
+        {pending !== null ? (
+          <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+            {PENDING_LABEL[pending] ?? "steering…"}
+          </span>
+        ) : (
+          <div className="flex shrink-0 items-center gap-1">
+            {busy && <Loader2 className="size-3.5 animate-spin text-muted-foreground" />}
+            {isTask && (
+              <>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  disabled={disabled}
+                  onClick={() => void steer("pause")}
+                >
+                  <Pause className="mr-1 size-3.5" />
+                  Pause
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  disabled={disabled}
+                  aria-pressed={redirecting}
+                  onClick={() => setRedirecting((r) => !r)}
+                >
+                  <CornerUpRight className="mr-1 size-3.5" />
+                  Redirect
+                </Button>
+              </>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-xs text-destructive hover:text-destructive"
+              disabled={disabled}
+              onClick={onCancel}
+            >
+              <X className="mr-1 size-3.5" />
+              Cancel
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {isTask && redirecting && pending === null && (
+        <div className="mt-1.5 flex items-center gap-1.5">
+          <Input
+            value={instruction}
+            onChange={(e) => setInstruction(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                onRedirect();
+              }
+            }}
+            placeholder="New instruction for this task…"
+            className="h-7 flex-1 text-xs"
+            autoFocus
+          />
+          <Button
+            size="icon"
+            className="size-7 shrink-0"
+            disabled={disabled || !instruction.trim()}
+            onClick={onRedirect}
+            aria-label="Send redirect"
+          >
+            <Send className="size-3.5" />
+          </Button>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -282,6 +282,7 @@ function TaskItem({
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return;
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           onOpen();

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Loader2, Plus, Trash2 } from "lucide-react";
+import { Loader2, Play, Plus, Trash2 } from "lucide-react";
 
 import {
   createTask,
@@ -118,6 +118,23 @@ export function TasksView({
     }
   }
 
+  // Re-dispatch a paused card (issue #111): a Resume moves it back into
+  // "In progress", which is what hands it to its assignee again. Optimistic,
+  // reconciled against the server echo — the same shape as a drag-move.
+  async function resume(task: Task) {
+    setTasks((ts) => ts.map((t) => (t.id === task.id ? { ...t, column: "in_progress" } : t)));
+    try {
+      const saved = await patchTask(client, company, task.id, { column: "in_progress" });
+      setTasks((ts) => ts.map((t) => (t.id === task.id ? saved : t)));
+      toast.success("Resumed — the assignee is working on it.");
+      // The turn runs server-side; poll a touch sooner so the result shows.
+      setTimeout(() => void refresh(), 1500);
+    } catch (e) {
+      setTasks((ts) => ts.map((t) => (t.id === task.id ? { ...t, column: task.column } : t)));
+      toast.error(e instanceof Error ? e.message : "could not resume the card");
+    }
+  }
+
   function openCard(task: Task) {
     if (dragged.current) {
       dragged.current = false;
@@ -186,6 +203,7 @@ export function TasksView({
                       task={t}
                       dragging={dragId === t.id}
                       onOpen={() => openCard(t)}
+                      onResume={() => void resume(t)}
                       onDragStart={() => {
                         dragged.current = true;
                         setDragId(t.id);
@@ -244,12 +262,14 @@ function TaskItem({
   task,
   dragging,
   onOpen,
+  onResume,
   onDragStart,
   onDragEnd,
 }: {
   task: Task;
   dragging: boolean;
   onOpen: () => void;
+  onResume: () => void;
   onDragStart: () => void;
   onDragEnd: () => void;
 }) {
@@ -293,6 +313,21 @@ function TaskItem({
           </span>
           <span className="truncate text-xs text-muted-foreground">{task.assignee}</span>
         </div>
+      )}
+      {task.column === "paused" && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-3 h-7 w-full"
+          onClick={(e) => {
+            // Don't let the click bubble to the card's open handler.
+            e.stopPropagation();
+            onResume();
+          }}
+        >
+          <Play className="mr-1.5 size-3.5" />
+          Resume
+        </Button>
       )}
     </div>
   );

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -119,6 +119,14 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("MCP call to {server}/{tool} failed ({status}): {message}"),
             "mcp.call_failed",
         ),
+        CompanyEvent::WorkflowCreated {
+            workflow_id, name, ..
+        } => (
+            Role::System,
+            "workflow".to_string(),
+            format!("Created workflow {name} ({workflow_id})"),
+            "workflow.created",
+        ),
     };
     WireEvent {
         seq,

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -127,6 +127,15 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("Created workflow {name} ({workflow_id})"),
             "workflow.created",
         ),
+        // Action-only body: the operator's redirect instruction is never wired.
+        CompanyEvent::TaskSteered {
+            task_id, action, ..
+        } => (
+            Role::System,
+            "operator".to_string(),
+            format!("Steered task {task_id} ({action})"),
+            "task.steered",
+        ),
     };
     WireEvent {
         seq,

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -20,6 +20,7 @@ pub mod runtime;
 mod skill_file;
 pub mod telegram;
 mod types;
+mod workflow_create;
 mod workflow_file;
 pub mod workspace_seed;
 
@@ -41,6 +42,9 @@ pub use workflow_file::{
 // from its request body, renders it to TOML, and re-parses it through
 // `parse_workflow` above for validation before writing to disk.
 pub(crate) use workflow_file::{RawEdge, RawNode, RawWorkflow, render_workflow};
+// Crate-internal only: the shared validated-persist core (issue #112) both the
+// REST `POST …/workflows` route and the orchestrator `create_workflow` tool run.
+pub(crate) use workflow_create::create_company_workflow;
 pub use workspace_seed::{NodeKind, SeedNode, extract_wikilinks, walk_workspace};
 
 use crate::{Result, VERSION};

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -18,6 +18,10 @@ pub mod mcp;
 pub mod mcp_oauth;
 pub mod runtime;
 mod skill_file;
+// Steer (issue #111): pause / cancel / redirect an in-flight task or delegation
+// from the operator chat. Always compiled + openhuman-free so the operator
+// control plane can steer in any build and no agent tool can ever reach it.
+pub mod steer;
 pub mod telegram;
 mod types;
 mod workflow_create;

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -105,6 +105,15 @@ pub struct CompanyRuntime {
     /// so the default build simply leaves it `None` and the run route reports
     /// "not wired".
     pub(crate) workflow_runner: Option<Arc<dyn crate::ports::WorkflowRunner>>,
+    /// Issue #111: the registry of in-flight, steerable runs. The operator steer
+    /// routes (`GET …/tasks/inflight`, `POST …/tasks/{key}/steer`) read and write
+    /// it; the harness brain registers a dispatched task / desk delegation here
+    /// before running it. Always present (the type is openhuman-free) — the
+    /// default build simply never registers anything, so the strip is empty and
+    /// every steer is `not in flight`. On the harness path the
+    /// [`RuntimeBuilder`](crate::runtime::RuntimeBuilder) wires in the same handle
+    /// the harness deps hold via [`set_steer`](Self::set_steer).
+    pub(crate) steer: crate::company::steer::InflightRegistry,
     /// Held for the duration of a cycle so cycles never interleave per company.
     pub(crate) serial: TokioMutex<()>,
     /// WS4: the embedded openhuman harness pool, when wired via
@@ -162,6 +171,7 @@ impl CompanyRuntime {
             filer,
             source_dir: None,
             workflow_runner: None,
+            steer: crate::company::steer::InflightRegistry::new(),
             serial: TokioMutex::new(()),
             #[cfg(feature = "openhuman")]
             harness: None,
@@ -220,6 +230,20 @@ impl CompanyRuntime {
     #[cfg(feature = "mcp")]
     pub fn mcp(&self) -> Option<&Arc<crate::harness::mcp::McpRuntime>> {
         self.mcp.as_ref()
+    }
+
+    /// Issue #111: replaces this runtime's in-flight steer registry with a shared
+    /// handle (wired by the [`RuntimeBuilder`](crate::runtime::RuntimeBuilder) to
+    /// the one the harness deps hold, so the operator routes and the brain see the
+    /// same runs).
+    pub fn set_steer(&mut self, steer: crate::company::steer::InflightRegistry) {
+        self.steer = steer;
+    }
+
+    /// This company's in-flight steer registry — the operator control plane for
+    /// pausing / cancelling / redirecting live runs.
+    pub fn steer(&self) -> &crate::company::steer::InflightRegistry {
+        &self.steer
     }
 
     /// This company's id.

--- a/src/company/steer.rs
+++ b/src/company/steer.rs
@@ -1,0 +1,420 @@
+//! Steer: pause / cancel / redirect an in-flight board task or delegation from
+//! the operator chat (issue #111, Epic #26).
+//!
+//! An operator watching a company work a task can now reach in mid-flight and
+//! pause it, cancel it, or redirect it with a fresh instruction — without
+//! waiting for the turn to finish or killing the whole company.
+//!
+//! ## Why this module is always compiled and openhuman-free
+//!
+//! Every type here is plain data + a `std::sync::Mutex`; nothing reaches into
+//! `openhuman`. That keeps steering available to the **operator control plane**
+//! (the REST routes + the runtime) in the default build, and — crucially — it
+//! keeps the mechanism **structurally non-agent-injectable**: no agent tool
+//! anywhere consumes a [`SteerControl`] or an [`InflightRegistry`], so an agent
+//! can never steer (or cancel) another agent's work. Steering is honored only
+//! between tool-loop iterations by the openhuman-gated
+//! [`SteerStopHook`](crate::harness::steer::SteerStopHook), which polls the
+//! shared control this module hands out.
+//!
+//! ## Shape
+//!
+//! * [`SteerControl`] — a one-shot, cheaply-cloned handle shared between the
+//!   registry (operator side) and the stop hook (turn side). The hook polls
+//!   [`requested`](SteerControl::requested) between iterations; the disposition
+//!   site [`take`](SteerControl::take)s the pending action once the turn ends.
+//!   Backed by a **std** `Mutex` held only for the length of a set/get — never
+//!   across an `await`.
+//! * [`InflightRegistry`] — `CompanyId → key → slot`, the live set of steerable
+//!   runs. [`register`](InflightRegistry::register) returns a
+//!   [`RegistrationGuard`] whose `Drop` deregisters the entry on **every** exit
+//!   path (success, error, panic-unwind) — RAII so a crashed turn never leaves a
+//!   ghost row in the operator strip.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use crate::ports::types::CompanyId;
+
+/// The maximum instruction length an operator redirect carries, in **chars**
+/// (not bytes — truncation is codepoint-safe). A redirect longer than this is
+/// truncated at the route boundary before it ever reaches an agent turn.
+pub const MAX_REDIRECT_CHARS: usize = 2000;
+
+/// What an operator asked us to do to an in-flight run.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SteerAction {
+    /// Stop the run and park the card in `paused`, preserving its partial work.
+    Pause,
+    /// Stop the run and drop its partial work, returning the card to `backlog`.
+    Cancel,
+    /// Stop the current attempt and re-run it with an appended operator
+    /// instruction. Bounded per dispatch (see the harness disposition).
+    Redirect {
+        /// The operator's fresh instruction, already codepoint-capped to
+        /// [`MAX_REDIRECT_CHARS`] at the route boundary.
+        instruction: String,
+    },
+}
+
+impl SteerAction {
+    /// The stable lowercase wire word for this action (`pause` / `cancel` /
+    /// `redirect`), used in the audit event, the pending-action badge, and the
+    /// route body.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SteerAction::Pause => "pause",
+            SteerAction::Cancel => "cancel",
+            SteerAction::Redirect { .. } => "redirect",
+        }
+    }
+}
+
+/// A one-shot control handle shared between the operator-facing
+/// [`InflightRegistry`] and the turn-side stop hook.
+///
+/// The registry [`request`](Self::request)s an action; the hook polls
+/// [`requested`](Self::requested) between tool-loop iterations and stops the
+/// turn when one pends; the disposition site [`take`](Self::take)s it once after
+/// the turn ends. **Last request wins** — a second operator action before the
+/// turn yields overwrites the first. Cheap to [`Clone`] (a shared handle).
+#[derive(Clone, Default)]
+pub struct SteerControl {
+    inner: Arc<Mutex<Option<SteerAction>>>,
+}
+
+impl SteerControl {
+    /// A fresh control with no action pending.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Requests a steer. Last write wins (a fresh action overwrites a pending
+    /// one that the turn has not yet observed).
+    pub fn request(&self, action: SteerAction) {
+        *self.inner.lock().expect("steer control poisoned") = Some(action);
+    }
+
+    /// Whether an action is pending — the stop hook's fast-path poll.
+    pub fn requested(&self) -> bool {
+        self.inner.lock().expect("steer control poisoned").is_some()
+    }
+
+    /// Takes the pending action, clearing it. The disposition site's one-shot
+    /// read after a turn ends.
+    pub fn take(&self) -> Option<SteerAction> {
+        self.inner.lock().expect("steer control poisoned").take()
+    }
+}
+
+/// What kind of in-flight run an [`InflightEntry`] tracks. Drives which actions
+/// the registry accepts: a `Task` supports all three; a `Delegation` is
+/// **cancel-only** in v1.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InflightKind {
+    /// A dispatched board task (`in_progress`), steerable in full.
+    Task,
+    /// A desk delegation from the orchestrator's turn, cancel-only in v1.
+    Delegation,
+}
+
+impl InflightKind {
+    /// The stable lowercase wire word (`task` / `delegation`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            InflightKind::Task => "task",
+            InflightKind::Delegation => "delegation",
+        }
+    }
+}
+
+/// One in-flight, steerable run surfaced to the operator's in-flight strip.
+#[derive(Clone, Debug)]
+pub struct InflightEntry {
+    /// The steer key — the identifier the `POST …/tasks/{key}/steer` route
+    /// addresses. For a board task it equals the task id; for a delegation it is
+    /// a synthetic run id.
+    pub key: String,
+    /// The board task id, when this run is a dispatched card. `None` for a
+    /// delegation (no card).
+    pub task_id: Option<String>,
+    /// Whether the run is a task or a delegation (gates the allowed actions).
+    pub kind: InflightKind,
+    /// A short human title for the strip (the card title, or the desk id).
+    pub title: String,
+    /// The roster agent running the turn.
+    pub agent_id: String,
+    /// When the run was registered (epoch millis), so the strip can show age.
+    pub started_at_millis: u64,
+    /// The last action requested against this run, as a wire word, so the strip
+    /// can show a "pausing…/cancelling…/redirecting…" badge. `None` until an
+    /// operator steers it.
+    pub pending_action: Option<String>,
+}
+
+/// The reason a [`steer`](InflightRegistry::steer) call did not apply.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SteerError {
+    /// No run with that key is in flight for the company (the strip is stale, or
+    /// the turn already finished).
+    NotInFlight,
+    /// The action is not supported for this run's kind (pause / redirect on a
+    /// delegation, which is cancel-only in v1).
+    Unsupported,
+}
+
+/// A live registry slot: the strip entry plus the control the turn polls.
+struct Slot {
+    entry: InflightEntry,
+    control: SteerControl,
+}
+
+/// The live set of steerable runs, keyed `CompanyId → key → slot`.
+///
+/// Cheap to [`Clone`] (a shared handle) — the same underlying map is seen by the
+/// [`HarnessBrain`](crate::harness::HarnessBrain) that registers runs, the
+/// operator routes that steer them, and the runtime that lists them, because a
+/// single registry is threaded through both [`HarnessDeps`] and
+/// [`CompanyRuntime`] at build time.
+///
+/// [`HarnessDeps`]: crate::harness::HarnessDeps
+/// [`CompanyRuntime`]: crate::company::runtime::CompanyRuntime
+#[derive(Clone, Default)]
+pub struct InflightRegistry {
+    inner: Arc<Mutex<HashMap<CompanyId, HashMap<String, Slot>>>>,
+}
+
+impl InflightRegistry {
+    /// An empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers an in-flight run and returns its shared [`SteerControl`] plus a
+    /// [`RegistrationGuard`] that deregisters the entry on drop.
+    ///
+    /// The caller runs the turn with the returned control's hook installed, then
+    /// reads the control's pending action; when the guard drops (on **any** exit
+    /// path) the strip row disappears.
+    pub fn register(&self, company: &CompanyId, entry: InflightEntry) -> RegistrationGuard {
+        let control = SteerControl::new();
+        let key = entry.key.clone();
+        {
+            let mut guard = self.inner.lock().expect("inflight registry poisoned");
+            guard.entry(company.clone()).or_default().insert(
+                key.clone(),
+                Slot {
+                    entry,
+                    control: control.clone(),
+                },
+            );
+        }
+        RegistrationGuard {
+            registry: self.clone(),
+            company: company.clone(),
+            key,
+            control,
+        }
+    }
+
+    /// Removes a run's slot (called by [`RegistrationGuard`]'s `Drop`).
+    fn deregister(&self, company: &CompanyId, key: &str) {
+        let mut guard = self.inner.lock().expect("inflight registry poisoned");
+        if let Some(runs) = guard.get_mut(company) {
+            runs.remove(key);
+            if runs.is_empty() {
+                guard.remove(company);
+            }
+        }
+    }
+
+    /// The in-flight runs for a company, for the operator strip. Order is
+    /// unspecified (the console sorts).
+    pub fn list(&self, company: &CompanyId) -> Vec<InflightEntry> {
+        self.inner
+            .lock()
+            .expect("inflight registry poisoned")
+            .get(company)
+            .map(|runs| runs.values().map(|slot| slot.entry.clone()).collect())
+            .unwrap_or_default()
+    }
+
+    /// Applies an operator steer to an in-flight run.
+    ///
+    /// Errors:
+    /// * [`SteerError::NotInFlight`] — no run with `key` is in flight.
+    /// * [`SteerError::Unsupported`] — the action is not allowed for the run's
+    ///   kind (pause / redirect on a delegation).
+    ///
+    /// On success the run's [`SteerControl`] is set (the turn stops at its next
+    /// iteration boundary) and the strip's pending-action badge is updated.
+    pub fn steer(
+        &self,
+        company: &CompanyId,
+        key: &str,
+        action: SteerAction,
+    ) -> Result<(), SteerError> {
+        let mut guard = self.inner.lock().expect("inflight registry poisoned");
+        let slot = guard
+            .get_mut(company)
+            .and_then(|runs| runs.get_mut(key))
+            .ok_or(SteerError::NotInFlight)?;
+        if slot.entry.kind == InflightKind::Delegation && !matches!(action, SteerAction::Cancel) {
+            return Err(SteerError::Unsupported);
+        }
+        slot.entry.pending_action = Some(action.as_str().to_string());
+        slot.control.request(action);
+        Ok(())
+    }
+}
+
+/// An RAII guard that deregisters an in-flight run when dropped, and hands the
+/// caller the run's shared [`SteerControl`].
+///
+/// Dropping this — whether the turn returned a reply, errored, or unwound —
+/// removes the strip row, so the operator never sees a ghost run.
+pub struct RegistrationGuard {
+    registry: InflightRegistry,
+    company: CompanyId,
+    key: String,
+    control: SteerControl,
+}
+
+impl RegistrationGuard {
+    /// The shared control for this run: install its hook around the turn, then
+    /// [`take`](SteerControl::take) the pending action after the turn ends.
+    pub fn control(&self) -> &SteerControl {
+        &self.control
+    }
+}
+
+impl Drop for RegistrationGuard {
+    fn drop(&mut self) {
+        self.registry.deregister(&self.company, &self.key);
+    }
+}
+
+/// Codepoint-safe truncation of an operator redirect instruction to
+/// [`MAX_REDIRECT_CHARS`]. Never splits a multi-byte character (unlike a byte
+/// slice), so a redirect ending in an emoji or accented letter can't panic.
+pub fn cap_redirect(instruction: &str) -> String {
+    instruction.chars().take(MAX_REDIRECT_CHARS).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(key: &str, kind: InflightKind) -> InflightEntry {
+        InflightEntry {
+            key: key.to_string(),
+            task_id: matches!(kind, InflightKind::Task).then(|| key.to_string()),
+            kind,
+            title: "Ship the thing".to_string(),
+            agent_id: "ceo".to_string(),
+            started_at_millis: 0,
+            pending_action: None,
+        }
+    }
+
+    #[test]
+    fn control_is_one_shot_and_last_write_wins() {
+        let control = SteerControl::new();
+        assert!(!control.requested());
+        control.request(SteerAction::Pause);
+        control.request(SteerAction::Cancel); // last write wins
+        assert!(control.requested());
+        assert_eq!(control.take(), Some(SteerAction::Cancel));
+        assert!(!control.requested(), "take clears the action");
+        assert_eq!(control.take(), None);
+    }
+
+    #[test]
+    fn register_lists_then_guard_drop_deregisters() {
+        let company = CompanyId::new("acme");
+        let reg = InflightRegistry::new();
+        {
+            let _guard = reg.register(&company, entry("t1", InflightKind::Task));
+            let listed = reg.list(&company);
+            assert_eq!(listed.len(), 1);
+            assert_eq!(listed[0].key, "t1");
+        }
+        // Guard dropped → the row is gone, and the empty company map is pruned.
+        assert!(reg.list(&company).is_empty());
+    }
+
+    #[test]
+    fn steer_sets_the_control_and_pending_badge() {
+        let company = CompanyId::new("acme");
+        let reg = InflightRegistry::new();
+        let guard = reg.register(&company, entry("t1", InflightKind::Task));
+        reg.steer(&company, "t1", SteerAction::Pause)
+            .expect("steers");
+        assert!(guard.control().requested(), "the turn's control is set");
+        assert_eq!(
+            reg.list(&company)[0].pending_action.as_deref(),
+            Some("pause"),
+            "the strip shows a pending badge"
+        );
+    }
+
+    #[test]
+    fn steer_unknown_key_is_not_in_flight() {
+        let company = CompanyId::new("acme");
+        let reg = InflightRegistry::new();
+        let err = reg
+            .steer(&company, "ghost", SteerAction::Cancel)
+            .expect_err("unknown key");
+        assert_eq!(err, SteerError::NotInFlight);
+    }
+
+    #[test]
+    fn delegation_is_cancel_only() {
+        let company = CompanyId::new("acme");
+        let reg = InflightRegistry::new();
+        let _guard = reg.register(&company, entry("d1", InflightKind::Delegation));
+        assert_eq!(
+            reg.steer(&company, "d1", SteerAction::Pause),
+            Err(SteerError::Unsupported)
+        );
+        assert_eq!(
+            reg.steer(
+                &company,
+                "d1",
+                SteerAction::Redirect {
+                    instruction: "do X".into()
+                }
+            ),
+            Err(SteerError::Unsupported)
+        );
+        // Cancel is allowed.
+        reg.steer(&company, "d1", SteerAction::Cancel)
+            .expect("cancel a delegation");
+    }
+
+    #[test]
+    fn deregister_on_error_path_via_guard_drop() {
+        // Simulate a turn that errors: the guard is created, then an early error
+        // return drops it. The registry must be clean afterward (RAII).
+        let company = CompanyId::new("acme");
+        let reg = InflightRegistry::new();
+        let run = || -> Result<(), &'static str> {
+            let _guard = reg.register(&company, entry("t1", InflightKind::Task));
+            Err("turn blew up")
+        };
+        assert!(run().is_err());
+        assert!(
+            reg.list(&company).is_empty(),
+            "the guard deregistered even on the error path"
+        );
+    }
+
+    #[test]
+    fn cap_redirect_is_codepoint_safe() {
+        let long: String = "é".repeat(MAX_REDIRECT_CHARS + 50);
+        let capped = cap_redirect(&long);
+        assert_eq!(capped.chars().count(), MAX_REDIRECT_CHARS);
+        // Byte length is a clean multiple of 2 (é is 2 bytes) — no split codepoint.
+        assert_eq!(capped.len(), MAX_REDIRECT_CHARS * 2);
+    }
+}

--- a/src/company/steer.rs
+++ b/src/company/steer.rs
@@ -100,6 +100,11 @@ impl SteerControl {
         self.inner.lock().expect("steer control poisoned").is_some()
     }
 
+    /// Clones the pending action without clearing it.
+    pub fn pending(&self) -> Option<SteerAction> {
+        self.inner.lock().expect("steer control poisoned").clone()
+    }
+
     /// Takes the pending action, clearing it. The disposition site's one-shot
     /// read after a turn ends.
     pub fn take(&self) -> Option<SteerAction> {

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -1,0 +1,796 @@
+//! Feature-free core for authoring a new workflow graph (issue #112).
+//!
+//! [`create_company_workflow`] is the single validated-persist sequence for
+//! creating a `workflows/<id>.toml`, lifted out of the REST handler so **both**
+//! the console's `POST …/workflows` route and the orchestrator's
+//! `create_workflow` tool run exactly the same checks and land the exact same
+//! artifact — no create-vs-run drift, one place to reason about safety.
+//!
+//! The sequence, in order, each step an actionable error before anything is
+//! written:
+//!
+//! 1. the id is a safe filename (no slashes / `..`) and within length caps;
+//! 2. the graph is within the node/edge size caps (a runaway graph can't be
+//!    persisted);
+//! 3. it names exactly one `trigger` (a freshly authored graph must say what
+//!    starts it — stricter than [`parse_workflow`], which allows many);
+//! 4. every `agent` node names a real roster teammate (manifest ∪ overlay);
+//! 5. its display name is unique (case-insensitive) against the company's
+//!    existing on-disk + manifest-enabled workflows;
+//! 6. the rendered TOML re-parses through [`parse_workflow`] (the same
+//!    structural validation a hand-authored file passes) and is within the
+//!    byte cap;
+//! 7. the file is written atomically (`create_new(true)` → a duplicate id is a
+//!    [`Conflict`](OpenCompanyError::Conflict), closing the TOCTOU gap);
+//! 8. the id is recorded as enabled on the operator's live record (the
+//!    version-controlled manifest is never rewritten — the team-overlay
+//!    convention); a store-save failure rolls the file back so the id isn't
+//!    orphaned;
+//! 9. a best-effort [`WorkflowCreated`](CompanyEvent::WorkflowCreated) audit
+//!    event is journaled — never rolling the create back if the journal fails.
+//!
+//! Steps 4–8 run under the per-company [`company_write_lock`] so a concurrent
+//! `create_workflow` (tool) and `POST …/workflows` (REST) can never clobber
+//! each other's `overlay`/`enabled` write, the same primitive `add_agent` uses.
+//!
+//! Compiled in the default build (no harness imports) so the REST route reaches
+//! it without any feature gate.
+
+use std::collections::HashSet;
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::company::{
+    RawWorkflow, WorkflowFile, load_company_workflows, parse_workflow, render_workflow,
+};
+use crate::error::{OpenCompanyError, Result};
+use crate::ports::CompanyStore;
+use crate::ports::events::EventLog;
+use crate::ports::store::company_write_lock;
+use crate::ports::types::{CompanyEvent, CompanyId};
+use crate::server::ops::language;
+
+/// Max nodes a freshly authored graph may declare. A larger graph is refused
+/// before anything is rendered or written.
+pub(crate) const MAX_WORKFLOW_NODES: usize = 50;
+/// Max edges a freshly authored graph may declare.
+pub(crate) const MAX_WORKFLOW_EDGES: usize = 100;
+/// Max size of the rendered `workflows/<id>.toml`, checked after render and
+/// before the file is written.
+pub(crate) const MAX_WORKFLOW_TOML_BYTES: usize = 64 * 1024;
+/// Max length of a workflow id (also the on-disk filename stem).
+pub(crate) const MAX_WORKFLOW_ID_LEN: usize = 64;
+/// Max length of a workflow display name.
+pub(crate) const MAX_WORKFLOW_NAME_LEN: usize = 200;
+
+/// Authors and persists a new workflow graph for `company`, returning the
+/// parsed [`WorkflowFile`] exactly as [`load_company_workflows`] would hand it
+/// to the runner (so what a caller reads back and what runs are identical).
+///
+/// `source_dir` is the company source directory (`companies/<name>`) whose
+/// `workflows/` subtree the graph lands in — the caller supplies it (both
+/// surfaces refuse a deployment with no source directory before calling here,
+/// with [`language::WORKFLOW_NEEDS_SOURCE_DIR`]). `events` is the company event
+/// log for the best-effort audit journal; pass `None` to skip journaling.
+///
+/// Errors map to the same HTTP statuses the REST route always returned:
+/// [`InvalidRequest`](OpenCompanyError::InvalidRequest) → 400,
+/// [`Conflict`](OpenCompanyError::Conflict) → 409.
+pub(crate) async fn create_company_workflow(
+    company: &CompanyId,
+    source_dir: &Path,
+    store: &Arc<dyn CompanyStore>,
+    events: Option<&Arc<dyn EventLog>>,
+    draft: RawWorkflow,
+) -> Result<WorkflowFile> {
+    // --- Input validation (no lock; pure function of the draft) -------------
+
+    if !is_safe_workflow_id(&draft.id) {
+        return Err(OpenCompanyError::InvalidRequest(
+            language::WORKFLOW_ID_INVALID.to_string(),
+        ));
+    }
+    if draft.id.len() > MAX_WORKFLOW_ID_LEN {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "a workflow id can be at most {MAX_WORKFLOW_ID_LEN} characters."
+        )));
+    }
+    if draft.name.trim().len() > MAX_WORKFLOW_NAME_LEN {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "a workflow name can be at most {MAX_WORKFLOW_NAME_LEN} characters."
+        )));
+    }
+    if draft.nodes.len() > MAX_WORKFLOW_NODES {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "a workflow can have at most {MAX_WORKFLOW_NODES} nodes (this one has {}).",
+            draft.nodes.len()
+        )));
+    }
+    if draft.edges.len() > MAX_WORKFLOW_EDGES {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "a workflow can have at most {MAX_WORKFLOW_EDGES} edges (this one has {}).",
+            draft.edges.len()
+        )));
+    }
+
+    // `parse_workflow` only rejects zero triggers (a saved graph may legally
+    // have more than one entry point); the creator is stricter — a freshly
+    // authored graph must name exactly one starting point.
+    let trigger_count = draft.nodes.iter().filter(|n| n.kind == "trigger").count();
+    if trigger_count != 1 {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "a workflow needs exactly one `trigger` node to say what starts it (found {trigger_count})."
+        )));
+    }
+
+    // --- Serialized write section -------------------------------------------
+    // Load record → roster check → name uniqueness → file write → save record
+    // all under the per-company write lock, so a concurrent create/add_agent
+    // can never clobber the record's `enabled`/`overlay` write.
+    let write_lock = company_write_lock(company);
+    let _lock = write_lock.lock().await;
+
+    let mut record = store
+        .load(company)
+        .await?
+        .ok_or_else(|| OpenCompanyError::CompanyNotFound(company.to_string()))?;
+
+    // Cross-check every `agent` node against the company's effective roster
+    // (manifest agents ∪ operator overlay teammates). `parse_workflow` checks
+    // the graph's own shape but has no roster to validate names against.
+    let roster: HashSet<&str> = record
+        .manifest
+        .agents
+        .iter()
+        .map(|a| a.id.as_str())
+        .chain(record.overlay_agents.iter().map(|a| a.id.as_str()))
+        .collect();
+    for node in &draft.nodes {
+        if node.kind != "agent" {
+            continue;
+        }
+        match node.agent.as_deref() {
+            Some(agent_id) if roster.contains(agent_id) => {}
+            Some(agent_id) => {
+                return Err(OpenCompanyError::InvalidRequest(format!(
+                    "node `{}` names teammate `{agent_id}`, which is not on this company's roster.",
+                    node.id
+                )));
+            }
+            None => {
+                return Err(OpenCompanyError::InvalidRequest(format!(
+                    "node `{}` is an agent node but names no teammate.",
+                    node.id
+                )));
+            }
+        }
+    }
+
+    // Case-insensitive display-name uniqueness against the company's existing
+    // workflows (on-disk ∪ manifest-enabled). Id uniqueness stays atomic via
+    // `create_new(true)` below — this only guards two *differently-id'd*
+    // workflows sharing one indistinguishable name in the picker.
+    let existing_names = existing_workflow_names(source_dir, &record.manifest.workflows.enabled);
+    if existing_names.contains(&draft.name.trim().to_ascii_lowercase()) {
+        return Err(OpenCompanyError::Conflict(format!(
+            "A workflow named `{}` already exists. Pick a different name.",
+            draft.name.trim()
+        )));
+    }
+
+    // Render the candidate to TOML and re-parse it through `parse_workflow`,
+    // the same structural validation a hand-authored file passes. Any problem
+    // becomes an `InvalidRequest` (400), never the 500 a malformed on-disk file
+    // gets from the read routes.
+    let toml_src = render_workflow(&draft)?;
+    if toml_src.len() > MAX_WORKFLOW_TOML_BYTES {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "the rendered workflow is {} bytes, over the {MAX_WORKFLOW_TOML_BYTES}-byte limit.",
+            toml_src.len()
+        )));
+    }
+    let file = parse_workflow(&toml_src).map_err(|err| match err {
+        OpenCompanyError::DataInvalid { problems, .. } => {
+            OpenCompanyError::InvalidRequest(problems.join(" "))
+        }
+        OpenCompanyError::DataParse { message, .. } => OpenCompanyError::InvalidRequest(message),
+        other => other,
+    })?;
+
+    let workflows_dir = source_dir.join("workflows");
+    let path = workflows_dir.join(format!("{}.toml", file.id));
+    std::fs::create_dir_all(&workflows_dir).map_err(|source| OpenCompanyError::StoreIo {
+        path: workflows_dir.clone(),
+        source,
+    })?;
+
+    // Write atomically: `create_new(true)` fails if the path already exists,
+    // closing the TOCTOU gap between a separate existence check and the write —
+    // a duplicate id is a clean `Conflict` (409). Clean the empty file up on a
+    // write failure so the id isn't permanently blocked.
+    let mut wf_file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .map_err(|e| match e.kind() {
+            std::io::ErrorKind::AlreadyExists => OpenCompanyError::Conflict(format!(
+                "A workflow named `{}` already exists.",
+                file.id
+            )),
+            _ => OpenCompanyError::StoreIo {
+                path: path.clone(),
+                source: e,
+            },
+        })?;
+    wf_file.write_all(toml_src.as_bytes()).map_err(|source| {
+        let _ = std::fs::remove_file(&path);
+        OpenCompanyError::StoreIo {
+            path: path.clone(),
+            source,
+        }
+    })?;
+    drop(wf_file);
+
+    // Record the id as enabled on the live record — mirrors the team overlay:
+    // the version-controlled `company.toml` on disk is never rewritten. Save
+    // **after** the file lands; on a save failure remove the file we wrote so a
+    // retry can succeed without admin intervention.
+    let save_result = if record
+        .manifest
+        .workflows
+        .enabled
+        .iter()
+        .any(|e| e == &file.id)
+    {
+        Ok(())
+    } else {
+        record.manifest.workflows.enabled.push(file.id.clone());
+        store.save(&record).await
+    };
+    if let Err(e) = save_result {
+        let _ = std::fs::remove_file(&path);
+        return Err(e);
+    }
+
+    // Drop the write lock before journaling: the audit event is best-effort and
+    // never gates the create, so it needn't hold the serialization lock.
+    drop(_lock);
+
+    // Best-effort audit journal. A journal failure never rolls the create back
+    // (the workflow is already persisted + enabled) — we only log it.
+    if let Some(log) = events
+        && let Err(err) = log
+            .append(
+                company,
+                CompanyEvent::WorkflowCreated {
+                    workflow_id: file.id.clone(),
+                    name: file.name.clone(),
+                    by: None,
+                },
+            )
+            .await
+    {
+        tracing::warn!(
+            company = %company,
+            workflow = %file.id,
+            error = %err,
+            "workflow created but audit journal append failed"
+        );
+    }
+
+    Ok(file)
+}
+
+/// The set of existing workflow display names (trimmed, lowercased) for
+/// `source_dir`'s company: every successfully-loaded on-disk `workflows/*.toml`
+/// name, unioned with the id-as-name fallback for each manifest-`enabled` id
+/// that has no loadable file — mirroring how `list_workflows` names the same
+/// set. A malformed on-disk file contributes no name (it's skipped, same as the
+/// picker), so it can't false-positive a conflict.
+fn existing_workflow_names(source_dir: &Path, enabled: &[String]) -> HashSet<String> {
+    let mut names = HashSet::new();
+    let mut seen_ids = HashSet::new();
+
+    if let Ok(entries) = std::fs::read_dir(source_dir.join("workflows")) {
+        let ids: Vec<String> = entries
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("toml"))
+            .filter_map(|path| {
+                path.file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .map(str::to_string)
+            })
+            .collect();
+        for id in ids {
+            match load_company_workflows(source_dir, std::slice::from_ref(&id)) {
+                Ok(mut files) => {
+                    if let Some(file) = files.pop() {
+                        names.insert(file.name.trim().to_ascii_lowercase());
+                        seen_ids.insert(file.id);
+                    }
+                }
+                // A malformed file skips only its own name (same tolerance the
+                // picker has); still mark the id seen so the enabled-fallback
+                // below doesn't re-add it as an id-named entry.
+                Err(_) => {
+                    seen_ids.insert(id);
+                }
+            }
+        }
+    }
+
+    // Manifest-enabled ids with no loadable on-disk file fall back to the id as
+    // their display name (what `list_workflows` shows), so a new workflow can't
+    // collide with that fallback name either.
+    for id in enabled {
+        if !seen_ids.contains(id) {
+            names.insert(id.trim().to_ascii_lowercase());
+        }
+    }
+
+    names
+}
+
+/// Whether `wid` is a single safe on-disk filename stem — no path separators, no
+/// `..`, not empty — so it can't escape the `workflows/` directory.
+fn is_safe_workflow_id(wid: &str) -> bool {
+    use std::path::Component;
+    let mut comps = Path::new(wid).components();
+    matches!(comps.next(), Some(Component::Normal(_))) && comps.next().is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    use crate::company::{CompanyManifest, RawEdge, RawNode};
+    use crate::ports::types::{CompanyRecord, CompanySummary, EventSeq, LedgerEntry, StoredEvent};
+    use async_trait::async_trait;
+    use futures::stream::{self, BoxStream};
+
+    // --- test doubles --------------------------------------------------------
+
+    /// An in-memory `CompanyStore` seeded with one record; `save` can be told to
+    /// fail so the file-rollback path is exercised.
+    #[derive(Default)]
+    struct MemStore {
+        record: StdMutex<Option<CompanyRecord>>,
+        fail_save: bool,
+    }
+
+    impl MemStore {
+        fn seeded(record: CompanyRecord) -> Self {
+            Self {
+                record: StdMutex::new(Some(record)),
+                fail_save: false,
+            }
+        }
+        fn failing(record: CompanyRecord) -> Self {
+            Self {
+                record: StdMutex::new(Some(record)),
+                fail_save: true,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl CompanyStore for MemStore {
+        async fn load(&self, _id: &CompanyId) -> Result<Option<CompanyRecord>> {
+            Ok(self.record.lock().unwrap().clone())
+        }
+        async fn save(&self, record: &CompanyRecord) -> Result<()> {
+            if self.fail_save {
+                return Err(OpenCompanyError::InvalidRequest("save boom".into()));
+            }
+            *self.record.lock().unwrap() = Some(record.clone());
+            Ok(())
+        }
+        async fn list(&self) -> Result<Vec<CompanySummary>> {
+            Ok(Vec::new())
+        }
+        async fn append_ledger(&self, _id: &CompanyId, _entry: LedgerEntry) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    /// An in-memory `EventLog` that records appended events so the audit journal
+    /// can be asserted.
+    #[derive(Default)]
+    struct MemLog {
+        events: StdMutex<Vec<CompanyEvent>>,
+    }
+
+    #[async_trait]
+    impl EventLog for MemLog {
+        async fn append(&self, _id: &CompanyId, event: CompanyEvent) -> Result<EventSeq> {
+            let mut guard = self.events.lock().unwrap();
+            guard.push(event);
+            Ok(EventSeq::new(guard.len() as u64))
+        }
+        async fn read_from(
+            &self,
+            _id: &CompanyId,
+            _seq: EventSeq,
+            _limit: usize,
+        ) -> Result<Vec<StoredEvent>> {
+            Ok(Vec::new())
+        }
+        fn subscribe(&self, _id: &CompanyId) -> BoxStream<'static, StoredEvent> {
+            Box::pin(stream::empty())
+        }
+    }
+
+    // --- fixtures ------------------------------------------------------------
+
+    /// A manifest with an `assistant` roster agent so `agent`-node graphs pass
+    /// the roster check.
+    fn manifest_with_assistant() -> CompanyManifest {
+        toml::from_str(
+            "[company]\nname = \"Acme\"\n[[agent]]\nid = \"assistant\"\nrole = \"Assistant\"\n",
+        )
+        .expect("valid manifest")
+    }
+
+    fn record(id: &CompanyId, manifest: CompanyManifest) -> CompanyRecord {
+        CompanyRecord {
+            id: id.clone(),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+        }
+    }
+
+    /// A valid trigger → agent → output draft naming the `assistant` teammate.
+    fn valid_draft(id: &str, name: &str) -> RawWorkflow {
+        RawWorkflow {
+            id: id.to_string(),
+            name: name.to_string(),
+            description: Some("A tiny graph.".to_string()),
+            nodes: vec![
+                RawNode {
+                    id: "start".to_string(),
+                    kind: "trigger".to_string(),
+                    name: "Start".to_string(),
+                    summary: None,
+                    agent: None,
+                },
+                RawNode {
+                    id: "worker".to_string(),
+                    kind: "agent".to_string(),
+                    name: "Worker".to_string(),
+                    summary: None,
+                    agent: Some("assistant".to_string()),
+                },
+                RawNode {
+                    id: "done".to_string(),
+                    kind: "output".to_string(),
+                    name: "Report".to_string(),
+                    summary: None,
+                    agent: None,
+                },
+            ],
+            edges: vec![
+                RawEdge {
+                    from: "start".to_string(),
+                    to: "worker".to_string(),
+                    label: None,
+                },
+                RawEdge {
+                    from: "worker".to_string(),
+                    to: "done".to_string(),
+                    label: Some("ok".to_string()),
+                },
+            ],
+        }
+    }
+
+    fn store_of(store: MemStore) -> Arc<dyn CompanyStore> {
+        Arc::new(store)
+    }
+
+    // --- happy path ----------------------------------------------------------
+
+    #[tokio::test]
+    async fn creates_enables_and_journals() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let log = Arc::new(MemLog::default());
+        let log_dyn: Arc<dyn EventLog> = log.clone();
+
+        let file = create_company_workflow(
+            &company,
+            dir.path(),
+            &store,
+            Some(&log_dyn),
+            valid_draft("greeter", "Greeter"),
+        )
+        .await
+        .expect("creates");
+
+        assert_eq!(file.id, "greeter");
+        assert_eq!(file.nodes.len(), 3);
+
+        // File landed and re-loads to exactly what we returned (contract).
+        let reloaded = load_company_workflows(dir.path(), std::slice::from_ref(&file.id))
+            .expect("reloads")
+            .into_iter()
+            .next()
+            .expect("one file");
+        assert_eq!(
+            reloaded, file,
+            "returned WorkflowFile must equal the on-disk load"
+        );
+
+        // Enabled on the record.
+        let record = store.load(&company).await.unwrap().unwrap();
+        assert!(
+            record
+                .manifest
+                .workflows
+                .enabled
+                .contains(&"greeter".to_string())
+        );
+
+        // Journaled a WorkflowCreated audit event.
+        let events = log.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            CompanyEvent::WorkflowCreated {
+                workflow_id,
+                name,
+                by,
+            } => {
+                assert_eq!(workflow_id, "greeter");
+                assert_eq!(name, "Greeter");
+                assert!(by.is_none());
+            }
+            other => panic!("expected WorkflowCreated, got {other:?}"),
+        }
+    }
+
+    // --- guardrail failures --------------------------------------------------
+
+    #[tokio::test]
+    async fn duplicate_id_is_conflict() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        create_company_workflow(
+            &company,
+            dir.path(),
+            &store,
+            None,
+            valid_draft("dup", "First"),
+        )
+        .await
+        .expect("first create");
+        let err = create_company_workflow(
+            &company,
+            dir.path(),
+            &store,
+            None,
+            valid_draft("dup", "Second name"),
+        )
+        .await
+        .expect_err("second create with same id");
+        assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn duplicate_name_case_insensitive_is_conflict() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        create_company_workflow(
+            &company,
+            dir.path(),
+            &store,
+            None,
+            valid_draft("one", "Greeter"),
+        )
+        .await
+        .expect("first");
+        let err = create_company_workflow(
+            &company,
+            dir.path(),
+            &store,
+            None,
+            valid_draft("two", "  GREETER  "),
+        )
+        .await
+        .expect_err("name collides case-insensitively");
+        assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn unknown_roster_teammate_is_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let mut draft = valid_draft("wf", "WF");
+        draft.nodes[1].agent = Some("ghost".to_string());
+
+        let err = create_company_workflow(&company, dir.path(), &store, None, draft)
+            .await
+            .expect_err("unknown teammate");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+        assert!(err.to_string().contains("ghost"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn missing_agent_on_agent_node_is_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let mut draft = valid_draft("wf", "WF");
+        draft.nodes[1].agent = None;
+
+        let err = create_company_workflow(&company, dir.path(), &store, None, draft)
+            .await
+            .expect_err("agent node with no teammate");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn zero_or_two_triggers_is_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        // Zero triggers.
+        let mut zero = valid_draft("z", "Z");
+        zero.nodes[0].kind = "output".to_string();
+        let err = create_company_workflow(&company, dir.path(), &store, None, zero)
+            .await
+            .expect_err("no trigger");
+        assert!(err.to_string().contains("exactly one `trigger`"), "{err}");
+
+        // Two triggers.
+        let mut two = valid_draft("t", "T");
+        two.nodes[2].kind = "trigger".to_string();
+        let err = create_company_workflow(&company, dir.path(), &store, None, two)
+            .await
+            .expect_err("two triggers");
+        assert!(err.to_string().contains("exactly one `trigger`"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn traversal_id_is_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let err = create_company_workflow(
+            &company,
+            dir.path(),
+            &store,
+            None,
+            valid_draft("../secrets", "Escape"),
+        )
+        .await
+        .expect_err("traversal id");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn oversized_node_count_is_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let mut draft = valid_draft("big", "Big");
+        for i in 0..MAX_WORKFLOW_NODES {
+            draft.nodes.push(RawNode {
+                id: format!("n{i}"),
+                kind: "output".to_string(),
+                name: format!("N{i}"),
+                summary: None,
+                agent: None,
+            });
+        }
+        assert!(draft.nodes.len() > MAX_WORKFLOW_NODES);
+        let err = create_company_workflow(&company, dir.path(), &store, None, draft)
+            .await
+            .expect_err("too many nodes");
+        assert!(err.to_string().contains("at most"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn oversized_toml_bytes_is_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        // Stay within the node cap but blow the byte cap with a huge summary.
+        let mut draft = valid_draft("fat", "Fat");
+        draft.nodes[0].summary = Some("x".repeat(MAX_WORKFLOW_TOML_BYTES + 10));
+        let err = create_company_workflow(&company, dir.path(), &store, None, draft)
+            .await
+            .expect_err("too many bytes");
+        assert!(err.to_string().contains("byte"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn store_save_failure_rolls_the_file_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::failing(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        let err = create_company_workflow(
+            &company,
+            dir.path(),
+            &store,
+            None,
+            valid_draft("rollback", "Rollback"),
+        )
+        .await
+        .expect_err("save fails");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+
+        // The file must have been removed so a retry can succeed.
+        let path = dir.path().join("workflows").join("rollback.toml");
+        assert!(!path.exists(), "the orphaned file must be cleaned up");
+    }
+
+    #[tokio::test]
+    async fn no_company_record_is_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("ghost");
+        let store: Arc<dyn CompanyStore> = Arc::new(MemStore::default());
+        let err =
+            create_company_workflow(&company, dir.path(), &store, None, valid_draft("wf", "WF"))
+                .await
+                .expect_err("no record");
+        assert!(
+            matches!(err, OpenCompanyError::CompanyNotFound(_)),
+            "{err:?}"
+        );
+    }
+}

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -215,7 +215,7 @@ pub(crate) async fn create_company_workflow(
         .open(&path)
         .map_err(|e| match e.kind() {
             std::io::ErrorKind::AlreadyExists => OpenCompanyError::Conflict(format!(
-                "A workflow named `{}` already exists.",
+                "A workflow with id `{}` already exists. Pick a different id.",
                 file.id
             )),
             _ => OpenCompanyError::StoreIo {

--- a/src/error.rs
+++ b/src/error.rs
@@ -107,6 +107,10 @@ pub enum OpenCompanyError {
     #[error("company not found: {0}")]
     CompanyNotFound(String),
 
+    /// An addressed resource other than a company does not exist.
+    #[error("not found: {0}")]
+    NotFound(String),
+
     /// No MCP install exists in the addressed company's registry store.
     #[cfg(feature = "mcp")]
     #[error("MCP server not found: {0}")]
@@ -226,6 +230,7 @@ impl OpenCompanyError {
             Self::StoreIo { .. } => "store_io".to_string(),
             Self::Serde(_) => "serialization_error".to_string(),
             Self::CompanyNotFound(_) => "company_not_found".to_string(),
+            Self::NotFound(_) => "not_found".to_string(),
             #[cfg(feature = "mcp")]
             Self::McpServerNotFound(_) => "mcp_server_not_found".to_string(),
             Self::ToolNotGranted(_) => "tool_not_granted".to_string(),

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -163,12 +163,11 @@ impl HarnessBrain {
                     // `paused` column. The cycle ends normally, so the per-tenant
                     // serial lock releases while parked — resume is a plain
                     // `column → in_progress` PATCH that re-triggers dispatch.
-                    let partial = outcome.as_ref().map(|o| o.reply.as_str()).unwrap_or("");
-                    card.note = Some(append_result(
-                        card.note.as_deref(),
-                        &responder,
-                        &format!("[paused] {partial}"),
-                    ));
+                    let partial = match &outcome {
+                        Ok(outcome) => format!("[paused] {}", outcome.reply),
+                        Err(err) => format!("[paused] dispatch failed: {err}"),
+                    };
+                    card.note = Some(append_result(card.note.as_deref(), &responder, &partial));
                     card.column = "paused".to_string();
                     break;
                 }
@@ -179,16 +178,14 @@ impl HarnessBrain {
                         "operator redirect",
                         &fresh,
                     ));
-                    if redirects >= MAX_REDIRECTS_PER_DISPATCH {
+                    if redirects > MAX_REDIRECTS_PER_DISPATCH {
                         // Exhausted the redirect budget — finalize the last run's
                         // reply to `in_review` rather than looping forever.
-                        if let Ok(outcome) = &outcome {
-                            card.note = Some(append_result(
-                                card.note.as_deref(),
-                                &responder,
-                                &outcome.reply,
-                            ));
-                        }
+                        let last = match &outcome {
+                            Ok(outcome) => outcome.reply.clone(),
+                            Err(err) => format!("dispatch failed: {err}"),
+                        };
+                        card.note = Some(append_result(card.note.as_deref(), &responder, &last));
                         card.column = "in_review".to_string();
                         break;
                     }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -22,8 +22,15 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::Result;
+use crate::company::steer::{InflightEntry, InflightKind, SteerAction, cap_redirect};
 use crate::harness::orchestrator::{self, Delegation};
 use crate::harness::{HarnessDeps, HarnessPool};
+
+/// The most operator redirects honored within a single task dispatch (issue
+/// #111). A redirect re-runs the turn in-loop with the fresh instruction
+/// appended; past this cap the run is finalized to `in_review` so a redirect
+/// storm can't loop forever.
+const MAX_REDIRECTS_PER_DISPATCH: u32 = 3;
 use crate::ports::brain::{Brain, CycleHost};
 use crate::ports::types::{
     CompanyEvent, CompanyRecord, CompressedTrace, CycleRequest, CycleResult, OutboundMessage,
@@ -79,32 +86,127 @@ impl HarnessBrain {
         };
 
         let responder = self.task_responder(&card.assignee);
-        let instruction = task_instruction(&card);
-        match self
-            .pool
-            .run(&self.record.id, &responder, &instruction, &self.deps)
-            .await
-        {
-            // A dispatched task discards its steps — the card note is text-only.
-            Ok(outcome) => {
-                card.note = Some(append_result(
-                    card.note.as_deref(),
+
+        // Register the run so an operator can steer it mid-flight. The guard's
+        // RAII `Drop` deregisters on every exit path (success, error, redirect
+        // exhaustion), so a crashed turn never leaves a ghost row in the strip.
+        let guard = self.deps.steer.register(
+            &self.record.id,
+            InflightEntry {
+                key: card.id.clone(),
+                task_id: Some(card.id.clone()),
+                kind: InflightKind::Task,
+                title: card.title.clone(),
+                agent_id: responder.clone(),
+                started_at_millis: now_millis(),
+                pending_action: None,
+            },
+        );
+        let control = guard.control().clone();
+
+        // The base turn instruction is frozen at dispatch (the card's note keeps
+        // accumulating operator/agent blocks, but a redirect always re-runs from
+        // the original brief plus the fresh instruction — last redirect wins).
+        let base_instruction = task_instruction(&card);
+        let mut instruction = base_instruction.clone();
+        let mut redirects: u32 = 0;
+
+        loop {
+            let outcome = self
+                .pool
+                .run_steered(
+                    &self.record.id,
                     &responder,
-                    &outcome.reply,
-                ));
-                card.column = "in_review".to_string();
-            }
-            Err(err) => {
-                card.note = Some(append_result(
-                    card.note.as_deref(),
-                    &responder,
-                    &format!("dispatch failed: {err}"),
-                ));
-                card.column = "backlog".to_string();
+                    &instruction,
+                    &self.deps,
+                    &control,
+                )
+                .await;
+            // One-shot read of what (if anything) the operator asked for. `None`
+            // is the ordinary, unsteered path.
+            match control.take() {
+                None => {
+                    // A dispatched task discards its steps — the note is text-only.
+                    match outcome {
+                        Ok(outcome) => {
+                            card.note = Some(append_result(
+                                card.note.as_deref(),
+                                &responder,
+                                &outcome.reply,
+                            ));
+                            card.column = "in_review".to_string();
+                        }
+                        Err(err) => {
+                            card.note = Some(append_result(
+                                card.note.as_deref(),
+                                &responder,
+                                &format!("dispatch failed: {err}"),
+                            ));
+                            card.column = "backlog".to_string();
+                        }
+                    }
+                    break;
+                }
+                Some(SteerAction::Cancel) => {
+                    // Partial work is DISCARDED — only a cancellation note lands,
+                    // and the card returns to `backlog`.
+                    card.note = Some(append_result(
+                        card.note.as_deref(),
+                        "operator",
+                        "cancelled while in flight",
+                    ));
+                    card.column = "backlog".to_string();
+                    break;
+                }
+                Some(SteerAction::Pause) => {
+                    // Partial work is PRESERVED in the note; the card parks in the
+                    // `paused` column. The cycle ends normally, so the per-tenant
+                    // serial lock releases while parked — resume is a plain
+                    // `column → in_progress` PATCH that re-triggers dispatch.
+                    let partial = outcome.as_ref().map(|o| o.reply.as_str()).unwrap_or("");
+                    card.note = Some(append_result(
+                        card.note.as_deref(),
+                        &responder,
+                        &format!("[paused] {partial}"),
+                    ));
+                    card.column = "paused".to_string();
+                    break;
+                }
+                Some(SteerAction::Redirect { instruction: fresh }) => {
+                    redirects += 1;
+                    card.note = Some(append_result(
+                        card.note.as_deref(),
+                        "operator redirect",
+                        &fresh,
+                    ));
+                    if redirects >= MAX_REDIRECTS_PER_DISPATCH {
+                        // Exhausted the redirect budget — finalize the last run's
+                        // reply to `in_review` rather than looping forever.
+                        if let Ok(outcome) = &outcome {
+                            card.note = Some(append_result(
+                                card.note.as_deref(),
+                                &responder,
+                                &outcome.reply,
+                            ));
+                        }
+                        card.column = "in_review".to_string();
+                        break;
+                    }
+                    // Re-run from the original brief plus the (codepoint-capped)
+                    // operator instruction.
+                    instruction = format!(
+                        "{base_instruction}\n\nOperator redirect: {}",
+                        cap_redirect(&fresh)
+                    );
+                    continue;
+                }
             }
         }
+
         card.updated_at_millis = now_millis();
         tasks.upsert(&self.record.id, &card).await?;
+        // `guard` drops here → the run leaves the in-flight strip.
+        drop(guard);
         Ok(())
     }
 
@@ -225,10 +327,31 @@ impl HarnessBrain {
                 let Some(member) = self.desk_lead(&desk) else {
                     return Ok(None);
                 };
+                // Register the delegated turn so an operator can CANCEL it
+                // mid-flight (cancel-only in v1 — pause/redirect are rejected at
+                // the route). RAII guard deregisters on every exit path.
+                let guard = self.deps.steer.register(
+                    &self.record.id,
+                    InflightEntry {
+                        key: generate_id(),
+                        task_id: None,
+                        kind: InflightKind::Delegation,
+                        title: desk.clone(),
+                        agent_id: member.clone(),
+                        started_at_millis: now_millis(),
+                        pending_action: None,
+                    },
+                );
+                let control = guard.control().clone();
                 let outcome = self
                     .pool
-                    .run(&self.record.id, &member, &instruction, &self.deps)
+                    .run_steered(&self.record.id, &member, &instruction, &self.deps, &control)
                     .await?;
+                // A cancel issued mid-flight discards the delegated reply — no
+                // bubble surfaces.
+                if matches!(control.take(), Some(SteerAction::Cancel)) {
+                    return Ok(None);
+                }
                 // The desk lead's own steps ride on its distinct bubble.
                 Ok(Some(OutboundMessage {
                     channel: member,
@@ -427,6 +550,7 @@ description = "Runs Acme."
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
             media: None,
+            steer: crate::company::steer::InflightRegistry::default(),
         };
         HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record())
     }
@@ -564,6 +688,7 @@ description = "Builds it."
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
             media: None,
+            steer: crate::company::steer::InflightRegistry::default(),
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record_two()),
@@ -765,6 +890,7 @@ members = ["engineer"]
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
             media: None,
+            steer: crate::company::steer::InflightRegistry::default(),
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record),
@@ -944,6 +1070,7 @@ name = "Design"
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
             media: None,
+            steer: crate::company::steer::InflightRegistry::default(),
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record());
 
@@ -983,6 +1110,198 @@ name = "Design"
                     if server == "browserbase" && status == "tool_call_rejected"
             )),
             "an McpCallFailed audit event was journaled"
+        );
+    }
+
+    // --- Steer disposition (issue #111) -------------------------------------
+
+    use crate::company::steer::InflightRegistry;
+    use openhuman_core::openhuman as oh;
+    use std::collections::VecDeque;
+    use std::sync::Mutex as StdMutex;
+
+    /// A provider that steers its OWN in-flight run on selected turns (via the
+    /// shared registry), so the disposition matrix can be driven deterministically
+    /// over an offline turn. It pops one queued action per `chat_with_system`
+    /// call and applies it against `key`, then echoes the message.
+    struct SteeringProvider {
+        steer: InflightRegistry,
+        company: CompanyId,
+        key: String,
+        actions: StdMutex<VecDeque<SteerAction>>,
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait]
+    impl oh::inference::provider::Provider for SteeringProvider {
+        fn telemetry_provider_id(&self) -> String {
+            "steering".to_string()
+        }
+        async fn chat_with_system(
+            &self,
+            _system: Option<&str>,
+            message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<String> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if let Some(action) = self.actions.lock().unwrap().pop_front() {
+                let _ = self.steer.steer(&self.company, &self.key, action);
+            }
+            Ok(format!("did: {message}"))
+        }
+    }
+
+    /// A brain whose provider steers the dispatched card `key` with `actions`
+    /// (one per turn). Returns the brain + its task store so a test can seed the
+    /// card and read the disposition back.
+    fn brain_that_steers_itself(
+        dir: &std::path::Path,
+        key: &str,
+        actions: Vec<SteerAction>,
+    ) -> (HarnessBrain, Arc<FsOps>) {
+        let steer = InflightRegistry::new();
+        let tasks = Arc::new(FsOps::new(dir));
+        let provider = Arc::new(SteeringProvider {
+            steer: steer.clone(),
+            company: CompanyId::new("acme"),
+            key: key.to_string(),
+            actions: StdMutex::new(actions.into_iter().collect()),
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let deps = HarnessDeps {
+            provider,
+            provider_slug: "steering".to_string(),
+            context: Arc::new(FsContextStore::new(dir)),
+            store: Arc::new(FsCompanyStore::new(dir)),
+            meter: None,
+            workspace_root: dir.to_path_buf(),
+            model_override: None,
+            tasks: Some(tasks.clone()),
+            skills: None,
+            skills_source_dir: None,
+            mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: orchestrator::DelegationQueue::default(),
+            workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
+            mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            plan: None,
+            media: None,
+            steer,
+        };
+        (
+            HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record()),
+            tasks,
+        )
+    }
+
+    /// Cancel mid-flight → the card returns to `backlog`, the partial reply is
+    /// DISCARDED, and only the operator cancellation note lands.
+    #[tokio::test]
+    async fn steer_cancel_returns_to_backlog_and_discards_partial() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks) = brain_that_steers_itself(dir.path(), "t1", vec![SteerAction::Cancel]);
+        tasks
+            .upsert(&CompanyId::new("acme"), &card("t1", ""))
+            .await
+            .unwrap();
+
+        brain
+            .run_cycle(
+                request(vec![CompanyEvent::TaskDispatched {
+                    task_id: "t1".into(),
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        let moved = only_card(&tasks).await;
+        assert_eq!(moved.column, "backlog");
+        let note = moved.note.expect("note");
+        assert!(note.contains("cancelled while in flight"), "{note:?}");
+        // The agent's partial reply must NOT be preserved on a cancel.
+        assert!(
+            !note.contains("did: "),
+            "cancel discards the partial: {note:?}"
+        );
+    }
+
+    /// Pause mid-flight → the card parks in the new `paused` column and the
+    /// partial reply is PRESERVED in the note.
+    #[tokio::test]
+    async fn steer_pause_parks_in_paused_and_preserves_partial() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks) = brain_that_steers_itself(dir.path(), "t1", vec![SteerAction::Pause]);
+        tasks
+            .upsert(&CompanyId::new("acme"), &card("t1", ""))
+            .await
+            .unwrap();
+
+        brain
+            .run_cycle(
+                request(vec![CompanyEvent::TaskDispatched {
+                    task_id: "t1".into(),
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        let moved = only_card(&tasks).await;
+        assert_eq!(moved.column, "paused");
+        let note = moved.note.expect("note");
+        assert!(note.contains("[paused]"), "{note:?}");
+        assert!(
+            note.contains("did: "),
+            "pause preserves the partial: {note:?}"
+        );
+    }
+
+    /// Redirect on every turn → the run re-runs in-loop carrying the operator
+    /// instruction, and the per-dispatch redirect cap (3) finalizes it to
+    /// `in_review` instead of looping forever.
+    #[tokio::test]
+    async fn steer_redirect_reruns_and_the_cap_finalizes_to_in_review() {
+        let dir = tempfile::tempdir().unwrap();
+        let redirect = || SteerAction::Redirect {
+            instruction: "focus on the API".to_string(),
+        };
+        // Steer a redirect on the first several turns; the cap should stop it.
+        let (brain, tasks) = brain_that_steers_itself(
+            dir.path(),
+            "t1",
+            vec![redirect(), redirect(), redirect(), redirect()],
+        );
+        tasks
+            .upsert(&CompanyId::new("acme"), &card("t1", ""))
+            .await
+            .unwrap();
+
+        brain
+            .run_cycle(
+                request(vec![CompanyEvent::TaskDispatched {
+                    task_id: "t1".into(),
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        let moved = only_card(&tasks).await;
+        // Redirect budget exhausted → finalized, not looping.
+        assert_eq!(moved.column, "in_review");
+        let note = moved.note.expect("note");
+        // The operator instruction was carried into the rerun, and the reruns
+        // echoed it back through the "Operator redirect:" preamble.
+        assert!(note.contains("focus on the API"), "{note:?}");
+        assert!(
+            note.contains("Operator redirect:"),
+            "the rerun carried the operator instruction: {note:?}"
         );
     }
 }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -1143,7 +1143,17 @@ name = "Design"
         ) -> anyhow::Result<String> {
             self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             if let Some(action) = self.actions.lock().unwrap().pop_front() {
-                let _ = self.steer.steer(&self.company, &self.key, action);
+                let key = if self.key.is_empty() {
+                    self.steer
+                        .list(&self.company)
+                        .into_iter()
+                        .next()
+                        .map(|entry| entry.key)
+                        .unwrap_or_default()
+                } else {
+                    self.key.clone()
+                };
+                let _ = self.steer.steer(&self.company, &key, action);
             }
             Ok(format!("did: {message}"))
         }
@@ -1156,7 +1166,7 @@ name = "Design"
         dir: &std::path::Path,
         key: &str,
         actions: Vec<SteerAction>,
-    ) -> (HarnessBrain, Arc<FsOps>) {
+    ) -> (HarnessBrain, Arc<FsOps>, Arc<SteeringProvider>) {
         let steer = InflightRegistry::new();
         let tasks = Arc::new(FsOps::new(dir));
         let provider = Arc::new(SteeringProvider {
@@ -1167,7 +1177,7 @@ name = "Design"
             calls: std::sync::atomic::AtomicUsize::new(0),
         });
         let deps = HarnessDeps {
-            provider,
+            provider: provider.clone(),
             provider_slug: "steering".to_string(),
             context: Arc::new(FsContextStore::new(dir)),
             store: Arc::new(FsCompanyStore::new(dir)),
@@ -1193,6 +1203,7 @@ name = "Design"
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record()),
             tasks,
+            provider,
         )
     }
 
@@ -1201,7 +1212,8 @@ name = "Design"
     #[tokio::test]
     async fn steer_cancel_returns_to_backlog_and_discards_partial() {
         let dir = tempfile::tempdir().unwrap();
-        let (brain, tasks) = brain_that_steers_itself(dir.path(), "t1", vec![SteerAction::Cancel]);
+        let (brain, tasks, _) =
+            brain_that_steers_itself(dir.path(), "t1", vec![SteerAction::Cancel]);
         tasks
             .upsert(&CompanyId::new("acme"), &card("t1", ""))
             .await
@@ -1233,7 +1245,8 @@ name = "Design"
     #[tokio::test]
     async fn steer_pause_parks_in_paused_and_preserves_partial() {
         let dir = tempfile::tempdir().unwrap();
-        let (brain, tasks) = brain_that_steers_itself(dir.path(), "t1", vec![SteerAction::Pause]);
+        let (brain, tasks, _) =
+            brain_that_steers_itself(dir.path(), "t1", vec![SteerAction::Pause]);
         tasks
             .upsert(&CompanyId::new("acme"), &card("t1", ""))
             .await
@@ -1269,7 +1282,7 @@ name = "Design"
             instruction: "focus on the API".to_string(),
         };
         // Steer a redirect on the first several turns; the cap should stop it.
-        let (brain, tasks) = brain_that_steers_itself(
+        let (brain, tasks, provider) = brain_that_steers_itself(
             dir.path(),
             "t1",
             vec![redirect(), redirect(), redirect(), redirect()],
@@ -1300,5 +1313,26 @@ name = "Design"
             note.contains("Operator redirect:"),
             "the rerun carried the operator instruction: {note:?}"
         );
+        assert_eq!(
+            provider.calls.load(std::sync::atomic::Ordering::SeqCst),
+            4,
+            "one initial turn plus three reruns"
+        );
+    }
+
+    #[tokio::test]
+    async fn steer_cancelled_delegation_returns_no_bubble() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, _, _) = brain_that_steers_itself(dir.path(), "", vec![SteerAction::Cancel]);
+
+        let result = brain
+            .run_delegation(Delegation::DelegateToDesk {
+                desk: "engineering".to_string(),
+                instruction: "investigate".to_string(),
+            })
+            .await
+            .expect("cancellation is handled");
+
+        assert!(result.is_none(), "cancelled delegation must not bubble");
     }
 }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -47,6 +47,7 @@ pub mod orchestrator;
 pub mod policy;
 pub mod provider;
 pub mod skills;
+pub mod steer;
 pub mod steps;
 pub mod toolbelt;
 
@@ -65,6 +66,7 @@ use oh::inference::provider::Provider;
 use crate::company::Agent as ManifestAgent;
 use crate::company::Policy;
 use crate::company::mcp::McpServerDecl;
+use crate::company::steer::SteerControl;
 use crate::error::OpenCompanyError;
 use crate::harness::cost::{TurnUsage, record_turn_cost};
 use crate::harness::mcp_probe::McpFailureQueue;
@@ -193,6 +195,15 @@ pub struct HarnessDeps {
     /// [`toolbelt::media_tools`]; a grant with no credential wires nothing and
     /// warns.
     pub media: Option<toolbelt::MediaBackend>,
+    /// Issue #111 — the shared registry of in-flight, steerable runs. The
+    /// [`HarnessBrain`] registers a dispatched task / desk delegation here before
+    /// running it (and installs the steer stop-hook over the slot's control), so
+    /// an operator can pause / cancel / redirect it mid-flight. The **same**
+    /// handle is threaded onto the [`CompanyRuntime`](crate::company::runtime::CompanyRuntime)
+    /// so the operator steer routes reach it. A cheap shared handle (like
+    /// [`delegations`](Self::delegations)); the default is an empty registry,
+    /// which simply lists nothing and rejects every steer as `not in flight`.
+    pub steer: crate::company::steer::InflightRegistry,
 }
 
 /// One live openhuman agent, keyed by its manifest id.
@@ -269,6 +280,29 @@ impl CompanyAgent {
     /// per-turn *local* — deliberately not a [`HarnessDeps`] field — so parallel
     /// turns never collide.
     pub async fn run(&self, message: &str) -> crate::Result<(TurnOutcome, Vec<TurnUsage>)> {
+        self.run_with_steer(message, None).await
+    }
+
+    /// Runs one turn with an optional operator **steer** control installed
+    /// (issue #111).
+    ///
+    /// When `steer` is `Some`, a [`SteerStopHook`](crate::harness::steer::SteerStopHook)
+    /// over the shared control is installed around the turn via
+    /// [`with_stop_hooks`](oh::agent::stop_hooks::with_stop_hooks). OpenHuman
+    /// fires stop hooks **between** tool-loop iterations (never mid-tool-call),
+    /// so an operator pause / cancel / redirect halts the turn gracefully at the
+    /// next iteration boundary. The control is `Box::pin`ned at the task-local
+    /// scope boundary to avoid the nested-scope stack-overflow trap.
+    ///
+    /// When a steer is pending after the first attempt yields the transient
+    /// empty-response class, the one-shot retry is **skipped** — a cancel (or
+    /// pause) issued before any text is produced must not silently restart the
+    /// work. With no steer this is byte-identical to the pre-#111 `run`.
+    pub async fn run_with_steer(
+        &self,
+        message: &str,
+        steer: Option<&SteerControl>,
+    ) -> crate::Result<(TurnOutcome, Vec<TurnUsage>)> {
         // Per-turn progress sink + an always-draining collector, so a burst of
         // events never blocks the turn loop on a full channel.
         let (tx, mut rx) = tokio::sync::mpsc::channel::<oh::agent::progress::AgentProgress>(1024);
@@ -282,29 +316,53 @@ impl CompanyAgent {
 
         let mut agent = self.agent.lock().await;
         agent.set_on_progress(Some(tx));
-        let mut usages: Vec<TurnUsage> = Vec::new();
 
-        // Attempt 1, falling through to a single retry only on the transient
-        // empty-response class. Both attempts feed the one progress channel.
-        let first = agent.turn(message).await;
-        usages.push(read_turn_usage(&agent));
-        let reply: crate::Result<String> = match self.classify_turn(first) {
-            AttemptOutcome::Reply(reply) => Ok(reply),
-            AttemptOutcome::Hard(err) => Err(err),
-            AttemptOutcome::Empty => {
-                // Attempt 2 (retry once).
-                let second = agent.turn(message).await;
-                usages.push(read_turn_usage(&agent));
-                match self.classify_turn(second) {
-                    AttemptOutcome::Reply(reply) => Ok(reply),
-                    // Still empty → graceful, scrubbed text (never an `Err`).
-                    AttemptOutcome::Empty => {
-                        Ok(crate::harness::mcp_probe::scrub(GRACEFUL_EMPTY_REPLY, &[]))
-                    }
-                    AttemptOutcome::Hard(err) => Err(err),
-                }
-            }
+        // Install the steer hook only when a control is provided; an empty hook
+        // list is exactly the pre-#111 behaviour.
+        let hooks: Vec<Arc<dyn oh::agent::stop_hooks::StopHook>> = match steer {
+            Some(control) => vec![Arc::new(crate::harness::steer::SteerStopHook::new(
+                control.clone(),
+            ))],
+            None => Vec::new(),
         };
+
+        // `Box::pin` at the task-local scope boundary (the nested-scope
+        // stack-overflow trap). The turn body owns the retry classification and
+        // reports every attempt's usage.
+        let (reply, usages): (crate::Result<String>, Vec<TurnUsage>) =
+            oh::agent::stop_hooks::with_stop_hooks(
+                hooks,
+                Box::pin(async {
+                    let mut usages: Vec<TurnUsage> = Vec::new();
+                    let first = agent.turn(message).await;
+                    usages.push(read_turn_usage(&agent));
+                    let reply: crate::Result<String> = match self.classify_turn(first) {
+                        AttemptOutcome::Reply(reply) => Ok(reply),
+                        AttemptOutcome::Hard(err) => Err(err),
+                        AttemptOutcome::Empty => {
+                            // Retry-guard edge: skip the one-shot retry when an
+                            // operator steer already pends, so a cancel/pause
+                            // before any text can't restart the work.
+                            if steer.map(|c| c.requested()).unwrap_or(false) {
+                                Ok(crate::harness::mcp_probe::scrub(GRACEFUL_EMPTY_REPLY, &[]))
+                            } else {
+                                let second = agent.turn(message).await;
+                                usages.push(read_turn_usage(&agent));
+                                match self.classify_turn(second) {
+                                    AttemptOutcome::Reply(reply) => Ok(reply),
+                                    AttemptOutcome::Empty => Ok(crate::harness::mcp_probe::scrub(
+                                        GRACEFUL_EMPTY_REPLY,
+                                        &[],
+                                    )),
+                                    AttemptOutcome::Hard(err) => Err(err),
+                                }
+                            }
+                        }
+                    };
+                    (reply, usages)
+                }),
+            )
+            .await;
 
         // Detach the sink (drops the only remaining `Sender`, closing the
         // channel), release the agent lock, then drain + fold. A `Hard` error
@@ -595,6 +653,34 @@ impl HarnessPool {
         message: &str,
         deps: &HarnessDeps,
     ) -> crate::Result<TurnOutcome> {
+        self.run_inner(company, agent_id, message, deps, None).await
+    }
+
+    /// Routes a message to one agent with an operator **steer** control installed
+    /// (issue #111), so a dispatched task / desk delegation can be paused,
+    /// cancelled, or redirected mid-flight. Otherwise identical to
+    /// [`run`](Self::run) — same retrieve→inject, cost accounting, and
+    /// memory-writeback. The steer hook fires only between tool-loop iterations.
+    pub async fn run_steered(
+        &self,
+        company: &CompanyId,
+        agent_id: &str,
+        message: &str,
+        deps: &HarnessDeps,
+        control: &SteerControl,
+    ) -> crate::Result<TurnOutcome> {
+        self.run_inner(company, agent_id, message, deps, Some(control))
+            .await
+    }
+
+    async fn run_inner(
+        &self,
+        company: &CompanyId,
+        agent_id: &str,
+        message: &str,
+        deps: &HarnessDeps,
+        steer: Option<&SteerControl>,
+    ) -> crate::Result<TurnOutcome> {
         let agent = {
             let guard = self.agents.read().await;
             let roster = guard
@@ -625,7 +711,7 @@ impl HarnessPool {
         // accessor and returns one entry per attempt (two when the empty-response
         // wrapper retried once). A zero-usage attempt (offline provider) writes
         // nothing, so the inert-metering contract holds.
-        let (outcome, turn_costs) = agent.run(&augmented).await?;
+        let (outcome, turn_costs) = agent.run_with_steer(&augmented, steer).await?;
         // Attribute cost to the provider this turn actually resolved to. With a
         // per-tenant [`TenantProvider`](crate::harness::provider::TenantProvider)
         // a console BYOK switch changes the slug between turns, so read it live
@@ -1058,6 +1144,7 @@ description = "Builds the product."
                 capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
                 plan: None,
                 media: None,
+                steer: crate::company::steer::InflightRegistry::default(),
             },
             store,
             meter,
@@ -1112,6 +1199,7 @@ description = "Builds the product."
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
             media: None,
+            steer: crate::company::steer::InflightRegistry::default(),
         };
 
         let roster = build_roster(&record(), &deps, &[]).expect("roster builds with skills");
@@ -1389,6 +1477,7 @@ description = "Builds the product."
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
             media: None,
+            steer: crate::company::steer::InflightRegistry::default(),
         };
         let roster = build_roster(&record(), &deps, &[]).expect("roster");
         // Keep the tempdir alive for the agent's workspace by leaking it into the
@@ -1410,6 +1499,36 @@ description = "Builds the product."
         );
         assert_eq!(usages.len(), 2, "both attempts' usage is returned");
     }
+
+    /// Issue #111 retry-guard edge: when a steer already pends and the first
+    /// attempt is the transient empty class, the one-shot retry is SKIPPED — so a
+    /// cancel/pause issued before any text can't silently restart the work. The
+    /// steered-empty turn therefore makes EXACTLY ONE attempt.
+    #[tokio::test]
+    async fn steered_empty_turn_makes_exactly_one_attempt() {
+        use crate::company::steer::SteerAction;
+        // Attempt 1 is empty; a normal `run` would retry and consume the second
+        // script entry. With a steer pending, the retry must not fire.
+        let (agent, _deps) = scripted_agent(vec![Ok(String::new()), Ok("second".into())]);
+        let control = SteerControl::new();
+        control.request(SteerAction::Cancel);
+        let (_outcome, usages) = agent
+            .run_with_steer("hi", Some(&control))
+            .await
+            .expect("runs");
+        assert_eq!(
+            usages.len(),
+            1,
+            "a steered empty turn does NOT retry — exactly one attempt"
+        );
+    }
+
+    // Note: the *installation* of the steer stop-hook can't be observed from the
+    // provider — the tinyagents adapter snapshots the hooks at turn entry and the
+    // provider call may run on a spawned task where the task-local isn't
+    // inherited. The steer mechanism is instead proven end-to-end by the
+    // retry-guard edge above and the `run_task` disposition matrix in
+    // `harness::brain::tests` (cancel / pause / redirect all take effect).
 
     /// Empty twice → a graceful, non-error reply (chat never shows "Couldn't
     /// send" for a transient hiccup), still two attempts.
@@ -1511,6 +1630,7 @@ description = "Builds the product."
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
             media: None,
+            steer: crate::company::steer::InflightRegistry::default(),
         };
         let pool = HarnessPool::new();
         let rec = record();
@@ -1620,6 +1740,7 @@ description = "Builds the product."
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
             media: None,
+            steer: crate::company::steer::InflightRegistry::default(),
         };
         let pool = HarnessPool::new();
 
@@ -1760,6 +1881,7 @@ description = "Sets direction."
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: Some(plan),
             media: None,
+            steer: crate::company::steer::InflightRegistry::default(),
         };
         let pool = HarnessPool::new();
         let rec = granting_record();

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -734,12 +734,17 @@ impl HarnessPool {
         // SECURITY: the reply **text only** — the scrubbed `outcome.steps` never
         // enter the memory store, so a step detail can never be retrieved and
         // re-injected into a later turn.
-        deps.context
-            .put(
-                company,
-                memory_loop::outcome_chunk(agent_id, message, &outcome.reply),
-            )
-            .await?;
+        if !matches!(
+            steer.and_then(SteerControl::pending),
+            Some(SteerAction::Cancel)
+        ) {
+            deps.context
+                .put(
+                    company,
+                    memory_loop::outcome_chunk(agent_id, message, &outcome.reply),
+                )
+                .await?;
+        }
 
         Ok(outcome)
     }

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -336,6 +336,9 @@ fn summarize_event(event: &CompanyEvent) -> String {
         CompanyEvent::WorkflowCreated {
             workflow_id, name, ..
         } => format!("workflow created: {name} ({workflow_id})"),
+        CompanyEvent::TaskSteered {
+            task_id, action, ..
+        } => format!("task steered ({action}): {task_id}"),
     }
 }
 

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -1189,8 +1189,13 @@ impl Tool for CreateWorkflowTool {
             }
             Err(err) => {
                 tracing::debug!(company = %self.company, error = %err, "create_workflow: rejected");
+                let detail = match &err {
+                    OpenCompanyError::InvalidRequest(message)
+                    | OpenCompanyError::Conflict(message) => message.clone(),
+                    _ => "the company couldn't save it right now; try again.".to_string(),
+                };
                 Ok(ToolResult::error(format!(
-                    "Couldn't create the workflow: {err}"
+                    "Couldn't create the workflow: {detail}"
                 )))
             }
         }

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -9,7 +9,7 @@
 //! first agent when none is tagged (so a company without an orchestrator behaves
 //! exactly as before).
 //!
-//! It reaches five tools, all wired only onto the orchestrator agent:
+//! It reaches six tools, all wired only onto the orchestrator agent:
 //!
 //! * [`QueryCompanyTool`] — a read surface over the company's [`FactStore`] and
 //!   recent [`EventLog`] history.
@@ -25,6 +25,11 @@
 //!   task waiting on a workflow can actually be run to completion. Unlike the
 //!   delegation tools it runs the graph inline and returns a concise summary of
 //!   the run rather than enqueuing deferred work.
+//! * [`CreateWorkflowTool`] (issue #112) — authors and saves a brand-new
+//!   workflow graph through the same validated-persist core the console
+//!   `POST .../workflows` route runs, so the orchestrator can capture a
+//!   repeatable process mid-chat; it lands enabled and runnable by
+//!   [`RunWorkflowTool`] the same turn.
 //! * [`AddAgentTool`] (issue #71) — writes a new [`OverlayAgent`] through the
 //!   same store path the console `POST .../team` route uses, so the
 //!   orchestrator can bring on a teammate mid-chat.
@@ -43,7 +48,10 @@ use openhuman_core::openhuman as oh;
 
 use oh::tools::traits::{PermissionLevel, Tool, ToolResult};
 
-use crate::company::{Agent as ManifestAgent, WorkflowFile, load_company_workflows};
+use crate::company::{
+    Agent as ManifestAgent, RawEdge, RawNode, RawWorkflow, WorkflowFile, create_company_workflow,
+    load_company_workflows,
+};
 use crate::error::OpenCompanyError;
 use crate::ports::events::EventLog;
 use crate::ports::facts::FactStore;
@@ -73,6 +81,8 @@ pub const DELEGATE_TO_DESK_TOOL: &str = "delegate_to_desk";
 pub const RUN_WORKFLOW_TOOL: &str = "run_workflow";
 /// The `add_agent` tool name (issue #71 — Active Runtime Teammates).
 pub const ADD_AGENT_TOOL: &str = "add_agent";
+/// The `create_workflow` tool name (issue #112 — author a saved workflow graph).
+pub const CREATE_WORKFLOW_TOOL: &str = "create_workflow";
 
 /// The id of the orchestrator agent for a roster: the first agent tagged
 /// `tier = "orchestrator"`, else the first roster agent, else `None` (empty
@@ -95,7 +105,10 @@ pub fn orchestrator_id(agents: &[ManifestAgent]) -> Option<String> {
 /// [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy) classifies them as
 /// internal — never an external effect to park or deny.
 pub fn is_delegation_tool(tool: &str) -> bool {
-    tool == SPAWN_TASK_TOOL || tool == DELEGATE_TO_DESK_TOOL || tool == ADD_AGENT_TOOL
+    tool == SPAWN_TASK_TOOL
+        || tool == DELEGATE_TO_DESK_TOOL
+        || tool == ADD_AGENT_TOOL
+        || tool == CREATE_WORKFLOW_TOOL
 }
 
 /// The orchestrator persona brief, appended to the orchestrator agent's persona.
@@ -107,10 +120,13 @@ company's durable facts and recent activity, `delegate_to_desk` to hand a turn t
 member, `spawn_task` to open a tracked task card, `run_workflow` to execute one of the \
 company's saved workflows by id (for example to advance or finish a task that is waiting on a \
 workflow run) — you can run workflows yourself; never claim the run_workflow tool is unavailable — \
-and `add_agent` to bring on a new teammate (a name, role, and optional mandate) when the company \
-genuinely needs one — it becomes a real, addressable member of the team starting next turn. \
-Delegate, run a workflow, or add a teammate only when it genuinely helps — otherwise answer \
-directly and concisely."
+`create_workflow` to author and save a brand-new workflow graph (a trigger plus agent / tool / \
+condition / output steps) when a repeatable process is worth capturing — it's enabled immediately \
+and runnable with run_workflow — and `add_agent` to bring on a new teammate (a name, role, and \
+optional mandate) when the company genuinely needs one — it becomes a real, addressable member of \
+the team starting next turn. \
+Delegate, run or create a workflow, or add a teammate only when it genuinely helps — otherwise \
+answer directly and concisely."
         .to_string()
 }
 
@@ -317,6 +333,9 @@ fn summarize_event(event: &CompanyEvent) -> String {
         CompanyEvent::McpCallFailed { server, tool, .. } => {
             format!("MCP call failed: {server}/{tool}")
         }
+        CompanyEvent::WorkflowCreated {
+            workflow_id, name, ..
+        } => format!("workflow created: {name} ({workflow_id})"),
     }
 }
 
@@ -605,9 +624,10 @@ impl Tool for AddAgentTool {
 // ---------------------------------------------------------------------------
 
 /// The complete tool set wired onto the company's orchestrator agent (issues
-/// #53, #67, and #71), in order: the `query_company` read surface, the
+/// #53, #67, #71, and #112), in order: the `query_company` read surface, the
 /// `spawn_task` and `delegate_to_desk` delegation tools, the `run_workflow`
-/// execution tool, and the `add_agent` roster-write tool.
+/// execution tool, the `create_workflow` authoring tool, and the `add_agent`
+/// roster-write tool.
 ///
 /// [`build_agent`](crate::harness::build::build_agent) extends the orchestrator
 /// agent's tools with exactly this vector, so a test over this function is the
@@ -628,13 +648,22 @@ pub fn orchestrator_tools(
     let mut tools: Vec<Box<dyn Tool>> = vec![Box::new(QueryCompanyTool::new(
         company.clone(),
         facts,
-        events,
+        events.clone(),
     ))];
     tools.extend(delegation_tools(queue));
     tools.push(Box::new(RunWorkflowTool::new(
         company.clone(),
-        workflow_source_dir,
+        workflow_source_dir.clone(),
         workflow_runner,
+    )));
+    // `create_workflow` (issue #112) shares the same source dir the run tool
+    // reads graphs from, plus the store it enables the new id on and the event
+    // log it journals the audit event to.
+    tools.push(Box::new(CreateWorkflowTool::new(
+        company.clone(),
+        workflow_source_dir,
+        store.clone(),
+        events,
     )));
     tools.push(Box::new(AddAgentTool::new(company, store)));
     tools
@@ -917,6 +946,254 @@ fn preview_item(item: &Value) -> String {
     }
 }
 
+// ---------------------------------------------------------------------------
+// create_workflow (issue #112)
+// ---------------------------------------------------------------------------
+
+/// The camelCase request shape the `create_workflow` tool accepts — the same
+/// graph shape the console's creator posts to `POST …/workflows` and the read
+/// routes return (`id`/`name`/`description?`/`nodes`/`edges`), so a graph the
+/// orchestrator authors is indistinguishable from one authored in the console.
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateWorkflowArgs {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    nodes: Vec<CreateWorkflowArgNode>,
+    #[serde(default)]
+    edges: Vec<CreateWorkflowArgEdge>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateWorkflowArgNode {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    kind: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    agent: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateWorkflowArgEdge {
+    #[serde(default)]
+    from: String,
+    #[serde(default)]
+    to: String,
+    #[serde(default)]
+    label: Option<String>,
+}
+
+impl From<CreateWorkflowArgs> for RawWorkflow {
+    fn from(args: CreateWorkflowArgs) -> Self {
+        Self {
+            id: args.id,
+            name: args.name,
+            description: args.description,
+            nodes: args
+                .nodes
+                .into_iter()
+                .map(|n| RawNode {
+                    id: n.id,
+                    kind: n.kind,
+                    name: n.name,
+                    summary: n.summary,
+                    agent: n.agent,
+                })
+                .collect(),
+            edges: args
+                .edges
+                .into_iter()
+                .map(|e| RawEdge {
+                    from: e.from,
+                    to: e.to,
+                    label: e.label,
+                })
+                .collect(),
+        }
+    }
+}
+
+/// A tool that lets the orchestrator author and save a brand-new workflow graph
+/// mid-chat (issue #112).
+///
+/// It runs the exact same validated-persist core the console's
+/// `POST …/workflows` route runs
+/// ([`create_company_workflow`](crate::company::create_company_workflow)): safe
+/// id + size caps, exactly one trigger, roster cross-check, case-insensitive
+/// name uniqueness, [`parse_workflow`](crate::company::parse_workflow)
+/// revalidation, atomic write, enable-on-record, best-effort audit event. So a
+/// workflow the orchestrator creates is byte-identical to one created in the
+/// console, immediately enabled, and runnable via `run_workflow` the same turn.
+///
+/// Every failure mode — no source directory, an invalid graph, a duplicate id
+/// or name, a store write error — is an agent-actionable [`ToolResult::error`]
+/// (the [`RunWorkflowTool`] convention), never a panic, so the orchestrator can
+/// reason about and report exactly what to fix.
+pub struct CreateWorkflowTool {
+    company: CompanyId,
+    source_dir: Option<PathBuf>,
+    store: Arc<dyn CompanyStore>,
+    events: Option<Arc<dyn EventLog>>,
+}
+
+impl CreateWorkflowTool {
+    /// Builds the tool over the company id, its on-disk source directory
+    /// (`companies/<name>`, whose `workflows/` subtree the graph lands in), the
+    /// company store (to enable the new id), and the event log (to journal the
+    /// audit event).
+    pub fn new(
+        company: CompanyId,
+        source_dir: Option<PathBuf>,
+        store: Arc<dyn CompanyStore>,
+        events: Option<Arc<dyn EventLog>>,
+    ) -> Self {
+        Self {
+            company,
+            source_dir,
+            store,
+            events,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for CreateWorkflowTool {
+    fn name(&self) -> &str {
+        CREATE_WORKFLOW_TOOL
+    }
+
+    fn description(&self) -> &str {
+        "Author and save a new workflow graph for the company, then enable it so it can be run with run_workflow. A workflow is a directed graph: exactly one `trigger` node (what starts it) plus any of `agent` (a roster teammate does a step — set `agent` to that teammate's id), `tool_call`, `http_request`, `condition`, and `output` nodes, joined by `edges` ({from, to, optional label}). Node ids must be unique; every `agent` node must name a real teammate. Use this to capture a repeatable process; then run it with run_workflow."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "A short unique id (the on-disk filename stem): no spaces, slashes, or `..`."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "A human-readable name, unique among the company's workflows (case-insensitive)."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "An optional one-line description of what the workflow does."
+                },
+                "nodes": {
+                    "type": "array",
+                    "description": "The graph's nodes. Exactly one must be a `trigger`.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": { "type": "string", "description": "Node id, unique within the graph." },
+                            "kind": {
+                                "type": "string",
+                                "enum": ["trigger", "agent", "tool_call", "http_request", "condition", "output"],
+                                "description": "One of the six node kinds."
+                            },
+                            "name": { "type": "string", "description": "Human-readable node name." },
+                            "summary": { "type": "string", "description": "Optional short description of the step." },
+                            "agent": { "type": "string", "description": "On an `agent` node only: the roster teammate id that performs the step." }
+                        },
+                        "required": ["id", "kind", "name"],
+                        "additionalProperties": false
+                    }
+                },
+                "edges": {
+                    "type": "array",
+                    "description": "Directed edges between node ids.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "from": { "type": "string", "description": "Source node id." },
+                            "to": { "type": "string", "description": "Destination node id." },
+                            "label": { "type": "string", "description": "Optional branch label (e.g. `yes`/`no` off a condition)." }
+                        },
+                        "required": ["from", "to"],
+                        "additionalProperties": false
+                    }
+                }
+            },
+            "required": ["id", "name", "nodes"],
+            "additionalProperties": false
+        })
+    }
+
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Write
+    }
+
+    fn supports_markdown(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let draft: RawWorkflow = match serde_json::from_value::<CreateWorkflowArgs>(args) {
+            Ok(args) => args.into(),
+            Err(err) => {
+                tracing::debug!(company = %self.company, error = %err, "create_workflow: unreadable args");
+                return Ok(ToolResult::error(format!(
+                    "Couldn't read the workflow definition: {err}. Provide `id`, `name`, and `nodes` (with an `edges` list)."
+                )));
+            }
+        };
+
+        // A deployment with no source directory has nowhere to write the graph.
+        let Some(source_dir) = self.source_dir.as_deref() else {
+            tracing::debug!(company = %self.company, "create_workflow: no source dir");
+            return Ok(ToolResult::error(
+                "This company has no on-disk workflow definitions on this deployment, so there's nowhere to save a new workflow.",
+            ));
+        };
+
+        tracing::debug!(company = %self.company, workflow = %draft.id, "create_workflow: authoring");
+        match create_company_workflow(
+            &self.company,
+            source_dir,
+            &self.store,
+            self.events.as_ref(),
+            draft,
+        )
+        .await
+        {
+            Ok(file) => {
+                tracing::debug!(company = %self.company, workflow = %file.id, "create_workflow: created");
+                let md = format!(
+                    "Created workflow **{}** (`{}`). It's enabled and ready to run — use `run_workflow` with id `{}` to execute it.",
+                    file.name.trim(),
+                    file.id,
+                    file.id
+                );
+                Ok(ToolResult::success_with_markdown(
+                    json!({ "workflow": file.id }),
+                    md,
+                ))
+            }
+            Err(err) => {
+                tracing::debug!(company = %self.company, error = %err, "create_workflow: rejected");
+                Ok(ToolResult::error(format!(
+                    "Couldn't create the workflow: {err}"
+                )))
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -961,6 +1238,7 @@ mod tests {
         assert!(is_delegation_tool(SPAWN_TASK_TOOL));
         assert!(is_delegation_tool(DELEGATE_TO_DESK_TOOL));
         assert!(is_delegation_tool(ADD_AGENT_TOOL));
+        assert!(is_delegation_tool(CREATE_WORKFLOW_TOOL));
         // The read tool is NOT a delegation tool.
         assert!(!is_delegation_tool(QUERY_COMPANY_TOOL));
         assert!(!is_delegation_tool("send_email"));
@@ -1270,7 +1548,7 @@ mod tests {
     }
 
     #[test]
-    fn orchestrator_tools_includes_all_five() {
+    fn orchestrator_tools_includes_all_six() {
         let queue = DelegationQueue::default();
         let tools = orchestrator_tools(
             CompanyId::new("acme"),
@@ -1282,7 +1560,9 @@ mod tests {
             Arc::new(MemStore::default()),
         );
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert_eq!(names.len(), 6, "got {names:?}");
         assert!(names.contains(&RUN_WORKFLOW_TOOL), "got {names:?}");
+        assert!(names.contains(&CREATE_WORKFLOW_TOOL), "got {names:?}");
         assert!(names.contains(&ADD_AGENT_TOOL), "got {names:?}");
         assert!(names.contains(&QUERY_COMPANY_TOOL), "got {names:?}");
         assert!(names.contains(&SPAWN_TASK_TOOL), "got {names:?}");
@@ -1423,5 +1703,151 @@ mod tests {
             .await
             .expect("execute");
         assert!(result.is_error);
+    }
+
+    // ---- create_workflow (issue #112) ----
+
+    /// A record with an `assistant` roster agent so an `agent`-node graph passes
+    /// the roster cross-check inside the create core.
+    fn record_with_assistant(company: &CompanyId) -> CompanyRecord {
+        let manifest: crate::company::CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n[[agent]]\nid = \"assistant\"\nrole = \"Assistant\"\n",
+        )
+        .expect("valid manifest");
+        CompanyRecord {
+            id: company.clone(),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+        }
+    }
+
+    /// The canonical happy graph the create tool accepts (camelCase body).
+    fn greeter_body() -> Value {
+        json!({
+            "id": "greeter",
+            "name": "Greeter",
+            "description": "Says hi.",
+            "nodes": [
+                { "id": "start", "kind": "trigger", "name": "Start" },
+                { "id": "worker", "kind": "agent", "name": "Worker", "agent": "assistant" },
+                { "id": "done", "kind": "output", "name": "Report" }
+            ],
+            "edges": [
+                { "from": "start", "to": "worker" },
+                { "from": "worker", "to": "done", "label": "ok" }
+            ]
+        })
+    }
+
+    #[tokio::test]
+    async fn create_workflow_tool_then_run_workflow_tool() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store: Arc<dyn CompanyStore> =
+            Arc::new(MemStore::seeded(record_with_assistant(&company)));
+
+        // Author the graph.
+        let create = CreateWorkflowTool::new(
+            company.clone(),
+            Some(dir.path().to_path_buf()),
+            store.clone(),
+            None,
+        );
+        let created = create.execute(greeter_body()).await.expect("execute");
+        assert!(!created.is_error, "create should succeed: {created:?}");
+        assert!(
+            created.output_for_llm(true).contains("run_workflow"),
+            "{created:?}"
+        );
+
+        // It's enabled on the record.
+        let record = store.load(&company).await.unwrap().unwrap();
+        assert!(
+            record
+                .manifest
+                .workflows
+                .enabled
+                .contains(&"greeter".to_string())
+        );
+
+        // And immediately runnable via the run tool over the same source dir.
+        let runner: Arc<dyn WorkflowRunner> = Arc::new(StubRunner::new(WorkflowRun {
+            output: json!({ "nodes": { "worker": { "items": ["hi"] } } }),
+            pending_approvals: Vec::new(),
+        }));
+        let handle = WorkflowRunnerHandle::default();
+        handle.set(&runner);
+        let run = RunWorkflowTool::new(company.clone(), Some(dir.path().to_path_buf()), handle);
+        let result = run
+            .execute(json!({ "id": "greeter" }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error, "run should succeed: {result:?}");
+        assert!(
+            result.output_for_llm(true).contains("Greeter"),
+            "{result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_workflow_tool_guardrail_failure_is_error_result() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store: Arc<dyn CompanyStore> =
+            Arc::new(MemStore::seeded(record_with_assistant(&company)));
+        let tool = CreateWorkflowTool::new(company, Some(dir.path().to_path_buf()), store, None);
+        // Zero triggers — a guardrail failure must be an is_error ToolResult, not
+        // a raised anyhow error.
+        let result = tool
+            .execute(json!({
+                "id": "bad",
+                "name": "Bad",
+                "nodes": [ { "id": "a", "kind": "output", "name": "A" } ],
+                "edges": []
+            }))
+            .await
+            .expect("execute returns a result, not an error");
+        assert!(result.is_error, "{result:?}");
+        assert!(
+            result.output_for_llm(false).contains("trigger"),
+            "{result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_workflow_tool_errors_without_source_dir() {
+        let store: Arc<dyn CompanyStore> = Arc::new(MemStore::default());
+        let tool = CreateWorkflowTool::new(CompanyId::new("acme"), None, store, None);
+        let result = tool
+            .execute(json!({ "id": "x", "name": "X", "nodes": [] }))
+            .await
+            .expect("execute");
+        assert!(result.is_error);
+        assert!(
+            result.output_for_llm(false).contains("nowhere to save"),
+            "{result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_workflow_tool_errors_on_unreadable_args() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn CompanyStore> = Arc::new(MemStore::default());
+        let tool = CreateWorkflowTool::new(
+            CompanyId::new("acme"),
+            Some(dir.path().to_path_buf()),
+            store,
+            None,
+        );
+        // A non-object payload can't deserialize into the create body.
+        let result = tool.execute(json!(42)).await.expect("execute");
+        assert!(result.is_error);
+        assert!(
+            result.output_for_llm(false).contains("Couldn't read"),
+            "{result:?}"
+        );
     }
 }

--- a/src/harness/steer.rs
+++ b/src/harness/steer.rs
@@ -1,0 +1,73 @@
+//! [`SteerStopHook`]: the openhuman [`StopHook`] that honors an operator steer
+//! between tool-loop iterations (issue #111).
+//!
+//! OpenHuman's stop hooks fire **between** iterations of an agent's tool-call
+//! loop — never mid-tool-call — and a [`StopDecision::Stop`] pauses the run
+//! gracefully before the next provider call
+//! ([`oh::agent::stop_hooks`]). This hook wraps one
+//! [`SteerControl`](crate::company::steer::SteerControl): while no operator
+//! action pends it returns [`Continue`](StopDecision::Continue); the moment the
+//! operator pauses / cancels / redirects the run, the shared control flips and
+//! the next `check` stops the turn. The disposition site then reads the action
+//! off the same control and moves the card.
+//!
+//! One control is registered per steerable turn (task-local, installed via
+//! [`with_stop_hooks`](oh::agent::stop_hooks::with_stop_hooks) around the turn),
+//! so two concurrent turns never see each other's steer.
+//!
+//! Compiled only under `feature = "openhuman"` (the whole `harness` module is).
+
+use async_trait::async_trait;
+
+use openhuman_core::openhuman as oh;
+
+use oh::agent::stop_hooks::{StopDecision, StopHook, TurnState};
+
+use crate::company::steer::SteerControl;
+
+/// A [`StopHook`] that stops the turn as soon as its [`SteerControl`] carries a
+/// pending operator action.
+pub struct SteerStopHook {
+    control: SteerControl,
+}
+
+impl SteerStopHook {
+    /// Builds a hook over a turn's shared steer control.
+    pub fn new(control: SteerControl) -> Self {
+        Self { control }
+    }
+}
+
+#[async_trait]
+impl StopHook for SteerStopHook {
+    fn name(&self) -> &str {
+        "steer"
+    }
+
+    async fn check(&self, _ctx: &TurnState<'_>) -> StopDecision {
+        if self.control.requested() {
+            StopDecision::Stop {
+                reason: "operator steer requested".to_string(),
+            }
+        } else {
+            StopDecision::Continue
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `TurnState.cost` names `openhuman::agent::cost::TurnCost`, whose module is
+    // crate-private to openhuman, so a `TurnState` cannot be constructed from
+    // here — the hook's Continue/Stop decision is instead proven end-to-end by
+    // the scripted-provider probe + the disposition matrix (see
+    // `harness::mod::tests` and `harness::brain::tests`), which drive a real turn
+    // through `with_stop_hooks`. This test pins the stable hook name.
+    #[test]
+    fn hook_has_a_stable_name() {
+        let hook = SteerStopHook::new(SteerControl::new());
+        assert_eq!(hook.name(), "steer");
+    }
+}

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -333,6 +333,24 @@ pub enum CompanyEvent {
         /// A short, scrubbed, operator-facing message.
         message: String,
     },
+    /// A new workflow graph was authored and enabled (issue #112), from either
+    /// the console `POST …/workflows` route or the orchestrator's
+    /// `create_workflow` tool. Journaled best-effort **after** the graph is
+    /// persisted and enabled, so it records a completed create — a journal
+    /// failure never rolls the create back. Additive: old logs never carry it,
+    /// and its presence doesn't change how any existing variant serializes.
+    WorkflowCreated {
+        /// The new workflow's id (its `workflows/<id>.toml` stem).
+        workflow_id: String,
+        /// The new workflow's display name.
+        name: String,
+        /// Who authored it, when known. `None` when created by a surface that
+        /// carries no attributed actor (the current create paths); kept as an
+        /// `Option` so a future attributed create needs no migration, mirroring
+        /// [`OperatorMessage`](Self::OperatorMessage)'s `by`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        by: Option<Actor>,
+    },
 }
 
 /// A `CompanyEvent` durably appended to the log with its sequence and time.

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -351,6 +351,30 @@ pub enum CompanyEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         by: Option<Actor>,
     },
+    /// An operator steered an in-flight run — paused, cancelled, or redirected a
+    /// dispatched task (or cancelled a delegation) from chat (issue #111).
+    /// Journaled best-effort **after** the steer is accepted by the in-flight
+    /// registry, so it records an accepted operator control action. Additive: old
+    /// logs never carry it, and its presence doesn't change how any existing
+    /// variant serializes (same `by` / skip-if-none precedent as
+    /// [`WorkflowCreated`](Self::WorkflowCreated)).
+    TaskSteered {
+        /// The steered run's key — the board task id, or a delegation run id.
+        task_id: String,
+        /// The action taken, as a stable wire word: `pause` / `cancel` /
+        /// `redirect`.
+        action: String,
+        /// The operator's redirect instruction (codepoint-capped), present only
+        /// on a `redirect`. Omitted from the wire otherwise, and — being
+        /// operator-authored free text — never projected onto the SSE stream.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        instruction: Option<String>,
+        /// Who steered, when known. `None` on a surface that carries no attributed
+        /// actor; kept `Option` so a future attributed steer needs no migration,
+        /// mirroring [`OperatorMessage`](Self::OperatorMessage)'s `by`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        by: Option<Actor>,
+    },
 }
 
 /// A `CompanyEvent` durably appended to the log with its sequence and time.
@@ -1294,6 +1318,36 @@ mod test {
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
             r#"{"kind":"McpCallFailed","server":"browserbase","tool":"browse","status":"tool_call_rejected","message":"server rejected the call"}"#
+        );
+    }
+
+    #[test]
+    fn task_steered_round_trips_and_omits_empty_fields() {
+        // A plain pause: no `instruction`, no `by` — both must be OMITTED from
+        // the wire (skip_serializing_if), so old logs stay byte-stable.
+        let pause = CompanyEvent::TaskSteered {
+            task_id: "t1".into(),
+            action: "pause".into(),
+            instruction: None,
+            by: None,
+        };
+        assert_eq!(round_trip(&pause), pause);
+        assert_eq!(
+            serde_json::to_string(&pause).unwrap(),
+            r#"{"kind":"TaskSteered","task_id":"t1","action":"pause"}"#
+        );
+
+        // A redirect carries its (capped) instruction; still no actor.
+        let redirect = CompanyEvent::TaskSteered {
+            task_id: "t1".into(),
+            action: "redirect".into(),
+            instruction: Some("focus on the API".into()),
+            by: None,
+        };
+        assert_eq!(round_trip(&redirect), redirect);
+        assert_eq!(
+            serde_json::to_string(&redirect).unwrap(),
+            r#"{"kind":"TaskSteered","task_id":"t1","action":"redirect","instruction":"focus on the API"}"#
         );
     }
 

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -725,6 +725,12 @@ impl RuntimeBuilder {
         // reuse the same metered pool/deps the brain runs on.
         #[cfg(feature = "openhuman")]
         let mut wf_runner: Option<Arc<dyn WorkflowRunner>> = None;
+        // Issue #111: one in-flight steer registry per company, shared between the
+        // harness deps (which register runs + install the steer hook) and the
+        // runtime (which the operator steer routes reach). Captured from the
+        // harness arm so `CompanyRuntime::set_steer` can be wired downstream.
+        #[cfg(feature = "openhuman")]
+        let mut steer_registry: Option<crate::company::steer::InflightRegistry> = None;
         let brain: Arc<dyn Brain> = match self.brain {
             Some(brain) => brain,
             None => {
@@ -866,6 +872,15 @@ impl RuntimeBuilder {
                                 // closed — `build_agent` wires no media tools even
                                 // for a company that grants `media`.
                                 media: self.media_backend.clone(),
+                                // Issue #111: the shared steer registry; the same
+                                // handle is wired onto the runtime below so the
+                                // operator steer routes reach the runs this brain
+                                // registers.
+                                steer: {
+                                    let reg = crate::company::steer::InflightRegistry::new();
+                                    steer_registry = Some(reg.clone());
+                                    reg
+                                },
                             };
                             let record = CompanyRecord {
                                 id: id.clone(),
@@ -1032,6 +1047,15 @@ impl RuntimeBuilder {
         #[cfg(feature = "openhuman")]
         if let Some(harness) = self.harness.clone() {
             runtime.set_harness(harness);
+        }
+
+        // Issue #111: attach the same steer registry the harness deps hold, so the
+        // operator steer routes and the in-flight strip reach the runs the brain
+        // registers. Only present on the harness path; the default build leaves
+        // the runtime's registry empty (every steer is `not in flight`).
+        #[cfg(feature = "openhuman")]
+        if let Some(registry) = steer_registry {
+            runtime.set_steer(registry);
         }
 
         // #29: install the workflow runner captured from the harness arm so

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -781,6 +781,10 @@ impl RuntimeBuilder {
                         .is_some();
 
                         if configured {
+                            // One shared steer registry; the same handle is wired
+                            // onto the runtime below.
+                            let steer = crate::company::steer::InflightRegistry::new();
+                            steer_registry = Some(steer.clone());
                             // Resolve the company's effective MCP servers to data
                             // (manifest ∪ runtime index, credentials materialized)
                             // before building sync deps. A corrupt index degrades
@@ -872,15 +876,7 @@ impl RuntimeBuilder {
                                 // closed — `build_agent` wires no media tools even
                                 // for a company that grants `media`.
                                 media: self.media_backend.clone(),
-                                // Issue #111: the shared steer registry; the same
-                                // handle is wired onto the runtime below so the
-                                // operator steer routes reach the runs this brain
-                                // registers.
-                                steer: {
-                                    let reg = crate::company::steer::InflightRegistry::new();
-                                    steer_registry = Some(reg.clone());
-                                    reg
-                                },
+                                steer,
                             };
                             let record = CompanyRecord {
                                 id: id.clone(),

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -33,7 +33,9 @@ impl ApiError {
     /// The HTTP status this error maps to.
     pub fn status(&self) -> StatusCode {
         match &self.0 {
-            OpenCompanyError::CompanyNotFound(_) => StatusCode::NOT_FOUND,
+            OpenCompanyError::CompanyNotFound(_) | OpenCompanyError::NotFound(_) => {
+                StatusCode::NOT_FOUND
+            }
             #[cfg(feature = "mcp")]
             OpenCompanyError::McpServerNotFound(_) => StatusCode::NOT_FOUND,
             OpenCompanyError::ManifestInvalid { .. }

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1727,6 +1727,43 @@ mod test {
     }
 
     #[test]
+    fn projects_task_steered_without_actor_or_instruction() {
+        let v = super::project_event(&stored(CompanyEvent::TaskSteered {
+            task_id: "t-9".into(),
+            action: "redirect".into(),
+            instruction: Some("focus on the API".into()),
+            by: Some(Actor {
+                kind: ActorKind::User,
+                id: "secret-user-id".into(),
+            }),
+        }))
+        .expect("task_steered is an attention signal");
+        assert_eq!(v["type"], "task_steered");
+        assert_eq!(v["taskId"], "t-9");
+        assert_eq!(v["action"], "redirect");
+        let wire = v.to_string();
+        assert!(!wire.contains("secret-user-id"));
+        assert!(!wire.contains("focus on the API"));
+    }
+
+    #[test]
+    fn projects_workflow_created_without_the_actor() {
+        let v = super::project_event(&stored(CompanyEvent::WorkflowCreated {
+            workflow_id: "greeter".into(),
+            name: "Greeter".into(),
+            by: Some(Actor {
+                kind: ActorKind::User,
+                id: "secret-user-id".into(),
+            }),
+        }))
+        .expect("workflow_created is an attention signal");
+        assert_eq!(v["type"], "workflow_created");
+        assert_eq!(v["workflowId"], "greeter");
+        assert_eq!(v["name"], "Greeter");
+        assert!(!v.to_string().contains("secret-user-id"));
+    }
+
+    #[test]
     fn projects_lifecycle_changed_without_the_actor() {
         let v = super::project_event(&stored(CompanyEvent::LifecycleChanged {
             from: "running".into(),

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -381,6 +381,18 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             o["memo"] = json!(memo);
             o
         }
+        // Issue #112: surface a newly authored workflow so the console can react
+        // live (e.g. refresh the Workflows tab). Only the id + display name go on
+        // the wire — the actor (`by`) is omitted, matching the deny-by-default
+        // projection of the other attributed events.
+        CompanyEvent::WorkflowCreated {
+            workflow_id, name, ..
+        } => {
+            let mut o = envelope("workflow_created");
+            o["workflowId"] = json!(workflow_id);
+            o["name"] = json!(name);
+            o
+        }
         // Not an attention signal, or carries a raw payload we never put on the
         // wire — dropped.
         _ => return None,

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -393,6 +393,18 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             o["name"] = json!(name);
             o
         }
+        // Issue #111: surface an accepted operator steer so the console's
+        // in-flight strip can refresh live. Only the task id + action word go on
+        // the wire — the actor (`by`) and the operator's redirect `instruction`
+        // are dropped, matching the deny-by-default projection.
+        CompanyEvent::TaskSteered {
+            task_id, action, ..
+        } => {
+            let mut o = envelope("task_steered");
+            o["taskId"] = json!(task_id);
+            o["action"] = json!(action);
+            o
+        }
         // Not an attention signal, or carries a raw payload we never put on the
         // wire — dropped.
         _ => return None,
@@ -1021,6 +1033,7 @@ mod test {
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
             media: None,
+            steer: crate::company::steer::InflightRegistry::default(),
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record);
 

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -7,23 +7,31 @@
 
 use axum::extract::Path;
 use axum::http::StatusCode;
-use axum::routing::{patch, post};
+use axum::routing::{get, patch, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
+use crate::company::steer::{InflightEntry, SteerAction, SteerError, cap_redirect};
 use crate::error::OpenCompanyError;
 use crate::ports::tasks::TaskRecord;
+use crate::ports::types::CompanyEvent;
 use crate::ports::{generate_id, now_millis};
 use crate::server::error::ApiError;
 use crate::server::ops::{ScopedCompany, scoped};
 
 /// Builds the task route fragment.
 pub fn router() -> Router<AppState> {
-    scoped("/tasks", post(create_task).get(list_tasks)).merge(scoped(
-        "/tasks/{task_id}",
-        patch(patch_task).delete(delete_task),
-    ))
+    scoped("/tasks", post(create_task).get(list_tasks))
+        // The static `/tasks/inflight` GET is registered before the dynamic
+        // `/tasks/{task_id}` so the operator strip's read never collides with a
+        // card id (`{task_id}` carries no GET anyway).
+        .merge(scoped("/tasks/inflight", get(list_inflight)))
+        .merge(scoped(
+            "/tasks/{task_id}",
+            patch(patch_task).delete(delete_task),
+        ))
+        .merge(scoped("/tasks/{task_id}/steer", post(steer_task)))
 }
 
 /// A task card as the console renders it.
@@ -164,5 +172,163 @@ async fn delete_task(
         Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
             "task {task_id}"
         ))))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Steer (issue #111): pause / cancel / redirect an in-flight run from chat.
+//
+// Both routes sit under the same operator-authenticated `ScopedCompany` guard as
+// every other task write. There is NO agent tool for steering anywhere — the
+// mechanism is reachable only from this operator control plane, so it is
+// structurally non-agent-injectable.
+// ---------------------------------------------------------------------------
+
+/// One in-flight, steerable run as the operator strip renders it.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InflightCard {
+    /// The board task id, or `null` for a delegation (no card).
+    task_id: Option<String>,
+    /// The steer key the `POST …/tasks/{key}/steer` route addresses.
+    key: String,
+    /// `"task"` or `"delegation"`.
+    kind: String,
+    title: String,
+    agent_id: String,
+    started_at: u64,
+    /// The last requested action word (`pause`/`cancel`/`redirect`), or `null`.
+    pending_action: Option<String>,
+}
+
+impl From<InflightEntry> for InflightCard {
+    fn from(e: InflightEntry) -> Self {
+        Self {
+            task_id: e.task_id,
+            key: e.key,
+            kind: e.kind.as_str().to_string(),
+            title: e.title,
+            agent_id: e.agent_id,
+            started_at: e.started_at_millis,
+            pending_action: e.pending_action,
+        }
+    }
+}
+
+/// The steer request body (`{action, instruction?, confirm?}`).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SteerBody {
+    /// `"pause"` | `"cancel"` | `"redirect"`.
+    action: String,
+    /// Required (non-empty) for `redirect`; ignored otherwise.
+    #[serde(default)]
+    instruction: Option<String>,
+    /// Must be `true` for `cancel` (a guardrail against an accidental cancel).
+    #[serde(default)]
+    confirm: Option<bool>,
+}
+
+/// `GET …/tasks/inflight` — the company's live, steerable runs, oldest first so
+/// the strip order is stable.
+async fn list_inflight(company: ScopedCompany) -> Result<Json<Vec<InflightCard>>, ApiError> {
+    let mut rows: Vec<InflightCard> = company
+        .runtime
+        .steer()
+        .list(company.id())
+        .into_iter()
+        .map(InflightCard::from)
+        .collect();
+    rows.sort_by_key(|r| r.started_at);
+    Ok(Json(rows))
+}
+
+/// `POST …/tasks/{task_id}/steer` — apply an operator steer to an in-flight run.
+///
+/// Validation (all `400`): unknown action; `cancel` without `confirm: true`;
+/// `redirect` without a non-empty `instruction`. An unknown key is `404`; a card
+/// that exists but is not in flight is `409`. On accept the run's control is set,
+/// a best-effort [`CompanyEvent::TaskSteered`] is journaled, and the route
+/// returns `202 Accepted` (the disposition lands on the card asynchronously).
+async fn steer_task(
+    company: ScopedCompany,
+    Path(TaskPath { task_id }): Path<TaskPath>,
+    Json(body): Json<SteerBody>,
+) -> Result<StatusCode, ApiError> {
+    let bad = |msg: &str| ApiError(OpenCompanyError::InvalidRequest(msg.to_string()));
+
+    let action = match body.action.as_str() {
+        "pause" => SteerAction::Pause,
+        "cancel" => {
+            if body.confirm != Some(true) {
+                return Err(bad("cancel requires confirm: true"));
+            }
+            SteerAction::Cancel
+        }
+        "redirect" => {
+            let instruction = body
+                .instruction
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| bad("redirect requires a non-empty instruction"))?;
+            SteerAction::Redirect {
+                instruction: cap_redirect(instruction),
+            }
+        }
+        other => return Err(bad(&format!("unknown steer action '{other}'"))),
+    };
+
+    // Capture the audit fields before the action is moved into the registry.
+    let action_word = action.as_str().to_string();
+    let instruction_for_event = match &action {
+        SteerAction::Redirect { instruction } => Some(instruction.clone()),
+        _ => None,
+    };
+
+    match company
+        .runtime
+        .steer()
+        .steer(company.id(), &task_id, action)
+    {
+        Ok(()) => {
+            // Best-effort audit: a journal failure never fails the accepted steer.
+            let _ = company
+                .runtime
+                .events()
+                .append(
+                    company.id(),
+                    CompanyEvent::TaskSteered {
+                        task_id: task_id.clone(),
+                        action: action_word,
+                        instruction: instruction_for_event,
+                        by: None,
+                    },
+                )
+                .await;
+            Ok(StatusCode::ACCEPTED)
+        }
+        // pause / redirect on a delegation (cancel-only in v1).
+        Err(SteerError::Unsupported) => Err(bad("this run only supports cancel")),
+        // No such run in flight: distinguish an idle card (409) from an unknown
+        // key (404) by consulting the board.
+        Err(SteerError::NotInFlight) => {
+            let exists = company
+                .runtime
+                .tasks()
+                .list(company.id())
+                .await?
+                .into_iter()
+                .any(|t| t.id == task_id);
+            if exists {
+                Err(ApiError(OpenCompanyError::Conflict(format!(
+                    "task {task_id} is not in flight"
+                ))))
+            } else {
+                Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
+                    "task {task_id}"
+                ))))
+            }
+        }
     }
 }

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -325,7 +325,7 @@ async fn steer_task(
                     "task {task_id} is not in flight"
                 ))))
             } else {
-                Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
+                Err(ApiError(OpenCompanyError::NotFound(format!(
                     "task {task_id}"
                 ))))
             }

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -37,7 +37,6 @@
 //! even on a build that cannot execute them.
 
 use std::collections::HashSet;
-use std::io::Write;
 use std::path::Path as FsPath;
 
 use axum::extract::Path;
@@ -50,7 +49,7 @@ use serde_json::Value;
 use crate::AppState;
 use crate::company::{
     RawEdge, RawNode, RawWorkflow, WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef,
-    load_company_workflows, parse_workflow, render_workflow,
+    create_company_workflow, load_company_workflows,
 };
 use crate::error::OpenCompanyError;
 use crate::server::error::ApiError;
@@ -307,156 +306,39 @@ impl From<CreateWorkflowBody> for RawWorkflow {
 /// form creator, or any direct API caller, posts the graph shape and it lands
 /// as a new `workflows/<id>.toml` in the company's source directory.
 ///
-/// Order of checks, each returning an actionable 4xx before anything is
-/// written: the id must be a safe filename, the deployment must have a source
-/// directory to write into, the id must not already be taken (409), every
-/// `agent` node must name a real roster teammate, and the graph must pass the
-/// same structural validation ([`parse_workflow`]) a hand-authored file would
-/// (at least one trigger, unique node ids, edges that reference real nodes, no
-/// stray `agent` field on a non-agent node).
+/// A thin shim over [`create_company_workflow`] (issue #112), the shared
+/// validated-persist core the orchestrator's `create_workflow` tool also runs —
+/// so both surfaces enforce the same checks (safe id + length/size caps,
+/// exactly one trigger, roster cross-check, case-insensitive name uniqueness,
+/// [`parse_workflow`](crate::company::parse_workflow) revalidation, atomic
+/// write, enable, best-effort audit event) and land the identical artifact.
+///
+/// The only work left at this layer is the two request-shaped concerns: refuse
+/// a deployment with no writable source directory (a hosted tenant with nothing
+/// seeded) before calling the core, and map the core's error variants to HTTP
+/// statuses — [`InvalidRequest`](OpenCompanyError::InvalidRequest) → 400,
+/// [`Conflict`](OpenCompanyError::Conflict) → 409 — via [`ApiError`].
 async fn create_workflow(
     company: ScopedCompany,
     Json(body): Json<CreateWorkflowBody>,
 ) -> Result<Json<WorkflowGraph>, ApiError> {
-    if !safe_wid(&body.id) {
-        return Err(ApiError(OpenCompanyError::InvalidRequest(
-            language::WORKFLOW_ID_INVALID.to_string(),
-        )));
-    }
-
+    // A deployment with no source directory (platform-provisioned mode with
+    // nothing seeded on disk yet) has nowhere to write the graph file.
     let source_dir = company.runtime.source_dir().ok_or_else(|| {
         ApiError(OpenCompanyError::InvalidRequest(
             language::WORKFLOW_NEEDS_SOURCE_DIR.to_string(),
         ))
     })?;
 
-    let workflows_dir = source_dir.join("workflows");
-    let path = workflows_dir.join(format!("{}.toml", body.id));
-
-    std::fs::create_dir_all(&workflows_dir).map_err(|source| {
-        ApiError(OpenCompanyError::StoreIo {
-            path: workflows_dir.clone(),
-            source,
-        })
-    })?;
-
-    // `parse_workflow` only rejects zero triggers (a saved graph may legally
-    // have more, e.g. multiple entry points); the creator is stricter — a
-    // freshly authored graph must name exactly one starting point.
-    let trigger_count = body.nodes.iter().filter(|n| n.kind == "trigger").count();
-    if trigger_count != 1 {
-        return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
-            "a workflow needs exactly one `trigger` node to say what starts it (found {trigger_count})."
-        ))));
-    }
-
-    // Cross-check every `agent` node against the company's effective roster
-    // (manifest agents + operator overlay teammates) before writing anything.
-    // `parse_workflow` validates the graph's own shape but has no roster to
-    // check names against.
-    let mut record = company
-        .runtime
-        .store()
-        .load(company.id())
-        .await?
-        .ok_or_else(|| OpenCompanyError::CompanyNotFound(company.id().to_string()))?;
-    let roster: HashSet<&str> = record
-        .manifest
-        .agents
-        .iter()
-        .map(|a| a.id.as_str())
-        .chain(record.overlay_agents.iter().map(|a| a.id.as_str()))
-        .collect();
-    for node in &body.nodes {
-        if node.kind != "agent" {
-            continue;
-        }
-        match node.agent.as_deref() {
-            Some(agent_id) if roster.contains(agent_id) => {}
-            Some(agent_id) => {
-                return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
-                    "node `{}` names teammate `{agent_id}`, which is not on this company's roster.",
-                    node.id
-                ))));
-            }
-            None => {
-                return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
-                    "node `{}` is an agent node but names no teammate.",
-                    node.id
-                ))));
-            }
-        }
-    }
-
-    // Save `body.id` before `body` is consumed by `Into<RawWorkflow>` below.
-    let body_id = body.id.clone();
-
-    // Render the candidate graph to TOML and reuse `parse_workflow` to
-    // validate its structure end to end — the same rules a hand-authored
-    // `workflows/<id>.toml` must satisfy. Any problem becomes a 400, never the
-    // 500 a malformed on-disk file gets from the read routes.
-    let toml_src = render_workflow(&body.into())?;
-    let file = parse_workflow(&toml_src).map_err(|err| match err {
-        OpenCompanyError::DataInvalid { problems, .. } => {
-            ApiError(OpenCompanyError::InvalidRequest(problems.join(" ")))
-        }
-        OpenCompanyError::DataParse { message, .. } => {
-            ApiError(OpenCompanyError::InvalidRequest(message))
-        }
-        other => ApiError(other),
-    })?;
-
-    // Write the file atomically: `create_new(true)` fails if the path already
-    // exists, closing the TOCTOU gap between a separate `is_file()` check and
-    // `fs::write`. If `write_all` fails, clean up the empty file so the id is
-    // not permanently blocked. Also, save the store record **after** the file
-    // lands so a store failure doesn't orphan a file — if the save fails the
-    // file is cleaned up and the caller can retry.
-    let mut wf_file = std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&path)
-        .map_err(|e| match e.kind() {
-            std::io::ErrorKind::AlreadyExists => ApiError(OpenCompanyError::Conflict(format!(
-                "A workflow named `{}` already exists.",
-                body_id
-            ))),
-            _ => ApiError(OpenCompanyError::StoreIo {
-                path: path.clone(),
-                source: e,
-            }),
-        })?;
-    wf_file.write_all(toml_src.as_bytes()).map_err(|source| {
-        let _ = std::fs::remove_file(&path);
-        ApiError(OpenCompanyError::StoreIo {
-            path: path.clone(),
-            source,
-        })
-    })?;
-    drop(wf_file);
-
-    // Record the id as enabled on the operator's live copy of the manifest —
-    // mirrors the team overlay: the version-controlled `company.toml` on disk
-    // is never rewritten (see `crate::server::ops::team`).
-    let save_result = if !record
-        .manifest
-        .workflows
-        .enabled
-        .iter()
-        .any(|e| e == &file.id)
-    {
-        record.manifest.workflows.enabled.push(file.id.clone());
-        company.runtime.store().save(&record).await
-    } else {
-        Ok(())
-    };
-
-    // If the store save failed, remove the file we just wrote so a retry can
-    // succeed without admin intervention.
-    if let Err(e) = save_result {
-        let _ = std::fs::remove_file(&path);
-        return Err(ApiError(e));
-    }
+    let file = create_company_workflow(
+        company.id(),
+        source_dir,
+        company.runtime.store(),
+        Some(company.runtime.events()),
+        body.into(),
+    )
+    .await
+    .map_err(ApiError)?;
 
     Ok(Json(WorkflowGraph::from(file)))
 }

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -8,7 +8,9 @@ use serde_json::{Value, json};
 use tower::ServiceExt;
 
 use crate::company::CompanyManifest;
+use crate::company::steer::{InflightEntry, InflightKind};
 use crate::ports::facts::{FactKind, FactRecord};
+use crate::ports::tasks::TaskRecord;
 use crate::ports::types::{CompanyId, CompanyRecord};
 use crate::runtime::RuntimeBuilder;
 use crate::server::router;
@@ -152,6 +154,117 @@ async fn tasks_crud_round_trips_under_both_scopes() {
     )
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+#[tokio::test]
+async fn steer_task_validates_statuses_and_journals_acceptance() {
+    let home = home();
+    let state = state_with_company(&home).await;
+    let company = CompanyId::new("acme");
+    let runtime = state.registry().get(&company).unwrap();
+    let endpoint = |key: &str| format!("/api/v1/company/tasks/{key}/steer");
+
+    for body in [
+        json!({"action": "unknown"}),
+        json!({"action": "cancel"}),
+        json!({"action": "redirect", "instruction": "   "}),
+    ] {
+        let (status, _) = send(&state, "POST", &endpoint("missing"), Some(body)).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    runtime
+        .tasks()
+        .upsert(
+            &company,
+            &TaskRecord {
+                id: "idle".into(),
+                title: "Idle".into(),
+                note: None,
+                column: "backlog".into(),
+                priority: "medium".into(),
+                assignee: String::new(),
+                updated_at_millis: 1,
+            },
+        )
+        .await
+        .unwrap();
+    let (status, _) = send(
+        &state,
+        "POST",
+        &endpoint("idle"),
+        Some(json!({"action": "pause"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+
+    let (status, _) = send(
+        &state,
+        "POST",
+        &endpoint("missing"),
+        Some(json!({"action": "pause"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let _delegation = runtime.steer().register(
+        &company,
+        InflightEntry {
+            key: "delegation".into(),
+            task_id: None,
+            kind: InflightKind::Delegation,
+            title: "Engineering".into(),
+            agent_id: "ceo".into(),
+            started_at_millis: 1,
+            pending_action: None,
+        },
+    );
+    let (status, _) = send(
+        &state,
+        "POST",
+        &endpoint("delegation"),
+        Some(json!({"action": "pause"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    let _task = runtime.steer().register(
+        &company,
+        InflightEntry {
+            key: "active".into(),
+            task_id: Some("active".into()),
+            kind: InflightKind::Task,
+            title: "Active".into(),
+            agent_id: "ceo".into(),
+            started_at_millis: 2,
+            pending_action: None,
+        },
+    );
+    let (status, _) = send(
+        &state,
+        "POST",
+        &endpoint("active"),
+        Some(json!({"action": "redirect", "instruction": "focus on the API"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+
+    let events = runtime
+        .events()
+        .read_from(&company, crate::ports::types::EventSeq::new(0), usize::MAX)
+        .await
+        .unwrap();
+    assert!(events.iter().any(|stored| matches!(
+        &stored.event,
+        crate::ports::types::CompanyEvent::TaskSteered {
+            task_id,
+            action,
+            instruction: Some(instruction),
+            ..
+        } if task_id == "active" && action == "redirect" && instruction == "focus on the API"
+    )));
 
     tokio::fs::remove_dir_all(&home).await.ok();
 }

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -154,6 +154,7 @@ description = "Runs Acme."
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
             plan: None,
             media: None,
+            steer: crate::company::steer::InflightRegistry::default(),
         }
     }
 


### PR DESCRIPTION
## Summary

Epic #26, #111: an operator can **pause / cancel / redirect a running board task** from company chat.

Uses OpenHuman's task-local `StopHook`, which fires *between* tool-loop iterations (never mid-tool-call) and is honored at the top of the next loop — so steer takes effect at a safe checkpoint, never corrupting an in-flight tool call.

- **Pause** → task moves to a new `Paused` column; the partial reply is preserved in the note; the per-tenant serial lock is **released** while parked (stop-and-park, not suspend-under-lock). Resume = `PATCH column → in_progress`, which re-fires dispatch.
- **Cancel** → task returns to `backlog`, partial reply discarded, note records the operator cancel.
- **Redirect** → the running turn reruns in-loop with the operator's instruction appended (2000-char codepoint-safe cap, bounded to 3 reruns; exhaustion falls to `in_review`).
- **Delegations** → cancel-only in v1. **Workflow runs** are not steerable (excluded by design).

**Structurally non-agent-injectable:** both steer routes ride the existing `ScopedCompany` operator guard, and **no agent tool anywhere touches `SteerControl`/`InflightRegistry`** — an agent cannot steer itself. Adds `CompanyEvent::TaskSteered` (append-only audit variant); the SSE projection exposes only `taskId` + `action` (operator instruction + actor are dropped from the stream).

Console gains an in-flight strip above the composer (Pause / Redirect-with-input / Cancel-with-confirm per row, cancel-only for delegations, pending badge) plus a Paused board column with a Resume button, refreshed over the existing SSE.

> **Stacked on #115 (#112).** #111 coincides with #112 on the four event-plumbing files (`ports/types.rs`, `orchestrator.rs`, `brain/medulla/effects.rs`, `server/operator.rs`); every addition is **append-only after #112's `WorkflowCreated`**, so it rebases clean once #115 merges. Per the cross-fork PR-base limit this bases on `main`, so the diff includes #112 until it merges — review commits `b4f5efb..548dad4`.

## API Or Behavior Changes

- New `GET /{scope}/tasks/inflight` and `POST /{scope}/tasks/{task_id}/steer` (operator-authenticated).
- New board column value `paused` (`column` is a free string — no store migration).
- `HarnessDeps` gains a `steer: InflightRegistry` field; `CompanyRuntime` gains `steer()`/`set_steer`.
- New `CompanyEvent::TaskSteered` (append-only at the enum tail).

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy` (authored files clean, scoped `--no-deps -p opencompany`; pre-existing base warnings in `build.rs`/`mcp_probe.rs` + a vendored `tinyagents` lint surface only under the full `openhuman -D warnings` combo, untouched here)
- [x] `cargo check --all-targets --features openhuman,mcp,telegram` — clean (verifies the 3 exhaustive `TaskSteered` arms)
- [x] `cargo test` — 626 default + 150 harness tests pass, incl. 13 new steer tests

Added: registry lifecycle incl. RAII deregister + `NotInFlight`; `SteerStopHook` Continue/Stop; the retry-guard edge (a steered-empty turn makes exactly one attempt); the `run_task` disposition matrix (none→in_review, cancel→backlog+discard, pause→paused+preserve, redirect→rerun carries `Operator redirect:` + 3-cap); `TaskSteered` serde round-trip + omitted-field byte-stability.

> **Honest coverage gaps (deferred under budget):** route-level HTTP tests (confirm gate / status codes) are not yet added — the underlying registry semantics and handler validation are unit-covered; and steer-hook *installation* is proven via the retry-guard + disposition tests rather than a task-local probe (task-local doesn't propagate into the provider task). CI never builds the full feature combo (known repo gap).

## Documentation

Behavior documented inline; the steer semantics (safe-checkpoint, park-releases-lock, resume path) are described in the module docs of `src/company/steer.rs` and `src/harness/steer.rs`.

Closes #111


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added operator controls for in-flight runs, including pause, cancel, and redirect actions.
  * Added an “In flight” panel to conversations with live status updates and steering controls.
  * Added workflow creation through the orchestrator and workflows API, with validation and immediate enablement.
  * Added support for resuming paused tasks from the task board.
* **Bug Fixes**
  * Improved task lifecycle updates and surfaced workflow creation and steering activity in event feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->