### PR TITLE
fix(tasks): a dispatched task that delegates runs the delegate and links it as the assignee

### DIFF
--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -128,7 +128,12 @@ impl HarnessBrain {
         }
         // A blank assignee is the one legitimate miss: nobody was named, so the
         // orchestrator picks it up.
-        let responder = resolution
+        //
+        // Not final: a turn that hands the work off (issue #204) reassigns the
+        // card to the delegate, and from that point the delegate is the
+        // responder every downstream write credits — the note, the artifact,
+        // the journal, and the relay.
+        let mut responder = resolution
             .working_agent()
             .unwrap_or(&self.responder)
             .to_string();
@@ -186,6 +191,11 @@ impl HarnessBrain {
         // record exactly the text the note does rather than a second, divergent
         // rendering of the same run.
         let result_text = loop {
+            // Start each turn from an empty queue so nothing a prior turn (this
+            // cycle's operator message, or an earlier redirect rerun) left
+            // behind can hijack this card — the same guard
+            // `handle_operator_message` opens with.
+            self.deps.delegations.clear();
             let outcome = run_turn
                 // A dispatched task card carries no chat bubble (its steps are
                 // discarded into the note), so its live turn frames must not leak
@@ -199,13 +209,71 @@ impl HarnessBrain {
                     // A dispatched task discards its steps — the note is text-only.
                     match outcome {
                         Ok(outcome) => {
-                            // `settle` writes the note (attributed to the
-                            // assignee) and the landing column via the #186
-                            // lifecycle seam; the loop still yields the reply so
-                            // the #185/#190 completion events report the same
-                            // text that landed in the note.
-                            let result = outcome.reply;
-                            settle(&mut card, TaskRunEnd::Completed, &responder, &result);
+                            // Issue #204: the turn may have DELEGATED rather
+                            // than done the work. The dispatched responder is
+                            // the orchestrator, which carries `delegate_to_desk`
+                            // / `spawn_task`, and nothing here used to drain
+                            // what those queued — so the hand-off was dropped,
+                            // the turn still read as a clean completion, and the
+                            // card landed in `in_review` under the delegator
+                            // with the delegate never having run. Draining here
+                            // runs the delegate, reassigns the card to them, and
+                            // settles it from THEIR output.
+                            let handoff = self
+                                .delegation_runner(&run_turn)
+                                .for_task(&card.id)
+                                .handle_task_delegations(&mut card, &responder)
+                                .await?;
+                            // `settle` writes the note (attributed to whoever
+                            // actually produced the text) and the landing column
+                            // via the #186 lifecycle seam; the loop still yields
+                            // the reply so the #185/#190 completion events
+                            // report the same text that landed in the note.
+                            let result = match handoff {
+                                // The delegate answered: they own the card, and
+                                // every downstream write credits them.
+                                Some(handoff) => {
+                                    responder = handoff.delegate;
+                                    match handoff.reply {
+                                        Some(reply) => {
+                                            settle(
+                                                &mut card,
+                                                TaskRunEnd::Completed,
+                                                &responder,
+                                                &reply,
+                                            );
+                                            reply
+                                        }
+                                        // The hand-off ran but produced nothing
+                                        // (an operator cancelled it in flight).
+                                        // Partial work is discarded and the card
+                                        // returns to the backlog, exactly as a
+                                        // cancelled dispatch does — it must not
+                                        // read as finished, and it must not
+                                        // strand in `in_progress` either.
+                                        None => {
+                                            let reply =
+                                                "the delegated run was cancelled before it \
+                                                 produced anything"
+                                                    .to_string();
+                                            settle(
+                                                &mut card,
+                                                TaskRunEnd::Cancelled,
+                                                &responder,
+                                                &reply,
+                                            );
+                                            reply
+                                        }
+                                    }
+                                }
+                                // Nothing was handed off — the responder did the
+                                // work itself, as before.
+                                None => {
+                                    let result = outcome.reply;
+                                    settle(&mut card, TaskRunEnd::Completed, &responder, &result);
+                                    result
+                                }
+                            };
                             break result;
                         }
                         Err(err) => {
@@ -3101,6 +3169,19 @@ members = ["eng1", "eng2"]
         queue: orchestrator::DelegationQueue,
         pushes: StdMutex<VecDeque<Option<Delegation>>>,
         calls: std::sync::atomic::AtomicUsize,
+        /// The same task store the brain writes through, so each invoke can
+        /// snapshot the board **as that turn sees it** — the only way a test can
+        /// observe a dispatched card mid-run (issue #204).
+        tasks: Arc<FsOps>,
+        /// `(column, assignee)` of the company's card at each invoke, in order.
+        board: StdMutex<Vec<(String, String)>>,
+    }
+
+    impl DelegatingProvider {
+        /// The board snapshot each turn ran against, in invoke order.
+        fn board(&self) -> Vec<(String, String)> {
+            self.board.lock().unwrap().clone()
+        }
     }
 
     #[async_trait]
@@ -3111,6 +3192,15 @@ members = ["eng1", "eng2"]
             request: ModelRequest,
         ) -> tinyagents::Result<ModelResponse> {
             self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let snapshot = self
+                .tasks
+                .list(&CompanyId::new("acme"))
+                .await
+                .ok()
+                .and_then(|cards| cards.into_iter().next())
+                .map(|card| (card.column, card.assignee))
+                .unwrap_or_default();
+            self.board.lock().unwrap().push(snapshot);
             if let Some(Some(delegation)) = self.pushes.lock().unwrap().pop_front() {
                 self.queue.push(delegation);
             }
@@ -3140,10 +3230,13 @@ members = ["eng1", "eng2"]
         pushes: Vec<Option<Delegation>>,
     ) -> (HarnessBrain, Arc<DelegatingProvider>) {
         let queue = orchestrator::DelegationQueue::default();
+        let tasks = Arc::new(FsOps::new(dir));
         let provider = Arc::new(DelegatingProvider {
             queue: queue.clone(),
             pushes: StdMutex::new(pushes.into_iter().collect()),
             calls: std::sync::atomic::AtomicUsize::new(0),
+            tasks: tasks.clone(),
+            board: StdMutex::new(Vec::new()),
         });
         let deps = HarnessDeps {
             provider: provider.clone(),
@@ -3153,7 +3246,7 @@ members = ["eng1", "eng2"]
             meter: None,
             workspace_root: dir.to_path_buf(),
             model_override: None,
-            tasks: Some(Arc::new(FsOps::new(dir))),
+            tasks: Some(tasks),
             skills: None,
             skills_source_dir: None,
             mcp_servers: Vec::new(),
@@ -3321,5 +3414,169 @@ members = ["eng1", "eng2"]
             "{:?}",
             result.channel_responses[0].text
         );
+    }
+
+    // --- Issue #204: a dispatched turn that delegates -----------------------
+
+    /// Seeds one dispatched card (blank assignee → the orchestrator runs it,
+    /// which is the shape that carries the delegation tools) and dispatches it.
+    async fn dispatch_card(brain: &HarnessBrain, tasks: &Arc<FsOps>, id: &str) {
+        let mut c = card(id, "");
+        c.column = "in_progress".to_string();
+        tasks.upsert(&CompanyId::new("acme"), &c).await.unwrap();
+        brain
+            .run_cycle(
+                request(vec![CompanyEvent::TaskDispatched {
+                    task_id: id.to_string(),
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+    }
+
+    /// The bug: a dispatched task the CEO delegated went straight to
+    /// `in_review` under the CEO with a blank assignee, and the delegate never
+    /// ran — `run_task` ran one turn and never drained the delegation queue.
+    ///
+    /// Now the delegate actually runs, is linked as the card's assignee, and
+    /// the card only reaches `in_review` on the back of THEIR output.
+    #[tokio::test]
+    async fn a_dispatched_turn_that_delegates_runs_the_delegate_and_links_them_to_the_card() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, provider) = brain_that_delegates(
+            dir.path(),
+            vec![Some(Delegation::DelegateToDesk {
+                desk: "eng_desk".to_string(),
+                instruction: "fetch my activity".to_string(),
+            })],
+        );
+        dispatch_card(&brain, &provider.tasks.clone(), "t-deleg").await;
+
+        assert_eq!(
+            provider.calls.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "the dispatched turn, then the delegate's own turn — the delegate must actually run"
+        );
+
+        let after = only_card(&provider.tasks).await;
+        assert_eq!(
+            after.assignee, "engineer",
+            "the delegate must be linked as the assignee, not left blank under the delegator"
+        );
+        assert_eq!(
+            after.column, "in_review",
+            "the card reaches review on the delegate's output"
+        );
+        let note = after.note.expect("note");
+        assert!(
+            note.contains("delegated to engineer: fetch my activity"),
+            "the hand-off is recorded in the delegator's voice: {note}"
+        );
+        // The delegate's own turn produced the result block: the mock echoes the
+        // instruction it was handed back under its own attribution.
+        let (_, delegate_block) = note
+            .split_once("[engineer] did:")
+            .unwrap_or_else(|| panic!("the delegate's output is the card's result: {note}"));
+        assert!(
+            delegate_block.contains("fetch my activity"),
+            "the delegate ran the instruction it was handed: {note}"
+        );
+
+        // …and while the delegate was working, the card showed THEM working it:
+        // its second turn ran against a card already reassigned and still in
+        // progress, not one parked in a terminal column.
+        assert_eq!(
+            provider.board()[1],
+            ("in_progress".to_string(), "engineer".to_string()),
+            "the delegate must be shown working the card while they work it"
+        );
+    }
+
+    /// The compatibility half: a dispatched turn that delegates nothing still
+    /// runs exactly one turn and settles under the agent that ran it.
+    ///
+    /// (Deliberately no assertion on `assignee` — linking the *non-delegating*
+    /// working agent to the card is issue #205's fix, and this test must not
+    /// pin the blank it leaves behind today.)
+    #[tokio::test]
+    async fn a_dispatched_turn_that_delegates_nothing_settles_exactly_as_before() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, provider) = brain_that_delegates(dir.path(), Vec::new());
+        dispatch_card(&brain, &provider.tasks.clone(), "t-plain").await;
+
+        assert_eq!(
+            provider.calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "no delegation → one turn, no hand-off"
+        );
+        let after = only_card(&provider.tasks).await;
+        assert_eq!(after.column, "in_review");
+        assert!(
+            after.note.expect("note").contains("[chief]"),
+            "the agent that ran it owns the result"
+        );
+    }
+
+    /// A hand-off to a desk nobody leads has nowhere to go: rather than
+    /// stranding the card in `in_progress` waiting on a delegate that will
+    /// never run, the delegator's own reply settles it exactly as before.
+    #[tokio::test]
+    async fn a_hand_off_to_an_unknown_desk_settles_under_the_delegator() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, provider) = brain_that_delegates(
+            dir.path(),
+            vec![Some(Delegation::DelegateToDesk {
+                desk: "ghost".to_string(),
+                instruction: "look into it".to_string(),
+            })],
+        );
+        dispatch_card(&brain, &provider.tasks.clone(), "t-ghost").await;
+
+        assert_eq!(
+            provider.calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "an unknown desk has no lead to run a second turn"
+        );
+        let after = only_card(&provider.tasks).await;
+        assert_eq!(
+            after.column, "in_review",
+            "the card must not strand in progress waiting on a delegate that cannot run"
+        );
+        assert_ne!(after.assignee, "ghost");
+    }
+
+    /// A `spawn_task` queued by a *dispatched* turn now opens its card with the
+    /// dispatched card as its parent — the lineage `run_delegation` could never
+    /// stamp while the task path did not drain the queue (issue #185's
+    /// `parent_task_id`).
+    #[tokio::test]
+    async fn a_task_spawned_by_a_dispatched_turn_records_its_parent_card() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, provider) = brain_that_delegates(
+            dir.path(),
+            vec![Some(Delegation::SpawnTask {
+                title: "Follow up next week".to_string(),
+                note: None,
+                assignee: None,
+            })],
+        );
+        dispatch_card(&brain, &provider.tasks.clone(), "t-parent").await;
+
+        let cards = provider.tasks.list(&CompanyId::new("acme")).await.unwrap();
+        let spawned = cards
+            .iter()
+            .find(|c| c.title == "Follow up next week")
+            .expect("the spawned card must actually be opened");
+        assert_eq!(spawned.column, "backlog");
+        assert_eq!(
+            spawned.parent_task_id.as_deref(),
+            Some("t-parent"),
+            "a card spawned inside a dispatch remembers the card it came from"
+        );
+        // The parent still settles on its own turn's reply — spawning follow-up
+        // work is not a hand-off.
+        let parent = cards.iter().find(|c| c.id == "t-parent").expect("parent");
+        assert_eq!(parent.column, "in_review");
     }
 }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -3202,7 +3202,7 @@ members = ["eng1", "eng2"]
     /// drain it after the turn.
     struct DelegatingProvider {
         queue: orchestrator::DelegationQueue,
-        pushes: StdMutex<VecDeque<Option<Delegation>>>,
+        pushes: StdMutex<VecDeque<Vec<Delegation>>>,
         calls: std::sync::atomic::AtomicUsize,
         /// The same task store the brain writes through, so each invoke can
         /// snapshot the board **as that turn sees it** — the only way a test can
@@ -3273,7 +3273,7 @@ members = ["eng1", "eng2"]
                 .map(|card| (card.column, card.assignee))
                 .unwrap_or_default();
             self.board.lock().unwrap().push(snapshot);
-            if let Some(Some(delegation)) = self.pushes.lock().unwrap().pop_front() {
+            for delegation in self.pushes.lock().unwrap().pop_front().unwrap_or_default() {
                 self.queue.push(delegation);
             }
             let message = request
@@ -3301,14 +3301,19 @@ members = ["eng1", "eng2"]
         dir: &std::path::Path,
         pushes: Vec<Option<Delegation>>,
     ) -> (HarnessBrain, Arc<DelegatingProvider>) {
-        brain_that_delegates_with(dir, pushes, TurnFaults::default())
+        brain_that_delegates_with(
+            dir,
+            pushes.into_iter().map(Vec::from_iter).collect(),
+            TurnFaults::default(),
+        )
     }
 
-    /// [`brain_that_delegates`], with scripted per-invoke faults so a test can
+    /// [`brain_that_delegates`], but each invoke pushes a whole *set* of
+    /// delegations (a single turn can queue several), and per-invoke faults can
     /// make a delegate's run fail or be cancelled mid-flight.
     fn brain_that_delegates_with(
         dir: &std::path::Path,
-        pushes: Vec<Option<Delegation>>,
+        pushes: Vec<Vec<Delegation>>,
         faults: TurnFaults,
     ) -> (HarnessBrain, Arc<DelegatingProvider>) {
         let queue = orchestrator::DelegationQueue::default();
@@ -3598,10 +3603,10 @@ members = ["eng1", "eng2"]
         // invoke 2 is the delegate's own turn, which errors.
         let (brain, provider) = brain_that_delegates_with(
             dir.path(),
-            vec![Some(Delegation::DelegateToDesk {
+            vec![vec![Delegation::DelegateToDesk {
                 desk: "eng_desk".to_string(),
                 instruction: "fetch my activity".to_string(),
-            })],
+            }]],
             TurnFaults {
                 fail_from: Some(2),
                 ..TurnFaults::default()
@@ -3646,10 +3651,10 @@ members = ["eng1", "eng2"]
         // invoke 2 is the delegate's turn, which cancels itself mid-run.
         let (brain, provider) = brain_that_delegates_with(
             dir.path(),
-            vec![Some(Delegation::DelegateToDesk {
+            vec![vec![Delegation::DelegateToDesk {
                 desk: "eng_desk".to_string(),
                 instruction: "fetch my activity".to_string(),
-            })],
+            }]],
             TurnFaults {
                 cancel_on: vec![2],
                 ..TurnFaults::default()
@@ -3672,6 +3677,61 @@ members = ["eng1", "eng2"]
         assert!(
             note.contains("[operator] the delegated run was cancelled"),
             "a cancellation is attributed to the operator: {note}"
+        );
+    }
+
+    /// A later hand-off that ANSWERS must not be discarded by an earlier one
+    /// that produced nothing (issue #213 review finding 3).
+    ///
+    /// Before this, the first hand-off owned the card unconditionally. A first
+    /// hand-off cancelled mid-flight still produced a `TaskHandoff`, so a second
+    /// hand-off in the same drain took the "does not own the card" arm: its
+    /// answer was appended to the note, but the card still settled `Cancelled`
+    /// -> `backlog` off the first. Work that ran and produced output ended up
+    /// filed under a card marked cancelled.
+    #[tokio::test]
+    async fn a_later_answering_hand_off_takes_the_card_over_from_an_earlier_empty_one() {
+        let dir = tempfile::tempdir().unwrap();
+        // Invoke 1 is the dispatched orchestrator turn, queuing BOTH hand-offs.
+        // Invoke 2 is the first delegate's run, cancelled mid-flight; invoke 3
+        // is the second delegate's run, which answers.
+        let (brain, provider) = brain_that_delegates_with(
+            dir.path(),
+            vec![vec![
+                Delegation::DelegateToDesk {
+                    desk: "eng_desk".to_string(),
+                    instruction: "first attempt".to_string(),
+                },
+                Delegation::DelegateToDesk {
+                    desk: "eng_desk".to_string(),
+                    instruction: "second attempt".to_string(),
+                },
+            ]],
+            TurnFaults {
+                cancel_on: vec![2],
+                ..TurnFaults::default()
+            },
+        );
+        dispatch_card(&brain, &provider.tasks.clone(), "t-two-handoffs").await;
+
+        let after = only_card(&provider.tasks).await;
+        assert_eq!(
+            after.column, "in_review",
+            "the card settles from the hand-off that actually produced work, not from the \
+             cancelled one that preceded it"
+        );
+        assert_eq!(
+            after.assignee, "engineer",
+            "the delegate that produced the work owns the card"
+        );
+        let note = after.note.expect("note");
+        assert!(
+            note.contains("second attempt"),
+            "the answering hand-off's output is the card's result: {note}"
+        );
+        assert!(
+            !note.contains("the delegated run was cancelled before it produced anything"),
+            "an earlier cancelled hand-off must not settle a card a later one completed: {note}"
         );
     }
 

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -270,8 +270,17 @@ impl HarnessBrain {
                                             );
                                             reply
                                         }
-                                        // The hand-off ran but produced nothing
-                                        // (an operator cancelled it in flight).
+                                        // The hand-off ran and an operator
+                                        // CANCELLED it in flight, so it produced
+                                        // nothing. Naming the cancellation here
+                                        // is safe because `TaskHandoff` only
+                                        // carries `reply: None` for a run
+                                        // `run_delegation` reported as cancelled
+                                        // — a hand-off that ends empty for any
+                                        // other reason reports no hand-off at
+                                        // all and never reaches this arm (issue
+                                        // #213 review).
+                                        //
                                         // Partial work is discarded and the card
                                         // returns to the backlog, exactly as a
                                         // cancelled dispatch does — it must not
@@ -2940,7 +2949,7 @@ members = ["eng1", "eng2"]
 
     // --- Steer disposition (issue #111) -------------------------------------
 
-    use crate::company::steer::InflightRegistry;
+    use crate::company::steer::{InflightKind, InflightRegistry};
     use std::collections::VecDeque;
     use std::sync::Mutex as StdMutex;
 
@@ -3201,13 +3210,25 @@ members = ["eng1", "eng2"]
         tasks: Arc<FsOps>,
         /// `(column, assignee)` of the company's card at each invoke, in order.
         board: StdMutex<Vec<(String, String)>>,
-        /// The 1-based invoke number from which every invoke ERRORS instead of
-        /// answering, so a test can make a delegate's own run fail and assert
-        /// the card still lands (issue #213 review finding 1). It is a *from*,
-        /// not an *on*: openhuman's agent loop retries a failed provider call
-        /// within the same turn, so failing one invoke only makes the turn
-        /// succeed on its retry.
-        fail_from_invoke: Option<usize>,
+        /// How this provider misbehaves, by invoke number.
+        faults: TurnFaults,
+        /// The same registry wired into [`HarnessDeps::steer`], so a scripted
+        /// invoke can cancel its own in-flight delegation.
+        steer: InflightRegistry,
+    }
+
+    /// How a [`DelegatingProvider`] misbehaves, keyed by 1-based invoke number
+    /// (issue #213 review).
+    #[derive(Default)]
+    struct TurnFaults {
+        /// Every invoke from here on ERRORS instead of answering, so a test can
+        /// make a delegate's own run fail. A *from*, not an *on*: openhuman's
+        /// agent loop retries a failed provider call within the same turn, so
+        /// failing a single invoke only makes the turn succeed on its retry.
+        fail_from: Option<usize>,
+        /// Invokes that CANCEL their own in-flight delegation mid-run, so the
+        /// delegated reply is discarded exactly as an operator cancel does.
+        cancel_on: Vec<usize>,
     }
 
     impl DelegatingProvider {
@@ -3225,10 +3246,23 @@ members = ["eng1", "eng2"]
             request: ModelRequest,
         ) -> tinyagents::Result<ModelResponse> {
             let invoke = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
-            if self.fail_from_invoke.is_some_and(|from| invoke >= from) {
+            if self.faults.fail_from.is_some_and(|from| invoke >= from) {
                 return Err(tinyagents::TinyAgentsError::Model(
                     "the delegate's provider fell over".to_string(),
                 ));
+            }
+            if self.faults.cancel_on.contains(&invoke) {
+                // The delegation's own in-flight entry, not the dispatched
+                // card's — cancelling the card would end the whole run.
+                let company = CompanyId::new("acme");
+                if let Some(entry) = self
+                    .steer
+                    .list(&company)
+                    .into_iter()
+                    .find(|e| e.kind == InflightKind::Delegation)
+                {
+                    let _ = self.steer.steer(&company, &entry.key, SteerAction::Cancel);
+                }
             }
             let snapshot = self
                 .tasks
@@ -3267,26 +3301,27 @@ members = ["eng1", "eng2"]
         dir: &std::path::Path,
         pushes: Vec<Option<Delegation>>,
     ) -> (HarnessBrain, Arc<DelegatingProvider>) {
-        brain_that_delegates_failing_from(dir, pushes, None)
+        brain_that_delegates_with(dir, pushes, TurnFaults::default())
     }
 
-    /// [`brain_that_delegates`], but every invoke from `fail_from_invoke`
-    /// (1-based) onward errors instead of answering — so a test can make the
-    /// *delegate's* run fail, retries included.
-    fn brain_that_delegates_failing_from(
+    /// [`brain_that_delegates`], with scripted per-invoke faults so a test can
+    /// make a delegate's run fail or be cancelled mid-flight.
+    fn brain_that_delegates_with(
         dir: &std::path::Path,
         pushes: Vec<Option<Delegation>>,
-        fail_from_invoke: Option<usize>,
+        faults: TurnFaults,
     ) -> (HarnessBrain, Arc<DelegatingProvider>) {
         let queue = orchestrator::DelegationQueue::default();
         let tasks = Arc::new(FsOps::new(dir));
+        let steer = InflightRegistry::new();
         let provider = Arc::new(DelegatingProvider {
             queue: queue.clone(),
             pushes: StdMutex::new(pushes.into_iter().collect()),
             calls: std::sync::atomic::AtomicUsize::new(0),
             tasks: tasks.clone(),
             board: StdMutex::new(Vec::new()),
-            fail_from_invoke,
+            faults,
+            steer: steer.clone(),
         });
         let deps = HarnessDeps {
             provider: provider.clone(),
@@ -3314,7 +3349,7 @@ members = ["eng1", "eng2"]
             plan: None,
             media: None,
             composio: None,
-            steer: crate::company::steer::InflightRegistry::default(),
+            steer,
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record_with_desk()),
@@ -3561,13 +3596,16 @@ members = ["eng1", "eng2"]
         let dir = tempfile::tempdir().unwrap();
         // Invoke 1 is the dispatched orchestrator turn (queues the hand-off);
         // invoke 2 is the delegate's own turn, which errors.
-        let (brain, provider) = brain_that_delegates_failing_from(
+        let (brain, provider) = brain_that_delegates_with(
             dir.path(),
             vec![Some(Delegation::DelegateToDesk {
                 desk: "eng_desk".to_string(),
                 instruction: "fetch my activity".to_string(),
             })],
-            Some(2),
+            TurnFaults {
+                fail_from: Some(2),
+                ..TurnFaults::default()
+            },
         );
         dispatch_card(&brain, &provider.tasks.clone(), "t-boom").await;
 
@@ -3591,6 +3629,49 @@ members = ["eng1", "eng2"]
         assert!(
             !note.contains("[operator]"),
             "an errored run is not an operator cancellation: {note}"
+        );
+    }
+
+    /// A hand-off an operator cancels mid-flight produced nothing, so the card
+    /// returns to the `backlog` reported as the cancellation it actually was.
+    ///
+    /// The claim is only made because `run_delegation` reports the cancellation
+    /// as a fact (`DelegationOutcome::cancelled`); a hand-off that ends empty
+    /// for any other reason no longer reaches this arm at all (issue #213
+    /// review finding 2).
+    #[tokio::test]
+    async fn a_cancelled_hand_off_returns_the_card_to_the_backlog_as_a_cancellation() {
+        let dir = tempfile::tempdir().unwrap();
+        // Invoke 1 is the dispatched orchestrator turn (queues the hand-off);
+        // invoke 2 is the delegate's turn, which cancels itself mid-run.
+        let (brain, provider) = brain_that_delegates_with(
+            dir.path(),
+            vec![Some(Delegation::DelegateToDesk {
+                desk: "eng_desk".to_string(),
+                instruction: "fetch my activity".to_string(),
+            })],
+            TurnFaults {
+                cancel_on: vec![2],
+                ..TurnFaults::default()
+            },
+        );
+        dispatch_card(&brain, &provider.tasks.clone(), "t-cancel").await;
+
+        let after = only_card(&provider.tasks).await;
+        assert_eq!(
+            after.column, "backlog",
+            "a cancelled hand-off must not read as finished, and must not strand in progress"
+        );
+        let note = after.note.expect("note");
+        assert!(
+            note.contains("the delegated run was cancelled before it produced anything"),
+            "the cancellation is reported as the cause: {note}"
+        );
+        // A cancellation is the operator's act, so the block is theirs — not the
+        // delegate's, who never said it.
+        assert!(
+            note.contains("[operator] the delegated run was cancelled"),
+            "a cancellation is attributed to the operator: {note}"
         );
     }
 

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -219,11 +219,37 @@ impl HarnessBrain {
                             // with the delegate never having run. Draining here
                             // runs the delegate, reassigns the card to them, and
                             // settles it from THEIR output.
-                            let handoff = self
+                            //
+                            // An errored hand-off lands exactly like an errored
+                            // turn (the `Err` arm below), and must NOT propagate
+                            // with `?`. By the time `run_delegation` can fail,
+                            // `hand_card_over` has already persisted the card as
+                            // `in_progress` reassigned to the delegate — so
+                            // unwinding here would skip both the settle and the
+                            // final `upsert` and leave the card sitting in
+                            // `in_progress` under a delegate that produced
+                            // nothing, with no result and nothing to re-dispatch
+                            // it: `task_enters_in_progress` only edge-fires on
+                            // the *transition* into that column, which already
+                            // happened. That is precisely the stranded state
+                            // this fix exists to eliminate.
+                            //
+                            // The card keeps the delegate as its assignee on the
+                            // way to `backlog` — the hand-off did happen, and a
+                            // re-dispatch should start from who it was given to.
+                            let handoff = match self
                                 .delegation_runner(&run_turn)
                                 .for_task(&card.id)
                                 .handle_task_delegations(&mut card, &responder)
-                                .await?;
+                                .await
+                            {
+                                Ok(handoff) => handoff,
+                                Err(err) => {
+                                    let result = format!("hand-off failed: {err}");
+                                    settle(&mut card, TaskRunEnd::Failed, &responder, &result);
+                                    break result;
+                                }
+                            };
                             // `settle` writes the note (attributed to whoever
                             // actually produced the text) and the landing column
                             // via the #186 lifecycle seam; the loop still yields
@@ -3175,6 +3201,13 @@ members = ["eng1", "eng2"]
         tasks: Arc<FsOps>,
         /// `(column, assignee)` of the company's card at each invoke, in order.
         board: StdMutex<Vec<(String, String)>>,
+        /// The 1-based invoke number from which every invoke ERRORS instead of
+        /// answering, so a test can make a delegate's own run fail and assert
+        /// the card still lands (issue #213 review finding 1). It is a *from*,
+        /// not an *on*: openhuman's agent loop retries a failed provider call
+        /// within the same turn, so failing one invoke only makes the turn
+        /// succeed on its retry.
+        fail_from_invoke: Option<usize>,
     }
 
     impl DelegatingProvider {
@@ -3191,7 +3224,12 @@ members = ["eng1", "eng2"]
             _state: &(),
             request: ModelRequest,
         ) -> tinyagents::Result<ModelResponse> {
-            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let invoke = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+            if self.fail_from_invoke.is_some_and(|from| invoke >= from) {
+                return Err(tinyagents::TinyAgentsError::Model(
+                    "the delegate's provider fell over".to_string(),
+                ));
+            }
             let snapshot = self
                 .tasks
                 .list(&CompanyId::new("acme"))
@@ -3229,6 +3267,17 @@ members = ["eng1", "eng2"]
         dir: &std::path::Path,
         pushes: Vec<Option<Delegation>>,
     ) -> (HarnessBrain, Arc<DelegatingProvider>) {
+        brain_that_delegates_failing_from(dir, pushes, None)
+    }
+
+    /// [`brain_that_delegates`], but every invoke from `fail_from_invoke`
+    /// (1-based) onward errors instead of answering — so a test can make the
+    /// *delegate's* run fail, retries included.
+    fn brain_that_delegates_failing_from(
+        dir: &std::path::Path,
+        pushes: Vec<Option<Delegation>>,
+        fail_from_invoke: Option<usize>,
+    ) -> (HarnessBrain, Arc<DelegatingProvider>) {
         let queue = orchestrator::DelegationQueue::default();
         let tasks = Arc::new(FsOps::new(dir));
         let provider = Arc::new(DelegatingProvider {
@@ -3237,6 +3286,7 @@ members = ["eng1", "eng2"]
             calls: std::sync::atomic::AtomicUsize::new(0),
             tasks: tasks.clone(),
             board: StdMutex::new(Vec::new()),
+            fail_from_invoke,
         });
         let deps = HarnessDeps {
             provider: provider.clone(),
@@ -3490,6 +3540,57 @@ members = ["eng1", "eng2"]
             provider.board()[1],
             ("in_progress".to_string(), "engineer".to_string()),
             "the delegate must be shown working the card while they work it"
+        );
+    }
+
+    /// An errored hand-off must not STRAND the card (issue #213 review).
+    ///
+    /// `hand_card_over` has already persisted the card as `in_progress`
+    /// reassigned to the delegate before their turn starts. If that turn then
+    /// errors and the failure is propagated out of `run_task`, the settle and
+    /// the final `upsert` are both skipped and the card sits in `in_progress`
+    /// under the delegate with no result — and nothing re-dispatches it, because
+    /// `task_enters_in_progress` only edge-fires on the *transition* into that
+    /// column and the card is already there. Exactly the state issue #204 exists
+    /// to eliminate, reintroduced through the error path.
+    ///
+    /// So an errored hand-off takes the same arm an errored turn does: settle
+    /// `Failed` → `backlog`, with the reason on the note.
+    #[tokio::test]
+    async fn a_hand_off_whose_delegate_errors_lands_in_backlog_not_stranded_in_progress() {
+        let dir = tempfile::tempdir().unwrap();
+        // Invoke 1 is the dispatched orchestrator turn (queues the hand-off);
+        // invoke 2 is the delegate's own turn, which errors.
+        let (brain, provider) = brain_that_delegates_failing_from(
+            dir.path(),
+            vec![Some(Delegation::DelegateToDesk {
+                desk: "eng_desk".to_string(),
+                instruction: "fetch my activity".to_string(),
+            })],
+            Some(2),
+        );
+        dispatch_card(&brain, &provider.tasks.clone(), "t-boom").await;
+
+        let after = only_card(&provider.tasks).await;
+        assert_eq!(
+            after.column, "backlog",
+            "an errored hand-off must return the card to the backlog, never leave it stranded in \
+             progress where nothing will re-dispatch it"
+        );
+        let note = after.note.expect("note");
+        assert!(
+            note.contains("hand-off failed:"),
+            "the failure reason lands on the note: {note}"
+        );
+        assert!(
+            note.contains("delegated to engineer: fetch my activity"),
+            "the hand-off that was attempted is still recorded: {note}"
+        );
+        // The failure is the assignee's, not the operator's — a cancellation is
+        // the only ending attributed to `operator`.
+        assert!(
+            !note.contains("[operator]"),
+            "an errored run is not an operator cancellation: {note}"
         );
     }
 

--- a/src/harness/lifecycle.rs
+++ b/src/harness/lifecycle.rs
@@ -49,13 +49,17 @@ use crate::ports::types::{OutboundMessage, ReplyTo};
 /// The definitions moved to the task **port** in issue #205: this module is
 /// `#[cfg(feature = "openhuman")]`, so the REST write boundary — which now
 /// validates a card's column — could not see them. `COLUMN_IN_REVIEW` is where
-/// a card awaits the orchestrator, `COLUMN_BACKLOG` where a stopped or failed
-/// run returns it, `COLUMN_PAUSED` where a paused run parks it (resume is a
-/// plain `column → in_progress` PATCH, which re-triggers dispatch), and
-/// `COLUMN_DONE` the terminal — reached by [`landing_column`] for a delegated
-/// card and by [`review_landing_column`] for an approved board card (issue #171
-/// / PR #179).
-pub use crate::ports::tasks::{COLUMN_BACKLOG, COLUMN_DONE, COLUMN_IN_REVIEW, COLUMN_PAUSED};
+/// a card awaits the orchestrator, `COLUMN_IN_PROGRESS` where a card is being
+/// worked — where a dispatched card already is, and where one whose turn
+/// **handed the work off** stays while the delegate runs (issue #204) —
+/// `COLUMN_BACKLOG` where a stopped or failed run returns it, `COLUMN_PAUSED`
+/// where a paused run parks it (resume is a plain `column → in_progress` PATCH,
+/// which re-triggers dispatch), and `COLUMN_DONE` the terminal — reached by
+/// [`landing_column`] for a delegated card and by [`review_landing_column`] for
+/// an approved board card (issue #171 / PR #179).
+pub use crate::ports::tasks::{
+    COLUMN_BACKLOG, COLUMN_DONE, COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, COLUMN_PAUSED,
+};
 
 /// The note attribution used for an operator-initiated stop, as opposed to a
 /// result the assignee produced.
@@ -70,6 +74,16 @@ pub const OPERATOR_ATTRIBUTION: &str = "operator";
 pub enum TaskRunEnd {
     /// The assignee finished its turn and produced a result.
     Completed,
+    /// The assignee's turn **handed the work off** to another agent rather than
+    /// doing it (issue #204). This is not an ending: the card is reassigned to
+    /// the delegate and stays in [`COLUMN_IN_PROGRESS`] while they run, and the
+    /// delegate's own ending — a [`Completed`](Self::Completed) with their
+    /// output, or a [`Cancelled`](Self::Cancelled) — settles it afterwards.
+    ///
+    /// Without this, "I finished the work" and "I handed it off" were the same
+    /// `Completed`, so a delegating dispatch landed in `in_review` under the
+    /// delegator with the delegate never having run.
+    Delegated,
     /// The turn itself errored (`dispatch failed: …`).
     Failed,
     /// An operator cancelled mid-flight. Partial work is discarded.
@@ -161,7 +175,8 @@ pub fn success_terminal_column(card: &TaskRecord) -> &'static str {
 /// The board column a run ending this way lands its card in.
 ///
 /// The single authority for that mapping. A failed or cancelled run goes back
-/// to `backlog` (it is not reviewable work); a paused one parks; everything
+/// to `backlog` (it is not reviewable work); a paused one parks; a hand-off
+/// stays in `in_progress` because the work has only changed hands; everything
 /// that produced a result goes to its [`success_terminal_column`] — `done` for
 /// a delegated card, `in_review` for a board-created one.
 pub fn landing_column(end: TaskRunEnd, card: &TaskRecord) -> &'static str {
@@ -169,6 +184,10 @@ pub fn landing_column(end: TaskRunEnd, card: &TaskRecord) -> &'static str {
         TaskRunEnd::Completed | TaskRunEnd::RedirectsExhausted => success_terminal_column(card),
         TaskRunEnd::Failed | TaskRunEnd::Cancelled => COLUMN_BACKLOG,
         TaskRunEnd::Paused => COLUMN_PAUSED,
+        // A hand-off is explicitly NOT a terminal: the delegate is running, so
+        // the card keeps the column it was dispatched in and only settles once
+        // they come back with something (issue #204).
+        TaskRunEnd::Delegated => COLUMN_IN_PROGRESS,
     }
 }
 
@@ -196,6 +215,7 @@ pub fn note_attribution(end: TaskRunEnd, responder: &str) -> String {
 pub fn relay_text(card: &TaskRecord, responder: &str, orchestrator: &str) -> String {
     let status = match card.column.as_str() {
         COLUMN_IN_REVIEW => "is ready for review",
+        COLUMN_IN_PROGRESS => "is still in progress",
         COLUMN_PAUSED => "is paused",
         COLUMN_BACKLOG => "went back to the backlog",
         COLUMN_DONE => "is done",
@@ -285,6 +305,30 @@ mod test {
             COLUMN_BACKLOG
         );
         assert_eq!(landing_column(TaskRunEnd::Paused, &board), COLUMN_PAUSED);
+        assert_eq!(
+            landing_column(TaskRunEnd::Delegated, &board),
+            COLUMN_IN_PROGRESS
+        );
+    }
+
+    /// Issue #204: handing the work off is not finishing it. A delegating turn
+    /// used to settle as `Completed`, which parked the card in its success
+    /// terminal under the *delegator* while the delegate had not even run — so
+    /// the hand-off keeps the card in progress instead, whatever its origin.
+    #[test]
+    fn a_hand_off_keeps_the_card_in_progress_rather_than_finishing_it() {
+        for card in [
+            card(COLUMN_IN_PROGRESS, None),
+            delegated_card(COLUMN_IN_PROGRESS),
+        ] {
+            let landed = landing_column(TaskRunEnd::Delegated, &card);
+            assert_eq!(landed, COLUMN_IN_PROGRESS);
+            assert_ne!(
+                landed,
+                success_terminal_column(&card),
+                "a hand-off must never reach a terminal column — the delegate has not run yet"
+            );
+        }
     }
 
     /// #171 (PR #179): a delegated card completes to `done` instead of

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -26,7 +26,7 @@ use crate::company::steer::{
     InflightEntry, InflightKind, InflightRegistry, SteerAction, SteerControl,
 };
 use crate::harness::TurnOutcome;
-use crate::harness::lifecycle;
+use crate::harness::lifecycle::{self, TaskRunEnd};
 use crate::harness::orchestrator::{self, Delegation, DelegationQueue};
 use crate::ports::types::{CompanyId, CompanyRecord, OutboundMessage, TurnStep};
 use crate::ports::{TaskRecord, TaskStore, generate_id, now_millis};
@@ -133,6 +133,20 @@ pub(crate) struct OperatorTurn {
     pub(crate) bubbles: Vec<OutboundMessage>,
 }
 
+/// What a **dispatched card's** turn handed off (issue #204).
+///
+/// Returned by [`DelegationRunner::handle_task_delegations`] when the turn
+/// called `delegate_to_desk` and the desk resolved to a real teammate: that
+/// teammate is now the card's assignee and has already run. `reply` is what
+/// they produced, or `None` when their run yielded nothing (an operator
+/// cancelled it mid-flight).
+pub(crate) struct TaskHandoff {
+    /// The delegate that took the card over — now its `assignee`.
+    pub(crate) delegate: String,
+    /// What the delegate produced, if anything.
+    pub(crate) reply: Option<String>,
+}
+
 /// Drives the brain-agnostic delegation orchestration over a [`RunTurn`]: run the
 /// responder's turn, drain and execute whatever it queued, and — when a desk
 /// answered synchronously — relay through exactly one more responder turn.
@@ -151,6 +165,10 @@ pub(crate) struct DelegationRunner<'a> {
     company: &'a CompanyId,
     queue: &'a DelegationQueue,
     max_delegations: usize,
+    /// The dispatched card this drain is running inside, when it is one (issue
+    /// #204). Owned rather than borrowed so a caller can hold the card mutably
+    /// while the runner runs. `None` for an operator chat turn.
+    task: Option<String>,
 }
 
 impl<'a> DelegationRunner<'a> {
@@ -173,7 +191,15 @@ impl<'a> DelegationRunner<'a> {
             company,
             queue,
             max_delegations,
+            task: None,
         }
+    }
+
+    /// Scopes this runner to a dispatched card, so anything the turn spawns
+    /// records that card as its parent (issue #185's `parent_task_id`).
+    pub(crate) fn for_task(mut self, task_id: &str) -> Self {
+        self.task = Some(task_id.to_string());
+        self
     }
 
     /// Handles one operator message end-to-end: clear stale delegations, run the
@@ -248,6 +274,124 @@ impl<'a> DelegationRunner<'a> {
         })
     }
 
+    /// Drains and executes whatever a **dispatched card's** turn queued (issue
+    /// #204), and reports the hand-off when one happened.
+    ///
+    /// Before this, `run_task` ran exactly one background turn and never
+    /// touched the queue — so when the dispatched responder (the orchestrator,
+    /// which carries the delegation tools) called `delegate_to_desk`, the
+    /// delegation was silently dropped, the turn still returned `Ok`, and the
+    /// card landed in `in_review` under the delegator with a blank assignee and
+    /// no delegate ever having run.
+    ///
+    /// The first hand-off to a desk with a resolvable lead **owns the card**:
+    /// the card is reassigned to that lead and persisted in
+    /// [`COLUMN_IN_PROGRESS`](lifecycle::COLUMN_IN_PROGRESS) *before* their turn
+    /// starts, so the board shows who is working it while they work it, and the
+    /// caller settles the card from their output afterwards. Every other
+    /// delegation — `spawn_task`, `assign_task`, `review_task`, a hand-off to a
+    /// desk nobody leads, and any further hand-off past the first — executes for
+    /// its side effect; a later hand-off's answer is appended to the note so it
+    /// is recorded rather than silently discarded.
+    ///
+    /// `chat_id` is `None` throughout: a dispatched card has no chat thread, and
+    /// stamping one would make a spawned card post back into an unrelated
+    /// conversation.
+    pub(crate) async fn handle_task_delegations(
+        &self,
+        card: &mut TaskRecord,
+        delegator: &str,
+    ) -> Result<Option<TaskHandoff>> {
+        let queued = self.queue.drain(self.max_delegations);
+        if queued.is_empty() {
+            return Ok(None);
+        }
+        tracing::debug!(
+            task_id = %card.id,
+            delegator = %delegator,
+            queued = queued.len(),
+            "[task] draining delegations queued by a dispatched turn"
+        );
+        let mut handoff: Option<TaskHandoff> = None;
+        for delegation in queued {
+            // Resolve the hand-off target BEFORE running it, so the card can be
+            // reassigned while the delegate works. `desk_lead` is pure, so the
+            // second resolution inside `run_delegation` yields the same member.
+            let lead = match &delegation {
+                Delegation::DelegateToDesk { desk, .. } => desk_lead(self.record, desk),
+                _ => None,
+            };
+            let Some(member) = lead else {
+                self.run_delegation(delegation, None).await?;
+                continue;
+            };
+            let owns_card = handoff.is_none();
+            if owns_card {
+                self.hand_card_over(card, delegator, &member, instruction_of(&delegation))
+                    .await?;
+            }
+            let reply = self
+                .run_delegation(delegation, None)
+                .await?
+                .desk_reply
+                .map(|desk| desk.reply);
+            match (owns_card, reply) {
+                (true, reply) => {
+                    handoff = Some(TaskHandoff {
+                        delegate: member,
+                        reply,
+                    });
+                }
+                // A second hand-off does not take the card over, but its answer
+                // is real work — record it rather than dropping it.
+                (false, Some(reply)) => {
+                    card.note = Some(append_note(card.note.as_deref(), &member, &reply));
+                }
+                (false, None) => {}
+            }
+        }
+        Ok(handoff)
+    }
+
+    /// Reassigns a dispatched card to the delegate taking it over and persists
+    /// it, so the board shows them working it *while* they work rather than
+    /// only once they are done (issue #204).
+    ///
+    /// The write goes through the [`TaskStore`] port, **not**
+    /// `CompanyRuntime::upsert_task`, so it cannot re-fire the
+    /// `column → in_progress` dispatch edge — the card is already in
+    /// `in_progress` and this only re-states it. No task store wired is a silent
+    /// no-op, matching every other task path on this seam.
+    async fn hand_card_over(
+        &self,
+        card: &mut TaskRecord,
+        delegator: &str,
+        member: &str,
+        instruction: &str,
+    ) -> Result<()> {
+        card.assignee = member.to_string();
+        card.note = Some(append_note(
+            card.note.as_deref(),
+            delegator,
+            &match instruction.trim() {
+                "" => format!("delegated to {member}"),
+                instruction => format!("delegated to {member}: {instruction}"),
+            },
+        ));
+        card.column = lifecycle::landing_column(TaskRunEnd::Delegated, card).to_string();
+        card.updated_at_millis = now_millis();
+        tracing::debug!(
+            task_id = %card.id,
+            delegate = %member,
+            column = %card.column,
+            "[task] card handed over to the delegate"
+        );
+        if let Some(tasks) = self.tasks {
+            tasks.upsert(self.company, card).await?;
+        }
+        Ok(())
+    }
+
     /// Executes one drained delegation.
     ///
     /// `spawn_task` opens a backlog card through the
@@ -284,15 +428,14 @@ impl<'a> DelegationRunner<'a> {
                     // so the completion can answer there instead of only landing in
                     // the note.
                     origin_chat_id: chat_id.map(str::to_string),
-                    // No parent (#185). `run_delegation` is only reached from an
-                    // orchestrator *chat* turn: `run_task` never drains the
-                    // delegation queue, and a dispatched card's responder is a desk
-                    // member, which carries no delegation tools ("no sub-agent
-                    // re-delegation in v1"). So no task is ever in scope here to be
-                    // the parent. Lineage is written through the task API's
-                    // `parentTaskId` instead; when task turns do gain delegation
-                    // tools, this is the site that stamps it.
-                    parent_task_id: None,
+                    // Lineage (#185): the dispatched card whose turn queued this
+                    // one, when the drain is running inside a task
+                    // (`for_task`) — since #204 a dispatched turn drains the
+                    // queue too, so a task IS in scope here and this is the site
+                    // that stamps it. An orchestrator *chat* turn has no task in
+                    // scope and still writes `None`; lineage for those is written
+                    // through the task API's `parentTaskId` instead.
+                    parent_task_id: self.task.clone(),
                 };
                 tasks.upsert(self.company, &card).await?;
                 Ok(DelegationOutcome::default())
@@ -456,6 +599,16 @@ impl<'a> DelegationRunner<'a> {
     /// which `orchestrator_id` already tolerates.
     fn orchestrator_id(&self) -> String {
         orchestrator::orchestrator_id(&self.record.manifest.agents).unwrap_or_default()
+    }
+}
+
+/// The instruction a hand-off carries, for the note that records it (issue
+/// #204). Empty for every other delegation kind — callers only ask this of a
+/// [`Delegation::DelegateToDesk`].
+fn instruction_of(delegation: &Delegation) -> &str {
+    match delegation {
+        Delegation::DelegateToDesk { instruction, .. } => instruction,
+        _ => "",
     }
 }
 

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -110,6 +110,15 @@ pub(crate) struct DelegationOutcome {
     pub(crate) bubble: Option<OutboundMessage>,
     /// A synchronous desk reply to relay through a second orchestrator turn.
     pub(crate) desk_reply: Option<DeskReply>,
+    /// Set when an operator CANCELLED this delegation's run mid-flight, so its
+    /// reply was discarded.
+    ///
+    /// `desk_reply: None` on its own does not mean "cancelled" —
+    /// `run_delegation` also returns an empty outcome for a desk with no
+    /// resolvable lead, and for every delegation that is not a hand-off. This
+    /// flag carries the cancellation as a **fact** so a caller can report the
+    /// cause rather than inferring one from an absence (issue #213 review).
+    pub(crate) cancelled: bool,
 }
 
 /// A synchronous desk-lead answer captured for the orchestrator to relay: which
@@ -138,12 +147,20 @@ pub(crate) struct OperatorTurn {
 /// Returned by [`DelegationRunner::handle_task_delegations`] when the turn
 /// called `delegate_to_desk` and the desk resolved to a real teammate: that
 /// teammate is now the card's assignee and has already run. `reply` is what
-/// they produced, or `None` when their run yielded nothing (an operator
-/// cancelled it mid-flight).
+/// they produced.
+///
+/// A `TaskHandoff` with `reply: None` is only ever built from a run an operator
+/// actually CANCELLED — [`DelegationOutcome::cancelled`] is the input, not the
+/// absence of a reply. A hand-off that yields nothing for any *other* reason
+/// reports no hand-off at all, so the delegator's own turn settles the card
+/// (the same path a desk with no resolvable lead already takes) rather than the
+/// card being settled as a cancellation that never happened (issue #213
+/// review).
 pub(crate) struct TaskHandoff {
     /// The delegate that took the card over — now its `assignee`.
     pub(crate) delegate: String,
-    /// What the delegate produced, if anything.
+    /// What the delegate produced. `None` means their run was cancelled
+    /// mid-flight, and nothing else.
     pub(crate) reply: Option<String>,
 }
 
@@ -330,24 +347,40 @@ impl<'a> DelegationRunner<'a> {
                 self.hand_card_over(card, delegator, &member, instruction_of(&delegation))
                     .await?;
             }
-            let reply = self
-                .run_delegation(delegation, None)
-                .await?
-                .desk_reply
-                .map(|desk| desk.reply);
-            match (owns_card, reply) {
-                (true, reply) => {
+            let outcome = self.run_delegation(delegation, None).await?;
+            match (owns_card, outcome.desk_reply, outcome.cancelled) {
+                // The delegate answered: they own the card and it settles from
+                // their output.
+                (true, Some(desk), _) => {
                     handoff = Some(TaskHandoff {
                         delegate: member,
-                        reply,
+                        reply: Some(desk.reply),
                     });
                 }
-                // A second hand-off does not take the card over, but its answer
-                // is real work — record it rather than dropping it.
-                (false, Some(reply)) => {
-                    card.note = Some(append_note(card.note.as_deref(), &member, &reply));
+                // An operator cancelled their run mid-flight, so it produced
+                // nothing. Reported as a cancellation because `run_delegation`
+                // said it was one — not because the reply is missing.
+                (true, None, true) => {
+                    handoff = Some(TaskHandoff {
+                        delegate: member,
+                        reply: None,
+                    });
                 }
-                (false, None) => {}
+                // Nothing produced and NOT a cancellation. `run_delegation`'s
+                // only other empty exit for a hand-off is a desk with no
+                // resolvable lead, which cannot be reached here — the lead
+                // resolved above and `desk_lead` is pure over the same record.
+                // If it ever becomes reachable, this reports *no hand-off*, so
+                // the delegator's own reply settles the card exactly as an
+                // unresolvable desk already does, rather than telling the
+                // operator their run was cancelled when it was not.
+                (true, None, false) => {}
+                // A later hand-off does not take the card over, but its answer
+                // is real work — record it rather than dropping it.
+                (false, Some(desk), _) => {
+                    card.note = Some(append_note(card.note.as_deref(), &member, &desk.reply));
+                }
+                (false, None, _) => {}
             }
         }
         Ok(handoff)
@@ -464,10 +497,15 @@ impl<'a> DelegationRunner<'a> {
                     .run_turn
                     .run_steered(self.company, &member, &instruction, &control, chat_id)
                     .await?;
-                // A cancel issued mid-flight discards the delegated reply — nothing
-                // is relayed.
+                // A cancel issued mid-flight discards the delegated reply —
+                // nothing is relayed. Flagged as a cancellation so a caller that
+                // has to explain the empty result can name the cause instead of
+                // guessing at it (issue #213 review).
                 if matches!(control.take(), Some(SteerAction::Cancel)) {
-                    return Ok(DelegationOutcome::default());
+                    return Ok(DelegationOutcome {
+                        cancelled: true,
+                        ..DelegationOutcome::default()
+                    });
                 }
                 // Hand the teammate's answer back to RELAY through a second
                 // orchestrator turn (the CEO-relay hand-back). Their steps ride
@@ -479,6 +517,7 @@ impl<'a> DelegationRunner<'a> {
                         reply: outcome.reply,
                         steps: outcome.steps,
                     }),
+                    cancelled: false,
                 })
             }
             // ── Issue #186 part b: orchestrator lifecycle authority ─────────

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -301,15 +301,23 @@ impl<'a> DelegationRunner<'a> {
     /// card landed in `in_review` under the delegator with a blank assignee and
     /// no delegate ever having run.
     ///
-    /// The first hand-off to a desk with a resolvable lead **owns the card**:
-    /// the card is reassigned to that lead and persisted in
-    /// [`COLUMN_IN_PROGRESS`](lifecycle::COLUMN_IN_PROGRESS) *before* their turn
-    /// starts, so the board shows who is working it while they work it, and the
-    /// caller settles the card from their output afterwards. Every other
-    /// delegation — `spawn_task`, `assign_task`, `review_task`, a hand-off to a
-    /// desk nobody leads, and any further hand-off past the first — executes for
-    /// its side effect; a later hand-off's answer is appended to the note so it
-    /// is recorded rather than silently discarded.
+    /// The first hand-off to a desk with a resolvable lead that **produces
+    /// something** owns the card: the card is reassigned to that lead and
+    /// persisted in [`COLUMN_IN_PROGRESS`](lifecycle::COLUMN_IN_PROGRESS)
+    /// *before* their turn starts, so the board shows who is working it while
+    /// they work it, and the caller settles the card from their output
+    /// afterwards.
+    ///
+    /// An earlier hand-off that produced nothing (its run was cancelled
+    /// mid-flight) holds the card only *provisionally* — a later hand-off that
+    /// answers takes it over. Otherwise the card would settle from the
+    /// cancellation while work that actually ran was merely appended to the
+    /// note, filing a real deliverable under a card marked cancelled.
+    ///
+    /// Every other delegation — `spawn_task`, `assign_task`, `review_task`, a
+    /// hand-off to a desk nobody leads, and any further hand-off once one has
+    /// answered — executes for its side effect; a later hand-off's answer is
+    /// appended to the note so it is recorded rather than silently discarded.
     ///
     /// `chat_id` is `None` throughout: a dispatched card has no chat thread, and
     /// stamping one would make a spawned card post back into an unrelated
@@ -342,7 +350,15 @@ impl<'a> DelegationRunner<'a> {
                 self.run_delegation(delegation, None).await?;
                 continue;
             };
-            let owns_card = handoff.is_none();
+            // The card belongs to the first hand-off that actually PRODUCES
+            // something. A hand-off whose run was cancelled produced nothing, so
+            // it does not get to keep the card: it would settle `Cancelled` ->
+            // `backlog` while a later hand-off that really ran had its answer
+            // merely appended to the note — filing work that happened under a
+            // card marked cancelled. So an empty hand-off is *provisional* and a
+            // later one that answers takes the card over from it (issue #213
+            // review finding 3).
+            let owns_card = handoff.as_ref().is_none_or(|prior| prior.reply.is_none());
             if owns_card {
                 self.hand_card_over(card, delegator, &member, instruction_of(&delegation))
                     .await?;


### PR DESCRIPTION
## Summary

Fixes #204.

A board task the CEO delegated to a web-searcher went straight to `in_review` under the CEO with a blank `assignee`, and the delegate never ran.

**Root cause.** `run_task` ran exactly one background turn and never drained the delegation queue. The dispatched responder is the orchestrator, which carries `delegate_to_desk` / `spawn_task`, so the `Delegation` its turn queued was pushed and silently dropped. The turn still returned `Ok`, so it settled as `Completed` → `landing_column` → `in_review` under the delegator, with nobody having done the work. `TaskRunEnd` also had no way to say "I handed it off" as distinct from "I finished it", so there was no state for a card whose work had only changed hands.

**The fix.**

- `TaskRunEnd::Delegated` lands a card in the new `COLUMN_IN_PROGRESS` — a hand-off is explicitly not a terminal.
- `DelegationRunner::handle_task_delegations` drains the queue in the task path. The first hand-off to a desk with a resolvable lead **owns the card**: it is reassigned to that lead and persisted in `in_progress` *before* their turn starts, so the board shows them working it while they work it. Every other delegation (`spawn_task`, `assign_task`, `review_task`, a hand-off to a desk nobody leads) executes for its side effect; a second hand-off's answer is appended to the note rather than dropped. The write goes through the `TaskStore` port, **not** `CompanyRuntime::upsert_task`, so it cannot re-fire the `column → in_progress` dispatch edge.
- `run_task` settles the card from the delegate's output and credits the delegate in every downstream write — note, artifact, journal, relay.
- The delegation queue is cleared before each dispatched turn, matching the operator path, so nothing a prior turn left behind can hijack a card.
- A `spawn_task` queued inside a dispatch now stamps `parent_task_id` with its parent card — the #185 lineage the old comment marked as unreachable *precisely because* the task path did not drain.

Two edge cases resolved deliberately: an **unresolvable desk** settles under the delegator exactly as before (no stranding in `in_progress` waiting on a delegate that can never run), and a hand-off **cancelled in flight** returns the card to `backlog` rather than reading as finished.

## API Or Behavior Changes

- **New `TaskRunEnd::Delegated` variant** and new `lifecycle::COLUMN_IN_PROGRESS` constant. `TaskRunEnd` is matched exhaustively in `landing_column`, which is pinned by a test, so a future variant still cannot be added without a deliberate column decision.
- **Behavior:** a dispatched turn that calls `delegate_to_desk` now runs a second turn (the delegate's) and writes the card twice — once mid-run to reassign it, once to settle it. Previously it ran one turn and wrote once. A dispatched turn that delegates nothing is byte-for-byte unchanged.
- **Behavior:** a card spawned by a dispatched turn now carries `parent_task_id`; one spawned from an operator chat turn still writes `None`.
- No REST/GraphQL schema changes.

## Tests

Both behaviour tests were verified to **fail** against the pre-fix path (drain stubbed back out) and pass after — the two compatibility tests pass either way, as they should.

New coverage:

- `a_dispatched_turn_that_delegates_runs_the_delegate_and_links_them_to_the_card` — the delegate actually runs (2 turns, not 1), is linked as `assignee`, the card reaches `in_review` on **their** output, and — via a per-invoke board snapshot — their turn ran against a card already reassigned and still `in_progress`.
- `a_dispatched_turn_that_delegates_nothing_settles_exactly_as_before` — the compatibility half.
- `a_hand_off_to_an_unknown_desk_settles_under_the_delegator` — no stranding.
- `a_task_spawned_by_a_dispatched_turn_records_its_parent_card` — #185 lineage.
- `a_hand_off_keeps_the_card_in_progress_rather_than_finishing_it` plus the extended exhaustive `landing_column` mapping, in both card shapes.

Commands run locally:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 899 + 6 pass
- [x] `cargo test --features openhuman` — 1236 + 6 pass (the harness suite is where this code lives; the default build does not compile `src/harness/`)

Pre-existing and untouched by this PR: `--all-features` does not compile (`store/sqlite.rs` test method ambiguity), and clippy under `--features openhuman` flags `harness/composio.rs` + `harness/mcp_probe.rs`. Neither is in this diff and neither is in a CI lane.

## Documentation

No doc updates needed — the behaviour and its reasoning are documented in the rustdoc on `TaskRunEnd::Delegated`, `landing_column`, `handle_task_delegations`, and `hand_card_over`, which is where this codebase keeps its lifecycle decisions. The stale comment in `run_delegation` that asserted "`run_task` never drains the delegation queue" is rewritten in the same commit.

## Overlap with #205 (merge order)

#205 is a sibling bug in the same dispatch path and **touches two of the same files** — `src/harness/brain.rs` (`task_responder` and the dispatch/settle path) and `src/harness/lifecycle.rs`. Expect a conflict in `run_task` if both land.

This PR is written to be the *later* of the two:

- `task_responder` is **not touched here** — resolving blank/invalid/overlay assignees is #205's fix.
- The `assignee` write here happens only inside the hand-off branch, and lands *after* where #205's dispatch-time write would go. The delegate overriding the resolved responder is the correct final state, so the two writes compose rather than fight.
- The compatibility test here deliberately asserts **nothing** about `assignee` on the non-delegating path, so it will not pin the blank that #205 is fixing.

Either merge order works; if #205 lands first, the conflict in `run_task` is mechanical.
