### PR TITLE
feat(companies): grant composio to agentic_software_company + e2e_harness

### DIFF
--- a/companies/agentic_software_company/company.toml
+++ b/companies/agentic_software_company/company.toml
@@ -7,6 +7,11 @@ name = "Agentic Software Company"
 output = "An entire SaaS product"
 human_role = "Product direction"
 
+[tools]
+# Composio integration tools (Gmail/Slack/GitHub). Fail-closed until a
+# per-company Composio bearer is set via the console.
+allow = ["composio"]
+
 [[agent]]
 id = "product_manager"
 role = "Product Manager"

--- a/companies/e2e_harness/company.toml
+++ b/companies/e2e_harness/company.toml
@@ -35,19 +35,19 @@ id = "ceo"
 role = "Chief Executive"
 description = "Sets direction, answers about the company, and delegates the work."
 tier = "orchestrator"
-tools = ["mcp:*"]
+tools = ["mcp:*", "composio"]
 
 [[agent]]
 id = "engineer"
 role = "Engineer"
 description = "Explains how things are built and proposes technical plans."
-tools = ["mcp:*"]
+tools = ["mcp:*", "composio"]
 
 [[agent]]
 id = "writer"
 role = "Writer"
 description = "Turns rough notes into short, clear written drafts."
-tools = ["mcp:*"]
+tools = ["mcp:*", "composio"]
 
 [[group_chat]]
 id = "engineering"

--- a/companies/e2e_harness/company.toml
+++ b/companies/e2e_harness/company.toml
@@ -25,6 +25,11 @@ mode = "full"
 # the company. It is the identity the e2e suite authenticates as.
 admins = ["harness-e2e@tinyhumans.ai"]
 
+[tools]
+# Composio integration tools (Gmail/Slack/GitHub). Fail-closed until a
+# per-company Composio bearer is set via the console.
+allow = ["composio"]
+
 [[agent]]
 id = "ceo"
 role = "Chief Executive"


### PR DESCRIPTION
## Summary

Enable **Composio** (Gmail/Slack/GitHub) for the `agentic_software_company` (smoke1 tenant) and `e2e_harness` companies.

Composio wiring requires **two** things — verified end-to-end (Gmail authorize + `GMAIL_LIST_MESSAGES` execute against staging):
1. **Company ceiling** — a `[tools] allow = ["composio"]` entry (else `grants_composio_explicit` is false).
2. **Agent request** — each agent's effective grants = its own `tools` list filtered by `allow` (empty `tools` ⇒ inherits the full `allow`). So an agent must either list `composio` in its `tools` or have no explicit `tools`.

## Changes

- **`agentic_software_company`** — added `[tools] allow = ["composio"]`. Its agents declare no explicit `tools`, so they inherit the allow-list → composio granted, no per-agent edit needed.
- **`e2e_harness`** — added `[tools] allow = ["composio"]` **and** appended `composio` to each agent's `tools` (they explicitly list `mcp:*`, so composio had to be requested or it was filtered out of their grants).

Integration stays **fail-closed**: composio tools only activate once a per-company Composio bearer is set via the console (`PUT …/composio/token`) — a session JWT or a `tiny_live_…` read+write API key. Missing token ⇒ no tools, never a borrowed identity.

## API Or Behavior Changes

Manifest/config only. Agents in these companies receive composio tools once a bearer is present. No code changes.

## Tests

- [x] Verified live locally: authorize (`composio_authorize gmail` → connect URL) + execute (`GMAIL_LIST_MESSAGES` returned real inbox data) against the staging backend.
- [x] Manifests parse / companies register on server start.

## Documentation

Inline manifest comments note fail-closed-until-bearer. The two-part grant model (company `allow` + agent `tools`) is the key non-obvious bit.

## Related

Pairs with the composio backend-URL fix (#157). Bearer is a per-company platform credential (session JWT / `tiny_live` key); isolation depends on it staying per-company.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Composio-backed tools in configured environments.
  - Authorized agents can now use Composio alongside existing MCP tools.
  - Tool access remains disabled by default until the required per-environment credential is configured through the console.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->