### PR TITLE
fix(composio): backend URL follows TINYHUMANS_API_URL before prod default

### DIFF
--- a/src/company/composio.rs
+++ b/src/company/composio.rs
@@ -19,20 +19,38 @@ use crate::ports::types::{CompanyId, SecretValue};
 /// raw token string.
 pub const TOKEN_KEY: &str = "composio/token";
 
-/// The environment override for the Composio backend URL. Only the **URL** has
-/// an env path — the **token** deliberately does not (fail-closed isolation).
+/// The explicit environment override for the Composio backend URL. Only the
+/// **URL** has an env path — the **token** deliberately does not (fail-closed
+/// isolation). When unset, resolution falls back to the tenant's shared API
+/// base ([`TINYHUMANS_API_URL_ENV`]) so staging Composio follows staging.
 pub const COMPOSIO_BACKEND_URL_ENV: &str = "OPENCOMPANY_COMPOSIO_BACKEND_URL";
 
-/// Default backend base URL for the Composio routes when the environment does
-/// not override it. Mirrors the media backend's default host.
+/// The tenant's shared TinyHumans API base URL (the same backend inference and
+/// the rest of the app already use). Used as the Composio backend fallback when
+/// [`COMPOSIO_BACKEND_URL_ENV`] is unset, so a staging tenant's Composio calls
+/// go to staging instead of the hardcoded prod default.
+pub const TINYHUMANS_API_URL_ENV: &str = "TINYHUMANS_API_URL";
+
+/// Default backend base URL for the Composio routes when neither the explicit
+/// override nor the tenant API base is set. Mirrors the media backend's default
+/// host (prod).
 pub const DEFAULT_BACKEND_URL: &str = "https://api.tinyhumans.ai";
 
