### PR TITLE
fix(console): remove stray vertical separator in header

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -40,7 +40,6 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { Button } from "@/components/ui/button";
-import { Separator } from "@/components/ui/separator";
 import { CompanySwitcher } from "@/components/company-switcher";
 import { FeedbackDialog } from "@/components/feedback-dialog";
 import { StatusPill } from "@/components/status-pill";
@@ -482,7 +481,6 @@ export function AppShell({
       <SidebarInset className="min-h-0">
         <header className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
           <SidebarTrigger className="-ml-1" />
-          <Separator orientation="vertical" className="mr-1 h-4" />
           <h1 className="text-sm font-semibold">{TITLES[view]}</h1>
           <div className="ml-auto flex items-center gap-2">
             <StatusPill lifecycle={feed.status.lifecycle} className="hidden sm:inline-flex" />


### PR DESCRIPTION
## Summary

The persistent app-shell header rendered a short vertical `Separator` (16px) between the sidebar toggle and the page title — a stray sliver visible on every page. This removes it (and the now-unused `Separator` import).

## API Or Behavior Changes

None. Cosmetic — the header now reads `[toggle] Title` with no divider. No route, DTO, or logic change.

## Tests

- [x] `cd frontend && npm run typecheck` — clean
- [x] `cd frontend && npm run build` — clean

Purely visual removal; verified via typecheck + build.

## Documentation

N/A: no doc surface changed.
