### PR TITLE
fix(brain): stamp context chunks so Memory "Last updated" reflects agent writes

### DIFF
--- a/docs/spec/company-brain/memory.md
+++ b/docs/spec/company-brain/memory.md
@@ -36,6 +36,20 @@ Memory spans three ports, not a database
 The first two ports are the brain's memory; `FactStore` is the operator's. All
 three key on `CompanyId` and travel with the export bundle.
 
+Every `ContextStore` chunk carries `ChunkMeta::stored_at_millis`, the wall-clock
+time it was stored; a chunk written before backends recorded one reports `0`.
+The console's Brain header needs it: agents write memory **only** through the
+`ContextStore`, so a freshness figure drawn from `FactStore` alone reads as
+"never updated" for any company whose operator has not hand-authored a fact.
+`GET /memory/stats` therefore reports `lastUpdatedAtMillis` as the max across
+both ports, alongside the facts-only `factsUpdatedAtMillis`.
+
+Read that stamp as a max across chunks, not as one row per body: the backends
+differ on a re-`put` of an identical body (sqlite and mongo dedupe on the
+content address and keep the first write; the fs index appends a second line),
+and neither the export bundle nor a restore preserves it — a restored chunk is
+stamped when it lands.
+
 **TinyCortex is the intended backend for `MemoryStore` and `ContextStore`**
 ([integrations/tinycortex.md](../integrations/tinycortex.md)) but is a
 choice, not a dependency: the fs default preserves the one-key promise, and

--- a/frontend/src/api/memory.ts
+++ b/frontend/src/api/memory.ts
@@ -29,7 +29,11 @@ export interface MemoryEntry {
   body: string;
   /** Which desk/teammate/agent captured it. */
   source: string;
-  /** Epoch-millis of the last update (`0` for context rows, which carry none). */
+  /**
+   * Epoch-millis of the last update. For context rows this is when the chunk
+   * was stored; `0` only when the backend has no stamp for it (chunks written
+   * before store times were recorded), which still renders as `—`.
+   */
   updatedAt: number;
 }
 
@@ -50,6 +54,15 @@ export interface MemoryStats {
   facts: number;
   /** The newest fact's last-updated epoch-millis (`0` when there are none). */
   factsUpdatedAtMillis: number;
+  /**
+   * The newest epoch-millis across *every* memory source — operator facts and
+   * the agents' context chunks alike (`0` when nothing is remembered yet).
+   *
+   * This, not `factsUpdatedAtMillis`, is what the "Last updated" stat renders:
+   * agents only ever write context chunks, so the facts-only figure sits at `0`
+   * for any company whose operator has not hand-authored a fact.
+   */
+  lastUpdatedAtMillis: number;
   /** Total agent-accessible context chunks (learned context + outcomes + mirrors). */
   agentChunks: number;
   /** Of those, how many are stored task outcomes. */

--- a/frontend/src/views/MemoryView.tsx
+++ b/frontend/src/views/MemoryView.tsx
@@ -269,7 +269,9 @@ function HealthStrip({
     { label: "Total items", value: String(total) },
     { label: "Agent memory", value: String(stats?.agentChunks ?? 0) },
     { label: "Task outcomes", value: String(stats?.taskOutcomes ?? 0) },
-    { label: "Last updated", value: formatUpdated(stats?.factsUpdatedAtMillis ?? 0) },
+    // Across every memory source, not just operator facts — agents write only
+    // context chunks, so a facts-only figure left this stat at "—" forever.
+    { label: "Last updated", value: formatUpdated(stats?.lastUpdatedAtMillis ?? 0) },
   ];
   return (
     <Card data-testid="memory-health">

--- a/src/harness/memory.rs
+++ b/src/harness/memory.rs
@@ -316,6 +316,9 @@ mod tests {
                     addr: addr.clone(),
                     label: c.label.clone(),
                     len: c.body.len(),
+                    // The mock does not model store time; these tests exercise
+                    // the adapter, not the Brain's freshness stat.
+                    stored_at_millis: 0,
                 })
                 .collect())
         }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1281,6 +1281,9 @@ mod tests {
                     addr: addr.clone(),
                     label: c.label.clone(),
                     len: c.body.len(),
+                    // The mock does not model store time; these tests exercise
+                    // the harness, not the Brain's freshness stat.
+                    stored_at_millis: 0,
                 })
                 .collect())
         }

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -534,6 +534,21 @@ pub struct ChunkMeta {
     pub label: String,
     /// The chunk's length in bytes.
     pub len: usize,
+    /// Epoch-millis when the chunk was stored (`0` for rows written before
+    /// backends started stamping, so old data reads as "unknown" rather than
+    /// as the epoch).
+    ///
+    /// This is what lets the Brain's "Last updated" stat move when agents write
+    /// memory — they write only through this port, never to the `FactStore`
+    /// (see `server::ops::memory::memory_stats`).
+    ///
+    /// Chunks are append-only and never rewritten, so this only ever moves for
+    /// a *new* chunk. Backends differ on a re-`put` of an identical body —
+    /// sqlite/mongo dedupe on the content address and keep the first write,
+    /// the fs index appends a second line — so read freshness as the max
+    /// across chunks rather than assuming one row per body.
+    #[serde(default)]
+    pub stored_at_millis: u64,
 }
 
 /// A single ledger movement.

