### PR TITLE
ci: build and publish this repo's tenant image to staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,159 @@
+# Build this repo's OWN image (the tenant workload) and put it in front of new
+# tenants on k3s staging.
+#
+# One repo, one image. This used to be built from the platform superproject
+# (tinyhumansai/opencompany-microservice), which meant a change here only shipped
+# when that repo's cron happened to notice the submodule pointer move. Now this
+# repo builds and publishes its own workload image, and the superproject builds
+# only the manager control plane.
+#
+# Required repository secrets:
+#   AWS_ROLE_ARN     — role assumed via OIDC to push to ECR. Its trust policy
+#                      must allow `repo:tinyhumansai/opencompany:*`.
+#   SSH_PRIVATE_KEY  — key trusted by root@ on the staging node.
+#   SSH_HOST         — staging node address.
+#
+# No PAT is needed: this repo and every crate the build compiles
+# (openhuman and its nested vendor graph) are public, so the default
+# GITHUB_TOKEN clones them all.
+name: Deploy tenant image to staging
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'frontend/**'
+      - 'companies/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'vendor/**'
+      - '.github/workflows/deploy-staging.yml'
+  workflow_dispatch:
+    inputs:
+      refresh_all_tenants:
+        description: 'Also restart already-running tenants onto the new image (disruptive: wakes idle tenants)'
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write # assume the AWS role via OIDC to push to ECR
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: tinyhumansai/opencompany-tenant
+  K8S_NAMESPACE: opencompany-system
+  MANAGER_DEPLOY: opencompany-manager
+  # The feature set the hosted tenant ships with. Kept verbatim from the
+  # pipeline this replaces — changing it changes what every tenant can do, so
+  # treat edits here as a product change, not a CI tweak.
+  TENANT_FEATURES: mongodb,openhuman,openhuman-rpc,tinyplace,github,smtp,dns,tinyhumans,webhooks,platform-jwt,export
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      # Path-limited on purpose. `--features openhuman` compiles the vendored
+      # openhuman crate and its nested graph, and cargo must be able to read the
+      # manifests behind [patch.crates-io], so both of these must be present.
+      # Recursing from the repo root instead would also drag in openhuman's
+      # desktop-only submodules (tauri-cef is a heavy CEF checkout) that no
+      # server build compiles.
+      - name: Fetch build vendor submodules
+        run: git submodule update --init --recursive vendor/openhuman vendor/tinyagents
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image to ECR
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          build-args: |
+            FEATURES=${{ env.TENANT_FEATURES }}
+          push: true
+          tags: |
+            ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:staging-${{ github.sha }}
+            ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:staging
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Add server to known hosts
+        run: ssh-keyscan -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Point the manager at the new tenant image
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          IMAGE: ${{ steps.ecr-login.outputs.registry }}/${{ env.ECR_REPOSITORY }}:staging-${{ github.sha }}
+          REFRESH_ALL: ${{ inputs.refresh_all_tenants }}
+        run: |
+          ssh root@${SSH_HOST} \
+            "IMAGE='${IMAGE}' K8S_NAMESPACE='${{ env.K8S_NAMESPACE }}' MANAGER_DEPLOY='${{ env.MANAGER_DEPLOY }}' REFRESH_ALL='${REFRESH_ALL:-false}' bash -s" << 'EOF'
+          set -euo pipefail
+          export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+
+          # Tenants pull with the ecr-creds Secret, which expires after 12h and is
+          # refreshed every 6h by a systemd timer. Force a refresh so a deploy
+          # landing late in that window cannot leave tenants in ImagePullBackOff.
+          echo "Refreshing ECR pull secret..."
+          /usr/local/bin/ecr-refresh.sh
+
+          # Tenant pods pin imagePullPolicy: IfNotPresent, so a moving tag is not
+          # re-pulled. The manager must be pointed at the immutable
+          # staging-<sha> tag, which a tag not already present locally always
+          # fetches. Never "deploy" by re-pushing :staging.
+          echo "Setting OCM_TENANT_IMAGE=${IMAGE}"
+          kubectl -n "${K8S_NAMESPACE}" set env "deploy/${MANAGER_DEPLOY}" "OCM_TENANT_IMAGE=${IMAGE}"
+
+          if ! kubectl -n "${K8S_NAMESPACE}" rollout status "deploy/${MANAGER_DEPLOY}" --timeout=300s; then
+            echo "ERROR: manager did not roll out; events and logs follow" >&2
+            kubectl -n "${K8S_NAMESPACE}" describe "deploy/${MANAGER_DEPLOY}" | tail -30 >&2
+            kubectl -n "${K8S_NAMESPACE}" logs "deploy/${MANAGER_DEPLOY}" --tail=100 >&2 || true
+            echo "Rolling back..." >&2
+            kubectl -n "${K8S_NAMESPACE}" rollout undo "deploy/${MANAGER_DEPLOY}"
+            kubectl -n "${K8S_NAMESPACE}" rollout status "deploy/${MANAGER_DEPLOY}" --timeout=180s >&2 || true
+            exit 1
+          fi
+
+          # New and woken tenants boot on the new image from here. ALREADY
+          # RUNNING tenants keep their current image until recreated — that is
+          # deliberate, since restarting them interrupts live agent work.
+          if [ "${REFRESH_ALL}" = "true" ]; then
+            echo "Restarting all running tenants onto the new image (requested)..."
+            kubectl rollout restart statefulset -A -l app=opencompany
+          else
+            echo "Running tenants keep their current image; re-run with refresh_all_tenants=true to roll them."
+          fi
+
+          kubectl -n "${K8S_NAMESPACE}" get deploy "${MANAGER_DEPLOY}" \
+            -o jsonpath='{range .spec.template.spec.containers[0].env[?(@.name=="OCM_TENANT_IMAGE")]}OCM_TENANT_IMAGE={.value}{"\n"}{end}'
+          EOF


### PR DESCRIPTION
## Summary

This repo owns the tenant workload, so it should own the tenant image. Adds `deploy-staging.yml`: build → push `opencompany-tenant` to ECR → point the manager's `OCM_TENANT_IMAGE` at the immutable `staging-<sha>` tag.

Companion PR: `tinyhumansai/opencompany-microservice#7` — that repo drops the tenant build and keeps only its own manager image.

## API Or Behavior Changes

None in the crate. This is CI only. Two operational behaviours worth stating explicitly:

- **New and woken tenants** boot on the new image as soon as `OCM_TENANT_IMAGE` moves.
- **Already-running tenants keep their current image** until recreated. That is deliberate — restarting them interrupts live agent work. `workflow_dispatch` exposes `refresh_all_tenants` to roll them all when you actually want that.

`TENANT_FEATURES` is carried over verbatim from the pipeline this replaces (`mongodb,openhuman,openhuman-rpc,tinyplace,github,smtp,dns,tinyhumans,webhooks,platform-jwt,export`). Nothing is added or removed, so the shipped feature set is unchanged. Editing that list is a product change, not a CI tweak, and the workflow says so.

## Problem

The tenant image was built from the platform superproject, which cloned this repo as a submodule and rebuilt on pointer movement. Two consequences:

1. **A change here shipped only when that repo's cron noticed** — this repo had no deploy path of its own.
2. **It had not shipped anything since 2026-07-20.** That pipeline's checkout passes `token: ${{ secrets.SUBMODULES_PAT }}`, the secret was never set, and every scheduled run failed with `Input required and not supplied: token`.

The PAT existed because the superproject cloned `backend` and `tinyhuman-landing` (both private) purely to sync their submodule pointers — neither is compiled by any build. Everything the tenant image actually compiles is public: this repo, `openhuman`, and openhuman's nested vendor crates. So building here needs **no** cross-repo token; the default `GITHUB_TOKEN` clones the whole graph.

## Tests

- `deploy-staging.yml` parses as valid YAML.
- Verified against the live staging cluster (read-only) that the target objects match what the workflow assumes: namespace `opencompany-system`, deployment `opencompany-manager`, ECR pull via the `ecr-creds` `dockerconfigjson` Secret, and tenant StatefulSets labelled `app=opencompany`.
- The build itself is unchanged from what the superproject ran — same `Dockerfile`, same `FEATURES`, same context — so this is a relocation of a working build rather than a new one.
- **Not exercised end to end** until the prerequisites below exist. First push to `main` is the real test; `workflow_dispatch` allows a deliberate trigger.

## Documentation

The workflow header documents the one-repo-one-image split, the required secrets, and why no PAT is needed. Deployment semantics (immutable tags, pull-secret refresh, tenant-restart policy) are documented in the inline comments at the point they matter, and in the companion PR's `deploy/ci/README.md`.

## Notes for review

**The submodule fetch is path-limited on purpose:**

```
git submodule update --init --recursive vendor/openhuman vendor/tinyagents
```

Recursing from the repo root would also pull openhuman's desktop-only submodules — `tauri-cef` is a heavy CEF checkout, and `tauri-plugin-notification` — which no server build compiles. Both are needed by `--features openhuman` only insofar as cargo must read the manifests behind `[patch.crates-io]`, which this covers.

**SSH rather than a kubeconfig** matches `tinyhumansai/backend` and is load-bearing: the kubelet's ECR pull secret expires after 12h and is refreshed by `/usr/local/bin/ecr-refresh.sh` **on the node**, which cannot be invoked through the Kubernetes API.

**Immutable tag, not `:staging`.** Tenant pods pin `imagePullPolicy: IfNotPresent`, so re-pushing a moving tag is silently ignored. The manager is pointed at `staging-<sha>`; `:staging` is a convenience alias only.

## Prerequisites (blocking — repo/AWS admin)

| What | Where |
|---|---|
| `AWS_ROLE_ARN` secret | this repo |
| OIDC trust policy updated to allow `repo:tinyhumansai/opencompany:*` | AWS |
| `SSH_PRIVATE_KEY`, `SSH_HOST` secrets | this repo |

If those secrets live in a GitHub Environment rather than at repo level, the job needs a matching `environment:` key — say so and I will add it.

## Related

- Companion: `tinyhumansai/opencompany-microservice#7`.
- Best landed together: #7 removes the old tenant pipeline, this adds the replacement.
