### PR TITLE
feat(plan): plan-level total-token cap — hard-refuse dispatch at exhaustion (#188)

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -372,6 +372,23 @@ export interface CapabilityTierDto {
 }
 
 /**
+ * The plan-level total token ceiling (issue #188). Unlike a per-namespace tier
+ * — a *soft* gate that only trims exec tools — crossing this is a *hard* stop:
+ * the harness refuses to dispatch further turns this period. Present only when
+ * the manifest set `[plan].total_tokens`.
+ */
+export interface CapabilityTotalDto {
+  /** Total tokens allowed this period before dispatch is refused. */
+  budgetTokens: number;
+  /** Tokens spent this period. */
+  spentTokens: number;
+  /** `budget - spent`, floored at zero. */
+  remainingTokens: number;
+  /** Whether spend has reached the ceiling — dispatch is paused until reset. */
+  exhausted: boolean;
+}
+
+/**
  * The company's capability-budget status. When no `[plan]` is configured only
  * `configured: false` is present; the other fields accompany a configured plan.
  */
@@ -387,6 +404,12 @@ export interface CapabilityStatusDto {
   spentTokens?: number;
   /** One row per configured tier, namespace-sorted. */
   tiers?: CapabilityTierDto[];
+  /**
+   * The plan-level total token ceiling (issue #188), when configured. Crossing
+   * it is a hard stop — the harness refuses to dispatch further turns this
+   * period, unlike the soft per-namespace `tiers`.
+   */
+  total?: CapabilityTotalDto;
   /**
    * Media generation (issue #109): whether the company **explicitly** grants the
    * real-money `media` namespace (a `*` wildcard does not count). Present

--- a/frontend/src/views/UsageView.tsx
+++ b/frontend/src/views/UsageView.tsx
@@ -234,13 +234,20 @@ export function UsageView({ client, company }: Props) {
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
+            {/* Plan-level total token ceiling (issue #188): a HARD stop — once
+                spend crosses it the harness refuses to dispatch further turns,
+                unlike the soft per-namespace bars below. Rendered first, and on
+                its own even when no per-namespace tiers are configured. */}
+            {capsLoaded && caps?.configured && caps.total ? (
+              <TotalCeilingRow total={caps.total} />
+            ) : null}
             {capsLoaded && caps?.configured && caps.tiers && caps.tiers.length > 0 ? (
               <div className="space-y-4">
                 {caps.tiers.map((tier) => (
                   <CapabilityRow key={tier.namespace} tier={tier} />
                 ))}
               </div>
-            ) : (
+            ) : capsLoaded && caps?.configured && caps.total ? null : (
               <p className="py-2 text-sm text-muted-foreground">
                 {capsLoaded ? "No token plan configured." : "Loading budgets…"}
               </p>
@@ -339,6 +346,54 @@ function composioStatus(caps: CapabilityStatusDto): { label: string; variant: Ba
 // A budget large enough that we treat it as effectively unlimited (the backend
 // sends u64::MAX for the `unlimited` tier, which arrives as a huge float).
 const UNLIMITED_THRESHOLD = 1e15;
+
+/**
+ * The plan-level total token ceiling (issue #188). Unlike a per-namespace tier
+ * bar — a soft gate that only trims exec tools — crossing this is a hard stop:
+ * the harness refuses to dispatch further turns this period. Rendered with
+ * stronger emphasis (its own labelled bar + a "Dispatch paused" badge when
+ * exhausted) so an operator can tell the hard cap apart from the soft ones.
+ */
+function TotalCeilingRow({ total }: { total: NonNullable<CapabilityStatusDto["total"]> }) {
+  const unlimited = total.budgetTokens >= UNLIMITED_THRESHOLD;
+  const pct = unlimited
+    ? Math.min(100, total.spentTokens > 0 ? 2 : 0)
+    : total.budgetTokens > 0
+      ? Math.min(100, (total.spentTokens / total.budgetTokens) * 100)
+      : 100;
+
+  return (
+    <div className="space-y-1.5 rounded-md border p-3">
+      <div className="flex items-center justify-between gap-2 text-sm">
+        <span className="font-medium">Total token ceiling</span>
+        {total.exhausted ? (
+          <Badge variant="destructive">Dispatch paused</Badge>
+        ) : (
+          <span className="text-xs text-muted-foreground tabular-nums">
+            {compact(total.remainingTokens)} left
+          </span>
+        )}
+      </div>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className={cn(
+            "h-full rounded-full transition-all",
+            total.exhausted ? "bg-destructive" : "bg-primary",
+          )}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div className="flex items-center justify-between text-xs text-muted-foreground tabular-nums">
+        <span>{compact(total.spentTokens)} spent</span>
+        <span>{unlimited ? "Unlimited" : `${compact(total.budgetTokens)} ceiling`}</span>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        A hard cap on total spend this period. When it&apos;s reached, new turns are
+        refused until the period resets — separate from the per-tool budgets below.
+      </p>
+    </div>
+  );
+}
 
 function CapabilityRow({ tier }: { tier: NonNullable<CapabilityStatusDto["tiers"]>[number] }) {
   const label = NAMESPACE_LABELS[tier.namespace] ?? tier.namespace;

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -558,6 +558,16 @@ pub struct Plan {
     /// tier's map; a gateable namespace absent here is denied.
     #[serde(default)]
     pub token_budgets: BTreeMap<String, u64>,
+    /// Plan-level **total token ceiling** for the period (issue #188). The
+    /// per-namespace `token_budgets` gate only *which exec tools* a turn may use
+    /// (a soft roster trim — an exhausted namespace's tools drop, but the turn
+    /// still runs on intrinsic tools and burns model tokens). This is the hard
+    /// stop: once the company's total period spend reaches this ceiling, the
+    /// harness **refuses to dispatch the turn at all** (no model call) until the
+    /// period resets. `None` (the default) leaves the total gate off — only the
+    /// per-namespace soft gate applies, byte-identical to pre-#188.
+    #[serde(default)]
+    pub total_tokens: Option<u64>,
 }
 
 impl Default for Plan {
@@ -570,16 +580,20 @@ impl Default for Plan {
             name: None,
             period: default_plan_period(),
             token_budgets: BTreeMap::new(),
+            total_tokens: None,
         }
     }
 }
 
 impl Plan {
-    /// Whether this section meaningfully configures a plan — a named tier or an
-    /// explicit budget. An absent `[plan]` deserializes to the default (period
-    /// only), which is *not* set, so gating stays off.
+    /// Whether this section meaningfully configures a plan — a named tier, an
+    /// explicit per-namespace budget, or a total-token ceiling (issue #188). An
+    /// absent `[plan]` deserializes to the default (period only), which is *not*
+    /// set, so gating stays off.
     pub fn is_set(&self) -> bool {
-        self.name.as_deref().is_some_and(|n| !n.trim().is_empty()) || !self.token_budgets.is_empty()
+        self.name.as_deref().is_some_and(|n| !n.trim().is_empty())
+            || !self.token_budgets.is_empty()
+            || self.total_tokens.is_some()
     }
 }
 
@@ -705,6 +719,7 @@ mod test {
             [plan]
             name = "starter"
             period = "monthly"
+            total_tokens = 2000000
 
             [plan.token_budgets]
             web = 500000
@@ -714,16 +729,32 @@ mod test {
         assert_eq!(manifest.plan.name.as_deref(), Some("starter"));
         assert_eq!(manifest.plan.period, "monthly");
         assert_eq!(manifest.plan.token_budgets.get("web"), Some(&500_000));
+        assert_eq!(manifest.plan.total_tokens, Some(2_000_000));
 
         let json = serde_json::to_string(&manifest).expect("serialize");
         let back: CompanyManifest = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.plan.name.as_deref(), Some("starter"));
         assert_eq!(back.plan.period, "monthly");
         assert_eq!(back.plan.token_budgets.get("web"), Some(&500_000));
+        assert_eq!(back.plan.total_tokens, Some(2_000_000));
 
         // An absent `[plan]` defaults to period-only, which is NOT set.
         let bare: CompanyManifest = toml::from_str("[company]\nname = \"Bare\"\n").unwrap();
         assert!(!bare.plan.is_set());
         assert_eq!(bare.plan.period, "daily");
+        assert_eq!(bare.plan.total_tokens, None);
+    }
+
+    /// A `[plan]` carrying **only** a `total_tokens` ceiling (issue #188) — no
+    /// name, no per-namespace budgets — is still a set plan, so the total gate
+    /// engages on its own.
+    #[test]
+    fn plan_total_tokens_only_is_set() {
+        let manifest: CompanyManifest =
+            toml::from_str("[company]\nname = \"Acme\"\n[plan]\ntotal_tokens = 1000\n").unwrap();
+        assert!(manifest.plan.is_set(), "a total-only plan must be set");
+        assert_eq!(manifest.plan.total_tokens, Some(1000));
+        assert!(manifest.plan.name.is_none());
+        assert!(manifest.plan.token_budgets.is_empty());
     }
 }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -255,6 +255,14 @@ pub struct CompanyAgent {
 /// class twice — so chat never shows a bare "Couldn't send" for a model hiccup.
 const GRACEFUL_EMPTY_REPLY: &str = "Sorry — I hit a temporary model hiccup and couldn't produce a reply. Please resend your message.";
 
+/// The operator-facing notice returned when the plan-level total token ceiling
+/// (issue #188) is reached — a hard dispatch refusal, so no model call is made.
+/// Surfaced as the turn's reply on every dispatch path (operator chat, task,
+/// steered/background), since they all funnel through
+/// [`HarnessPool::run_inner`](HarnessPool::run_inner).
+const TOTAL_BUDGET_EXHAUSTED_NOTICE: &str =
+    "Token budget for this period is exhausted — dispatch paused until the period resets.";
+
 /// The classification of a single `agent.turn` attempt, for the retry wrapper.
 enum AttemptOutcome {
     /// A non-empty reply.
@@ -940,6 +948,65 @@ impl HarnessPool {
                     ))
                 })?
         };
+
+        // Plan-level total-token ceiling (issue #188): a HARD dispatch refusal
+        // that never reaches the model once the tenant's total period spend
+        // crosses the cap. The per-namespace budget gate in `ensure` is *soft* —
+        // it only trims which exec tools the roster carries; an exhausted
+        // tenant's turn still runs on intrinsic tools and burns model tokens.
+        // This closes that gap by refusing dispatch outright, before any model
+        // call, on every path that funnels through `run_inner` (operator chat,
+        // task, steered/background). We return early here — before retrieve→
+        // inject and the memory writeback — so a refused turn costs nothing and
+        // leaves no fabricated outcome in the memory store.
+        //
+        // Fail-closed tradeoff (issue #188): the hard refusal fires ONLY when
+        // spend is actually readable. With no meter, or a meter whose query
+        // errors, we do NOT brick the tenant on a transient read failure — we
+        // fall through to run the turn, which the per-namespace fail-closed path
+        // in `resolve_filter`/`ensure` has already stripped of every exec tool.
+        // A `warn!` records the deferral. Refusing every turn on a flaky meter
+        // read would be a strictly worse failure mode than letting an
+        // intrinsic-tools-only turn through.
+        if let Some(plan) = deps.plan.as_ref()
+            && plan.total_budget.is_some()
+        {
+            match deps.meter.as_deref() {
+                Some(meter) => {
+                    let since = plan.period.period_start_millis(crate::ports::now_millis());
+                    match meter.query(company, since).await {
+                        Ok(samples) => {
+                            let spent = capability_budget::tokens_in(&samples);
+                            if plan.total_exhausted(spent) {
+                                tracing::info!(
+                                    company = %company,
+                                    agent = agent_id,
+                                    spent,
+                                    "[capability-budget] total token ceiling reached; refusing dispatch (no model call) until the period resets"
+                                );
+                                return Ok(TurnOutcome {
+                                    reply: TOTAL_BUDGET_EXHAUSTED_NOTICE.to_string(),
+                                    steps: Vec::new(),
+                                });
+                            }
+                        }
+                        Err(error) => {
+                            tracing::warn!(
+                                company = %company,
+                                %error,
+                                "[capability-budget] total-ceiling spend query failed; not hard-refusing — deferring to the per-namespace fail-closed roster"
+                            );
+                        }
+                    }
+                }
+                None => {
+                    tracing::warn!(
+                        company = %company,
+                        "[capability-budget] no usage meter; cannot enforce the total token ceiling — deferring to the per-namespace fail-closed roster"
+                    );
+                }
+            }
+        }
 
         // Retrieve→inject: pull the top-K prior task outcomes relevant to this
         // message and prepend them as context. On a cold store this yields no
@@ -2385,6 +2452,7 @@ description = "Sets direction."
         let plan = crate::harness::capability_budget::CapabilityPlan {
             period: crate::harness::capability_budget::BudgetPeriod::Daily,
             budgets: std::collections::BTreeMap::from([("shell".to_string(), 100u64)]),
+            total_budget: None,
         };
         let deps = HarnessDeps {
             provider: Arc::new(MockProvider::new("mock: ")),
@@ -2510,6 +2578,158 @@ description = "Sets direction."
             pool.capability_fingerprint_of(&rec.id).await,
             Some(fp),
             "no plan → stable fingerprint → no capability-driven rebuild"
+        );
+    }
+
+    /// Builds a `HarnessDeps` carrying the given plan + meter, for the total-
+    /// ceiling dispatch tests (issue #188). Everything else is the inert fixture
+    /// wiring (mock provider/context, recording store).
+    fn deps_with_plan(
+        dir: &std::path::Path,
+        context: Arc<MockContext>,
+        meter: Option<Arc<RecordingMeter>>,
+        plan: Option<crate::harness::capability_budget::CapabilityPlan>,
+    ) -> HarnessDeps {
+        HarnessDeps {
+            provider: Arc::new(MockProvider::new("mock: ")),
+            provider_slug: "mock".to_string(),
+            context,
+            store: Arc::new(RecordingStore::default()),
+            meter: meter.map(|m| m as Arc<dyn UsageMeter>),
+            workspace_root: dir.to_path_buf(),
+            model_override: None,
+            tasks: None,
+            skills: None,
+            skills_source_dir: None,
+            mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: DelegationQueue::default(),
+            workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
+            mcp_failures: McpFailureQueue::default(),
+            approval_requests: ApprovalRequestQueue::default(),
+            secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            workflow_source_dir: None,
+            plan,
+            media: None,
+            composio: None,
+            steer: crate::company::steer::InflightRegistry::default(),
+        }
+    }
+
+    /// The hard total-token ceiling (issue #188): once the tenant's total period
+    /// spend crosses the plan's `total_budget`, the very next dispatch is refused
+    /// **before any model call** — the reply is the fixed operator notice, the
+    /// prompt is never echoed (proving the model was not run), and no fabricated
+    /// outcome lands in memory. A turn under the ceiling still runs normally.
+    #[tokio::test]
+    async fn run_refuses_dispatch_once_the_total_ceiling_is_crossed() {
+        let dir = tempfile::tempdir().unwrap();
+        let context = Arc::new(MockContext::default());
+        let meter = Arc::new(RecordingMeter::default());
+        let plan = crate::harness::capability_budget::CapabilityPlan {
+            period: crate::harness::capability_budget::BudgetPeriod::Daily,
+            budgets: std::collections::BTreeMap::new(),
+            total_budget: Some(100),
+        };
+        let deps = deps_with_plan(dir.path(), context.clone(), Some(meter.clone()), Some(plan));
+        let pool = HarnessPool::new();
+        let rec = record();
+        pool.ensure(&rec, &deps).await.expect("ensure");
+
+        // Under the ceiling (0 spend < 100): the turn runs and echoes the prompt.
+        let ok = pool
+            .run(&rec.id, "ceo", "hello-marker", &deps, None)
+            .await
+            .expect("under-ceiling turn runs")
+            .reply;
+        assert!(
+            ok.contains("hello-marker"),
+            "under the ceiling the model runs: {ok:?}"
+        );
+
+        // Push total period spend to 150 — past the 100-token ceiling.
+        meter
+            .record(
+                &rec.id,
+                &UsageSample {
+                    at_millis: crate::ports::now_millis(),
+                    agent: "ceo".into(),
+                    provider: "managed".into(),
+                    input_tokens: 100,
+                    output_tokens: 50,
+                    cached_input_tokens: 0,
+                    cost_usd: 0.0,
+                    kind: crate::ports::SampleKind::Inference,
+                },
+            )
+            .await
+            .unwrap();
+
+        let before = context
+            .list(&rec.id, memory_loop::OUTCOME_LABEL_PREFIX)
+            .await
+            .unwrap()
+            .len();
+
+        // Over the ceiling: dispatch is refused with a benign notice — NOT an Err.
+        let refused = pool
+            .run(&rec.id, "ceo", "should-not-echo", &deps, None)
+            .await
+            .expect("a refusal is a benign outcome, not a hard error")
+            .reply;
+        assert_eq!(
+            refused, TOTAL_BUDGET_EXHAUSTED_NOTICE,
+            "the refusal returns the fixed operator notice"
+        );
+        assert!(
+            !refused.contains("should-not-echo"),
+            "the model was never called, so the prompt is not echoed: {refused:?}"
+        );
+
+        // A refused turn writes no outcome back to memory.
+        let after = context
+            .list(&rec.id, memory_loop::OUTCOME_LABEL_PREFIX)
+            .await
+            .unwrap()
+            .len();
+        assert_eq!(before, after, "a refused turn stores nothing in memory");
+    }
+
+    /// Fail-closed tradeoff (issue #188): with a total ceiling configured but no
+    /// meter to read spend from, the hard refusal does NOT fire — a transient
+    /// unreadable-spend condition must not brick every turn. The turn runs (the
+    /// per-namespace fail-closed roster already handles exec-tool stripping).
+    #[tokio::test]
+    async fn run_does_not_refuse_when_spend_is_unreadable() {
+        let dir = tempfile::tempdir().unwrap();
+        let context = Arc::new(MockContext::default());
+        // A zero ceiling would refuse from the first token IF spend were readable;
+        // with no meter wired the gate must defer, not brick.
+        let plan = crate::harness::capability_budget::CapabilityPlan {
+            period: crate::harness::capability_budget::BudgetPeriod::Daily,
+            budgets: std::collections::BTreeMap::new(),
+            total_budget: Some(0),
+        };
+        let deps = deps_with_plan(dir.path(), context.clone(), None, Some(plan));
+        let pool = HarnessPool::new();
+        let rec = record();
+        pool.ensure(&rec, &deps).await.expect("ensure");
+
+        let reply = pool
+            .run(&rec.id, "ceo", "hello-marker", &deps, None)
+            .await
+            .expect("no meter must not brick the turn")
+            .reply;
+        assert!(
+            reply.contains("hello-marker"),
+            "an unreadable ceiling defers to running the turn: {reply:?}"
+        );
+        assert_ne!(
+            reply, TOTAL_BUDGET_EXHAUSTED_NOTICE,
+            "the hard refusal must not fire without a spend read"
         );
     }
 }