--- a/src/server/ops/memory.rs
+++ b/src/server/ops/memory.rs
@@ -120,6 +120,9 @@ struct RawChunk {
     addr: String,
     label: String,
     body: String,
+    /// Epoch-millis the chunk was first stored (`0` when the backend has no
+    /// stamp for it — chunks written before backends began recording one).
+    stored_at_millis: u64,
 }
 
 /// Truncates `s` to at most `max` characters on a char boundary, appending an
@@ -203,8 +206,9 @@ fn context_entries(chunks: Vec<RawChunk>, query: Option<&str>) -> Vec<MemoryEntr
             title,
             body,
             source,
-            // Context chunks carry no timestamp; the console renders `—`.
-            updated_at: 0,
+            // A chunk stored before backends began stamping reports `0`, which
+            // the console still renders as `—`.
+            updated_at: chunk.stored_at_millis,
         });
     }
 
@@ -248,6 +252,16 @@ struct MemoryStats {
     facts: usize,
     /// The newest fact's last-updated epoch-millis (`0` when there are none).
     facts_updated_at_millis: u64,
+    /// The newest epoch-millis across *every* memory source — operator facts
+    /// and the agents' context chunks alike (`0` when the company remembers
+    /// nothing yet).
+    ///
+    /// This, not [`Self::facts_updated_at_millis`], is what the console's
+    /// "Last updated" stat renders. Agents only ever write to the
+    /// `ContextStore`, so a facts-only figure sat at `0` — and the stat at "—"
+    /// — for any company whose operator had not hand-authored a fact, however
+    /// much memory the agents had accumulated.
+    last_updated_at_millis: u64,
     /// Total agent-accessible context chunks — learned context, task outcomes,
     /// and the operator-fact mirrors together.
     agent_chunks: usize,
@@ -317,6 +331,7 @@ async fn list_facts(
                 addr: meta.addr.to_string(),
                 label: meta.label,
                 body,
+                stored_at_millis: meta.stored_at_millis,
             });
         }
         entries.extend(context_entries(chunks, query.as_deref()));
@@ -337,7 +352,11 @@ async fn memory_stats(company: ScopedCompany) -> Result<Json<MemoryStats>, ApiEr
     let facts_updated_at_millis = facts.first().map(|f| f.updated_at_millis).unwrap_or(0);
     // Prefix `""` lists every chunk; the task-outcome prefix narrows to stored
     // outcomes (a subset of the total).
-    let agent_chunks = company.runtime.context.list(company.id(), "").await?.len();
+    let chunks = company.runtime.context.list(company.id(), "").await?;
+    let agent_chunks = chunks.len();
+    // Chunks list in insertion order, not freshness order, and a backend that
+    // predates the stamp reports `0` — so take the max rather than the head.
+    let chunks_stored_at_millis = chunks.iter().map(|m| m.stored_at_millis).max().unwrap_or(0);
     let task_outcomes = company
         .runtime
         .context
@@ -347,6 +366,7 @@ async fn memory_stats(company: ScopedCompany) -> Result<Json<MemoryStats>, ApiEr
     Ok(Json(MemoryStats {
         facts: facts.len(),
         facts_updated_at_millis,
+        last_updated_at_millis: facts_updated_at_millis.max(chunks_stored_at_millis),
         agent_chunks,
         task_outcomes,
     }))
