### PR TITLE
feat(connections): enable OAuth connect + connection-status list route

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,14 @@ bs58 = { version = "0.5", default-features = false, features = ["std"], optional
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"], optional = true }
 
 [features]
-default = []
+# `oauth` ships in the standard build: the connection write routes
+# (authorize-url + server-side token exchange) are a first-class console
+# surface, so a company can connect GitHub end-to-end without a custom feature
+# build. It only pulls in `reqwest`, which several already-shipped features
+# (`github`, `telegram`, `medulla`, …) also depend on, so the default build
+# gains no new heavy native dependency. The read-only status route
+# (`ops::connections_read`) is un-gated and available regardless.
+default = ["oauth"]
 tiny = ["tinyagents"]
 # WS4: embed `vendor/openhuman` (`openhuman_core`) directly as the tenant agent
 # harness via `AgentBuilder`. `src/harness/` compiles only under this feature;

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -49,6 +49,8 @@ import { DiscordIcon } from "@/components/discord-icon";
 import { useCompany } from "@/hooks/use-company";
 import { type AgentReplyEvent, useEvents } from "@/hooks/use-events";
 import { useHashView } from "@/hooks/use-hash-view";
+import { toast } from "sonner";
+
 import { type ChatMessage, fromHistory, makeMessage } from "@/lib/chat";
 import { DISCORD_INVITE_URL } from "@/lib/links";
 import { defaultThreads, threadsFromDesks } from "@/lib/threads";
@@ -194,6 +196,27 @@ export function AppShell({
   const feed = useCompany(client, company, initialStatus);
 
   const pending = feed.status.pending_approvals;
+
+  // OAuth connect bounce-back: the host's callback redirects the browser to
+  // `…/connections?connected={provider}` after storing the token. Land the
+  // operator on the Connections view, confirm with a toast, then strip the
+  // param so a refresh doesn't re-fire it. Runs once; StrictMode's double
+  // invoke is harmless because the first run clears the param the second reads.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const connected = params.get("connected");
+    if (!connected) return;
+    params.delete("connected");
+    const query = params.toString();
+    window.history.replaceState(
+      {},
+      "",
+      window.location.pathname + (query ? `?${query}` : "") + window.location.hash,
+    );
+    setView("connections");
+    toast.success(`Connected ${connected}.`);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Build the chat threads from the company's real desks (issue #53); keep the
   // static defaults when the host doesn't expose `/desks` (404) or defines none.

--- a/src/server/ops/connections_read.rs
+++ b/src/server/ops/connections_read.rs
@@ -161,11 +161,13 @@ mod tests {
             &home,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
              [[connection]]\nprovider = \"github\"\n\
-             [[connection]]\nprovider = \"slack\"\n",
+             [[connection]]\nprovider = \"slack\"\n\
+             [[connection]]\nprovider = \"gmail\"\n",
         )
         .await;
 
         // Store a GitHub token blob (github connected, with an account label);
+        // a Gmail token blob with NO account label (connected, account omitted);
         // slack stays untouched (not connected).
         let id = CompanyId::new("acme");
         let runtime = state.registry().get(&id).unwrap();
@@ -184,11 +186,25 @@ mod tests {
             )
             .await
             .unwrap();
+        runtime
+            .secrets()
+            .set(
+                &id,
+                "oauth/gmail",
+                SecretValue(
+                    serde_json::json!({
+                        "token": { "access_token": "ya29_secret_should_never_leak" }
+                    })
+                    .to_string(),
+                ),
+            )
+            .await
+            .unwrap();
 
         let (status, body) = get_connections(&state).await;
         assert_eq!(status, StatusCode::OK);
         let list = body.as_array().expect("array body");
-        assert_eq!(list.len(), 2, "one row per manifest connection: {body}");
+        assert_eq!(list.len(), 3, "one row per manifest connection: {body}");
 
         let github = list
             .iter()
@@ -207,9 +223,26 @@ mod tests {
             "no account when not connected: {slack}"
         );
 
+        // A connected provider whose stored blob carries no `account` label is
+        // still `connected: true`, and the `account` field is omitted entirely
+        // (never serialized as null) — the `skip_serializing_if` path.
+        let gmail = list
+            .iter()
+            .find(|c| c["provider"] == "gmail")
+            .expect("gmail row");
+        assert_eq!(gmail["connected"], true);
+        assert!(
+            gmail.get("account").is_none(),
+            "no account when the stored blob carries no label: {gmail}"
+        );
+
         // SECURITY: no token material may appear anywhere in the response.
         assert!(
             !body.to_string().contains("gho_secret_should_never_leak"),
+            "token material leaked into the connections response: {body}"
+        );
+        assert!(
+            !body.to_string().contains("ya29_secret_should_never_leak"),
             "token material leaked into the connections response: {body}"
         );
         assert!(

--- a/src/server/ops/connections_read.rs
+++ b/src/server/ops/connections_read.rs
@@ -1,0 +1,241 @@
+//! Read-only connection status (`GET …/connections`).
+//!
+//! Deliberately **un-gated**: connection *status* is readable even when the
+//! token-exchanging OAuth write routes ([`ops::connections`](super::connections),
+//! the `oauth` feature) are not compiled. Without this route the console's
+//! `GET …/connections` 404s and the page falls back to the read-only
+//! "connections unavailable" banner; with it the console renders real
+//! per-provider state and lights up the Connect buttons.
+//!
+//! Every field here is a **non-secret projection** — the provider id, a
+//! `connected` boolean, and an optional account label — mirroring the GraphQL
+//! `Company.connections` resolver
+//! ([`resolve_connections`](crate::server::graphql::connections::resolve_connections)).
+//! The stored OAuth token material never appears in the response or any log.
+
+use axum::Json;
+use axum::Router;
+use axum::routing::get;
+use serde::Serialize;
+
+use crate::AppState;
+use crate::company::runtime::CompanyRuntime;
+use crate::server::error::ApiError;
+use crate::server::ops::{ScopedCompany, scoped};
+
+/// One connection's non-secret status, matching the console `ConnectionState`
+/// wire type (`frontend/src/api/types.ts`): `{ provider, connected, account? }`.
+#[derive(Debug, Serialize)]
+struct ConnectionStateDto {
+    /// The provider id (e.g. `github`, `slack`, `gmail`).
+    provider: String,
+    /// Whether a non-empty OAuth token is stored for this provider.
+    connected: bool,
+    /// The connected account label, when known — never token material. Omitted
+    /// when not connected or when the stored blob carries no account.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    account: Option<String>,
+}
+
+/// Builds the connection-status route fragment (both scope forms).
+pub fn router() -> Router<AppState> {
+    scoped("/connections", get(list))
+}
+
+/// Projects each manifest connection into its non-secret status by reading the
+/// `oauth/{provider}` secret. Mirrors
+/// [`resolve_connections`](crate::server::graphql::connections::resolve_connections):
+/// only `provider` / `connected` / `account` ever leave this function — the
+/// token blob stays in the [`SecretStore`](crate::ports::SecretStore).
+async fn project(runtime: &CompanyRuntime) -> Result<Vec<ConnectionStateDto>, ApiError> {
+    let Some(record) = runtime.store().load(runtime.id()).await.map_err(ApiError)? else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::with_capacity(record.manifest.connections.len());
+    for connection in &record.manifest.connections {
+        let key = format!("oauth/{}", connection.provider);
+        let (connected, account) = match runtime
+            .secrets()
+            .get(runtime.id(), &key)
+            .await
+            .map_err(ApiError)?
+        {
+            Some(value) if !value.expose().trim().is_empty() => {
+                // Read only the `account` label out of the stored blob; the
+                // `token` field is intentionally never touched.
+                let account = serde_json::from_str::<serde_json::Value>(value.expose())
+                    .ok()
+                    .and_then(|json| {
+                        json.get("account")
+                            .and_then(|a| a.as_str())
+                            .map(str::to_string)
+                    });
+                (true, account)
+            }
+            _ => (false, None),
+        };
+        out.push(ConnectionStateDto {
+            provider: connection.provider.clone(),
+            connected,
+            account,
+        });
+    }
+    Ok(out)
+}
+
+/// `GET …/connections` — the company's non-secret connection status list.
+async fn list(company: ScopedCompany) -> Result<Json<Vec<ConnectionStateDto>>, ApiError> {
+    Ok(Json(project(company.runtime.as_ref()).await?))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use serde_json::Value;
+    use tower::ServiceExt;
+
+    use crate::company::CompanyManifest;
+    use crate::ports::types::{CompanyId, CompanyRecord, SecretValue};
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+    use crate::store::FsCompanyStore;
+    use crate::{AppConfig, AppState};
+
+    fn home() -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("oc-connections-{}", crate::ports::generate_id()))
+    }
+
+    async fn state_with_manifest(home: &std::path::Path, manifest_toml: &str) -> AppState {
+        use crate::ports::CompanyStore;
+        let manifest: CompanyManifest = toml::from_str(manifest_toml).unwrap();
+        let store = FsCompanyStore::new(home.to_path_buf());
+        let id = CompanyId::new("acme");
+        store
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        state
+    }
+
+    async fn get_connections(state: &AppState) -> (StatusCode, Value) {
+        let request = Request::builder()
+            .method("GET")
+            .uri("/api/v1/company/connections")
+            .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+            .body(Body::empty())
+            .unwrap();
+        let response = router(state.clone()).oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value = if bytes.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+        };
+        (status, value)
+    }
+
+    /// The list route projects a connected provider (token stored) and a
+    /// not-connected one (no token) side by side — the shape the console needs
+    /// to flip from "unavailable" to live buttons.
+    #[tokio::test]
+    async fn projects_connected_and_not_connected() {
+        let home = home();
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+             [[connection]]\nprovider = \"github\"\n\
+             [[connection]]\nprovider = \"slack\"\n",
+        )
+        .await;
+
+        // Store a GitHub token blob (github connected, with an account label);
+        // slack stays untouched (not connected).
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+        runtime
+            .secrets()
+            .set(
+                &id,
+                "oauth/github",
+                SecretValue(
+                    serde_json::json!({
+                        "token": { "access_token": "gho_secret_should_never_leak" },
+                        "account": "octocat"
+                    })
+                    .to_string(),
+                ),
+            )
+            .await
+            .unwrap();
+
+        let (status, body) = get_connections(&state).await;
+        assert_eq!(status, StatusCode::OK);
+        let list = body.as_array().expect("array body");
+        assert_eq!(list.len(), 2, "one row per manifest connection: {body}");
+
+        let github = list
+            .iter()
+            .find(|c| c["provider"] == "github")
+            .expect("github row");
+        assert_eq!(github["connected"], true);
+        assert_eq!(github["account"], "octocat");
+
+        let slack = list
+            .iter()
+            .find(|c| c["provider"] == "slack")
+            .expect("slack row");
+        assert_eq!(slack["connected"], false);
+        assert!(
+            slack.get("account").is_none(),
+            "no account when not connected: {slack}"
+        );
+
+        // SECURITY: no token material may appear anywhere in the response.
+        assert!(
+            !body.to_string().contains("gho_secret_should_never_leak"),
+            "token material leaked into the connections response: {body}"
+        );
+        assert!(
+            !body.to_string().contains("access_token"),
+            "token field leaked into the connections response: {body}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// A company with no `[[connection]]` entries returns an empty list (200),
+    /// not a 404 — so the console renders "ready" with an empty catalog rather
+    /// than the "unavailable" fallback.
+    #[tokio::test]
+    async fn empty_when_no_connections_declared() {
+        let home = home();
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n",
+        )
+        .await;
+
+        let (status, body) = get_connections(&state).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, serde_json::json!([]), "empty array: {body}");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -18,6 +18,7 @@
 pub mod capabilities;
 pub mod channels;
 pub mod composio;
+pub mod connections_read;
 pub mod domain;
 pub mod inbox;
 pub mod inference;
@@ -138,6 +139,7 @@ impl std::fmt::Debug for ConnectionsRuntime {
 pub fn router() -> Router<AppState> {
     let router = Router::new()
         .merge(capabilities::router())
+        .merge(connections_read::router())
         .merge(channels::router())
         .merge(composio::router())
         .merge(domain::router())


### PR DESCRIPTION
## Summary

The console **Connections** page showed a read-only "unavailable" banner — the operator could never actually connect a provider. Two grounded causes: the `oauth` feature was off in the default build (so the start/callback/disconnect routes 404'd), and there was **no REST list route**, so the console's `GET .../connections` 404'd → caught → `load="unavailable"`.

The OAuth machinery already existed (signed-state nonce, per-company token storage in the SecretStore under `oauth/{provider}`, and a GraphQL `resolve_connections` projection). This PR is Phase 1 — it turns the feature on and adds the missing read route so **GitHub connects end-to-end**.

- **Ship `oauth` in the default build** — `Cargo.toml` `default = ["oauth"]` (was `[]`). Only pulls `reqwest`, already resolved via other optional features → **zero new `Cargo.lock` entries**.
- **New un-gated list route** — `GET /api/v1/companies/{id}/connections` in a new always-compiled module `src/server/ops/connections_read.rs`. It projects `{provider, connected, account}` per manifest connection, reading the `oauth/{provider}` secret, mirroring the GraphQL `resolve_connections` logic. It lives *outside* the `#[cfg(feature="oauth")]`-gated `connections.rs` on purpose: connection **status** must be readable even when token-exchange isn't compiled — that's what flips the console off the "unavailable" banner. The write routes stay gated as before.
- **Console bounce-back toast** — landed in `app-shell.tsx` (not `ConnectionsView.tsx`): the console is hash-routed but the host callback redirects to the *pathname* `…/connections?connected={provider}`, which `ConnectionsView` never sees. The shell reads the param once on mount, routes to Connections, toasts, and strips it. `ConnectionsView` already flips `unavailable → ready` on its own once the list route returns 200.

### Host configuration (for GitHub connect — nothing committed)

Set on the host (never in code/logs): `OPENCOMPANY_OAUTH_GITHUB_ID`, `OPENCOMPANY_OAUTH_GITHUB_SECRET`, optional `OPENCOMPANY_OAUTH_GITHUB_SCOPES`; `OPENCOMPANY_OAUTH_REDIRECT_BASE` (register `{base}/api/v1/oauth/callback` as the GitHub App callback); `OPENCOMPANY_OAUTH_STATE_SECRET` (defaults to a weak constant — **must** set in prod); `OPENCOMPANY_CONSOLE_URL`. The company's `company.toml` must declare `[[connection]] provider = "github"`, else the provider isn't projected.

## API Or Behavior Changes

- **New route**: `GET /api/v1/companies/{id}/connections` (and the single-company alias) — un-gated, returns `[{provider, connected, account}]`. No token material in the response (asserted by test).
- **Build**: `oauth` feature now on by default; the OAuth start/callback/disconnect routes compile in the standard build.
- No schema change, no persistence change. The write path and token storage are unchanged from what already existed.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — **693 passed / 0 failed**, incl. 2 new `connections_read` tests (connected + not-connected projection, plus a **token-leak assertion** that the stored token never appears in the response body)
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run build`

## Documentation

Behavior is carried by the route + module docs inline. The host env recipe + `[[connection]]` manifest requirement are documented in the Summary above for operators enabling the flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Connections view that displays configured providers and their connection status.
  * OAuth support is now enabled by default.
  * Added a successful connection notification and automatic navigation to the Connections view after authorization.
  * Connection listings show provider names and account labels without exposing access tokens.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->