### PR TITLE
fix(workflows): bound workflow re-entry so a cycle cannot abort the host (#151 part a)

### DIFF
--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -1251,4 +1251,3 @@ to = "done"
         assert!(out.is_ok(), "a run below the limit must execute: {out:?}");
     }
 }
-

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -19,6 +19,34 @@ use crate::harness::{HarnessDeps, HarnessPool};
 use crate::ports::types::{CompanyId, CompanyRecord};
 use crate::ports::{WorkflowRun, WorkflowRunner};
 
+/// How deeply a workflow may re-enter itself before the run is refused
+/// (issue #151 part a).
+///
+/// One level of nesting is legitimate and useful — a `sub_workflow` node, or a
+/// workflow whose agent node asks the orchestrator to run a second, different
+/// graph. Beyond that a chain is almost certainly a cycle rather than a plan,
+/// and the cost of being wrong is asymmetric: refusing a deep run returns a
+/// readable tool error, while allowing it aborts the host.
+pub(crate) const MAX_WORKFLOW_DEPTH: usize = 4;
+
+tokio::task_local! {
+    /// How many workflow runs are already on this call chain.
+    ///
+    /// A task-local, not a counter on the runner, and that distinction is the
+    /// point: a workflow run, the agent turns inside it, and any tool those
+    /// turns call all execute inline on **one** tokio task (the only `spawn` on
+    /// the path is the progress-event collector, which runs nothing re-entrant).
+    /// So this counts exactly one causal chain. A shared counter would instead
+    /// count *concurrent* runs and refuse two operators running unrelated
+    /// workflows at the same time.
+    static WORKFLOW_DEPTH: usize;
+}
+
+/// The current re-entry depth, `0` outside any workflow run.
+fn current_workflow_depth() -> usize {
+    WORKFLOW_DEPTH.try_with(|d| *d).unwrap_or(0)
+}
+
 /// Runs `workflow` for the company described by `record` on the tinyflows engine
 /// with the trigger `input`, returning the final run state and any nodes left
 /// pending approval.
@@ -32,6 +60,48 @@ use crate::ports::{WorkflowRun, WorkflowRunner};
 /// (agent nodes address it by teammate id) — [`HarnessWorkflowRunner::run`] does
 /// this via [`HarnessPool::ensure`] before delegating here.
 pub async fn run_workflow(
+    pool: Arc<HarnessPool>,
+    deps: HarnessDeps,
+    record: &CompanyRecord,
+    workflow: &WorkflowFile,
+    input: Value,
+) -> Result<WorkflowRun> {
+    // Issue #151 part a: refuse an unbounded re-entry before it takes the host
+    // down. `run_workflow` is an orchestrator tool, and a workflow `agent` node
+    // may address the orchestrator — so a graph whose agent node runs a
+    // workflow that reaches the orchestrator again recurses with no bound. Each
+    // level is a whole agent turn plus an engine run, so the process dies on a
+    // stack overflow rather than returning an error, taking every other tenant
+    // on the host with it. `MAX_DELEGATIONS_PER_TURN` caps fan-out *within* one
+    // turn and does nothing about depth.
+    let depth = current_workflow_depth();
+    if depth >= MAX_WORKFLOW_DEPTH {
+        tracing::warn!(
+            company = %record.id,
+            workflow = %workflow.id,
+            depth,
+            "workflow: refusing a run past the re-entry limit"
+        );
+        return Err(OpenCompanyError::Harness(format!(
+            "workflow `{}` was not run: it is already {depth} workflow runs deep, at the \
+             re-entry limit of {}. A workflow whose agent node runs another workflow that \
+             reaches back here will loop forever — break the cycle, or run the inner \
+             workflow on its own.",
+            workflow.id, MAX_WORKFLOW_DEPTH
+        )));
+    }
+
+    WORKFLOW_DEPTH
+        .scope(
+            depth + 1,
+            run_workflow_inner(pool, deps, record, workflow, input),
+        )
+        .await
+}
+
+/// The run itself, always executed inside a [`WORKFLOW_DEPTH`] scope so a
+/// nested run sees this one on the chain.
+async fn run_workflow_inner(
     pool: Arc<HarnessPool>,
     deps: HarnessDeps,
     record: &CompanyRecord,
@@ -1072,4 +1142,113 @@ to = "done"
             run.output
         );
     }
