### PR TITLE
feat(usage): real Usage & Finances data over REST (drop sample rendering)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -28,7 +28,9 @@ import {
   type FeedbackInput,
   type FeedbackResponse,
   type FeedbackSummary,
+  type FinancesDto,
   type TeamMemberDto,
+  type UsageDto,
   type Verdict,
 } from "./types";
 
@@ -151,6 +153,26 @@ export class OpenCompanyClient {
    */
   capabilityStatus(company?: string | null): Promise<CapabilityStatusDto> {
     return this.request<CapabilityStatusDto>("GET", `${this.scope(company)}/capabilities`);
+  }
+
+  /**
+   * The company's usage read (Usage view): daily token series, tokens by desk,
+   * OAuth calls by provider, and window totals over a `7d` / `30d` / `90d`
+   * range. Token figures are real-or-zero — the offline build reports a
+   * zero-filled series until the harness cost hook meters spend.
+   */
+  usage(range?: string | null, company?: string | null): Promise<UsageDto> {
+    const qs = range ? `?range=${encodeURIComponent(range)}` : "";
+    return this.request<UsageDto>("GET", `${this.scope(company)}/usage${qs}`);
+  }
+
+  /**
+   * The company's finance read (Finances view): balance, budget vs spend,
+   * revenue, spend by category, and the transaction journal. Figures are
+   * real-or-zero — the offline build reports zeroes until the ledger fills.
+   */
+  finances(company?: string | null): Promise<FinancesDto> {
+    return this.request<FinancesDto>("GET", `${this.scope(company)}/finances`);
   }
 
   /**

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -324,6 +324,89 @@ export interface CapabilityStatusDto {
   composioTokenConfigured?: boolean;
 }
 
+/** One day's token totals in the usage series (`GET .../usage`). */
+export interface UsagePointDto {
+  /** ISO day, `YYYY-MM-DD`. */
+  date: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/** Tokens attributed to one teammate (desk) over the window. */
+export interface AgentTokensDto {
+  name: string;
+  tokens: number;
+}
+
+/** OAuth-connected calls counted for one provider over the window. */
+export interface ProviderCallsDto {
+  provider: string;
+  calls: number;
+}
+
+/** Rolled-up usage totals for the window. */
+export interface UsageTotalsDto {
+  inputTokens: number;
+  outputTokens: number;
+  tokens: number;
+  costUsd: number;
+  oauthCalls: number;
+  connections: number;
+}
+
+/**
+ * `GET .../usage?range=` — the company's usage read. A REST twin of the
+ * `Company.usage(range)` GraphQL surface. Token/cost figures populate on a
+ * harness build; the offline build reports a zero-filled series (that is the
+ * real value, not a stub). `byProvider` / `oauthCalls` stay empty/zero until the
+ * OAuth-call emit lands (Phase 2).
+ */
+export interface UsageDto {
+  /** Zero-filled daily token series over the range, oldest first. */
+  series: UsagePointDto[];
+  /** Tokens per teammate (desk), highest first. */
+  byAgent: AgentTokensDto[];
+  /** OAuth calls per provider, highest first (empty until Phase 2 emit). */
+  byProvider: ProviderCallsDto[];
+  totals: UsageTotalsDto;
+}
+
+/** Spend rolled up by prosumer category (`GET .../finances`). */
+export interface CategorySpendDto {
+  category: string;
+  amount: number;
+}
+
+/** One monetary ledger movement in the finance journal. */
+export interface TransactionDto {
+  id: string;
+  /** ISO day, `YYYY-MM-DD`. */
+  date: string;
+  description: string;
+  category: string;
+  /** Absolute USD magnitude; sign is carried by `direction`. */
+  amountUsd: number;
+  direction: "in" | "out";
+}
+
+/**
+ * `GET .../finances` — the company's finance read. A REST twin of the
+ * `Company.finances` GraphQL surface: the ledger + manifest `[budget]` folded
+ * into balance, budget vs spend, revenue, spend by category, and the journal.
+ * The ledger fills on a harness build; the offline build reports zeroes.
+ * `balanceUsd` is the bookkeeping net until the wallet balance is surfaced
+ * (Phase 2).
+ */
+export interface FinancesDto {
+  balanceUsd: number;
+  budgetUsd: number;
+  spentUsd: number;
+  revenueUsd: number;
+  netUsd: number;
+  byCategory: CategorySpendDto[];
+  transactions: TransactionDto[];
+}
+
 /** Error envelope shape: `{ error, code }`. */
 export interface ApiErrorBody {
   error: string;

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -450,7 +450,7 @@ export function AppShell({
                 </div>
               }
             >
-              <FinancesView />
+              <FinancesView client={client} company={company} />
             </Suspense>
           )}
           {view === "connections" && <ConnectionsView client={client} company={company} />}

--- a/frontend/src/views/FinancesView.tsx
+++ b/frontend/src/views/FinancesView.tsx
@@ -1,7 +1,9 @@
-import { useMemo } from "react";
+import { useEffect, useState } from "react";
 import { Bar, BarChart, LabelList, XAxis, YAxis } from "recharts";
 import { ArrowDownLeft, ArrowUpRight, Coins, PiggyBank, TrendingUp, Wallet } from "lucide-react";
 
+import type { OpenCompanyClient } from "@/api/client";
+import type { FinancesDto } from "@/api/types";
 import {
   Card,
   CardContent,
@@ -15,19 +17,52 @@ import {
   ChartTooltipContent,
   type ChartConfig,
 } from "@/components/ui/chart";
-import { buildFinance, usd } from "@/lib/finance-sample";
+import { usd } from "@/lib/finance-sample";
 import { cn } from "@/lib/utils";
 
 const chartConfig = {
   amount: { label: "Spend", theme: { light: "#2a78d6", dark: "#3987e5" } },
 } satisfies ChartConfig;
 
-const TODAY_MS = Date.now();
+interface Props {
+  client: OpenCompanyClient;
+  company: string | null;
+}
+
+// The empty finances read — shown before the first fetch resolves and as the
+// fallback when a host doesn't expose the surface yet (404). Real-or-zero: no
+// fabricated balance, budget, or transactions.
+const EMPTY_FINANCE: FinancesDto = {
+  balanceUsd: 0,
+  budgetUsd: 0,
+  spentUsd: 0,
+  revenueUsd: 0,
+  netUsd: 0,
+  byCategory: [],
+  transactions: [],
+};
 
 /** Company finances: balance, budget, revenue, spend by category, transactions. */
-export function FinancesView() {
-  const data = useMemo(() => buildFinance(TODAY_MS), []);
-  const budgetPct = Math.min(100, Math.round((data.spentUsd / data.budgetUsd) * 100));
+export function FinancesView({ client, company }: Props) {
+  const [data, setData] = useState<FinancesDto>(EMPTY_FINANCE);
+  useEffect(() => {
+    let alive = true;
+    client
+      .finances(company)
+      .then((finances) => {
+        if (alive) setData(finances);
+      })
+      // Hosts without the surface (older builds) 404 — show the empty state.
+      .catch(() => {
+        if (alive) setData(EMPTY_FINANCE);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [client, company]);
+  // Guard against an uncapped budget (0) so the bar reads 0%, not NaN.
+  const budgetPct =
+    data.budgetUsd > 0 ? Math.min(100, Math.round((data.spentUsd / data.budgetUsd) * 100)) : 0;
 
   return (
     <div className="flex-1 overflow-y-auto">

--- a/frontend/src/views/UsageView.tsx
+++ b/frontend/src/views/UsageView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Area,
   AreaChart,
@@ -12,7 +12,7 @@ import {
 import { Coins, CreditCard, Gauge, Plug, Zap } from "lucide-react";
 
 import type { OpenCompanyClient } from "@/api/client";
-import type { CapabilityStatusDto } from "@/api/types";
+import type { CapabilityStatusDto, UsageDto } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
 import {
   Card,
@@ -36,7 +36,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { buildUsage, compact, usd } from "@/lib/usage-sample";
+import { compact, usd } from "@/lib/usage-sample";
 import { cn } from "@/lib/utils";
 
 const RANGES: Record<string, number> = { "7d": 7, "30d": 30, "90d": 90 };
@@ -49,18 +49,41 @@ const chartConfig = {
   calls: { label: "Calls", theme: { light: "#1baf7a", dark: "#199e70" } },
 } satisfies ChartConfig;
 
-// A stable "today" so the seeded series don't shift between renders.
-const TODAY_MS = Date.now();
-
 interface Props {
   client: OpenCompanyClient;
   company: string | null;
 }
 
+// The empty usage read — shown before the first fetch resolves and as the
+// fallback when a host doesn't expose the surface yet (404). Real-or-zero: an
+// empty series renders flat rather than inventing numbers.
+const EMPTY_USAGE: UsageDto = {
+  series: [],
+  byAgent: [],
+  byProvider: [],
+  totals: { inputTokens: 0, outputTokens: 0, tokens: 0, costUsd: 0, oauthCalls: 0, connections: 0 },
+};
+
 /** In-depth usage: token burn over time, by agent, and OAuth calls by provider. */
 export function UsageView({ client, company }: Props) {
   const [range, setRange] = useState("30d");
-  const data = useMemo(() => buildUsage(RANGES[range], TODAY_MS), [range]);
+  const [data, setData] = useState<UsageDto>(EMPTY_USAGE);
+  useEffect(() => {
+    let alive = true;
+    client
+      .usage(range, company)
+      .then((usage) => {
+        if (alive) setData(usage);
+      })
+      // Hosts without the surface (older builds) 404 — show the empty state
+      // rather than fabricating a series.
+      .catch(() => {
+        if (alive) setData(EMPTY_USAGE);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [client, company, range]);
   const { totals } = data;
 
   // Capability budgets (issue #108) — the one live-wired card on this view.

--- a/src/server/ops/finances.rs
+++ b/src/server/ops/finances.rs
@@ -1,0 +1,220 @@
+//! REST finances read surface (Phase 1): `GET …/finances`.
+//!
+//! A REST twin of the `Company.finances` GraphQL resolver
+//! (`graphql/finances.rs`). The operator console is REST-only and ships no
+//! GraphQL client, so the Finances view could only render sample data; this
+//! exposes the same pure projection
+//! ([`finances_from`](crate::metering::finances_from)) — the ledger + the
+//! manifest `[budget]` folded into balance, budget-vs-spend, revenue, spend by
+//! category, and the transaction journal. No ledger writes: the ledger stays the
+//! single financial source of truth and this only reads it.
+//!
+//! Data maturity: the ledger fills on a harness (`openhuman`-feature) build via
+//! `src/harness/cost.rs` (an `inference.spend` line per billed turn); the
+//! offline build has no cost hook, so the journal is empty and every figure is
+//! (correctly) zero. The wallet balance is Phase 2: like the GraphQL resolver we
+//! pass `economy_balance = None`, so `balanceUsd` reads the bookkeeping net until
+//! the economy wallet balance is surfaced through a read accessor.
+
+use axum::Json;
+use axum::Router;
+use axum::routing::get;
+
+use crate::AppState;
+use crate::company::runtime::CompanyRuntime;
+use crate::metering::{Finances, finances_from};
+use crate::ports::now_millis;
+use crate::server::error::ApiError;
+use crate::server::ops::{ScopedCompany, scoped};
+
+/// Builds the finances read route fragment (both scope forms).
+pub fn router() -> Router<AppState> {
+    scoped("/finances", get(get_finances))
+}
+
+/// Loads the ledger + budget and projects a company's finances.
+///
+/// [`Finances`] is itself the camelCase DTO the console keys off (`balanceUsd`,
+/// `budgetUsd`, `spentUsd`, `revenueUsd`, `netUsd`, `byCategory`,
+/// `transactions`), so it serializes straight to the wire.
+async fn project_finances(runtime: &CompanyRuntime) -> Result<Finances, ApiError> {
+    let record = runtime.store().load(runtime.id()).await.map_err(ApiError)?;
+    let (ledger, budget) = match &record {
+        Some(record) => (record.ledger.clone(), record.manifest.budget.clone()),
+        None => (Vec::new(), crate::company::Budget::default()),
+    };
+    // The economy wallet balance is not yet surfaced through a read accessor
+    // (Phase 2); ledger-only projection mirrors `graphql/finances.rs`.
+    let economy_balance = None;
+    Ok(finances_from(
+        &ledger,
+        &budget,
+        economy_balance,
+        now_millis(),
+    ))
+}
+
+/// `GET …/finances` — the company's finance read surface.
+async fn get_finances(company: ScopedCompany) -> Result<Json<Finances>, ApiError> {
+    Ok(Json(project_finances(company.runtime.as_ref()).await?))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use serde_json::Value;
+    use tower::ServiceExt;
+
+    use crate::company::CompanyManifest;
+    use crate::ports::types::{CompanyId, CompanyRecord, LedgerEntry};
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+    use crate::store::FsCompanyStore;
+    use crate::{AppConfig, AppState};
+
+    fn home() -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("oc-finances-{}", crate::ports::generate_id()))
+    }
+
+    /// Builds a runtime under `manifest_toml`, then appends `ledger` through the
+    /// runtime's own store (post-build, so `RuntimeBuilder` can't clobber it —
+    /// the same append path the harness cost hook uses).
+    async fn state_with_ledger(
+        home: &std::path::Path,
+        manifest_toml: &str,
+        ledger: Vec<LedgerEntry>,
+    ) -> AppState {
+        use crate::ports::CompanyStore;
+        let manifest: CompanyManifest = toml::from_str(manifest_toml).unwrap();
+        let store = FsCompanyStore::new(home.to_path_buf());
+        let id = CompanyId::new("acme");
+        store
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        for entry in ledger {
+            runtime.store().append_ledger(&id, entry).await.unwrap();
+        }
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        state
+    }
+
+    async fn get_finances(state: &AppState) -> (StatusCode, Value) {
+        let request = Request::builder()
+            .method("GET")
+            .uri("/api/v1/company/finances")
+            .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+            .body(Body::empty())
+            .unwrap();
+        let response = router(state.clone()).oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value = if bytes.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+        };
+        (status, value)
+    }
+
+    /// An empty ledger projects an all-zero finances DTO, with the budget cap
+    /// still read from the manifest `[budget]`.
+    #[tokio::test]
+    async fn empty_ledger_projects_zeroes_with_budget() {
+        let home = home();
+        let state = state_with_ledger(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[budget]\nmonthly_usd = 2000.0\n",
+            Vec::new(),
+        )
+        .await;
+
+        let (status, dto) = get_finances(&state).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(dto["budgetUsd"], 2000.0, "{dto}");
+        assert_eq!(dto["spentUsd"], 0.0);
+        assert_eq!(dto["revenueUsd"], 0.0);
+        assert_eq!(dto["netUsd"], 0.0);
+        assert!(dto["byCategory"].as_array().unwrap().is_empty(), "{dto}");
+        assert!(dto["transactions"].as_array().unwrap().is_empty(), "{dto}");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// A ledger with a spend and a revenue entry this month projects the
+    /// expected budget / spend / revenue / net, by-category, and journal.
+    #[tokio::test]
+    async fn ledger_projects_spend_revenue_and_journal() {
+        let home = home();
+        // Timestamp entries "now" so they land in the current UTC month.
+        let now = crate::ports::now_millis();
+        let ledger = vec![
+            LedgerEntry {
+                at_millis: now,
+                kind: "inference.spend".to_string(),
+                amount_usd: -12.0,
+                memo: "ceo turn".to_string(),
+            },
+            LedgerEntry {
+                at_millis: now,
+                kind: "x402.in".to_string(),
+                amount_usd: 30.0,
+                memo: "a2a sale".to_string(),
+            },
+        ];
+        let state = state_with_ledger(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[budget]\nmonthly_usd = 2000.0\n",
+            ledger,
+        )
+        .await;
+
+        let (status, dto) = get_finances(&state).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(dto["budgetUsd"], 2000.0, "{dto}");
+        assert!(
+            (dto["spentUsd"].as_f64().unwrap() - 12.0).abs() < 1e-9,
+            "{dto}"
+        );
+        assert!(
+            (dto["revenueUsd"].as_f64().unwrap() - 30.0).abs() < 1e-9,
+            "{dto}"
+        );
+        assert!(
+            (dto["netUsd"].as_f64().unwrap() - 18.0).abs() < 1e-9,
+            "{dto}"
+        );
+
+        // Spend rolls up under the "Inference" category.
+        let by_category = dto["byCategory"].as_array().unwrap();
+        assert_eq!(by_category.len(), 1, "{dto}");
+        assert_eq!(by_category[0]["category"], "Inference");
+        assert!((by_category[0]["amount"].as_f64().unwrap() - 12.0).abs() < 1e-9);
+
+        // Both monetary entries are in the journal, newest first, directional.
+        let txns = dto["transactions"].as_array().unwrap();
+        assert_eq!(txns.len(), 2, "{dto}");
+        let dirs: Vec<&str> = txns
+            .iter()
+            .map(|t| t["direction"].as_str().unwrap())
+            .collect();
+        assert!(dirs.contains(&"in") && dirs.contains(&"out"), "{dto}");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -19,6 +19,7 @@ pub mod capabilities;
 pub mod channels;
 pub mod composio;
 pub mod domain;
+pub mod finances;
 pub mod inbox;
 pub mod inference;
 pub mod language;
@@ -142,6 +143,7 @@ pub fn router() -> Router<AppState> {
         .merge(channels::router())
         .merge(composio::router())
         .merge(domain::router())
+        .merge(finances::router())
         .merge(usage::router())
         .merge(smtp::router())
         .merge(inbox::router())

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -31,6 +31,7 @@ pub mod skills;
 pub mod smtp;
 pub mod tasks;
 pub mod team;
+pub mod usage;
 pub mod workflows;
 pub mod workspace;
 
@@ -141,6 +142,7 @@ pub fn router() -> Router<AppState> {
         .merge(channels::router())
         .merge(composio::router())
         .merge(domain::router())
+        .merge(usage::router())
         .merge(smtp::router())
         .merge(inbox::router())
         .merge(tasks::router())

--- a/src/server/ops/usage.rs
+++ b/src/server/ops/usage.rs
@@ -1,0 +1,279 @@
+//! REST usage read surface (Phase 1): `GET …/usage?range=…`.
+//!
+//! A REST twin of the `Company.usage(range)` GraphQL resolver
+//! (`graphql/usage.rs`). The operator console is REST-only and ships no GraphQL
+//! client, so the Usage view could only render sample data; this exposes the
+//! same pure projection ([`bucket_usage`](crate::metering::bucket_usage)) over
+//! the write-plane's dual-scope router. No new business logic — it queries the
+//! [`UsageMeter`](crate::ports::UsageMeter) for the window, resolves the roster
+//! display-name map, and buckets.
+//!
+//! Data maturity: token/cost samples only populate on a harness
+//! (`openhuman`-feature) build via `src/harness/cost.rs`. The offline build has
+//! no cost hook, so the meter is empty and the series is (correctly) zero-filled
+//! — that is the true value, not a stub. OAuth-call samples
+//! ([`SampleKind::OauthCall`](crate::ports::usage::SampleKind)) are not yet
+//! emitted anywhere, so `byProvider` / `oauthCalls` read zero until the Phase 2
+//! emit work lands.
+
+use axum::Json;
+use axum::Router;
+use axum::extract::Query;
+use axum::routing::get;
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+use crate::company::runtime::CompanyRuntime;
+use crate::metering::{
+    AgentTokens, ProviderCalls, Usage, UsagePoint, UsageRange, UsageTotals, bucket_usage,
+    roster_display_names,
+};
+use crate::ports::now_millis;
+use crate::server::error::ApiError;
+use crate::server::ops::{ScopedCompany, scoped};
+
+/// Milliseconds in a UTC day — the meter is queried `range.days()` of these back.
+const MILLIS_PER_DAY: u64 = 86_400_000;
+
+/// Builds the usage read route fragment (both scope forms).
+pub fn router() -> Router<AppState> {
+    scoped("/usage", get(get_usage))
+}
+
+/// The `?range=` selector. Accepts the console's `7d` / `30d` / `90d` keys (and
+/// the bare-number / `D7` forms); anything else falls back to the 30-day default,
+/// matching the GraphQL resolver's default window.
+#[derive(Debug, Deserialize)]
+struct UsageQuery {
+    range: Option<String>,
+}
+
+/// Parses a `?range=` value into a [`UsageRange`], defaulting to 30 days.
+fn parse_range(raw: Option<&str>) -> UsageRange {
+    match raw.map(|s| s.trim().to_ascii_lowercase()).as_deref() {
+        Some("7d" | "7" | "d7") => UsageRange::D7,
+        Some("90d" | "90" | "d90") => UsageRange::D90,
+        _ => UsageRange::D30,
+    }
+}
+
+/// The Usage read as the console renders it (camelCase). Wraps the pure
+/// [`Usage`] projection; the inner types already serialize camelCase, but
+/// [`Usage`] itself does not rename its fields, so this DTO carries the
+/// `byAgent` / `byProvider` casing the frontend keys off.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UsageDto {
+    /// Zero-filled daily token series over the range, oldest first.
+    series: Vec<UsagePoint>,
+    /// Tokens per teammate (desk), highest first.
+    by_agent: Vec<AgentTokens>,
+    /// OAuth calls per provider, highest first (empty until Phase 2 emit).
+    by_provider: Vec<ProviderCalls>,
+    /// Window totals.
+    totals: UsageTotals,
+}
+
+impl From<Usage> for UsageDto {
+    fn from(usage: Usage) -> Self {
+        Self {
+            series: usage.series,
+            by_agent: usage.by_agent,
+            by_provider: usage.by_provider,
+            totals: usage.totals,
+        }
+    }
+}
+
+/// Queries the meter and projects a company's usage for the window.
+async fn project_usage(runtime: &CompanyRuntime, range: UsageRange) -> Result<UsageDto, ApiError> {
+    let now = now_millis();
+    let since = now.saturating_sub(range.days().saturating_mul(MILLIS_PER_DAY));
+    let samples = runtime
+        .usage()
+        .query(runtime.id(), since)
+        .await
+        .map_err(ApiError)?;
+
+    let record = runtime.store().load(runtime.id()).await.map_err(ApiError)?;
+    let roster = record
+        .as_ref()
+        .map(|record| roster_display_names(&record.manifest.agents, &record.overlay_agents))
+        .unwrap_or_default();
+
+    Ok(bucket_usage(&samples, range, now, &roster).into())
+}
+
+/// `GET …/usage?range=` — the company's usage read for the window.
+async fn get_usage(
+    company: ScopedCompany,
+    Query(query): Query<UsageQuery>,
+) -> Result<Json<UsageDto>, ApiError> {
+    let range = parse_range(query.range.as_deref());
+    Ok(Json(project_usage(company.runtime.as_ref(), range).await?))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use serde_json::Value;
+    use tower::ServiceExt;
+
+    use crate::company::CompanyManifest;
+    use crate::ports::types::{CompanyId, CompanyRecord};
+    use crate::ports::usage::{SampleKind, UsageSample};
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+    use crate::store::FsCompanyStore;
+    use crate::{AppConfig, AppState};
+
+    fn home() -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("oc-usage-{}", crate::ports::generate_id()))
+    }
+
+    async fn state_with_manifest(home: &std::path::Path, manifest_toml: &str) -> AppState {
+        use crate::ports::CompanyStore;
+        let manifest: CompanyManifest = toml::from_str(manifest_toml).unwrap();
+        let store = FsCompanyStore::new(home.to_path_buf());
+        let id = CompanyId::new("acme");
+        store
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        state
+    }
+
+    async fn get_usage(state: &AppState, query: &str) -> (StatusCode, Value) {
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("/api/v1/company/usage{query}"))
+            .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+            .body(Body::empty())
+            .unwrap();
+        let response = router(state.clone()).oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value = if bytes.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+        };
+        (status, value)
+    }
+
+    /// An empty meter zero-fills the series to the range length and totals zero.
+    #[tokio::test]
+    async fn empty_meter_projects_a_zero_filled_series() {
+        let home = home();
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n",
+        )
+        .await;
+
+        let (status, dto) = get_usage(&state, "?range=7d").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(dto["series"].as_array().unwrap().len(), 7, "{dto}");
+        assert_eq!(dto["totals"]["tokens"], 0.0);
+        assert_eq!(dto["totals"]["connections"], 0);
+        assert!(dto["byAgent"].as_array().unwrap().is_empty(), "{dto}");
+        assert!(dto["byProvider"].as_array().unwrap().is_empty(), "{dto}");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// A couple of recorded samples project the expected DTO: totals sum, the
+    /// series carries the day's tokens, and `byAgent` resolves the roster role.
+    #[tokio::test]
+    async fn recorded_samples_project_totals_series_and_by_desk() {
+        let home = home();
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+             [[agent]]\nid = \"ceo\"\nrole = \"Chief Executive\"\n",
+        )
+        .await;
+
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+        let now = crate::ports::now_millis();
+        for (input, output) in [(100u64, 40u64), (20, 5)] {
+            runtime
+                .usage()
+                .record(
+                    &id,
+                    &UsageSample {
+                        at_millis: now,
+                        agent: "ceo".into(),
+                        provider: "managed".into(),
+                        input_tokens: input,
+                        output_tokens: output,
+                        cached_input_tokens: 0,
+                        cost_usd: 0.25,
+                        kind: SampleKind::Inference,
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        let (status, dto) = get_usage(&state, "?range=30d").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(dto["series"].as_array().unwrap().len(), 30, "{dto}");
+        assert_eq!(dto["totals"]["inputTokens"], 120.0, "{dto}");
+        assert_eq!(dto["totals"]["outputTokens"], 45.0, "{dto}");
+        assert_eq!(dto["totals"]["tokens"], 165.0, "{dto}");
+        assert!(
+            (dto["totals"]["costUsd"].as_f64().unwrap() - 0.5).abs() < 1e-9,
+            "{dto}"
+        );
+
+        // The most recent bucket (today) carries the whole burn.
+        let series = dto["series"].as_array().unwrap();
+        let today = series.last().unwrap();
+        assert_eq!(today["inputTokens"], 120.0, "{today}");
+        assert_eq!(today["outputTokens"], 45.0, "{today}");
+
+        // byAgent resolves the manifest role as the display name.
+        let by_agent = dto["byAgent"].as_array().unwrap();
+        assert_eq!(by_agent.len(), 1, "{dto}");
+        assert_eq!(by_agent[0]["name"], "Chief Executive");
+        assert_eq!(by_agent[0]["tokens"], 165.0);
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// An absent / unknown `?range=` defaults to the 30-day window.
+    #[tokio::test]
+    async fn range_defaults_to_thirty_days() {
+        let home = home();
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n",
+        )
+        .await;
+
+        let (_, dto) = get_usage(&state, "").await;
+        assert_eq!(dto["series"].as_array().unwrap().len(), 30, "{dto}");
+        let (_, dto_bad) = get_usage(&state, "?range=nonsense").await;
+        assert_eq!(dto_bad["series"].as_array().unwrap().len(), 30, "{dto_bad}");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+}


### PR DESCRIPTION
## Summary

The console **Usage** and **Finances** pages rendered hardcoded sample `.ts` data. The real projections already existed — but only over GraphQL (`Company.usage(range)`, `Company.finances`), while the console is 100% REST with no GraphQL client, so nothing was ever wired to them. This is Phase 1: expose those projections over REST and point the two views at live data. **No new business logic** — the projections in `src/metering/` (`bucket_usage`, `finances_from`) are reused as-is.

**Backend — REST twins of the existing resolvers:**
- `src/server/ops/usage.rs` (new) — `GET .../usage?range=` resolves the company via `ScopedCompany` (same pattern as `capabilities.rs`), queries the usage store, runs `bucket_usage(...)`, and serializes a camelCase `UsageDto` (series + tokens-by-desk + calls-by-provider + totals). `?range=` accepts `7d`/`30d`/`90d`, default 30d.
- `src/server/ops/finances.rs` (new) — `GET .../finances` loads `record.ledger` + manifest `[budget]` and runs `finances_from(...)`; the pure `Finances` struct already serializes to the frontend shape, so it *is* the DTO.
- Both registered via the existing dual-scope `scoped(...)` helper, auth-gated identically to `/capabilities`.

**Frontend — wired to fetch:**
- `frontend/src/api/types.ts` — `UsageDto` / `FinancesDto` (+ row types), field-for-field mirrors.
- `frontend/src/api/client.ts` — `client.usage(range, company)` / `client.finances(company)`.
- `UsageView.tsx` fetches instead of `buildUsage(...)`; `FinancesView.tsx` now takes `{client, company}` and fetches instead of `buildFinance(...)` (threaded from `app-shell.tsx`); both keep the existing recharts components (field names unchanged) and guard the empty/404 + budget-0 cases.
- Sample `.ts` kept intentionally as the empty-state shape + `usd`/`compact` helpers — their deletion is Phase 3.

## Data maturity (real values, not bugs — flagged honestly)

1. **Token/cost series** populate only on a harness (`openhuman`-feature) build via `src/harness/cost.rs`. The default/offline build has no cost hook, so the series is correctly **zero-filled** — real, not a stub.
2. **OAuth-call KPIs** (`byProvider`/`oauthCalls`) read zero because `SampleKind::OauthCall` is never emitted yet — emitting it is **Phase 2**.
3. **Wallet balance** shows the bookkeeping net (`economy_balance = None`, matching the GraphQL resolver); surfacing the real tiny.place balance is **Phase 2**.

All three show real-or-zero now; no invented numbers.

## API Or Behavior Changes

- **New routes**: `GET /api/v1/companies/{id}/usage?range=` and `GET /api/v1/companies/{id}/finances` (+ `/api/v1/company/...` aliases). Return camelCase `UsageDto` / `FinancesDto`.
- Usage & Finances console pages now render live per-company data instead of sample constants.
- No schema or persistence change.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — green, **5 new** REST handler tests (usage: series/by-desk/range projection; finances: ledger + budget projection)
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run build`

## Documentation

Route behavior documented inline on the two handlers. The Phase-2/3 follow-ons (OAuth-call sample emission, wallet-balance read, sample-file removal) are called out above.