@@ -430,10 +450,15 @@ mod combined_list_tests {
     use super::*;
 
     fn chunk(label: &str, body: &str) -> RawChunk {
+        chunk_at(label, body, 0)
+    }
+
+    fn chunk_at(label: &str, body: &str, stored_at_millis: u64) -> RawChunk {
         RawChunk {
             addr: format!("addr-{label}"),
             label: label.to_string(),
             body: body.to_string(),
+            stored_at_millis,
         }
     }
 
@@ -507,6 +532,29 @@ mod combined_list_tests {
             !ctx[0].editable,
             "read-only rows expose no edit/delete affordance"
         );
+    }
+
+    #[test]
+    fn context_rows_carry_their_stored_at_stamp() {
+        // Context rows used to hardcode `updated_at: 0`, so every agent-written
+        // memory rendered "—" no matter how recently it landed.
+        let entries = context_entries(
+            vec![
+                chunk_at("agent-1/notes", "recent", 2_000),
+                chunk_at("task-outcome/agent-1", "Task: t\nOutcome: o", 3_000),
+            ],
+            None,
+        );
+        assert_eq!(entries[0].updated_at, 2_000);
+        assert_eq!(entries[1].updated_at, 3_000);
+    }
+
+    #[test]
+    fn unstamped_context_rows_stay_dashed() {
+        // A chunk written before backends stamped has no store time; reporting
+        // `0` keeps the console's "—" rather than inventing the epoch.
+        let entries = context_entries(vec![chunk("agent-1/notes", "legacy")], None);
+        assert_eq!(entries[0].updated_at, 0);
     }
 
     #[test]

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -11,7 +11,7 @@ use crate::company::CompanyManifest;
 use crate::company::steer::{InflightEntry, InflightKind};
 use crate::ports::facts::{FactKind, FactRecord};
 use crate::ports::tasks::TaskRecord;
-use crate::ports::types::{CompanyId, CompanyRecord};
+use crate::ports::types::{CompanyId, CompanyRecord, ContextChunk};
 use crate::runtime::RuntimeBuilder;
 use crate::server::router;
 use crate::store::FsCompanyStore;
