### PR TITLE
feat(console): new-user onboarding product tour

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "next-themes": "^0.4.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-joyride": "^3.2.0",
         "react-markdown": "^10.1.0",
         "recharts": "^3.8.0",
         "remark-gfm": "^4.0.1",
@@ -1093,6 +1094,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
@@ -1138,6 +1155,33 @@
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@gilbarbara/deep-equal": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.4.1.tgz",
+      "integrity": "sha512-QF2BGeQjsa59T59XvFdR3is5jrl28Eg0J6giXAC5919bcqvR8XP4B+07tpbs6Y6/IQd4FBncaL2WVXIBgSxt4w==",
+      "license": "MIT"
+    },
+    "node_modules/@gilbarbara/hooks": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/hooks/-/hooks-0.11.0.tgz",
+      "integrity": "sha512-CIVazdxqFRplUfm9wZL3/0X1TURJekhPMWGFdWzEmyJrGPiotX2yxA1KiB8N7VnhawIaMtb2Apnda4Y6DRwi2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.4.1"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19"
+      }
+    },
+    "node_modules/@gilbarbara/types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/types/-/types-0.2.2.tgz",
+      "integrity": "sha512-QuQDBRRcm1Q8AbSac2W1YElurOhprj3Iko/o+P1fJxUWS4rOGKMVli98OXS7uo4z+cKAif6a+L9bcZFSyauQpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.1.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -4281,6 +4325,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-2.0.0.tgz",
+      "integrity": "sha512-70f2BMIQlbSUXVKaZUd9a9fJH3IH1PDckV0m4BIIO4LjnNYvOh4Ng7vXIXEwpA0KDZknRq+7fHwGTu0jIdx28g==",
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6470,12 +6520,44 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-innertext": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
+      "integrity": "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": ">=0.0.0 <=99",
+        "react": ">=0.0.0 <=99"
+      }
+    },
     "node_modules/react-is": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
       "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-joyride": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-3.2.0.tgz",
