### PR TITLE
test(connections): de-flake the tamper-rejection assertion

### DIFF
--- a/src/server/ops/connections.rs
+++ b/src/server/ops/connections.rs
@@ -497,10 +497,14 @@ mod test {
         assert_eq!(company, "acme");
         assert_eq!(provider, "slack");
 
-        // A tampered signature fails.
+        // A tampered signature fails. Flip the last char to a guaranteed-different
+        // one so the mutation is never a no-op (a blind `push('0')` leaves the
+        // string unchanged — and the assertion flaky — whenever it already ends
+        // in '0').
         let mut tampered = state.clone();
-        tampered.pop();
-        tampered.push('0');
+        let last = tampered.pop().expect("encoded state is non-empty");
+        tampered.push(if last == '0' { '1' } else { '0' });
+        assert_ne!(tampered, state, "tamper must actually change the state");
         assert!(decode_state(&tampered).is_none());
     }
 


### PR DESCRIPTION
## Summary

Fix a flaky CI test. `state_round_trips_and_rejects_tampering` tampered the signed OAuth state with `tampered.pop(); tampered.push('0')` — a no-op whenever the encoded state already ended in `'0'`, leaving `tampered == state` so `decode_state` validated it and `assert!(… .is_none())` failed. It bit real PRs at random (~1/16–1/64 per run; hit #146 today). The fix flips the last char to a guaranteed-different value and asserts the mutation actually changed the string.

## API Or Behavior Changes

None — test-only change.

## Tests

- [x] `cargo fmt --all -- --check`
- [ ] `cargo build --all-targets` — not run locally; the change is a test-only one-liner, CI runs the suite
- [ ] `cargo test` — CI verifies `server::ops::connections::test::state_round_trips_and_rejects_tampering`

## Documentation

None needed.
