### PR TITLE
ci: pre-pull the tenant image into containerd so tenants can actually run it

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -121,11 +121,42 @@ jobs:
           set -euo pipefail
           export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 
-          # Tenants pull with the ecr-creds Secret, which expires after 12h and is
+          # The manager namespace's ecr-creds Secret expires after 12h and is
           # refreshed every 6h by a systemd timer. Force a refresh so a deploy
-          # landing late in that window cannot leave tenants in ImagePullBackOff.
+          # landing late in that window cannot fail on a stale token.
           echo "Refreshing ECR pull secret..."
           /usr/local/bin/ecr-refresh.sh
+
+          # Pre-pull the tenant image into the node's containerd.
+          #
+          # This is REQUIRED, not an optimisation. Tenant StatefulSets carry no
+          # imagePullSecrets, tenant namespaces have no ecr-creds, and there is no
+          # node-level registries.yaml — so a tenant pod pulling from ECR itself
+          # gets `403 Forbidden` and sits in ImagePullBackOff. containerd's image
+          # store is node-wide, so pulling here (with the credential the kubelet
+          # already holds) means every tenant's imagePullPolicy: IfNotPresent
+          # finds the image locally and never authenticates.
+          #
+          # This works because staging is a single node. The durable fix is for
+          # the manager to provision a per-tenant-namespace pull secret and set
+          # imagePullSecrets on the tenant pod spec; until that lands, this step
+          # is what makes a freshly pushed tenant image actually runnable.
+          echo "Pre-pulling ${IMAGE} into containerd..."
+          ECR_HOST="${IMAGE%%/*}"
+          PULL_USER=$(kubectl -n "${K8S_NAMESPACE}" get secret ecr-creds \
+            -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d \
+            | jq -r --arg r "${ECR_HOST}" '.auths[$r].username // "AWS"')
+          PULL_PW=$(kubectl -n "${K8S_NAMESPACE}" get secret ecr-creds \
+            -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d \
+            | jq -r --arg r "${ECR_HOST}" '.auths[$r].password')
+          if [ -z "${PULL_PW}" ] || [ "${PULL_PW}" = "null" ]; then
+            echo "ERROR: could not read an ECR credential for ${ECR_HOST} from ecr-creds" >&2
+            exit 1
+          fi
+          # Credential is passed as an argument to ctr only; never echoed.
+          k3s ctr images pull --user "${PULL_USER}:${PULL_PW}" "${IMAGE}"
+          k3s ctr images ls | awk '{print $1}' | grep -qx "${IMAGE}" \
+            || { echo "ERROR: ${IMAGE} is not in containerd after pull" >&2; exit 1; }
 
           # Tenant pods pin imagePullPolicy: IfNotPresent, so a moving tag is not
           # re-pulled. The manager must be pointed at the immutable

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -154,9 +154,13 @@ jobs:
             exit 1
           fi
           # Credential is passed as an argument to ctr only; never echoed.
-          k3s ctr images pull --user "${PULL_USER}:${PULL_PW}" "${IMAGE}"
-          k3s ctr images ls | awk '{print $1}' | grep -qx "${IMAGE}" \
-            || { echo "ERROR: ${IMAGE} is not in containerd after pull" >&2; exit 1; }
+          # -n k8s.io is explicit on purpose: the kubelet only sees images in that
+          # containerd namespace. `k3s ctr` already defaults to it (unlike plain
+          # `ctr`, which defaults to `default`), but naming it means this does not
+          # silently break if that wrapper default ever changes.
+          k3s ctr -n k8s.io images pull --user "${PULL_USER}:${PULL_PW}" "${IMAGE}"
+          k3s ctr -n k8s.io images ls -q | grep -Fqx "${IMAGE}" \
+            || { echo "ERROR: ${IMAGE} is not in the k8s.io containerd namespace after pull" >&2; exit 1; }
 
           # Tenant pods pin imagePullPolicy: IfNotPresent, so a moving tag is not
           # re-pulled. The manager must be pointed at the immutable


