### PR TITLE
fix(console): task board columns and task detail now scroll

### DIFF
--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -138,7 +138,7 @@ function SidebarProvider({
           } as React.CSSProperties
         }
         className={cn(
-          "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+          "group/sidebar-wrapper flex h-svh min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
           className
         )}
         {...props}

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -243,7 +243,7 @@ export function TaskDetailView({
   }
 
   return (
-    <div className="flex flex-1 flex-col overflow-hidden">
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <div className="flex items-center gap-2 border-b px-4 py-3">
         <Button variant="ghost" size="sm" className="-ml-2 h-8 px-2" onClick={onBack}>
           <ArrowLeft className="mr-1.5 size-4" />
@@ -267,7 +267,7 @@ export function TaskDetailView({
           <Skeleton className="h-48 rounded-xl" />
         </div>
       ) : detail ? (
-        <ScrollArea className="flex-1">
+        <ScrollArea className="min-h-0 flex-1">
           <div className="mx-auto w-full max-w-3xl space-y-5 p-4">
             <DetailHeader task={detail.task} worked={worked} />
 

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -189,7 +189,7 @@ export function TasksView({
   }
 
   return (
-    <div className="flex flex-1 flex-col overflow-hidden">
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <div className="flex items-center justify-between border-b px-4 py-3">
         <div className="flex items-center gap-2">
           <h2 className="text-sm font-semibold">Board</h2>
@@ -208,7 +208,7 @@ export function TasksView({
         </div>
       )}
 
-      <div className="flex flex-1 gap-4 overflow-x-auto py-4 pl-4">
+      <div className="flex min-h-0 flex-1 gap-4 overflow-x-auto py-4 pl-4">
         {TASK_COLUMNS.map((col) => {
           const items = tasks.filter((t) => t.column === col.id);
           return (
@@ -221,7 +221,7 @@ export function TasksView({
               onDragLeave={() => setOverCol((c) => (c === col.id ? null : c))}
               onDrop={() => void moveTo(col.id)}
               className={cn(
-                "flex w-72 shrink-0 flex-col rounded-xl border bg-card/40 transition-colors",
+                "flex min-h-0 w-72 shrink-0 flex-col rounded-xl border bg-card/40 transition-colors",
                 overCol === col.id && "border-primary/40 bg-accent/40",
               )}
             >
@@ -238,7 +238,7 @@ export function TasksView({
                   <Plus className="size-4" />
                 </button>
               </div>
-              <div className="flex flex-1 flex-col gap-2 overflow-y-auto px-2 pb-2">
+              <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2 pb-2">
                 {loading && items.length === 0 ? (
                   <Skeleton className="h-20 rounded-lg" />
                 ) : (


### PR DESCRIPTION
## Summary

The task board's columns and the task-detail body could not scroll. A full **Done** column (or a long task timeline) overflowed off-screen instead of scrolling to it.

Two layered causes:

1. **Frame had no height ceiling.** The shadcn sidebar wrapper was `min-h-svh` — a *floor*, not a ceiling. A pane taller than the viewport grew the whole frame past `svh`; `<main>` is `overflow-hidden`, so the excess was clipped and the inner `overflow-y-auto` panes never received a bounded height to scroll within. Set the wrapper to `h-svh` (definite viewport height). `<main>` is `overflow-hidden` and every view scrolls internally (no view page-scrolls), so this cannot regress another view.
2. **Broken `min-h-0` chain.** Flex items default to `min-height:auto`, which stops a `flex-1` + `overflow-*-auto` child from shrinking below its content. Added `min-h-0` down the board chain (board root → columns row → column → card list) and the task-detail body + `ScrollArea`.

Both are needed together: the frame bound gives a definite height to shrink into, `min-h-0` lets the scroll containers actually shrink.

## API Or Behavior Changes

None. Frontend-only layout fix. `Done` was simply the first column tall enough to expose the bug; the fix applies to every column and to task detail.

## Tests

Frontend-only change — Rust gates N/A (no Rust touched):

- N/A: `cargo fmt --all -- --check`
- N/A: `cargo clippy --all-targets -- -D warnings`
- N/A: `cargo build --all-targets`
- N/A: `cargo test`

Frontend (npm) gates run:

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] Manual: verified a full Done column and a long task timeline scroll in the running console.

## Documentation

None needed — no API, config, or behavior contract changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar and task view layouts to fit the viewport more reliably.
  * Fixed scrolling in task boards, columns, cards, and task detail views within flexible layouts.
  * Prevented content areas from expanding beyond their available space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->