### PR TITLE
feat(composio): per-tenant Composio tools — Gmail/Slack/GitHub (#110)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,6 +199,18 @@ mcp = ["openhuman", "openhuman_core/mcp", "dep:uuid", "dep:base64", "dep:url"]
 # these tools, so they are wired only when a company explicitly grants `media`
 # (never via the `*` wildcard) AND a managed credential is configured.
 media = ["openhuman", "openhuman_core/media"]
+# Per-tenant Composio tools (issue #110, epic #26 Cell D). Bridges OpenHuman's
+# backend-mode Composio surface (Gmail / Slack / GitHub via
+# `composio_list_toolkits`, `composio_list_connections`, `composio_list_tools`,
+# `composio_authorize`, `composio_execute`) into a company agent's toolbelt
+# behind the opt-in `composio` grant namespace and a per-tenant OAuth bearer
+# token. The upstream `composio` domain is not itself feature-gated, so no
+# `openhuman_core/*` subfeature is needed — enabling this only pulls in the
+# embedded harness. The default build links none of it. Tenant isolation is the
+# server-side-constructed bearer token (the backend derives the Composio entity
+# from the JWT); the token has NO env fallback and a missing token fails closed
+# (no tools wired), so a company can never reach another tenant's connections.
+composio = ["openhuman"]
 # Real HTTP transport to openhuman-core. The trait + offline mock + providers
 # compile without this; only `HttpOpenHumanRpc` is gated behind it.
 openhuman-rpc = ["dep:reqwest"]

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -115,6 +115,7 @@ async fn main() -> anyhow::Result<()> {
         workflow_source_dir: None,
         plan: None,
         media: None,
+        composio: None,
         steer: opencompany::company::steer::InflightRegistry::default(),
     };
 

--- a/frontend/src/api/composio.ts
+++ b/frontend/src/api/composio.ts
@@ -1,0 +1,52 @@
+// The live Composio API (issue #110, epic #26 Cell D): the console reads the
+// company's Composio status and writes its per-tenant OAuth bearer token through
+// the host's `.../composio` routes (REST, camelCase over the wire).
+//
+// The token is the entire tenant-isolation lever — the backend derives the
+// Composio entity from it — so it is WRITE-ONLY: sent on `PUT .../composio/token`
+// and stored in the host's secret store; it is never returned. The read shape
+// carries only a `tokenConfigured` boolean plus non-secret routing (backend URL,
+// toolkit allowlist). Standalone functions over the shared client (mirrors
+// `api/inference.ts`), so no change to `OpenCompanyClient` is needed.
+
+import type { OpenCompanyClient } from "./client";
+
+/** The company's Composio status. Never carries the token. */
+export interface ComposioStatus {
+  /** Whether the `composio` feature is compiled into this build at all. */
+  inBuild: boolean;
+  /** Whether the company explicitly grants `composio` (a `*` wildcard does not count). */
+  granted: boolean;
+  /** Whether a per-tenant token is stored — never the token itself. */
+  tokenConfigured: boolean;
+  /** The effective Composio backend URL (non-secret). */
+  backendUrl: string;
+  /** The manifest toolkit allowlist (empty = defer to the backend allowlist). */
+  toolkits: string[];
+}
+
+/** A mutating response: the resulting status plus a plain-language note. */
+export interface ComposioMutation {
+  status: ComposioStatus;
+  note: string;
+}
+
+/** The company's Composio status. */
+export function getComposioStatus(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<ComposioStatus> {
+  return client.get<ComposioStatus>(`${client.scopeFor(company)}/composio`);
+}
+
+/**
+ * Set / rotate / clear the write-only per-tenant Composio token. A non-empty
+ * value rotates it; an empty string clears it.
+ */
+export function setComposioToken(
+  client: OpenCompanyClient,
+  company: string | null,
+  token: string,
+): Promise<ComposioMutation> {
+  return client.put<ComposioMutation>(`${client.scopeFor(company)}/composio/token`, { token });
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -312,6 +312,16 @@ export interface CapabilityStatusDto {
   mediaInBuild?: boolean;
   /** Whether a managed media credential is configured on this build (env-only). */
   mediaCredentialConfigured?: boolean;
+  /**
+   * Per-tenant Composio (issue #110): whether the company **explicitly** grants
+   * the `composio` namespace (a `*` wildcard does not count). Opt-in per tool
+   * grant, independent of a `[plan]`.
+   */
+  composioGranted?: boolean;
+  /** Whether the `composio` feature is compiled into this build at all. */
+  composioInBuild?: boolean;
+  /** Whether a per-tenant Composio token is stored — never the token itself. */
+  composioTokenConfigured?: boolean;
 }
 
 /** Error envelope shape: `{ error, code }`. */

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/lib/connections";
 import { cn } from "@/lib/utils";
 import { InferenceSection } from "@/views/connections/InferenceSection";
+import { ComposioSection } from "@/views/connections/ComposioSection";
 import { ChannelsSection } from "./connections/ChannelsSection";
 
 interface Props {
@@ -134,6 +135,8 @@ export function ConnectionsView({ client, company }: Props) {
         <McpServersSection client={client} company={company} />
 
         <InferenceSection client={client} company={company} />
+
+        <ComposioSection client={client} company={company} />
 
         <ChannelsSection client={client} company={company} />
 

--- a/frontend/src/views/UsageView.tsx
+++ b/frontend/src/views/UsageView.tsx
@@ -215,6 +215,9 @@ export function UsageView({ client, company }: Props) {
             {/* Media generation (issue #109): opt-in, managed-credential-gated —
                 its own status row, separate from the token-budget bars. */}
             {capsLoaded && caps ? <MediaStatusRow caps={caps} /> : null}
+            {/* Per-tenant Composio (issue #110): opt-in, per-tenant-token-gated —
+                its own status row like media. */}
+            {capsLoaded && caps ? <ComposioStatusRow caps={caps} /> : null}
           </CardContent>
         </Card>
       </div>
@@ -229,6 +232,7 @@ const NAMESPACE_LABELS: Record<string, string> = {
   web: "Web & HTTP",
   subagent: "Sub-agents",
   media: "Media generation",
+  composio: "Composio (Gmail/Slack/GitHub)",
 };
 
 // Badge variant subset the media status row uses.
@@ -264,6 +268,38 @@ function mediaStatus(caps: CapabilityStatusDto): { label: string; variant: Badge
   if (!caps.mediaGranted) return { label: "Not granted", variant: "secondary" };
   if (!caps.mediaCredentialConfigured)
     return { label: "Awaiting credential", variant: "destructive" };
+  return { label: "Active", variant: "default" };
+}
+
+/**
+ * The Composio capability (issue #110) is opt-in per tool grant and gated on a
+ * per-tenant OAuth token, so it gets its own status row like media. Four states:
+ * not compiled into this build, not granted, granted-but-awaiting-token, and
+ * active. Set the token from Connections.
+ */
+function ComposioStatusRow({ caps }: { caps: CapabilityStatusDto }) {
+  const { label, variant } = composioStatus(caps);
+  return (
+    <div className="flex items-center justify-between gap-3 border-t pt-4 text-sm">
+      <div className="space-y-0.5">
+        <span className="font-medium">Composio integrations</span>
+        <p className="text-xs text-muted-foreground">
+          Gmail, Slack &amp; GitHub via Composio — opt-in, runs on the company&apos;s own OAuth
+          token, and every send/authorize is approved before it runs. Set the token in Connections.
+        </p>
+      </div>
+      <Badge variant={variant} className="shrink-0">
+        {label}
+      </Badge>
+    </div>
+  );
+}
+
+function composioStatus(caps: CapabilityStatusDto): { label: string; variant: BadgeVariant } {
+  if (caps.composioInBuild === false) return { label: "Not in this build", variant: "outline" };
+  if (!caps.composioGranted) return { label: "Not granted", variant: "secondary" };
+  if (!caps.composioTokenConfigured)
+    return { label: "Awaiting token", variant: "destructive" };
   return { label: "Active", variant: "default" };
 }
 

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -1,0 +1,172 @@
+import { useCallback, useEffect, useState } from "react";
+import { Check, KeyRound, Loader2, Plug, Save, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { getComposioStatus, setComposioToken, type ComposioStatus } from "@/api/composio";
+import { ApiError } from "@/api/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface Props {
+  client: OpenCompanyClient;
+  company: string | null;
+}
+
+/**
+ * Per-tenant Composio connection management (issue #110, Cell D). Shows the
+ * company's Composio status (granted / token configured / toolkit allowlist) and
+ * a WRITE-ONLY token input: the per-tenant OAuth bearer is the entire isolation
+ * lever, so it is stored and never shown again. A set/clear takes effect on the
+ * agents' next turn, no restart. Hidden entirely when the feature is not in the
+ * build.
+ */
+export function ComposioSection({ client, company }: Props) {
+  const [load, setLoad] = useState<"loading" | "ready" | "unavailable">("loading");
+  const [status, setStatus] = useState<ComposioStatus | null>(null);
+  const [token, setToken] = useState("");
+  const [busy, setBusy] = useState<"save" | "clear" | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const s = await getComposioStatus(client, company);
+      setStatus(s);
+      // Hide the whole section when the feature is not compiled into this build.
+      setLoad(s.inBuild ? "ready" : "unavailable");
+    } catch {
+      setLoad("unavailable");
+    }
+  }, [client, company]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  async function save() {
+    if (!token.trim()) return;
+    setBusy("save");
+    try {
+      const res = await setComposioToken(client, company, token.trim());
+      setStatus(res.status);
+      setToken("");
+      toast.success(res.note);
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Could not save the token.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function clear() {
+    setBusy("clear");
+    try {
+      const res = await setComposioToken(client, company, "");
+      setStatus(res.status);
+      setToken("");
+      toast.success("Composio token cleared.");
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Could not clear the token.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (load === "unavailable") return null;
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Plug className="size-4 text-muted-foreground" />
+        <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          Composio (Gmail / Slack / GitHub)
+        </h3>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Give your agents Gmail, Slack &amp; GitHub via Composio. Paste this company&apos;s Composio
+        OAuth token — it is the per-tenant identity the backend bills and isolates, stored securely
+        and never shown again. A change takes effect on the next turn, no restart.
+      </p>
+
+      {load === "loading" ? (
+        <Skeleton className="h-32 rounded-xl" />
+      ) : (
+        <Card>
+          <CardContent className="space-y-4 py-4">
+            {status && (
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant={status.granted ? "secondary" : "outline"}>
+                  {status.granted ? "granted" : "not granted"}
+                </Badge>
+                {status.tokenConfigured ? (
+                  <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+                    <Check className="size-3" /> token set
+                  </span>
+                ) : (
+                  <span className="text-xs text-muted-foreground">no token yet</span>
+                )}
+                {status.toolkits.length > 0 && (
+                  <span className="text-xs text-muted-foreground">
+                    toolkits: {status.toolkits.join(", ")}
+                  </span>
+                )}
+              </div>
+            )}
+
+            {status && !status.granted && (
+              <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+                This company does not grant the <span className="font-mono">composio</span> tool
+                namespace, so agents will not receive Composio tools even with a token set. Add
+                <span className="font-mono"> composio</span> to the company&apos;s tool grants first.
+              </p>
+            )}
+
+            <div className="space-y-1">
+              <Label htmlFor="composio-token" className="text-xs">
+                Composio token {status?.tokenConfigured ? "(leave blank to keep)" : ""}
+              </Label>
+              <Input
+                id="composio-token"
+                type="password"
+                autoComplete="off"
+                placeholder="paste the company's Composio OAuth token"
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+              />
+              {status && <p className="truncate text-xs text-muted-foreground">{status.backendUrl}</p>}
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Button disabled={busy !== null || !token.trim()} onClick={() => void save()}>
+                {busy === "save" ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Save className="size-4" />
+                )}
+                Save token
+              </Button>
+              {status?.tokenConfigured && (
+                <Button
+                  variant="outline"
+                  disabled={busy !== null}
+                  onClick={() => void clear()}
+                >
+                  {busy === "clear" ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="size-4" />
+                  )}
+                  Clear
+                </Button>
+              )}
+              <KeyRound className="ml-auto size-4 text-muted-foreground" />
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Check, KeyRound, Loader2, Plug, Save, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -31,18 +31,25 @@ export function ComposioSection({ client, company }: Props) {
   const [token, setToken] = useState("");
   const [busy, setBusy] = useState<"save" | "clear" | null>(null);
 
+  const requestGeneration = useRef(0);
+
   const refresh = useCallback(async () => {
+    const generation = ++requestGeneration.current;
     try {
       const s = await getComposioStatus(client, company);
+      if (generation !== requestGeneration.current) return;
       setStatus(s);
       // Hide the whole section when the feature is not compiled into this build.
       setLoad(s.inBuild ? "ready" : "unavailable");
     } catch {
+      if (generation !== requestGeneration.current) return;
       setLoad("unavailable");
     }
   }, [client, company]);
 
   useEffect(() => {
+    setStatus(null);
+    setLoad("loading");
     void refresh();
   }, [refresh]);
 

--- a/src/company/composio.rs
+++ b/src/company/composio.rs
@@ -1,0 +1,77 @@
+//! Per-tenant Composio credential + backend routing (issue #110, epic #26 Cell
+//! D). Always compiled (so the console read/write plane can manage the token
+//! even in the default build); the live agent tools that consume it live in the
+//! feature-gated [`harness::composio`](crate::harness::composio).
+//!
+//! The per-tenant OAuth bearer token is **write-only**: it is set through the
+//! console `PUT …/composio/token` route, stored under [`TOKEN_KEY`], and never
+//! returned. The read shape carries only a `tokenConfigured` boolean. The token
+//! has **no environment fallback** — a missing token means no tools (fail
+//! closed), never a borrowed identity. Only the backend URL may be overridden
+//! from the environment.
+
+use crate::Result;
+use crate::ports::SecretStore;
+use crate::ports::types::{CompanyId, SecretValue};
+
+/// The canonical per-company Composio credential key. The per-tenant OAuth
+/// bearer token is stored here (write-only via the console); the value is the
+/// raw token string.
+pub const TOKEN_KEY: &str = "composio/token";
+
+/// The environment override for the Composio backend URL. Only the **URL** has
+/// an env path — the **token** deliberately does not (fail-closed isolation).
+pub const COMPOSIO_BACKEND_URL_ENV: &str = "OPENCOMPANY_COMPOSIO_BACKEND_URL";
+
+/// Default backend base URL for the Composio routes when the environment does
+/// not override it. Mirrors the media backend's default host.
+pub const DEFAULT_BACKEND_URL: &str = "https://api.tinyhumans.ai";
+
+/// The effective backend URL: the trimmed env override when non-empty, else the
+/// default. Credential-free — safe to surface on the console read plane.
+pub fn backend_url_or_default(env_url: Option<String>) -> String {
+    env_url
+        .map(|u| u.trim().to_string())
+        .filter(|u| !u.is_empty())
+        .unwrap_or_else(|| DEFAULT_BACKEND_URL.to_string())
+}
+
+/// Store (or rotate/clear) the per-tenant Composio token. A non-empty value
+/// rotates it; an empty string clears it. Write-only — the value is never read
+/// back over the API.
+pub async fn store_token(
+    company: &CompanyId,
+    secrets: &dyn SecretStore,
+    token: &str,
+) -> Result<()> {
+    secrets
+        .set(company, TOKEN_KEY, SecretValue(token.trim().to_string()))
+        .await
+}
+
+/// Whether a non-empty per-tenant token is stored — never the token itself.
+pub async fn token_configured(company: &CompanyId, secrets: &dyn SecretStore) -> Result<bool> {
+    Ok(secrets
+        .get(company, TOKEN_KEY)
+        .await?
+        .map(|SecretValue(token)| !token.trim().is_empty())
+        .unwrap_or(false))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backend_url_prefers_env_then_default() {
+        assert_eq!(backend_url_or_default(None), DEFAULT_BACKEND_URL);
+        assert_eq!(
+            backend_url_or_default(Some("  ".into())),
+            DEFAULT_BACKEND_URL
+        );
+        assert_eq!(
+            backend_url_or_default(Some("https://custom.example".into())),
+            "https://custom.example"
+        );
+    }
+}

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -5,6 +5,7 @@
 //! report its effective configuration. The cognition kernel (Brain, cycle
 //! loop, stores) lands in later phases; see `docs/spec/roadmap.md`.
 
+pub mod composio;
 #[cfg(test)]
 mod content_test;
 pub mod dns;
@@ -34,10 +35,11 @@ use std::path::Path;
 pub use manifest::{LEGACY_MANIFEST_FILE, Located, MANIFEST_FILE, discover};
 pub use skill_file::{SkillDoc, load_dir_skills, parse_skill_md};
 pub use types::{
-    Agent, BRAIN_MODES, Brain, Budget, ChannelConfig, Company, CompanyManifest, Connection,
-    DEFAULT_ALWAYS_APPROVE, GATEABLE_NAMESPACES, INFERENCE_PROVIDERS, INFERENCE_TIERS, Inference,
-    KNOWN_CHANNELS, McpServer, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, Place, Plan, Policy,
-    Schedule, Skill, TIERS, TOOL_PROVIDERS, Tools, grants_media_explicit,
+    Agent, BRAIN_MODES, Brain, Budget, ChannelConfig, Company, CompanyManifest, ComposioTools,
+    Connection, DEFAULT_ALWAYS_APPROVE, GATEABLE_NAMESPACES, INFERENCE_PROVIDERS, INFERENCE_TIERS,
+    Inference, KNOWN_CHANNELS, McpServer, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, Place, Plan,
+    Policy, Schedule, Skill, TIERS, TOOL_PROVIDERS, Tools, grants_composio_explicit,
+    grants_media_explicit,
 };
 pub use workflow_file::{
     WORKFLOW_NODE_KINDS, WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef, WorkflowNodeKind,

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -62,7 +62,8 @@ pub const CONNECTION_PRIORITIES: &[&str] = &["low", "medium", "high"];
 /// maps individual tools onto these namespaces. A `[plan].token_budgets` key
 /// outside this set is a manifest error. Lives here (not the feature-gated
 /// harness) so manifest validation can see it in the default build.
-pub const GATEABLE_NAMESPACES: [&str; 5] = ["shell", "code", "web", "subagent", "media"];
+pub const GATEABLE_NAMESPACES: [&str; 6] =
+    ["shell", "code", "web", "subagent", "media", "composio"];
 
 /// Whether a tool-grant list **explicitly** grants the real-money `media`
 /// namespace (issue #109).
@@ -77,6 +78,23 @@ pub fn grants_media_explicit(grants: &[String]) -> bool {
     grants
         .iter()
         .any(|grant| grant == "media" || grant.starts_with("media."))
+}
+
+/// Whether a tool-grant list **explicitly** grants the per-tenant `composio`
+/// namespace (issue #110).
+///
+/// Like [`grants_media_explicit`], the catch-all `*` does **not** grant
+/// `composio`: the Composio tools reach third-party accounts (Gmail / Slack /
+/// GitHub) over a tenant OAuth token and move real side effects (send email,
+/// open PRs), so they must be opted into by name, never ridden in on a
+/// wildcard. Matches the bare `composio` grant or any `composio.*` sub-grant.
+/// Lives here (always compiled) so both the feature-gated harness wiring
+/// (`build::build_agent`) and the always-compiled console capability route key
+/// off one source of truth.
+pub fn grants_composio_explicit(grants: &[String]) -> bool {
+    grants
+        .iter()
+        .any(|grant| grant == "composio" || grant.starts_with("composio."))
 }
 
 /// Built-in capability tier names selectable in `[plan].name` (issue #108). The
@@ -410,6 +428,26 @@ pub struct Tools {
     /// explicit allow-all-public wildcard.
     #[serde(default)]
     pub web_allowed_domains: Vec<String>,
+    /// Per-tenant Composio tools (issue #110, Cell D): the `[tools.composio]`
+    /// sub-section. The `toolkits` allowlist narrows which Composio toolkits the
+    /// agent may target (Gmail / Slack / GitHub, …). Empty (the default) DEFERS
+    /// to the backend's own server-enforced allowlist — *open mode*, mirroring
+    /// [`web_allowed_domains`]; a non-empty list is strict client-side narrowing
+    /// (a toolkit outside it is rejected before any network call). Independent of
+    /// the `composio` grant: the grant admits the tool family, this narrows what
+    /// it can reach.
+    #[serde(default)]
+    pub composio: ComposioTools,
+}
+
+/// `[tools.composio]` — the per-tenant Composio toolkit allowlist (issue #110).
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct ComposioTools {
+    /// Toolkit slugs the agent may target (e.g. `gmail`, `slack`, `github`).
+    /// Empty defers to the backend's server-enforced allowlist (open mode);
+    /// non-empty narrows strictly, client-side, before any network round-trip.
+    #[serde(default)]
+    pub toolkits: Vec<String>,
 }
 
 impl Default for Tools {
@@ -418,6 +456,7 @@ impl Default for Tools {
             provider: default_tool_provider(),
             allow: Vec::new(),
             web_allowed_domains: Vec::new(),
+            composio: ComposioTools::default(),
         }
     }
 }
@@ -576,6 +615,42 @@ mod test {
         assert!(!grants_media_explicit(&[]));
         // A substring match ("mediation") must not count as the media namespace.
         assert!(!grants_media_explicit(&["mediation".into()]));
+    }
+
+    /// Per-tenant `composio` (issue #110) is granted ONLY by an explicit
+    /// `composio` / `composio.*` grant — never by the catch-all `*`. The tools
+    /// reach third-party accounts over a tenant OAuth token, so a broadly-
+    /// permissioned company must still opt into them by name.
+    #[test]
+    fn composio_grant_requires_explicit_namespace_not_wildcard() {
+        assert!(grants_composio_explicit(&["composio".into()]));
+        assert!(grants_composio_explicit(&["composio.gmail".into()]));
+        assert!(grants_composio_explicit(&[
+            "web.*".into(),
+            "composio".into()
+        ]));
+        // The catch-all `*` must NOT grant composio.
+        assert!(!grants_composio_explicit(&["*".into()]));
+        assert!(!grants_composio_explicit(&["web.*".into()]));
+        assert!(!grants_composio_explicit(&[]));
+        // A substring match must not count as the composio namespace.
+        assert!(!grants_composio_explicit(&["composiotools".into()]));
+    }
+
+    /// The `[tools.composio]` sub-section parses its toolkit allowlist and an
+    /// absent section defaults to open mode (empty list).
+    #[test]
+    fn tools_composio_section_parses_toolkits_and_defaults_empty() {
+        let with_section: CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n[tools.composio]\ntoolkits = [\"gmail\", \"slack\"]\n",
+        )
+        .unwrap();
+        assert_eq!(
+            with_section.tools.composio.toolkits,
+            vec!["gmail".to_string(), "slack".to_string()]
+        );
+        let without: CompanyManifest = toml::from_str("[company]\nname = \"Acme\"\n").unwrap();
+        assert!(without.tools.composio.toolkits.is_empty());
     }
 
     // Guards the newly-added `Serialize` derive: a manifest with renamed

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -548,6 +548,7 @@ description = "Runs Acme."
             workflow_source_dir: None,
             plan: None,
             media: None,
+            composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
         };
         HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record())
@@ -687,6 +688,7 @@ description = "Builds it."
             workflow_source_dir: None,
             plan: None,
             media: None,
+            composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
         };
         (
@@ -890,6 +892,7 @@ members = ["engineer"]
             workflow_source_dir: None,
             plan: None,
             media: None,
+            composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
         };
         (
@@ -1071,6 +1074,7 @@ name = "Design"
             workflow_source_dir: None,
             plan: None,
             media: None,
+            composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record());
@@ -1200,8 +1204,10 @@ name = "Design"
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            workflow_source_dir: None,
             plan: None,
             media: None,
+            composio: None,
             steer,
         };
         (

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -238,6 +238,34 @@ pub fn build_agent(
         }
     }
 
+    // Per-tenant Composio (issue #110) — Gmail / Slack / GitHub over the
+    // company's OAuth token. Two hard gates before any tool is wired:
+    //
+    //  1. an **EXPLICIT** `composio` grant (`grants_composio_explicit`) — like
+    //     `media`, the catch-all `*` does NOT grant it, so a broadly-permissioned
+    //     company never accidentally hands its agents a live account-reaching
+    //     surface; it must opt in by name.
+    //  2. a resolved per-tenant token on the deps (`deps.composio`), read from the
+    //     company secret store by `HarnessPool::ensure` — never an env/platform
+    //     key. The backend derives the Composio entity from THIS token, so it is
+    //     the entire tenant-isolation lever.
+    //
+    // Granted-but-tokenless wires nothing and warns (fail-closed). The
+    // `authorize` / `execute` tools additionally park for operator approval via
+    // the `ApprovalPolicy`. Gated on the `composio` feature; the default/
+    // `openhuman` build never compiles this.
+    #[cfg(feature = "composio")]
+    if crate::company::grants_composio_explicit(grants) {
+        match &deps.composio {
+            Some(config) => tools.extend(crate::harness::composio::composio_tools(config)),
+            None => tracing::warn!(
+                company = %company,
+                agent = %manifest_agent.id,
+                "[build] agent explicitly grants `composio` but no per-tenant Composio token is configured; composio tools NOT wired (fail-closed)"
+            ),
+        }
+    }
+
     // Persona over openhuman's own identity: `omit_identity = true` drops the
     // "you are OpenHuman" preamble so the agent speaks as its company role.
     let mut persona = persona_prompt(company_name, manifest_agent);

--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -1,0 +1,906 @@
+//! Per-tenant Composio tools (issue #110, epic #26 Cell D): the Gmail / Slack /
+//! GitHub surface OpenHuman exposes through its backend-proxied Composio routes,
+//! bridged into a company agent's toolbelt behind the opt-in `composio` grant.
+//!
+//! ## Tenant isolation (the security spine)
+//!
+//! In OpenHuman's **backend mode**, no Composio call carries an `entity_id`: the
+//! backend derives the Composio entity from the **bearer JWT** on the request.
+//! So the *only* isolation lever is **which token the client is constructed
+//! with**, and that construction happens **server-side** here — never from agent
+//! input and never from manifest free-text. The token is resolved from the
+//! company's [`SecretStore`] under [`TOKEN_KEY`]; it has **no environment
+//! fallback**, so a missing/empty secret yields `None` and no tools are wired
+//! (fail closed). Two companies pasting the *same* token would share one entity
+//! — that cannot be prevented client-side and is documented as a deployment
+//! caveat (one backend token per company).
+//!
+//! ## Write-only token
+//!
+//! The token is a write-only credential. It is scrubbed out of **every**
+//! `ToolResult` (success and error), every tracing line, and the [`Debug`]
+//! impl. Only non-secret status (backend URL, toolkit allowlist) is ever
+//! surfaced.
+
+use std::sync::Arc;
+
+use crate::ports::SecretStore;
+use crate::ports::types::{CompanyId, SecretValue};
+
+// The credential key + backend routing live in the always-compiled
+// `company::composio` module (so the console read/write plane can manage the
+// token in the default build); re-exported here for the harness call sites.
+pub use crate::company::composio::{COMPOSIO_BACKEND_URL_ENV, TOKEN_KEY, backend_url_or_default};
+
+/// A per-tenant Composio configuration: the backend URL, the tenant's OAuth
+/// bearer token, and the toolkit allowlist.
+///
+/// **Security invariant**: `auth_token` is a per-company credential. The backend
+/// derives the Composio entity from it, so a company can only ever reach its own
+/// connected accounts. The token is never logged, returned, or `Debug`-printed.
+///
+/// Always compiled (so the [`HarnessDeps`](crate::harness::HarnessDeps) field
+/// exists in every `openhuman` build and every construction site fails closed
+/// with `None`); the live tool constructors in [`composio_tools`] are gated
+/// behind the `composio` feature.
+#[derive(Clone)]
+pub struct TenantComposio {
+    /// The Composio backend base URL (e.g. `https://api.tinyhumans.ai`).
+    pub backend_url: String,
+    /// The per-tenant OAuth bearer token. Never a managed/platform key; the
+    /// backend derives the tenant's Composio entity from it. Write-only.
+    pub auth_token: String,
+    /// The toolkit allowlist (Gmail / Slack / GitHub, …). Empty defers to the
+    /// backend's server-enforced allowlist (open mode); non-empty narrows
+    /// strictly, client-side, before any network round-trip.
+    pub toolkits: Vec<String>,
+}
+
+impl std::fmt::Debug for TenantComposio {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never let the tenant credential land in a trace.
+        f.debug_struct("TenantComposio")
+            .field("backend_url", &self.backend_url)
+            .field(
+                "auth_token",
+                &if self.auth_token.is_empty() {
+                    "<unset>"
+                } else {
+                    "<redacted>"
+                },
+            )
+            .field("toolkits", &self.toolkits)
+            .finish()
+    }
+}
+
+impl TenantComposio {
+    /// Resolve a per-tenant Composio config from the company secret store, or
+    /// `None` (fail closed) when no non-empty token is stored.
+    ///
+    /// The token comes **only** from [`TOKEN_KEY`] in the secret store — there is
+    /// no environment or platform-key fallback, by design: an absent token must
+    /// mean "no tools", never "borrow someone else's identity". The URL *may*
+    /// come from [`COMPOSIO_BACKEND_URL_ENV`], falling back to
+    /// [`DEFAULT_COMPOSIO_BACKEND_URL`]. `toolkits` is the manifest allowlist,
+    /// threaded through unchanged.
+    ///
+    /// A secret-store read error degrades to `None` (fail closed) rather than
+    /// bubbling — a transient store hiccup withholds the tools for that turn
+    /// instead of bricking the roster build.
+    pub async fn resolve(
+        company: &CompanyId,
+        secrets: &dyn SecretStore,
+        toolkits: Vec<String>,
+        backend_url_env: Option<String>,
+    ) -> Option<Self> {
+        let token = match secrets.get(company, TOKEN_KEY).await {
+            Ok(Some(SecretValue(token))) => token,
+            _ => return None,
+        };
+        let token = token.trim().to_string();
+        if token.is_empty() {
+            return None;
+        }
+        Some(Self {
+            backend_url: backend_url_or_default(backend_url_env),
+            auth_token: token,
+            toolkits,
+        })
+    }
+
+    /// A stable, credential-safe fingerprint of the resolved config, folded into
+    /// the harness roster fingerprint so a console token set/rotate (or a
+    /// toolkit-allowlist change) rebuilds the roster on the next turn without a
+    /// restart. Hashes the token too so a rotation is detected — but the hash is
+    /// one-way, so the fingerprint never carries the secret.
+    pub fn fingerprint(config: &Option<TenantComposio>) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        match config {
+            None => 0u8.hash(&mut hasher),
+            Some(c) => {
+                1u8.hash(&mut hasher);
+                c.backend_url.hash(&mut hasher);
+                c.auth_token.hash(&mut hasher);
+                c.toolkits.hash(&mut hasher);
+            }
+        }
+        hasher.finish()
+    }
+}
+
+/// Whether a toolkit is admitted by an allowlist. An **empty** allowlist defers
+/// to the backend's server-enforced allowlist (open mode) and admits every
+/// toolkit; a non-empty allowlist admits only its members (case-insensitive).
+fn toolkit_allowed(allowlist: &[String], toolkit: &str) -> bool {
+    allowlist.is_empty()
+        || allowlist
+            .iter()
+            .any(|allowed| allowed.eq_ignore_ascii_case(toolkit))
+}
+
+/// The toolkit a Composio action slug belongs to: the segment before the first
+/// `_`, lowercased (`GMAIL_SEND_EMAIL` → `gmail`). Empty slug → empty string.
+fn slug_toolkit(slug: &str) -> String {
+    slug.split('_').next().unwrap_or("").to_ascii_lowercase()
+}
+
+#[cfg(feature = "composio")]
+pub use live::composio_tools;
+
+#[cfg(feature = "composio")]
+mod live {
+    use super::*;
+
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use serde_json::{Value, json};
+
+    use crate::harness::mcp_probe::scrub;
+
+    use oh::composio::ComposioClient;
+    use oh::integrations::IntegrationClient;
+    use oh::tools::traits::{PermissionLevel, Tool, ToolResult};
+    use openhuman_core::openhuman as oh;
+
+    /// Build the five per-tenant Composio tools over the tenant's bearer token.
+    ///
+    /// Each tool holds its own [`ComposioClient`] (cheap `Arc` clone over the
+    /// shared [`IntegrationClient`]), the known-secret vector `[auth_token]` fed
+    /// to [`scrub`] so the credential can never survive into agent-visible
+    /// output, and the toolkit allowlist. The read tools are `ReadOnly`; the
+    /// `authorize` / `execute` tools are `Execute` and additionally park for
+    /// operator approval through the harness [`ApprovalPolicy`](crate::harness::policy).
+    ///
+    /// Gated on the `composio` feature; the default/`openhuman` build never
+    /// compiles this.
+    pub fn composio_tools(config: &TenantComposio) -> Vec<Box<dyn Tool>> {
+        // The Config-free seam: `IntegrationClient::new(backend_url, auth_token)`
+        // takes the per-tenant credential directly, with no OpenHuman global
+        // `Config`. The bearer is the ONLY isolation lever — see the module docs.
+        let client = ComposioClient::new(Arc::new(IntegrationClient::new(
+            config.backend_url.clone(),
+            config.auth_token.clone(),
+        )));
+        let secrets = vec![config.auth_token.clone()];
+        let toolkits = Arc::new(config.toolkits.clone());
+        vec![
+            Box::new(ComposioListToolkitsTool {
+                client: client.clone(),
+                secrets: secrets.clone(),
+                toolkits: Arc::clone(&toolkits),
+            }),
+            Box::new(ComposioListConnectionsTool {
+                client: client.clone(),
+                secrets: secrets.clone(),
+                toolkits: Arc::clone(&toolkits),
+            }),
+            Box::new(ComposioListToolsTool {
+                client: client.clone(),
+                secrets: secrets.clone(),
+                toolkits: Arc::clone(&toolkits),
+            }),
+            Box::new(ComposioAuthorizeTool {
+                client: client.clone(),
+                secrets: secrets.clone(),
+                toolkits: Arc::clone(&toolkits),
+            }),
+            Box::new(ComposioExecuteTool {
+                client,
+                secrets,
+                toolkits,
+            }),
+        ]
+    }
+
+    /// Serialize a successful response to JSON, then scrub it against the tenant
+    /// token before it can reach the agent. Text-only output — the structured
+    /// value is dropped so a credential the backend might reflect can never ride
+    /// out in a JSON field.
+    fn scrubbed_ok(value: Value, secrets: &[String]) -> ToolResult {
+        let text = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
+        ToolResult::success(scrub(&text, secrets))
+    }
+
+    /// A scrubbed error result — the tenant token is stripped from any error
+    /// body (mirrors [`crate::harness::mcp`]'s failure handling).
+    fn scrubbed_err(context: &str, err: &anyhow::Error, secrets: &[String]) -> ToolResult {
+        ToolResult::error(scrub(&format!("{context}: {err}"), secrets))
+    }
+
+    /// Pull a required, non-empty string argument.
+    fn required_string_arg(args: &Value, key: &str) -> Result<String> {
+        args.get(key)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .ok_or_else(|| anyhow::anyhow!("missing required `{key}` string argument"))
+    }
+
+    // ── composio_list_toolkits ──────────────────────────────────────────
+
+    struct ComposioListToolkitsTool {
+        client: ComposioClient,
+        secrets: Vec<String>,
+        toolkits: Arc<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl Tool for ComposioListToolkitsTool {
+        fn name(&self) -> &str {
+            "composio_list_toolkits"
+        }
+
+        fn description(&self) -> &str {
+            "List the Composio toolkits (integrations such as Gmail, Slack, GitHub) available to this company. Read-only."
+        }
+
+        fn parameters_schema(&self) -> Value {
+            json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            })
+        }
+
+        fn permission_level(&self) -> PermissionLevel {
+            PermissionLevel::ReadOnly
+        }
+
+        async fn execute(&self, _args: Value) -> Result<ToolResult> {
+            tracing::debug!(
+                allowlist = ?self.toolkits,
+                "[composio] list_toolkits"
+            );
+            match self.client.list_toolkits().await {
+                Ok(mut resp) => {
+                    if !self.toolkits.is_empty() {
+                        resp.toolkits
+                            .retain(|slug| toolkit_allowed(&self.toolkits, slug));
+                        resp.catalog
+                            .retain(|entry| toolkit_allowed(&self.toolkits, &entry.slug));
+                    }
+                    Ok(scrubbed_ok(
+                        serde_json::to_value(&resp).unwrap_or(Value::Null),
+                        &self.secrets,
+                    ))
+                }
+                Err(err) => Ok(scrubbed_err(
+                    "composio_list_toolkits failed",
+                    &err,
+                    &self.secrets,
+                )),
+            }
+        }
+    }
+
+    // ── composio_list_connections ───────────────────────────────────────
+
+    struct ComposioListConnectionsTool {
+        client: ComposioClient,
+        secrets: Vec<String>,
+        toolkits: Arc<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl Tool for ComposioListConnectionsTool {
+        fn name(&self) -> &str {
+            "composio_list_connections"
+        }
+
+        fn description(&self) -> &str {
+            "List this company's connected Composio accounts (which Gmail / Slack / GitHub integrations are authorized). Read-only."
+        }
+
+        fn parameters_schema(&self) -> Value {
+            json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            })
+        }
+
+        fn permission_level(&self) -> PermissionLevel {
+            PermissionLevel::ReadOnly
+        }
+
+        async fn execute(&self, _args: Value) -> Result<ToolResult> {
+            tracing::debug!(
+                allowlist = ?self.toolkits,
+                "[composio] list_connections"
+            );
+            match self.client.list_connections().await {
+                Ok(mut resp) => {
+                    if !self.toolkits.is_empty() {
+                        resp.connections.retain(|conn| {
+                            toolkit_allowed(&self.toolkits, &conn.normalized_toolkit())
+                        });
+                    }
+                    Ok(scrubbed_ok(
+                        serde_json::to_value(&resp).unwrap_or(Value::Null),
+                        &self.secrets,
+                    ))
+                }
+                Err(err) => Ok(scrubbed_err(
+                    "composio_list_connections failed",
+                    &err,
+                    &self.secrets,
+                )),
+            }
+        }
+    }
+
+    // ── composio_list_tools ─────────────────────────────────────────────
+
+    struct ComposioListToolsTool {
+        client: ComposioClient,
+        secrets: Vec<String>,
+        toolkits: Arc<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl Tool for ComposioListToolsTool {
+        fn name(&self) -> &str {
+            "composio_list_tools"
+        }
+
+        fn description(&self) -> &str {
+            "List the callable Composio actions (function schemas) for one or more toolkits. Pass `toolkits` (array of slugs) to narrow; omit to list every allowed toolkit's actions. Read-only."
+        }
+
+        fn parameters_schema(&self) -> Value {
+            json!({
+                "type": "object",
+                "properties": {
+                    "toolkits": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Toolkit slugs to list actions for (e.g. `gmail`, `slack`, `github`)."
+                    }
+                },
+                "additionalProperties": false
+            })
+        }
+
+        fn permission_level(&self) -> PermissionLevel {
+            PermissionLevel::ReadOnly
+        }
+
+        async fn execute(&self, args: Value) -> Result<ToolResult> {
+            // Requested toolkits (if any) intersected with the allowlist; when
+            // the request is empty and an allowlist is set, use the allowlist as
+            // the query so the backend never returns a toolkit the tenant is not
+            // permitted to see.
+            let requested: Vec<String> = args
+                .get("toolkits")
+                .and_then(Value::as_array)
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(Value::as_str)
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_string)
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let effective: Vec<String> = if self.toolkits.is_empty() {
+                requested
+            } else if requested.is_empty() {
+                self.toolkits.as_ref().clone()
+            } else {
+                requested
+                    .into_iter()
+                    .filter(|t| toolkit_allowed(&self.toolkits, t))
+                    .collect()
+            };
+            tracing::debug!(
+                effective = ?effective,
+                allowlist = ?self.toolkits,
+                "[composio] list_tools"
+            );
+
+            let query = if effective.is_empty() {
+                None
+            } else {
+                Some(effective.as_slice())
+            };
+            match self.client.list_tools(query, None).await {
+                Ok(mut resp) => {
+                    if !self.toolkits.is_empty() {
+                        resp.tools.retain(|schema| {
+                            toolkit_allowed(&self.toolkits, &slug_toolkit(&schema.function.name))
+                        });
+                    }
+                    Ok(scrubbed_ok(
+                        serde_json::to_value(&resp).unwrap_or(Value::Null),
+                        &self.secrets,
+                    ))
+                }
+                Err(err) => Ok(scrubbed_err(
+                    "composio_list_tools failed",
+                    &err,
+                    &self.secrets,
+                )),
+            }
+        }
+    }
+
+    // ── composio_authorize ──────────────────────────────────────────────
+
+    struct ComposioAuthorizeTool {
+        client: ComposioClient,
+        secrets: Vec<String>,
+        toolkits: Arc<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl Tool for ComposioAuthorizeTool {
+        fn name(&self) -> &str {
+            "composio_authorize"
+        }
+
+        fn description(&self) -> &str {
+            "Begin an OAuth handoff for a Composio toolkit (e.g. `gmail`) and return the hosted connect URL the operator opens in a browser to connect the account."
+        }
+
+        fn parameters_schema(&self) -> Value {
+            json!({
+                "type": "object",
+                "properties": {
+                    "toolkit": {
+                        "type": "string",
+                        "description": "Toolkit slug to authorize (e.g. `gmail`, `slack`, `github`)."
+                    },
+                    "extra_params": {
+                        "type": "object",
+                        "description": "Optional extra fields some toolkits require during authorization."
+                    }
+                },
+                "required": ["toolkit"],
+                "additionalProperties": false
+            })
+        }
+
+        fn permission_level(&self) -> PermissionLevel {
+            PermissionLevel::Execute
+        }
+
+        async fn execute(&self, args: Value) -> Result<ToolResult> {
+            let toolkit = match required_string_arg(&args, "toolkit") {
+                Ok(t) => t,
+                Err(err) => return Ok(scrubbed_err("composio_authorize", &err, &self.secrets)),
+            };
+            // Enforce the allowlist BEFORE any network call — a toolkit the
+            // tenant is not permitted to connect never reaches the backend.
+            if !toolkit_allowed(&self.toolkits, &toolkit) {
+                return Ok(ToolResult::error(format!(
+                    "toolkit `{toolkit}` is not in this company's Composio allowlist"
+                )));
+            }
+            let extra = args.get("extra_params").cloned();
+            tracing::debug!(toolkit = %toolkit, "[composio] authorize");
+            match self.client.authorize(&toolkit, extra).await {
+                Ok(resp) => Ok(scrubbed_ok(
+                    serde_json::to_value(&resp).unwrap_or(Value::Null),
+                    &self.secrets,
+                )),
+                Err(err) => Ok(scrubbed_err(
+                    "composio_authorize failed",
+                    &err,
+                    &self.secrets,
+                )),
+            }
+        }
+    }
+
+    // ── composio_execute ────────────────────────────────────────────────
+
+    struct ComposioExecuteTool {
+        client: ComposioClient,
+        secrets: Vec<String>,
+        toolkits: Arc<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl Tool for ComposioExecuteTool {
+        fn name(&self) -> &str {
+            "composio_execute"
+        }
+
+        fn description(&self) -> &str {
+            "Run a Composio action by its slug (e.g. `GMAIL_SEND_EMAIL`) with a JSON `arguments` object. Use `composio_list_tools` first to discover the slug and its parameters."
+        }
+
+        fn parameters_schema(&self) -> Value {
+            json!({
+                "type": "object",
+                "properties": {
+                    "tool": {
+                        "type": "string",
+                        "description": "Composio action slug from `composio_list_tools` (e.g. `GMAIL_SEND_EMAIL`)."
+                    },
+                    "arguments": {
+                        "type": "object",
+                        "description": "Arguments object passed through to the Composio action."
+                    }
+                },
+                "required": ["tool"],
+                "additionalProperties": false
+            })
+        }
+
+        fn permission_level(&self) -> PermissionLevel {
+            PermissionLevel::Execute
+        }
+
+        async fn execute(&self, args: Value) -> Result<ToolResult> {
+            let tool = match required_string_arg(&args, "tool") {
+                Ok(t) => t,
+                Err(err) => return Ok(scrubbed_err("composio_execute", &err, &self.secrets)),
+            };
+            // Enforce the allowlist on the slug's toolkit prefix BEFORE any
+            // network call (e.g. `GMAIL_SEND_EMAIL` → `gmail`).
+            let toolkit = slug_toolkit(&tool);
+            if !toolkit_allowed(&self.toolkits, &toolkit) {
+                return Ok(ToolResult::error(format!(
+                    "action `{tool}` targets toolkit `{toolkit}`, which is not in this company's Composio allowlist"
+                )));
+            }
+            let arguments = args.get("arguments").cloned();
+            // tracing carries the slug/toolkit only — NEVER arguments or bodies.
+            tracing::debug!(tool = %tool, toolkit = %toolkit, "[composio] execute");
+            match self.client.execute_tool(&tool, arguments).await {
+                Ok(resp) => Ok(scrubbed_ok(
+                    serde_json::to_value(&resp).unwrap_or(Value::Null),
+                    &self.secrets,
+                )),
+                Err(err) => Ok(scrubbed_err("composio_execute failed", &err, &self.secrets)),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn toolkit_allowed_empty_defers_to_backend() {
+        // Empty allowlist = open mode: every toolkit admitted.
+        assert!(toolkit_allowed(&[], "gmail"));
+        assert!(toolkit_allowed(&[], "anything"));
+    }
+
+    #[test]
+    fn toolkit_allowed_non_empty_narrows_case_insensitively() {
+        let allow = vec!["gmail".to_string(), "github".to_string()];
+        assert!(toolkit_allowed(&allow, "gmail"));
+        assert!(toolkit_allowed(&allow, "GMAIL"));
+        assert!(toolkit_allowed(&allow, "GitHub"));
+        assert!(!toolkit_allowed(&allow, "slack"));
+    }
+
+    #[test]
+    fn slug_toolkit_extracts_lowercased_prefix() {
+        assert_eq!(slug_toolkit("GMAIL_SEND_EMAIL"), "gmail");
+        assert_eq!(slug_toolkit("SLACK_POST_MESSAGE"), "slack");
+        assert_eq!(slug_toolkit("GITHUB_CREATE_ISSUE"), "github");
+        assert_eq!(slug_toolkit(""), "");
+    }
+
+    #[test]
+    fn debug_redacts_the_token() {
+        let config = TenantComposio {
+            backend_url: "https://api.tinyhumans.ai".to_string(),
+            auth_token: "super-secret-tenant-token".to_string(),
+            toolkits: vec!["gmail".to_string()],
+        };
+        let shown = format!("{config:?}");
+        assert!(
+            !shown.contains("super-secret-tenant-token"),
+            "token leaked: {shown}"
+        );
+        assert!(shown.contains("<redacted>"), "{shown}");
+        assert!(shown.contains("api.tinyhumans.ai"), "{shown}");
+        assert!(
+            shown.contains("gmail"),
+            "toolkits should be visible: {shown}"
+        );
+    }
+
+    #[test]
+    fn debug_marks_unset_token() {
+        let config = TenantComposio {
+            backend_url: "https://api.tinyhumans.ai".to_string(),
+            auth_token: String::new(),
+            toolkits: Vec::new(),
+        };
+        let shown = format!("{config:?}");
+        assert!(shown.contains("<unset>"), "{shown}");
+    }
+
+    /// Tenant isolation at the resolver seam (issue #110): the token comes ONLY
+    /// from the company secret store — there is no env/platform-key fallback — so
+    /// a company with no stored token resolves to `None` (fail closed, no tools),
+    /// never a borrowed identity, even if a platform key like `TINYHUMANS_API_KEY`
+    /// exists in the environment. A stored token resolves to a config that
+    /// carries exactly that token.
+    #[tokio::test]
+    async fn resolve_is_fail_closed_without_a_stored_token_and_has_no_env_fallback() {
+        use crate::ports::SecretStore;
+        use crate::ports::types::{CompanyId, SecretValue};
+        use crate::store::FsSecretStore;
+
+        let dir =
+            std::env::temp_dir().join(format!("oc-composio-res-{}", crate::ports::generate_id()));
+        let secrets = FsSecretStore::new(&dir);
+        let company = CompanyId::new("acme");
+
+        // A platform key in the environment must NOT leak in — the resolver never
+        // reads it. (No token stored → None.)
+        // SAFETY: single-threaded test; we set then restore the env.
+        unsafe { std::env::set_var("TINYHUMANS_API_KEY", "platform-managed-key") };
+        assert!(
+            TenantComposio::resolve(&company, &secrets, Vec::new(), None)
+                .await
+                .is_none(),
+            "no stored token must fail closed, ignoring any env platform key"
+        );
+
+        // An explicitly-empty token still fails closed.
+        secrets
+            .set(&company, TOKEN_KEY, SecretValue("   ".to_string()))
+            .await
+            .unwrap();
+        assert!(
+            TenantComposio::resolve(&company, &secrets, Vec::new(), None)
+                .await
+                .is_none(),
+            "an empty/whitespace token must fail closed"
+        );
+
+        // A real stored token resolves and carries exactly that token + default URL.
+        secrets
+            .set(
+                &company,
+                TOKEN_KEY,
+                SecretValue("tenant-token-xyz".to_string()),
+            )
+            .await
+            .unwrap();
+        let resolved = TenantComposio::resolve(&company, &secrets, vec!["gmail".into()], None)
+            .await
+            .expect("a stored token resolves");
+        assert_eq!(resolved.auth_token, "tenant-token-xyz");
+        assert_eq!(resolved.backend_url, "https://api.tinyhumans.ai");
+        assert_eq!(resolved.toolkits, vec!["gmail".to_string()]);
+
+        unsafe { std::env::remove_var("TINYHUMANS_API_KEY") };
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn fingerprint_changes_on_token_rotation_and_none() {
+        let a = Some(TenantComposio {
+            backend_url: "https://api.tinyhumans.ai".to_string(),
+            auth_token: "token-a".to_string(),
+            toolkits: vec!["gmail".to_string()],
+        });
+        let b = Some(TenantComposio {
+            backend_url: "https://api.tinyhumans.ai".to_string(),
+            auth_token: "token-b".to_string(),
+            toolkits: vec!["gmail".to_string()],
+        });
+        assert_ne!(
+            TenantComposio::fingerprint(&a),
+            TenantComposio::fingerprint(&b),
+            "a rotated token must move the fingerprint"
+        );
+        assert_ne!(
+            TenantComposio::fingerprint(&a),
+            TenantComposio::fingerprint(&None),
+            "None (fail-closed) must differ from a configured tenant"
+        );
+        assert_eq!(
+            TenantComposio::fingerprint(&a),
+            TenantComposio::fingerprint(&a.clone()),
+            "the same config fingerprints stably"
+        );
+    }
+}
+
+/// The mandatory tenant-isolation test (issue #110): two per-tenant configs (A
+/// and B) over a mock backend that records the `Authorization` header of each
+/// request and answers with tenant-specific data. Proves the ONLY isolation
+/// lever — which token the client is constructed with — actually holds: A's
+/// request carries token A (never B), and A's result carries only A's account.
+#[cfg(all(test, feature = "composio"))]
+mod isolation_tests {
+    use super::*;
+
+    use std::net::SocketAddr;
+    use std::sync::{Arc, Mutex};
+
+    use axum::Router;
+    use axum::extract::State;
+    use axum::http::HeaderMap;
+    use axum::routing::get;
+    use oh::tools::traits::Tool;
+    use openhuman_core::openhuman as oh;
+    use serde_json::{Value, json};
+
+    /// Shared recorder for every `Authorization` header the mock backend saw.
+    type AuthLog = Arc<Mutex<Vec<String>>>;
+
+    /// The mock `/agent-integrations/composio/connections` handler: records the
+    /// bearer it received and returns a `{success,data}` envelope whose single
+    /// connection's `account_email` is derived from that bearer — so a caller can
+    /// prove it only ever sees *its own* tenant's data.
+    async fn connections(State(log): State<AuthLog>, headers: HeaderMap) -> axum::Json<Value> {
+        let auth = headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        log.lock().unwrap().push(auth.clone());
+        // Derive tenant identity purely from the presented bearer.
+        let email = if auth.contains("token-a") {
+            "a@example.com"
+        } else if auth.contains("token-b") {
+            "b@example.com"
+        } else {
+            "unknown@example.com"
+        };
+        axum::Json(json!({
+            "success": true,
+            "data": {
+                "connections": [
+                    { "id": "conn-1", "toolkit": "gmail", "status": "ACTIVE", "accountEmail": email }
+                ]
+            }
+        }))
+    }
+
+    /// Spawn the mock backend on an ephemeral port; returns its base URL + the
+    /// auth-header recorder.
+    async fn spawn_backend() -> (String, AuthLog) {
+        let log: AuthLog = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/agent-integrations/composio/connections", get(connections))
+            .with_state(log.clone());
+        let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{addr}"), log)
+    }
+
+    fn config(url: &str, token: &str) -> TenantComposio {
+        TenantComposio {
+            backend_url: url.to_string(),
+            auth_token: token.to_string(),
+            toolkits: Vec::new(),
+        }
+    }
+
+    fn list_connections_tool(config: &TenantComposio) -> Box<dyn Tool> {
+        composio_tools(config)
+            .into_iter()
+            .find(|t| t.name() == "composio_list_connections")
+            .expect("composio_list_connections tool present")
+    }
+
+    #[tokio::test]
+    async fn each_tenant_only_ever_carries_its_own_token_and_sees_its_own_accounts() {
+        let (url, log) = spawn_backend().await;
+
+        let tool_a = list_connections_tool(&config(&url, "token-a"));
+        let tool_b = list_connections_tool(&config(&url, "token-b"));
+
+        let out_a = tool_a.execute(json!({})).await.unwrap();
+        let text_a = out_a.output();
+        let out_b = tool_b.execute(json!({})).await.unwrap();
+        let text_b = out_b.output();
+
+        // A saw only A's account; never B's account nor B's token.
+        assert!(
+            text_a.contains("a@example.com"),
+            "A missing its account: {text_a}"
+        );
+        assert!(
+            !text_a.contains("b@example.com"),
+            "A leaked B's account: {text_a}"
+        );
+        assert!(!text_a.contains("token-b"), "A leaked B's token: {text_a}");
+        // Symmetrically for B.
+        assert!(
+            text_b.contains("b@example.com"),
+            "B missing its account: {text_b}"
+        );
+        assert!(
+            !text_b.contains("a@example.com"),
+            "B leaked A's account: {text_b}"
+        );
+
+        // A's own token is scrubbed out of its own successful output.
+        assert!(
+            !text_a.contains("token-a"),
+            "A leaked its own token: {text_a}"
+        );
+
+        // The backend received exactly the two distinct bearers — each request
+        // carried its own tenant's token, never the other's.
+        let seen = log.lock().unwrap().clone();
+        assert_eq!(seen.len(), 2, "expected one request per tenant: {seen:?}");
+        assert!(
+            seen.iter().any(|a| a == "Bearer token-a"),
+            "missing A bearer: {seen:?}"
+        );
+        assert!(
+            seen.iter().any(|a| a == "Bearer token-b"),
+            "missing B bearer: {seen:?}"
+        );
+        assert!(
+            !seen
+                .iter()
+                .any(|a| a.contains("token-a") && a.contains("token-b")),
+            "a single request must never carry both tokens: {seen:?}"
+        );
+    }
+
+    /// A mock backend that echoes the caller's bearer inside an error body; the
+    /// tool's scrub must strip it before the agent ever sees it.
+    #[tokio::test]
+    async fn error_body_reflecting_the_token_is_scrubbed() {
+        async fn reflect(headers: HeaderMap) -> axum::Json<Value> {
+            let auth = headers
+                .get("authorization")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("")
+                .to_string();
+            // A 2xx envelope failure whose message reflects the raw bearer.
+            axum::Json(json!({ "success": false, "error": format!("upstream said: {auth}") }))
+        }
+        let app = Router::new().route("/agent-integrations/composio/connections", get(reflect));
+        let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let url = format!("http://{addr}");
+
+        let tool = list_connections_tool(&config(&url, "reflected-secret-token"));
+        let out = tool.execute(json!({})).await.unwrap();
+        let text = out.output();
+        assert!(
+            !text.contains("reflected-secret-token"),
+            "the reflected token leaked into agent-visible output: {text}"
+        );
+    }
+}

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -38,6 +38,7 @@
 pub mod brain;
 pub mod build;
 pub mod capability_budget;
+pub mod composio;
 pub mod cost;
 pub mod mcp;
 pub mod mcp_probe;
@@ -66,7 +67,7 @@ use oh::inference::provider::Provider;
 use crate::company::Agent as ManifestAgent;
 use crate::company::Policy;
 use crate::company::mcp::McpServerDecl;
-use crate::company::steer::SteerControl;
+use crate::company::steer::{SteerAction, SteerControl};
 use crate::error::OpenCompanyError;
 use crate::harness::cost::{TurnUsage, record_turn_cost};
 use crate::harness::mcp_probe::McpFailureQueue;
@@ -204,6 +205,16 @@ pub struct HarnessDeps {
     /// [`toolbelt::media_tools`]; a grant with no credential wires nothing and
     /// warns.
     pub media: Option<toolbelt::MediaBackend>,
+    /// The per-tenant Composio configuration (issue #110). `None` (the default
+    /// at every construction site) fails closed — no Composio tools are wired.
+    /// [`HarnessPool::ensure`] re-resolves it from the [`SecretStore`] under
+    /// [`composio::TOKEN_KEY`](crate::harness::composio::TOKEN_KEY) each turn
+    /// (folded into the roster fingerprint) so a console token set/rotate takes
+    /// effect next turn with no restart. Only wired when a company **explicitly**
+    /// grants `composio` **and** a non-empty token is stored; the token has no
+    /// env fallback, so an absent token means no tools (never a borrowed
+    /// identity).
+    pub composio: Option<composio::TenantComposio>,
     /// Issue #111 — the shared registry of in-flight, steerable runs. The
     /// [`HarnessBrain`] registers a dispatched task / desk delegation here before
     /// running it (and installs the steer stop-hook over the slot's control), so
@@ -446,6 +457,15 @@ pub struct HarnessPool {
     /// [`HarnessDeps::capabilities`], whose fingerprint never moves — no rebuild,
     /// byte-identical to Cell A.
     capability_fingerprints: RwLock<HashMap<CompanyId, u64>>,
+    /// Fingerprint of the resolved per-tenant [`TenantComposio`](composio::TenantComposio)
+    /// config the cached roster was built from, keyed by company (issue #110).
+    /// Drives Composio-freshness: [`ensure`](Self::ensure) re-resolves the token
+    /// (+ toolkit allowlist) from the [`SecretStore`] on every call and rebuilds
+    /// the roster whenever it changes — so a console token set/rotate/clear takes
+    /// effect on the company's **next** turn with no restart. With no secret
+    /// store wired the config is the static [`HarnessDeps::composio`], whose
+    /// fingerprint never moves.
+    composio_fingerprints: RwLock<HashMap<CompanyId, u64>>,
 }
 
 impl Default for HarnessPool {
@@ -462,6 +482,7 @@ impl HarnessPool {
             mcp_fingerprints: RwLock::new(HashMap::new()),
             overlay_fingerprints: RwLock::new(HashMap::new()),
             capability_fingerprints: RwLock::new(HashMap::new()),
+            composio_fingerprints: RwLock::new(HashMap::new()),
         }
     }
 
@@ -499,15 +520,25 @@ impl HarnessPool {
         let capability_filter = self.resolve_capability_filter(company, deps).await;
         let capability_fp = capability_budget::filter_fingerprint(&capability_filter);
 
+        // Re-resolve + fingerprint the per-tenant Composio config (issue #110):
+        // the token (+ toolkit allowlist) read live from the secret store, so a
+        // console token set/rotate/clear takes effect on the next turn. With no
+        // secret store wired this is the static `deps.composio`, whose
+        // fingerprint is stable — so that company never rebuilds on this axis.
+        let composio_config = self.resolve_composio(company, deps).await;
+        let composio_fp = composio::TenantComposio::fingerprint(&composio_config);
+
         {
             let agents = self.agents.read().await;
             let mcp_fingerprints = self.mcp_fingerprints.read().await;
             let overlay_fingerprints = self.overlay_fingerprints.read().await;
             let capability_fingerprints = self.capability_fingerprints.read().await;
+            let composio_fingerprints = self.composio_fingerprints.read().await;
             if agents.contains_key(&company.id)
                 && mcp_fingerprints.get(&company.id) == Some(&mcp_fp)
                 && overlay_fingerprints.get(&company.id) == Some(&overlay_fp)
                 && capability_fingerprints.get(&company.id) == Some(&capability_fp)
+                && composio_fingerprints.get(&company.id) == Some(&composio_fp)
             {
                 return Ok(());
             }
@@ -530,6 +561,9 @@ impl HarnessPool {
         // crossed a tier budget gets a roster whose exec tools are actually
         // trimmed. With no plan this is just `deps.capabilities` unchanged.
         fresh_deps.capabilities = capability_filter;
+        // Install the freshly-resolved Composio config the same way, so a token
+        // set/rotate/clear reaches the rebuilt agents (issue #110).
+        fresh_deps.composio = composio_config;
         // Same treatment for the overlay-agent set: `company` may be a stale
         // boot-time snapshot (e.g. `HarnessBrain::record`), so the roster is
         // built from the live-resolved overlay set, not `company.overlay_agents`.
@@ -551,6 +585,10 @@ impl HarnessPool {
             .write()
             .await
             .insert(company.id.clone(), capability_fp);
+        self.composio_fingerprints
+            .write()
+            .await
+            .insert(company.id.clone(), composio_fp);
         Ok(())
     }
 
@@ -577,6 +615,36 @@ impl HarnessPool {
                 .await
             }
             None => deps.capabilities.clone(),
+        }
+    }
+
+    /// Re-resolves the company's per-tenant Composio config (issue #110) from the
+    /// [`SecretStore`], so a console token set/rotate/clear takes effect on the
+    /// next turn. Only companies that **explicitly** grant `composio` touch the
+    /// secret store on this axis; others resolve to `None` (no tools). With no
+    /// secret store wired this degrades to the static [`HarnessDeps::composio`].
+    ///
+    /// The token has no env fallback — an absent/empty secret yields `None` (fail
+    /// closed). The backend URL honors [`composio::COMPOSIO_BACKEND_URL_ENV`],
+    /// read process-globally so a live re-resolution keeps the override even when
+    /// no token was stored at boot.
+    async fn resolve_composio(
+        &self,
+        company: &CompanyRecord,
+        deps: &HarnessDeps,
+    ) -> Option<composio::TenantComposio> {
+        if !crate::company::grants_composio_explicit(&company.manifest.tools.allow) {
+            return None;
+        }
+        let toolkits = company.manifest.tools.composio.toolkits.clone();
+        match &deps.secrets {
+            Some(secrets) => {
+                use crate::app::config::EnvSource;
+                let url = crate::app::config::ProcessEnv.get(composio::COMPOSIO_BACKEND_URL_ENV);
+                composio::TenantComposio::resolve(&company.id, secrets.as_ref(), toolkits, url)
+                    .await
+            }
+            None => deps.composio.clone(),
         }
     }
 
@@ -1159,6 +1227,7 @@ description = "Builds the product."
                 workflow_source_dir: None,
                 plan: None,
                 media: None,
+                composio: None,
                 steer: crate::company::steer::InflightRegistry::default(),
             },
             store,
@@ -1215,6 +1284,7 @@ description = "Builds the product."
             workflow_source_dir: None,
             plan: None,
             media: None,
+            composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
         };
 
@@ -1494,6 +1564,7 @@ description = "Builds the product."
             workflow_source_dir: None,
             plan: None,
             media: None,
+            composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
         };
         let roster = build_roster(&record(), &deps, &[]).expect("roster");
@@ -1523,7 +1594,6 @@ description = "Builds the product."
     /// steered-empty turn therefore makes EXACTLY ONE attempt.
     #[tokio::test]
     async fn steered_empty_turn_makes_exactly_one_attempt() {
-        use crate::company::steer::SteerAction;
         // Attempt 1 is empty; a normal `run` would retry and consume the second
         // script entry. With a steer pending, the retry must not fire.
         let (agent, _deps) = scripted_agent(vec![Ok(String::new()), Ok("second".into())]);
@@ -1648,6 +1718,7 @@ description = "Builds the product."
             workflow_source_dir: None,
             plan: None,
             media: None,
+            composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
         };
         let pool = HarnessPool::new();
@@ -1759,6 +1830,7 @@ description = "Builds the product."
             workflow_source_dir: None,
             plan: None,
             media: None,
+            composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
         };
         let pool = HarnessPool::new();
@@ -1901,6 +1973,7 @@ description = "Sets direction."
             workflow_source_dir: None,
             plan: Some(plan),
             media: None,
+            composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
         };
         let pool = HarnessPool::new();

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -201,6 +201,18 @@ fn is_external_effect(tool_name: &str) -> bool {
     if tool_name.eq_ignore_ascii_case("media_list_models") {
         return false;
     }
+    // The Composio read tools (issue #110) are read-only GETs: listing toolkits,
+    // connections, or action schemas reaches no third party and must never park
+    // for approval, even though the `composio_*` name has no read-only prefix.
+    // `composio_authorize` / `composio_execute` are NOT listed here — they begin
+    // an OAuth handoff / run a real action, so they fall through to the external-
+    // effect default (park under supervised, deny under readonly).
+    if matches!(
+        tool_name.to_ascii_lowercase().as_str(),
+        "composio_list_toolkits" | "composio_list_connections" | "composio_list_tools"
+    ) {
+        return false;
+    }
     const READ_ONLY_PREFIXES: &[&str] = &[
         "read",
         "list",
@@ -223,6 +235,15 @@ fn classify_group(tool_name: &str) -> EffectGroup {
     let name = tool_name.to_ascii_lowercase();
     if name == "mcp_registry_tool_call" {
         EffectGroup::Other
+    } else if name == "composio_authorize" {
+        // Beginning an OAuth handoff establishes an account identity for the
+        // company (issue #110) — an identity effect, parked before it lands.
+        EffectGroup::Identity
+    } else if name == "composio_execute" {
+        // Running a Composio action reaches a third-party account (send an
+        // email, post a message, open a PR) — a send effect. Placed before the
+        // generic `contains` heuristics so the slug can't be misclassified.
+        EffectGroup::Send
     } else if name.starts_with("media_generate") {
         // Image/video generation is billed by the backend on submit (issue
         // #109), so it is a spend effect — parked for approval before money
@@ -416,6 +437,75 @@ mod tests {
             p.effect_for("media_generate_video", &serde_json::json!({}))
                 .group,
             EffectGroup::Spend
+        );
+    }
+
+    /// Per-tenant Composio (issue #110): the read tools are read-only (allowed
+    /// even under supervised/readonly), while `composio_authorize` /
+    /// `composio_execute` are external — parked under supervised, denied under
+    /// readonly.
+    #[tokio::test]
+    async fn composio_reads_allowed_but_authorize_execute_park_or_deny() {
+        let supervised = policy("supervised", &[], None);
+        for tool in [
+            "composio_list_toolkits",
+            "composio_list_connections",
+            "composio_list_tools",
+        ] {
+            assert_eq!(
+                supervised
+                    .check(&request(tool, serde_json::json!({})))
+                    .await,
+                ToolPolicyDecision::Allow,
+                "{tool} is read-only and must be allowed"
+            );
+        }
+        for tool in ["composio_authorize", "composio_execute"] {
+            assert!(
+                matches!(
+                    supervised
+                        .check(&request(tool, serde_json::json!({})))
+                        .await,
+                    ToolPolicyDecision::RequireApproval { .. }
+                ),
+                "{tool} must park under supervised"
+            );
+        }
+
+        let readonly = policy("readonly", &[], None);
+        // A read-only desk may still browse the Composio surface.
+        assert_eq!(
+            readonly
+                .check(&request("composio_list_connections", serde_json::json!({})))
+                .await,
+            ToolPolicyDecision::Allow
+        );
+        for tool in ["composio_authorize", "composio_execute"] {
+            assert!(
+                matches!(
+                    readonly.check(&request(tool, serde_json::json!({}))).await,
+                    ToolPolicyDecision::Deny { .. }
+                ),
+                "{tool} must be denied under readonly"
+            );
+        }
+    }
+
+    /// Composio effect groups (issue #110): authorize is an Identity effect,
+    /// execute is a Send effect — pinned before the generic `contains`
+    /// heuristics could misclassify the slug.
+    #[test]
+    fn composio_classifies_authorize_identity_and_execute_send() {
+        let p = policy("supervised", &[], None);
+        assert_eq!(
+            p.effect_for("composio_authorize", &serde_json::json!({}))
+                .group,
+            EffectGroup::Identity
+        );
+        assert_eq!(
+            p.effect_for("composio_execute", &serde_json::json!({}))
+                .group,
+            EffectGroup::Send
         );
     }
 

--- a/src/harness/toolbelt.rs
+++ b/src/harness/toolbelt.rs
@@ -73,7 +73,7 @@ const CURL_DEST_SUBDIR: &str = "downloads";
 /// The canonical list lives in [`crate::company::GATEABLE_NAMESPACES`] (always
 /// compiled, so manifest validation can see it in the default build); this is a
 /// re-export for the harness call sites that key off it.
-pub const GATEABLE_NAMESPACES: [&str; 5] = crate::company::GATEABLE_NAMESPACES;
+pub const GATEABLE_NAMESPACES: [&str; 6] = crate::company::GATEABLE_NAMESPACES;
 
 /// Map a tool's runtime `name()` onto its grant namespace, or `None` when the
 /// tool is **intrinsic** (memory / MCP / orchestrator / file / skill tools),
@@ -92,6 +92,16 @@ pub fn namespace_of(tool_name: &str) -> Option<&'static str> {
         // namespace mapping is a pure string match so the capability filter and
         // the gateable-coverage invariant see `media` in every build.
         "media_generate_image" | "media_generate_video" | "media_list_models" => Some("media"),
+        // Per-tenant Composio (issue #110). Mapped unconditionally for the same
+        // reason as `media`: the arm is inert without the `composio` feature (the
+        // tools are never built), but the namespace mapping is a pure string
+        // match so the capability filter and the gateable-coverage invariant see
+        // `composio` in every build.
+        "composio_list_toolkits"
+        | "composio_list_connections"
+        | "composio_list_tools"
+        | "composio_authorize"
+        | "composio_execute" => Some("composio"),
         _ => None,
     }
 }
@@ -536,6 +546,12 @@ mod tests {
         assert_eq!(namespace_of("media_generate_image"), Some("media"));
         assert_eq!(namespace_of("media_generate_video"), Some("media"));
         assert_eq!(namespace_of("media_list_models"), Some("media"));
+        // Per-tenant Composio (issue #110) maps to the `composio` namespace.
+        assert_eq!(namespace_of("composio_list_toolkits"), Some("composio"));
+        assert_eq!(namespace_of("composio_list_connections"), Some("composio"));
+        assert_eq!(namespace_of("composio_list_tools"), Some("composio"));
+        assert_eq!(namespace_of("composio_authorize"), Some("composio"));
+        assert_eq!(namespace_of("composio_execute"), Some("composio"));
         // Intrinsic tools are unmapped (always kept by the filter).
         assert_eq!(namespace_of("memory_store"), None);
         assert_eq!(namespace_of("memory_recall"), None);
@@ -561,6 +577,11 @@ mod tests {
             "media_generate_image",
             "media_generate_video",
             "media_list_models",
+            "composio_list_toolkits",
+            "composio_list_connections",
+            "composio_list_tools",
+            "composio_authorize",
+            "composio_execute",
         ];
         for tool in mapped {
             let ns = namespace_of(tool).expect("mapped tool has a namespace");
@@ -576,6 +597,10 @@ mod tests {
         assert!(
             GATEABLE_NAMESPACES.contains(&"media"),
             "the real-money media namespace must be gateable"
+        );
+        assert!(
+            GATEABLE_NAMESPACES.contains(&"composio"),
+            "the per-tenant composio namespace must be gateable"
         );
     }
 

--- a/src/metering/capability.rs
+++ b/src/metering/capability.rs
@@ -153,9 +153,11 @@ impl CapabilityPlan {
 /// * `starter` — `shell` + `code` at 200k tokens/day.
 /// * `pro` — `shell` + `code` + `web` at 1M tokens/day.
 /// * `unlimited` — every gateable namespace at `u64::MAX` (effectively
-///   uncapped), including the real-money `media` tier (issue #109). `media` is
-///   absent from `free` / `starter` / `pro`, so those tiers deny it outright
-///   unless the manifest opts in with an explicit `token_budgets = { media = N }`.
+///   uncapped), including the real-money `media` tier (issue #109) and the
+///   per-tenant `composio` tier (issue #110). `media` / `composio` are absent
+///   from `free` / `starter` / `pro`, so those tiers deny them outright unless
+///   the manifest opts in with an explicit `token_budgets = { media = N }` /
+///   `{ composio = N }`.
 ///
 /// Every built-in is daily; the manifest `[plan].period` can widen the window.
 pub fn plan_named(name: &str) -> Option<CapabilityPlan> {
@@ -173,6 +175,7 @@ pub fn plan_named(name: &str) -> Option<CapabilityPlan> {
             ("web", u64::MAX),
             ("subagent", u64::MAX),
             ("media", u64::MAX),
+            ("composio", u64::MAX),
         ],
         _ => return None,
     };
@@ -361,6 +364,52 @@ mod tests {
                 "{tier} must deny the real-money media tier by default"
             );
         }
+    }
+
+    /// The per-tenant `composio` tier (issue #110) is uncapped under `unlimited`
+    /// but denied by every other built-in tier — a company opts into it via an
+    /// explicit `token_budgets = { composio = N }`, never a wildcard.
+    #[test]
+    fn composio_tier_is_unlimited_only_and_denied_elsewhere() {
+        assert!(
+            !plan_named("unlimited")
+                .unwrap()
+                .denied_namespaces(0)
+                .contains("composio"),
+            "unlimited grants composio"
+        );
+        for tier in ["free", "starter", "pro"] {
+            assert!(
+                plan_named(tier)
+                    .unwrap()
+                    .denied_namespaces(0)
+                    .contains("composio"),
+                "{tier} must deny the composio tier by default"
+            );
+        }
+    }
+
+    /// A manifest can opt a non-`unlimited` plan into `composio` with an explicit
+    /// token budget; exhausting that budget drops exactly `composio`.
+    #[test]
+    fn explicit_composio_budget_grants_then_exhausts_only_composio() {
+        let mut token_budgets = BTreeMap::new();
+        token_budgets.insert("composio".to_string(), 100_000);
+        let plan = CapabilityPlan::from_manifest(&Plan {
+            name: Some("starter".into()),
+            period: "daily".into(),
+            token_budgets,
+        })
+        .unwrap();
+        // Under budget: composio granted, shell/code still granted.
+        let under = plan.denied_namespaces(50_000);
+        assert!(!under.contains("composio"));
+        assert!(!under.contains("shell"));
+        // At the composio budget but under starter's 200k shell/code: only
+        // composio drops.
+        let at = plan.denied_namespaces(100_000);
+        assert!(at.contains("composio"), "composio exhausted at its budget");
+        assert!(!at.contains("shell"), "shell still under its 200k budget");
     }
 
     #[test]

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -803,6 +803,31 @@ impl RuntimeBuilder {
                                 );
                                 Vec::new()
                             });
+                            // Issue #110: resolve the per-tenant Composio config
+                            // at boot from the company secret store (token) + the
+                            // manifest toolkit allowlist + the env URL override.
+                            // Only companies that explicitly grant `composio`
+                            // touch the store; the token has no env fallback, so a
+                            // missing token stays `None` (fail closed).
+                            // `HarnessPool::ensure` re-resolves this each turn so a
+                            // console token change takes effect without restart.
+                            let composio_config = if crate::company::grants_composio_explicit(
+                                &self.manifest.tools.allow,
+                            ) {
+                                use crate::app::config::EnvSource;
+                                let toolkits = self.manifest.tools.composio.toolkits.clone();
+                                let url = crate::app::config::ProcessEnv
+                                    .get(crate::harness::composio::COMPOSIO_BACKEND_URL_ENV);
+                                crate::harness::composio::TenantComposio::resolve(
+                                    &id,
+                                    secrets.as_ref(),
+                                    toolkits,
+                                    url,
+                                )
+                                .await
+                            } else {
+                                None
+                            };
                             let deps = HarnessDeps {
                                 // A per-tenant provider that re-resolves the
                                 // effective inference config on every turn, so a
@@ -881,11 +906,10 @@ impl RuntimeBuilder {
                                 // closed — `build_agent` wires no media tools even
                                 // for a company that grants `media`.
                                 media: self.media_backend.clone(),
-                                // #113 P2: the company source dir so a workflow's
-                                // `sub_workflow` node resolves a child by id from
-                                // `workflows/<id>.toml`. Same origin as the skills
-                                // source dir but a distinct seam.
-                                workflow_source_dir: self.seed_dir.clone(),
+                                // Issue #110: the per-tenant Composio config
+                                // resolved above (token from the secret store,
+                                // never an env/platform key). `None` fails closed.
+                                composio: composio_config,
                                 steer,
                             };
                             let record = CompanyRecord {

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1034,6 +1034,7 @@ mod test {
             workflow_source_dir: None,
             plan: None,
             media: None,
+            composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record);

--- a/src/server/ops/capabilities.rs
+++ b/src/server/ops/capabilities.rs
@@ -156,12 +156,15 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<CapabilityStatusDt
     let flags = OptInFlags {
         media_granted: crate::company::grants_media_explicit(&record.manifest.tools.allow),
         composio_granted: crate::company::grants_composio_explicit(&record.manifest.tools.allow),
+        // Degrade to "unconfigured" on a transient secret-store error rather
+        // than failing the whole /capabilities response (budget/tier data is
+        // unrelated to Composio). Mirrors other opt-in-credential probes.
         composio_token_configured: crate::company::composio::token_configured(
             runtime.id(),
             runtime.secrets().as_ref(),
         )
         .await
-        .map_err(ApiError)?,
+        .unwrap_or(false),
     };
     let manifest_plan = &record.manifest.plan;
     let Some(plan) = CapabilityPlan::from_manifest(manifest_plan) else {

--- a/src/server/ops/capabilities.rs
+++ b/src/server/ops/capabilities.rs
@@ -63,6 +63,15 @@ struct CapabilityStatusDto {
     /// Whether a MANAGED media credential is resolvable from the environment on
     /// this build (feature on + env present). Never reflects a tenant secret.
     media_credential_configured: bool,
+    /// Per-tenant Composio (issue #110): whether this company **explicitly**
+    /// grants the `composio` namespace (a `*` wildcard does NOT count). Opt-in
+    /// per tool grant, independent of a `[plan]`.
+    composio_granted: bool,
+    /// Whether the `composio` feature is compiled into this build at all.
+    composio_in_build: bool,
+    /// Whether a non-empty per-tenant Composio token is stored — never the token
+    /// itself. Unlike media's env credential, this is a tenant secret.
+    composio_token_configured: bool,
 }
 
 /// One tier's budget row.
@@ -82,9 +91,28 @@ struct TierDto {
     exhausted: bool,
 }
 
-/// The unconfigured response: `{ configured: false }` plus the media-status
-/// flags (media is opt-in per tool grant, independent of a `[plan]`).
-fn unconfigured(media_granted: bool) -> CapabilityStatusDto {
+/// The opt-in-capability status flags carried on every response (media +
+/// composio), independent of whether a `[plan]` is configured.
+struct OptInFlags {
+    media_granted: bool,
+    composio_granted: bool,
+    composio_token_configured: bool,
+}
+
+impl OptInFlags {
+    /// All-false — used when no company record is present.
+    fn none() -> Self {
+        Self {
+            media_granted: false,
+            composio_granted: false,
+            composio_token_configured: false,
+        }
+    }
+}
+
+/// The unconfigured response: `{ configured: false }` plus the opt-in-capability
+/// flags (media + composio are opt-in per tool grant, independent of a `[plan]`).
+fn unconfigured(flags: OptInFlags) -> CapabilityStatusDto {
     CapabilityStatusDto {
         configured: false,
         plan: None,
@@ -92,9 +120,12 @@ fn unconfigured(media_granted: bool) -> CapabilityStatusDto {
         period_start_millis: None,
         spent_tokens: None,
         tiers: Vec::new(),
-        media_granted,
+        media_granted: flags.media_granted,
         media_in_build: cfg!(feature = "media"),
         media_credential_configured: media_credential_configured(),
+        composio_granted: flags.composio_granted,
+        composio_in_build: cfg!(feature = "composio"),
+        composio_token_configured: flags.composio_token_configured,
     }
 }
 
@@ -118,14 +149,23 @@ fn media_credential_configured() -> bool {
 async fn effective_status(runtime: &CompanyRuntime) -> Result<CapabilityStatusDto, ApiError> {
     let record = runtime.store().load(runtime.id()).await.map_err(ApiError)?;
     let Some(record) = record else {
-        return Ok(unconfigured(false));
+        return Ok(unconfigured(OptInFlags::none()));
     };
-    // Media is opt-in per tool grant (explicit `media`, never `*`) and lives on
-    // the manifest regardless of whether a capability `[plan]` is configured.
-    let media_granted = crate::company::grants_media_explicit(&record.manifest.tools.allow);
+    // Media + composio are opt-in per tool grant (explicit namespace, never `*`)
+    // and live on the manifest regardless of whether a `[plan]` is configured.
+    let flags = OptInFlags {
+        media_granted: crate::company::grants_media_explicit(&record.manifest.tools.allow),
+        composio_granted: crate::company::grants_composio_explicit(&record.manifest.tools.allow),
+        composio_token_configured: crate::company::composio::token_configured(
+            runtime.id(),
+            runtime.secrets().as_ref(),
+        )
+        .await
+        .map_err(ApiError)?,
+    };
     let manifest_plan = &record.manifest.plan;
     let Some(plan) = CapabilityPlan::from_manifest(manifest_plan) else {
-        return Ok(unconfigured(media_granted));
+        return Ok(unconfigured(flags));
     };
 
     let now = now_millis();
@@ -156,9 +196,12 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<CapabilityStatusDt
         period_start_millis: Some(since),
         spent_tokens: Some(spent),
         tiers,
-        media_granted,
+        media_granted: flags.media_granted,
         media_in_build: cfg!(feature = "media"),
         media_credential_configured: media_credential_configured(),
+        composio_granted: flags.composio_granted,
+        composio_in_build: cfg!(feature = "composio"),
+        composio_token_configured: flags.composio_token_configured,
     })
 }
 
@@ -283,6 +326,39 @@ mod tests {
         assert_eq!(
             dto2["mediaGranted"], false,
             "the `*` wildcard must not grant the real-money media family: {dto2}"
+        );
+        std::fs::remove_dir_all(&home_b).ok();
+    }
+
+    /// Per-tenant Composio (issue #110): the route surfaces `composioGranted`
+    /// from the explicit grant (never `*`) and the trio flags, even with no
+    /// `[plan]`.
+    #[tokio::test]
+    async fn reports_composio_flags_from_explicit_grant_only() {
+        let home_a = home();
+        let state = state_with_manifest(
+            &home_a,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"composio\"]\n",
+        )
+        .await;
+        let (status, dto) = get_capabilities(&state).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(dto["composioGranted"], true, "{dto}");
+        assert_eq!(dto["composioTokenConfigured"], false, "no token yet: {dto}");
+        assert!(dto.get("composioInBuild").is_some(), "{dto}");
+        std::fs::remove_dir_all(&home_a).ok();
+
+        // A `*` wildcard grant must NOT count as a composio grant.
+        let home_b = home();
+        let state2 = state_with_manifest(
+            &home_b,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"*\"]\n",
+        )
+        .await;
+        let (_, dto2) = get_capabilities(&state2).await;
+        assert_eq!(
+            dto2["composioGranted"], false,
+            "the `*` wildcard must not grant composio: {dto2}"
         );
         std::fs::remove_dir_all(&home_b).ok();
     }

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -1,0 +1,256 @@
+//! Per-tenant Composio connection management (issue #110, epic #26 Cell D): read
+//! the company's Composio status and set its write-only OAuth bearer token.
+//!
+//! The token is the entire tenant-isolation lever — the backend derives the
+//! Composio entity from it — so it is **write-only** over the API: set through
+//! the `token` field, stored in the secret store under
+//! [`TOKEN_KEY`](crate::company::composio::TOKEN_KEY), and **never** echoed. The
+//! read shape carries only a `tokenConfigured` boolean plus non-secret routing
+//! (backend URL, toolkit allowlist). A token set/rotate/clear takes effect on
+//! the agents' **next turn** with no restart (the harness re-resolves it each
+//! turn and rebuilds the roster when it changes).
+
+use axum::Json;
+use axum::Router;
+use axum::routing::{get, put};
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+use crate::company::composio::{backend_url_or_default, store_token, token_configured};
+use crate::company::runtime::CompanyRuntime;
+use crate::server::error::ApiError;
+use crate::server::ops::{ScopedCompany, scoped};
+
+/// The reminder attached to every mutating response.
+const SWITCH_NOTE: &str =
+    "Agents pick up the new Composio token on their next turn — no restart needed.";
+
+/// Builds the Composio management route fragment.
+pub fn router() -> Router<AppState> {
+    scoped("/composio", get(get_status)).merge(scoped("/composio/token", put(set_token)))
+}
+
+/// The company's Composio status as the console renders it. **Never** carries the
+/// token — only a non-secret `tokenConfigured` flag plus routing.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ComposioStatusDto {
+    /// Whether the `composio` feature is compiled into this build at all (the
+    /// tools only exist under it). `false` lets the console show a "not in this
+    /// build" state rather than implying a missing token.
+    in_build: bool,
+    /// Whether the company **explicitly** grants the `composio` namespace (a `*`
+    /// wildcard does NOT count).
+    granted: bool,
+    /// Whether a non-empty per-tenant token is stored — never the token itself.
+    token_configured: bool,
+    /// The effective Composio backend URL (env override or default). Non-secret.
+    backend_url: String,
+    /// The manifest toolkit allowlist (empty = defer to the backend allowlist).
+    toolkits: Vec<String>,
+}
+
+/// A mutating response: the resulting status plus the switch reminder.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MutationResponse {
+    status: ComposioStatusDto,
+    note: String,
+}
+
+/// Set-token body. `token` is write-only intake (never returned): a non-empty
+/// value rotates it, an explicit empty string clears it.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetToken {
+    token: String,
+}
+
+/// Resolves the Composio status DTO for a company.
+async fn effective_status(runtime: &CompanyRuntime) -> Result<ComposioStatusDto, ApiError> {
+    let record = runtime.store().load(runtime.id()).await.map_err(ApiError)?;
+    let (granted, toolkits) = match record {
+        Some(record) => (
+            crate::company::grants_composio_explicit(&record.manifest.tools.allow),
+            record.manifest.tools.composio.toolkits.clone(),
+        ),
+        None => (false, Vec::new()),
+    };
+    let configured = token_configured(runtime.id(), runtime.secrets().as_ref())
+        .await
+        .map_err(ApiError)?;
+    let env_url = {
+        use crate::app::config::EnvSource;
+        crate::app::config::ProcessEnv.get(crate::company::composio::COMPOSIO_BACKEND_URL_ENV)
+    };
+    Ok(ComposioStatusDto {
+        in_build: cfg!(feature = "composio"),
+        granted,
+        token_configured: configured,
+        backend_url: backend_url_or_default(env_url),
+        toolkits,
+    })
+}
+
+/// `GET …/composio` — the company's Composio status.
+async fn get_status(company: ScopedCompany) -> Result<Json<ComposioStatusDto>, ApiError> {
+    Ok(Json(effective_status(company.runtime.as_ref()).await?))
+}
+
+/// `PUT …/composio/token` — set / rotate / clear the write-only per-tenant token.
+async fn set_token(
+    company: ScopedCompany,
+    Json(body): Json<SetToken>,
+) -> Result<Json<MutationResponse>, ApiError> {
+    let runtime = company.runtime.as_ref();
+    store_token(runtime.id(), runtime.secrets().as_ref(), &body.token)
+        .await
+        .map_err(ApiError)?;
+    Ok(Json(MutationResponse {
+        status: effective_status(runtime).await?,
+        note: SWITCH_NOTE.to_string(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+
+    use crate::company::CompanyManifest;
+    use crate::ports::types::{CompanyId, CompanyRecord};
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+    use crate::store::FsCompanyStore;
+    use crate::{AppConfig, AppState};
+
+    const TOKEN: &str = "composio-tenant-bearer-SECRET-xyz";
+
+    fn home() -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("oc-composio-{}", crate::ports::generate_id()))
+    }
+
+    async fn state_with_manifest(home: &std::path::Path, manifest_toml: &str) -> AppState {
+        use crate::ports::CompanyStore;
+        let manifest: CompanyManifest = toml::from_str(manifest_toml).unwrap();
+        let store = FsCompanyStore::new(home.to_path_buf());
+        let id = CompanyId::new("acme");
+        store
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        state
+    }
+
+    async fn send(
+        state: &AppState,
+        method: &str,
+        uri: &str,
+        body: Option<Value>,
+    ) -> (StatusCode, Value, String) {
+        let request = Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("cookie", crate::server::test_support::fixed_cookie("acme"));
+        let request = match body {
+            Some(body) => request
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+            None => request.body(Body::empty()).unwrap(),
+        };
+        let response = router(state.clone()).oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let raw = String::from_utf8_lossy(&bytes).to_string();
+        let value = if bytes.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+        };
+        (status, value, raw)
+    }
+
+    #[tokio::test]
+    async fn status_reports_grant_and_toolkits_then_token_round_trips_write_only() {
+        let home = home();
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"composio\"]\n[tools.composio]\ntoolkits = [\"gmail\", \"github\"]\n",
+        )
+        .await;
+
+        // Initial status: granted, toolkits surfaced, no token yet.
+        let (status, dto, _) = send(&state, "GET", "/api/v1/company/composio", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(dto["granted"], true);
+        assert_eq!(dto["tokenConfigured"], false);
+        assert_eq!(dto["toolkits"], json!(["gmail", "github"]));
+        assert!(dto.get("backendUrl").is_some());
+        assert!(
+            dto.get("token").is_none(),
+            "status must never carry a token"
+        );
+
+        // Set the write-only token.
+        let (status, resp, raw) = send(
+            &state,
+            "PUT",
+            "/api/v1/company/composio/token",
+            Some(json!({ "token": TOKEN })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_eq!(resp["status"]["tokenConfigured"], true);
+        assert!(!raw.contains(TOKEN), "PUT response leaked the token: {raw}");
+
+        // GET reflects it and still never carries the token.
+        let (_, dto, raw) = send(&state, "GET", "/api/v1/company/composio", None).await;
+        assert_eq!(dto["tokenConfigured"], true);
+        assert!(!raw.contains(TOKEN), "GET status leaked the token: {raw}");
+
+        // Clearing with "" removes it.
+        let (_, resp, _) = send(
+            &state,
+            "PUT",
+            "/api/v1/company/composio/token",
+            Some(json!({ "token": "" })),
+        )
+        .await;
+        assert_eq!(resp["status"]["tokenConfigured"], false);
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// A `*` wildcard grant must NOT count as a composio grant on the status
+    /// route (mirrors the harness build gate).
+    #[tokio::test]
+    async fn wildcard_grant_does_not_count_as_composio() {
+        let home = home();
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"*\"]\n",
+        )
+        .await;
+        let (_, dto, _) = send(&state, "GET", "/api/v1/company/composio", None).await;
+        assert_eq!(dto["granted"], false, "{dto}");
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod capabilities;
 pub mod channels;
+pub mod composio;
 pub mod domain;
 pub mod inbox;
 pub mod inference;
@@ -138,6 +139,7 @@ pub fn router() -> Router<AppState> {
     let router = Router::new()
         .merge(capabilities::router())
         .merge(channels::router())
+        .merge(composio::router())
         .merge(domain::router())
         .merge(smtp::router())
         .merge(inbox::router())

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -163,6 +163,8 @@ description = "Runs Acme."
             workflow_source_dir: None,
             plan: None,
             media: None,
+            composio: None,
+            steer: crate::company::steer::InflightRegistry::default(),
         }
     }
 


### PR DESCRIPTION
## Summary

Epic #26 Cell D — per-tenant Composio tools (Gmail / Slack / GitHub) for company agents, mirroring the merged media (#109) + capability-gate (#108) patterns.

Company agents can now list Composio toolkits/connections/actions, begin OAuth handoffs, and run actions — all under strict per-tenant isolation, an opt-in `composio` grant, and operator approval for the effectful tools.

**Security model.** In OpenHuman's backend mode no Composio call carries an `entity_id`; the backend derives the Composio entity from the bearer JWT. So the **only** isolation lever is *which token the client is constructed with*, and that construction is **server-side only**:
- The per-tenant token is resolved from the company secret store (`composio/token`). It has **no env/platform-key fallback** — a missing/empty token yields `None` and **no tools are wired** (fail closed), never a borrowed identity.
- The token is **write-only**: scrubbed out of every `ToolResult` (success and error), every trace line, the `Debug` impl, and every console GET/PUT response. `Debug` redaction + the known-secret scrub vector are wired.
- `composio` is opt-in **by name** (never via the `*` wildcard). `composio_authorize` / `composio_execute` park under Supervised and deny under Readonly; Full-mode autonomy is the tenant's explicit choice.
- The toolkit allowlist (`[tools.composio] toolkits`) narrows client-side **before** any network call (empty = defer to the backend's server-enforced allowlist).

**Isolation caveat (cannot be enforced client-side).** Two companies that paste the *same* Composio token share one Composio entity. This is inherent to token-derived identity — provision **one backend token per company**.

**Flagged risk.** The backend auth contract (JWT → entity) lives in the backend, not this repo, so it cannot be verified here (same class as #109). No fallback was invented; the wiring assumes the documented contract.

## API Or Behavior Changes

- Manifest: new `[tools.composio] toolkits = [...]` section; `composio` is a new gateable namespace and a new opt-in tool-grant.
- Plans: `composio` is granted by the `unlimited` tier only; other tiers deny it unless a manifest sets `token_budgets = { composio = N }`.
- Agent tools (feature `composio`): `composio_list_toolkits`, `composio_list_connections`, `composio_list_tools`, `composio_authorize`, `composio_execute`. No agent-side `delete_connection` (disconnect stays a console/backend concern).
- Console: `GET .../composio` (status) + `PUT .../composio/token` (write-only); `GET .../capabilities` gains the composio status trio. New Connections token card + Usage status row.

## Tests

Built with the full `--features openhuman,mcp,telegram,media,composio` union (CI never builds this combo — built locally).

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --features openhuman,mcp,telegram,media,composio` — 0 errors
- [x] `cargo build --all-targets --features openhuman,mcp,telegram,media,composio`
- [x] `cargo test --features openhuman,mcp,telegram,media,composio --lib` (composio + policy + metering + capabilities)
- [x] `npm run typecheck` + `npm run build` (frontend)

Headline **tenant-isolation** test: two `TenantComposio` (A/B) over a mock backend recording `Authorization` per request — A's request carries only token-A, returns only A's account, never B's token/account. Plus: reflected-token-in-error-body scrub, fail-closed resolver (no env fallback even with a platform key present), Debug redaction, policy park/deny + Identity/Send effect groups, plan-tier grant/exhaustion, and the console write-only round-trip asserting the token never appears in any response.

This PR also fixes two pre-existing breaks the union build surfaces (a duplicated `workflow_source_dir` field in the builder and a missing `SteerAction` import) — CI never exercises the full feature combo.

## Documentation

Inline module docs cover the isolation model, fail-closed resolution, and write-only token handling. No separate spec doc changed.

Closes #110


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-tenant Composio integration for Gmail, Slack, and GitHub tools.
  * Added Connections settings to configure, rotate, or clear Composio tokens securely.
  * Added capability status indicators showing availability, grants, token setup, and active state.
  * Added toolkit allowlists and approval controls for Composio actions.
* **Security**
  * Tokens are write-only, tenant-scoped, and redacted from tool output.
  * Composio access is disabled unless explicitly granted and configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->