### PR TITLE
fix(telegram): receive inbound over getUpdates polling, not a webhook

### DIFF
--- a/docs/modules/runtime/README.md
+++ b/docs/modules/runtime/README.md
@@ -48,6 +48,31 @@ count dropping to zero — so a schedule saved later onto a still-unwired compan
 is reported rather than swallowed by the latch. A company with no scheduled
 workflows and no runner is not misconfigured and stays silent.
 
+## Background listeners
+
+Two per-company background loops sit beside the scheduler, both spawned in
+`serve` and stopped by the same shutdown `Notify`:
+
+- `mailbox_poller.rs` — the IMAP mailbox poll (feature `imap`), on a fixed
+  interval (`OPENCOMPANY_MAIL_POLL_SECONDS`, default `60`).
+- `telegram_poller.rs` — Telegram `getUpdates` long-polling (feature
+  `telegram`), the inbound path that **needs no public URL**. It dials out to
+  `api.telegram.org`, so it works on localhost, behind NAT, and on any
+  self-hosted box — where Telegram's servers can never reach an inbound
+  `/hooks/{company}/telegram` route. Setup is the bot token alone; the loop
+  idles until one is stored and picks up a token pasted into the console on its
+  next tick, with no restart. Long-poll hold and idle back-off are
+  `OPENCOMPANY_TELEGRAM_POLL_SECONDS` (default `30`).
+
+The webhook route (`server::hooks`) stays as an optional hosted fast-path, and
+is offered only when `OPENCOMPANY_PUBLIC_URL` is a public **https** URL. The two
+paths never both consume an update: Telegram refuses `getUpdates` while a
+webhook is registered, so the poller checks `getWebhookInfo` first and stands by
+on a publicly reachable host — while on a host with no public URL a registered
+webhook can only be a dead endpoint, so it clears it and takes inbound back.
+Both paths run the same turn and share `telegram::deliver_replies`, so which one
+delivered an update is invisible downstream.
+
 ## Harness pool (`src/harness/`, feature `openhuman`)
 
 `src/harness/` embeds `openhuman_core` as a library (see

--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -122,3 +122,17 @@ Relevant configuration:
   `https://api.tiny.place`).
 - `OPENCOMPANY_PUBLIC_URL` — public host base embedded in published Agent Card
   endpoints. When unset, the endpoint falls back to `http://{bind}`.