@@ -369,6 +369,8 @@ async fn memory_list_filters_stats_and_dual_write() {
     assert_eq!(stats["factsUpdatedAtMillis"], 3_000);
     assert_eq!(stats["agentChunks"], 0);
     assert_eq!(stats["taskOutcomes"], 0);
+    // Nothing but facts so far, so "Last updated" tracks the newest fact.
+    assert_eq!(stats["lastUpdatedAtMillis"], 3_000);
 
     // Dual-write: the HTTP create path mirrors the fact into the ContextStore so
     // the agent can recall it. A direct search finds the mirrored text — the
@@ -397,6 +399,106 @@ async fn memory_list_filters_stats_and_dual_write() {
     assert_eq!(stats["facts"], 4);
     assert_eq!(stats["agentChunks"], 1);
     assert_eq!(stats["taskOutcomes"], 0);
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+/// The Brain's "Last updated" stat must move when *agents* write memory, not
+/// only when the operator hand-authors a fact.
+///
+/// The reported bug (#153): agent memory and task outcomes land exclusively in
+/// the `ContextStore`, and the stat was computed from the `FactStore` alone —
+/// so a company whose agents were actively remembering, but whose operator had
+/// never added a fact, showed "—" forever.
+#[tokio::test]
+async fn memory_stats_last_updated_covers_agent_written_context() {
+    let home = home();
+    let state = state_with_company(&home).await;
+    let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+
+    // A brand-new company remembers nothing: the stat is genuinely empty, and
+    // "—" is the honest rendering.
+    let (status, stats) = send(&state, "GET", "/api/v1/company/memory/stats", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(stats["facts"], 0);
+    assert_eq!(stats["agentChunks"], 0);
+    assert_eq!(
+        stats["lastUpdatedAtMillis"], 0,
+        "no memory of any kind yet, so the stat has nothing to report"
+    );
+
+    // Now an agent writes memory — no operator fact anywhere in sight. This is
+    // the exact state that used to pin the stat at 0.
+    let before = crate::ports::now_millis();
+    for (label, body) in [
+        ("agent-ceo/notes", "the launch slipped to Friday"),
+        ("task-outcome/agent-ceo", "Task: ship it\nOutcome: done"),
+    ] {
+        runtime
+            .context
+            .put(
+                runtime.id(),
+                ContextChunk {
+                    label: label.to_string(),
+                    body: body.to_string(),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    let (status, stats) = send(&state, "GET", "/api/v1/company/memory/stats", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(stats["facts"], 0, "still no operator facts");
+    assert_eq!(stats["agentChunks"], 2);
+    assert_eq!(stats["taskOutcomes"], 1);
+    assert_eq!(
+        stats["factsUpdatedAtMillis"], 0,
+        "the facts-only figure is unchanged — it is simply not the whole story"
+    );
+    let last_updated = stats["lastUpdatedAtMillis"].as_u64().unwrap();
+    assert!(
+        last_updated >= before,
+        "agent-written memory must move the Brain's Last updated stat, got {last_updated}"
+    );
+
+    // An operator fact newer than any chunk takes over the stat.
+    runtime
+        .facts()
+        .upsert(
+            runtime.id(),
+            &FactRecord {
+                id: "f-future".into(),
+                kind: FactKind::Fact,
+                title: "Board meeting".into(),
+                body: "moved to Monday".into(),
+                source: "You".into(),
+                updated_at_millis: last_updated + 60_000,
+            },
+        )
+        .await
+        .unwrap();
+    let (status, stats) = send(&state, "GET", "/api/v1/company/memory/stats", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        stats["lastUpdatedAtMillis"],
+        last_updated + 60_000,
+        "the stat is the max across every memory source, whichever is freshest"
+    );
+
+    // The list surfaces the same stamps per row, so a context card no longer
+    // renders "—" while the header claims recent activity.
+    let (status, rows) = send(&state, "GET", "/api/v1/company/memory", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let rows = rows.as_array().unwrap();
+    let context_rows: Vec<&Value> = rows.iter().filter(|r| r["origin"] != "fact").collect();
+    assert_eq!(context_rows.len(), 2);
+    assert!(
+        context_rows
+            .iter()
+            .all(|r| r["updatedAt"].as_u64().unwrap() >= before),
+        "each agent-written row carries the time it was stored"
+    );
 
     tokio::fs::remove_dir_all(&home).await.ok();
 }

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -1080,6 +1080,49 @@ pub async fn assert_fact_store(facts: Arc<dyn FactStore>) {
     assert_eq!(facts.list(&alpha, None, None).await.unwrap().len(), 1);
 }
 
+/// Asserts every [`ContextStore`] stamps a stored chunk with the wall-clock
+/// time it was written, and surfaces that stamp through `list`.
+///
+/// This is what lets the Brain's "Last updated" stat move when agents write
+/// memory: agent memory and task outcomes only ever land in the `ContextStore`,
+/// so without a per-chunk stamp the stat can only reflect operator-authored
+/// facts (see `server::ops::memory::memory_stats`).
+///
+/// Deliberately says nothing about re-`put`ting an identical body: the backends
+/// genuinely differ there (sqlite/mongo dedupe on the content address and keep
+/// the first write, the fs index appends a second line), and pinning one
+/// behaviour here would assert a contract the suite's own backends do not share.
+/// Readers of the stamp take the max across chunks for that reason.
+pub async fn assert_context_chunk_stamps(context: Arc<dyn ContextStore>) {
+    let alpha = CompanyId::new("alpha");
+    let beta = CompanyId::new("beta");
+    let before = now_millis();
+
+    context
+        .put(
+            &alpha,
+            ContextChunk {
+                label: "agent/ceo".to_string(),
+                body: "the launch slipped to Friday".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    let after = now_millis();
+
+    let metas = context.list(&alpha, "").await.unwrap();
+    assert_eq!(metas.len(), 1);
+    let stamped = metas[0].stored_at_millis;
+    assert!(
+        (before..=after).contains(&stamped),
+        "a stored chunk must carry the time it was written; got {stamped}, expected within \
+         {before}..={after}"
+    );
+
+    // The stamp travels per company, like every other field on the port.
+    assert!(context.list(&beta, "").await.unwrap().is_empty());
+}
+
 /// Asserts the [`UsageMeter`] contract: isolation, record, and windowed query.
 pub async fn assert_usage_meter(usage: Arc<dyn UsageMeter>) {
     let alpha = CompanyId::new("alpha");

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -484,12 +484,18 @@ impl MemoryStore for FsMemoryStore {
 // ContextStore
 // ---------------------------------------------------------------------------
 
-/// A context index line pairing an address with its label and length.
+/// A context index line pairing an address with its label, length, and the
+/// epoch-millis it was first stored.
+///
+/// `stored_at_millis` defaults to `0` so index lines written before the field
+/// existed still deserialize — they simply report an unknown store time.
 #[derive(serde::Serialize, serde::Deserialize)]
 struct IndexEntry {
     addr: String,
     label: String,
     len: usize,
+    #[serde(default)]
+    stored_at_millis: u64,
 }
 
 /// Filesystem [`ContextStore`]: content-addressed blobs plus a JSONL index.
@@ -535,6 +541,7 @@ impl ContextStore for FsContextStore {
             addr: addr.clone(),
             label: chunk.label,
             len: chunk.body.len(),
+            stored_at_millis: now_millis(),
         };
         append_line(&index_path, &serde_json::to_string(&entry)?).await?;
         Ok(ChunkAddr::new(addr))
@@ -549,6 +556,7 @@ impl ContextStore for FsContextStore {
                 addr: ChunkAddr::new(e.addr),
                 label: e.label,
                 len: e.len,
+                stored_at_millis: e.stored_at_millis,
             })
             .collect())
     }
@@ -868,6 +876,13 @@ mod test {
     async fn conformance_inbox_store() {
         let root = tmp_root();
         conformance::assert_inbox_store(Arc::new(FsInboxStore::new(&root))).await;
+        tokio::fs::remove_dir_all(&root).await.ok();
+    }
+
+    #[tokio::test]
+    async fn conformance_context_chunk_stamps() {
+        let root = tmp_root();
+        conformance::assert_context_chunk_stamps(Arc::new(FsContextStore::new(&root))).await;
         tokio::fs::remove_dir_all(&root).await.ok();
     }
 

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -886,6 +886,20 @@ mod test {
         tokio::fs::remove_dir_all(&root).await.ok();
     }
 
+    /// The fs backend's migration path: index lines written before
+    /// `stored_at_millis` existed carry no such field, and must still
+    /// deserialize — reporting an unknown (`0`) store time rather than failing
+    /// the read and blanking the whole Brain list.
+    #[test]
+    fn legacy_context_index_line_without_a_stamp_still_parses() {
+        let legacy = r#"{"addr":"abc123","label":"agent/ceo","len":24}"#;
+        let entry: IndexEntry = serde_json::from_str(legacy).expect("legacy index line parses");
+        assert_eq!(entry.addr, "abc123");
+        assert_eq!(entry.label, "agent/ceo");
+        assert_eq!(entry.len, 24);
+        assert_eq!(entry.stored_at_millis, 0);
+    }
+
     #[tokio::test]
     async fn conformance_export_totality() {
         let root = tmp_root();

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -556,6 +556,7 @@ impl ContextStore for MongoStore {
                     "body": &chunk.body,
                     "len": chunk.body.len() as i64,
                     "ord": ord as i64,
+                    "stored_ms": now_millis() as i64,
                 }},
             )
             .with_options(UpdateOptions::builder().upsert(true).build())
@@ -581,6 +582,10 @@ impl ContextStore for MongoStore {
                     addr: ChunkAddr::new(get_str(&doc, "addr")?),
                     label,
                     len: get_i64(&doc, "len")? as usize,
+                    // Absent on documents written before the field existed;
+                    // those read as an unknown (`0`) store time rather than
+                    // failing the whole list.
+                    stored_at_millis: doc.get_i64("stored_ms").unwrap_or(0).max(0) as u64,
                 });
             }
         }
@@ -1782,6 +1787,13 @@ mod test {
     async fn conformance_fact_store() {
         let Some(s) = store().await else { return };
         conformance::assert_fact_store(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_chunk_stamps() {
+        let Some(s) = store().await else { return };
+        conformance::assert_context_chunk_stamps(s.clone()).await;
         drop_db(&s).await;
     }
 

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1839,6 +1839,80 @@ mod test {
         conformance::assert_context_chunk_stamps(store()).await;
     }
 
+    /// The migration path a fresh database never exercises.
+    ///
+    /// [`MIGRATIONS`] is all `CREATE TABLE IF NOT EXISTS`, which is a no-op
+    /// against a database that already has `context_chunks` — so on an existing
+    /// deployment only [`add_column_if_missing`] can add `stored_ms`. Without
+    /// it, every read of the column would fail with "no such column" and the
+    /// whole Brain list/stats surface would 500.
+    #[tokio::test]
+    async fn legacy_context_chunks_table_gains_stored_ms_on_open() {
+        // A database as it looked before the column existed, with a row in it.
+        let conn = Connection::open_in_memory().expect("open in-memory sqlite");
+        conn.execute_batch(
+            "CREATE TABLE context_chunks (
+                 company_id TEXT NOT NULL,
+                 addr       TEXT NOT NULL,
+                 label      TEXT NOT NULL,
+                 body       TEXT NOT NULL,
+                 len        INTEGER NOT NULL,
+                 PRIMARY KEY (company_id, addr)
+             );
+             INSERT INTO context_chunks (company_id, addr, label, body, len)
+             VALUES ('acme', 'legacy-addr', 'agent/ceo', 'remembered before stamps', 24);",
+        )
+        .expect("seed a pre-`stored_ms` database");
+
+        let store = SqliteStore::from_conn(conn).expect("migrations run on a legacy database");
+        let id = CompanyId::new("acme");
+
+        // The legacy row survives the migration and reports an *unknown* store
+        // time — not the epoch, and not a misleading "migrated just now".
+        let metas = store.list(&id, "").await.expect("list after migration");
+        assert_eq!(metas.len(), 1, "the legacy row must not be dropped");
+        assert_eq!(metas[0].label, "agent/ceo");
+        assert_eq!(
+            metas[0].stored_at_millis, 0,
+            "a row written before stamps existed has no store time to report"
+        );
+
+        // A write after the migration is stamped for real.
+        let before = now_millis();
+        store
+            .put(
+                &id,
+                ContextChunk {
+                    label: "agent/ops".to_string(),
+                    body: "remembered after the migration".to_string(),
+                },
+            )
+            .await
+            .expect("put into a migrated database");
+
+        let metas = store.list(&id, "").await.expect("list after put");
+        assert_eq!(metas.len(), 2);
+        let fresh = metas
+            .iter()
+            .find(|m| m.label == "agent/ops")
+            .expect("the new chunk is listed");
+        assert!(
+            fresh.stored_at_millis >= before,
+            "a post-migration write must carry a real stamp, got {}",
+            fresh.stored_at_millis
+        );
+
+        // Reopening an already-migrated database must not try to add the column
+        // a second time — the `ALTER` would fail with "duplicate column name".
+        add_column_if_missing(
+            &store.conn(),
+            "context_chunks",
+            "stored_ms",
+            "INTEGER NOT NULL DEFAULT 0",
+        )
+        .expect("adding an existing column is a no-op, not an error");
+    }
+
     #[tokio::test]
     async fn conformance_usage_meter() {
         conformance::assert_usage_meter(store()).await;

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -94,6 +94,7 @@ CREATE TABLE IF NOT EXISTS context_chunks (
     label      TEXT NOT NULL,
     body       TEXT NOT NULL,
     len        INTEGER NOT NULL,
+    stored_ms  INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (company_id, addr)
 );
 CREATE TABLE IF NOT EXISTS secrets (
@@ -205,6 +206,39 @@ fn sql_err(e: rusqlite::Error) -> OpenCompanyError {
     OpenCompanyError::Store(format!("sqlite error: {e}"))
 }
 
+/// Adds `column` to `table` when it is absent, so an additive schema change
+/// reaches databases created before the column existed.
+///
+/// [`MIGRATIONS`] is a bundle of `CREATE TABLE IF NOT EXISTS` statements, which
+/// silently skip an already-created table — new columns would therefore never
+/// land on an existing file. `PRAGMA table_info` is the check rather than
+/// swallowing the `ALTER`'s "duplicate column name" error, so a genuine `ALTER`
+/// failure still surfaces.
+fn add_column_if_missing(conn: &Connection, table: &str, column: &str, decl: &str) -> Result<()> {
+    let present = {
+        let mut stmt = conn
+            .prepare(&format!("PRAGMA table_info({table})"))
+            .map_err(sql_err)?;
+        // `table_info` column 1 is the column name.
+        let rows = stmt
+            .query_map([], |r| r.get::<_, String>(1))
+            .map_err(sql_err)?;
+        let mut found = false;
+        for row in rows {
+            if row.map_err(sql_err)? == column {
+                found = true;
+                break;
+            }
+        }
+        found
+    };
+    if present {
+        return Ok(());
+    }
+    conn.execute_batch(&format!("ALTER TABLE {table} ADD COLUMN {column} {decl}"))
+        .map_err(sql_err)
+}
+
 /// Translates a `usize` limit into a SQLite `LIMIT` value. `usize::MAX` (the
 /// "read everything" sentinel used by export/replay) maps to `-1`, SQLite's
 /// unbounded-limit encoding.
@@ -239,6 +273,14 @@ impl SqliteStore {
 
     fn from_conn(conn: Connection) -> Result<Self> {
         conn.execute_batch(MIGRATIONS).map_err(sql_err)?;
+        // `CREATE TABLE IF NOT EXISTS` is a no-op on a database that predates a
+        // column, so additive columns need their own idempotent step.
+        add_column_if_missing(
+            &conn,
+            "context_chunks",
+            "stored_ms",
+            "INTEGER NOT NULL DEFAULT 0",
+        )?;
         Ok(Self {
             conn: Arc::new(StdMutex::new(conn)),
             senders: Arc::new(StdMutex::new(HashMap::new())),
@@ -553,14 +595,15 @@ impl ContextStore for SqliteStore {
         let addr = content_address(&chunk.body);
         let conn = self.conn();
         conn.execute(
-            "INSERT OR IGNORE INTO context_chunks (company_id, addr, label, body, len) \
-             VALUES (?1, ?2, ?3, ?4, ?5)",
+            "INSERT OR IGNORE INTO context_chunks (company_id, addr, label, body, len, stored_ms) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
                 id.as_ref(),
                 addr,
                 chunk.label,
                 chunk.body,
-                chunk.body.len() as i64
+                chunk.body.len() as i64,
+                now_millis() as i64
             ],
         )
         .map_err(sql_err)?;
@@ -571,7 +614,8 @@ impl ContextStore for SqliteStore {
         let conn = self.conn();
         let mut stmt = conn
             .prepare(
-                "SELECT addr, label, len FROM context_chunks WHERE company_id = ?1 ORDER BY rowid",
+                "SELECT addr, label, len, stored_ms FROM context_chunks \
+                 WHERE company_id = ?1 ORDER BY rowid",
             )
             .map_err(sql_err)?;
         let rows = stmt
@@ -580,17 +624,19 @@ impl ContextStore for SqliteStore {
                     r.get::<_, String>(0)?,
                     r.get::<_, String>(1)?,
                     r.get::<_, i64>(2)?,
+                    r.get::<_, i64>(3)?,
                 ))
             })
             .map_err(sql_err)?;
         let mut out = Vec::new();
         for row in rows {
-            let (addr, label, len) = row.map_err(sql_err)?;
+            let (addr, label, len, stored_ms) = row.map_err(sql_err)?;
             if label.starts_with(prefix) {
                 out.push(ChunkMeta {
                     addr: ChunkAddr::new(addr),
                     label,
                     len: len as usize,
+                    stored_at_millis: stored_ms.max(0) as u64,
                 });
             }
         }
@@ -1786,6 +1832,11 @@ mod test {
     #[tokio::test]
     async fn conformance_fact_store() {
         conformance::assert_fact_store(store()).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_chunk_stamps() {
+        conformance::assert_context_chunk_stamps(store()).await;
     }
 
     #[tokio::test]

--- a/src/store/tinycortex.rs
+++ b/src/store/tinycortex.rs
@@ -38,6 +38,7 @@ use crate::Result;
 use crate::error::OpenCompanyError;
 use crate::ports::context::ContextStore;
 use crate::ports::memory::MemoryStore;
+use crate::ports::now_millis;
 use crate::ports::types::{
     ChunkAddr, ChunkHit, ChunkMeta, CompanyId, CompressedTrace, ContextChunk, EvictionPolicy,
     TaskResult,
@@ -109,12 +110,14 @@ struct CompanyCells {
     chunks: Vec<StoredChunk>,
 }
 
-/// A stored context chunk: its content address, label, and body.
+/// A stored context chunk: its content address, label, body, and the
+/// epoch-millis it was first stored.
 #[derive(Clone)]
 struct StoredChunk {
     addr: String,
     label: String,
     body: String,
+    stored_at_millis: u64,
 }
 
 /// An offline, in-memory [`CortexClient`] backing the cortex stores.
@@ -198,6 +201,7 @@ impl CortexClient for InMemoryCortex {
                     addr: addr.to_string(),
                     label: chunk.label,
                     body: chunk.body,
+                    stored_at_millis: now_millis(),
                 });
             }
         });
@@ -213,6 +217,7 @@ impl CortexClient for InMemoryCortex {
                     addr: ChunkAddr::new(s.addr.clone()),
                     label: s.label.clone(),
                     len: s.body.len(),
+                    stored_at_millis: s.stored_at_millis,
                 })
                 .collect()
         }))
@@ -592,6 +597,13 @@ mod test {
         let dir = tempfile::tempdir().unwrap();
         let (store, events, mem, ctx) = stores(dir.path());
         conformance::assert_export_totality(store, events, mem, ctx).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_context_chunk_stamps() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_store, _events, _mem, ctx) = stores(dir.path());
+        conformance::assert_context_chunk_stamps(ctx).await;
     }
 
     fn company() -> CompanyId {


### PR DESCRIPTION
## Summary

Fixes #153.

The Brain header's **"Last updated" stat read "—"** on any company whose operator
had never hand-authored a fact — however much memory its agents had accumulated.

**The issue's stated root cause does not match the code.** It says the stat "is
simply not bound" to `updated_at_millis`. It has been bound since #36
(`MemoryView.tsx` → `stats.factsUpdatedAtMillis`, with `memory_stats` already
computing it server-side). Fixing what the issue describes would have changed
nothing.

The real gap is upstream of the binding. Agents write memory **exclusively**
through the `ContextStore` — learned context and task outcomes — and never to
the `FactStore`, whose only write sites are the four operator-facing REST
handlers. `GET /memory/stats` derived its freshness figure from the `FactStore`
alone, so the number was structurally `0` for the common case. `ChunkMeta`
carried no timestamp for it to read, which is also why every agent-written row
in the list rendered "—" while the header counted recent activity
(`updated_at: 0` was hardcoded for context rows).

So: add `ChunkMeta::stored_at_millis`, recorded at `put` by every backend, and
report `lastUpdatedAtMillis` as the max across both ports. There is no smaller
correct fix — without a per-chunk stamp there is nothing for the stat to compute
from. `factsUpdatedAtMillis` is unchanged and still reported.

### Backwards compatibility

Old data reads as *unknown*, never as the epoch — an unstamped chunk reports `0`
and still renders "—":

- **fs** — `#[serde(default)]` on the index line, so pre-existing
  `context_index.jsonl` entries still deserialize.
- **sqlite** — the `MIGRATIONS` bundle is all `CREATE TABLE IF NOT EXISTS`,
  which silently skips an already-created table, so a new column would never
  reach an existing database. Added `add_column_if_missing`, an idempotent
  `PRAGMA table_info`-guarded `ALTER`. It checks rather than swallowing the
  "duplicate column name" error, so a genuine `ALTER` failure still surfaces.
- **mongo** — documents without the field read as `0`.

### Two caveats documented rather than hidden

- Backends genuinely disagree on a re-`put` of an identical body: sqlite/mongo
  dedupe on the content address and keep the first write; the fs index appends a
  second line. The conformance assertion is therefore scoped to "stamped within
  the write window" rather than pinning a re-put contract the backends do not
  share, and both the port docs and the spec say to read freshness as a max
  across chunks.
- The export bundle does not carry the stamp — a restored chunk is stamped when
  it lands. Noted in the spec.

## API Or Behavior Changes

- `ChunkMeta` gains `stored_at_millis: u64` (`#[serde(default)]`). The
  `ContextStore` trait signature is unchanged.
- `GET /memory/stats` gains `lastUpdatedAtMillis`. Additive —
  `factsUpdatedAtMillis` keeps its meaning and value.
- `GET /memory` context rows now carry a real `updatedAt` instead of a hardcoded
  `0`, so agent-memory and task-outcome cards show when they landed.
- sqlite `context_chunks` gains a `stored_ms` column (default `0`).

## Tests

Regression test reproduces the exact reported state — agent-written chunks, zero
operator facts — and fails on `main`:

- `memory_stats_last_updated_covers_agent_written_context` (`server/ops/write_test.rs`)
  — empty company reports `0`; agent chunks alone move `lastUpdatedAtMillis`
  while `factsUpdatedAtMillis` stays `0`; a newer fact then takes over; list rows
  carry their stamps.
- `assert_context_chunk_stamps` (`store/conformance.rs`) — new port-conformance
  assertion, wired into the fs, sqlite, mongo, and tinycortex backends.
- `context_rows_carry_their_stored_at_stamp` and `unstamped_context_rows_stay_dashed`
  (`server/ops/memory.rs`) — unit-level.
- Existing `memory_list_filters_stats_and_dual_write` extended with the
  facts-only expectation.

Run locally:

- [x] `rustfmt --edition 2024 --check` on every changed Rust file
- [x] `tsc -b --noEmit` (frontend)
- [ ] `cargo fmt --all -- --check` — cannot run locally: `cargo metadata` fails
      because the `vendor/` submodules are not initialised in this checkout.
      Covered by CI.
- [ ] `cargo clippy --all-targets -- -D warnings` — same; relying on CI.
- [ ] `cargo test` — same; relying on CI.

## Documentation

`docs/spec/company-brain/memory.md` — documents `stored_at_millis`, why the
console needs it, the per-backend re-`put` divergence, and the export-fidelity
gap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory entries now show when agent-written context was stored.
  * The “Last updated” health stat includes both operator facts and agent context.
  * Memory statistics accurately reflect the newest update across all memory sources.
  * Existing memory data remains compatible, with unknown timestamps displayed appropriately. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->