### PR TITLE
fix(delegation): answer in the thread a dispatched task came from (#151 part b)

### DIFF
--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -849,7 +849,10 @@ description = "Builds it."
         let (brain, tasks) = brain_with_tasks(dir.path());
         let mut c = card("t-no-origin", "maya");
         c.origin_chat_id = None;
-        tasks.upsert(&CompanyId::new("acme"), &c).await.expect("seed");
+        tasks
+            .upsert(&CompanyId::new("acme"), &c)
+            .await
+            .expect("seed");
 
         let posted = brain.run_task("t-no-origin").await.expect("run");
         assert!(
@@ -868,7 +871,10 @@ description = "Builds it."
         let (brain, tasks) = brain_with_tasks(dir.path());
         let mut c = card("t-origin", "maya");
         c.origin_chat_id = Some("strategy".to_string());
-        tasks.upsert(&CompanyId::new("acme"), &c).await.expect("seed");
+        tasks
+            .upsert(&CompanyId::new("acme"), &c)
+            .await
+            .expect("seed");
 
         let posted = brain
             .run_task("t-origin")

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -72,9 +72,17 @@ impl HarnessBrain {
     /// onto the board — moved to `in_review` on success, back to `backlog` with
     /// the error noted on failure. A missing task store or a card that has since
     /// vanished is a silent no-op.
-    async fn run_task(&self, task_id: &str) -> Result<()> {
+    /// Runs a dispatched card to completion and, when the card remembers the
+    /// conversation it was spawned from, returns the reply to post back there
+    /// (issue #151 §3.2).
+    ///
+    /// Before this the answer only ever reached `card.note`: the card runs
+    /// asynchronously, long after the turn that spawned it has answered, so the
+    /// operator had to know to go and look. The note is still written — it stays
+    /// the durable record — and the post-back is additive.
+    async fn run_task(&self, task_id: &str) -> Result<Option<OutboundMessage>> {
         let Some(tasks) = self.deps.tasks.as_ref() else {
-            return Ok(());
+            return Ok(None);
         };
         let Some(mut card) = tasks
             .list(&self.record.id)
@@ -82,7 +90,7 @@ impl HarnessBrain {
             .into_iter()
             .find(|t| t.id == task_id)
         else {
-            return Ok(());
+            return Ok(None);
         };
 
         let responder = self.task_responder(&card.assignee);
@@ -207,7 +215,25 @@ impl HarnessBrain {
         tasks.upsert(&self.record.id, &card).await?;
         // `guard` drops here → the run leaves the in-flight strip.
         drop(guard);
-        Ok(())
+
+        // Issue #151 §3.2: answer in the conversation the card was spawned
+        // from. Only a card that remembers an origin posts back — one created
+        // straight on the board, or written before `origin_chat_id` existed,
+        // has no thread to answer in and behaves exactly as before.
+        //
+        // The bubble is attributed to the responder (matching a delegated desk
+        // reply) and carries the card's landing column, so the operator reads
+        // one line and knows both what came back and where the card went. Steps
+        // are deliberately empty: a dispatched card discards them into the note.
+        let Some(origin) = card.origin_chat_id.clone() else {
+            return Ok(None);
+        };
+        Ok(Some(OutboundMessage {
+            channel: responder,
+            text: task_postback_text(&card),
+            reply_to: Some(origin),
+            steps: Vec::new(),
+        }))
     }
 
     /// Resolves which roster agent runs a task: its `assignee` when that names a
@@ -321,6 +347,10 @@ impl HarnessBrain {
                     priority: "medium".to_string(),
                     assignee: assignee.unwrap_or_default(),
                     updated_at_millis: now_millis(),
+                    // Issue #151 §3.2: remember which conversation asked for
+                    // this, so the completion can answer there instead of only
+                    // landing in the note.
+                    origin_chat_id: chat_id.map(str::to_string),
                 };
                 tasks.upsert(&self.record.id, &card).await?;
                 Ok(None)
@@ -379,6 +409,25 @@ fn task_instruction(card: &TaskRecord) -> String {
     match card.note.as_deref().filter(|n| !n.is_empty()) {
         Some(note) => format!("Task: {}\n\n{}", card.title, note),
         None => format!("Task: {}", card.title),
+    }
+}
+
+/// The post-back line for a finished card (issue #151 §3.2): what the card was,
+/// where it landed, and the reply itself.
+///
+/// Reads the *result* out of the card rather than taking the raw turn reply, so
+/// a cancelled or paused run posts the same thing the board shows instead of
+/// claiming an answer it does not have.
+fn task_postback_text(card: &TaskRecord) -> String {
+    let status = match card.column.as_str() {
+        "in_review" => "is ready for review",
+        "paused" => "is paused",
+        "backlog" => "went back to the backlog",
+        other => other,
+    };
+    match card.note.as_deref().filter(|n| !n.trim().is_empty()) {
+        Some(note) => format!("\"{}\" {status}.\n\n{note}", card.title),
+        None => format!("\"{}\" {status}.", card.title),
     }
 }
 
@@ -452,7 +501,9 @@ impl Brain for HarnessBrain {
                     channel_responses.extend(delegated);
                 }
                 CompanyEvent::TaskDispatched { task_id } => {
-                    self.run_task(task_id).await?;
+                    if let Some(message) = self.run_task(task_id).await? {
+                        channel_responses.push(message);
+                    }
                 }
                 _ => {}
             }
@@ -734,7 +785,104 @@ description = "Builds it."
             priority: "high".to_string(),
             assignee: assignee.to_string(),
             updated_at_millis: 0,
+            origin_chat_id: None,
         }
+    }
+
+    // ── Issue #151 §3.2: a finished card answers where it was asked ──────
+
+    /// The post-back names the card, where it landed, and the result — so the
+    /// operator reads one bubble instead of going to find the note.
+    #[test]
+    fn postback_reports_the_card_title_status_and_result() {
+        let mut finished = card("t1", "maya");
+        finished.column = "in_review".to_string();
+        finished.note = Some("[maya] Draft is up.".to_string());
+
+        let text = task_postback_text(&finished);
+        assert!(text.contains("Ship the thing"), "{text}");
+        assert!(text.contains("is ready for review"), "{text}");
+        assert!(text.contains("Draft is up."), "{text}");
+    }
+
+    /// A cancelled or paused run must not claim an answer it does not have —
+    /// the post-back reads the card, not the raw turn reply.
+    #[test]
+    fn postback_reflects_the_landing_column_not_a_presumed_success() {
+        let mut paused = card("t1", "maya");
+        paused.column = "paused".to_string();
+        paused.note = Some("[maya] [paused] halfway".to_string());
+        assert!(task_postback_text(&paused).contains("is paused"));
+
+        let mut cancelled = card("t1", "maya");
+        cancelled.column = "backlog".to_string();
+        cancelled.note = Some("[operator] cancelled while in flight".to_string());
+        let text = task_postback_text(&cancelled);
+        assert!(text.contains("went back to the backlog"), "{text}");
+        assert!(!text.contains("ready for review"), "{text}");
+    }
+
+    /// A card with no note still posts a readable line rather than a title
+    /// followed by a dangling blank block.
+    #[test]
+    fn postback_without_a_note_is_still_a_complete_sentence() {
+        let mut finished = card("t1", "maya");
+        finished.column = "in_review".to_string();
+        finished.note = None;
+        let text = task_postback_text(&finished);
+        assert_eq!(text, "\"Ship the thing\" is ready for review.");
+
+        finished.note = Some("   ".to_string());
+        assert_eq!(
+            task_postback_text(&finished),
+            "\"Ship the thing\" is ready for review.",
+            "a whitespace-only note must not append an empty block"
+        );
+    }
+
+    /// The compatibility guarantee: a card with no remembered origin — one made
+    /// straight on the board, or written before `origin_chat_id` existed —
+    /// posts back nowhere and behaves exactly as it did before.
+    #[tokio::test]
+    async fn a_card_with_no_origin_posts_back_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks) = brain_with_tasks(dir.path());
+        let mut c = card("t-no-origin", "maya");
+        c.origin_chat_id = None;
+        tasks.upsert(&CompanyId::new("acme"), &c).await.expect("seed");
+
+        let posted = brain.run_task("t-no-origin").await.expect("run");
+        assert!(
+            posted.is_none(),
+            "a card with no originating thread must not post back"
+        );
+        // The note is still the durable record.
+        assert!(only_card(&tasks).await.note.is_some());
+    }
+
+    /// …and one that does remember its origin answers there, attributed to the
+    /// responder and threaded with `reply_to`.
+    #[tokio::test]
+    async fn a_card_with_an_origin_posts_back_to_that_thread() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks) = brain_with_tasks(dir.path());
+        let mut c = card("t-origin", "maya");
+        c.origin_chat_id = Some("strategy".to_string());
+        tasks.upsert(&CompanyId::new("acme"), &c).await.expect("seed");
+
+        let posted = brain
+            .run_task("t-origin")
+            .await
+            .expect("run")
+            .expect("a card with an origin must post back");
+        assert_eq!(posted.reply_to.as_deref(), Some("strategy"));
+        assert!(
+            !posted.channel.is_empty(),
+            "the bubble must be attributed to the responder"
+        );
+        assert!(posted.text.contains("Ship the thing"), "{}", posted.text);
+        // A dispatched card discards its steps into the note.
+        assert!(posted.steps.is_empty());
     }
 
     async fn only_card(tasks: &Arc<FsOps>) -> TaskRecord {

--- a/src/ports/tasks.rs
+++ b/src/ports/tasks.rs
@@ -31,6 +31,20 @@ pub struct TaskRecord {
     pub assignee: String,
     /// Epoch-millis timestamp of the last update.
     pub updated_at_millis: u64,
+    /// The chat/desk thread the task was created from, when it came from a
+    /// delegation (issue #151 §3.2).
+    ///
+    /// A dispatched card runs asynchronously, long after the turn that spawned
+    /// it has answered, so the completion reply has no ambient thread to post
+    /// onto — without this it can only be written into `note`, where the
+    /// operator has to go looking for it. Stamped by `spawn_task` from the
+    /// delegating turn's chat id.
+    ///
+    /// `None` for a card created straight on the board (no originating
+    /// conversation) and for every card written before this field existed —
+    /// both simply get no post-back, exactly as today.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin_chat_id: Option<String>,
 }
 
 /// Durable per-company task board. Company A's tasks MUST be invisible to

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -31,6 +31,7 @@ use crate::ports::types::{
     EffectDisposition, EffectGroup, LedgerEntry, OutboundMessage, PolicyDecision, ToolCall,
     ToolResult, Verdict,
 };
+use crate::runtime::channel::OPERATOR_CHANNEL;
 use crate::runtime::types::CycleReport;
 use crate::server::ops::mailer::{MailCredentials, OutboundEmail};
 
@@ -211,7 +212,36 @@ impl<'a> CycleRunner<'a> {
                 return Ok(());
             }
         }
