### PR TITLE
feat(chat): open a dashboard task card for actionable chat requests

### DIFF
--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -22,6 +22,7 @@ mod skill_file;
 // from the operator chat. Always compiled + openhuman-free so the operator
 // control plane can steer in any build and no agent tool can ever reach it.
 pub mod steer;
+pub mod task_intent;
 pub mod telegram;
 mod types;
 #[cfg(feature = "openhuman")]

--- a/src/company/task_intent.rs
+++ b/src/company/task_intent.rs
@@ -1,0 +1,445 @@
+//! Detect an **actionable request** in an operator chat message, so the chat
+//! handler can deterministically open a dashboard task card for it.
+//!
+//! OpenCompany's chat can already produce task cards — but only when the
+//! orchestrator model chooses to call its `spawn_task` tool, and the
+//! orchestrator brief biases toward just replying, so a "do this" ask often
+//! leaves no visible work item. This module adds the deterministic half: when an
+//! operator message is an actionable request ("build the landing page",
+//! "can you set up the newsletter"), [`detect_task_intent`] returns a cleaned
+//! task title and the handler opens a `backlog` card. The model's `spawn_task`
+//! stays available for sub-tasks it wants to open on top.
+//!
+//! Conservative and cheap by design (no model call): it fires on imperative
+//! requests and request-framed action asks, and stays silent on pure questions
+//! ("what's our revenue?"), greetings/acknowledgements ("hi", "thanks"), and
+//! neutral chatter — so the board fills with work, not small talk.
+
+/// Bare greeting / acknowledgement messages that must never open a card, matched
+/// against the whole message (punctuation stripped). Kept short and exact so a
+/// longer message that merely *starts* with "ok" ("ok now build the page")
+/// still qualifies.
+const GREETINGS: &[&str] = &[
+    "hi",
+    "hii",
+    "hey",
+    "hello",
+    "yo",
+    "sup",
+    "gm",
+    "good morning",
+    "good evening",
+    "thanks",
+    "thank you",
+    "ty",
+    "thx",
+    "cheers",
+    "ok",
+    "okay",
+    "k",
+    "kk",
+    "cool",
+    "nice",
+    "great",
+    "awesome",
+    "perfect",
+    "got it",
+    "gotcha",
+    "sounds good",
+    "sg",
+    "np",
+    "no problem",
+    "yes",
+    "yep",
+    "yeah",
+    "yup",
+    "no",
+    "nope",
+    "sure",
+    "done",
+    "lgtm",
+    "nvm",
+];
+
+/// Single-word imperative action verbs. A message whose first word is one of
+/// these is an instruction to act.
+const ACTION_VERBS: &[&str] = &[
+    "build",
+    "create",
+    "make",
+    "add",
+    "fix",
+    "find",
+    "get",
+    "write",
+    "draft",
+    "send",
+    "schedule",
+    "book",
+    "research",
+    "prepare",
+    "plan",
+    "generate",
+    "design",
+    "update",
+    "review",
+    "analyze",
+    "analyse",
+    "compile",
+    "organize",
+    "organise",
+    "launch",
+    "publish",
+    "post",
+    "email",
+    "message",
+    "call",
+    "contact",
+    "order",
+    "buy",
+    "hire",
+    "recruit",
+    "remove",
+    "delete",
+    "cancel",
+    "start",
+    "stop",
+    "implement",
+    "deploy",
+    "configure",
+    "install",
+    "download",
+    "upload",
+    "summarize",
+    "summarise",
+    "list",
+    "track",
+    "monitor",
+    "investigate",
+    "handle",
+    "fetch",
+    "gather",
+    "collect",
+    "arrange",
+    "coordinate",
+    "outreach",
+    "onboard",
+    "migrate",
+    "refactor",
+    "test",
+    "audit",
+    "estimate",
+    "calculate",
+    "translate",
+    "edit",
+    "improve",
+    "optimize",
+    "optimise",
+    "setup",
+];
+
+/// Multi-word imperative action phrases (checked as a prefix + trailing space).
+const ACTION_PHRASES: &[&str] = &[
+    "set up",
+    "look into",
+    "put together",
+    "work on",
+    "take care of",
+    "follow up",
+    "reach out",
+    "figure out",
+    "come up with",
+    "draw up",
+    "go through",
+    "sign up",
+    "spin up",
+    "kick off",
+    "roll out",
+    "keep an eye on",
+];
+
+/// Request-framing prefixes. On their own these are polite wrappers ("can you",
+/// "please"); combined with an action verb *anywhere* in the message they mark a
+/// request to act (so "can you build X" fires but "can you tell me the revenue"
+/// — no action verb — does not). Also stripped from the title.
+const REQUEST_FRAMES: &[&str] = &[
+    "can you ",
+    "could you ",
+    "would you ",
+    "will you ",
+    "please ",
+    "pls ",
+    "i need you to ",
+    "i want you to ",
+    "i'd like you to ",
+    "i would like you to ",
+    "we need you to ",
+    "we want you to ",
+    "i need to ",
+    "i want to ",
+    "we need to ",
+    "we want to ",
+    "i'd like to ",
+    "we'd like to ",
+    "let's ",
+    "lets ",
+    "go ahead and ",
+    "make sure to ",
+    "make sure you ",
+    "can we ",
+    "could we ",
+];
+
+/// Leading filler / acknowledgement / connective words that a real ask can open
+/// with ("ok now build …", "and also fix …"). Stripped before the actionability
+/// check and from the title, so the action verb underneath is seen. Kept
+/// conservative to avoid eating a genuine first word.
+const LEAD_INS: &[&str] = &[
+    "ok ",
+    "okay ",
+    "k ",
+    "now ",
+    "also ",
+    "then ",
+    "so ",
+    "alright ",
+    "and ",
+    "next ",
+    "plus ",
+    "hey ",
+    "hi ",
+    "yo ",
+    "sure ",
+    "actually ",
+];
+
+/// Max length of a generated task title.
+const TITLE_MAX: usize = 80;
+
+/// Returns a cleaned task title when `text` is an actionable request, else
+/// `None`. See the module docs for the intent.
+pub fn detect_task_intent(text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let lower = trimmed.to_lowercase();
+    // Whole-message greeting/ack check (strip trailing punctuation first).
+    let bare = lower.trim_end_matches(['.', '!', '?', ' ']).trim();
+    if GREETINGS.contains(&bare) {
+        return None;
+    }
+
+    // Strip leading filler ("ok now …", "and also …") so the ask underneath is
+    // judged on its own.
+    let core = strip_lead_ins(&lower);
+    if !is_actionable(core) {
+        return None;
+    }
+
+    Some(to_title(trimmed))
+}
+
+/// Remove stacked leading filler words from a lowercased message.
+fn strip_lead_ins(lower: &str) -> &str {
+    let mut s = lower.trim_start();
+    loop {
+        match LEAD_INS
+            .iter()
+            .find(|f| s.starts_with(**f))
+            .map(|f| f.len())
+        {
+            Some(len) => s = s[len..].trim_start(),
+            None => return s,
+        }
+    }
+}
+
+/// Whether the lowercased message is an actionable request.
+fn is_actionable(lower: &str) -> bool {
+    // A leading imperative verb/phrase is unambiguously an instruction.
+    if starts_with_action(lower) {
+        return true;
+    }
+    // A request frame counts only when it wraps an actual action verb, so a
+    // framed question ("can you tell me …") does not qualify.
+    if REQUEST_FRAMES.iter().any(|f| lower.starts_with(f)) && contains_action(lower) {
+        return true;
+    }
+    false
+}
+
+/// The message's first word (or a leading multi-word phrase) is an action verb.
+fn starts_with_action(lower: &str) -> bool {
+    if ACTION_PHRASES.iter().any(|p| starts_with_word(lower, p)) {
+        return true;
+    }
+    let first = lower.split_whitespace().next().unwrap_or("");
+    // Trim trailing punctuation on the first word ("build," / "fix:").
+    let first = first.trim_end_matches([',', ':', ';', '.', '!']);
+    ACTION_VERBS.contains(&first)
+}
+
+/// An action verb/phrase appears anywhere (used behind a request frame).
+fn contains_action(lower: &str) -> bool {
+    if ACTION_PHRASES.iter().any(|p| lower.contains(p)) {
+        return true;
+    }
+    lower
+        .split(|c: char| !c.is_alphanumeric())
+        .any(|word| ACTION_VERBS.contains(&word))
+}
+
+/// True when `lower` begins with `phrase` followed by a word boundary.
+fn starts_with_word(lower: &str, phrase: &str) -> bool {
+    lower == phrase
+        || lower
+            .strip_prefix(phrase)
+            .is_some_and(|rest| rest.starts_with(' '))
+}
+
+/// Build a task title: strip a leading request frame, drop trailing
+/// punctuation, upper-case the first letter, and bound the length.
+fn to_title(original: &str) -> String {
+    let mut s = original.trim();
+    // Strip stacked leading filler ("ok now …") and request-framing prefixes
+    // ("please can you …") for a clean imperative title.
+    loop {
+        let lower = s.to_lowercase();
+        let hit = LEAD_INS
+            .iter()
+            .chain(REQUEST_FRAMES.iter())
+            .find(|f| lower.starts_with(**f))
+            .map(|f| f.len());
+        match hit {
+            Some(len) => s = s[len..].trim_start(),
+            None => break,
+        }
+    }
+    let s = s.trim_end_matches(['?', '.', '!', ' ']).trim();
+    if s.is_empty() {
+        // A frame with no residual body ("please.") — fall back to the original.
+        return truncate(original.trim(), TITLE_MAX);
+    }
+    let capped = truncate(s, TITLE_MAX);
+    capitalize_first(&capped)
+}
+
+/// Upper-case the first character, leaving the rest untouched.
+fn capitalize_first(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+/// UTF-8-safe truncation to at most `max` chars, appending `…` when cut.
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leading_imperative_is_actionable() {
+        for msg in [
+            "Build the landing page",
+            "create a new email campaign",
+            "fix the checkout bug",
+            "find three suppliers for widgets",
+            "set up the weekly newsletter",
+            "look into why signups dropped",
+            "research competitors in the EU",
+        ] {
+            assert!(detect_task_intent(msg).is_some(), "should fire: {msg}");
+        }
+    }
+
+    #[test]
+    fn framed_request_with_action_verb_is_actionable() {
+        assert_eq!(
+            detect_task_intent("Can you build the landing page?").as_deref(),
+            Some("Build the landing page")
+        );
+        assert!(detect_task_intent("please set up the newsletter").is_some());
+        assert!(detect_task_intent("I need you to draft the pitch").is_some());
+        assert!(detect_task_intent("let's launch the beta").is_some());
+    }
+
+    #[test]
+    fn pure_questions_do_not_fire() {
+        for msg in [
+            "what's our revenue this month?",
+            "how many users signed up?",
+            "who is on the growth desk?",
+            "can you tell me the latest numbers?", // framed, but no action verb
+            "is the campaign live?",
+            "why did signups drop?",
+        ] {
+            assert!(detect_task_intent(msg).is_none(), "should not fire: {msg}");
+        }
+    }
+
+    #[test]
+    fn greetings_and_acks_do_not_fire() {
+        for msg in [
+            "hi",
+            "Hello!",
+            "hey",
+            "thanks",
+            "thank you",
+            "ok",
+            "okay",
+            "cool",
+            "got it",
+            "sounds good",
+            "perfect",
+            "yes",
+            "no",
+            "sure",
+            "done",
+        ] {
+            assert!(detect_task_intent(msg).is_none(), "should not fire: {msg}");
+        }
+    }
+
+    #[test]
+    fn title_strips_frame_caps_and_trims() {
+        assert_eq!(
+            detect_task_intent("please can you fix the login bug!").as_deref(),
+            Some("Fix the login bug")
+        );
+        assert_eq!(
+            detect_task_intent("go ahead and publish the blog post").as_deref(),
+            Some("Publish the blog post")
+        );
+    }
+
+    #[test]
+    fn title_is_bounded() {
+        let long = format!("build {}", "a very detailed feature ".repeat(20));
+        let title = detect_task_intent(&long).expect("actionable");
+        assert!(title.chars().count() <= TITLE_MAX + 1, "bounded: {title}");
+    }
+
+    #[test]
+    fn empty_and_whitespace_do_not_fire() {
+        assert!(detect_task_intent("").is_none());
+        assert!(detect_task_intent("   ").is_none());
+    }
+
+    #[test]
+    fn ack_prefix_then_request_still_fires() {
+        // "ok" as a whole message is an ack, but not as a prefix of a real ask.
+        assert!(detect_task_intent("ok now build the dashboard").is_some());
+    }
+}

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -514,6 +514,31 @@ async fn run_chat(
     } else {
         None
     };
