### PR TITLE
fix(console): render markdown in chat + brain memory

### DIFF
--- a/frontend/src/components/markdown.tsx
+++ b/frontend/src/components/markdown.tsx
@@ -1,0 +1,27 @@
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared markdown renderer used across chat, memory, workspace, and workflow
+ * surfaces so `**bold**`, lists, links, and inline code render consistently
+ * instead of leaking literal markup. Wraps `react-markdown` + `remark-gfm` in a
+ * `prose` container and honors both themes via `dark:prose-invert`.
+ *
+ * Mirrors the recipe already used by WorkspaceView (NoteMarkdown) and
+ * WorkflowsView so every surface shares one renderer and one look.
+ */
+export function Markdown({
+  children,
+  className,
+}: {
+  children: string;
+  className?: string;
+}) {
+  return (
+    <div className={cn("prose prose-sm max-w-none dark:prose-invert", className)}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{children}</ReactMarkdown>
+    </div>
+  );
+}

--- a/frontend/src/views/Conversation.tsx
+++ b/frontend/src/views/Conversation.tsx
@@ -20,6 +20,7 @@ import { toast } from "sonner";
 import type { OpenCompanyClient } from "@/api/client";
 import { ApiError, type TurnStep, type TurnStepKind } from "@/api/types";
 import { listInflight, steerTask, type InflightRun, type SteerAction } from "@/api/tasks";
+import { Markdown } from "@/components/markdown";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -573,7 +574,6 @@ function Bubble({ message, mine, last }: { message: ChatMessage; mine: boolean; 
         last && (mine ? "rounded-br-md" : "rounded-bl-md"),
       )}
     >
-      <span className="whitespace-pre-wrap break-words align-bottom">{message.text}</span>
       <span
         className={cn(
           "float-right ml-2 translate-y-1 select-none text-[10px]",
@@ -582,6 +582,16 @@ function Bubble({ message, mine, last }: { message: ChatMessage; mine: boolean; 
       >
         {formatTime(message.at)}
       </span>
+      {mine ? (
+        // User-typed bubbles stay plain text so literal asterisks/underscores a
+        // person types aren't reinterpreted as markdown.
+        <span className="whitespace-pre-wrap break-words align-bottom">{message.text}</span>
+      ) : (
+        // Company/agent replies render markdown so **bold**, lists, and links
+        // show formatted instead of leaking raw markup. Trim the first/last
+        // block margins so a reply stays flush inside the tight bubble padding.
+        <Markdown className="[&>:first-child]:mt-0 [&>:last-child]:mb-0">{message.text}</Markdown>
+      )}
     </div>
   );
 }

--- a/frontend/src/views/MemoryView.tsx
+++ b/frontend/src/views/MemoryView.tsx
@@ -17,6 +17,7 @@ import {
   type MemoryStats,
 } from "@/api/memory";
 import type { OpenCompanyClient } from "@/api/client";
+import { Markdown } from "@/components/markdown";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -308,7 +309,14 @@ function MemoryCard({ entry, onDelete }: { entry: MemoryEntry; onDelete: () => v
             {badge.label}
           </Badge>
         </div>
-        {entry.body && <p className="text-sm text-muted-foreground">{entry.body}</p>}
+        {entry.body && (
+          // Render markdown so **bold**/lists in memory bodies format instead
+          // of showing raw markup. Force muted-foreground on every descendant so
+          // prose's own palette doesn't override the card's muted body styling.
+          <Markdown className="text-muted-foreground [&_*]:text-muted-foreground [&>:first-child]:mt-0 [&>:last-child]:mb-0">
+            {entry.body}
+          </Markdown>
+        )}
         <div className="flex items-center justify-between pt-1">
           <span className="text-xs text-muted-foreground">via {entry.source}</span>
           {/* Delete is only offered on operator facts; agent memory and task


### PR DESCRIPTION
## Summary

Render markdown in the Conversation chat and Brain memory entries, which previously showed literal `**asterisks**` while Workflow results and Workspace notes rendered correctly. There was no shared renderer — the working views used `react-markdown` inline; Chat `Bubble` and `MemoryCard` emitted raw text nodes.

Fix: add a shared `frontend/src/components/markdown.tsx` (`react-markdown` + `remark-gfm`, `prose prose-sm max-w-none dark:prose-invert`, mirroring the recipe the working views already use), then route Chat company/agent bubbles and Brain memory bodies through it. User-typed bubbles stay plain text so literal asterisks a person types are not reinterpreted.

## API Or Behavior Changes

Agent/company chat replies and memory-card bodies now render markdown (bold, lists, links, etc.). User messages unchanged. No API change. `react-markdown@10`/`remark-gfm@4` were already in `package.json` — no dependency added.

## Tests

Frontend-only; Rust suite N/A.
- [x] `npm ci`
- [x] `npm run typecheck` — pass
- [x] `npm run build` — pass (only the pre-existing >500 kB chunk-size warning, unrelated)
- [ ] `cargo fmt --all -- --check` — N/A (no Rust changes)
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A
- [ ] `cargo build --all-targets` — N/A
- [ ] `cargo test` — N/A

Note: two prose-overlay tweaks (agent-bubble timestamp float under prose, memory-body muted-color override) are reasoned from CSS/tailwind-typography semantics; typecheck+build prove compilation only — worth a quick visual pass in light + dark.

## Documentation

None needed.