-        // No adapter for this channel id: drop silently in Phase 1.
+        // Issue #151: an agent reply is addressed by *agent id*, not by adapter
+        // id — a delegated desk bubble and a dispatched card's post-back both
+        // carry `channel: "<agent_id>"` so the console can attribute them. No
+        // adapter answers to an agent id, so this used to drop them silently:
+        // the operator REST route reads `CycleReport.responses` directly and
+        // never noticed, but a company reached over a real channel adapter got
+        // the orchestrator's reply and lost every delegated one.
+        //
+        // Fall back to the operator adapter, which is the console's own surface
+        // and always the right destination for an agent→human reply. The
+        // message is forwarded unchanged, so its `channel` still names the agent
+        // and attribution survives.
+        if let Some(operator) = self
+            .rt
+            .channels
+            .iter()
+            .find(|c| c.channel_id() == OPERATOR_CHANNEL)
+        {
+            tracing::debug!(
+                channel = %msg.channel,
+                "no adapter for this channel id; delivering via the operator channel"
+            );
+            operator.send(msg.clone()).await?;
+            return Ok(());
+        }
+        // Nothing to deliver on at all (a runtime with no operator adapter).
+        tracing::debug!(
+            channel = %msg.channel,
+            "no adapter for this channel id and no operator channel; response not delivered"
+        );
         Ok(())
     }
 }
