### PR TITLE
fix(harness): bound agent/workflow re-entry depth to stop stack-overflow crash (#155)

### DIFF
--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -82,6 +82,30 @@ use crate::ports::{
 };
 use crate::runtime::builder::agent_effective_grants;
 
+tokio::task_local! {
+    /// Re-entry depth across the harness↔workflow-engine boundary (issue #155).
+    ///
+    /// Incremented once per [`HarnessPool::run_inner`] entry — the single choke
+    /// point every agent turn flows through (`run` / `run_background` /
+    /// `run_steered` / `run_steered_background`). A workflow `agent` node
+    /// re-enters the pool via [`run_background`](HarnessPool::run_background);
+    /// when that node resolves to an orchestrator carrying the `run_workflow`
+    /// tool, it can call the engine again and re-enter here, so this counter is
+    /// the only thing that spans the harness→engine→harness cycle. Tinyflows'
+    /// own `MAX_SUB_WORKFLOW_DEPTH` counts `sub_workflow` nodes *within one*
+    /// `engine::run` and resets to 0 on every fresh `run_workflow` tool call, so
+    /// it cannot see the cycle. Reading this outside any scope defaults to 0.
+    static AGENT_REENTRY_DEPTH: usize;
+}
+
+/// The maximum harness↔engine re-entry depth before a turn is refused
+/// (issue #155). Matches tinyflows' `MAX_SUB_WORKFLOW_DEPTH` (8): a
+/// deep-but-legitimate workflow→agent→workflow nesting stays well under it,
+/// while the unbounded self-delegation cycle (an `agent` node that resolves back
+/// to the orchestrator, which runs the same workflow again) is cut before it can
+/// overflow the Tokio worker stack and abort the host.
+const MAX_AGENT_REENTRY_DEPTH: usize = 8;
+
 /// Shared dependencies every harness-built agent draws on.
 #[derive(Clone)]
 pub struct HarnessDeps {
@@ -897,7 +921,63 @@ impl HarnessPool {
         .await
     }
 
+    /// The single choke point every turn passes through, wrapping
+    /// [`run_inner_body`](Self::run_inner_body) with the harness↔engine re-entry
+    /// depth guard (issue #155).
+    ///
+    /// A workflow `agent` node re-enters the pool through
+    /// [`run_background`](Self::run_background); when it resolves back to an
+    /// orchestrator that runs the same workflow, that would recurse without bound
+    /// — each `run_workflow` tool call starts a *fresh* engine, so tinyflows' own
+    /// sub-workflow depth guard resets and never sees the cycle — until the Tokio
+    /// worker stack overflows and the host aborts. The task-local
+    /// [`AGENT_REENTRY_DEPTH`] counter (read as 0 outside any scope) bounds that
+    /// cycle: once it reaches [`MAX_AGENT_REENTRY_DEPTH`] the turn is refused with
+    /// a clean [`OpenCompanyError::Harness`] rather than recursing, which
+    /// [`RunWorkflowTool`](crate::harness::orchestrator::RunWorkflowTool) turns
+    /// into a tool error and
+    /// [`HarnessAgentRunner`](crate::workflows::caps) into an
+    /// `EngineError::Capability` — so the workflow run fails gracefully and the
+    /// host stays up.
+    ///
+    /// [`Box::pin`] at the scope boundary keeps the added future frame off the
+    /// worker stack (the nested-`task_local::scope` overflow trap the turn loop's
+    /// [`with_stop_hooks`](oh::agent::stop_hooks::with_stop_hooks) call already
+    /// boxes around).
     async fn run_inner(
+        &self,
+        company: &CompanyId,
+        agent_id: &str,
+        message: &str,
+        deps: &HarnessDeps,
+        steer: Option<&SteerControl>,
+        live: LiveStream<'_>,
+    ) -> crate::Result<TurnOutcome> {
+        // Default to 0 when no scope is active (a normal top-level turn) — never
+        // an `unwrap` that would panic outside the task-local.
+        let depth = AGENT_REENTRY_DEPTH.try_with(|d| *d).unwrap_or(0);
+        if depth >= MAX_AGENT_REENTRY_DEPTH {
+            tracing::warn!(
+                company = %company,
+                agent = agent_id,
+                depth,
+                max = MAX_AGENT_REENTRY_DEPTH,
+                "agent/workflow re-entry depth exceeded; refusing to recurse"
+            );
+            return Err(OpenCompanyError::Harness(
+                "agent/workflow re-entry depth exceeded".to_string(),
+            ));
+        }
+
+        AGENT_REENTRY_DEPTH
+            .scope(
+                depth + 1,
+                Box::pin(self.run_inner_body(company, agent_id, message, deps, steer, live)),
+            )
+            .await
+    }
+
+    async fn run_inner_body(
         &self,
         company: &CompanyId,
         agent_id: &str,

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -1072,4 +1072,250 @@ to = "done"
             run.output
         );
     }
+
+    // --- Issue #155: harness↔engine re-entry depth guard --------------------
+
+    use std::sync::LazyLock;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use tinyagents::harness::message::{AssistantMessage, Message};
+    use tinyagents::harness::model::{ChatModel, ModelProfile, ModelRequest, ModelResponse};
+    use tinyagents::harness::tool::ToolCall;
+
+    use crate::harness::provider::HarnessModel;
+    use crate::ports::types::{CompanySummary, LedgerEntry, OverlayAgent};
+
+    /// A native-tool-calling capability profile (`tool_calling: true`), so the
+    /// harness drives the reliable [`NativeToolDispatcher`] path (issue #145)
+    /// rather than the prompt-guided XML fallback — mirroring the managed
+    /// inference surface the product actually runs.
+    static LOOP_PROFILE: LazyLock<ModelProfile> = LazyLock::new(|| ModelProfile {
+        tool_calling: true,
+        ..ModelProfile::default()
+    });
+
+    /// A self-referential workflow: `trigger → agent(ceo) → output`. Its agent
+    /// node routes back to the orchestrator (`ceo`), which carries the
+    /// `run_workflow` tool over the shared runner handle — so running it can run
+    /// it again, forming the harness↔engine re-entry cycle of issue #155.
+    const LOOP_WF: &str = r#"
+id = "loop"
+name = "Loop"
+
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+
+[[node]]
+id = "call"
+kind = "agent"
+name = "Call orchestrator"
+agent = "ceo"
+
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+
+[[edge]]
+from = "start"
+to = "call"
+
+[[edge]]
+from = "call"
+to = "done"
+"#;
+
+    /// A scripted native-tool-calling model (advertises [`LOOP_PROFILE`] so the
+    /// harness drives structured tool calls, no network) that asks to run the
+    /// `loop` workflow on the first invoke of a turn, then replies plainly once
+    /// the tool has answered. It records whether the re-entry guard's clean error
+    /// ever surfaced back into a conversation.
+    #[derive(Default)]
+    struct LoopModel {
+        invokes: AtomicUsize,
+        saw_depth_error: AtomicBool,
+    }
+
+    #[async_trait]
+    impl ChatModel<()> for LoopModel {
+        fn profile(&self) -> Option<&ModelProfile> {
+            Some(&LOOP_PROFILE)
+        }
+
+        async fn invoke(
+            &self,
+            _state: &(),
+            request: ModelRequest,
+        ) -> tinyagents::Result<ModelResponse> {
+            let n = self.invokes.fetch_add(1, Ordering::SeqCst);
+            // The guard returns a clean `Error` that `RunWorkflowTool` turns into a
+            // tool-error result; seeing it fed back into a later conversation
+            // proves the cycle failed gracefully rather than overflowing.
+            if request
+                .messages
+                .iter()
+                .any(|m| m.text().contains("re-entry depth exceeded"))
+            {
+                self.saw_depth_error.store(true, Ordering::SeqCst);
+            }
+            // Each recursion level runs on a freshly rebuilt agent, so any prior
+            // assistant or tool message means the tool already ran this turn →
+            // stop and reply. The absolute invoke ceiling is a belt-and-suspenders
+            // bound so a heuristic miss can never run away.
+            let is_followup = request
+                .messages
+                .iter()
+                .any(|m| matches!(m, Message::Assistant(_) | Message::Tool(_)));
+            if is_followup || n > 64 {
+                return Ok(ModelResponse::assistant("done"));
+            }
+            // Ask to run the `loop` workflow via a structured (native) tool call.
+            Ok(ModelResponse {
+                message: AssistantMessage {
+                    id: None,
+                    content: Vec::new(),
+                    tool_calls: vec![ToolCall {
+                        id: format!("call-{n}"),
+                        name: "run_workflow".to_string(),
+                        arguments: serde_json::json!({ "id": "loop" }),
+                        invalid: None,
+                    }],
+                    usage: None,
+                },
+                usage: None,
+                finish_reason: Some("tool_calls".to_string()),
+                raw: None,
+                resolved_model: None,
+                continue_turn: None,
+            })
+        }
+    }
+
+    impl HarnessModel for LoopModel {
+        fn telemetry_provider_id(&self) -> String {
+            "loop-test".to_string()
+        }
+    }
+
+    /// A [`CompanyStore`] whose `load` returns a record with a *different* overlay
+    /// teammate on every call, so [`HarnessPool::ensure`] re-fingerprints and
+    /// rebuilds the roster each time the runner consults it. This models the
+    /// production condition under which the re-entry cycle recurses on *fresh*
+    /// orchestrator instances (rather than deadlocking on one agent's re-entrant
+    /// `Mutex`), which is exactly when the depth guard is the operative bound.
+    #[derive(Default)]
+    struct RebuildStore {
+        loads: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl crate::ports::CompanyStore for RebuildStore {
+        async fn load(&self, _id: &CompanyId) -> crate::Result<Option<CompanyRecord>> {
+            let n = self.loads.fetch_add(1, Ordering::SeqCst);
+            let mut rec = record();
+            rec.overlay_agents = vec![OverlayAgent {
+                id: format!("ghost-{n}"),
+                name: "Ghost".into(),
+                role: "Rebuild trigger".into(),
+                description: None,
+            }];
+            Ok(Some(rec))
+        }
+        async fn save(&self, _record: &CompanyRecord) -> crate::Result<()> {
+            Ok(())
+        }
+        async fn list(&self) -> crate::Result<Vec<CompanySummary>> {
+            Ok(Vec::new())
+        }
+        async fn append_ledger(&self, _id: &CompanyId, _entry: LedgerEntry) -> crate::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Regression for issue #155. An `agent` node that resolves back to the
+    /// orchestrator (which re-runs the same workflow) forms a harness↔engine
+    /// re-entry cycle. Pre-fix it recursed without bound until the Tokio worker
+    /// stack overflowed and aborted the host; post-fix the task-local depth guard
+    /// in [`HarnessPool::run_inner`] refuses past `MAX_AGENT_REENTRY_DEPTH`, the
+    /// workflow run fails gracefully, and the turn returns normally.
+    #[test]
+    fn workflow_agent_reentry_is_bounded_not_a_stack_overflow() {
+        // Drive the async body on a dedicated, generous stack with a
+        // current-thread runtime (the `#[tokio::test]` default flavour). The
+        // *bounded* 8-level re-entry chain — each level a full turn-loop + engine
+        // + tool-dispatch frame — is deep, so libtest's small default stack would
+        // false-overflow even the fixed code. Pre-fix the same chain recurses
+        // WITHOUT bound and exhausts even this 32 MiB; the depth guard is what
+        // stops it. A `spawn`ed thread that `join`s propagates a real overflow as
+        // an abort (test failure), so this still fails loudly on a regression.
+        std::thread::Builder::new()
+            .stack_size(32 * 1024 * 1024)
+            .name("wf155-reentry".into())
+            .spawn(|| {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("current-thread runtime builds")
+                    .block_on(reentry_body());
+            })
+            .expect("spawn re-entry thread")
+            .join()
+            .expect("the bounded re-entry cycle must not overflow/abort the host");
+    }
+
+    async fn reentry_body() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = tempfile::tempdir().unwrap();
+        write_wf(source.path(), "loop", LOOP_WF);
+
+        let model = Arc::new(LoopModel::default());
+        let mut deps = deps(dir.path());
+        deps.provider = model.clone();
+        deps.store = Arc::new(RebuildStore::default());
+        // Doubles as the run_workflow tool's source dir: `build_agent` wires the
+        // orchestrator's run_workflow tool from `skills_source_dir`.
+        deps.skills_source_dir = Some(source.path().to_path_buf());
+
+        let rec = record(); // single `ceo` agent → the orchestrator
+        let pool = Arc::new(HarnessPool::new());
+
+        // Fill the shared handle exactly as the runtime builder does, so the
+        // orchestrator's run_workflow tool reaches a real HarnessWorkflowRunner
+        // over the same pool/deps.
+        let runner: Arc<dyn WorkflowRunner> = Arc::new(HarnessWorkflowRunner::new(
+            pool.clone(),
+            deps.clone(),
+            rec.clone(),
+        ));
+        deps.workflow_runner.set(&runner);
+
+        pool.ensure(&rec, &deps)
+            .await
+            .expect("initial roster builds");
+
+        // One orchestrator turn drives the whole cycle. It MUST return — not hang,
+        // not overflow/abort. The depth cap keeps the recursion shallow and fast.
+        let outcome = pool
+            .run(&rec.id, "ceo", "kick off the loop", &deps, None)
+            .await
+            .expect("the bounded re-entry cycle resolves gracefully");
+
+        // Proof the guard actually fired and its clean error propagated back into
+        // the workflow run as a tool error (graceful failure, not a crash).
+        assert!(
+            model.saw_depth_error.load(Ordering::SeqCst),
+            "the re-entry depth guard must fire and surface a clean error to the turn"
+        );
+        // The top turn still resolves to a normal reply.
+        assert!(
+            !outcome.reply.is_empty(),
+            "the top-level turn should produce a reply, got empty"
+        );
+
+        // The handle holds only a Weak; keep the strong runner alive to here.
+        drop(runner);
+    }
 }


### PR DESCRIPTION
## Summary

Bound agent/workflow **re-entry depth** so a workflow that (directly or transitively) runs an orchestrator agent can no longer recurse without limit and overflow the worker stack / abort the host. Closes #155.

## Problem

`run_workflow` runs the tinyflows engine **inline inside the tool call**, and the engine runs `agent` nodes **inline back into the harness** (all awaited in-stack, no spawn). When a workflow `agent` node resolves to the **orchestrator** — which itself carries `RunWorkflowTool` over the same shared runner — it calls `run_workflow` again → the engine runs the orchestrator node again → unbounded depth → `tokio-rt-worker` stack overflow → the tenant host aborts (console then shows "cannot reach the company host"). Reachable with shipped seed companies (e.g. the first roster agent defaulting to orchestrator while also being a pipeline node).

Existing guards don't catch it: tinyflows' `MAX_SUB_WORKFLOW_DEPTH=8` counts `sub_workflow` nodes *within one* `engine::run`, but each `run_workflow` tool call starts a **fresh** engine (depth reset); the `Box::pin` in `run_with_steer` bounds future *size*, not recursion *depth*. Made live by native tool-calling (#145) — before it the orchestrator tools never executed.

## Solution

Add a re-entry **depth guard that spans the harness↔engine boundary**:
- A `tokio::task_local!` counter `AGENT_REENTRY_DEPTH` + `const MAX_AGENT_REENTRY_DEPTH = 8` (matches tinyflows' sub-workflow bound).
- `HarnessPool::run_inner` (the single choke point for `run`/`run_background`/`run_steered*`) reads the task-local (defaulting to 0 outside any scope), returns a clean `Harness("agent/workflow re-entry depth exceeded")` once depth hits the cap, else runs the body inside `AGENT_REENTRY_DEPTH.scope(depth+1, Box::pin(..))`. The `Box::pin` at the scope boundary mirrors the existing `with_stop_hooks` pattern to avoid the nested-`task_local::scope` worker-stack trap.
- The error surfaces gracefully: `run_agent` maps it to `EngineError::Capability`, the engine run fails, and `RunWorkflowTool::execute` returns a `ToolResult::error` — the calling orchestrator turn replies normally and **the process stays up**. No changes needed at those call sites (they already handle a `crate::Error`).

## API Or Behavior Changes

No public API change. A workflow that self-recurses past 8 levels of agent-driven re-entry now fails that run with a clear tool-error instead of crashing the host. Legitimate nesting stays well under 8.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --features openhuman`
- [x] `cargo test --features openhuman` — `workflows::runner` 16/16 (incl. new `workflow_agent_reentry_is_bounded_not_a_stack_overflow`), `harness::` 211/211
- [x] `cargo clippy --features openhuman,composio --no-deps -- -D warnings` — clean

Regression test reproduces the overflow pre-fix (unbounded chain exhausts even a 32 MiB thread) and asserts a bounded clean refusal post-fix.

## Documentation

None needed — internal harness safety guard.

## Related

Closes #155. Exposed by #145 (native tool-calling). Unblocks the Workflows feature + the hand-off loop (#154, #151).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added protection against unbounded workflow and agent recursion.
  * Recursion now stops with a clear error instead of risking crashes or stalled runs.
  * Top-level workflow runs continue completing normally when recursive re-entry is detected.

* **Tests**
  * Added regression coverage for recursive workflow execution and clean error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->