### PR TITLE
feat(delegation): brain-agnostic seam + hosted-path delegation + handed-task awareness (#176)

### DIFF
--- a/src/brain/hosted/test.rs
+++ b/src/brain/hosted/test.rs
@@ -503,3 +503,191 @@ async fn e2e_supervised_effect_parks_and_acks_not_ok() {
 
     tokio::fs::remove_dir_all(&home).await.ok();
 }
+
+// ---------------------------------------------------------------------------
+// Issue #176: hosted-path delegation (durable async hand-off, no local
+// cognition) + handed-task awareness.
+// ---------------------------------------------------------------------------
+
+/// A manifest with an Engineering desk (`eng`) whose lead is `eng1`, plus a
+/// hosted brain. Used to prove hosted `delegate_to_desk` resolves the desk and
+/// records the hand-off against it.
+fn desk_manifest() -> CompanyManifest {
+    let toml_src = r#"
+        [company]
+        name = "Acme"
+
+        [brain]
+        mode = "hosted"
+
+        [tools]
+        allow = ["noop"]
+
+        [policy]
+        mode = "full"
+
+        [[agent]]
+        id = "chief"
+        role = "Chief"
+        tier = "orchestrator"
+
+        [[agent]]
+        id = "eng1"
+        role = "Engineer"
+
+        [[group_chat]]
+        id = "eng"
+        name = "Engineering"
+        members = ["eng1"]
+        "#;
+    toml::from_str(toml_src).expect("valid manifest")
+}
+
+/// The hosted catalog registered with Medulla must advertise the delegation
+/// tools on top of the manifest's own `tools.allow`, so a hosted company's
+/// orchestrator can actually delegate.
+#[tokio::test]
+async fn e2e_hosted_catalog_advertises_delegation_tools() {
+    let home = tmp_home();
+    let transport = Arc::new(MockTransport::new());
+    let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
+        .with_brain_mode(BrainMode::Hosted)
+        .with_credential(SecretValue("th_live".into()))
+        .with_transport(transport.clone())
+        .build()
+        .await
+        .unwrap();
+
+    rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+        text: "hi".into(),
+        by: None,
+        chat: None,
+    }])
+    .await
+    .unwrap();
+
+    let registered = transport.registered_tools();
+    assert_eq!(registered.len(), 1, "tools register exactly once");
+    let names: Vec<&str> = registered[0].iter().map(|e| e.name.as_str()).collect();
+    assert!(names.contains(&"noop"), "manifest tool kept: {names:?}");
+    assert!(
+        names.contains(&"spawn_task"),
+        "spawn_task advertised: {names:?}"
+    );
+    assert!(
+        names.contains(&"delegate_to_desk"),
+        "delegate_to_desk advertised: {names:?}"
+    );
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+/// Medulla emitting a `spawn_task` tool-call on the hosted path opens a durable
+/// board card device-side and answers ok — no local cognition needed.
+#[tokio::test]
+async fn e2e_spawn_task_tool_call_opens_a_board_card() {
+    let home = tmp_home();
+    let transport = Arc::new(MockTransport::new());
+    transport.script_cycle(
+        runtime_cid(),
+        vec![tool_call_frame(
+            "spawn_task",
+            0,
+            json!({ "title": "Ship the invoice flow", "assignee": "eng" }),
+        )],
+    );
+
+    let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
+        .with_brain_mode(BrainMode::Hosted)
+        .with_credential(SecretValue("th_live".into()))
+        .with_transport(transport.clone())
+        .build()
+        .await
+        .unwrap();
+
+    rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+        text: "open a task to ship invoicing".into(),
+        by: None,
+        chat: None,
+    }])
+    .await
+    .unwrap();
+
+    // The tool was answered ok.
+    let answers = transport.tool_answers();
+    assert_eq!(answers.len(), 1);
+    assert!(answers[0].ok, "spawn_task answered ok: {:?}", answers[0]);
+
+    // A durable card landed on the board.
+    let cards = rt.tasks().list(rt.id()).await.unwrap();
+    assert_eq!(cards.len(), 1, "one card opened: {cards:?}");
+    assert_eq!(cards[0].title, "Ship the invoice flow");
+    assert_eq!(cards[0].assignee, "eng");
+    assert_eq!(cards[0].column, "backlog");
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+/// Medulla emitting a `delegate_to_desk` tool-call resolves the desk and records
+/// a durable hand-off card assigned to that desk (so it surfaces when the desk
+/// is asked directly). An unknown desk is a clean tool error, not a lost card.
+#[tokio::test]
+async fn e2e_delegate_to_desk_tool_call_writes_a_handoff_card() {
+    let home = tmp_home();
+    let transport = Arc::new(MockTransport::new());
+    transport.script_cycle(
+        runtime_cid(),
+        vec![
+            tool_call_frame(
+                "delegate_to_desk",
+                0,
+                json!({ "desk": "Engineering", "instruction": "build the invoice importer" }),
+            ),
+            tool_call_frame(
+                "delegate_to_desk",
+                1,
+                json!({ "desk": "Nonexistent", "instruction": "do a thing" }),
+            ),
+        ],
+    );
+
+    let rt = RuntimeBuilder::new(home.clone(), desk_manifest())
+        .with_brain_mode(BrainMode::Hosted)
+        .with_credential(SecretValue("th_live".into()))
+        .with_transport(transport.clone())
+        .build()
+        .await
+        .unwrap();
+
+    rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+        text: "have engineering build invoicing".into(),
+        by: None,
+        chat: None,
+    }])
+    .await
+    .unwrap();
+
+    let answers = transport.tool_answers();
+    assert_eq!(answers.len(), 2);
+    // First hand-off resolved the desk by name and succeeded.
+    assert!(answers[0].ok, "known desk hands off ok: {:?}", answers[0]);
+    // Unknown desk answered ok:false (clean error) and wrote no card.
+    assert!(
+        !answers[1].ok,
+        "unknown desk is a clean error: {:?}",
+        answers[1]
+    );
+
+    let cards = rt.tasks().list(rt.id()).await.unwrap();
+    assert_eq!(cards.len(), 1, "only the known desk got a card: {cards:?}");
+    // Assigned to the resolved desk id, with the lead recorded in the note.
+    assert_eq!(cards[0].assignee, "eng");
+    let note = cards[0].note.as_deref().unwrap_or_default();
+    assert!(note.contains("eng1"), "note records the lead: {note}");
+    assert!(
+        note.contains("build the invoice importer"),
+        "note carries the instruction"
+    );
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -23,8 +23,15 @@ use async_trait::async_trait;
 
 use crate::Result;
 use crate::company::steer::{InflightEntry, InflightKind, SteerAction, cap_redirect};
-use crate::harness::orchestrator::{self, Delegation};
+use crate::harness::orchestrator;
+// `Delegation` is only named by the test-only `run_delegation` wrapper and the
+// delegation tests (via `use super::*`); the cycle path drives the runner's
+// `handle_operator_message` and never spells the type out.
+#[cfg(test)]
+use crate::harness::orchestrator::Delegation;
+use crate::harness::run_turn::HarnessRunTurn;
 use crate::harness::{HarnessDeps, HarnessPool};
+use crate::runtime::delegation::{self, DelegationRunner, RunTurn};
 
 /// The most operator redirects honored within a single task dispatch (issue
 /// #111). A redirect re-runs the turn in-loop with the fresh instruction
@@ -42,7 +49,7 @@ use crate::ports::types::{
     CompanyEvent, CompanyRecord, CompressedTrace, CycleRequest, CycleResult, OutboundMessage,
     TokenUsage, TurnStep, TurnStepKind, TurnStepStatus,
 };
