### PR TITLE
feat(harness): relay delegate_to_desk answer through a second orchestrator turn

### DIFF
--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -46,6 +46,32 @@ pub struct HarnessBrain {
     responder: String,
 }
 
+/// The outcome of draining one queued delegation.
+///
+/// A `spawn_task` yields nothing operator-visible (it only opens a board card).
+/// A synchronous `delegate_to_desk` yields a [`DeskReply`] — the teammate's
+/// answer captured so the orchestrator can **relay** it in a follow-up turn
+/// (the CEO-relay hand-back) instead of leaving it as a disconnected sibling
+/// bubble. `bubble` stays for any future delegation that surfaces its own
+/// standalone message directly.
+#[derive(Default)]
+struct DelegationOutcome {
+    /// A chat bubble to surface as-is (unused by the current delegations).
+    bubble: Option<OutboundMessage>,
+    /// A synchronous desk reply to relay through a second orchestrator turn.
+    desk_reply: Option<DeskReply>,
+}
+
+/// A synchronous desk-lead answer captured for the orchestrator to relay: which
+/// member answered, their reply text, and their own turn steps (folded onto the
+/// operator timeline so the teammate's activity stays visible on the single
+/// relayed bubble).
+struct DeskReply {
+    member: String,
+    reply: String,
+    steps: Vec<TurnStep>,
+}
+
 impl HarnessBrain {
     /// Builds a harness brain for `record`, answering unaddressed operator
     /// messages with the company orchestrator (the `tier = "orchestrator"` agent,
@@ -340,15 +366,18 @@ impl HarnessBrain {
     /// [`TaskStore::upsert`](crate::ports::TaskStore) path the console uses and
     /// surfaces nothing extra (a missing task store is a silent no-op).
     /// `delegate_to_desk` runs a single turn on the desk's lead member and
-    /// returns its reply as its own chat bubble — `channel = <member id>`, the
-    /// distinct-bubble path the console already renders. An unknown desk (no
-    /// roster-backed lead) is a silent no-op. No sub-agent re-delegation in v1:
-    /// desk members carry no delegation tools, so their turns queue nothing.
+    /// **returns its reply for the orchestrator to relay** (a [`DeskReply`]) —
+    /// the CEO-relay hand-back: instead of a disconnected sibling bubble the
+    /// teammate's answer feeds a second orchestrator turn so the CEO comes back
+    /// with it in one coherent conversation. An unknown desk (no roster-backed
+    /// lead) or a cancelled run yields nothing to relay. No sub-agent
+    /// re-delegation in v1: desk members carry no delegation tools, so their
+    /// turns queue nothing.
     async fn run_delegation(
         &self,
         delegation: Delegation,
         chat_id: Option<&str>,
-    ) -> Result<Option<OutboundMessage>> {
+    ) -> Result<DelegationOutcome> {
         match delegation {
             Delegation::SpawnTask {
                 title,
@@ -356,7 +385,7 @@ impl HarnessBrain {
                 assignee,
             } => {
                 let Some(tasks) = self.deps.tasks.as_ref() else {
-                    return Ok(None);
+                    return Ok(DelegationOutcome::default());
                 };
                 let card = TaskRecord {
                     id: generate_id(),
@@ -372,11 +401,11 @@ impl HarnessBrain {
                     origin_chat_id: chat_id.map(str::to_string),
                 };
                 tasks.upsert(&self.record.id, &card).await?;
-                Ok(None)
+                Ok(DelegationOutcome::default())
             }
             Delegation::DelegateToDesk { desk, instruction } => {
                 let Some(member) = self.desk_lead(&desk) else {
-                    return Ok(None);
+                    return Ok(DelegationOutcome::default());
                 };
                 // Register the delegated turn so an operator can CANCEL it
                 // mid-flight (cancel-only in v1 — pause/redirect are rejected at
@@ -405,21 +434,41 @@ impl HarnessBrain {
                         chat_id,
                     )
                     .await?;
-                // A cancel issued mid-flight discards the delegated reply — no
-                // bubble surfaces.
+                // A cancel issued mid-flight discards the delegated reply —
+                // nothing is relayed.
                 if matches!(control.take(), Some(SteerAction::Cancel)) {
-                    return Ok(None);
+                    return Ok(DelegationOutcome::default());
                 }
-                // The desk lead's own steps ride on its distinct bubble.
-                Ok(Some(OutboundMessage {
-                    channel: member,
-                    text: outcome.reply,
-                    reply_to: None,
-                    steps: outcome.steps,
-                }))
+                // Hand the teammate's answer back to the caller to RELAY through
+                // a second orchestrator turn (the CEO-relay hand-back). Their
+                // steps ride along and get folded onto the relayed operator
+                // bubble so the teammate's activity stays visible.
+                Ok(DelegationOutcome {
+                    bubble: None,
+                    desk_reply: Some(DeskReply {
+                        member,
+                        reply: outcome.reply,
+                        steps: outcome.steps,
+                    }),
+                })
             }
         }
     }
+}
+
+/// The prompt for the CEO-relay hand-back turn: the operator's original message
+/// plus each teammate's reply, framed so the orchestrator relays the answer back
+/// as its own single, coherent response and does not delegate again.
+fn build_relay_prompt(original: &str, desk_replies: &[(String, String)]) -> String {
+    let mut prompt = format!(
+        "The operator asked:\n{original}\n\nYou delegated this to your team and their reply is \
+below. Relay their answer back to the operator now as your own single, coherent response — \
+summarize it or pass it along. Do not delegate again; just relay what came back."
+    );
+    for (member, reply) in desk_replies {
+        prompt.push_str(&format!("\n\n{member} replied:\n{reply}"));
+    }
+    prompt
 }
 
 /// The turn instruction for a dispatched card: its title, plus its note when it
@@ -490,30 +539,76 @@ impl Brain for HarnessBrain {
                         .pool
                         .run(&self.record.id, &responder, text, &self.deps, chat_id)
                         .await?;
-                    // The orchestrator's own steps ride on the operator bubble.
+                    // The orchestrator's own steps ride on the operator bubble;
+                    // its reply is the operator-facing text UNLESS a synchronous
+                    // desk delegation runs, in which case the relay turn's reply
+                    // replaces it (below).
                     let mut operator_steps = outcome.steps;
-                    // Run whatever the orchestrator queued; each delegated desk
-                    // bubble carries its own lead's steps. Collect them first so
-                    // the operator bubble can still be finalized before it is
-                    // pushed (any MCP failure a delegated turn recorded lands on
-                    // the operator timeline).
+                    let mut operator_reply = outcome.reply;
+                    // Run whatever the orchestrator queued. A `spawn_task` opens a
+                    // card silently; a `delegate_to_desk` runs the desk lead and
+                    // hands its answer back to RELAY (the CEO-relay hand-back)
+                    // rather than surfacing as a disconnected sibling bubble. Any
+                    // future delegation that surfaces its own bubble lands in
+                    // `delegated`.
                     let mut delegated = Vec::new();
+                    let mut desk_replies: Vec<(String, String)> = Vec::new();
                     for delegation in self
                         .deps
                         .delegations
                         .drain(orchestrator::MAX_DELEGATIONS_PER_TURN)
                     {
-                        if let Some(message) = self.run_delegation(delegation, chat_id).await? {
-                            delegated.push(message);
+                        let out = self.run_delegation(delegation, chat_id).await?;
+                        if let Some(bubble) = out.bubble {
+                            delegated.push(bubble);
+                        }
+                        if let Some(desk) = out.desk_reply {
+                            // Fold the teammate's activity onto the operator
+                            // timeline, then remember the answer to relay.
+                            operator_steps.extend(desk.steps);
+                            desk_replies.push((desk.member, desk.reply));
                         }
                     }
+                    // CEO-relay hand-back: when a synchronous desk delegation
+                    // answered, run exactly ONE more orchestrator turn whose
+                    // prompt is the original message plus the teammate reply,
+                    // and surface THAT as the operator bubble — so the CEO comes
+                    // back with the answer in one coherent conversation. The
+                    // relay turn must not re-delegate: its prompt is relay-only,
+                    // and as a safety net the delegation queue is cleared before
+                    // it and drained-and-discarded after, so anything it tries
+                    // to queue is dropped (bounding cost to one extra turn, no
+                    // re-delegation loop). No delegation → the single first turn
+                    // stays exactly as before.
+                    if !desk_replies.is_empty() {
+                        let relay_prompt = build_relay_prompt(text, &desk_replies);
+                        self.deps.delegations.clear();
+                        let relay = self
+                            .pool
+                            .run(
+                                &self.record.id,
+                                &responder,
+                                &relay_prompt,
+                                &self.deps,
+                                chat_id,
+                            )
+                            .await?;
+                        // Discard anything the relay turn queued — it can only
+                        // relay, never re-delegate.
+                        let _ = self
+                            .deps
+                            .delegations
+                            .drain(orchestrator::MAX_DELEGATIONS_PER_TURN);
+                        operator_reply = relay.reply;
+                        operator_steps.extend(relay.steps);
+                    }
                     // Re-skin any MCP tool-call failures (from the orchestrator
-                    // turn or a delegated desk turn) as error steps on the
-                    // operator bubble — one surface, one renderer.
+                    // turn, a delegated desk turn, or the relay turn) as error
+                    // steps on the operator bubble — one surface, one renderer.
                     self.surface_mcp_failures(&mut operator_steps).await?;
                     channel_responses.push(OutboundMessage {
                         channel: "operator".to_string(),
-                        text: outcome.reply,
+                        text: operator_reply,
                         reply_to: None,
                         steps: operator_steps,
                     });
@@ -1368,7 +1463,10 @@ members = ["eng1", "eng2"]
             )
             .await
             .expect("delegation runs");
-        assert!(out.is_none(), "spawn_task surfaces no chat bubble");
+        assert!(
+            out.bubble.is_none() && out.desk_reply.is_none(),
+            "spawn_task surfaces nothing to relay or bubble"
+        );
 
         let cards = tasks.list(&CompanyId::new("acme")).await.unwrap();
         assert_eq!(cards.len(), 1);
@@ -1377,8 +1475,9 @@ members = ["eng1", "eng2"]
         assert_eq!(cards[0].assignee, "engineer");
     }
 
-    /// A `delegate_to_desk` delegation runs the desk lead and surfaces its reply
-    /// as its own bubble (`channel = <member id>`); an unknown desk is a no-op.
+    /// A `delegate_to_desk` delegation runs the desk lead and hands its reply
+    /// back to relay (a `DeskReply` attributed to the lead, no standalone
+    /// bubble); an unknown desk yields nothing.
     #[tokio::test]
     async fn delegate_to_desk_delegation_answers_as_the_desk_lead() {
         let dir = tempfile::tempdir().unwrap();
@@ -1399,12 +1498,17 @@ members = ["eng1", "eng2"]
                 None,
             )
             .await
-            .expect("delegation runs")
-            .expect("desk lead replies");
-        // The reply is its own bubble attributed to the desk lead, and the mock
-        // provider echoes the instruction, proving the member's turn ran.
-        assert_eq!(out.channel, "engineer");
-        assert!(out.text.contains("ship-marker"), "{:?}", out.text);
+            .expect("delegation runs");
+        // The answer comes back as a DeskReply to relay — not a standalone
+        // bubble — attributed to the desk lead, and the mock provider echoes the
+        // instruction, proving the member's turn ran.
+        assert!(
+            out.bubble.is_none(),
+            "the desk reply is relayed, not bubbled"
+        );
+        let desk = out.desk_reply.expect("desk lead replies");
+        assert_eq!(desk.member, "engineer");
+        assert!(desk.reply.contains("ship-marker"), "{:?}", desk.reply);
 
         // An unknown desk delegates to nobody.
         let none = brain
@@ -1417,7 +1521,10 @@ members = ["eng1", "eng2"]
             )
             .await
             .expect("delegation runs");
-        assert!(none.is_none(), "an unknown desk is a silent no-op");
+        assert!(
+            none.bubble.is_none() && none.desk_reply.is_none(),
+            "an unknown desk yields nothing"
+        );
     }
 
     // --- MCP failure drain --------------------------------------------------
@@ -1737,6 +1844,241 @@ members = ["eng1", "eng2"]
             .await
             .expect("cancellation is handled");
 
-        assert!(result.is_none(), "cancelled delegation must not bubble");
+        assert!(
+            result.bubble.is_none() && result.desk_reply.is_none(),
+            "cancelled delegation must not bubble or relay"
+        );
+    }
+
+    // --- CEO-relay hand-back (delegate_to_desk second turn) ------------------
+
+    /// A provider that simulates the orchestrator queuing a `delegate_to_desk`
+    /// on its turns: on each invoke it pops the next scripted delegation (if any)
+    /// onto the shared queue — exactly what the real tool call does — then echoes
+    /// the last user message so a test can read the turn's reply. Sharing the
+    /// queue handle with [`HarnessDeps::delegations`] is what lets the brain
+    /// drain it after the turn.
+    struct DelegatingProvider {
+        queue: orchestrator::DelegationQueue,
+        pushes: StdMutex<VecDeque<Option<Delegation>>>,
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ChatModel<()> for DelegatingProvider {
+        async fn invoke(
+            &self,
+            _state: &(),
+            request: ModelRequest,
+        ) -> tinyagents::Result<ModelResponse> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if let Some(Some(delegation)) = self.pushes.lock().unwrap().pop_front() {
+                self.queue.push(delegation);
+            }
+            let message = request
+                .messages
+                .iter()
+                .rev()
+                .find(|m| matches!(m, Message::User(_)))
+                .map(|m| m.text())
+                .unwrap_or_default();
+            Ok(ModelResponse::assistant(format!("did: {message}")))
+        }
+    }
+
+    impl HarnessModel for DelegatingProvider {
+        fn telemetry_provider_id(&self) -> String {
+            "delegating".to_string()
+        }
+    }
+
+    /// A brain over the desk-bearing record whose provider is a
+    /// [`DelegatingProvider`] scripted to push `pushes[i]` on invoke `i + 1`.
+    /// Returns the brain plus the shared provider so a test can read the invoke
+    /// count.
+    fn brain_that_delegates(
+        dir: &std::path::Path,
+        pushes: Vec<Option<Delegation>>,
+    ) -> (HarnessBrain, Arc<DelegatingProvider>) {
+        let queue = orchestrator::DelegationQueue::default();
+        let provider = Arc::new(DelegatingProvider {
+            queue: queue.clone(),
+            pushes: StdMutex::new(pushes.into_iter().collect()),
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let deps = HarnessDeps {
+            provider: provider.clone(),
+            provider_slug: "delegating".to_string(),
+            context: Arc::new(FsContextStore::new(dir)),
+            store: Arc::new(FsCompanyStore::new(dir)),
+            meter: None,
+            workspace_root: dir.to_path_buf(),
+            model_override: None,
+            tasks: Some(Arc::new(FsOps::new(dir))),
+            skills: None,
+            skills_source_dir: None,
+            mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: queue,
+            workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
+            mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            workflow_source_dir: None,
+            plan: None,
+            media: None,
+            composio: None,
+            steer: crate::company::steer::InflightRegistry::default(),
+        };
+        (
+            HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record_with_desk()),
+            provider,
+        )
+    }
+
+    /// (a) After a `delegate_to_desk`, the operator-facing reply is a SECOND
+    /// orchestrator turn that relays the teammate's answer — one coherent
+    /// bubble, not a disconnected sibling.
+    #[tokio::test]
+    async fn delegate_to_desk_relays_the_answer_in_a_second_orchestrator_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        // Invoke 1 (orchestrator) queues a delegate_to_desk; invoke 2 is the desk
+        // lead's turn; invoke 3 is the relay turn (queues nothing).
+        let (brain, provider) = brain_that_delegates(
+            dir.path(),
+            vec![Some(Delegation::DelegateToDesk {
+                desk: "eng_desk".to_string(),
+                instruction: "diagnose the outage".to_string(),
+            })],
+        );
+
+        let result = brain
+            .run_cycle(
+                request(vec![CompanyEvent::OperatorMessage {
+                    text: "why is the site down?".into(),
+                    by: None,
+                    chat: None,
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        // The operator sees ONE bubble — the CEO's relay, not a separate teammate
+        // sibling bubble.
+        assert_eq!(result.channel_responses.len(), 1);
+        let bubble = &result.channel_responses[0];
+        assert_eq!(bubble.channel, "operator");
+        // Three turns ran: orchestrator → desk lead → exactly one relay turn.
+        assert_eq!(
+            provider.calls.load(std::sync::atomic::Ordering::SeqCst),
+            3,
+            "orchestrator, desk lead, then exactly one relay turn"
+        );
+        // The relayed bubble carries the teammate's answer (the desk lead echoed
+        // its instruction, and the relay prompt embeds that reply under an
+        // `engineer replied:` frame) — proving the operator reply is the SECOND
+        // turn relaying the teammate, not the pre-delegation first reply.
+        assert!(
+            bubble.text.contains("engineer replied:")
+                && bubble.text.contains("diagnose the outage"),
+            "the relay carries the teammate's answer: {:?}",
+            bubble.text
+        );
+        // …and it is the relay turn, whose prompt framed the hand-back.
+        assert!(
+            bubble.text.contains("Relay their answer"),
+            "the operator bubble is the relay turn: {:?}",
+            bubble.text
+        );
+    }
+
+    /// (b) The relay turn cannot re-delegate: a delegation it queues is
+    /// discarded, so no further desk turn or relay runs (cost stays bounded to
+    /// one extra turn).
+    #[tokio::test]
+    async fn the_relay_turn_cannot_re_delegate() {
+        let dir = tempfile::tempdir().unwrap();
+        // Invoke 1 queues a delegation; invoke 3 (the relay) ALSO tries to queue
+        // one — which must be discarded, so no fourth/fifth turn runs.
+        let (brain, provider) = brain_that_delegates(
+            dir.path(),
+            vec![
+                Some(Delegation::DelegateToDesk {
+                    desk: "eng_desk".to_string(),
+                    instruction: "first".to_string(),
+                }),
+                None, // the desk lead's turn queues nothing
+                Some(Delegation::DelegateToDesk {
+                    desk: "eng_desk".to_string(),
+                    instruction: "second".to_string(),
+                }),
+            ],
+        );
+
+        let result = brain
+            .run_cycle(
+                request(vec![CompanyEvent::OperatorMessage {
+                    text: "handle it".into(),
+                    by: None,
+                    chat: None,
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        // Exactly three turns: orchestrator, desk lead, relay. The relay's queued
+        // delegation was dropped — no fourth (desk-lead) or fifth (relay) turn.
+        assert_eq!(
+            provider.calls.load(std::sync::atomic::Ordering::SeqCst),
+            3,
+            "the relay turn's delegation is discarded — one extra turn, no loop"
+        );
+        // The discard actually emptied the queue (not left dirty for next cycle).
+        assert_eq!(
+            brain.deps.delegations.queued(),
+            0,
+            "the relay turn's queued delegation was discarded"
+        );
+        // Still exactly one operator bubble.
+        assert_eq!(result.channel_responses.len(), 1);
+        assert_eq!(result.channel_responses[0].channel, "operator");
+    }
+
+    /// (c) A normal, non-delegating message still produces exactly one turn — the
+    /// relay path is entered only when a `delegate_to_desk` actually answered.
+    #[tokio::test]
+    async fn a_non_delegating_message_runs_exactly_one_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        // No scripted delegations → the orchestrator answers directly.
+        let (brain, provider) = brain_that_delegates(dir.path(), Vec::new());
+
+        let result = brain
+            .run_cycle(
+                request(vec![CompanyEvent::OperatorMessage {
+                    text: "status?".into(),
+                    by: None,
+                    chat: None,
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        assert_eq!(
+            provider.calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "no delegation → a single orchestrator turn, no relay"
+        );
+        assert_eq!(result.channel_responses.len(), 1);
+        assert_eq!(result.channel_responses[0].channel, "operator");
+        assert!(
+            result.channel_responses[0].text.contains("status?"),
+            "{:?}",
+            result.channel_responses[0].text
+        );
     }
 }


### PR DESCRIPTION
## Summary
Closes the delegation loop so the CEO actually **relays a teammate's answer back to the operator**. Before, when the orchestrator delegated via `delegate_to_desk`, the CEO's own reply bubble was finalized **before** the teammate ran, and the teammate's answer came back as a separate sibling bubble — the operator saw two disconnected bubbles ("on it" + the answer), never a CEO that came back with the answer.

Now: the teammate's reply is fed back and the orchestrator runs **one** additional turn that relays it, so the operator sees a single coherent CEO bubble carrying the answer.

Part of the #151 delegation series (this is the synchronous `delegate_to_desk` hand-back; the async `spawn_task` post-back is #163, already merged).

## Problem
`HarnessBrain::run_cycle` ran the orchestrator turn first and pushed its reply, then drained delegations and emitted each teammate reply as its own `OutboundMessage` (sibling bubble). The orchestrator was never re-invoked with the teammate's answer, so it could not relay anything.

## Solution
- `run_delegation` (`DelegateToDesk` arm) now returns the teammate's reply (a `DeskReply { member, reply, steps }`) to the caller instead of only emitting a standalone bubble.
- `run_cycle` (`OperatorMessage` branch): after a `delegate_to_desk` reply is captured, run **exactly one** more orchestrator turn whose prompt = the operator's original message + the teammate reply framed as "You delegated this to <member>. They replied: <reply>. Relay their answer… Do not delegate again." That relay turn's reply replaces the pre-delegation bubble as the operator-facing message; the teammate's steps are folded onto that bubble.
- **Relay-only, loop-safe:** the relay turn cannot re-delegate — the delegation queue is cleared before it and any queued delegation from it is drained-and-discarded, bounding cost to exactly one extra turn per cycle.
- No delegation → unchanged single-turn behavior. `spawn_task` (async) is untouched.

## Submission Checklist
- [x] `cargo check` (default) passes
- [x] `cargo check --features openhuman,mcp,composio` passes
- [x] `cargo test --features openhuman --lib harness::brain` passes (29/0; 3 new tests)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --features openhuman --lib` clean (brain.rs)
- [ ] Live delegation smoke on a build with a real inference key — pending (echo brain can't exercise delegation)

## Impact
Delegation via a desk now reads as a real hand-back: the CEO comes back with the teammate's answer in one bubble. Cost bounded to one extra orchestrator turn per `delegate_to_desk`; no re-delegation loop possible.

## Related
Part of #151. Complements #163 (async post-back). Fixes the "agent replies promised in chat never arrive back" behavior from 7/29 testing.