--- a/src/metering/capability.rs
+++ b/src/metering/capability.rs
@@ -81,6 +81,17 @@ pub struct CapabilityPlan {
     /// Gateable namespace → tokens allowed per period. `u64::MAX` is effectively
     /// unlimited.
     pub budgets: BTreeMap<String, u64>,
+    /// Plan-level **total token ceiling** for the period (issue #188), or `None`
+    /// when no ceiling is set.
+    ///
+    /// The `budgets` map is a **soft** gate — it only trims *which* exec tool
+    /// families a turn may reach; an exhausted namespace's tools drop off the
+    /// roster but the turn still runs on intrinsic tools and burns model tokens.
+    /// This is the **hard** gate: once the tenant's total period spend reaches
+    /// this value, dispatch is refused outright (no model call) until the period
+    /// resets. Carried from the manifest `[plan].total_tokens`; the built-in
+    /// named tiers leave it `None` (a manifest overlays it explicitly).
+    pub total_budget: Option<u64>,
 }
 
 impl CapabilityPlan {
@@ -102,6 +113,7 @@ impl CapabilityPlan {
             None => CapabilityPlan {
                 period: BudgetPeriod::Daily,
                 budgets: BTreeMap::new(),
+                total_budget: None,
             },
         };
         // The manifest `period` field is authoritative for the window (defaults
@@ -112,7 +124,33 @@ impl CapabilityPlan {
         for (namespace, tokens) in &plan.token_budgets {
             resolved.budgets.insert(namespace.clone(), *tokens);
         }
+        // The plan-level total ceiling (issue #188) is a manifest-only overlay —
+        // the built-in tiers carry none, so `total_tokens` is authoritative when
+        // present and leaves the hard gate off when absent.
+        resolved.total_budget = plan.total_tokens;
         Some(resolved)
+    }
+
+    /// Whether the tenant's total period `spent` has reached the plan-level token
+    /// ceiling (issue #188). `false` when no ceiling is configured (the hard gate
+    /// is off) or when spend is still under it. The boundary is `>=`, matching the
+    /// per-namespace [`denied_namespaces`](Self::denied_namespaces) exhaustion so
+    /// the total gate trips exactly when a namespace budget equal to it would.
+    pub fn total_exhausted(&self, spent: u64) -> bool {
+        self.total_budget.is_some_and(|cap| spent >= cap)
+    }
+
+    /// The plan-level total-budget status row for the console read surface (issue
+    /// #188), or `None` when no total ceiling is configured. Mirrors
+    /// [`TierBudgetStatus`] but describes the whole-period ceiling, not one
+    /// namespace.
+    pub fn total_status(&self, spent: u64) -> Option<TotalBudgetStatus> {
+        self.total_budget.map(|budget| TotalBudgetStatus {
+            budget,
+            spent,
+            remaining: budget.saturating_sub(spent),
+            exhausted: spent >= budget,
+        })
     }
 
     /// The gateable namespaces this plan denies at `spent` tokens: every gateable
@@ -185,6 +223,9 @@ pub fn plan_named(name: &str) -> Option<CapabilityPlan> {
             .iter()
             .map(|(ns, tokens)| ((*ns).to_string(), *tokens))
             .collect(),
+        // The plan-level total ceiling (issue #188) is opt-in via the manifest
+        // `[plan].total_tokens` overlay only — a named tier never sets it.
+        total_budget: None,
     })
 }
 