-use crate::ports::{TaskRecord, generate_id, now_millis};
+use crate::ports::{TaskRecord, now_millis};
 
 /// A [`Brain`] that answers with a live openhuman agent turn.
 pub struct HarnessBrain {
@@ -50,32 +57,6 @@ pub struct HarnessBrain {
     deps: HarnessDeps,
     record: CompanyRecord,
     responder: String,
-}
-
-/// The outcome of draining one queued delegation.
-///
-/// A `spawn_task` yields nothing operator-visible (it only opens a board card).
-/// A synchronous `delegate_to_desk` yields a [`DeskReply`] — the teammate's
-/// answer captured so the orchestrator can **relay** it in a follow-up turn
-/// (the CEO-relay hand-back) instead of leaving it as a disconnected sibling
-/// bubble. `bubble` stays for any future delegation that surfaces its own
-/// standalone message directly.
-#[derive(Default)]
-struct DelegationOutcome {
-    /// A chat bubble to surface as-is (unused by the current delegations).
-    bubble: Option<OutboundMessage>,
-    /// A synchronous desk reply to relay through a second orchestrator turn.
-    desk_reply: Option<DeskReply>,
-}
-
-/// A synchronous desk-lead answer captured for the orchestrator to relay: which
-/// member answered, their reply text, and their own turn steps (folded onto the
-/// operator timeline so the teammate's activity stays visible on the single
-/// relayed bubble).
-struct DeskReply {
-    member: String,
-    reply: String,
-    steps: Vec<TurnStep>,
 }
 
 impl HarnessBrain {
@@ -152,19 +133,16 @@ impl HarnessBrain {
         let mut instruction = base_instruction.clone();
         let mut redirects: u32 = 0;
 
+        // Route the background turn through the brain-agnostic `RunTurn` seam
+        // (issue #176), re-attaching `HarnessDeps` behind `HarnessRunTurn`.
+        let run_turn = HarnessRunTurn::new(&self.pool, &self.deps);
+
         loop {
-            let outcome = self
-                .pool
+            let outcome = run_turn
                 // A dispatched task card carries no chat bubble (its steps are
                 // discarded into the note), so its live turn frames must not leak
                 // onto the console timeline — run it un-streamed (#125 review).
-                .run_steered_background(
-                    &self.record.id,
-                    &responder,
-                    &instruction,
-                    &self.deps,
-                    &control,
-                )
+                .run_steered_background(&self.record.id, &responder, &instruction, &control)
                 .await;
             // One-shot read of what (if anything) the operator asked for. `None`
             // is the ordinary, unsteered path.
@@ -323,14 +301,10 @@ impl HarnessBrain {
     /// agent or a team-overlay teammate, so an overlay-added lead is reachable on
     /// a desk the manifest left empty.
     fn desk_lead(&self, desk: &str) -> Option<String> {
-        // Resolve the desk key (id or case-insensitive name) against both the
-        // manifest desks and the operator-created overlay desks, so a
-        // runtime-created desk routes exactly like a blueprint one.
-        let desk_id = self.record.resolve_desk_id(desk)?;
-        self.record
-            .effective_desk_members(&desk_id)
-            .into_iter()
-            .find(|m| self.record.is_roster_agent(m))
+        // Desk-lead resolution is brain-agnostic — it reads only `CompanyRecord`
+        // — so it lives on the delegation seam (issue #176); this stays a thin
+        // wrapper for the routing callers on the brain.
+        delegation::desk_lead(&self.record, desk)
     }
 
     /// Drains the MCP failure queue **onto the operator bubble's step timeline**
@@ -443,102 +417,41 @@ impl HarnessBrain {
     /// lead) or a cancelled run yields nothing to relay. No sub-agent
     /// re-delegation in v1: desk members carry no delegation tools, so their
     /// turns queue nothing.
+    ///
+    /// The orchestration lives on the brain-agnostic seam (issue #176); this is
+    /// a thin wrapper that re-attaches `HarnessDeps` behind a
+    /// [`HarnessRunTurn`] and drives a [`DelegationRunner`]. It exists only to
+    /// keep the delegation tests exercising the same code path the cycle drives
+    /// through [`DelegationRunner::handle_operator_message`], so it is
+    /// test-only — the cycle never calls it directly.
+    #[cfg(test)]
     async fn run_delegation(
         &self,
         delegation: Delegation,
         chat_id: Option<&str>,
-    ) -> Result<DelegationOutcome> {
-        match delegation {
-            Delegation::SpawnTask {
-                title,
-                note,
-                assignee,
-            } => {
-                let Some(tasks) = self.deps.tasks.as_ref() else {
-                    return Ok(DelegationOutcome::default());
-                };
-                let card = TaskRecord {
-                    id: generate_id(),
-                    title,
-                    note,
-                    column: "backlog".to_string(),
-                    priority: "medium".to_string(),
-                    assignee: assignee.unwrap_or_default(),
-                    updated_at_millis: now_millis(),
-                    // Issue #151 §3.2: remember which conversation asked for
-                    // this, so the completion can answer there instead of only
-                    // landing in the note.
-                    origin_chat_id: chat_id.map(str::to_string),
-                };
-                tasks.upsert(&self.record.id, &card).await?;
-                Ok(DelegationOutcome::default())
-            }
-            Delegation::DelegateToDesk { desk, instruction } => {
-                let Some(member) = self.desk_lead(&desk) else {
-                    return Ok(DelegationOutcome::default());
-                };
-                // Register the delegated turn so an operator can CANCEL it
-                // mid-flight (cancel-only in v1 — pause/redirect are rejected at
-                // the route). RAII guard deregisters on every exit path.
-                let guard = self.deps.steer.register(
-                    &self.record.id,
-                    InflightEntry {
-                        key: generate_id(),
-                        task_id: None,
-                        kind: InflightKind::Delegation,
-                        title: desk.clone(),
-                        agent_id: member.clone(),
-                        started_at_millis: now_millis(),
-                        pending_action: None,
-                    },
-                );
-                let control = guard.control().clone();
-                let outcome = self
-                    .pool
-                    .run_steered(
-                        &self.record.id,
-                        &member,
-                        &instruction,
-                        &self.deps,
-                        &control,
-                        chat_id,
-                    )
-                    .await?;
-                // A cancel issued mid-flight discards the delegated reply —
-                // nothing is relayed.
-                if matches!(control.take(), Some(SteerAction::Cancel)) {
-                    return Ok(DelegationOutcome::default());
-                }
-                // Hand the teammate's answer back to the caller to RELAY through
-                // a second orchestrator turn (the CEO-relay hand-back). Their
-                // steps ride along and get folded onto the relayed operator
-                // bubble so the teammate's activity stays visible.
-                Ok(DelegationOutcome {
-                    bubble: None,
-                    desk_reply: Some(DeskReply {
-                        member,
-                        reply: outcome.reply,
-                        steps: outcome.steps,
-                    }),
-                })
-            }
-        }
+    ) -> Result<delegation::DelegationOutcome> {
+        let run_turn = HarnessRunTurn::new(&self.pool, &self.deps);
+        self.delegation_runner(&run_turn)
+            .run_delegation(delegation, chat_id)
+            .await
     }
-}
 
-/// The prompt for the CEO-relay hand-back turn: the operator's original message
-/// plus each teammate's reply, framed so the orchestrator relays the answer back
-/// as its own single, coherent response and does not delegate again.
-fn build_relay_prompt(original: &str, desk_replies: &[(String, String)]) -> String {
-    let mut prompt = format!(
-        "The operator asked:\n{original}\n\nYou delegated this to your team and their reply is \
-below. Relay their answer back to the operator now as your own single, coherent response — \
-summarize it or pass it along. Do not delegate again; just relay what came back."
-    );
-    for (member, reply) in desk_replies {
-        prompt.push_str(&format!("\n\n{member} replied:\n{reply}"));
+    /// Builds a [`DelegationRunner`] over `run_turn`, threading the brain-agnostic
+    /// handles it needs — the record (desk-lead resolution), the task store, the
+    /// steer registry, the company id, and the shared delegation queue the turn
+    /// pushes onto. `HarnessDeps` never crosses the seam; it stays behind
+    /// `run_turn`.
+    fn delegation_runner<'a>(&'a self, run_turn: &'a HarnessRunTurn<'a>) -> DelegationRunner<'a> {
+        DelegationRunner::new(
+            run_turn,
+            &self.record,
+            self.deps.tasks.as_ref(),
+            &self.deps.steer,
+            &self.record.id,
+            &self.deps.delegations,
+            orchestrator::MAX_DELEGATIONS_PER_TURN,
+        )
     }
-    prompt
 }
 
 /// The turn instruction for a dispatched card: its title, plus its note when it
@@ -628,79 +541,21 @@ impl Brain for HarnessBrain {
                     // in this cycle rides the same operator thread, so it gets the
                     // same id.
                     let chat_id = chat.as_deref();
-                    // Clear stale delegations + MCP failures so nothing leaks from
-                    // a prior turn, run the turn (metered through `deps`), then
-                    // drain whatever the orchestrator queued (capped; discarded
-                    // past the cap).
-                    self.deps.delegations.clear();
+                    // Clear stale MCP failures so nothing leaks from a prior turn
+                    // (the delegation queue is cleared inside the runner, right
+                    // before the orchestrator turn).
                     self.deps.mcp_failures.clear();
-                    let outcome = self
-                        .pool
-                        .run(&self.record.id, &responder, text, &self.deps, chat_id)
+                    // Drive the brain-agnostic delegation seam (issue #176): the
+                    // orchestrator turn, its queued delegations, and the CEO-relay
+                    // hand-back all run behind the `RunTurn` impl. `HarnessDeps` is
+                    // re-attached behind `HarnessRunTurn`.
+                    let run_turn = HarnessRunTurn::new(&self.pool, &self.deps);
+                    let turn = self
+                        .delegation_runner(&run_turn)
+                        .handle_operator_message(&responder, text, chat_id)
                         .await?;
-                    // The orchestrator's own steps ride on the operator bubble;
-                    // its reply is the operator-facing text UNLESS a synchronous
-                    // desk delegation runs, in which case the relay turn's reply
-                    // replaces it (below).
-                    let mut operator_steps = outcome.steps;
-                    let mut operator_reply = outcome.reply;
-                    // Run whatever the orchestrator queued. A `spawn_task` opens a
-                    // card silently; a `delegate_to_desk` runs the desk lead and
-                    // hands its answer back to RELAY (the CEO-relay hand-back)
-                    // rather than surfacing as a disconnected sibling bubble. Any
-                    // future delegation that surfaces its own bubble lands in
-                    // `delegated`.
-                    let mut delegated = Vec::new();
-                    let mut desk_replies: Vec<(String, String)> = Vec::new();
-                    for delegation in self
-                        .deps
-                        .delegations
-                        .drain(orchestrator::MAX_DELEGATIONS_PER_TURN)
-                    {
-                        let out = self.run_delegation(delegation, chat_id).await?;
-                        if let Some(bubble) = out.bubble {
-                            delegated.push(bubble);
-                        }
-                        if let Some(desk) = out.desk_reply {
-                            // Fold the teammate's activity onto the operator
-                            // timeline, then remember the answer to relay.
-                            operator_steps.extend(desk.steps);
-                            desk_replies.push((desk.member, desk.reply));
-                        }
-                    }
-                    // CEO-relay hand-back: when a synchronous desk delegation
-                    // answered, run exactly ONE more orchestrator turn whose
-                    // prompt is the original message plus the teammate reply,
-                    // and surface THAT as the operator bubble — so the CEO comes
-                    // back with the answer in one coherent conversation. The
-                    // relay turn must not re-delegate: its prompt is relay-only,
-                    // and as a safety net the delegation queue is cleared before
-                    // it and drained-and-discarded after, so anything it tries
-                    // to queue is dropped (bounding cost to one extra turn, no
-                    // re-delegation loop). No delegation → the single first turn
-                    // stays exactly as before.
-                    if !desk_replies.is_empty() {
-                        let relay_prompt = build_relay_prompt(text, &desk_replies);
-                        self.deps.delegations.clear();
-                        let relay = self
-                            .pool
-                            .run(
-                                &self.record.id,
-                                &responder,
-                                &relay_prompt,
-                                &self.deps,
-                                chat_id,
-                            )
-                            .await?;
-                        // Discard anything the relay turn queued — it can only
-                        // relay, never re-delegate.
-                        let _ = self
-                            .deps
-                            .delegations
-                            .drain(orchestrator::MAX_DELEGATIONS_PER_TURN);
-                        operator_reply = relay.reply;
-                        operator_steps.extend(relay.steps);
-                    }
+                    let mut operator_steps = turn.steps;
+                    let operator_reply = turn.reply;
                     // Re-skin any MCP tool-call failures (from the orchestrator
                     // turn, a delegated desk turn, or the relay turn) as error
                     // steps on the operator bubble — one surface, one renderer.
@@ -711,7 +566,7 @@ impl Brain for HarnessBrain {
                         reply_to: None,
                         steps: operator_steps,
                     });
-                    channel_responses.extend(delegated);
+                    channel_responses.extend(turn.bubbles);
                 }
                 CompanyEvent::TaskDispatched { task_id } => {
                     if let Some(message) = self.run_task(task_id).await? {

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -47,6 +47,7 @@ pub mod memory_loop;
 pub mod orchestrator;
 pub mod policy;
 pub mod provider;
+pub mod run_turn;
 pub mod skills;
 pub mod steer;
 pub mod steps;

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -73,10 +73,10 @@ const FACT_LIMIT: usize = 20;
 
 /// The `query_company` tool name.
 pub const QUERY_COMPANY_TOOL: &str = "query_company";
-/// The `spawn_task` tool name.
-pub const SPAWN_TASK_TOOL: &str = "spawn_task";
-/// The `delegate_to_desk` tool name.
-pub const DELEGATE_TO_DESK_TOOL: &str = "delegate_to_desk";
+// The `spawn_task` / `delegate_to_desk` names are the brain-agnostic canonical
+// constants (issue #176) — re-exported here so the harness path and the hosted
+// path share one definition and cannot drift.
+pub use crate::runtime::delegation_tools::{DELEGATE_TO_DESK_TOOL, SPAWN_TASK_TOOL};
 /// The `run_workflow` tool name (issue #67).
 pub const RUN_WORKFLOW_TOOL: &str = "run_workflow";
 /// The `add_agent` tool name (issue #71 — Active Runtime Teammates).
@@ -447,16 +447,7 @@ impl Tool for SpawnTaskTool {
     }
 
     fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "title": { "type": "string", "description": "The task title." },
-                "note": { "type": "string", "description": "An optional longer brief." },
-                "assignee": { "type": "string", "description": "An optional desk/teammate id to own it." }
-            },
-            "required": ["title"],
-            "additionalProperties": false
-        })
+        crate::runtime::delegation_tools::spawn_task_schema()
     }
 
     fn permission_level(&self) -> PermissionLevel {
@@ -520,15 +511,7 @@ impl Tool for DelegateToDeskTool {
     }
 
     fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "desk": { "type": "string", "description": "The desk id or name to delegate to." },
-                "instruction": { "type": "string", "description": "The instruction for the desk's lead member." }
-            },
-            "required": ["desk", "instruction"],
-            "additionalProperties": false
-        })
+        crate::runtime::delegation_tools::delegate_to_desk_schema()
     }
 
     fn permission_level(&self) -> PermissionLevel {

--- a/src/harness/run_turn.rs
+++ b/src/harness/run_turn.rs
@@ -1,0 +1,71 @@
+//! [`HarnessRunTurn`]: the harness's [`RunTurn`] implementation.
+//!
+//! Wraps a [`HarnessPool`] and the [`HarnessDeps`] every turn draws on, and
+//! forwards each [`RunTurn`] method to the matching `pool.run*` call — the one
+//! place [`HarnessDeps`] is re-attached to the brain-agnostic delegation seam
+//! (issue #176). Both are borrowed, so the shared delegation queue and steer
+//! registry inside `deps` stay the very handles the
+//! [`DelegationRunner`](crate::runtime::delegation::DelegationRunner) drains.
+//!
+//! Compiled only under `feature = "openhuman"`.
+
+use async_trait::async_trait;
+
+use crate::Result;
+use crate::company::steer::SteerControl;
+use crate::harness::{HarnessDeps, HarnessPool, TurnOutcome};
+use crate::ports::types::CompanyId;
+use crate::runtime::delegation::RunTurn;
+
+/// The harness's [`RunTurn`]: re-attaches [`HarnessDeps`] onto each pool turn.
+pub struct HarnessRunTurn<'a> {
+    pool: &'a HarnessPool,
+    deps: &'a HarnessDeps,
+}
+
+impl<'a> HarnessRunTurn<'a> {
+    /// Wraps a pool + deps for one cycle's worth of turns.
+    pub fn new(pool: &'a HarnessPool, deps: &'a HarnessDeps) -> Self {
+        Self { pool, deps }
+    }
+}
+
+#[async_trait]
+impl RunTurn for HarnessRunTurn<'_> {
+    async fn run(
+        &self,
+        company: &CompanyId,
+        agent_id: &str,
+        message: &str,
+        chat_id: Option<&str>,
+    ) -> Result<TurnOutcome> {
+        self.pool
+            .run(company, agent_id, message, self.deps, chat_id)
+            .await
+    }
+
+    async fn run_steered(
+        &self,
+        company: &CompanyId,
+        agent_id: &str,
+        message: &str,
+        control: &SteerControl,
+        chat_id: Option<&str>,
+    ) -> Result<TurnOutcome> {
+        self.pool
+            .run_steered(company, agent_id, message, self.deps, control, chat_id)
+            .await
+    }
+
+    async fn run_steered_background(
+        &self,
+        company: &CompanyId,
+        agent_id: &str,
+        message: &str,
+        control: &SteerControl,
+    ) -> Result<TurnOutcome> {
+        self.pool
+            .run_steered_background(company, agent_id, message, self.deps, control)
+            .await
+    }
+}

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1031,7 +1031,7 @@ impl RuntimeBuilder {
                 if let Some(brain) = harness_brain {
                     brain
                 } else {
-                    let tool_catalog: Vec<ToolManifestEntry> = self
+                    let mut tool_catalog: Vec<ToolManifestEntry> = self
                         .manifest
                         .tools
                         .allow
@@ -1042,6 +1042,18 @@ impl RuntimeBuilder {
                             input_schema: None,
                         })
                         .collect();
+                    // Issue #176: advertise the delegation tools to Medulla on
+                    // the hosted path, so a hosted company's orchestrator can
+                    // delegate exactly as the harness one does. The device
+                    // services the resulting tool-call frames in `CycleHostImpl`
+                    // (a durable board-card hand-off) with no local cognition.
+                    // De-duped against `tools.allow` so a manifest that already
+                    // lists a delegation tool is not advertised twice.
+                    for entry in crate::runtime::delegation_tools::delegation_manifest_entries() {
+                        if !tool_catalog.iter().any(|e| e.name == entry.name) {
+                            tool_catalog.push(entry);
+                        }
+                    }
                     select_hosted_or_echo(
                         self.brain_mode.unwrap_or(BrainMode::Hosted),
                         self.credential,

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1815,7 +1815,7 @@ mod test {
         .await
         .unwrap();
 
-        let seen = seen.lock().unwrap();
+        let seen = seen.lock().unwrap().clone();
         assert_eq!(seen.len(), 2);
         assert!(
             seen[0].contains("Open work already handed to you")
@@ -1863,7 +1863,7 @@ mod test {
         }])
         .await
         .unwrap();
-        let seen = seen.lock().unwrap();
+        let seen = seen.lock().unwrap().clone();
         assert!(
             !seen[0].contains("Open work already handed to you"),
             "done cards are not surfaced as open work: {:?}",

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -25,13 +25,17 @@ use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
 use crate::feedback::tool::SEND_EMAIL_TOOL;
 use crate::ports::brain::CycleHost;
-use crate::ports::now_millis;
+use crate::ports::tasks::TaskRecord;
 use crate::ports::types::{
-    Actor, ApprovalId, CompanyEvent, CompanyId, ContextOp, ContextOpResult, CycleRequest, Effect,
-    EffectDisposition, EffectGroup, LedgerEntry, OutboundMessage, PolicyDecision, ToolCall,
-    ToolResult, Verdict,
+    Actor, ApprovalId, CompanyEvent, CompanyId, CompanyRecord, ContextOp, ContextOpResult,
+    CycleRequest, Effect, EffectDisposition, EffectGroup, LedgerEntry, OutboundMessage,
+    PolicyDecision, ToolCall, ToolResult, Verdict,
 };
+use crate::ports::{generate_id, now_millis};
 use crate::runtime::channel::OPERATOR_CHANNEL;
+use crate::runtime::delegation_tools::{
+    DELEGATE_TO_DESK_TOOL, DelegateArgs, SPAWN_TASK_TOOL, SpawnTaskArgs, desk_lead,
+};
 use crate::runtime::types::CycleReport;
 use crate::server::ops::mailer::{MailCredentials, OutboundEmail};
 
@@ -60,7 +64,7 @@ impl<'a> CycleRunner<'a> {
         self.run_locked(events).await
     }
 
-    async fn run_locked(&self, events: Vec<CompanyEvent>) -> Result<CycleReport> {
+    async fn run_locked(&self, mut events: Vec<CompanyEvent>) -> Result<CycleReport> {
         let company = self.rt.id.clone();
 
         // 2. Persist input — durable before any thinking.
@@ -79,7 +83,8 @@ impl<'a> CycleRunner<'a> {
             .recent_traces(&company, HISTORY_LIMIT)
             .await?;
         let context_index = self.rt.context.list(&company, "").await?;
-        let roster = match self.rt.store.load(&company).await? {
+        let record = self.rt.store.load(&company).await?;
+        let roster = match &record {
             Some(record) => record
                 .manifest
                 .agents
@@ -88,6 +93,17 @@ impl<'a> CycleRunner<'a> {
                 .collect(),
             None => Vec::new(),
         };
+
+        // Issue #176 (handed-task awareness): when an operator message is
+        // addressed to a desk/agent that already has open work handed to it,
+        // fold a briefing of that work into the message the brain sees — so a
+        // direct "what are you working on?" surfaces the handed task truthfully.
+        // Brain-agnostic (both brains read `req.events`); mutates only the
+        // in-memory copy handed to the brain, never the durable log persisted
+        // above.
+        if let Some(record) = &record {
+            self.inject_handed_task_awareness(record, &mut events).await;
+        }
 
         let cycle_id = crate::ports::generate_id();
         let request = CycleRequest {
@@ -123,6 +139,64 @@ impl<'a> CycleRunner<'a> {
             parked,
             persisted_seq,
         })
+    }
+
+    /// Folds a briefing of open handed work into any operator message addressed
+    /// to a desk/agent that owns it (issue #176, handed-task awareness). Reads
+    /// open task cards once and appends, to each addressed `OperatorMessage`,
+    /// the cards whose assignee resolves to the addressed target — so a direct
+    /// "what are you working on?" is answered truthfully. A no-op when nothing
+    /// is addressed or no open work matches. Mutates only the in-memory events
+    /// handed to the brain, never the durable event log.
+    async fn inject_handed_task_awareness(
+        &self,
+        record: &CompanyRecord,
+        events: &mut [CompanyEvent],
+    ) {
+        // Cheap exit before touching the task store: nothing is addressed.
+        if !events
+            .iter()
+            .any(|e| matches!(e, CompanyEvent::OperatorMessage { chat: Some(_), .. }))
+        {
+            return;
+        }
+        let cards = self.rt.tasks().list(&self.rt.id).await.unwrap_or_default();
+        let open: Vec<&TaskRecord> = cards
+            .iter()
+            .filter(|c| c.column != "done" && !c.assignee.trim().is_empty())
+            .collect();
+        if open.is_empty() {
+            return;
+        }
+        for event in events.iter_mut() {
+            let CompanyEvent::OperatorMessage {
+                text,
+                chat: Some(target),
+                ..
+            } = event
+            else {
+                continue;
+            };
+            let mut lines: Vec<String> = open
+                .iter()
+                .filter(|c| assignment_matches(record, target.as_str(), &c.assignee))
+                .map(|c| match &c.note {
+                    Some(note) if !note.trim().is_empty() => {
+                        format!("- {} — {}", c.title, first_line(note, 120))
+                    }
+                    _ => format!("- {}", c.title),
+                })
+                .collect();
+            if lines.is_empty() {
+                continue;
+            }
+            lines.sort();
+            text.push_str(&format!(
+                "\n\n[Open work already handed to you (answer truthfully if asked what you are \
+working on):\n{}\n]",
+                lines.join("\n")
+            ));
+        }
     }
 
     /// Resolves a parked approval, executes the effect on approval, and runs a
@@ -523,6 +597,147 @@ impl<'a> CycleHostImpl<'a> {
             }),
         }
     }
+
+    /// Services the `spawn_task` tool (issue #176): opens a tracked task card on
+    /// the company's board through the same [`TaskStore`](crate::ports::TaskStore)
+    /// path the console and the harness path use. A blank title is a clean tool
+    /// error rather than a silent no-op. The card is durable, so a later direct
+    /// query to its assignee surfaces it (handed-task awareness).
+    async fn spawn_task(&self, args: serde_json::Value) -> Result<ToolResult> {
+        let Some(parsed) = SpawnTaskArgs::parse(&args) else {
+            return Ok(ToolResult {
+                ok: false,
+                output: serde_json::json!({ "error": "spawn_task requires a non-empty title" }),
+            });
+        };
+        let card = TaskRecord {
+            id: generate_id(),
+            title: parsed.title.clone(),
+            note: parsed.note,
+            column: "backlog".to_string(),
+            priority: "medium".to_string(),
+            assignee: parsed.assignee.unwrap_or_default(),
+            updated_at_millis: now_millis(),
+            origin_chat_id: None,
+        };
+        self.rt.tasks().upsert(&self.company, &card).await?;
+        Ok(ToolResult {
+            ok: true,
+            output: serde_json::json!({
+                "status": "queued",
+                "task_id": card.id,
+                "title": parsed.title,
+            }),
+        })
+    }
+
+    /// Services the `delegate_to_desk` tool (issue #176) on the hosted path: a
+    /// *durable, asynchronous* hand-off. Resolves the target desk, writes a task
+    /// card assigned to that desk (so a later direct query to the desk surfaces
+    /// the handed work), and returns a summary the remote cognition relays to
+    /// the operator.
+    ///
+    /// This deliberately does NOT run the desk lead's turn: a hosted build has
+    /// no in-process cognition pool. The synchronous, one-voice relay the
+    /// harness performs needs Medulla multi-agent support and is tracked in
+    /// #176; the durable hand-off is the brain-agnostic capability that ships
+    /// now. An unknown desk is a clean tool error, not a lost hand-off.
+    async fn delegate_to_desk(&self, args: serde_json::Value) -> Result<ToolResult> {
+        let Some(parsed) = DelegateArgs::parse(&args) else {
+            return Ok(ToolResult {
+                ok: false,
+                output: serde_json::json!({
+                    "error": "delegate_to_desk requires a desk and an instruction"
+                }),
+            });
+        };
+        let record = self.rt.store.load(&self.company).await?;
+        let Some(desk_id) = record
+            .as_ref()
+            .and_then(|r| r.resolve_desk_id(&parsed.desk))
+        else {
+            return Ok(ToolResult {
+                ok: false,
+                output: serde_json::json!({
+                    "status": "unknown_desk",
+                    "error": format!("no desk matches \"{}\"", parsed.desk),
+                }),
+            });
+        };
+        // The desk's lead, when it has a roster-backed one, is recorded in the
+        // note; the card is assigned to the DESK so an operator asking the desk
+        // directly (chat targets the desk) sees the hand-off.
+        let lead = record.as_ref().and_then(|r| desk_lead(r, &parsed.desk));
+        let note = match &lead {
+            Some(member) => format!(
+                "Delegated to the {desk_id} desk (lead: {member}).\n\n{instruction}",
+                instruction = parsed.instruction
+            ),
+            None => format!(
+                "Delegated to the {desk_id} desk (no lead member on the roster yet).\n\n{instruction}",
+                instruction = parsed.instruction
+            ),
+        };
+        let card = TaskRecord {
+            id: generate_id(),
+            title: first_line(&parsed.instruction, 80),
+            note: Some(note),
+            column: "backlog".to_string(),
+            priority: "medium".to_string(),
+            assignee: desk_id.clone(),
+            updated_at_millis: now_millis(),
+            origin_chat_id: None,
+        };
+        self.rt.tasks().upsert(&self.company, &card).await?;
+        Ok(ToolResult {
+            ok: true,
+            output: serde_json::json!({
+                "status": "handed_off",
+                "desk": desk_id,
+                "lead": lead,
+                "task_id": card.id,
+            }),
+        })
+    }
+}
+
+/// The first non-empty line of `text`, trimmed and capped to `max` chars — the
+/// task-card title derived from a delegation instruction (which may be a whole
+/// paragraph). Falls back to a short cap of the whole string when there is no
+/// line break. UTF-8-safe: never slices mid-codepoint.
+fn first_line(text: &str, max: usize) -> String {
+    let line = text
+        .lines()
+        .find(|l| !l.trim().is_empty())
+        .unwrap_or(text)
+        .trim();
+    match line.char_indices().nth(max) {
+        Some((idx, _)) => format!("{}…", &line[..idx]),
+        None => line.to_string(),
+    }
+}
+
+/// Whether a task card assigned to `assignee` counts as "handed to" the target
+/// a direct operator message is addressed to (issue #176). Matches when the two
+/// are the same string (case-insensitively), resolve to the same desk, or the
+/// assignee is the addressed desk's lead — so a hand-off recorded against a desk
+/// id surfaces when the operator addresses that desk by id or name, and a card
+/// assigned to a person surfaces when that person is addressed.
+fn assignment_matches(record: &CompanyRecord, target: &str, assignee: &str) -> bool {
+    if assignee.eq_ignore_ascii_case(target) {
+        return true;
+    }
+    if let (Some(a), Some(b)) = (
+        record.resolve_desk_id(target),
+        record.resolve_desk_id(assignee),
+    ) && a == b
+    {
+        return true;
+    }
+    if let Some(lead) = desk_lead(record, target) {
+        return lead.eq_ignore_ascii_case(assignee);
+    }
+    false
 }
 
 #[async_trait]
@@ -530,6 +745,19 @@ impl CycleHost for CycleHostImpl<'_> {
     async fn call_tool(&self, call: ToolCall) -> Result<ToolResult> {
         if call.tool == SEND_EMAIL_TOOL {
             return self.send_email(call.args).await;
+        }
+        // Issue #176: service the delegation tools device-side so the hosted
+        // (Medulla) path can delegate. Unlike the harness path — which runs the
+        // desk lead's turn in-process and relays it in one voice — a hosted
+        // build has no local cognition pool, so the hand-off is *durable and
+        // asynchronous*: a board card the desk sees when asked directly. (The
+        // synchronous cross-agent cognition relay needs Medulla multi-agent
+        // support; tracked in #176.)
+        if call.tool == SPAWN_TASK_TOOL {
+            return self.spawn_task(call.args).await;
+        }
+        if call.tool == DELEGATE_TO_DESK_TOOL {
+            return self.delegate_to_desk(call.args).await;
         }
         // The provider enforces the manifest grant before any side effect.
         self.rt.tools.invoke(&self.company, call).await
@@ -1396,6 +1624,251 @@ mod test {
             .unwrap();
         assert_eq!(res.output["status"], "sent");
         assert_eq!(sender.sent().len(), 1);
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #176: delegation host arms + handed-task awareness.
+    // -----------------------------------------------------------------------
+
+    /// A manifest with an Engineering desk (`eng`, lead `eng1`) — for the desk
+    /// resolution paths of `delegate_to_desk` and the awareness matcher.
+    fn desk_manifest() -> CompanyManifest {
+        let toml_src = r#"
+            [company]
+            name = "Acme"
+
+            [[agent]]
+            id = "chief"
+            role = "Chief"
+            tier = "orchestrator"
+
+            [[agent]]
+            id = "eng1"
+            role = "Engineer"
+
+            [[group_chat]]
+            id = "eng"
+            name = "Engineering"
+            members = ["eng1"]
+
+            [policy]
+            mode = "full"
+            "#;
+        toml::from_str(toml_src).expect("parse desk manifest")
+    }
+
+    /// A brain that records the text of every operator message it is handed, so
+    /// a test can assert what awareness the kernel folded in before the brain.
+    struct CapturingBrain {
+        seen: Arc<StdMutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl Brain for CapturingBrain {
+        async fn run_cycle(&self, req: CycleRequest, _host: &dyn CycleHost) -> Result<CycleResult> {
+            for event in &req.events {
+                if let CompanyEvent::OperatorMessage { text, .. } = event {
+                    self.seen.lock().expect("seen").push(text.clone());
+                }
+            }
+            Ok(CycleResult {
+                channel_responses: Vec::new(),
+                new_traces: vec![CompressedTrace::now(&req.cycle_id, "capture")],
+                ledger_deltas: Vec::new(),
+                token_usage: TokenUsage::default(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_task_arm_opens_a_board_card() {
+        let home = tmp_home();
+        let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
+            .build()
+            .await
+            .unwrap();
+        let host = CycleHostImpl::new(rt.id().clone(), "cyc".into(), &rt);
+
+        let res = host
+            .spawn_task(serde_json::json!({ "title": "  Ship it ", "assignee": " eng " }))
+            .await
+            .unwrap();
+        assert!(res.ok);
+        assert_eq!(res.output["status"], "queued");
+
+        let cards = rt.tasks().list(rt.id()).await.unwrap();
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].title, "Ship it");
+        assert_eq!(cards[0].assignee, "eng");
+
+        // A blank title is a clean tool error, no card.
+        let bad = host
+            .spawn_task(serde_json::json!({ "title": "  " }))
+            .await
+            .unwrap();
+        assert!(!bad.ok);
+        assert_eq!(rt.tasks().list(rt.id()).await.unwrap().len(), 1);
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    #[tokio::test]
+    async fn delegate_to_desk_arm_records_handoff_and_rejects_unknown_desk() {
+        let home = tmp_home();
+        let rt = RuntimeBuilder::new(home.clone(), desk_manifest())
+            .build()
+            .await
+            .unwrap();
+        let host = CycleHostImpl::new(rt.id().clone(), "cyc".into(), &rt);
+
+        // Known desk (by name) → card assigned to the resolved desk id, lead noted.
+        let ok = host
+            .delegate_to_desk(
+                serde_json::json!({ "desk": "Engineering", "instruction": "build invoicing" }),
+            )
+            .await
+            .unwrap();
+        assert!(ok.ok);
+        assert_eq!(ok.output["desk"], "eng");
+        assert_eq!(ok.output["lead"], "eng1");
+
+        // Unknown desk → clean error, no card.
+        let bad = host
+            .delegate_to_desk(serde_json::json!({ "desk": "Legal", "instruction": "review" }))
+            .await
+            .unwrap();
+        assert!(!bad.ok);
+        assert_eq!(bad.output["status"], "unknown_desk");
+
+        let cards = rt.tasks().list(rt.id()).await.unwrap();
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].assignee, "eng");
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    #[tokio::test]
+    async fn call_tool_dispatches_delegation_tools() {
+        let home = tmp_home();
+        let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
+            .build()
+            .await
+            .unwrap();
+        let host = CycleHostImpl::new(rt.id().clone(), "cyc".into(), &rt);
+
+        // Reached through the CycleHost trait exactly as the hosted brain does.
+        let res = host
+            .call_tool(ToolCall {
+                tool: SPAWN_TASK_TOOL.to_string(),
+                args: serde_json::json!({ "title": "via call_tool" }),
+            })
+            .await
+            .unwrap();
+        assert!(res.ok);
+        assert_eq!(rt.tasks().list(rt.id()).await.unwrap().len(), 1);
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    #[tokio::test]
+    async fn handed_task_awareness_surfaces_open_cards_on_a_direct_query() {
+        let home = tmp_home();
+        let seen = Arc::new(StdMutex::new(Vec::new()));
+        let rt = RuntimeBuilder::new(home.clone(), desk_manifest())
+            .with_brain(Arc::new(CapturingBrain { seen: seen.clone() }))
+            .build()
+            .await
+            .unwrap();
+
+        // Hand work to the Engineering desk (card assigned to the desk id).
+        rt.tasks()
+            .upsert(
+                rt.id(),
+                &TaskRecord {
+                    id: "t1".into(),
+                    title: "Ship invoicing".into(),
+                    note: Some("build the importer".into()),
+                    column: "backlog".into(),
+                    priority: "medium".into(),
+                    assignee: "eng".into(),
+                    updated_at_millis: 0,
+                    origin_chat_id: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Asking the desk directly (by name) surfaces the handed task...
+        rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            text: "what are you working on?".into(),
+            by: None,
+            chat: Some("Engineering".into()),
+        }])
+        .await
+        .unwrap();
+
+        // ...and asking with no address (the orchestrator) does NOT get the
+        // desk's briefing folded into it.
+        rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            text: "status?".into(),
+            by: None,
+            chat: None,
+        }])
+        .await
+        .unwrap();
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 2);
+        assert!(
+            seen[0].contains("Open work already handed to you")
+                && seen[0].contains("Ship invoicing"),
+            "direct query carries the briefing: {:?}",
+            seen[0]
+        );
+        assert!(
+            !seen[1].contains("Open work already handed to you"),
+            "unaddressed query has no desk briefing: {:?}",
+            seen[1]
+        );
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    #[tokio::test]
+    async fn awareness_skips_done_cards() {
+        let home = tmp_home();
+        let seen = Arc::new(StdMutex::new(Vec::new()));
+        let rt = RuntimeBuilder::new(home.clone(), desk_manifest())
+            .with_brain(Arc::new(CapturingBrain { seen: seen.clone() }))
+            .build()
+            .await
+            .unwrap();
+        rt.tasks()
+            .upsert(
+                rt.id(),
+                &TaskRecord {
+                    id: "t1".into(),
+                    title: "Already finished".into(),
+                    note: None,
+                    column: "done".into(),
+                    priority: "medium".into(),
+                    assignee: "eng".into(),
+                    updated_at_millis: 0,
+                    origin_chat_id: None,
+                },
+            )
+            .await
+            .unwrap();
+        rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            text: "what's up?".into(),
+            by: None,
+            chat: Some("eng".into()),
+        }])
+        .await
+        .unwrap();
+        let seen = seen.lock().unwrap();
+        assert!(
+            !seen[0].contains("Open work already handed to you"),
+            "done cards are not surfaced as open work: {:?}",
+            seen[0]
+        );
         tokio::fs::remove_dir_all(&home).await.ok();
     }
 }

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -73,22 +73,11 @@ pub trait RunTurn: Send + Sync {
     ) -> Result<TurnOutcome>;
 }
 
-/// The lead member of a desk: the first effective member (manifest ∪ overlay)
-/// that is a real roster teammate. `None` when no desk matches or none of its
-/// members are on the roster.
-///
-/// Resolves the desk key (id or case-insensitive name) against both manifest and
-/// operator-created overlay desks, then reads the same **effective** membership
-/// the REST `list_desks` handler uses
-/// ([`CompanyRecord::effective_desk_members`]), so routing and the console cannot
-/// drift. An overlay-added lead is reachable on a desk the manifest left empty.
-pub(crate) fn desk_lead(record: &CompanyRecord, desk: &str) -> Option<String> {
-    let desk_id = record.resolve_desk_id(desk)?;
-    record
-        .effective_desk_members(&desk_id)
-        .into_iter()
-        .find(|m| record.is_roster_agent(m))
-}
+// `desk_lead` is the brain-agnostic desk-lead resolver — it moved to
+// `runtime::delegation_tools` (issue #176) so the hosted path can resolve a
+// desk lead without the `openhuman` feature. Re-exported here so this module's
+// callers (and its tests) keep using `desk_lead(...)` unchanged.
+pub(crate) use crate::runtime::delegation_tools::desk_lead;
 
 /// The prompt for the CEO-relay hand-back turn: the operator's original message
 /// plus each teammate's reply, framed so the orchestrator relays the answer back

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -1,0 +1,343 @@
+//! Brain-agnostic delegation seam (issue #176, slice 1).
+//!
+//! Delegation — opening board tasks, handing a turn to a desk's lead member, and
+//! the CEO-relay hand-back — used to live wired directly into
+//! [`HarnessBrain`](crate::harness::brain::HarnessBrain), hard-coupled to the
+//! [`HarnessPool`](crate::harness::HarnessPool). This module lifts that
+//! orchestration out behind the [`RunTurn`] trait so a later slice can give the
+//! hosted Medulla brain the same delegation without duplicating it.
+//!
+//! Slice 1 is a behaviour-preserving refactor: the harness path stays
+//! byte-for-byte equivalent — [`HarnessBrain`](crate::harness::brain::HarnessBrain)
+//! now drives a [`DelegationRunner`] over a
+//! [`HarnessRunTurn`](crate::harness::run_turn::HarnessRunTurn) (the trait impl
+//! that re-attaches [`HarnessDeps`](crate::harness::HarnessDeps)).
+//!
+//! Compiled only under `feature = "openhuman"`: [`TurnOutcome`] and the
+//! delegation queue the runner drains are harness types. Slice 2 will generalise
+//! the trait's turn types so a non-harness brain can implement it.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::Result;
+use crate::company::steer::{
+    InflightEntry, InflightKind, InflightRegistry, SteerAction, SteerControl,
+};
+use crate::harness::TurnOutcome;
+use crate::harness::orchestrator::{Delegation, DelegationQueue};
+use crate::ports::types::{CompanyId, CompanyRecord, OutboundMessage, TurnStep};
+use crate::ports::{TaskRecord, TaskStore, generate_id, now_millis};
+
+/// One agent turn, abstracted so delegation orchestration never touches the
+/// harness-specific [`HarnessDeps`](crate::harness::HarnessDeps).
+///
+/// The three methods mirror the [`HarnessPool`](crate::harness::HarnessPool)
+/// turn-runners the harness brain used inline: a streamed operator/desk turn
+/// ([`run`](RunTurn::run)), a steered streamed turn
+/// ([`run_steered`](RunTurn::run_steered)), and a steered, un-streamed background
+/// turn ([`run_steered_background`](RunTurn::run_steered_background)). The impl
+/// re-attaches whatever dependencies the concrete runtime needs; the runner only
+/// ever sees a [`TurnOutcome`].
+#[async_trait]
+pub trait RunTurn: Send + Sync {
+    /// A streamed turn on `agent_id` answering `message` in `chat_id`.
+    async fn run(
+        &self,
+        company: &CompanyId,
+        agent_id: &str,
+        message: &str,
+        chat_id: Option<&str>,
+    ) -> Result<TurnOutcome>;
+
+    /// A streamed, operator-steerable turn (pause / cancel / redirect).
+    async fn run_steered(
+        &self,
+        company: &CompanyId,
+        agent_id: &str,
+        message: &str,
+        control: &SteerControl,
+        chat_id: Option<&str>,
+    ) -> Result<TurnOutcome>;
+
+    /// A steerable turn WITHOUT live streaming — for a dispatched card whose
+    /// steps are discarded into its note and must not leak onto the console
+    /// timeline.
+    async fn run_steered_background(
+        &self,
+        company: &CompanyId,
+        agent_id: &str,
+        message: &str,
+        control: &SteerControl,
+    ) -> Result<TurnOutcome>;
+}
+
+/// The lead member of a desk: the first effective member (manifest ∪ overlay)
+/// that is a real roster teammate. `None` when no desk matches or none of its
+/// members are on the roster.
+///
+/// Resolves the desk key (id or case-insensitive name) against both manifest and
+/// operator-created overlay desks, then reads the same **effective** membership
+/// the REST `list_desks` handler uses
+/// ([`CompanyRecord::effective_desk_members`]), so routing and the console cannot
+/// drift. An overlay-added lead is reachable on a desk the manifest left empty.
+pub(crate) fn desk_lead(record: &CompanyRecord, desk: &str) -> Option<String> {
+    let desk_id = record.resolve_desk_id(desk)?;
+    record
+        .effective_desk_members(&desk_id)
+        .into_iter()
+        .find(|m| record.is_roster_agent(m))
+}
+
+/// The prompt for the CEO-relay hand-back turn: the operator's original message
+/// plus each teammate's reply, framed so the orchestrator relays the answer back
+/// as its own single, coherent response and does not delegate again.
+pub(crate) fn build_relay_prompt(original: &str, desk_replies: &[(String, String)]) -> String {
+    let mut prompt = format!(
+        "The operator asked:\n{original}\n\nYou delegated this to your team and their reply is \
+below. Relay their answer back to the operator now as your own single, coherent response — \
+summarize it or pass it along. Do not delegate again; just relay what came back."
+    );
+    for (member, reply) in desk_replies {
+        prompt.push_str(&format!("\n\n{member} replied:\n{reply}"));
+    }
+    prompt
+}
+
+/// The outcome of draining one queued delegation.
+///
+/// A `spawn_task` yields nothing operator-visible (it only opens a board card).
+/// A synchronous `delegate_to_desk` yields a [`DeskReply`] — the teammate's
+/// answer captured so the orchestrator can **relay** it in a follow-up turn (the
+/// CEO-relay hand-back) instead of leaving it as a disconnected sibling bubble.
+/// `bubble` stays for any future delegation that surfaces its own standalone
+/// message directly.
+#[derive(Default)]
+pub(crate) struct DelegationOutcome {
+    /// A chat bubble to surface as-is (unused by the current delegations).
+    pub(crate) bubble: Option<OutboundMessage>,
+    /// A synchronous desk reply to relay through a second orchestrator turn.
+    pub(crate) desk_reply: Option<DeskReply>,
+}
+
+/// A synchronous desk-lead answer captured for the orchestrator to relay: which
+/// member answered, their reply text, and their own turn steps (folded onto the
+/// operator timeline so the teammate's activity stays visible on the single
+/// relayed bubble).
+pub(crate) struct DeskReply {
+    pub(crate) member: String,
+    pub(crate) reply: String,
+    pub(crate) steps: Vec<TurnStep>,
+}
+
+/// The operator-facing result of one operator message after delegation: the
+/// bubble's reply and folded step timeline, plus any standalone delegation
+/// bubbles to append as sibling channel responses. None of the current
+/// delegations surface a standalone bubble; the field keeps the seam open for
+/// one that does.
+pub(crate) struct OperatorTurn {
+    pub(crate) reply: String,
+    pub(crate) steps: Vec<TurnStep>,
+    pub(crate) bubbles: Vec<OutboundMessage>,
+}
+
+/// Drives the brain-agnostic delegation orchestration over a [`RunTurn`]: run the
+/// responder's turn, drain and execute whatever it queued, and — when a desk
+/// answered synchronously — relay through exactly one more responder turn.
+///
+/// Holds only brain-agnostic handles: the company record (for desk-lead
+/// resolution), the task store, the steer registry, the company id, the shared
+/// delegation queue the turn pushes onto, and the per-turn delegation cap. The
+/// harness-specific [`HarnessDeps`](crate::harness::HarnessDeps) is deliberately
+/// absent — that is the whole point of the seam; it lives behind the [`RunTurn`]
+/// impl.
+pub(crate) struct DelegationRunner<'a> {
+    run_turn: &'a dyn RunTurn,
+    record: &'a CompanyRecord,
+    tasks: Option<&'a Arc<dyn TaskStore>>,
+    steer: &'a InflightRegistry,
+    company: &'a CompanyId,
+    queue: &'a DelegationQueue,
+    max_delegations: usize,
+}
+
+impl<'a> DelegationRunner<'a> {
+    /// Wires a runner over `run_turn` with the brain-agnostic handles it needs.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        run_turn: &'a dyn RunTurn,
+        record: &'a CompanyRecord,
+        tasks: Option<&'a Arc<dyn TaskStore>>,
+        steer: &'a InflightRegistry,
+        company: &'a CompanyId,
+        queue: &'a DelegationQueue,
+        max_delegations: usize,
+    ) -> Self {
+        Self {
+            run_turn,
+            record,
+            tasks,
+            steer,
+            company,
+            queue,
+            max_delegations,
+        }
+    }
+
+    /// Handles one operator message end-to-end: clear stale delegations, run the
+    /// responder's turn, drain whatever it queued (capped, discarded past the
+    /// cap), and — when a synchronous desk delegation answered — run exactly one
+    /// CEO-relay hand-back turn whose reply replaces the operator-facing text.
+    ///
+    /// The relay turn must not re-delegate: its prompt is relay-only, and as a
+    /// safety net the delegation queue is cleared before it and drained-and-
+    /// discarded after, so anything it queues is dropped (cost bounded to one
+    /// extra turn, no re-delegation loop). With no delegation the single first
+    /// turn is surfaced unchanged.
+    pub(crate) async fn handle_operator_message(
+        &self,
+        responder: &str,
+        message: &str,
+        chat_id: Option<&str>,
+    ) -> Result<OperatorTurn> {
+        // Clear stale delegations so nothing leaks from a prior turn, run the
+        // responder's turn (metered behind the `RunTurn` impl), then drain
+        // whatever it queued.
+        self.queue.clear();
+        let outcome = self
+            .run_turn
+            .run(self.company, responder, message, chat_id)
+            .await?;
+        // The responder's own steps ride on the operator bubble; its reply is the
+        // operator-facing text UNLESS a synchronous desk delegation runs, in which
+        // case the relay turn's reply replaces it (below).
+        let mut operator_steps = outcome.steps;
+        let mut operator_reply = outcome.reply;
+        // A `spawn_task` opens a card silently; a `delegate_to_desk` runs the desk
+        // lead and hands its answer back to RELAY rather than surfacing as a
+        // disconnected sibling bubble. Any future delegation that surfaces its own
+        // bubble lands in `bubbles`.
+        let mut bubbles = Vec::new();
+        let mut desk_replies: Vec<(String, String)> = Vec::new();
+        for delegation in self.queue.drain(self.max_delegations) {
+            let out = self.run_delegation(delegation, chat_id).await?;
+            if let Some(bubble) = out.bubble {
+                bubbles.push(bubble);
+            }
+            if let Some(desk) = out.desk_reply {
+                // Fold the teammate's activity onto the operator timeline, then
+                // remember the answer to relay.
+                operator_steps.extend(desk.steps);
+                desk_replies.push((desk.member, desk.reply));
+            }
+        }
+        // CEO-relay hand-back: when a synchronous desk delegation answered, run
+        // exactly ONE more responder turn whose prompt is the original message
+        // plus the teammate reply, and surface THAT as the operator bubble — so
+        // the orchestrator comes back with the answer in one coherent
+        // conversation.
+        if !desk_replies.is_empty() {
+            let relay_prompt = build_relay_prompt(message, &desk_replies);
+            self.queue.clear();
+            let relay = self
+                .run_turn
+                .run(self.company, responder, &relay_prompt, chat_id)
+                .await?;
+            // Discard anything the relay turn queued — it can only relay, never
+            // re-delegate.
+            let _ = self.queue.drain(self.max_delegations);
+            operator_reply = relay.reply;
+            operator_steps.extend(relay.steps);
+        }
+        Ok(OperatorTurn {
+            reply: operator_reply,
+            steps: operator_steps,
+            bubbles,
+        })
+    }
+
+    /// Executes one drained delegation.
+    ///
+    /// `spawn_task` opens a backlog card through the
+    /// [`TaskStore::upsert`](crate::ports::TaskStore) path the console uses and
+    /// surfaces nothing extra (a missing task store is a silent no-op).
+    /// `delegate_to_desk` runs a single turn on the desk's lead member and
+    /// **returns its reply for the orchestrator to relay** (a [`DeskReply`]). An
+    /// unknown desk (no roster-backed lead) or a cancelled run yields nothing to
+    /// relay. No sub-agent re-delegation in v1: desk members carry no delegation
+    /// tools, so their turns queue nothing.
+    pub(crate) async fn run_delegation(
+        &self,
+        delegation: Delegation,
+        chat_id: Option<&str>,
+    ) -> Result<DelegationOutcome> {
+        match delegation {
+            Delegation::SpawnTask {
+                title,
+                note,
+                assignee,
+            } => {
+                let Some(tasks) = self.tasks else {
+                    return Ok(DelegationOutcome::default());
+                };
+                let card = TaskRecord {
+                    id: generate_id(),
+                    title,
+                    note,
+                    column: "backlog".to_string(),
+                    priority: "medium".to_string(),
+                    assignee: assignee.unwrap_or_default(),
+                    updated_at_millis: now_millis(),
+                    // Issue #151 §3.2: remember which conversation asked for this,
+                    // so the completion can answer there instead of only landing in
+                    // the note.
+                    origin_chat_id: chat_id.map(str::to_string),
+                };
+                tasks.upsert(self.company, &card).await?;
+                Ok(DelegationOutcome::default())
+            }
+            Delegation::DelegateToDesk { desk, instruction } => {
+                let Some(member) = desk_lead(self.record, &desk) else {
+                    return Ok(DelegationOutcome::default());
+                };
+                // Register the delegated turn so an operator can CANCEL it
+                // mid-flight (cancel-only in v1 — pause/redirect are rejected at
+                // the route). RAII guard deregisters on every exit path.
+                let guard = self.steer.register(
+                    self.company,
+                    InflightEntry {
+                        key: generate_id(),
+                        task_id: None,
+                        kind: InflightKind::Delegation,
+                        title: desk.clone(),
+                        agent_id: member.clone(),
+                        started_at_millis: now_millis(),
+                        pending_action: None,
+                    },
+                );
+                let control = guard.control().clone();
+                let outcome = self
+                    .run_turn
+                    .run_steered(self.company, &member, &instruction, &control, chat_id)
+                    .await?;
+                // A cancel issued mid-flight discards the delegated reply — nothing
+                // is relayed.
+                if matches!(control.take(), Some(SteerAction::Cancel)) {
+                    return Ok(DelegationOutcome::default());
+                }
+                // Hand the teammate's answer back to RELAY through a second
+                // orchestrator turn (the CEO-relay hand-back). Their steps ride
+                // along and get folded onto the relayed operator bubble.
+                Ok(DelegationOutcome {
+                    bubble: None,
+                    desk_reply: Some(DeskReply {
+                        member,
+                        reply: outcome.reply,
+                        steps: outcome.steps,
+                    }),
+                })
+            }
+        }
+    }
+}

