### PR TITLE
feat(chat): give every teammate a DM thread (#151 part c)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -54,7 +54,7 @@ import { toast } from "sonner";
 import { type ChatMessage, fromHistory, makeMessage } from "@/lib/chat";
 import { CONNECTION_PROVIDERS } from "@/lib/connections";
 import { DISCORD_INVITE_URL } from "@/lib/links";
-import { defaultThreads, threadsFromDesks } from "@/lib/threads";
+import { agentDmThreads, defaultThreads, threadsFromDesks } from "@/lib/threads";
 import { Overview } from "@/views/Overview";
 import { Conversation } from "@/views/Conversation";
 import { ApprovalsView } from "@/views/ApprovalsView";
@@ -280,9 +280,21 @@ export function AppShell({
 
     client
       .listDesks(company)
-      .then((desks) => {
+      .then(async (desks) => {
         if (cancelled) return;
-        const resolved = threadsFromDesks(desks);
+        // Issue #151 §3.3: desks first, then one DM thread per roster teammate.
+        // The roster is fetched separately and tolerated as optional — a host
+        // that 404s `/team` keeps its desks rather than losing the whole list.
+        const team = await client.listTeam(company).catch(() => []);
+        if (cancelled) return;
+        const deskThreads = threadsFromDesks(desks);
+        const resolved = [
+          ...deskThreads,
+          ...agentDmThreads(
+            team,
+            deskThreads.map((t) => t.id),
+          ),
+        ];
         setThreads((prev) => {
           const byId = new Map(prev.map((t) => [t.id, t]));
           return resolved.map((t) => {

--- a/frontend/src/lib/threads.ts
+++ b/frontend/src/lib/threads.ts
@@ -2,8 +2,9 @@
 // talks to the same company chat endpoint; a thread just scopes a transcript
 // and gives the company side a consistent identity (a "desk" you're talking to).
 
-import type { DeskDto } from "../api/types";
+import type { DeskDto, TeamMemberDto } from "../api/types";
 import type { ChatMessage } from "./chat";
+import { toneFor } from "./team";
 
 export interface ThreadContact {
   name: string;
@@ -77,4 +78,41 @@ export function threadsFromDesks(desks: DeskDto[]): Thread[] {
     messages: [],
   }));
   return [mainThread(), ...deskThreads];
+}
+
+/**
+ * One DM thread per roster teammate (issue #151 §3.3): the agent's own console,
+ * so an operator can follow up with the teammate who did the work instead of
+ * going back through the orchestrator.
+ *
+ * Keyed by the **agent id**, which the host resolves straight to that teammate.
+ * Desks are listed first and win any id collision — `existingIds` is what keeps
+ * a teammate who is already reachable as a desk from appearing twice.
+ *
+ * Kept separate from {@link threadsFromDesks} so a host that exposes desks but
+ * not `/team` (or fails that fetch) simply gets no DMs, rather than losing its
+ * desk list too.
+ */
+export function agentDmThreads(
+  team: TeamMemberDto[],
+  existingIds: Iterable<string>,
+): Thread[] {
+  const taken = new Set(existingIds);
+  const seen = new Set<string>();
+  const threads: Thread[] = [];
+  for (const member of team) {
+    const id = member.id?.trim();
+    // A teammate with no id has nothing the host could route to, and a
+    // duplicate id would collide with the thread already added for it.
+    if (!id || taken.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    const name = member.name?.trim() || member.role;
+    threads.push({
+      id,
+      contact: { name, kind: "agent", tone: toneFor(id) },
+      blurb: member.description?.trim() || member.role,
+      messages: [],
+    });
+  }
+  return threads;
 }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -220,15 +220,34 @@ impl HarnessBrain {
         }
     }
 
-    /// Resolves which agent answers an operator message. A message addressed to a
-    /// desk (its `chat` field naming a group chat with a lead member) is answered
-    /// by that desk's lead; everything else — including the "General" desk and
-    /// unaddressed messages — goes to the orchestrator (the default responder).
+    /// Resolves which agent answers an operator message.
+    ///
+    /// Resolution order, and the order matters:
+    ///
+    /// 1. a **desk** (the `chat` field naming a group chat with a lead member) is
+    ///    answered by that desk's lead — unchanged;
+    /// 2. a **roster teammate id** is answered by that teammate directly, which
+    ///    is what makes a per-agent DM thread possible (issue #151 §3.3);
+    /// 3. everything else — the "General" desk, an unknown id, an unaddressed
+    ///    message — goes to the orchestrator, as before.
+    ///
+    /// Desks are tried first so a desk whose id happens to match an agent id
+    /// keeps routing as a desk; the DM case only ever claims ids that resolve to
+    /// no desk at all. Without step 2 a DM thread would silently reach the
+    /// orchestrator instead of the teammate the operator opened — the console
+    /// would look like it were addressing an agent while talking to someone
+    /// else.
     fn responder_for(&self, chat: Option<&str>) -> String {
-        match chat.and_then(|desk| self.desk_lead(desk)) {
-            Some(member) => member,
-            None => self.responder.clone(),
+        let Some(chat) = chat else {
+            return self.responder.clone();
+        };
+        if let Some(lead) = self.desk_lead(chat) {
+            return lead;
         }
+        if self.record.is_roster_agent(chat) {
+            return chat.to_string();
+        }
+        self.responder.clone()
     }
 
     /// The lead member of a desk: the first member of the matching group chat
@@ -958,6 +977,33 @@ members = ["engineer"]
         assert_eq!(brain.responder_for(Some("General")), "chief");
         assert_eq!(brain.responder_for(Some("nope")), "chief");
         assert_eq!(brain.responder_for(None), "chief");
+    }
+
+    // ── Issue #151 §3.3: a DM thread reaches the teammate it names ──
+
+    /// A chat id naming a roster teammate answers as that teammate, which is
+    /// what a per-agent DM thread is. Before this it fell through to the
+    /// orchestrator, so the console would show an agent's thread while someone
+    /// else answered in it.
+    #[test]
+    fn responder_for_routes_a_roster_agent_id_to_that_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, _tasks) = brain_with_desk(dir.path());
+        assert_eq!(brain.responder_for(Some("engineer")), "engineer");
+        assert_eq!(brain.responder_for(Some("chief")), "chief");
+    }
+
+    /// Desks still win. A desk id is resolved as a desk even if an agent shares
+    /// the name, so no existing thread changes where it lands.
+    #[test]
+    fn a_desk_still_outranks_an_agent_of_the_same_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, _tasks) = brain_with_desk(dir.path());
+        // `eng_desk` is a desk led by `engineer`; it must resolve through the
+        // desk path, not the DM path.
+        assert_eq!(brain.responder_for(Some("eng_desk")), "engineer");
+        // And an id that is neither still reaches the orchestrator.
+        assert_eq!(brain.responder_for(Some("not-a-teammate")), "chief");
     }
 
     /// An operator-added overlay member is resolved as a desk's lead (issue #72):


### PR DESCRIPTION
**Part (c) of #151** — the §3.3 agent DM surface, and the last of the three PRs:

| | Part | Status |
|---|---|---|
| 1 | (b) dispatched-task post-back + adapter drop | #163 |
| 2 | (a) workflow re-entry guard | #164 |
| 3 | **(c)** agent DM surface | **this PR** |

This is the PR that closes #151. **It should land after #163 and #164** — they are independent of each other but all three are needed before the loop is actually closed.

## Summary

An operator could talk to the company's main line and to each desk, but not to a *teammate*. Once work came back from a delegated agent there was no thread to follow up in — the only way to reach the teammate who did it was to go back through the orchestrator and hope it delegated to the same one again.

The console now lists **one DM thread per roster teammate**, after the desks. It reuses the existing conversation surface — a thread is just an id the chat endpoint routes on — so the transcript, live turn frames, history rehydration, and per-bubble step timelines all work with no new plumbing.

## The part that could not stay frontend-only

`responder_for` resolved a chat id as a **desk** and nothing else:

```rust
match chat.and_then(|desk| self.desk_lead(desk)) {
    Some(member) => member,
    None => self.responder.clone(),   // ← an agent id landed here
}
```

So a thread keyed by an agent id would have fallen through to the orchestrator: the console would show a teammate's name and avatar while somebody else answered in the thread. That is a silent mis-attribution — the same class of failure #151 is about — so the DM surface is not shippable without the routing change.

Resolution is now: **desk → roster teammate → orchestrator**. Desks are tried first deliberately, so a desk whose id happens to match an agent id keeps routing as a desk and no existing thread changes where it lands. The DM branch only ever claims ids that resolve to no desk at all.

## Degrading well

Two choices worth calling out, both about not making things worse when a host is partial:

- The roster fetch is **separate from and optional to** the desks fetch. A host that does not expose `/team`, or fails that call, keeps its desks and simply gets no DMs — rather than the whole thread list collapsing to the static defaults.
- A teammate already reachable as a desk is **skipped, not listed twice**. `agentDmThreads` takes the ids already in the list and filters against them (and against duplicate ids within the roster itself).

## API Or Behavior Changes

- `responder_for` gains the roster-teammate branch described above. Additive: every id that resolved somewhere before resolves to the same place now. Only ids that previously fell through to the orchestrator — and that name a real roster teammate — change destination, which is the fix.
- Console: the conversation list gains one entry per roster teammate. No change to any existing thread.
- New exported helper `agentDmThreads(team, existingIds)` in `lib/threads.ts`.

## Scope note — §3.6 is not covered here

#151 lists three return paths. §3.2 (post back into the originating thread) is #163 and §3.3 (agent DM) is this PR, but **§3.6 — the sub-agent's output and artifacts on the delegated task's *detail* timeline — is not implemented in any of the three.** #163 posts a finished card's result back to the conversation it came from instead, which closes the loop from the operator's side without a task-detail timeline.

This PR carries `Fixes #151` per the agreed plan; if §3.6 should stay tracked, the cleanest thing is to split it into its own issue rather than hold #151 open.

Also worth recording: while tracing this work the **synchronous `delegate_to_desk` path already appeared to deliver** its reply into the originating thread. The two demonstrable drops are fixed in #163, and the likeliest cause of the reported symptom (an unbounded re-entry aborting the host) is fixed in #164.

## Tests

Rust:

- `responder_for_routes_a_roster_agent_id_to_that_agent` — the DM route
- `a_desk_still_outranks_an_agent_of_the_same_name` — the ordering guarantee, plus an unknown id still reaching the orchestrator
- the existing `responder_for_routes_desk_to_lead_else_orchestrator` is unchanged and still passes as the regression anchor

Commands run locally:

- [x] `npx tsc -b --noEmit` (frontend) — **passes**.
- [ ] `cargo fmt --all -- --check` — **not run**: cargo was excluded for this task, relying on CI.
- [ ] `cargo clippy --all-targets -- -D warnings` — not run, same reason.
- [ ] `cargo build --all-targets` — not run, same reason.
- [ ] `cargo test` — not run, same reason.

The console has **no unit-test runner** in this repo (Playwright e2e only), so the TypeScript side is covered by typecheck rather than tests — stated plainly rather than implied. **The live symptom in #151 could not be reproduced locally**; this stack is not runnable here, so the change is argued from the code path and the routing tests.

## Documentation

Documented inline: `responder_for` carries its resolution order and why desks are tried first, and `agentDmThreads` carries why it is separate from `threadsFromDesks` and why it filters against existing ids.

Fixes #151
