### PR TITLE
fix(harness): set approval_requests on a stale test HarnessDeps literal

### DIFF
--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -2371,6 +2371,7 @@ members = ["eng1", "eng2"]
             facts: None,
             events: None,
             delegations: queue,
+            approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             secrets: None,


### PR DESCRIPTION
## Summary

A test-only `HarnessDeps` literal in `src/harness/brain.rs` (the delegating-brain test) was never updated when `approval_requests` was added to `HarnessDeps`. Because the field/constructor is behind the `openhuman` feature — which CI does not build (known feature-combo gap) — `cargo test --features openhuman` fails to compile locally, invisibly to CI. This adds the missing field (`ApprovalRequestQueue::default()`, matching every sibling constructor).

## API Or Behavior Changes

None. Test-only; a default (empty) queue, behaviorally inert.

## Tests

- [x] `cargo test --lib --features openhuman,tinycortex --no-run` — the openhuman test binary compiles (was E0063 before). Only stale constructor; nothing else missing.
- [ ] full `--all-targets` suite / CI verifier (CI does not build the openhuman feature — that gap is why this rotted).

## Documentation

None needed.