+
+## Inbound channel webhooks (`hooks.rs`)
+
+`POST /hooks/{company}/telegram` is the **optional hosted fast-path** for
+Telegram inbound, not the default. Telegram can only deliver to it from the
+public internet, so it is surfaced only when `OPENCOMPANY_PUBLIC_URL` is a
+public **https** URL (`AppConfig::public_webhook_base_url`); otherwise
+`GET …/channels/telegram` reports `webhookUrl: null` and
+`POST …/channels/telegram/webhook` is refused with `400`, rather than handing an
+operator a `http://127.0.0.1:<port>/hooks/…` URL that can never receive a
+delivery. Everywhere else — local and most self-hosted deployments — inbound
+arrives over `getUpdates` long-polling
+([`runtime::telegram_poller`](../runtime/README.md#background-listeners)) and a
+bot token is the whole setup: no webhook secret, no `setWebhook`, no public URL.

--- a/frontend/src/api/channels.ts
+++ b/frontend/src/api/channels.ts
@@ -4,22 +4,34 @@
 //
 // The bot token and webhook secret are write-only: they are sent on PUT and
 // stored in the host's secret store; neither is ever returned. The read shape
-// (`TelegramChannelStatus`) carries only presence booleans and the public
-// webhook URL. Mirrors `api/mcp.ts` — standalone functions over the shared
-// client, so no change to `OpenCompanyClient` is needed.
+// (`TelegramChannelStatus`) carries only presence booleans, how inbound
+// arrives, and the webhook URL when the host has a usable one. Mirrors
+// `api/mcp.ts` — standalone functions over the shared client, so no change to
+// `OpenCompanyClient` is needed.
+//
+// Issue #203: a bot token alone is a working channel. Inbound arrives over
+// `getUpdates` long-polling, which dials out and so needs no public URL; the
+// webhook is an optional hosted fast-path the host advertises (a non-null
+// `webhookUrl`) only when Telegram could actually deliver to it.
 
 import type { OpenCompanyClient } from "./client";
 
 /** The non-secret status of a company's Telegram channel. */
 export interface TelegramChannelStatus {
-  /** True once both the bot token and the webhook secret are stored. */
+  /** True once a bot token is stored — that alone is a working channel. */
   configured: boolean;
   /** Whether a bot token is stored (never the token itself). */
   tokenSet: boolean;
   /** Whether a webhook secret is stored (never the secret itself). */
   secretSet: boolean;
-  /** The URL to register with Telegram (`setWebhook`) / paste into BotFather. */
-  webhookUrl: string;
+  /**
+   * The URL to register with Telegram (`setWebhook`), or `null` when this host
+   * has no publicly reachable https URL — every local and most self-hosted
+   * deployment. Never show a webhook affordance while this is `null`.
+   */
+  webhookUrl: string | null;
+  /** Whether this host long-polls Telegram for inbound updates. */
+  polling: boolean;
 }
 
 /** The write-only config body. Only present, non-empty fields are applied. */
@@ -34,7 +46,7 @@ export interface TelegramConfigBody {
 export interface SetWebhookResult {
   ok: boolean;
   message: string;
-  webhookUrl: string;
+  webhookUrl: string | null;
 }
 
 /** Read the company's Telegram channel status. */

--- a/frontend/src/views/connections/ChannelsSection.tsx
+++ b/frontend/src/views/connections/ChannelsSection.tsx
@@ -25,9 +25,17 @@ interface Props {
 type Load = "loading" | "ready" | "unavailable";
 
 /**
- * Configure the company's Telegram channel: store the bot token + webhook
- * secret (both write-only), show the webhook URL to paste into BotFather /
- * `setWebhook`, and register the webhook when the host has the transport wired.
+ * Configure the company's Telegram channel.
+ *
+ * Setup is a bot token, and nothing else: the host receives inbound over
+ * `getUpdates` long-polling, which dials out to Telegram and therefore works on
+ * localhost, behind NAT, and on any self-hosted box (issue #203).
+ *
+ * The inbound webhook is an optional hosted fast-path. The host advertises it
+ * by returning a non-null `webhookUrl`, which it only does when it has a
+ * publicly reachable https URL — so this card shows the webhook block *only*
+ * then, rather than handing the operator a `http://127.0.0.1:<port>/hooks/...`
+ * URL that Telegram's servers can never deliver to.
  */
 export function ChannelsSection({ client, company }: Props) {
   const [load, setLoad] = useState<Load>("loading");
@@ -54,7 +62,7 @@ export function ChannelsSection({ client, company }: Props) {
   async function save() {
     if (busy) return;
     if (!botToken.trim() && !webhookSecret.trim()) {
-      toast.error("Enter a bot token and/or a webhook secret to save.");
+      toast.error("Enter a bot token to save.");
       return;
     }
     setBusy("save");
@@ -98,10 +106,11 @@ export function ChannelsSection({ client, company }: Props) {
         toast.error(res.message);
       }
     } catch (err) {
-      // A 404 means the host has no outbound Telegram transport in this build.
+      // A 404 means the host has no outbound Telegram transport in this build,
+      // in which case neither the webhook nor polling can work.
       toast.error(
         err instanceof ApiError && err.code === "not_wired"
-          ? "This host can't call Telegram directly — paste the webhook URL into BotFather instead."
+          ? "This host can't reach Telegram — rebuild it with the `telegram` feature."
           : err instanceof ApiError
             ? err.message
             : "Couldn't register the webhook.",
@@ -112,7 +121,7 @@ export function ChannelsSection({ client, company }: Props) {
   }
 
   async function copyWebhookUrl() {
-    if (!status) return;
+    if (!status?.webhookUrl) return;
     try {
       await navigator.clipboard.writeText(status.webhookUrl);
       toast.success("Webhook URL copied.");
@@ -143,31 +152,15 @@ export function ChannelsSection({ client, company }: Props) {
           <div className="space-y-1">
             <p className="text-sm font-medium">Telegram</p>
             <p className="text-sm text-muted-foreground">
-              Receive and reply to Telegram DMs. Create a bot with @BotFather, paste its token and
-              a webhook secret below, then point the bot&apos;s webhook at the URL shown here.
+              Receive and reply to Telegram DMs. Create a bot with @BotFather and paste its token
+              below — that&apos;s the whole setup. This host connects out to Telegram to collect
+              messages, so it needs no public URL and no webhook.
             </p>
           </div>
 
-          {/* The public webhook URL to register with Telegram / BotFather. */}
-          {status && (
-            <div className="space-y-1">
-              <Label className="text-xs">Webhook URL</Label>
-              <div className="flex items-center gap-2">
-                <Input readOnly value={status.webhookUrl} className="font-mono text-xs" />
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon"
-                  onClick={() => void copyWebhookUrl()}
-                  aria-label="Copy webhook URL"
-                >
-                  <Copy className="size-4" />
-                </Button>
-              </div>
-            </div>
-          )}
-
-          <div className="grid gap-3 sm:grid-cols-2">
+          {/* The webhook secret sits beside the token only on a host that can
+              actually serve a webhook — elsewhere it configures nothing. */}
+          <div className={status?.webhookUrl ? "grid gap-3 sm:grid-cols-2" : "space-y-1"}>
             <div className="space-y-1">
               <Label htmlFor="tg-token" className="text-xs">
                 Bot token {status?.tokenSet ? "(stored — leave blank to keep)" : ""}
@@ -181,37 +174,41 @@ export function ChannelsSection({ client, company }: Props) {
                 onChange={(e) => setBotToken(e.target.value)}
               />
             </div>
-            <div className="space-y-1">
-              <Label htmlFor="tg-secret" className="text-xs">
-                Webhook secret {status?.secretSet ? "(stored — leave blank to keep)" : ""}
-              </Label>
-              <Input
-                id="tg-secret"
-                type="password"
-                autoComplete="off"
-                placeholder={status?.secretSet ? "•••••• write-only" : "a long random string"}
-                value={webhookSecret}
-                onChange={(e) => setWebhookSecret(e.target.value)}
-              />
-            </div>
+            {status?.webhookUrl && (
+              <div className="space-y-1">
+                <Label htmlFor="tg-secret" className="text-xs">
+                  Webhook secret {status.secretSet ? "(stored — leave blank to keep)" : ""}
+                </Label>
+                <Input
+                  id="tg-secret"
+                  type="password"
+                  autoComplete="off"
+                  placeholder={status.secretSet ? "•••••• write-only" : "a long random string"}
+                  value={webhookSecret}
+                  onChange={(e) => setWebhookSecret(e.target.value)}
+                />
+              </div>
+            )}
           </div>
+
+          {/* How inbound actually arrives, so the operator can tell whether a
+              saved token is being used. */}
+          {status?.configured && status.polling && !status.webhookUrl && (
+            <p className="text-xs text-muted-foreground">
+              Listening for messages by polling Telegram — no public URL needed.
+            </p>
+          )}
+          {status?.configured && !status.polling && (
+            <p className="text-xs text-muted-foreground">
+              This host has no outbound Telegram transport, so it can neither collect messages nor
+              reply. Rebuild it with the <code className="font-mono">telegram</code> feature.
+            </p>
+          )}
 
           <div className="flex flex-wrap items-center gap-2">
             <Button disabled={busy !== null} onClick={() => void save()}>
               {busy === "save" ? <Loader2 className="size-4 animate-spin" /> : <Check className="size-4" />}
               Save
-            </Button>
-            <Button
-              variant="outline"
-              disabled={busy !== null || !status?.configured}
-              onClick={() => void register()}
-            >
-              {busy === "webhook" ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                <Send className="size-4" />
-              )}
-              Register webhook
             </Button>
             <Button
               variant="ghost"
@@ -226,6 +223,52 @@ export function ChannelsSection({ client, company }: Props) {
               Clear
             </Button>
           </div>
+
+          {/* The webhook fast-path. Shown only when the host reports a URL
+              Telegram can actually deliver to — otherwise offering it would
+              hand the operator a dead loopback endpoint (issue #203), and
+              registering it would also block the polling that does work. */}
+          {status?.webhookUrl && (
+            <div className="space-y-3 border-t pt-4">
+              <div className="space-y-1">
+                <p className="text-xs font-medium">Webhook (optional)</p>
+                <p className="text-xs text-muted-foreground">
+                  This host is publicly reachable, so Telegram can push updates straight to it
+                  instead of being polled. Save a webhook secret above, then register — polling
+                  stands down while a webhook is active.
+                </p>
+              </div>
+
+              <div className="space-y-1">
+                <Label className="text-xs">Webhook URL</Label>
+                <div className="flex items-center gap-2">
+                  <Input readOnly value={status.webhookUrl} className="font-mono text-xs" />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    onClick={() => void copyWebhookUrl()}
+                    aria-label="Copy webhook URL"
+                  >
+                    <Copy className="size-4" />
+                  </Button>
+                </div>
+              </div>
+
+              <Button
+                variant="outline"
+                disabled={busy !== null || !status.configured || !status.secretSet}
+                onClick={() => void register()}
+              >
+                {busy === "webhook" ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Send className="size-4" />
+                )}
+                Register webhook
+              </Button>
+            </div>
+          )}
         </CardContent>
       </Card>
     </section>

--- a/gitbooks/developers/configuration.md
+++ b/gitbooks/developers/configuration.md
@@ -79,6 +79,25 @@ Both optional and off by default:
 Requires the `tinyplace` feature and `serve --discoverable` to reach the
 network — see [The tiny.place economy](../overview/tiny-place.md).
 
+## Channels: Telegram
+
+Setup is a bot token and nothing else. Create a bot with @BotFather and paste
+its token under **Connections → Channels**; the host collects messages by
+long-polling Telegram (`getUpdates`), which dials *out*, so it works on
+localhost, behind NAT, and on any self-hosted box with no public URL. Needs the
+`telegram` feature for the outbound transport.
+
+| Variable | Purpose |
+| --- | --- |
+| `OPENCOMPANY_TELEGRAM_POLL_SECONDS` | Long-poll hold and idle back-off; default `30`. |
+
+An inbound **webhook** is an optional fast-path for a publicly reachable host:
+set `OPENCOMPANY_PUBLIC_URL` to a public **https** URL and the console offers a
+webhook URL plus a secret to register with. Without one there is nothing to
+offer — Telegram cannot deliver to a private address — so the console shows no
+webhook at all, rather than a URL that silently never fires. Polling stands down
+on its own while a webhook is registered.
+
 ## Inspect what's set
 
 `opencompany doctor` reports the effective configuration, which layer set each

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -179,6 +179,31 @@ impl AppConfig {
         }
     }
 
+    /// The base URL a third party can deliver an inbound webhook to, if there
+    /// is one — otherwise `None`.
+    ///
+    /// Distinct from [`Self::host_base_url`], which always answers *something*
+    /// (falling back to `http://{bind}`) because an Agent Card must carry an
+    /// endpoint. A webhook URL has no such fallback: a provider that cannot
+    /// reach the URL simply never delivers. So this is `Some` only when an
+    /// explicit `public_url` is configured **and** it is `https` — Telegram
+    /// (issue #203) refuses any other scheme for `setWebhook`, and the
+    /// `http://127.0.0.1:<port>` bind fallback is unreachable from the internet
+    /// by construction. Callers use it to decide whether to offer a webhook at
+    /// all, rather than showing an operator a URL that can never work.
+    pub fn public_webhook_base_url(&self) -> Option<&str> {
+        self.public_url
+            .as_deref()
+            .map(str::trim)
+            .map(|url| url.trim_end_matches('/'))
+            .filter(|url| {
+                url.len() > "https://".len()
+                    && url
+                        .get(.."https://".len())
+                        .is_some_and(|scheme| scheme.eq_ignore_ascii_case("https://"))
+            })
+    }
+
     /// Whether this host is reachable only from this machine.
     ///
     /// Gates behavior that is safe on a developer's laptop and unsafe anywhere
@@ -750,6 +775,44 @@ mod tests {
             ..AppConfig::default()
         };
         assert_eq!(public.host_base_url(), "https://acme.example");
+    }
+
+    /// Issue #203: unlike `host_base_url`, this has no bind fallback — a URL a
+    /// provider cannot reach is worse than none, because it silently swallows
+    /// every inbound delivery.
+    #[test]
+    fn public_webhook_base_url_requires_an_explicit_https_url() {
+        // The default (loopback bind, no public_url) offers no webhook — this
+        // is exactly the `http://127.0.0.1:8080/hooks/...` URL of issue #203.
+        assert_eq!(AppConfig::default().public_webhook_base_url(), None);
+
+        let with = |url: &str| AppConfig {
+            public_url: Some(url.into()),
+            ..AppConfig::default()
+        };
+        // Plain http never qualifies: Telegram's setWebhook refuses it, and a
+        // public-looking http URL is no more deliverable than a loopback one.
+        assert_eq!(with("http://acme.example").public_webhook_base_url(), None);
+        // Neither does a scheme-less or empty value.
+        assert_eq!(with("acme.example").public_webhook_base_url(), None);
+        assert_eq!(with("   ").public_webhook_base_url(), None);
+        assert_eq!(with("https://").public_webhook_base_url(), None);
+
+        assert_eq!(
+            with("https://acme.example").public_webhook_base_url(),
+            Some("https://acme.example")
+        );
+        // Surrounding whitespace and a trailing slash are normalized away, so
+        // callers can join a `/hooks/...` path without doubling the separator.
+        assert_eq!(
+            with("  https://acme.example/  ").public_webhook_base_url(),
+            Some("https://acme.example")
+        );
+        // The scheme is case-insensitive, as in any URL.
+        assert_eq!(
+            with("HTTPS://acme.example").public_webhook_base_url(),
+            Some("HTTPS://acme.example")
+        );
     }
 
     #[test]

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -362,6 +362,43 @@ fn spawn_mailbox_poller(
     }
 }
 
+/// Starts a company's Telegram `getUpdates` long-polling listener as a
+/// background task, whenever this host has an outbound Telegram transport wired
+/// (the `telegram` feature).
+///
+/// Issue #203: this is what makes inbound Telegram work on a local or
+/// self-hosted instance, where Telegram's servers can never reach an inbound
+/// `/hooks/...` URL. It is started unconditionally rather than only when a bot
+/// token is already stored — the poller idles cheaply until one appears, so an
+/// operator who pastes a token in the console is receiving DMs on the next tick
+/// with no restart. On a publicly reachable host that opted into the webhook
+/// fast-path, the poller sees the registration and stands by.
+fn spawn_telegram_poller(
+    state: &AppState,
+    id: &str,
+    shutdown: &Arc<Notify>,
+    handles: &mut Vec<tokio::task::JoinHandle<()>>,
+) {
+    let Some(api) = state.connections().telegram.clone() else {
+        return;
+    };
+    let Some(runtime) = state.registry().get(&CompanyId::new(id)) else {
+        return;
+    };
+    let poll_secs = std::env::var("OPENCOMPANY_TELEGRAM_POLL_SECONDS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(opencompany::runtime::telegram_poller::DEFAULT_POLL_SECONDS);
+    let webhook_capable = state.config().public_webhook_base_url().is_some();
+    let poller = opencompany::runtime::telegram_poller::TelegramPoller::new(
+        runtime,
+        api,
+        poll_secs,
+        webhook_capable,
+    );
+    handles.push(poller.spawn(shutdown.clone()));
+}
+
 /// Attaches an OpenHuman JSON-RPC transport when the `openhuman-rpc` feature is
 /// enabled and `OPENCOMPANY_OPENHUMAN_URL` is set (the attach path).
 ///
@@ -865,6 +902,7 @@ async fn main() -> Result<()> {
                     );
                 }
                 spawn_mailbox_poller(&state, &id, &shutdown, &mut scheduler_handles);
+                spawn_telegram_poller(&state, &id, &shutdown, &mut scheduler_handles);
             }
             if companies.is_empty() {
                 println!("serving with no companies; pass --company <dir> to load one");

--- a/src/company/telegram.rs
+++ b/src/company/telegram.rs
@@ -1,12 +1,27 @@
 //! The Telegram channel adapter: inbound-update parsing, outbound delivery, and
 //! the token-scrubbing that keeps the bot credential out of every log and error.
 //!
-//! A company receives Telegram DMs through the signed webhook route
-//! ([`crate::server::hooks`]) and replies back into the same chat. Inbound
+//! A company receives Telegram DMs and replies back into the same chat. Inbound
 //! routing mirrors OpenHuman: a bot DM is a **web/chat turn** tagged with its
 //! origin (the Telegram `chat.id`), not a bespoke "telegram provider" — so the
 //! brain runs an ordinary company turn and the reply is addressed back with an
 //! [`OutboundMessage::reply_to`](crate::ports::types::OutboundMessage).
+//!
+//! ## Two inbound paths — polling is the default
+//!
+//! There are two ways an update reaches the company, and they are mutually
+//! exclusive at Telegram's end (it rejects `getUpdates` with `409 Conflict`
+//! while a webhook is registered):
+//!
+//! 1. **`getUpdates` long-polling** ([`crate::runtime::telegram_poller`]) — the
+//!    default, and what OpenHuman does. The host dials *out* to
+//!    `api.telegram.org`, so it works on localhost, behind NAT, and in any
+//!    self-hosted deployment with no public URL. Setup is just the bot token.
+//! 2. **The inbound webhook** ([`crate::server::hooks`]) — an optional hosted
+//!    fast-path. Telegram POSTs to `{public_url}/hooks/{company}/telegram`, so
+//!    it requires a publicly reachable **https** URL. A host without one never
+//!    surfaces it (issue #203: a `http://127.0.0.1:8091/hooks/…` webhook URL is
+//!    one Telegram's servers can never deliver to).
 //!
 //! ## Credentials are write-only
 //!
@@ -22,15 +37,16 @@
 //! ## Network seam
 //!
 //! [`TelegramApi`] is the outbound seam. The default build and every test use
-//! the in-memory [`RecordingTelegramApi`]; the real HTTPS `sendMessage` /
-//! `setWebhook` transport ([`HttpTelegramApi`]) is gated behind the `telegram`
-//! feature so the offline build links no HTTP client.
+//! the in-memory [`RecordingTelegramApi`]; the real HTTPS transport
+//! ([`HttpTelegramApi`]) is gated behind the `telegram` feature so the offline
+//! build links no HTTP client.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
 
 use crate::error::OpenCompanyError;
+use crate::ports::types::{CompanyId, OutboundMessage};
 
 /// The channel id inbound Telegram turns and their replies are tagged with.
 pub const TELEGRAM_CHANNEL: &str = "telegram";
@@ -113,7 +129,16 @@ pub fn scrub_token(text: &str, token: &str) -> String {
     text.replace(token, "***")
 }
 
-/// The outbound Telegram seam: send a reply and (re)register the webhook.
+/// The `update_id` of a raw Telegram update, if it carries one.
+///
+/// The poller acks a batch by asking for `max(update_id) + 1` next — see
+/// [`crate::runtime::telegram_poller`].
+pub fn update_id(update: &serde_json::Value) -> Option<i64> {
+    update.get("update_id").and_then(|v| v.as_i64())
+}
+
+/// The outbound Telegram seam: poll for updates, send a reply, and manage the
+/// (optional, hosted-only) webhook registration.
 ///
 /// Mockable so every calling path is exercised offline; the real HTTPS
 /// transport is feature-gated. An implementation MUST NOT surface the `token`
@@ -129,6 +154,32 @@ pub trait TelegramApi: Send + Sync {
         text: &str,
     ) -> Result<(), OpenCompanyError>;
 
+    /// Long-polls Telegram for the next batch of raw updates
+    /// (`getUpdates`) — the inbound path that needs no public URL.
+    ///
+    /// `offset` acks every update below it: passing `max(update_id) + 1` from
+    /// the previous batch is what stops Telegram redelivering it. `None` asks
+    /// for everything Telegram still holds unconfirmed, which is exactly the
+    /// right thing after a restart — the confirmed watermark lives on
+    /// Telegram's side, so nothing already processed comes back.
+    ///
+    /// `timeout_secs` is the server-side long-poll hold: the call blocks there
+    /// until an update arrives or the timeout elapses, then returns (possibly
+    /// empty). This, not a client-side sleep, is what paces the poll loop.
+    async fn get_updates(
+        &self,
+        token: &str,
+        offset: Option<i64>,
+        timeout_secs: u64,
+    ) -> Result<Vec<serde_json::Value>, OpenCompanyError>;
+
+    /// The URL Telegram currently delivers this bot's updates to
+    /// (`getWebhookInfo`), or `None` when no webhook is registered.
+    ///
+    /// A registered webhook makes [`Self::get_updates`] fail with `409
+    /// Conflict`, so the poller checks this before it starts.
+    async fn get_webhook_info(&self, token: &str) -> Result<Option<String>, OpenCompanyError>;
+
     /// Points Telegram's webhook for bot `token` at `url`, guarded by `secret`
     /// (Telegram `setWebhook`, `secret_token` field).
     async fn set_webhook(
@@ -137,16 +188,72 @@ pub trait TelegramApi: Send + Sync {
         url: &str,
         secret: &str,
     ) -> Result<(), OpenCompanyError>;
+
+    /// Clears the bot's webhook registration (`deleteWebhook`), handing inbound
+    /// back to [`Self::get_updates`].
+    async fn delete_webhook(&self, token: &str) -> Result<(), OpenCompanyError>;
+}
+
+/// Posts every `telegram`-channel reply in `responses` back to its origin chat,
+/// returning how many were delivered.
+///
+/// Shared by both inbound paths (the webhook route and the poller) so a reply
+/// is addressed identically however the update arrived. A missing/unparseable
+/// `reply_to` chat id or a transport failure is logged and skipped rather than
+/// propagated: the turn already ran, so a delivery gap must never fail the
+/// caller. Every error is passed through [`scrub_token`] before it is logged.
+pub async fn deliver_replies(
+    api: &dyn TelegramApi,
+    company: &CompanyId,
+    token: &str,
+    responses: &[OutboundMessage],
+) -> usize {
+    let mut delivered = 0usize;
+    for msg in responses {
+        if msg.channel != TELEGRAM_CHANNEL {
+            continue;
+        }
+        let Some(reply_to) = &msg.reply_to else {
+            continue;
+        };
+        let Ok(chat_id) = reply_to.chat_id.parse::<i64>() else {
+            tracing::warn!(
+                company = %company,
+                "telegram reply has a non-numeric chat id; skipped"
+            );
+            continue;
+        };
+        match api.send_message(token, chat_id, &msg.text).await {
+            Ok(()) => delivered += 1,
+            Err(err) => {
+                // Never let the bot token reach the log line.
+                tracing::warn!(
+                    company = %company,
+                    "telegram delivery failed: {}",
+                    scrub_token(&err.to_string(), token)
+                );
+            }
+        }
+    }
+    delivered
 }
 
 /// An offline [`TelegramApi`] that records deliveries for assertions and never
-/// touches the network. It intentionally records only `(chat_id, text)` and the
-/// webhook `url` — never the token — so a test proving "delivery carries no
-/// credential" reads the recording directly.
+/// touches the network. It intentionally records only `(chat_id, text)`, the
+/// webhook `url`, and the requested poll offsets — never the token — so a test
+/// proving "delivery carries no credential" reads the recording directly.
 #[derive(Clone, Default)]
 pub struct RecordingTelegramApi {
     sent: Arc<std::sync::Mutex<Vec<(i64, String)>>>,
     webhooks: Arc<std::sync::Mutex<Vec<String>>>,
+    /// Batches `get_updates` hands out, oldest first; empty once drained.
+    batches: Arc<std::sync::Mutex<std::collections::VecDeque<Vec<serde_json::Value>>>>,
+    /// Every `offset` a `get_updates` call asked for, in order.
+    offsets: Arc<std::sync::Mutex<Vec<Option<i64>>>>,
+    /// The URL `get_webhook_info` reports; cleared by `delete_webhook`.
+    registered_webhook: Arc<std::sync::Mutex<Option<String>>>,
+    /// How many times `delete_webhook` was called.
+    deletes: Arc<std::sync::atomic::AtomicUsize>,
     /// When set, `send_message` fails and — modelling a real transport leaking
     /// the credential into its error URL — echoes the received token into the
     /// error text, so a scrubbing test has something to scrub.
@@ -154,7 +261,7 @@ pub struct RecordingTelegramApi {
 }
 
 impl RecordingTelegramApi {
-    /// A recording API that always accepts.
+    /// A recording API that always accepts and polls empty.
     pub fn new() -> Self {
         Self::default()
     }
@@ -166,6 +273,24 @@ impl RecordingTelegramApi {
             fail_echoing_token: true,
             ..Self::default()
         }
+    }
+
+    /// Queues one batch of raw updates for the next `get_updates` call. Batches
+    /// are handed out in the order queued; once drained, polls return empty.
+    pub fn push_updates(&self, batch: Vec<serde_json::Value>) {
+        self.batches
+            .lock()
+            .expect("telegram recorder poisoned")
+            .push_back(batch);
+    }
+
+    /// Pre-registers a webhook URL, so `get_webhook_info` reports it — the
+    /// state a poller must notice before it can long-poll.
+    pub fn set_registered_webhook(&self, url: &str) {
+        *self
+            .registered_webhook
+            .lock()
+            .expect("telegram recorder poisoned") = Some(url.to_string());
     }
 
     /// Every `(chat_id, text)` delivered so far.
@@ -182,6 +307,19 @@ impl RecordingTelegramApi {
             .lock()
             .expect("telegram recorder poisoned")
             .clone()
+    }
+
+    /// Every `offset` a `get_updates` call asked for, in order.
+    pub fn poll_offsets(&self) -> Vec<Option<i64>> {
+        self.offsets
+            .lock()
+            .expect("telegram recorder poisoned")
+            .clone()
+    }
+
+    /// How many times the webhook was deleted.
+    pub fn delete_webhook_calls(&self) -> usize {
+        self.deletes.load(std::sync::atomic::Ordering::SeqCst)
     }
 }
 
@@ -205,6 +343,43 @@ impl TelegramApi for RecordingTelegramApi {
         Ok(())
     }
 
+    async fn get_updates(
+        &self,
+        _token: &str,
+        offset: Option<i64>,
+        _timeout_secs: u64,
+    ) -> Result<Vec<serde_json::Value>, OpenCompanyError> {
+        self.offsets
+            .lock()
+            .expect("telegram recorder poisoned")
+            .push(offset);
+        // Model the real API: a registered webhook makes `getUpdates` conflict.
+        if self
+            .registered_webhook
+            .lock()
+            .expect("telegram recorder poisoned")
+            .is_some()
+        {
+            return Err(OpenCompanyError::Store(
+                "telegram getUpdates returned 409 Conflict: can't use getUpdates method while webhook is active".to_string(),
+            ));
+        }
+        Ok(self
+            .batches
+            .lock()
+            .expect("telegram recorder poisoned")
+            .pop_front()
+            .unwrap_or_default())
+    }
+
+    async fn get_webhook_info(&self, _token: &str) -> Result<Option<String>, OpenCompanyError> {
+        Ok(self
+            .registered_webhook
+            .lock()
+            .expect("telegram recorder poisoned")
+            .clone())
+    }
+
     async fn set_webhook(
         &self,
         _token: &str,
@@ -215,6 +390,20 @@ impl TelegramApi for RecordingTelegramApi {
             .lock()
             .expect("telegram recorder poisoned")
             .push(url.to_string());
+        *self
+            .registered_webhook
+            .lock()
+            .expect("telegram recorder poisoned") = Some(url.to_string());
+        Ok(())
+    }
+
+    async fn delete_webhook(&self, _token: &str) -> Result<(), OpenCompanyError> {
+        self.deletes
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        *self
+            .registered_webhook
+            .lock()
+            .expect("telegram recorder poisoned") = None;
         Ok(())
     }
 }
@@ -224,6 +413,7 @@ impl std::fmt::Debug for RecordingTelegramApi {
         f.debug_struct("RecordingTelegramApi")
             .field("sent", &self.sent().len())
             .field("webhooks", &self.webhooks().len())
+            .field("polls", &self.poll_offsets().len())
             .finish()
     }
 }
@@ -239,10 +429,58 @@ pub struct HttpTelegramApi {
 #[cfg(feature = "telegram")]
 impl HttpTelegramApi {
     /// Builds a transport over a fresh HTTPS client.
+    ///
+    /// No client-level request timeout is set: `getUpdates` deliberately blocks
+    /// server-side for its long-poll window, and a blanket timeout shorter than
+    /// that window would abort every idle poll. Each call passes its own bound
+    /// instead (see [`TelegramApi::get_updates`]).
     pub fn new() -> Self {
         Self {
             client: reqwest::Client::new(),
         }
+    }
+
+    /// `POST /bot<token>/<method>` with `body`, returning the parsed `result`
+    /// field. Every error is scrubbed of the token before it escapes.
+    async fn call(
+        &self,
+        token: &str,
+        method: &str,
+        body: serde_json::Value,
+        timeout: std::time::Duration,
+    ) -> Result<serde_json::Value, OpenCompanyError> {
+        let url = format!("https://api.telegram.org/bot{token}/{method}");
+        let resp = self
+            .client
+            .post(&url)
+            .json(&body)
+            .timeout(timeout)
+            .send()
+            .await
+            .map_err(|e| {
+                OpenCompanyError::Store(scrub_token(
+                    &format!("telegram {method} failed: {e}"),
+                    token,
+                ))
+            })?;
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(OpenCompanyError::Store(scrub_token(
+                &format!("telegram {method} returned {status}: {text}"),
+                token,
+            )));
+        }
+        let parsed: serde_json::Value = serde_json::from_str(&text).map_err(|e| {
+            OpenCompanyError::Store(scrub_token(
+                &format!("telegram {method} returned unparseable JSON: {e}"),
+                token,
+            ))
+        })?;
+        Ok(parsed
+            .get("result")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null))
     }
 }
 
@@ -262,29 +500,52 @@ impl TelegramApi for HttpTelegramApi {
         chat_id: i64,
         text: &str,
     ) -> Result<(), OpenCompanyError> {
-        let url = format!("https://api.telegram.org/bot{token}/sendMessage");
-        let resp = self
-            .client
-            .post(&url)
-            .json(&serde_json::json!({ "chat_id": chat_id, "text": text }))
-            .send()
-            .await
-            .map_err(|e| {
-                OpenCompanyError::Store(scrub_token(
-                    &format!("telegram sendMessage failed: {e}"),
-                    token,
-                ))
-            })?;
-        if resp.status().is_success() {
-            Ok(())
-        } else {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            Err(OpenCompanyError::Store(scrub_token(
-                &format!("telegram sendMessage returned {status}: {body}"),
-                token,
-            )))
+        self.call(
+            token,
+            "sendMessage",
+            serde_json::json!({ "chat_id": chat_id, "text": text }),
+            std::time::Duration::from_secs(30),
+        )
+        .await
+        .map(|_| ())
+    }
+
+    async fn get_updates(
+        &self,
+        token: &str,
+        offset: Option<i64>,
+        timeout_secs: u64,
+    ) -> Result<Vec<serde_json::Value>, OpenCompanyError> {
+        let mut body = serde_json::json!({ "timeout": timeout_secs });
+        if let Some(offset) = offset {
+            body["offset"] = serde_json::json!(offset);
         }
+        // Give the transport a margin over Telegram's own long-poll hold, so a
+        // healthy idle poll returns on Telegram's schedule and only a genuinely
+        // wedged connection trips the client-side bound.
+        let budget = std::time::Duration::from_secs(timeout_secs.saturating_add(15));
+        let result = self.call(token, "getUpdates", body, budget).await?;
+        Ok(match result {
+            serde_json::Value::Array(updates) => updates,
+            _ => Vec::new(),
+        })
+    }
+
+    async fn get_webhook_info(&self, token: &str) -> Result<Option<String>, OpenCompanyError> {
+        let result = self
+            .call(
+                token,
+                "getWebhookInfo",
+                serde_json::json!({}),
+                std::time::Duration::from_secs(30),
+            )
+            .await?;
+        Ok(result
+            .get("url")
+            .and_then(|u| u.as_str())
+            .map(str::trim)
+            .filter(|u| !u.is_empty())
+            .map(str::to_string))
     }
 
     async fn set_webhook(
@@ -293,29 +554,28 @@ impl TelegramApi for HttpTelegramApi {
         url: &str,
         secret: &str,
     ) -> Result<(), OpenCompanyError> {
-        let api = format!("https://api.telegram.org/bot{token}/setWebhook");
-        let resp = self
-            .client
-            .post(&api)
-            .json(&serde_json::json!({ "url": url, "secret_token": secret }))
-            .send()
-            .await
-            .map_err(|e| {
-                OpenCompanyError::Store(scrub_token(
-                    &format!("telegram setWebhook failed: {e}"),
-                    token,
-                ))
-            })?;
-        if resp.status().is_success() {
-            Ok(())
-        } else {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            Err(OpenCompanyError::Store(scrub_token(
-                &format!("telegram setWebhook returned {status}: {body}"),
-                token,
-            )))
-        }
+        self.call(
+            token,
+            "setWebhook",
+            serde_json::json!({ "url": url, "secret_token": secret }),
+            std::time::Duration::from_secs(30),
+        )
+        .await
+        .map(|_| ())
+    }
+
+    async fn delete_webhook(&self, token: &str) -> Result<(), OpenCompanyError> {
+        // `drop_pending_updates` stays false: an update that arrived while the
+        // unreachable webhook was registered is still owed a reply, and the
+        // poller picks it up on its first `getUpdates`.
+        self.call(
+            token,
+            "deleteWebhook",
+            serde_json::json!({ "drop_pending_updates": false }),
+            std::time::Duration::from_secs(30),
+        )
+        .await
+        .map(|_| ())
     }
 }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -35,6 +35,9 @@ pub mod journal;
 pub mod mailbox_poller;
 pub mod registry;
 pub mod scheduler;
+/// Issue #203: the Telegram `getUpdates` long-polling listener — the inbound
+/// path that needs no public URL, mirroring OpenHuman. See [`telegram_poller`].
+pub mod telegram_poller;
 pub mod tools;
 pub mod types;
 pub mod workflow_scheduler;

--- a/src/runtime/telegram_poller.rs
+++ b/src/runtime/telegram_poller.rs
@@ -1,0 +1,530 @@
+//! Per-company Telegram `getUpdates` long-polling listener (issue #203).
+//!
+//! This is the inbound path that works **without a public URL**. Telegram's
+//! webhook delivery ([`crate::server::hooks`]) requires a publicly reachable
+//! https endpoint, so on localhost, behind NAT, or on any self-hosted box it
+//! can never fire — the console used to hand the operator a
+//! `http://127.0.0.1:8091/hooks/<company>/telegram` URL that Telegram's servers
+//! cannot resolve, leaving inbound DMs dead. Mirroring OpenHuman, the host
+//! instead dials **out** to `api.telegram.org` and holds a long poll open.
+//!
+//! Structured like [`MailboxPoller`](crate::runtime::mailbox_poller): an
+//! injectable loop whose [`tick`](TelegramPoller::tick) is a plain async fn, so
+//! every branch is testable offline against
+//! [`RecordingTelegramApi`](crate::company::telegram::RecordingTelegramApi).
+//!
+//! ## What one tick does
+//!
+//! 1. Reads the bot token from the company's
+//!    [`SecretStore`](crate::ports::SecretStore). Unset (or cleared) is idle,
+//!    not an error — the operator may paste a token at any time and the very
+//!    next tick picks it up, with no restart. A **changed** token resets the
+//!    poll offset, since offsets are per-bot.
+//! 2. Skips while the company is asleep (scale-to-zero). Unread updates stay
+//!    parked on Telegram's side and arrive on the first tick after wake.
+//! 3. Handshakes once per token: Telegram rejects `getUpdates` with `409
+//!    Conflict` while a webhook is registered, so the poller asks
+//!    `getWebhookInfo` first. See [`TelegramPoller::handshake`] for how the two
+//!    modes divide.
+//! 4. Long-polls, and runs each update as an ordinary company turn
+//!    ([`CompanyEvent::WebhookReceived`] on the `telegram` channel) whose reply
+//!    is addressed back to the origin chat — byte-identical routing to the
+//!    webhook path, which is what keeps the two inbound paths in agreement.
+//!
+//! ## Delivery semantics
+//!
+//! The poll offset is **in-memory only, by design**. Telegram itself holds the
+//! confirmed watermark: asking for `max(update_id) + 1` is what acks a batch,
+//! and a fresh process asking with no offset gets only what was never
+//! confirmed. So a restart resumes exactly where it left off without any local
+//! persistence — and cannot replay an already-answered DM. The offset advances
+//! only after a batch has been processed, so a crash mid-batch redelivers that
+//! batch (at-least-once) rather than dropping it.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+
+use crate::company::runtime::CompanyRuntime;
+use crate::company::telegram::{
+    TELEGRAM_CHANNEL, TELEGRAM_TOKEN_KEY, TelegramApi, deliver_replies, scrub_token, update_id,
+};
+use crate::ports::types::CompanyEvent;
+
+/// Default long-poll hold, in seconds. Also the back-off between idle re-checks
+/// (no token stored, company asleep, or a webhook owning inbound).
+pub const DEFAULT_POLL_SECONDS: u64 = 30;
+
+/// What one [`TelegramPoller::tick`] did. Drives the loop's pacing: a poll that
+/// actually ran was already paced by Telegram's server-side hold, so the loop
+/// goes straight round again; anything else backs off for the idle interval.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PollOutcome {
+    /// Nothing to poll: no bot token stored, the company is not running, or a
+    /// webhook owns inbound on this host.
+    Idle,
+    /// A `getUpdates` long poll ran and produced this many company turns.
+    Polled(usize),
+}
+
+/// Drives one company's Telegram inbound over `getUpdates` long-polling.
+pub struct TelegramPoller {
+    runtime: Arc<CompanyRuntime>,
+    api: Arc<dyn TelegramApi>,
+    /// Long-poll hold handed to `getUpdates`, and the idle back-off.
+    poll: Duration,
+    /// Whether this host could serve a Telegram webhook at all — i.e. whether a
+    /// publicly reachable `https` base URL is configured. Decides what a
+    /// pre-existing webhook registration means (see [`Self::handshake`]).
+    webhook_capable: bool,
+    /// The token the current offset belongs to; offsets are per-bot.
+    token: Option<String>,
+    /// The next `update_id` to ask for — `None` means "whatever Telegram still
+    /// holds unconfirmed", which is the correct cold-start ask.
+    offset: Option<i64>,
+    /// Whether the webhook handshake has settled for the current token. Cleared
+    /// on a token change and after any poll error, so a webhook registered
+    /// mid-flight is noticed rather than 409-looping forever.
+    handshaked: bool,
+}
+
+impl TelegramPoller {
+    /// Binds a poller to `runtime`, long-polling for `poll_secs` at a time
+    /// (clamped to at least 1 so the loop can never spin).
+    ///
+    /// `webhook_capable` is the host's own answer to "could Telegram reach my
+    /// `/hooks/...` route?" — see
+    /// [`AppConfig::public_webhook_base_url`](crate::app::AppConfig::public_webhook_base_url).
+    pub fn new(
+        runtime: Arc<CompanyRuntime>,
+        api: Arc<dyn TelegramApi>,
+        poll_secs: u64,
+        webhook_capable: bool,
+    ) -> Self {
+        Self {
+            runtime,
+            api,
+            poll: Duration::from_secs(poll_secs.max(1)),
+            webhook_capable,
+            token: None,
+            offset: None,
+            handshaked: false,
+        }
+    }
+
+    /// The bot token for this company, or `None` when unset/blank. An empty
+    /// stored value means "cleared" everywhere else in the Telegram surface, so
+    /// it means the same here.
+    async fn load_token(&self) -> crate::Result<Option<String>> {
+        Ok(self
+            .runtime
+            .secrets()
+            .get(self.runtime.id(), TELEGRAM_TOKEN_KEY)
+            .await?
+            .map(|v| v.expose().to_string())
+            .filter(|v| !v.is_empty()))
+    }
+
+    /// Settles which inbound path owns this bot, returning whether to poll.
+    ///
+    /// A registered webhook is the only thing that can block `getUpdates`, and
+    /// what it means depends entirely on whether this host can actually be
+    /// reached:
+    ///
+    /// - **Webhook-capable host** (a public https URL is configured): the
+    ///   operator opted into the hosted fast-path, and it works. The poller
+    ///   stands by so the two paths never both consume the same update, and
+    ///   re-checks each idle tick, so deleting the webhook resumes polling.
+    /// - **Not webhook-capable** — this is issue #203 exactly: a webhook is
+    ///   registered against a URL Telegram can never deliver to, so inbound is
+    ///   silently dead and `getUpdates` is refused as well. The poller reclaims
+    ///   inbound by clearing the stale registration, then polls. Nothing is
+    ///   lost: `deleteWebhook` keeps pending updates, so anything that queued
+    ///   up arrives in the first batch.
+    async fn handshake(&mut self, token: &str) -> crate::Result<bool> {
+        match self.api.get_webhook_info(token).await? {
+            Some(url) if !url.trim().is_empty() => {
+                if self.webhook_capable {
+                    tracing::debug!(
+                        company = %self.runtime.id(),
+                        "telegram webhook is registered and this host is publicly reachable; \
+                         polling stands by"
+                    );
+                    return Ok(false);
+                }
+                tracing::warn!(
+                    company = %self.runtime.id(),
+                    "telegram webhook is registered but this host has no public https URL, so \
+                     Telegram cannot deliver to it; clearing it and switching to getUpdates polling"
+                );
+                self.api.delete_webhook(token).await?;
+            }
+            _ => {}
+        }
+        self.handshaked = true;
+        Ok(true)
+    }
+
+    /// Polls once and runs a company turn per actionable update.
+    ///
+    /// Returns [`PollOutcome::Idle`] when there was nothing to poll (see the
+    /// module docs for the three cases). A turn that fails is logged and
+    /// skipped — the batch still advances, because Telegram would otherwise
+    /// redeliver the same poisoned update forever.
+    pub async fn tick(&mut self) -> crate::Result<PollOutcome> {
+        let Some(token) = self.load_token().await? else {
+            // Cleared credentials: forget the offset so a later token starts
+            // clean rather than acking another bot's update ids.
+            self.token = None;
+            self.offset = None;
+            self.handshaked = false;
+            return Ok(PollOutcome::Idle);
+        };
+        if self.token.as_deref() != Some(token.as_str()) {
+            self.token = Some(token.clone());
+            self.offset = None;
+            self.handshaked = false;
+        }
+        if self.runtime.ensure_running().await.is_err() {
+            return Ok(PollOutcome::Idle);
+        }
+        if !self.handshaked && !self.handshake(&token).await? {
+            return Ok(PollOutcome::Idle);
+        }
+
+        let updates = match self
+            .api
+            .get_updates(&token, self.offset, self.poll.as_secs())
+            .await
+        {
+            Ok(updates) => updates,
+            Err(err) => {
+                // Re-handshake next tick: the most likely cause of a hard
+                // failure here is a webhook registered while we were polling
+                // (Telegram answers 409), and that is exactly what the
+                // handshake resolves.
+                self.handshaked = false;
+                return Err(crate::error::OpenCompanyError::Store(scrub_token(
+                    &err.to_string(),
+                    &token,
+                )));
+            }
+        };
+
+        let mut turns = 0usize;
+        for update in updates {
+            // Ack before running: `update_id` is the only thing that stops
+            // Telegram redelivering, and a turn that panics the batch must not
+            // strand the poller on the same update.
+            if let Some(id) = update_id(&update) {
+                self.offset = Some(match self.offset {
+                    Some(current) => current.max(id + 1),
+                    None => id + 1,
+                });
+            }
+            let event = CompanyEvent::WebhookReceived {
+                channel: TELEGRAM_CHANNEL.to_string(),
+                body: update,
+            };
+            match self.runtime.run_cycle(vec![event]).await {
+                Ok(report) => {
+                    turns += 1;
+                    deliver_replies(
+                        self.api.as_ref(),
+                        self.runtime.id(),
+                        &token,
+                        &report.responses,
+                    )
+                    .await;
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        company = %self.runtime.id(),
+                        "telegram polled cycle failed: {}",
+                        scrub_token(&err.to_string(), &token)
+                    );
+                }
+            }
+        }
+        Ok(PollOutcome::Polled(turns))
+    }
+
+    /// Spawns the poll loop; stops on `shutdown`.
+    ///
+    /// Unlike the interval-driven [`MailboxPoller`](crate::runtime::mailbox_poller),
+    /// pacing comes from Telegram's server-side long-poll hold: a poll that ran
+    /// loops straight round, and only an idle or failed tick backs off. Being
+    /// dropped mid-tick is safe — an unacked batch is simply redelivered.
+    pub fn spawn(mut self, shutdown: Arc<Notify>) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = shutdown.notified() => break,
+                    backoff = async {
+                        match self.tick().await {
+                            Ok(PollOutcome::Polled(_)) => false,
+                            Ok(PollOutcome::Idle) => true,
+                            Err(err) => {
+                                tracing::warn!(
+                                    company = %self.runtime.id(),
+                                    %err,
+                                    "telegram poll failed"
+                                );
+                                true
+                            }
+                        }
+                    } => {
+                        if backoff {
+                            tokio::select! {
+                                _ = shutdown.notified() => break,
+                                _ = tokio::time::sleep(self.poll) => {}
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::company::CompanyManifest;
+    use crate::company::telegram::RecordingTelegramApi;
+    use crate::ports::generate_id;
+    use crate::ports::types::SecretValue;
+    use crate::runtime::RuntimeBuilder;
+
+    const TOKEN: &str = "7654321:AAExampleBotTokenNeverLeaks";
+
+    fn tmp_home() -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("opencompany-tgpoll-{}", generate_id()))
+    }
+
+    fn manifest() -> CompanyManifest {
+        let toml_src = r#"
+            [company]
+            name = "Acme"
+
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+
+            [policy]
+            mode = "full"
+        "#;
+        toml::from_str(toml_src).expect("parse manifest")
+    }
+
+    fn update(id: i64, chat_id: i64, text: &str) -> serde_json::Value {
+        serde_json::json!({
+            "update_id": id,
+            "message": {
+                "message_id": id,
+                "from": { "id": 999, "username": "bob" },
+                "chat": { "id": chat_id, "type": "private" },
+                "text": text,
+            }
+        })
+    }
+
+    async fn company(home: &std::path::Path) -> Arc<CompanyRuntime> {
+        Arc::new(
+            RuntimeBuilder::fs_defaults(home.to_path_buf(), manifest())
+                .await
+                .expect("build runtime"),
+        )
+    }
+
+    async fn store_token(runtime: &CompanyRuntime, token: &str) {
+        runtime
+            .secrets()
+            .set(
+                runtime.id(),
+                TELEGRAM_TOKEN_KEY,
+                SecretValue(token.to_string()),
+            )
+            .await
+            .expect("store token");
+    }
+
+    /// The whole point of the issue: a bot token alone — no webhook secret, no
+    /// public URL, no `setWebhook` — is enough to receive a DM and answer it.
+    #[tokio::test]
+    async fn polls_updates_and_replies_without_any_webhook() {
+        let home = tmp_home();
+        let runtime = company(&home).await;
+        store_token(&runtime, TOKEN).await;
+
+        let api = Arc::new(RecordingTelegramApi::new());
+        api.push_updates(vec![update(41, 555, "status?")]);
+        let mut poller = TelegramPoller::new(runtime.clone(), api.clone(), 1, false);
+
+        assert_eq!(poller.tick().await.unwrap(), PollOutcome::Polled(1));
+        // The echo brain answers the DM back into the origin chat.
+        let sent = api.sent();
+        assert_eq!(sent.len(), 1, "one reply delivered: {sent:?}");
+        assert_eq!(sent[0].0, 555);
+        assert!(sent[0].1.contains("status?"), "reply echoes: {sent:?}");
+        // Cold start asks with no offset; the next poll acks update 41.
+        assert_eq!(api.poll_offsets(), vec![None]);
+        assert_eq!(poller.offset, Some(42));
+
+        // A second tick carries the ack forward even with nothing to fetch.
+        assert_eq!(poller.tick().await.unwrap(), PollOutcome::Polled(0));
+        assert_eq!(api.poll_offsets(), vec![None, Some(42)]);
+
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    /// Issue #203's broken state: a webhook is registered against a URL Telegram
+    /// can never reach, so inbound is dead *and* `getUpdates` is refused. The
+    /// poller must clear it and take over rather than 409-loop.
+    #[tokio::test]
+    async fn clears_an_unreachable_webhook_and_takes_over_inbound() {
+        let home = tmp_home();
+        let runtime = company(&home).await;
+        store_token(&runtime, TOKEN).await;
+
+        let api = Arc::new(RecordingTelegramApi::new());
+        api.set_registered_webhook("http://127.0.0.1:8091/hooks/acme/telegram");
+        api.push_updates(vec![update(7, 42, "hello")]);
+        // `webhook_capable: false` — no public https URL on this host.
+        let mut poller = TelegramPoller::new(runtime.clone(), api.clone(), 1, false);
+
+        assert_eq!(poller.tick().await.unwrap(), PollOutcome::Polled(1));
+        assert_eq!(api.delete_webhook_calls(), 1, "stale webhook was cleared");
+        assert_eq!(api.sent().len(), 1, "the parked DM got answered");
+
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    /// On a host Telegram *can* reach, a registered webhook is a deliberate
+    /// choice. The poller must stand by rather than delete it or double-consume
+    /// updates — and must re-check, so unregistering resumes polling.
+    #[tokio::test]
+    async fn stands_by_for_a_webhook_on_a_publicly_reachable_host() {
+        let home = tmp_home();
+        let runtime = company(&home).await;
+        store_token(&runtime, TOKEN).await;
+
+        let api = Arc::new(RecordingTelegramApi::new());
+        api.set_registered_webhook("https://acme.example/hooks/acme/telegram");
+        api.push_updates(vec![update(1, 42, "hi")]);
+        let mut poller = TelegramPoller::new(runtime.clone(), api.clone(), 1, true);
+
+        assert_eq!(poller.tick().await.unwrap(), PollOutcome::Idle);
+        assert_eq!(api.delete_webhook_calls(), 0, "never clears a live webhook");
+        assert!(api.poll_offsets().is_empty(), "never polled");
+        assert!(api.sent().is_empty(), "the webhook route owns this update");
+
+        // Standby is re-checked every tick, so removing the webhook resumes.
+        api.delete_webhook(TOKEN).await.unwrap();
+        assert_eq!(poller.tick().await.unwrap(), PollOutcome::Polled(1));
+        assert_eq!(api.sent().len(), 1);
+
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    /// No token stored is idle, not an error — and a token pasted later is
+    /// picked up on the very next tick, with no restart.
+    #[tokio::test]
+    async fn idles_without_a_token_then_picks_one_up_live() {
+        let home = tmp_home();
+        let runtime = company(&home).await;
+
+        let api = Arc::new(RecordingTelegramApi::new());
+        api.push_updates(vec![update(3, 9, "yo")]);
+        let mut poller = TelegramPoller::new(runtime.clone(), api.clone(), 1, false);
+
+        assert_eq!(poller.tick().await.unwrap(), PollOutcome::Idle);
+        assert!(api.poll_offsets().is_empty(), "no token means no call");
+
+        store_token(&runtime, TOKEN).await;
+        assert_eq!(poller.tick().await.unwrap(), PollOutcome::Polled(1));
+
+        // Clearing the credential parks the poller and drops the offset, so a
+        // different bot's update ids can never be acked against it.
+        store_token(&runtime, "").await;
+        assert_eq!(poller.tick().await.unwrap(), PollOutcome::Idle);
+        assert_eq!(poller.offset, None);
+
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    /// Scale-to-zero: a paused company polls nothing. Updates wait on
+    /// Telegram's side and arrive on the first tick after wake.
+    #[tokio::test]
+    async fn skips_while_the_company_is_not_running() {
+        let home = tmp_home();
+        let runtime = company(&home).await;
+        store_token(&runtime, TOKEN).await;
+        let mut record = runtime.store.load(runtime.id()).await.unwrap().unwrap();
+        record.lifecycle = "paused".into();
+        runtime.store.save(&record).await.unwrap();
+
+        let api = Arc::new(RecordingTelegramApi::new());
+        api.push_updates(vec![update(1, 42, "hi")]);
+        let mut poller = TelegramPoller::new(runtime.clone(), api.clone(), 1, false);
+
+        assert_eq!(poller.tick().await.unwrap(), PollOutcome::Idle);
+        assert!(api.poll_offsets().is_empty());
+
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    /// A poll failure must never echo the bot token, and must re-arm the
+    /// handshake so a mid-flight webhook registration is noticed.
+    #[tokio::test]
+    async fn poll_errors_are_scrubbed_and_rearm_the_handshake() {
+        let home = tmp_home();
+        let runtime = company(&home).await;
+        store_token(&runtime, TOKEN).await;
+
+        let api = Arc::new(RecordingTelegramApi::new());
+        let mut poller = TelegramPoller::new(runtime.clone(), api.clone(), 1, true);
+        // Settle the handshake with no webhook registered...
+        assert_eq!(poller.tick().await.unwrap(), PollOutcome::Polled(0));
+        assert!(poller.handshaked);
+
+        // ...then register one, so the next poll conflicts.
+        api.set_registered_webhook("https://acme.example/hooks/acme/telegram");
+        let err = poller.tick().await.unwrap_err().to_string();
+        assert!(!err.contains(TOKEN), "token leaked into the error: {err}");
+        assert!(!poller.handshaked, "handshake re-armed after a failure");
+
+        // Re-handshaking resolves it: the webhook owns inbound, so stand by.
+        assert_eq!(poller.tick().await.unwrap(), PollOutcome::Idle);
+
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    /// Changing the bot token discards the previous bot's offset — update ids
+    /// are per-bot, so carrying one over would ack the wrong updates.
+    #[tokio::test]
+    async fn a_new_token_resets_the_offset() {
+        let home = tmp_home();
+        let runtime = company(&home).await;
+        store_token(&runtime, TOKEN).await;
+
+        let api = Arc::new(RecordingTelegramApi::new());
+        api.push_updates(vec![update(500, 1, "first bot")]);
+        let mut poller = TelegramPoller::new(runtime.clone(), api.clone(), 1, false);
+        assert_eq!(poller.tick().await.unwrap(), PollOutcome::Polled(1));
+        assert_eq!(poller.offset, Some(501));
+
+        store_token(&runtime, "111111:AADifferentBotEntirely").await;
+        assert_eq!(poller.tick().await.unwrap(), PollOutcome::Polled(0));
+        assert_eq!(
+            api.poll_offsets(),
+            vec![None, None],
+            "the second bot is asked cold, not at the first bot's offset"
+        );
+
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+}

--- a/src/server/hooks.rs
+++ b/src/server/hooks.rs
@@ -1,7 +1,17 @@
 //! Inbound channel webhooks: `POST /hooks/{company}/{channel}`.
 //!
-//! Today the one wired channel is Telegram. Telegram delivers each bot update
-//! to `POST /hooks/{company}/telegram` with an
+//! **The optional hosted fast-path, not the default.** Telegram can only
+//! deliver here when the host has a publicly reachable https URL, so a local or
+//! self-hosted instance receives inbound over `getUpdates` long-polling instead
+//! ([`crate::runtime::telegram_poller`], issue #203). This route stays wired
+//! either way — it costs nothing when Telegram never calls it — and the two
+//! paths run the *same* turn and share
+//! [`deliver_replies`](crate::company::telegram::deliver_replies), so which one
+//! delivered an update is invisible downstream. They never both consume the
+//! same update: Telegram refuses `getUpdates` while a webhook is registered,
+//! and the poller stands by when it sees one.
+//!
+//! Telegram delivers each bot update to `POST /hooks/{company}/telegram` with an
 //! `X-Telegram-Bot-Api-Secret-Token` header carrying the secret configured via
 //! `setWebhook`. The handler verifies that header (constant-time) against the
 //! company's stored webhook secret **before parsing anything**; an unverifiable
@@ -30,9 +40,7 @@ use serde_json::json;
 
 use crate::AppState;
 use crate::company::runtime::CompanyRuntime;
-use crate::company::telegram::{
-    SECRET_TOKEN_HEADER, TELEGRAM_SECRET_KEY, TELEGRAM_TOKEN_KEY, scrub_token,
-};
+use crate::company::telegram::{SECRET_TOKEN_HEADER, TELEGRAM_SECRET_KEY, TELEGRAM_TOKEN_KEY};
 use crate::ports::types::CompanyEvent;
 use crate::server::ops::resolve;
 
@@ -145,10 +153,14 @@ async fn handle_telegram(
         .into_response()
 }
 
-/// Posts every `telegram`-channel reply back to its origin chat. Returns how
-/// many were delivered. Missing token / unwired transport / a bad chat id are
-/// logged and skipped — the turn already ran, so a delivery gap never fails the
-/// webhook. Any transport error is scrubbed of the bot token before logging.
+/// Resolves this host's transport + the company's bot token, then hands the
+/// replies to the shared
+/// [`deliver_replies`](crate::company::telegram::deliver_replies) — the same
+/// delivery the poller uses, so a reply looks identical whichever inbound path
+/// produced it. Returns how many were delivered.
+///
+/// A missing token or an unwired transport is logged and skipped: the turn
+/// already ran, so a delivery gap must never fail the webhook.
 async fn deliver_replies(
     state: &AppState,
     runtime: &CompanyRuntime,
@@ -187,34 +199,7 @@ async fn deliver_replies(
         }
     };
 
-    let mut delivered = 0usize;
-    for msg in responses {
-        if msg.channel != TELEGRAM_CHANNEL {
-            continue;
-        }
-        let Some(reply_to) = &msg.reply_to else {
-            continue;
-        };
-        let Ok(chat_id) = reply_to.chat_id.parse::<i64>() else {
-            tracing::warn!(
-                company = %runtime.id(),
-                "telegram reply has a non-numeric chat id; skipped"
-            );
-            continue;
-        };
-        match api.send_message(&token, chat_id, &msg.text).await {
-            Ok(()) => delivered += 1,
-            Err(err) => {
-                // Never let the bot token reach the log line.
-                tracing::warn!(
-                    company = %runtime.id(),
-                    "telegram delivery failed: {}",
-                    scrub_token(&err.to_string(), &token)
-                );
-            }
-        }
-    }
-    delivered
+    crate::company::telegram::deliver_replies(api.as_ref(), runtime.id(), &token, responses).await
 }
 
 #[cfg(test)]

--- a/src/server/ops/channels.rs
+++ b/src/server/ops/channels.rs
@@ -1,13 +1,24 @@
 //! The Telegram channel configuration write-plane: store the bot token +
-//! webhook secret (both **write-only**) and register the webhook.
+//! (optional) webhook secret — both **write-only** — and register the webhook.
 //!
 //! `GET …/channels/telegram` returns only the non-secret
-//! [`TelegramChannelStatus`] — presence booleans and the webhook URL to paste
-//! into BotFather / `setWebhook`. Neither the bot token nor the webhook secret
-//! is ever serialized into any response, by construction: they live in
+//! [`TelegramChannelStatus`]. Neither the bot token nor the webhook secret is
+//! ever serialized into any response, by construction: they live in
 //! [`SecretStore`](crate::ports::SecretStore) as raw strings under
 //! [`TELEGRAM_TOKEN_KEY`] / [`TELEGRAM_SECRET_KEY`] and this module reads them
 //! back only to *use* them (verify, deliver, `setWebhook`), never to echo them.
+//!
+//! ## A bot token is the whole setup (issue #203)
+//!
+//! Inbound arrives by `getUpdates` long-polling
+//! ([`crate::runtime::telegram_poller`]), which dials out and therefore needs
+//! no public URL — so [`TelegramChannelStatus::configured`] tracks the **bot
+//! token alone**. The webhook is an optional hosted fast-path, and this module
+//! surfaces it *only* on a host that Telegram could actually deliver to (see
+//! [`AppConfig::public_webhook_base_url`](crate::app::AppConfig::public_webhook_base_url)).
+//! On a local or self-hosted instance `webhookUrl` is `null` and `setWebhook`
+//! is refused with an explanation, rather than handing the operator a
+//! `http://127.0.0.1:<port>/hooks/…` URL that can never receive a delivery.
 //!
 //! `PUT …/channels/telegram` is a partial write: only the fields present in the
 //! body are updated, so an operator can rotate the secret without re-entering
@@ -30,29 +41,41 @@ use crate::server::error::ApiError;
 use crate::server::ops::{ScopedCompany, scoped};
 
 /// The non-secret status of a company's Telegram channel. Carries presence
-/// booleans and the webhook URL only — never the token or the secret.
+/// booleans, how inbound arrives, and the webhook URL when there is a usable
+/// one — never the token or the secret.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TelegramChannelStatus {
-    /// True once both the bot token and the webhook secret are stored — the
-    /// channel can then receive verified updates and reply.
+    /// True once a bot token is stored. That alone is a working channel:
+    /// inbound arrives by `getUpdates` long-polling, which needs no public URL
+    /// and no webhook secret.
     pub configured: bool,
     /// Whether a bot token is stored (never the token itself).
     pub token_set: bool,
-    /// Whether a webhook secret is stored (never the secret itself).
+    /// Whether a webhook secret is stored (never the secret itself). Only
+    /// meaningful on a host that can serve the webhook fast-path.
     pub secret_set: bool,
-    /// The URL to register with Telegram (`setWebhook`) / paste into BotFather.
-    /// Non-secret — it embeds only the public host and the company id.
-    pub webhook_url: String,
+    /// The URL to register with Telegram (`setWebhook`), or `null` when this
+    /// host has no publicly reachable https URL for Telegram to deliver to —
+    /// which is every local and most self-hosted deployments. Non-secret when
+    /// present: it embeds only the public host and the company id.
+    pub webhook_url: Option<String>,
+    /// Whether this host long-polls Telegram for inbound updates — true
+    /// whenever an outbound Telegram transport is wired. The default offline
+    /// build has none, so it neither polls nor delivers.
+    pub polling: bool,
 }
 
-/// The webhook URL Telegram should deliver this company's updates to.
-fn webhook_url(state: &AppState, company: &CompanyId) -> String {
-    format!(
-        "{}/hooks/{}/telegram",
-        state.config().host_base_url(),
-        company.as_ref()
-    )
+/// The webhook URL Telegram should deliver this company's updates to, or `None`
+/// when this host has no publicly reachable https base URL.
+///
+/// Deliberately **not** derived from
+/// [`host_base_url`](crate::app::AppConfig::host_base_url): that falls back to
+/// the bind address, which produced the `http://127.0.0.1:<port>/hooks/…` URL
+/// of issue #203 — syntactically fine, undeliverable in practice.
+fn webhook_url(state: &AppState, company: &CompanyId) -> Option<String> {
+    let base = state.config().public_webhook_base_url()?;
+    Some(format!("{base}/hooks/{}/telegram", company.as_ref()))
 }
 
 /// Reads a stored secret and reports whether it is present and non-empty.
@@ -73,10 +96,12 @@ async fn status_of(
     let token_set = is_set(runtime, TELEGRAM_TOKEN_KEY).await?;
     let secret_set = is_set(runtime, TELEGRAM_SECRET_KEY).await?;
     Ok(TelegramChannelStatus {
-        configured: token_set && secret_set,
+        // The bot token alone is a working channel — polling covers inbound.
+        configured: token_set,
         token_set,
         secret_set,
         webhook_url: webhook_url(state, runtime.id()),
+        polling: state.connections().telegram.is_some(),
     })
 }
 
@@ -192,16 +217,23 @@ struct SetWebhookResult {
     ok: bool,
     /// A prosumer-friendly description of the outcome.
     message: String,
-    /// The URL that was registered.
-    webhook_url: String,
+    /// The URL that was registered, or `null` when there was none to register.
+    webhook_url: Option<String>,
 }
 
 /// `POST …/channels/telegram/webhook` — register the webhook with Telegram.
+///
+/// The hosted fast-path only. Refused outright on a host with no publicly
+/// reachable https URL (issue #203): Telegram would accept nothing, or worse
+/// accept a URL it can never deliver to — which also blocks `getUpdates` and so
+/// would take the working polling path down with it.
 async fn set_webhook(company: ScopedCompany, State(state): State<AppState>) -> Response {
     use axum::response::IntoResponse;
 
     let runtime = &company.runtime;
-    let url = webhook_url(&state, runtime.id());
+    let Some(url) = webhook_url(&state, runtime.id()) else {
+        return unreachable_host().into_response();
+    };
 
     // Not wired without a transport (default build / no `telegram` feature).
     let Some(api) = state.connections().telegram.clone() else {
@@ -224,7 +256,7 @@ async fn set_webhook(company: ScopedCompany, State(state): State<AppState>) -> R
         Ok(()) => Json(SetWebhookResult {
             ok: true,
             message: "Webhook registered with Telegram.".to_string(),
-            webhook_url: url,
+            webhook_url: Some(url),
         })
         .into_response(),
         Err(err) => Json(SetWebhookResult {
@@ -234,7 +266,7 @@ async fn set_webhook(company: ScopedCompany, State(state): State<AppState>) -> R
                 "setWebhook failed: {}",
                 scrub_token(&err.to_string(), &token)
             ),
-            webhook_url: url,
+            webhook_url: Some(url),
         })
         .into_response(),
     }
@@ -257,6 +289,16 @@ fn missing(what: &str) -> ApiError {
     )))
 }
 
+/// A `400` for a `setWebhook` attempt on a host Telegram cannot reach.
+fn unreachable_host() -> ApiError {
+    ApiError(crate::error::OpenCompanyError::InvalidRequest(
+        "telegram cannot deliver a webhook to this host: set OPENCOMPANY_PUBLIC_URL to a public \
+         https URL first. Inbound already works without one — the bot token alone enables \
+         getUpdates polling."
+            .to_string(),
+    ))
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -267,13 +309,34 @@ mod test {
             configured: true,
             token_set: true,
             secret_set: true,
-            webhook_url: "https://host/hooks/acme/telegram".to_string(),
+            webhook_url: Some("https://host/hooks/acme/telegram".to_string()),
+            polling: true,
         };
         let json = serde_json::to_string(&status).unwrap();
-        // Presence booleans and the URL only — no field can carry secret bytes.
+        // Presence booleans, the mode, and the URL only — no field can carry
+        // secret bytes.
         assert!(json.contains("\"tokenSet\":true"));
         assert!(json.contains("hooks/acme/telegram"));
         assert!(!json.contains("bot_token"));
         assert!(!json.contains("webhook_secret"));
+    }
+
+    /// Issue #203: a host with no public https URL must report `null` rather
+    /// than a loopback URL Telegram can never deliver to.
+    #[test]
+    fn status_omits_the_webhook_url_on_an_unreachable_host() {
+        let local = TelegramChannelStatus {
+            configured: true,
+            token_set: true,
+            secret_set: false,
+            webhook_url: None,
+            polling: true,
+        };
+        let json = serde_json::to_string(&local).unwrap();
+        assert!(json.contains("\"webhookUrl\":null"), "{json}");
+        assert!(!json.contains("127.0.0.1"), "{json}");
+        // The channel is still fully configured — polling covers inbound.
+        assert!(json.contains("\"configured\":true"));
+        assert!(json.contains("\"polling\":true"));
     }
 }

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -1874,8 +1874,20 @@ async fn mcp_add_probes_without_rollback_and_persists_health() {
 use crate::company::telegram::RecordingTelegramApi;
 
 /// A running "acme" company whose host has a recording Telegram transport
-/// injected, so the inbound webhook can actually deliver a reply offline.
+/// injected, so the inbound webhook can actually deliver a reply offline. The
+/// host is loopback-only (no `public_url`) — the local/self-host shape of issue
+/// #203.
 async fn state_with_telegram(home: &std::path::Path, api: RecordingTelegramApi) -> AppState {
+    state_with_telegram_at(home, api, None).await
+}
+
+/// As [`state_with_telegram`], but with `public_url` set — the hosted shape,
+/// where Telegram can actually deliver to the `/hooks/...` route.
+async fn state_with_telegram_at(
+    home: &std::path::Path,
+    api: RecordingTelegramApi,
+    public_url: Option<&str>,
+) -> AppState {
     use crate::ports::CompanyStore;
     let store = FsCompanyStore::new(home.to_path_buf());
     let id = CompanyId::new("acme");
@@ -1901,7 +1913,11 @@ async fn state_with_telegram(home: &std::path::Path, api: RecordingTelegramApi) 
         .unwrap();
     let connections =
         crate::server::ops::ConnectionsRuntime::new().with_telegram(std::sync::Arc::new(api));
-    let state = AppState::new(AppConfig::default()).with_connections(connections);
+    let state = AppState::new(AppConfig {
+        public_url: public_url.map(str::to_string),
+        ..AppConfig::default()
+    })
+    .with_connections(connections);
     state.registry().insert(id, std::sync::Arc::new(runtime));
     crate::server::test_support::seed_fixed_admin(&state, "acme").await;
     state
@@ -1954,17 +1970,14 @@ async fn telegram_config_is_write_only_and_status_reads_back() {
     let home = home();
     let state = state_with_company(&home).await;
 
-    // Nothing configured yet.
+    // Nothing configured yet. This host binds loopback with no `public_url`, so
+    // it never offers a webhook URL (issue #203) — Telegram could not deliver
+    // to one, and inbound rides `getUpdates` polling instead.
     let (status, cfg) = send(&state, "GET", "/api/v1/company/channels/telegram", None).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(cfg["configured"], false);
     assert_eq!(cfg["tokenSet"], false);
-    assert!(
-        cfg["webhookUrl"]
-            .as_str()
-            .unwrap()
-            .ends_with("/hooks/acme/telegram")
-    );
+    assert!(cfg["webhookUrl"].is_null(), "unreachable host: {cfg}");
 
     // Store both credentials (write-only).
     let (status, cfg) = send(
@@ -2071,6 +2084,47 @@ async fn telegram_inbound_runs_a_turn_and_delivers_the_reply_back() {
 async fn telegram_set_webhook_registers_the_public_url() {
     let home = home();
     let api = RecordingTelegramApi::new();
+    // The hosted shape: a real public https URL Telegram can deliver to.
+    let state = state_with_telegram_at(&home, api.clone(), Some("https://acme.example")).await;
+    send(
+        &state,
+        "PUT",
+        "/api/v1/company/channels/telegram",
+        Some(json!({ "botToken": BOT_TOKEN, "webhookSecret": WEBHOOK_SECRET })),
+    )
+    .await;
+
+    // The status advertises the webhook only on such a host.
+    let (_, cfg) = send(&state, "GET", "/api/v1/company/channels/telegram", None).await;
+    assert_eq!(
+        cfg["webhookUrl"],
+        "https://acme.example/hooks/acme/telegram"
+    );
+
+    let (status, res) = send(
+        &state,
+        "POST",
+        "/api/v1/company/channels/telegram/webhook",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(res["ok"], true);
+    let webhooks = api.webhooks();
+    assert_eq!(webhooks.len(), 1);
+    assert_eq!(webhooks[0], "https://acme.example/hooks/acme/telegram");
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+/// Issue #203: on a host with no public https URL, registering a webhook is
+/// refused outright. Accepting it would be actively harmful — Telegram could
+/// never deliver to the URL *and* a registration blocks `getUpdates`, so it
+/// would take down the one inbound path that does work.
+#[tokio::test]
+async fn telegram_set_webhook_is_refused_on_a_host_telegram_cannot_reach() {
+    let home = home();
+    let api = RecordingTelegramApi::new();
     let state = state_with_telegram(&home, api.clone()).await;
     send(
         &state,
@@ -2087,11 +2141,40 @@ async fn telegram_set_webhook_registers_the_public_url() {
         None,
     )
     .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        res.to_string().contains("OPENCOMPANY_PUBLIC_URL"),
+        "the refusal must say how to fix it: {res}"
+    );
+    assert!(
+        api.webhooks().is_empty(),
+        "no loopback URL was ever handed to Telegram"
+    );
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+/// The channel is usable with a bot token alone: no webhook secret, no public
+/// URL, no `setWebhook` — the polling listener covers inbound.
+#[tokio::test]
+async fn telegram_is_configured_by_a_bot_token_alone() {
+    let home = home();
+    let api = RecordingTelegramApi::new();
+    let state = state_with_telegram(&home, api).await;
+
+    let (status, cfg) = send(
+        &state,
+        "PUT",
+        "/api/v1/company/channels/telegram",
+        Some(json!({ "botToken": BOT_TOKEN })),
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(res["ok"], true);
-    let webhooks = api.webhooks();
-    assert_eq!(webhooks.len(), 1);
-    assert!(webhooks[0].ends_with("/hooks/acme/telegram"));
+    assert_eq!(cfg["configured"], true, "a token is the whole setup: {cfg}");
+    assert_eq!(cfg["secretSet"], false);
+    assert!(cfg["webhookUrl"].is_null());
+    // The host has a transport wired, so it long-polls for inbound.
+    assert_eq!(cfg["polling"], true);
 
     tokio::fs::remove_dir_all(&home).await.ok();
 }


### PR DESCRIPTION
## Summary

Fixes #203.

Telegram's webhook can only reach a host on the public internet, but `webhook_url()` derived its URL from `AppConfig::host_base_url()` — which falls back to `http://{bind}`. So the console told every operator to point BotFather at `http://127.0.0.1:8091/hooks/<company>/telegram`. On any local or self-hosted instance that URL is undeliverable, so inbound DMs never arrived and the whole receive-and-reply flow was dead.

Mirroring OpenHuman, the host now dials **out** instead of waiting to be called.

- **`runtime::telegram_poller` (new)** — a per-company `getUpdates` long-poll, spawned in `serve` beside `MailboxPoller` and stopped by the same shutdown `Notify`. It idles until a bot token is stored and picks one up on the next tick, so pasting a token into the console starts inbound with no restart; it skips while the company is asleep (scale-to-zero). The poll offset is **in-memory by design**: Telegram holds the confirmed watermark, so a fresh process asking with no offset gets only what was never acked — a restart resumes exactly, without replaying an answered DM and without any local persistence. Pacing comes from Telegram's server-side long-poll hold, so only an idle or failed tick backs off.
- **`TelegramApi`** grows `get_updates` / `get_webhook_info` / `delete_webhook`; `HttpTelegramApi` routes every method through one token-scrubbing `call` helper.
- **The webhook becomes an optional hosted fast-path**, surfaced only when `OPENCOMPANY_PUBLIC_URL` is a public **https** URL (new `AppConfig::public_webhook_base_url`, deliberately with no bind fallback). Elsewhere `webhookUrl` is `null` and `POST …/channels/telegram/webhook` is refused with `400` and an explanation. Refusing matters: a registration Telegram can't deliver to *also* blocks `getUpdates`, so accepting one would take down the path that does work.
- **The two paths never both consume an update.** The poller checks `getWebhookInfo` before polling: on a publicly reachable host it stands by (re-checking each tick, so unregistering resumes polling); on a host with no public URL a registration can only be a dead endpoint, so it clears it and takes inbound back — `deleteWebhook` keeps pending updates, so anything queued arrives in the first batch. Both paths run the same turn and share the extracted `telegram::deliver_replies`.
- **Console** — asks for a bot token and says polling needs no public URL; the webhook block (URL + secret + register) renders only when the host advertises a usable URL.

## API Or Behavior Changes

Yes — three, all intended by the issue:

- `GET …/channels/telegram` → `webhookUrl` is now `string | null` (`null` on any host with no public https URL, so the console never shows an undeliverable URL). `SetWebhookResult.webhookUrl` likewise.
- `configured` now means **a bot token is stored**, no longer "token *and* webhook secret" — a token alone is a working channel via polling. A new `polling: boolean` field reports whether the host has the outbound transport wired.
- `POST …/channels/telegram/webhook` returns `400` on a host with no public https URL instead of registering a loopback URL.

New env var: `OPENCOMPANY_TELEGRAM_POLL_SECONDS` (default `30`).

Not in scope: the managed shared-bot + `telegram_login_start`/`_check` account-link flow (the issue's suggested direction #2). That needs a backend-side managed bot and a pairing surface this repo doesn't have; the issue's own refinement comment scopes the minimal fix to the personal-bot path, which is what this PR ships.

## Tests

12 new tests, 2 existing updated to the new contract; 910 passing.

- Poller (`src/runtime/telegram_poller.rs`): `polls_updates_and_replies_without_any_webhook` (the issue's ask — a token alone receives and answers a DM), `clears_an_unreachable_webhook_and_takes_over_inbound` (the exact broken state from the repro), `stands_by_for_a_webhook_on_a_publicly_reachable_host` (and resumes when it is deleted), `idles_without_a_token_then_picks_one_up_live`, `skips_while_the_company_is_not_running`, `poll_errors_are_scrubbed_and_rearm_the_handshake`, `a_new_token_resets_the_offset`.
- Server (`src/server/ops/`): `telegram_set_webhook_is_refused_on_a_host_telegram_cannot_reach`, `telegram_is_configured_by_a_bot_token_alone`, `status_omits_the_webhook_url_on_an_unreachable_host`; `telegram_set_webhook_registers_the_public_url` and `telegram_config_is_write_only_and_status_reads_back` updated.
- Config (`src/app/types.rs`): `public_webhook_base_url_requires_an_explicit_https_url`.

Commands run locally:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features telegram -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` (910 passed, 0 failed)
- [x] `pnpm typecheck` (frontend)

## Documentation

- `docs/modules/runtime/README.md` — new "Background listeners" section covering both pollers and how the two Telegram inbound paths divide.
- `docs/modules/server/README.md` — new "Inbound channel webhooks" section explaining that `/hooks/{company}/telegram` is the optional hosted fast-path and when it is surfaced.
- `gitbooks/developers/configuration.md` — new "Channels: Telegram" section (operator-facing setup + `OPENCOMPANY_TELEGRAM_POLL_SECONDS`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Telegram long-polling for local and self-hosted deployments.
  * Added optional webhook support for deployments with a publicly reachable HTTPS URL.
  * Webhooks and polling now coordinate automatically, including fallback when webhooks are unavailable.
  * Telegram connections can be configured with a bot token alone.
  * Added transport status indicators and clearer setup guidance.

* **Documentation**
  * Documented polling intervals, webhook requirements, configuration, coexistence rules, fallback behavior, and shutdown handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->