### PR TITLE
fix(example): add missing CompanyRecord overlay fields to live_company_turn

### DIFF
--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -88,6 +88,8 @@ async fn main() -> anyhow::Result<()> {
         lifecycle: "running".to_string(),
         overlay_agents: Vec::new(),
         overlay_desk_members: Vec::new(),
+        overlay_desk_order: Vec::new(),
+        overlay_desks: Vec::new(),
         template_provenance: None,
     };
 


### PR DESCRIPTION
## Summary

`examples/live_company_turn.rs` constructs a `CompanyRecord` literal that omits the `overlay_desks` and `overlay_desk_order` fields the struct now requires. Because `cargo build/test/clippy --all-targets` compiles examples, this breaks those gates on a clean `main` — every open PR inherits the red. This adds the two missing fields (`Vec::new()`, matching the adjacent `overlay_desk_members`).

## API Or Behavior Changes

None. Example-only; the two new fields are empty vecs, so the smoke behaves exactly as before.

## Tests

- [x] `cargo build --example live_company_turn --features openhuman,tinycortex` — compiles (was E0063 before this change).
- [ ] full `--all-targets` suite not run locally (vendored-submodule env); CI is the verifier — and this change is what turns it green.

## Documentation

None needed — example completeness fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the live company turn example to initialize optional desk configuration fields, ensuring the smoke run starts with complete record data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->