### PR TITLE
fix(tasks): keep trailing gutter after Done column on Kanban board

### DIFF
--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -163,7 +163,7 @@ export function TasksView({
         </div>
       )}
 
-      <div className="flex flex-1 gap-4 overflow-x-auto p-4">
+      <div className="flex flex-1 gap-4 overflow-x-auto py-4 pl-4">
         {TASK_COLUMNS.map((col) => {
           const items = tasks.filter((t) => t.column === col.id);
           return (
@@ -227,6 +227,9 @@ export function TasksView({
             </div>
           );
         })}
+        {/* Trailing gutter: flex scroll containers drop their padding-inline-end,
+            so this spacer keeps ~16px of breathing room past the last column. */}
+        <div aria-hidden className="w-4 shrink-0" />
       </div>
 
       <TaskDetailDialog


### PR DESCRIPTION
## Summary

Keep a trailing gutter after the last ("Done") column on the Tasks Kanban board. The columns live in a horizontal flex scroll container that carried its right gutter via `p-4`; browsers drop the padding-inline-end of a flex scroll container, so scrolling fully right clipped the Done column flush against the edge.

Fix (`TasksView.tsx`): change the container `p-4` → `py-4 pl-4` (keep the left gutter + all vertical padding, drop the ignored right padding) and append an `aria-hidden` `w-4 shrink-0` spacer as the last flex child — a real, non-shrinking item whose 16 px is part of the scroll extent, so the Done column now has breathing room past its right edge.

## API Or Behavior Changes

None. Layout/CSS-only change.

## Tests

Frontend-only; Rust suite N/A.
- [x] `npm ci`
- [x] `npm run typecheck` (tsc -b) — pass
- [x] `npm run build` (vite) — pass
- [ ] `cargo fmt --all -- --check` — N/A (no Rust changes)
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A
- [ ] `cargo build --all-targets` — N/A
- [ ] `cargo test` — N/A

## Documentation

None needed.
