### PR TITLE
feat(credentials): resolve the tinyhumans bearer from a token source instead of holding one

### DIFF
--- a/docs/spec/runtime/config.md
+++ b/docs/spec/runtime/config.md
@@ -40,15 +40,20 @@ two-tier source (`company::credentials`). Highest precedence first:
 
 | Tier | Env | Who sets it | Shape |
 | --- | --- | --- | --- |
-| projected file | `TINYHUMANS_TOKEN_FILE` | the hosting platform | a short-lived, audience-bound token in a file the platform **rewrites in place** (roughly every 8 minutes) |
+| projected file | `TINYHUMANS_TOKEN_FILE` | the hosting platform | a short-lived, audience-bound token in a file the platform **rewrites in place** (600-second expiry, so roughly every 8 minutes) |
 | static | `TINYHUMANS_API_KEY` | you | a long-lived key held for the life of the process |
 
-A hosted tenant gets the projected file and stores no secret at all. The file is
+A hosted tenant gets the projected file and stores no secret at all: the platform
+mounts it read-only at `/var/run/secrets/tinyhumans.ai/token` and the env var
+carries that **path** — never a token value. The tier is selected only when the
+path exists, so a leftover variable under a runtime that mounts nothing (docker)
+falls through to the static tier instead of failing every request. The file is
 re-read as it rotates: a read is cached for 80% of the token's remaining TTL,
 capped at 60 seconds, and a token whose `exp` cannot be read (or has already
-passed) is not cached at all. Expiry is parsed out of the JWT **without verifying
-the signature** — the runtime needs the date, and the backend is the party that
-verifies the token.
+passed) is not cached at all, and a `401` from the backend drops the cached read
+so the next request goes straight back to the file. Expiry is parsed out of the
+JWT **without verifying the signature** — the runtime needs the date, and the
+backend is the party that verifies the token.
 
 The static tier is what `docker compose` uses, and it is the only credential path
 available if you run this repo standalone. Standalone/self-hosted operation is

--- a/docs/spec/runtime/config.md
+++ b/docs/spec/runtime/config.md
@@ -50,8 +50,8 @@ path exists, so a leftover variable under a runtime that mounts nothing (docker)
 falls through to the static tier instead of failing every request. The file is
 re-read as it rotates: a read is cached for 80% of the token's remaining TTL,
 capped at 60 seconds, and a token whose `exp` cannot be read (or has already
-passed) is not cached at all, and a `401` from the backend drops the cached read
-so the next request goes straight back to the file. Expiry is parsed out of the
+passed) is not cached at all. A `401` from the backend drops the cached read, so
+the next request goes straight back to the file. Expiry is parsed out of the
 JWT **without verifying the signature** — the runtime needs the date, and the
 backend is the party that verifies the token.
 
@@ -66,7 +66,7 @@ report nor any API response ever carries the token.
 ## Precedence
 
 ```text
-env (OPENCOMPANY_*, TINYHUMANS_API_KEY)
+env (OPENCOMPANY_*, TINYHUMANS_TOKEN_FILE, TINYHUMANS_API_KEY)
   ⟵ ~/.opencompany/config.toml
   ⟵ company manifest
   ⟵ built-in defaults

--- a/docs/spec/runtime/config.md
+++ b/docs/spec/runtime/config.md
@@ -33,6 +33,31 @@ Without a credential the runtime still builds, validates manifests, runs
 README promise that you can build/inspect/explore keyless. Cycles require the
 credential; feedback falls back to the local GitHub/manual-link path.
 
+## Where the credential comes from
+
+The runtime does not hold a credential — it *obtains* one, per request, from a
+two-tier source (`company::credentials`). Highest precedence first:
+
+| Tier | Env | Who sets it | Shape |
+| --- | --- | --- | --- |
+| projected file | `TINYHUMANS_TOKEN_FILE` | the hosting platform | a short-lived, audience-bound token in a file the platform **rewrites in place** (roughly every 8 minutes) |
+| static | `TINYHUMANS_API_KEY` | you | a long-lived key held for the life of the process |
+
+A hosted tenant gets the projected file and stores no secret at all. The file is
+re-read as it rotates: a read is cached for 80% of the token's remaining TTL,
+capped at 60 seconds, and a token whose `exp` cannot be read (or has already
+passed) is not cached at all. Expiry is parsed out of the JWT **without verifying
+the signature** — the runtime needs the date, and the backend is the party that
+verifies the token.
+
+The static tier is what `docker compose` uses, and it is the only credential path
+available if you run this repo standalone. Standalone/self-hosted operation is
+**not supported** this milestone: it is an escape hatch, not a deployment mode.
+
+`opencompany doctor` prints the active tier as `credential_source`
+(`attested` / `static` / `none`) alongside the token-file path. Neither the
+report nor any API response ever carries the token.
+
 ## Precedence
 
 ```text
@@ -49,7 +74,8 @@ layer set it, and what is missing for each optional capability.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `TINYHUMANS_API_KEY` | — (required for cycles) | TinyHumans credential (JWT or API key) |
+| `TINYHUMANS_TOKEN_FILE` | — | Platform-projected, audience-bound token file; rotates in place and outranks `TINYHUMANS_API_KEY` |
+| `TINYHUMANS_API_KEY` | — (required for cycles when no token file) | Static TinyHumans credential (JWT or API key) |
 | `TINYHUMANS_API_URL` | `https://api.tinyhumans.ai` | Backend base URL |
 | `OPENCOMPANY_BIND` | `127.0.0.1:8080` | HTTP bind address |
 | `OPENCOMPANY_DATA_DIR` | `~/.opencompany` | Bundle root for fs stores |

--- a/frontend/src/api/composio.ts
+++ b/frontend/src/api/composio.ts
@@ -1,15 +1,28 @@
 // The live Composio API (issue #110, epic #26 Cell D): the console reads the
-// company's Composio status and writes its per-tenant OAuth bearer token through
-// the host's `.../composio` routes (REST, camelCase over the wire).
+// company's Composio status and — when a company brings its own account — writes
+// a per-company OAuth bearer token through the host's `.../composio` routes
+// (REST, camelCase over the wire).
 //
-// The token is the entire tenant-isolation lever — the backend derives the
-// Composio entity from it — so it is WRITE-ONLY: sent on `PUT .../composio/token`
-// and stored in the host's secret store; it is never returned. The read shape
-// carries only a `tokenConfigured` boolean plus non-secret routing (backend URL,
+// On the hosted platform nothing is pasted: the instance authenticates with a
+// platform-minted, audience-bound identity and Composio calls present that, which
+// the read shape reports as `credentialSource: "attested"`. The write route is the
+// per-company BYO override, and the only option when this repo is run standalone
+// — which is UNSUPPORTED. Either way the token is WRITE-ONLY: sent on
+// `PUT .../composio/token`, stored in the host's secret store, never returned. The
+// read shape carries only `credentialSource` plus non-secret routing (backend URL,
 // toolkit allowlist). Standalone functions over the shared client (mirrors
 // `api/inference.ts`), so no change to `OpenCompanyClient` is needed.
 
 import type { OpenCompanyClient } from "./client";
