### PR TITLE
feat(connections): P2 — toast display name, 2nd-provider alignment, best-effort revoke

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -52,6 +52,7 @@ import { useHashView } from "@/hooks/use-hash-view";
 import { toast } from "sonner";
 
 import { type ChatMessage, fromHistory, makeMessage } from "@/lib/chat";
+import { CONNECTION_PROVIDERS } from "@/lib/connections";
 import { DISCORD_INVITE_URL } from "@/lib/links";
 import { defaultThreads, threadsFromDesks } from "@/lib/threads";
 import { Overview } from "@/views/Overview";
@@ -236,7 +237,11 @@ export function AppShell({
       window.location.pathname + (query ? `?${query}` : "") + window.location.hash,
     );
     setView("connections");
-    toast.success(`Connected ${connected}.`);
+    // The callback param carries the raw provider id (e.g. "slack"); show the
+    // catalog display name ("Slack") when we know it, falling back to the id.
+    const providerName =
+      CONNECTION_PROVIDERS.find((p) => p.id === connected)?.name ?? connected;
+    toast.success(`Connected ${providerName}.`);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/frontend/src/lib/connections.ts
+++ b/frontend/src/lib/connections.ts
@@ -11,6 +11,16 @@ export type ConnectionCategory =
   | "Storage";
 
 export interface ConnectionProvider {
+  /**
+   * The provider identity. This string MUST be identical end-to-end: the
+   * manifest `[[connection]] provider = "…"`, this catalog `id`, and the
+   * backend `well_known(provider)` key (`src/server/ops/connections.rs`) are the
+   * same token. A tile whose `id` has no matching backend key can never
+   * complete OAuth — `startConnection(id)` resolves no `provider_config` and the
+   * host answers "provider not enabled". Backend keys today: `slack`, `github`,
+   * `google`, `gmail`. Keep new tiles aligned to an existing key (or add the
+   * backend key first); do not invent console-only ids.
+   */
   id: string;
   name: string;
   description: string;
@@ -39,6 +49,11 @@ export const CONNECTION_PROVIDERS: ConnectionProvider[] = [
     glyph: "#",
   },
   {
+    // DEAD TILE until aligned: backend `well_known` has no `google-calendar`
+    // key — the closest existing key is `google`. Connecting this tile fails
+    // ("provider not enabled") until either the id is changed to `google` (or a
+    // dedicated `google-calendar` key + scopes are added to
+    // `well_known`/`provider_config` in src/server/ops/connections.rs).
     id: "google-calendar",
     name: "Google Calendar",
     description: "Schedule and read events on a shared calendar.",
@@ -55,6 +70,9 @@ export const CONNECTION_PROVIDERS: ConnectionProvider[] = [
     glyph: "N",
   },
   {
+    // DEAD TILE until aligned: backend `well_known` has no `google-drive` key
+    // (closest existing key is `google`). See the `google-calendar` note above —
+    // align the id to a backend key or add the key before this tile can connect.
     id: "google-drive",
     name: "Google Drive",
     description: "Store and retrieve files and deliverables.",

--- a/src/server/ops/connections.rs
+++ b/src/server/ops/connections.rs
@@ -349,11 +349,94 @@ fn extract_account(token: &serde_json::Value) -> Option<String> {
 // Disconnect
 // ---------------------------------------------------------------------------
 
-/// Deletes stored tokens (best-effort revoke is a follow-up).
+/// The provider's token-revocation endpoint, if one is known. GitHub's URL
+/// carries the app `client_id` in its path. Overridable per provider via
+/// `OPENCOMPANY_OAUTH_<P>_REVOKE_URL` (tests point this at a local mock).
+/// `None` means "no known revoke flow" — disconnect still blanks the local
+/// secret; there is simply no remote call to make.
+fn revoke_url(provider: &str, config: &ProviderConfig) -> Option<String> {
+    let key = provider.to_ascii_uppercase();
+    if let Some(url) = std::env::var(format!("OPENCOMPANY_OAUTH_{key}_REVOKE_URL"))
+        .ok()
+        .filter(|u| !u.is_empty())
+    {
+        return Some(url);
+    }
+    match provider {
+        "slack" => Some("https://slack.com/api/auth.revoke".to_string()),
+        "github" => Some(format!(
+            "https://api.github.com/applications/{}/grant",
+            config.client_id
+        )),
+        _ => None,
+    }
+}
+
+/// Reads the stored `access_token` for a provider, if a non-empty token blob is
+/// present. Returns `None` when nothing is stored or the blob has no token.
+/// The token is used only to build the revoke request and is never logged.
+async fn stored_access_token(runtime: &CompanyRuntime, provider: &str) -> Option<String> {
+    let value = runtime
+        .secrets()
+        .get(runtime.id(), &oauth_key(provider))
+        .await
+        .ok()
+        .flatten()?;
+    if value.expose().trim().is_empty() {
+        return None;
+    }
+    serde_json::from_str::<serde_json::Value>(value.expose())
+        .ok()?
+        .get("token")
+        .and_then(|t| t.get("access_token"))
+        .and_then(|a| a.as_str())
+        .map(str::to_string)
+}
+
+/// Best-effort provider-side token revocation, run before the local secret is
+/// blanked. Any failure — unknown provider, unconfigured app credentials, a
+/// network error, or a non-success status — is logged and swallowed so the
+/// disconnect always proceeds. Token material is never logged or returned.
+async fn best_effort_revoke(runtime: &CompanyRuntime, provider: &str) {
+    let Some(access_token) = stored_access_token(runtime, provider).await else {
+        return;
+    };
+    let Some(config) = provider_config(provider) else {
+        return;
+    };
+    let Some(url) = revoke_url(provider, &config) else {
+        return;
+    };
+    let client = reqwest::Client::new();
+    let request = match provider {
+        // GitHub revokes a grant with an authenticated DELETE carrying the token
+        // in the JSON body and the app credentials as Basic auth.
+        "github" => client
+            .delete(&url)
+            .basic_auth(&config.client_id, Some(&config.client_secret))
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", "opencompany")
+            .json(&json!({ "access_token": access_token })),
+        // Slack (and any override that behaves like it) revokes with a POST form.
+        _ => client.post(&url).form(&[("token", access_token.as_str())]),
+    };
+    match request.send().await {
+        Ok(resp) if resp.status().is_success() => {}
+        Ok(resp) => {
+            tracing::warn!(provider, status = %resp.status(), "oauth revoke returned non-success")
+        }
+        Err(err) => tracing::warn!(provider, "oauth revoke request failed: {err}"),
+    }
+}
+
+/// Revokes the provider grant (best-effort) then deletes the stored tokens.
 async fn do_disconnect(
     runtime: Arc<CompanyRuntime>,
     provider: &str,
 ) -> Result<Json<serde_json::Value>, ApiError> {
+    // Ask the provider to invalidate the grant first, best-effort: a failed or
+    // absent revoke must never block the local disconnect below.
+    best_effort_revoke(&runtime, provider).await;
     // Overwrite with an empty marker: the secret store has no delete; an empty
     // value reads back as "not connected" on the read side.
     runtime
@@ -430,5 +513,171 @@ mod test {
             Some("Acme".to_string())
         );
         assert_eq!(extract_account(&json!({ "access_token": "x" })), None);
+    }
+
+    // ---- disconnect / best-effort revoke ----------------------------------
+
+    use crate::company::CompanyManifest;
+    use crate::company::runtime::CompanyRuntime;
+    use crate::runtime::RuntimeBuilder;
+
+    /// Builds an isolated in-memory company runtime for disconnect tests.
+    async fn test_runtime() -> (Arc<CompanyRuntime>, std::path::PathBuf) {
+        let home = std::env::temp_dir().join(format!("oc-disc-{}", crate::ports::generate_id()));
+        let manifest: CompanyManifest =
+            toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n").unwrap();
+        let runtime = RuntimeBuilder::new(home.clone(), manifest)
+            .with_id(CompanyId::new("acme"))
+            .build()
+            .await
+            .unwrap();
+        (Arc::new(runtime), home)
+    }
+
+    /// A process-unique provider id (env-key safe) so the env vars each test
+    /// sets never collide with a sibling test running in parallel.
+    fn unique_provider() -> String {
+        format!("revtest{}", crate::ports::generate_id().replace('-', ""))
+    }
+
+    async fn store_token(runtime: &CompanyRuntime, provider: &str, access_token: &str) {
+        runtime
+            .secrets()
+            .set(
+                runtime.id(),
+                &oauth_key(provider),
+                SecretValue(
+                    json!({ "token": { "access_token": access_token }, "account": "acc" })
+                        .to_string(),
+                ),
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn is_blanked(runtime: &CompanyRuntime, provider: &str) -> bool {
+        runtime
+            .secrets()
+            .get(runtime.id(), &oauth_key(provider))
+            .await
+            .unwrap()
+            .map(|v| v.expose().trim().is_empty())
+            .unwrap_or(true)
+    }
+
+    /// No app credentials configured → provider_config is `None`, so there is no
+    /// remote to revoke, but the disconnect must still blank the local secret.
+    #[tokio::test]
+    async fn disconnect_blanks_secret_without_revoke_config() {
+        let (runtime, home) = test_runtime().await;
+        let provider = unique_provider();
+        store_token(&runtime, &provider, "CANARY-should-never-leak").await;
+
+        let resp = do_disconnect(runtime.clone(), &provider).await.unwrap();
+        assert_eq!(resp.0["connected"], false);
+        assert!(is_blanked(&runtime, &provider).await, "secret not blanked");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// The best-effort revoke path is invoked: with app credentials + a revoke
+    /// URL configured, disconnect POSTs the token to the provider endpoint AND
+    /// blanks the local secret.
+    #[tokio::test]
+    async fn disconnect_invokes_provider_revoke() {
+        use axum::extract::State;
+        use axum::routing::post;
+
+        let hits: Arc<tokio::sync::Mutex<Vec<String>>> =
+            Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route(
+                "/revoke",
+                post(|State(hits): State<Arc<tokio::sync::Mutex<Vec<String>>>>, body: String| async move {
+                    hits.lock().await.push(body);
+                    "ok"
+                }),
+            )
+            .with_state(hits.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let (runtime, home) = test_runtime().await;
+        let provider = unique_provider();
+        let key = provider.to_ascii_uppercase();
+        // SAFETY: unique per-test provider name → no cross-test env collision.
+        unsafe {
+            std::env::set_var(format!("OPENCOMPANY_OAUTH_{key}_ID"), "cid");
+            std::env::set_var(format!("OPENCOMPANY_OAUTH_{key}_SECRET"), "csec");
+            std::env::set_var(
+                format!("OPENCOMPANY_OAUTH_{key}_AUTHORIZE_URL"),
+                "http://x/a",
+            );
+            std::env::set_var(format!("OPENCOMPANY_OAUTH_{key}_TOKEN_URL"), "http://x/t");
+            std::env::set_var(
+                format!("OPENCOMPANY_OAUTH_{key}_REVOKE_URL"),
+                format!("http://{addr}/revoke"),
+            );
+        }
+
+        store_token(&runtime, &provider, "CANARY-revoke-me").await;
+        let _ = do_disconnect(runtime.clone(), &provider).await.unwrap();
+
+        let received = hits.lock().await;
+        assert_eq!(received.len(), 1, "revoke endpoint was not called");
+        assert!(
+            received[0].contains("CANARY-revoke-me"),
+            "revoke request did not carry the stored token"
+        );
+        drop(received);
+        assert!(is_blanked(&runtime, &provider).await, "secret not blanked");
+
+        unsafe {
+            for suffix in ["ID", "SECRET", "AUTHORIZE_URL", "TOKEN_URL", "REVOKE_URL"] {
+                std::env::remove_var(format!("OPENCOMPANY_OAUTH_{key}_{suffix}"));
+            }
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// A revoke endpoint that refuses the connection must not fail the
+    /// disconnect: the local secret is still blanked.
+    #[tokio::test]
+    async fn disconnect_blanks_secret_when_revoke_fails() {
+        // Bind then drop to obtain a port with nothing listening on it.
+        let dead = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let dead_addr = dead.local_addr().unwrap();
+        drop(dead);
+
+        let (runtime, home) = test_runtime().await;
+        let provider = unique_provider();
+        let key = provider.to_ascii_uppercase();
+        // SAFETY: unique per-test provider name → no cross-test env collision.
+        unsafe {
+            std::env::set_var(format!("OPENCOMPANY_OAUTH_{key}_ID"), "cid");
+            std::env::set_var(format!("OPENCOMPANY_OAUTH_{key}_SECRET"), "csec");
+            std::env::set_var(
+                format!("OPENCOMPANY_OAUTH_{key}_AUTHORIZE_URL"),
+                "http://x/a",
+            );
+            std::env::set_var(format!("OPENCOMPANY_OAUTH_{key}_TOKEN_URL"), "http://x/t");
+            std::env::set_var(
+                format!("OPENCOMPANY_OAUTH_{key}_REVOKE_URL"),
+                format!("http://{dead_addr}/revoke"),
+            );
+        }
+
+        store_token(&runtime, &provider, "CANARY-unreachable").await;
+        // Must still succeed even though the revoke POST cannot connect.
+        let _ = do_disconnect(runtime.clone(), &provider).await.unwrap();
+        assert!(is_blanked(&runtime, &provider).await, "secret not blanked");
+
+        unsafe {
+            for suffix in ["ID", "SECRET", "AUTHORIZE_URL", "TOKEN_URL", "REVOKE_URL"] {
+                std::env::remove_var(format!("OPENCOMPANY_OAUTH_{key}_{suffix}"));
+            }
+        }
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/server/ops/connections.rs
+++ b/src/server/ops/connections.rs
@@ -407,7 +407,21 @@ async fn best_effort_revoke(runtime: &CompanyRuntime, provider: &str) {
     let Some(url) = revoke_url(provider, &config) else {
         return;
     };
-    let client = reqwest::Client::new();
+    // Bound the best-effort revoke: a provider that accepts the connection but
+    // hangs (or a slow `_REVOKE_URL` override) must not block the disconnect
+    // handler indefinitely. A builder failure skips the remote revoke entirely
+    // — the caller blanks the local secret unconditionally, so this stays
+    // best-effort without blocking or panicking.
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+    {
+        Ok(client) => client,
+        Err(err) => {
+            tracing::warn!(provider, "oauth revoke client build failed: {err}");
+            return;
+        }
+    };
     let request = match provider {
         // GitHub revokes a grant with an authenticated DELETE carrying the token
         // in the JSON body and the app credentials as Basic auth.


### PR DESCRIPTION
## Summary

Follow-on to PR #129 (Connections P1). Three tight fixes so the console connections flow is complete beyond GitHub.

**Fix 1 — connect toast shows the display name.** The OAuth bounce-back `useEffect` (`app-shell.tsx`) toasted the raw `?connected={provider}` id, so it read "Connected slack." It now maps the id through the `CONNECTION_PROVIDERS` catalog → "Connected Slack." (falls back to the raw id when unknown). The disconnect toast already used the display name.

**Fix 2 — catalog-id ↔ backend-key alignment (2nd provider connects end-to-end).** For a provider to connect, the manifest `[[connection]] provider`, the console catalog `id`, and the backend `well_known` key must be the *same* string. Slack now works end-to-end because its catalog `id === "slack"` matches the backend key (GitHub/Gmail already aligned). The invariant is documented on `ConnectionProvider.id`, and the `google-calendar` / `google-drive` tiles — whose ids map to no backend key — are flagged as dead in a code comment. No new backend providers were invented (comment-only for the google-* mismatch).

**Fix 3 — best-effort provider-side revoke on disconnect.** `do_disconnect` previously only blanked the local `oauth/{provider}` secret (SecretStore has no delete). It now attempts a real provider-side revoke *first*: GitHub → authenticated `DELETE /applications/{client_id}/grant`, Slack → `POST auth.revoke`. Any failure (unknown provider, unconfigured creds, network error, non-2xx) is logged with **provider + status only — never the token** — and swallowed, so the local secret-blank always runs. A new optional `OPENCOMPANY_OAUTH_<P>_REVOKE_URL` override mirrors the existing `_AUTHORIZE_URL` / `_TOKEN_URL` pattern.

### Host configuration (for a 2nd provider, e.g. Slack — nothing committed)
Set on the host: `OPENCOMPANY_OAUTH_SLACK_ID`, `OPENCOMPANY_OAUTH_SLACK_SECRET`, optional `OPENCOMPANY_OAUTH_SLACK_SCOPES` / `_REVOKE_URL`; the company `company.toml` must declare `[[connection]] provider = "slack"`. Same `OPENCOMPANY_OAUTH_REDIRECT_BASE` / `OPENCOMPANY_CONSOLE_URL` as P1.

## API Or Behavior Changes

- Disconnect now makes a best-effort provider-side token revocation before blanking the local secret. Behavior is unchanged when the provider has no known revoke endpoint or the call fails (secret still blanked).
- New optional env override `OPENCOMPANY_OAUTH_<P>_REVOKE_URL`.
- Console: connect toast shows the provider display name; a 2nd provider (Slack) connects end-to-end.
- No schema, persistence, or route change. No token material appears in any response or log (asserted by test).

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — **708 passed / 1 ignored / 0 failed**, incl. 3 new revoke tests: revoke invoked against a mock server (asserts the token is carried to the provider) + secret blanked; secret still blanked when the provider is unconfigured; secret still blanked when the revoke endpoint is unreachable
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run build`

## Documentation

Behavior carried by inline route/module docs. The `ConnectionProvider.id` end-to-end invariant and the dead-tile flags are documented inline; the host env recipe for a 2nd provider is in the Summary above.
