### PR TITLE
fix(orchestrator): query_company lists saved workflows + team roster

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -25,6 +25,18 @@ export interface WorkflowNode {
   summary?: string;
   /** The roster agent id — only present on `agent` nodes. */
   agent?: string;
+  /** Kind-specific configuration (a slug, URL, case labels, schema, …). */
+  config?: unknown;
+  /** How the engine handles an error on this node, when set. */
+  onError?: string;
+  /** The node's retry policy, when set. */
+  retry?: {
+    maxAttempts?: number;
+    backoffMs?: number;
+    backoff?: string;
+  };
+  /** Whether the node pauses for a human approval before proceeding. */
+  requiresApproval?: boolean;
 }
 
 /** A directed edge between two node ids, with an optional branch label. */

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -357,11 +357,16 @@ function NodeDetailPanel({
           </DetailField>
         )}
 
-        {!node.summary && !node.agent && !hasConfig && !node.onError && !node.retry && (
-          <p className="text-xs text-muted-foreground">
-            This node has no extra details beyond its kind and name.
-          </p>
-        )}
+        {!node.summary &&
+          !node.agent &&
+          !hasConfig &&
+          !node.onError &&
+          !node.retry &&
+          !node.requiresApproval && (
+            <p className="text-xs text-muted-foreground">
+              This node has no extra details beyond its kind and name.
+            </p>
+          )}
       </div>
     </div>
   );

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import {
   Background,
   BackgroundVariant,
@@ -20,6 +20,7 @@ import {
   listWorkflows,
   runWorkflow,
   type WorkflowGraph,
+  type WorkflowNode as WorkflowNodeModel,
   type WorkflowRunResult,
   type WorkflowSummary,
 } from "@/api/workflows";
@@ -69,6 +70,7 @@ export function WorkflowsView({
   const [result, setResult] = useState<WorkflowRunResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
   // Load the workflow list once, and auto-select the first entry.
   useEffect(() => {
@@ -106,6 +108,7 @@ export function WorkflowsView({
     let live = true;
     setLoadingGraph(true);
     setResult(null);
+    setSelectedNodeId(null);
     (async () => {
       try {
         const g = await getWorkflow(client, company, selectedId);
@@ -155,6 +158,18 @@ export function WorkflowsView({
   const { nodes, edges } = useMemo(() => (graph ? layout(graph) : { nodes: [], edges: [] }), [graph]);
 
   const selected = workflows.find((w) => w.id === selectedId) ?? null;
+
+  // The full node model (kind/name/summary/agent/config) for the clicked node,
+  // looked up from the loaded graph so the inspector shows fields the laid-out
+  // canvas node data doesn't carry (agent, config, …).
+  const selectedNode = useMemo(
+    () => graph?.nodes.find((n) => n.id === selectedNodeId) ?? null,
+    [graph, selectedNodeId],
+  );
+
+  const onNodeClick = useCallback((_: unknown, node: Node) => {
+    setSelectedNodeId(node.id);
+  }, []);
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
@@ -222,22 +237,29 @@ export function WorkflowsView({
             </Button>
           </div>
         ) : (
-          <ReactFlow
-            nodes={nodes}
-            edges={edges}
-            nodeTypes={NODE_TYPES}
-            colorMode={resolvedTheme === "dark" ? "dark" : "light"}
-            fitView
-            fitViewOptions={{ padding: 0.2 }}
-            nodesDraggable={false}
-            nodesConnectable={false}
-            elementsSelectable
-            proOptions={{ hideAttribution: true }}
-          >
-            <Background variant={BackgroundVariant.Dots} gap={20} size={1} />
-            <Controls showInteractive={false} />
-            <MiniMap pannable zoomable className="!hidden sm:!block" />
-          </ReactFlow>
+          <>
+            <ReactFlow
+              nodes={nodes}
+              edges={edges}
+              nodeTypes={NODE_TYPES}
+              colorMode={resolvedTheme === "dark" ? "dark" : "light"}
+              fitView
+              fitViewOptions={{ padding: 0.2 }}
+              nodesDraggable={false}
+              nodesConnectable={false}
+              elementsSelectable
+              onNodeClick={onNodeClick}
+              onPaneClick={() => setSelectedNodeId(null)}
+              proOptions={{ hideAttribution: true }}
+            >
+              <Background variant={BackgroundVariant.Dots} gap={20} size={1} />
+              <Controls showInteractive={false} />
+              <MiniMap pannable zoomable className="!hidden sm:!block" />
+            </ReactFlow>
+            {selectedNode && (
+              <NodeDetailPanel node={selectedNode} onClose={() => setSelectedNodeId(null)} />
+            )}
+          </>
         )}
       </div>
 
@@ -252,6 +274,105 @@ export function WorkflowsView({
         onOpenChange={setCreateOpen}
         onCreated={handleCreated}
       />
+    </div>
+  );
+}
+
+/** A read-only inspector for a single graph node, overlaid on the canvas when
+ * the operator clicks a node. Surfaces the fields already on the wire from
+ * `GET …/workflows/{wid}`: kind, name, summary, the assigned agent (agent
+ * nodes), and any kind-specific config / error-handling policy. */
+function NodeDetailPanel({
+  node,
+  onClose,
+}: {
+  node: WorkflowNodeModel;
+  onClose: () => void;
+}) {
+  const meta = nodeKindMeta(node.kind);
+  const hasConfig =
+    node.config !== undefined && node.config !== null &&
+    !(typeof node.config === "object" && Object.keys(node.config as object).length === 0);
+
+  return (
+    <div className="absolute right-3 top-3 bottom-3 z-10 flex w-72 flex-col overflow-hidden rounded-xl border bg-card/95 shadow-lg backdrop-blur sm:w-80">
+      <div className="flex items-start justify-between gap-2 border-b px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="text-base leading-none" aria-hidden>
+            {meta.emoji}
+          </span>
+          <div className="min-w-0">
+            <div className="truncate text-sm font-semibold">{node.name}</div>
+            <div className="truncate text-[11px] text-muted-foreground">{node.id}</div>
+          </div>
+        </div>
+        <Button variant="ghost" size="sm" className="-mr-1 h-7 px-2" onClick={onClose}>
+          Close
+        </Button>
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-3 overflow-auto px-3 py-3 text-sm">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Badge variant="outline" className="font-normal">
+            {node.kind}
+          </Badge>
+          {node.requiresApproval && (
+            <Badge variant="outline" className="border-amber-500/40 bg-amber-500/10 font-normal">
+              requires approval
+            </Badge>
+          )}
+        </div>
+
+        {node.summary && (
+          <DetailField label="Summary">
+            <p className="text-sm leading-snug">{node.summary}</p>
+          </DetailField>
+        )}
+
+        {node.agent && (
+          <DetailField label="Assigned agent">
+            <p className="font-mono text-xs">{node.agent}</p>
+          </DetailField>
+        )}
+
+        {hasConfig && (
+          <DetailField label="Config">
+            <pre className="overflow-auto rounded-lg border bg-muted/40 p-2 font-mono text-[11px] leading-snug">
+              {JSON.stringify(node.config, null, 2)}
+            </pre>
+          </DetailField>
+        )}
+
+        {node.onError && (
+          <DetailField label="On error">
+            <p className="font-mono text-xs">{node.onError}</p>
+          </DetailField>
+        )}
+
+        {node.retry && (
+          <DetailField label="Retry">
+            <pre className="overflow-auto rounded-lg border bg-muted/40 p-2 font-mono text-[11px] leading-snug">
+              {JSON.stringify(node.retry, null, 2)}
+            </pre>
+          </DetailField>
+        )}
+
+        {!node.summary && !node.agent && !hasConfig && !node.onError && !node.retry && (
+          <p className="text-xs text-muted-foreground">
+            This node has no extra details beyond its kind and name.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** A labelled block inside the node inspector. */
+function DetailField({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <p className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</p>
+      {children}
     </div>
   );
 }

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -44,7 +44,7 @@ pub use types::{
 };
 pub use workflow_file::{
     WORKFLOW_NODE_KINDS, WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef, WorkflowNodeKind,
-    WorkflowRetryDef, load_company_workflows, parse_workflow,
+    WorkflowRetryDef, list_source_workflows, load_company_workflows, parse_workflow,
 };
 // Crate-internal only: the workflow creator (issue #69) builds a `RawWorkflow`
 // from its request body, renders it to TOML, and re-parses it through

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -337,6 +337,43 @@ pub fn load_company_workflows(dir: &Path, enabled: &[String]) -> Result<Vec<Work
     Ok(out)
 }
 
+/// Scans a company's `workflows/` directory and loads every `*.toml` graph it
+/// finds, in stable id order.
+///
+/// The single on-disk enumeration both the REST `list_workflows` route and the
+/// orchestrator's `query_company` surface read, so the console picker and the
+/// agent can never disagree about which workflows a company has saved. `None`
+/// (platform-provisioned mode) or a missing `workflows/` directory yields an
+/// empty vec. A malformed `workflows/<id>.toml` skips only itself (logged) so
+/// one bad file never hides the rest.
+pub fn list_source_workflows(source_dir: Option<&Path>) -> Vec<WorkflowFile> {
+    let Some(source_dir) = source_dir else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(source_dir.join("workflows")) else {
+        return Vec::new();
+    };
+    let mut ids: Vec<String> = entries
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("toml"))
+        .filter_map(|path| {
+            path.file_stem()
+                .and_then(|stem| stem.to_str())
+                .map(str::to_string)
+        })
+        .collect();
+    ids.sort();
+    let mut files = Vec::with_capacity(ids.len());
+    for id in &ids {
+        match load_company_workflows(source_dir, std::slice::from_ref(id)) {
+            Ok(loaded) => files.extend(loaded),
+            Err(err) => tracing::warn!(workflow = %id, error = %err, "skipping malformed workflow"),
+        }
+    }
+    files
+}
+
 /// Collects every validation problem in prosumer language. Empty means valid.
 fn validate(raw: &RawWorkflow) -> Vec<String> {
     let mut problems = Vec::new();

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -50,7 +50,7 @@ use oh::tools::traits::{PermissionLevel, Tool, ToolResult};
 
 use crate::company::{
     Agent as ManifestAgent, RawEdge, RawNode, RawWorkflow, WorkflowFile, create_company_workflow,
-    load_company_workflows,
+    list_source_workflows, load_company_workflows,
 };
 use crate::error::OpenCompanyError;
 use crate::ports::events::EventLog;
@@ -116,7 +116,10 @@ pub fn orchestrator_brief() -> String {
     " You are also this company's orchestrator: the single point of contact for the operator. \
 Answer from whole-company context, and when a request belongs to a specialist desk or should be \
 tracked as work, delegate instead of guessing. Use `query_company` to ground answers in the \
-company's durable facts and recent activity, `delegate_to_desk` to hand a turn to a desk's lead \
+company's durable facts, recent activity, saved workflows, and team roster — it is the source of \
+truth for what workflows exist and who is on the team, so consult it before answering \"what \
+workflows/teammates do we have?\" rather than guessing or naming a skill \
+— `delegate_to_desk` to hand a turn to a desk's lead \
 member, `spawn_task` to open a tracked task card, `run_workflow` to execute one of the \
 company's saved workflows by id (for example to advance or finish a task that is waiting on a \
 workflow run) — you can run workflows yourself; never claim the run_workflow tool is unavailable — \
@@ -208,20 +211,32 @@ pub struct QueryCompanyTool {
     company: CompanyId,
     facts: Option<Arc<dyn FactStore>>,
     events: Option<Arc<dyn EventLog>>,
+    /// The company's source directory, so the tool can enumerate saved
+    /// `workflows/*.toml` graphs — the same on-disk list the REST picker reads.
+    /// `None` in platform-provisioned mode (nothing on disk to scan).
+    workflow_source_dir: Option<PathBuf>,
+    /// The company store, so the tool can read the persisted roster (manifest
+    /// agents + operator-added overlay teammates) and the manifest's enabled
+    /// workflow ids. `None` on builds with no store wired.
+    store: Option<Arc<dyn CompanyStore>>,
 }
 
 impl QueryCompanyTool {
-    /// Builds the tool over the company's read ports. Either handle may be
-    /// `None`; the tool reports whatever surface is wired.
+    /// Builds the tool over the company's read ports. Any handle may be `None`;
+    /// the tool reports whatever surface is wired.
     pub fn new(
         company: CompanyId,
         facts: Option<Arc<dyn FactStore>>,
         events: Option<Arc<dyn EventLog>>,
+        workflow_source_dir: Option<PathBuf>,
+        store: Option<Arc<dyn CompanyStore>>,
     ) -> Self {
         Self {
             company,
             facts,
             events,
+            workflow_source_dir,
+            store,
         }
     }
 }
@@ -233,7 +248,7 @@ impl Tool for QueryCompanyTool {
     }
 
     fn description(&self) -> &str {
-        "Read the company's durable facts and recent activity to ground an answer in whole-company context. Optionally pass a `query` to filter facts by a case-insensitive substring."
+        "Read the company's durable facts, recent activity, saved workflows, and team roster to ground an answer in whole-company context — use this to answer \"what workflows do we have?\" or \"who is on the team?\" instead of guessing. Optionally pass a `query` to filter facts by a case-insensitive substring."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -306,10 +321,76 @@ impl Tool for QueryCompanyTool {
             md.push('\n');
         }
 
+        // Load the persisted record once: it carries both the roster and the
+        // manifest's enabled workflow ids (the seed workflows that have no file
+        // under `workflows/`). `None`/error → those sections read empty rather
+        // than failing the whole surface.
+        let record = match &self.store {
+            Some(store) => store.load(&self.company).await.ok().flatten(),
+            None => None,
+        };
+
+        // Saved workflows: the on-disk `workflows/*.toml` graphs (what
+        // `create_workflow` writes and the REST picker lists), unioned with the
+        // manifest's enabled ids so seed workflows show too. This is the section
+        // that makes "what workflows do we have?" answerable — before it, the
+        // orchestrator had no way to enumerate saved workflows and would fall
+        // back to its skills catalog.
+        let mut workflows: Vec<(String, String)> =
+            list_source_workflows(self.workflow_source_dir.as_deref())
+                .into_iter()
+                .map(|f| (f.id, f.name))
+                .collect();
+        let mut seen: std::collections::HashSet<String> =
+            workflows.iter().map(|(id, _)| id.clone()).collect();
+        if let Some(record) = &record {
+            for id in &record.manifest.workflows.enabled {
+                if seen.insert(id.clone()) {
+                    workflows.push((id.clone(), id.clone()));
+                }
+            }
+        }
+        workflows.sort_by(|a, b| a.0.cmp(&b.0));
+        md.push_str("\n## Saved workflows\n");
+        if workflows.is_empty() {
+            md.push_str("_No saved workflows. Author one with `create_workflow`._\n");
+        } else {
+            for (id, name) in &workflows {
+                md.push_str(&format!(
+                    "- **{}** (`{}`) — run with `run_workflow`\n",
+                    name.trim(),
+                    id
+                ));
+            }
+        }
+
+        // Team roster: manifest agents plus operator-added overlay teammates
+        // (the ones `add_agent` persists), so a freshly added teammate is
+        // visible on the next query instead of looking unpersisted.
+        let mut roster: Vec<(String, String)> = Vec::new();
+        if let Some(record) = &record {
+            for agent in &record.manifest.agents {
+                roster.push((agent.id.clone(), agent.role.clone()));
+            }
+            for overlay in &record.overlay_agents {
+                roster.push((overlay.id.clone(), overlay.role.clone()));
+            }
+        }
+        md.push_str("\n## Team\n");
+        if roster.is_empty() {
+            md.push_str("_Roster unavailable._\n");
+        } else {
+            for (id, role) in &roster {
+                md.push_str(&format!("- **{}** — {}\n", id, role.trim()));
+            }
+        }
+
         Ok(ToolResult::success_with_markdown(
             json!({
                 "facts": facts.len(),
                 "recent_events": recent.len(),
+                "workflows": workflows.len(),
+                "team": roster.len(),
             }),
             md,
         ))
@@ -652,6 +733,8 @@ pub fn orchestrator_tools(
         company.clone(),
         facts,
         events.clone(),
+        workflow_source_dir.clone(),
+        Some(store.clone()),
     ))];
     tools.extend(delegation_tools(queue));
     tools.push(Box::new(RunWorkflowTool::new(
@@ -1337,12 +1420,67 @@ mod tests {
 
     #[tokio::test]
     async fn query_company_tool_reports_no_data_when_unwired() {
-        let tool = QueryCompanyTool::new(CompanyId::new("acme"), None, None);
+        let tool = QueryCompanyTool::new(CompanyId::new("acme"), None, None, None, None);
         let result = tool.execute(json!({})).await.expect("execute");
         // The insight surface lives in the markdown; `output()` is the summary.
         let out = result.output_for_llm(true);
         assert!(out.contains("No durable facts recorded"), "{out}");
         assert!(out.contains("No recent activity"), "{out}");
+        assert!(out.contains("No saved workflows"), "{out}");
+    }
+
+    /// Regression: a saved workflow (on disk) and an operator-added overlay
+    /// teammate both show up in `query_company`. Before this the orchestrator
+    /// had no way to enumerate either, so a freshly created workflow / added
+    /// teammate looked unpersisted when the operator asked about it.
+    #[tokio::test]
+    async fn query_company_tool_lists_saved_workflows_and_roster() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("workflows")).unwrap();
+        std::fs::write(
+            dir.path().join("workflows").join("daily-standup.toml"),
+            r#"
+id = "daily-standup"
+name = "Daily Standup"
+description = "Morning summary."
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Morning"
+"#,
+        )
+        .unwrap();
+
+        // A record whose overlay adds a teammate — the `add_agent`
+        // persistence shape.
+        let mut record = seeded_record(&CompanyId::new("acme"));
+        record.overlay_agents.push(OverlayAgent {
+            id: "fact-fetcher".to_string(),
+            name: "Fact Fetcher".to_string(),
+            role: "Researcher".to_string(),
+            description: None,
+        });
+        let store: Arc<dyn CompanyStore> = Arc::new(MemStore::seeded(record));
+
+        let tool = QueryCompanyTool::new(
+            CompanyId::new("acme"),
+            None,
+            None,
+            Some(dir.path().to_path_buf()),
+            Some(store),
+        );
+        let out = tool
+            .execute(json!({}))
+            .await
+            .expect("execute")
+            .output_for_llm(true);
+
+        assert!(out.contains("Daily Standup"), "workflow missing: {out}");
+        assert!(out.contains("daily-standup"), "workflow id missing: {out}");
+        assert!(
+            out.contains("fact-fetcher"),
+            "overlay teammate missing: {out}"
+        );
     }
 
     // --- add_agent (issue #71) ----------------------------------------------

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -373,7 +373,7 @@ impl Tool for QueryCompanyTool {
                 roster.push((agent.id.clone(), agent.role.clone()));
             }
             for overlay in &record.overlay_agents {
-                roster.push((overlay.id.clone(), overlay.role.clone()));
+                roster.push((overlay.name.clone(), overlay.role.clone()));
             }
         }
         md.push_str("\n## Team\n");
@@ -1478,8 +1478,8 @@ name = "Morning"
         assert!(out.contains("Daily Standup"), "workflow missing: {out}");
         assert!(out.contains("daily-standup"), "workflow id missing: {out}");
         assert!(
-            out.contains("fact-fetcher"),
-            "overlay teammate missing: {out}"
+            out.contains("Fact Fetcher"),
+            "overlay teammate name missing: {out}"
         );
     }
 

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -50,7 +50,8 @@ use serde_json::Value;
 use crate::AppState;
 use crate::company::{
     RawEdge, RawNode, RawWorkflow, WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef,
-    WorkflowRetryDef, load_company_workflows, parse_workflow, render_workflow,
+    WorkflowRetryDef, list_source_workflows, load_company_workflows, parse_workflow,
+    render_workflow,
 };
 use crate::error::OpenCompanyError;
 use crate::server::error::ApiError;
@@ -207,7 +208,7 @@ impl From<WorkflowEdgeDef> for WorkflowEdge {
 /// console renders "no workflows yet" rather than a failure.
 async fn list_workflows(company: ScopedCompany) -> Result<Json<Vec<WorkflowSummary>>, ApiError> {
     let source_dir = company.runtime.source_dir();
-    let files = load_source_workflows(source_dir)?;
+    let files = list_source_workflows(source_dir);
     let mut seen: HashSet<String> = files.iter().map(|f| f.id.clone()).collect();
     let mut summaries: Vec<WorkflowSummary> =
         files.into_iter().map(WorkflowSummary::from).collect();
@@ -556,39 +557,6 @@ async fn create_workflow(
     Ok(Json(WorkflowGraph::from(file)))
 }
 
-/// Loads every saved workflow under `source_dir/workflows/`, or an empty list
-/// when there is no source directory or no `workflows/` directory.
-fn load_source_workflows(source_dir: Option<&FsPath>) -> Result<Vec<WorkflowFile>, ApiError> {
-    let Some(source_dir) = source_dir else {
-        return Ok(Vec::new());
-    };
-    let Ok(entries) = std::fs::read_dir(source_dir.join("workflows")) else {
-        return Ok(Vec::new());
-    };
-    let mut ids: Vec<String> = entries
-        .filter_map(|entry| entry.ok())
-        .map(|entry| entry.path())
-        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("toml"))
-        .filter_map(|path| {
-            path.file_stem()
-                .and_then(|stem| stem.to_str())
-                .map(str::to_string)
-        })
-        .collect();
-    // Stable, deterministic order for the picker.
-    ids.sort();
-    // Load each id on its own so one malformed `workflows/*.toml` skips only
-    // itself instead of 500-ing the whole picker.
-    let mut files = Vec::with_capacity(ids.len());
-    for id in &ids {
-        match load_company_workflows(source_dir, std::slice::from_ref(id)) {
-            Ok(loaded) => files.extend(loaded),
-            Err(err) => tracing::warn!(workflow = %id, error = %err, "skipping malformed workflow"),
-        }
-    }
-    Ok(files)
-}
-
 /// Whether `wid` is a single safe on-disk filename stem — no path separators,
 /// no `..`, not empty — so it can't escape the `workflows/` directory.
 fn safe_wid(wid: &str) -> bool {
@@ -708,7 +676,7 @@ mod tests {
     #[test]
     fn list_returns_a_summary_per_saved_workflow() {
         let dir = seed_demo();
-        let files = load_source_workflows(Some(dir.path())).expect("lists");
+        let files = list_source_workflows(Some(dir.path()));
         let summaries: Vec<WorkflowSummary> =
             files.into_iter().map(WorkflowSummary::from).collect();
         assert_eq!(summaries.len(), 1);
@@ -751,13 +719,13 @@ mod tests {
 
     #[test]
     fn no_source_dir_lists_empty() {
-        assert!(load_source_workflows(None).unwrap().is_empty());
+        assert!(list_source_workflows(None).is_empty());
     }
 
     #[test]
     fn no_workflows_dir_lists_empty() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(load_source_workflows(Some(dir.path())).unwrap().is_empty());
+        assert!(list_source_workflows(Some(dir.path())).is_empty());
     }
 
     #[test]
@@ -929,7 +897,7 @@ mod tests {
             "id = \"broken\"\nname = \n[[node]] oops",
         )
         .unwrap();
-        let files = load_source_workflows(Some(dir.path())).expect("lists despite a bad file");
+        let files = list_source_workflows(Some(dir.path()));
         let ids: Vec<_> = files.iter().map(|f| f.id.as_str()).collect();
         assert_eq!(ids, vec!["demo"]);
     }


### PR DESCRIPTION
## Summary

The company chat's orchestrator could not tell the operator which workflows or teammates the company had. `query_company` — its one grounding tool — surfaced only **Facts** and **Recent activity**, never the saved workflows or the roster. So when asked "what workflows do we have?", the orchestrator had nothing to enumerate and fell back to its skills catalog (reporting a *skill*, e.g. "Web Research"), which made a freshly-created workflow — or an `add_agent` overlay teammate — look like it hadn't persisted. It had: the graphs are on disk under `workflows/*.toml` (the REST picker lists them and they run), and overlay teammates are on the company record.

This is a visibility gap, not a persistence bug. The fix gives `query_company` two new read-only sections:

- **Saved workflows** — the on-disk `workflows/*.toml` graphs unioned with the manifest's `[workflows].enabled` ids (id + name, "run with `run_workflow`").
- **Team** — manifest agents plus operator-added overlay teammates.

To avoid introducing a *new* split source, the `workflows/` directory scan the REST `list_workflows` route used is factored into a shared `company::list_source_workflows`, and both the route and `query_company` now read it. The tool description and orchestrator brief are updated to point at `query_company` as the source of truth for "what workflows / teammates exist" so it stops guessing.

No change to any create/persist path — those already worked.

### Follow-on: clickable workflow nodes (console)

Same visibility theme, one layer up. In the Workflows canvas, clicking a graph node did nothing — nodes rendered *selectable* but `onNodeClick` was never wired, and no detail component existed. The data was already on the wire: `GET .../workflows/{wid}` serializes each node's `kind/name/summary/agent/config/onError/retry/requiresApproval`, they were just unconsumed. This adds a read-only `NodeDetailPanel` that opens on node click (dismiss on pane-click / Close) and surfaces those fields — so an operator can inspect what each step of a workflow does. Pure frontend; no backend change.

## API Or Behavior Changes

- `query_company` tool output gains **Saved workflows** and **Team** markdown sections, and its JSON summary gains `workflows` and `team` counts. Additive.
- New public helper `company::list_source_workflows(Option<&Path>) -> Vec<WorkflowFile>`; the REST `GET .../workflows` route now delegates to it (behavior unchanged).
- Console: clicking a workflow node now opens a read-only detail panel. The client `WorkflowNode` type is extended with the `config/onError/retry/requiresApproval` fields already present on the wire. No HTTP route, schema, or persistence change.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (no warnings in changed files; only pre-existing vendored)
- [x] `cargo build --all-targets` (`--features openhuman,mcp,telegram,media`)
- [x] `cargo test` (78 passed in the touched modules)
- [x] `npm run typecheck` (console — clean)
- [x] `npm run build` (console — built)

Added: `query_company_tool_lists_saved_workflows_and_roster` (a created workflow + an overlay teammate both surface); `query_company_tool_reports_no_data_when_unwired` extended to assert the empty-workflows line. The node-inspector change is UI-only, verified via typecheck + build (no backend contract touched).

## Documentation

No doc surface changed — the tool's own description carries the behavior. Module docs on `query_company` and the new `NodeDetailPanel` are updated inline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved workflow discovery and listing from saved workflow definitions, with stable ordering and safe handling of missing sources.
  * Expanded company query results to include saved workflows and the team roster, plus workflow and team counts.
  * Added a node inspector in the Workflows canvas (read-only details on selection), and extended workflow node fields to support config, error handling, retry policy, and approval requirements.
* **Bug Fixes**
  * Malformed workflow files no longer block other workflows from loading or appearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
