### PR TITLE
fix(email): repair IMAP receive + wire inbox to the web console (follow-up to #143)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -30,6 +30,8 @@ import {
   type FeedbackResponse,
   type FeedbackSummary,
   type FinancesDto,
+  type InboxDto,
+  type InboxMessageDto,
   type TeamMemberDto,
   type UsageDto,
   type Verdict,
@@ -344,6 +346,37 @@ export class OpenCompanyClient {
     return this.request<void>(
       "DELETE",
       `${this.scope(company)}/team/${encodeURIComponent(agentId)}`,
+    );
+  }
+
+  /**
+   * The company's inboxes with unread counts (Inbox tab). Both inbound paths —
+   * the ingest webhook and the IMAP poller — file into the store this reads, so
+   * received mail appears here. Hosts without the surface 404; callers treat
+   * that as "no inboxes".
+   */
+  listInboxes(company?: string | null): Promise<InboxDto[]> {
+    return this.request<InboxDto[]>("GET", `${this.scope(company)}/inboxes`);
+  }
+
+  /** One inbox's messages, oldest first. */
+  inboxMessages(key: string, company?: string | null): Promise<InboxMessageDto[]> {
+    return this.request<InboxMessageDto[]>(
+      "GET",
+      `${this.scope(company)}/inboxes/${encodeURIComponent(key)}/messages`,
+    );
+  }
+
+  /** Mark inbox messages read (the given ids, or all when omitted); returns the count still unread. */
+  markInboxRead(
+    key: string,
+    ids?: string[],
+    company?: string | null,
+  ): Promise<{ unread: number }> {
+    return this.request<{ unread: number }>(
+      "POST",
+      `${this.scope(company)}/inboxes/${encodeURIComponent(key)}/read`,
+      ids ? { ids } : undefined,
     );
   }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -237,6 +237,43 @@ export interface TeamMemberDto {
 }
 
 /**
+ * One teammate inbox's non-secret status, from `GET .../inboxes`. Both inbound
+ * paths (the ingest webhook and the IMAP poller) file into the same store this
+ * projects, so received mail shows up here.
+ */
+export interface InboxDto {
+  /** The inbox key (a teammate's local part / slug). */
+  key: string;
+  /** The teammate's display name. */
+  name: string;
+  /** The full address (`{key}@{domain}` when a domain is configured). */
+  address: string;
+  /** Whether the inbox is enabled on the Team page. */
+  enabled: boolean;
+  /** The number of unread received (inbound) messages. */
+  unread: number;
+}
+
+/** One email in an inbox, from `GET .../inboxes/{key}/messages`. */
+export interface InboxMessageDto {
+  id: string;
+  /** The inbox this belongs to (the teammate local part). */
+  inbox: string;
+  /** The sender's display name (may be empty). */
+  fromName: string;
+  /** The sender's email address. */
+  fromEmail: string;
+  subject: string;
+  /** Plain-text body. */
+  body: string;
+  /** When it arrived / was sent, epoch millis. */
+  atMillis: number;
+  read: boolean;
+  /** True for a sent message, false for a received one. */
+  outbound: boolean;
+}
+
+/**
  * One third-party connection's state, from `GET .../connections`.
  * Forward-looking: hosts that don't expose the connections surface yet simply
  * 404, and the console treats connections as unavailable.

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -528,7 +528,7 @@ export function AppShell({
               onSendEnd={onSendEnd}
             />
           )}
-          {view === "inbox" && <InboxView company={company} />}
+          {view === "inbox" && <InboxView client={client} company={company} />}
           {view === "tasks" && <TasksView client={client} company={company} />}
           {view === "team" && <TeamView client={client} company={company} />}
           {view === "desks" && <DesksView client={client} company={company} />}

--- a/frontend/src/views/InboxView.tsx
+++ b/frontend/src/views/InboxView.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ArrowLeft, Inbox as InboxIcon, Mail } from "lucide-react";
 
+import type { OpenCompanyClient } from "@/api/client";
+import type { InboxDto, InboxMessageDto } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -11,49 +13,107 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-import {
-  type EmailMessage,
-  enabledInboxes,
-  type Inbox,
-  loadInboxes,
-  saveInboxes,
-  slugify,
-  unreadCount,
-} from "@/lib/inbox";
 
 interface Props {
+  client: OpenCompanyClient;
   company: string | null;
 }
 
-/** An email inbox surface. Each agent with an inbox enabled gets its own. */
-export function InboxView({ company }: Props) {
-  const [store, setStore] = useState(() => loadInboxes(company));
-  const inboxes = useMemo(() => enabledInboxes(store), [store]);
-  const [activeKey, setActiveKey] = useState<string>(() => enabledInboxes(loadInboxes(company))[0]?.key ?? "");
+/** A short one-line preview derived from the plain-text body. */
+function preview(body: string): string {
+  return body.replace(/\s+/g, " ").trim().slice(0, 120);
+}
+
+/** The email inbox surface — reads a teammate's mail from the server (both the
+ * ingest webhook and the IMAP poller file into the same store). */
+export function InboxView({ client, company }: Props) {
+  const [inboxes, setInboxes] = useState<InboxDto[]>([]);
+  const [loadingInboxes, setLoadingInboxes] = useState(true);
+  const [activeKey, setActiveKey] = useState<string>("");
+  const [messages, setMessages] = useState<InboxMessageDto[]>([]);
+  const [loadingMessages, setLoadingMessages] = useState(false);
   const [openId, setOpenId] = useState<string | null>(null);
   const [mobilePane, setMobilePane] = useState<"list" | "read">("list");
 
+  // Load the inbox list on mount / company change. A host without the route
+  // (older build) 404s — treat that as "no inboxes" rather than an error wall.
   useEffect(() => {
-    saveInboxes(company, store);
-  }, [company, store]);
+    let live = true;
+    setLoadingInboxes(true);
+    client
+      .listInboxes(company)
+      .then((list) => {
+        if (!live) return;
+        setInboxes(list);
+        setActiveKey((k) => (list.some((i) => i.key === k) ? k : (list[0]?.key ?? "")));
+      })
+      .catch(() => {
+        if (live) setInboxes([]);
+      })
+      .finally(() => {
+        if (live) setLoadingInboxes(false);
+      });
+    return () => {
+      live = false;
+    };
+  }, [client, company]);
 
-  const active = inboxes.find((i) => i.key === activeKey) ?? inboxes[0];
-  const openMsg = active?.messages.find((m) => m.id === openId) ?? null;
+  // Load the active inbox's messages whenever it changes.
+  useEffect(() => {
+    if (!activeKey) {
+      setMessages([]);
+      return;
+    }
+    let live = true;
+    setLoadingMessages(true);
+    setOpenId(null);
+    client
+      .inboxMessages(activeKey, company)
+      .then((msgs) => {
+        if (live) setMessages(msgs);
+      })
+      .catch(() => {
+        if (live) setMessages([]);
+      })
+      .finally(() => {
+        if (live) setLoadingMessages(false);
+      });
+    return () => {
+      live = false;
+    };
+  }, [client, company, activeKey]);
 
-  function openMessage(inboxKey: string, id: string) {
-    setOpenId(id);
-    setMobilePane("read");
-    setStore((s) => {
-      const inbox = s[inboxKey];
-      if (!inbox) return s;
-      return {
-        ...s,
-        [inboxKey]: {
-          ...inbox,
-          messages: inbox.messages.map((m) => (m.id === id ? { ...m, read: true } : m)),
-        },
-      };
-    });
+  const active = useMemo(
+    () => inboxes.find((i) => i.key === activeKey) ?? inboxes[0],
+    [inboxes, activeKey],
+  );
+  const unread = useMemo(
+    () => messages.filter((m) => !m.outbound && !m.read).length,
+    [messages],
+  );
+  const openMsg = messages.find((m) => m.id === openId) ?? null;
+
+  const openMessage = useCallback(
+    (id: string) => {
+      setOpenId(id);
+      setMobilePane("read");
+      const target = messages.find((m) => m.id === id);
+      if (!target || target.read || !active) return;
+      // Optimistically mark read; persist to the server (fire-and-forget).
+      setMessages((ms) => ms.map((m) => (m.id === id ? { ...m, read: true } : m)));
+      client.markInboxRead(active.key, [id], company).catch(() => {
+        /* leave the optimistic state; a reload reconciles */
+      });
+    },
+    [messages, active, client, company],
+  );
+
+  if (loadingInboxes) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+        Loading inboxes…
+      </div>
+    );
   }
 
   if (inboxes.length === 0) {
@@ -64,12 +124,15 @@ export function InboxView({ company }: Props) {
           <p className="font-medium text-foreground">No inboxes yet</p>
           <p className="max-w-sm text-sm">
             Give an agent its own inbox from the <span className="font-medium">Team</span> page —
-            flip on the inbox toggle for anyone who needs to receive email.
+            flip on the inbox toggle for anyone who needs to receive email. Mail sent to that
+            address shows up here.
           </p>
         </div>
       </div>
     );
   }