+
+/**
+ * Where this company's Composio credential comes from.
+ *
+ * - `attested` — the instance's own platform identity; nothing is stored here.
+ * - `static` — a token this company pasted, or a static instance key.
+ * - `none` — no credential can be obtained, so agents get no Composio tools.
+ */
+export type ComposioCredentialSource = "attested" | "static" | "none";
 
 /** The company's Composio status. Never carries the token. */
 export interface ComposioStatus {
@@ -17,8 +30,8 @@ export interface ComposioStatus {
   inBuild: boolean;
   /** Whether the company explicitly grants `composio` (a `*` wildcard does not count). */
   granted: boolean;
-  /** Whether a per-tenant token is stored — never the token itself. */
-  tokenConfigured: boolean;
+  /** Which credential this company's Composio calls present — never the credential itself. */
+  credentialSource: ComposioCredentialSource;
   /** The effective Composio backend URL (non-secret). */
   backendUrl: string;
   /** The manifest toolkit allowlist (empty = defer to the backend allowlist). */
@@ -54,8 +67,9 @@ export function getComposioStatus(
 }
 
 /**
- * Set / rotate / clear the write-only per-tenant Composio token. A non-empty
- * value rotates it; an empty string clears it.
+ * Set / rotate / clear this company's own Composio token. A non-empty value
+ * rotates it; an empty string clears it, reverting to the instance's identity
+ * where there is one.
  */
 export function setComposioToken(
   client: OpenCompanyClient,

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -319,7 +319,7 @@ export function ComposioSection({ client, company }: Props) {
                 )}
                 <div className="space-y-1">
                   <Label htmlFor="composio-token" className="text-xs">
-                    Composio token {byoToken ? "— set, leave blank to keep" : ""}
+                    Composio token {byoToken ? "— set (paste a new value to rotate)" : ""}
                   </Label>
                   <Input
                     id="composio-token"

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Check, KeyRound, Loader2, LogIn, Plug, Save, Trash2 } from "lucide-react";
+import { Check, KeyRound, Loader2, LogIn, Plug, Save, ShieldCheck, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
@@ -38,13 +38,25 @@ function toolkitLabel(slug: string): string {
 }
 
 /**
- * Per-tenant Composio connection management (issue #110, Cell D). Two ways to
- * connect: a per-provider OAuth "Sign in" list driven by the granted toolkits
- * (Composio runs the hosted OAuth; we open it in a tab and poll until the
- * toolkit reports connected), and — as a fallback — a WRITE-ONLY token input
- * (the per-tenant OAuth bearer is the entire isolation lever, so it is stored
- * and never shown again). A set/clear takes effect on the agents' next turn, no
- * restart. Hidden entirely when the feature is not in the build.
+ * Per-tenant Composio connection management (issue #110, Cell D).
+ *
+ * Two layers, and they are independent:
+ *
+ * 1. **Which credential this company reaches Composio with**, reported as
+ *    `credentialSource`:
+ *    - `attested` (hosted) — the instance already holds a platform identity, so
+ *      there is nothing to paste and nothing stored here. A company that wants
+ *      to use its OWN Composio account can still override.
+ *    - `static` — a token this company pasted, or a static instance key.
+ *    - `none` — no credential can be obtained, so there is nothing to authorize
+ *      against and agents get no Composio tools.
+ * 2. **Which providers are connected**, via a per-provider OAuth "Sign in" list
+ *    driven by the granted toolkits. Composio runs the hosted OAuth; we open it
+ *    in a tab and poll until the toolkit reports connected.
+ *
+ * The pasted token is WRITE-ONLY: stored and never shown again. A set/clear
+ * takes effect on the agents' next turn, no restart. Hidden entirely when the
+ * feature is not in the build.
  */
 export function ComposioSection({ client, company }: Props) {
   const [load, setLoad] = useState<"loading" | "ready" | "unavailable">("loading");
@@ -55,6 +67,9 @@ export function ComposioSection({ client, company }: Props) {
   const [connected, setConnected] = useState<Record<string, boolean>>({});
   // toolkit slug currently mid-sign-in (open tab + poll).
   const [signingIn, setSigningIn] = useState<string | null>(null);
+  // Only meaningful in the attested state, where the paste card is an override
+  // rather than the way in.
+  const [showOverride, setShowOverride] = useState(false);
 
   const requestGeneration = useRef(0);
   const pollTimers = useRef<Record<string, number>>({});
@@ -70,8 +85,9 @@ export function ComposioSection({ client, company }: Props) {
 
   const refreshConnections = useCallback(
     async (s: ComposioStatus) => {
-      // Connections need a configured token; skip the call otherwise (it 409s).
-      if (!s.tokenConfigured || s.toolkits.length === 0) {
+      // Listing connections needs *a* credential — any tier. With none there is
+      // nothing to authorize against, and the call 409s.
+      if (s.credentialSource === "none" || s.toolkits.length === 0) {
         setConnected({});
         return;
       }
@@ -104,6 +120,7 @@ export function ComposioSection({ client, company }: Props) {
   useEffect(() => {
     setStatus(null);
     setConnected({});
+    setShowOverride(false);
     setLoad("loading");
     void refresh();
   }, [refresh]);
@@ -131,7 +148,10 @@ export function ComposioSection({ client, company }: Props) {
       setStatus(res.status);
       setToken("");
       setConnected({});
+      // Clearing an override falls back to whatever tier remains — re-probe
+      // rather than assuming there is no credential left.
       toast.success("Composio token cleared.");
+      void refreshConnections(res.status);
     } catch (err) {
       toast.error(err instanceof ApiError ? err.message : "Could not clear the token.");
     } finally {
@@ -182,7 +202,14 @@ export function ComposioSection({ client, company }: Props) {
 
   if (load === "unavailable") return null;
 
+  const attested = status?.credentialSource === "attested";
+  const byoToken = status?.credentialSource === "static";
+  // No credential of any tier: there is nothing to authorize a provider against.
+  const noCredential = status?.credentialSource === "none";
   const showProviders = load === "ready" && status !== null && status.toolkits.length > 0;
+  // In the attested state the paste card is a deliberate override; everywhere
+  // else it is the only way to connect, so it is always on screen.
+  const showTokenCard = !attested || showOverride || byoToken;
 
   return (
     <section className="space-y-3">
@@ -193,9 +220,9 @@ export function ComposioSection({ client, company }: Props) {
         </h3>
       </div>
       <p className="text-sm text-muted-foreground">
-        Give your agents Gmail, Slack &amp; GitHub via Composio. Sign in per provider below, or paste
-        this company&apos;s Composio OAuth token directly. Either way, the connection takes effect on
-        the next turn, no restart.
+        {attested
+          ? "Give your agents Gmail, Slack & GitHub via Composio. This company is linked through this instance's own cluster identity — there is no key to copy and nothing stored here. Sign in per provider below."
+          : "Give your agents Gmail, Slack & GitHub via Composio. Paste this company's Composio OAuth token — it is the identity the backend bills and isolates, stored securely and never shown again — then sign in per provider below. A change takes effect on the next turn, no restart."}
       </p>
 
       {load === "loading" ? (
@@ -207,12 +234,16 @@ export function ComposioSection({ client, company }: Props) {
               <Badge variant={status.granted ? "secondary" : "outline"}>
                 {status.granted ? "granted" : "not granted"}
               </Badge>
-              {status.tokenConfigured ? (
+              {attested ? (
+                <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+                  <ShieldCheck className="size-3" /> Linked via cluster identity — nothing stored
+                </span>
+              ) : byoToken ? (
                 <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
                   <Check className="size-3" /> token set
                 </span>
               ) : (
-                <span className="text-xs text-muted-foreground">no token yet</span>
+                <span className="text-xs text-muted-foreground">not connected</span>
               )}
             </div>
           )}
@@ -229,10 +260,10 @@ export function ComposioSection({ client, company }: Props) {
             <Card>
               <CardContent className="space-y-2 py-4">
                 <p className="text-xs font-medium text-muted-foreground">Sign in per provider</p>
-                {!status.tokenConfigured && (
+                {noCredential && (
                   <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
-                    Set the Composio token below first — it is the per-tenant identity the sign-in
-                    flow authorizes against.
+                    No Composio credential is available for this company yet, so there is nothing to
+                    authorize against. Paste a token below first.
                   </p>
                 )}
                 <ul className="divide-y divide-border">
@@ -250,9 +281,7 @@ export function ComposioSection({ client, company }: Props) {
                           <Button
                             size="sm"
                             variant="outline"
-                            disabled={
-                              signingIn !== null || !status.tokenConfigured
-                            }
+                            disabled={signingIn !== null || noCredential}
                             onClick={() => void signIn(toolkit)}
                           >
                             {isSigningIn ? (
@@ -271,53 +300,64 @@ export function ComposioSection({ client, company }: Props) {
             </Card>
           )}
 
-          <Card>
-            <CardContent className="space-y-4 py-4">
-              <div className="space-y-1">
-                <Label htmlFor="composio-token" className="text-xs">
-                  Composio token (fallback){" "}
-                  {status?.tokenConfigured ? "— set, leave blank to keep" : ""}
-                </Label>
-                <p className="text-xs text-muted-foreground">
-                  Paste this company&apos;s Composio OAuth token directly if you already have one. It
-                  is stored securely and never shown again.
-                </p>
-                <Input
-                  id="composio-token"
-                  type="password"
-                  autoComplete="off"
-                  placeholder="paste the company's Composio OAuth token"
-                  value={token}
-                  onChange={(e) => setToken(e.target.value)}
-                />
-                {status && (
-                  <p className="truncate text-xs text-muted-foreground">{status.backendUrl}</p>
-                )}
-              </div>
+          {attested && !showTokenCard && (
+            <Button variant="outline" size="sm" onClick={() => setShowOverride(true)}>
+              <KeyRound className="size-4" />
+              Use your own Composio account instead
+            </Button>
+          )}
 
-              <div className="flex items-center gap-2">
-                <Button disabled={busy !== null || !token.trim()} onClick={() => void save()}>
-                  {busy === "save" ? (
-                    <Loader2 className="size-4 animate-spin" />
-                  ) : (
-                    <Save className="size-4" />
+          {showTokenCard && (
+            <Card>
+              <CardContent className="space-y-4 py-4">
+                {attested && (
+                  <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+                    Optional. A token set here overrides the instance identity for this company only
+                    — use it when the company has its own Composio account. Clear it to go back to
+                    the cluster identity.
+                  </p>
+                )}
+                <div className="space-y-1">
+                  <Label htmlFor="composio-token" className="text-xs">
+                    Composio token {byoToken ? "— set, leave blank to keep" : ""}
+                  </Label>
+                  <Input
+                    id="composio-token"
+                    type="password"
+                    autoComplete="off"
+                    placeholder="paste the company's Composio OAuth token"
+                    value={token}
+                    onChange={(e) => setToken(e.target.value)}
+                  />
+                  {status && (
+                    <p className="truncate text-xs text-muted-foreground">{status.backendUrl}</p>
                   )}
-                  Save token
-                </Button>
-                {status?.tokenConfigured && (
-                  <Button variant="outline" disabled={busy !== null} onClick={() => void clear()}>
-                    {busy === "clear" ? (
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <Button disabled={busy !== null || !token.trim()} onClick={() => void save()}>
+                    {busy === "save" ? (
                       <Loader2 className="size-4 animate-spin" />
                     ) : (
-                      <Trash2 className="size-4" />
+                      <Save className="size-4" />
                     )}
-                    Clear
+                    Save token
                   </Button>
-                )}
-                <KeyRound className="ml-auto size-4 text-muted-foreground" />
-              </div>
-            </CardContent>
-          </Card>
+                  {byoToken && (
+                    <Button variant="outline" disabled={busy !== null} onClick={() => void clear()}>
+                      {busy === "clear" ? (
+                        <Loader2 className="size-4 animate-spin" />
+                      ) : (
+                        <Trash2 className="size-4" />
+                      )}
+                      Clear
+                    </Button>
+                  )}
+                  <KeyRound className="ml-auto size-4 text-muted-foreground" />
+                </div>
+              </CardContent>
+            </Card>
+          )}
         </>
       )}
     </section>

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -724,14 +724,14 @@ mod test {
     fn projected_token_file_alone_enables_cycles() {
         let env = MapEnv::new([(
             crate::company::credentials::TOKEN_FILE_ENV,
-            "/var/run/secrets/tinyhumans/token",
+            "/var/run/secrets/tinyhumans.ai/token",
         )]);
         let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
 
         assert!(cfg.tinyhumans_credential.is_none(), "no static secret held");
         assert_eq!(
             cfg.tinyhumans_token_file.as_deref(),
-            Some(std::path::Path::new("/var/run/secrets/tinyhumans/token"))
+            Some(std::path::Path::new("/var/run/secrets/tinyhumans.ai/token"))
         );
         assert!(cfg.credential_available());
         assert!(cfg.cycles_available());

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -338,21 +338,22 @@ impl RuntimeConfig {
     /// asking about a stored secret would report a perfectly healthy instance as
     /// unable to think.
     pub fn credential_available(&self) -> bool {
-        self.tinyhumans_token_file.is_some() || self.tinyhumans_credential.is_some()
+        self.credential_source() != crate::company::CredentialSource::None
     }
 
     /// Which tier the credential comes from, for operator-facing output.
-    /// Projected file wins, mirroring
-    /// [`TinyhumansTokenSource::from_env`](crate::company::credentials::TinyhumansTokenSource::from_env).
+    ///
+    /// Delegates to
+    /// [`TinyhumansTokenSource::source_of_parts`](crate::company::credentials::TinyhumansTokenSource::source_of_parts)
+    /// rather than restating the rule: the projected tier counts only when the
+    /// named path **exists**, so a leftover `TINYHUMANS_TOKEN_FILE` pointing at
+    /// something the runtime never mounted reports the static tier (or `none`)
+    /// instead of claiming an identity this instance cannot present.
     pub fn credential_source(&self) -> crate::company::CredentialSource {
-        use crate::company::CredentialSource;
-        if self.tinyhumans_token_file.is_some() {
-            CredentialSource::Attested
-        } else if self.tinyhumans_credential.is_some() {
-            CredentialSource::Static
-        } else {
-            CredentialSource::None
-        }
+        crate::company::credentials::TinyhumansTokenSource::source_of_parts(
+            self.tinyhumans_token_file.as_deref(),
+            self.tinyhumans_credential.is_some(),
+        )
     }
 }
 
@@ -722,17 +723,21 @@ mod test {
     /// and the source reads `attested`.
     #[test]
     fn projected_token_file_alone_enables_cycles() {
+        // The path must actually exist: the projected tier is selected on
+        // existence, not on the variable merely being set.
+        let dir = std::env::temp_dir().join(format!("oc-cfg-{}", crate::ports::generate_id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("token");
+        std::fs::write(&path, "projected-token").unwrap();
+
         let env = MapEnv::new([(
             crate::company::credentials::TOKEN_FILE_ENV,
-            "/var/run/secrets/tinyhumans.ai/token",
+            path.to_str().unwrap(),
         )]);
         let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
 
         assert!(cfg.tinyhumans_credential.is_none(), "no static secret held");
-        assert_eq!(
-            cfg.tinyhumans_token_file.as_deref(),
-            Some(std::path::Path::new("/var/run/secrets/tinyhumans.ai/token"))
-        );
+        assert_eq!(cfg.tinyhumans_token_file.as_deref(), Some(path.as_path()));
         assert!(cfg.credential_available());
         assert!(cfg.cycles_available());
         assert_eq!(
@@ -740,13 +745,72 @@ mod test {
             crate::company::CredentialSource::Attested
         );
         assert_eq!(prov.layer("tinyhumans_token_file"), Some(ConfigLayer::Env));
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
-    /// Precedence: a projected file outranks a leftover static key.
+    /// The docker case: a leftover `TINYHUMANS_TOKEN_FILE` naming a path nothing
+    /// mounted must NOT report an identity this instance cannot present. Reporting
+    /// `attested` here would also make `cycles_available` true with no obtainable
+    /// bearer, so hosted cognition would be gated on a credential that does not
+    /// exist. Regression test for the config surface disagreeing with
+    /// `TinyhumansTokenSource::from_env`.
+    #[test]
+    fn a_token_file_that_does_not_exist_is_not_attested() {
+        let missing =
+            std::env::temp_dir().join(format!("oc-absent-{}", crate::ports::generate_id()));
+        assert!(!missing.exists(), "fixture path must not exist");
+
+        let env = MapEnv::new([(
+            crate::company::credentials::TOKEN_FILE_ENV,
+            missing.to_str().unwrap(),
+        )]);
+        let (cfg, _) = resolve(&env, None, &default_manifest()).unwrap();
+
+        assert_eq!(
+            cfg.credential_source(),
+            crate::company::CredentialSource::None,
+            "an unmounted path must not read as attested"
+        );
+        assert!(!cfg.credential_available());
+        assert!(!cfg.cycles_available());
+    }
+
+    /// Same unmounted path, but a static key is present: the source degrades to
+    /// the static tier rather than to `none`, matching `from_env`'s fallback.
+    #[test]
+    fn a_missing_token_file_degrades_to_the_static_tier() {
+        let missing =
+            std::env::temp_dir().join(format!("oc-absent-{}", crate::ports::generate_id()));
+        let env = MapEnv::new([
+            (
+                crate::company::credentials::TOKEN_FILE_ENV,
+                missing.to_str().unwrap(),
+            ),
+            (crate::company::credentials::API_KEY_ENV, "th_static"),
+        ]);
+        let (cfg, _) = resolve(&env, None, &default_manifest()).unwrap();
+
+        assert_eq!(
+            cfg.credential_source(),
+            crate::company::CredentialSource::Static
+        );
+        assert!(cfg.credential_available());
+    }
+
+    /// Precedence: a projected file that exists outranks a leftover static key.
     #[test]
     fn projected_file_outranks_a_static_key_for_the_source() {
+        let dir = std::env::temp_dir().join(format!("oc-cfg-{}", crate::ports::generate_id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("token");
+        std::fs::write(&path, "projected-token").unwrap();
+
         let env = MapEnv::new([
-            (crate::company::credentials::TOKEN_FILE_ENV, "/run/token"),
+            (
+                crate::company::credentials::TOKEN_FILE_ENV,
+                path.to_str().unwrap(),
+            ),
             (crate::company::credentials::API_KEY_ENV, "th_static"),
         ]);
         let (cfg, _) = resolve(&env, None, &default_manifest()).unwrap();
@@ -754,6 +818,7 @@ mod test {
             cfg.credential_source(),
             crate::company::CredentialSource::Attested
         );
+        std::fs::remove_dir_all(&dir).ok();
 
         // Docker development keeps working on the static tier alone.
         let static_only = MapEnv::new([(crate::company::credentials::API_KEY_ENV, "th_static")]);

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -315,14 +315,44 @@ pub struct RuntimeConfig {
     pub github_token: Option<SecretValue>,
     /// TinyHumans hosted-brain credential, if configured. Redacted in `Debug`.
     pub tinyhumans_credential: Option<SecretValue>,
+    /// Path to the platform-projected TinyHumans token file
+    /// ([`TOKEN_FILE_ENV`](crate::company::credentials::TOKEN_FILE_ENV)), when the
+    /// platform hands this instance a rotating, audience-bound identity instead of
+    /// a static key. A path, not a secret — safe to print.
+    pub tinyhumans_token_file: Option<PathBuf>,
     /// Resolved `[workspace]` data-dir layout configuration.
     pub workspace: WorkspaceConfig,
 }
 
 impl RuntimeConfig {
-    /// True when hosted cognition can run: hosted mode plus a credential.
+    /// True when hosted cognition can run: hosted mode plus a credential this
+    /// instance can **obtain** — see [`Self::credential_available`].
     pub fn cycles_available(&self) -> bool {
-        self.brain_mode == BrainMode::Hosted && self.tinyhumans_credential.is_some()
+        self.brain_mode == BrainMode::Hosted && self.credential_available()
+    }
+
+    /// Whether a TinyHumans credential can be obtained at all.
+    ///
+    /// The question is "can I get a token?", not "do I hold a secret?": a hosted
+    /// tenant holds nothing and reads a projected file that rotates in place, so
+    /// asking about a stored secret would report a perfectly healthy instance as
+    /// unable to think.
+    pub fn credential_available(&self) -> bool {
+        self.tinyhumans_token_file.is_some() || self.tinyhumans_credential.is_some()
+    }
+
+    /// Which tier the credential comes from, for operator-facing output.
+    /// Projected file wins, mirroring
+    /// [`TinyhumansTokenSource::from_env`](crate::company::credentials::TinyhumansTokenSource::from_env).
+    pub fn credential_source(&self) -> crate::company::CredentialSource {
+        use crate::company::CredentialSource;
+        if self.tinyhumans_token_file.is_some() {
+            CredentialSource::Attested
+        } else if self.tinyhumans_credential.is_some() {
+            CredentialSource::Static
+        } else {
+            CredentialSource::None
+        }
     }
 }
 
@@ -343,6 +373,7 @@ impl std::fmt::Debug for RuntimeConfig {
                 "tinyhumans_credential",
                 &redacted(&self.tinyhumans_credential),
             )
+            .field("tinyhumans_token_file", &self.tinyhumans_token_file)
             .finish()
     }
 }
@@ -440,10 +471,20 @@ pub fn resolve(
     let tinyhumans_credential = resolve_opt(
         &mut prov,
         "tinyhumans_credential",
-        env.get("TINYHUMANS_API_KEY"),
+        env.get(crate::company::credentials::API_KEY_ENV),
         config_toml.and_then(|c| c.tinyhumans_api_key.clone()),
     )
     .map(SecretValue);
+
+    // The projected token file is injected by the platform, never written by an
+    // operator, so it has no `config.toml` layer to fall back to.
+    let tinyhumans_token_file = resolve_opt(
+        &mut prov,
+        "tinyhumans_token_file",
+        env.get(crate::company::credentials::TOKEN_FILE_ENV),
+        None,
+    )
+    .map(PathBuf::from);
 
     let workspace = config_toml
         .map(|c| c.workspace.resolve())
@@ -459,6 +500,7 @@ pub fn resolve(
         public_url,
         github_token,
         tinyhumans_credential,
+        tinyhumans_token_file,
         workspace,
     };
     Ok((config, prov))
@@ -673,6 +715,61 @@ mod test {
         assert!(cfg.tinyhumans_credential.is_some());
         assert!(cfg.cycles_available());
         assert_eq!(prov.layer("tinyhumans_credential"), Some(ConfigLayer::Env));
+    }
+
+    /// The hosted path: no static key at all, just a platform-projected token
+    /// file. Cycles must still be available — the instance can *obtain* a token —
+    /// and the source reads `attested`.
+    #[test]
+    fn projected_token_file_alone_enables_cycles() {
+        let env = MapEnv::new([(
+            crate::company::credentials::TOKEN_FILE_ENV,
+            "/var/run/secrets/tinyhumans/token",
+        )]);
+        let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
+
+        assert!(cfg.tinyhumans_credential.is_none(), "no static secret held");
+        assert_eq!(
+            cfg.tinyhumans_token_file.as_deref(),
+            Some(std::path::Path::new("/var/run/secrets/tinyhumans/token"))
+        );
+        assert!(cfg.credential_available());
+        assert!(cfg.cycles_available());
+        assert_eq!(
+            cfg.credential_source(),
+            crate::company::CredentialSource::Attested
+        );
+        assert_eq!(prov.layer("tinyhumans_token_file"), Some(ConfigLayer::Env));
+    }
+
+    /// Precedence: a projected file outranks a leftover static key.
+    #[test]
+    fn projected_file_outranks_a_static_key_for_the_source() {
+        let env = MapEnv::new([
+            (crate::company::credentials::TOKEN_FILE_ENV, "/run/token"),
+            (crate::company::credentials::API_KEY_ENV, "th_static"),
+        ]);
+        let (cfg, _) = resolve(&env, None, &default_manifest()).unwrap();
+        assert_eq!(
+            cfg.credential_source(),
+            crate::company::CredentialSource::Attested
+        );
+
+        // Docker development keeps working on the static tier alone.
+        let static_only = MapEnv::new([(crate::company::credentials::API_KEY_ENV, "th_static")]);
+        let (cfg, _) = resolve(&static_only, None, &default_manifest()).unwrap();
+        assert_eq!(
+            cfg.credential_source(),
+            crate::company::CredentialSource::Static
+        );
+
+        // Neither tier configured → nothing obtainable, no cycles.
+        let (cfg, _) = resolve(&MapEnv::default(), None, &default_manifest()).unwrap();
+        assert_eq!(
+            cfg.credential_source(),
+            crate::company::CredentialSource::None
+        );
+        assert!(!cfg.credential_available());
     }
 
     #[test]

--- a/src/app/doctor.rs
+++ b/src/app/doctor.rs
@@ -235,9 +235,16 @@ mod test {
     /// printed so an operator can confirm the projection landed.
     #[test]
     fn projected_token_file_reports_the_attested_tier() {
+        // A real file: the attested tier is selected on the path existing, not on
+        // the variable being set, so a fixture path would report `none` here.
+        let dir = std::env::temp_dir().join(format!("oc-doctor-{}", crate::ports::generate_id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("token");
+        std::fs::write(&path, "projected-token").unwrap();
+
         let env = MapEnv::new([(
             crate::company::credentials::TOKEN_FILE_ENV,
-            "/var/run/secrets/tinyhumans.ai/token",
+            path.to_str().unwrap(),
         )]);
         let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
         let report = report(&cfg, &prov);
@@ -247,8 +254,29 @@ mod test {
         assert_eq!(value(&report, "tinyhumans_credential"), "missing");
         assert_eq!(
             value(&report, "tinyhumans_token_file"),
-            "/var/run/secrets/tinyhumans.ai/token"
+            path.to_str().unwrap()
         );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A leftover `TINYHUMANS_TOKEN_FILE` naming an unmounted path must not tell
+    /// an operator the instance is attested — doctor is the surface they check to
+    /// confirm the projection actually landed, so a false `attested` there is
+    /// worse than an honest `none`.
+    #[test]
+    fn a_token_file_that_does_not_exist_does_not_report_attested() {
+        let missing =
+            std::env::temp_dir().join(format!("oc-doctor-absent-{}", crate::ports::generate_id()));
+        let env = MapEnv::new([(
+            crate::company::credentials::TOKEN_FILE_ENV,
+            missing.to_str().unwrap(),
+        )]);
+        let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
+        let report = report(&cfg, &prov);
+
+        assert!(!cap(&report, "cycles").available);
+        assert_eq!(value(&report, "credential_source"), "none");
     }
 
     #[test]

--- a/src/app/doctor.rs
+++ b/src/app/doctor.rs
@@ -237,7 +237,7 @@ mod test {
     fn projected_token_file_reports_the_attested_tier() {
         let env = MapEnv::new([(
             crate::company::credentials::TOKEN_FILE_ENV,
-            "/var/run/secrets/tinyhumans/token",
+            "/var/run/secrets/tinyhumans.ai/token",
         )]);
         let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
         let report = report(&cfg, &prov);
@@ -247,7 +247,7 @@ mod test {
         assert_eq!(value(&report, "tinyhumans_credential"), "missing");
         assert_eq!(
             value(&report, "tinyhumans_token_file"),
-            "/var/run/secrets/tinyhumans/token"
+            "/var/run/secrets/tinyhumans.ai/token"
         );
     }
 

--- a/src/app/doctor.rs
+++ b/src/app/doctor.rs
@@ -82,6 +82,13 @@ fn value_of(cfg: &RuntimeConfig, field: &str) -> String {
         "tinyplace_api_url" => cfg.tinyplace_api_url.clone(),
         "github_token" => redacted(&cfg.github_token).to_string(),
         "tinyhumans_credential" => redacted(&cfg.tinyhumans_credential).to_string(),
+        // A path, not a secret — printing it is how an operator confirms the pod
+        // was handed a projected identity at all.
+        "tinyhumans_token_file" => cfg
+            .tinyhumans_token_file
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "unset".into()),
         other => format!("<unknown field {other}>"),
     }
 }
@@ -96,11 +103,15 @@ const FIELDS: &[&str] = &[
     "tinyplace_api_url",
     "github_token",
     "tinyhumans_credential",
+    "tinyhumans_token_file",
 ];
+
+/// The name of the derived row naming the active credential tier.
+const CREDENTIAL_SOURCE_FIELD: &str = "credential_source";
 
 /// Builds a [`DoctorReport`] from resolved config and its provenance.
 pub fn report(cfg: &RuntimeConfig, prov: &ConfigProvenance) -> DoctorReport {
-    let values = FIELDS
+    let mut values: Vec<DoctorValue> = FIELDS
         .iter()
         .map(|&field| DoctorValue {
             name: field,
@@ -109,13 +120,34 @@ pub fn report(cfg: &RuntimeConfig, prov: &ConfigProvenance) -> DoctorReport {
         })
         .collect();
 
+    // The active tier, spelled out. Two rows above say what is set; this one says
+    // which of them the outbound bearer will actually come from — and it is a
+    // tier name, never a credential.
+    let source = cfg.credential_source();
+    values.push(DoctorValue {
+        name: CREDENTIAL_SOURCE_FIELD,
+        value: source.to_string(),
+        // The derived row inherits the layer of whichever field won the tier.
+        layer: match source {
+            crate::company::CredentialSource::Attested => prov.layer("tinyhumans_token_file"),
+            crate::company::CredentialSource::Static => prov.layer("tinyhumans_credential"),
+            crate::company::CredentialSource::None => None,
+        }
+        .unwrap_or(ConfigLayer::Default)
+        .label(),
+    });
+
     let cycles = DoctorCapability {
         name: "cycles",
         available: cfg.cycles_available(),
         needs: if cfg.cycles_available() {
             String::new()
-        } else if cfg.tinyhumans_credential.is_none() {
-            "needs TINYHUMANS_API_KEY".into()
+        } else if !cfg.credential_available() {
+            format!(
+                "needs {} (hosted) or {}",
+                crate::company::credentials::TOKEN_FILE_ENV,
+                crate::company::credentials::API_KEY_ENV
+            )
         } else {
             format!("needs brain_mode = hosted (currently {})", cfg.brain_mode)
         },
@@ -171,6 +203,15 @@ mod test {
             .expect("capability present")
     }
 
+    fn value<'a>(report: &'a DoctorReport, name: &str) -> &'a str {
+        report
+            .values
+            .iter()
+            .find(|v| v.name == name)
+            .map(|v| v.value.as_str())
+            .expect("value present")
+    }
+
     #[test]
     fn cycles_unavailable_without_credential() {
         let env = MapEnv::default();
@@ -179,7 +220,43 @@ mod test {
 
         let cycles = cap(&report, "cycles");
         assert!(!cycles.available);
-        assert_eq!(cycles.needs, "needs TINYHUMANS_API_KEY");
+        assert!(
+            cycles.needs.contains("TINYHUMANS_TOKEN_FILE")
+                && cycles.needs.contains("TINYHUMANS_API_KEY"),
+            "both tiers must be named: {}",
+            cycles.needs
+        );
+        assert_eq!(value(&report, "credential_source"), "none");
+        assert_eq!(value(&report, "tinyhumans_token_file"), "unset");
+    }
+
+    /// The hosted path: a projected token file and no static key. Cycles are
+    /// available, the tier is named `attested`, and the path (not a secret) is
+    /// printed so an operator can confirm the projection landed.
+    #[test]
+    fn projected_token_file_reports_the_attested_tier() {
+        let env = MapEnv::new([(
+            crate::company::credentials::TOKEN_FILE_ENV,
+            "/var/run/secrets/tinyhumans/token",
+        )]);
+        let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
+        let report = report(&cfg, &prov);
+
+        assert!(cap(&report, "cycles").available);
+        assert_eq!(value(&report, "credential_source"), "attested");
+        assert_eq!(value(&report, "tinyhumans_credential"), "missing");
+        assert_eq!(
+            value(&report, "tinyhumans_token_file"),
+            "/var/run/secrets/tinyhumans/token"
+        );
+    }
+
+    #[test]
+    fn static_key_reports_the_static_tier() {
+        let env = MapEnv::new([(crate::company::credentials::API_KEY_ENV, "th_secret")]);
+        let (cfg, prov) = resolve(&env, None, &default_manifest()).unwrap();
+        let report = report(&cfg, &prov);
+        assert_eq!(value(&report, "credential_source"), "static");
     }
 
     #[test]

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -778,14 +778,27 @@ mod tests {
         );
     }
 
+    /// A temp directory holding a stand-in for the platform's projected token
+    /// file (mounted at `/var/run/secrets/tinyhumans.ai/token` in production).
+    /// The tier is only selected when the path exists, so the test needs a real
+    /// one.
+    fn projected_token_file() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("oc-appcfg-{}", crate::ports::generate_id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("token");
+        std::fs::write(&path, "projected-token").unwrap();
+        path
+    }
+
     /// The hosted shape: no static secret at all, just a projected token file.
     /// Cognition must be considered available, and the source reads `attested`.
     #[test]
     fn a_projected_token_file_alone_enables_cycles() {
         use crate::app::config::MapEnv;
+        let path = projected_token_file();
         let env = MapEnv::new([(
             crate::company::credentials::TOKEN_FILE_ENV,
-            "/var/run/secrets/tinyhumans/token",
+            path.display().to_string(),
         )]);
         let config = AppConfig::default();
         assert!(config.tinyhumans_credential.is_none(), "nothing stored");
@@ -802,6 +815,8 @@ mod tests {
             ..AppConfig::default()
         };
         assert!(!sidecar.cycles_available_in(&env));
+
+        std::fs::remove_dir_all(path.parent().unwrap()).ok();
     }
 
     /// Docker development is unaffected: the static tier still answers yes, and
@@ -820,11 +835,29 @@ mod tests {
             CredentialSource::Static
         );
 
-        let projected = MapEnv::new([(crate::company::credentials::TOKEN_FILE_ENV, "/run/token")]);
+        let path = projected_token_file();
+        let projected = MapEnv::new([(
+            crate::company::credentials::TOKEN_FILE_ENV,
+            path.display().to_string(),
+        )]);
         assert_eq!(
             config.credential_source_in(&projected),
             CredentialSource::Attested
         );
+
+        // A leftover variable pointing at a path the runtime never mounted (the
+        // docker case) degrades to the static tier rather than breaking cycles.
+        let stale = MapEnv::new([(
+            crate::company::credentials::TOKEN_FILE_ENV,
+            "/nonexistent/oc/token",
+        )]);
+        assert_eq!(
+            config.credential_source_in(&stale),
+            CredentialSource::Static
+        );
+        assert!(config.cycles_available_in(&stale));
+
+        std::fs::remove_dir_all(path.parent().unwrap()).ok();
     }
 
     #[test]

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -4,8 +4,8 @@ use std::sync::{Arc, OnceLock, RwLock};
 
 use serde::Serialize;
 
-use crate::app::config::{BrainMode, redacted};
-use crate::company::{SkillDoc, load_dir_skills};
+use crate::app::config::{BrainMode, EnvSource, redacted};
+use crate::company::{CredentialSource, SkillDoc, TinyhumansTokenSource, load_dir_skills};
 use crate::ports::types::{CompanyId, SecretValue};
 use crate::runtime::CompanyRegistry;
 use crate::server::platform_auth::PlatformAuthConfig;
@@ -31,7 +31,11 @@ pub struct AppConfig {
     /// Public host base URL advertised in published Agent Cards. When `None`,
     /// the card endpoint falls back to `http://{bind}`.
     pub public_url: Option<String>,
-    /// TinyHumans hosted-brain credential, if configured. Redacted in `Debug`.
+    /// A **static** TinyHumans hosted-brain credential, if configured. Redacted
+    /// in `Debug`. This is only the static tier: a hosted tenant instead reads a
+    /// platform-projected token file, so ask
+    /// [`credential_available`](Self::credential_available) — not this field —
+    /// whether a credential can be obtained.
     pub tinyhumans_credential: Option<SecretValue>,
     /// Platform (multi-tenant) auth. When set, `{id}` routes honor tenant scopes
     /// and provisioning/suspension require the `platform` scope.
@@ -108,9 +112,48 @@ pub fn canonical_tenant(tenant: &str) -> &str {
 }
 
 impl AppConfig {
-    /// True when hosted cognition can run: hosted mode plus a credential.
+    /// True when hosted cognition can run: hosted brain mode plus a credential
+    /// this instance can **obtain** — see [`Self::credential_available`].
     pub fn cycles_available(&self) -> bool {
-        self.brain_mode == BrainMode::Hosted && self.tinyhumans_credential.is_some()
+        self.cycles_available_in(&crate::app::config::ProcessEnv)
+    }
+
+    /// [`Self::cycles_available`] against an explicit environment seam.
+    pub fn cycles_available_in(&self, env: &dyn EnvSource) -> bool {
+        self.brain_mode == BrainMode::Hosted && self.credential_available_in(env)
+    }
+
+    /// Whether a TinyHumans credential can be obtained at all — a static one
+    /// resolved into [`Self::tinyhumans_credential`], **or** a platform-projected
+    /// token source ([`TinyhumansTokenSource::from_env`]).
+    ///
+    /// The question changed from "do I hold a secret?" to "can I get a token?".
+    /// A hosted tenant holds nothing: the platform projects a short-lived,
+    /// audience-bound token into a file that rotates in place. Asking about a
+    /// stored secret would report such an instance as unable to think.
+    ///
+    /// The projected file is read from the **environment** rather than threaded
+    /// through a config layer on purpose: the platform injects it into the pod and
+    /// an operator never configures it, so there is nothing to resolve by
+    /// precedence. [`Self::credential_available_in`] takes the seam explicitly for
+    /// tests.
+    pub fn credential_available(&self) -> bool {
+        self.credential_available_in(&crate::app::config::ProcessEnv)
+    }
+
+    /// [`Self::credential_available`] against an explicit environment seam.
+    pub fn credential_available_in(&self, env: &dyn EnvSource) -> bool {
+        self.tinyhumans_credential.is_some() || TinyhumansTokenSource::from_env(env).is_some()
+    }
+
+    /// Which tier the credential comes from, for operator-facing output. The
+    /// projected file wins, mirroring [`TinyhumansTokenSource::from_env`].
+    pub fn credential_source_in(&self, env: &dyn EnvSource) -> CredentialSource {
+        match TinyhumansTokenSource::from_env(env) {
+            Some(source) => source.credential_source(),
+            None if self.tinyhumans_credential.is_some() => CredentialSource::Static,
+            None => CredentialSource::None,
+        }
     }
 
     /// Namespaces a company id for shared-single-DB mode.
@@ -569,8 +612,8 @@ pub struct AppSpec {
     pub openhuman_root: Option<String>,
     /// TinyHumans orchestration API base URL.
     pub api_url: String,
-    /// Whether hosted cognition can run (hosted brain plus a credential). No
-    /// secret bytes are surfaced.
+    /// Whether hosted cognition can run (hosted brain plus a credential this
+    /// instance can obtain, from either tier). No secret bytes are surfaced.
     pub cycles_available: bool,
 }
 
@@ -720,9 +763,68 @@ mod tests {
         assert!(rendered.contains("set"));
     }
 
+    /// With neither tier configured there is nothing to obtain, so no cycles.
+    /// Driven through the env seam so an ambient `TINYHUMANS_*` in a developer's
+    /// shell cannot decide the result.
     #[test]
     fn default_config_cannot_run_cycles() {
-        assert!(!AppConfig::default().cycles_available());
+        use crate::app::config::MapEnv;
+        let empty = MapEnv::default();
+        assert!(!AppConfig::default().cycles_available_in(&empty));
+        assert!(!AppConfig::default().credential_available_in(&empty));
+        assert_eq!(
+            AppConfig::default().credential_source_in(&empty),
+            CredentialSource::None
+        );
+    }
+
+    /// The hosted shape: no static secret at all, just a projected token file.
+    /// Cognition must be considered available, and the source reads `attested`.
+    #[test]
+    fn a_projected_token_file_alone_enables_cycles() {
+        use crate::app::config::MapEnv;
+        let env = MapEnv::new([(
+            crate::company::credentials::TOKEN_FILE_ENV,
+            "/var/run/secrets/tinyhumans/token",
+        )]);
+        let config = AppConfig::default();
+        assert!(config.tinyhumans_credential.is_none(), "nothing stored");
+        assert!(config.credential_available_in(&env));
+        assert!(config.cycles_available_in(&env));
+        assert_eq!(
+            config.credential_source_in(&env),
+            CredentialSource::Attested
+        );
+
+        // A sidecar brain still cannot run hosted cycles, credential or not.
+        let sidecar = AppConfig {
+            brain_mode: crate::app::config::BrainMode::Sidecar,
+            ..AppConfig::default()
+        };
+        assert!(!sidecar.cycles_available_in(&env));
+    }
+
+    /// Docker development is unaffected: the static tier still answers yes, and
+    /// a projected file present alongside it outranks it as the source.
+    #[test]
+    fn static_tier_still_answers_and_is_outranked_by_a_projected_file() {
+        use crate::app::config::MapEnv;
+        let config = AppConfig {
+            tinyhumans_credential: Some(SecretValue("th_static".into())),
+            ..AppConfig::default()
+        };
+        let empty = MapEnv::default();
+        assert!(config.cycles_available_in(&empty));
+        assert_eq!(
+            config.credential_source_in(&empty),
+            CredentialSource::Static
+        );
+
+        let projected = MapEnv::new([(crate::company::credentials::TOKEN_FILE_ENV, "/run/token")]);
+        assert_eq!(
+            config.credential_source_in(&projected),
+            CredentialSource::Attested
+        );
     }
 
     #[test]

--- a/src/company/credentials.rs
+++ b/src/company/credentials.rs
@@ -199,22 +199,55 @@ impl TinyhumansTokenSource {
     /// — the docker runtime mounts nothing, so a leftover variable degrades to the
     /// static tier (with a warning) instead of failing every request.
     pub fn from_env(env: &dyn EnvSource) -> Option<Self> {
-        if let Some(path) = env.get(TOKEN_FILE_ENV).map(|p| p.trim().to_string())
-            && !path.is_empty()
-        {
-            if Path::new(&path).exists() {
-                return Some(Self::projected_file(path));
+        Self::from_parts(
+            env.get(TOKEN_FILE_ENV).as_deref().map(Path::new),
+            env.get(API_KEY_ENV).as_deref(),
+        )
+    }
+
+    /// The precedence rule itself, over already-resolved parts.
+    ///
+    /// [`Self::from_env`] is this function plus an environment read. Callers that
+    /// already hold the resolved values — `RuntimeConfig`, which parsed them at
+    /// load — must route through here rather than re-deriving the rule, because a
+    /// second copy is a second chance to forget the existence check and answer
+    /// `attested` for a path the runtime never mounted.
+    ///
+    /// Both inputs are trimmed; blank is treated as absent.
+    pub fn from_parts(token_file: Option<&Path>, api_key: Option<&str>) -> Option<Self> {
+        if let Some(path) = token_file {
+            let path = Path::new(path.as_os_str().to_str().map(str::trim).unwrap_or_default());
+            if !path.as_os_str().is_empty() {
+                if path.exists() {
+                    return Some(Self::projected_file(path));
+                }
+                tracing::warn!(
+                    token_file = %path.display(),
+                    "{TOKEN_FILE_ENV} names a path that does not exist; falling back to the static credential tier"
+                );
             }
-            tracing::warn!(
-                token_file = %path,
-                "{TOKEN_FILE_ENV} names a path that does not exist; falling back to the static credential tier"
-            );
         }
-        let key = env.get(API_KEY_ENV).map(|k| k.trim().to_string())?;
+        let key = api_key?.trim();
         if key.is_empty() {
             return None;
         }
         Some(Self::static_key(key))
+    }
+
+    /// The tier a set of resolved parts selects, without building a source.
+    ///
+    /// `has_static_credential` stands in for a held secret the caller must not
+    /// hand over (`RuntimeConfig` keeps its key behind a redacting wrapper), so
+    /// the static tier is reported from its presence rather than its value.
+    pub fn source_of_parts(
+        token_file: Option<&Path>,
+        has_static_credential: bool,
+    ) -> CredentialSource {
+        match Self::from_parts(token_file, None) {
+            Some(source) => source.credential_source(),
+            None if has_static_credential => CredentialSource::Static,
+            None => CredentialSource::None,
+        }
     }
 
     /// Which tier this source resolved to.

--- a/src/company/credentials.rs
+++ b/src/company/credentials.rs
@@ -1,0 +1,683 @@
+//! How this instance obtains its TinyHumans credential.
+//!
+//! A hosted tenant holds **no** static secret. The platform gives its pod a
+//! short-lived, audience-bound token in a file that the kubelet rewrites **in
+//! place** (roughly every 8 minutes), so the credential must be *obtained* per
+//! request rather than read once at boot into a `String`.
+//!
+//! [`TinyhumansTokenSource`] is that seam. It has exactly two tiers, in strict
+//! precedence order:
+//!
+//! 1. **[`Tier::ProjectedFile`]** — the path named by [`TOKEN_FILE_ENV`]. The
+//!    file is re-read whenever the cached copy is past its window, so a rotation
+//!    is picked up without a restart. A permanent cache here would be a latent
+//!    outage: the pod would keep presenting a token the cluster already rotated
+//!    away from.
+//! 2. **[`Tier::Static`]** — the long-lived [`API_KEY_ENV`] value. This keeps
+//!    `docker compose` development alive and serves the (explicitly
+//!    **unsupported**) self-host case. It is not going away.
+//!
+//! ## Expiry is read, never trusted
+//!
+//! The cache window is derived from the token's own `exp` claim, parsed
+//! **without verifying the signature** — this process needs the expiry only, and
+//! the backend is the party that verifies. A token whose `exp` cannot be read
+//! (not a JWT, malformed payload, no `exp`) is never cached: correctness beats a
+//! saved file read. An already-expired token is still returned — refusing to
+//! send it would turn a recoverable 401 into a local outage — but likewise never
+//! cached.
+//!
+//! ## Redaction
+//!
+//! Nothing here renders the token. [`Debug`] shows the tier (and, for a
+//! projected file, the path — not a secret); [`TinyhumansTokenSource::describe`]
+//! is the operator-facing one-liner the doctor prints.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime};
+
+use serde::Serialize;
+
+use crate::Result;
+use crate::app::config::EnvSource;
+use crate::error::OpenCompanyError;
+
+/// Environment variable naming the platform-projected token file. Set by the
+/// platform (a kubelet-projected, audience-bound ServiceAccount token volume) —
+/// never by an operator, and never present in `docker compose`.
+pub const TOKEN_FILE_ENV: &str = "TINYHUMANS_TOKEN_FILE";
+
+/// Environment variable holding a long-lived static TinyHumans API key. The
+/// docker-development credential, and the unsupported self-host escape hatch.
+pub const API_KEY_ENV: &str = "TINYHUMANS_API_KEY";
+
+/// Hard ceiling on how long a projected token is cached, regardless of how much
+/// TTL it claims to have left. A projected file rotates on the platform's
+/// schedule, not ours, so the ceiling bounds how stale a bearer can get even if
+/// a token advertises hours of validity.
+pub const MAX_CACHE_WINDOW: Duration = Duration::from_secs(60);
+
+/// Fraction of a token's remaining TTL we are willing to cache for, so a
+/// re-read always happens with time left on the clock.
+const TTL_FRACTION: f64 = 0.8;
+
+/// Which tier a token was obtained from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TokenTier {
+    /// A platform-projected file that rotates in place ([`TOKEN_FILE_ENV`]).
+    ProjectedFile,
+    /// A long-lived static key ([`API_KEY_ENV`]).
+    Static,
+}
+
+impl TokenTier {
+    /// The stable wire/diagnostic spelling of this tier.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ProjectedFile => "projected_file",
+            Self::Static => "static",
+        }
+    }
+
+    /// How this tier is named on the console read plane.
+    pub fn credential_source(self) -> CredentialSource {
+        match self {
+            Self::ProjectedFile => CredentialSource::Attested,
+            Self::Static => CredentialSource::Static,
+        }
+    }
+}
+
+impl std::fmt::Display for TokenTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Where a company's outbound credential comes from, as the console renders it.
+/// Carries no secret and no path — just the shape of the answer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CredentialSource {
+    /// The pod presents a platform-minted, audience-bound identity. Nothing is
+    /// stored on this instance.
+    Attested,
+    /// A static key/token is configured — the docker-development path, or a
+    /// per-company token an operator pasted in.
+    Static,
+    /// No credential can be obtained at all.
+    None,
+}
+
+impl CredentialSource {
+    /// The stable wire spelling (`attested` / `static` / `none`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Attested => "attested",
+            Self::Static => "static",
+            Self::None => "none",
+        }
+    }
+}
+
+impl std::fmt::Display for CredentialSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A projected token cached until `good_until`.
+struct Cached {
+    token: String,
+    good_until: SystemTime,
+}
+
+/// The resolved tier, with whatever state it needs to keep answering.
+enum Tier {
+    /// A rotating file plus the currently-cached read of it.
+    ProjectedFile {
+        path: PathBuf,
+        cache: Mutex<Option<Cached>>,
+    },
+    /// A static value held in memory for the life of the process.
+    Static { token: String },
+}
+
+/// How this instance obtains its TinyHumans credential — see the module docs.
+///
+/// Construct once and share behind an `Arc`: the projected-file tier keeps a
+/// small cache, so cloning the source would clone the cache and defeat it.
+pub struct TinyhumansTokenSource {
+    tier: Tier,
+}
+
+impl TinyhumansTokenSource {
+    /// A source that re-reads `path` as it rotates.
+    pub fn projected_file(path: impl Into<PathBuf>) -> Self {
+        Self {
+            tier: Tier::ProjectedFile {
+                path: path.into(),
+                cache: Mutex::new(None),
+            },
+        }
+    }
+
+    /// A source over a static, long-lived key.
+    pub fn static_key(token: impl Into<String>) -> Self {
+        Self {
+            tier: Tier::Static {
+                token: token.into(),
+            },
+        }
+    }
+
+    /// Resolves the source from the environment, honouring the documented
+    /// precedence **[`TOKEN_FILE_ENV`] > [`API_KEY_ENV`]**, or `None` when
+    /// neither is configured (fail closed — the caller keeps its offline brain).
+    ///
+    /// The projected file wins deliberately: a pod that has been handed a
+    /// cluster identity must present *that*, even if a stale static key is still
+    /// lying around in its environment.
+    pub fn from_env(env: &dyn EnvSource) -> Option<Self> {
+        if let Some(path) = env.get(TOKEN_FILE_ENV).map(|p| p.trim().to_string())
+            && !path.is_empty()
+        {
+            return Some(Self::projected_file(path));
+        }
+        let key = env.get(API_KEY_ENV).map(|k| k.trim().to_string())?;
+        if key.is_empty() {
+            return None;
+        }
+        Some(Self::static_key(key))
+    }
+
+    /// Which tier this source resolved to.
+    pub fn tier(&self) -> TokenTier {
+        match &self.tier {
+            Tier::ProjectedFile { .. } => TokenTier::ProjectedFile,
+            Tier::Static { .. } => TokenTier::Static,
+        }
+    }
+
+    /// How the console names this source.
+    pub fn credential_source(&self) -> CredentialSource {
+        self.tier().credential_source()
+    }
+
+    /// The projected token file, when this is the projected-file tier.
+    pub fn token_file(&self) -> Option<&Path> {
+        match &self.tier {
+            Tier::ProjectedFile { path, .. } => Some(path.as_path()),
+            Tier::Static { .. } => None,
+        }
+    }
+
+    /// An operator-facing, credential-free one-liner for the doctor: the active
+    /// tier, plus the file path when there is one. Never the token.
+    pub fn describe(&self) -> String {
+        match &self.tier {
+            Tier::ProjectedFile { path, .. } => {
+                format!("projected_file ({})", path.display())
+            }
+            Tier::Static { .. } => "static (set)".to_string(),
+        }
+    }
+
+    /// Folds this source's *identity* into `hasher` for a roster fingerprint.
+    ///
+    /// The projected-file tier contributes its **tier + path**, never the token
+    /// value: the whole point is that the token rotates every few minutes while
+    /// the identity behind it does not. Hashing the value there would rebuild
+    /// every agent's tool roster on the platform's rotation schedule. The static
+    /// tier contributes its **value**, because for a static key a changed value
+    /// *is* a changed identity (an operator rotated it) and must rebuild.
+    pub fn hash_identity<H: std::hash::Hasher>(&self, hasher: &mut H) {
+        use std::hash::Hash;
+        match &self.tier {
+            Tier::ProjectedFile { path, .. } => {
+                0u8.hash(hasher);
+                path.hash(hasher);
+            }
+            Tier::Static { token } => {
+                1u8.hash(hasher);
+                token.hash(hasher);
+            }
+        }
+    }
+
+    /// The credential to present on the next outbound request.
+    ///
+    /// For the static tier this is the configured value. For the projected-file
+    /// tier it is the cached read while the cache window holds, and otherwise a
+    /// fresh read of the file — which is how an in-place rotation is picked up.
+    pub async fn current(&self) -> Result<String> {
+        self.current_at(SystemTime::now()).await
+    }
+
+    /// [`Self::current`] against an explicit clock, so the cache window can be
+    /// exercised deterministically in tests.
+    pub async fn current_at(&self, now: SystemTime) -> Result<String> {
+        let (path, cache) = match &self.tier {
+            Tier::Static { token } => return Ok(token.clone()),
+            Tier::ProjectedFile { path, cache } => (path, cache),
+        };
+
+        // Scoped so the guard is dropped before the await below.
+        {
+            let guard = cache.lock().expect("token cache poisoned");
+            if let Some(cached) = guard.as_ref()
+                && cached.good_until > now
+            {
+                return Ok(cached.token.clone());
+            }
+        }
+
+        let raw = tokio::fs::read_to_string(path).await.map_err(|e| {
+            OpenCompanyError::Config(format!(
+                "could not read the projected TinyHumans token file {}: {e}",
+                path.display()
+            ))
+        })?;
+        let token = raw.trim().to_string();
+        if token.is_empty() {
+            return Err(OpenCompanyError::Config(format!(
+                "the projected TinyHumans token file {} is empty",
+                path.display()
+            )));
+        }
+
+        // A token we cannot date, or one already past `exp`, is never cached.
+        let window = cache_window(now, unverified_jwt_exp(&token));
+        *cache.lock().expect("token cache poisoned") = window.map(|window| Cached {
+            token: token.clone(),
+            good_until: now + window,
+        });
+        Ok(token)
+    }
+}
+
+impl std::fmt::Debug for TinyhumansTokenSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.tier {
+            Tier::ProjectedFile { path, .. } => f
+                .debug_struct("TinyhumansTokenSource")
+                .field("tier", &"projected_file")
+                .field("path", path)
+                .finish(),
+            Tier::Static { token } => f
+                .debug_struct("TinyhumansTokenSource")
+                .field("tier", &"static")
+                .field(
+                    "token",
+                    &if token.is_empty() {
+                        "<unset>"
+                    } else {
+                        "<redacted>"
+                    },
+                )
+                .finish(),
+        }
+    }
+}
+
+/// How long a token read at `now` may be cached: 80% of its remaining TTL,
+/// capped at [`MAX_CACHE_WINDOW`]. `None` — meaning "do not cache" — when the
+/// expiry is unknown, already passed, or so close that no window is left.
+fn cache_window(now: SystemTime, expiry: Option<SystemTime>) -> Option<Duration> {
+    let remaining = expiry?.duration_since(now).ok()?;
+    let window = remaining.mul_f64(TTL_FRACTION).min(MAX_CACHE_WINDOW);
+    if window.is_zero() { None } else { Some(window) }
+}
+
+/// The `exp` claim of a JWT, read **without verifying the signature**.
+///
+/// This process needs the expiry to schedule a re-read; the backend is the party
+/// that verifies the token, so validating here would buy nothing and would need
+/// the cluster's public keys. `None` for anything that is not a three-segment
+/// JWT with a numeric `exp` — the caller then declines to cache.
+pub fn unverified_jwt_exp(token: &str) -> Option<SystemTime> {
+    let mut segments = token.trim().split('.');
+    let _header = segments.next()?;
+    let payload = segments.next()?;
+    // A JWS has exactly three segments; anything else is not a token we can read.
+    segments.next()?;
+    if segments.next().is_some() {
+        return None;
+    }
+    let claims: serde_json::Value = serde_json::from_slice(&base64url_decode(payload)?).ok()?;
+    let exp = claims.get("exp")?.as_u64()?;
+    Some(SystemTime::UNIX_EPOCH + Duration::from_secs(exp))
+}
+
+/// Decodes unpadded base64url (RFC 4648 §5) — the JWT segment encoding.
+/// `None` on any character outside the alphabet.
+fn base64url_decode(input: &str) -> Option<Vec<u8>> {
+    let mut out = Vec::with_capacity(input.len() * 3 / 4);
+    let mut buffer: u32 = 0;
+    let mut bits: u32 = 0;
+    for byte in input.bytes() {
+        let value = match byte {
+            b'A'..=b'Z' => byte - b'A',
+            b'a'..=b'z' => byte - b'a' + 26,
+            b'0'..=b'9' => byte - b'0' + 52,
+            b'-' => 62,
+            b'_' => 63,
+            // Tolerate the padded form even though JWT segments omit it.
+            b'=' => break,
+            _ => return None,
+        };
+        buffer = (buffer << 6) | u32::from(value);
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push((buffer >> bits) as u8);
+        }
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::config::MapEnv;
+
+    /// Builds an unsigned-but-well-shaped JWT carrying `claims` as its payload.
+    fn jwt(claims: serde_json::Value) -> String {
+        let encode = |bytes: &[u8]| {
+            const ALPHA: &[u8] =
+                b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+            let mut out = String::new();
+            for chunk in bytes.chunks(3) {
+                let b = [
+                    chunk[0],
+                    chunk.get(1).copied().unwrap_or(0),
+                    chunk.get(2).copied().unwrap_or(0),
+                ];
+                let n = (u32::from(b[0]) << 16) | (u32::from(b[1]) << 8) | u32::from(b[2]);
+                let take = chunk.len() + 1;
+                for i in 0..take {
+                    out.push(ALPHA[((n >> (18 - 6 * i)) & 0x3F) as usize] as char);
+                }
+            }
+            out
+        };
+        format!(
+            "{}.{}.{}",
+            encode(br#"{"alg":"RS256"}"#),
+            encode(claims.to_string().as_bytes()),
+            "c2lnbmF0dXJl"
+        )
+    }
+
+    fn unix(secs: u64) -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_secs(secs)
+    }
+
+    fn temp_file(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("oc-tokensrc-{}", crate::ports::generate_id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join(name)
+    }
+
+    // ---- tier precedence ---------------------------------------------------
+
+    #[test]
+    fn projected_file_beats_static_key() {
+        let env = MapEnv::new([
+            (TOKEN_FILE_ENV, "/var/run/secrets/tinyhumans/token"),
+            (API_KEY_ENV, "th_static"),
+        ]);
+        let source = TinyhumansTokenSource::from_env(&env).expect("configured");
+        assert_eq!(source.tier(), TokenTier::ProjectedFile);
+        assert_eq!(
+            source.token_file(),
+            Some(Path::new("/var/run/secrets/tinyhumans/token"))
+        );
+        assert_eq!(source.credential_source(), CredentialSource::Attested);
+    }
+
+    #[test]
+    fn static_key_is_the_fallback_tier() {
+        let env = MapEnv::new([(API_KEY_ENV, "th_static")]);
+        let source = TinyhumansTokenSource::from_env(&env).expect("configured");
+        assert_eq!(source.tier(), TokenTier::Static);
+        assert!(source.token_file().is_none());
+        assert_eq!(source.credential_source(), CredentialSource::Static);
+    }
+
+    #[test]
+    fn neither_configured_resolves_to_none() {
+        assert!(TinyhumansTokenSource::from_env(&MapEnv::default()).is_none());
+        // Blank values are not configuration.
+        let blank = MapEnv::new([(TOKEN_FILE_ENV, "   "), (API_KEY_ENV, "  ")]);
+        assert!(TinyhumansTokenSource::from_env(&blank).is_none());
+        // A blank token file falls through to the static key rather than
+        // resolving to a source that can never read anything.
+        let fallthrough = MapEnv::new([(TOKEN_FILE_ENV, " "), (API_KEY_ENV, "th_static")]);
+        assert_eq!(
+            TinyhumansTokenSource::from_env(&fallthrough)
+                .expect("configured")
+                .tier(),
+            TokenTier::Static
+        );
+    }
+
+    #[tokio::test]
+    async fn static_tier_returns_its_configured_value() {
+        let source = TinyhumansTokenSource::static_key("th_static");
+        assert_eq!(source.current().await.unwrap(), "th_static");
+    }
+
+    // ---- projected-file rotation + cache window ----------------------------
+
+    /// The kubelet rewrites the projected file **in place**. Once the cache
+    /// window closes, the next call must present the new token — a permanent
+    /// cache here is the latent outage this tier exists to avoid.
+    #[tokio::test]
+    async fn projected_file_picks_up_an_in_place_rotation() {
+        let path = temp_file("token");
+        // exp 1000s out at t=0 → window = min(0.8 * 1000, 60) = 60s.
+        std::fs::write(&path, jwt(serde_json::json!({ "exp": 1000 }))).unwrap();
+        let first = std::fs::read_to_string(&path).unwrap();
+        let source = TinyhumansTokenSource::projected_file(&path);
+
+        assert_eq!(source.current_at(unix(0)).await.unwrap(), first);
+
+        // Rotation lands. Inside the window the cached copy is still served —
+        // that is what keeps the hot path off the filesystem.
+        std::fs::write(&path, jwt(serde_json::json!({ "exp": 2000 }))).unwrap();
+        let second = std::fs::read_to_string(&path).unwrap();
+        assert_ne!(first, second, "the rotation must change the file");
+        assert_eq!(
+            source.current_at(unix(59)).await.unwrap(),
+            first,
+            "inside the cache window the previous read is reused"
+        );
+
+        // Past the window the file is re-read and the rotated token is served.
+        assert_eq!(
+            source.current_at(unix(61)).await.unwrap(),
+            second,
+            "past the cache window the rotated token must be picked up"
+        );
+
+        std::fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
+    /// The window is driven by the token's own expiry: 80% of the remaining TTL,
+    /// capped at [`MAX_CACHE_WINDOW`], and never for a token we cannot date.
+    #[test]
+    fn cache_window_is_eighty_percent_of_remaining_ttl_capped_at_a_minute() {
+        // 10s left → 8s window (well under the cap).
+        assert_eq!(
+            cache_window(unix(0), Some(unix(10))),
+            Some(Duration::from_secs(8))
+        );
+        // 8 minutes left (the projected-token rotation period) → capped at 60s.
+        assert_eq!(
+            cache_window(unix(0), Some(unix(480))),
+            Some(MAX_CACHE_WINDOW)
+        );
+        // Already expired, or expiring exactly now → never cache.
+        assert_eq!(cache_window(unix(100), Some(unix(90))), None);
+        assert_eq!(cache_window(unix(100), Some(unix(100))), None);
+        // Unknown expiry → never cache.
+        assert_eq!(cache_window(unix(0), None), None);
+    }
+
+    /// A token whose expiry cannot be read is re-read on **every** call. Slower,
+    /// but it can never serve a credential the platform already rotated away.
+    #[tokio::test]
+    async fn an_undatable_token_is_never_cached() {
+        let path = temp_file("token");
+        std::fs::write(&path, "opaque-not-a-jwt").unwrap();
+        let source = TinyhumansTokenSource::projected_file(&path);
+        assert_eq!(
+            source.current_at(unix(0)).await.unwrap(),
+            "opaque-not-a-jwt"
+        );
+
+        std::fs::write(&path, "opaque-rotated").unwrap();
+        assert_eq!(
+            source.current_at(unix(0)).await.unwrap(),
+            "opaque-rotated",
+            "with no readable expiry every call re-reads the file"
+        );
+
+        std::fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
+    /// An expired token is still presented — the backend decides, and refusing
+    /// locally would turn a recoverable 401 into an outage — but never cached.
+    #[tokio::test]
+    async fn an_expired_token_is_served_but_not_cached() {
+        let path = temp_file("token");
+        std::fs::write(&path, jwt(serde_json::json!({ "exp": 50 }))).unwrap();
+        let stale = std::fs::read_to_string(&path).unwrap();
+        let source = TinyhumansTokenSource::projected_file(&path);
+        assert_eq!(source.current_at(unix(100)).await.unwrap(), stale);
+
+        std::fs::write(&path, jwt(serde_json::json!({ "exp": 9000 }))).unwrap();
+        let fresh = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            source.current_at(unix(100)).await.unwrap(),
+            fresh,
+            "an expired token must not have been cached"
+        );
+
+        std::fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
+    #[tokio::test]
+    async fn a_missing_or_empty_token_file_is_a_config_error() {
+        let missing = TinyhumansTokenSource::projected_file("/nonexistent/oc/token");
+        let err = missing.current().await.expect_err("unreadable");
+        assert_eq!(err.code(), "config_error");
+
+        let path = temp_file("token");
+        std::fs::write(&path, "   \n").unwrap();
+        let empty = TinyhumansTokenSource::projected_file(&path);
+        assert_eq!(
+            empty.current().await.expect_err("empty").code(),
+            "config_error"
+        );
+        std::fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
+    // ---- fingerprint identity ---------------------------------------------
+
+    fn identity_of(source: &TinyhumansTokenSource) -> u64 {
+        use std::hash::Hasher;
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        source.hash_identity(&mut hasher);
+        hasher.finish()
+    }
+
+    /// The load-bearing fingerprint contract: a kubelet rotation changes the
+    /// token but NOT the identity, so the agents' tool roster is not rebuilt
+    /// every few minutes. A tier change or a static-value change does move it.
+    #[test]
+    fn identity_is_stable_across_rotation_and_moves_on_tier_or_value_change() {
+        let projected = TinyhumansTokenSource::projected_file("/var/run/token");
+        let same_path = TinyhumansTokenSource::projected_file("/var/run/token");
+        assert_eq!(
+            identity_of(&projected),
+            identity_of(&same_path),
+            "the same projected path is the same identity whatever the file holds"
+        );
+
+        let other_path = TinyhumansTokenSource::projected_file("/var/run/other");
+        assert_ne!(identity_of(&projected), identity_of(&other_path));
+
+        let static_a = TinyhumansTokenSource::static_key("key-a");
+        let static_b = TinyhumansTokenSource::static_key("key-b");
+        assert_ne!(
+            identity_of(&static_a),
+            identity_of(&static_b),
+            "a rotated static key IS a new identity"
+        );
+        assert_ne!(
+            identity_of(&projected),
+            identity_of(&static_a),
+            "a tier change must move the identity"
+        );
+    }
+
+    // ---- redaction ---------------------------------------------------------
+
+    #[test]
+    fn debug_and_describe_never_render_the_token() {
+        let source = TinyhumansTokenSource::static_key("th_super_secret_value");
+        for rendered in [format!("{source:?}"), source.describe()] {
+            assert!(!rendered.contains("th_super_secret_value"), "{rendered}");
+        }
+        assert!(format!("{source:?}").contains("<redacted>"));
+
+        let projected = TinyhumansTokenSource::projected_file("/var/run/secrets/token");
+        assert!(projected.describe().contains("/var/run/secrets/token"));
+        assert!(projected.describe().contains("projected_file"));
+    }
+
+    // ---- jwt / base64url ---------------------------------------------------
+
+    #[test]
+    fn unverified_jwt_exp_reads_the_claim_without_verifying() {
+        assert_eq!(
+            unverified_jwt_exp(&jwt(serde_json::json!({ "exp": 1893456000u64 }))),
+            Some(unix(1_893_456_000))
+        );
+        // No exp, not a JWT, wrong segment count, non-numeric exp → unreadable.
+        assert!(unverified_jwt_exp(&jwt(serde_json::json!({ "aud": "x" }))).is_none());
+        assert!(unverified_jwt_exp("not-a-jwt").is_none());
+        assert!(unverified_jwt_exp("a.b").is_none());
+        assert!(unverified_jwt_exp("a.b.c.d").is_none());
+        assert!(unverified_jwt_exp(&jwt(serde_json::json!({ "exp": "soon" }))).is_none());
+        // A payload that is not base64url at all.
+        assert!(unverified_jwt_exp("aaa.!!!!.bbb").is_none());
+    }
+
+    #[test]
+    fn base64url_decodes_the_unpadded_alphabet() {
+        assert_eq!(base64url_decode("aGVsbG8").unwrap(), b"hello");
+        assert_eq!(base64url_decode("aGVsbG8=").unwrap(), b"hello");
+        assert_eq!(base64url_decode("").unwrap(), Vec::<u8>::new());
+        // `-` and `_` are the url-safe substitutions for `+` and `/`.
+        assert_eq!(base64url_decode("--__").unwrap(), vec![0xFB, 0xEF, 0xFF]);
+        assert!(base64url_decode("a+b/c").is_none());
+    }
+
+    /// The tier's DTO spelling is a wire contract the console switches on.
+    #[test]
+    fn credential_source_wire_spellings_are_stable() {
+        assert_eq!(CredentialSource::Attested.as_str(), "attested");
+        assert_eq!(CredentialSource::Static.as_str(), "static");
+        assert_eq!(CredentialSource::None.as_str(), "none");
+        assert_eq!(
+            serde_json::to_string(&CredentialSource::Attested).unwrap(),
+            "\"attested\""
+        );
+        assert_eq!(TokenTier::ProjectedFile.as_str(), "projected_file");
+        assert_eq!(TokenTier::Static.as_str(), "static");
+    }
+}

--- a/src/company/credentials.rs
+++ b/src/company/credentials.rs
@@ -12,7 +12,9 @@
 //!    file is re-read whenever the cached copy is past its window, so a rotation
 //!    is picked up without a restart. A permanent cache here would be a latent
 //!    outage: the pod would keep presenting a token the cluster already rotated
-//!    away from.
+//!    away from. The platform mounts it read-only as
+//!    `/var/run/secrets/tinyhumans.ai/token` with a 600-second expiry; the env var
+//!    carries the **path**, never a token value.
 //! 2. **[`Tier::Static`]** — the long-lived [`API_KEY_ENV`] value. This keeps
 //!    `docker compose` development alive and serves the (explicitly
 //!    **unsupported**) self-host case. It is not going away.
@@ -26,6 +28,21 @@
 //! saved file read. An already-expired token is still returned — refusing to
 //! send it would turn a recoverable 401 into a local outage — but likewise never
 //! cached.
+//!
+//! ## Degrading to the static tier
+//!
+//! The projected tier is only selected when the named path actually exists. The
+//! docker runtime injects nothing, so a leftover [`TOKEN_FILE_ENV`] pointing at
+//! a path that was never mounted must fall through to the static tier rather
+//! than failing every request. Once the tier *is* selected, a later read failure
+//! is a hard error: silently swapping to a different identity mid-life is worse
+//! than a loud failure.
+//!
+//! ## Rejected tokens
+//!
+//! Callers invalidate the cache with [`TinyhumansTokenSource::invalidate`] when
+//! the backend rejects a bearer (401), so the very next request re-reads the file
+//! instead of waiting out the window with a token the cluster has moved past.
 //!
 //! ## Redaction
 //!
@@ -176,14 +193,22 @@ impl TinyhumansTokenSource {
     /// precedence **[`TOKEN_FILE_ENV`] > [`API_KEY_ENV`]**, or `None` when
     /// neither is configured (fail closed — the caller keeps its offline brain).
     ///
-    /// The projected file wins deliberately: a pod that has been handed a
-    /// cluster identity must present *that*, even if a stale static key is still
-    /// lying around in its environment.
+    /// The projected file wins deliberately: a pod that has been handed a cluster
+    /// identity must present *that*, even if a stale static key is still lying
+    /// around in its environment. It is chosen only when the named path **exists**
+    /// — the docker runtime mounts nothing, so a leftover variable degrades to the
+    /// static tier (with a warning) instead of failing every request.
     pub fn from_env(env: &dyn EnvSource) -> Option<Self> {
         if let Some(path) = env.get(TOKEN_FILE_ENV).map(|p| p.trim().to_string())
             && !path.is_empty()
         {
-            return Some(Self::projected_file(path));
+            if Path::new(&path).exists() {
+                return Some(Self::projected_file(path));
+            }
+            tracing::warn!(
+                token_file = %path,
+                "{TOKEN_FILE_ENV} names a path that does not exist; falling back to the static credential tier"
+            );
         }
         let key = env.get(API_KEY_ENV).map(|k| k.trim().to_string())?;
         if key.is_empty() {
@@ -246,6 +271,16 @@ impl TinyhumansTokenSource {
         }
     }
 
+    /// Drops any cached read, so the next [`Self::current`] goes back to the
+    /// file. Called when the backend rejects a bearer (401): the cluster may have
+    /// rotated the token early, and waiting out the cache window would keep
+    /// presenting the rejected one. A no-op for the static tier.
+    pub fn invalidate(&self) {
+        if let Tier::ProjectedFile { cache, .. } = &self.tier {
+            *cache.lock().expect("token cache poisoned") = None;
+        }
+    }
+
     /// The credential to present on the next outbound request.
     ///
     /// For the static tier this is the configured value. For the projected-file
@@ -294,6 +329,108 @@ impl TinyhumansTokenSource {
             good_until: now + window,
         });
         Ok(token)
+    }
+}
+
+/// One resolved outbound credential: nothing, a value someone gave us, or a
+/// [`TinyhumansTokenSource`] that must be read per request.
+///
+/// This is the seam that keeps a rotating token from being flattened into a
+/// `String` at build time. Anything holding a credential holds *this*, resolves
+/// it with [`Self::current`] on the request path, and asks
+/// [`Self::configured`]/[`Self::source`] for status — so a rotation never needs a
+/// rebuild and status never needs the value.
+#[derive(Clone, Default)]
+pub enum Credential {
+    /// No credential — omit the bearer entirely (e.g. a keyless local Ollama).
+    #[default]
+    None,
+    /// A value held in memory: a per-company token an operator pasted into the
+    /// secret store, or a BYOK key. A changed value is a changed identity.
+    Value(String),
+    /// A platform token source. Read per request; the value it yields rotates
+    /// while the identity behind it does not.
+    Source(std::sync::Arc<TinyhumansTokenSource>),
+}
+
+impl Credential {
+    /// A credential from a stored value, treating blank as "not configured".
+    pub fn from_value(value: impl Into<String>) -> Self {
+        let value = value.into();
+        if value.trim().is_empty() {
+            Self::None
+        } else {
+            Self::Value(value)
+        }
+    }
+
+    /// A credential over a shared token source.
+    pub fn from_source(source: std::sync::Arc<TinyhumansTokenSource>) -> Self {
+        Self::Source(source)
+    }
+
+    /// Whether a credential can be obtained — the non-secret status the read
+    /// planes surface. Never returns the value.
+    pub fn configured(&self) -> bool {
+        !matches!(self, Self::None)
+    }
+
+    /// Which tier this credential comes from, as the console names it.
+    pub fn source(&self) -> CredentialSource {
+        match self {
+            Self::None => CredentialSource::None,
+            Self::Value(_) => CredentialSource::Static,
+            Self::Source(source) => source.credential_source(),
+        }
+    }
+
+    /// The bearer to present on the next request, or `None` to omit the header.
+    /// A [`Self::Source`] is read here — that is what makes a rotation take
+    /// effect without a rebuild.
+    pub async fn current(&self) -> Result<Option<String>> {
+        let token = match self {
+            Self::None => return Ok(None),
+            Self::Value(value) => value.clone(),
+            Self::Source(source) => source.current().await?,
+        };
+        let token = token.trim().to_string();
+        Ok(if token.is_empty() { None } else { Some(token) })
+    }
+
+    /// Forwards a rejection (401) to the underlying source so the next request
+    /// re-reads it. A no-op for a value we were handed.
+    pub fn invalidate(&self) {
+        if let Self::Source(source) = self {
+            source.invalidate();
+        }
+    }
+
+    /// Folds this credential's *identity* into `hasher` for a roster
+    /// fingerprint — see [`TinyhumansTokenSource::hash_identity`] for why a
+    /// projected source contributes its path rather than its rotating value.
+    pub fn hash_identity<H: std::hash::Hasher>(&self, hasher: &mut H) {
+        use std::hash::Hash;
+        match self {
+            Self::None => 0u8.hash(hasher),
+            Self::Value(value) => {
+                1u8.hash(hasher);
+                value.hash(hasher);
+            }
+            Self::Source(source) => {
+                2u8.hash(hasher);
+                source.hash_identity(hasher);
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for Credential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => f.write_str("Credential(<unset>)"),
+            Self::Value(_) => f.write_str("Credential(<redacted>)"),
+            Self::Source(source) => write!(f, "Credential({})", source.describe()),
+        }
     }
 }
 
@@ -424,17 +561,34 @@ mod tests {
 
     #[test]
     fn projected_file_beats_static_key() {
+        let path = temp_file("token");
+        std::fs::write(&path, "projected").unwrap();
         let env = MapEnv::new([
-            (TOKEN_FILE_ENV, "/var/run/secrets/tinyhumans/token"),
-            (API_KEY_ENV, "th_static"),
+            (TOKEN_FILE_ENV, path.display().to_string()),
+            (API_KEY_ENV, "th_static".to_string()),
         ]);
         let source = TinyhumansTokenSource::from_env(&env).expect("configured");
         assert_eq!(source.tier(), TokenTier::ProjectedFile);
-        assert_eq!(
-            source.token_file(),
-            Some(Path::new("/var/run/secrets/tinyhumans/token"))
-        );
+        assert_eq!(source.token_file(), Some(path.as_path()));
         assert_eq!(source.credential_source(), CredentialSource::Attested);
+        std::fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
+    /// The docker runtime mounts nothing. A leftover `TINYHUMANS_TOKEN_FILE`
+    /// pointing at a path that was never projected must degrade to the static
+    /// tier — not select a tier that can only ever fail.
+    #[test]
+    fn a_token_file_that_does_not_exist_degrades_to_the_static_tier() {
+        let env = MapEnv::new([
+            (TOKEN_FILE_ENV, "/nonexistent/oc/token"),
+            (API_KEY_ENV, "th_static"),
+        ]);
+        let source = TinyhumansTokenSource::from_env(&env).expect("configured");
+        assert_eq!(source.tier(), TokenTier::Static);
+
+        // With nothing to fall back to, there is simply no source.
+        let alone = MapEnv::new([(TOKEN_FILE_ENV, "/nonexistent/oc/token")]);
+        assert!(TinyhumansTokenSource::from_env(&alone).is_none());
     }
 
     #[test]
@@ -524,6 +678,27 @@ mod tests {
         assert_eq!(cache_window(unix(100), Some(unix(100))), None);
         // Unknown expiry → never cache.
         assert_eq!(cache_window(unix(0), None), None);
+    }
+
+    /// A rejected bearer (401) must not wait out the cache window: invalidating
+    /// sends the next call straight back to the file.
+    #[tokio::test]
+    async fn invalidate_forces_a_re_read_inside_the_cache_window() {
+        let path = temp_file("token");
+        std::fs::write(&path, jwt(serde_json::json!({ "exp": 1000 }))).unwrap();
+        let first = std::fs::read_to_string(&path).unwrap();
+        let source = TinyhumansTokenSource::projected_file(&path);
+        assert_eq!(source.current_at(unix(0)).await.unwrap(), first);
+
+        std::fs::write(&path, jwt(serde_json::json!({ "exp": 1001 }))).unwrap();
+        let second = std::fs::read_to_string(&path).unwrap();
+        // Same instant, so the window is wide open — but the cache is gone.
+        source.invalidate();
+        assert_eq!(source.current_at(unix(0)).await.unwrap(), second);
+
+        // Harmless on the static tier.
+        TinyhumansTokenSource::static_key("k").invalidate();
+        std::fs::remove_dir_all(path.parent().unwrap()).ok();
     }
 
     /// A token whose expiry cannot be read is re-read on **every** call. Slower,
@@ -665,6 +840,55 @@ mod tests {
         // `-` and `_` are the url-safe substitutions for `+` and `/`.
         assert_eq!(base64url_decode("--__").unwrap(), vec![0xFB, 0xEF, 0xFF]);
         assert!(base64url_decode("a+b/c").is_none());
+    }
+
+    // ---- Credential --------------------------------------------------------
+
+    #[tokio::test]
+    async fn credential_variants_report_status_and_resolve() {
+        use std::sync::Arc;
+
+        let none = Credential::None;
+        assert!(!none.configured());
+        assert_eq!(none.source(), CredentialSource::None);
+        assert_eq!(none.current().await.unwrap(), None);
+
+        // Blank is not configuration.
+        assert!(!Credential::from_value("   ").configured());
+
+        let value = Credential::from_value("pasted-token");
+        assert!(value.configured());
+        assert_eq!(value.source(), CredentialSource::Static);
+        assert_eq!(
+            value.current().await.unwrap().as_deref(),
+            Some("pasted-token")
+        );
+
+        let path = temp_file("token");
+        std::fs::write(&path, "projected-token").unwrap();
+        let source =
+            Credential::from_source(Arc::new(TinyhumansTokenSource::projected_file(&path)));
+        assert!(source.configured());
+        assert_eq!(source.source(), CredentialSource::Attested);
+        assert_eq!(
+            source.current().await.unwrap().as_deref(),
+            Some("projected-token")
+        );
+        // The value it yields follows the file, per call.
+        std::fs::write(&path, "rotated-token").unwrap();
+        assert_eq!(
+            source.current().await.unwrap().as_deref(),
+            Some("rotated-token")
+        );
+        std::fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn credential_debug_never_renders_a_value() {
+        let rendered = format!("{:?}", Credential::from_value("super-secret"));
+        assert!(!rendered.contains("super-secret"), "{rendered}");
+        assert!(rendered.contains("<redacted>"));
+        assert!(format!("{:?}", Credential::None).contains("<unset>"));
     }
 
     /// The tier's DTO spelling is a wire contract the console switches on.

--- a/src/company/inference.rs
+++ b/src/company/inference.rs
@@ -17,17 +17,20 @@
 //!
 //! Credentials live apart from the declarations. The outbound key is written to
 //! its own [`KEY_KEY`] secret (write-only via the console) — never inline in the
-//! runtime config blob or the manifest — and is resolved into the
-//! [`InferenceDecl`]'s private field only at build/turn time by
-//! [`resolve_effective`]. Nothing here ever serializes a credential into an API
-//! response, log line, or agent-visible output: [`InferenceDecl`] derives no
-//! `Serialize` and its `Debug` redacts the key.
+//! runtime config blob or the manifest — and is attached to the
+//! [`InferenceDecl`] as a [`Credential`] by [`resolve_effective`], then read on
+//! the request path by [`InferenceDecl::bearer`]. Deferring the read is what lets
+//! the managed tier be a *rotating* platform token rather than a value captured
+//! once at boot. Nothing here ever serializes a credential into an API response,
+//! log line, or agent-visible output: [`InferenceDecl`] derives no `Serialize`
+//! and its `Debug` redacts the credential.
 
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
 use crate::Result;
+use crate::company::credentials::Credential;
 use crate::company::types::{INFERENCE_PROVIDERS, Inference};
 use crate::error::OpenCompanyError;
 use crate::ports::SecretStore;
@@ -69,30 +72,18 @@ pub enum InferenceSource {
 
 /// The platform-injected managed default (from `harness_inference_from_env`):
 /// the base URL + credential the manager supplies. Passed to
-/// [`resolve_effective`] as the lowest-precedence source. Carries no `Debug`
-/// derive so the credential never lands in a trace.
-#[derive(Clone)]
+/// [`resolve_effective`] as the lowest-precedence source.
+///
+/// The credential is a [`Credential`], not a `String`: on the hosted platform it
+/// is a projected token that rotates in place, so it is resolved per request
+/// rather than captured here.
+#[derive(Clone, Debug)]
 pub struct EnvDefault {
     /// Managed base URL (env `OPENCOMPANY_INFERENCE_URL` or the default).
     pub base_url: String,
-    /// Managed credential (`OPENCOMPANY_INFERENCE_KEY` / `TINYHUMANS_API_KEY`).
-    pub api_key: String,
-}
-
-impl std::fmt::Debug for EnvDefault {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("EnvDefault")
-            .field("base_url", &self.base_url)
-            .field(
-                "api_key",
-                &if self.api_key.is_empty() {
-                    "<unset>"
-                } else {
-                    "<redacted>"
-                },
-            )
-            .finish()
-    }
+    /// Managed credential — a projected platform token source, or the static
+    /// `OPENCOMPANY_INFERENCE_KEY` / `TINYHUMANS_API_KEY` value.
+    pub credential: Credential,
 }
 
 /// The on-disk runtime inference override stored under [`RUNTIME_CONFIG_KEY`].
@@ -110,12 +101,12 @@ pub struct RuntimeInference {
 }
 
 /// One company's *effective* inference configuration — the highest-precedence
-/// of runtime / manifest / env, with the credential resolved to a private field
-/// at build/turn time.
+/// of runtime / manifest / env, carrying the credential as a resolvable
+/// [`Credential`] rather than a captured value.
 ///
 /// Derives **no** `Serialize` (the key must never cross a wire) and its `Debug`
-/// redacts the key.
-#[derive(Clone)]
+/// redacts the credential.
+#[derive(Clone, Debug)]
 pub struct InferenceDecl {
     /// Provider slug — one of [`INFERENCE_PROVIDERS`].
     pub provider: String,
@@ -126,47 +117,38 @@ pub struct InferenceDecl {
     pub models: BTreeMap<String, String>,
     /// Provenance badge for the console.
     pub source: InferenceSource,
-    /// Resolved outbound credential. Empty means "no bearer" (e.g. Ollama).
-    /// Private — read only through [`api_key`](Self::api_key); never serialized.
-    api_key: String,
+    /// The outbound credential. Private — read only through
+    /// [`bearer`](Self::bearer); never serialized.
+    credential: Credential,
 }
 
 impl InferenceDecl {
-    /// The resolved outbound credential (empty = omit the bearer header). Kept
-    /// crate-internal so the request builder can read it; never serialized.
-    pub fn api_key(&self) -> &str {
-        &self.api_key
+    /// The outbound credential, unresolved. Callers on the request path want
+    /// [`bearer`](Self::bearer); this is for status and fingerprinting.
+    pub fn credential(&self) -> &Credential {
+        &self.credential
+    }
+
+    /// The bearer to present on **this** request, or `None` to omit the header
+    /// (the keyless Ollama case).
+    ///
+    /// Resolved per call rather than captured at build time: a hosted tenant's
+    /// managed credential is a projected token the platform rotates in place, so
+    /// a value captured once would go stale within minutes.
+    pub async fn bearer(&self) -> Result<Option<String>> {
+        self.credential.current().await
     }
 
     /// Whether an outbound credential is configured — the non-secret status the
-    /// read APIs surface. Never returns the value.
+    /// read APIs surface. Never returns the value, and never reads the token.
     pub fn key_configured(&self) -> bool {
-        !self.api_key.trim().is_empty()
+        self.credential.configured()
     }
 
     /// The stable telemetry slug for this provider (`managed` / `openrouter` /
     /// `byok` / `ollama`).
     pub fn telemetry_slug(&self) -> &'static str {
         provider_slug(&self.provider)
-    }
-}
-
-impl std::fmt::Debug for InferenceDecl {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("InferenceDecl")
-            .field("provider", &self.provider)
-            .field("base_url", &self.base_url)
-            .field("models", &self.models)
-            .field("source", &self.source)
-            .field(
-                "api_key",
-                &if self.api_key.is_empty() {
-                    "<unset>"
-                } else {
-                    "<redacted>"
-                },
-            )
-            .finish()
     }
 }
 
@@ -181,7 +163,7 @@ pub fn provider_slug(provider: &str) -> &'static str {
     }
 }
 
-/// Resolves the effective `(base_url, api_key)` for a provider.
+/// Resolves the effective `(base_url, credential)` for a provider.
 ///
 /// The `managed` kind is special: it is the *platform* brain, so it inherits the
 /// env default's base URL and credential when a source (manifest/runtime) names
@@ -193,21 +175,26 @@ fn resolve_endpoint(
     base_url_override: Option<&str>,
     key: String,
     env_default: Option<&EnvDefault>,
-) -> (String, String) {
+) -> (String, Credential) {
     let base_url_override = base_url_override.map(str::trim).filter(|s| !s.is_empty());
     if provider.trim() == "managed" {
         let base_url = base_url_override
             .map(str::to_string)
             .or_else(|| env_default.map(|e| e.base_url.clone()))
             .unwrap_or_else(|| MANAGED_BASE_URL.to_string());
-        let api_key = if !key.trim().is_empty() {
-            key
+        let credential = if !key.trim().is_empty() {
+            Credential::from_value(key)
         } else {
-            env_default.map(|e| e.api_key.clone()).unwrap_or_default()
+            env_default
+                .map(|e| e.credential.clone())
+                .unwrap_or(Credential::None)
         };
-        (base_url, api_key)
+        (base_url, credential)
     } else {
-        (effective_base_url(provider, base_url_override), key)
+        (
+            effective_base_url(provider, base_url_override),
+            Credential::from_value(key),
+        )
     }
 }
 
@@ -342,14 +329,14 @@ pub async fn resolve_effective(
     if let Some(runtime) = load_runtime_config(company, secrets).await? {
         let provider = runtime.provider.trim().to_string();
         let key = load_key(company, secrets, None).await?;
-        let (base_url, api_key) =
+        let (base_url, credential) =
             resolve_endpoint(&provider, runtime.base_url.as_deref(), key, env_default);
         return Ok(Some(InferenceDecl {
             provider,
             base_url,
             models: runtime.models,
             source: InferenceSource::Runtime,
-            api_key,
+            credential,
         }));
     }
 
@@ -362,14 +349,14 @@ pub async fn resolve_effective(
             .trim()
             .to_string();
         let key = load_key(company, secrets, manifest.api_key_secret.as_deref()).await?;
-        let (base_url, api_key) =
+        let (base_url, credential) =
             resolve_endpoint(&provider, manifest.base_url.as_deref(), key, env_default);
         return Ok(Some(InferenceDecl {
             provider,
             base_url,
             models: manifest.models.clone(),
             source: InferenceSource::Manifest,
-            api_key,
+            credential,
         }));
     }
 
@@ -380,7 +367,7 @@ pub async fn resolve_effective(
             base_url: env.base_url.clone(),
             models: BTreeMap::new(),
             source: InferenceSource::Default,
-            api_key: env.api_key.clone(),
+            credential: env.credential.clone(),
         }));
     }
 
@@ -492,6 +479,11 @@ mod tests {
 
     use async_trait::async_trait;
 
+    /// The resolved bearer for a decl, for the assertions below.
+    async fn bearer(decl: &InferenceDecl) -> Option<String> {
+        decl.bearer().await.expect("credential resolves")
+    }
+
     fn inference(provider: &str) -> Inference {
         Inference {
             provider: Some(provider.to_string()),
@@ -530,7 +522,7 @@ mod tests {
         let secrets = MemSecrets::default();
         let env = EnvDefault {
             base_url: "https://env.example/v1".into(),
-            api_key: "env-key".into(),
+            credential: Credential::from_value("env-key"),
         };
         let mut manifest = inference("openai_compatible");
         manifest.base_url = Some("https://manifest.example/v1".into());
@@ -542,7 +534,7 @@ mod tests {
             .expect("env default resolves");
         assert_eq!(decl.source, InferenceSource::Default);
         assert_eq!(decl.provider, "managed");
-        assert_eq!(decl.api_key(), "env-key");
+        assert_eq!(bearer(&decl).await.as_deref(), Some("env-key"));
 
         // Manifest beats env.
         let decl = resolve_effective(&company, &manifest, Some(&env), &secrets)
@@ -573,7 +565,7 @@ mod tests {
         assert_eq!(decl.source, InferenceSource::Runtime);
         assert_eq!(decl.provider, "openrouter");
         assert_eq!(decl.base_url, OPENROUTER_BASE_URL);
-        assert_eq!(decl.api_key(), "or-secret");
+        assert_eq!(bearer(&decl).await.as_deref(), Some("or-secret"));
         assert!(decl.key_configured());
     }
 
@@ -585,7 +577,7 @@ mod tests {
         let secrets = MemSecrets::default();
         let env = EnvDefault {
             base_url: "https://env.example/openai/v1".into(),
-            api_key: "platform-key".into(),
+            credential: Credential::from_value("platform-key"),
         };
         let decl = resolve_effective(&company, &inference("managed"), Some(&env), &secrets)
             .await
@@ -594,7 +586,7 @@ mod tests {
         assert_eq!(decl.source, InferenceSource::Manifest);
         assert_eq!(decl.provider, "managed");
         assert_eq!(decl.base_url, "https://env.example/openai/v1");
-        assert_eq!(decl.api_key(), "platform-key");
+        assert_eq!(bearer(&decl).await.as_deref(), Some("platform-key"));
     }
 
     #[tokio::test]
@@ -659,7 +651,7 @@ mod tests {
             .unwrap()
             .unwrap();
         // The key resolves for request building…
-        assert_eq!(decl.api_key(), "sk-super-secret");
+        assert_eq!(bearer(&decl).await.as_deref(), Some("sk-super-secret"));
         // …but never appears in the Debug rendering.
         let debug = format!("{decl:?}");
         assert!(!debug.contains("sk-super-secret"), "{debug}");
@@ -695,7 +687,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(decl.api_key(), "named-secret");
+        assert_eq!(bearer(&decl).await.as_deref(), Some("named-secret"));
     }
 
     // ---- validation --------------------------------------------------------

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -8,6 +8,10 @@
 pub mod composio;
 #[cfg(test)]
 mod content_test;
+// How this instance obtains its TinyHumans credential (projected, rotating
+// platform token vs a static key). Always compiled: the answer decides whether a
+// company can think at all, in every build.
+pub mod credentials;
 pub mod dns;
 pub mod inference;
 mod manifest;
@@ -33,6 +37,7 @@ pub mod workspace_seed;
 
 use std::path::Path;
 
+pub use credentials::{CredentialSource, TinyhumansTokenSource, TokenTier};
 pub use manifest::{LEGACY_MANIFEST_FILE, Located, MANIFEST_FILE, discover};
 pub use skill_file::{SkillDoc, load_dir_skills, parse_skill_md};
 pub use types::{

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -37,7 +37,7 @@ pub mod workspace_seed;
 
 use std::path::Path;
 
-pub use credentials::{CredentialSource, TinyhumansTokenSource, TokenTier};
+pub use credentials::{Credential, CredentialSource, TinyhumansTokenSource, TokenTier};
 pub use manifest::{LEGACY_MANIFEST_FILE, Located, MANIFEST_FILE, discover};
 pub use skill_file::{SkillDoc, load_dir_skills, parse_skill_md};
 pub use types::{

--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -331,28 +331,6 @@ mod live {
             .ok_or_else(|| anyhow::anyhow!("missing required `{key}` string argument"))
     }
 
-    /// Build a [`ComposioClient`] over a resolved tenant config.
-    ///
-    /// The Config-free seam: `IntegrationClient::new(backend_url, auth_token)`
-    /// takes the per-tenant credential directly, with no OpenHuman global
-    /// `Config`. The bearer is the ONLY isolation lever — see the module docs.
-    /// Shared by the agent tools ([`composio_tools`]) and the operator-console
-    /// ops handlers ([`authorize_connect_url`], [`list_connection_states`]) so
-    /// both dial the backend the exact same way.
-    fn client_for(config: &TenantComposio) -> ComposioClient {
-        ComposioClient::new(Arc::new(IntegrationClient::new(
-            config.backend_url.clone(),
-            config.auth_token.clone(),
-        )))
-    }
-
-    /// Scrub the tenant bearer out of an upstream error before it can bubble to
-    /// a console handler or a log line — the backend can reflect the presented
-    /// bearer in an error body, and the ops surface must never echo it.
-    fn scrub_err(err: &anyhow::Error, config: &TenantComposio) -> anyhow::Error {
-        anyhow::anyhow!(scrub(&format!("{err}"), &[config.auth_token.clone()]))
-    }
-
     /// Begin an OAuth handoff for `toolkit` and return the Composio-hosted
     /// connect URL the operator opens in a browser. Backs the console's
     /// `POST …/composio/authorize` route (the same building block the
@@ -374,9 +352,10 @@ mod live {
             anyhow::bail!("toolkit `{toolkit}` is not in this company's Composio allowlist");
         }
         tracing::debug!(toolkit = %toolkit, "[composio] ops authorize");
-        match client_for(config).authorize(toolkit, None).await {
+        let (client, secrets) = live_call(config).await?;
+        match client.authorize(toolkit, None).await {
             Ok(resp) => Ok(resp.connect_url),
-            Err(err) => Err(scrub_err(&err, config)),
+            Err(err) => Err(anyhow::anyhow!(scrub(&format!("{err}"), &secrets))),
         }
     }
 
@@ -391,9 +370,10 @@ mod live {
     /// is scrubbed of the tenant bearer before it bubbles.
     pub async fn list_connection_states(config: &TenantComposio) -> Result<Vec<(String, bool)>> {
         tracing::debug!(allowlist = ?config.toolkits, "[composio] ops list_connections");
-        let resp = match client_for(config).list_connections().await {
+        let (client, secrets) = live_call(config).await?;
+        let resp = match client.list_connections().await {
             Ok(resp) => resp,
-            Err(err) => return Err(scrub_err(&err, config)),
+            Err(err) => return Err(anyhow::anyhow!(scrub(&format!("{err}"), &secrets))),
         };
         let mut states: std::collections::BTreeMap<String, bool> =
             std::collections::BTreeMap::new();
@@ -1185,11 +1165,11 @@ mod ops_helper_tests {
     }
 
     fn config(url: &str, toolkits: Vec<String>) -> TenantComposio {
-        TenantComposio {
-            backend_url: url.to_string(),
-            auth_token: "tenant-token".to_string(),
+        TenantComposio::new(
+            url.to_string(),
+            Credential::from_value("tenant-token"),
             toolkits,
-        }
+        )
     }
 
     #[tokio::test]

--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -6,24 +6,45 @@
 //!
 //! In OpenHuman's **backend mode**, no Composio call carries an `entity_id`: the
 //! backend derives the Composio entity from the **bearer JWT** on the request.
-//! So the *only* isolation lever is **which token the client is constructed
-//! with**, and that construction happens **server-side** here — never from agent
-//! input and never from manifest free-text. The token is resolved from the
-//! company's [`SecretStore`] under [`TOKEN_KEY`]; it has **no environment
-//! fallback**, so a missing/empty secret yields `None` and no tools are wired
-//! (fail closed). Two companies pasting the *same* token would share one entity
-//! — that cannot be prevented client-side and is documented as a deployment
-//! caveat (one backend token per company).
+//! So the *only* isolation lever is **which credential the call is made with**,
+//! and that resolution happens **server-side** here — never from agent input and
+//! never from manifest free-text.
 //!
-//! ## Write-only token
+//! Two sources, in strict precedence:
 //!
-//! The token is a write-only credential. It is scrubbed out of **every**
-//! `ToolResult` (success and error), every tracing line, and the [`Debug`]
-//! impl. Only non-secret status (backend URL, toolkit allowlist) is ever
-//! surfaced.
+//! 1. **The company's own token**, stored in its [`SecretStore`] under
+//!    [`TOKEN_KEY`] by the console. A company that brings its own Composio
+//!    identity keeps it, always.
+//! 2. **This instance's platform identity** — the
+//!    [`TinyhumansTokenSource`](crate::company::credentials::TinyhumansTokenSource)
+//!    the runtime authenticates with everywhere else. On the hosted platform that
+//!    is a projected, audience-bound token the cluster rotates in place, so it is
+//!    read **per call**, never captured when the roster is built.
+//!
+//! With neither, resolution yields `None` and no tools are wired (fail closed) —
+//! an absent credential must mean "no tools", never a borrowed identity. Two
+//! companies pasting the *same* token would share one entity; that cannot be
+//! prevented client-side and is documented as a deployment caveat.
+//!
+//! ## Rotation must not churn the roster
+//!
+//! The roster fingerprint hashes the credential's **identity**, not its bytes:
+//! for the projected tier that is the tier + path (see
+//! [`Credential::hash_identity`]). Hashing the value would rebuild every agent's
+//! tool roster on the platform's rotation schedule — every few minutes, forever.
+//! A pasted per-company token still fingerprints by value, because there a new
+//! value really is a new identity.
+//!
+//! ## Write-only credential
+//!
+//! The token is write-only. Whatever value a call resolves is fed to [`scrub`] as
+//! a known secret, so it cannot survive into **any** `ToolResult` (success or
+//! error); it is absent from every tracing line and from the [`Debug`] impl. Only
+//! non-secret status (backend URL, toolkit allowlist) is ever surfaced.
 
 use std::sync::Arc;
 
+use crate::company::credentials::{Credential, TinyhumansTokenSource};
 use crate::ports::SecretStore;
 use crate::ports::types::{CompanyId, SecretValue};
 
@@ -34,90 +55,113 @@ pub use crate::company::composio::{
     COMPOSIO_BACKEND_URL_ENV, TINYHUMANS_API_URL_ENV, TOKEN_KEY, backend_url_or_default,
 };
 
-/// A per-tenant Composio configuration: the backend URL, the tenant's OAuth
-/// bearer token, and the toolkit allowlist.
+/// A per-tenant Composio configuration: the backend URL, how the outbound bearer
+/// is obtained, and the toolkit allowlist.
 ///
-/// **Security invariant**: `auth_token` is a per-company credential. The backend
-/// derives the Composio entity from it, so a company can only ever reach its own
-/// connected accounts. The token is never logged, returned, or `Debug`-printed.
+/// **Security invariant**: the credential decides which Composio entity the
+/// backend resolves, so a company can only ever reach its own connected
+/// accounts. It is never logged, returned, or `Debug`-printed.
 ///
 /// Always compiled (so the [`HarnessDeps`](crate::harness::HarnessDeps) field
 /// exists in every `openhuman` build and every construction site fails closed
 /// with `None`); the live tool constructors in [`composio_tools`] are gated
 /// behind the `composio` feature.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TenantComposio {
     /// The Composio backend base URL (e.g. `https://api.tinyhumans.ai`).
     pub backend_url: String,
-    /// The per-tenant OAuth bearer token. Never a managed/platform key; the
-    /// backend derives the tenant's Composio entity from it. Write-only.
-    pub auth_token: String,
+    /// How the outbound bearer is obtained: the company's own stored token, or
+    /// this instance's platform identity. Resolved per call — see the module docs.
+    credential: Credential,
     /// The toolkit allowlist (Gmail / Slack / GitHub, …). Empty defers to the
     /// backend's server-enforced allowlist (open mode); non-empty narrows
     /// strictly, client-side, before any network round-trip.
     pub toolkits: Vec<String>,
 }
 
-impl std::fmt::Debug for TenantComposio {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Never let the tenant credential land in a trace.
-        f.debug_struct("TenantComposio")
-            .field("backend_url", &self.backend_url)
-            .field(
-                "auth_token",
-                &if self.auth_token.is_empty() {
-                    "<unset>"
-                } else {
-                    "<redacted>"
-                },
-            )
-            .field("toolkits", &self.toolkits)
-            .finish()
-    }
-}
-
 impl TenantComposio {
-    /// Resolve a per-tenant Composio config from the company secret store, or
-    /// `None` (fail closed) when no non-empty token is stored.
+    /// A config over an explicit credential — the constructor tests and callers
+    /// outside the resolver use.
+    pub fn new(
+        backend_url: impl Into<String>,
+        credential: Credential,
+        toolkits: Vec<String>,
+    ) -> Self {
+        Self {
+            backend_url: backend_url.into(),
+            credential,
+            toolkits,
+        }
+    }
+
+    /// Resolve a per-tenant Composio config, or `None` (fail closed) when no
+    /// credential can be obtained at all.
     ///
-    /// The token comes **only** from [`TOKEN_KEY`] in the secret store — there is
-    /// no environment or platform-key fallback, by design: an absent token must
-    /// mean "no tools", never "borrow someone else's identity". The URL resolves
-    /// from [`COMPOSIO_BACKEND_URL_ENV`], then the tenant API base
-    /// [`TINYHUMANS_API_URL_ENV`], then [`DEFAULT_BACKEND_URL`] — see
+    /// Precedence: the company's **own** token under [`TOKEN_KEY`] in the secret
+    /// store wins; otherwise this instance's platform identity (`token_source`)
+    /// is used. A company that pasted its own Composio token therefore keeps it
+    /// even on the hosted platform, and a company that pasted nothing borrows no
+    /// one else's identity — it presents the identity of the instance it runs in,
+    /// which the backend resolves to that instance's owner.
+    ///
+    /// The URL resolves from [`COMPOSIO_BACKEND_URL_ENV`], then the tenant API
+    /// base [`TINYHUMANS_API_URL_ENV`], then [`DEFAULT_BACKEND_URL`] — see
     /// [`backend_url_or_default`]. `toolkits` is the manifest allowlist, threaded
     /// through unchanged.
     ///
-    /// A secret-store read error degrades to `None` (fail closed) rather than
-    /// bubbling — a transient store hiccup withholds the tools for that turn
-    /// instead of bricking the roster build.
+    /// A secret-store read error degrades to the token source (and, failing that,
+    /// to `None`) rather than bubbling — a transient store hiccup must not brick
+    /// the roster build.
     pub async fn resolve(
         company: &CompanyId,
         secrets: &dyn SecretStore,
         toolkits: Vec<String>,
         backend_url_env: Option<String>,
         api_url_env: Option<String>,
+        token_source: Option<Arc<TinyhumansTokenSource>>,
     ) -> Option<Self> {
-        let token = match secrets.get(company, TOKEN_KEY).await {
-            Ok(Some(SecretValue(token))) => token,
-            _ => return None,
+        let stored = match secrets.get(company, TOKEN_KEY).await {
+            Ok(Some(SecretValue(token))) => Credential::from_value(token),
+            _ => Credential::None,
         };
-        let token = token.trim().to_string();
-        if token.is_empty() {
-            return None;
-        }
-        Some(Self {
-            backend_url: backend_url_or_default(backend_url_env, api_url_env),
-            auth_token: token,
+        let credential = match (stored, token_source) {
+            // The company's own token always wins.
+            (stored @ Credential::Value(_), _) => stored,
+            (_, Some(source)) => Credential::from_source(source),
+            (_, None) => return None,
+        };
+        Some(Self::new(
+            backend_url_or_default(backend_url_env, api_url_env),
+            credential,
             toolkits,
-        })
+        ))
+    }
+
+    /// The credential this config presents. Status and fingerprinting only —
+    /// callers on the request path want [`Self::current_token`].
+    pub fn credential(&self) -> &Credential {
+        &self.credential
+    }
+
+    /// The bearer to present on **this** Composio call.
+    ///
+    /// Resolved per call so a platform token the cluster rotated in place is
+    /// picked up without rebuilding the roster. `None` would mean no credential
+    /// at all, which [`Self::resolve`] already rules out; the tools refuse the
+    /// call rather than dialling the backend unauthenticated.
+    pub async fn current_token(&self) -> crate::Result<Option<String>> {
+        self.credential.current().await
     }
 
     /// A stable, credential-safe fingerprint of the resolved config, folded into
     /// the harness roster fingerprint so a console token set/rotate (or a
     /// toolkit-allowlist change) rebuilds the roster on the next turn without a
-    /// restart. Hashes the token too so a rotation is detected — but the hash is
-    /// one-way, so the fingerprint never carries the secret.
+    /// restart.
+    ///
+    /// The credential contributes its **identity**, not its bytes: a projected
+    /// platform token rotates every few minutes, and hashing the value would
+    /// rebuild the whole roster on that schedule. A pasted per-company token does
+    /// contribute its value, since changing it is a real identity change.
     pub fn fingerprint(config: &Option<TenantComposio>) -> u64 {
         use std::hash::{Hash, Hasher};
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -126,7 +170,7 @@ impl TenantComposio {
             Some(c) => {
                 1u8.hash(&mut hasher);
                 c.backend_url.hash(&mut hasher);
-                c.auth_token.hash(&mut hasher);
+                c.credential.hash_identity(&mut hasher);
                 c.toolkits.hash(&mut hasher);
             }
         }
@@ -188,13 +232,13 @@ mod live {
         pub meter: Option<Arc<dyn UsageMeter>>,
     }
 
-    /// Build the five per-tenant Composio tools over the tenant's bearer token.
+    /// Build the five per-tenant Composio tools over the tenant's credential.
     ///
-    /// Each tool holds its own [`ComposioClient`] (cheap `Arc` clone over the
-    /// shared [`IntegrationClient`]), the known-secret vector `[auth_token]` fed
-    /// to [`scrub`] so the credential can never survive into agent-visible
-    /// output, and the toolkit allowlist. The read tools are `ReadOnly`; the
-    /// `authorize` / `execute` tools are `Execute` and additionally park for
+    /// Each tool holds the shared [`TenantComposio`] and the toolkit allowlist,
+    /// and builds its [`ComposioClient`] **when it runs** via [`live_call`] — the
+    /// bearer is resolved then, not now, so a platform token that rotated since
+    /// the roster was built still authenticates. The read tools are `ReadOnly`;
+    /// the `authorize` / `execute` tools are `Execute` and additionally park for
     /// operator approval through the harness [`ApprovalPolicy`](crate::harness::policy).
     ///
     /// `metering` lets `composio_execute` record a
@@ -208,40 +252,58 @@ mod live {
         config: &TenantComposio,
         metering: ComposioMetering,
     ) -> Vec<Box<dyn Tool>> {
-        // The Config-free seam: `IntegrationClient::new(backend_url, auth_token)`
-        // takes the per-tenant credential directly, with no OpenHuman global
-        // `Config`. The bearer is the ONLY isolation lever — see the module docs.
-        let client = client_for(config);
-        let secrets = vec![config.auth_token.clone()];
+        let config = Arc::new(config.clone());
         let toolkits = Arc::new(config.toolkits.clone());
         vec![
             Box::new(ComposioListToolkitsTool {
-                client: client.clone(),
-                secrets: secrets.clone(),
+                config: Arc::clone(&config),
                 toolkits: Arc::clone(&toolkits),
             }),
             Box::new(ComposioListConnectionsTool {
-                client: client.clone(),
-                secrets: secrets.clone(),
+                config: Arc::clone(&config),
                 toolkits: Arc::clone(&toolkits),
             }),
             Box::new(ComposioListToolsTool {
-                client: client.clone(),
-                secrets: secrets.clone(),
+                config: Arc::clone(&config),
                 toolkits: Arc::clone(&toolkits),
             }),
             Box::new(ComposioAuthorizeTool {
-                client: client.clone(),
-                secrets: secrets.clone(),
+                config: Arc::clone(&config),
                 toolkits: Arc::clone(&toolkits),
             }),
             Box::new(ComposioExecuteTool {
-                client,
-                secrets,
+                config,
                 toolkits,
                 metering,
             }),
         ]
+    }
+
+    /// A client for one call plus the known-secret vector that call's output must
+    /// be scrubbed against.
+    ///
+    /// Built per call on purpose. The Config-free seam
+    /// `IntegrationClient::new(backend_url, auth_token)` takes the credential
+    /// directly (no OpenHuman global `Config`), and the bearer it is handed is the
+    /// ONLY isolation lever — see the module docs — so it must be the value the
+    /// credential yields *now*. A per-call client costs one HTTP-client
+    /// construction on a path that is already a network round-trip; capturing the
+    /// token once instead would leave a hosted tenant presenting a bearer the
+    /// cluster rotated away from minutes ago.
+    ///
+    /// The scrub vector carries exactly the token that went out, so it cannot
+    /// survive into agent-visible output even if the backend reflects it.
+    async fn live_call(config: &TenantComposio) -> Result<(ComposioClient, Vec<String>)> {
+        let token = config
+            .current_token()
+            .await
+            .map_err(|e| anyhow::anyhow!("resolving this company's Composio credential: {e}"))?
+            .ok_or_else(|| anyhow::anyhow!("no Composio credential is configured"))?;
+        let client = ComposioClient::new(Arc::new(IntegrationClient::new(
+            config.backend_url.clone(),
+            token.clone(),
+        )));
+        Ok((client, vec![token]))
     }
 
     /// Serialize a successful response to JSON, then scrub it against the tenant
@@ -352,8 +414,7 @@ mod live {
     // ── composio_list_toolkits ──────────────────────────────────────────
 
     struct ComposioListToolkitsTool {
-        client: ComposioClient,
-        secrets: Vec<String>,
+        config: Arc<TenantComposio>,
         toolkits: Arc<Vec<String>>,
     }
 
@@ -384,7 +445,15 @@ mod live {
                 allowlist = ?self.toolkits,
                 "[composio] list_toolkits"
             );
-            match self.client.list_toolkits().await {
+            let (client, secrets) = match live_call(&self.config).await {
+                Ok(live) => live,
+                Err(err) => {
+                    return Ok(ToolResult::error(format!(
+                        "composio_list_toolkits failed: {err}"
+                    )));
+                }
+            };
+            match client.list_toolkits().await {
                 Ok(mut resp) => {
                     if !self.toolkits.is_empty() {
                         resp.toolkits
@@ -394,13 +463,13 @@ mod live {
                     }
                     Ok(scrubbed_ok(
                         serde_json::to_value(&resp).unwrap_or(Value::Null),
-                        &self.secrets,
+                        &secrets,
                     ))
                 }
                 Err(err) => Ok(scrubbed_err(
                     "composio_list_toolkits failed",
                     &err,
-                    &self.secrets,
+                    &secrets,
                 )),
             }
         }
@@ -409,8 +478,7 @@ mod live {
     // ── composio_list_connections ───────────────────────────────────────
 
     struct ComposioListConnectionsTool {
-        client: ComposioClient,
-        secrets: Vec<String>,
+        config: Arc<TenantComposio>,
         toolkits: Arc<Vec<String>>,
     }
 
@@ -441,7 +509,15 @@ mod live {
                 allowlist = ?self.toolkits,
                 "[composio] list_connections"
             );
-            match self.client.list_connections().await {
+            let (client, secrets) = match live_call(&self.config).await {
+                Ok(live) => live,
+                Err(err) => {
+                    return Ok(ToolResult::error(format!(
+                        "composio_list_connections failed: {err}"
+                    )));
+                }
+            };
+            match client.list_connections().await {
                 Ok(mut resp) => {
                     if !self.toolkits.is_empty() {
                         resp.connections.retain(|conn| {
@@ -450,13 +526,13 @@ mod live {
                     }
                     Ok(scrubbed_ok(
                         serde_json::to_value(&resp).unwrap_or(Value::Null),
-                        &self.secrets,
+                        &secrets,
                     ))
                 }
                 Err(err) => Ok(scrubbed_err(
                     "composio_list_connections failed",
                     &err,
-                    &self.secrets,
+                    &secrets,
                 )),
             }
         }
@@ -465,8 +541,7 @@ mod live {
     // ── composio_list_tools ─────────────────────────────────────────────
 
     struct ComposioListToolsTool {
-        client: ComposioClient,
-        secrets: Vec<String>,
+        config: Arc<TenantComposio>,
         toolkits: Arc<Vec<String>>,
     }
 
@@ -537,7 +612,15 @@ mod live {
             } else {
                 Some(effective.as_slice())
             };
-            match self.client.list_tools(query, None).await {
+            let (client, secrets) = match live_call(&self.config).await {
+                Ok(live) => live,
+                Err(err) => {
+                    return Ok(ToolResult::error(format!(
+                        "composio_list_tools failed: {err}"
+                    )));
+                }
+            };
+            match client.list_tools(query, None).await {
                 Ok(mut resp) => {
                     if !self.toolkits.is_empty() {
                         resp.tools.retain(|schema| {
@@ -546,14 +629,10 @@ mod live {
                     }
                     Ok(scrubbed_ok(
                         serde_json::to_value(&resp).unwrap_or(Value::Null),
-                        &self.secrets,
+                        &secrets,
                     ))
                 }
-                Err(err) => Ok(scrubbed_err(
-                    "composio_list_tools failed",
-                    &err,
-                    &self.secrets,
-                )),
+                Err(err) => Ok(scrubbed_err("composio_list_tools failed", &err, &secrets)),
             }
         }
     }
@@ -561,8 +640,7 @@ mod live {
     // ── composio_authorize ──────────────────────────────────────────────
 
     struct ComposioAuthorizeTool {
-        client: ComposioClient,
-        secrets: Vec<String>,
+        config: Arc<TenantComposio>,
         toolkits: Arc<Vec<String>>,
     }
 
@@ -601,7 +679,7 @@ mod live {
         async fn execute(&self, args: Value) -> Result<ToolResult> {
             let toolkit = match required_string_arg(&args, "toolkit") {
                 Ok(t) => t,
-                Err(err) => return Ok(scrubbed_err("composio_authorize", &err, &self.secrets)),
+                Err(err) => return Ok(ToolResult::error(format!("composio_authorize: {err}"))),
             };
             // Enforce the allowlist BEFORE any network call — a toolkit the
             // tenant is not permitted to connect never reaches the backend.
@@ -612,16 +690,20 @@ mod live {
             }
             let extra = args.get("extra_params").cloned();
             tracing::debug!(toolkit = %toolkit, "[composio] authorize");
-            match self.client.authorize(&toolkit, extra).await {
+            let (client, secrets) = match live_call(&self.config).await {
+                Ok(live) => live,
+                Err(err) => {
+                    return Ok(ToolResult::error(format!(
+                        "composio_authorize failed: {err}"
+                    )));
+                }
+            };
+            match client.authorize(&toolkit, extra).await {
                 Ok(resp) => Ok(scrubbed_ok(
                     serde_json::to_value(&resp).unwrap_or(Value::Null),
-                    &self.secrets,
+                    &secrets,
                 )),
-                Err(err) => Ok(scrubbed_err(
-                    "composio_authorize failed",
-                    &err,
-                    &self.secrets,
-                )),
+                Err(err) => Ok(scrubbed_err("composio_authorize failed", &err, &secrets)),
             }
         }
     }
@@ -629,8 +711,7 @@ mod live {
     // ── composio_execute ────────────────────────────────────────────────
 
     struct ComposioExecuteTool {
-        client: ComposioClient,
-        secrets: Vec<String>,
+        config: Arc<TenantComposio>,
         toolkits: Arc<Vec<String>>,
         metering: ComposioMetering,
     }
@@ -670,7 +751,7 @@ mod live {
         async fn execute(&self, args: Value) -> Result<ToolResult> {
             let tool = match required_string_arg(&args, "tool") {
                 Ok(t) => t,
-                Err(err) => return Ok(scrubbed_err("composio_execute", &err, &self.secrets)),
+                Err(err) => return Ok(ToolResult::error(format!("composio_execute: {err}"))),
             };
             // Enforce the allowlist on the slug's toolkit prefix BEFORE any
             // network call (e.g. `GMAIL_SEND_EMAIL` → `gmail`).
@@ -683,7 +764,13 @@ mod live {
             let arguments = args.get("arguments").cloned();
             // tracing carries the slug/toolkit only — NEVER arguments or bodies.
             tracing::debug!(tool = %tool, toolkit = %toolkit, "[composio] execute");
-            match self.client.execute_tool(&tool, arguments).await {
+            let (client, secrets) = match live_call(&self.config).await {
+                Ok(live) => live,
+                Err(err) => {
+                    return Ok(ToolResult::error(format!("composio_execute failed: {err}")));
+                }
+            };
+            match client.execute_tool(&tool, arguments).await {
                 Ok(resp) => {
                     // Metered only on success — i.e. a call that actually
                     // reached the connected account. `connections` in the read
@@ -703,10 +790,10 @@ mod live {
                     }
                     Ok(scrubbed_ok(
                         serde_json::to_value(&resp).unwrap_or(Value::Null),
-                        &self.secrets,
+                        &secrets,
                     ))
                 }
-                Err(err) => Ok(scrubbed_err("composio_execute failed", &err, &self.secrets)),
+                Err(err) => Ok(scrubbed_err("composio_execute failed", &err, &secrets)),
             }
         }
     }
@@ -749,11 +836,11 @@ mod live {
         /// paths under test — both return before any network call.
         fn tool_with(meter: Arc<RecordingMeter>) -> ComposioExecuteTool {
             ComposioExecuteTool {
-                client: ComposioClient::new(Arc::new(IntegrationClient::new(
-                    "https://example.invalid".to_string(),
-                    "token".to_string(),
-                ))),
-                secrets: vec!["token".to_string()],
+                config: Arc::new(TenantComposio::new(
+                    "https://example.invalid",
+                    Credential::from_value("token"),
+                    vec!["gmail".to_string()],
+                )),
                 toolkits: Arc::new(vec!["gmail".to_string()]),
                 metering: ComposioMetering {
                     company: CompanyId::new("acme"),
@@ -822,11 +909,11 @@ mod tests {
 
     #[test]
     fn debug_redacts_the_token() {
-        let config = TenantComposio {
-            backend_url: "https://api.tinyhumans.ai".to_string(),
-            auth_token: "super-secret-tenant-token".to_string(),
-            toolkits: vec!["gmail".to_string()],
-        };
+        let config = TenantComposio::new(
+            "https://api.tinyhumans.ai",
+            Credential::from_value("super-secret-tenant-token"),
+            vec!["gmail".to_string()],
+        );
         let shown = format!("{config:?}");
         assert!(
             !shown.contains("super-secret-tenant-token"),
@@ -842,23 +929,18 @@ mod tests {
 
     #[test]
     fn debug_marks_unset_token() {
-        let config = TenantComposio {
-            backend_url: "https://api.tinyhumans.ai".to_string(),
-            auth_token: String::new(),
-            toolkits: Vec::new(),
-        };
+        let config = TenantComposio::new("https://api.tinyhumans.ai", Credential::None, Vec::new());
         let shown = format!("{config:?}");
         assert!(shown.contains("<unset>"), "{shown}");
     }
 
-    /// Tenant isolation at the resolver seam (issue #110): the token comes ONLY
-    /// from the company secret store — there is no env/platform-key fallback — so
-    /// a company with no stored token resolves to `None` (fail closed, no tools),
-    /// never a borrowed identity, even if a platform key like `TINYHUMANS_API_KEY`
-    /// exists in the environment. A stored token resolves to a config that
-    /// carries exactly that token.
+    /// The resolver's precedence and its fail-closed floor: the company's own
+    /// stored token always wins; with none stored the instance's platform token
+    /// source is used; with neither there is no config at all (no tools) — never a
+    /// borrowed identity. A raw `TINYHUMANS_API_KEY` in the environment is not a
+    /// source: the platform identity is passed in explicitly by the caller.
     #[tokio::test]
-    async fn resolve_is_fail_closed_without_a_stored_token_and_has_no_env_fallback() {
+    async fn resolve_prefers_the_stored_token_then_the_token_source_then_fails_closed() {
         use crate::ports::SecretStore;
         use crate::ports::types::{CompanyId, SecretValue};
         use crate::store::FsSecretStore;
@@ -867,31 +949,50 @@ mod tests {
             std::env::temp_dir().join(format!("oc-composio-res-{}", crate::ports::generate_id()));
         let secrets = FsSecretStore::new(&dir);
         let company = CompanyId::new("acme");
+        let source = || Arc::new(TinyhumansTokenSource::static_key("platform-identity"));
 
-        // A platform key in the environment must NOT leak in — the resolver never
-        // reads it. (No token stored → None.)
+        // Nothing stored and no platform identity → fail closed, and an ambient
+        // env key is never consulted.
         // SAFETY: single-threaded test; we set then restore the env.
         unsafe { std::env::set_var("TINYHUMANS_API_KEY", "platform-managed-key") };
         assert!(
-            TenantComposio::resolve(&company, &secrets, Vec::new(), None, None)
+            TenantComposio::resolve(&company, &secrets, Vec::new(), None, None, None)
                 .await
                 .is_none(),
-            "no stored token must fail closed, ignoring any env platform key"
+            "no credential at all must fail closed, ignoring any env platform key"
         );
 
-        // An explicitly-empty token still fails closed.
+        // Nothing stored, but this instance has an identity → it is used.
+        let attested =
+            TenantComposio::resolve(&company, &secrets, Vec::new(), None, None, Some(source()))
+                .await
+                .expect("the platform identity resolves");
+        assert_eq!(
+            token_of(&attested).await.as_deref(),
+            Some("platform-identity")
+        );
+
+        // An explicitly-empty stored token is not a token: still the source.
         secrets
             .set(&company, TOKEN_KEY, SecretValue("   ".to_string()))
             .await
             .unwrap();
-        assert!(
-            TenantComposio::resolve(&company, &secrets, Vec::new(), None, None)
+        let attested =
+            TenantComposio::resolve(&company, &secrets, Vec::new(), None, None, Some(source()))
                 .await
-                .is_none(),
-            "an empty/whitespace token must fail closed"
+                .expect("the platform identity resolves");
+        assert_eq!(
+            token_of(&attested).await.as_deref(),
+            Some("platform-identity")
+        );
+        // …and with no source either, an empty stored token fails closed.
+        assert!(
+            TenantComposio::resolve(&company, &secrets, Vec::new(), None, None, None)
+                .await
+                .is_none()
         );
 
-        // A real stored token resolves and carries exactly that token + default URL.
+        // The company's OWN token wins over the platform identity.
         secrets
             .set(
                 &company,
@@ -900,11 +1001,21 @@ mod tests {
             )
             .await
             .unwrap();
-        let resolved =
-            TenantComposio::resolve(&company, &secrets, vec!["gmail".into()], None, None)
-                .await
-                .expect("a stored token resolves");
-        assert_eq!(resolved.auth_token, "tenant-token-xyz");
+        let resolved = TenantComposio::resolve(
+            &company,
+            &secrets,
+            vec!["gmail".into()],
+            None,
+            None,
+            Some(source()),
+        )
+        .await
+        .expect("a stored token resolves");
+        assert_eq!(
+            token_of(&resolved).await.as_deref(),
+            Some("tenant-token-xyz"),
+            "a company that brought its own token keeps it"
+        );
         assert_eq!(resolved.backend_url, "https://api.tinyhumans.ai");
         assert_eq!(resolved.toolkits, vec!["gmail".to_string()]);
 
@@ -916,6 +1027,7 @@ mod tests {
             Vec::new(),
             None,
             Some("https://staging-api.tinyhumans.ai".into()),
+            None,
         )
         .await
         .expect("a stored token resolves");
@@ -925,22 +1037,70 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
+    /// The bearer a config would present right now.
+    async fn token_of(config: &TenantComposio) -> Option<String> {
+        config.current_token().await.expect("resolves")
+    }
+
+    fn config_with(credential: Credential) -> Option<TenantComposio> {
+        Some(TenantComposio::new(
+            "https://api.tinyhumans.ai",
+            credential,
+            vec!["gmail".to_string()],
+        ))
+    }
+
+    /// The rotation contract: a projected platform token whose bytes change every
+    /// few minutes must NOT move the roster fingerprint, or every agent's tool
+    /// roster is rebuilt on the cluster's rotation schedule. A tier change or a
+    /// changed *stored* token must still move it.
+    #[tokio::test]
+    async fn fingerprint_is_stable_across_a_projected_rotation() {
+        let dir =
+            std::env::temp_dir().join(format!("oc-composio-fp-{}", crate::ports::generate_id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("token");
+        std::fs::write(&path, "token-before").unwrap();
+
+        let projected = config_with(Credential::from_source(Arc::new(
+            TinyhumansTokenSource::projected_file(&path),
+        )));
+        let before = TenantComposio::fingerprint(&projected);
+        assert_eq!(
+            token_of(projected.as_ref().unwrap()).await.as_deref(),
+            Some("token-before")
+        );
+
+        // The kubelet rewrites the file in place.
+        std::fs::write(&path, "token-after").unwrap();
+        assert_eq!(
+            token_of(projected.as_ref().unwrap()).await.as_deref(),
+            Some("token-after"),
+            "the call must pick up the rotated token"
+        );
+        assert_eq!(
+            TenantComposio::fingerprint(&projected),
+            before,
+            "a rotation must NOT rebuild the roster"
+        );
+
+        // A different projected path is a different identity.
+        let other = config_with(Credential::from_source(Arc::new(
+            TinyhumansTokenSource::projected_file(dir.join("other")),
+        )));
+        assert_ne!(TenantComposio::fingerprint(&other), before);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
     #[test]
-    fn fingerprint_changes_on_token_rotation_and_none() {
-        let a = Some(TenantComposio {
-            backend_url: "https://api.tinyhumans.ai".to_string(),
-            auth_token: "token-a".to_string(),
-            toolkits: vec!["gmail".to_string()],
-        });
-        let b = Some(TenantComposio {
-            backend_url: "https://api.tinyhumans.ai".to_string(),
-            auth_token: "token-b".to_string(),
-            toolkits: vec!["gmail".to_string()],
-        });
+    fn fingerprint_moves_on_tier_and_stored_value_changes() {
+        let a = config_with(Credential::from_value("token-a"));
+        let b = config_with(Credential::from_value("token-b"));
         assert_ne!(
             TenantComposio::fingerprint(&a),
             TenantComposio::fingerprint(&b),
-            "a rotated token must move the fingerprint"
+            "a rotated stored token must move the fingerprint"
         );
         assert_ne!(
             TenantComposio::fingerprint(&a),
@@ -951,6 +1111,16 @@ mod tests {
             TenantComposio::fingerprint(&a),
             TenantComposio::fingerprint(&a.clone()),
             "the same config fingerprints stably"
+        );
+
+        // Swapping a stored token for the platform identity is a tier change.
+        let attested = config_with(Credential::from_source(Arc::new(
+            TinyhumansTokenSource::projected_file("/var/run/secrets/tinyhumans.ai/token"),
+        )));
+        assert_ne!(
+            TenantComposio::fingerprint(&attested),
+            TenantComposio::fingerprint(&a),
+            "a tier change must move the fingerprint"
         );
     }
 }
@@ -1142,11 +1312,7 @@ mod isolation_tests {
     }
 
     fn config(url: &str, token: &str) -> TenantComposio {
-        TenantComposio {
-            backend_url: url.to_string(),
-            auth_token: token.to_string(),
-            toolkits: Vec::new(),
-        }
+        TenantComposio::new(url, Credential::from_value(token), Vec::new())
     }
 
     fn list_connections_tool(config: &TenantComposio) -> Box<dyn Tool> {
@@ -1217,6 +1383,78 @@ mod isolation_tests {
                 .any(|a| a.contains("token-a") && a.contains("token-b")),
             "a single request must never carry both tokens: {seen:?}"
         );
+    }
+
+    /// The rotation contract at the tool boundary: a projected platform token the
+    /// cluster rewrites in place must reach the backend on the **next** call, with
+    /// no roster rebuild — and the freshly-resolved value must be the one the
+    /// scrub vector protects, so a backend that reflects it still cannot leak it.
+    #[tokio::test]
+    async fn a_rotated_projected_token_is_presented_and_scrubbed_per_call() {
+        use crate::company::credentials::TinyhumansTokenSource;
+
+        // Reflect the bearer back inside an envelope failure, and record it.
+        async fn reflect(State(log): State<AuthLog>, headers: HeaderMap) -> axum::Json<Value> {
+            let auth = headers
+                .get("authorization")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("")
+                .to_string();
+            log.lock().unwrap().push(auth.clone());
+            axum::Json(json!({ "success": false, "error": format!("upstream said: {auth}") }))
+        }
+        let log: AuthLog = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/agent-integrations/composio/connections", get(reflect))
+            .with_state(log.clone());
+        let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let dir =
+            std::env::temp_dir().join(format!("oc-composio-rot-{}", crate::ports::generate_id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("token");
+        std::fs::write(&path, "projected-secret-before").unwrap();
+
+        // ONE config, built once — exactly what a roster holds across turns.
+        let config = TenantComposio::new(
+            format!("http://{addr}"),
+            Credential::from_source(Arc::new(TinyhumansTokenSource::projected_file(&path))),
+            Vec::new(),
+        );
+        let tool = list_connections_tool(&config);
+
+        let first = tool.execute(json!({})).await.unwrap();
+        assert!(
+            !first.output().contains("projected-secret-before"),
+            "the resolved token leaked into agent-visible output: {}",
+            first.output()
+        );
+
+        // The kubelet rewrites the file in place; the SAME tool must present the
+        // new token and scrub that one.
+        std::fs::write(&path, "projected-secret-after").unwrap();
+        let second = tool.execute(json!({})).await.unwrap();
+        assert!(
+            !second.output().contains("projected-secret-after"),
+            "the rotated token leaked into agent-visible output: {}",
+            second.output()
+        );
+
+        let seen = log.lock().unwrap().clone();
+        assert_eq!(
+            seen,
+            vec![
+                "Bearer projected-secret-before".to_string(),
+                "Bearer projected-secret-after".to_string()
+            ],
+            "each call must carry the token the file held at that moment: {seen:?}"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// A mock backend that echoes the caller's bearer inside an error body; the

--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -931,15 +931,18 @@ mod tests {
         let company = CompanyId::new("acme");
         let source = || Arc::new(TinyhumansTokenSource::static_key("platform-identity"));
 
-        // Nothing stored and no platform identity → fail closed, and an ambient
-        // env key is never consulted.
-        // SAFETY: single-threaded test; we set then restore the env.
-        unsafe { std::env::set_var("TINYHUMANS_API_KEY", "platform-managed-key") };
+        // Nothing stored and no platform identity → fail closed. That an ambient
+        // `TINYHUMANS_API_KEY` cannot be consulted is guaranteed by the signature
+        // — `resolve` takes the source explicitly and has no `EnvSource` — so it
+        // needs no proof by process-env mutation. Setting one here used to leak
+        // into every other test in this binary (`std::env` is process-wide and
+        // nothing restored it), which made an ops-route assertion on
+        // `credentialSource == "none"` flake depending on test order.
         assert!(
             TenantComposio::resolve(&company, &secrets, Vec::new(), None, None, None)
                 .await
                 .is_none(),
-            "no credential at all must fail closed, ignoring any env platform key"
+            "no credential at all must fail closed"
         );
 
         // Nothing stored, but this instance has an identity → it is used.

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -212,13 +212,13 @@ pub struct HarnessDeps {
     pub media: Option<toolbelt::MediaBackend>,
     /// The per-tenant Composio configuration (issue #110). `None` (the default
     /// at every construction site) fails closed — no Composio tools are wired.
-    /// [`HarnessPool::ensure`] re-resolves it from the [`SecretStore`] under
-    /// [`composio::TOKEN_KEY`](crate::harness::composio::TOKEN_KEY) each turn
-    /// (folded into the roster fingerprint) so a console token set/rotate takes
-    /// effect next turn with no restart. Only wired when a company **explicitly**
-    /// grants `composio` **and** a non-empty token is stored; the token has no
-    /// env fallback, so an absent token means no tools (never a borrowed
-    /// identity).
+    /// [`HarnessPool::ensure`] re-resolves it each turn (folded into the roster
+    /// fingerprint) so a console token set/rotate takes effect next turn with no
+    /// restart. Only wired when a company **explicitly** grants `composio` **and**
+    /// a credential can be obtained: the company's own token under
+    /// [`composio::TOKEN_KEY`](crate::harness::composio::TOKEN_KEY) if it has one,
+    /// else this instance's platform identity. With neither, no tools are wired —
+    /// never a borrowed identity.
     pub composio: Option<composio::TenantComposio>,
     /// Issue #111 — the shared registry of in-flight, steerable runs. The
     /// [`HarnessBrain`] registers a dispatched task / desk delegation here before
@@ -701,12 +701,16 @@ impl HarnessPool {
     /// secret store on this axis; others resolve to `None` (no tools). With no
     /// secret store wired this degrades to the static [`HarnessDeps::composio`].
     ///
-    /// The token has no env fallback — an absent/empty secret yields `None` (fail
-    /// closed). The backend URL resolves from
-    /// [`composio::COMPOSIO_BACKEND_URL_ENV`], then the tenant API base
-    /// [`composio::TINYHUMANS_API_URL_ENV`], then the prod default — read
-    /// process-globally so a live re-resolution keeps the override even when no
-    /// token was stored at boot.
+    /// Resolution prefers the company's own stored token and falls back to this
+    /// instance's platform identity; with neither it yields `None` (fail closed).
+    /// Both the backend URL (from [`composio::COMPOSIO_BACKEND_URL_ENV`], then the
+    /// tenant API base [`composio::TINYHUMANS_API_URL_ENV`], then the prod
+    /// default) and the platform identity are read process-globally here, so a
+    /// live re-resolution keeps them even when nothing was stored at boot.
+    ///
+    /// Re-deriving the token source every turn costs nothing — building it reads
+    /// no file — and the roster that keeps it holds one instance for its whole
+    /// lifetime, so its rotation cache still works.
     async fn resolve_composio(
         &self,
         company: &CompanyRecord,
@@ -728,6 +732,7 @@ impl HarnessPool {
                     toolkits,
                     url,
                     api_url,
+                    crate::company::TinyhumansTokenSource::from_env(&env).map(std::sync::Arc::new),
                 )
                 .await
             }

--- a/src/harness/provider.rs
+++ b/src/harness/provider.rs
@@ -44,6 +44,7 @@ use tinyagents::{Result as TaResult, TinyAgentsError};
 
 use crate::app::config::EnvSource;
 use crate::company::Inference;
+use crate::company::credentials::{Credential, TinyhumansTokenSource};
 use crate::company::inference::{self, EnvDefault, InferenceDecl};
 use crate::ports::SecretStore;
 use crate::ports::types::CompanyId;
@@ -82,24 +83,32 @@ pub trait HarnessModel: ChatModel<()> {
 }
 
 /// Resolve a [`HostedProvider`] configuration (and its default model) from the
-/// environment, or `None` when no credential is present.
+/// environment, or `None` when no credential can be obtained.
 ///
 /// Precedence, most specific first:
 ///
-/// * key — `OPENCOMPANY_INFERENCE_KEY`, else `TINYHUMANS_API_KEY`. **No key ⇒
-///   `None`**, and the runtime keeps its offline echo brain.
+/// * credential — `OPENCOMPANY_INFERENCE_KEY` if set, else the platform token
+///   source ([`TinyhumansTokenSource::from_env`]: a projected `TINYHUMANS_TOKEN_FILE`
+///   ahead of a static `TINYHUMANS_API_KEY`). **Nothing configured ⇒ `None`**, and
+///   the runtime keeps its offline echo brain.
 /// * url — `OPENCOMPANY_INFERENCE_URL`, else [`DEFAULT_TINYHUMANS_INFERENCE_URL`].
 /// * model — `OPENCOMPANY_INFERENCE_MODEL`, else [`DEFAULT_HOSTED_MODEL`].
 ///
-/// The two-name key precedence keeps a per-tenant override
-/// (`OPENCOMPANY_INFERENCE_KEY`) distinct from the platform-wide TinyHumans
-/// credential the manager injects (`TINYHUMANS_API_KEY`).
+/// `OPENCOMPANY_INFERENCE_KEY` is checked first because it is a *different*
+/// credential — a per-tenant inference key an operator supplied — not the
+/// platform's TinyHumans identity. Within the platform identity itself the
+/// documented tier order (projected file over static key) applies.
 pub fn harness_inference_from_env(
     env: &dyn EnvSource,
 ) -> Option<(HostedProviderConfig, Option<String>)> {
-    let api_key = env
+    let credential = match env
         .get("OPENCOMPANY_INFERENCE_KEY")
-        .or_else(|| env.get("TINYHUMANS_API_KEY"))?;
+        .map(|key| key.trim().to_string())
+        .filter(|key| !key.is_empty())
+    {
+        Some(key) => Credential::from_value(key),
+        None => Credential::from_source(Arc::new(TinyhumansTokenSource::from_env(env)?)),
+    };
     let base_url = env
         .get("OPENCOMPANY_INFERENCE_URL")
         .unwrap_or_else(|| DEFAULT_TINYHUMANS_INFERENCE_URL.to_string());
@@ -111,7 +120,7 @@ pub fn harness_inference_from_env(
     Some((
         HostedProviderConfig {
             base_url,
-            api_key,
+            credential,
             extra_headers: Vec::new(),
         },
         model_override,
@@ -528,35 +537,19 @@ impl HarnessModel for MockProvider {
 }
 
 /// Configuration for the hosted inference model.
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct HostedProviderConfig {
     /// Base URL of the OpenAI-compatible chat-completions API, e.g.
     /// `https://api.tinyhumans.ai/v1`. The provider POSTs to
     /// `{base_url}/chat/completions`.
     pub base_url: String,
-    /// Bearer credential for the hosted brain. Empty string omits the header.
-    pub api_key: String,
+    /// How the bearer for the hosted brain is obtained. Resolved on **every**
+    /// request, so a platform token that rotates in place is picked up without a
+    /// rebuild; [`Credential::None`] omits the header.
+    pub credential: Credential,
     /// Extra request headers to attach on every call (e.g. OpenRouter's
     /// `HTTP-Referer` / `X-Title` attribution headers).
     pub extra_headers: Vec<(String, String)>,
-}
-
-impl std::fmt::Debug for HostedProviderConfig {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Never let the credential land in a trace.
-        f.debug_struct("HostedProviderConfig")
-            .field("base_url", &self.base_url)
-            .field(
-                "api_key",
-                &if self.api_key.is_empty() {
-                    "<unset>"
-                } else {
-                    "<redacted>"
-                },
-            )
-            .field("extra_headers", &self.extra_headers)
-            .finish()
-    }
 }
 
 /// Hosted TinyHumans / Medulla inference model.
@@ -589,8 +582,9 @@ impl ChatModel<()> for HostedProvider {
     }
 
     /// Structured multi-turn chat — the path [`Agent::turn`] actually calls. The
-    /// full history reaches the backend so multi-turn context survives, and the
-    /// response's token/cost usage is parsed back out (the WS5 metering signal).
+    /// full history reaches the backend so multi-turn context survives, the bearer
+    /// is resolved fresh for this request, and the response's token/cost usage is
+    /// parsed back out (the WS5 metering signal).
     ///
     /// [`Agent::turn`]: openhuman_core::openhuman::agent::Agent
     async fn invoke(&self, _state: &(), request: ModelRequest) -> TaResult<ModelResponse> {
@@ -615,8 +609,13 @@ impl ChatModel<()> for HostedProvider {
             self.config.base_url.trim_end_matches('/')
         );
         let mut http = self.client.post(&url).json(&body);
-        if !self.config.api_key.is_empty() {
-            http = http.bearer_auth(&self.config.api_key);
+        // Resolved per request, never captured: on the hosted platform this reads
+        // a token file the cluster rewrites in place every few minutes.
+        let bearer = self.config.credential.current().await.map_err(|e| {
+            TinyAgentsError::Model(format!("resolving the TinyHumans credential: {e}"))
+        })?;
+        if let Some(bearer) = &bearer {
+            http = http.bearer_auth(bearer);
         }
         for (name, value) in &self.config.extra_headers {
             http = http.header(name, value);
@@ -628,6 +627,12 @@ impl ChatModel<()> for HostedProvider {
             .map_err(|e| TinyAgentsError::Model(format!("hosted inference request failed: {e}")))?;
         let status = response.status();
         if !status.is_success() {
+            // A rejected bearer may mean the platform rotated the token early;
+            // drop the cached read so the next turn goes back to the file rather
+            // than re-presenting what was just refused.
+            if status == reqwest::StatusCode::UNAUTHORIZED {
+                self.config.credential.invalidate();
+            }
             let text = response.text().await.unwrap_or_default();
             return Err(TinyAgentsError::Model(format!(
                 "hosted inference returned {status}: {text}"
@@ -657,7 +662,9 @@ pub struct RequestPlan {
     pub url: String,
     /// The concrete provider model id after tier mapping.
     pub model: String,
-    /// The bearer credential, or `None` to omit the header (e.g. Ollama).
+    /// The bearer credential for THIS request, resolved when the plan was built
+    /// (never captured at roster-build time), or `None` to omit the header (e.g.
+    /// Ollama).
     pub bearer: Option<String>,
     /// Extra request headers (OpenRouter attribution) to attach.
     pub headers: Vec<(&'static str, String)>,
@@ -671,11 +678,13 @@ pub struct RequestPlan {
 ///   `[inference].models` table; an unmapped tier passes through verbatim.
 /// * OpenRouter gets its mandatory `HTTP-Referer` / `X-Title` attribution
 ///   headers; other providers get none.
-/// * An empty resolved key omits the bearer (the Ollama / keyless case).
+/// * The bearer is resolved from the decl's [`Credential`] **here**, so every
+///   plan carries a freshly-read token; no credential omits the header entirely
+///   (the Ollama / keyless case).
 /// * `tools` (already in OpenAI wire shape via [`wire_tools`]) and `tool_choice`
 ///   are attached only when the turn exposes tools, so a bare chat turn stays
 ///   byte-identical to the pre-tool-calling body.
-pub fn request_plan(
+pub async fn request_plan(
     decl: &InferenceDecl,
     abstract_model: &str,
     messages: Vec<serde_json::Value>,
@@ -683,19 +692,17 @@ pub fn request_plan(
     max_tokens: Option<u32>,
     tools: Vec<serde_json::Value>,
     tool_choice: &ToolChoice,
-) -> RequestPlan {
+) -> anyhow::Result<RequestPlan> {
     let model = decl
         .models
         .get(abstract_model)
         .cloned()
         .unwrap_or_else(|| abstract_model.to_string());
     let url = format!("{}/chat/completions", decl.base_url.trim_end_matches('/'));
-    let key = decl.api_key().trim();
-    let bearer = if key.is_empty() {
-        None
-    } else {
-        Some(key.to_string())
-    };
+    let bearer = decl
+        .bearer()
+        .await
+        .map_err(|e| anyhow::anyhow!("resolving the outbound inference credential: {e}"))?;
     let headers = if decl.provider == "openrouter" {
         vec![
             ("HTTP-Referer", OPENROUTER_REFERER.to_string()),
@@ -713,21 +720,26 @@ pub fn request_plan(
         body["max_tokens"] = serde_json::json!(cap);
     }
     attach_tools(&mut body, tools, tool_choice);
-    RequestPlan {
+    Ok(RequestPlan {
         url,
         model,
         bearer,
         headers,
         body,
-    }
+    })
 }
 
 /// Issues a prepared [`RequestPlan`] against `client`, returning the raw JSON
 /// payload. Every error string is scrubbed of the bearer, so a credential can
 /// never leak into a log line or an operator-visible message.
+///
+/// `credential` is the source the plan's bearer came from: a 401 invalidates it,
+/// so a token the platform rotated early is re-read on the next attempt instead
+/// of being presented again until its cache window closes.
 async fn send_plan(
     client: &reqwest::Client,
     plan: &RequestPlan,
+    credential: &Credential,
 ) -> anyhow::Result<serde_json::Value> {
     let mut request = client.post(&plan.url).json(&plan.body);
     if let Some(bearer) = &plan.bearer {
@@ -746,6 +758,9 @@ async fn send_plan(
         .map_err(|e| anyhow::anyhow!("inference request failed: {}", scrub(e.to_string())))?;
     let status = response.status();
     if !status.is_success() {
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            credential.invalidate();
+        }
         let text = response.text().await.unwrap_or_default();
         return Err(anyhow::anyhow!(
             "inference returned {status}: {}",
@@ -849,8 +864,10 @@ impl ChatModel<()> for TenantProvider {
             request.max_tokens,
             wire_tools(&request.tools),
             &request.tool_choice,
-        );
-        let payload = send_plan(&self.client, &plan)
+        )
+        .await
+        .map_err(|e| TinyAgentsError::Model(e.to_string()))?;
+        let payload = send_plan(&self.client, &plan, decl.credential())
             .await
             .map_err(|e| TinyAgentsError::Model(e.to_string()))?;
         model_response_from_payload(payload)
@@ -879,8 +896,9 @@ pub async fn probe(decl: &InferenceDecl) -> anyhow::Result<()> {
         Some(16),
         Vec::new(),
         &ToolChoice::Auto,
-    );
-    let payload = send_plan(&client, &plan).await?;
+    )
+    .await?;
+    let payload = send_plan(&client, &plan, decl.credential()).await?;
     payload
         .pointer("/choices/0/message/content")
         .and_then(|c| c.as_str())
@@ -893,6 +911,36 @@ mod tests {
     use super::*;
     use crate::app::config::MapEnv;
 
+    /// A three-segment JWT whose `exp` is `secs_from_now` in the future, so the
+    /// projected-file cache window is wide open for the whole test.
+    fn jwt_with_exp(secs_from_now: u64) -> String {
+        const ALPHA: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+        let exp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + secs_from_now;
+        let payload = serde_json::json!({ "exp": exp }).to_string();
+        let mut encoded = String::new();
+        for chunk in payload.as_bytes().chunks(3) {
+            let b = [
+                chunk[0],
+                chunk.get(1).copied().unwrap_or(0),
+                chunk.get(2).copied().unwrap_or(0),
+            ];
+            let n = (u32::from(b[0]) << 16) | (u32::from(b[1]) << 8) | u32::from(b[2]);
+            for i in 0..chunk.len() + 1 {
+                encoded.push(ALPHA[((n >> (18 - 6 * i)) & 0x3F) as usize] as char);
+            }
+        }
+        format!("aGVhZGVy.{encoded}.c2ln")
+    }
+
+    /// The bearer a config would present right now.
+    async fn bearer_of(config: &HostedProviderConfig) -> Option<String> {
+        config.credential.current().await.expect("resolves")
+    }
+
     /// Build a single-user-message request the way the harness turn does.
     fn user_request(message: &str) -> ModelRequest {
         ModelRequest {
@@ -901,18 +949,18 @@ mod tests {
         }
     }
 
-    #[test]
-    fn env_config_prefers_specific_key_and_fills_defaults() {
+    #[tokio::test]
+    async fn env_config_prefers_specific_key_and_fills_defaults() {
         let env = MapEnv::new([("OPENCOMPANY_INFERENCE_KEY", "sk-specific")]);
         let (cfg, model) = harness_inference_from_env(&env).expect("configured");
-        assert_eq!(cfg.api_key, "sk-specific");
+        assert_eq!(bearer_of(&cfg).await.as_deref(), Some("sk-specific"));
         assert_eq!(cfg.base_url, DEFAULT_TINYHUMANS_INFERENCE_URL);
         // No explicit model → no roster-wide override (each agent keeps its tier).
         assert_eq!(model, None);
     }
 
-    #[test]
-    fn env_config_falls_back_to_tinyhumans_key_and_honors_overrides() {
+    #[tokio::test]
+    async fn env_config_falls_back_to_tinyhumans_key_and_honors_overrides() {
         let env = MapEnv::new([
             ("TINYHUMANS_API_KEY", "sk-platform"),
             (
@@ -922,7 +970,7 @@ mod tests {
             ("OPENCOMPANY_INFERENCE_MODEL", "reasoning-v1"),
         ]);
         let (cfg, model) = harness_inference_from_env(&env).expect("configured");
-        assert_eq!(cfg.api_key, "sk-platform");
+        assert_eq!(bearer_of(&cfg).await.as_deref(), Some("sk-platform"));
         assert_eq!(cfg.base_url, "https://staging-api.tinyhumans.ai/openai/v1");
         assert_eq!(model.as_deref(), Some("reasoning-v1"));
     }
@@ -931,6 +979,43 @@ mod tests {
     fn env_config_is_none_without_any_key() {
         let env = MapEnv::new([("OPENCOMPANY_INFERENCE_URL", "https://x/v1")]);
         assert!(harness_inference_from_env(&env).is_none());
+    }
+
+    /// The hosted path: no static key anywhere, just a projected token file. The
+    /// harness must still resolve a managed brain, reading the file per request.
+    #[tokio::test]
+    async fn env_config_resolves_a_projected_token_file() {
+        let dir = std::env::temp_dir().join(format!("oc-prov-{}", crate::ports::generate_id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("token");
+        std::fs::write(&path, "projected-token").unwrap();
+
+        let env = MapEnv::new([(
+            crate::company::credentials::TOKEN_FILE_ENV,
+            path.display().to_string(),
+        )]);
+        let (cfg, _) = harness_inference_from_env(&env).expect("configured");
+        assert_eq!(
+            cfg.credential.source(),
+            crate::company::CredentialSource::Attested
+        );
+        assert_eq!(bearer_of(&cfg).await.as_deref(), Some("projected-token"));
+
+        // A projected file outranks a static key that is still lying around.
+        let both = MapEnv::new([
+            (
+                crate::company::credentials::TOKEN_FILE_ENV,
+                path.display().to_string(),
+            ),
+            (
+                crate::company::credentials::API_KEY_ENV,
+                "th-static".to_string(),
+            ),
+        ]);
+        let (cfg, _) = harness_inference_from_env(&both).expect("configured");
+        assert_eq!(bearer_of(&cfg).await.as_deref(), Some("projected-token"));
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     // ---- media backend (issue #109) ---------------------------------------
@@ -989,7 +1074,7 @@ mod tests {
     fn hosted_provider_reports_managed_telemetry_id() {
         let provider = HostedProvider::new(HostedProviderConfig {
             base_url: "https://example.test/v1".to_string(),
-            api_key: String::new(),
+            credential: Credential::None,
             extra_headers: Vec::new(),
         });
         assert_eq!(provider.telemetry_provider_id(), "managed");
@@ -1202,7 +1287,7 @@ mod tests {
     fn hosted_provider_advertises_native_tool_calling() {
         let provider = HostedProvider::new(HostedProviderConfig {
             base_url: "https://example.test/v1".to_string(),
-            api_key: String::new(),
+            credential: Credential::None,
             extra_headers: Vec::new(),
         });
         let profile = provider.profile().expect("hosted profile is advertised");
@@ -1210,6 +1295,193 @@ mod tests {
             profile.tool_calling,
             "native tool calling must be advertised"
         );
+    }
+
+    /// A stub that records the `Authorization` header of every request it
+    /// answers, so a test can prove which bearer actually went out.
+    async fn spawn_auth_recorder() -> (String, Arc<std::sync::Mutex<Vec<String>>>) {
+        use axum::http::HeaderMap;
+        use axum::routing::post;
+        use axum::{Json, Router};
+
+        let seen: Arc<std::sync::Mutex<Vec<String>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let log = Arc::clone(&seen);
+        let app = Router::new().route(
+            "/chat/completions",
+            post(move |headers: HeaderMap| {
+                let log = Arc::clone(&log);
+                async move {
+                    log.lock().unwrap().push(
+                        headers
+                            .get("authorization")
+                            .and_then(|v| v.to_str().ok())
+                            .unwrap_or("")
+                            .to_string(),
+                    );
+                    Json(serde_json::json!({
+                        "choices": [{ "message": { "role": "assistant", "content": "ok" } }]
+                    }))
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (format!("http://{addr}"), seen)
+    }
+
+    /// The rotation contract at the transport: the SAME provider instance must
+    /// present the token the projected file holds **now**, not the one it held
+    /// when the provider was built. Without this, a hosted pod keeps sending a
+    /// bearer the cluster rotated away from and every turn 401s.
+    #[tokio::test]
+    async fn hosted_provider_resolves_the_bearer_per_request() {
+        let (url, seen) = spawn_auth_recorder().await;
+        let dir = std::env::temp_dir().join(format!("oc-prov-rot-{}", crate::ports::generate_id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("token");
+        // No `exp` to read ⇒ never cached ⇒ every request re-reads the file.
+        std::fs::write(&path, "token-before-rotation").unwrap();
+
+        let provider = HostedProvider::new(HostedProviderConfig {
+            base_url: url,
+            credential: Credential::from_source(Arc::new(TinyhumansTokenSource::projected_file(
+                &path,
+            ))),
+            extra_headers: Vec::new(),
+        });
+
+        provider.invoke(&(), user_request("one")).await.expect("t1");
+        std::fs::write(&path, "token-after-rotation").unwrap();
+        provider.invoke(&(), user_request("two")).await.expect("t2");
+
+        let headers = seen.lock().unwrap().clone();
+        assert_eq!(
+            headers,
+            vec![
+                "Bearer token-before-rotation".to_string(),
+                "Bearer token-after-rotation".to_string()
+            ],
+            "the bearer must be resolved per request, not captured at build time"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// With no credential at all the header is omitted rather than sent empty.
+    #[tokio::test]
+    async fn hosted_provider_omits_the_bearer_without_a_credential() {
+        let (url, seen) = spawn_auth_recorder().await;
+        let provider = HostedProvider::new(HostedProviderConfig {
+            base_url: url,
+            credential: Credential::None,
+            extra_headers: Vec::new(),
+        });
+        provider
+            .invoke(&(), user_request("hi"))
+            .await
+            .expect("turn");
+        assert_eq!(seen.lock().unwrap().clone(), vec![String::new()]);
+    }
+
+    /// A 401 invalidates the cached read, so the next turn presents whatever the
+    /// file holds now instead of re-sending a bearer the backend just refused —
+    /// the recovery path for a token the platform rotated early.
+    #[tokio::test]
+    async fn a_rejected_bearer_forces_a_re_read_on_the_next_turn() {
+        use axum::http::{HeaderMap, StatusCode};
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use axum::{Json, Router};
+
+        let seen: Arc<std::sync::Mutex<Vec<String>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let log = Arc::clone(&seen);
+        let app = Router::new().route(
+            "/chat/completions",
+            post(move |headers: HeaderMap| {
+                let log = Arc::clone(&log);
+                async move {
+                    let auth = headers
+                        .get("authorization")
+                        .and_then(|v| v.to_str().ok())
+                        .unwrap_or("")
+                        .to_string();
+                    let first = {
+                        let mut guard = log.lock().unwrap();
+                        guard.push(auth);
+                        guard.len() == 1
+                    };
+                    // Refuse the first bearer, accept the second.
+                    if first {
+                        (StatusCode::UNAUTHORIZED, Json(serde_json::json!({}))).into_response()
+                    } else {
+                        Json(serde_json::json!({
+                            "choices": [{ "message": { "role": "assistant", "content": "ok" } }]
+                        }))
+                        .into_response()
+                    }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let dir = std::env::temp_dir().join(format!("oc-prov-401-{}", crate::ports::generate_id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("token");
+        // A long-lived `exp` ⇒ the window would normally hold this read for the
+        // full cap, so only invalidation can explain the second value going out.
+        let long_lived = jwt_with_exp(60 * 60 * 24 * 365 * 100);
+        std::fs::write(&path, format!("stale-{long_lived}")).unwrap();
+
+        let provider = HostedProvider::new(HostedProviderConfig {
+            base_url: format!("http://{addr}"),
+            credential: Credential::from_source(Arc::new(TinyhumansTokenSource::projected_file(
+                &path,
+            ))),
+            extra_headers: Vec::new(),
+        });
+
+        provider
+            .invoke(&(), user_request("one"))
+            .await
+            .expect_err("first turn is refused");
+        std::fs::write(&path, format!("rotated-{long_lived}")).unwrap();
+        provider.invoke(&(), user_request("two")).await.expect("t2");
+
+        let headers = seen.lock().unwrap().clone();
+        assert_eq!(headers.len(), 2, "{headers:?}");
+        assert!(headers[0].starts_with("Bearer stale-"), "{headers:?}");
+        assert!(
+            headers[1].starts_with("Bearer rotated-"),
+            "a 401 must send the next turn back to the file: {headers:?}"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// An unreadable projected file fails the turn with a model error that names
+    /// the problem — it must never silently send no bearer and get a confusing
+    /// 401 from the backend instead.
+    #[tokio::test]
+    async fn hosted_provider_surfaces_an_unreadable_token_file() {
+        let provider = HostedProvider::new(HostedProviderConfig {
+            base_url: "http://127.0.0.1:1/v1".to_string(),
+            credential: Credential::from_source(Arc::new(TinyhumansTokenSource::projected_file(
+                "/nonexistent/oc/token",
+            ))),
+            extra_headers: Vec::new(),
+        });
+        let err = provider
+            .invoke(&(), user_request("hi"))
+            .await
+            .expect_err("unreadable credential");
+        assert!(err.to_string().contains("credential"), "{err}");
     }
 
     // ---- TenantProvider (issue #56 — BYOK) --------------------------------
@@ -1274,7 +1546,9 @@ mod tests {
             None,
             Vec::new(),
             &ToolChoice::Auto,
-        );
+        )
+        .await
+        .expect("plan");
         assert_eq!(
             plan.model, "deepseek/deepseek-chat",
             "tier maps through table"
@@ -1308,7 +1582,9 @@ mod tests {
             None,
             Vec::new(),
             &ToolChoice::Auto,
-        );
+        )
+        .await
+        .expect("plan");
         assert_eq!(passthrough.model, "reasoning-v1");
     }
 
@@ -1330,7 +1606,9 @@ mod tests {
             None,
             Vec::new(),
             &ToolChoice::Auto,
-        );
+        )
+        .await
+        .expect("plan");
         assert!(plan.bearer.is_none(), "keyless Ollama sends no bearer");
         assert!(plan.headers.is_empty(), "no OpenRouter headers for Ollama");
     }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -814,7 +814,10 @@ impl RuntimeBuilder {
                                 .as_ref()
                                 .map(|(config, _)| EnvDefault {
                                     base_url: config.base_url.clone(),
-                                    api_key: config.api_key.clone(),
+                                    // A handle, not a value: the managed
+                                    // credential may be a platform token that
+                                    // rotates in place, so it is read per request.
+                                    credential: config.credential.clone(),
                                 });
                         // An explicit `OPENCOMPANY_INFERENCE_MODEL` flattens the
                         // whole roster to one workload; otherwise each agent keeps
@@ -1932,7 +1935,7 @@ mod test {
             .with_harness_inference(
                 HostedProviderConfig {
                     base_url: stub,
-                    api_key: "k".to_string(),
+                    credential: crate::company::Credential::from_value("k"),
                     extra_headers: Vec::new(),
                 },
                 None,

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -874,15 +874,16 @@ impl RuntimeBuilder {
                                 Vec::new()
                             });
                             // Issue #110: resolve the per-tenant Composio config
-                            // at boot from the company secret store (token) + the
-                            // manifest toolkit allowlist + the env URL override,
-                            // falling back to the tenant API base so staging
-                            // Composio follows staging. Only companies that
-                            // explicitly grant `composio` touch the store; the
-                            // token has no env fallback, so a missing token stays
-                            // `None` (fail closed). `HarnessPool::ensure`
-                            // re-resolves this each turn so a console token change
-                            // takes effect without restart.
+                            // at boot from the company secret store (its own
+                            // token, if any) else this instance's platform
+                            // identity, plus the manifest toolkit allowlist and
+                            // the env URL override, falling back to the tenant API
+                            // base so staging Composio follows staging. Only
+                            // companies that explicitly grant `composio` resolve at
+                            // all; with no credential obtainable it stays `None`
+                            // (fail closed). `HarnessPool::ensure` re-resolves this
+                            // each turn so a console token change takes effect
+                            // without restart.
                             let composio_config = if crate::company::grants_composio_explicit(
                                 &self.manifest.tools.allow,
                             ) {
@@ -899,6 +900,11 @@ impl RuntimeBuilder {
                                     toolkits,
                                     url,
                                     api_url,
+                                    // Falls back to this instance's platform
+                                    // identity when the company stored no token
+                                    // of its own.
+                                    crate::company::TinyhumansTokenSource::from_env(&env)
+                                        .map(Arc::new),
                                 )
                                 .await
                             } else {

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -1,14 +1,36 @@
 //! Per-tenant Composio connection management (issue #110, epic #26 Cell D): read
-//! the company's Composio status and set its write-only OAuth bearer token.
+//! the company's Composio status and set a per-company OAuth bearer token.
 //!
-//! The token is the entire tenant-isolation lever — the backend derives the
-//! Composio entity from it — so it is **write-only** over the API: set through
-//! the `token` field, stored in the secret store under
+//! ## Where the credential normally comes from
+//!
+//! On the hosted platform a company needs to paste nothing. The instance already
+//! authenticates with a platform-minted, audience-bound identity, and Composio
+//! calls present that — the backend derives the Composio entity from it. The read
+//! shape reports this as `credentialSource: "attested"`, and there is nothing
+//! stored on the instance to leak, rotate, or lose.
+//!
+//! ## `PUT …/composio/token` — the BYO override
+//!
+//! The write route stays, and it is **not** the hosted path. It is:
+//!
+//! * the **per-company BYO override** — a company that has its own Composio
+//!   account/token can set it here, and it wins over the instance identity for
+//!   that company only; and
+//! * the escape hatch for running this repo **standalone**. This repository is
+//!   public and people do run it that way, but self-hosting is **unsupported**:
+//!   there is no platform identity to present, so pasting a token is the only way
+//!   to reach Composio at all. Do not read this as parity with the hosted
+//!   product — it is a hatch, not a deployment mode, and nothing else about
+//!   standalone operation is supported this milestone.
+//!
+//! Either way the token is **write-only** over the API: set through the `token`
+//! field, stored in the secret store under
 //! [`TOKEN_KEY`](crate::company::composio::TOKEN_KEY), and **never** echoed. The
-//! read shape carries only a `tokenConfigured` boolean plus non-secret routing
-//! (backend URL, toolkit allowlist). A token set/rotate/clear takes effect on
-//! the agents' **next turn** with no restart (the harness re-resolves it each
-//! turn and rebuilds the roster when it changes).
+//! read shape carries only `credentialSource` plus non-secret routing (backend
+//! URL, toolkit allowlist) — never a token, and never a file path. A set / rotate
+//! / clear takes effect on the agents' **next turn** with no restart (the harness
+//! re-resolves the credential each turn and rebuilds the roster when the
+//! *identity* behind it changes).
 
 use axum::Json;
 use axum::Router;
@@ -17,6 +39,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::AppState;
 use crate::company::composio::{backend_url_or_default, store_token, token_configured};
+use crate::company::credentials::{CredentialSource, TinyhumansTokenSource};
 use crate::company::runtime::CompanyRuntime;
 use crate::server::error::ApiError;
 use crate::server::ops::{ScopedCompany, scoped};
@@ -42,19 +65,25 @@ pub fn router() -> Router<AppState> {
 }
 
 /// The company's Composio status as the console renders it. **Never** carries the
-/// token — only a non-secret `tokenConfigured` flag plus routing.
+/// token — only the non-secret `credentialSource` plus routing.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ComposioStatusDto {
     /// Whether the `composio` feature is compiled into this build at all (the
     /// tools only exist under it). `false` lets the console show a "not in this
-    /// build" state rather than implying a missing token.
+    /// build" state rather than implying a missing credential.
     in_build: bool,
     /// Whether the company **explicitly** grants the `composio` namespace (a `*`
     /// wildcard does NOT count).
     granted: bool,
-    /// Whether a non-empty per-tenant token is stored — never the token itself.
-    token_configured: bool,
+    /// Where this company's Composio credential comes from:
+    ///
+    /// * `attested` — the instance's platform identity (nothing is stored here);
+    /// * `static` — a token this company pasted, or a static instance key;
+    /// * `none` — no credential can be obtained, so no tools are wired.
+    ///
+    /// A tier name, never a credential and never a path.
+    credential_source: CredentialSource,
     /// The effective Composio backend URL (env override or default). Non-secret.
     backend_url: String,
     /// The manifest toolkit allowlist (empty = defer to the backend allowlist).
@@ -70,7 +99,8 @@ struct MutationResponse {
 }
 
 /// Set-token body. `token` is write-only intake (never returned): a non-empty
-/// value rotates it, an explicit empty string clears it.
+/// value rotates the company's BYO override, an explicit empty string clears it
+/// (reverting to the instance identity, where there is one).
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct SetToken {
@@ -105,6 +135,24 @@ struct ConnectionDto {
     connected: bool,
 }
 
+/// Which tier a company's Composio credential comes from, mirroring the harness
+/// resolver's precedence: the company's **own** stored token wins, else this
+/// instance's platform identity, else nothing.
+///
+/// Takes the environment as a seam so the matrix is testable without mutating the
+/// process environment.
+fn credential_source_for(
+    stored: bool,
+    env: &dyn crate::app::config::EnvSource,
+) -> CredentialSource {
+    if stored {
+        return CredentialSource::Static;
+    }
+    TinyhumansTokenSource::from_env(env)
+        .map(|source| source.credential_source())
+        .unwrap_or(CredentialSource::None)
+}
+
 /// Resolves the Composio status DTO for a company.
 async fn effective_status(runtime: &CompanyRuntime) -> Result<ComposioStatusDto, ApiError> {
     let record = runtime.store().load(runtime.id()).await.map_err(ApiError)?;
@@ -115,21 +163,24 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<ComposioStatusDto,
         ),
         None => (false, Vec::new()),
     };
-    let configured = token_configured(runtime.id(), runtime.secrets().as_ref())
+    // Mirrors the harness resolver: this company's own token wins, else the
+    // instance's platform identity, else nothing.
+    let stored = token_configured(runtime.id(), runtime.secrets().as_ref())
         .await
         .map_err(ApiError)?;
+    let env = crate::app::config::ProcessEnv;
     let (env_url, api_url) = {
         use crate::app::config::EnvSource;
-        let env = crate::app::config::ProcessEnv;
         (
             env.get(crate::company::composio::COMPOSIO_BACKEND_URL_ENV),
             env.get(crate::company::composio::TINYHUMANS_API_URL_ENV),
         )
     };
+    let credential_source = credential_source_for(stored, &env);
     Ok(ComposioStatusDto {
         in_build: cfg!(feature = "composio"),
         granted,
-        token_configured: configured,
+        credential_source,
         backend_url: backend_url_or_default(env_url, api_url),
         toolkits,
     })
@@ -140,7 +191,9 @@ async fn get_status(company: ScopedCompany) -> Result<Json<ComposioStatusDto>, A
     Ok(Json(effective_status(company.runtime.as_ref()).await?))
 }
 
-/// `PUT …/composio/token` — set / rotate / clear the write-only per-tenant token.
+/// `PUT …/composio/token` — set / rotate / clear this company's BYO token. See
+/// the module docs: the hosted path needs no token, and standalone operation
+/// (where this is the only option) is unsupported.
 async fn set_token(
     company: ScopedCompany,
     Json(body): Json<SetToken>,
@@ -271,6 +324,8 @@ async fn connections_impl(_runtime: &CompanyRuntime) -> Result<Json<Vec<Connecti
 
 #[cfg(test)]
 mod tests {
+    use super::{ComposioStatusDto, CredentialSource, credential_source_for};
+
     use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode};
     use serde_json::{Value, json};
@@ -348,8 +403,12 @@ mod tests {
         (status, value, raw)
     }
 
+    /// The `credentialSource` matrix as the console consumes it, plus the
+    /// write-only contract. Runs with no platform identity in the environment, so
+    /// the instance contributes nothing and the company's own token is the only
+    /// credential in play: `none` → `static` → `none`.
     #[tokio::test]
-    async fn status_reports_grant_and_toolkits_then_token_round_trips_write_only() {
+    async fn credential_source_tracks_the_byo_token_and_never_carries_it() {
         let home = home();
         let state = state_with_manifest(
             &home,
@@ -357,19 +416,23 @@ mod tests {
         )
         .await;
 
-        // Initial status: granted, toolkits surfaced, no token yet.
+        // Initial status: granted, toolkits surfaced, no credential obtainable.
         let (status, dto, _) = send(&state, "GET", "/api/v1/company/composio", None).await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(dto["granted"], true);
-        assert_eq!(dto["tokenConfigured"], false);
+        assert_eq!(dto["credentialSource"], "none");
         assert_eq!(dto["toolkits"], json!(["gmail", "github"]));
         assert!(dto.get("backendUrl").is_some());
         assert!(
             dto.get("token").is_none(),
             "status must never carry a token"
         );
+        assert!(
+            dto.get("tokenConfigured").is_none(),
+            "the boolean surface is replaced by credentialSource"
+        );
 
-        // Set the write-only token.
+        // Set the write-only BYO token → the static tier.
         let (status, resp, raw) = send(
             &state,
             "PUT",
@@ -378,15 +441,15 @@ mod tests {
         )
         .await;
         assert_eq!(status, StatusCode::OK, "{raw}");
-        assert_eq!(resp["status"]["tokenConfigured"], true);
+        assert_eq!(resp["status"]["credentialSource"], "static");
         assert!(!raw.contains(TOKEN), "PUT response leaked the token: {raw}");
 
         // GET reflects it and still never carries the token.
         let (_, dto, raw) = send(&state, "GET", "/api/v1/company/composio", None).await;
-        assert_eq!(dto["tokenConfigured"], true);
+        assert_eq!(dto["credentialSource"], "static");
         assert!(!raw.contains(TOKEN), "GET status leaked the token: {raw}");
 
-        // Clearing with "" removes it.
+        // Clearing with "" reverts to whatever the instance offers — here nothing.
         let (_, resp, _) = send(
             &state,
             "PUT",
@@ -394,9 +457,80 @@ mod tests {
             Some(json!({ "token": "" })),
         )
         .await;
-        assert_eq!(resp["status"]["tokenConfigured"], false);
+        assert_eq!(resp["status"]["credentialSource"], "none");
 
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// The hosted shape, driven through the env seam (no process mutation): a
+    /// company that pasted nothing reads `attested` from the instance identity,
+    /// its own token still outranks that, and neither yields `none`.
+    #[test]
+    fn credential_source_matrix_follows_the_resolver_precedence() {
+        use crate::app::config::MapEnv;
+
+        let dir = std::env::temp_dir().join(format!("oc-dto-{}", crate::ports::generate_id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("token");
+        std::fs::write(&path, "projected-instance-token").unwrap();
+        let projected = MapEnv::new([(
+            crate::company::credentials::TOKEN_FILE_ENV,
+            path.display().to_string(),
+        )]);
+
+        // Nothing stored + a projected instance identity → attested.
+        assert_eq!(
+            credential_source_for(false, &projected),
+            CredentialSource::Attested
+        );
+        // The company's own token outranks the instance identity.
+        assert_eq!(
+            credential_source_for(true, &projected),
+            CredentialSource::Static
+        );
+        // A static instance key is the static tier too.
+        assert_eq!(
+            credential_source_for(
+                false,
+                &MapEnv::new([(crate::company::credentials::API_KEY_ENV, "th_static")])
+            ),
+            CredentialSource::Static
+        );
+        // Neither → nothing obtainable, so no tools.
+        assert_eq!(
+            credential_source_for(false, &MapEnv::default()),
+            CredentialSource::None
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The DTO's whole surface, serialized: a tier name and non-secret routing.
+    /// No token, and no token-file path either — the console never needs to know
+    /// where on disk the instance's identity lives.
+    #[test]
+    fn the_dto_carries_a_tier_name_and_nothing_secret() {
+        let dto = ComposioStatusDto {
+            in_build: true,
+            granted: true,
+            credential_source: CredentialSource::Attested,
+            backend_url: "https://api.tinyhumans.ai".to_string(),
+            toolkits: vec!["gmail".to_string()],
+        };
+        let json = serde_json::to_value(&dto).unwrap();
+        assert_eq!(json["credentialSource"], "attested");
+        let keys: Vec<&String> = json.as_object().unwrap().keys().collect();
+        assert_eq!(
+            keys,
+            vec![
+                "inBuild",
+                "granted",
+                "credentialSource",
+                "backendUrl",
+                "toolkits"
+            ],
+            "the read shape must stay exactly this: {keys:?}"
+        );
     }
 
     /// A `*` wildcard grant must NOT count as a composio grant on the status

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -233,8 +233,10 @@ async fn connections(company: ScopedCompany) -> Result<Json<Vec<ConnectionDto>>,
 
 /// Resolve the per-tenant Composio config (bearer + backend URL + toolkit
 /// allowlist) the way the harness roster build does, so the console dials the
-/// backend with the exact same tenant identity. A `409 Conflict` when no token
-/// is configured — the operator must set it (paste-token card) before OAuth.
+/// backend with the exact same tenant identity. A `409 Conflict` when no
+/// credential of any tier can be resolved — neither this company's own stored
+/// token nor a platform identity — in which case the operator must paste a token
+/// before OAuth.
 #[cfg(feature = "composio")]
 async fn resolve_tenant(
     runtime: &CompanyRuntime,
@@ -254,11 +256,14 @@ async fn resolve_tenant(
         toolkits,
         backend_env,
         api_env,
+        crate::company::TinyhumansTokenSource::from_env(&env).map(std::sync::Arc::new),
     )
     .await
     .ok_or_else(|| {
         ApiError(crate::error::OpenCompanyError::Conflict(
-            "no Composio token configured for this company — set the token first".to_string(),
+            "no Composio credential is available for this company — this instance has no platform \
+             identity, so paste the company's Composio token first"
+                .to_string(),
         ))
     })
 }


### PR DESCRIPTION
## Summary

Teaches a company to *obtain* its tinyhumans credential instead of *holding* one.

`TinyhumansTokenSource` has two tiers — a platform-projected token file, else a static value. On a hosted pod the token is a kubelet-rotated, audience-bound ServiceAccount token that no operator ever sees, pastes, or rotates. Inference and Composio now carry a resolvable `Credential` rather than a `String` captured at construction time.

This is the tenant side of the cross-repo change that removes static tenant credentials.

## API Or Behavior Changes

**`credentialSource` replaces `tokenConfigured`** on `GET …/composio`: `"attested"` (platform-projected file) / `"static"` (a pasted per-company token or static instance key) / `"none"` (nothing obtainable → no tools wired). The token itself is still never echoed, and tests assert it cannot appear in any response.

**`PUT …/composio/token` is retained**, re-documented as a per-company BYO override rather than the entire isolation lever. Precedence is explicit: a per-company stored token wins over the ambient token source.

**Two consequences worth reviewing, both deliberate:**

`resolve_effective` no longer reads a token, so "is inference configured?" costs no I/O — and a transient file error at boot can no longer permanently downgrade a company to the echo brain. The bearer is resolved inside `request_plan` (now async) and `HostedProvider::invoke`.

Each Composio tool builds its `IntegrationClient` **per call** via `live_call()`. This was necessary, not stylistic: the roster deliberately does *not* rebuild on rotation, so a client built at roster time would hold a bearer the cluster had already moved past. The scrub vector is built from the token that actually went out.

**The roster fingerprint hashes source *identity*, not token bytes** — for the projected tier, tier + path. Hashing the value would rebuild every agent's tool roster on the platform's ~8-minute rotation schedule. The static tier still hashes its value, because there a changed value genuinely *is* a changed identity (an operator rotated it) and must rebuild.

Caching respects the 600s projected-token lifetime: window is `min(0.8 × remaining TTL, 60s)`, plus invalidation on a 401 from either request path. Expiry is read from an unverified JWT `exp` by local base64url decode — no new dependency — and a token that cannot be dated, or is already expired, is served but never cached.

A `TINYHUMANS_TOKEN_FILE` pointing at a path that was never projected **degrades to the static tier with a warning rather than erroring**, so the docker runtime is unaffected. `Debug` is redacted on both the credential and the source.

## Tests

- default: `cargo test` **784 passed / 0 failed**; `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean
- `--features openhuman,composio`: `cargo test --lib` **1086 passed / 0 failed**; `cargo check` clean
- `--all-features`: `cargo check` clean
- frontend: `npm ci`, `npm run typecheck`, `npm run build` clean

Fixed a latent break in this area: `harness::composio::isolation_tests` called `composio_tools(config)` against a two-parameter function, so `cargo test --features composio` had **never** compiled. It does now.

## Documentation

`docs/spec/runtime/config.md` updated for the token source and the `credentialSource` shape. Module docs on the composio ops route were rewritten — the per-tenant token is no longer "the entire tenant-isolation lever", it is one tier below platform attestation.

---

### Overlap with #167

This touches four files also touched by open PR **#167** (`frontend/src/api/composio.ts`, `frontend/src/views/connections/ComposioSection.tsx`, `src/harness/composio.rs`, `src/server/ops/composio.rs`). Whichever merges second needs a rebase.

Worth flagging for review rather than leaving to be discovered: #167's sign-in half has a company operator paste a tinyhumans JWT into the company. This change is the alternative to that — the credential arrives as platform-attested workload identity and there is nothing for a user to paste. The console plumbing in #167 remains useful; the paste-a-token flow is what this supersedes.

### Pre-existing, not introduced here

Three full-feature build gaps exist on the base commit and are untouched by this branch (none of the files are in its diff), so `--all-features` / `--features openhuman,composio` test runs cannot link or compile:

- `examples/live_company_turn.rs` is missing two `CompanyRecord` fields (blocks linking under `--features openhuman,composio`)
- `src/store/sqlite.rs:1872,1893` has an ambiguous `store.list(...)` in its own tests (reproduces with `--features sqlite` alone)
- `src/harness/mcp_probe.rs:446` trips `clippy::to_string_in_format_args`

These need an owner; they were left alone to keep this diff scoped.

`Cargo.lock` was deliberately left unmodified — it regenerates ~700 lines locally against the vendored submodule pins, and this change adds no dependency.

### Related

Companion PRs: `opencompany-microservice` (workload identity + JWKS route), `backend` (verifier + machine-only `connections` scope), `landing` (link-health surface).


---

**Cross-repo change set** (all four ship dark; activation is a separate, ordered step):

| Repo | PR | Role |
|---|---|---|
| `opencompany-microservice` | tinyhumansai/opencompany-microservice#6 | per-tenant workload identity, JWKS route — **land first** |
| `backend` | tinyhumansai/backend#1174 | verifier, JWKS pull, machine-only `connections` scope |
| `opencompany` | tinyhumansai/opencompany#189 | tenant-side token source |
| `landing` | tinyhumansai/landing#18 | link-health surface |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for platform-projected, rotating credentials with static API-key fallback.
  * Credentials are resolved per request, allowing token rotation without restarting the service.
  * Composio now supports platform identity credentials, optional personal-token overrides, and clearer credential-source statuses.
  * Added credential-source details to diagnostics and connection status reporting.

* **Bug Fixes**
  * Improved handling of expired or rejected credentials by refreshing them automatically.
  * Prevented credential values from appearing in tool outputs, errors, or status responses.

* **Documentation**
  * Documented credential sources, precedence, rotation behavior, and configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->