### PR TITLE
fix(docker): make the openhuman-feature tenant build work

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,12 +14,20 @@ target/
 # tree cannot be excluded (that was the packaging bug: `cargo build` failed with
 # "failed to read vendor/openhuman/Cargo.toml"). We therefore keep every
 # Cargo.toml + src/ tree and strip only the documentation, generated books,
-# desktop app, and media that bloat the raw checkout to ~300 MB. openhuman's
-# build.rs is written to tolerate a source-only build (it emits an empty raw-
-# coverage module list when tests/ is absent), and every include_str!/-bytes! in
-# openhuman's sources resolves inside src/, so a `--features openhuman` compile
-# still works from this trimmed context.
-**/docs/
+# desktop app, and media that bloat the raw checkout to ~300 MB.
+#
+# CAVEAT (why the `!` exception below): a `--features openhuman` build compiles
+# the vendored `tinyagents`, whose `src/registry/catalog.rs` does
+# `include_str!("../../docs/modules/registry/model-catalog.snapshot.json")`. A
+# blanket `**/docs/` exclude drops that file and the build fails with
+# "couldn't read .../model-catalog.snapshot.json". So we exclude docs *contents*
+# broadly but re-include every tinyagents `docs/` tree (there are three copies
+# in the nested vendor graph). Excluding `docs/**` rather than `docs/` keeps the
+# directory entry walkable, so the `!` re-include works reliably (Docker cannot
+# re-include a file whose parent directory itself was excluded). No other doc
+# file is a compile input — openhuman's own `include_str!`s all resolve in `src/`.
+**/docs/**
+!**/tinyagents/docs/**
 **/gitbooks/
 **/website/
 **/paper/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,24 @@ FROM rust:1-slim-bookworm AS builder
 ARG FEATURES=""
 WORKDIR /build
 
+# `--features openhuman` transitively needs system libraries at build time that
+# the small default/mongodb builds don't:
+#   * OpenSSL headers — native-tls → openssl-sys (via motosan-ai-oauth →
+#     hyper-tls in the vendored openhuman tree).
+#   * X11 dev libs — openhuman's unconditional `rdev`/`arboard` deps (input +
+#     clipboard) link against libX11/libXi/libXtst/libxcb/libxkbcommon even in
+#     a headless server build; the matching .so runtime libs are added to the
+#     runtime stage so the dynamic linker is satisfied (the code paths never
+#     run here). These are no-ops for the default/mongodb builds.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       pkg-config ca-certificates libssl-dev \
+       libx11-dev libxi-dev libxtst-dev libxrandr-dev libxcb1-dev libxkbcommon-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 # The whole workspace is copied (examples/*/Cargo.toml load the workspace;
 # vendor/tinyagents backs the [patch.crates-io] entry). vendor/openhuman,
-# target/, and node_modules are excluded via .dockerignore.
+# target/, and node_modules are trimmed via .dockerignore.
 COPY . .
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
@@ -47,8 +62,14 @@ ENV OPENCOMPANY_BIND=0.0.0.0:8080 \
 
 # ── runtime ────────────────────────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
+# libssl3 + the X11 runtime shared libraries satisfy the dynamic linker for the
+# openssl-sys/native-tls and rdev/arboard links the `openhuman` feature pulls in
+# (the desktop-automation code paths never run in a headless tenant, but the .so
+# files must be present to load the binary). No-ops for the small builds.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates curl libssl3 \
+       libx11-6 libxi6 libxtst6 libxrandr2 libxcb1 libxkbcommon0 \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Building a tenant image with `--features openhuman` (the real hosted brain — embedded harness cognition) fails three ways the small default/`mongodb` builds never hit. This makes the `openhuman`-feature build work. Found while getting the staging tenant off the echo brain onto real cognition.

- **openssl headers.** `--features openhuman` transitively pulls `native-tls → openssl-sys` (via `motosan-ai-oauth → hyper-tls` in the vendored openhuman tree). The builder stage now installs `libssl-dev` + `pkg-config`.
- **X11 libs.** openhuman declares `rdev` (input sim) and `arboard` (clipboard) as **unconditional** deps, which link `libX11/libXi/libXtst/libxcb/libxkbcommon` even in a headless server build. The builder gets the `-dev` headers; the runtime gets the matching `.so` libs so the binary loads (the desktop-automation code paths never run in a tenant).
- **Dropped compile input.** The blanket `**/docs/` ignore removed `vendor/**/tinyagents/docs/modules/registry/model-catalog.snapshot.json`, which `tinyagents/src/registry/catalog.rs` `include_str!`s — so cargo failed `couldn't read .../model-catalog.snapshot.json`. Now excludes docs **contents** (`**/docs/**`) and re-includes the tinyagents docs trees, so the snapshot stays in context while the bulk docs (openhuman book, tinyjuice benchmark fixtures) are still trimmed.

All changes are **no-ops for the default/`mongodb`/`medulla` builds** — extra apt packages and a more precise ignore.

## API Or Behavior Changes

None. Build-plumbing only.

## Tests

Docker isn't part of the Rust test suite; verified out of band:

- **Context probe** (busybox `COPY .`): all **3** tinyagents `model-catalog.snapshot.json` copies present; `vendor/openhuman/docs` and `tinyjuice/docs` contents dropped (0 files); context ~80 MB.
- **Full build**: `docker build --build-arg FEATURES="mongodb openhuman openhuman-rpc tinyplace github smtp dns tinyhumans webhooks platform-jwt export"` compiles the `openhuman` crate clean and produces a runnable tenant image (deployed to staging `smoke1`, which now serves real chat instead of the echo brain).

Rust checkboxes N/A — no Rust source changed:

- [ ] `cargo fmt --all -- --check` — N/A (no Rust change)
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A
- [ ] `cargo build --all-targets` — N/A
- [ ] `cargo test` — N/A

## Documentation

Updated the `.dockerignore` comment to explain why docs are excluded by *contents* with a tinyagents re-include (the `include_str!` compile-input caveat), so the next person doesn't re-introduce the blanket exclude.

## Related

Prereq for `tinyhumansai/opencompany-microservice#4` (auto-sync/redeploy CI), whose tenant build bumps this repo as a submodule and needs these deps to build the `openhuman` feature.