### PR TITLE
fix(usage): emit OauthCall samples so oauthCalls/connections aren't always zero

### DIFF
--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -261,7 +261,18 @@ pub fn build_agent(
     #[cfg(feature = "composio")]
     if crate::company::grants_composio_explicit(grants) {
         match &deps.composio {
-            Some(config) => tools.extend(crate::harness::composio::composio_tools(config)),
+            // The metering handle lets `composio_execute` record an `OauthCall`
+            // usage sample per completed call, so the Usage view's
+            // calls-by-provider chart reflects real connected-tool activity
+            // (issue #152). A `None` meter simply leaves metering off.
+            Some(config) => tools.extend(crate::harness::composio::composio_tools(
+                config,
+                crate::harness::composio::ComposioMetering {
+                    company: company.clone(),
+                    agent: manifest_agent.id.clone(),
+                    meter: deps.meter.clone(),
+                },
+            )),
             None => tracing::warn!(
                 company = %company,
                 agent = %manifest_agent.id,

--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -147,7 +147,7 @@ fn slug_toolkit(slug: &str) -> String {
 }
 
 #[cfg(feature = "composio")]
-pub use live::composio_tools;
+pub use live::{ComposioMetering, composio_tools};
 
 #[cfg(feature = "composio")]
 mod live {
@@ -158,11 +158,31 @@ mod live {
     use serde_json::{Value, json};
 
     use crate::harness::mcp_probe::scrub;
+    use crate::metering::record_oauth_call;
+    use crate::ports::UsageMeter;
+    use crate::ports::now_millis;
 
     use oh::composio::ComposioClient;
     use oh::integrations::IntegrationClient;
     use oh::tools::traits::{PermissionLevel, Tool, ToolResult};
     use openhuman_core::openhuman as oh;
+
+    /// What `composio_execute` needs to meter a call it just made: the company
+    /// the sample belongs to, the agent that made it, and the meter to write to.
+    ///
+    /// Bundled because these three travel together and are individually
+    /// meaningless — and because [`composio_tools`] would otherwise grow four
+    /// positional parameters at a call site that already has many.
+    #[derive(Clone)]
+    pub struct ComposioMetering {
+        /// The company the sample is scoped to.
+        pub company: CompanyId,
+        /// The agent whose turn made the call.
+        pub agent: String,
+        /// The usage meter. `None` leaves metering off entirely (the harness
+        /// wires no meter in some embeddings) — the tools still work.
+        pub meter: Option<Arc<dyn UsageMeter>>,
+    }
 
     /// Build the five per-tenant Composio tools over the tenant's bearer token.
     ///
@@ -173,9 +193,17 @@ mod live {
     /// `authorize` / `execute` tools are `Execute` and additionally park for
     /// operator approval through the harness [`ApprovalPolicy`](crate::harness::policy).
     ///
+    /// `metering` lets `composio_execute` record a
+    /// [`SampleKind::OauthCall`](crate::ports::usage::SampleKind) sample per
+    /// call it completes, which is what puts numbers in the Usage view's
+    /// calls-by-provider chart (issue #152).
+    ///
     /// Gated on the `composio` feature; the default/`openhuman` build never
     /// compiles this.
-    pub fn composio_tools(config: &TenantComposio) -> Vec<Box<dyn Tool>> {
+    pub fn composio_tools(
+        config: &TenantComposio,
+        metering: ComposioMetering,
+    ) -> Vec<Box<dyn Tool>> {
         // The Config-free seam: `IntegrationClient::new(backend_url, auth_token)`
         // takes the per-tenant credential directly, with no OpenHuman global
         // `Config`. The bearer is the ONLY isolation lever — see the module docs.
@@ -210,6 +238,7 @@ mod live {
                 client,
                 secrets,
                 toolkits,
+                metering,
             }),
         ]
     }
@@ -522,6 +551,7 @@ mod live {
         client: ComposioClient,
         secrets: Vec<String>,
         toolkits: Arc<Vec<String>>,
+        metering: ComposioMetering,
     }
 
     #[async_trait]
@@ -573,12 +603,110 @@ mod live {
             // tracing carries the slug/toolkit only — NEVER arguments or bodies.
             tracing::debug!(tool = %tool, toolkit = %toolkit, "[composio] execute");
             match self.client.execute_tool(&tool, arguments).await {
-                Ok(resp) => Ok(scrubbed_ok(
-                    serde_json::to_value(&resp).unwrap_or(Value::Null),
-                    &self.secrets,
-                )),
+                Ok(resp) => {
+                    // Metered only on success — i.e. a call that actually
+                    // reached the connected account. `connections` in the read
+                    // model is the *count of providers seen*, so counting a
+                    // failed call would report a connection for a provider this
+                    // company may not even be connected to. Never fails the
+                    // call: `record_oauth_call` logs and swallows.
+                    if let Some(meter) = self.metering.meter.as_deref() {
+                        record_oauth_call(
+                            meter,
+                            &self.metering.company,
+                            &self.metering.agent,
+                            &toolkit,
+                            now_millis(),
+                        )
+                        .await;
+                    }
+                    Ok(scrubbed_ok(
+                        serde_json::to_value(&resp).unwrap_or(Value::Null),
+                        &self.secrets,
+                    ))
+                }
                 Err(err) => Ok(scrubbed_err("composio_execute failed", &err, &self.secrets)),
             }
+        }
+    }
+
+    #[cfg(test)]
+    mod live_tests {
+        use super::*;
+
+        use std::sync::Mutex;
+
+        use crate::ports::types::CompanyId;
+        use crate::ports::usage::UsageSample;
+
+        #[derive(Default)]
+        struct RecordingMeter {
+            samples: Mutex<Vec<UsageSample>>,
+        }
+
+        #[async_trait]
+        impl UsageMeter for RecordingMeter {
+            async fn record(
+                &self,
+                _company: &CompanyId,
+                sample: &UsageSample,
+            ) -> crate::Result<()> {
+                self.samples.lock().unwrap().push(sample.clone());
+                Ok(())
+            }
+            async fn query(
+                &self,
+                _company: &CompanyId,
+                _since: u64,
+            ) -> crate::Result<Vec<UsageSample>> {
+                Ok(self.samples.lock().unwrap().clone())
+            }
+        }
+
+        /// An execute tool whose allowlist admits `gmail` only, wired to a
+        /// recording meter. The client is constructed but never dialled by the
+        /// paths under test — both return before any network call.
+        fn tool_with(meter: Arc<RecordingMeter>) -> ComposioExecuteTool {
+            ComposioExecuteTool {
+                client: ComposioClient::new(Arc::new(IntegrationClient::new(
+                    "https://example.invalid".to_string(),
+                    "token".to_string(),
+                ))),
+                secrets: vec!["token".to_string()],
+                toolkits: Arc::new(vec!["gmail".to_string()]),
+                metering: ComposioMetering {
+                    company: CompanyId::new("acme"),
+                    agent: "ceo".to_string(),
+                    meter: Some(meter),
+                },
+            }
+        }
+
+        /// A call blocked by the toolkit allowlist never reaches the provider,
+        /// so it must not count towards `oauthCalls` — and must not invent a
+        /// `connections` entry for a toolkit this company cannot even use.
+        #[tokio::test]
+        async fn allowlist_rejection_records_no_sample() {
+            let meter = Arc::new(RecordingMeter::default());
+            let result = tool_with(meter.clone())
+                .execute(json!({"tool": "SLACK_POST_MESSAGE"}))
+                .await
+                .expect("execute returns a result rather than erroring");
+            assert!(result.is_error, "the call should be refused");
+            assert!(meter.samples.lock().unwrap().is_empty());
+        }
+
+        /// A malformed call is rejected before the client is touched, so it is
+        /// likewise not a metered OAuth call.
+        #[tokio::test]
+        async fn missing_tool_argument_records_no_sample() {
+            let meter = Arc::new(RecordingMeter::default());
+            let result = tool_with(meter.clone())
+                .execute(json!({}))
+                .await
+                .expect("execute returns a result rather than erroring");
+            assert!(result.is_error, "the call should be refused");
+            assert!(meter.samples.lock().unwrap().is_empty());
         }
     }
 }

--- a/src/metering/mod.rs
+++ b/src/metering/mod.rs
@@ -10,6 +10,12 @@
 //!   balance → [`Finances`] (balance, budget vs spend, revenue, spend by
 //!   category, the transaction journal).
 //!
+//! [`oauth`] is the one write-side piece: it mints the
+//! [`SampleKind::OauthCall`](crate::ports::usage::SampleKind) samples
+//! [`bucket_usage`] turns into the calls-by-provider chart. It sits here rather
+//! than at the (feature-gated) connected-tool call sites so the contract is
+//! compiled and tested by the default CI build — see its module docs.
+//!
 //! WS2 owns the async-graphql wrappers (`graphql/usage.rs`,
 //! `graphql/finances.rs`); this module deliberately has no async-graphql
 //! dependency so the projections can be unit-tested against seeded data and
@@ -23,11 +29,13 @@ use crate::ports::types::OverlayAgent;
 mod calendar;
 pub mod capability;
 mod finances;
+pub mod oauth;
 mod types;
 mod usage;
 
 pub use capability::{BudgetPeriod, CapabilityPlan, TierBudgetStatus, plan_named, tokens_in};
 pub use finances::{category_label, finances_from};
+pub use oauth::{UNKNOWN_PROVIDER, oauth_call_sample, record_oauth_call};
 pub use types::{
     AgentTokens, CategorySpend, Direction, Finances, ProviderCalls, Transaction, Usage, UsagePoint,
     UsageRange, UsageTotals,

--- a/src/metering/oauth.rs
+++ b/src/metering/oauth.rs
@@ -1,0 +1,215 @@
+//! Emitting [`SampleKind::OauthCall`] usage samples — the write half of the
+//! Usage view's calls-by-provider chart.
+//!
+//! [`bucket_usage`](super::bucket_usage) has always summed `OauthCall` samples
+//! into `oauthCalls`, `byProvider`, and `connections`, but nothing ever emitted
+//! one, so those three counters were structurally zero however much
+//! connected-tool activity a company had. This module is the emit side.
+//!
+//! ## Why it lives here (always compiled) and not at the call site
+//!
+//! The connected-tool execution sites are behind non-default features
+//! (`composio`, `mcp`), and CI builds only the default feature set — so code
+//! written *at* those sites is neither compiled nor tested by CI. Keeping the
+//! sample shape and the record-and-swallow behaviour here, beside the
+//! aggregation that reads it, means the contract is unit-tested on every CI run
+//! and the gated call site stays a single line.
+//!
+//! ## Metering never fails the work it meters
+//!
+//! [`record_oauth_call`] logs and swallows a meter error rather than
+//! propagating it. A usage sample is accounting, not the operator's tool call:
+//! a full disk or a transient store fault must not turn a Gmail send that
+//! already happened into a tool-call failure the agent then retries.
+
+use crate::ports::types::CompanyId;
+use crate::ports::usage::{SampleKind, UsageMeter, UsageSample};
+
+/// The provider slug recorded when a call site cannot name its provider.
+///
+/// Better than dropping the sample: the call genuinely happened, so
+/// `oauthCalls` should count it even when the breakdown cannot attribute it.
+pub const UNKNOWN_PROVIDER: &str = "unknown";
+
+/// Normalises a provider slug for grouping: trimmed and lowercased, falling
+/// back to [`UNKNOWN_PROVIDER`] when empty.
+///
+/// `byProvider` groups on the raw string, so `GitHub` and `github` would
+/// otherwise land as two rows — and, because `connections` is the *count* of
+/// those rows, inflate the connection count for a single connected account.
+pub fn normalize_provider(provider: &str) -> String {
+    let trimmed = provider.trim();
+    if trimmed.is_empty() {
+        return UNKNOWN_PROVIDER.to_string();
+    }
+    trimmed.to_ascii_lowercase()
+}
+
+/// Builds the [`UsageSample`] for one connected-tool invocation.
+///
+/// Carries no tokens and no cost: an OAuth call is counted, not billed by token
+/// — the money for a connected tool moves at the provider, not through our
+/// inference meter. Keeping the token fields at zero is what lets the sample
+/// share a stream with inference samples without polluting the token series.
+pub fn oauth_call_sample(agent: &str, provider: &str, at_millis: u64) -> UsageSample {
+    UsageSample {
+        at_millis,
+        agent: agent.to_string(),
+        provider: normalize_provider(provider),
+        input_tokens: 0,
+        output_tokens: 0,
+        cached_input_tokens: 0,
+        cost_usd: 0.0,
+        kind: SampleKind::OauthCall,
+    }
+}
+
+/// Records one connected-tool invocation against the company's usage meter.
+///
+/// Call this **after** a connected tool has actually reached its provider, so
+/// the counters reflect calls that happened rather than calls that were
+/// attempted. A meter failure is logged and swallowed — see the module docs.
+pub async fn record_oauth_call(
+    meter: &dyn UsageMeter,
+    company: &CompanyId,
+    agent: &str,
+    provider: &str,
+    at_millis: u64,
+) {
+    let sample = oauth_call_sample(agent, provider, at_millis);
+    if let Err(err) = meter.record(company, &sample).await {
+        tracing::warn!(
+            company = %company,
+            agent = %agent,
+            provider = %sample.provider,
+            error = %err,
+            "[usage] failed to record an OAuth-call sample; the tool call itself succeeded"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+
+    use crate::error::OpenCompanyError;
+
+    #[derive(Default)]
+    struct RecordingMeter {
+        samples: Mutex<Vec<UsageSample>>,
+    }
+
+    #[async_trait]
+    impl UsageMeter for RecordingMeter {
+        async fn record(&self, _company: &CompanyId, sample: &UsageSample) -> crate::Result<()> {
+            self.samples.lock().unwrap().push(sample.clone());
+            Ok(())
+        }
+        async fn query(
+            &self,
+            _company: &CompanyId,
+            _since: u64,
+        ) -> crate::Result<Vec<UsageSample>> {
+            Ok(self.samples.lock().unwrap().clone())
+        }
+    }
+
+    /// A meter whose writes always fail — proves metering cannot fail the work.
+    struct FailingMeter;
+
+    #[async_trait]
+    impl UsageMeter for FailingMeter {
+        async fn record(&self, _company: &CompanyId, _sample: &UsageSample) -> crate::Result<()> {
+            Err(OpenCompanyError::Store("disk on fire".to_string()))
+        }
+        async fn query(
+            &self,
+            _company: &CompanyId,
+            _since: u64,
+        ) -> crate::Result<Vec<UsageSample>> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[test]
+    fn sample_is_a_zero_token_zero_cost_oauth_call() {
+        let s = oauth_call_sample("ceo", "gmail", 1_700);
+        assert_eq!(s.kind, SampleKind::OauthCall);
+        assert_eq!(s.agent, "ceo");
+        assert_eq!(s.provider, "gmail");
+        assert_eq!(s.at_millis, 1_700);
+        // An OAuth call is counted, never token-billed — zeros here keep it out
+        // of the token series it shares a stream with.
+        assert_eq!(s.input_tokens, 0);
+        assert_eq!(s.output_tokens, 0);
+        assert_eq!(s.cached_input_tokens, 0);
+        assert_eq!(s.cost_usd, 0.0);
+    }
+
+    #[test]
+    fn provider_is_normalized_so_one_account_is_one_connection() {
+        assert_eq!(normalize_provider("GitHub"), "github");
+        assert_eq!(normalize_provider("  gmail  "), "gmail");
+        assert_eq!(normalize_provider("SLACK"), "slack");
+    }
+
+    #[test]
+    fn blank_provider_falls_back_rather_than_dropping_the_call() {
+        assert_eq!(normalize_provider(""), UNKNOWN_PROVIDER);
+        assert_eq!(normalize_provider("   "), UNKNOWN_PROVIDER);
+        assert_eq!(oauth_call_sample("ceo", "", 1).provider, UNKNOWN_PROVIDER);
+    }
+
+    #[tokio::test]
+    async fn record_writes_one_sample_per_call() {
+        let meter = RecordingMeter::default();
+        let company = CompanyId::new("acme");
+        record_oauth_call(&meter, &company, "ceo", "GMAIL", 1_000).await;
+        record_oauth_call(&meter, &company, "ceo", "gmail", 2_000).await;
+
+        let samples = meter.samples.lock().unwrap();
+        assert_eq!(samples.len(), 2);
+        assert!(samples.iter().all(|s| s.kind == SampleKind::OauthCall));
+        // Both spellings collapse onto one provider, so this reads as one
+        // connection with two calls rather than two connections with one each.
+        assert!(samples.iter().all(|s| s.provider == "gmail"));
+    }
+
+    #[tokio::test]
+    async fn a_meter_failure_never_surfaces_to_the_caller() {
+        // The tool call already reached the provider; failing here would make
+        // the agent believe a completed action failed, and retry it.
+        record_oauth_call(&FailingMeter, &CompanyId::new("acme"), "ceo", "gmail", 1).await;
+    }
+
+    /// The emitted sample must survive the aggregation that reads it — the
+    /// whole point of the issue is that these three counters stop being zero.
+    #[test]
+    fn emitted_samples_reach_the_console_counters() {
+        use std::collections::HashMap;
+
+        use crate::metering::{UsageRange, bucket_usage};
+
+        let now = 1_700_000_000_000u64;
+        let samples = vec![
+            oauth_call_sample("ceo", "gmail", now),
+            oauth_call_sample("ceo", "gmail", now),
+            oauth_call_sample("ops", "github", now),
+        ];
+        let usage = bucket_usage(&samples, UsageRange::D7, now, &HashMap::new());
+
+        assert_eq!(usage.totals.oauth_calls, 3);
+        assert_eq!(usage.totals.connections, 2);
+        assert_eq!(usage.by_provider.len(), 2);
+        assert_eq!(usage.by_provider[0].provider, "gmail");
+        assert_eq!(usage.by_provider[0].calls, 2);
+        assert_eq!(usage.by_provider[1].provider, "github");
+        assert_eq!(usage.by_provider[1].calls, 1);
+        // OAuth calls carry no tokens, so they never distort the token series.
+        assert_eq!(usage.totals.tokens, 0);
+    }
+}

--- a/src/metering/usage.rs
+++ b/src/metering/usage.rs
@@ -48,7 +48,15 @@ pub fn bucket_usage(
         total_output += s.output_tokens;
         total_cost += s.cost_usd;
 
-        *per_agent.entry(s.agent.clone()).or_default() += s.input_tokens + s.output_tokens;
+        // "Tokens by teammate" is a token chart, so a token-less sample must not
+        // mint a row there. `OauthCall` samples are deliberately zero-token, and
+        // before they were ever emitted this branch could not be reached by one;
+        // without the guard, an agent that only made connected-tool calls would
+        // appear as a 0-token bar.
+        let tokens = s.input_tokens + s.output_tokens;
+        if tokens > 0 {
+            *per_agent.entry(s.agent.clone()).or_default() += tokens;
+        }
 
         if s.kind == SampleKind::OauthCall {
             oauth_calls += 1;
@@ -261,5 +269,29 @@ mod tests {
         assert_eq!(u.totals.connections, 2);
         // OAuth calls carry no tokens.
         assert_eq!(u.totals.tokens, 150);
+    }
+
+    #[test]
+    fn oauth_only_agents_do_not_appear_as_zero_token_teammates() {
+        // "Tokens by teammate" is a token chart. An agent whose whole window is
+        // connected-tool calls has no tokens to show, so it must not render as
+        // an empty bar beside the agents that actually spent.
+        let now = at(2026, 7, 16);
+        let samples = vec![
+            inference(at(2026, 7, 16), "ceo", 100, 50, 0.1),
+            oauth(at(2026, 7, 16), "github"),
+            // `ops` only ever made an OAuth call this window.
+            UsageSample {
+                agent: "ops".to_string(),
+                ..oauth(at(2026, 7, 16), "gmail")
+            },
+        ];
+        let u = bucket_usage(&samples, UsageRange::D7, now, &HashMap::new());
+        assert_eq!(u.by_agent.len(), 1);
+        assert_eq!(u.by_agent[0].name, "ceo");
+        assert_eq!(u.by_agent[0].tokens, 150);
+        // The calls still count — only the token attribution is withheld.
+        assert_eq!(u.totals.oauth_calls, 2);
+        assert_eq!(u.totals.connections, 2);
     }
 }

--- a/src/server/ops/usage.rs
+++ b/src/server/ops/usage.rs
@@ -11,10 +11,15 @@
 //! Data maturity: token/cost samples only populate on a harness
 //! (`openhuman`-feature) build via `src/harness/cost.rs`. The offline build has
 //! no cost hook, so the meter is empty and the series is (correctly) zero-filled
-//! — that is the true value, not a stub. OAuth-call samples
-//! ([`SampleKind::OauthCall`](crate::ports::usage::SampleKind)) are not yet
-//! emitted anywhere, so `byProvider` / `oauthCalls` read zero until the Phase 2
-//! emit work lands.
+//! — that is the true value, not a stub.
+//!
+//! The same holds for OAuth-call samples
+//! ([`SampleKind::OauthCall`](crate::ports::usage::SampleKind)): they are now
+//! emitted per completed connected-tool call (see
+//! [`metering::oauth`](crate::metering::oauth)), but only a `composio`-feature
+//! build wires a connected-tool surface at all — so on a default build
+//! `byProvider` / `oauthCalls` still read zero, and that zero is now the honest
+//! answer ("no connected tools in this build") rather than a missing hook.
 
 use axum::Json;
 use axum::Router;
@@ -68,7 +73,8 @@ struct UsageDto {
     series: Vec<UsagePoint>,
     /// Tokens per teammate (desk), highest first.
     by_agent: Vec<AgentTokens>,
-    /// OAuth calls per provider, highest first (empty until Phase 2 emit).
+    /// OAuth calls per provider, highest first. Empty on a build with no
+    /// connected-tool surface compiled in — see the module docs.
     by_provider: Vec<ProviderCalls>,
     /// Window totals.
     totals: UsageTotals,


### PR DESCRIPTION
## Summary

Fixes #152.

`bucket_usage` has always summed `SampleKind::OauthCall` into `oauthCalls`,
`byProvider`, and `connections` — but **nothing ever emitted one**, so all three
counters were structurally zero regardless of connected-tool activity.
`server/ops/usage.rs` documented its own gap ("not yet emitted anywhere … until
the Phase 2 emit work lands"). This is that emit side.

`metering::oauth` mints the sample and records it; `composio_execute` calls it
once per completed action, tagged with the action's toolkit
(`GMAIL_SEND_EMAIL` → `gmail`).

### Three judgement calls

**The logic lives in `metering` (always compiled), not at the call site.** The
connected-tool execution sites are behind non-default features (`composio`,
`mcp`) and CI builds only the default set, so code written *at* those sites is
neither compiled nor tested by CI. Keeping the sample shape and the
record-and-swallow behaviour beside the aggregation that reads it means the
contract is unit-tested on every CI run and the gated site is a single call.

**Metered on success only.** `connections` in the read model is the *count of
providers seen*, so counting a failed call would report a connection for a
provider this company may not be connected to at all. A call rejected by the
toolkit allowlist, or one with malformed arguments, never reaches the provider
and is not metered.

**Providers are normalised** (trimmed, lowercased) before recording. `byProvider`
groups on the raw string and `connections` is the count of those groups, so
`GitHub` and `github` would otherwise read as two connections with one call each
instead of one connection with two.

Metering never fails the work it meters: `record_oauth_call` logs and swallows a
meter error. A full disk must not turn a Gmail send that already happened into a
tool-call failure the agent then retries.

### Knock-on fix: zero-token samples in "tokens by teammate"

`bucket_usage` fed *every* sample into the per-teammate token accumulator. That
branch was unreachable by a zero-token sample before this change, because none
were ever emitted. Now that they are, an agent whose whole window was
connected-tool calls would render as a 0-token bar in a token chart. Guarded,
with a test.

## API Or Behavior Changes

- New `metering::oauth` module: `oauth_call_sample`, `record_oauth_call`,
  `normalize_provider`, `UNKNOWN_PROVIDER`. Additive.
- `harness::composio::composio_tools` takes a second argument, the new
  `ComposioMetering { company, agent, meter }`. A `None` meter leaves metering
  off and the tools behave exactly as before. Only reachable under
  `--features composio`.
- `bucket_usage` no longer creates a `byAgent` row for a sample carrying no
  tokens. No existing behaviour changes on a token-bearing sample.
- No wire-format change. `GET …/usage` keeps its shape; `byProvider` /
  `oauthCalls` simply stop being permanently zero on a build that has a
  connected-tool surface.

## Tests

Always compiled, so **CI runs these**:

- `metering/oauth.rs` — sample is zero-token/zero-cost and correctly kinded;
  provider normalisation collapses casing; a blank provider falls back to
  `unknown` rather than dropping the call; `record_oauth_call` writes one sample
  per call; a failing meter never surfaces to the caller; and
  `emitted_samples_reach_the_console_counters` drives emitted samples through
  `bucket_usage` to assert `oauthCalls` / `byProvider` / `connections` are the
  numbers the issue says should be non-zero.
- `metering/usage.rs` — `oauth_only_agents_do_not_appear_as_zero_token_teammates`.

Behind `--features composio` (**not built by CI** — see limitations):

- `allowlist_rejection_records_no_sample`, `missing_tool_argument_records_no_sample`.

### Limitations, stated plainly

- **CI does not compile the `composio` feature**, so the wiring in
  `harness/composio.rs` and `harness/build.rs` is not covered by a green check on
  this PR. It needs review eyes. (Pre-existing repo-wide gap — the same is true
  of every `openhuman` / `mcp` / `media` path, and is already noted in
  `harness/build.rs`.)
- The **positive** end-to-end path (a real `composio_execute` → provider →
  exactly one sample) is not unit-tested: it requires a live `ComposioClient`
  round-trip. The two rejection paths are tested because they return before any
  network call.
- **MCP is deliberately out of scope.** `harness/mcp.rs` maps both
  `AuthMaterial::OAuth` and a static bearer onto the same
  `McpAuthConfig::BearerToken`, so the call site cannot distinguish an
  OAuth-backed server from a statically-credentialed one — metering all of them
  as OAuth calls would over-count `connections`. Threading the original
  `AuthMaterial` through to `OcMcpCallTool` is a separate change; Composio alone
  is enough for the counters to stop being structurally zero.

Run locally:

- [x] `rustfmt --edition 2024 --check` on every changed Rust file
- [ ] `cargo fmt --all -- --check` — cannot run locally: `cargo metadata` fails
      because the `vendor/` submodules are not initialised in this checkout.
      Covered by CI.
- [ ] `cargo clippy --all-targets -- -D warnings` — same; relying on CI.
- [ ] `cargo test` — same; relying on CI (covers `metering::oauth`, not the
      composio wiring).

## Documentation

`server/ops/usage.rs` module docs and the `byProvider` field doc updated: the
"not yet emitted anywhere / Phase 2" note is replaced with the accurate state —
samples are emitted per completed connected-tool call, and a default build reads
zero because it compiles in no connected-tool surface, not because a hook is
missing. New `metering/oauth.rs` carries its own module docs covering the
placement rationale and the never-fail-the-caller contract.