@@ -214,6 +255,24 @@ pub struct TierBudgetStatus {
     pub remaining: u64,
     /// Whether spend has reached the threshold (`spent >= budget`) — the tier's
     /// tools are disabled.
+    pub exhausted: bool,
+}
+
+/// The plan-level total-budget status for the console read surface (issue #188).
+///
+/// Unlike [`TierBudgetStatus`] — a per-namespace **soft** gate that only trims a
+/// tool family — `exhausted` here means the tenant has crossed the **hard**
+/// ceiling and the harness will refuse to dispatch further turns this period.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TotalBudgetStatus {
+    /// The total token ceiling for the period.
+    pub budget: u64,
+    /// The tenant's total period spend.
+    pub spent: u64,
+    /// `budget - spent`, saturating at zero.
+    pub remaining: u64,
+    /// Whether spend has reached the ceiling (`spent >= budget`) — dispatch is
+    /// refused until the period resets.
     pub exhausted: bool,
 }
 
@@ -399,6 +458,7 @@ mod tests {
             name: Some("starter".into()),
             period: "daily".into(),
             token_budgets,
+            total_tokens: None,
         })
         .unwrap();
         // Under budget: composio granted, shell/code still granted.
@@ -459,6 +519,7 @@ mod tests {
             name: Some("starter".into()),
             period: "daily".into(),
             token_budgets: BTreeMap::new(),
+            total_tokens: None,
         };
         let resolved = CapabilityPlan::from_manifest(&plan).unwrap();
         assert_eq!(resolved.period, BudgetPeriod::Daily);
