### PR TITLE
feat(workflows): give a workflow run its topic

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -28,6 +28,7 @@ import type { OpenCompanyClient } from "@/api/client";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -68,6 +69,11 @@ export function WorkflowsView({
   const [loadingGraph, setLoadingGraph] = useState(false);
   const [running, setRunning] = useState(false);
   const [result, setResult] = useState<WorkflowRunResult | null>(null);
+  // Issue #154: what the operator is asking this run to work on. `ranWith` is
+  // pinned when the run is dispatched so the result panel echoes the request the
+  // shown output came from, not whatever has been typed since.
+  const [request, setRequest] = useState("");
+  const [ranWith, setRanWith] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
@@ -131,8 +137,17 @@ export function WorkflowsView({
   const run = useCallback(async () => {
     if (!selectedId) return;
     setRunning(true);
+    // Trimmed once here so the echoed request and the payload the host receives
+    // can never disagree.
+    const asked = request.trim();
     try {
-      const res = await runWorkflow(client, company, selectedId);
+      const res = await runWorkflow(
+        client,
+        company,
+        selectedId,
+        asked ? { request: asked } : {},
+      );
+      setRanWith(asked);
       setResult(res);
       toast.success("Workflow ran.");
     } catch (e) {
@@ -140,7 +155,7 @@ export function WorkflowsView({
     } finally {
       setRunning(false);
     }
-  }, [client, company, selectedId]);
+  }, [client, company, selectedId, request]);
 
   // The creator posts the full graph back, so the new entry can be spliced
   // straight into the list and selected — no extra round trip to re-list.
@@ -200,6 +215,19 @@ export function WorkflowsView({
               ))}
             </SelectContent>
           </Select>
+          <Input
+            value={request}
+            onChange={(e) => setRequest(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && selectedId && !running && !loadingGraph) {
+                void run();
+              }
+            }}
+            disabled={!selectedId || running}
+            placeholder="What should this run work on?"
+            aria-label="Request for this run"
+            className="h-8 w-64"
+          />
           <Button size="sm" onClick={() => void run()} disabled={!selectedId || running || loadingGraph}>
             {running ? (
               <Loader2 className="mr-1.5 size-4 animate-spin" />
@@ -264,7 +292,12 @@ export function WorkflowsView({
       </div>
 
       {result && (
-        <RunResultPanel result={result} graph={graph} onClose={() => setResult(null)} />
+        <RunResultPanel
+          result={result}
+          graph={graph}
+          request={ranWith}
+          onClose={() => setResult(null)}
+        />
       )}
 
       <WorkflowCreateDialog
@@ -390,10 +423,14 @@ function DetailField({ label, children }: { label: string; children: ReactNode }
 function RunResultPanel({
   result,
   graph,
+  request,
   onClose,
 }: {
   result: WorkflowRunResult;
   graph: WorkflowGraph | null;
+  /** What the operator asked this run for (issue #154); "" when they asked for
+   * nothing, in which case the line is omitted rather than showing a bare dash. */
+  request: string;
   onClose: () => void;
 }) {
   const nodeResults = useMemo(
@@ -418,6 +455,11 @@ function RunResultPanel({
         </Button>
       </div>
       <div className="max-h-72 overflow-auto px-4 pb-3">
+        {request && (
+          <p className="mb-2 text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">Requested:</span> {request}
+          </p>
+        )}
         {result.pendingApprovals.length > 0 && (
           <p className="mb-2 text-xs text-muted-foreground">
             Waiting on: {result.pendingApprovals.join(", ")}

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -234,10 +234,8 @@ impl AgentRunner for HarnessAgentRunner {
         request: Value,
         _conn: Option<&str>,
     ) -> TfResult<Value> {
-        let message = compose_turn_message(
-            &message_from_request(&request),
-            self.run_request.as_deref(),
-        );
+        let message =
+            compose_turn_message(&message_from_request(&request), self.run_request.as_deref());
         tracing::debug!(
             company = %self.company,
             agent = agent_ref,

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -311,7 +311,7 @@ pub(super) fn run_request_text(input: &Value) -> Option<String> {
         _ => return None,
     };
     let trimmed = text.trim();
-    (!trimmed.is_empty()).then(|| trimmed.to_string())
+    (!trimmed.is_empty()).then_some(trimmed.to_string())
 }
 
 /// The bare-completion fallback. An `agent` node with no `agent_ref` would land

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -74,12 +74,17 @@ use self::tools::WorkflowToolInvoker;
 ///
 /// `pool`/`deps` are shared with the rest of the harness surface — the roster the
 /// agent nodes address is the one already resident in `pool`.
+///
+/// `run_request` is the operator's topic for this run (issue #154), threaded to
+/// the agent capability so every agent node's turn message carries what was
+/// actually asked, not just the node's authored instruction.
 pub async fn build_capabilities(
     pool: Arc<HarnessPool>,
     deps: HarnessDeps,
     record: &CompanyRecord,
     workflow_id: &str,
     run_id: &str,
+    run_request: Option<String>,
 ) -> Capabilities {
     let company = record.id.clone();
     let mode = PolicyMode::parse(&record.manifest.policy.mode);
@@ -149,7 +154,12 @@ pub async fn build_capabilities(
         // `deps` moves in last — the borrows above (`deps.capabilities`,
         // `deps.secrets`, `deps.workspace_root`, `deps.workflow_source_dir`) are
         // all done by here.
-        agent: Some(Arc::new(HarnessAgentRunner::new(pool, deps, company))),
+        agent: Some(Arc::new(HarnessAgentRunner::new(
+            pool,
+            deps,
+            company,
+            run_request,
+        ))),
     }
 }
 
@@ -191,15 +201,27 @@ pub struct HarnessAgentRunner {
     pool: Arc<HarnessPool>,
     deps: HarnessDeps,
     company: CompanyId,
+    /// What the operator asked for on this run (issue #154), when they supplied
+    /// it. A node's `prompt` is authored into the graph and is the same on every
+    /// run, so without this the run's topic never reaches the teammate doing the
+    /// work — the agent would run, find no subject, and ask for one.
+    run_request: Option<String>,
 }
 
 impl HarnessAgentRunner {
-    /// Builds a runner over an already-populated pool for `company`.
-    pub fn new(pool: Arc<HarnessPool>, deps: HarnessDeps, company: CompanyId) -> Self {
+    /// Builds a runner over an already-populated pool for `company`, carrying
+    /// the operator's run request (issue #154) when one was supplied.
+    pub fn new(
+        pool: Arc<HarnessPool>,
+        deps: HarnessDeps,
+        company: CompanyId,
+        run_request: Option<String>,
+    ) -> Self {
         Self {
             pool,
             deps,
             company,
+            run_request,
         }
     }
 }
@@ -212,7 +234,10 @@ impl AgentRunner for HarnessAgentRunner {
         request: Value,
         _conn: Option<&str>,
     ) -> TfResult<Value> {
-        let message = message_from_request(&request);
+        let message = compose_turn_message(
+            &message_from_request(&request),
+            self.run_request.as_deref(),
+        );
         tracing::debug!(
             company = %self.company,
             agent = agent_ref,
@@ -241,6 +266,54 @@ fn message_from_request(request: &Value) -> String {
         }
     }
     request.to_string()
+}
+
+/// Combines a node's authored instruction with the operator's run request
+/// (issue #154).
+///
+/// A node's `prompt` is baked into the graph, so it is identical on every run —
+/// it says *what this step does*, never *what was asked this time*. Before this,
+/// the run's topic stopped at the trigger node and the agent had no subject to
+/// work on, which is what made a run end with the agent asking the operator for
+/// a topic they had no field to supply.
+///
+/// The instruction stays first so the node's job still leads; the request is
+/// appended under a labelled heading so a teammate can tell the standing
+/// instruction from this run's subject. A blank or whitespace-only request is
+/// treated as absent, leaving the message byte-identical to the previous
+/// behaviour — runs that supply no topic are unchanged.
+fn compose_turn_message(instruction: &str, run_request: Option<&str>) -> String {
+    let request = run_request.map(str::trim).filter(|r| !r.is_empty());
+    match request {
+        Some(request) => {
+            let instruction = instruction.trim();
+            if instruction.is_empty() {
+                return request.to_string();
+            }
+            format!("{instruction}\n\nRequest for this run:\n{request}")
+        }
+        None => instruction.to_string(),
+    }
+}
+
+/// Extracts a human-readable run request from the trigger input (issue #154).
+///
+/// The console posts `{"request": "…"}`, but the run endpoint accepts an
+/// arbitrary JSON trigger payload, so this also accepts a bare string and the
+/// nearby key spellings a hand-written call or an older client may use. Anything
+/// else (an object with no recognised key, a number, `null`) yields `None` and
+/// the run proceeds exactly as it did before — the topic is an addition, not a
+/// new requirement.
+pub(super) fn run_request_text(input: &Value) -> Option<String> {
+    let text = match input {
+        Value::String(s) => s.as_str(),
+        Value::Object(_) => ["request", "input", "topic", "message", "text"]
+            .iter()
+            .find_map(|key| input.get(*key).and_then(Value::as_str))?,
+        _ => return None,
+    };
+    let trimmed = text.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
 /// The bare-completion fallback. An `agent` node with no `agent_ref` would land
@@ -300,6 +373,93 @@ mod tests {
         );
         assert_eq!(message_from_request(&json!({ "input": "I" })), "I");
         assert_eq!(message_from_request(&json!({ "message": "M" })), "M");
+    }
+
+    // ── Issue #154: the operator's run request reaches the agent ──
+
+    #[test]
+    fn run_request_is_appended_under_a_labelled_heading() {
+        let out = compose_turn_message("Draft the launch post.", Some("dark mode for iOS"));
+        // The node's standing instruction still leads.
+        assert!(out.starts_with("Draft the launch post."), "{out}");
+        // …and this run's subject is distinguishable from it.
+        assert!(out.contains("Request for this run:"), "{out}");
+        assert!(out.contains("dark mode for iOS"), "{out}");
+    }
+
+    #[test]
+    fn a_run_with_no_request_is_byte_identical_to_the_old_message() {
+        // The guarantee that makes this safe to land: runs that supply no topic
+        // must behave exactly as they did before.
+        for empty in [None, Some(""), Some("   "), Some("\n\t ")] {
+            assert_eq!(
+                compose_turn_message("Draft the launch post.", empty),
+                "Draft the launch post.",
+                "empty request {empty:?} must not alter the message"
+            );
+        }
+    }
+
+    #[test]
+    fn a_request_with_no_instruction_stands_on_its_own() {
+        // No dangling heading when the node carries no usable instruction.
+        assert_eq!(
+            compose_turn_message("", Some("ship dark mode")),
+            "ship dark mode"
+        );
+        assert_eq!(
+            compose_turn_message("   ", Some("ship dark mode")),
+            "ship dark mode"
+        );
+    }
+
+    #[test]
+    fn run_request_text_reads_the_console_payload_and_a_bare_string() {
+        assert_eq!(
+            run_request_text(&json!({ "request": "dark mode" })).as_deref(),
+            Some("dark mode")
+        );
+        assert_eq!(
+            run_request_text(&json!("dark mode")).as_deref(),
+            Some("dark mode")
+        );
+        // Tolerated spellings from a hand-written call or an older client.
+        for key in ["input", "topic", "message", "text"] {
+            let mut payload = serde_json::Map::new();
+            payload.insert(key.to_string(), json!("dark mode"));
+            assert_eq!(
+                run_request_text(&Value::Object(payload)).as_deref(),
+                Some("dark mode"),
+                "key {key} should be accepted"
+            );
+        }
+        // Trimmed.
+        assert_eq!(
+            run_request_text(&json!({ "request": "  dark mode  " })).as_deref(),
+            Some("dark mode")
+        );
+    }
+
+    #[test]
+    fn run_request_text_is_none_for_payloads_that_carry_no_topic() {
+        // These are the shapes an existing caller already sends — none may start
+        // injecting a topic into agent messages.
+        for payload in [
+            json!({}),
+            json!(null),
+            json!(42),
+            json!({ "request": "" }),
+            json!({ "request": "   " }),
+            json!({ "unrelated": "value" }),
+            json!({ "request": 7 }),
+            json!(["dark mode"]),
+        ] {
+            assert_eq!(
+                run_request_text(&payload),
+                None,
+                "payload {payload} must carry no topic"
+            );
+        }
     }
 
     #[test]

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -41,8 +41,14 @@ pub async fn run_workflow(
     let graph = super::translate::translate(workflow);
     let compiled = tinyflows::compiler::compile(&graph).map_err(map_engine_error)?;
     let run_id = uuid::Uuid::new_v4().to_string();
+    // Issue #154: the operator's run request rides the trigger payload. Pull it
+    // out before the input is handed to the engine so every agent node's turn
+    // message carries the topic — a node's authored `prompt` is the same on
+    // every run and cannot say what was asked this time.
+    let run_request = super::caps::run_request_text(&input);
     let capabilities =
-        super::caps::build_capabilities(pool, deps, record, &workflow.id, &run_id).await;
+        super::caps::build_capabilities(pool, deps, record, &workflow.id, &run_id, run_request)
+            .await;
     let outcome = tinyflows::engine::run(&compiled, input, &capabilities)
         .await
         .map_err(map_engine_error)?;


### PR DESCRIPTION
## Summary

Running a workflow from the console had no way to say **what it should work on**. The run dispatched with an empty trigger payload, so the agent had no subject — a run typically ended with the teammate asking the operator for a topic they had no field to supply. The result panel's requested line showed a bare `—` for the same reason.

Two halves, because the console change alone would not have fixed it:

- **Console** — a *"What should this run work on?"* field beside **Run**, posting `{"request": "<topic>"}` as the trigger payload (Enter also dispatches).
- **Host** — the topic is threaded onto every agent node's turn message, so it actually reaches the teammates doing the work.

### Why the host half is needed

`runWorkflow` already accepted an `input` argument and `POST …/workflows/{wid}/run` already forwarded it to the engine — but the topic still could not reach an agent node. An agent node's `prompt` is authored into the graph, so it is **identical on every run**: it says *what this step does*, never *what was asked this time*. And the engine hands `AgentRunner::run_agent` only the node's **resolved config**, never the incoming item (`tinyflows/src/nodes/integration/agent.rs`). The trigger payload therefore dead-ended at the trigger node.

So `run_request_text` pulls a human-readable request off the trigger payload, `build_capabilities` threads it to the agent capability, and `compose_turn_message` composes each turn as the node's instruction followed by a labelled `Request for this run:` section. The instruction still leads, so a teammate can tell the standing job from this run's subject.

### Result echo

`ranWith` is pinned at dispatch, so the result panel echoes the request the **shown output actually came from** rather than whatever has been typed since. With no request the panel omits the line entirely instead of rendering a dash.

## API Or Behavior Changes

**No breaking change.** The run endpoint's wire contract is unchanged — `input` was already an arbitrary JSON trigger payload and still is.

The one behavioral addition is opt-in and fails safe: a payload carrying no topic (`{}`, `null`, a number, an unrelated object, a blank or whitespace-only string) yields `None`, and the composed turn message is **byte-identical to before**. Existing runs, and any other caller of the run endpoint, are unaffected. A dedicated test pins exactly that.

Alongside the console's `request` key the extractor also accepts a bare JSON string and the nearby spellings a hand-written call or an older client may send (`input`, `topic`, `message`, `text`).

Internal signature changes (both `pub` within the crate, no external callers): `build_capabilities` takes a trailing `run_request: Option<String>`, and `HarnessAgentRunner::new` takes the same. `HarnessAgentRunner` is constructed in exactly one place.

## Tests

Added to `src/workflows/caps/mod.rs`:

- `run_request_is_appended_under_a_labelled_heading` — instruction leads, request is distinguishable.
- `a_run_with_no_request_is_byte_identical_to_the_old_message` — the compatibility guarantee, across `None` / `""` / whitespace.
- `a_request_with_no_instruction_stands_on_its_own` — no dangling heading.
- `run_request_text_reads_the_console_payload_and_a_bare_string` — console shape, bare string, tolerated keys, trimming.
- `run_request_text_is_none_for_payloads_that_carry_no_topic` — every no-topic shape an existing caller might already send.

Commands run locally:

- [x] `npx tsc -b --noEmit` (frontend) — **passes**. It caught a real bug during development: the `request` prop was added to `RunResultPanel`'s type but not its destructuring pattern.
- [ ] `cargo fmt --all -- --check` — **not run**: cargo was excluded for this task, relying on CI.
- [ ] `cargo clippy --all-targets -- -D warnings` — not run, same reason.
- [ ] `cargo build --all-targets` — not run, same reason.
- [ ] `cargo test` — not run, same reason.

Because the Rust is not compiler-checked here, two hazards were hand-checked rather than discovered by a build: `json!({ key: … })` with a **variable** key (the macro needs a literal, so the test builds a `serde_json::Map` instead), and rustfmt line width (the only remaining >100-char line is a pre-existing string literal). Reviewers may want to look hardest at the `pub(super)` visibility of `run_request_text` as used from the sibling `runner` module, and the `?` inside the `Value::Object` match arm.

## Documentation

No doc change needed: this adds a field to an existing surface and a trigger-payload key that the run endpoint's rustdoc already describes as an arbitrary JSON payload. The new behaviour is documented inline on `compose_turn_message` and `run_request_text`, including why an authored node prompt cannot carry the run's topic.

Fixes #154


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an operator request field when starting workflow runs.
  * Workflow agents now use the request alongside their configured instructions.
  * Run results display the request associated with the executed run.

* **Bug Fixes**
  * Improved handling of blank or differently structured request input.
  * Requests are trimmed before being processed and displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->