### PR TITLE
fix(connections): stop credential-autofill leaking admin login into Add-MCP form

### DIFF
--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -609,8 +609,10 @@ function McpServersSection({
                   </Label>
                   <Input
                     id="mcp-endpoint"
+                    name="mcp-endpoint-url"
                     value={endpoint}
                     placeholder="https://host/mcp"
+                    autoComplete="url"
                     onChange={(e) => setEndpoint(e.target.value)}
                   />
                 </div>
@@ -651,10 +653,11 @@ function McpServersSection({
                   </Label>
                   <Input
                     id="mcp-token"
+                    name="mcp-token-secret"
                     type="password"
                     value={token}
                     placeholder="write-only"
-                    autoComplete="off"
+                    autoComplete="new-password"
                     onChange={(e) => setToken(e.target.value)}
                   />
                 </div>


### PR DESCRIPTION
## Summary

Stop the browser credential manager from autofilling the saved admin login into the Connections → "Add MCP server" form. The Endpoint field was arriving pre-filled with the admin email and the Token field with a hidden saved password — a text field followed by a password field is heuristically treated as a username/password pair. Real risk: a pre-injected admin token could be POSTed to a wrong/hostile MCP endpoint.

Fix (frontend, `ConnectionsView.tsx`): Endpoint input gets `autoComplete="url"` + a non-username `name="mcp-endpoint-url"`; Token input changes `autoComplete="off"` → `autoComplete="new-password"` (the reliable signal that suppresses saved-password injection; plain `off` is ignored on password fields) + `name="mcp-token-secret"`.

## API Or Behavior Changes

None. Form-attribute-only change; no API, no data flow change.

## Tests

Frontend-only; Rust suite N/A.
- [x] `npm ci`
- [x] `npm run typecheck` (tsc -b) — pass
- [x] `npm run build` (vite) — pass
- [ ] `cargo fmt --all -- --check` — N/A (no Rust changes)
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A
- [ ] `cargo build --all-targets` — N/A
- [ ] `cargo test` — N/A

Residual: autofill is heuristic — `new-password` reliably stops automatic injection across Chrome/Firefox/Safari/Edge, but a user manually picking a saved credential from the dropdown can still fill a field (user-initiated, out of scope).

## Documentation

None needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser autofill behavior when adding MCP servers.
  * Endpoint and credential fields now receive more appropriate autofill suggestions while preserving secure credential entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->