@@ -476,6 +537,7 @@ mod tests {
             name: Some("starter".into()),
             period: "monthly".into(),
             token_budgets,
+            total_tokens: None,
         };
         let resolved = CapabilityPlan::from_manifest(&plan).unwrap();
         assert_eq!(resolved.period, BudgetPeriod::Monthly, "period field wins");
@@ -492,9 +554,89 @@ mod tests {
             name: None,
             period: "daily".into(),
             token_budgets,
+            total_tokens: None,
         };
         let resolved = CapabilityPlan::from_manifest(&plan).unwrap();
         assert_eq!(resolved.budgets.len(), 1);
         assert_eq!(resolved.budgets.get("shell"), Some(&500));
+    }
+
+    // --- total budget (issue #188) ------------------------------------------
+
+    #[test]
+    fn total_exhausted_none_budget_is_never_exhausted() {
+        let plan = plan_named("starter").unwrap();
+        assert!(plan.total_budget.is_none(), "named tiers carry no total");
+        assert!(!plan.total_exhausted(0));
+        assert!(!plan.total_exhausted(u64::MAX));
+    }
+
+    #[test]
+    fn total_exhausted_trips_at_the_ge_boundary() {
+        let mut plan = plan_named("free").unwrap();
+        plan.total_budget = Some(1_000);
+        assert!(!plan.total_exhausted(999), "under budget runs");
+        assert!(plan.total_exhausted(1_000), ">= boundary refuses");
+        assert!(plan.total_exhausted(1_001), "over budget refuses");
+    }
+
+    #[test]
+    fn total_exhausted_zero_budget_refuses_from_the_first_token() {
+        let mut plan = plan_named("free").unwrap();
+        plan.total_budget = Some(0);
+        assert!(
+            plan.total_exhausted(0),
+            "a zero ceiling refuses immediately"
+        );
+    }
+
+    #[test]
+    fn total_status_none_when_no_ceiling() {
+        let plan = plan_named("pro").unwrap();
+        assert!(plan.total_status(0).is_none());
+    }
+
+    #[test]
+    fn total_status_reports_budget_spend_remaining_and_exhaustion() {
+        let mut plan = plan_named("free").unwrap();
+        plan.total_budget = Some(1_000);
+        let under = plan.total_status(400).unwrap();
+        assert_eq!(under.budget, 1_000);
+        assert_eq!(under.spent, 400);
+        assert_eq!(under.remaining, 600);
+        assert!(!under.exhausted);
+        // At/over the ceiling: remaining saturates at zero and exhausted flips.
+        let over = plan.total_status(1_500).unwrap();
+        assert_eq!(over.remaining, 0);
+        assert!(over.exhausted);
+    }
+
+    #[test]
+    fn from_manifest_carries_total_tokens_and_named_tier_leaves_it_none() {
+        // A bare total-only plan: no name, no per-namespace budgets.
+        let plan = Plan {
+            name: None,
+            period: "daily".into(),
+            token_budgets: BTreeMap::new(),
+            total_tokens: Some(5_000),
+        };
+        let resolved = CapabilityPlan::from_manifest(&plan).unwrap();
+        assert_eq!(resolved.total_budget, Some(5_000));
+        assert!(resolved.budgets.is_empty(), "no per-namespace gate");
+
+        // A named tier with an explicit total overlay carries the ceiling too.
+        let overlaid = CapabilityPlan::from_manifest(&Plan {
+            name: Some("starter".into()),
+            period: "daily".into(),
+            token_budgets: BTreeMap::new(),
+            total_tokens: Some(9_000),
+        })
+        .unwrap();
+        assert_eq!(overlaid.total_budget, Some(9_000));
+        assert_eq!(overlaid.budgets.get("shell"), Some(&200_000));
+
+        // A named tier with no overlay leaves the total gate off.
+        let plain = plan_named("starter").unwrap();
+        assert!(plain.total_budget.is_none());
     }
 }