@@ -583,6 +613,73 @@ mod test {
                 token_usage: TokenUsage::default(),
             })
         }
+    }
+
+    /// A brain that answers on the operator channel and *also* emits a
+    /// delegated reply addressed by agent id — the shape `run_delegation` and a
+    /// dispatched card's post-back both produce.
+    struct DelegatingBrain;
+
+    #[async_trait]
+    impl Brain for DelegatingBrain {
+        async fn run_cycle(&self, req: CycleRequest, _host: &dyn CycleHost) -> Result<CycleResult> {
+            Ok(CycleResult {
+                channel_responses: vec![
+                    OutboundMessage {
+                        channel: "operator".into(),
+                        text: "orchestrator".into(),
+                        steps: Vec::new(),
+                        reply_to: None,
+                    },
+                    OutboundMessage {
+                        // Addressed by *agent id*: no adapter answers to this.
+                        channel: "maya".into(),
+                        text: "delegated reply".into(),
+                        steps: Vec::new(),
+                        reply_to: Some("strategy".into()),
+                    },
+                ],
+                new_traces: vec![CompressedTrace::now(&req.cycle_id, "delegating cycle")],
+                ledger_deltas: Vec::new(),
+                token_usage: TokenUsage::default(),
+            })
+        }
+    }
+
+    /// Issue #151: a delegated reply is addressed by agent id, so no adapter
+    /// matches it. It used to be dropped silently — the operator REST route
+    /// never noticed because it reads `CycleReport.responses` directly, but a
+    /// company reached over a channel adapter lost every delegated reply while
+    /// still receiving the orchestrator's.
+    #[tokio::test]
+    async fn a_reply_addressed_by_agent_id_reaches_the_operator_channel() {
+        let home = tmp_home();
+        let operator_channel = OperatorChannel::new();
+        let channels: Vec<Arc<dyn ChannelAdapter>> = vec![Arc::new(operator_channel.clone())];
+        let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
+            .with_brain(Arc::new(DelegatingBrain))
+            .with_channels(channels)
+            .build()
+            .await
+            .unwrap();
+
+        rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            text: "hand it off".into(),
+            by: None,
+            chat: None,
+        }])
+        .await
+        .unwrap();
+
+        let sent = operator_channel.sent();
+        assert_eq!(sent.len(), 2, "both replies must be delivered: {sent:?}");
+        // Attribution survives the fallback — the bubble still names the agent.
+        let delegated = sent
+            .iter()
+            .find(|m| m.text == "delegated reply")
+            .expect("the delegated reply must be delivered");
+        assert_eq!(delegated.channel, "maya");
+        assert_eq!(delegated.reply_to.as_deref(), Some("strategy"));
     }
 
     #[tokio::test]

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -28,8 +28,8 @@ use crate::ports::brain::CycleHost;
 use crate::ports::now_millis;
 use crate::ports::types::{
     Actor, ApprovalId, CompanyEvent, CompanyId, ContextOp, ContextOpResult, CycleRequest, Effect,
-    EffectDisposition, EffectGroup, LedgerEntry, OutboundMessage, PolicyDecision, ReplyTo,
-    ToolCall, ToolResult, Verdict,
+    EffectDisposition, EffectGroup, LedgerEntry, OutboundMessage, PolicyDecision, ToolCall,
+    ToolResult, Verdict,
 };
 use crate::runtime::channel::OPERATOR_CHANNEL;
 use crate::runtime::types::CycleReport;