+
+  const sorted = messages.slice().sort((a, b) => b.atMillis - a.atMillis);
 
   return (
     <div className="flex flex-1 overflow-hidden">
@@ -81,7 +144,11 @@ export function InboxView({ company }: Props) {
         )}
       >
         <div className="flex items-center gap-2 border-b px-3 py-2.5">
-          <Select value={active?.key} onValueChange={(v) => v && (setActiveKey(v), setOpenId(null))} items={Object.fromEntries(inboxes.map((i) => [i.key, i.name]))}>
+          <Select
+            value={active?.key}
+            onValueChange={(v) => v && (setActiveKey(v), setOpenId(null))}
+            items={Object.fromEntries(inboxes.map((i) => [i.key, i.name]))}
+          >
             <SelectTrigger className="h-8 flex-1">
               <SelectValue />
             </SelectTrigger>
@@ -93,21 +160,20 @@ export function InboxView({ company }: Props) {
               ))}
             </SelectContent>
           </Select>
-          {active && unreadCount(active) > 0 && <Badge variant="secondary">{unreadCount(active)}</Badge>}
+          {unread > 0 && <Badge variant="secondary">{unread}</Badge>}
         </div>
         <div className="flex-1 overflow-y-auto">
-          {active && active.messages.length > 0 ? (
-            active.messages
-              .slice()
-              .sort((a, b) => b.at - a.at)
-              .map((m) => (
-                <MessageRow
-                  key={m.id}
-                  message={m}
-                  active={m.id === openId}
-                  onClick={() => openMessage(active.key, m.id)}
-                />
-              ))
+          {loadingMessages ? (
+            <div className="p-8 text-center text-sm text-muted-foreground">Loading…</div>
+          ) : sorted.length > 0 ? (
+            sorted.map((m) => (
+              <MessageRow
+                key={m.id}
+                message={m}
+                active={m.id === openId}
+                onClick={() => openMessage(m.id)}
+              />
+            ))
           ) : (
             <div className="p-8 text-center text-sm text-muted-foreground">No messages.</div>
           )}
@@ -134,10 +200,11 @@ function MessageRow({
   active,
   onClick,
 }: {
-  message: EmailMessage;
+  message: InboxMessageDto;
   active: boolean;
   onClick: () => void;
 }) {
+  const who = message.outbound ? "You" : message.fromName || message.fromEmail;
   return (
     <button
       onClick={onClick}
@@ -146,23 +213,25 @@ function MessageRow({
         active ? "bg-accent" : "hover:bg-accent/50",
       )}
     >
-      <Avatar name={message.fromName} />
+      <Avatar name={who} />
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline justify-between gap-2">
-          <span className={cn("truncate text-sm", !message.read && "font-semibold")}>{message.fromName}</span>
-          <span className="shrink-0 text-[11px] text-muted-foreground">{formatTime(message.at)}</span>
+          <span className={cn("truncate text-sm", !message.read && !message.outbound && "font-semibold")}>{who}</span>
+          <span className="shrink-0 text-[11px] text-muted-foreground">{formatTime(message.atMillis)}</span>
         </div>
-        <p className={cn("truncate text-sm", message.read ? "text-muted-foreground" : "font-medium")}>
+        <p className={cn("truncate text-sm", message.read || message.outbound ? "text-muted-foreground" : "font-medium")}>
           {message.subject}
         </p>
-        <p className="truncate text-xs text-muted-foreground">{message.preview}</p>
+        <p className="truncate text-xs text-muted-foreground">{preview(message.body)}</p>
       </div>
-      {!message.read && <span className="mt-1.5 size-2 shrink-0 rounded-full bg-primary" />}
+      {!message.read && !message.outbound && <span className="mt-1.5 size-2 shrink-0 rounded-full bg-primary" />}
     </button>
   );
 }
 
-function Reading({ message, inbox, onBack }: { message: EmailMessage; inbox: Inbox; onBack: () => void }) {
+function Reading({ message, inbox, onBack }: { message: InboxMessageDto; inbox: InboxDto; onBack: () => void }) {
+  const who = message.outbound ? "You" : message.fromName || message.fromEmail;
+  const addr = inbox.address || `${inbox.key}@company`;
   return (
     <>
       <div className="flex items-center gap-2 border-b px-4 py-2.5">
@@ -177,14 +246,14 @@ function Reading({ message, inbox, onBack }: { message: EmailMessage; inbox: Inb
       <div className="flex-1 overflow-y-auto">
         <div className="mx-auto max-w-2xl px-6 py-6">
           <div className="mb-4 flex items-center gap-3">
-            <Avatar name={message.fromName} />
+            <Avatar name={who} />
             <div className="min-w-0">
-              <p className="text-sm font-medium">{message.fromName}</p>
+              <p className="text-sm font-medium">{who}</p>
               <p className="truncate text-xs text-muted-foreground">
-                {message.fromEmail} · to {slugify(inbox.name)}@company
+                {message.fromEmail} · {message.outbound ? "from" : "to"} {addr}
               </p>
             </div>
-            <span className="ml-auto shrink-0 text-xs text-muted-foreground">{formatDateTime(message.at)}</span>
+            <span className="ml-auto shrink-0 text-xs text-muted-foreground">{formatDateTime(message.atMillis)}</span>
           </div>
           <div className="text-sm leading-relaxed whitespace-pre-wrap">{message.body}</div>
         </div>

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -721,9 +721,17 @@ async fn main() -> Result<()> {
                 .ok()
                 .filter(|value| !value.trim().is_empty())
                 .map(opencompany::ports::types::SecretValue);
+            // Honor TINYHUMANS_API_URL (e.g. staging) — the config layer reads
+            // it, but this manual AppConfig build otherwise falls to the prod
+            // default, so a staging credential could never reach staging.
+            let api_url = std::env::var("TINYHUMANS_API_URL")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| AppConfig::default().api_url);
             let mut state = AppState::new(AppConfig {
                 bind,
                 openhuman_root,
+                api_url,
                 tinyplace_api_url,
                 public_url,
                 tenant_namespace,

--- a/src/server/ops/imap.rs
+++ b/src/server/ops/imap.rs
@@ -181,8 +181,15 @@ impl AsyncImapReceiver {
                 .map(|n| n.to_string())
                 .collect::<Vec<_>>()
                 .join(",");
+            // The parens are load-bearing: async-imap sends the query string
+            // verbatim, and RFC 3501 requires a multi-item fetch to be a
+            // parenthesized list. Without them the command is `UID FETCH <set>
+            // UID BODY.PEEK[]` — two bare fetch-atts, which strict servers
+            // (Stalwart) reject past the first, so `BODY[]` never comes back and
+            // every message parses to an empty body. `UID` is requested
+            // explicitly for clarity even though UID FETCH always echoes it.
             let mut fetches = session
-                .uid_fetch(&set, "UID BODY.PEEK[]")
+                .uid_fetch(&set, "(UID BODY.PEEK[])")
                 .await
                 .map_err(|e| OpenCompanyError::Store(format!("imap fetch: {e}")))?;
             while let Some(f) = fetches

--- a/src/server/ops/inbox.rs
+++ b/src/server/ops/inbox.rs
@@ -1,14 +1,22 @@
 //! Inbound email ingest transport.
 //!
-//! `POST …/inboxes/ingest` is the HMAC-signed webhook a mail-forwarding
-//! provider (or, in managed deployments, the platform manager that owns MX)
-//! pushes received mail into — there is no IMAP polling in v1. The request body
-//! is verified against the per-company ingest secret in
-//! [`SecretStore`](crate::ports::SecretStore) using the same signer seam as the
-//! platform webhooks; an unverifiable payload is dropped with `401` and never
-//! becomes an event.
+//! There are two ways mail reaches a company, and they converge on the same
+//! filing tail ([`file_and_notify`]):
 //!
-//! A verified payload is appended to the addressed teammate's
+//! 1. **HMAC-signed webhook** — `POST …/inboxes/ingest`, this module. A
+//!    mail-forwarding provider (or, in managed deployments, the platform
+//!    component that owns MX) pushes received mail in. The request body is
+//!    verified against the per-company ingest secret in
+//!    [`SecretStore`](crate::ports::SecretStore) using the same signer seam as
+//!    the platform webhooks; an unverifiable payload is dropped with `401` and
+//!    never becomes an event. Push-based, so it only reaches an awake company.
+//! 2. **IMAP poll** (`imap` feature) — the managed default, where each company
+//!    reads its own Stalwart mailbox with the injected credentials
+//!    (`MailboxPoller` → `AsyncImapReceiver`). Pull-based, so mail accumulates
+//!    in Stalwart while a company is scaled to zero and is picked up on the
+//!    next tick after it wakes.
+//!
+//! Either way a message is appended to the addressed teammate's
 //! [`InboxStore`](crate::ports::InboxStore) and drives one cycle with a
 //! [`CompanyEvent::WebhookReceived`](crate::ports::types::CompanyEvent) on the
 //! `email` channel so the teammate can act on the mail.

--- a/src/server/ops/mail.rs
+++ b/src/server/ops/mail.rs
@@ -1,22 +1,47 @@
-//! Mailbox read-state writes: `POST /inboxes/{key}/read` under both scope forms.
+//! Mailbox reads + read-state writes under both scope forms:
+//! `GET /inboxes`, `GET /inboxes/{key}/messages`, `POST /inboxes/{key}/read`.
 //!
-//! Marks messages in an inbox read (the given `ids`, or all when omitted) and
-//! returns the count still unread. Delivery/ingest lives in
-//! [`inbox`](super::inbox); message metadata lands in the
-//! [`InboxStore`](crate::ports::InboxStore).
+//! The reads project the [`InboxStore`](crate::ports::InboxStore) into the
+//! operator console's Inbox tab — the REST twin of the GraphQL
+//! `Company.inboxes` resolver ([`graphql::inbox`](crate::server::graphql::inbox)),
+//! so a message filed by either inbound path (the ingest webhook or the IMAP
+//! poller, see [`inbox`](super::inbox)) is visible in the web app. The write
+//! marks messages read and returns the count still unread. Every field here is
+//! non-secret message metadata/body; credentials never appear.
 
 use axum::extract::Path;
-use axum::routing::post;
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
+use crate::ports::inbox::EmailRecord;
 use crate::server::error::ApiError;
 use crate::server::ops::{ScopedCompany, scoped};
 
-/// Builds the mailbox read-state route fragment.
+/// Builds the mailbox read + read-state route fragment.
 pub fn router() -> Router<AppState> {
-    scoped("/inboxes/{key}/read", post(mark_read))
+    scoped("/inboxes", get(list_inboxes))
+        .merge(scoped("/inboxes/{key}/messages", get(list_messages)))
+        .merge(scoped("/inboxes/{key}/read", post(mark_read)))
+}
+
+/// One inbox's non-secret status for the Inbox tab. Mirrors
+/// [`InboxMeta`](crate::ports::inbox::InboxMeta) plus the unread count the
+/// GraphQL `Inbox.unread` field computes.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InboxDto {
+    /// The inbox key (a teammate's local part / slug).
+    key: String,
+    /// The teammate's display name.
+    name: String,
+    /// The full address (`{key}@{domain}` when a domain is configured).
+    address: String,
+    /// Whether the inbox is enabled on the Team page.
+    enabled: bool,
+    /// The number of unread received (inbound) messages.
+    unread: u64,
 }
 
 /// The mark-read body: an optional id list (omitted = mark the whole inbox).
@@ -36,6 +61,43 @@ struct UnreadCount {
 #[derive(Debug, Deserialize)]
 struct InboxKeyPath {
     key: String,
+}
+
+/// `GET …/inboxes` — every inbox with its non-secret metadata and unread count.
+/// Mirrors the GraphQL `Company.inboxes` resolver.
+async fn list_inboxes(company: ScopedCompany) -> Result<Json<Vec<InboxDto>>, ApiError> {
+    let metas = company.runtime.inbox().inboxes(company.id()).await?;
+    let mut out = Vec::with_capacity(metas.len());
+    for meta in metas {
+        let messages = company
+            .runtime
+            .inbox()
+            .messages(company.id(), &meta.key, usize::MAX, 0)
+            .await?;
+        let unread = messages.iter().filter(|m| !m.outbound && !m.read).count() as u64;
+        out.push(InboxDto {
+            key: meta.key,
+            name: meta.name,
+            address: meta.address,
+            enabled: meta.enabled,
+            unread,
+        });
+    }
+    Ok(Json(out))
+}
+
+/// `GET …/inboxes/{key}/messages` — one inbox's mail, oldest first. Records
+/// serialize camelCase (`fromEmail`, `atMillis`, …) matching the console.
+async fn list_messages(
+    company: ScopedCompany,
+    Path(InboxKeyPath { key }): Path<InboxKeyPath>,
+) -> Result<Json<Vec<EmailRecord>>, ApiError> {
+    let messages = company
+        .runtime
+        .inbox()
+        .messages(company.id(), &key, usize::MAX, 0)
+        .await?;
+    Ok(Json(messages))
 }
 
 async fn mark_read(

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -819,6 +819,73 @@ async fn inbox_read_marks_and_reports_unread() {
 }
 
 #[tokio::test]
+async fn inbox_list_and_messages_project_store() {
+    use crate::ports::inbox::EmailRecord;
+    let home = home();
+    let state = state_with_company(&home).await;
+    let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+    // One inbound (unread) + one outbound reply in inbox "ceo".
+    runtime
+        .inbox()
+        .append(
+            runtime.id(),
+            &EmailRecord {
+                id: "in1".into(),
+                inbox: "ceo".into(),
+                from_name: "Priya".into(),
+                from_email: "p@x.test".into(),
+                subject: "hi".into(),
+                body: "hello world".into(),
+                at_millis: 1,
+                read: false,
+                outbound: false,
+            },
+        )
+        .await
+        .unwrap();
+    runtime
+        .inbox()
+        .append(
+            runtime.id(),
+            &EmailRecord {
+                id: "out1".into(),
+                inbox: "ceo".into(),
+                from_name: String::new(),
+                from_email: "ceo@acme.test".into(),
+                subject: "re: hi".into(),
+                body: "reply".into(),
+                at_millis: 2,
+                read: false,
+                outbound: true,
+            },
+        )
+        .await
+        .unwrap();
+
+    // GET /inboxes surfaces the message-bearing inbox; outbound doesn't count toward unread.
+    let (status, body) = send(&state, "GET", "/api/v1/company/inboxes", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let ceo = body
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|i| i["key"] == "ceo")
+        .expect("ceo inbox listed");
+    assert_eq!(ceo["unread"], 1);
+
+    // GET messages returns both, camelCase, oldest first.
+    let (status, body) = send(&state, "GET", "/api/v1/company/inboxes/ceo/messages", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let msgs = body.as_array().unwrap();
+    assert_eq!(msgs.len(), 2);
+    assert_eq!(msgs[0]["id"], "in1");
+    assert_eq!(msgs[0]["fromEmail"], "p@x.test");
+    assert_eq!(msgs[1]["outbound"], true);
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+#[tokio::test]
 async fn chat_accepts_desk_id_and_replies() {
     let home = home();
     let state = state_with_company(&home).await;


### PR DESCRIPTION
Closes #94

Follow-up to #143. That PR merged the per-company email feature, but it was squash-merged **before** these fixes — all found while validating the feature live against a real Stalwart mailbox and Gmail. Without them, `main`'s receive path is broken.

## What's here (4 commits)

1. **`fix(imap)`: parenthesize the multi-item `UID FETCH`** — the receive bug.
   `fetch_new` sent `UID FETCH <n> UID BODY.PEEK[]` (two bare fetch-atts). RFC 3501 requires a multi-item fetch to be a parenthesized list; `async-imap` forwards the query verbatim. Strict servers (Stalwart) echo the UID for free but drop the un-parenthesized `BODY[]`, so **every message parsed to an empty body and was silently filtered out** — the poller reported "0 unseen" for mail that raw `SEARCH UNSEEN` plainly found. Fixed to `(UID BODY.PEEK[])`. (Dovecot is lenient and hid this.)

2. **`feat(inbox)`: serve inbox reads over REST + wire the web Inbox tab to the server.**
   Added `GET …/inboxes` and `GET …/inboxes/{key}/messages` (the REST twin of the GraphQL `Company.inboxes` resolver), and rewired `InboxView` off its localStorage fixtures to fetch from the server. Previously mail filed into `InboxStore` (by either the ingest webhook or the IMAP poller) never appeared in the console.

3. **`fix(serve)`: honor `TINYHUMANS_API_URL`.** The `serve` command built `AppConfig` by hand and let `api_url` fall to the prod default, reading `TINYPLACE_API_URL` and `TINYHUMANS_API_KEY` but never `TINYHUMANS_API_URL` — so a workload could not be pointed at a non-prod TinyHumans backend (a staging credential was always sent to prod and rejected).

4. **`docs(inbox)`: correct the module header** — it still claimed "there is no IMAP polling in v1", which this branch's poller contradicts.

## Verification

- `cargo test --features imap,smtp`: **747 passed**, 2 ignored (live smoke tests), 0 failed. `clippy` + `fmt` clean. Frontend `tsc -b` clean.
- **Proven live, both directions:** Gmail → Stalwart → IMAP poller → `InboxStore` → REST → visible in the web Inbox tab; and `alice@…` → Stalwart → delivered to Gmail (DKIM-signed, inbox). The SMTP-465 implicit-TLS fix from the original branch is already in `main`; these four complete the round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added company inbox listings and message views with unread counts.
  - Added message details, sender information, timestamps, and inbound/outbound indicators.
  - Added support for marking inbox messages as read.
  - Added server endpoints for retrieving inboxes and messages.

- **Bug Fixes**
  - Improved compatibility with strict IMAP servers when fetching message bodies.
  - Server configuration now honors the configured API URL environment setting.

- **Tests**
  - Added coverage for inbox listing, message ordering, unread counts, and message metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->