+      "integrity": "sha512-UrA/XWdWElMLNnjZt2eWmPFmpHl1IZ2CeI9XhS+PuEVvfqHMD9U4tavCq1csDAGVoj0YEGfaCDmhZwgNc9yE2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/deepmerge": "^3.2.1",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@gilbarbara/deep-equal": "^0.4.1",
+        "@gilbarbara/hooks": "^0.11.0",
+        "@gilbarbara/types": "^0.2.2",
+        "is-lite": "^2.0.0",
+        "react-innertext": "^1.1.5",
+        "scroll": "^3.0.1",
+        "scrollparent": "^2.1.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19",
+        "react-dom": "16.8 - 19"
+      }
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -6844,6 +6926,18 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/scroll": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
+      "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==",
+      "license": "MIT"
+    },
+    "node_modules/scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==",
+      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -7398,6 +7492,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Wombosvideo"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "next-themes": "^0.4.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-joyride": "^3.2.0",
     "react-markdown": "^10.1.0",
     "recharts": "^3.8.0",
     "remark-gfm": "^4.0.1",

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -423,9 +423,8 @@ export function AppShell({
               <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
               <SidebarMenu>
                 {group.items.map((item) => (
-                  <SidebarMenuItem key={item.view}>
+                  <SidebarMenuItem key={item.view} data-tour={`nav-${item.view}`}>
                     <SidebarMenuButton
-                      data-tour={`nav-${item.view}`}
                       isActive={view === item.view}
                       tooltip={item.label}
                       onClick={() => setView(item.view)}
@@ -578,7 +577,7 @@ export function AppShell({
         onOpenChange={setFeedbackOpen}
       />
 
-      <TourController company={company} view={view} setView={setView} />
+      <TourController company={company} setView={setView} />
     </SidebarProvider>
   );
 }

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -43,6 +43,7 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { CompanySwitcher } from "@/components/company-switcher";
 import { FeedbackDialog } from "@/components/feedback-dialog";
+import { TourController } from "@/tour/TourController";
 import { StatusPill } from "@/components/status-pill";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { DiscordIcon } from "@/components/discord-icon";
@@ -416,7 +417,7 @@ export function AppShell({
             onBackToPicker={onBackToPicker}
           />
         </SidebarHeader>
-        <SidebarContent>
+        <SidebarContent data-tour="sidebar">
           {NAV.map((group) => (
             <SidebarGroup key={group.label}>
               <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
@@ -424,6 +425,7 @@ export function AppShell({
                 {group.items.map((item) => (
                   <SidebarMenuItem key={item.view}>
                     <SidebarMenuButton
+                      data-tour={`nav-${item.view}`}
                       isActive={view === item.view}
                       tooltip={item.label}
                       onClick={() => setView(item.view)}
@@ -575,6 +577,8 @@ export function AppShell({
         open={feedbackOpen}
         onOpenChange={setFeedbackOpen}
       />
+
+      <TourController company={company} view={view} setView={setView} />
     </SidebarProvider>
   );
 }

--- a/frontend/src/tour/TourController.tsx
+++ b/frontend/src/tour/TourController.tsx
@@ -1,0 +1,179 @@
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import type { Step, TourData } from "react-joyride";
+
+import type { View } from "@/components/app-shell";
+import { TOUR, waitForTarget } from "./steps";
+import { TourTooltip } from "./TourTooltip";
+import { WelcomeDialog } from "./WelcomeDialog";
+import { RESTART_EVENT, tourForced, tourSeen, writeTourState } from "./state";
+
+// react-joyride (and its floater/popper deps) is a fair chunk; only operators
+// who actually run the tour download it. Types above are `import type`, so they
+// erase and don't pull the module eagerly.
+const Joyride = lazy(() => import("react-joyride").then((m) => ({ default: m.Joyride })));
+
+// react-joyride status/action values as string literals, so we don't statically
+// import the runtime `STATUS`/`ACTIONS` enums (which would defeat the lazy load).
+const STATUS_FINISHED = "finished";
+const STATUS_SKIPPED = "skipped";
+const ACTION_PREV = "prev";
+const ACTION_SKIP = "skip";
+const ACTION_CLOSE = "close";
+
+const STEPS: Step[] = TOUR.map((s) => ({
+  target: s.target,
+  title: s.title,
+  content: s.body,
+  placement: s.placement,
+  disableBeacon: true,
+}));
+
+/**
+ * Owns the onboarding lifecycle: the one-time welcome dialog, then a controlled
+ * react-joyride spotlight that navigates the console view-by-view. Mounted once
+ * inside `AppShell` (a sibling of the feedback dialog) so it overlays every view
+ * and can drive `setView` itself.
+ *
+ * The crux is cross-view stepping against a hash router with lazy views: on each
+ * Back/Next we pause the tour (`active=false`), switch the pane, wait for the
+ * next target to actually mount, then resume at the new index — so the spotlight
+ * never anchors on a stale or not-yet-mounted node.
+ */
+export function TourController({
+  company,
+  view,
+  setView,
+}: {
+  company: string | null;
+  view: View;
+  setView: (view: View) => void;
+}) {
+  const [welcomeOpen, setWelcomeOpen] = useState(false);
+  const [session, setSession] = useState(false); // whole tour lifetime (mounts Joyride)
+  const [active, setActive] = useState(false); // run prop (paused during nav)
+  const [stepIndex, setStepIndex] = useState(0);
+  // True only while we're navigating+waiting between steps, so the
+  // external-navigation guard doesn't fire on our own view switch.
+  const transitioning = useRef(false);
+
+  // Offer the tour once per company on first arrival (or every load under the
+  // dev-force flag). Runs when the console mounts / the company changes.
+  useEffect(() => {
+    if (tourForced() || !tourSeen(company)) setWelcomeOpen(true);
+    else setWelcomeOpen(false);
+  }, [company]);
+
+  const finish = useCallback(
+    (skipped: boolean) => {
+      transitioning.current = false;
+      setActive(false);
+      setSession(false);
+      setStepIndex(0);
+      writeTourState(company, skipped ? { skipped: true } : { completed: true });
+    },
+    [company],
+  );
+
+  // Land on a given step: pause, switch view if needed, wait for the target to
+  // mount, then resume there. A target that never mounts ends the tour cleanly.
+  const goTo = useCallback(
+    async (nextIndex: number) => {
+      const stop = TOUR[nextIndex];
+      if (!stop) {
+        finish(false);
+        return;
+      }
+      transitioning.current = true;
+      setActive(false);
+      setView(stop.view);
+      const ok = await waitForTarget(stop.target);
+      transitioning.current = false;
+      if (!ok) {
+        finish(false);
+        return;
+      }
+      setStepIndex(nextIndex);
+      setActive(true);
+    },
+    [setView, finish],
+  );
+
+  const start = useCallback(async () => {
+    setSession(true);
+    setStepIndex(0);
+    await goTo(0);
+  }, [goTo]);
+
+  const handleStart = useCallback(() => {
+    setWelcomeOpen(false);
+    void start();
+  }, [start]);
+
+  const handleSkip = useCallback(() => {
+    setWelcomeOpen(false);
+    writeTourState(company, { skipped: true });
+  }, [company]);
+
+  // "Replay product tour" from Settings clears the flag and dispatches
+  // RESTART_EVENT; jump straight into the tour (no welcome dialog).
+  useEffect(() => {
+    const onRestart = () => {
+      setWelcomeOpen(false);
+      void start();
+    };
+    window.addEventListener(RESTART_EVENT, onRestart);
+    return () => window.removeEventListener(RESTART_EVENT, onRestart);
+  }, [start]);
+
+  // If the operator navigates away mid-tour (sidebar click, browser back), the
+  // spotlight would point at the wrong pane — end the tour quietly instead.
+  useEffect(() => {
+    if (!active || transitioning.current) return;
+    if (view !== TOUR[stepIndex]?.view) finish(true);
+  }, [view, active, stepIndex, finish]);
+
+  // react-joyride v3 fires this `after` hook once per completed step, carrying
+  // the action the operator took. We control `stepIndex`, so we translate that
+  // into a navigate-then-wait `goTo` (or end the tour on skip/close/finish).
+  const handleAfter = useCallback(
+    (data: TourData) => {
+      const { status, action, index } = data;
+      const skipped = action === ACTION_SKIP || status === STATUS_SKIPPED;
+      if (skipped || action === ACTION_CLOSE || status === STATUS_FINISHED) {
+        finish(skipped);
+        return;
+      }
+      void goTo(action === ACTION_PREV ? index - 1 : index + 1);
+    },
+    [finish, goTo],
+  );
+
+  return (
+    <>
+      <WelcomeDialog
+        open={welcomeOpen}
+        onOpenChange={setWelcomeOpen}
+        onStart={handleStart}
+        onSkip={handleSkip}
+      />
+      {session && (
+        <Suspense fallback={null}>
+          <Joyride
+            steps={STEPS}
+            run={active}
+            stepIndex={stepIndex}
+            continuous
+            tooltipComponent={TourTooltip}
+            options={{
+              zIndex: 1200,
+              overlayColor: "rgba(0,0,0,0.45)",
+              spotlightPadding: 6,
+              arrowSize: 0,
+              after: handleAfter,
+            }}
+          />
+        </Suspense>
+      )}
+    </>
+  );
+}

--- a/frontend/src/tour/TourController.tsx
+++ b/frontend/src/tour/TourController.tsx
@@ -57,6 +57,11 @@ export function TourController({
   // Offer the tour once per company on first arrival (or every load under the
   // dev-force flag).
   useEffect(() => {
+    // A company switch must tear down the prior company's in-flight tour first,
+    // otherwise `finish` would record its completion/skip under the NEW
+    // company's key (cross-company contamination).
+    setRun(false);
+    setSession(false);
     if (tourForced() || !tourSeen(company)) setWelcomeOpen(true);
     else setWelcomeOpen(false);
   }, [company]);

--- a/frontend/src/tour/TourController.tsx
+++ b/frontend/src/tour/TourController.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import type { Step, TourData } from "react-joyride";
 
 import type { View } from "@/components/app-shell";
@@ -12,102 +12,69 @@ import { RESTART_EVENT, tourForced, tourSeen, writeTourState } from "./state";
 // erase and don't pull the module eagerly.
 const Joyride = lazy(() => import("react-joyride").then((m) => ({ default: m.Joyride })));
 
-// react-joyride status/action values as string literals, so we don't statically
-// import the runtime `STATUS`/`ACTIONS` enums (which would defeat the lazy load).
+// react-joyride status values as string literals, so we don't statically import
+// the runtime `STATUS` enum (which would defeat the lazy load).
 const STATUS_FINISHED = "finished";
 const STATUS_SKIPPED = "skipped";
-const ACTION_PREV = "prev";
-const ACTION_SKIP = "skip";
-const ACTION_CLOSE = "close";
 
 const STEPS: Step[] = TOUR.map((s) => ({
   target: s.target,
   title: s.title,
   content: s.body,
   placement: s.placement,
-  disableBeacon: true,
+  // v3 renamed `disableBeacon` → `skipBeacon`; open straight to the tooltip.
+  skipBeacon: true,
+  // Let react-joyride wait for the target to mount after we switch views — this
+  // covers both the route swap and lazy Suspense chunks (Workflows, Usage, …),
+  // so we don't need to hand-roll the wait.
+  targetWaitTimeout: 6000,
+  // A walkthrough shouldn't trap keyboard focus inside the tooltip.
+  disableFocusTrap: true,
 }));
 
 /**
- * Owns the onboarding lifecycle: the one-time welcome dialog, then a controlled
- * react-joyride spotlight that navigates the console view-by-view. Mounted once
- * inside `AppShell` (a sibling of the feedback dialog) so it overlays every view
- * and can drive `setView` itself.
+ * Owns the onboarding lifecycle: the one-time welcome dialog, then the
+ * react-joyride spotlight. Mounted once inside `AppShell` (a sibling of the
+ * feedback dialog) so it overlays every view and can drive `setView` itself.
  *
- * The crux is cross-view stepping against a hash router with lazy views: on each
- * Back/Next we pause the tour (`active=false`), switch the pane, wait for the
- * next target to actually mount, then resume at the new index — so the spotlight
- * never anchors on a stale or not-yet-mounted node.
+ * We let react-joyride own the stepping. Its `before` hook fires right before
+ * each step renders — we use it to switch the console to that step's view, and
+ * joyride then waits (`targetWaitTimeout`) for the target to mount before
+ * spotlighting. That delegates the cross-view + lazy-Suspense timing to
+ * joyride's tested machinery instead of a hand-rolled controlled `stepIndex`.
  */
 export function TourController({
   company,
-  view,
   setView,
 }: {
   company: string | null;
-  view: View;
   setView: (view: View) => void;
 }) {
   const [welcomeOpen, setWelcomeOpen] = useState(false);
-  const [session, setSession] = useState(false); // whole tour lifetime (mounts Joyride)
-  const [active, setActive] = useState(false); // run prop (paused during nav)
-  const [stepIndex, setStepIndex] = useState(0);
-  // True only while we're navigating+waiting between steps, so the
-  // external-navigation guard doesn't fire on our own view switch.
-  const transitioning = useRef(false);
+  const [session, setSession] = useState(false); // mounts Joyride for the run
+  const [run, setRun] = useState(false); // joyride active
 
   // Offer the tour once per company on first arrival (or every load under the
-  // dev-force flag). Runs when the console mounts / the company changes.
+  // dev-force flag).
   useEffect(() => {
     if (tourForced() || !tourSeen(company)) setWelcomeOpen(true);
     else setWelcomeOpen(false);
   }, [company]);
 
+  const start = useCallback(() => {
+    setWelcomeOpen(false);
+    setSession(true);
+    setRun(true);
+  }, []);
+
   const finish = useCallback(
     (skipped: boolean) => {
-      transitioning.current = false;
-      setActive(false);
+      setRun(false);
       setSession(false);
-      setStepIndex(0);
       writeTourState(company, skipped ? { skipped: true } : { completed: true });
     },
     [company],
   );
-
-  // Land on a given step: pause, switch view if needed, wait for the target to
-  // mount, then resume there. A target that never mounts ends the tour cleanly.
-  const goTo = useCallback(
-    async (nextIndex: number) => {
-      const stop = TOUR[nextIndex];
-      if (!stop) {
-        finish(false);
-        return;
-      }
-      transitioning.current = true;
-      setActive(false);
-      setView(stop.view);
-      const ok = await waitForTarget(stop.target);
-      transitioning.current = false;
-      if (!ok) {
-        finish(false);
-        return;
-      }
-      setStepIndex(nextIndex);
-      setActive(true);
-    },
-    [setView, finish],
-  );
-
-  const start = useCallback(async () => {
-    setSession(true);
-    setStepIndex(0);
-    await goTo(0);
-  }, [goTo]);
-
-  const handleStart = useCallback(() => {
-    setWelcomeOpen(false);
-    void start();
-  }, [start]);
 
   const handleSkip = useCallback(() => {
     setWelcomeOpen(false);
@@ -117,35 +84,34 @@ export function TourController({
   // "Replay product tour" from Settings clears the flag and dispatches
   // RESTART_EVENT; jump straight into the tour (no welcome dialog).
   useEffect(() => {
-    const onRestart = () => {
-      setWelcomeOpen(false);
-      void start();
-    };
-    window.addEventListener(RESTART_EVENT, onRestart);
-    return () => window.removeEventListener(RESTART_EVENT, onRestart);
+    window.addEventListener(RESTART_EVENT, start);
+    return () => window.removeEventListener(RESTART_EVENT, start);
   }, [start]);
 
-  // If the operator navigates away mid-tour (sidebar click, browser back), the
-  // spotlight would point at the wrong pane — end the tour quietly instead.
-  useEffect(() => {
-    if (!active || transitioning.current) return;
-    if (view !== TOUR[stepIndex]?.view) finish(true);
-  }, [view, active, stepIndex, finish]);
-
-  // react-joyride v3 fires this `after` hook once per completed step, carrying
-  // the action the operator took. We control `stepIndex`, so we translate that
-  // into a navigate-then-wait `goTo` (or end the tour on skip/close/finish).
-  const handleAfter = useCallback(
-    (data: TourData) => {
-      const { status, action, index } = data;
-      const skipped = action === ACTION_SKIP || status === STATUS_SKIPPED;
-      if (skipped || action === ACTION_CLOSE || status === STATUS_FINISHED) {
-        finish(skipped);
-        return;
-      }
-      void goTo(action === ACTION_PREV ? index - 1 : index + 1);
+  // Before each step renders, switch the console to that step's view AND wait
+  // for its target to actually be in the DOM before letting joyride proceed.
+  // joyride awaits this hook, so a content anchor on a just-navigated view
+  // (e.g. the chat composer on Conversation) is spotlighted only once mounted —
+  // otherwise joyride checks too early, finds nothing, and skips the step.
+  // `setView` is idempotent (no-op when already there), so this is safe on Back.
+  const before = useCallback(
+    async (data: TourData) => {
+      const stop = TOUR[data.index];
+      if (!stop) return;
+      setView(stop.view);
+      await waitForTarget(stop.target);
     },
-    [finish, goTo],
+    [setView],
+  );
+
+  // End the tour (recording completed vs skipped) when joyride reports it done.
+  const after = useCallback(
+    (data: TourData) => {
+      if (data.status === STATUS_FINISHED || data.status === STATUS_SKIPPED) {
+        finish(data.status === STATUS_SKIPPED);
+      }
+    },
+    [finish],
   );
 
   return (
@@ -153,15 +119,14 @@ export function TourController({
       <WelcomeDialog
         open={welcomeOpen}
         onOpenChange={setWelcomeOpen}
-        onStart={handleStart}
+        onStart={start}
         onSkip={handleSkip}
       />
       {session && (
         <Suspense fallback={null}>
           <Joyride
             steps={STEPS}
-            run={active}
-            stepIndex={stepIndex}
+            run={run}
             continuous
             tooltipComponent={TourTooltip}
             options={{
@@ -169,7 +134,8 @@ export function TourController({
               overlayColor: "rgba(0,0,0,0.45)",
               spotlightPadding: 6,
               arrowSize: 0,
-              after: handleAfter,
+              before,
+              after,
             }}
           />
         </Suspense>

--- a/frontend/src/tour/TourTooltip.tsx
+++ b/frontend/src/tour/TourTooltip.tsx
@@ -2,11 +2,14 @@ import type { ReactNode } from "react";
 import type { TooltipRenderProps } from "react-joyride";
 
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 /**
  * The tour's spotlight card — a design-system-native replacement for
- * react-joyride's default tooltip: title, a step counter, the body copy, a
- * progress bar, and Skip / Back / Next controls (Base UI buttons).
+ * react-joyride's default tooltip. Everything is driven by theme tokens
+ * (`popover`, `primary`, `muted`, `border`), so it reads correctly in both
+ * light and dark. Shows a step chip, the copy, a segmented progress rail, and
+ * Skip / Back / Next controls.
  */
 export function TourTooltip({
   index,
@@ -18,33 +21,39 @@ export function TourTooltip({
   tooltipProps,
   isLastStep,
 }: TooltipRenderProps) {
-  const pct = Math.round(((index + 1) / size) * 100);
   return (
     <div
       {...tooltipProps}
-      className="w-80 max-w-[calc(100vw-2rem)] rounded-xl bg-popover p-4 text-popover-foreground shadow-lg ring-1 ring-foreground/10"
+      className="w-[340px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-2xl border border-border bg-popover text-popover-foreground shadow-xl ring-1 ring-black/5 dark:ring-white/10"
     >
-      <div className="flex items-center justify-between gap-2">
-        <span className="font-heading text-sm font-semibold">{step.title as ReactNode}</span>
-        <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
-          {index + 1} / {size}
+      <div className="px-4 pt-4">
+        <span className="inline-flex items-center rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium tracking-wide text-primary tabular-nums">
+          Step {index + 1} of {size}
         </span>
+        <h3 className="mt-2.5 font-heading text-[15px] leading-tight font-semibold">
+          {step.title as ReactNode}
+        </h3>
+        <p className="mt-1.5 text-[13px] leading-relaxed text-muted-foreground">
+          {step.content as ReactNode}
+        </p>
       </div>
 
-      <p className="mt-2 text-sm leading-snug text-muted-foreground">
-        {step.content as ReactNode}
-      </p>
-
-      <div className="mt-3 h-1 w-full overflow-hidden rounded-full bg-muted">
-        <div
-          className="h-full rounded-full bg-primary transition-all"
-          style={{ width: `${pct}%` }}
-        />
+      {/* Segmented progress rail — one bar per step, filled up to the current. */}
+      <div className="flex gap-1 px-4 pt-3.5">
+        {Array.from({ length: size }).map((_, i) => (
+          <span
+            key={i}
+            className={cn(
+              "h-1 flex-1 rounded-full transition-colors",
+              i <= index ? "bg-primary" : "bg-muted",
+            )}
+          />
+        ))}
       </div>
 
-      <div className="mt-3 flex items-center justify-between">
-        <Button variant="ghost" size="sm" {...skipProps}>
-          Skip
+      <div className="flex items-center justify-between gap-2 p-4 pt-3.5">
+        <Button variant="ghost" size="sm" className="text-muted-foreground" {...skipProps}>
+          Skip tour
         </Button>
         <div className="flex items-center gap-2">
           {index > 0 && (
@@ -53,7 +62,7 @@ export function TourTooltip({
             </Button>
           )}
           <Button size="sm" {...primaryProps}>
-            {isLastStep ? "Finish" : "Next"}
+            {isLastStep ? "Done" : "Next"}
           </Button>
         </div>
       </div>

--- a/frontend/src/tour/TourTooltip.tsx
+++ b/frontend/src/tour/TourTooltip.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react";
+import type { TooltipRenderProps } from "react-joyride";
+
+import { Button } from "@/components/ui/button";
+
+/**
+ * The tour's spotlight card — a design-system-native replacement for
+ * react-joyride's default tooltip: title, a step counter, the body copy, a
+ * progress bar, and Skip / Back / Next controls (Base UI buttons).
+ */
+export function TourTooltip({
+  index,
+  size,
+  step,
+  backProps,
+  primaryProps,
+  skipProps,
+  tooltipProps,
+  isLastStep,
+}: TooltipRenderProps) {
+  const pct = Math.round(((index + 1) / size) * 100);
+  return (
+    <div
+      {...tooltipProps}
+      className="w-80 max-w-[calc(100vw-2rem)] rounded-xl bg-popover p-4 text-popover-foreground shadow-lg ring-1 ring-foreground/10"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-heading text-sm font-semibold">{step.title as ReactNode}</span>
+        <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
+          {index + 1} / {size}
+        </span>
+      </div>
+
+      <p className="mt-2 text-sm leading-snug text-muted-foreground">
+        {step.content as ReactNode}
+      </p>
+
+      <div className="mt-3 h-1 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full rounded-full bg-primary transition-all"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+
+      <div className="mt-3 flex items-center justify-between">
+        <Button variant="ghost" size="sm" {...skipProps}>
+          Skip
+        </Button>
+        <div className="flex items-center gap-2">
+          {index > 0 && (
+            <Button variant="outline" size="sm" {...backProps}>
+              Back
+            </Button>
+          )}
+          <Button size="sm" {...primaryProps}>
+            {isLastStep ? "Finish" : "Next"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/tour/WelcomeDialog.tsx
+++ b/frontend/src/tour/WelcomeDialog.tsx
@@ -1,0 +1,52 @@
+import { Compass } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+/**
+ * The non-blocking welcome moment shown once to a new operator. "Take the tour"
+ * starts the guided spotlight; "Skip for now" records the tour as seen. Closing
+ * by Esc/backdrop just dismisses (no decision recorded) so it re-offers on the
+ * next load.
+ */
+export function WelcomeDialog({
+  open,
+  onOpenChange,
+  onStart,
+  onSkip,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onStart: () => void;
+  onSkip: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent showCloseButton={false} className="sm:max-w-md">
+        <DialogHeader>
+          <div className="mb-1 flex size-11 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <Compass className="size-5" />
+          </div>
+          <DialogTitle>Welcome to your company</DialogTitle>
+          <DialogDescription>
+            This is your operator console — where your AI staff, their desks, workflows, and
+            connections all live. Take a two-minute tour to see where everything is.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={onSkip}>
+            Skip for now
+          </Button>
+          <Button onClick={onStart}>Take the tour</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/tour/state.ts
+++ b/frontend/src/tour/state.ts
@@ -1,0 +1,61 @@
+// Product-tour first-run state.
+//
+// The console has no per-user preferences field on the backend yet
+// (`UserRecord` carries none), so — exactly like the workspace and inbox
+// surfaces (`lib/workspace.ts`, `lib/inbox.ts`) — we persist "has seen the
+// tour" in localStorage, keyed per company. A backend `UserRecord` flag for
+// cross-device memory is a named follow-up, out of this v1's scope.
+
+const KEY = (company: string | null): string => `oc-tour:${company ?? "single"}`;
+
+export interface TourState {
+  completed?: boolean;
+  skipped?: boolean;
+  seenAt?: number;
+}
+
+/** Fired by `restartTour` so a mounted controller can replay from the top. */
+export const RESTART_EVENT = "oc-tour:restart";
+
+export function readTourState(company: string | null): TourState {
+  try {
+    const raw = localStorage.getItem(KEY(company));
+    return raw ? (JSON.parse(raw) as TourState) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function writeTourState(company: string | null, next: TourState): void {
+  try {
+    localStorage.setItem(KEY(company), JSON.stringify({ ...next, seenAt: Date.now() }));
+  } catch {
+    /* private mode / quota — the tour simply re-offers on next load */
+  }
+}
+
+/** Has the operator already finished or skipped the tour for this company? */
+export function tourSeen(company: string | null): boolean {
+  const s = readTourState(company);
+  return Boolean(s.completed || s.skipped);
+}
+
+/** Clear the seen flag and ask any mounted controller to replay from step 1. */
+export function restartTour(company: string | null): void {
+  try {
+    localStorage.removeItem(KEY(company));
+  } catch {
+    /* ignore */
+  }
+  window.dispatchEvent(new CustomEvent(RESTART_EVENT));
+}
+
+/**
+ * Dev-only force flag (mirrors OpenHuman's `VITE_DEV_FORCE_ONBOARDING`): set
+ * `VITE_DEV_FORCE_TOUR=true` in a dev build to reopen the tour every load.
+ * Read defensively so it needs no addition to the Vite env type surface.
+ */
+export function tourForced(): boolean {
+  const env = import.meta.env as Record<string, string | boolean | undefined>;
+  return Boolean(env.DEV) && env.VITE_DEV_FORCE_TOUR === "true";
+}

--- a/frontend/src/tour/steps.ts
+++ b/frontend/src/tour/steps.ts
@@ -1,0 +1,113 @@
+import type { Step } from "react-joyride";
+
+import type { View } from "@/components/app-shell";
+
+/**
+ * One stop on the guided tour: a spotlight target plus the console view it
+ * belongs to, so the controller can switch panes before highlighting.
+ *
+ * Anchoring strategy: most stops target an always-mounted **sidebar nav**
+ * element (`[data-tour="nav-<view>"]`), which sidesteps the lazy/Suspense race
+ * entirely — navigating still swaps the main pane so the operator sees the
+ * view, but the spotlight never waits on a code-split chunk. Only the two
+ * richest moments (Overview quick-actions, the chat composer) anchor to
+ * content on non-lazy views.
+ */
+export interface TourStop {
+  view: View;
+  target: string;
+  title: string;
+  body: string;
+  placement?: Step["placement"];
+}
+
+export const TOUR: TourStop[] = [
+  {
+    view: "overview",
+    target: '[data-tour="sidebar"]',
+    placement: "right",
+    title: "Welcome to your company",
+    body: "Everything your company can do lives in this sidebar. Let's take a quick look around.",
+  },
+  {
+    view: "overview",
+    target: '[data-tour="overview-quickactions"]',
+    placement: "top",
+    title: "Start here each day",
+    body: "Talk to your company, review what's waiting on you, or flag anything that looks off.",
+  },
+  {
+    view: "conversation",
+    target: '[data-tour="chat-composer"]',
+    placement: "top",
+    title: "Talk to your company",
+    body: "Ask for an update or hand off a task in plain language — like messaging a teammate.",
+  },
+  {
+    view: "team",
+    target: '[data-tour="nav-team"]',
+    placement: "right",
+    title: "Your AI staff",
+    body: "The agents that actually do the work. Each has a role and the tools to match.",
+  },
+  {
+    view: "desks",
+    target: '[data-tour="nav-desks"]',
+    placement: "right",
+    title: "Desks",
+    body: "Teammates group into desks by function — Engineering, Support, and so on. Work routed to a desk goes to its lead.",
+  },
+  {
+    view: "workflows",
+    target: '[data-tour="nav-workflows"]',
+    placement: "right",
+    title: "Workflows",
+    body: "Turn recurring work into a repeatable workflow — a graph of steps your agents run end to end.",
+  },
+  {
+    view: "approvals",
+    target: '[data-tour="nav-approvals"]',
+    placement: "right",
+    title: "Approvals",
+    body: "Anything that needs your sign-off before it happens waits here. Nothing risky runs without you.",
+  },
+  {
+    view: "connections",
+    target: '[data-tour="nav-connections"]',
+    placement: "right",
+    title: "Connect your tools",
+    body: "Plug in the tools your company already uses — Gmail, Slack, GitHub — so your agents can act for real.",
+  },
+  {
+    view: "conversation",
+    target: '[data-tour="chat-composer"]',
+    placement: "top",
+    title: "You're all set",
+    body: "That's the tour. Say hi to your company to get going — you can replay this anytime from Settings.",
+  },
+];
+
+/**
+ * Poll for a step's target to mount. Route swaps and lazy Suspense chunks
+ * resolve a tick or two after navigation, so a spotlight can't anchor on the
+ * same frame it navigates. Resolves `false` on timeout so a missing anchor
+ * degrades to a skipped step instead of wedging the tour. Mirrors OpenHuman's
+ * `waitForTarget` (walkthroughSteps.ts).
+ */
+export function waitForTarget(selector: string, timeoutMs = 5000): Promise<boolean> {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const tick = () => {
+      if (document.querySelector(selector)) {
+        resolve(true);
+        return;
+      }
+      if (Date.now() - start > timeoutMs) {
+        resolve(false);
+        return;
+      }
+      window.setTimeout(tick, 50);
+    };
+    tick();
+  });
+}

--- a/frontend/src/tour/steps.ts
+++ b/frontend/src/tour/steps.ts
@@ -55,7 +55,7 @@ export const TOUR: TourStop[] = [
     target: '[data-tour="nav-desks"]',
     placement: "right",
     title: "Desks",
-    body: "Teammates group into desks by function — Engineering, Support, and so on. Work routed to a desk goes to its lead.",
+    body: "Teammates group into desks by function — Engineering, Support, and so on. Work routed to a desk goes to its lead. Spin up your own with New desk anytime.",
   },
   {
     view: "workflows",

--- a/frontend/src/views/Conversation.tsx
+++ b/frontend/src/views/Conversation.tsx
@@ -267,7 +267,10 @@ function ChatPane({
       {/* Composer */}
       <div className="border-t bg-background/80 backdrop-blur">
         <div className="mx-auto w-full max-w-3xl px-4 py-3">
-          <div className="relative flex items-end gap-2 rounded-xl border bg-card p-2 shadow-sm focus-within:ring-2 focus-within:ring-ring/50">
+          <div
+            data-tour="chat-composer"
+            className="relative flex items-end gap-2 rounded-xl border bg-card p-2 shadow-sm focus-within:ring-2 focus-within:ring-ring/50"
+          >
             <Textarea
               value={draft}
               onChange={(e) => setDraft(e.target.value)}

--- a/frontend/src/views/Overview.tsx
+++ b/frontend/src/views/Overview.tsx
@@ -114,7 +114,7 @@ export function Overview({ feed, onNavigate, onFlag }: Props) {
         </Card>
 
         {/* Quick actions */}
-        <div className="grid gap-3 sm:grid-cols-3">
+        <div className="grid gap-3 sm:grid-cols-3" data-tour="overview-quickactions">
           <QuickAction icon={MessagesSquare} label="Talk to your company" onClick={() => onNavigate("conversation")} />
           <QuickAction icon={ShieldCheck} label="Review approvals" onClick={() => onNavigate("approvals")} />
           <QuickAction icon={Flag} label="Flag something" onClick={onFlag} />

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Flag, Globe, Pause, Play, Power, Archive as ArchiveIcon } from "lucide-react";
+import { Compass, Flag, Globe, Pause, Play, Power, Archive as ArchiveIcon } from "lucide-react";
 import { toast } from "sonner";
 
 import type { LifecycleAction, OpenCompanyClient } from "@/api/client";
@@ -27,6 +27,7 @@ import { DomainSettings } from "@/components/domain-settings";
 import { StatusPill } from "@/components/status-pill";
 import { ThemeToggle } from "@/components/theme-toggle";
 import type { CompanyFeed } from "@/hooks/use-company";
+import { restartTour } from "@/tour/state";
 
 interface Props {
   client: OpenCompanyClient;
@@ -95,6 +96,25 @@ export function SettingsView({ client, company, feed, onFlag }: Props) {
               <CardDescription>Switch between light, dark, and system themes.</CardDescription>
             </div>
             <ThemeToggle />
+          </CardHeader>
+        </Card>
+
+        {/* Product tour */}
+        <Card>
+          <CardHeader className="flex-row items-center justify-between space-y-0">
+            <div className="space-y-1">
+              <CardTitle className="text-base">Product tour</CardTitle>
+              <CardDescription>Replay the guided walkthrough of the console.</CardDescription>
+            </div>
+            <Button
+              variant="outline"
+              onClick={() => {
+                restartTour(company);
+                toast.success("Starting the product tour.");
+              }}
+            >
+              <Compass className="size-4" /> Replay tour
+            </Button>
           </CardHeader>
         </Card>
 


### PR DESCRIPTION
## Summary

A new operator landing in the console gets no orientation — `AppShell` drops them on Overview facing 16 nav destinations with zero guidance. This adds a **new-user product tour**: a one-time welcome dialog, then a dismissible, replayable guided spotlight that walks the console view-by-view (inspired by OpenHuman's `react-joyride` walkthrough).

The tour is self-contained under a new `frontend/src/tour/` module and mounted once in `AppShell` (a sibling of the feedback dialog) so it overlays every view and can drive navigation itself. react-joyride owns the stepping: a `before` hook switches the console to each step's view and waits for that step's target to mount before spotlighting — so it works across the hash router **and** lazy/Suspense views (Workflows, Usage, …) without a hand-rolled controlled `stepIndex`.

Tour script (9 steps): sidebar orientation → Overview quick-actions → chat composer → Team → Desks → Workflows → Approvals → Connections → back to the chat composer (warm ending).

"Has seen the tour" is stored per-company in `localStorage` (the console's established idiom where there's no backend field yet — cf. `lib/workspace.ts`). A **Replay product tour** row is added to Settings, and `VITE_DEV_FORCE_TOUR=true` forces it open every load in dev.

## API Or Behavior Changes

- **Frontend only, additive.** New dependency `react-joyride` (lazy-loaded — only tour-takers download the chunk).
- New `frontend/src/tour/` module (state, steps, welcome dialog, tooltip, controller).
- `AppShell` mounts `<TourController>`; spotlight anchors added as `data-tour="…"` attributes on existing elements (sidebar items + a few view containers) — no structural or style changes.
- Settings gains a "Replay product tour" control.
- **No backend, HTTP route, schema, or persistence change.**
- **Deferred follow-up (out of scope):** cross-device "seen" persistence needs an onboarding/prefs field on `UserRecord` + store migration + `/auth/me` surfacing (size L). v1 is single-device via `localStorage`.

## Tests

Frontend-only change — the Rust gates are N/A here:

- [x] N/A: `cargo fmt --all -- --check` — no Rust changed
- [x] N/A: `cargo clippy --all-targets -- -D warnings` — no Rust changed
- [x] N/A: `cargo build --all-targets` — no Rust changed
- [x] N/A: `cargo test` — no Rust changed
- [x] `npm run typecheck` (console — clean)
- [x] `npm run build` (console — built)

Manual verification on a dev host against a running company (`VITE_DEV_FORCE_TOUR=true`):
- Fresh company → welcome auto-opens once; full 9-step walk, including the lazy **Workflows** step and both **Conversation** content-anchored steps (the `before`-hook target wait covers route-swap + Suspense mounts).
- "Skip for now" and mid-tour Skip → console usable, no re-prompt on reload.
- Settings → **Replay product tour** → restarts from step 1.
- Light + dark themes — tooltip is token-driven (`popover`/`primary`/`muted`), reads correctly in both.

## Documentation

No doc surface changed. The tour module carries inline docs (controller lifecycle, the `before`-hook stepping rationale, the localStorage state contract, and the named backend follow-up).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guided product tour with step-by-step spotlight highlights across key areas of the app.
  * Introduced a welcome prompt for first-time visitors with options to start or skip.
  * Implemented custom tour navigation UI with progress indicators and themed spotlight tooltips.
  * Added a **Replay tour** action in Settings to restart the tour on demand.
  * Remembered tour completion/skips per company to avoid repeat prompts unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->