### PR TITLE
fix: restore openhuman build (duplicate field + missing SteerAction import)

### DIFF
--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -66,7 +66,7 @@ use oh::inference::provider::Provider;
 use crate::company::Agent as ManifestAgent;
 use crate::company::Policy;
 use crate::company::mcp::McpServerDecl;
-use crate::company::steer::SteerControl;
+use crate::company::steer::{SteerAction, SteerControl};
 use crate::error::OpenCompanyError;
 use crate::harness::cost::{TurnUsage, record_turn_cost};
 use crate::harness::mcp_probe::McpFailureQueue;

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -881,11 +881,6 @@ impl RuntimeBuilder {
                                 // closed — `build_agent` wires no media tools even
                                 // for a company that grants `media`.
                                 media: self.media_backend.clone(),
-                                // #113 P2: the company source dir so a workflow's
-                                // `sub_workflow` node resolves a child by id from
-                                // `workflows/<id>.toml`. Same origin as the skills
-                                // source dir but a distinct seam.
-                                workflow_source_dir: self.seed_dir.clone(),
                                 steer,
                             };
                             let record = CompanyRecord {


### PR DESCRIPTION
## Summary

`main` currently **does not compile under the `openhuman` feature** — two breaks slipped in via the #119/#120 squash-merges. CI stayed green because the default CI build doesn't enable `openhuman` (the known full-feature CI gap), so nothing compiled the affected paths. This fixes both so the real app + any `openhuman` build works again.

1. **Duplicate struct field** — `src/runtime/builder.rs` set `workflow_source_dir: self.seed_dir.clone()` **twice** in the same `HarnessDeps { … }` initializer (identical field + comment, a union-merge artifact). That's a hard `E0062` "field specified more than once" error under any build that compiles the production runtime builder. Removed the duplicate.
2. **Missing import** — `src/harness/mod.rs:748` uses `SteerAction::Cancel` in the run loop, but the module imported only `SteerControl` (the sole `SteerAction` import lived inside a `#[cfg(test)]` fn). Added `SteerAction` to the module-level `use`.

## API Or Behavior Changes

None — build-only fix. No functional change.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --lib --features openhuman,mcp,telegram` — **compiles clean** (was E0062 + unresolved `SteerAction` before). Only the pre-existing vendored-openhuman warnings remain.

## Documentation

None needed. (Root cause is the documented full-feature CI gap — CI never builds the `openhuman` combo, so these slipped through.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling so canceled turns do not save unnecessary memory or context.

* **New Features**
  * Media-generation capabilities are now available when explicitly configured through the runtime.
  * Media generation is unavailable by default when no backend is configured, preventing unintended access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->