--- a/src/server/ops/capabilities.rs
+++ b/src/server/ops/capabilities.rs
@@ -51,6 +51,12 @@ struct CapabilityStatusDto {
     /// One row per configured tier, namespace-sorted. Omitted when unconfigured.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tiers: Vec<TierDto>,
+    /// The plan-level **total token ceiling** (issue #188), when one is
+    /// configured. Unlike the per-namespace `tiers` — a *soft* gate that only
+    /// trims exec tools — crossing this is a *hard* stop: the harness refuses to
+    /// dispatch further turns this period. Omitted when no ceiling is set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    total: Option<TotalDto>,
     /// Media generation (issue #109): whether this company **explicitly** grants
     /// the real-money `media` namespace (a `*` wildcard does NOT count). Sent
     /// regardless of whether a `[plan]` is configured, since media is opt-in per
@@ -91,6 +97,22 @@ struct TierDto {
     exhausted: bool,
 }
 
+/// The plan-level total token ceiling row (issue #188).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TotalDto {
+    /// Total tokens allowed this period before dispatch is refused.
+    budget_tokens: u64,
+    /// Tokens spent this period (the same company-wide figure the tiers compare
+    /// against).
+    spent_tokens: u64,
+    /// `budget - spent`, saturating at zero.
+    remaining_tokens: u64,
+    /// Whether spend has reached the ceiling — the harness refuses to dispatch
+    /// further turns until the period resets.
+    exhausted: bool,
+}
+
 /// The opt-in-capability status flags carried on every response (media +
 /// composio), independent of whether a `[plan]` is configured.
 struct OptInFlags {
@@ -120,6 +142,7 @@ fn unconfigured(flags: OptInFlags) -> CapabilityStatusDto {
         period_start_millis: None,
         spent_tokens: None,
         tiers: Vec::new(),
+        total: None,
         media_granted: flags.media_granted,
         media_in_build: cfg!(feature = "media"),
         media_credential_configured: media_credential_configured(),
@@ -192,6 +215,17 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<CapabilityStatusDt
         })
         .collect();
 