@@ -550,7 +550,7 @@ mod test {
     use crate::ports::ChannelAdapter;
     use crate::ports::brain::Brain;
     use crate::ports::types::{
-        ActorKind, CompressedTrace, CycleResult, EffectGroup, EventSeq, TokenUsage,
+        ActorKind, CompressedTrace, CycleResult, EffectGroup, EventSeq, ReplyTo, TokenUsage,
     };
     use crate::runtime::RuntimeBuilder;
     use crate::runtime::channel::OperatorChannel;

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -28,8 +28,8 @@ use crate::ports::brain::CycleHost;
 use crate::ports::now_millis;
 use crate::ports::types::{
     Actor, ApprovalId, CompanyEvent, CompanyId, ContextOp, ContextOpResult, CycleRequest, Effect,
-    EffectDisposition, EffectGroup, LedgerEntry, OutboundMessage, PolicyDecision, ToolCall,
-    ToolResult, Verdict,
+    EffectDisposition, EffectGroup, LedgerEntry, OutboundMessage, PolicyDecision, ReplyTo,
+    ToolCall, ToolResult, Verdict,
 };
 use crate::runtime::channel::OPERATOR_CHANNEL;
 use crate::runtime::types::CycleReport;
@@ -636,7 +636,9 @@ mod test {
                         channel: "maya".into(),
                         text: "delegated reply".into(),
                         steps: Vec::new(),
-                        reply_to: Some("strategy".into()),
+                        reply_to: Some(ReplyTo {
+                            chat_id: "strategy".into(),
+                        }),
                     },
                 ],
                 new_traces: vec![CompressedTrace::now(&req.cycle_id, "delegating cycle")],