+
+    /// A trivial graph is enough — the guard fires before translation.
+    const TRIVIAL: &str = r#"
+id = "trivial"
+name = "Trivial"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+[[edge]]
+from = "start"
+to = "done"
+"#;
+
+    /// Outside any run the chain is empty, so nothing is refused.
+    #[tokio::test]
+    async fn depth_is_zero_outside_a_run() {
+        assert_eq!(current_workflow_depth(), 0);
+    }
+
+    /// Each nested run sees the ones already on the chain — this is what makes
+    /// the guard count a causal chain rather than a moment in time.
+    #[tokio::test]
+    async fn depth_accumulates_down_a_nested_chain() {
+        WORKFLOW_DEPTH
+            .scope(1, async {
+                assert_eq!(current_workflow_depth(), 1);
+                WORKFLOW_DEPTH
+                    .scope(2, async {
+                        assert_eq!(current_workflow_depth(), 2);
+                    })
+                    .await;
+                // Leaving the inner scope restores the outer depth.
+                assert_eq!(current_workflow_depth(), 1);
+            })
+            .await;
+        assert_eq!(current_workflow_depth(), 0);
+    }
+
+    /// Two runs side by side are not a chain. A shared counter would refuse the
+    /// second; a task-local correctly sees each at depth 0.
+    #[tokio::test]
+    async fn concurrent_unrelated_runs_do_not_stack() {
+        let a = WORKFLOW_DEPTH.scope(1, async { current_workflow_depth() });
+        let b = async { current_workflow_depth() };
+        let (inside, outside) = tokio::join!(a, b);
+        assert_eq!(inside, 1);
+        assert_eq!(
+            outside, 0,
+            "a concurrent run must not inherit another chain's depth"
+        );
+    }
+
+    /// At the limit the run is refused with a message naming the workflow and
+    /// the limit — and, critically, it returns rather than recursing.
+    #[tokio::test]
+    async fn a_run_at_the_limit_is_refused_with_an_actionable_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = crate::company::parse_workflow(TRIVIAL).expect("parses");
+
+        let err = WORKFLOW_DEPTH
+            .scope(MAX_WORKFLOW_DEPTH, async {
+                run_workflow(
+                    Arc::new(HarnessPool::new()),
+                    deps(dir.path()),
+                    &tools_record(),
+                    &file,
+                    Value::Null,
+                )
+                .await
+            })
+            .await
+            .expect_err("a run at the re-entry limit must be refused");
+
+        let msg = err.to_string();
+        assert!(msg.contains("trivial"), "must name the workflow: {msg}");
+        assert!(msg.contains("re-entry limit"), "{msg}");
+        assert!(
+            msg.contains(&MAX_WORKFLOW_DEPTH.to_string()),
+            "must state the limit: {msg}"
+        );
+    }
+
+    /// One level below the limit still runs — the guard bounds recursion, it
+    /// does not ban nesting.
+    #[tokio::test]
+    async fn a_run_below_the_limit_still_executes() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = crate::company::parse_workflow(TRIVIAL).expect("parses");
+
+        let out = WORKFLOW_DEPTH
+            .scope(MAX_WORKFLOW_DEPTH - 1, async {
+                run_workflow(
+                    Arc::new(HarnessPool::new()),
+                    deps(dir.path()),
+                    &tools_record(),
+                    &file,
+                    Value::Null,
+                )
+                .await
+            })
+            .await;
+        assert!(out.is_ok(), "a run below the limit must execute: {out:?}");
+    }
 }
+


### PR DESCRIPTION
**Part (a) of #151** — the delegation re-entry crash. Second of three PRs:

| | Part | Status |
|---|---|---|
| 1 | (b) dispatched-task post-back + adapter drop | #163 |
| 2 | **(a)** workflow re-entry guard | **this PR** |
| 3 | (c) agent DM surface (§3.3) | next |

**#151 stays open until all three land** — only PR 3 will close it.

## Summary

`run_workflow` is an orchestrator tool, and a workflow `agent` node addresses a roster teammate **by id** — which may be the orchestrator itself. So a graph whose agent node runs a workflow that reaches the orchestrator again recurses with no bound:

```
orchestrator turn
  → run_workflow tool
    → engine run
      → agent node (agent_ref = the orchestrator)
        → orchestrator turn
          → run_workflow tool …
```

Every level is a whole agent turn plus an engine run, all inline on one task, so the process dies on a **stack overflow** rather than returning an error — taking every other tenant on the host with it.

