### PR TITLE
fix(harness): build ReplyTo struct for dispatched-task post-back

### DIFF
--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -231,7 +231,7 @@ impl HarnessBrain {
         Ok(Some(OutboundMessage {
             channel: responder,
             text: task_postback_text(&card),
-            reply_to: Some(origin),
+            reply_to: Some(crate::ports::types::ReplyTo { chat_id: origin }),
             steps: Vec::new(),
         }))
     }
@@ -900,7 +900,10 @@ description = "Builds it."
             .await
             .expect("run")
             .expect("a card with an origin must post back");
-        assert_eq!(posted.reply_to.as_deref(), Some("strategy"));
+        assert_eq!(
+            posted.reply_to.as_ref().map(|r| r.chat_id.as_str()),
+            Some("strategy")
+        );
         assert!(
             !posted.channel.is_empty(),
             "the bubble must be attributed to the responder"


### PR DESCRIPTION
## Summary
Restores a compiling `main`. #163 was branched before `OutboundMessage.reply_to` became `Option<ReplyTo>` (`ReplyTo { chat_id: String }`) on main — it was `Option<String>` at the time. #163 merged clean textually (no line overlap) but its post-back site passed a bare `String` and its test asserted through `.as_deref()`, so the tree stopped compiling the moment it landed.

## Problem
`src/harness/brain.rs:234` — `reply_to: Some(origin)` where `origin: String`, against a field now typed `Option<ReplyTo>` → `E0308`. Affects both the default and `openhuman,mcp,composio` builds (the file is not feature-gated).

## Solution
- Construct `ReplyTo { chat_id: origin }` at the post-back site.
- Read `.chat_id` in the test assertion (`as_ref().map(|r| r.chat_id.as_str())`).

Behaviour unchanged: the origin chat id still threads back as the reply target.

## Verification
- `cargo check` (default): 0 errors
- `cargo check --features openhuman,mcp,composio`: 0 errors
- `cargo test --features openhuman --lib harness::brain`
- `cargo fmt --all`

## Related
Fixes the regression introduced by #163.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Card completion replies now correctly post back to the originating conversation thread.
  * Updated validation ensures replies reference the intended conversation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->