@@ -679,7 +681,10 @@ mod test {
             .find(|m| m.text == "delegated reply")
             .expect("the delegated reply must be delivered");
         assert_eq!(delegated.channel, "maya");
-        assert_eq!(delegated.reply_to.as_deref(), Some("strategy"));
+        assert_eq!(
+            delegated.reply_to.as_ref().map(|r| r.chat_id.as_str()),
+            Some("strategy")
+        );
     }
 
     #[tokio::test]

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -319,6 +319,7 @@ async fn tasks_page_reflects_upserts_and_column_filter() {
                 priority: "high".into(),
                 assignee: "maya".into(),
                 updated_at_millis: 1_700_000_000_000,
+                origin_chat_id: None,
             },
         )
         .await

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -838,6 +838,7 @@ async fn run_chat(
             priority: "medium".to_string(),
             assignee: String::new(),
             updated_at_millis: crate::ports::now_millis(),
+            origin_chat_id: None,
         };
         if let Err(err) = runtime.upsert_task(&record).await {
             tracing::warn!(error = %err, "failed to open task card for chat request");

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -119,6 +119,7 @@ async fn create_task(
         priority: body.priority.unwrap_or_else(|| "medium".to_string()),
         assignee: body.assignee.unwrap_or_default(),
         updated_at_millis: now_millis(),
+        origin_chat_id: None,
     };
     company.runtime.upsert_task(&record).await?;
     Ok(Json(record.into()))

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -190,6 +190,7 @@ async fn steer_task_validates_statuses_and_journals_acceptance() {
                 priority: "medium".into(),
                 assignee: String::new(),
                 updated_at_millis: 1,
+                origin_chat_id: None,
             },
         )
         .await

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -542,6 +542,7 @@ pub async fn assert_task_store(tasks: Arc<dyn TaskStore>) {
         priority: "medium".to_string(),
         assignee: "Strategy desk".to_string(),
         updated_at_millis: at,
+        origin_chat_id: None,
     };
 
     tasks


### PR DESCRIPTION
**Part (b) of #151** — the §3.2 MVP return path, no new UI. First of three PRs:

| | Part | Status |
|---|---|---|
| 1 | **(b)** dispatched-task post-back + adapter drop | **this PR** |
| 2 | (a) delegation re-entry guard (the Path-A symptom) | next |
| 3 | (c) agent DM surface (§3.3) | after (a) |

**#151 stays open until all three land** — only PR 3 will close it.

## Summary

Two places a delegated reply was being lost. Neither is the `delegate_to_desk` chat path, which — see below — already works.

**1. A dispatched card's answer never left the board.** `spawn_task` creates a card and returns no reply by design; the work happens later, when `TaskDispatched` fires. `run_task` folded the result into `card.note`, moved the column, and returned `()`. Nothing was pushed onto the cycle's channel responses, so the only way to see the answer was to go to the board and open the card.