-/// The effective backend URL: the trimmed env override when non-empty, else the
-/// default. Credential-free — safe to surface on the console read plane.
-pub fn backend_url_or_default(env_url: Option<String>) -> String {
-    env_url
+/// The effective Composio backend URL, resolved in this order (first non-empty,
+/// trimmed, wins):
+///
+/// 1. `env_override` — [`COMPOSIO_BACKEND_URL_ENV`], the explicit override.
+/// 2. `api_url` — [`TINYHUMANS_API_URL_ENV`], the tenant's shared backend base,
+///    so Composio follows staging/prod with the rest of the app.
+/// 3. [`DEFAULT_BACKEND_URL`] (prod) — last resort.
+///
+/// Credential-free — safe to surface on the console read plane.
+pub fn backend_url_or_default(env_override: Option<String>, api_url: Option<String>) -> String {
+    [env_override, api_url]
+        .into_iter()
+        .flatten()
         .map(|u| u.trim().to_string())
-        .filter(|u| !u.is_empty())
+        .find(|u| !u.is_empty())
         .unwrap_or_else(|| DEFAULT_BACKEND_URL.to_string())
 }
 
@@ -63,15 +81,44 @@ mod tests {
     use super::*;
 
     #[test]
-    fn backend_url_prefers_env_then_default() {
-        assert_eq!(backend_url_or_default(None), DEFAULT_BACKEND_URL);
+    fn backend_url_prefers_override_then_api_url_then_default() {
+        // Neither set → prod default.
+        assert_eq!(backend_url_or_default(None, None), DEFAULT_BACKEND_URL);
+
+        // Explicit override wins over everything.
         assert_eq!(
-            backend_url_or_default(Some("  ".into())),
+            backend_url_or_default(
+                Some("https://custom.example".into()),
+                Some("https://staging-api.tinyhumans.ai".into())
+            ),
+            "https://custom.example"
+        );
+
+        // No override → follow the tenant API base (the staging case).
+        assert_eq!(
+            backend_url_or_default(None, Some("https://staging-api.tinyhumans.ai".into())),
+            "https://staging-api.tinyhumans.ai"
+        );
+
+        // Whitespace/empty override falls through to the api_url fallback.
+        assert_eq!(
+            backend_url_or_default(
+                Some("  ".into()),
+                Some("https://staging-api.tinyhumans.ai".into())
+            ),
+            "https://staging-api.tinyhumans.ai"
+        );
+
+        // Whitespace/empty api_url falls through to the prod default.
+        assert_eq!(
+            backend_url_or_default(Some("".into()), Some("   ".into())),
             DEFAULT_BACKEND_URL
         );
+
+        // api_url is trimmed before use.
         assert_eq!(
-            backend_url_or_default(Some("https://custom.example".into())),
-            "https://custom.example"
+            backend_url_or_default(None, Some("  https://staging-api.tinyhumans.ai  ".into())),
+            "https://staging-api.tinyhumans.ai"
         );
     }
 }

--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -30,7 +30,9 @@ use crate::ports::types::{CompanyId, SecretValue};
 // The credential key + backend routing live in the always-compiled
 // `company::composio` module (so the console read/write plane can manage the
 // token in the default build); re-exported here for the harness call sites.
-pub use crate::company::composio::{COMPOSIO_BACKEND_URL_ENV, TOKEN_KEY, backend_url_or_default};
+pub use crate::company::composio::{
+    COMPOSIO_BACKEND_URL_ENV, TINYHUMANS_API_URL_ENV, TOKEN_KEY, backend_url_or_default,
+};
 
 /// A per-tenant Composio configuration: the backend URL, the tenant's OAuth
 /// bearer token, and the toolkit allowlist.
@@ -80,10 +82,11 @@ impl TenantComposio {
     ///
     /// The token comes **only** from [`TOKEN_KEY`] in the secret store — there is
     /// no environment or platform-key fallback, by design: an absent token must
-    /// mean "no tools", never "borrow someone else's identity". The URL *may*
-    /// come from [`COMPOSIO_BACKEND_URL_ENV`], falling back to
-    /// [`DEFAULT_COMPOSIO_BACKEND_URL`]. `toolkits` is the manifest allowlist,
-    /// threaded through unchanged.
+    /// mean "no tools", never "borrow someone else's identity". The URL resolves
+    /// from [`COMPOSIO_BACKEND_URL_ENV`], then the tenant API base
+    /// [`TINYHUMANS_API_URL_ENV`], then [`DEFAULT_BACKEND_URL`] — see
+    /// [`backend_url_or_default`]. `toolkits` is the manifest allowlist, threaded
+    /// through unchanged.
     ///
     /// A secret-store read error degrades to `None` (fail closed) rather than
     /// bubbling — a transient store hiccup withholds the tools for that turn
@@ -93,6 +96,7 @@ impl TenantComposio {
         secrets: &dyn SecretStore,
         toolkits: Vec<String>,
         backend_url_env: Option<String>,
+        api_url_env: Option<String>,
     ) -> Option<Self> {
         let token = match secrets.get(company, TOKEN_KEY).await {
             Ok(Some(SecretValue(token))) => token,
@@ -103,7 +107,7 @@ impl TenantComposio {
             return None;
         }
         Some(Self {
-            backend_url: backend_url_or_default(backend_url_env),
+            backend_url: backend_url_or_default(backend_url_env, api_url_env),
             auth_token: token,
             toolkits,
         })
@@ -664,7 +668,7 @@ mod tests {
         // SAFETY: single-threaded test; we set then restore the env.
         unsafe { std::env::set_var("TINYHUMANS_API_KEY", "platform-managed-key") };
         assert!(
-            TenantComposio::resolve(&company, &secrets, Vec::new(), None)
+            TenantComposio::resolve(&company, &secrets, Vec::new(), None, None)
                 .await
                 .is_none(),
             "no stored token must fail closed, ignoring any env platform key"
@@ -676,7 +680,7 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            TenantComposio::resolve(&company, &secrets, Vec::new(), None)
+            TenantComposio::resolve(&company, &secrets, Vec::new(), None, None)
                 .await
                 .is_none(),
             "an empty/whitespace token must fail closed"
@@ -691,12 +695,26 @@ mod tests {
             )
             .await
             .unwrap();
-        let resolved = TenantComposio::resolve(&company, &secrets, vec!["gmail".into()], None)
-            .await
-            .expect("a stored token resolves");
+        let resolved =
+            TenantComposio::resolve(&company, &secrets, vec!["gmail".into()], None, None)
+                .await
+                .expect("a stored token resolves");
         assert_eq!(resolved.auth_token, "tenant-token-xyz");
         assert_eq!(resolved.backend_url, "https://api.tinyhumans.ai");
         assert_eq!(resolved.toolkits, vec!["gmail".to_string()]);
+
+        // With no explicit override, the tenant API base is threaded into the
+        // backend URL so a staging tenant's Composio follows staging.
+        let staged = TenantComposio::resolve(
+            &company,
+            &secrets,
+            Vec::new(),
+            None,
+            Some("https://staging-api.tinyhumans.ai".into()),
+        )
+        .await
+        .expect("a stored token resolves");
+        assert_eq!(staged.backend_url, "https://staging-api.tinyhumans.ai");
 
         unsafe { std::env::remove_var("TINYHUMANS_API_KEY") };
         std::fs::remove_dir_all(&dir).ok();

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -702,9 +702,11 @@ impl HarnessPool {
     /// secret store wired this degrades to the static [`HarnessDeps::composio`].
     ///
     /// The token has no env fallback — an absent/empty secret yields `None` (fail
-    /// closed). The backend URL honors [`composio::COMPOSIO_BACKEND_URL_ENV`],
-    /// read process-globally so a live re-resolution keeps the override even when
-    /// no token was stored at boot.
+    /// closed). The backend URL resolves from
+    /// [`composio::COMPOSIO_BACKEND_URL_ENV`], then the tenant API base
+    /// [`composio::TINYHUMANS_API_URL_ENV`], then the prod default — read
+    /// process-globally so a live re-resolution keeps the override even when no
+    /// token was stored at boot.
     async fn resolve_composio(
         &self,
         company: &CompanyRecord,
@@ -717,9 +719,17 @@ impl HarnessPool {
         match &deps.secrets {
             Some(secrets) => {
                 use crate::app::config::EnvSource;
-                let url = crate::app::config::ProcessEnv.get(composio::COMPOSIO_BACKEND_URL_ENV);
-                composio::TenantComposio::resolve(&company.id, secrets.as_ref(), toolkits, url)
-                    .await
+                let env = crate::app::config::ProcessEnv;
+                let url = env.get(composio::COMPOSIO_BACKEND_URL_ENV);
+                let api_url = env.get(composio::TINYHUMANS_API_URL_ENV);
+                composio::TenantComposio::resolve(
+                    &company.id,
+                    secrets.as_ref(),
+                    toolkits,
+                    url,
+                    api_url,
+                )
+                .await
             }
             None => deps.composio.clone(),
         }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -872,24 +872,30 @@ impl RuntimeBuilder {
                             });
                             // Issue #110: resolve the per-tenant Composio config
                             // at boot from the company secret store (token) + the
-                            // manifest toolkit allowlist + the env URL override.
-                            // Only companies that explicitly grant `composio`
-                            // touch the store; the token has no env fallback, so a
-                            // missing token stays `None` (fail closed).
-                            // `HarnessPool::ensure` re-resolves this each turn so a
-                            // console token change takes effect without restart.
+                            // manifest toolkit allowlist + the env URL override,
+                            // falling back to the tenant API base so staging
+                            // Composio follows staging. Only companies that
+                            // explicitly grant `composio` touch the store; the
+                            // token has no env fallback, so a missing token stays
+                            // `None` (fail closed). `HarnessPool::ensure`
+                            // re-resolves this each turn so a console token change
+                            // takes effect without restart.
                             let composio_config = if crate::company::grants_composio_explicit(
                                 &self.manifest.tools.allow,
                             ) {
                                 use crate::app::config::EnvSource;
                                 let toolkits = self.manifest.tools.composio.toolkits.clone();
-                                let url = crate::app::config::ProcessEnv
-                                    .get(crate::harness::composio::COMPOSIO_BACKEND_URL_ENV);
+                                let env = crate::app::config::ProcessEnv;
+                                let url =
+                                    env.get(crate::harness::composio::COMPOSIO_BACKEND_URL_ENV);
+                                let api_url =
+                                    env.get(crate::harness::composio::TINYHUMANS_API_URL_ENV);
                                 crate::harness::composio::TenantComposio::resolve(
                                     &id,
                                     secrets.as_ref(),
                                     toolkits,
                                     url,
+                                    api_url,
                                 )
                                 .await
                             } else {

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -79,15 +79,19 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<ComposioStatusDto,
     let configured = token_configured(runtime.id(), runtime.secrets().as_ref())
         .await
         .map_err(ApiError)?;
-    let env_url = {
+    let (env_url, api_url) = {
         use crate::app::config::EnvSource;
-        crate::app::config::ProcessEnv.get(crate::company::composio::COMPOSIO_BACKEND_URL_ENV)
+        let env = crate::app::config::ProcessEnv;
+        (
+            env.get(crate::company::composio::COMPOSIO_BACKEND_URL_ENV),
+            env.get(crate::company::composio::TINYHUMANS_API_URL_ENV),
+        )
     };
     Ok(ComposioStatusDto {
         in_build: cfg!(feature = "composio"),
         granted,
         token_configured: configured,
-        backend_url: backend_url_or_default(env_url),
+        backend_url: backend_url_or_default(env_url, api_url),
         toolkits,
     })
 }


### PR DESCRIPTION
## Summary

Make the Composio backend URL **follow the tenant's `TINYHUMANS_API_URL`** before falling back to the hardcoded prod default, so a staging tenant's Composio calls hit staging instead of prod.

## Problem

Composio's backend resolved as `OPENCOMPANY_COMPOSIO_BACKEND_URL` (if set) **else** the hardcoded `https://api.tinyhumans.ai` (prod). On hosted tenants the manager injects `TINYHUMANS_API_URL` (e.g. `https://staging-api.tinyhumans.ai`) but **not** a composio-specific override — so Composio silently talked to **prod** while inference and the rest of the app were on staging.

## Solution

Insert `TINYHUMANS_API_URL` as a middle fallback (first trimmed non-empty wins):

1. `OPENCOMPANY_COMPOSIO_BACKEND_URL` — explicit override (unchanged, still wins)
2. **`TINYHUMANS_API_URL`** — the tenant's shared backend base (NEW)
3. `https://api.tinyhumans.ai` — last-resort default

`backend_url_or_default(env_override)` → `backend_url_or_default(env_override, api_url)`; added `TINYHUMANS_API_URL_ENV` const; threaded the api-url read through all four call sites (`server/ops/composio.rs`, `harness/composio.rs`, `harness/mod.rs::resolve_composio`, `runtime/builder.rs`). On smoke1 (override unset, `TINYHUMANS_API_URL=staging-api`) Composio now resolves to staging automatically; the only path to the prod default is both unset (a bare local run).

## API Or Behavior Changes

No public API change. Composio backend routing now follows the tenant's backend by default instead of hardcoding prod. Explicit override behavior unchanged.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo build` + `cargo build --features composio`
- [x] `cargo test --lib company::composio` (1) + `cargo test --features composio --lib harness::composio` (9) — pass; resolution-order cases covered (neither→default, override wins, override-empty→api_url, both-empty→default, trimming)
- [x] `cargo clippy --features composio --lib` — clean on touched files

## Documentation

Doc comments on `backend_url_or_default` / `DEFAULT_BACKEND_URL` / `COMPOSIO_BACKEND_URL_ENV` updated to state the 3-step order.

## Related

Part of making the Connections feature work on staging (Composio was hitting prod).
