### PR TITLE
feat(composio): per-provider OAuth authorize + connections routes for the Connections tab

### DIFF
--- a/frontend/src/api/composio.ts
+++ b/frontend/src/api/composio.ts
@@ -31,6 +31,20 @@ export interface ComposioMutation {
   note: string;
 }
 
+/** The `POST …/composio/authorize` response: the hosted connect URL to open. */
+export interface ComposioAuthorize {
+  /** Composio-hosted OAuth URL the operator opens in a new browser tab. */
+  connectUrl: string;
+}
+
+/** One toolkit's connected state, as returned by `GET …/composio/connections`. */
+export interface ComposioConnection {
+  /** Toolkit slug, e.g. `gmail`. */
+  toolkit: string;
+  /** Whether the company has at least one active connection for this toolkit. */
+  connected: boolean;
+}
+
 /** The company's Composio status. */
 export function getComposioStatus(
   client: OpenCompanyClient,
@@ -49,4 +63,34 @@ export function setComposioToken(
   token: string,
 ): Promise<ComposioMutation> {
   return client.put<ComposioMutation>(`${client.scopeFor(company)}/composio/token`, { token });
+}
+
+/**
+ * Begin a per-provider OAuth handoff for `toolkit` (e.g. `gmail`). Returns the
+ * Composio-hosted connect URL the console opens in a new tab. Composio runs the
+ * OAuth itself — there is no local callback — so the console then polls
+ * {@link listComposioConnections} until the toolkit reports connected. 409 when
+ * the feature is not in the build, or no per-tenant token is configured yet.
+ */
+export function startComposioAuthorize(
+  client: OpenCompanyClient,
+  company: string | null,
+  toolkit: string,
+): Promise<ComposioAuthorize> {
+  return client.post<ComposioAuthorize>(`${client.scopeFor(company)}/composio/authorize`, {
+    toolkit,
+  });
+}
+
+/**
+ * The company's per-toolkit connected state — one row per toolkit that has at
+ * least one connection. The console cross-references this against the granted
+ * `toolkits` to render each provider row's connected / sign-in state. 409 when
+ * the feature is not in the build, or no per-tenant token is configured yet.
+ */
+export function listComposioConnections(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<ComposioConnection[]> {
+  return client.get<ComposioConnection[]>(`${client.scopeFor(company)}/composio/connections`);
 }

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -1,9 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Check, KeyRound, Loader2, Plug, Save, Trash2 } from "lucide-react";
+import { Check, KeyRound, Loader2, LogIn, Plug, Save, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
-import { getComposioStatus, setComposioToken, type ComposioStatus } from "@/api/composio";
+import {
+  getComposioStatus,
+  listComposioConnections,
+  setComposioToken,
+  startComposioAuthorize,
+  type ComposioStatus,
+} from "@/api/composio";
 import { ApiError } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -17,21 +23,68 @@ interface Props {
   company: string | null;
 }
 
+/** Friendly display labels for the common toolkits; slug-cased fallback otherwise. */
+const TOOLKIT_LABELS: Record<string, string> = {
+  gmail: "Gmail",
+  slack: "Slack",
+  github: "GitHub",
+  googlecalendar: "Google Calendar",
+  notion: "Notion",
+  linear: "Linear",
+};
+
+function toolkitLabel(slug: string): string {
+  return TOOLKIT_LABELS[slug.toLowerCase()] ?? slug.charAt(0).toUpperCase() + slug.slice(1);
+}
+
 /**
- * Per-tenant Composio connection management (issue #110, Cell D). Shows the
- * company's Composio status (granted / token configured / toolkit allowlist) and
- * a WRITE-ONLY token input: the per-tenant OAuth bearer is the entire isolation
- * lever, so it is stored and never shown again. A set/clear takes effect on the
- * agents' next turn, no restart. Hidden entirely when the feature is not in the
- * build.
+ * Per-tenant Composio connection management (issue #110, Cell D). Two ways to
+ * connect: a per-provider OAuth "Sign in" list driven by the granted toolkits
+ * (Composio runs the hosted OAuth; we open it in a tab and poll until the
+ * toolkit reports connected), and — as a fallback — a WRITE-ONLY token input
+ * (the per-tenant OAuth bearer is the entire isolation lever, so it is stored
+ * and never shown again). A set/clear takes effect on the agents' next turn, no
+ * restart. Hidden entirely when the feature is not in the build.
  */
 export function ComposioSection({ client, company }: Props) {
   const [load, setLoad] = useState<"loading" | "ready" | "unavailable">("loading");
   const [status, setStatus] = useState<ComposioStatus | null>(null);
   const [token, setToken] = useState("");
   const [busy, setBusy] = useState<"save" | "clear" | null>(null);
+  // toolkit slug -> connected. Absent = unknown / not yet fetched.
+  const [connected, setConnected] = useState<Record<string, boolean>>({});
+  // toolkit slug currently mid-sign-in (open tab + poll).
+  const [signingIn, setSigningIn] = useState<string | null>(null);
 
   const requestGeneration = useRef(0);
+  const pollTimers = useRef<Record<string, number>>({});
+
+  // Clear any in-flight poll timers on unmount / company switch.
+  useEffect(() => {
+    const timers = pollTimers.current;
+    return () => {
+      Object.values(timers).forEach((id) => window.clearTimeout(id));
+      pollTimers.current = {};
+    };
+  }, [company]);
+
+  const refreshConnections = useCallback(
+    async (s: ComposioStatus) => {
+      // Connections need a configured token; skip the call otherwise (it 409s).
+      if (!s.tokenConfigured || s.toolkits.length === 0) {
+        setConnected({});
+        return;
+      }
+      try {
+        const rows = await listComposioConnections(client, company);
+        setConnected(Object.fromEntries(rows.map((r) => [r.toolkit.toLowerCase(), r.connected])));
+      } catch {
+        // Non-fatal: leave the provider rows in their "sign in" state.
+        setConnected({});
+      }
+    },
+    [client, company],
+  );
 
   const refresh = useCallback(async () => {
     const generation = ++requestGeneration.current;
@@ -41,14 +94,16 @@ export function ComposioSection({ client, company }: Props) {
       setStatus(s);
       // Hide the whole section when the feature is not compiled into this build.
       setLoad(s.inBuild ? "ready" : "unavailable");
+      if (s.inBuild) void refreshConnections(s);
     } catch {
       if (generation !== requestGeneration.current) return;
       setLoad("unavailable");
     }
-  }, [client, company]);
+  }, [client, company, refreshConnections]);
 
   useEffect(() => {
     setStatus(null);
+    setConnected({});
     setLoad("loading");
     void refresh();
   }, [refresh]);
@@ -61,6 +116,7 @@ export function ComposioSection({ client, company }: Props) {
       setStatus(res.status);
       setToken("");
       toast.success(res.note);
+      void refreshConnections(res.status);
     } catch (err) {
       toast.error(err instanceof ApiError ? err.message : "Could not save the token.");
     } finally {
@@ -74,6 +130,7 @@ export function ComposioSection({ client, company }: Props) {
       const res = await setComposioToken(client, company, "");
       setStatus(res.status);
       setToken("");
+      setConnected({});
       toast.success("Composio token cleared.");
     } catch (err) {
       toast.error(err instanceof ApiError ? err.message : "Could not clear the token.");
@@ -82,7 +139,50 @@ export function ComposioSection({ client, company }: Props) {
     }
   }
 
+  // Per-provider OAuth: open Composio's hosted connect URL in a new tab, then
+  // poll the connection list every 2s up to ~2 minutes until this toolkit flips
+  // to connected (Composio completes the OAuth on its side — no local callback).
+  async function signIn(toolkit: string) {
+    // Guard the shared flag AND a poll already in flight for this toolkit.
+    if (signingIn || pollTimers.current[toolkit] !== undefined) return;
+    setSigningIn(toolkit);
+    const label = toolkitLabel(toolkit);
+    try {
+      const { connectUrl } = await startComposioAuthorize(client, company, toolkit);
+      window.open(connectUrl, "_blank", "noopener,noreferrer");
+      toast.message(`Complete ${label} sign-in in the new tab.`);
+      const deadline = Date.now() + 120_000;
+      const poll = async () => {
+        delete pollTimers.current[toolkit];
+        if (Date.now() > deadline) {
+          setSigningIn((t) => (t === toolkit ? null : t));
+          toast.message(`${label} sign-in timed out. Try again if it didn't complete.`);
+          return;
+        }
+        try {
+          const rows = await listComposioConnections(client, company);
+          const map = Object.fromEntries(rows.map((r) => [r.toolkit.toLowerCase(), r.connected]));
+          setConnected(map);
+          if (map[toolkit.toLowerCase()]) {
+            setSigningIn((t) => (t === toolkit ? null : t));
+            toast.success(`Connected ${label}.`);
+            return;
+          }
+        } catch {
+          // Ignore transient probe errors while the operator finishes sign-in.
+        }
+        pollTimers.current[toolkit] = window.setTimeout(() => void poll(), 2_000);
+      };
+      pollTimers.current[toolkit] = window.setTimeout(() => void poll(), 2_000);
+    } catch (err) {
+      setSigningIn((t) => (t === toolkit ? null : t));
+      toast.error(err instanceof ApiError ? err.message : `Couldn't start ${label} sign-in.`);
+    }
+  }
+
   if (load === "unavailable") return null;
+
+  const showProviders = load === "ready" && status !== null && status.toolkits.length > 0;
 
   return (
     <section className="space-y-3">
@@ -93,86 +193,132 @@ export function ComposioSection({ client, company }: Props) {
         </h3>
       </div>
       <p className="text-sm text-muted-foreground">
-        Give your agents Gmail, Slack &amp; GitHub via Composio. Paste this company&apos;s Composio
-        OAuth token — it is the per-tenant identity the backend bills and isolates, stored securely
-        and never shown again. A change takes effect on the next turn, no restart.
+        Give your agents Gmail, Slack &amp; GitHub via Composio. Sign in per provider below, or paste
+        this company&apos;s Composio OAuth token directly. Either way, the connection takes effect on
+        the next turn, no restart.
       </p>
 
       {load === "loading" ? (
         <Skeleton className="h-32 rounded-xl" />
       ) : (
-        <Card>
-          <CardContent className="space-y-4 py-4">
-            {status && (
-              <div className="flex flex-wrap items-center gap-2">
-                <Badge variant={status.granted ? "secondary" : "outline"}>
-                  {status.granted ? "granted" : "not granted"}
-                </Badge>
-                {status.tokenConfigured ? (
-                  <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
-                    <Check className="size-3" /> token set
-                  </span>
-                ) : (
-                  <span className="text-xs text-muted-foreground">no token yet</span>
+        <>
+          {status && (
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant={status.granted ? "secondary" : "outline"}>
+                {status.granted ? "granted" : "not granted"}
+              </Badge>
+              {status.tokenConfigured ? (
+                <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+                  <Check className="size-3" /> token set
+                </span>
+              ) : (
+                <span className="text-xs text-muted-foreground">no token yet</span>
+              )}
+            </div>
+          )}
+
+          {status && !status.granted && (
+            <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+              This company does not grant the <span className="font-mono">composio</span> tool
+              namespace, so agents will not receive Composio tools even once connected. Add
+              <span className="font-mono"> composio</span> to the company&apos;s tool grants first.
+            </p>
+          )}
+
+          {showProviders && status && (
+            <Card>
+              <CardContent className="space-y-2 py-4">
+                <p className="text-xs font-medium text-muted-foreground">Sign in per provider</p>
+                {!status.tokenConfigured && (
+                  <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+                    Set the Composio token below first — it is the per-tenant identity the sign-in
+                    flow authorizes against.
+                  </p>
                 )}
-                {status.toolkits.length > 0 && (
-                  <span className="text-xs text-muted-foreground">
-                    toolkits: {status.toolkits.join(", ")}
-                  </span>
+                <ul className="divide-y divide-border">
+                  {status.toolkits.map((toolkit) => {
+                    const isConnected = connected[toolkit.toLowerCase()] === true;
+                    const isSigningIn = signingIn === toolkit;
+                    return (
+                      <li key={toolkit} className="flex items-center justify-between py-2">
+                        <span className="text-sm">{toolkitLabel(toolkit)}</span>
+                        {isConnected ? (
+                          <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+                            <Check className="size-3" /> connected
+                          </span>
+                        ) : (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={
+                              signingIn !== null || !status.tokenConfigured
+                            }
+                            onClick={() => void signIn(toolkit)}
+                          >
+                            {isSigningIn ? (
+                              <Loader2 className="size-4 animate-spin" />
+                            ) : (
+                              <LogIn className="size-4" />
+                            )}
+                            Sign in
+                          </Button>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </CardContent>
+            </Card>
+          )}
+
+          <Card>
+            <CardContent className="space-y-4 py-4">
+              <div className="space-y-1">
+                <Label htmlFor="composio-token" className="text-xs">
+                  Composio token (fallback){" "}
+                  {status?.tokenConfigured ? "— set, leave blank to keep" : ""}
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Paste this company&apos;s Composio OAuth token directly if you already have one. It
+                  is stored securely and never shown again.
+                </p>
+                <Input
+                  id="composio-token"
+                  type="password"
+                  autoComplete="off"
+                  placeholder="paste the company's Composio OAuth token"
+                  value={token}
+                  onChange={(e) => setToken(e.target.value)}
+                />
+                {status && (
+                  <p className="truncate text-xs text-muted-foreground">{status.backendUrl}</p>
                 )}
               </div>
-            )}
 
-            {status && !status.granted && (
-              <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
-                This company does not grant the <span className="font-mono">composio</span> tool
-                namespace, so agents will not receive Composio tools even with a token set. Add
-                <span className="font-mono"> composio</span> to the company&apos;s tool grants first.
-              </p>
-            )}
-
-            <div className="space-y-1">
-              <Label htmlFor="composio-token" className="text-xs">
-                Composio token {status?.tokenConfigured ? "(leave blank to keep)" : ""}
-              </Label>
-              <Input
-                id="composio-token"
-                type="password"
-                autoComplete="off"
-                placeholder="paste the company's Composio OAuth token"
-                value={token}
-                onChange={(e) => setToken(e.target.value)}
-              />
-              {status && <p className="truncate text-xs text-muted-foreground">{status.backendUrl}</p>}
-            </div>
-
-            <div className="flex items-center gap-2">
-              <Button disabled={busy !== null || !token.trim()} onClick={() => void save()}>
-                {busy === "save" ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : (
-                  <Save className="size-4" />
-                )}
-                Save token
-              </Button>
-              {status?.tokenConfigured && (
-                <Button
-                  variant="outline"
-                  disabled={busy !== null}
-                  onClick={() => void clear()}
-                >
-                  {busy === "clear" ? (
+              <div className="flex items-center gap-2">
+                <Button disabled={busy !== null || !token.trim()} onClick={() => void save()}>
+                  {busy === "save" ? (
                     <Loader2 className="size-4 animate-spin" />
                   ) : (
-                    <Trash2 className="size-4" />
+                    <Save className="size-4" />
                   )}
-                  Clear
+                  Save token
                 </Button>
-              )}
-              <KeyRound className="ml-auto size-4 text-muted-foreground" />
-            </div>
-          </CardContent>
-        </Card>
+                {status?.tokenConfigured && (
+                  <Button variant="outline" disabled={busy !== null} onClick={() => void clear()}>
+                    {busy === "clear" ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <Trash2 className="size-4" />
+                    )}
+                    Clear
+                  </Button>
+                )}
+                <KeyRound className="ml-auto size-4 text-muted-foreground" />
+              </div>
+            </CardContent>
+          </Card>
+        </>
       )}
     </section>
   );

--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -151,7 +151,7 @@ fn slug_toolkit(slug: &str) -> String {
 }
 
 #[cfg(feature = "composio")]
-pub use live::{ComposioMetering, composio_tools};
+pub use live::{ComposioMetering, authorize_connect_url, composio_tools, list_connection_states};
 
 #[cfg(feature = "composio")]
 mod live {
@@ -211,10 +211,7 @@ mod live {
         // The Config-free seam: `IntegrationClient::new(backend_url, auth_token)`
         // takes the per-tenant credential directly, with no OpenHuman global
         // `Config`. The bearer is the ONLY isolation lever — see the module docs.
-        let client = ComposioClient::new(Arc::new(IntegrationClient::new(
-            config.backend_url.clone(),
-            config.auth_token.clone(),
-        )));
+        let client = client_for(config);
         let secrets = vec![config.auth_token.clone()];
         let toolkits = Arc::new(config.toolkits.clone());
         vec![
@@ -270,6 +267,86 @@ mod live {
             .filter(|s| !s.is_empty())
             .map(str::to_string)
             .ok_or_else(|| anyhow::anyhow!("missing required `{key}` string argument"))
+    }
+
+    /// Build a [`ComposioClient`] over a resolved tenant config.
+    ///
+    /// The Config-free seam: `IntegrationClient::new(backend_url, auth_token)`
+    /// takes the per-tenant credential directly, with no OpenHuman global
+    /// `Config`. The bearer is the ONLY isolation lever — see the module docs.
+    /// Shared by the agent tools ([`composio_tools`]) and the operator-console
+    /// ops handlers ([`authorize_connect_url`], [`list_connection_states`]) so
+    /// both dial the backend the exact same way.
+    fn client_for(config: &TenantComposio) -> ComposioClient {
+        ComposioClient::new(Arc::new(IntegrationClient::new(
+            config.backend_url.clone(),
+            config.auth_token.clone(),
+        )))
+    }
+
+    /// Scrub the tenant bearer out of an upstream error before it can bubble to
+    /// a console handler or a log line — the backend can reflect the presented
+    /// bearer in an error body, and the ops surface must never echo it.
+    fn scrub_err(err: &anyhow::Error, config: &TenantComposio) -> anyhow::Error {
+        anyhow::anyhow!(scrub(&format!("{err}"), &[config.auth_token.clone()]))
+    }
+
+    /// Begin an OAuth handoff for `toolkit` and return the Composio-hosted
+    /// connect URL the operator opens in a browser. Backs the console's
+    /// `POST …/composio/authorize` route (the same building block the
+    /// `composio_authorize` agent tool wraps).
+    ///
+    /// Composio runs the OAuth itself — there is **no** local callback route.
+    /// The console opens the returned URL in a new tab and polls
+    /// [`list_connection_states`] until the toolkit reports connected.
+    ///
+    /// The tenant allowlist is enforced **before** any network call — a toolkit
+    /// the company is not permitted to connect never reaches the backend. Any
+    /// upstream error is scrubbed of the tenant bearer before it bubbles.
+    pub async fn authorize_connect_url(config: &TenantComposio, toolkit: &str) -> Result<String> {
+        let toolkit = toolkit.trim();
+        if toolkit.is_empty() {
+            anyhow::bail!("composio authorize: toolkit must not be empty");
+        }
+        if !toolkit_allowed(&config.toolkits, toolkit) {
+            anyhow::bail!("toolkit `{toolkit}` is not in this company's Composio allowlist");
+        }
+        tracing::debug!(toolkit = %toolkit, "[composio] ops authorize");
+        match client_for(config).authorize(toolkit, None).await {
+            Ok(resp) => Ok(resp.connect_url),
+            Err(err) => Err(scrub_err(&err, config)),
+        }
+    }
+
+    /// The per-toolkit connected state the console renders as provider rows: one
+    /// `(toolkit, connected)` pair per toolkit that has at least one connection,
+    /// with `connected == true` when **any** connection for that toolkit is
+    /// active. Backs the console's `GET …/composio/connections` route.
+    ///
+    /// Filtered to the tenant allowlist (mirrors the `composio_list_connections`
+    /// agent tool) so a connection outside the company's grant is never
+    /// surfaced. Sorted by toolkit for a stable render order. Any upstream error
+    /// is scrubbed of the tenant bearer before it bubbles.
+    pub async fn list_connection_states(config: &TenantComposio) -> Result<Vec<(String, bool)>> {
+        tracing::debug!(allowlist = ?config.toolkits, "[composio] ops list_connections");
+        let resp = match client_for(config).list_connections().await {
+            Ok(resp) => resp,
+            Err(err) => return Err(scrub_err(&err, config)),
+        };
+        let mut states: std::collections::BTreeMap<String, bool> =
+            std::collections::BTreeMap::new();
+        for conn in resp.connections {
+            let toolkit = conn.normalized_toolkit();
+            if !toolkit_allowed(&config.toolkits, &toolkit) {
+                continue;
+            }
+            let active = conn.is_active();
+            states
+                .entry(toolkit)
+                .and_modify(|c| *c = *c || active)
+                .or_insert(active);
+        }
+        Ok(states.into_iter().collect())
     }
 
     // ── composio_list_toolkits ──────────────────────────────────────────
@@ -878,6 +955,123 @@ mod tests {
     }
 }
 
+/// The console-facing ops helpers ([`authorize_connect_url`],
+/// [`list_connection_states`]) over a mock Composio backend: proves the connect
+/// URL is surfaced, the allowlist is enforced before any network call, and
+/// connection rows aggregate to per-toolkit `connected` state filtered to the
+/// tenant grant.
+#[cfg(all(test, feature = "composio"))]
+mod ops_helper_tests {
+    use super::*;
+
+    use std::net::SocketAddr;
+
+    use axum::Router;
+    use axum::routing::{get, post};
+    use serde_json::{Value, json};
+
+    /// Mock `POST /agent-integrations/composio/authorize` — returns a hosted
+    /// connect URL inside the backend's `{success,data}` envelope.
+    async fn authorize_handler() -> axum::Json<Value> {
+        axum::Json(json!({
+            "success": true,
+            "data": { "connectUrl": "https://connect.composio.dev/abc", "connectionId": "conn-xyz" }
+        }))
+    }
+
+    /// Mock `GET /agent-integrations/composio/connections` — gmail has one
+    /// active + one pending row (→ connected), slack only pending (→ not
+    /// connected), notion active (filtered out unless allowlisted).
+    async fn connections_handler() -> axum::Json<Value> {
+        axum::Json(json!({
+            "success": true,
+            "data": { "connections": [
+                { "id": "c1", "toolkit": "gmail", "status": "ACTIVE" },
+                { "id": "c2", "toolkit": "gmail", "status": "INITIATED" },
+                { "id": "c3", "toolkit": "slack", "status": "INITIATED" },
+                { "id": "c4", "toolkit": "notion", "status": "ACTIVE" }
+            ] }
+        }))
+    }
+
+    async fn spawn_backend() -> String {
+        let app = Router::new()
+            .route(
+                "/agent-integrations/composio/authorize",
+                post(authorize_handler),
+            )
+            .route(
+                "/agent-integrations/composio/connections",
+                get(connections_handler),
+            );
+        let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    fn config(url: &str, toolkits: Vec<String>) -> TenantComposio {
+        TenantComposio {
+            backend_url: url.to_string(),
+            auth_token: "tenant-token".to_string(),
+            toolkits,
+        }
+    }
+
+    #[tokio::test]
+    async fn authorize_returns_hosted_connect_url() {
+        let url = spawn_backend().await;
+        let out = authorize_connect_url(&config(&url, vec!["gmail".into()]), "gmail")
+            .await
+            .expect("authorize returns a connect URL");
+        assert_eq!(out, "https://connect.composio.dev/abc");
+    }
+
+    #[tokio::test]
+    async fn authorize_rejects_toolkit_outside_allowlist_before_any_network_call() {
+        // Backend URL is unreachable — the allowlist rejection must fire first.
+        let out =
+            authorize_connect_url(&config("http://127.0.0.1:1", vec!["gmail".into()]), "slack")
+                .await;
+        let err = out.expect_err("a toolkit outside the allowlist must be refused");
+        assert!(err.to_string().contains("allowlist"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn list_connection_states_aggregates_active_and_filters_to_allowlist() {
+        let url = spawn_backend().await;
+        // gmail + slack allowed; notion is active upstream but not in the grant.
+        let states = list_connection_states(&config(&url, vec!["gmail".into(), "slack".into()]))
+            .await
+            .expect("list connections");
+        assert_eq!(
+            states,
+            vec![("gmail".to_string(), true), ("slack".to_string(), false)],
+            "gmail active (one ACTIVE row), slack pending only, notion filtered out"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_connection_states_empty_allowlist_admits_every_toolkit() {
+        let url = spawn_backend().await;
+        let states = list_connection_states(&config(&url, Vec::new()))
+            .await
+            .expect("list connections");
+        assert_eq!(
+            states,
+            vec![
+                ("gmail".to_string(), true),
+                ("notion".to_string(), true),
+                ("slack".to_string(), false),
+            ]
+        );
+    }
+}
+
 /// The mandatory tenant-isolation test (issue #110): two per-tenant configs (A
 /// and B) over a mock backend that records the `Authorization` header of each
 /// request and answers with tenant-specific data. Proves the ONLY isolation
@@ -956,7 +1150,12 @@ mod isolation_tests {
     }
 
     fn list_connections_tool(config: &TenantComposio) -> Box<dyn Tool> {
-        composio_tools(config)
+        let metering = ComposioMetering {
+            company: CompanyId::new("acme"),
+            agent: "ceo".to_string(),
+            meter: None,
+        };
+        composio_tools(config, metering)
             .into_iter()
             .find(|t| t.name() == "composio_list_connections")
             .expect("composio_list_connections tool present")

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -12,7 +12,7 @@
 
 use axum::Json;
 use axum::Router;
-use axum::routing::{get, put};
+use axum::routing::{get, post, put};
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
@@ -26,8 +26,19 @@ const SWITCH_NOTE: &str =
     "Agents pick up the new Composio token on their next turn — no restart needed.";
 
 /// Builds the Composio management route fragment.
+///
+/// The read/write-token plane (`GET …/composio`, `PUT …/composio/token`) is
+/// always present. The per-provider OAuth sign-in plane (`POST
+/// …/composio/authorize`, `GET …/composio/connections`) is **also** always
+/// present in the route table — mirroring how `get_status` stays wired and
+/// reports `inBuild:false` rather than `#[cfg]`-ing itself out — but its
+/// handlers only reach the live Composio client under the `composio` feature;
+/// otherwise they answer `409 Conflict` "not in this build".
 pub fn router() -> Router<AppState> {
-    scoped("/composio", get(get_status)).merge(scoped("/composio/token", put(set_token)))
+    scoped("/composio", get(get_status))
+        .merge(scoped("/composio/token", put(set_token)))
+        .merge(scoped("/composio/authorize", post(authorize)))
+        .merge(scoped("/composio/connections", get(connections)))
 }
 
 /// The company's Composio status as the console renders it. **Never** carries the
@@ -64,6 +75,34 @@ struct MutationResponse {
 #[serde(rename_all = "camelCase")]
 struct SetToken {
     token: String,
+}
+
+/// `POST …/composio/authorize` body: the toolkit slug (`gmail` / `slack` /
+/// `github` / …) to begin an OAuth handoff for.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AuthorizeBody {
+    toolkit: String,
+}
+
+/// `POST …/composio/authorize` response: the Composio-hosted connect URL the
+/// operator opens in a browser tab. Composio runs the OAuth itself; there is no
+/// local callback — the console polls [`ConnectionDto`] until the toolkit
+/// reports connected.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AuthorizeDto {
+    connect_url: String,
+}
+
+/// One per-toolkit connected state in the `GET …/composio/connections`
+/// response: `connected` is true when the company has at least one active
+/// connection for that toolkit.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConnectionDto {
+    toolkit: String,
+    connected: bool,
 }
 
 /// Resolves the Composio status DTO for a company.
@@ -114,6 +153,120 @@ async fn set_token(
         status: effective_status(runtime).await?,
         note: SWITCH_NOTE.to_string(),
     }))
+}
+
+/// `POST …/composio/authorize` — begin a per-provider OAuth handoff and return
+/// the Composio-hosted connect URL the operator opens in a browser tab.
+///
+/// Composio runs the OAuth flow itself — there is **no** local callback route.
+/// The console opens the URL and polls [`connections`] until the toolkit
+/// reports connected. Under a non-`composio` build this answers `409 Conflict`
+/// (see [`router`]).
+async fn authorize(
+    company: ScopedCompany,
+    Json(body): Json<AuthorizeBody>,
+) -> Result<Json<AuthorizeDto>, ApiError> {
+    authorize_impl(company.runtime.as_ref(), body.toolkit).await
+}
+
+/// `GET …/composio/connections` — the company's per-toolkit connected state,
+/// one [`ConnectionDto`] per toolkit that has at least one connection. The
+/// console cross-references this against the granted `toolkits` to render each
+/// provider row's connected/sign-in state. `409 Conflict` on a non-`composio`
+/// build.
+async fn connections(company: ScopedCompany) -> Result<Json<Vec<ConnectionDto>>, ApiError> {
+    connections_impl(company.runtime.as_ref()).await
+}
+
+/// Resolve the per-tenant Composio config (bearer + backend URL + toolkit
+/// allowlist) the way the harness roster build does, so the console dials the
+/// backend with the exact same tenant identity. A `409 Conflict` when no token
+/// is configured — the operator must set it (paste-token card) before OAuth.
+#[cfg(feature = "composio")]
+async fn resolve_tenant(
+    runtime: &CompanyRuntime,
+) -> Result<crate::harness::composio::TenantComposio, ApiError> {
+    use crate::app::config::EnvSource;
+
+    let record = runtime.store().load(runtime.id()).await.map_err(ApiError)?;
+    let toolkits = record
+        .map(|record| record.manifest.tools.composio.toolkits.clone())
+        .unwrap_or_default();
+    let env = crate::app::config::ProcessEnv;
+    let backend_env = env.get(crate::company::composio::COMPOSIO_BACKEND_URL_ENV);
+    let api_env = env.get(crate::company::composio::TINYHUMANS_API_URL_ENV);
+    crate::harness::composio::TenantComposio::resolve(
+        runtime.id(),
+        runtime.secrets().as_ref(),
+        toolkits,
+        backend_env,
+        api_env,
+    )
+    .await
+    .ok_or_else(|| {
+        ApiError(crate::error::OpenCompanyError::Conflict(
+            "no Composio token configured for this company — set the token first".to_string(),
+        ))
+    })
+}
+
+#[cfg(feature = "composio")]
+async fn authorize_impl(
+    runtime: &CompanyRuntime,
+    toolkit: String,
+) -> Result<Json<AuthorizeDto>, ApiError> {
+    let config = resolve_tenant(runtime).await?;
+    let connect_url = crate::harness::composio::authorize_connect_url(&config, &toolkit)
+        .await
+        .map_err(|err| {
+            ApiError(crate::error::OpenCompanyError::TinyHumans {
+                code: "composio_authorize".to_string(),
+                message: err.to_string(),
+            })
+        })?;
+    Ok(Json(AuthorizeDto { connect_url }))
+}
+
+#[cfg(feature = "composio")]
+async fn connections_impl(runtime: &CompanyRuntime) -> Result<Json<Vec<ConnectionDto>>, ApiError> {
+    let config = resolve_tenant(runtime).await?;
+    let states = crate::harness::composio::list_connection_states(&config)
+        .await
+        .map_err(|err| {
+            ApiError(crate::error::OpenCompanyError::TinyHumans {
+                code: "composio_connections".to_string(),
+                message: err.to_string(),
+            })
+        })?;
+    Ok(Json(
+        states
+            .into_iter()
+            .map(|(toolkit, connected)| ConnectionDto { toolkit, connected })
+            .collect(),
+    ))
+}
+
+/// A `409 Conflict` "Composio is not in this build" — the OAuth plane's off-state
+/// under a non-`composio` build. Mirrors the status route's `inBuild:false`
+/// semantics rather than pretending nothing is connected.
+#[cfg(not(feature = "composio"))]
+fn not_in_build() -> ApiError {
+    ApiError(crate::error::OpenCompanyError::Conflict(
+        "Composio is not compiled into this build".to_string(),
+    ))
+}
+
+#[cfg(not(feature = "composio"))]
+async fn authorize_impl(
+    _runtime: &CompanyRuntime,
+    _toolkit: String,
+) -> Result<Json<AuthorizeDto>, ApiError> {
+    Err(not_in_build())
+}
+
+#[cfg(not(feature = "composio"))]
+async fn connections_impl(_runtime: &CompanyRuntime) -> Result<Json<Vec<ConnectionDto>>, ApiError> {
+    Err(not_in_build())
 }
 
 #[cfg(test)]
@@ -258,6 +411,53 @@ mod tests {
         .await;
         let (_, dto, _) = send(&state, "GET", "/api/v1/company/composio", None).await;
         assert_eq!(dto["granted"], false, "{dto}");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// The OAuth sign-in plane is always wired into the route table (like the
+    /// status route), so `POST …/composio/authorize` is never a 404. Without a
+    /// usable Composio client it conflicts (`409`): on the default build because
+    /// the feature is not compiled in; under the `composio` feature because no
+    /// per-tenant token is configured yet. Either way the console gets a clear,
+    /// non-404 signal rather than a missing route.
+    #[tokio::test]
+    async fn authorize_route_conflicts_without_build_or_token() {
+        let home = home();
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"composio\"]\n[tools.composio]\ntoolkits = [\"gmail\"]\n",
+        )
+        .await;
+
+        let (status, body, raw) = send(
+            &state,
+            "POST",
+            "/api/v1/company/composio/authorize",
+            Some(json!({ "toolkit": "gmail" })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CONFLICT, "{raw}");
+        assert_eq!(body["code"], "conflict", "{body}");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// `GET …/composio/connections` is likewise always wired and conflicts
+    /// (`409`) when there is no usable client — no build feature or no token.
+    #[tokio::test]
+    async fn connections_route_conflicts_without_build_or_token() {
+        let home = home();
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"composio\"]\n[tools.composio]\ntoolkits = [\"gmail\"]\n",
+        )
+        .await;
+
+        let (status, body, raw) =
+            send(&state, "GET", "/api/v1/company/composio/connections", None).await;
+        assert_eq!(status, StatusCode::CONFLICT, "{raw}");
+        assert_eq!(body["code"], "conflict", "{body}");
+
         std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
## Summary

Console plumbing for the Connections tab: per-provider OAuth authorize + connection listing, wired from the harness helpers through the ops routes to the frontend API clients and the Composio section UI.

**Scope changed — the sign-in half has been removed from this PR** (see below). What remains is the per-provider OAuth surface, which stands on its own.

## API Or Behavior Changes

- harness: `authorize` + `connections` helpers exposed for the ops plane
- ops: per-provider OAuth authorize + connections routes
- console: API clients for both, and a per-provider list in the Composio section

## Tests

- `cargo check --all-targets` — clean
- frontend `npm run typecheck`, `npm run build` — clean

## Documentation

None beyond the route/helper doc comments in the diff.

---

### What was removed, and why

Two commits were dropped from this branch (`04211d8b`, `39c00b20`): the "Sign in with tinyhumans" card, the `frontend/src/lib/composio-signin.ts` module, and its `App.tsx` callback hook. Together they captured a tinyhumans web sign-in JWT in the browser and used it as the company's Composio bearer.

That approach is being retired rather than reviewed. Handing a company a user's JWT as its outbound credential means a long-lived user token living in tenant state, and it asks an operator — including our own teammates — to paste a credential by hand. It is replaced by platform workload-identity attestation: a hosted tenant proves *what it is* with a short-lived, audience-bound token it never stores, and the backend derives *who owns it*. There is nothing for a user to paste, copy, or rotate.

That replacement is in flight as a four-repo change set:

| Repo | PR |
|---|---|
| `opencompany-microservice` | tinyhumansai/opencompany-microservice#6 |
| `backend` | tinyhumansai/backend#1174 |
| `opencompany` | tinyhumansai/opencompany#189 |
| `landing` | tinyhumansai/landing#18 |

The console plumbing in *this* PR is unaffected by that change and still wanted — only the credential-acquisition half was superseded.

### Overlap with #189

Both this PR and #189 touch all four of `frontend/src/api/composio.ts`, `frontend/src/views/connections/ComposioSection.tsx`, `src/harness/composio.rs`, `src/server/ops/composio.rs`. **Whichever merges second needs a rebase.** #189 changes the composio status shape (`tokenConfigured` → `credentialSource`), so a rebase of this branch onto a merged #189 will need the section UI reconciled with the new state model.

### Outstanding review comments

The earlier CodeRabbit review requested 4 changes. One of them — the never-expiring pending marker in `composio-signin.ts` — is moot, since that file no longer exists. **Three are still open and not addressed by this force-push:**

- `ComposioSection.tsx` — no generation guard, so a late `refreshConnections` response can clobber a newly-switched company's state
- `ComposioSection.tsx` — `window.open` after an `await` is popup-blocked in Safari/Firefox because the user gesture has already been consumed
- `src/server/ops/composio.rs` — client-side validation failures (empty toolkit, toolkit outside the company allowlist) surface as `502 Bad Gateway` instead of a 4xx

Flagging them as open rather than implying the rewrite resolved them.