`TaskRecord` now remembers the conversation it came from (`origin_chat_id`, stamped by `spawn_task` from the delegating turn's chat id), and a finished card posts one bubble back to that thread — the card's title, where it landed, and the result — attributed to the responder and threaded with `reply_to`. The note is still written and remains the durable record; the post-back is additive.

The post-back is derived from the **card**, not the raw turn reply, so a cancelled or paused run reports what the board actually shows instead of claiming an answer it does not have.

**2. Agent-addressed replies were dropped on any real channel adapter.** `route_response` matched `OutboundMessage.channel` against registered adapters and, on no match, dropped the message — the comment said *"drop silently in Phase 1"*. But an agent reply is addressed by **agent id**, not adapter id: a delegated desk bubble (`brain.rs`, `channel: member`) and this new post-back both do that so the console can attribute them, and no adapter answers to an agent id.

The operator REST route never noticed, because it reads `CycleReport.responses` directly and bypasses `route_response` entirely. A company reached over a real channel adapter, though, received the orchestrator's reply and lost every delegated one. Unmatched responses now fall back to the operator adapter and are forwarded **unchanged**, so `channel` still names the agent and attribution survives.

## Scope note — what this PR deliberately does not claim

While tracing the reply path I could not find a drop on the **synchronous `delegate_to_desk`** path described in the issue:

```
run_delegation → run_steered → OutboundMessage{channel: <agent_id>}   brain.rs
  → channel_responses.extend(delegated)                               brain.rs
  → operator.rs journals AgentReply{chat_id: desk, agent_id} for EVERY response
     and returns them all in the HTTP body
  → Conversation.tsx renders ALL reply.responses, attributed by channel
```

That path appears to deliver the reply into the originating thread already. **The live symptom could not be reproduced locally** — this stack is not runnable here — so this PR fixes the two drops that are demonstrable from the code and leaves the reported Path-A symptom to PR 2, where the likeliest cause (unbounded `run_workflow` → orchestrator-agent-node re-entry aborting the host) is addressed. If the host crashes mid-turn, no reply arrives regardless of routing.

## API Or Behavior Changes

**Additive, and fails safe in both halves.**

- `TaskRecord` gains `origin_chat_id: Option<String>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`, so stored records round-trip byte-identically and the key is absent on the wire unless set. A card with no remembered origin — created straight on the board, or written before this field existed — posts back nowhere and behaves exactly as before.
- `HarnessBrain::run_task` returns `Result<Option<OutboundMessage>>` instead of `Result<()>` (private method, one call site).
- `route_response` no longer drops unmatched responses when an operator adapter is registered. A runtime with **no** operator adapter keeps the previous non-delivery, now logged rather than silent.

## Tests

Added:

- `postback_reports_the_card_title_status_and_result`
- `postback_reflects_the_landing_column_not_a_presumed_success` — paused and cancelled runs must not read as success
- `postback_without_a_note_is_still_a_complete_sentence` — including a whitespace-only note
- `a_card_with_no_origin_posts_back_nothing` — the compatibility guarantee
- `a_card_with_an_origin_posts_back_to_that_thread` — attribution + `reply_to` + empty steps
- `a_reply_addressed_by_agent_id_reaches_the_operator_channel` — drives a real cycle through a recording `OperatorChannel` and asserts both replies land with the delegated one's `channel`/`reply_to` intact

Commands run locally:

- [ ] `cargo fmt --all -- --check` — **not run**: cargo was excluded for this task, relying on CI.
- [ ] `cargo clippy --all-targets -- -D warnings` — not run, same reason.
- [ ] `cargo build --all-targets` — not run, same reason.
- [ ] `cargo test` — not run, same reason.

Since none of this is compiler-checked locally, the mechanical part carries the most risk and is worth a reviewer's eye: adding a field to `TaskRecord` required edits at **9 construction sites across 6 files**. A scripted first pass mis-fired and inserted the field into two `-> TaskRecord {` *function bodies* in `brain.rs`; both were caught and reverted by inspection. Two new tests initially called the non-async `brain_with_tasks()` with `.await` and were corrected. All added lines are within the width limit (the long lines the diff touches are pre-existing).

## Documentation

No separate doc change: the new field, the post-back rule, and the adapter fallback are documented inline where the behaviour lives, each explaining what used to happen and why the new path fails safe.

Refs #151


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task completion updates now post results back to the conversation where the task originated.
  * Completion messages indicate the task’s final status and include relevant notes or results.
  * Delegated tasks retain their originating conversation for accurate follow-up.
* **Bug Fixes**
  * Responses are no longer dropped when a destination channel is unavailable; they are delivered through the operator channel while preserving reply context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->