`MAX_DELEGATIONS_PER_TURN` does not help: it caps fan-out *within* one turn and says nothing about depth. Desk-to-desk re-delegation is already impossible (delegation tools are attached only when `is_orchestrator`, and delegated leads run through `run_steered` / `run_background`), so the workflow tool is the one reachable cycle.

`run_workflow` now refuses a run once `MAX_WORKFLOW_DEPTH` (4) are already on the chain, returning an error naming the workflow and the limit instead of recursing.

## Why a task-local, and not a counter on the runner

This is the substantive decision in the change.

A run, the agent turns inside it, and any tool those turns call all execute **inline on one tokio task** — the only `spawn` on the path is the progress-event collector, which runs nothing re-entrant. A task-local therefore counts exactly one *causal chain*.

A counter on the runner (or any shared state) would count *concurrent* runs instead, and would refuse two operators running unrelated workflows at the same time — a false positive on a perfectly good request. `concurrent_unrelated_runs_do_not_stack` pins that this does not happen.

## Why the limit is 4 and not 1

One level of nesting is legitimate and useful: a `sub_workflow` node, or a workflow whose agent node asks the orchestrator to run a second, different graph. Beyond a few levels a chain is almost certainly a cycle rather than a plan.

The asymmetry settles the exact number: refusing a deep run returns a readable tool error the agent can recover from, while allowing one aborts the host. Erring shallow is cheap; erring deep is not.

## Relationship to the reported #151 symptom

This is, in my reading, the **most likely cause** of the reported symptom that a delegated reply never reaches the human: a host that crashes mid-turn returns nothing, and no amount of reply routing would surface that.

I could not confirm it — **the live symptom could not be reproduced locally**, as this stack is not runnable here. So this PR fixes the crash on its own terms and deliberately does **not** claim the symptom closed. PR 1 (#163) fixes the two reply drops that are demonstrable from the code; PR 3 adds the DM surface.

Worth recording for whoever reads #151 next: while tracing, the **synchronous `delegate_to_desk` path already appears to deliver** the reply into the originating thread (`run_delegation` → `channel_responses` → `operator.rs` journals and returns every response → `Conversation.tsx` renders them all). That is why the crash, rather than a missing route, is the leading explanation.

## API Or Behavior Changes

One behavior change, in the refusal direction only: a workflow run that is already 4 runs deep on the same call chain now returns a `Harness` error instead of recursing. Nothing that previously completed is affected — a chain that deep could not previously return at all.

`MAX_WORKFLOW_DEPTH` is `pub(crate)`; the task-local and its accessor are private. No public API change.

## Tests

- `depth_is_zero_outside_a_run`
- `depth_accumulates_down_a_nested_chain` — including that leaving an inner scope restores the outer depth
- `concurrent_unrelated_runs_do_not_stack` — the false-positive guard the task-local choice exists for
- `a_run_at_the_limit_is_refused_with_an_actionable_error` — refused, and the message names the workflow and the limit
- `a_run_below_the_limit_still_executes` — the guard bounds recursion without banning nesting

Commands run locally:

- [ ] `cargo fmt --all -- --check` — **not run**: cargo was excluded for this task, relying on CI.
- [ ] `cargo clippy --all-targets -- -D warnings` — not run, same reason.
- [ ] `cargo build --all-targets` — not run, same reason.
- [ ] `cargo test` — not run, same reason.

Two issues a compiler would have caught were found by inspection instead: the tests were first written in a sibling `mod reentry_tests`, which cannot reach the `deps` / `tools_record` helpers that are private to `mod tests` (folded in), and an implicit `{MAX_WORKFLOW_DEPTH}` format capture was replaced with an explicit positional argument rather than relying on const capture. The `tokio::task_local!` declaration and the `.scope(...)` wrapper around the returned future are the spots most worth a reviewer's eye.

## Documentation

Documented inline where the behaviour lives: the constant carries the rationale for its value, and the task-local carries the reason it is a task-local rather than shared state — the two things a future reader would otherwise be tempted to "simplify".

Refs #151


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards to prevent workflows from exceeding the supported nesting limit.
  * Runs that reach the limit now stop with a clear, actionable error message.
  * Improved stability and stack safety for nested workflow execution.
  * Ensured independent concurrent workflow runs do not interfere with one another.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->