--- a/src/runtime/delegation_tools.rs
+++ b/src/runtime/delegation_tools.rs
@@ -1,0 +1,231 @@
+//! Brain-agnostic delegation-tool primitives (issue #176, slice 2).
+//!
+//! The delegation *runtime* — draining a queue and running desk-lead turns —
+//! lives in [`delegation`](crate::runtime::delegation) and is harness-only
+//! (it needs in-process cognition). But the delegation *tools* themselves —
+//! their names, their argument schemas, and the desk-lead resolver — are
+//! brain-agnostic: the hosted Medulla path advertises the same tools to the
+//! remote cognition service and services them device-side.
+//!
+//! This module holds those brain-agnostic pieces so BOTH brains share one
+//! definition:
+//!
+//! - the canonical tool-name constants ([`SPAWN_TASK_TOOL`],
+//!   [`DELEGATE_TO_DESK_TOOL`]) — the harness `orchestrator` module re-exports
+//!   them so the two paths cannot drift;
+//! - [`delegation_manifest_entries`], the [`ToolManifestEntry`] catalog the
+//!   hosted brain registers with Medulla;
+//! - [`desk_lead`], the desk-lead resolver (moved here from the harness-only
+//!   [`delegation`](crate::runtime::delegation) module so the hosted path can
+//!   resolve a desk's lead without the `openhuman` feature);
+//! - the argument parsers ([`SpawnTaskArgs`], [`DelegateArgs`]) the host uses
+//!   to service a `spawn_task` / `delegate_to_desk` tool-call frame.
+//!
+//! Compiled in every build (no feature gate): the hosted brain is in the
+//! default build, and the harness path re-exports from here.
+
+use serde_json::{Value, json};
+
+use crate::brain::medulla::wire::ToolManifestEntry;
+use crate::ports::types::CompanyRecord;
+
+/// The `spawn_task` tool name — open a tracked task card on the board.
+pub const SPAWN_TASK_TOOL: &str = "spawn_task";
+/// The `delegate_to_desk` tool name — hand work to a desk's lead member.
+pub const DELEGATE_TO_DESK_TOOL: &str = "delegate_to_desk";
+
+/// The `spawn_task` argument schema, shared by the harness tool's
+/// `parameters_schema` and the hosted manifest entry so the two never drift.
+pub fn spawn_task_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "title": { "type": "string", "description": "The task title." },
+            "note": { "type": "string", "description": "An optional longer brief." },
+            "assignee": { "type": "string", "description": "An optional desk/teammate id to own it." }
+        },
+        "required": ["title"],
+        "additionalProperties": false
+    })
+}
+
+/// The `delegate_to_desk` argument schema, shared by the harness tool and the
+/// hosted manifest entry.
+pub fn delegate_to_desk_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "desk": { "type": "string", "description": "The desk id or name to delegate to." },
+            "instruction": { "type": "string", "description": "The instruction for the desk's lead member." }
+        },
+        "required": ["desk", "instruction"],
+        "additionalProperties": false
+    })
+}
+
+/// The delegation tools advertised to Medulla on the hosted path: `spawn_task`
+/// and `delegate_to_desk`, with the same names + schemas the harness exposes.
+///
+/// Registered on top of the manifest's own `tools.allow` catalog so a hosted
+/// company's orchestrator can delegate exactly as the harness one does. The
+/// device services the resulting tool-call frames in
+/// [`CycleHostImpl`](crate::runtime::cycle) without any local cognition — a
+/// `spawn_task` opens a board card, a `delegate_to_desk` writes a durable
+/// hand-off card assigned to the desk. (The *synchronous* desk-lead cognition
+/// relay the harness performs in-process needs Medulla multi-agent support and
+/// is tracked separately in #176 — the hosted hand-off is durable and
+/// asynchronous.)
+pub fn delegation_manifest_entries() -> Vec<ToolManifestEntry> {
+    vec![
+        ToolManifestEntry {
+            name: SPAWN_TASK_TOOL.to_string(),
+            description: Some(
+                "Open a tracked task card on the company's board for work that should be \
+followed up. Provide a `title`, an optional `note` brief, and an optional `assignee` (a desk \
+or teammate id)."
+                    .to_string(),
+            ),
+            input_schema: Some(spawn_task_schema()),
+        },
+        ToolManifestEntry {
+            name: DELEGATE_TO_DESK_TOOL.to_string(),
+            description: Some(
+                "Hand work to a desk's lead member. Provide the `desk` (its id or name) and the \
+`instruction` to carry out. The hand-off is tracked as a task card assigned to that desk, so \
+the desk knows it was handed the work when asked directly."
+                    .to_string(),
+            ),
+            input_schema: Some(delegate_to_desk_schema()),
+        },
+    ]
+}
+
+/// The lead member of a desk: the first effective member (manifest ∪ overlay)
+/// that is a real roster teammate. `None` when no desk matches or none of its
+/// members are on the roster.
+///
+/// Resolves the desk key (id or case-insensitive name) against both manifest
+/// and operator-created overlay desks, then reads the same **effective**
+/// membership the REST `list_desks` handler uses
+/// ([`CompanyRecord::effective_desk_members`]), so routing and the console
+/// cannot drift. An overlay-added lead is reachable on a desk the manifest left
+/// empty.
+///
+/// Lifted here from the harness-only delegation runtime so the hosted path can
+/// resolve a desk lead without the `openhuman` feature.
+pub fn desk_lead(record: &CompanyRecord, desk: &str) -> Option<String> {
+    let desk_id = record.resolve_desk_id(desk)?;
+    record
+        .effective_desk_members(&desk_id)
+        .into_iter()
+        .find(|m| record.is_roster_agent(m))
+}
+
+/// Parsed `spawn_task` arguments: a required title, an optional brief note, and
+/// an optional assignee. Blank strings are treated as absent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpawnTaskArgs {
+    /// The task title (required, non-blank).
+    pub title: String,
+    /// An optional longer brief.
+    pub note: Option<String>,
+    /// An optional desk/teammate id to own the card.
+    pub assignee: Option<String>,
+}
+
+impl SpawnTaskArgs {
+    /// Parses `spawn_task` args, returning `None` when `title` is missing or
+    /// blank (the one hard requirement).
+    pub fn parse(args: &Value) -> Option<Self> {
+        let title = trimmed_str(args, "title")?;
+        Some(Self {
+            title,
+            note: trimmed_str(args, "note"),
+            assignee: trimmed_str(args, "assignee"),
+        })
+    }
+}
+
+/// Parsed `delegate_to_desk` arguments: the target desk and the instruction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DelegateArgs {
+    /// The desk id or name to hand the work to.
+    pub desk: String,
+    /// The instruction the desk should carry out.
+    pub instruction: String,
+}
+
+impl DelegateArgs {
+    /// Parses `delegate_to_desk` args, returning `None` when either `desk` or
+    /// `instruction` is missing or blank.
+    pub fn parse(args: &Value) -> Option<Self> {
+        Some(Self {
+            desk: trimmed_str(args, "desk")?,
+            instruction: trimmed_str(args, "instruction")?,
+        })
+    }
+}
+
+/// Reads `key` as a string, trims it, and returns it only when non-empty.
+fn trimmed_str(args: &Value, key: &str) -> Option<String> {
+    args.get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn manifest_entries_cover_both_delegation_tools() {
+        let entries = delegation_manifest_entries();
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&SPAWN_TASK_TOOL), "got {names:?}");
+        assert!(names.contains(&DELEGATE_TO_DESK_TOOL), "got {names:?}");
+        // Every entry carries a schema so Medulla can shape the call.
+        assert!(
+            entries
+                .iter()
+                .all(|e| e.input_schema.is_some() && e.description.is_some())
+        );
+    }
+
+    #[test]
+    fn spawn_task_args_require_a_nonblank_title() {
+        assert_eq!(SpawnTaskArgs::parse(&json!({})), None);
+        assert_eq!(SpawnTaskArgs::parse(&json!({ "title": "  " })), None);
+        let parsed = SpawnTaskArgs::parse(&json!({
+            "title": "  Ship it ",
+            "note": " brief ",
+            "assignee": " eng "
+        }))
+        .expect("valid");
+        assert_eq!(parsed.title, "Ship it");
+        assert_eq!(parsed.note.as_deref(), Some("brief"));
+        assert_eq!(parsed.assignee.as_deref(), Some("eng"));
+        // Blank optionals collapse to None.
+        let bare = SpawnTaskArgs::parse(&json!({ "title": "x", "note": "", "assignee": "" }))
+            .expect("valid");
+        assert_eq!(bare.note, None);
+        assert_eq!(bare.assignee, None);
+    }
+
+    #[test]
+    fn delegate_args_require_desk_and_instruction() {
+        assert_eq!(DelegateArgs::parse(&json!({ "desk": "eng" })), None);
+        assert_eq!(
+            DelegateArgs::parse(&json!({ "instruction": "do it" })),
+            None
+        );
+        let parsed = DelegateArgs::parse(&json!({
+            "desk": " engineering ",
+            "instruction": " build the thing "
+        }))
+        .expect("valid");
+        assert_eq!(parsed.desk, "engineering");
+        assert_eq!(parsed.instruction, "build the thing");
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -23,6 +23,11 @@ pub mod cycle;
 /// [`TurnOutcome`]: crate::harness::TurnOutcome
 #[cfg(feature = "openhuman")]
 pub mod delegation;
+/// Brain-agnostic delegation-tool primitives (issue #176): the tool names,
+/// argument schemas, hosted [`ToolManifestEntry`](crate::brain::medulla::wire::ToolManifestEntry)
+/// catalog, and desk-lead resolver shared by BOTH the harness and hosted paths.
+/// Compiled in every build (the hosted brain ships in the default build).
+pub mod delegation_tools;
 pub mod journal;
 pub mod mailbox_poller;
 pub mod registry;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -13,6 +13,16 @@ pub mod builder;
 pub mod channel;
 pub mod cron;
 pub mod cycle;
+/// Brain-agnostic delegation seam (issue #176): the [`RunTurn`] trait +
+/// [`DelegationRunner`] the harness brain drives. Compiled only under
+/// `openhuman` — it drains the harness delegation queue and yields harness
+/// [`TurnOutcome`]s. See [`delegation`].
+///
+/// [`RunTurn`]: delegation::RunTurn
+/// [`DelegationRunner`]: delegation::DelegationRunner
+/// [`TurnOutcome`]: crate::harness::TurnOutcome
+#[cfg(feature = "openhuman")]
+pub mod delegation;
 pub mod journal;
 pub mod mailbox_poller;
 pub mod registry;


### PR DESCRIPTION
## Summary

Makes delegation **brain-agnostic** and gives the hosted (Medulla) cognition path delegation, which it entirely lacked — on smoke1 and every hosted tenant the orchestrator could not delegate at all (its catalog was only `manifest.tools.allow` and `CycleHostImpl::call_tool` had no delegation arm). Closes the core of #176.

- **RunTurn seam** — lifts delegation orchestration out of `HarnessBrain` behind a `RunTurn` trait (`src/runtime/delegation.rs`) + `HarnessRunTurn` impl; the harness path is behavior-preserving.
- **Shared primitives** — new non-gated `src/runtime/delegation_tools.rs`: canonical tool names, argument schemas, the hosted `ToolManifestEntry` catalog, and the desk-lead resolver — one definition for both brains (the harness orchestrator re-exports them, drift-safe).
- **Hosted delegation (durable async hand-off)** — the builder advertises `spawn_task`/`delegate_to_desk` to Medulla; `CycleHostImpl` services them device-side: `spawn_task` opens a board card; `delegate_to_desk` resolves the desk and writes a durable hand-off card assigned to it (lead noted), unknown desk = clean tool error. A hosted build has no in-process cognition pool, so this is a durable **asynchronous** hand-off, not a synchronous in-voice relay.
- **Handed-task awareness (#176 scope C)** — when an operator message is addressed to a desk/agent that owns open work, the kernel folds a briefing of that work into the message the brain sees (brain-agnostic; mutates only the in-memory copy, never the durable log), so a direct "what are you working on?" is answered truthfully.

### Scope boundary (honest)

- The **synchronous** cross-agent cognition relay and recursive desk depth are **not** in this PR — a hosted build runs no local cognition, so a live desk reply needs either a core-in-pod build (`openhuman` feature) or Medulla multi-agent sub-cycles. Verified live that the **core-in-pod** build already does the full loop (CEO → desk → one-voice relay, and the follow-up answers).
- This branch carries one base-dependency commit — `0fd01f6` ("relay delegate_to_desk answer through a second orchestrator turn", the #175 relay) — which is not yet in `main` and has no open PR; the seam refactor builds on it. Flagging so a maintainer can decide whether to land it here or separately.

## API Or Behavior Changes

- Hosted brain now advertises and services `spawn_task` / `delegate_to_desk` (new device tools) — previously unavailable on the hosted path.
- Addressed operator messages may carry an in-memory handed-work briefing to the brain; the durable event log is unchanged.
- Harness (openhuman) path is behavior-preserving.

## Tests

- [x] `cargo fmt --all -- --check` — clean
- [ ] `cargo clippy --all-targets -- -D warnings` — clippy **default** build clean on touched files; full `--all-targets` is blocked by pre-existing vendored-dep lints, unrelated to this change
- [x] `cargo build --all-targets` — builds (default + `--features openhuman,mcp,telegram`)
- [x] `cargo test` — default lib **769 passed**; hosted brain **15** (3 new e2e: catalog advertises delegation tools, `spawn_task` card, `delegate_to_desk` hand-off); cycle **21** (5 new: host arms + awareness + dispatch), parity under `--features openhuman`; harness brain **29** + orchestrator **27** behavior-preserving; `delegation_tools` **3**

Also verified end-to-end on a running core-in-pod server against staging inference: CEO delegated to the engineering desk, relayed the reply in one voice, and the follow-up query answered.

## Documentation

Module-level docs added in the new files (`delegation_tools.rs`, `run_turn.rs`, delegation seam). The design, the hosted vs core-in-pod boundary, and the deferred synchronous-relay/recursion scope are recorded on issue #176. No user-facing docs needed for this slice.
