### PR TITLE
fix(approvals): park approval-gated tool calls so they reach the operator (#172)

### DIFF
--- a/docs/modules/openhuman/README.md
+++ b/docs/modules/openhuman/README.md
@@ -20,7 +20,9 @@ The builder seams are wired to OpenCompany's own ports:
   for offline tests.
 - **Approval policy** → `harness::policy::ApprovalPolicy` maps `[policy].mode`
   onto openhuman's `ToolPolicy`; the security-tier words
-  (readonly/supervised/full) line up 1:1.
+  (readonly/supervised/full) line up 1:1. See
+  [approval parking](#approval-parking) for how a gated call reaches the
+  operator.
 - **Tools / skills** → injected from the company's manifest grants.
 
 See [`docs/modules/runtime/README.md`](../runtime/README.md) for `HarnessPool`
@@ -38,6 +40,34 @@ no explicit brain — brain precedence is `with_brain` > harness > hosted/echo.
 The `opencompany` binary's `attach_harness` resolves that config from the
 environment (below), so `serve` boots on the harness brain automatically when a
 credential is present.
+
+## Approval parking
+
+openhuman resolves a `ToolPolicyDecision::RequireApproval` **inline**: it blocks
+the tool call and feeds the model a refusal, then lets the turn continue. That
+refusal used to be the only trace a gated call left — nothing was written to
+OpenCompany's `ApprovalGate` or its journal, so the operator's Approvals page
+stayed empty however many tools an agent parked (issue #172).
+
+The two halves are now joined:
+
+1. `ApprovalPolicy::check` projects every `RequireApproval` onto an `Effect`
+   (`effect_for` — the tool name becomes the effect `kind`, the arguments become
+   the payload) and pushes it onto the shared `ApprovalRequestQueue` carried on
+   `HarnessDeps`. Duplicates (a model re-trying the same blocked call) collapse.
+2. `HarnessBrain::run_cycle` clears that queue before its turns and drains it
+   after, parking each request through `CycleHost::park_effect` — capped at
+   `MAX_APPROVAL_REQUESTS_PER_TURN`.
+
+`park_effect` is deliberately **not** `emit_effect`: the verdict was already
+reached inside the turn, and re-evaluating it against the coarser `ApprovalGate`
+taxonomy would `Allow` (and so "execute" as a no-op) anything in the `Other`
+group — which is most gated tool calls — making the request vanish again.
+
+**Not yet wired: resume-after-approval.** Because openhuman resolves the decision
+inline, approving a parked tool call records the verdict and clears the queue but
+does not re-dispatch the tool; the operator re-asks. Suspending and resuming a
+call inside openhuman's session loop is separate work.
 
 ## Inference config (environment)
 

--- a/docs/modules/policy/README.md
+++ b/docs/modules/policy/README.md
@@ -10,6 +10,19 @@ against the manifest `[policy]` block into `Allow`, `RequireApproval`, or
 The gate is consulted by the `CycleRunner` before any effect crosses the trust
 boundary; parked effects surface in the operator's approvals inbox.
 
+There are two ways onto that queue, both landing in `CycleHostImpl::park` (so a
+parked effect is journaled one way and survives a restart with its original id):
+
+- `CycleHost::emit_effect` — an effect the brain submits for a **decision**. The
+  gate evaluates it and parks only on `RequireApproval`.
+- `CycleHost::park_effect` — an effect whose verdict the brain **already**
+  reached, parked as-is. This is the harness brain's path: its openhuman
+  `ApprovalPolicy` blocks a gated tool call inside the agent turn, and the
+  projected call is then held for the operator rather than re-decided (issue
+  #172). Re-evaluating it here would `Allow` — and so silently "execute" as a
+  no-op — anything in the `Other` group, which is most gated tool calls. See
+  [the OpenHuman module](../openhuman/README.md#approval-parking).
+
 Effects are classified into the checkpoint groups (Spend / Send / Sign /
 Publish / Hire / Identity) with per-group supervised defaults. Parked approvals
 **default-deny on silence**: they expire to `deny` after a configurable window

--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -24,6 +24,8 @@ pub trait CycleHost: Send + Sync {
     async fn call_tool(&self, call: ToolCall) -> Result<ToolResult>;
     async fn context_op(&self, op: ContextOp) -> Result<ContextOpResult>;
     async fn emit_effect(&self, effect: Effect) -> Result<EffectDisposition>;
+    /// Parks an already-decided effect for approval, without re-evaluating it.
+    async fn park_effect(&self, effect: Effect) -> Result<ApprovalId>;
 }
 
 pub enum EffectDisposition {
@@ -32,6 +34,14 @@ pub enum EffectDisposition {
     Denied { reason: String },
 }
 ```
+
+`emit_effect` submits an effect for a **decision** — the gate evaluates it and
+executes, parks, or denies it. `park_effect` is for a brain that hosts its own
+policy layer and has **already** decided: the harness brain's openhuman
+`ApprovalPolicy` blocks a gated tool call inside the agent turn, and the
+projected call is parked as-is so the operator can see and resolve it. Passing
+it back through `emit_effect` would re-decide it against the coarser
+`ApprovalGate` taxonomy and quietly drop it (issue #172).
 
 `CycleRequest` carries `{cycle_id, company_id, events, compressed_history,
 roster, context_index}`; `CycleResult` carries channel responses, new

--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -37,6 +37,15 @@ const EFFECT_LABELS: Record<string, string> = {
   "handle.register": "Claim a public handle",
   "handle.renew": "Renew a public handle",
   "key.rotate": "Rotate its security key",
+  // A tool call the company parked mid-conversation. The effect kind is the
+  // tool's own name, which is a runtime internal — the glossary rule above says
+  // an operator never sees one, so the gated tools get plain-language labels
+  // rather than the title-cased fallback ("Composio Execute").
+  composio_authorize: "Connect one of its accounts",
+  composio_execute: "Act in one of its connected accounts",
+  mcp_registry_tool_call: "Use a connected tool",
+  media_generate_image: "Generate an image",
+  media_generate_video: "Generate a video",
 };
 
 export function effectAction(kind: string): string {

--- a/src/brain/echo.rs
+++ b/src/brain/echo.rs
@@ -111,7 +111,7 @@ impl Brain for EchoBrain {
 mod test {
     use super::*;
     use crate::ports::types::{
-        CompanyId, ContextOp, ContextOpResult, EffectDisposition, ToolCall, ToolResult,
+        ApprovalId, CompanyId, ContextOp, ContextOpResult, EffectDisposition, ToolCall, ToolResult,
     };
 
     /// A minimal host that records emitted effects and auto-executes them.
@@ -136,6 +136,11 @@ mod test {
         async fn emit_effect(&self, effect: Effect) -> Result<EffectDisposition> {
             self.effects.lock().unwrap().push(effect);
             Ok(EffectDisposition::Executed)
+        }
+
+        async fn park_effect(&self, effect: Effect) -> Result<ApprovalId> {
+            self.effects.lock().unwrap().push(effect);
+            Ok(ApprovalId::new("appr-parked"))
         }
     }
 

--- a/src/brain/hosted/test.rs
+++ b/src/brain/hosted/test.rs
@@ -71,6 +71,11 @@ impl CycleHost for RecordingHost {
         self.effects.lock().unwrap().push(effect);
         Ok(self.disposition.clone())
     }
+
+    async fn park_effect(&self, effect: Effect) -> Result<ApprovalId> {
+        self.effects.lock().unwrap().push(effect);
+        Ok(ApprovalId::new("appr-parked"))
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/brain/sidecar/test.rs
+++ b/src/brain/sidecar/test.rs
@@ -70,6 +70,11 @@ impl CycleHost for RecordingHost {
         self.effects.lock().unwrap().push(effect);
         Ok(self.disposition.clone())
     }
+
+    async fn park_effect(&self, effect: Effect) -> Result<ApprovalId> {
+        self.effects.lock().unwrap().push(effect);
+        Ok(ApprovalId::new("appr-parked"))
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/feedback/store.rs
+++ b/src/feedback/store.rs
@@ -8,7 +8,6 @@
 
 use std::path::PathBuf;
 
-use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex as TokioMutex;
 
 use crate::Result;
@@ -33,6 +32,16 @@ impl FeedbackStore {
     }
 
     /// Appends a feedback item to the log.
+    ///
+    /// Delegates to [`append_line`](crate::store::fs::append_line), which writes
+    /// the record **and** its newline in a single blocking `write_all` under
+    /// `O_APPEND`. Writing them as two `write_all` calls on a `tokio::fs::File`
+    /// — as this did — can surface as a `serde_json` "trailing characters" error
+    /// from [`Self::list`]: tokio's async `File` buffers internally and may
+    /// return before the kernel write lands, so the newline can be reordered or
+    /// lost against a concurrent append and two records end up on one physical
+    /// line. Identical to the corruption PR #43 removed from
+    /// `store::fs::append_line`; the feedback store was the remaining twin.
     pub async fn append(&self, item: &FeedbackItem) -> Result<()> {
         let line = serde_json::to_string(item)?;
         let _guard = self.write_lock.lock().await;
@@ -41,19 +50,7 @@ impl FeedbackStore {
                 .await
                 .map_err(|e| self.io_err(parent.to_path_buf(), e))?;
         }
-        let mut file = tokio::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.path)
-            .await
-            .map_err(|e| self.io_err(self.path.clone(), e))?;
-        file.write_all(line.as_bytes())
-            .await
-            .map_err(|e| self.io_err(self.path.clone(), e))?;
-        file.write_all(b"\n")
-            .await
-            .map_err(|e| self.io_err(self.path.clone(), e))?;
-        Ok(())
+        crate::store::fs::append_line(&self.path, &line).await
     }
 
     /// Lists every stored feedback item, oldest first.
@@ -202,6 +199,43 @@ mod test {
         // The other item is untouched.
         let other = all.iter().find(|i| i.id == a.id).unwrap();
         assert!(other.filed_issue_url.is_none());
+        tokio::fs::remove_dir_all(bundle.dir()).await.ok();
+    }
+
+    /// Every appended item must occupy its own physical line.
+    ///
+    /// `append` used to write the record and its `\n` as two `write_all` calls on
+    /// a `tokio::fs::File`, which buffers and can return before the kernel write
+    /// lands — so a newline could be reordered or lost and two records shared one
+    /// line, which `list` then rejects with a `serde_json` "trailing characters"
+    /// error. That is what intermittently failed
+    /// `update_status_records_url_without_losing_others` in CI. Mirrors
+    /// `store::fs::test::concurrent_appends_stay_one_record_per_line` (PR #43).
+    #[tokio::test]
+    async fn concurrent_appends_stay_one_record_per_line() {
+        let bundle = tmp_bundle();
+        let store = std::sync::Arc::new(FeedbackStore::new(&bundle));
+
+        const N: usize = 32;
+        let mut set = tokio::task::JoinSet::new();
+        for i in 0..N {
+            let store = store.clone();
+            set.spawn(async move { store.append(&item(&format!("note-{i}"))).await });
+        }
+        while let Some(res) = set.join_next().await {
+            res.unwrap().expect("append succeeds");
+        }
+
+        // `list` parses every line: a merged record would fail here rather than
+        // silently vanish.
+        let all = store.list().await.expect("no corrupt lines");
+        assert_eq!(all.len(), N, "every append is its own line");
+        let mut notes: Vec<String> = all.into_iter().map(|i| i.operator_words).collect();
+        notes.sort();
+        let mut want: Vec<String> = (0..N).map(|i| format!("note-{i}")).collect();
+        want.sort();
+        assert_eq!(notes, want, "all records intact");
+
         tokio::fs::remove_dir_all(bundle.dir()).await.ok();
     }
 }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -334,6 +334,48 @@ impl HarnessBrain {
         Ok(())
     }
 
+    /// Drains the approval-request queue and parks each request on the host's
+    /// approval gate, so an approval-gated tool call the agent hit during this
+    /// cycle reaches the operator's Approvals page (issue #172).
+    ///
+    /// The missing half of the approval path. openhuman resolves a
+    /// `RequireApproval` **inline** — it blocks the tool and narrates the
+    /// refusal to the model — so nothing downstream of the turn ever learned a
+    /// request existed and `journal.pending()` stayed empty. The
+    /// [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy) now records
+    /// each blocked call on the shared queue; this drains it once per cycle and
+    /// parks it through
+    /// [`CycleHost::park_effect`](crate::ports::brain::CycleHost::park_effect).
+    ///
+    /// Parked, not re-evaluated:
+    /// [`emit_effect`](crate::ports::brain::CycleHost::emit_effect) would
+    /// re-decide the request against the runtime
+    /// [`ApprovalGate`](crate::ports::ApprovalGate), which allows (and therefore
+    /// "executes") anything it classifies as
+    /// [`EffectGroup::Other`](crate::ports::types::EffectGroup::Other) — most
+    /// gated tool calls — and the request would disappear again. The verdict was
+    /// already reached inside the turn; the runtime's job here is only to hold
+    /// it for the operator.
+    ///
+    /// Bounded by
+    /// [`MAX_APPROVAL_REQUESTS_PER_TURN`](crate::harness::policy::MAX_APPROVAL_REQUESTS_PER_TURN);
+    /// anything past the cap is discarded rather than flooding the queue.
+    async fn park_approval_requests(&self, host: &dyn CycleHost) -> Result<()> {
+        for request in self
+            .deps
+            .approval_requests
+            .drain(crate::harness::policy::MAX_APPROVAL_REQUESTS_PER_TURN)
+        {
+            let approval_id = host.park_effect(request.effect).await?;
+            log::info!(
+                "[harness::brain] parked '{}' for operator approval (id={approval_id}): {}",
+                request.tool,
+                request.reason
+            );
+        }
+        Ok(())
+    }
+
     /// Executes one drained delegation from the orchestrator's turn.
     ///
     /// `spawn_task` opens a backlog card through the same
@@ -463,9 +505,16 @@ fn append_result(prev: Option<&str>, responder: &str, body: &str) -> String {
 
 #[async_trait]
 impl Brain for HarnessBrain {
-    async fn run_cycle(&self, req: CycleRequest, _host: &dyn CycleHost) -> Result<CycleResult> {
+    async fn run_cycle(&self, req: CycleRequest, host: &dyn CycleHost) -> Result<CycleResult> {
         // Idempotent — builds the roster on the first cycle, a no-op after.
         self.pool.ensure(&self.record, &self.deps).await?;
+
+        // Issue #172: start from an empty approval queue so nothing a prior
+        // cycle — or a workflow run sharing these deps — left behind is parked
+        // under this cycle. Every turn this cycle runs (the operator turn, its
+        // delegated desk turns, a dispatched card) pushes onto the same queue and
+        // is drained once at the end.
+        self.deps.approval_requests.clear();
 
         let mut channel_responses = Vec::new();
         for event in &req.events {
@@ -527,6 +576,12 @@ impl Brain for HarnessBrain {
                 _ => {}
             }
         }
+
+        // Issue #172: every approval-gated tool call this cycle's turns hit is
+        // parked on the host's gate now, so it shows up on the operator's
+        // Approvals page instead of only being narrated away in chat.
+        self.park_approval_requests(host).await?;
+
         // The runtime requires at least one channel response per cycle.
         if channel_responses.is_empty() {
             channel_responses.push(OutboundMessage {
@@ -565,12 +620,13 @@ mod tests {
     use crate::harness::provider::{HarnessModel, MockProvider};
     use crate::ports::brain::CycleHost;
     use crate::ports::types::{
-        CompanyId, ContextOp, ContextOpResult, Effect, EffectDisposition, ToolCall, ToolResult,
+        ApprovalId, CompanyId, ContextOp, ContextOpResult, Effect, EffectDisposition, ToolCall,
+        ToolResult,
     };
     use crate::store::{FsCompanyStore, FsContextStore, FsOps};
 
-    /// A `CycleHost` that auto-executes anything the brain asks for; the harness
-    /// brain v1 makes no host calls, so it stays inert.
+    /// A `CycleHost` that auto-executes anything the brain asks for and swallows
+    /// anything it parks; used by every test that isn't about approvals.
     #[derive(Default)]
     struct NoopHost;
 
@@ -587,6 +643,45 @@ mod tests {
         }
         async fn emit_effect(&self, _effect: Effect) -> Result<EffectDisposition> {
             Ok(EffectDisposition::Executed)
+        }
+        async fn park_effect(&self, _effect: Effect) -> Result<ApprovalId> {
+            Ok(ApprovalId::new("appr-parked"))
+        }
+    }
+
+    /// A `CycleHost` that records every effect parked for approval, so the
+    /// approval drain can be asserted on (issue #172). Anything else it does is
+    /// inert.
+    #[derive(Default)]
+    struct ParkingHost {
+        parked: std::sync::Mutex<Vec<Effect>>,
+    }
+
+    impl ParkingHost {
+        /// The effects parked through `park_effect`, in order.
+        fn parked(&self) -> Vec<Effect> {
+            self.parked.lock().expect("parked").clone()
+        }
+    }
+
+    #[async_trait]
+    impl CycleHost for ParkingHost {
+        async fn call_tool(&self, _call: ToolCall) -> Result<ToolResult> {
+            Ok(ToolResult {
+                ok: true,
+                output: serde_json::Value::Null,
+            })
+        }
+        async fn context_op(&self, _op: ContextOp) -> Result<ContextOpResult> {
+            Ok(ContextOpResult::Text(String::new()))
+        }
+        async fn emit_effect(&self, _effect: Effect) -> Result<EffectDisposition> {
+            panic!("an approval request must be parked, never re-evaluated as an effect");
+        }
+        async fn park_effect(&self, effect: Effect) -> Result<ApprovalId> {
+            let mut parked = self.parked.lock().expect("parked");
+            parked.push(effect);
+            Ok(ApprovalId::new(format!("appr-{}", parked.len())))
         }
     }
 
@@ -637,6 +732,7 @@ description = "Runs Acme."
             delegations: orchestrator::DelegationQueue::default(),
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
@@ -780,6 +876,7 @@ description = "Builds it."
             delegations: orchestrator::DelegationQueue::default(),
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
@@ -1093,6 +1190,7 @@ members = ["engineer"]
             delegations: orchestrator::DelegationQueue::default(),
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
@@ -1452,6 +1550,7 @@ members = ["eng1", "eng2"]
             delegations: orchestrator::DelegationQueue::default(),
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: failures.clone(),
+            approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
@@ -1500,6 +1599,138 @@ members = ["eng1", "eng2"]
             )),
             "an McpCallFailed audit event was journaled"
         );
+    }
+
+    // --- Approval parking (issue #172) --------------------------------------
+
+    /// A brain over `dir` whose deps carry `requests` as the shared
+    /// approval-request queue — the same handle every roster agent's
+    /// `ApprovalPolicy` pushes onto.
+    fn brain_with_approval_queue(
+        dir: &std::path::Path,
+        requests: crate::harness::policy::ApprovalRequestQueue,
+    ) -> HarnessBrain {
+        let deps = HarnessDeps {
+            provider: Arc::new(MockProvider::new("mock: ")),
+            provider_slug: "mock".to_string(),
+            context: Arc::new(FsContextStore::new(dir)),
+            store: Arc::new(FsCompanyStore::new(dir)),
+            meter: None,
+            workspace_root: dir.to_path_buf(),
+            model_override: None,
+            tasks: None,
+            skills: None,
+            skills_source_dir: None,
+            mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: orchestrator::DelegationQueue::default(),
+            workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
+            mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            approval_requests: requests,
+            secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            workflow_source_dir: None,
+            plan: None,
+            media: None,
+            composio: None,
+            steer: crate::company::steer::InflightRegistry::default(),
+        };
+        HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record())
+    }
+
+    /// The regression for #172: a `RequireApproval` recorded during a turn is
+    /// **parked** on the host, so it lands in the journal the Approvals page
+    /// reads instead of being narrated away in chat and lost.
+    ///
+    /// `ParkingHost` panics on `emit_effect`, which pins the other half of the
+    /// fix: the request must NOT be re-evaluated by the runtime gate (which
+    /// allows — and so silently "executes" — the `Other` group most gated tool
+    /// calls classify into).
+    #[tokio::test]
+    async fn approval_requests_are_parked_for_the_operator() {
+        use crate::harness::policy::{ApprovalPolicy, ApprovalRequestQueue};
+        use openhuman_core::openhuman::agent::tool_policy::{
+            ToolCallContext, ToolPolicy, ToolPolicyDecision, ToolPolicyRequest,
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let requests = ApprovalRequestQueue::default();
+        let brain = brain_with_approval_queue(dir.path(), requests.clone());
+
+        // Exactly what a supervised policy records when the agent reaches for a
+        // gated tool mid-turn.
+        let policy = ApprovalPolicy::new(
+            &crate::company::Policy {
+                mode: "supervised".to_string(),
+                always_approve: Vec::new(),
+                auto_approve_under_usd: None,
+            },
+            None,
+        )
+        .with_requests(requests.clone());
+        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        let request = ToolPolicyRequest::new(
+            "composio_execute",
+            args.clone(),
+            ToolCallContext::session("s", "chat", "ceo", "call-1", 0),
+        );
+        assert!(
+            matches!(
+                policy.check(&request).await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "the fixture must reproduce a gated call"
+        );
+        assert_eq!(requests.queued(), 1, "the decision was recorded to park");
+
+        let host = ParkingHost::default();
+        brain
+            .park_approval_requests(&host)
+            .await
+            .expect("the drain parks");
+
+        let parked = host.parked();
+        assert_eq!(parked.len(), 1, "one approval reached the operator");
+        assert_eq!(parked[0].kind, "composio_execute");
+        assert_eq!(
+            parked[0].payload, args,
+            "the call's arguments are preserved"
+        );
+        assert_eq!(requests.queued(), 0, "the queue is drained");
+    }
+
+    /// A second drain parks nothing: the queue is emptied, so a later cycle
+    /// can't re-park a request the operator has already been shown.
+    #[tokio::test]
+    async fn draining_twice_parks_nothing_the_second_time() {
+        use crate::harness::policy::{ApprovalRequest, ApprovalRequestQueue};
+        use crate::ports::types::EffectGroup;
+
+        let dir = tempfile::tempdir().unwrap();
+        let requests = ApprovalRequestQueue::default();
+        let brain = brain_with_approval_queue(dir.path(), requests.clone());
+        requests.push(ApprovalRequest {
+            tool: "media_generate_image".to_string(),
+            reason: "supervised".to_string(),
+            effect: Effect {
+                kind: "media_generate_image".to_string(),
+                group: EffectGroup::Spend,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: serde_json::json!({ "prompt": "a logo" }),
+            },
+        });
+
+        let host = ParkingHost::default();
+        brain.park_approval_requests(&host).await.expect("drain");
+        brain
+            .park_approval_requests(&host)
+            .await
+            .expect("second drain");
+        assert_eq!(host.parked().len(), 1, "parked once, not twice");
     }
 
     // --- Steer disposition (issue #111) -------------------------------------
@@ -1592,6 +1823,7 @@ members = ["eng1", "eng2"]
             delegations: orchestrator::DelegationQueue::default(),
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -360,18 +360,36 @@ impl HarnessBrain {
     /// Bounded by
     /// [`MAX_APPROVAL_REQUESTS_PER_TURN`](crate::harness::policy::MAX_APPROVAL_REQUESTS_PER_TURN);
     /// anything past the cap is discarded rather than flooding the queue.
+    ///
+    /// **A failed park never takes the batch or the turn down with it.**
+    /// [`ApprovalRequestQueue::drain`](crate::harness::policy::ApprovalRequestQueue::drain)
+    /// empties the shared queue up front, so propagating the first
+    /// [`CycleHost::park_effect`](crate::ports::brain::CycleHost::park_effect)
+    /// error with `?` would lose every *later* request in the batch — already out
+    /// of the queue and never retried — and would discard the turn's
+    /// already-computed operator reply along with it. That is precisely the
+    /// silent-disappearance failure this issue exists to fix, so each failure is
+    /// logged at `error` and the drain continues.
     async fn park_approval_requests(&self, host: &dyn CycleHost) -> Result<()> {
         for request in self
             .deps
             .approval_requests
             .drain(crate::harness::policy::MAX_APPROVAL_REQUESTS_PER_TURN)
         {
-            let approval_id = host.park_effect(request.effect).await?;
-            log::info!(
-                "[harness::brain] parked '{}' for operator approval (id={approval_id}): {}",
-                request.tool,
-                request.reason
-            );
+            match host.park_effect(request.effect).await {
+                Ok(approval_id) => log::info!(
+                    "[harness::brain] parked '{}' for operator approval (id={approval_id}): {}",
+                    request.tool,
+                    request.reason
+                ),
+                // Loud, and the only trace of a request the operator will never
+                // see — the queue entry is already gone.
+                Err(err) => log::error!(
+                    "[harness::brain] failed to park '{}' for operator approval ({}): {err}",
+                    request.tool,
+                    request.reason
+                ),
+            }
         }
         Ok(())
     }
@@ -1731,6 +1749,87 @@ members = ["eng1", "eng2"]
             .await
             .expect("second drain");
         assert_eq!(host.parked().len(), 1, "parked once, not twice");
+    }
+
+    /// A host that fails to park the *first* effect it is handed, then behaves.
+    /// Models a transient journal/IO fault mid-batch.
+    #[derive(Default)]
+    struct FlakyParkingHost {
+        parked: std::sync::Mutex<Vec<Effect>>,
+        seen: std::sync::atomic::AtomicUsize,
+    }
+
+    impl FlakyParkingHost {
+        fn parked(&self) -> Vec<Effect> {
+            self.parked.lock().expect("parked").clone()
+        }
+    }
+
+    #[async_trait]
+    impl CycleHost for FlakyParkingHost {
+        async fn call_tool(&self, _call: ToolCall) -> Result<ToolResult> {
+            Ok(ToolResult {
+                ok: true,
+                output: serde_json::Value::Null,
+            })
+        }
+        async fn context_op(&self, _op: ContextOp) -> Result<ContextOpResult> {
+            Ok(ContextOpResult::Text(String::new()))
+        }
+        async fn emit_effect(&self, _effect: Effect) -> Result<EffectDisposition> {
+            panic!("an approval request must be parked, never re-evaluated as an effect");
+        }
+        async fn park_effect(&self, effect: Effect) -> Result<ApprovalId> {
+            if self.seen.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                return Err(crate::OpenCompanyError::Store(
+                    "journal on fire".to_string(),
+                ));
+            }
+            let mut parked = self.parked.lock().expect("parked");
+            parked.push(effect);
+            Ok(ApprovalId::new(format!("appr-{}", parked.len())))
+        }
+    }
+
+    /// One failed park must not take the rest of the batch — or the turn's reply
+    /// — down with it. `drain` has already emptied the shared queue, so a `?`
+    /// here would lose every later request forever and abort `run_cycle`,
+    /// reproducing for the remainder of the batch exactly the silent
+    /// disappearance this issue fixes.
+    #[tokio::test]
+    async fn a_failed_park_does_not_drop_the_rest_of_the_batch() {
+        use crate::harness::policy::{ApprovalRequest, ApprovalRequestQueue};
+        use crate::ports::types::EffectGroup;
+
+        let dir = tempfile::tempdir().unwrap();
+        let requests = ApprovalRequestQueue::default();
+        let brain = brain_with_approval_queue(dir.path(), requests.clone());
+        for tool in ["first_tool", "second_tool", "third_tool"] {
+            requests.push(ApprovalRequest {
+                tool: tool.to_string(),
+                reason: "supervised".to_string(),
+                effect: Effect {
+                    kind: tool.to_string(),
+                    group: EffectGroup::Other,
+                    amount_usd: None,
+                    established_thread: false,
+                    first_time_counterparty: false,
+                    payload: serde_json::json!({ "tool": tool }),
+                },
+            });
+        }
+
+        let host = FlakyParkingHost::default();
+        brain
+            .park_approval_requests(&host)
+            .await
+            .expect("a park failure is logged, not propagated");
+
+        // The first park failed; the two after it still reached the operator.
+        let parked = host.parked();
+        assert_eq!(parked.len(), 2, "the batch continued past the failure");
+        assert_eq!(parked[0].kind, "second_tool");
+        assert_eq!(parked[1].kind, "third_tool");
     }
 
     // --- Steer disposition (issue #111) -------------------------------------

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -74,7 +74,7 @@ use crate::error::OpenCompanyError;
 use crate::harness::cost::{TurnUsage, record_turn_cost};
 use crate::harness::mcp_probe::McpFailureQueue;
 use crate::harness::orchestrator::DelegationQueue;
-use crate::harness::policy::ApprovalPolicy;
+use crate::harness::policy::{ApprovalPolicy, ApprovalRequestQueue};
 use crate::ports::skills_state::{SkillState, SkillStateStore};
 use crate::ports::types::{CompanyId, CompanyRecord, OverlayAgent, TurnStep};
 use crate::ports::{
@@ -163,6 +163,14 @@ pub struct HarnessDeps {
     /// cheap-shared-handle pattern as [`Self::delegations`]; every string it
     /// carries is scrubbed at the source. Default is an empty queue.
     pub mcp_failures: McpFailureQueue,
+    /// The shared approval-request queue every agent's [`ApprovalPolicy`] pushes
+    /// a `RequireApproval` decision onto and the [`HarnessBrain`] drains after a
+    /// turn, parking each request through
+    /// [`CycleHost::park_effect`](crate::ports::brain::CycleHost::park_effect)
+    /// so it reaches the operator's Approvals page (issue #172). Same
+    /// cheap-shared-handle pattern as [`Self::delegations`]; the default is an
+    /// empty queue, which simply means nothing is ever parked.
+    pub approval_requests: ApprovalRequestQueue,
     /// The company's [`SecretStore`], so [`HarnessPool::ensure`] can **re-resolve**
     /// the effective MCP server set on each call and rebuild the roster when a
     /// console add/remove/enable-toggle changes it — the MCP-freshness fix (a
@@ -1175,7 +1183,8 @@ pub(crate) fn build_roster(
         Vec::with_capacity(company.manifest.agents.len() + company.overlay_agents.len());
 
     for manifest_agent in &company.manifest.agents {
-        let agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily);
+        let agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily)
+            .with_requests(deps.approval_requests.clone());
         let is_orchestrator = orchestrator.as_deref() == Some(manifest_agent.id.as_str());
         let grants = agent_effective_grants(allow, &manifest_agent.tools);
         let agent = build::build_agent(
@@ -1211,7 +1220,8 @@ pub(crate) fn build_roster(
         let manifest_agent = overlay_agent_to_manifest(overlay);
         // No per-teammate budget cap or cognition-tier hint in v1 — see
         // `overlay_agent_to_manifest`.
-        let agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily);
+        let agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily)
+            .with_requests(deps.approval_requests.clone());
         let grants = agent_effective_grants(allow, &manifest_agent.tools);
         let agent = build::build_agent(
             &company.id,
@@ -1440,6 +1450,7 @@ description = "Builds the product."
                 delegations: DelegationQueue::default(),
                 workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
                 mcp_failures: McpFailureQueue::default(),
+                approval_requests: ApprovalRequestQueue::default(),
                 secrets: None,
                 web_allowed_domains: Vec::new(),
                 capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
@@ -1497,6 +1508,7 @@ description = "Builds the product."
             delegations: DelegationQueue::default(),
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
+            approval_requests: ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
@@ -1779,6 +1791,7 @@ description = "Builds the product."
             delegations: DelegationQueue::default(),
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
+            approval_requests: ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
@@ -1933,6 +1946,7 @@ description = "Builds the product."
             delegations: DelegationQueue::default(),
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
+            approval_requests: ApprovalRequestQueue::default(),
             secrets: Some(secrets.clone()),
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
@@ -2239,6 +2253,7 @@ description = "Builds the product."
             delegations: DelegationQueue::default(),
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
+            approval_requests: ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
@@ -2387,6 +2402,7 @@ description = "Sets direction."
             delegations: DelegationQueue::default(),
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
+            approval_requests: ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -6,17 +6,36 @@
 //! `always_approve` effect kinds and the per-agent `budget_usd_daily` /
 //! `auto_approve_under_usd` thresholds.
 //!
-//! ## Where approvals actually park (flagged seam)
+//! ## Where approvals actually park (issue #172)
 //!
 //! openhuman's [`ToolPolicy`] returns
 //! [`ToolPolicyDecision::RequireApproval`](oh::agent::tool_policy::ToolPolicyDecision::RequireApproval),
 //! which the session turn loop treats **fail-closed** — it blocks the tool call
-//! rather than suspending and resuming it inline. To realise the spec's
-//! "park → resolve → resume" flow through opencompany's [`ApprovalGate`] port
-//! and journal, the runtime/chat layer (WS3) maps the flagged tool call to an
-//! [`Effect`] via [`ApprovalPolicy::effect_for`], parks it on the gate, and
-//! re-runs the turn once the operator resolves it. That runtime wiring is the
-//! WS3 seam; this module provides the decision + the effect projection.
+//! and feeds the model a refusal rather than suspending and resuming it inline.
+//! That refusal was for a long time the *only* trace a gated call left: nothing
+//! was ever written to opencompany's [`ApprovalGate`] port or its journal, so
+//! the operator's Approvals page stayed empty however many tools an agent
+//! parked, and the work silently dead-ended.
+//!
+//! The bridge is now closed. Every `RequireApproval` this policy returns also
+//! projects the flagged call onto an opencompany [`Effect`]
+//! ([`ApprovalPolicy::effect_for`]) and pushes it onto the shared
+//! [`ApprovalRequestQueue`] carried on
+//! [`HarnessDeps`](crate::harness::HarnessDeps). The
+//! [`HarnessBrain`](crate::harness::HarnessBrain) drains that queue after the
+//! turn and parks each request through
+//! [`CycleHost::park_effect`](crate::ports::brain::CycleHost::park_effect), so
+//! the request lands in the journal the Approvals page reads and survives a
+//! restart. Same cheap-shared-handle pattern as the delegation and MCP-failure
+//! queues.
+//!
+//! **Still out of scope:** resume-after-approval. openhuman resolves the
+//! decision inline, so approving a parked tool call records the verdict and
+//! clears the queue but does not re-dispatch the tool — the operator re-asks.
+//! Suspending and resuming a call inside openhuman's session loop is a separate
+//! piece of work.
+
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use openhuman_core::openhuman as oh;
@@ -25,6 +44,12 @@ use oh::agent::tool_policy::{ToolPolicy, ToolPolicyDecision, ToolPolicyRequest};
 
 use crate::company::Policy;
 use crate::ports::types::{Effect, EffectGroup};
+
+/// Most approval requests parked out of a single turn. A model that keeps
+/// re-trying a blocked tool (openhuman feeds it a refusal and lets it continue)
+/// must not be able to flood the operator's queue, so the drain is bounded the
+/// same way delegation is.
+pub const MAX_APPROVAL_REQUESTS_PER_TURN: usize = 8;
 
 /// The three approval tiers, mirroring OpenHuman's security tiers 1:1.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -58,6 +83,71 @@ impl PolicyMode {
     }
 }
 
+/// One approval-gated tool call observed during an agent turn: the projected
+/// [`Effect`] the operator will see, plus the tool and the policy's own reason
+/// for logging.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ApprovalRequest {
+    /// The tool the agent tried to call.
+    pub tool: String,
+    /// Why the policy flagged it (the same wording openhuman feeds the model).
+    pub reason: String,
+    /// The projected effect to park on the gate.
+    pub effect: Effect,
+}
+
+/// A shared, in-memory queue of approval-gated tool calls — the exact
+/// [`DelegationQueue`](crate::harness::orchestrator::DelegationQueue) /
+/// [`McpFailureQueue`](crate::harness::mcp_probe::McpFailureQueue) pattern.
+/// Cheap to [`Clone`] (a shared handle); the [`ApprovalPolicy`] installed on
+/// every roster agent and the [`HarnessBrain`](crate::harness::HarnessBrain)
+/// that drains it see the same queue because
+/// [`HarnessDeps`](crate::harness::HarnessDeps) clones share this handle.
+#[derive(Clone, Default)]
+pub struct ApprovalRequestQueue {
+    inner: Arc<Mutex<Vec<ApprovalRequest>>>,
+}
+
+impl ApprovalRequestQueue {
+    /// Records a gated call, ignoring one already queued for the same tool and
+    /// arguments.
+    ///
+    /// openhuman blocks the call but lets the turn continue, so a model that
+    /// re-tries the same tool would otherwise park the identical request several
+    /// times over and show the operator a queue of duplicates.
+    pub fn push(&self, request: ApprovalRequest) {
+        let mut guard = self.inner.lock().expect("approval request queue");
+        if guard.iter().any(|q| {
+            q.effect.kind == request.effect.kind && q.effect.payload == request.effect.payload
+        }) {
+            return;
+        }
+        guard.push(request);
+    }
+
+    /// Empties the queue (called before a turn so a request from a prior turn —
+    /// or from a workflow run that shares these deps — never leaks into it).
+    pub fn clear(&self) {
+        self.inner.lock().expect("approval request queue").clear();
+    }
+
+    /// Drains up to `cap` queued requests (FIFO) and discards the rest, so one
+    /// turn can never flood the operator's queue.
+    pub fn drain(&self, cap: usize) -> Vec<ApprovalRequest> {
+        let mut guard = self.inner.lock().expect("approval request queue");
+        let take = guard.len().min(cap);
+        let drained: Vec<ApprovalRequest> = guard.drain(..take).collect();
+        guard.clear();
+        drained
+    }
+
+    /// The number of queued requests (test/observability).
+    #[cfg(test)]
+    pub fn queued(&self) -> usize {
+        self.inner.lock().expect("approval request queue").len()
+    }
+}
+
 /// openhuman [`ToolPolicy`] derived from a company's manifest `[policy]` and a
 /// single agent's per-agent budget.
 pub struct ApprovalPolicy {
@@ -67,6 +157,12 @@ pub struct ApprovalPolicy {
     /// Per-agent daily spend cap; retained for the runtime budget gate. `None`
     /// leaves budget enforcement to the company-wide `[budget]` ceiling.
     budget_usd_daily: Option<f64>,
+    /// Where a `RequireApproval` decision is recorded so the runtime can park it
+    /// (issue #172). The default is a private queue nobody drains, which keeps
+    /// every non-harness construction site (and every test) behaving exactly as
+    /// before; `build_roster` installs the shared one off
+    /// [`HarnessDeps`](crate::harness::HarnessDeps).
+    requests: ApprovalRequestQueue,
 }
 
 impl ApprovalPolicy {
@@ -78,7 +174,15 @@ impl ApprovalPolicy {
             always_approve: policy.always_approve.clone(),
             auto_approve_under_usd: policy.auto_approve_under_usd,
             budget_usd_daily,
+            requests: ApprovalRequestQueue::default(),
         }
+    }
+
+    /// Installs the shared queue every `RequireApproval` decision is recorded on,
+    /// so the brain can park the request after the turn (issue #172).
+    pub fn with_requests(mut self, requests: ApprovalRequestQueue) -> Self {
+        self.requests = requests;
+        self
     }
 
     /// The resolved tier.
@@ -122,6 +226,30 @@ impl ApprovalPolicy {
             payload: args.clone(),
         }
     }
+
+    /// The one construction site for a `RequireApproval` decision (issue #172):
+    /// record the projected effect on the shared queue so the brain can park it
+    /// after the turn, then return the decision openhuman blocks the call with.
+    ///
+    /// Every `RequireApproval` arm of [`check`](ToolPolicy::check) goes through
+    /// here — a decision that skipped it would refuse the tool without ever
+    /// reaching the operator, which is exactly the bug this closes.
+    fn require_approval(
+        &self,
+        tool: &str,
+        args: &serde_json::Value,
+        reason: String,
+    ) -> ToolPolicyDecision {
+        self.requests.push(ApprovalRequest {
+            tool: tool.to_string(),
+            reason: reason.clone(),
+            effect: self.effect_for(tool, args),
+        });
+        log::debug!(
+            "[approval] tool '{tool}' requires operator approval — queued to park ({reason})"
+        );
+        ToolPolicyDecision::require_approval(reason)
+    }
 }
 
 #[async_trait]
@@ -135,9 +263,11 @@ impl ToolPolicy for ApprovalPolicy {
 
         // `always_approve` wins over everything, including Full autonomy.
         if self.always_requires_approval(tool) {
-            return ToolPolicyDecision::require_approval(format!(
-                "'{tool}' is in the company's always-approve list"
-            ));
+            return self.require_approval(
+                tool,
+                &request.arguments,
+                format!("'{tool}' is in the company's always-approve list"),
+            );
         }
 
         // Auto-approve small spends under the configured threshold.
@@ -154,9 +284,11 @@ impl ToolPolicy for ApprovalPolicy {
             PolicyMode::Full => ToolPolicyDecision::Allow,
             PolicyMode::Supervised => {
                 if external {
-                    ToolPolicyDecision::require_approval(format!(
-                        "'{tool}' has an external effect and this desk runs supervised"
-                    ))
+                    self.require_approval(
+                        tool,
+                        &request.arguments,
+                        format!("'{tool}' has an external effect and this desk runs supervised"),
+                    )
                 } else {
                     ToolPolicyDecision::Allow
                 }
@@ -516,5 +648,135 @@ mod tests {
         assert_eq!(effect.kind, "pay_invoice");
         assert_eq!(effect.group, EffectGroup::Spend);
         assert_eq!(effect.amount_usd, Some(12.5));
+    }
+
+    // --- The park queue (issue #172) ----------------------------------------
+
+    fn queued_policy(mode: &str, always: &[&str]) -> (ApprovalPolicy, ApprovalRequestQueue) {
+        let queue = ApprovalRequestQueue::default();
+        (
+            policy(mode, always, None).with_requests(queue.clone()),
+            queue,
+        )
+    }
+
+    /// The core of #172: a `RequireApproval` decision no longer evaporates into
+    /// the model's transcript — it is recorded, with the call projected onto the
+    /// effect the operator will see, so the runtime can park it.
+    #[tokio::test]
+    async fn require_approval_records_the_request_to_park() {
+        let (p, queue) = queued_policy("supervised", &[]);
+        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        assert!(matches!(
+            p.check(&request("composio_execute", args.clone())).await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
+
+        let queued = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
+        assert_eq!(queued.len(), 1, "the gated call was recorded");
+        assert_eq!(queued[0].tool, "composio_execute");
+        assert_eq!(queued[0].effect.kind, "composio_execute");
+        assert_eq!(queued[0].effect.group, EffectGroup::Send);
+        assert_eq!(queued[0].effect.payload, args);
+        assert!(
+            queued[0].reason.contains("supervised"),
+            "the operator-facing reason rides along: {}",
+            queued[0].reason
+        );
+    }
+
+    /// `always_approve` parks regardless of tier — including under `full` — so
+    /// that arm has to record its request too.
+    #[tokio::test]
+    async fn always_approve_records_the_request_even_under_full_autonomy() {
+        let (p, queue) = queued_policy("full", &["payment"]);
+        assert!(matches!(
+            p.check(&request(
+                "payment.send",
+                serde_json::json!({ "amount_usd": 40.0 })
+            ))
+            .await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
+        let queued = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].effect.kind, "payment.send");
+        assert_eq!(queued[0].effect.amount_usd, Some(40.0));
+    }
+
+    /// Allowed and denied calls leave the queue alone: only a call actually
+    /// waiting on the operator may reach the Approvals page.
+    #[tokio::test]
+    async fn allow_and_deny_record_nothing() {
+        let (supervised, allow_queue) = queued_policy("supervised", &[]);
+        assert_eq!(
+            supervised
+                .check(&request("read_file", serde_json::json!({})))
+                .await,
+            ToolPolicyDecision::Allow
+        );
+        assert_eq!(allow_queue.queued(), 0, "an allowed call parks nothing");
+
+        let (readonly, deny_queue) = queued_policy("readonly", &[]);
+        assert!(matches!(
+            readonly
+                .check(&request("publish_post", serde_json::json!({})))
+                .await,
+            ToolPolicyDecision::Deny { .. }
+        ));
+        assert_eq!(
+            deny_queue.queued(),
+            0,
+            "a denied call is refused outright, never parked"
+        );
+    }
+
+    /// openhuman blocks a gated call but lets the turn continue, so a model that
+    /// keeps re-trying the same tool must not stack up duplicate approvals.
+    #[tokio::test]
+    async fn a_retried_call_is_recorded_once() {
+        let (p, queue) = queued_policy("supervised", &[]);
+        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        for _ in 0..3 {
+            let _ = p.check(&request("composio_execute", args.clone())).await;
+        }
+        assert_eq!(queue.queued(), 1, "the same call parks once");
+
+        // A different call to the same tool is a distinct request.
+        let _ = p
+            .check(&request(
+                "composio_execute",
+                serde_json::json!({ "tool_slug": "SLACK_POST" }),
+            ))
+            .await;
+        assert_eq!(queue.queued(), 2);
+    }
+
+    /// The drain is capped, so a runaway turn can't flood the operator's queue.
+    #[tokio::test]
+    async fn the_drain_is_capped_and_empties_the_queue() {
+        let (p, queue) = queued_policy("supervised", &[]);
+        for i in 0..(MAX_APPROVAL_REQUESTS_PER_TURN + 4) {
+            let _ = p
+                .check(&request(
+                    "composio_execute",
+                    serde_json::json!({ "tool_slug": format!("TOOL_{i}") }),
+                ))
+                .await;
+        }
+        let drained = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
+        assert_eq!(drained.len(), MAX_APPROVAL_REQUESTS_PER_TURN);
+        assert_eq!(queue.queued(), 0, "the overflow is discarded, not carried");
+    }
+
+    /// A queue nobody installed stays inert — the default policy behaves exactly
+    /// as it did before #172 for every non-harness construction site.
+    #[tokio::test]
+    async fn a_policy_without_a_shared_queue_still_decides_normally() {
+        let p = policy("supervised", &[], None);
+        assert!(matches!(
+            p.check(&request("send_email", serde_json::json!({}))).await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
     }
 }

--- a/src/ports/brain.rs
+++ b/src/ports/brain.rs
@@ -8,8 +8,8 @@ use async_trait::async_trait;
 
 use crate::Result;
 use crate::ports::types::{
-    ContextOp, ContextOpResult, CycleRequest, CycleResult, Effect, EffectDisposition, ToolCall,
-    ToolResult,
+    ApprovalId, ContextOp, ContextOpResult, CycleRequest, CycleResult, Effect, EffectDisposition,
+    ToolCall, ToolResult,
 };
 
 /// The cognition port. One `run_cycle` call turns a batch of events into a
@@ -29,4 +29,21 @@ pub trait CycleHost: Send + Sync {
     async fn context_op(&self, op: ContextOp) -> Result<ContextOpResult>;
     /// Emits a side effect for policy evaluation and dispatch.
     async fn emit_effect(&self, effect: Effect) -> Result<EffectDisposition>;
+    /// Parks an effect for operator approval **without** re-evaluating it.
+    ///
+    /// The counterpart to [`emit_effect`](Self::emit_effect), for a decision the
+    /// brain has already made. A brain that hosts its own policy layer — the
+    /// harness brain's openhuman `ApprovalPolicy`, which blocks a gated tool call
+    /// *inside* the agent turn — has no effect to submit for evaluation: the
+    /// verdict is already `RequireApproval`, and the projected effect exists only
+    /// so the operator can see and resolve it. Routing it through `emit_effect`
+    /// would re-decide it against the coarser
+    /// [`ApprovalGate`](crate::ports::ApprovalGate) taxonomy, which allows (and
+    /// so "executes") anything it classifies as
+    /// [`EffectGroup::Other`](crate::ports::types::EffectGroup::Other) — the
+    /// request would vanish instead of parking.
+    ///
+    /// Parks on the gate, journals the record so it survives a restart, and
+    /// returns the new [`ApprovalId`]. (Issue #172.)
+    async fn park_effect(&self, effect: Effect) -> Result<ApprovalId>;
 }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -949,6 +949,8 @@ impl RuntimeBuilder {
                                 // MCP set each turn (MCP-freshness) rather than the
                                 // snapshot frozen here at boot.
                                 mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+                                approval_requests:
+                                    crate::harness::policy::ApprovalRequestQueue::default(),
                                 secrets: Some(secrets.clone()),
                                 // Cell A: the `web` toolbelt SSRF allowlist.
                                 // Domains come straight from the manifest.

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -435,25 +435,44 @@ impl<'a> CycleHostImpl<'a> {
                 Ok(EffectDisposition::Executed)
             }
             PolicyDecision::RequireApproval => {
-                let approval_id = self
-                    .rt
-                    .approvals
-                    .park(&self.company, effect.clone())
-                    .await?;
-                self.rt
-                    .journal
-                    .record_parked(&approval_id, &effect, now_millis())
-                    .await?;
-                self.parked
-                    .lock()
-                    .expect("parked poisoned")
-                    .push(approval_id.clone());
-                Ok(EffectDisposition::PendingApproval(approval_id))
+                Ok(EffectDisposition::PendingApproval(self.park(effect).await?))
             }
             PolicyDecision::Deny => Ok(EffectDisposition::Denied {
                 reason: format!("policy denied {}", effect.kind),
             }),
         }
+    }
+
+    /// Parks `effect` on the approval gate, journals it durably, and records the
+    /// id on this cycle's outcome.
+    ///
+    /// The single write path into the operator's approval queue: the
+    /// `RequireApproval` arm of [`gate_effect`](Self::gate_effect) and the
+    /// already-decided [`CycleHost::park_effect`] callback both land here, so a
+    /// parked effect is journaled exactly one way and survives a restart with its
+    /// original [`ApprovalId`] regardless of who decided it.
+    async fn park(&self, effect: Effect) -> Result<ApprovalId> {
+        let approval_id = self
+            .rt
+            .approvals
+            .park(&self.company, effect.clone())
+            .await?;
+        self.rt
+            .journal
+            .record_parked(&approval_id, &effect, now_millis())
+            .await?;
+        self.parked
+            .lock()
+            .expect("parked poisoned")
+            .push(approval_id.clone());
+        tracing::debug!(
+            kind = %effect.kind,
+            group = ?effect.group,
+            approval_id = %approval_id,
+            cycle = %self.cycle_id,
+            "[cycle] parked effect for operator approval"
+        );
+        Ok(approval_id)
     }
 
     /// Intercepts the `send_email` tool: parses `to`/`subject`/`body`, checks
@@ -536,6 +555,10 @@ impl CycleHost for CycleHostImpl<'_> {
     async fn emit_effect(&self, effect: Effect) -> Result<EffectDisposition> {
         self.gate_effect(effect).await
     }
+
+    async fn park_effect(&self, effect: Effect) -> Result<ApprovalId> {
+        self.park(effect).await
+    }
 }
 
 #[cfg(test)]
@@ -609,6 +632,37 @@ mod test {
             Ok(CycleResult {
                 channel_responses: responses,
                 new_traces: vec![CompressedTrace::now(&req.cycle_id, "effect cycle")],
+                ledger_deltas: Vec::new(),
+                token_usage: TokenUsage::default(),
+            })
+        }
+    }
+
+    /// A brain that parks one caller-supplied effect per `OperatorMessage`
+    /// through [`CycleHost::park_effect`] — the shape the harness brain produces
+    /// when its openhuman policy blocked a tool call inside the turn (#172).
+    struct ParkingBrain {
+        effect: Effect,
+    }
+
+    #[async_trait]
+    impl Brain for ParkingBrain {
+        async fn run_cycle(&self, req: CycleRequest, host: &dyn CycleHost) -> Result<CycleResult> {
+            let mut responses = Vec::new();
+            for event in &req.events {
+                if let CompanyEvent::OperatorMessage { text, .. } = event {
+                    host.park_effect(self.effect.clone()).await?;
+                    responses.push(OutboundMessage {
+                        channel: "operator".into(),
+                        text: format!("that needs your approval: {text}"),
+                        steps: Vec::new(),
+                        reply_to: None,
+                    });
+                }
+            }
+            Ok(CycleResult {
+                channel_responses: responses,
+                new_traces: vec![CompressedTrace::now(&req.cycle_id, "parking cycle")],
                 ledger_deltas: Vec::new(),
                 token_usage: TokenUsage::default(),
             })
@@ -805,6 +859,68 @@ mod test {
             .unwrap();
         assert!(follow_up.parked.is_empty());
         assert!(rt.pending_approvals().is_empty());
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    /// Issue #172: an already-decided approval request parks and reaches the
+    /// operator's queue **without** being re-evaluated.
+    ///
+    /// The company runs `full` autonomy and the effect classifies as `Other` —
+    /// the two conditions under which `ApprovalGate::evaluate` returns `Allow`.
+    /// Had the request gone through `emit_effect` it would have been "executed"
+    /// as a no-op and vanished, which is exactly how a chat-gated tool call used
+    /// to disappear before ever reaching the Approvals page.
+    #[tokio::test]
+    async fn a_decided_request_parks_without_being_re_evaluated() {
+        let home = tmp_home();
+        let tool_effect = Effect {
+            kind: "composio_execute".into(),
+            group: EffectGroup::Other,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
+        };
+        let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
+            .with_brain(Arc::new(ParkingBrain {
+                effect: tool_effect.clone(),
+            }))
+            .build()
+            .await
+            .unwrap();
+
+        let report = rt
+            .run_cycle(vec![CompanyEvent::OperatorMessage {
+                text: "send that email".into(),
+                by: None,
+                chat: None,
+            }])
+            .await
+            .unwrap();
+
+        assert_eq!(report.parked.len(), 1, "the request parked");
+        assert!(
+            report.executed_effects.is_empty(),
+            "a parked request must not execute"
+        );
+
+        // The Approvals page reads exactly this.
+        let pending = rt.pending_approvals();
+        assert_eq!(pending.len(), 1, "the operator sees the request");
+        assert_eq!(pending[0].kind, "composio_execute");
+        assert_eq!(pending[0].id, report.parked[0]);
+
+        // And it is durable: a fresh runtime over the same home replays it, so a
+        // restart does not lose what the operator still owes an answer to.
+        let rt2 = RuntimeBuilder::new(home.clone(), manifest("full"))
+            .with_brain(Arc::new(ParkingBrain {
+                effect: tool_effect,
+            }))
+            .build()
+            .await
+            .unwrap();
+        assert_eq!(rt2.pending_approvals().len(), 1);
+
         tokio::fs::remove_dir_all(&home).await.ok();
     }
 

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1420,6 +1420,7 @@ mod test {
             delegations: crate::harness::orchestrator::DelegationQueue::default(),
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -236,6 +236,7 @@ description = "Runs Acme."
             delegations: crate::harness::orchestrator::DelegationQueue::default(),
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,


### PR DESCRIPTION
## Summary

Fixes #172.

An agent that hit an approval-gated tool during a chat turn left no trace the
operator could act on. openhuman resolves a `RequireApproval` from its
`ToolPolicy` **inline** — it blocks the call and narrates a refusal to the model
("… is still blocked by approval policy") — and nothing was ever written to
OpenCompany's `ApprovalGate` or its journal. `journal.pending()` stayed empty,
`GET /api/v1/company/approvals` returned `[]`, and the Approvals page rendered
"All clear" however many tools an agent had parked. The work silently
dead-ended.

The two mechanisms are now joined:

1. **`ApprovalPolicy::check`** (`src/harness/policy.rs`) routes both
   `RequireApproval` arms through one site that projects the flagged call onto an
   `Effect` via `effect_for` — previously called only from tests — and records it
   on a shared `ApprovalRequestQueue` carried on `HarnessDeps`. Same
   cheap-shared-handle pattern as `DelegationQueue` / `McpFailureQueue`. A model
   re-trying the same blocked call (openhuman lets the turn continue) collapses
   to one request.
2. **`HarnessBrain::run_cycle`** (`src/harness/brain.rs`) takes its `CycleHost`
   for real — it ignored it as `_host`. It clears the queue before its turns and
   drains it after, bounded by `MAX_APPROVAL_REQUESTS_PER_TURN`. One drain covers
   every turn in the cycle: the orchestrator turn, its delegated desk turns, and
   a dispatched card.
3. **`CycleHost::park_effect`** (new) parks an already-decided effect.
   `CycleHostImpl::park` is now the single write path into the operator's queue,
   shared with the `RequireApproval` arm of `gate_effect`, so a parked effect is
   journaled one way and survives a restart with its original `ApprovalId`.

### Why `park_effect` and not `emit_effect`

The issue's proposed fix suggests `host.emit_effect(effect)`. That would
re-decide the request against `ManifestApprovalGate`, whose supervised taxonomy
maps `EffectGroup::Other → Allow` — and `Other` is what most gated tool calls
classify into (`composio_execute`, `describe_workflow`,
`mcp_registry_tool_call`). The request would be "executed" as a no-op by
`perform_effect` (no `amount_usd`, no `channel`/`text` payload) and disappear:
the same bug, one layer down. The verdict was already reached inside the turn;
the runtime's job here is only to hold it for the operator. The
`runtime/cycle.rs` test below pins exactly this.

### Not included: resume-after-approval

Held to the issue's stated "minimum viable" scope. Because openhuman resolves the
decision inline, approving a parked tool call records the verdict and clears the
queue but does **not** re-dispatch the tool — the operator re-asks. Doing it
properly needs a suspend/resume seam inside openhuman's session loop plus a
one-shot grant keyed to the specific call, which the issue itself flags as
separate complexity. Called out in the module docs and in the code.

## API Or Behavior Changes

- **`CycleHost` gains a required method**, `park_effect(&self, effect: Effect) ->
  Result<ApprovalId>`. All four in-tree implementations are updated.
  `emit_effect` semantics are unchanged.
- **`HarnessDeps` gains `approval_requests: ApprovalRequestQueue`.** The default
  is an empty queue nobody drains, so every construction site that doesn't opt in
  behaves exactly as before.
- New public items in `harness::policy`: `ApprovalRequest`,
  `ApprovalRequestQueue`, `ApprovalPolicy::with_requests`,
  `MAX_APPROVAL_REQUESTS_PER_TURN`. Decision logic for `Allow` / `Deny` is
  untouched — only the `RequireApproval` path gained a side effect.
- **Operator-visible:** approval-gated tool calls now appear on the Approvals
  page. They expire to default-deny on the normal TTL like any other parked
  effect.
- **Console:** `EFFECT_LABELS` in `frontend/src/lib/language.ts` gains five
  entries. A parked effect's `kind` is the tool's own name, so without this the
  new requests render through the title-cased fallback as "Composio Execute" — a
  runtime internal in operator-facing text, which that file's own glossary rule
  forbids. No type or API change; the fallback is unchanged.

## Tests

Seven new tests, each failing before the change:

- `src/harness/policy.rs` — a `RequireApproval` records the request with the
  right tool/group/amount/payload and reason; `always_approve` records even under
  `full` autonomy; `Allow` and `Deny` record nothing; a retried call is recorded
  once; the drain caps and empties; a policy with no shared queue still decides
  normally.
- `src/harness/brain.rs` — a drained request is parked with its arguments
  preserved, and a second drain parks nothing. The test host **panics** on
  `emit_effect`, pinning the no-re-evaluation half of the fix.
- `src/runtime/cycle.rs` — end-to-end through a real `CompanyRuntime`: under
  `full` autonomy with an `Other`-group effect (precisely where re-evaluation
  would have silently dropped it) the request parks, executes nothing, appears in
  `pending_approvals()` under the tool's name, and is replayed by a fresh runtime
  over the same home.

Ran locally: `rustfmt --edition 2024 --check` over every changed Rust file —
clean.

**Not run locally, and CI will not cover it either.** `.github/workflows/ci.yml`
builds with default features, and `openhuman` is not in `default` — so
`src/harness/**` (the policy and brain halves of this change, and five of the
seven new tests) is not compiled by the CI lane. CI does cover `ports/brain.rs`,
`runtime/cycle.rs`, `src/brain/*` and the three cycle-level assertions. This gap
is pre-existing (`src/harness/build.rs` already notes "the full
`openhuman,mcp,telegram` clippy combo, which CI does not build"), but it is worth
a reviewer's attention here, and adding an `--features openhuman` lane would be a
worthwhile follow-up.

## Documentation

- `docs/modules/openhuman/README.md` — new "Approval parking" section: the inline
  fail-closed behaviour, the two-step queue → park path, why `park_effect` rather
  than `emit_effect`, and the explicit resume-after-approval gap.
- `docs/modules/policy/README.md` — the two ways onto the approval queue.
- `docs/spec/runtime/ports.md` — `CycleHost` signature updated with `park_effect`
  and the distinction between deciding and holding.
- Module-level docs in `src/harness/policy.rs` rewritten: the "flagged WS3 seam"
  note described a bridge that was never built; it now describes the one that is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tool actions requiring approval are now queued and shown to operators after each agent turn (instead of being lost).
  - Approval requests are deduplicated and limited to eight per turn.
  - Parked approvals preserve the original decision and persist across restarts.
  - Approval UI text now uses clearer labels for tool authorization, execution, media generation, and registry actions.
- **Bug Fixes**
  - Failures while parking an approval no longer prevent later approvals in the same cycle.
  - Fixed a concurrency issue that could corrupt feedback JSONL output.
- **Documentation**
  - Expanded guidance on approval parking, queued effects, and how pending approvals are handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->