### PR TITLE
fix(workflows): persist created graph bodies through the store, not the read-only source tree (#168)

### DIFF
--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -93,6 +93,17 @@ construction, ≥1 response per cycle) are inherited, not re-verified.
 
 Durable company records: charter, roster, ledger, approval queue.
 
+The record also carries the **operator overlays** — teammates, desk members,
+desk order, operator-created desks, and (issue #168) `overlay_workflows`: the
+workflow graph bodies authored at runtime through the console's create dialog or
+the orchestrator's `create_workflow` tool. These are persisted here rather than
+written into `companies/<name>/workflows/<id>.toml` because the company source
+tree is the version-controlled seed and, in hosted mode, a read-only crate mount
+(writing there failed every hosted tenant with `EROFS`). Every reader unions the
+two sources — `load_workflow_union` / `list_workflows_union` in
+`src/company/workflow_file.rs` — with the committed seed file winning on an id
+collision, matching the manifest-first convention the desk resolvers use.
+
 ```rust
 // src/ports/store.rs
 pub trait CompanyStore: Send + Sync {

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -90,6 +90,7 @@ async fn main() -> anyhow::Result<()> {
         overlay_desk_members: Vec::new(),
         overlay_desk_order: Vec::new(),
         overlay_desks: Vec::new(),
+        overlay_workflows: Vec::new(),
         template_provenance: None,
     };
 

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -93,11 +93,12 @@ export function runWorkflow(
 }
 
 /**
- * Authors a new workflow graph (issue #69): the console's form creator posts
- * the same shape `getWorkflow` returns, and the host writes it to
- * `workflows/{id}.toml`. Rejections carry a prosumer-language `ApiError`
- * message (bad id, duplicate id, an edge or `agent` node the graph can't
- * support, no writable source directory on this deployment).
+ * Authors a new workflow graph (issues #69, #168): the console's form creator
+ * posts the same shape `getWorkflow` returns, and the host persists it on the
+ * company record — so this works on every deployment, including a hosted tenant
+ * whose company source tree is a read-only mount. Rejections carry a
+ * prosumer-language `ApiError` message (bad id, duplicate id or name, an edge or
+ * `agent` node the graph can't support).
  */
 export function createWorkflow(
   client: OpenCompanyClient,

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -30,7 +30,6 @@ pub mod steer;
 pub mod task_intent;
 pub mod telegram;
 mod types;
-#[cfg(feature = "openhuman")]
 mod workflow_create;
 mod workflow_file;
 pub mod workspace_seed;
@@ -49,7 +48,8 @@ pub use types::{
 };
 pub use workflow_file::{
     WORKFLOW_NODE_KINDS, WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef, WorkflowNodeKind,
-    WorkflowRetryDef, list_source_workflows, load_company_workflows, parse_workflow,
+    WorkflowRetryDef, list_source_workflows, list_workflows_union, load_company_workflows,
+    load_workflow_union, parse_workflow,
 };
 // Crate-internal only: the workflow creator (issue #69) builds a `RawWorkflow`
 // from its request body, renders it to TOML, and re-parses it through
@@ -57,7 +57,8 @@ pub use workflow_file::{
 pub(crate) use workflow_file::{RawEdge, RawNode, RawWorkflow, render_workflow};
 // Crate-internal only: the shared validated-persist core (issue #112) both the
 // REST `POST …/workflows` route and the orchestrator `create_workflow` tool run.
-#[cfg(feature = "openhuman")]
+// Ungated: the REST route is in the default build, so gating this behind
+// `openhuman` is what let the two surfaces drift apart (issue #168).
 pub(crate) use workflow_create::create_company_workflow;
 pub use workspace_seed::{NodeKind, SeedNode, extract_wikilinks, walk_workspace};
 

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -1,54 +1,64 @@
 //! Feature-free core for authoring a new workflow graph (issue #112).
 //!
 //! [`create_company_workflow`] is the single validated-persist sequence for
-//! creating a `workflows/<id>.toml`, lifted out of the REST handler so **both**
-//! the console's `POST …/workflows` route and the orchestrator's
-//! `create_workflow` tool run exactly the same checks and land the exact same
-//! artifact — no create-vs-run drift, one place to reason about safety.
+//! creating a workflow graph, shared by **both** the console's
+//! `POST …/workflows` route and the orchestrator's `create_workflow` tool so
+//! they run exactly the same checks and land the exact same artifact — no
+//! create-vs-run drift, one place to reason about safety.
+//!
+//! The graph body is persisted **on the company record** as an
+//! [`OverlayWorkflow`], never written into the company source tree. The source
+//! tree is the version-controlled seed and, in hosted mode, a read-only crate
+//! mount — writing there failed every hosted tenant with `EROFS` (issue #168).
+//! Readers union the two sources via
+//! [`load_workflow_union`](crate::company::load_workflow_union), with the seed
+//! file winning on an id collision.
 //!
 //! The sequence, in order, each step an actionable error before anything is
-//! written:
+//! persisted:
 //!
-//! 1. the id is a safe filename (no slashes / `..`) and within length caps;
+//! 1. the id is a safe filename stem (no slashes / `..`) and within length caps
+//!    — it is still an id a seed file could carry, so the two sources stay
+//!    interchangeable;
 //! 2. the graph is within the node/edge size caps (a runaway graph can't be
 //!    persisted);
 //! 3. it names exactly one `trigger` (a freshly authored graph must say what
 //!    starts it — stricter than [`parse_workflow`], which allows many);
 //! 4. every `agent` node names a real roster teammate (manifest ∪ overlay);
-//! 5. its display name is unique (case-insensitive) against the company's
-//!    existing on-disk + manifest-enabled workflows;
-//! 6. the rendered TOML re-parses through [`parse_workflow`] (the same
-//!    structural validation a hand-authored file passes) and is within the
-//!    byte cap;
-//! 7. the file is written atomically (`create_new(true)` → a duplicate id is a
-//!    [`Conflict`](OpenCompanyError::Conflict), closing the TOCTOU gap);
-//! 8. the id is recorded as enabled on the operator's live record (the
-//!    version-controlled manifest is never rewritten — the team-overlay
-//!    convention); a store-save failure rolls the file back so the id isn't
-//!    orphaned;
+//! 5. its id is unique against the company's seed ids ∪ overlay ids ∪
+//!    manifest-enabled ids (a [`Conflict`](OpenCompanyError::Conflict));
+//! 6. its display name is unique (case-insensitive) against the company's
+//!    existing seed + overlay + manifest-enabled workflows;
+//! 7. the rendered TOML re-parses through [`parse_workflow`] (the same
+//!    structural validation a hand-authored file passes) and is within the byte
+//!    cap;
+//! 8. the body **and** the enabled id are pushed onto the record and persisted
+//!    in **one** [`save`](CompanyStore::save) — a single atomic write, so there
+//!    is no half-created state to roll back;
 //! 9. a best-effort [`WorkflowCreated`](CompanyEvent::WorkflowCreated) audit
 //!    event is journaled — never rolling the create back if the journal fails.
 //!
 //! Steps 4–8 run under the per-company [`company_write_lock`] so a concurrent
 //! `create_workflow` (tool) and `POST …/workflows` (REST) can never clobber
 //! each other's `overlay`/`enabled` write, the same primitive `add_agent` uses.
+//! That lock is what makes the id-uniqueness check of step 5 atomic now that
+//! the filesystem's `create_new(true)` no longer serializes the two surfaces.
 //!
 //! Compiled in the default build (no harness imports) so the REST route reaches
 //! it without any feature gate.
 
 use std::collections::HashSet;
-use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
 
 use crate::company::{
-    RawWorkflow, WorkflowFile, load_company_workflows, parse_workflow, render_workflow,
+    RawWorkflow, WorkflowFile, list_workflows_union, parse_workflow, render_workflow,
 };
 use crate::error::{OpenCompanyError, Result};
 use crate::ports::CompanyStore;
 use crate::ports::events::EventLog;
 use crate::ports::store::company_write_lock;
-use crate::ports::types::{CompanyEvent, CompanyId};
+use crate::ports::types::{CompanyEvent, CompanyId, OverlayWorkflow};
 use crate::server::ops::language;
 
 /// Max nodes a freshly authored graph may declare. A larger graph is refused
@@ -65,21 +75,24 @@ pub(crate) const MAX_WORKFLOW_ID_LEN: usize = 64;
 pub(crate) const MAX_WORKFLOW_NAME_LEN: usize = 200;
 
 /// Authors and persists a new workflow graph for `company`, returning the
-/// parsed [`WorkflowFile`] exactly as [`load_company_workflows`] would hand it
+/// parsed [`WorkflowFile`] exactly as
+/// [`load_workflow_union`](crate::company::load_workflow_union) would hand it
 /// to the runner (so what a caller reads back and what runs are identical).
 ///
-/// `source_dir` is the company source directory (`companies/<name>`) whose
-/// `workflows/` subtree the graph lands in — the caller supplies it (both
-/// surfaces refuse a deployment with no source directory before calling here,
-/// with [`language::WORKFLOW_NEEDS_SOURCE_DIR`]). `events` is the company event
-/// log for the best-effort audit journal; pass `None` to skip journaling.
+/// The body is persisted on the company record, so this works on a deployment
+/// with **no** source directory at all — the hosted case that used to be
+/// refused outright and then failed with `EROFS` anyway (issue #168).
+/// `source_dir` is the company source directory (`companies/<name>`) when one
+/// exists, read-only here: its `workflows/` subtree contributes the seed ids and
+/// names the uniqueness checks guard against. `events` is the company event log
+/// for the best-effort audit journal; pass `None` to skip journaling.
 ///
 /// Errors map to the same HTTP statuses the REST route always returned:
 /// [`InvalidRequest`](OpenCompanyError::InvalidRequest) → 400,
 /// [`Conflict`](OpenCompanyError::Conflict) → 409.
 pub(crate) async fn create_company_workflow(
     company: &CompanyId,
-    source_dir: &Path,
+    source_dir: Option<&Path>,
     store: &Arc<dyn CompanyStore>,
     events: Option<&Arc<dyn EventLog>>,
     draft: RawWorkflow,
@@ -125,9 +138,9 @@ pub(crate) async fn create_company_workflow(
     }
 
     // --- Serialized write section -------------------------------------------
-    // Load record → roster check → name uniqueness → file write → save record
-    // all under the per-company write lock, so a concurrent create/add_agent
-    // can never clobber the record's `enabled`/`overlay` write.
+    // Load record → roster check → id/name uniqueness → save record all under
+    // the per-company write lock, so a concurrent create/add_agent can never
+    // clobber the record's `enabled`/`overlay` write.
     let write_lock = company_write_lock(company);
     let _lock = write_lock.lock().await;
 
@@ -167,11 +180,41 @@ pub(crate) async fn create_company_workflow(
         }
     }
 
+    // Id uniqueness against every id this company already answers for: the seed
+    // files, the record's overlay bodies, and the manifest-enabled ids. The
+    // write lock held above is what makes this atomic — it replaces the
+    // filesystem `create_new(true)` that used to serialize the two surfaces.
+    // The seed side is checked by path rather than by scanning: a *malformed*
+    // seed file still owns its id (it would shadow the overlay body on read),
+    // and a scan would silently skip it.
+    let seed_file_exists = source_dir.is_some_and(|dir| {
+        dir.join("workflows")
+            .join(format!("{}.toml", draft.id))
+            .is_file()
+    });
+    let id_taken = seed_file_exists
+        || record.overlay_workflows.iter().any(|w| w.id == draft.id)
+        || record
+            .manifest
+            .workflows
+            .enabled
+            .iter()
+            .any(|id| id == &draft.id);
+    if id_taken {
+        return Err(OpenCompanyError::Conflict(format!(
+            "A workflow with id `{}` already exists. Pick a different id.",
+            draft.id
+        )));
+    }
+
     // Case-insensitive display-name uniqueness against the company's existing
-    // workflows (on-disk ∪ manifest-enabled). Id uniqueness stays atomic via
-    // `create_new(true)` below — this only guards two *differently-id'd*
-    // workflows sharing one indistinguishable name in the picker.
-    let existing_names = existing_workflow_names(source_dir, &record.manifest.workflows.enabled);
+    // workflows (seed ∪ overlay ∪ manifest-enabled), so two differently-id'd
+    // workflows can't share one indistinguishable name in the picker.
+    let existing_names = existing_workflow_names(
+        source_dir,
+        &record.overlay_workflows,
+        &record.manifest.workflows.enabled,
+    );
     if existing_names.contains(&draft.name.trim().to_ascii_lowercase()) {
         return Err(OpenCompanyError::Conflict(format!(
             "A workflow named `{}` already exists. Pick a different name.",
@@ -198,60 +241,25 @@ pub(crate) async fn create_company_workflow(
         other => other,
     })?;
 
-    let workflows_dir = source_dir.join("workflows");
-    let path = workflows_dir.join(format!("{}.toml", file.id));
-    std::fs::create_dir_all(&workflows_dir).map_err(|source| OpenCompanyError::StoreIo {
-        path: workflows_dir.clone(),
-        source,
-    })?;
-
-    // Write atomically: `create_new(true)` fails if the path already exists,
-    // closing the TOCTOU gap between a separate existence check and the write —
-    // a duplicate id is a clean `Conflict` (409). Clean the empty file up on a
-    // write failure so the id isn't permanently blocked.
-    let mut wf_file = std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&path)
-        .map_err(|e| match e.kind() {
-            std::io::ErrorKind::AlreadyExists => OpenCompanyError::Conflict(format!(
-                "A workflow with id `{}` already exists. Pick a different id.",
-                file.id
-            )),
-            _ => OpenCompanyError::StoreIo {
-                path: path.clone(),
-                source: e,
-            },
-        })?;
-    wf_file.write_all(toml_src.as_bytes()).map_err(|source| {
-        let _ = std::fs::remove_file(&path);
-        OpenCompanyError::StoreIo {
-            path: path.clone(),
-            source,
-        }
-    })?;
-    drop(wf_file);
-
-    // Record the id as enabled on the live record — mirrors the team overlay:
-    // the version-controlled `company.toml` on disk is never rewritten. Save
-    // **after** the file lands; on a save failure remove the file we wrote so a
-    // retry can succeed without admin intervention.
-    let save_result = if record
+    // Persist the graph body and the enabled id in ONE save. Both live on the
+    // record, so there is no file-then-record window to roll back: the save
+    // either lands both or neither. The version-controlled `company.toml` on
+    // disk is never rewritten — the same team-overlay convention `add_agent`
+    // follows.
+    record.overlay_workflows.push(OverlayWorkflow {
+        id: file.id.clone(),
+        toml: toml_src,
+    });
+    if !record
         .manifest
         .workflows
         .enabled
         .iter()
         .any(|e| e == &file.id)
     {
-        Ok(())
-    } else {
         record.manifest.workflows.enabled.push(file.id.clone());
-        store.save(&record).await
-    };
-    if let Err(e) = save_result {
-        let _ = std::fs::remove_file(&path);
-        return Err(e);
     }
+    store.save(&record).await?;
 
     // Drop the write lock before journaling: the audit event is best-effort and
     // never gates the create, so it needn't hold the serialization lock.
@@ -282,47 +290,35 @@ pub(crate) async fn create_company_workflow(
     Ok(file)
 }
 
-/// The set of existing workflow display names (trimmed, lowercased) for
-/// `source_dir`'s company: every successfully-loaded on-disk `workflows/*.toml`
-/// name, unioned with the id-as-name fallback for each manifest-`enabled` id
-/// that has no loadable file — mirroring how `list_workflows` names the same
-/// set. A malformed on-disk file contributes no name (it's skipped, same as the
-/// picker), so it can't false-positive a conflict.
-fn existing_workflow_names(source_dir: &Path, enabled: &[String]) -> HashSet<String> {
+/// The set of existing workflow display names (trimmed, lowercased) for a
+/// company: every graph the union read path can serve — the seed
+/// `workflows/*.toml` files and the record's overlay bodies — plus the
+/// id-as-name fallback for each manifest-`enabled` id that has neither, exactly
+/// how `list_workflows` names the same set. A malformed graph contributes no
+/// name (it's skipped, same as the picker), so it can't false-positive a
+/// conflict; an absent or unreadable source tree simply degrades to overlay ∪
+/// enabled.
+fn existing_workflow_names(
+    source_dir: Option<&Path>,
+    overlays: &[OverlayWorkflow],
+    enabled: &[String],
+) -> HashSet<String> {
     let mut names = HashSet::new();
     let mut seen_ids = HashSet::new();
 
-    if let Ok(entries) = std::fs::read_dir(source_dir.join("workflows")) {
-        let ids: Vec<String> = entries
-            .filter_map(|entry| entry.ok())
-            .map(|entry| entry.path())
-            .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("toml"))
-            .filter_map(|path| {
-                path.file_stem()
-                    .and_then(|stem| stem.to_str())
-                    .map(str::to_string)
-            })
-            .collect();
-        for id in ids {
-            match load_company_workflows(source_dir, std::slice::from_ref(&id)) {
-                Ok(mut files) => {
-                    if let Some(file) = files.pop() {
-                        names.insert(file.name.trim().to_ascii_lowercase());
-                        seen_ids.insert(file.id);
-                    }
-                }
-                // A malformed file skips only its own name (same tolerance the
-                // picker has); still mark the id seen so the enabled-fallback
-                // below doesn't re-add it as an id-named entry.
-                Err(_) => {
-                    seen_ids.insert(id);
-                }
-            }
-        }
+    for file in list_workflows_union(source_dir, overlays) {
+        names.insert(file.name.trim().to_ascii_lowercase());
+        seen_ids.insert(file.id);
+    }
+    // A malformed graph is skipped by the union scan above but still owns its
+    // id, so mark those seen too — otherwise the enabled-fallback below would
+    // re-add them as id-named entries.
+    for overlay in overlays {
+        seen_ids.insert(overlay.id.clone());
     }
 
-    // Manifest-enabled ids with no loadable on-disk file fall back to the id as
-    // their display name (what `list_workflows` shows), so a new workflow can't
+    // Manifest-enabled ids with no loadable graph fall back to the id as their
+    // display name (what `list_workflows` shows), so a new workflow can't
     // collide with that fallback name either.
     for id in enabled {
         if !seen_ids.contains(id) {
@@ -346,7 +342,7 @@ mod tests {
     use super::*;
     use std::sync::Mutex as StdMutex;
 
-    use crate::company::{CompanyManifest, RawEdge, RawNode};
+    use crate::company::{CompanyManifest, RawEdge, RawNode, load_workflow_union};
     use crate::ports::types::{CompanyRecord, CompanySummary, EventSeq, LedgerEntry, StoredEvent};
     use async_trait::async_trait;
     use futures::stream::{self, BoxStream};
@@ -425,6 +421,23 @@ mod tests {
 
     // --- fixtures ------------------------------------------------------------
 
+    /// A committed seed graph, id `seeded` / name `Seeded flow`.
+    const SEED_TOML: &str = r#"
+id = "seeded"
+name = "Seeded flow"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+[[edge]]
+from = "start"
+to = "done"
+"#;
+
     /// A manifest with an `assistant` roster agent so `agent`-node graphs pass
     /// the roster check.
     fn manifest_with_assistant() -> CompanyManifest {
@@ -444,6 +457,7 @@ mod tests {
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         }
     }
@@ -523,7 +537,7 @@ mod tests {
 
         let file = create_company_workflow(
             &company,
-            dir.path(),
+            Some(dir.path()),
             &store,
             Some(&log_dyn),
             valid_draft("greeter", "Greeter"),
@@ -534,19 +548,26 @@ mod tests {
         assert_eq!(file.id, "greeter");
         assert_eq!(file.nodes.len(), 3);
 
-        // File landed and re-loads to exactly what we returned (contract).
-        let reloaded = load_company_workflows(dir.path(), std::slice::from_ref(&file.id))
+        // The body landed on the RECORD, not in the (read-only in hosted mode)
+        // source tree — the whole point of #168.
+        let record = store.load(&company).await.unwrap().unwrap();
+        assert_eq!(record.overlay_workflows.len(), 1);
+        assert_eq!(record.overlay_workflows[0].id, "greeter");
+        assert!(
+            !dir.path().join("workflows").exists(),
+            "creation must not write into the company source tree"
+        );
+
+        // The persisted body re-loads to exactly what we returned (contract).
+        let reloaded = load_workflow_union(Some(dir.path()), &record.overlay_workflows, &file.id)
             .expect("reloads")
-            .into_iter()
-            .next()
             .expect("one file");
         assert_eq!(
             reloaded, file,
-            "returned WorkflowFile must equal the on-disk load"
+            "returned WorkflowFile must equal what the union read path serves"
         );
 
         // Enabled on the record.
-        let record = store.load(&company).await.unwrap().unwrap();
         assert!(
             record
                 .manifest
@@ -574,6 +595,7 @@ mod tests {
 
     // --- guardrail failures --------------------------------------------------
 
+    /// A second create with the same id collides against the record's overlay.
     #[tokio::test]
     async fn duplicate_id_is_conflict() {
         let dir = tempfile::tempdir().unwrap();
@@ -585,7 +607,7 @@ mod tests {
 
         create_company_workflow(
             &company,
-            dir.path(),
+            Some(dir.path()),
             &store,
             None,
             valid_draft("dup", "First"),
@@ -594,7 +616,7 @@ mod tests {
         .expect("first create");
         let err = create_company_workflow(
             &company,
-            dir.path(),
+            Some(dir.path()),
             &store,
             None,
             valid_draft("dup", "Second name"),
@@ -615,7 +637,7 @@ mod tests {
 
         create_company_workflow(
             &company,
-            dir.path(),
+            Some(dir.path()),
             &store,
             None,
             valid_draft("one", "Greeter"),
@@ -624,7 +646,7 @@ mod tests {
         .expect("first");
         let err = create_company_workflow(
             &company,
-            dir.path(),
+            Some(dir.path()),
             &store,
             None,
             valid_draft("two", "  GREETER  "),
@@ -645,7 +667,7 @@ mod tests {
         let mut draft = valid_draft("wf", "WF");
         draft.nodes[1].agent = Some("ghost".to_string());
 
-        let err = create_company_workflow(&company, dir.path(), &store, None, draft)
+        let err = create_company_workflow(&company, Some(dir.path()), &store, None, draft)
             .await
             .expect_err("unknown teammate");
         assert!(
@@ -666,7 +688,7 @@ mod tests {
         let mut draft = valid_draft("wf", "WF");
         draft.nodes[1].agent = None;
 
-        let err = create_company_workflow(&company, dir.path(), &store, None, draft)
+        let err = create_company_workflow(&company, Some(dir.path()), &store, None, draft)
             .await
             .expect_err("agent node with no teammate");
         assert!(
@@ -687,7 +709,7 @@ mod tests {
         // Zero triggers.
         let mut zero = valid_draft("z", "Z");
         zero.nodes[0].kind = "output".to_string();
-        let err = create_company_workflow(&company, dir.path(), &store, None, zero)
+        let err = create_company_workflow(&company, Some(dir.path()), &store, None, zero)
             .await
             .expect_err("no trigger");
         assert!(err.to_string().contains("exactly one `trigger`"), "{err}");
@@ -695,7 +717,7 @@ mod tests {
         // Two triggers.
         let mut two = valid_draft("t", "T");
         two.nodes[2].kind = "trigger".to_string();
-        let err = create_company_workflow(&company, dir.path(), &store, None, two)
+        let err = create_company_workflow(&company, Some(dir.path()), &store, None, two)
             .await
             .expect_err("two triggers");
         assert!(err.to_string().contains("exactly one `trigger`"), "{err}");
@@ -711,7 +733,7 @@ mod tests {
         )));
         let err = create_company_workflow(
             &company,
-            dir.path(),
+            Some(dir.path()),
             &store,
             None,
             valid_draft("../secrets", "Escape"),
@@ -747,7 +769,7 @@ mod tests {
             });
         }
         assert!(draft.nodes.len() > MAX_WORKFLOW_NODES);
-        let err = create_company_workflow(&company, dir.path(), &store, None, draft)
+        let err = create_company_workflow(&company, Some(dir.path()), &store, None, draft)
             .await
             .expect_err("too many nodes");
         assert!(err.to_string().contains("at most"), "{err}");
@@ -764,14 +786,17 @@ mod tests {
         // Stay within the node cap but blow the byte cap with a huge summary.
         let mut draft = valid_draft("fat", "Fat");
         draft.nodes[0].summary = Some("x".repeat(MAX_WORKFLOW_TOML_BYTES + 10));
-        let err = create_company_workflow(&company, dir.path(), &store, None, draft)
+        let err = create_company_workflow(&company, Some(dir.path()), &store, None, draft)
             .await
             .expect_err("too many bytes");
         assert!(err.to_string().contains("byte"), "{err}");
     }
 
+    /// The body and the enabled id land in ONE save, so a failing save leaves
+    /// the record exactly as it was — no orphaned body, no orphaned enabled id,
+    /// nothing to roll back. (Before #168 this needed a file-removal dance.)
     #[tokio::test]
-    async fn store_save_failure_rolls_the_file_back() {
+    async fn store_save_failure_leaves_the_record_unchanged() {
         let dir = tempfile::tempdir().unwrap();
         let company = CompanyId::new("acme");
         let store = store_of(MemStore::failing(record(
@@ -781,7 +806,7 @@ mod tests {
 
         let err = create_company_workflow(
             &company,
-            dir.path(),
+            Some(dir.path()),
             &store,
             None,
             valid_draft("rollback", "Rollback"),
@@ -793,9 +818,151 @@ mod tests {
             "{err:?}"
         );
 
-        // The file must have been removed so a retry can succeed.
-        let path = dir.path().join("workflows").join("rollback.toml");
-        assert!(!path.exists(), "the orphaned file must be cleaned up");
+        let record = store.load(&company).await.unwrap().unwrap();
+        assert!(record.overlay_workflows.is_empty(), "no orphaned body");
+        assert!(
+            record.manifest.workflows.enabled.is_empty(),
+            "no orphaned enabled id"
+        );
+        assert!(
+            !dir.path().join("workflows").join("rollback.toml").exists(),
+            "nothing was written to the source tree"
+        );
+    }
+
+    // --- #168: no source directory at all (the hosted case) ------------------
+
+    /// The direct #168 regression at the core level: a hosted tenant has no
+    /// source directory (its crate mount is read-only), and creation must still
+    /// succeed by persisting the body on the record.
+    #[tokio::test]
+    async fn creates_with_no_source_dir() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        let file = create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            valid_draft("hosted", "Hosted"),
+        )
+        .await
+        .expect("creates with no source dir");
+        assert_eq!(file.id, "hosted");
+
+        let record = store.load(&company).await.unwrap().unwrap();
+        assert_eq!(record.overlay_workflows.len(), 1);
+        assert_eq!(record.overlay_workflows[0].id, "hosted");
+        assert!(
+            record
+                .manifest
+                .workflows
+                .enabled
+                .contains(&"hosted".to_string())
+        );
+        // And it reads back as a full graph through the union path.
+        let loaded = load_workflow_union(None, &record.overlay_workflows, "hosted")
+            .expect("loads")
+            .expect("present");
+        assert_eq!(loaded, file);
+    }
+
+    /// An id already taken by a *seed* file is a 409 even though the new body
+    /// would live somewhere else entirely — the seed would shadow it on read.
+    #[tokio::test]
+    async fn id_colliding_with_a_seed_file_is_conflict() {
+        let dir = tempfile::tempdir().unwrap();
+        let workflows = dir.path().join("workflows");
+        std::fs::create_dir_all(&workflows).unwrap();
+        std::fs::write(workflows.join("seeded.toml"), SEED_TOML).unwrap();
+
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let err = create_company_workflow(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            valid_draft("seeded", "Different name"),
+        )
+        .await
+        .expect_err("id is taken by a seed file");
+        assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
+        assert!(err.to_string().contains("seeded"), "{err}");
+    }
+
+    /// A *name* already used by a seed file collides too — the picker would show
+    /// two indistinguishable entries.
+    #[tokio::test]
+    async fn name_colliding_with_a_seed_file_is_conflict() {
+        let dir = tempfile::tempdir().unwrap();
+        let workflows = dir.path().join("workflows");
+        std::fs::create_dir_all(&workflows).unwrap();
+        std::fs::write(workflows.join("seeded.toml"), SEED_TOML).unwrap();
+
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let err = create_company_workflow(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            valid_draft("other", "  seeded FLOW  "),
+        )
+        .await
+        .expect_err("name collides with the seed file's name");
+        assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
+    }
+
+    /// With no source tree at all, the name guard still works — it degrades to
+    /// overlay ∪ enabled rather than erroring or silently allowing duplicates.
+    #[tokio::test]
+    async fn name_guard_works_without_a_source_tree() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        create_company_workflow(&company, None, &store, None, valid_draft("one", "Greeter"))
+            .await
+            .expect("first");
+        let err =
+            create_company_workflow(&company, None, &store, None, valid_draft("two", "GREETER"))
+                .await
+                .expect_err("name collides with the overlay body");
+        assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
+    }
+
+    /// A manifest-`enabled` id with no body in either source is shown by the
+    /// picker under its id, so a new workflow can't take that name either.
+    #[tokio::test]
+    async fn name_collides_with_a_bodiless_enabled_id() {
+        let company = CompanyId::new("acme");
+        let mut rec = record(&company, manifest_with_assistant());
+        rec.manifest.workflows.enabled.push("legacy".to_string());
+        let store = store_of(MemStore::seeded(rec));
+
+        let err = create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            valid_draft("new", "  LEGACY  "),
+        )
+        .await
+        .expect_err("name collides with the enabled-id fallback name");
+        assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
     }
 
     #[tokio::test]
@@ -803,10 +970,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let company = CompanyId::new("ghost");
         let store: Arc<dyn CompanyStore> = Arc::new(MemStore::default());
-        let err =
-            create_company_workflow(&company, dir.path(), &store, None, valid_draft("wf", "WF"))
-                .await
-                .expect_err("no record");
+        let err = create_company_workflow(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            valid_draft("wf", "WF"),
+        )
+        .await
+        .expect_err("no record");
         assert!(
             matches!(err, OpenCompanyError::CompanyNotFound(_)),
             "{err:?}"

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -374,6 +374,98 @@ pub fn list_source_workflows(source_dir: Option<&Path>) -> Vec<WorkflowFile> {
     files
 }
 
+/// Loads one workflow graph by id from the **union** of a company's two graph
+/// sources: the version-controlled seed file (`source_dir/workflows/<id>.toml`)
+/// and the record's runtime-authored [`OverlayWorkflow`] bodies.
+///
+/// This is the single read path for "give me graph `<id>`" — the REST
+/// `GET …/workflows/{wid}` and run routes, the GraphQL resolver, the
+/// orchestrator's `run_workflow` tool, and the `sub_workflow` resolver all go
+/// through it, so they can never disagree about which graphs exist.
+///
+/// **The seed file wins on an id collision.** An overlay body with the same id
+/// as a committed file is shadowed, not destroyed — it stays on the record and
+/// resurfaces if the file goes away. This matches the manifest-first convention
+/// [`CompanyRecord::effective_desk_members`](crate::ports::types::CompanyRecord::effective_desk_members)
+/// already uses: the version-controlled definition is authoritative.
+///
+/// `Ok(None)` means neither source has that id — the caller's clean 404. An
+/// `Err` means the body that *was* found is malformed (the same error a
+/// hand-authored file would give).
+pub fn load_workflow_union(
+    source_dir: Option<&Path>,
+    overlays: &[crate::ports::types::OverlayWorkflow],
+    id: &str,
+) -> Result<Option<WorkflowFile>> {
+    if let Some(dir) = source_dir {
+        let path = dir.join("workflows").join(format!("{id}.toml"));
+        // Only load ids that exist on disk, so a missing file falls through to
+        // the overlay rather than becoming a `DataRead` error.
+        if path.is_file() {
+            let ids = [id.to_string()];
+            return load_company_workflows(dir, &ids).map(|mut files| files.pop());
+        }
+    }
+
+    let Some(overlay) = overlays.iter().find(|w| w.id == id) else {
+        return Ok(None);
+    };
+    // Re-label parse/validation errors with the id, matching how the on-disk
+    // loader re-labels them with the real path.
+    let labelled = PathBuf::from(format!("{id}.toml"));
+    match parse_workflow(&overlay.toml) {
+        Ok(workflow) => Ok(Some(workflow)),
+        Err(OpenCompanyError::DataInvalid { problems, .. }) => Err(OpenCompanyError::DataInvalid {
+            path: labelled,
+            problems,
+        }),
+        Err(OpenCompanyError::DataParse { message, .. }) => Err(OpenCompanyError::DataParse {
+            path: labelled,
+            message,
+        }),
+        Err(other) => Err(other),
+    }
+}
+
+/// Every workflow graph a company has, from the **union** of its seed
+/// `workflows/*.toml` files and its runtime-authored
+/// [`OverlayWorkflow`](crate::ports::types::OverlayWorkflow) bodies.
+///
+/// The seed scan comes first (in stable id order, via
+/// [`list_source_workflows`]), then overlay graphs the scan did not already
+/// yield, in stable id order — so a seed file **wins** over an overlay of the
+/// same id, the same precedence [`load_workflow_union`] applies. A malformed
+/// overlay body skips only itself (logged), the same tolerance the seed scan
+/// has, so one bad graph never hides the rest.
+pub fn list_workflows_union(
+    source_dir: Option<&Path>,
+    overlays: &[crate::ports::types::OverlayWorkflow],
+) -> Vec<WorkflowFile> {
+    let mut files = list_source_workflows(source_dir);
+    let mut seen: std::collections::HashSet<String> = files.iter().map(|f| f.id.clone()).collect();
+
+    let mut extra: Vec<&crate::ports::types::OverlayWorkflow> = overlays
+        .iter()
+        .filter(|overlay| !seen.contains(&overlay.id))
+        .collect();
+    extra.sort_by(|a, b| a.id.cmp(&b.id));
+
+    for overlay in extra {
+        // Two overlay entries with the same id can only happen on a corrupted
+        // record; keep the first and skip the rest rather than double-listing.
+        if !seen.insert(overlay.id.clone()) {
+            continue;
+        }
+        match parse_workflow(&overlay.toml) {
+            Ok(file) => files.push(file),
+            Err(err) => {
+                tracing::warn!(workflow = %overlay.id, error = %err, "skipping malformed saved workflow")
+            }
+        }
+    }
+    files
+}
+
 /// Collects every validation problem in prosumer language. Empty means valid.
 fn validate(raw: &RawWorkflow) -> Vec<String> {
     let mut problems = Vec::new();
@@ -1276,5 +1368,157 @@ mod tests {
         assert!(start.on_error.is_none());
         assert!(start.retry.is_none());
         assert!(start.requires_approval.is_none());
+    }
+
+    // --- seed ∪ overlay union (issue #168) ----------------------------------
+
+    use crate::ports::types::OverlayWorkflow;
+
+    /// A minimal valid graph body with the given id and display name.
+    fn body(id: &str, name: &str) -> String {
+        format!(
+            r#"
+id = "{id}"
+name = "{name}"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+[[edge]]
+from = "start"
+to = "done"
+"#
+        )
+    }
+
+    fn overlay(id: &str, name: &str) -> OverlayWorkflow {
+        OverlayWorkflow {
+            id: id.to_string(),
+            toml: body(id, name),
+        }
+    }
+
+    /// Writes a seed graph to `<dir>/workflows/<id>.toml`.
+    fn seed(dir: &Path, id: &str, name: &str) {
+        let workflows = dir.join("workflows");
+        std::fs::create_dir_all(&workflows).unwrap();
+        std::fs::write(workflows.join(format!("{id}.toml")), body(id, name)).unwrap();
+    }
+
+    /// The hosted shape: no source directory at all, so the overlay is the only
+    /// source. This is the read half of the #168 fix.
+    #[test]
+    fn load_union_falls_back_to_the_overlay_with_no_source_dir() {
+        let overlays = vec![overlay("hosted", "Hosted flow")];
+        let file = load_workflow_union(None, &overlays, "hosted")
+            .expect("loads")
+            .expect("present");
+        assert_eq!(file.id, "hosted");
+        assert_eq!(file.name, "Hosted flow");
+        assert_eq!(file.nodes.len(), 2);
+    }
+
+    /// A source directory that simply has no file for the id also falls through.
+    #[test]
+    fn load_union_falls_back_when_the_seed_file_is_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        seed(dir.path(), "other", "Other");
+        let overlays = vec![overlay("mine", "Mine")];
+        let file = load_workflow_union(Some(dir.path()), &overlays, "mine")
+            .expect("loads")
+            .expect("present");
+        assert_eq!(file.name, "Mine");
+    }
+
+    /// Documented precedence: the committed seed file wins over an overlay body
+    /// with the same id. The overlay is shadowed, not destroyed.
+    #[test]
+    fn load_union_prefers_the_seed_file_on_an_id_collision() {
+        let dir = tempfile::tempdir().unwrap();
+        seed(dir.path(), "dup", "From seed");
+        let overlays = vec![overlay("dup", "From overlay")];
+        let file = load_workflow_union(Some(dir.path()), &overlays, "dup")
+            .expect("loads")
+            .expect("present");
+        assert_eq!(file.name, "From seed");
+    }
+
+    /// An id neither source has is `Ok(None)` — the caller's clean 404, not an
+    /// error.
+    #[test]
+    fn load_union_of_an_unknown_id_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        seed(dir.path(), "known", "Known");
+        assert!(
+            load_workflow_union(Some(dir.path()), &[], "ghost")
+                .expect("no error")
+                .is_none()
+        );
+        assert!(
+            load_workflow_union(None, &[], "ghost")
+                .expect("no error")
+                .is_none()
+        );
+    }
+
+    /// A malformed overlay body surfaces as an error labelled with its id — the
+    /// same shape a malformed on-disk file gets.
+    #[test]
+    fn load_union_of_a_malformed_overlay_is_an_error() {
+        let overlays = vec![OverlayWorkflow {
+            id: "broken".to_string(),
+            toml: "id = \"broken\"\nname = \"Broken\"\n".to_string(),
+        }];
+        let err = load_workflow_union(None, &overlays, "broken").unwrap_err();
+        assert!(err.to_string().contains("trigger"), "{err}");
+        assert!(err.to_string().contains("broken.toml"), "{err}");
+    }
+
+    /// The list union dedupes by id with the seed winning, and keeps a stable
+    /// order (seed scan first, then overlays by id).
+    #[test]
+    fn list_union_dedupes_with_source_winning() {
+        let dir = tempfile::tempdir().unwrap();
+        seed(dir.path(), "dup", "From seed");
+        seed(dir.path(), "aaa", "Seed A");
+        let overlays = vec![
+            overlay("zzz", "Overlay Z"),
+            overlay("dup", "From overlay"),
+            overlay("mmm", "Overlay M"),
+        ];
+        let files = list_workflows_union(Some(dir.path()), &overlays);
+        let ids: Vec<&str> = files.iter().map(|f| f.id.as_str()).collect();
+        assert_eq!(ids, vec!["aaa", "dup", "mmm", "zzz"]);
+        let dup = files.iter().find(|f| f.id == "dup").unwrap();
+        assert_eq!(dup.name, "From seed", "the seed file must win");
+    }
+
+    /// With no source directory, the list is exactly the overlay set.
+    #[test]
+    fn list_union_with_no_source_dir_is_the_overlay_set() {
+        let overlays = vec![overlay("b", "B"), overlay("a", "A")];
+        let files = list_workflows_union(None, &overlays);
+        let ids: Vec<&str> = files.iter().map(|f| f.id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "b"]);
+    }
+
+    /// One malformed overlay skips only itself — the same tolerance the seed
+    /// scan has, so a single bad graph never empties the picker.
+    #[test]
+    fn list_union_skips_a_malformed_overlay() {
+        let overlays = vec![
+            overlay("good", "Good"),
+            OverlayWorkflow {
+                id: "bad".to_string(),
+                toml: "id = \"bad\"\nname =".to_string(),
+            },
+        ];
+        let files = list_workflows_union(None, &overlays);
+        let ids: Vec<&str> = files.iter().map(|f| f.id.as_str()).collect();
+        assert_eq!(ids, vec!["good"]);
     }
 }

--- a/src/economy/adapter.rs
+++ b/src/economy/adapter.rs
@@ -348,6 +348,7 @@ mod test {
                 overlay_desk_members: Vec::new(),
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -903,6 +903,7 @@ description = "Runs Acme."
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         }
     }
@@ -1045,6 +1046,7 @@ description = "Builds it."
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         }
     }
@@ -1564,6 +1566,7 @@ members = ["engineer"]
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         }
     }
@@ -1704,6 +1707,7 @@ name = "Design"
             }],
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         };
         let (brain, _tasks) = brain_over(dir.path(), record);
@@ -1761,6 +1765,7 @@ members = ["eng1", "eng2"]
                 ordered: vec!["cto".to_string(), "eng1".to_string(), "eng2".to_string()],
             }],
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         };
         let (brain, _tasks) = brain_over(dir.path(), record);
@@ -1814,6 +1819,7 @@ members = ["eng1", "eng2"]
                 overlay_desk_members: Vec::new(),
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1498,6 +1498,7 @@ description = "Builds the product."
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         }
     }
@@ -2441,6 +2442,7 @@ description = "Sets direction."
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         }
     }

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -56,7 +56,7 @@ use oh::tools::traits::{PermissionLevel, Tool, ToolResult};
 
 use crate::company::{
     Agent as ManifestAgent, RawEdge, RawNode, RawWorkflow, WorkflowFile, create_company_workflow,
-    list_source_workflows, load_company_workflows,
+    list_workflows_union, load_workflow_union,
 };
 use crate::error::OpenCompanyError;
 use crate::harness::lifecycle::ReviewDecision;
@@ -366,14 +366,19 @@ impl Tool for QueryCompanyTool {
             None => None,
         };
 
-        // Saved workflows: the on-disk `workflows/*.toml` graphs (what
-        // `create_workflow` writes and the REST picker lists), unioned with the
-        // manifest's enabled ids so seed workflows show too. This is the section
+        // Saved workflows: the seed `workflows/*.toml` graphs unioned with the
+        // record's runtime-authored bodies (what `create_workflow` persists and
+        // the REST picker lists), then with the manifest's enabled ids so
+        // provisioned-but-bodiless workflows show too. This is the section
         // that makes "what workflows do we have?" answerable — before it, the
         // orchestrator had no way to enumerate saved workflows and would fall
         // back to its skills catalog.
+        let overlay_workflows = record
+            .as_ref()
+            .map(|r| r.overlay_workflows.clone())
+            .unwrap_or_default();
         let mut workflows: Vec<(String, String)> =
-            list_source_workflows(self.workflow_source_dir.as_deref())
+            list_workflows_union(self.workflow_source_dir.as_deref(), &overlay_workflows)
                 .into_iter()
                 .map(|f| (f.id, f.name))
                 .collect();
@@ -935,6 +940,7 @@ pub fn orchestrator_tools(
     tools.push(Box::new(RunWorkflowTool::new(
         company.clone(),
         workflow_source_dir.clone(),
+        store.clone(),
         workflow_runner,
     )));
     // `create_workflow` (issue #112) shares the same source dir the run tool
@@ -1005,21 +1011,27 @@ const ITEM_PREVIEW_CHARS: usize = 120;
 pub struct RunWorkflowTool {
     company: CompanyId,
     source_dir: Option<PathBuf>,
+    /// The company store, so the tool reads the record's runtime-authored graph
+    /// bodies — the only place a hosted tenant's workflows live (issue #168).
+    store: Arc<dyn CompanyStore>,
     runner: WorkflowRunnerHandle,
 }
 
 impl RunWorkflowTool {
     /// Builds the tool over the company id, its on-disk source directory
-    /// (`companies/<name>`, whose `workflows/` subtree holds the graphs), and the
+    /// (`companies/<name>`, whose `workflows/` subtree holds the seed graphs),
+    /// the company store (holding the runtime-authored graph bodies), and the
     /// shared runner handle.
     pub fn new(
         company: CompanyId,
         source_dir: Option<PathBuf>,
+        store: Arc<dyn CompanyStore>,
         runner: WorkflowRunnerHandle,
     ) -> Self {
         Self {
             company,
             source_dir,
+            store,
             runner,
         }
     }
@@ -1093,25 +1105,23 @@ impl Tool for RunWorkflowTool {
             ));
         };
 
-        // Load the saved graph from the company's on-disk source directory.
-        let Some(source_dir) = self.source_dir.as_deref() else {
-            tracing::debug!(company = %self.company, workflow = %wid, "run_workflow: no source dir");
-            return Ok(ToolResult::error(
-                "This company has no on-disk workflow definitions on this deployment, so there is nothing to run.",
-            ));
+        // Load the saved graph from the seed ∪ overlay union, so a workflow the
+        // console (or this agent) created on a hosted tenant runs the same as a
+        // committed one.
+        let overlays = match self.store.load(&self.company).await {
+            Ok(record) => record.map(|r| r.overlay_workflows).unwrap_or_default(),
+            Err(err) => {
+                tracing::debug!(company = %self.company, workflow = %wid, error = %err, "run_workflow: record load failed");
+                return Ok(ToolResult::error(format!(
+                    "Couldn't read this company's saved workflows: {err}"
+                )));
+            }
         };
-        // Mirror the REST run route: a missing file is a clean "unknown id"
-        // rather than a raw filesystem read error (which would also leak the
+        // Mirror the REST run route: an id neither source has is a clean
+        // "unknown id" rather than a raw read error (which would also leak the
         // on-disk path into agent-visible text).
-        let path = source_dir.join("workflows").join(format!("{wid}.toml"));
-        if !path.is_file() {
-            tracing::debug!(company = %self.company, workflow = %wid, "run_workflow: unknown id");
-            return Ok(ToolResult::error(format!(
-                "No workflow with id `{wid}` exists. Check the workflows list for valid ids."
-            )));
-        }
-        let file = match load_company_workflows(source_dir, std::slice::from_ref(&wid)) {
-            Ok(files) => files.into_iter().next(),
+        let file = match load_workflow_union(self.source_dir.as_deref(), &overlays, &wid) {
+            Ok(file) => file,
             Err(err) => {
                 tracing::debug!(company = %self.company, workflow = %wid, error = %err, "run_workflow: load failed");
                 return Ok(ToolResult::error(format!(
@@ -1438,18 +1448,13 @@ impl Tool for CreateWorkflowTool {
             }
         };
 
-        // A deployment with no source directory has nowhere to write the graph.
-        let Some(source_dir) = self.source_dir.as_deref() else {
-            tracing::debug!(company = %self.company, "create_workflow: no source dir");
-            return Ok(ToolResult::error(
-                "This company has no on-disk workflow definitions on this deployment, so there's nowhere to save a new workflow.",
-            ));
-        };
-
+        // No source directory is needed: the graph body is persisted on the
+        // company record, which is the only writable surface a hosted tenant has
+        // (issue #168).
         tracing::debug!(company = %self.company, workflow = %draft.id, "create_workflow: authoring");
         match create_company_workflow(
             &self.company,
-            source_dir,
+            self.source_dir.as_deref(),
             &self.store,
             self.events.as_ref(),
             draft,
@@ -1828,6 +1833,7 @@ name = "Morning"
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         }
     }
@@ -2041,6 +2047,7 @@ name = "Morning"
         let tool = RunWorkflowTool::new(
             CompanyId::new("acme"),
             Some(dir.path().to_path_buf()),
+            Arc::new(MemStore::default()),
             handle,
         );
         let result = tool
@@ -2071,6 +2078,7 @@ name = "Morning"
         let tool = RunWorkflowTool::new(
             CompanyId::new("acme"),
             Some(dir.path().to_path_buf()),
+            Arc::new(MemStore::default()),
             handle,
         );
         let result = tool
@@ -2091,6 +2099,7 @@ name = "Morning"
         let tool = RunWorkflowTool::new(
             CompanyId::new("acme"),
             Some(dir.path().to_path_buf()),
+            Arc::new(MemStore::default()),
             WorkflowRunnerHandle::default(),
         );
         let result = tool
@@ -2112,6 +2121,7 @@ name = "Morning"
         let tool = RunWorkflowTool::new(
             CompanyId::new("acme"),
             Some(dir.path().to_path_buf()),
+            Arc::new(MemStore::default()),
             handle,
         );
         let result = tool
@@ -2130,6 +2140,7 @@ name = "Morning"
         let tool = RunWorkflowTool::new(
             CompanyId::new("acme"),
             None,
+            Arc::new(MemStore::default()),
             WorkflowRunnerHandle::default(),
         );
         let result = tool.execute(json!({})).await.expect("execute");
@@ -2148,6 +2159,7 @@ name = "Morning"
         let tool = RunWorkflowTool::new(
             CompanyId::new("acme"),
             Some(std::path::PathBuf::from("/tmp")),
+            Arc::new(MemStore::default()),
             handle,
         );
         let result = tool
@@ -2175,6 +2187,7 @@ name = "Morning"
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         }
     }
@@ -2235,7 +2248,12 @@ name = "Morning"
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
-        let run = RunWorkflowTool::new(company.clone(), Some(dir.path().to_path_buf()), handle);
+        let run = RunWorkflowTool::new(
+            company.clone(),
+            Some(dir.path().to_path_buf()),
+            store.clone(),
+            handle,
+        );
         let result = run
             .execute(json!({ "id": "greeter" }))
             .await
@@ -2272,19 +2290,47 @@ name = "Morning"
         );
     }
 
+    /// Issue #168: a hosted tenant has no source directory, and the tool must
+    /// still create — the graph body is persisted on the record. It used to
+    /// refuse outright with "nowhere to save".
     #[tokio::test]
-    async fn create_workflow_tool_errors_without_source_dir() {
-        let store: Arc<dyn CompanyStore> = Arc::new(MemStore::default());
-        let tool = CreateWorkflowTool::new(CompanyId::new("acme"), None, store, None);
+    async fn create_workflow_tool_creates_without_source_dir() {
+        let company = CompanyId::new("acme");
+        let store: Arc<dyn CompanyStore> =
+            Arc::new(MemStore::seeded(record_with_assistant(&company)));
+        let tool = CreateWorkflowTool::new(company.clone(), None, store.clone(), None);
         let result = tool
-            .execute(json!({ "id": "x", "name": "X", "nodes": [] }))
+            .execute(json!({
+                "id": "hosted",
+                "name": "Hosted",
+                "nodes": [
+                    { "id": "start", "kind": "trigger", "name": "Start" },
+                    { "id": "done", "kind": "output", "name": "Done" }
+                ],
+                "edges": [ { "from": "start", "to": "done" } ]
+            }))
             .await
             .expect("execute");
-        assert!(result.is_error);
-        assert!(
-            result.output_for_llm(false).contains("nowhere to save"),
-            "{result:?}"
-        );
+        assert!(!result.is_error, "{result:?}");
+
+        let record = store.load(&company).await.unwrap().unwrap();
+        assert_eq!(record.overlay_workflows.len(), 1);
+        assert_eq!(record.overlay_workflows[0].id, "hosted");
+
+        // And it runs, with no source directory anywhere in the picture.
+        let runner: Arc<dyn WorkflowRunner> = Arc::new(StubRunner::new(WorkflowRun {
+            output: json!({ "nodes": { "done": { "items": ["ok"] } } }),
+            pending_approvals: Vec::new(),
+        }));
+        let handle = WorkflowRunnerHandle::default();
+        handle.set(&runner);
+        let run = RunWorkflowTool::new(company, None, store, handle);
+        let result = run
+            .execute(json!({ "id": "hosted" }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error, "run should succeed: {result:?}");
+        assert!(result.output_for_llm(true).contains("Hosted"), "{result:?}");
     }
 
     #[tokio::test]

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -1049,6 +1049,30 @@ pub struct OverlayDesk {
     pub members: Vec<String>,
 }
 
+/// A workflow graph body authored at runtime (the console's create dialog or
+/// the orchestrator's `create_workflow` tool) and persisted on the
+/// [`CompanyRecord`] rather than written into the company source tree.
+///
+/// The source tree (`companies/<name>/workflows/<id>.toml`) is the
+/// version-controlled seed and, in hosted mode, a **read-only** crate mount —
+/// writing a graph there fails with `EROFS` (issue #168). So a created graph
+/// lands here instead, next to the enabled id, and every reader unions the two
+/// sets (see [`load_workflow_union`](crate::company::load_workflow_union)).
+///
+/// The stored value is the **rendered TOML**, already validated at create time:
+/// readers re-parse it through
+/// [`parse_workflow`](crate::company::parse_workflow), so an overlay graph
+/// passes exactly the same validation an on-disk seed file does, with no second
+/// model shape to drift. Deliberately no `name` field — the name lives inside
+/// the TOML, one source of truth.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OverlayWorkflow {
+    /// The workflow id — what the seed file would be named (`<id>.toml`).
+    pub id: String,
+    /// The rendered, already-validated workflow graph TOML.
+    pub toml: String,
+}
+
 /// The operator overlays persisted as a single JSON blob by the string-column
 /// stores (sqlite + mongodb `overlay_json`). The filesystem store keeps the two
 /// collections as typed fields on its own `Meta` instead.
@@ -1071,6 +1095,11 @@ pub struct OverlayBlob {
     /// creation existed, so `#[serde(default)]` loads them as empty.
     #[serde(default)]
     pub desks: Vec<OverlayDesk>,
+    /// The operator-authored workflow graph bodies. Absent on rows written
+    /// before runtime workflow authoring persisted through the store, so
+    /// `#[serde(default)]` loads them as empty.
+    #[serde(default)]
+    pub workflows: Vec<OverlayWorkflow>,
     /// The source-template provenance recorded at launch. `None` for companies
     /// provisioned from a raw manifest and for legacy rows written before
     /// provenance existed (the `#[serde(default)]` keeps those rows loading).
@@ -1086,6 +1115,7 @@ impl OverlayBlob {
             desk_members: record.overlay_desk_members.clone(),
             desk_order: record.overlay_desk_order.clone(),
             desks: record.overlay_desks.clone(),
+            workflows: record.overlay_workflows.clone(),
             provenance: record.template_provenance.clone(),
         }
     }
@@ -1107,6 +1137,7 @@ impl OverlayBlob {
                     desk_members: Vec::new(),
                     desk_order: Vec::new(),
                     desks: Vec::new(),
+                    workflows: Vec::new(),
                     provenance: None,
                 })
                 .map_err(|_| original),
@@ -1142,6 +1173,14 @@ pub struct CompanyRecord {
     /// overlay). Merged with the manifest's `[[group_chat]]` desks at read time.
     #[serde(default)]
     pub overlay_desks: Vec<OverlayDesk>,
+    /// Workflow graphs authored at runtime (console create dialog / orchestrator
+    /// `create_workflow`), persisted here instead of in the company source tree —
+    /// which is read-only in hosted mode (issue #168). Unioned with the seed
+    /// `workflows/*.toml` files by every reader; the seed wins on an id
+    /// collision. The `#[serde(default)]` keeps records written before runtime
+    /// authoring persisted through the store loading without a migration.
+    #[serde(default)]
+    pub overlay_workflows: Vec<OverlayWorkflow>,
     /// Where this company's manifest was seeded from — the source template's
     /// stable identity, stamped once at launch and carried across rebuilds.
     /// `None` for companies provisioned from a raw manifest body. The
@@ -1929,6 +1968,7 @@ mod test {
             overlay_desk_members: overlay,
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         }
     }
@@ -2171,6 +2211,39 @@ mod test {
         let json = serde_json::to_string(&OverlayBlob::from_record(&record)).expect("serialize");
         let blob = OverlayBlob::parse(&json).expect("reparse");
         assert_eq!(blob.provenance, record.template_provenance);
+    }
+
+    /// Issue #168: a runtime-authored workflow body round-trips through the
+    /// `OverlayBlob` the sqlite/mongodb stores persist as `overlay_json`. On a
+    /// hosted tenant this blob is the ONLY copy of the graph, so a serialization
+    /// gap here would silently delete the workflow.
+    #[test]
+    fn overlay_blob_round_trips_workflows() {
+        let mut record = desk_record("[company]\nname = \"Acme\"\n", Vec::new());
+        record.overlay_workflows.push(OverlayWorkflow {
+            id: "greeter".to_string(),
+            toml: "id = \"greeter\"\nname = \"Greeter\"\n".to_string(),
+        });
+        let json = serde_json::to_string(&OverlayBlob::from_record(&record)).expect("serialize");
+        let blob = OverlayBlob::parse(&json).expect("reparse");
+        assert_eq!(blob.workflows, record.overlay_workflows);
+
+        // A row written before workflow bodies persisted (no `workflows` key)
+        // loads as empty — no migration needed.
+        let legacy = r#"{"agents":[],"desk_members":[]}"#;
+        assert!(
+            OverlayBlob::parse(legacy)
+                .expect("pre-workflows object")
+                .workflows
+                .is_empty()
+        );
+        // …and so does the legacy bare-array form.
+        assert!(
+            OverlayBlob::parse("[]")
+                .expect("legacy array")
+                .workflows
+                .is_empty()
+        );
     }
 
     /// An operator-created overlay desk resolves through the same

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -798,6 +798,13 @@ impl RuntimeBuilder {
             .as_ref()
             .map(|r| r.overlay_desks.clone())
             .unwrap_or_default();
+        // Issue #168: the runtime-authored workflow graph bodies. A rebuild that
+        // dropped these would delete every workflow the console created on a
+        // hosted tenant — they have no on-disk copy to fall back to.
+        let overlay_workflows = existing
+            .as_ref()
+            .map(|r| r.overlay_workflows.clone())
+            .unwrap_or_default();
         // Issue #85: carry an existing record's source-template provenance
         // forward across the rebuild (a rebuild never re-stamps it); on the very
         // first launch, stamp from the value the launch path recorded (a slug for
@@ -1020,6 +1027,7 @@ impl RuntimeBuilder {
                                 overlay_desk_members: overlay_desk_members.clone(),
                                 overlay_desk_order: overlay_desk_order.clone(),
                                 overlay_desks: overlay_desks.clone(),
+                                overlay_workflows: overlay_workflows.clone(),
                                 template_provenance: template_provenance.clone(),
                             };
                             // Workflow agent nodes execute on the same pool as the
@@ -1107,7 +1115,8 @@ impl RuntimeBuilder {
         // (before the brain was constructed, so the brain could be seeded from
         // them); a rebuild never rewrites the version-controlled manifest, and must
         // not drop the operator-added teammates, desk memberships, desk order,
-        // operator-created desks, or the source-template provenance either.
+        // operator-created desks, runtime-authored workflow graphs, or the
+        // source-template provenance either.
         store
             .save(&CompanyRecord {
                 id: id.clone(),
@@ -1118,6 +1127,7 @@ impl RuntimeBuilder {
                 overlay_desk_members,
                 overlay_desk_order,
                 overlay_desks,
+                overlay_workflows,
                 template_provenance,
             })
             .await?;
@@ -1968,6 +1978,7 @@ mod test {
                     ordered: vec!["eng2".to_string(), "eng1".to_string()],
                 }],
                 overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/graphql/company.rs
+++ b/src/server/graphql/company.rs
@@ -139,7 +139,9 @@ impl CompanyGql {
         memory_facts::resolve(&self.runtime, query, kind, first, offset).await
     }
 
-    /// The enabled workflows, as one-line summaries.
+    /// The company's saved workflows, as one-line summaries — seed graphs and
+    /// runtime-authored ones alike. Each carries an `enabled` flag reporting
+    /// manifest membership; listing is not gated on it.
     async fn workflows(&self, ctx: &Context<'_>) -> async_graphql::Result<Vec<WorkflowSummaryGql>> {
         workflows::resolve_summaries(ctx, &self.runtime).await
     }

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -137,7 +137,9 @@ type Company {
 	"""
 	memory(query: String, kind: MemoryKind, first: Int! = 50, offset: Int! = 0): MemoryFactPage!
 	"""
-	The enabled workflows, as one-line summaries.
+	The company's saved workflows, as one-line summaries — seed graphs and
+	runtime-authored ones alike. Each carries an `enabled` flag reporting
+	manifest membership; listing is not gated on it.
 	"""
 	workflows: [WorkflowSummary!]!
 	"""
@@ -932,7 +934,14 @@ type WorkflowSummary {
 	"""
 	name: String!
 	"""
-	Whether the workflow is enabled in the manifest.
+	Whether the workflow id appears in the company manifest's
+	`[workflows].enabled` list.
+	
+	This is manifest membership, **not** "does this workflow exist and can it
+	run". A runtime-authored workflow is listed here whether or not it is
+	manifest-enabled, and `Company.workflow(id)` / the run routes serve any
+	saved graph regardless of this flag — nothing consults it to decide
+	whether a workflow may run. Treat it as "declared by the blueprint".
 	"""
 	enabled: Boolean!
 }

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -686,6 +686,105 @@ async fn workflows_resolve_from_the_record_overlay_with_no_source_dir() {
     tokio::fs::remove_dir_all(&home).await.ok();
 }
 
+/// Issue #168: a runtime-authored workflow with an **empty** manifest
+/// `[workflows].enabled` — the post-restart state on the fs backend, since the
+/// boot rebuild overwrites the record's manifest with the seed manifest — must
+/// still appear in `Company.workflows`. The resolver used to drive its id set
+/// off the enabled list alone, so this returned `[]` while `Company.workflow`
+/// happily returned the full graph.
+///
+/// Also pins REST/GraphQL agreement: both surfaces must report the same id set.
+#[tokio::test]
+async fn workflows_summary_lists_an_overlay_workflow_with_no_enabled_entry() {
+    let home = home();
+    let id = CompanyId::new("acme");
+
+    // Nothing enabled in the manifest — the graph body is the only evidence.
+    let manifest: CompanyManifest =
+        toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n").unwrap();
+    let store = FsCompanyStore::new(home.to_path_buf());
+    store
+        .save(&CompanyRecord {
+            id: id.clone(),
+            manifest: manifest.clone(),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: vec![crate::ports::types::OverlayWorkflow {
+                id: "orphan".to_string(),
+                toml: "id = \"orphan\"\nname = \"Orphan Flow\"\n\
+                       [[node]]\nid = \"n1\"\nkind = \"trigger\"\nname = \"Start\"\n"
+                    .to_string(),
+            }],
+            template_provenance: None,
+        })
+        .await
+        .unwrap();
+
+    let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+        .with_id(id.clone())
+        .build()
+        .await
+        .unwrap();
+    assert!(
+        runtime.source_dir().is_none(),
+        "no source dir in hosted mode"
+    );
+    let state = AppState::new(AppConfig::default()).with_home(home.to_path_buf());
+    state.registry().insert(id, Arc::new(runtime));
+    crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+
+    let value = query(
+        router(state.clone()),
+        r#"{"query":"{ company(id:\"acme\"){ workflows { id name enabled } } }"}"#,
+    )
+    .await;
+    let summaries = value["data"]["company"]["workflows"]
+        .as_array()
+        .expect("summaries");
+    assert_eq!(summaries.len(), 1, "value: {value}");
+    assert_eq!(summaries[0]["id"], "orphan");
+    assert_eq!(summaries[0]["name"], "Orphan Flow");
+    // Honest flag: the graph exists and is runnable, but the manifest does not
+    // declare it, so `enabled` reads false rather than being faked to true.
+    assert_eq!(
+        summaries[0]["enabled"], false,
+        "`enabled` reports manifest membership, not existence"
+    );
+
+    // REST and GraphQL must report the same id set.
+    let response = router(state)
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/company/workflows")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let rest: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let rest_ids: Vec<&str> = rest
+        .as_array()
+        .expect("array")
+        .iter()
+        .map(|row| row["id"].as_str().unwrap())
+        .collect();
+    let gql_ids: Vec<&str> = summaries
+        .iter()
+        .map(|row| row["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(rest_ids, gql_ids, "REST and GraphQL disagree on the id set");
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
 /// The committed SDL snapshot freezes the read contract. Regenerate with
 /// `cargo test -- --ignored regenerate_sdl_snapshot` after any schema change.
 #[test]

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -36,6 +36,7 @@ pub(crate) async fn state_with_company(home: &std::path::Path) -> AppState {
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -177,6 +178,7 @@ async fn state_with_rich_company(home: &std::path::Path) -> AppState {
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -577,6 +579,7 @@ async fn skills_and_workflows_resolve_from_source_dir() {
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -610,6 +613,75 @@ async fn skills_and_workflows_resolve_from_source_dir() {
     // skillRegistry reads the repo-level shared library.
     let registry = value["data"]["skillRegistry"].as_array().unwrap();
     assert!(registry.iter().any(|s| s["id"] == "web-research"));
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+/// Issue #168: a hosted tenant has no source directory, so its workflows live
+/// only as runtime-authored bodies on the record. `Company.workflows` must
+/// resolve their real display name (not the id fallback) and `Company.workflow`
+/// must return the full graph.
+#[tokio::test]
+async fn workflows_resolve_from_the_record_overlay_with_no_source_dir() {
+    let home = home();
+    let id = CompanyId::new("acme");
+
+    let manifest: CompanyManifest = toml::from_str(
+        "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[workflows]\nenabled = [\"hosted\"]\n",
+    )
+    .unwrap();
+    let store = FsCompanyStore::new(home.to_path_buf());
+    store
+        .save(&CompanyRecord {
+            id: id.clone(),
+            manifest: manifest.clone(),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: vec![crate::ports::types::OverlayWorkflow {
+                id: "hosted".to_string(),
+                toml: "id = \"hosted\"\nname = \"Hosted Flow\"\n\
+                       [[node]]\nid = \"n1\"\nkind = \"trigger\"\nname = \"Start\"\n\
+                       [[node]]\nid = \"n2\"\nkind = \"output\"\nname = \"Done\"\n\
+                       [[edge]]\nfrom = \"n1\"\nto = \"n2\"\n"
+                    .to_string(),
+            }],
+            template_provenance: None,
+        })
+        .await
+        .unwrap();
+
+    // Built WITHOUT `with_seed_dir` — the hosted shape.
+    let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+        .with_id(id.clone())
+        .build()
+        .await
+        .unwrap();
+    assert!(
+        runtime.source_dir().is_none(),
+        "no source dir in hosted mode"
+    );
+    let state = AppState::new(AppConfig::default()).with_home(home.to_path_buf());
+    state.registry().insert(id, Arc::new(runtime));
+    crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+
+    let value = query(
+        router(state),
+        r#"{"query":"{ company(id:\"acme\"){ workflows { id name enabled } workflow(id:\"hosted\"){ id name nodes { id } edges { from to } } } }"}"#,
+    )
+    .await;
+    let company = &value["data"]["company"];
+    let summaries = company["workflows"].as_array().expect("summaries");
+    assert_eq!(summaries.len(), 1, "value: {value}");
+    assert_eq!(summaries[0]["id"], "hosted");
+    // The real name from the overlay body, not the id fallback.
+    assert_eq!(summaries[0]["name"], "Hosted Flow");
+    assert_eq!(company["workflow"]["name"], "Hosted Flow");
+    assert_eq!(company["workflow"]["nodes"].as_array().unwrap().len(), 2);
+    assert_eq!(company["workflow"]["edges"].as_array().unwrap().len(), 1);
 
     tokio::fs::remove_dir_all(&home).await.ok();
 }

--- a/src/server/graphql/workflows.rs
+++ b/src/server/graphql/workflows.rs
@@ -8,12 +8,13 @@
 //! its graphs are overlay bodies; resolving only the seed side used to render
 //! them as bare ids with no graph (issue #168).
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use async_graphql::{Context, ID, SimpleObject};
 
 use crate::company::runtime::CompanyRuntime;
-use crate::company::{WorkflowFile, load_workflow_union};
+use crate::company::{WorkflowFile, list_workflows_union, load_workflow_union};
 use crate::ports::types::OverlayWorkflow;
 
 /// A one-line workflow summary for the workflows list.
@@ -24,7 +25,14 @@ pub struct WorkflowSummaryGql {
     pub id: ID,
     /// The workflow display name.
     pub name: String,
-    /// Whether the workflow is enabled in the manifest.
+    /// Whether the workflow id appears in the company manifest's
+    /// `[workflows].enabled` list.
+    ///
+    /// This is manifest membership, **not** "does this workflow exist and can it
+    /// run". A runtime-authored workflow is listed here whether or not it is
+    /// manifest-enabled, and `Company.workflow(id)` / the run routes serve any
+    /// saved graph regardless of this flag — nothing consults it to decide
+    /// whether a workflow may run. Treat it as "declared by the blueprint".
     pub enabled: bool,
 }
 
@@ -165,26 +173,54 @@ async fn overlays(runtime: &Arc<CompanyRuntime>) -> async_graphql::Result<Vec<Ov
         .unwrap_or_default())
 }
 
-/// Resolves `Company.workflows`.
+/// Resolves `Company.workflows` — every workflow the company has saved.
+///
+/// The id set is built exactly the way the REST picker
+/// (`GET …/workflows`) builds it, so the two read surfaces cannot disagree:
+/// first every graph that has a body (seed ∪ overlay, deduped with the seed
+/// winning), then any manifest-`enabled` id that has no body in either source,
+/// named after itself.
+///
+/// Driving this off the manifest's enabled list alone — as it used to — made a
+/// runtime-authored workflow invisible here while `Company.workflow(id)`
+/// returned its full graph. That gap is not hypothetical: the boot rebuild
+/// overwrites the persisted record's manifest with the seed manifest
+/// (`RuntimeBuilder`), so a runtime-added enabled id is gone after a restart and
+/// the graph body on the record is the only surviving evidence the workflow
+/// exists.
 pub(crate) async fn resolve_summaries(
     _ctx: &Context<'_>,
     runtime: &Arc<CompanyRuntime>,
 ) -> async_graphql::Result<Vec<WorkflowSummaryGql>> {
     let overlays = overlays(runtime).await?;
-    let ids = enabled_ids(runtime).await?;
-    Ok(ids
-        .into_iter()
-        .map(|id| {
-            let name = load_one(runtime, &overlays, &id)
-                .map(|file| file.name)
-                .unwrap_or_else(|| id.clone());
-            WorkflowSummaryGql {
-                id: ID(id),
-                name,
-                enabled: true,
-            }
-        })
-        .collect())
+    let enabled = enabled_ids(runtime).await?;
+    let enabled_set: HashSet<&str> = enabled.iter().map(String::as_str).collect();
+
+    let mut summaries = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for file in list_workflows_union(runtime.source_dir(), &overlays) {
+        seen.insert(file.id.clone());
+        summaries.push(WorkflowSummaryGql {
+            enabled: enabled_set.contains(file.id.as_str()),
+            id: ID(file.id),
+            name: file.name,
+        });
+    }
+
+    // Manifest-enabled ids with no loadable graph anywhere still list, named
+    // after themselves — the same fallback the REST picker uses.
+    for id in enabled {
+        if !seen.insert(id.clone()) {
+            continue;
+        }
+        summaries.push(WorkflowSummaryGql {
+            id: ID(id.clone()),
+            name: id,
+            enabled: true,
+        });
+    }
+
+    Ok(summaries)
 }
 
 /// Resolves `Company.workflow(id)`, returning null when the graph is unavailable.

--- a/src/server/graphql/workflows.rs
+++ b/src/server/graphql/workflows.rs
@@ -1,14 +1,20 @@
 //! Workflow reads: `Company.workflows` summaries (from the manifest's enabled
-//! list) and `Company.workflow(id)` graphs (parsed from
-//! `{company}/workflows/<id>.toml` via WS1's `workflow_file`).
+//! list) and `Company.workflow(id)` graphs.
+//!
+//! Graph bodies come from the union of the company's two sources — the seed
+//! files at `{company}/workflows/<id>.toml` and the runtime-authored bodies on
+//! the [`CompanyRecord`](crate::ports::types::CompanyRecord) overlay — via
+//! [`load_workflow_union`]. A hosted tenant has no source directory, so all of
+//! its graphs are overlay bodies; resolving only the seed side used to render
+//! them as bare ids with no graph (issue #168).
 
-use std::path::Path;
 use std::sync::Arc;
 
 use async_graphql::{Context, ID, SimpleObject};
 
 use crate::company::runtime::CompanyRuntime;
-use crate::company::{WorkflowFile, parse_workflow};
+use crate::company::{WorkflowFile, load_workflow_union};
+use crate::ports::types::OverlayWorkflow;
 
 /// A one-line workflow summary for the workflows list.
 #[derive(SimpleObject)]
@@ -130,13 +136,17 @@ impl From<WorkflowFile> for WorkflowGql {
     }
 }
 
-/// Best-effort parse of one workflow graph from the company source directory
-/// (`companies/<name>/workflows/<id>.toml`). Yields `None` when the company has
-/// no source dir (platform-provisioned mode) or the file is missing/invalid.
-fn load_one(dir: Option<&Path>, id: &str) -> Option<WorkflowFile> {
-    let path = dir?.join("workflows").join(format!("{id}.toml"));
-    let text = std::fs::read_to_string(path).ok()?;
-    parse_workflow(&text).ok()
+/// Best-effort load of one workflow graph from the seed ∪ overlay union.
+/// Yields `None` when neither source has the id, or the body it finds is
+/// invalid — a resolver never fails the whole query over one bad graph.
+fn load_one(
+    runtime: &Arc<CompanyRuntime>,
+    overlays: &[OverlayWorkflow],
+    id: &str,
+) -> Option<WorkflowFile> {
+    load_workflow_union(runtime.source_dir(), overlays, id)
+        .ok()
+        .flatten()
 }
 
 /// The enabled workflow ids from the company manifest.
@@ -144,17 +154,28 @@ async fn enabled_ids(runtime: &Arc<CompanyRuntime>) -> async_graphql::Result<Vec
     Ok(runtime.enabled_workflow_ids().await?)
 }
 
+/// The company's runtime-authored graph bodies, read once per resolve. A
+/// company with no persisted record contributes none.
+async fn overlays(runtime: &Arc<CompanyRuntime>) -> async_graphql::Result<Vec<OverlayWorkflow>> {
+    Ok(runtime
+        .store()
+        .load(runtime.id())
+        .await?
+        .map(|record| record.overlay_workflows)
+        .unwrap_or_default())
+}
+
 /// Resolves `Company.workflows`.
 pub(crate) async fn resolve_summaries(
     _ctx: &Context<'_>,
     runtime: &Arc<CompanyRuntime>,
 ) -> async_graphql::Result<Vec<WorkflowSummaryGql>> {
-    let dir = runtime.source_dir();
+    let overlays = overlays(runtime).await?;
     let ids = enabled_ids(runtime).await?;
     Ok(ids
         .into_iter()
         .map(|id| {
-            let name = load_one(dir, &id)
+            let name = load_one(runtime, &overlays, &id)
                 .map(|file| file.name)
                 .unwrap_or_else(|| id.clone());
             WorkflowSummaryGql {
@@ -172,12 +193,14 @@ pub(crate) async fn resolve_one(
     runtime: &Arc<CompanyRuntime>,
     id: &str,
 ) -> async_graphql::Result<Option<WorkflowGql>> {
-    Ok(load_one(runtime.source_dir(), id).map(WorkflowGql::from))
+    let overlays = overlays(runtime).await?;
+    Ok(load_one(runtime, &overlays, id).map(WorkflowGql::from))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::company::parse_workflow;
     use serde_json::json;
 
     #[test]

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1306,6 +1306,7 @@ mod test {
                 overlay_desk_members: Vec::new(),
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
                 template_provenance: None,
             })
             .await
@@ -1426,6 +1427,7 @@ mod test {
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         };
         FsCompanyStore::new(home.to_path_buf())
@@ -1532,6 +1534,7 @@ mod test {
                 overlay_desk_members: Vec::new(),
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/ops/capabilities.rs
+++ b/src/server/ops/capabilities.rs
@@ -282,6 +282,7 @@ mod tests {
                 overlay_desk_members: Vec::new(),
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -364,6 +364,7 @@ mod tests {
                 overlay_desk_members: Vec::new(),
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/ops/connections_read.rs
+++ b/src/server/ops/connections_read.rs
@@ -121,6 +121,7 @@ mod tests {
                 overlay_desk_members: Vec::new(),
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/ops/finances.rs
+++ b/src/server/ops/finances.rs
@@ -99,6 +99,7 @@ mod tests {
                 overlay_desk_members: Vec::new(),
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -309,6 +309,7 @@ mod tests {
                 overlay_desk_members: Vec::new(),
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/ops/language.rs
+++ b/src/server/ops/language.rs
@@ -37,11 +37,6 @@ pub const WORKSPACE_CYCLE: &str = "You can't move a folder into itself.";
 /// Error shown when a custom skill is missing its required fields.
 pub const SKILL_FIELDS_REQUIRED: &str = "A skill needs a name and a description.";
 
-/// Error shown when creating a workflow on a deployment with no writable
-/// company source directory (hosted/platform mode without one provisioned).
-pub const WORKFLOW_NEEDS_SOURCE_DIR: &str =
-    "Workflow creation needs a company source directory, and this deployment doesn't have one yet.";
-
 /// Error shown when a workflow id is not safe to use as a filename.
 pub const WORKFLOW_ID_INVALID: &str =
     "A workflow id can't be empty or contain slashes or `..` — use a plain name.";

--- a/src/server/ops/test.rs
+++ b/src/server/ops/test.rs
@@ -46,6 +46,7 @@ async fn state_with(home: &std::path::Path, connections: ConnectionsRuntime) -> 
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         })
         .await

--- a/src/server/ops/usage.rs
+++ b/src/server/ops/usage.rs
@@ -153,6 +153,7 @@ mod tests {
                 overlay_desk_members: Vec::new(),
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -2,42 +2,41 @@
 //! saved graphs (`GET /workflows`, `GET /workflows/{wid}`), and run one
 //! (`POST /workflows/{wid}/run`) — under both scope forms.
 //!
-//! Graphs are loaded from the company's on-disk source directory
-//! (`companies/<name>/workflows/<wid>.toml`) via
-//! [`load_company_workflows`](crate::company::load_company_workflows), which
-//! takes an explicit id list (it never scans) — so `list_workflows` enumerates
-//! the `workflows/` directory itself to build that list.
+//! A company's graphs come from two places, unioned by
+//! [`load_workflow_union`](crate::company::load_workflow_union) /
+//! [`list_workflows_union`](crate::company::list_workflows_union):
 //!
-//! A platform-provisioned tenant has no source directory, so there is nothing
-//! to scan — but it can still declare `[workflows].enabled` ids in its
-//! manifest. `list_workflows` unions those manifest-enabled ids in (deduped by
-//! id) so the console's picker isn't empty just because the deployment has no
-//! `workflows/*.toml` files on disk, mirroring the `Company.workflows`
-//! GraphQL resolver. Where the definition body isn't available to load (no
-//! source directory, or the id has no matching file), the summary falls back
-//! to the id as its name — the same fallback the GraphQL resolver uses. Full
-//! graphs (`GET …/workflows/{wid}`) still require a source directory, since
-//! there is currently no other place a graph body can come from.
+//! * the **seed** files committed to the company source directory
+//!   (`companies/<name>/workflows/<wid>.toml`), and
+//! * the **runtime-authored** graph bodies persisted on the [`CompanyRecord`]
+//!   overlay.
 //!
-//! Creation (issue #69) writes a new `workflows/<id>.toml` into that same
-//! source directory — reusing [`parse_workflow`](crate::company::parse_workflow)
-//! to validate the graph a caller posts before anything touches disk — and
-//! records the id as enabled on the operator's live [`CompanyRecord`], mirroring
-//! the team overlay convention: the version-controlled `company.toml` is never
-//! rewritten (see `crate::server::ops::team`). A deployment with no source
-//! directory (platform-provisioned mode with nothing seeded on disk yet) has
-//! nowhere to write the graph file, so creation is refused with a 4xx rather
-//! than crashing.
+//! The seed wins on an id collision. A hosted tenant has no source directory at
+//! all (or a read-only one), so every graph it owns is an overlay body — which
+//! is why these routes never require a source directory to answer.
+//!
+//! Creation (issues #69, #112, #168) delegates to
+//! [`create_company_workflow`](crate::company::create_company_workflow), the
+//! single validated-persist core the orchestrator's `create_workflow` tool also
+//! runs, so the two surfaces cannot drift. It persists the graph body **and**
+//! the enabled id on the operator's live record in one save; the
+//! version-controlled `company.toml` and the source tree are never written
+//! (see `crate::server::ops::team`) — the source tree is read-only in hosted
+//! mode, which is what issue #168 reports.
+//!
+//! `list_workflows` additionally unions in the manifest's `[workflows].enabled`
+//! ids that have no body in either source, falling back to the id as the display
+//! name — the same fallback the GraphQL `Company.workflows` resolver uses — so a
+//! provisioned tenant's picker isn't empty.
 //!
 //! Execution is dependency-inverted behind the [`WorkflowRunner`] port: when no
 //! runner is wired (the default build, or a runtime built without a harness) the
 //! run route reports `not_wired` — the same 404 seam the DNS/SMTP surfaces use —
 //! so the default build stays inert. The read routes need no runner: they only
-//! parse the committed graph files, so the console can list and render workflows
-//! even on a build that cannot execute them.
+//! parse the saved graphs, so the console can list and render workflows even on
+//! a build that cannot execute them.
 
 use std::collections::HashSet;
-use std::io::Write;
 use std::path::Path as FsPath;
 
 use axum::extract::Path;
@@ -50,12 +49,11 @@ use serde_json::Value;
 use crate::AppState;
 use crate::company::{
     RawEdge, RawNode, RawWorkflow, WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef,
-    WorkflowRetryDef, list_source_workflows, load_company_workflows, parse_workflow,
-    render_workflow,
+    WorkflowRetryDef, create_company_workflow, list_workflows_union, load_workflow_union,
 };
 use crate::error::OpenCompanyError;
+use crate::ports::types::{CompanyRecord, OverlayWorkflow};
 use crate::server::error::ApiError;
-use crate::server::ops::language;
 use crate::server::ops::{ScopedCompany, scoped};
 
 /// Builds the workflow route fragment: create + list, one graph read, and the
@@ -195,20 +193,33 @@ impl From<WorkflowEdgeDef> for WorkflowEdge {
     }
 }
 
+/// The company's runtime-authored graph bodies, read once per request from the
+/// live record. A company with no persisted record contributes none — the read
+/// routes stay tolerant (they still serve the seed files), and the create route
+/// re-loads the record under its write lock and 404s properly there.
+async fn overlay_workflows(company: &ScopedCompany) -> Result<Vec<OverlayWorkflow>, ApiError> {
+    let record: Option<CompanyRecord> = company
+        .runtime
+        .store()
+        .load(company.id())
+        .await
+        .map_err(ApiError)?;
+    Ok(record.map(|r| r.overlay_workflows).unwrap_or_default())
+}
+
 /// `GET …/workflows` — the company's saved workflows as picker summaries.
 ///
-/// The loader takes an explicit id list rather than scanning, so this reads the
-/// company's `workflows/` directory to collect the `*.toml` file stems as ids,
-/// then loads and summarizes them. No source directory (platform-provisioned
-/// mode) or no `workflows/` directory yields an empty filesystem scan — but not
-/// necessarily an empty response: the manifest's `[workflows].enabled` ids are
-/// unioned in (deduped against the filesystem scan by id), falling back to the
-/// id as the name when there's no file to load a real name from. Only when
-/// both the scan and the manifest are empty does this return `200 []`, so the
-/// console renders "no workflows yet" rather than a failure.
+/// Summaries come from the union of the company's two graph sources — the seed
+/// `workflows/*.toml` files and the record's runtime-authored bodies — so a
+/// hosted tenant with no source directory still lists everything it created.
+/// The manifest's `[workflows].enabled` ids are then unioned in (deduped by id),
+/// falling back to the id as the name for an id with no body in either source —
+/// the same fallback the GraphQL resolver uses. Only when all three are empty
+/// does this return `200 []`, so the console renders "no workflows yet" rather
+/// than a failure.
 async fn list_workflows(company: ScopedCompany) -> Result<Json<Vec<WorkflowSummary>>, ApiError> {
-    let source_dir = company.runtime.source_dir();
-    let files = list_source_workflows(source_dir);
+    let overlays = overlay_workflows(&company).await?;
+    let files = list_workflows_union(company.runtime.source_dir(), &overlays);
     let mut seen: HashSet<String> = files.iter().map(|f| f.id.clone()).collect();
     let mut summaries: Vec<WorkflowSummary> =
         files.into_iter().map(WorkflowSummary::from).collect();
@@ -219,22 +230,15 @@ async fn list_workflows(company: ScopedCompany) -> Result<Json<Vec<WorkflowSumma
         .await
         .map_err(ApiError)?;
     for id in enabled_ids {
-        // Already present from the filesystem scan — skip so hosted mode
-        // (source dir present, manifest also lists the same ids) doesn't
-        // double-list.
+        // Already summarized from a real body — skip so an id that is both
+        // enabled and saved doesn't double-list.
         if !seen.insert(id.clone()) {
             continue;
         }
-        let loaded = source_dir
-            .and_then(|dir| load_company_workflows(dir, std::slice::from_ref(&id)).ok())
-            .and_then(|mut files| files.pop());
-        summaries.push(match loaded {
-            Some(file) => WorkflowSummary::from(file),
-            None => WorkflowSummary {
-                id: id.clone(),
-                name: id,
-                description: None,
-            },
+        summaries.push(WorkflowSummary {
+            id: id.clone(),
+            name: id,
+            description: None,
         });
     }
 
@@ -243,34 +247,23 @@ async fn list_workflows(company: ScopedCompany) -> Result<Json<Vec<WorkflowSumma
 
 /// `GET …/workflows/{wid}` — the full graph for one workflow.
 ///
-/// An unknown `wid` (or a deployment with no source directory) is a `404`,
+/// Reads through the seed ∪ overlay union, so a graph created on a hosted
+/// tenant (no source directory) resolves here too. An unknown `wid` is a `404`,
 /// mirroring the sub-resource-not-found shape the task routes use.
 async fn get_workflow(
     company: ScopedCompany,
     Path(WorkflowPath { wid }): Path<WorkflowPath>,
 ) -> Result<Json<WorkflowGraph>, ApiError> {
-    // `wid` becomes a filename — reject anything that could escape `workflows/`.
+    // `wid` may become a filename on the seed side — reject anything that could
+    // escape `workflows/`.
     if !safe_wid(&wid) {
         return Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
             "workflow {wid}"
         ))));
     }
-    let source_dir = company
-        .runtime
-        .source_dir()
-        .ok_or_else(|| ApiError(OpenCompanyError::CompanyNotFound(format!("workflow {wid}"))))?;
-    // Only try to load ids that exist on disk, so a missing file is a clean 404
-    // rather than the loader's `DataRead` (a 500).
-    let path = source_dir.join("workflows").join(format!("{wid}.toml"));
-    if !path.is_file() {
-        return Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
-            "workflow {wid}"
-        ))));
-    }
-    let file = load_company_workflows(source_dir, std::slice::from_ref(&wid))
+    let overlays = overlay_workflows(&company).await?;
+    let file = load_workflow_union(company.runtime.source_dir(), &overlays, &wid)
         .map_err(ApiError)?
-        .into_iter()
-        .next()
         .ok_or_else(|| ApiError(OpenCompanyError::CompanyNotFound(format!("workflow {wid}"))))?;
     Ok(Json(WorkflowGraph::from(file)))
 }
@@ -399,161 +392,34 @@ impl TryFrom<CreateWorkflowBody> for RawWorkflow {
     }
 }
 
-/// `POST …/workflows` — authors a new workflow graph (issue #69): the console's
-/// form creator, or any direct API caller, posts the graph shape and it lands
-/// as a new `workflows/<id>.toml` in the company's source directory.
+/// `POST …/workflows` — authors a new workflow graph (issues #69, #112, #168):
+/// the console's form creator, or any direct API caller, posts the graph shape
+/// and it is persisted on the company record.
 ///
-/// Order of checks, each returning an actionable 4xx before anything is
-/// written: the id must be a safe filename, the deployment must have a source
-/// directory to write into, the id must not already be taken (409), every
-/// `agent` node must name a real roster teammate, and the graph must pass the
-/// same structural validation ([`parse_workflow`]) a hand-authored file would
-/// (at least one trigger, unique node ids, edges that reference real nodes, no
-/// stray `agent` field on a non-agent node).
+/// The whole validated-persist sequence lives in
+/// [`create_company_workflow`] — the same core the orchestrator's
+/// `create_workflow` tool runs — so the two surfaces cannot drift: safe id,
+/// size caps, exactly one trigger, every `agent` node on the roster, unique id
+/// (409) and unique display name (409), full [`parse_workflow`] structural
+/// validation, one atomic record save, and an audit event.
+///
+/// No source directory is required: the body lands on the record, so a hosted
+/// tenant whose source tree is a read-only mount can create workflows (issue
+/// #168 — this used to fail with `EROFS`).
 async fn create_workflow(
     company: ScopedCompany,
     Json(body): Json<CreateWorkflowBody>,
 ) -> Result<Json<WorkflowGraph>, ApiError> {
-    if !safe_wid(&body.id) {
-        return Err(ApiError(OpenCompanyError::InvalidRequest(
-            language::WORKFLOW_ID_INVALID.to_string(),
-        )));
-    }
-
-    let source_dir = company.runtime.source_dir().ok_or_else(|| {
-        ApiError(OpenCompanyError::InvalidRequest(
-            language::WORKFLOW_NEEDS_SOURCE_DIR.to_string(),
-        ))
-    })?;
-
-    let workflows_dir = source_dir.join("workflows");
-    let path = workflows_dir.join(format!("{}.toml", body.id));
-
-    std::fs::create_dir_all(&workflows_dir).map_err(|source| {
-        ApiError(OpenCompanyError::StoreIo {
-            path: workflows_dir.clone(),
-            source,
-        })
-    })?;
-
-    // `parse_workflow` only rejects zero triggers (a saved graph may legally
-    // have more, e.g. multiple entry points); the creator is stricter — a
-    // freshly authored graph must name exactly one starting point.
-    let trigger_count = body.nodes.iter().filter(|n| n.kind == "trigger").count();
-    if trigger_count != 1 {
-        return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
-            "a workflow needs exactly one `trigger` node to say what starts it (found {trigger_count})."
-        ))));
-    }
-
-    // Cross-check every `agent` node against the company's effective roster
-    // (manifest agents + operator overlay teammates) before writing anything.
-    // `parse_workflow` validates the graph's own shape but has no roster to
-    // check names against.
-    let mut record = company
-        .runtime
-        .store()
-        .load(company.id())
-        .await?
-        .ok_or_else(|| OpenCompanyError::CompanyNotFound(company.id().to_string()))?;
-    let roster: HashSet<&str> = record
-        .manifest
-        .agents
-        .iter()
-        .map(|a| a.id.as_str())
-        .chain(record.overlay_agents.iter().map(|a| a.id.as_str()))
-        .collect();
-    for node in &body.nodes {
-        if node.kind != "agent" {
-            continue;
-        }
-        match node.agent.as_deref() {
-            Some(agent_id) if roster.contains(agent_id) => {}
-            Some(agent_id) => {
-                return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
-                    "node `{}` names teammate `{agent_id}`, which is not on this company's roster.",
-                    node.id
-                ))));
-            }
-            None => {
-                return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
-                    "node `{}` is an agent node but names no teammate.",
-                    node.id
-                ))));
-            }
-        }
-    }
-
-    // Save `body.id` before `body` is consumed by `Into<RawWorkflow>` below.
-    let body_id = body.id.clone();
-
-    // Render the candidate graph to TOML and reuse `parse_workflow` to
-    // validate its structure end to end — the same rules a hand-authored
-    // `workflows/<id>.toml` must satisfy. Any problem becomes a 400, never the
-    // 500 a malformed on-disk file gets from the read routes.
-    let toml_src = render_workflow(&RawWorkflow::try_from(body)?)?;
-    let file = parse_workflow(&toml_src).map_err(|err| match err {
-        OpenCompanyError::DataInvalid { problems, .. } => {
-            ApiError(OpenCompanyError::InvalidRequest(problems.join(" ")))
-        }
-        OpenCompanyError::DataParse { message, .. } => {
-            ApiError(OpenCompanyError::InvalidRequest(message))
-        }
-        other => ApiError(other),
-    })?;
-
-    // Write the file atomically: `create_new(true)` fails if the path already
-    // exists, closing the TOCTOU gap between a separate `is_file()` check and
-    // `fs::write`. If `write_all` fails, clean up the empty file so the id is
-    // not permanently blocked. Also, save the store record **after** the file
-    // lands so a store failure doesn't orphan a file — if the save fails the
-    // file is cleaned up and the caller can retry.
-    let mut wf_file = std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&path)
-        .map_err(|e| match e.kind() {
-            std::io::ErrorKind::AlreadyExists => ApiError(OpenCompanyError::Conflict(format!(
-                "A workflow named `{}` already exists.",
-                body_id
-            ))),
-            _ => ApiError(OpenCompanyError::StoreIo {
-                path: path.clone(),
-                source: e,
-            }),
-        })?;
-    wf_file.write_all(toml_src.as_bytes()).map_err(|source| {
-        let _ = std::fs::remove_file(&path);
-        ApiError(OpenCompanyError::StoreIo {
-            path: path.clone(),
-            source,
-        })
-    })?;
-    drop(wf_file);
-
-    // Record the id as enabled on the operator's live copy of the manifest —
-    // mirrors the team overlay: the version-controlled `company.toml` on disk
-    // is never rewritten (see `crate::server::ops::team`).
-    let save_result = if !record
-        .manifest
-        .workflows
-        .enabled
-        .iter()
-        .any(|e| e == &file.id)
-    {
-        record.manifest.workflows.enabled.push(file.id.clone());
-        company.runtime.store().save(&record).await
-    } else {
-        Ok(())
-    };
-
-    // If the store save failed, remove the file we just wrote so a retry can
-    // succeed without admin intervention.
-    if let Err(e) = save_result {
-        let _ = std::fs::remove_file(&path);
-        return Err(ApiError(e));
-    }
-
+    let draft = RawWorkflow::try_from(body)?;
+    let file = create_company_workflow(
+        company.id(),
+        company.runtime.source_dir(),
+        company.runtime.store(),
+        Some(company.runtime.events()),
+        draft,
+    )
+    .await
+    .map_err(ApiError)?;
     Ok(Json(WorkflowGraph::from(file)))
 }
 
@@ -607,15 +473,13 @@ async fn run_workflow(
         );
     }
 
-    // Load the saved graph from the company's on-disk source directory. Without
-    // one (platform-provisioned mode) there is nothing to run.
-    let source_dir = company.runtime.source_dir().ok_or_else(|| {
-        super::not_wired("workflow source (no company definition directory on this deployment)")
-    })?;
-    let file = load_company_workflows(source_dir, std::slice::from_ref(&wid))
+    // Load the saved graph from the seed ∪ overlay union, so a graph created on
+    // a hosted tenant (no source directory) runs the same as a committed one.
+    let overlays = overlay_workflows(&company)
+        .await
+        .map_err(IntoResponse::into_response)?;
+    let file = load_workflow_union(company.runtime.source_dir(), &overlays, &wid)
         .map_err(|e| ApiError(e).into_response())?
-        .into_iter()
-        .next()
         .ok_or_else(|| {
             ApiError(OpenCompanyError::CompanyNotFound(format!("workflow {wid}"))).into_response()
         })?;
@@ -676,7 +540,7 @@ mod tests {
     #[test]
     fn list_returns_a_summary_per_saved_workflow() {
         let dir = seed_demo();
-        let files = list_source_workflows(Some(dir.path()));
+        let files = list_workflows_union(Some(dir.path()), &[]);
         let summaries: Vec<WorkflowSummary> =
             files.into_iter().map(WorkflowSummary::from).collect();
         assert_eq!(summaries.len(), 1);
@@ -691,11 +555,8 @@ mod tests {
     #[test]
     fn get_returns_the_full_graph_with_nodes_and_edges() {
         let dir = seed_demo();
-        let ids = ["demo".to_string()];
-        let file = load_company_workflows(dir.path(), &ids)
+        let file = load_workflow_union(Some(dir.path()), &[], "demo")
             .expect("loads")
-            .into_iter()
-            .next()
             .expect("one file");
         let graph = WorkflowGraph::from(file);
 
@@ -718,24 +579,21 @@ mod tests {
     }
 
     #[test]
-    fn no_source_dir_lists_empty() {
-        assert!(list_source_workflows(None).is_empty());
+    fn no_source_dir_and_no_overlay_lists_empty() {
+        assert!(list_workflows_union(None, &[]).is_empty());
     }
 
     #[test]
     fn no_workflows_dir_lists_empty() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(list_source_workflows(Some(dir.path())).is_empty());
+        assert!(list_workflows_union(Some(dir.path()), &[]).is_empty());
     }
 
     #[test]
     fn json_serializes_camelcase_and_omits_empty_options() {
         let dir = seed_demo();
-        let ids = ["demo".to_string()];
-        let file = load_company_workflows(dir.path(), &ids)
+        let file = load_workflow_union(Some(dir.path()), &[], "demo")
             .unwrap()
-            .into_iter()
-            .next()
             .unwrap();
         let json = serde_json::to_value(WorkflowGraph::from(file)).unwrap();
         // A node with no summary/agent omits those keys entirely.
@@ -813,8 +671,8 @@ mod tests {
         .expect("body deserializes");
 
         let raw = RawWorkflow::try_from(body).expect("converts");
-        let toml_src = render_workflow(&raw).expect("renders");
-        let file = parse_workflow(&toml_src).expect("re-parses");
+        let toml_src = crate::company::render_workflow(&raw).expect("renders");
+        let file = crate::company::parse_workflow(&toml_src).expect("re-parses");
 
         let tf = file.nodes.iter().find(|n| n.id == "tf").unwrap();
         assert_eq!(tf.kind, WorkflowNodeKind::Transform);
@@ -897,7 +755,7 @@ mod tests {
             "id = \"broken\"\nname = \n[[node]] oops",
         )
         .unwrap();
-        let files = list_source_workflows(Some(dir.path()));
+        let files = list_workflows_union(Some(dir.path()), &[]);
         let ids: Vec<_> = files.iter().map(|f| f.id.as_str()).collect();
         assert_eq!(ids, vec!["demo"]);
     }
@@ -951,6 +809,7 @@ mod tests {
                     overlay_desk_members: Vec::new(),
                     overlay_desk_order: Vec::new(),
                     overlay_desks: Vec::new(),
+                    overlay_workflows: Vec::new(),
                     template_provenance: None,
                 })
                 .await
@@ -1000,6 +859,210 @@ mod tests {
             // name — same fallback the GraphQL `Company.workflows` resolver
             // uses for the same case.
             assert_eq!(items[0]["name"], "demo");
+
+            std::fs::remove_dir_all(&home).ok();
+        }
+
+        /// A hosted tenant's record with no manifest-enabled workflows — the
+        /// blank-slate a real tenant starts from before it creates anything.
+        fn empty_manifest() -> CompanyManifest {
+            toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n").unwrap()
+        }
+
+        /// Same as [`state_with_hosted_company`] but with nothing enabled, and
+        /// returning the store so a test can rebuild state from it.
+        async fn hosted_state(home: &std::path::Path) -> (AppState, FsCompanyStore, CompanyId) {
+            let store = FsCompanyStore::new(home.to_path_buf());
+            let id = CompanyId::new("acme");
+            store
+                .save(&CompanyRecord {
+                    id: id.clone(),
+                    manifest: empty_manifest(),
+                    ledger: Vec::new(),
+                    lifecycle: "running".to_string(),
+                    overlay_agents: Vec::new(),
+                    overlay_desk_members: Vec::new(),
+                    overlay_desk_order: Vec::new(),
+                    overlay_desks: Vec::new(),
+                    overlay_workflows: Vec::new(),
+                    template_provenance: None,
+                })
+                .await
+                .unwrap();
+            let state = state_over(home, &id, true).await;
+            (state, store, id)
+        }
+
+        /// Builds an `AppState` whose runtime for `id` has **no source
+        /// directory** — the hosted shape — over the store rooted at `home`.
+        ///
+        /// `seed_admin` seeds the fixed admin + session; a *rebuild* over the
+        /// same home must pass `false` (the durable user store already has that
+        /// admin, and its session survives with it).
+        async fn state_over(home: &std::path::Path, id: &CompanyId, seed_admin: bool) -> AppState {
+            let runtime = RuntimeBuilder::new(home.to_path_buf(), empty_manifest())
+                .with_id(id.clone())
+                .build()
+                .await
+                .unwrap();
+            assert!(
+                runtime.source_dir().is_none(),
+                "test setup must simulate hosted mode: no source dir"
+            );
+            let state = AppState::new(AppConfig::default());
+            state
+                .registry()
+                .insert(id.clone(), std::sync::Arc::new(runtime));
+            if seed_admin {
+                crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+            }
+            state
+        }
+
+        /// The graph body the console posts.
+        fn create_body() -> serde_json::Value {
+            serde_json::json!({
+                "id": "greeter",
+                "name": "Greeter",
+                "description": "Say hi.",
+                "nodes": [
+                    { "id": "start", "kind": "trigger", "name": "Start" },
+                    { "id": "done", "kind": "output", "name": "Report" }
+                ],
+                "edges": [ { "from": "start", "to": "done", "label": "ok" } ]
+            })
+        }
+
+        fn request(method: &str, uri: &str, body: Option<serde_json::Value>) -> Request<Body> {
+            let builder = Request::builder()
+                .method(method)
+                .uri(uri)
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"));
+            match body {
+                Some(json) => builder
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&json).unwrap()))
+                    .unwrap(),
+                None => builder.body(Body::empty()).unwrap(),
+            }
+        }
+
+        async fn json_body(response: axum::response::Response) -> serde_json::Value {
+            let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+        }
+
+        /// **The #168 regression test.** Creating a workflow on a tenant with no
+        /// (writable) source directory used to fail with
+        /// `Read-only file system (os error 30)` — the handler wrote the graph
+        /// into the crate's read-only company source tree. It now persists on
+        /// the record, so the create succeeds, the graph lists under its real
+        /// name, and the full body reads back.
+        #[tokio::test]
+        async fn create_persists_and_reads_back_with_no_source_dir() {
+            let home = home();
+            let (state, _store, _id) = hosted_state(&home).await;
+
+            // POST → 200 with the graph echoed back.
+            let response = router(state.clone())
+                .oneshot(request(
+                    "POST",
+                    "/api/v1/company/workflows",
+                    Some(create_body()),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let created = json_body(response).await;
+            assert_eq!(created["id"], "greeter");
+            assert_eq!(created["nodes"].as_array().unwrap().len(), 2);
+
+            // GET list → the real name, not the id fallback.
+            let response = router(state.clone())
+                .oneshot(request("GET", "/api/v1/company/workflows", None))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let listed = json_body(response).await;
+            let items = listed.as_array().expect("array");
+            assert_eq!(items.len(), 1, "body: {listed}");
+            assert_eq!(items[0]["id"], "greeter");
+            assert_eq!(items[0]["name"], "Greeter");
+            assert_eq!(items[0]["description"], "Say hi.");
+
+            // GET one → the full graph.
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/greeter", None))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let graph = json_body(response).await;
+            assert_eq!(graph["id"], "greeter");
+            assert_eq!(graph["edges"][0]["label"], "ok");
+
+            std::fs::remove_dir_all(&home).ok();
+        }
+
+        /// A duplicate id is a clean 409, not a 500 — the id-uniqueness check
+        /// that replaced the filesystem's `create_new(true)`.
+        #[tokio::test]
+        async fn duplicate_create_is_a_conflict() {
+            let home = home();
+            let (state, _store, _id) = hosted_state(&home).await;
+
+            let first = router(state.clone())
+                .oneshot(request(
+                    "POST",
+                    "/api/v1/company/workflows",
+                    Some(create_body()),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(first.status(), StatusCode::OK);
+
+            let second = router(state)
+                .oneshot(request(
+                    "POST",
+                    "/api/v1/company/workflows",
+                    Some(create_body()),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(second.status(), StatusCode::CONFLICT);
+
+            std::fs::remove_dir_all(&home).ok();
+        }
+
+        /// Restart survival: a workflow created through the API is still listed
+        /// by a completely fresh `AppState` rebuilt over the same store — proving
+        /// the body is durable, not process-local.
+        #[tokio::test]
+        async fn a_created_workflow_survives_a_state_rebuild() {
+            let home = home();
+            let (state, _store, id) = hosted_state(&home).await;
+
+            let response = router(state)
+                .oneshot(request(
+                    "POST",
+                    "/api/v1/company/workflows",
+                    Some(create_body()),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+
+            // Rebuild everything from the same durable store.
+            let rebuilt = state_over(&home, &id, false).await;
+            let response = router(rebuilt)
+                .oneshot(request("GET", "/api/v1/company/workflows", None))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let listed = json_body(response).await;
+            let items = listed.as_array().expect("array");
+            assert_eq!(items.len(), 1, "body: {listed}");
+            assert_eq!(items[0]["id"], "greeter");
+            assert_eq!(items[0]["name"], "Greeter");
 
             std::fs::remove_dir_all(&home).ok();
         }

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -42,6 +42,7 @@ async fn state_with_company(home: &std::path::Path) -> AppState {
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -1328,6 +1329,7 @@ async fn state_with_manifest(home: &std::path::Path, manifest: CompanyManifest) 
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -1576,6 +1578,7 @@ async fn state_with_source_dir(
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -1611,8 +1614,11 @@ fn workflow_body(id: &str) -> Value {
     })
 }
 
+/// Issue #168: the create path persists the graph **on the record**, never in
+/// the company source tree (which is a read-only mount in hosted mode), and
+/// both read routes serve it from there.
 #[tokio::test]
-async fn workflow_create_writes_file_appends_enabled_and_is_listed() {
+async fn workflow_create_persists_on_the_record_appends_enabled_and_is_listed() {
     let home = home();
     let seed_dir = home.join("seed");
     std::fs::create_dir_all(&seed_dir).unwrap();
@@ -1630,22 +1636,23 @@ async fn workflow_create_writes_file_appends_enabled_and_is_listed() {
     assert_eq!(created["nodes"].as_array().unwrap().len(), 3);
     assert_eq!(created["edges"].as_array().unwrap().len(), 2);
 
-    // The graph landed on disk as TOML under the seed dir.
+    // Nothing was written into the company source tree — the read-only mount in
+    // hosted mode, and the whole reason #168 failed with EROFS.
     let path = seed_dir.join("workflows").join("greet.toml");
-    assert!(path.is_file(), "workflow file was written to {path:?}");
-    let on_disk = std::fs::read_to_string(&path).unwrap();
-    assert!(on_disk.contains("id = \"greet\""));
-    assert!(on_disk.contains("agent = \"ceo\""));
+    assert!(!path.exists(), "the source tree must not be written to");
 
-    // The operator's live manifest record gained the id in `[workflows].enabled`
-    // — the version-controlled seed dir's own `company.toml` was never touched
+    // The body and the enabled id both landed on the operator's live record —
+    // the version-controlled seed dir's own `company.toml` was never touched
     // (there isn't one here; only the store's copy is checked).
     use crate::ports::CompanyStore;
     let store = FsCompanyStore::new(home.to_path_buf());
     let record = store.load(&CompanyId::new("acme")).await.unwrap().unwrap();
     assert_eq!(record.manifest.workflows.enabled, vec!["greet".to_string()]);
+    assert_eq!(record.overlay_workflows.len(), 1);
+    assert_eq!(record.overlay_workflows[0].id, "greet");
+    assert!(record.overlay_workflows[0].toml.contains("agent = \"ceo\""));
 
-    // `GET …/workflows` (which scans the seed dir) now lists it.
+    // `GET …/workflows` (seed ∪ overlay) now lists it.
     let (status, list) = send(&state, "GET", "/api/v1/company/workflows", None).await;
     assert_eq!(status, StatusCode::OK);
     let rows = list.as_array().unwrap();
@@ -1761,21 +1768,27 @@ async fn workflow_create_rejects_bad_edges_missing_agent_and_no_trigger() {
 }
 
 #[tokio::test]
-async fn workflow_create_without_source_dir_is_bad_request() {
+async fn workflow_create_without_source_dir_succeeds() {
     let home = home();
     // `state_with_company` boots with no `seed_dir`, so the company has no
-    // writable source directory — the platform-provisioned-mode case.
+    // source directory at all — the platform-provisioned-mode case. Issue #168:
+    // creation used to be refused here with a 400; the body now lands on the
+    // record, so it succeeds and reads back.
     let state = state_with_company(&home).await;
 
-    let (status, body) = send(
+    let (status, created) = send(
         &state,
         "POST",
         "/api/v1/company/workflows",
         Some(workflow_body("greet")),
     )
     .await;
-    assert_eq!(status, StatusCode::BAD_REQUEST);
-    assert_eq!(body["code"], "invalid_request");
+    assert_eq!(status, StatusCode::OK, "body: {created}");
+    assert_eq!(created["id"], "greet");
+
+    let (status, graph) = send(&state, "GET", "/api/v1/company/workflows/greet", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(graph["nodes"].as_array().unwrap().len(), 3);
 
     tokio::fs::remove_dir_all(&home).await.ok();
 }
@@ -1876,6 +1889,7 @@ async fn state_with_telegram(home: &std::path::Path, api: RecordingTelegramApi) 
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         })
         .await

--- a/src/server/users/auth_test.rs
+++ b/src/server/users/auth_test.rs
@@ -45,6 +45,7 @@ async fn state_with(home: &std::path::Path, companies: &[&str]) -> AppState {
                 overlay_desk_members: Vec::new(),
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/users/routes_test.rs
+++ b/src/server/users/routes_test.rs
@@ -43,6 +43,7 @@ async fn state_with(home: &std::path::Path, connections: ConnectionsRuntime) -> 
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -581,6 +582,7 @@ async fn a_https_deployment_marks_the_cookie_secure() {
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -1055,6 +1057,7 @@ async fn a_routable_host_never_echoes_the_code_even_with_no_mail() {
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         })
         .await

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -64,10 +64,24 @@ fn sample_provenance() -> TemplateProvenance {
     }
 }
 
+/// The runtime-authored workflow graph the fixture seeds every record with, so
+/// each backend (fs, sqlite, mongodb) proves it persists and rehydrates
+/// console-created workflow bodies (issue #168) — on a hosted tenant this is the
+/// ONLY copy of that graph.
+fn sample_overlay_workflow() -> crate::ports::types::OverlayWorkflow {
+    crate::ports::types::OverlayWorkflow {
+        id: "conformance_flow".to_string(),
+        toml: "id = \"conformance_flow\"\nname = \"Conformance flow\"\n\
+               [[node]]\nid = \"start\"\nkind = \"trigger\"\nname = \"Start\"\n"
+            .to_string(),
+    }
+}
+
 /// Builds a running record for `id` carrying a non-empty desk-order overlay (so
-/// the store round-trip covers the operator desk-hierarchy field, issue #131)
-/// and stamped with the sample template provenance (so round-trips assert it
-/// survives persistence, issue #85).
+/// the store round-trip covers the operator desk-hierarchy field, issue #131), a
+/// runtime-authored workflow body (issue #168), and stamped with the sample
+/// template provenance (so round-trips assert it survives persistence, issue
+/// #85).
 fn record(id: &CompanyId) -> CompanyRecord {
     CompanyRecord {
         id: id.clone(),
@@ -81,6 +95,7 @@ fn record(id: &CompanyId) -> CompanyRecord {
             ordered: vec!["ceo".to_string(), "eng".to_string()],
         }],
         overlay_desks: Vec::new(),
+        overlay_workflows: vec![sample_overlay_workflow()],
         template_provenance: Some(sample_provenance()),
     }
 }
@@ -172,6 +187,13 @@ pub async fn assert_isolation_by_company(
             ordered: vec!["ceo".to_string(), "eng".to_string()],
         }],
         "overlay_desk_order did not survive save/load"
+    );
+    // The runtime-authored workflow body survives the store round-trip too
+    // (issue #168) — losing it would delete a hosted tenant's workflow.
+    assert_eq!(
+        loaded.overlay_workflows,
+        vec![sample_overlay_workflow()],
+        "overlay_workflows did not survive save/load"
     );
     assert_eq!(
         events
@@ -387,6 +409,13 @@ pub async fn assert_export_totality(
         loaded.template_provenance,
         Some(sample_provenance()),
         "template provenance did not round-trip through the store"
+    );
+    // Issue #168: the runtime-authored graph bodies round-trip too — an export
+    // that dropped them would lose every console-created workflow.
+    assert_eq!(
+        loaded.overlay_workflows,
+        vec![sample_overlay_workflow()],
+        "overlay_workflows did not round-trip through the store"
     );
 
     // Full event log round-trips with seqs and payloads intact.

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -32,7 +32,8 @@ use crate::ports::memory::MemoryStore;
 use crate::ports::store::CompanyStore;
 use crate::ports::types::{
     CompanyId, CompanyRecord, CompressedTrace, ContextChunk, EventSeq, LedgerEntry, OverlayAgent,
-    OverlayDesk, OverlayDeskMember, OverlayDeskOrder, StoredEvent, TemplateProvenance,
+    OverlayDesk, OverlayDeskMember, OverlayDeskOrder, OverlayWorkflow, StoredEvent,
+    TemplateProvenance,
 };
 
 /// Canonical bundle file and directory names, matching the fs
@@ -110,6 +111,13 @@ struct BundleMeta {
     /// bundles.
     #[serde(default)]
     overlay_desks: Vec<OverlayDesk>,
+    /// The operator workflow-authoring overlay — graph bodies created from the
+    /// console or the orchestrator tool, which live on the record (never in the
+    /// read-only source tree). Preserved so console-created workflows survive an
+    /// export→import instead of being silently dropped. `#[serde(default)]` for
+    /// back-compat with older bundles.
+    #[serde(default)]
+    overlay_workflows: Vec<OverlayWorkflow>,
     /// The source-template provenance, when the exported company carried one.
     /// `#[serde(default)]` keeps older bundles written before provenance existed
     /// importing cleanly (they decode to `None` — no migration).
@@ -155,6 +163,9 @@ struct BundleContents {
     /// The operator-created desk overlay, carried through the bundle so
     /// export→import preserves operator-created desks.
     overlay_desks: Vec<OverlayDesk>,
+    /// The operator workflow-authoring overlay, carried through the bundle so
+    /// export→import preserves console-created workflow graphs.
+    overlay_workflows: Vec<OverlayWorkflow>,
 }
 
 impl BundleContents {
@@ -198,6 +209,7 @@ impl BundleContents {
             overlay_desk_members: record.overlay_desk_members,
             overlay_desk_order: record.overlay_desk_order,
             overlay_desks: record.overlay_desks,
+            overlay_workflows: record.overlay_workflows,
         })
     }
 
@@ -224,6 +236,7 @@ impl BundleContents {
                 overlay_desk_members: self.overlay_desk_members.clone(),
                 overlay_desk_order: self.overlay_desk_order.clone(),
                 overlay_desks: self.overlay_desks.clone(),
+                overlay_workflows: self.overlay_workflows.clone(),
                 template_provenance: self.template_provenance.clone(),
             })
             .await?;
@@ -265,6 +278,7 @@ impl BundleContents {
             overlay_desk_members: self.overlay_desk_members.clone(),
             overlay_desk_order: self.overlay_desk_order.clone(),
             overlay_desks: self.overlay_desks.clone(),
+            overlay_workflows: self.overlay_workflows.clone(),
             template_provenance: self.template_provenance.clone(),
         };
         write_file(
@@ -347,6 +361,7 @@ impl BundleContents {
             overlay_desk_members: meta.overlay_desk_members,
             overlay_desk_order: meta.overlay_desk_order,
             overlay_desks: meta.overlay_desks,
+            overlay_workflows: meta.overlay_workflows,
         })
     }
 }
@@ -793,6 +808,7 @@ mod test {
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -863,6 +879,7 @@ mod test {
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: Some(provenance.clone()),
         })
         .await
@@ -891,7 +908,8 @@ mod test {
 
     /// EVERY operator overlay — the team (`overlay_agents`), desk memberships
     /// (`overlay_desk_members`), the desk-order hierarchy (`overlay_desk_order`),
-    /// and operator-created desks (`overlay_desks`) — survives an export→import.
+    /// operator-created desks (`overlay_desks`), and runtime-authored workflow
+    /// graphs (`overlay_workflows`) — survives an export→import.
     /// A prior version threaded only `overlay_desk_order` through the bundle, so a
     /// round-trip silently ERASED operator-added teammates, desk memberships, and
     /// operator-created desks (data loss). This asserts all four come back intact
@@ -950,6 +968,15 @@ mod test {
             description: Some("Marketing pod".into()),
             members: vec!["ceo".into()],
         }];
+        // A workflow graph authored at runtime (issue #168). On a hosted tenant
+        // this body is the ONLY copy — a bundle that dropped it would lose the
+        // workflow outright.
+        let workflows = vec![OverlayWorkflow {
+            id: "console_flow".into(),
+            toml: "id = \"console_flow\"\nname = \"Console flow\"\n\
+                   [[node]]\nid = \"start\"\nkind = \"trigger\"\nname = \"Start\"\n"
+                .into(),
+        }];
 
         let (s1, e1, m1, c1) = fs_ports(&home1);
         s1.save(&CompanyRecord {
@@ -961,6 +988,7 @@ mod test {
             overlay_desk_members: desk_members.clone(),
             overlay_desk_order: order.clone(),
             overlay_desks: desks.clone(),
+            overlay_workflows: workflows.clone(),
             template_provenance: None,
         })
         .await
@@ -1009,6 +1037,14 @@ mod test {
         assert_eq!(
             dst_record.overlay_desks, desks,
             "operator-created desks altered by the bundle round-trip"
+        );
+        assert!(
+            !dst_record.overlay_workflows.is_empty(),
+            "runtime-authored workflows erased by the bundle round-trip"
+        );
+        assert_eq!(
+            dst_record.overlay_workflows, workflows,
+            "runtime-authored workflows altered by the bundle round-trip"
         );
         // And the hierarchy still drives routing: `cto` remains the lead after
         // import.

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -142,6 +142,11 @@ struct Meta {
     /// The operator desk-creation overlay (desks created at runtime).
     #[serde(default)]
     overlay_desks: Vec<crate::ports::types::OverlayDesk>,
+    /// The operator workflow-authoring overlay (graphs created at runtime).
+    /// Absent on meta files written before runtime workflow bodies persisted
+    /// through the store, so `#[serde(default)]` keeps those loading.
+    #[serde(default)]
+    overlay_workflows: Vec<crate::ports::types::OverlayWorkflow>,
     /// The source-template provenance stamped at launch. `None` for companies
     /// provisioned from a raw manifest and for legacy meta files written before
     /// provenance existed (the `#[serde(default)]` keeps those loading).
@@ -195,10 +200,12 @@ impl CompanyStore for FsCompanyStore {
             overlay_desk_members,
             overlay_desk_order,
             overlay_desks,
+            overlay_workflows,
             template_provenance,
         ) = if meta_src.trim().is_empty() {
             (
                 "running".to_string(),
+                Vec::new(),
                 Vec::new(),
                 Vec::new(),
                 Vec::new(),
@@ -213,6 +220,7 @@ impl CompanyStore for FsCompanyStore {
                 meta.overlay_desk_members,
                 meta.overlay_desk_order,
                 meta.overlay_desks,
+                meta.overlay_workflows,
                 meta.template_provenance,
             )
         };
@@ -228,6 +236,7 @@ impl CompanyStore for FsCompanyStore {
             overlay_desk_members,
             overlay_desk_order,
             overlay_desks,
+            overlay_workflows,
             template_provenance,
         }))
     }
@@ -246,6 +255,7 @@ impl CompanyStore for FsCompanyStore {
             overlay_desk_members: record.overlay_desk_members.clone(),
             overlay_desk_order: record.overlay_desk_order.clone(),
             overlay_desks: record.overlay_desks.clone(),
+            overlay_workflows: record.overlay_workflows.clone(),
             template_provenance: record.template_provenance.clone(),
         };
         write_atomic(&bundle.meta_json(), &serde_json::to_string(&meta)?).await?;
@@ -943,6 +953,7 @@ mod test {
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         };
         store.save(&record).await.unwrap();
@@ -981,6 +992,7 @@ mod test {
                 overlay_desk_members: Vec::new(),
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -299,6 +299,7 @@ impl CompanyStore for MongoStore {
             overlay_desk_members: overlay.desk_members,
             overlay_desk_order: overlay.desk_order,
             overlay_desks: overlay.desks,
+            overlay_workflows: overlay.workflows,
             template_provenance: overlay.provenance,
         }))
     }
@@ -1768,6 +1769,7 @@ mod test {
                 overlay_desk_members: Vec::new(),
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
                 template_provenance: None,
             };
             // Same template name under two tenants: distinct namespaced ids, no

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -352,6 +352,7 @@ impl CompanyStore for SqliteStore {
             overlay_desk_members: overlay.desk_members,
             overlay_desk_order: overlay.desk_order,
             overlay_desks: overlay.desks,
+            overlay_workflows: overlay.workflows,
             template_provenance: overlay.provenance,
         }))
     }
@@ -2073,6 +2074,7 @@ mod test {
                 overlay_desk_members: Vec::new(),
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -26,11 +26,11 @@
 //!
 //! * **sub_workflow** ([`StoreWorkflowResolver`](resolver::StoreWorkflowResolver))
 //!   — a `sub_workflow` node referencing a child by `workflow_id` resolves it
-//!   from the company's on-disk `workflows/` directory (full validation + a
-//!   static cycle guard), when a source directory is wired
-//!   ([`HarnessDeps::workflow_source_dir`](crate::harness::HarnessDeps)). A
-//!   platform-provisioned tenant with no source directory keeps the
-//!   [`UnwiredResolver`] stub.
+//!   from the union of the company's seed `workflows/` directory
+//!   ([`HarnessDeps::workflow_source_dir`](crate::harness::HarnessDeps)) and the
+//!   record's runtime-authored graph bodies (full validation + a static cycle
+//!   guard). A platform-provisioned tenant has no source directory, so every
+//!   child it owns resolves from the record.
 //!
 //! Still **not wired**: the bare-completion `LlmProvider` fallback and `code`
 //! nodes. They are explicit stubs that return a clear capability error rather
@@ -50,7 +50,6 @@ use tinyflows::caps::{
     AgentRunner, Capabilities, CodeLanguage, CodeRunner, LlmProvider, StateStore, WorkflowResolver,
 };
 use tinyflows::error::{EngineError, Result as TfResult};
-use tinyflows::model::WorkflowGraph;
 
 use crate::harness::policy::PolicyMode;
 use crate::harness::{HarnessDeps, HarnessPool, toolbelt};
@@ -133,16 +132,16 @@ pub async fn build_capabilities(
         }
     };
 
-    // sub_workflow-by-id resolves children from the company's on-disk
-    // `workflows/` directory when a source dir is wired; a platform tenant with
-    // none keeps the loud stub. Read before `deps` moves into the agent runner.
-    let resolver: Arc<dyn WorkflowResolver> = match &deps.workflow_source_dir {
-        Some(source_dir) => Arc::new(StoreWorkflowResolver::new(
-            source_dir.clone(),
-            workflow_id.to_string(),
-        )),
-        None => Arc::new(UnwiredResolver),
-    };
+    // sub_workflow-by-id resolves children from the union of the company's seed
+    // `workflows/` directory and the record's runtime-authored bodies — so a
+    // platform tenant with no source dir still resolves the workflows it
+    // created (issue #168). Read before `deps` moves into the agent runner.
+    let resolver: Arc<dyn WorkflowResolver> = Arc::new(StoreWorkflowResolver::new(
+        deps.workflow_source_dir.clone(),
+        deps.store.clone(),
+        company.clone(),
+        workflow_id.to_string(),
+    ));
 
     Capabilities {
         llm: Arc::new(UnwiredLlm),
@@ -340,22 +339,6 @@ impl CodeRunner for UnwiredCode {
         Err(EngineError::Capability(
             "code execution is not supported for company workflows".to_string(),
         ))
-    }
-}
-
-/// The `sub_workflow`-by-id fallback for a deployment with no source directory
-/// (platform-provisioned mode): there is nowhere on disk to resolve a child
-/// graph from, so a reached `sub_workflow` node fails loudly rather than
-/// silently. A deployment WITH a source directory uses
-/// [`StoreWorkflowResolver`](resolver::StoreWorkflowResolver) instead.
-struct UnwiredResolver;
-
-#[async_trait]
-impl WorkflowResolver for UnwiredResolver {
-    async fn resolve(&self, workflow_id: &str) -> TfResult<WorkflowGraph> {
-        Err(EngineError::Capability(format!(
-            "sub_workflow reference '{workflow_id}' is not supported for company workflows"
-        )))
     }
 }
 

--- a/src/workflows/caps/resolver.rs
+++ b/src/workflows/caps/resolver.rs
@@ -3,10 +3,16 @@
 //! tinyflows is persistence-free: when a `sub_workflow` node references a child
 //! by `workflow_id`, the engine asks the host to resolve that id to a runnable
 //! [`WorkflowGraph`](tinyflows::model::WorkflowGraph). [`StoreWorkflowResolver`]
-//! serves that from the company's on-disk source directory
-//! (`companies/<name>/workflows/<id>.toml`), running the child through the SAME
-//! full [`parse_workflow`](crate::company::parse_workflow) validation a
+//! serves that from the union of the company's two graph sources — the seed
+//! files (`companies/<name>/workflows/<id>.toml`) and the runtime-authored
+//! bodies on the [`CompanyRecord`](crate::ports::types::CompanyRecord) overlay —
+//! running the child through the SAME full
+//! [`parse_workflow`](crate::company::parse_workflow) validation a
 //! hand-authored or console-created workflow gets, then translating it.
+//!
+//! Reading the overlay matters for more than availability: a hosted tenant's
+//! children live *only* there, so a resolver that saw the seed side alone would
+//! both fail to resolve them and — worse — miss them in the cycle scan below.
 //!
 //! ## Cycle safety
 //!
@@ -23,18 +29,22 @@
 //!   [`MAX_SUB_WORKFLOW_DEPTH`](tinyflows::engine::MAX_SUB_WORKFLOW_DEPTH) bound
 //!   still terminates any cycle formed through expression-computed ids.
 //!
-//! The resolver is stateless per call — each `resolve` re-derives everything from
-//! the source directory, so a workflow edited on disk between steps is picked up.
+//! The resolver is stateless per call — each `resolve` re-loads the record and
+//! re-reads the source directory, so a workflow edited between steps is picked
+//! up.
 
 use std::collections::{HashSet, VecDeque};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use tinyflows::caps::WorkflowResolver;
 use tinyflows::error::{EngineError, Result as TfResult};
 use tinyflows::model::WorkflowGraph;
 
-use crate::company::{WorkflowFile, WorkflowNodeKind, load_company_workflows};
+use crate::company::{WorkflowFile, WorkflowNodeKind, load_workflow_union};
+use crate::ports::CompanyStore;
+use crate::ports::types::{CompanyId, OverlayWorkflow};
 
 /// Hard bound on how many workflows the static cycle scan visits before giving
 /// up. A store this deep is either pathological or adversarial; refusing to run
@@ -44,20 +54,33 @@ const MAX_STATIC_RESOLVE_NODES: usize = 64;
 /// A [`WorkflowResolver`] serving `sub_workflow`-by-id from a company's on-disk
 /// `workflows/` directory, with a static transitive-closure cycle guard.
 pub struct StoreWorkflowResolver {
-    /// The company source directory (`companies/<name>`); children live under
-    /// its `workflows/<id>.toml`.
-    source_dir: PathBuf,
+    /// The company source directory (`companies/<name>`); seed children live
+    /// under its `workflows/<id>.toml`. `None` on a hosted tenant, whose
+    /// children are all overlay bodies.
+    source_dir: Option<PathBuf>,
+    /// The company store, read per resolve for the runtime-authored graph
+    /// bodies (the overlay half of the union).
+    store: Arc<dyn CompanyStore>,
+    /// The company whose record carries those bodies.
+    company: CompanyId,
     /// The id of the top-level workflow the current run started from — a child
     /// whose closure reaches back to it would loop the whole run.
     root_id: String,
 }
 
 impl StoreWorkflowResolver {
-    /// Builds a resolver serving children from `source_dir` for a run rooted at
-    /// `root_id`.
-    pub fn new(source_dir: PathBuf, root_id: String) -> Self {
+    /// Builds a resolver serving children from `source_dir` ∪ `company`'s
+    /// overlay bodies, for a run rooted at `root_id`.
+    pub fn new(
+        source_dir: Option<PathBuf>,
+        store: Arc<dyn CompanyStore>,
+        company: CompanyId,
+        root_id: String,
+    ) -> Self {
         Self {
             source_dir,
+            store,
+            company,
             root_id,
         }
     }
@@ -87,7 +110,8 @@ impl StoreWorkflowResolver {
     /// [`MAX_STATIC_RESOLVE_NODES`]; an unresolvable child is not a cycle (it
     /// fails loudly at its own resolve) so it is skipped here.
     fn guard_cycle(
-        source_dir: PathBuf,
+        source_dir: Option<PathBuf>,
+        overlays: Vec<OverlayWorkflow>,
         root_id: String,
         start_id: String,
         start_file: WorkflowFile,
@@ -117,12 +141,8 @@ impl StoreWorkflowResolver {
             }
             // An unresolvable / invalid child is not itself a cycle — it will
             // fail loudly when the engine resolves it. Skip it in the scan.
-            let Ok(mut loaded) =
-                load_company_workflows(&source_dir, std::slice::from_ref(&current))
+            let Ok(Some(file)) = load_workflow_union(source_dir.as_deref(), &overlays, &current)
             else {
-                continue;
-            };
-            let Some(file) = loaded.pop() else {
                 continue;
             };
             for referenced in Self::static_refs(&file) {
@@ -150,27 +170,39 @@ impl WorkflowResolver for StoreWorkflowResolver {
             )));
         }
 
-        // (b) Load the child, re-running full OpenCompany parse + validation on
-        // it (the same rules a hand-authored or console-created graph passes).
-        let id = workflow_id.to_string();
-        let file = load_company_workflows(&self.source_dir, std::slice::from_ref(&id))
+        // (b) The company's runtime-authored bodies, read once and reused by the
+        // load and the cycle scan below so both see the same snapshot.
+        let overlays = self
+            .store
+            .load(&self.company)
+            .await
+            .map_err(|err| {
+                EngineError::Capability(format!(
+                    "sub_workflow '{workflow_id}': could not read saved workflows: {err}"
+                ))
+            })?
+            .map(|record| record.overlay_workflows)
+            .unwrap_or_default();
+
+        // (c) Load the child from the seed ∪ overlay union, re-running full
+        // OpenCompany parse + validation on it (the same rules a hand-authored
+        // or console-created graph passes).
+        let file = load_workflow_union(self.source_dir.as_deref(), &overlays, workflow_id)
             .map_err(|err| EngineError::Capability(format!("sub_workflow '{workflow_id}': {err}")))?
-            .into_iter()
-            .next()
             .ok_or_else(|| {
                 EngineError::Capability(format!(
                     "sub_workflow '{workflow_id}' is not a saved workflow on this company"
                 ))
             })?;
 
-        // (c) Static cycle guard over the store, before the child is handed back
-        // to the engine to compile + run.
+        // (d) Static cycle guard over the same union, before the child is handed
+        // back to the engine to compile + run.
         let source_dir = self.source_dir.clone();
         let root_id = self.root_id.clone();
         let start_id = workflow_id.to_string();
         let start_file = file.clone();
         tokio::task::spawn_blocking(move || {
-            Self::guard_cycle(source_dir, root_id, start_id, start_file)
+            Self::guard_cycle(source_dir, overlays, root_id, start_id, start_file)
         })
         .await
         .map_err(|err| {
@@ -179,7 +211,7 @@ impl WorkflowResolver for StoreWorkflowResolver {
             ))
         })??;
 
-        // (d) Translate to a runnable tinyflows graph.
+        // (e) Translate to a runnable tinyflows graph.
         Ok(crate::workflows::translate::translate(&file))
     }
 }
@@ -196,6 +228,77 @@ fn is_safe_workflow_id(id: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::company::CompanyManifest;
+    use crate::error::Result as OcResult;
+    use crate::ports::types::{CompanyRecord, CompanySummary, LedgerEntry};
+
+    /// An in-memory `CompanyStore` holding one record, so the resolver's overlay
+    /// half can be seeded without a real backend.
+    struct MemStore(std::sync::Mutex<Option<CompanyRecord>>);
+
+    #[async_trait]
+    impl CompanyStore for MemStore {
+        async fn load(&self, _id: &CompanyId) -> OcResult<Option<CompanyRecord>> {
+            Ok(self.0.lock().unwrap().clone())
+        }
+        async fn save(&self, record: &CompanyRecord) -> OcResult<()> {
+            *self.0.lock().unwrap() = Some(record.clone());
+            Ok(())
+        }
+        async fn list(&self) -> OcResult<Vec<CompanySummary>> {
+            Ok(Vec::new())
+        }
+        async fn append_ledger(&self, _id: &CompanyId, _entry: LedgerEntry) -> OcResult<()> {
+            Ok(())
+        }
+    }
+
+    /// A store whose record carries `overlays` as its runtime-authored graphs.
+    fn store_with(overlays: Vec<OverlayWorkflow>) -> Arc<dyn CompanyStore> {
+        let manifest: CompanyManifest =
+            toml::from_str("[company]\nname = \"Acme\"\n").expect("valid manifest");
+        Arc::new(MemStore(std::sync::Mutex::new(Some(CompanyRecord {
+            id: CompanyId::new("acme"),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: overlays,
+            template_provenance: None,
+        }))))
+    }
+
+    /// A resolver over a seed directory only (no runtime-authored graphs).
+    fn seed_resolver(dir: &std::path::Path, root_id: &str) -> StoreWorkflowResolver {
+        StoreWorkflowResolver::new(
+            Some(dir.to_path_buf()),
+            store_with(Vec::new()),
+            CompanyId::new("acme"),
+            root_id.to_string(),
+        )
+    }
+
+    /// A resolver with NO seed directory, serving only overlay bodies — the
+    /// hosted shape (issue #168).
+    fn overlay_resolver(overlays: Vec<OverlayWorkflow>, root_id: &str) -> StoreWorkflowResolver {
+        StoreWorkflowResolver::new(
+            None,
+            store_with(overlays),
+            CompanyId::new("acme"),
+            root_id.to_string(),
+        )
+    }
+
+    fn overlay(id: &str, toml: String) -> OverlayWorkflow {
+        OverlayWorkflow {
+            id: id.to_string(),
+            toml,
+        }
+    }
 
     /// Writes `src` to `<dir>/workflows/<id>.toml`.
     fn write_wf(dir: &std::path::Path, id: &str, src: &str) {
@@ -252,7 +355,7 @@ to = "sub"
     async fn resolves_a_saved_child_into_a_compilable_graph() {
         let dir = tempfile::tempdir().unwrap();
         write_wf(dir.path(), "child", &leaf("child"));
-        let resolver = StoreWorkflowResolver::new(dir.path().to_path_buf(), "root".to_string());
+        let resolver = seed_resolver(dir.path(), "root");
 
         let graph = resolver.resolve("child").await.expect("resolves");
         assert_eq!(graph.id.as_deref(), Some("child"));
@@ -263,7 +366,7 @@ to = "sub"
     #[tokio::test]
     async fn unknown_child_is_a_capability_error() {
         let dir = tempfile::tempdir().unwrap();
-        let resolver = StoreWorkflowResolver::new(dir.path().to_path_buf(), "root".into());
+        let resolver = seed_resolver(dir.path(), "root");
         let err = resolver.resolve("ghost").await.unwrap_err();
         assert!(err.to_string().contains("ghost"), "{err}");
     }
@@ -271,7 +374,7 @@ to = "sub"
     #[tokio::test]
     async fn traversal_id_is_refused() {
         let dir = tempfile::tempdir().unwrap();
-        let resolver = StoreWorkflowResolver::new(dir.path().to_path_buf(), "root".into());
+        let resolver = seed_resolver(dir.path(), "root");
         let err = resolver.resolve("../secrets").await.unwrap_err();
         assert!(err.to_string().contains("not a valid workflow id"), "{err}");
     }
@@ -284,7 +387,7 @@ to = "sub"
         // reject because `a` is in `b`'s closure.
         write_wf(dir.path(), "a", &parent_of("a", "b"));
         write_wf(dir.path(), "b", &parent_of("b", "a"));
-        let resolver = StoreWorkflowResolver::new(dir.path().to_path_buf(), "a".into());
+        let resolver = seed_resolver(dir.path(), "a");
         let err = resolver.resolve("b").await.unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("cycle"), "{msg}");
@@ -303,7 +406,7 @@ to = "sub"
         write_wf(dir.path(), "flow_a", &parent_of("flow_a", "flow_b"));
         write_wf(dir.path(), "flow_b", &parent_of("flow_b", "flow_a"));
         // Root is flow_a; the engine resolves flow_b first.
-        let resolver = StoreWorkflowResolver::new(dir.path().to_path_buf(), "flow_a".into());
+        let resolver = seed_resolver(dir.path(), "flow_a");
         let err = resolver.resolve("flow_b").await.unwrap_err();
         assert!(err.to_string().contains("cycle"), "{err}");
     }
@@ -316,9 +419,65 @@ to = "sub"
         write_wf(dir.path(), "b", &parent_of("b", "d"));
         write_wf(dir.path(), "c", &parent_of("c", "d"));
         write_wf(dir.path(), "d", &leaf("d"));
-        let resolver = StoreWorkflowResolver::new(dir.path().to_path_buf(), "root".into());
+        let resolver = seed_resolver(dir.path(), "root");
         resolver.resolve("b").await.expect("b resolves");
         resolver.resolve("c").await.expect("c resolves");
         resolver.resolve("d").await.expect("d resolves");
+    }
+
+    // --- #168: overlay-only (hosted) children --------------------------------
+
+    /// A `sub_workflow` child that exists ONLY as a runtime-authored body — the
+    /// hosted case — resolves into a compilable graph.
+    #[tokio::test]
+    async fn resolves_an_overlay_child_with_no_source_dir() {
+        let resolver = overlay_resolver(vec![overlay("child", leaf("child"))], "root");
+        let graph = resolver.resolve("child").await.expect("resolves");
+        assert_eq!(graph.id.as_deref(), Some("child"));
+        tinyflows::compiler::compile(&graph).expect("resolved overlay child compiles");
+    }
+
+    /// The static cycle scan must walk overlay children too — otherwise a cycle
+    /// formed entirely from console-created workflows would only be caught by the
+    /// engine's depth backstop, deep into the run.
+    #[tokio::test]
+    async fn cycle_through_overlay_children_is_rejected() {
+        let resolver = overlay_resolver(
+            vec![
+                overlay("flow_a", parent_of("flow_a", "flow_b")),
+                overlay("flow_b", parent_of("flow_b", "flow_a")),
+            ],
+            "flow_a",
+        );
+        let err = resolver.resolve("flow_b").await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("cycle"), "{msg}");
+        assert!(
+            !msg.contains("depth"),
+            "should be the static cycle msg: {msg}"
+        );
+    }
+
+    /// A seed file and an overlay body sharing one id: the seed wins, matching
+    /// `load_workflow_union`'s documented precedence.
+    #[tokio::test]
+    async fn a_seed_file_shadows_an_overlay_of_the_same_id() {
+        let dir = tempfile::tempdir().unwrap();
+        write_wf(dir.path(), "child", &leaf("child"));
+        // The overlay body of the same id is a *parent* graph — if it won, the
+        // resolved graph would carry a sub_workflow node.
+        let resolver = StoreWorkflowResolver::new(
+            Some(dir.path().to_path_buf()),
+            store_with(vec![overlay("child", parent_of("child", "other"))]),
+            CompanyId::new("acme"),
+            "root".to_string(),
+        );
+        let graph = resolver.resolve("child").await.expect("resolves");
+        assert_eq!(graph.id.as_deref(), Some("child"));
+        assert_eq!(
+            graph.nodes.len(),
+            2,
+            "the seed leaf must win over the overlay parent"
+        );
     }
 }

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -214,6 +214,7 @@ description = "Runs Acme."
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         }
     }
@@ -290,6 +291,7 @@ allow = ["*"]
             overlay_desk_members: Vec::new(),
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
             template_provenance: None,
         }
     }


### PR DESCRIPTION
## Summary

Workflow creation wrote the graph body into the company **source** directory (`companies/<name>/workflows/<id>.toml`), which is the read-only crate mount in hosted deployments. Every hosted tenant got `Read-only file system (os error 30)` and could not create a workflow at all.

Created graphs now persist on the company record as `overlay_workflows` — the same writable-store overlay already used for runtime-created teammates and desks — and every reader resolves a graph from the union of the committed seed tree and that overlay, with the committed file winning on an id collision.

Closes #168.

## API Or Behavior Changes

**Fixed**: `POST /companies/{id}/workflows` succeeds on a tenant whose source tree is read-only, and on one with no source directory at all. The graph survives a restart, lists with its real name, and is loadable by the REST, GraphQL, orchestrator-tool, and `sub_workflow` read paths.

**Behavior change for non-hosted deployments**: the REST create handler carried a drifted copy of the create logic; it now routes through the shared core (`create_company_workflow`). Name-uniqueness, node/edge/byte caps, the company write lock, and `WorkflowCreated` audit events therefore apply to REST callers too — they previously applied only to the orchestrator tool.

**Id-uniqueness** is now a membership check under the company write lock (seed path ∪ overlay ids ∪ enabled ids) rather than `create_new(true)`; the lock serializes both API surfaces. A duplicate id is still a 409. The seed check tests the path rather than a directory scan, so a malformed committed `workflows/<id>.toml` still counts as taking its id — otherwise it would shadow an overlay body that had been allowed to claim the same id.

**`Company.workflows.enabled` (GraphQL)** now reports manifest membership rather than existence, and the field description says so. The id set for that resolver comes from the union, matching REST. Descriptions-only SDL change; no field or type shape moved.

**`WorkflowRunner` / record shape**: `CompanyRecord` gains `overlay_workflows: Vec<OverlayWorkflow>` (`#[serde(default)]`, so existing records load unchanged), carried through the fs, sqlite, and MongoDB backends and the export bundle.

**`create_company_workflow` and `StoreWorkflowResolver`** now take `Option<&Path>` / `Option<PathBuf>` for the source dir. `UnwiredResolver` is deleted — with an optional source dir there is no deployment shape it served.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 899 passed, 0 failed

Also run: `cargo check --all-features` and `cargo check --features openhuman,mcp,telegram` (a mandatory new record field rots in sites those combos alone compile), plus `npm ci && npm run typecheck && npm run build`.

New coverage: seed-vs-overlay union precedence and malformed-overlay tolerance; create with no source dir; id and name collisions against seed and overlay; a `hosted_mode` HTTP suite (create on a no-source-dir tenant → 200, list shows the real name, GET returns the graph, duplicate → 409, and a freshly rebuilt `AppState` over the same store still lists it); GraphQL summaries listing an overlay workflow with an empty `enabled` list, asserted equal to the REST id set; overlay `sub_workflow` resolution and cycle rejection; store conformance and an export→import round-trip carrying the overlay.

**Manual verification against a running server** (`--features openhuman,mcp,telegram`, `companies/e2e_harness`, source directory `chmod a-w` so it was genuinely unwritable, no `workflows/` subdirectory present):

- create → 200, and no file appeared anywhere under the source tree
- list and GET return the workflow; duplicate create → 409
- process killed and restarted over the same store → still listed; the persisted record carries the overlay body
- GraphQL `Company.workflows` and REST list agree on the id set

**Known gaps**: the MongoDB conformance assertions skip without a live server (`OPENCOMPANY_MONGODB_URI`); its `load` mapping compiles and its persisted shape is covered by a unit test over `OverlayBlob`. `cargo test --features sqlite` does not compile on `main` either (`E0034` in `src/store/sqlite.rs`), so the sqlite conformance path is unverified here; that failure is pre-existing and out of scope for this PR.

## Documentation

`docs/spec/runtime/ports.md` describes the overlay and the union read path. Module docs on `workflow_file.rs`, `workflow_create.rs`, and `server/ops/workflows.rs` are updated; the obsolete "no writable source directory" rejection note is removed from the `createWorkflow` doc comment in `frontend/src/api/workflows.ts`.

## Related

Follow-up worth its own issue, found while verifying this one and deliberately **not** fixed here: a boot rebuild overwrites the persisted record's manifest with the one parsed from the seed `company.toml` (`src/runtime/builder.rs:1121`), so every runtime manifest mutation — including the `[workflows].enabled` push this create path performs — is lost on the next boot. It is visible in this PR only as `Company.workflows.enabled` reading `true` before a restart and `false` after. Nothing consults `enabled` to decide whether a workflow may run, so #168 does not depend on it, and the correct fix is a decision about whether the seed file or the persisted record owns each manifest field — wider than this change and deserving its own review.