+    // Deterministic task card: an actionable operator request ("build the
+    // landing page", "can you set up the newsletter") opens a `backlog` card so
+    // "do X" always leaves a visible work item on the dashboard — independent of
+    // whether the orchestrator model also calls `spawn_task` (it may open
+    // sub-tasks on top). Pure questions, greetings, and acknowledgements don't
+    // fire, so the board fills with work, not small talk. Best-effort: a card
+    // write failure must never sink the chat reply.
+    if let Some(title) = crate::company::task_intent::detect_task_intent(&message.text) {
+        // Keep the full message as the note only when the title was shortened
+        // from it, so a one-line ask doesn't duplicate itself.
+        let note =
+            (title.trim_end_matches('…') != message.text.trim()).then(|| message.text.clone());
+        let record = crate::ports::tasks::TaskRecord {
+            id: crate::ports::generate_id(),
+            title,
+            note,
+            column: "backlog".to_string(),
+            priority: "medium".to_string(),
+            assignee: String::new(),
+            updated_at_millis: crate::ports::now_millis(),
+        };
+        if let Err(err) = runtime.upsert_task(&record).await {
+            tracing::warn!(error = %err, "failed to open task card for chat request");
+        }
+    }
     let report = runtime
         .run_cycle(vec![CompanyEvent::OperatorMessage {
             text: message.text,
@@ -974,6 +999,53 @@ mod test {
         let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(value["responses"][0]["text"], "You said: hi");
         assert_eq!(value["responses"][0]["channel"], "operator");
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    /// An actionable operator chat opens exactly one `backlog` task card on the
+    /// dashboard (deterministic, independent of the brain's own `spawn_task`),
+    /// and a greeting opens none. Runs on the default echo brain, so it proves
+    /// the handler-level wiring, not model behaviour.
+    #[tokio::test]
+    async fn actionable_chat_opens_a_backlog_task_card() {
+        let home = home();
+        let state = state_with_company(&home, "running").await;
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+        let app = router(state);
+
+        let chat = |text: &str| {
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/company/chat")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .header("content-type", "application/json")
+                .body(Body::from(format!(
+                    r#"{{"text":{}}}"#,
+                    serde_json::json!(text)
+                )))
+                .unwrap()
+        };
+
+        // Actionable → one backlog card, titled from the ask.
+        let r = app
+            .clone()
+            .oneshot(chat("build the landing page"))
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+        let tasks = runtime.tasks().list(&id).await.unwrap();
+        assert_eq!(tasks.len(), 1, "an actionable ask opens one card");
+        assert_eq!(tasks[0].column, "backlog");
+        assert_eq!(tasks[0].priority, "medium");
+        assert_eq!(tasks[0].title, "Build the landing page");
+
+        // Greeting → no new card.
+        let r = app.oneshot(chat("thanks!")).await.unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+        let tasks = runtime.tasks().list(&id).await.unwrap();
+        assert_eq!(tasks.len(), 1, "a greeting must not open a card");
+
         tokio::fs::remove_dir_all(&home).await.ok();
     }
 


### PR DESCRIPTION
## Summary

Make the company (CEO) chat **open a dashboard task card for actionable requests**, so telling the company to "build the landing page" or "set up the newsletter" always leaves a visible work item on the board.

The plumbing already existed — the orchestrator's `spawn_task` tool creates a `backlog` card via the delegation queue — but it was **100% model-driven**, and the orchestrator brief biases toward just replying ("answer directly and concisely… delegate only when it genuinely helps"). So most "do X" chats produced a reply and no card.

This adds the deterministic half:

- **`detect_task_intent`** (`src/company/task_intent.rs`) — a conservative, no-model heuristic that recognises an actionable request: a leading imperative verb (`build`, `create`, `fix`, `set up`, `research`, …), or a request frame (`can you`, `please`, `I need you to`, `let's`, …) wrapping an action verb, tolerant of `ok now …` / `and also …` lead-ins. It returns a cleaned, bounded task title. It stays silent on pure questions ("what's our revenue?"), greetings, and acknowledgements ("hi", "thanks", "ok").
- **Wiring** in `run_chat` (`src/server/operator.rs`) — mirrors the existing feedback-intent hook: on an actionable message it upserts a `backlog` card (medium priority, title from the ask, full message kept as the note when it was shortened) before running the cycle. Best-effort — a card write failure is logged and never sinks the chat reply. The orchestrator's `spawn_task` stays available for sub-tasks it wants to open on top.

Scope decision (with the user): **actionable requests only** — questions and small talk deliberately do not open cards, to keep the board full of work rather than chatter.

## API Or Behavior Changes

- Behavior: an actionable operator chat message now deterministically opens one `backlog` task card (visible on the Tasks dashboard / `GET …/tasks`). Questions, greetings, and acknowledgements do not. No API shape changes — cards use the existing `TaskRecord` / `TaskStore` and the same route the manual "New task" button and `spawn_task` already write to.
- No change to the chat request/response contract.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` (default build — 679 pass, incl. 8 classifier unit tests + 1 handler integration test)

New tests:
- `task_intent` unit tests: leading imperative fires; framed request with an action verb fires; pure questions / greetings / empty do not; title strips frames + lead-ins, capitalises, and is length-bounded; `ok now build …` still fires.
- `actionable_chat_opens_a_backlog_task_card` (handler integration, echo brain): an actionable `POST /company/chat` opens exactly one `backlog` card titled from the ask; a greeting opens none.

Feature builds and tests entirely under the default features (no `openhuman` toolchain needed).

## Documentation

Module-level rustdoc on `src/company/task_intent.rs` explains the intent, the conservative-by-design stance, and how it complements the model's `spawn_task`. No user-facing doc surface changed.