+    // The plan-level total ceiling (issue #188): present only when the manifest
+    // set `[plan].total_tokens`. This is the hard gate the harness enforces by
+    // refusing dispatch — the console renders it alongside the soft per-namespace
+    // tiers.
+    let total = plan.total_status(spent).map(|status| TotalDto {
+        budget_tokens: status.budget,
+        spent_tokens: status.spent,
+        remaining_tokens: status.remaining,
+        exhausted: status.exhausted,
+    });
+
     Ok(CapabilityStatusDto {
         configured: true,
         plan: manifest_plan.name.clone(),
@@ -199,6 +233,7 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<CapabilityStatusDt
         period_start_millis: Some(since),
         spent_tokens: Some(spent),
         tiers,
+        total,
         media_granted: flags.media_granted,
         media_in_build: cfg!(feature = "media"),
         media_credential_configured: media_credential_configured(),
@@ -414,6 +449,56 @@ mod tests {
             assert_eq!(tier["remainingTokens"], 0);
             assert_eq!(tier["exhausted"], true);
         }
+        // No `[plan].total_tokens` → the hard-ceiling row is absent.
+        assert!(
+            dto.get("total").is_none(),
+            "no total ceiling configured: {dto}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// The plan-level total token ceiling (issue #188) surfaces its own `total`
+    /// row — budget, spend, remaining, exhausted — alongside the per-namespace
+    /// tiers, and reports `exhausted` once period spend crosses it.
+    #[tokio::test]
+    async fn reports_total_ceiling_row_when_configured() {
+        let home = home();
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[plan]\nname = \"starter\"\ntotal_tokens = 300000\n",
+        )
+        .await;
+
+        // Seed 250k inference tokens — under the 300k total ceiling.
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+        runtime
+            .usage()
+            .record(
+                &id,
+                &UsageSample {
+                    at_millis: crate::ports::now_millis(),
+                    agent: "ceo".into(),
+                    provider: "managed".into(),
+                    input_tokens: 200_000,
+                    output_tokens: 50_000,
+                    cached_input_tokens: 0,
+                    cost_usd: 0.0,
+                    kind: SampleKind::Inference,
+                },
+            )
+            .await
+            .unwrap();
+
+        let (status, dto) = get_capabilities(&state).await;
+        assert_eq!(status, StatusCode::OK);
+        let total = &dto["total"];
+        assert!(total.is_object(), "total ceiling row present: {dto}");
+        assert_eq!(total["budgetTokens"], 300_000);
+        assert_eq!(total["spentTokens"], 250_000);
+        assert_eq!(total["remainingTokens"], 50_000);
+        assert_eq!(total["exhausted"], false, "250k < 300k is under budget");
 
         std::fs::remove_dir_all(&home).ok();
     }


### PR DESCRIPTION
## Summary

Adds a plan-level **total-token ceiling** — the metering capability epic #188 slice **188b**. Today's budgets gate only *per-exec-tool-namespace* spend, and softly (an exhausted namespace just drops its tools from the roster; the turn still runs on intrinsic tools and **still burns model tokens**). An exhausted tenant could therefore keep spending model tokens indefinitely.

This introduces a single hard ceiling over **total** period spend that **refuses dispatch** — no model call at all — once crossed:

- **Manifest**: new optional `[plan].total_tokens` (`Option<u64>`, `#[serde(default)]`). Absent ⇒ no total cap, behavior byte-identical to before. Built-in named tiers (free/starter/pro/unlimited) carry no total ceiling — it's a manifest-only overlay.
- **Runtime**: `CapabilityPlan.total_budget` + `total_exhausted(spent)` (`>=` boundary) + `total_status(spent)` for the console.
- **Enforcement**: at `HarnessPool::run_inner` — the single choke point every dispatch path (operator chat, task cards, steered/background) funnels through. When the ceiling is set and readable period spend `>=` it, the turn returns a benign outcome carrying an operator notice ("token budget for this period is exhausted — dispatch paused until reset"), **skipping the model call and any memory writeback**. Not a hard error — the cycle stays healthy.
- **Console (end-to-end)**: the total ceiling is surfaced on `GET …/capabilities` and rendered as a dedicated row (budget / spent / remaining, with a "Dispatch paused" badge when exhausted) above the per-namespace tier bars in the Usage view — distinguishing the hard cap from the soft per-tool budgets.

**Fail-closed tradeoff (deliberate):** the hard refusal fires **only when spend is readable**. With no meter, or a meter whose query errors, it does **not** brick the tenant — it logs `warn!` and falls through to a turn that the pre-existing per-namespace fail-closed path has already stripped of every exec tool. Refusing every turn on a transient meter read is a strictly worse failure mode than an intrinsic-tools-only turn.

Enforcement lives in the `openhuman`-gated harness (default `EchoBrain` dispatches no agent), consistent with the rest of the epic.

## API Or Behavior Changes

- New optional manifest field `[plan].total_tokens`. Unset ⇒ **no behavior change** (pre-#188 identical).
- New field `total` on the `GET …/capabilities` response DTO (`budgetTokens`/`spentTokens`/`remainingTokens`/`exhausted`), omitted when unconfigured.
- When configured and exhausted: dispatch is refused with an operator-facing notice instead of running a model turn.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 825 passed, 0 failed, 1 ignored

Added: manifest round-trip + `is_set` (total-only), `CapabilityPlan` total exhaustion/status boundary tests, two dispatch-gate tests (`run_refuses_dispatch_once_the_total_ceiling_is_crossed`, `run_does_not_refuse_when_spend_is_unreadable`), a `/capabilities` DTO test, and frontend `typecheck`+`build`. Also verified under `--features openhuman` (scoped `metering::capability` 26/0, `harness::capability_budget` 8/0, both new gate tests) and `cargo check --all-features`.

Note: one pre-existing openhuman-gated test failure (`harness::brain::tests::dispatched_card_with_an_origin_completes_to_done`) reproduces identically on the clean merge base `16ed9ee` and is unrelated to this change (its fixture has no plan, so the total gate never engages) — left untouched.

## Documentation

Inline: the fail-closed tradeoff is documented at the `run_inner` gate; the manifest field carries a doc comment; module docs describe the total-vs-per-namespace distinction. No external doc file needed.

Closes part of #188.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plan-level total token budgets with usage, remaining balance, and exhaustion status.
  * Usage views and capability reporting now display total budget progress.
  * Added an “Dispatch paused” status when the total budget is exhausted.

* **Bug Fixes**
  * Dispatch is blocked before execution when a configured total token ceiling is reached.
  * Dispatch continues when usage data is unavailable or unreadable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->