### PR DESCRIPTION
## Summary

Follow-up to #200. Pushing a tenant image to ECR is not enough to make it runnable — tenant pods cannot pull from ECR at all — so this pre-pulls the pushed image into the node's containerd before pointing tenants at it.

This was pushed to #200's branch shortly after that PR merged, so it missed the merge.

## API Or Behavior Changes

None in the crate. CI only. One behavioural change to the deploy: it now **fails** if the image is not present in containerd afterwards, instead of succeeding and leaving tenants to discover the problem at wake time.

## Problem

Tenant pods have no route to authenticate to ECR:

- tenant StatefulSets carry no `imagePullSecrets`
- tenant namespaces have no `ecr-creds` Secret (only `opencompany-system` and `app` have one)
- there is no node-level `/etc/rancher/k3s/registries.yaml`

So the kubelet pulls anonymously and ECR refuses. Observed on staging while restoring the `smoke1` tenant:

```
Failed to pull image ".../tinyhumansai/opencompany-tenant:staging":
failed to resolve reference: unexpected status from HEAD request to
https://<acct>.dkr.ecr.us-east-1.amazonaws.com/v2/tinyhumansai/opencompany-tenant/manifests/staging: 403 Forbidden
```

**This is pre-existing, not introduced by #200.** `OCM_TENANT_IMAGE` on staging already points at ECR, so *any* tenant wake fails this way today — `john` and `tinyhumans-marketing` would fail identically. It has gone unnoticed because all three tenants are scaled to zero and nothing had woken them. The effect of #200 without this fix is that the pipeline keeps publishing images no tenant can run.

## Solution

After pushing, pull the image into the node's containerd using the credential the kubelet already holds (read from the `ecr-creds` Secret in `opencompany-system`, passed to `ctr` as an argument and never echoed). containerd's image store is node-wide, so every tenant's `imagePullPolicy: IfNotPresent` then resolves locally and never authenticates.

Verified by hand on staging before writing it: after `k3s ctr images pull`, the previously failing tenant pod progressed past `ImagePullBackOff` to `Running` on the same image reference that had been returning 403.

The step asserts the image really is in containerd afterwards and fails the job if not, so a silent pull failure cannot turn into a tenant that cannot start.

## Tests

- Workflow parses as valid YAML.
- The mechanism was exercised manually against the live staging node: credential read from `ecr-creds` via `jq`, `k3s ctr images pull` succeeded (16.5 MB in 1.8s), image then listed in `k3s ctr images ls`, and the tenant pod reached `Running` where it had previously been stuck on 403.
- Not yet run through the workflow itself, which is blocked on the `AWS_ROLE_ARN` / `SSH_PRIVATE_KEY` / `SSH_HOST` secrets and the OIDC trust-policy update.

## Documentation

The step carries an inline comment stating why it is required rather than an optimisation, and — explicitly — that it is single-node-staging specific.

## Notes for review

**This is a workaround, and the comment in the workflow says so.** The durable fix belongs in the manager: provision a pull secret per tenant namespace and set `imagePullSecrets` on the tenant pod spec, with the ECR refresh timer covering those namespaces. That is an `opencompany-microservice` change, so it is deliberately not attempted here. Happy to file it there if you would rather have it tracked than remembered.

Two properties worth checking in review:

- The credential is only ever passed as an argument to `ctr`; it is not printed, and the step prints only the image reference.
- It reads `ecr-creds` from `opencompany-system` (which the refresh timer maintains) rather than creating any new secret.

## Related

- #200 — added the tenant image pipeline this completes.
- `tinyhumansai/opencompany-microservice#7` — the companion manager-image pipeline, still open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging deployments by refreshing container registry credentials before deployment.
  * Added validation to confirm required image credentials and local image availability.
  * Preloads tenant images onto staging nodes to reduce deployment failures caused by image-pull issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->