### PR TITLE
fix(tasks): link the working agent to the card and validate the assignee (#205)

### DIFF
--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -330,7 +330,21 @@ pub trait TaskStore: Send + Sync {
 ```
 
 `TaskRecord` carries `{id, title, note, column, priority, assignee,
-updated_at}`. `column` ∈ `backlog|in_progress|in_review|done`.
+updated_at}`.
+
+`column` ∈ `backlog|in_progress|paused|in_review|done` — the `BOARD_COLUMNS`
+constant in `src/ports/tasks.rs`, which is the one authority the REST write
+boundary, the dispatch edge and the harness lifecycle seam all read. (`paused`
+arrived with steering, issue #111; this line used to omit it.) Entering
+`in_progress` is what dispatches the card; nothing dispatches out of `done`.
+
+`assignee` names a **roster teammate id, a desk, or nobody** (`""`), resolved by
+`crate::runtime::assignee` against the full roster — manifest agents, operator
+overlay teammates, and desks (by id or case-insensitive name). The write plane
+rejects anything else with a `400` and stores the canonical key rather than what
+was typed; dispatch refuses a card whose assignee no longer resolves, returning
+it to `backlog` with the reason on the note, and writes the agent that actually
+worked the card back onto `assignee` so the board names the doer (issue #205).
 
 ### ArtifactStore
 

--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -345,6 +345,11 @@ rejects anything else with a `400` and stores the canonical key rather than what
 was typed; dispatch refuses a card whose assignee no longer resolves, returning
 it to `backlog` with the reason on the note, and writes the agent that actually
 worked the card back onto `assignee` so the board names the doer (issue #205).
+That write-back covers an unassigned card and a card assigned to a teammate; a
+card assigned to a **desk** keeps the desk id. A desk assignment records who the
+card belongs to, and dispatch only chooses which member runs the current turn, so
+writing the lead back would erase the desk from the board the first time the card
+ran — the member that did the work is named on the note instead.
 
 ### ArtifactStore
 

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -29,8 +29,10 @@ use crate::ports::{
     SkillStateStore, TaskRecord, TaskStore, ToolProvider, UsageMeter, UserStore, WorkspaceStore,
 };
 
-/// The board column a task must enter to be dispatched to its assignee.
-const IN_PROGRESS: &str = "in_progress";
+/// The board column a task must enter to be dispatched to its assignee. Read
+/// from the task port (#205) so this edge and the write boundary that validates
+/// the column cannot drift onto two different literals.
+use crate::ports::tasks::COLUMN_IN_PROGRESS as IN_PROGRESS;
 
 /// Whether an upsert moves a card **into** `in_progress` (the dispatch edge).
 /// A card already in `in_progress` re-saved is not a fresh dispatch.

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -32,6 +32,7 @@ use crate::harness::orchestrator;
 use crate::harness::orchestrator::Delegation;
 use crate::harness::run_turn::HarnessRunTurn;
 use crate::harness::{HarnessDeps, HarnessPool};
+use crate::runtime::assignee;
 use crate::runtime::delegation::{self, DelegationRunner, RunTurn};
 
 /// The most operator redirects honored within a single task dispatch (issue
@@ -106,7 +107,45 @@ impl HarnessBrain {
             return Ok(None);
         };
 
-        let responder = self.task_responder(&card.assignee);
+        // Issue #205: who works this card, resolved against the FULL roster —
+        // teammates, operator-overlay teammates and desks alike.
+        let resolution = assignee::resolve(&self.record, &card.assignee);
+        if let Some(reason) = resolution.rejection() {
+            // The card names somebody this company does not have. Before this
+            // it dispatched to the orchestrator anyway and the board kept the
+            // invalid name, so the only trace was a timeline that read "reply
+            // from ceo" on a card assigned to somebody else. Refuse instead: no
+            // turn is run (nothing was asked of the orchestrator), the card
+            // returns to `backlog` carrying the reason, and the operator is
+            // told — on the board, on the timeline, and in the thread the card
+            // came from.
+            tracing::warn!(
+                task_id = %card.id,
+                assignee = %card.assignee,
+                "[task] refusing dispatch: {reason}"
+            );
+            return self.refuse_dispatch(tasks, card, &reason).await;
+        }
+        // A blank assignee is the one legitimate miss: nobody was named, so the
+        // orchestrator picks it up.
+        let responder = resolution
+            .working_agent()
+            .unwrap_or(&self.responder)
+            .to_string();
+
+        // Link the working agent to the card, and persist it BEFORE the turn
+        // runs (#205). A card the CEO picked up used to keep `assignee = ""`
+        // for the whole run and forever after, so the board never named who was
+        // doing the work; a desk-assigned card never named the member that
+        // actually ran it. Writing it up front is what makes the board show the
+        // card "working" under a real agent while the turn is in flight — the
+        // store `upsert` here is the plain persistence path, not
+        // `CompanyRuntime::upsert_task`, so it cannot re-fire the dispatch edge.
+        if card.assignee != responder {
+            card.assignee = responder.clone();
+            card.updated_at_millis = now_millis();
+            tasks.upsert(&self.record.id, &card).await?;
+        }
 
         // Register the run so an operator can steer it mid-flight. The guard's
         // RAII `Drop` deregisters on every exit path (success, error, redirect
@@ -281,61 +320,8 @@ impl HarnessBrain {
             );
         }
 
-        if let Some(events) = self.deps.events.as_ref() {
-            // The run's reply, tagged so the per-task timeline can filter it out
-            // of the company-scoped journal.
-            //
-            // `chat_id` is the **card id**, deliberately, not the card's origin
-            // thread. `chat_history::owns` routes a reply into a desk's history
-            // by matching `chat_id` against the desk id/name, so using the
-            // origin here would inject this record into that desk's chat — a
-            // behaviour change well outside a read foundation, and a duplicate
-            // of the live post-back bubble below. A card id matches no desk, so
-            // the record stays exactly what it is: timeline material, reachable
-            // only through `task_id`. An empty string would be worse still — it
-            // folds into the General desk.
-            if let Err(err) = events
-                .append(
-                    &self.record.id,
-                    CompanyEvent::AgentReply {
-                        chat_id: card.id.clone(),
-                        agent_id: responder.clone(),
-                        text: result_text.clone(),
-                        steps: Vec::new(),
-                        task_id: Some(card.id.clone()),
-                    },
-                )
-                .await
-            {
-                tracing::warn!(
-                    task_id = %card.id,
-                    error = %err,
-                    "[task] failed to journal dispatch reply; continuing"
-                );
-            }
-            // The terminal anchor, journaled after the card's landing column is
-            // persisted so it always records a completed run. Attempted even if
-            // the reply above failed — the anchor is what closes a timeline, so
-            // dropping it is strictly worse than dropping the reply.
-            if let Err(err) = events
-                .append(
-                    &self.record.id,
-                    CompanyEvent::DeskTaskCompleted {
-                        task_id: card.id.clone(),
-                        desk: responder.clone(),
-                        output: result_text,
-                        column: card.column.clone(),
-                    },
-                )
-                .await
-            {
-                tracing::warn!(
-                    task_id = %card.id,
-                    error = %err,
-                    "[task] failed to journal task completion; continuing"
-                );
-            }
-        }
+        self.journal_task_outcome(&card, &responder, result_text)
+            .await;
 
         // Issue #151 §3.2: answer in the conversation the card was spawned
         // from. Only a card that remembers an origin posts back — one created
@@ -363,6 +349,114 @@ impl HarnessBrain {
             &self.orchestrator(),
             origin,
         )))
+    }
+
+    /// Ends a dispatch that never ran because its `assignee` names nobody this
+    /// company has (issue #205).
+    ///
+    /// Takes the same three exits a finished run does — the card is settled and
+    /// persisted, the outcome is journaled onto the task's timeline, and a card
+    /// that remembers an origin thread is answered there — so the refusal is
+    /// visible everywhere a result would have been, instead of being the silence
+    /// this issue is about. It deliberately skips the three things that belong
+    /// to a run that happened: no in-flight registration (nothing is in flight),
+    /// no MCP drain (no turn queued anything), and no artifact (`Failed` lands
+    /// in `backlog`, never a success terminal).
+    ///
+    /// Attributed to the **orchestrator**: it is the company answering for its
+    /// own roster, and the named assignee does not exist to speak.
+    async fn refuse_dispatch(
+        &self,
+        tasks: &Arc<dyn crate::ports::TaskStore>,
+        mut card: TaskRecord,
+        reason: &str,
+    ) -> Result<Option<OutboundMessage>> {
+        let orchestrator = self.orchestrator();
+        let text = format!("dispatch refused: {reason}");
+        settle(&mut card, TaskRunEnd::Failed, &orchestrator, &text);
+        card.updated_at_millis = now_millis();
+        tasks.upsert(&self.record.id, &card).await?;
+
+        self.journal_task_outcome(&card, &orchestrator, text).await;
+
+        let Some(origin) = card.origin_chat_id.clone() else {
+            return Ok(None);
+        };
+        Ok(Some(lifecycle::relay_reply(
+            &card,
+            &orchestrator,
+            &orchestrator,
+            origin,
+        )))
+    }
+
+    /// Journals a finished dispatch onto its card's timeline (issue #185): the
+    /// run's reply, then the terminal anchor that closes the timeline.
+    ///
+    /// Every write is **best-effort** and the errors are logged, never
+    /// propagated. The card is already persisted by the time this runs, so
+    /// failing the cycle over a bookkeeping write would abandon the terminal
+    /// anchor *and* the #151 post-back for a dispatch that has in fact landed —
+    /// leaving a timeline stuck "still running" for a card the board already
+    /// shows in its terminal column. Matches the existing journal-after-persist
+    /// sites (`chat_and_emit`, `WorkflowCreated`, `TaskSteered`).
+    async fn journal_task_outcome(&self, card: &TaskRecord, responder: &str, result_text: String) {
+        let Some(events) = self.deps.events.as_ref() else {
+            return;
+        };
+        // The run's reply, tagged so the per-task timeline can filter it out of
+        // the company-scoped journal.
+        //
+        // `chat_id` is the **card id**, deliberately, not the card's origin
+        // thread. `chat_history::owns` routes a reply into a desk's history by
+        // matching `chat_id` against the desk id/name, so using the origin here
+        // would inject this record into that desk's chat — a behaviour change
+        // well outside a read foundation, and a duplicate of the live post-back
+        // bubble the caller returns. A card id matches no desk, so the record
+        // stays exactly what it is: timeline material, reachable only through
+        // `task_id`. An empty string would be worse still — it folds into the
+        // General desk.
+        if let Err(err) = events
+            .append(
+                &self.record.id,
+                CompanyEvent::AgentReply {
+                    chat_id: card.id.clone(),
+                    agent_id: responder.to_string(),
+                    text: result_text.clone(),
+                    steps: Vec::new(),
+                    task_id: Some(card.id.clone()),
+                },
+            )
+            .await
+        {
+            tracing::warn!(
+                task_id = %card.id,
+                error = %err,
+                "[task] failed to journal dispatch reply; continuing"
+            );
+        }
+        // The terminal anchor, journaled after the card's landing column is
+        // persisted so it always records a completed run. Attempted even if the
+        // reply above failed — the anchor is what closes a timeline, so dropping
+        // it is strictly worse than dropping the reply.
+        if let Err(err) = events
+            .append(
+                &self.record.id,
+                CompanyEvent::DeskTaskCompleted {
+                    task_id: card.id.clone(),
+                    desk: responder.to_string(),
+                    output: result_text,
+                    column: card.column.clone(),
+                },
+            )
+            .await
+        {
+            tracing::warn!(
+                task_id = %card.id,
+                error = %err,
+                "[task] failed to journal task completion; continuing"
+            );
+        }
     }
 
     /// The company orchestrator's agent id — the single voice that answers the
@@ -422,16 +516,6 @@ impl HarnessBrain {
         };
         artifacts.upsert(&self.record.id, &record).await?;
         Ok(())
-    }
-
-    /// Resolves which roster agent runs a task: its `assignee` when that names a
-    /// roster member, else the brain's default responder.
-    fn task_responder(&self, assignee: &str) -> String {
-        if !assignee.is_empty() && self.record.manifest.agents.iter().any(|a| a.id == assignee) {
-            assignee.to_string()
-        } else {
-            self.responder.clone()
-        }
     }
 
     /// Resolves which agent answers an operator message.
@@ -810,11 +894,12 @@ mod tests {
     use tinyagents::harness::message::Message;
     use tinyagents::harness::model::{ChatModel, ModelRequest, ModelResponse};
 
+    use crate::company::CompanyManifest;
     use crate::harness::provider::{HarnessModel, MockProvider};
     use crate::ports::brain::CycleHost;
     use crate::ports::types::{
-        ApprovalId, CompanyId, ContextOp, ContextOpResult, Effect, EffectDisposition, ToolCall,
-        ToolResult,
+        ApprovalId, CompanyId, ContextOp, ContextOpResult, Effect, EffectDisposition, OverlayAgent,
+        ToolCall, ToolResult,
     };
     use crate::store::{FsCompanyStore, FsContextStore, FsOps};
 
@@ -1089,6 +1174,31 @@ description = "Builds it."
         )
     }
 
+    /// As [`brain_with_tasks`], but the roster also carries an `eng` desk led by
+    /// the engineer — the shape `delegate_to_desk` writes into a card's
+    /// `assignee` (issue #205).
+    fn brain_with_desk_tasks(dir: &std::path::Path) -> (HarnessBrain, Arc<FsOps>) {
+        let (mut brain, tasks) = brain_with_tasks(dir);
+        brain.record.manifest.group_chats = toml::from_str::<CompanyManifest>(
+            r#"
+[company]
+name = "Acme"
+
+[[agent]]
+id = "engineer"
+role = "Engineer"
+
+[[group_chat]]
+id = "eng"
+name = "Engineering desk"
+members = ["engineer"]
+"#,
+        )
+        .expect("valid manifest")
+        .group_chats;
+        (brain, tasks)
+    }
+
     /// As [`brain_with_tasks`], but with the artifact store wired to the same
     /// [`FsOps`] handle (it implements both), so a dispatch's versioned output
     /// is observable.
@@ -1158,7 +1268,10 @@ description = "Builds it."
     async fn a_card_with_no_origin_posts_back_nothing() {
         let dir = tempfile::tempdir().unwrap();
         let (brain, tasks) = brain_with_tasks(dir.path());
-        let mut c = card("t-no-origin", "maya");
+        // A roster assignee: since #205 an off-roster one is refused outright,
+        // which would satisfy the no-post-back assertion below without ever
+        // running the dispatch this test is about.
+        let mut c = card("t-no-origin", "engineer");
         c.origin_chat_id = None;
         tasks
             .upsert(&CompanyId::new("acme"), &c)
@@ -1273,7 +1386,9 @@ description = "Builds it."
     async fn dispatched_card_with_an_origin_completes_to_done() {
         let dir = tempfile::tempdir().unwrap();
         let (brain, tasks) = brain_with_tasks(dir.path());
-        let mut c = card("t-origin", "maya");
+        // A roster assignee: since #205 an off-roster one never runs a turn, so
+        // it would settle to `backlog` and prove nothing about the terminal.
+        let mut c = card("t-origin", "engineer");
         c.origin_chat_id = Some("strategy".to_string());
         tasks
             .upsert(&CompanyId::new("acme"), &c)
@@ -1474,13 +1589,130 @@ description = "Builds it."
         assert!(note.contains("[engineer]"), "{note:?}");
     }
 
-    /// An assignee that is not on the roster falls back to the default responder.
+    // ── Issue #205: the working agent is linked, and a bad assignee is refused ──
+
+    /// The reported bug. A card assigned to "Shane" — nobody this company has —
+    /// used to dispatch to the orchestrator anyway, keeping `assignee = "Shane"`
+    /// while the timeline read "reply from ceo" and nothing said the name was
+    /// invalid. It must now be **refused**: the card goes back to `backlog`
+    /// carrying the reason, and the orchestrator runs no turn on its behalf.
     #[tokio::test]
-    async fn task_dispatch_unknown_assignee_falls_back() {
+    async fn task_dispatch_off_roster_assignee_is_refused_not_silently_reassigned() {
         let dir = tempfile::tempdir().unwrap();
         let (brain, tasks) = brain_with_tasks(dir.path());
         tasks
-            .upsert(&CompanyId::new("acme"), &card("t1", "ghost"))
+            .upsert(&CompanyId::new("acme"), &card("t1", "Shane"))
+            .await
+            .unwrap();
+
+        brain
+            .run_cycle(
+                request(vec![CompanyEvent::TaskDispatched {
+                    task_id: "t1".into(),
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        let refused = only_card(&tasks).await;
+        assert_eq!(
+            refused.column, "backlog",
+            "a card nobody can work must not sit in in_progress"
+        );
+        assert_eq!(
+            refused.assignee, "Shane",
+            "the invalid name is left as typed for the operator to correct"
+        );
+        let note = refused.note.expect("the refusal is written to the note");
+        assert!(
+            note.contains("Shane"),
+            "the operator must be told which name is not a teammate: {note:?}"
+        );
+        assert!(
+            note.contains("dispatch refused"),
+            "the note must read as a refusal, not as work the CEO did: {note:?}"
+        );
+        assert!(
+            !note.contains("mock: "),
+            "no turn may run for an assignee nobody answers to: {note:?}"
+        );
+    }
+
+    /// The other half of #205: a card the orchestrator picks up because nobody
+    /// was named gets that orchestrator written onto it, so the board names who
+    /// is actually doing the work instead of showing a blank assignee.
+    #[tokio::test]
+    async fn task_dispatch_links_the_working_agent_to_an_unassigned_card() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks) = brain_with_tasks(dir.path());
+        tasks
+            .upsert(&CompanyId::new("acme"), &card("t1", ""))
+            .await
+            .unwrap();
+
+        brain
+            .run_cycle(
+                request(vec![CompanyEvent::TaskDispatched {
+                    task_id: "t1".into(),
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        assert_eq!(
+            only_card(&tasks).await.assignee,
+            "ceo",
+            "the orchestrator that worked the card must be linked to it"
+        );
+    }
+
+    /// A card assigned to a **desk** is worked by that desk's lead, and the card
+    /// is relinked to the member that ran it. `delegate_to_desk` writes a desk
+    /// id into `assignee`, so this is the shape a hand-off actually produces.
+    #[tokio::test]
+    async fn task_dispatch_routes_a_desk_assignee_to_its_lead_and_links_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks) = brain_with_desk_tasks(dir.path());
+        tasks
+            .upsert(&CompanyId::new("acme"), &card("t1", "eng"))
+            .await
+            .unwrap();
+
+        brain
+            .run_cycle(
+                request(vec![CompanyEvent::TaskDispatched {
+                    task_id: "t1".into(),
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        let worked = only_card(&tasks).await;
+        assert_eq!(
+            worked.assignee, "engineer",
+            "the desk's lead member did the work, so the card names them"
+        );
+        let note = worked.note.expect("note");
+        assert!(note.contains("[engineer]"), "{note:?}");
+    }
+
+    /// An **operator-overlay** teammate is a roster teammate. The narrow
+    /// `manifest.agents`-only lookup used to drop these onto the orchestrator.
+    #[tokio::test]
+    async fn task_dispatch_routes_to_an_overlay_teammate() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut brain, tasks) = brain_with_tasks(dir.path());
+        brain.record.overlay_agents.push(OverlayAgent {
+            id: "nova".into(),
+            name: "Nova".into(),
+            role: "Growth".into(),
+            description: None,
+        });
+        tasks
+            .upsert(&CompanyId::new("acme"), &card("t1", "nova"))
             .await
             .unwrap();
 
@@ -1495,7 +1727,40 @@ description = "Builds it."
             .expect("cycle runs");
 
         let note = only_card(&tasks).await.note.expect("note");
-        assert!(note.contains("[ceo]"), "{note:?}");
+        assert!(
+            note.contains("[nova]"),
+            "an overlay teammate must work their own card: {note:?}"
+        );
+    }
+
+    /// A refused dispatch still answers in the thread the card came from —
+    /// otherwise a delegated hand-off to a bad assignee is silent twice over.
+    #[tokio::test]
+    async fn a_refused_dispatch_posts_the_reason_back_to_its_origin() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks) = brain_with_tasks(dir.path());
+        let mut c = card("t-origin", "Shane");
+        c.origin_chat_id = Some("strategy".to_string());
+        tasks
+            .upsert(&CompanyId::new("acme"), &c)
+            .await
+            .expect("seed");
+
+        let posted = brain
+            .run_task("t-origin")
+            .await
+            .expect("run")
+            .expect("a refused card with an origin must still post back");
+        assert_eq!(
+            posted.reply_to.as_ref().map(|r| r.chat_id.as_str()),
+            Some("strategy")
+        );
+        assert_eq!(
+            posted.channel,
+            brain.orchestrator(),
+            "the orchestrator answers for its own roster"
+        );
+        assert!(posted.text.contains("Shane"), "{}", posted.text);
     }
 
     /// A dispatch for a card that no longer exists is a silent no-op, not an
@@ -1926,6 +2191,39 @@ members = ["eng1", "eng2"]
             note.contains(&format!("[{}]", brain.orchestrator())),
             "the assignment is recorded in the orchestrator's voice: {note}"
         );
+    }
+
+    /// #205: `assign_task` takes its `assignee` from an LLM tool call, so it can
+    /// name somebody the company does not have just as easily as the operator's
+    /// free-text field can. The bad name must not reach the card — the previous
+    /// owner stays, and the refusal is recorded on the note.
+    #[tokio::test]
+    async fn assign_task_refuses_an_off_roster_assignee_and_keeps_the_current_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks) = brain_with_tasks(dir.path());
+        let mut c = card("t-assign", "engineer");
+        c.column = "backlog".to_string();
+        tasks.upsert(&CompanyId::new("acme"), &c).await.unwrap();
+
+        brain
+            .run_delegation(
+                Delegation::AssignTask {
+                    task_id: "t-assign".to_string(),
+                    assignee: "Shane".to_string(),
+                    note: None,
+                },
+                None,
+            )
+            .await
+            .expect("delegation runs");
+
+        let after = only_card(&tasks).await;
+        assert_eq!(
+            after.assignee, "engineer",
+            "a name nobody answers to must not displace the real owner"
+        );
+        let note = after.note.expect("note");
+        assert!(note.contains("could not assign to Shane"), "{note}");
     }
 
     /// Approving finishes a board-created card: this is #171's `in_review →

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -2239,6 +2239,46 @@ members = ["eng1", "eng2"]
         assert!(note.contains("could not assign to Shane"), "{note}");
     }
 
+    /// #214 review: a blank `assignee` resolves to `Unassigned`, whose canonical
+    /// form is `""`. Clearing the owner is correct — unassigning is a real
+    /// request — but the note must say so. It used to fall through the named
+    /// arm and record `assigned to ` with nothing after it.
+    #[tokio::test]
+    async fn assign_task_with_a_blank_assignee_clears_the_owner_and_says_so() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks) = brain_with_tasks(dir.path());
+        let mut c = card("t-assign", "engineer");
+        c.column = "backlog".to_string();
+        tasks.upsert(&CompanyId::new("acme"), &c).await.unwrap();
+
+        brain
+            .run_delegation(
+                Delegation::AssignTask {
+                    task_id: "t-assign".to_string(),
+                    assignee: "   ".to_string(),
+                    note: None,
+                },
+                None,
+            )
+            .await
+            .expect("delegation runs");
+
+        let after = only_card(&tasks).await;
+        assert_eq!(
+            after.assignee, "",
+            "a blank assignee unassigns the card, which is a legitimate write"
+        );
+        let note = after.note.expect("note");
+        assert!(
+            note.contains("cleared the assignee"),
+            "the note names the effect rather than trailing off: {note}"
+        );
+        assert!(
+            !note.contains("assigned to "),
+            "the truncated 'assigned to <nothing>' note must not come back: {note}"
+        );
+    }
+
     /// Approving finishes a board-created card: this is #171's `in_review →
     /// done` write (PR #179) for the card shape #179's own origin rule cannot
     /// reach, with the verdict recorded on the note.

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -1675,11 +1675,14 @@ members = ["engineer"]
         );
     }
 
-    /// A card assigned to a **desk** is worked by that desk's lead, and the card
-    /// is relinked to the member that ran it. `delegate_to_desk` writes a desk
-    /// id into `assignee`, so this is the shape a hand-off actually produces.
+    /// A card assigned to a **desk** is worked by that desk's lead, but the card
+    /// stays the desk's. `delegate_to_desk` writes a desk id into `assignee`, so
+    /// this is the shape a hand-off actually produces. Dispatch picks who runs
+    /// this turn, not who owns the card, so only the note names the member that
+    /// ran it — relinking the lead onto `assignee` would erase the desk from the
+    /// board the first time the card ran (#214 review).
     #[tokio::test]
-    async fn task_dispatch_routes_a_desk_assignee_to_its_lead_and_links_it() {
+    async fn task_dispatch_routes_a_desk_assignee_to_its_lead_but_keeps_the_desk() {
         let dir = tempfile::tempdir().unwrap();
         let (brain, tasks) = brain_with_desk_tasks(dir.path());
         tasks
@@ -1699,11 +1702,14 @@ members = ["engineer"]
 
         let worked = only_card(&tasks).await;
         assert_eq!(
-            worked.assignee, "engineer",
-            "the desk's lead member did the work, so the card names them"
+            worked.assignee, "eng",
+            "a desk assignment is ownership: the card stays the desk's"
         );
         let note = worked.note.expect("note");
-        assert!(note.contains("[engineer]"), "{note:?}");
+        assert!(
+            note.contains("[engineer]"),
+            "the desk's lead member still did the work, and the note names them: {note:?}"
+        );
     }
 
     /// An **operator-overlay** teammate is a roster teammate. The narrow

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -136,12 +136,19 @@ impl HarnessBrain {
         // Link the working agent to the card, and persist it BEFORE the turn
         // runs (#205). A card the CEO picked up used to keep `assignee = ""`
         // for the whole run and forever after, so the board never named who was
-        // doing the work; a desk-assigned card never named the member that
-        // actually ran it. Writing it up front is what makes the board show the
+        // doing the work. Writing it up front is what makes the board show the
         // card "working" under a real agent while the turn is in flight — the
         // store `upsert` here is the plain persistence path, not
         // `CompanyRuntime::upsert_task`, so it cannot re-fire the dispatch edge.
-        if card.assignee != responder {
+        //
+        // Only for an assignee that names a teammate or nobody, though. A desk
+        // assignment is ownership and stays one — `AssigneeResolution::canonical`
+        // deliberately stores the **desk** id and the REST boundary honours it;
+        // dispatch only picks which member runs *this* turn. Writing the lead
+        // back would silently turn a card assigned to `eng` into one assigned to
+        // `engineer` the first time it ran, erasing the desk from the board and
+        // breaking the very invariant `canonical()` documents (#214 review).
+        if resolution.links_working_agent() && card.assignee != responder {
             card.assignee = responder.clone();
             card.updated_at_millis = now_millis();
             tasks.upsert(&self.record.id, &card).await?;

--- a/src/harness/lifecycle.rs
+++ b/src/harness/lifecycle.rs
@@ -43,17 +43,19 @@
 use crate::ports::TaskRecord;
 use crate::ports::types::{OutboundMessage, ReplyTo};
 
-/// The board column a card in review sits in, awaiting the orchestrator.
-pub const COLUMN_IN_REVIEW: &str = "in_review";
-/// The board column a stopped or failed run returns its card to.
-pub const COLUMN_BACKLOG: &str = "backlog";
-/// The board column a paused run parks its card in. Resume is a plain
-/// `column → in_progress` PATCH, which re-triggers dispatch.
-pub const COLUMN_PAUSED: &str = "paused";
-/// The terminal column — nothing dispatches out of it. Reached by
-/// [`landing_column`] for a delegated card and by [`review_landing_column`] for
-/// an approved board card (issue #171 / PR #179).
-pub const COLUMN_DONE: &str = "done";
+/// The board's column vocabulary, re-exported so every `lifecycle::COLUMN_*`
+/// path here is unchanged.
+///
+/// The definitions moved to the task **port** in issue #205: this module is
+/// `#[cfg(feature = "openhuman")]`, so the REST write boundary — which now
+/// validates a card's column — could not see them. `COLUMN_IN_REVIEW` is where
+/// a card awaits the orchestrator, `COLUMN_BACKLOG` where a stopped or failed
+/// run returns it, `COLUMN_PAUSED` where a paused run parks it (resume is a
+/// plain `column → in_progress` PATCH, which re-triggers dispatch), and
+/// `COLUMN_DONE` the terminal — reached by [`landing_column`] for a delegated
+/// card and by [`review_landing_column`] for an approved board card (issue #171
+/// / PR #179).
+pub use crate::ports::tasks::{COLUMN_BACKLOG, COLUMN_DONE, COLUMN_IN_REVIEW, COLUMN_PAUSED};
 
 /// The note attribution used for an operator-initiated stop, as opposed to a
 /// result the assignee produced.

--- a/src/ports/tasks.rs
+++ b/src/ports/tasks.rs
@@ -12,6 +12,49 @@ use serde::{Deserialize, Serialize};
 use crate::Result;
 use crate::ports::types::CompanyId;
 
+// ---------------------------------------------------------------------------
+// The board's column vocabulary (issue #205)
+// ---------------------------------------------------------------------------
+//
+// Transcribed once here — the port every writer already depends on — rather
+// than in the harness lifecycle seam, which is `#[cfg(feature = "openhuman")]`
+// and therefore invisible to the REST write boundary and to the default build.
+// `crate::harness::lifecycle` re-exports these so its `COLUMN_*` paths are
+// unchanged, and `CompanyRuntime`'s dispatch edge reads `COLUMN_IN_PROGRESS`
+// from here, so each literal exists in exactly one place.
+
+/// Where new work waits, and where a failed, cancelled or revised run returns.
+pub const COLUMN_BACKLOG: &str = "backlog";
+/// The dispatch column: entering it hands the card to its assignee.
+pub const COLUMN_IN_PROGRESS: &str = "in_progress";
+/// Where a steered-to-pause run parks. Resume is a `column → in_progress` PATCH.
+pub const COLUMN_PAUSED: &str = "paused";
+/// Where a finished board-created card waits for its operator reviewer.
+pub const COLUMN_IN_REVIEW: &str = "in_review";
+/// The terminal column — nothing dispatches out of it.
+pub const COLUMN_DONE: &str = "done";
+
+/// Every column the board renders, in board order — the host's half of the
+/// console's `TASK_COLUMNS` (`frontend/src/lib/tasks-sample.ts`).
+///
+/// A card's `column` is a plain string on the wire, so before #205 a typo'd or
+/// invented column was persisted verbatim and then simply never rendered: the
+/// card vanished from the board with no error, and — since only the exact
+/// literal `in_progress` edge-fires a dispatch — a typo'd `in-progress` also
+/// silently never ran. This list is what the write boundary checks against.
+pub const BOARD_COLUMNS: [&str; 5] = [
+    COLUMN_BACKLOG,
+    COLUMN_IN_PROGRESS,
+    COLUMN_PAUSED,
+    COLUMN_IN_REVIEW,
+    COLUMN_DONE,
+];
+
+/// Whether `column` names a column the board actually renders.
+pub fn is_board_column(column: &str) -> bool {
+    BOARD_COLUMNS.contains(&column)
+}
+
 /// One card on the company's task board.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -1312,6 +1312,31 @@ impl CompanyRecord {
             .find(|id| id.eq_ignore_ascii_case(agent_key))
             .cloned()
     }
+
+    /// Canonical ids of operator-added teammates whose **display name** matches
+    /// `name_key` case-insensitively.
+    ///
+    /// The companion to [`Self::resolve_roster_agent_id`] for the half of the
+    /// roster that has no typable id. `server::ops::team` mints an overlay
+    /// teammate with `id: generate_id()`, so an operator who adds "Shane" never
+    /// sees anything but the name — matching on ids alone made every teammate
+    /// they added unassignable, on a board whose Assignee field is free text
+    /// with no picker. Manifest agents keep their id-only namespace: their ids
+    /// (`ceo`, `engineer`) are human-authored and typable, and
+    /// [`Self::resolve_roster_agent_id`] is tried first, so a display name can
+    /// never shadow a real id.
+    ///
+    /// Returns **every** match rather than the first, so the caller can tell a
+    /// unique name from a collision the operator created. Silently routing to
+    /// whichever teammate was added first would reintroduce exactly the
+    /// misrouting this resolver exists to end.
+    pub fn overlay_agent_ids_by_name(&self, name_key: &str) -> Vec<String> {
+        self.overlay_agents
+            .iter()
+            .filter(|a| a.name.eq_ignore_ascii_case(name_key))
+            .map(|a| a.id.clone())
+            .collect()
+    }
 }
 
 /// A compact company listing entry.

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -1287,6 +1287,31 @@ impl CompanyRecord {
         self.manifest.agents.iter().any(|a| a.id == agent_id)
             || self.overlay_agents.iter().any(|a| a.id == agent_id)
     }
+
+    /// Resolves an operator-typed teammate key to its canonical roster id,
+    /// searching manifest agents first and then the overlay teammates.
+    ///
+    /// The case-insensitive companion to [`Self::is_roster_agent`], for the one
+    /// place a human types the key by hand: a card's `assignee` (issue #205).
+    /// [`Self::resolve_desk_id`] already accepts a desk by id **or** name
+    /// case-insensitively, so an assignee naming a desk resolved while the same
+    /// string naming a teammate — `"Engineer"` for `engineer` — did not.
+    ///
+    /// Matches on **id only** (never `role`, never an overlay teammate's
+    /// display name) so the key stays one unambiguous namespace; folding the
+    /// case is what stops a typed capital reading as an unknown agent.
+    ///
+    /// [`Self::is_roster_agent`] keeps its exact-match contract: it guards the
+    /// desk overlay, whose ids are machine-written rather than typed.
+    pub fn resolve_roster_agent_id(&self, agent_key: &str) -> Option<String> {
+        self.manifest
+            .agents
+            .iter()
+            .map(|a| &a.id)
+            .chain(self.overlay_agents.iter().map(|a| &a.id))
+            .find(|id| id.eq_ignore_ascii_case(agent_key))
+            .cloned()
+    }
 }
 
 /// A compact company listing entry.

--- a/src/runtime/assignee.rs
+++ b/src/runtime/assignee.rs
@@ -1,0 +1,351 @@
+//! Resolving a task card's `assignee` against the company roster (issue #205).
+//!
+//! A card's `assignee` is a free-text string: an operator types it into the
+//! board's Assignee field, and `spawn_task` / `delegate_to_desk` let a model
+//! write one. It can therefore name four different things — nobody, a roster
+//! teammate, a desk, or something that simply does not exist — and every
+//! consumer used to decide for itself which of those it recognised.
+//!
+//! It decided badly. `HarnessBrain::task_responder` matched **only**
+//! `manifest.agents`, so a card assigned to an operator-added overlay teammate,
+//! or to a desk, fell through the same arm as a card assigned to nobody and the
+//! same arm as a card assigned to a name nobody on the roster answers to — and
+//! all four silently dispatched to the orchestrator while the card kept whatever
+//! string it had. The board said "Shane"; the CEO did the work; nothing said
+//! "Shane" is not a teammate.
+//!
+//! This module is the one resolver, brain-agnostic (it reads only
+//! [`CompanyRecord`]) and compiled in every build so both the harness dispatch
+//! path and the REST write boundary share one answer. Crucially it keeps the
+//! four cases **distinct** — [`AssigneeResolution`] — so a caller can give the
+//! blank card to the orchestrator and still refuse the invalid one.
+
+use crate::ports::types::CompanyRecord;
+use crate::runtime::delegation_tools::desk_lead;
+
+/// What a card's `assignee` string names on the company roster.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AssigneeResolution {
+    /// Blank (or whitespace) — nobody was named. Not an error: the card is
+    /// simply unassigned, and dispatch hands it to the orchestrator.
+    Unassigned,
+    /// A roster teammate — a manifest agent or an operator-overlay one. Carries
+    /// the **canonical** id, so a typed `"Engineer"` resolves to `engineer`.
+    Agent(String),
+    /// A desk. Its lead member works the card; both ids are canonical.
+    Desk {
+        /// The canonical desk id.
+        desk: String,
+        /// The desk's lead member — the agent that actually runs the turn.
+        lead: String,
+    },
+    /// A desk that exists but has no roster-backed member to work the card.
+    /// Real enough to assign to, not real enough to dispatch to.
+    EmptyDesk(String),
+    /// Names nothing on the roster. Carries the string as typed, so the
+    /// operator is told back exactly what they wrote.
+    Unknown(String),
+}
+
+impl AssigneeResolution {
+    /// The agent that will actually run the card, when the assignee names one.
+    ///
+    /// `None` covers three different situations on purpose — [`Self::Unassigned`]
+    /// (nobody named; the caller's default responder takes it) and the two
+    /// unworkable forms. Callers separate them with [`Self::rejection`]: a
+    /// `None` with no rejection is the legitimate unassigned card.
+    pub fn working_agent(&self) -> Option<&str> {
+        match self {
+            Self::Agent(id) => Some(id.as_str()),
+            Self::Desk { lead, .. } => Some(lead.as_str()),
+            Self::Unassigned | Self::EmptyDesk(_) | Self::Unknown(_) => None,
+        }
+    }
+
+    /// The canonical string to store for this assignee: the resolved teammate
+    /// id, the resolved **desk** id (a desk assignment is ownership, and stays
+    /// a desk assignment — dispatch is what picks the lead), or `""` when
+    /// nobody was named. `None` for an [`Self::Unknown`], which has no
+    /// canonical form because it names nothing.
+    ///
+    /// Writing this rather than the raw string is what keeps the board's
+    /// assignee column one namespace of real ids: a typed `"Engineer"` or
+    /// `"Engineering Desk"` is stored as `engineer` / `eng`, so every reader —
+    /// the board, the timeline, `assignment_matches` — sees the same key.
+    pub fn canonical(&self) -> Option<&str> {
+        match self {
+            Self::Unassigned => Some(""),
+            Self::Agent(id) => Some(id.as_str()),
+            Self::Desk { desk, .. } => Some(desk.as_str()),
+            Self::EmptyDesk(desk) => Some(desk.as_str()),
+            Self::Unknown(_) => None,
+        }
+    }
+
+    /// Whether the string names something that exists — a teammate, a desk, or
+    /// nothing at all. The **write-boundary** predicate: assigning a card to a
+    /// desk whose members have yet to be added is a legitimate thing to do, so
+    /// only [`Self::Unknown`] is refused on write.
+    pub fn names_something_real(&self) -> bool {
+        !matches!(self, Self::Unknown(_))
+    }
+
+    /// The operator-facing reason this assignee cannot be worked, or `None`
+    /// when it can (including the unassigned card, which the orchestrator
+    /// picks up).
+    ///
+    /// This sentence is the feedback that was missing: it lands in the card's
+    /// note, in the relayed reply, and — for a write — in the `400`.
+    pub fn rejection(&self) -> Option<String> {
+        match self {
+            Self::Unassigned | Self::Agent(_) | Self::Desk { .. } => None,
+            Self::EmptyDesk(desk) => Some(format!(
+                "the desk \"{desk}\" has no teammates on it, so there is nobody to work this — \
+add a member to the desk, or assign the card to a teammate directly"
+            )),
+            Self::Unknown(raw) => Some(format!(
+                "\"{raw}\" is not a teammate or a desk on this company's roster — \
+assign the card to one of them, or leave the assignee blank to hand it to the orchestrator"
+            )),
+        }
+    }
+}
+
+/// Resolves `assignee` against `record`'s full roster.
+///
+/// Resolution order, and the order matters: **desks first**, mirroring
+/// [`responder_for`](crate::harness) — a desk whose id happens to match a
+/// teammate id keeps routing as a desk, exactly as it does for an operator
+/// message addressed to that chat. A teammate id is then matched
+/// case-insensitively ([`CompanyRecord::resolve_roster_agent_id`]), because
+/// unlike a desk key it is typed by hand and `resolve_desk_id` was already
+/// forgiving about case.
+pub fn resolve(record: &CompanyRecord, assignee: &str) -> AssigneeResolution {
+    let key = assignee.trim();
+    if key.is_empty() {
+        return AssigneeResolution::Unassigned;
+    }
+    if let Some(desk) = record.resolve_desk_id(key) {
+        return match desk_lead(record, &desk) {
+            Some(lead) => AssigneeResolution::Desk { desk, lead },
+            None => AssigneeResolution::EmptyDesk(desk),
+        };
+    }
+    if let Some(id) = record.resolve_roster_agent_id(key) {
+        return AssigneeResolution::Agent(id);
+    }
+    AssigneeResolution::Unknown(key.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::company::CompanyManifest;
+    use crate::ports::types::{CompanyId, OverlayAgent, OverlayDeskMember};
+
+    fn record(manifest: &str) -> CompanyRecord {
+        let manifest: CompanyManifest = toml::from_str(manifest).expect("valid manifest");
+        CompanyRecord {
+            id: CompanyId::new("acme"),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            template_provenance: None,
+        }
+    }
+
+    fn acme() -> CompanyRecord {
+        record(
+            r#"
+[company]
+name = "Acme"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+
+[[agent]]
+id = "engineer"
+role = "Engineer"
+
+[[group_chat]]
+id = "eng"
+name = "Engineering desk"
+members = ["engineer"]
+
+[[group_chat]]
+id = "empty"
+name = "Nobody home"
+members = []
+"#,
+        )
+    }
+
+    /// Blank is not an error — it is the ordinary unassigned card, and the
+    /// caller's default responder takes it.
+    #[test]
+    fn blank_is_unassigned_not_unknown() {
+        let record = acme();
+        assert_eq!(resolve(&record, ""), AssigneeResolution::Unassigned);
+        assert_eq!(resolve(&record, "   "), AssigneeResolution::Unassigned);
+        assert!(resolve(&record, "").rejection().is_none());
+        assert!(resolve(&record, "").working_agent().is_none());
+    }
+
+    /// A manifest teammate resolves to itself, case-folded to the canonical id.
+    #[test]
+    fn a_manifest_teammate_resolves_case_insensitively() {
+        let record = acme();
+        assert_eq!(
+            resolve(&record, "engineer"),
+            AssigneeResolution::Agent("engineer".into())
+        );
+        assert_eq!(
+            resolve(&record, "Engineer"),
+            AssigneeResolution::Agent("engineer".into()),
+            "a typed capital must not read as an unknown agent"
+        );
+        assert_eq!(
+            resolve(&record, " engineer ").working_agent(),
+            Some("engineer"),
+            "the board's text field keeps whatever whitespace was typed"
+        );
+    }
+
+    /// The narrow-lookup half of #205: an operator-added overlay teammate is a
+    /// roster teammate, and used to fall through to the orchestrator.
+    #[test]
+    fn an_overlay_teammate_resolves() {
+        let mut record = acme();
+        record.overlay_agents.push(OverlayAgent {
+            id: "nova".into(),
+            name: "Nova".into(),
+            role: "Growth".into(),
+            description: None,
+        });
+        assert_eq!(
+            resolve(&record, "nova"),
+            AssigneeResolution::Agent("nova".into())
+        );
+    }
+
+    /// A desk resolves to its lead — by id and by (case-insensitive) name, the
+    /// two keys `resolve_desk_id` already accepts. `delegate_to_desk` writes a
+    /// desk id into `assignee`, so this is a live shape, not a hypothetical.
+    #[test]
+    fn a_desk_resolves_to_its_lead() {
+        let record = acme();
+        let expected = AssigneeResolution::Desk {
+            desk: "eng".into(),
+            lead: "engineer".into(),
+        };
+        assert_eq!(resolve(&record, "eng"), expected);
+        assert_eq!(resolve(&record, "Engineering Desk"), expected);
+        assert_eq!(resolve(&record, "eng").working_agent(), Some("engineer"));
+        assert!(resolve(&record, "eng").rejection().is_none());
+    }
+
+    /// A desk whose membership is entirely operator-overlay still resolves —
+    /// the effective roster, not just the manifest one.
+    #[test]
+    fn an_overlay_member_can_lead_a_manifest_empty_desk() {
+        let mut record = acme();
+        record.overlay_agents.push(OverlayAgent {
+            id: "nova".into(),
+            name: "Nova".into(),
+            role: "Growth".into(),
+            description: None,
+        });
+        record.overlay_desk_members.push(OverlayDeskMember {
+            desk_id: "empty".into(),
+            agent_id: "nova".into(),
+        });
+        assert_eq!(
+            resolve(&record, "empty"),
+            AssigneeResolution::Desk {
+                desk: "empty".into(),
+                lead: "nova".into(),
+            }
+        );
+    }
+
+    /// A real desk with nobody on it: assignable, but not dispatchable, and the
+    /// refusal says which of the two it is.
+    #[test]
+    fn an_empty_desk_is_real_but_unworkable() {
+        let record = acme();
+        let resolved = resolve(&record, "empty");
+        assert_eq!(resolved, AssigneeResolution::EmptyDesk("empty".into()));
+        assert!(resolved.names_something_real(), "the desk does exist");
+        assert!(resolved.working_agent().is_none());
+        let rejection = resolved.rejection().expect("unworkable");
+        assert!(rejection.contains("empty"), "{rejection}");
+    }
+
+    /// The reported bug: "Shane" is nobody. It must not resolve, and the
+    /// refusal must quote what was typed back at the operator.
+    #[test]
+    fn an_off_roster_name_is_unknown_and_quoted_back() {
+        let record = acme();
+        let resolved = resolve(&record, "Shane");
+        assert_eq!(resolved, AssigneeResolution::Unknown("Shane".into()));
+        assert!(!resolved.names_something_real());
+        assert!(resolved.working_agent().is_none());
+        let rejection = resolved.rejection().expect("unknown is a rejection");
+        assert!(rejection.contains("Shane"), "{rejection}");
+    }
+
+    /// What a write stores: the canonical key, never what was typed — except
+    /// for the unknown, which has no canonical form and is refused instead.
+    /// A desk assignment stays a **desk** assignment; picking the lead is
+    /// dispatch's job, not the write boundary's.
+    #[test]
+    fn canonical_is_the_stored_key() {
+        let record = acme();
+        assert_eq!(resolve(&record, "  ").canonical(), Some(""));
+        assert_eq!(resolve(&record, "Engineer").canonical(), Some("engineer"));
+        assert_eq!(
+            resolve(&record, "Engineering desk").canonical(),
+            Some("eng")
+        );
+        assert_eq!(resolve(&record, "empty").canonical(), Some("empty"));
+        assert_eq!(resolve(&record, "Shane").canonical(), None);
+    }
+
+    /// Desks win a key collision, matching `responder_for`'s documented
+    /// precedence for an addressed chat.
+    #[test]
+    fn a_desk_wins_a_key_collision_with_a_teammate() {
+        let record = record(
+            r#"
+[company]
+name = "Acme"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+
+[[agent]]
+id = "engineer"
+role = "Engineer"
+
+[[group_chat]]
+id = "engineer"
+name = "Engineering desk"
+members = ["ceo"]
+"#,
+        );
+        assert_eq!(
+            resolve(&record, "engineer"),
+            AssigneeResolution::Desk {
+                desk: "engineer".into(),
+                lead: "ceo".into(),
+            }
+        );
+    }
+}

--- a/src/runtime/assignee.rs
+++ b/src/runtime/assignee.rs
@@ -45,6 +45,17 @@ pub enum AssigneeResolution {
     /// Names nothing on the roster. Carries the string as typed, so the
     /// operator is told back exactly what they wrote.
     Unknown(String),
+    /// Names more than one operator-added teammate: two teammates carry the
+    /// same display name. Real, but not resolvable to a single worker — kept
+    /// distinct from [`Self::Unknown`] because the fix is different (rename one
+    /// of them, or assign by id) and because silently taking the first is the
+    /// misrouting this module exists to end.
+    AmbiguousTeammate {
+        /// The string as typed.
+        raw: String,
+        /// How many teammates answer to it.
+        count: usize,
+    },
 }
 
 impl AssigneeResolution {
@@ -58,8 +69,24 @@ impl AssigneeResolution {
         match self {
             Self::Agent(id) => Some(id.as_str()),
             Self::Desk { lead, .. } => Some(lead.as_str()),
-            Self::Unassigned | Self::EmptyDesk(_) | Self::Unknown(_) => None,
+            Self::Unassigned
+            | Self::EmptyDesk(_)
+            | Self::Unknown(_)
+            | Self::AmbiguousTeammate { .. } => None,
         }
+    }
+
+    /// Whether dispatch should write the working agent back onto the card.
+    ///
+    /// True for [`Self::Unassigned`] and [`Self::Agent`] only. A **desk**
+    /// assignment is ownership and stays a desk assignment — see
+    /// [`Self::canonical`], which deliberately stores the desk id. The lead is
+    /// who runs this turn, not who the card belongs to, so writing the lead
+    /// back would erase the desk from the board the first time the card ran and
+    /// contradict the invariant `canonical()` exists to hold. The unworkable
+    /// kinds never reach the write-back: dispatch refuses them first.
+    pub fn links_working_agent(&self) -> bool {
+        matches!(self, Self::Unassigned | Self::Agent(_))
     }
 
     /// The canonical string to store for this assignee: the resolved teammate
@@ -78,7 +105,7 @@ impl AssigneeResolution {
             Self::Agent(id) => Some(id.as_str()),
             Self::Desk { desk, .. } => Some(desk.as_str()),
             Self::EmptyDesk(desk) => Some(desk.as_str()),
-            Self::Unknown(_) => None,
+            Self::Unknown(_) | Self::AmbiguousTeammate { .. } => None,
         }
     }
 
@@ -87,7 +114,7 @@ impl AssigneeResolution {
     /// desk whose members have yet to be added is a legitimate thing to do, so
     /// only [`Self::Unknown`] is refused on write.
     pub fn names_something_real(&self) -> bool {
-        !matches!(self, Self::Unknown(_))
+        !matches!(self, Self::Unknown(_) | Self::AmbiguousTeammate { .. })
     }
 
     /// The operator-facing reason this assignee cannot be worked, or `None`
@@ -106,6 +133,10 @@ add a member to the desk, or assign the card to a teammate directly"
             Self::Unknown(raw) => Some(format!(
                 "\"{raw}\" is not a teammate or a desk on this company's roster — \
 assign the card to one of them, or leave the assignee blank to hand it to the orchestrator"
+            )),
+            Self::AmbiguousTeammate { raw, count } => Some(format!(
+                "\"{raw}\" names {count} teammates on this company's roster, so there is no way \
+to tell which one you meant — rename one of them, or assign the card by teammate id"
             )),
         }
     }
@@ -134,7 +165,20 @@ pub fn resolve(record: &CompanyRecord, assignee: &str) -> AssigneeResolution {
     if let Some(id) = record.resolve_roster_agent_id(key) {
         return AssigneeResolution::Agent(id);
     }
-    AssigneeResolution::Unknown(key.to_string())
+    // Then operator-added teammates by display name. Tried only after the id
+    // namespace so a display name can never shadow a real id. `ops::team` mints
+    // these with `id: generate_id()`, so the name is the only string the
+    // operator ever sees — matching ids alone made every teammate they added
+    // unassignable on a free-text Assignee field (#214 review).
+    let by_name = record.overlay_agent_ids_by_name(key);
+    match by_name.len() {
+        0 => AssigneeResolution::Unknown(key.to_string()),
+        1 => AssigneeResolution::Agent(by_name.into_iter().next().expect("one match")),
+        count => AssigneeResolution::AmbiguousTeammate {
+            raw: key.to_string(),
+            count,
+        },
+    }
 }
 
 #[cfg(test)]
@@ -346,6 +390,115 @@ members = ["ceo"]
                 desk: "engineer".into(),
                 lead: "ceo".into(),
             }
+        );
+    }
+
+    /// An operator-added teammate is reachable by the only string the operator
+    /// ever sees. `server::ops::team` mints these with `id: generate_id()`, so
+    /// an id-only match made every teammate the operator added unassignable on
+    /// a free-text Assignee field with no picker (#214 review).
+    #[test]
+    fn an_operator_added_teammate_resolves_by_display_name() {
+        let mut record = acme();
+        record.overlay_agents.push(OverlayAgent {
+            id: "01J9XKQ2M7Z4B8N0".into(),
+            name: "Shane".into(),
+            role: "Support".into(),
+            description: None,
+        });
+        assert_eq!(
+            resolve(&record, "Shane"),
+            AssigneeResolution::Agent("01J9XKQ2M7Z4B8N0".into()),
+            "the display name is the only key the operator can discover"
+        );
+        assert_eq!(
+            resolve(&record, "shane"),
+            AssigneeResolution::Agent("01J9XKQ2M7Z4B8N0".into()),
+            "matched case-insensitively, like every other typed key"
+        );
+        assert!(resolve(&record, "Shane").rejection().is_none());
+    }
+
+    /// The id namespace still wins. A teammate whose *display name* happens to
+    /// equal a manifest *id* must not steal that id's assignments.
+    #[test]
+    fn a_display_name_cannot_shadow_a_manifest_id() {
+        let mut record = acme();
+        record.overlay_agents.push(OverlayAgent {
+            id: "01J9XKQ2M7Z4B8N0".into(),
+            name: "engineer".into(),
+            role: "Support".into(),
+            description: None,
+        });
+        assert_eq!(
+            resolve(&record, "engineer"),
+            AssigneeResolution::Agent("engineer".into()),
+            "ids are resolved before display names"
+        );
+    }
+
+    /// Two teammates sharing a display name is the operator's own doing, and it
+    /// is reported as such. Silently taking the first would reintroduce exactly
+    /// the misrouting this module exists to end.
+    #[test]
+    fn two_teammates_sharing_a_display_name_are_refused_not_guessed() {
+        let mut record = acme();
+        for id in ["01J9XKQ2M7Z4B8N0", "01J9XKQ2M7Z4B8N1"] {
+            record.overlay_agents.push(OverlayAgent {
+                id: id.into(),
+                name: "Shane".into(),
+                role: "Support".into(),
+                description: None,
+            });
+        }
+        let resolution = resolve(&record, "Shane");
+        assert_eq!(
+            resolution,
+            AssigneeResolution::AmbiguousTeammate {
+                raw: "Shane".into(),
+                count: 2,
+            }
+        );
+        assert!(resolution.working_agent().is_none());
+        assert!(resolution.canonical().is_none());
+        assert!(
+            !resolution.names_something_real(),
+            "an ambiguous name is refused at the write boundary"
+        );
+        let reason = resolution.rejection().expect("must be refused");
+        assert!(reason.contains("2 teammates"), "reason={reason}");
+        assert!(
+            reason.contains("teammate id"),
+            "the operator is told how to disambiguate: reason={reason}"
+        );
+    }
+
+    /// A desk assignment is ownership and survives dispatch. `working_agent()`
+    /// returns the desk's *lead* so the turn runs, but the card must keep the
+    /// desk id — otherwise a card assigned to `eng` silently becomes assigned
+    /// to `engineer` the first time it runs (#214 review).
+    #[test]
+    fn a_desk_assignment_is_not_relinked_to_its_lead() {
+        let record = acme();
+        let desk = resolve(&record, "eng");
+        assert_eq!(desk.working_agent(), Some("engineer"), "the lead runs it");
+        assert_eq!(
+            desk.canonical(),
+            Some("eng"),
+            "but the card stays the desk's"
+        );
+        assert!(
+            !desk.links_working_agent(),
+            "dispatch must not write the lead over a desk assignment"
+        );
+
+        assert!(
+            AssigneeResolution::Unassigned.links_working_agent(),
+            "an unassigned card DOES get the orchestrator linked to it (#205)"
+        );
+        assert!(
+            AssigneeResolution::Agent("engineer".into()).links_working_agent(),
+            "a teammate assignment is already canonical and stays linked"
         );
     }
 }

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -367,6 +367,20 @@ impl<'a> DelegationRunner<'a> {
                 // that an assignment was attempted.
                 let resolved = assignee::resolve(self.record, &assignee);
                 let entry = match resolved.canonical() {
+                    // A blank or whitespace-only `assignee` resolves to
+                    // `Unassigned`, whose canonical form is `""`. Clearing the
+                    // owner is the right write — unassigning a card is a real
+                    // thing to ask for — but there is no name to put in the
+                    // note, and `assigned to {assignee}` would record a
+                    // sentence that trails off with nothing after it. Name the
+                    // effect instead, so the timeline says what happened.
+                    Some(canonical) if canonical.is_empty() => {
+                        card.assignee = String::new();
+                        match note {
+                            Some(note) => format!("cleared the assignee — {note}"),
+                            None => "cleared the assignee".to_string(),
+                        }
+                    }
                     Some(canonical) => {
                         card.assignee = canonical.to_string();
                         match note {

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -30,6 +30,7 @@ use crate::harness::lifecycle;
 use crate::harness::orchestrator::{self, Delegation, DelegationQueue};
 use crate::ports::types::{CompanyId, CompanyRecord, OutboundMessage, TurnStep};
 use crate::ports::{TaskRecord, TaskStore, generate_id, now_millis};
+use crate::runtime::assignee;
 
 /// One agent turn, abstracted so delegation orchestration never touches the
 /// harness-specific [`HarnessDeps`](crate::harness::HarnessDeps).
@@ -356,14 +357,34 @@ impl<'a> DelegationRunner<'a> {
                 let Some((tasks, mut card)) = self.load_card(&task_id).await? else {
                     return Ok(DelegationOutcome::default());
                 };
-                card.assignee = assignee.clone();
+                // Issue #205: the orchestrator writes this `assignee` out of an
+                // LLM tool call, so it is exactly as capable of naming somebody
+                // who does not exist as the operator's free-text field is. Held
+                // to the same contract: an unresolvable name is not written to
+                // the card at all — leaving the previous owner in place — and
+                // the refusal is recorded in the orchestrator's own voice, so
+                // the board neither shows a phantom owner nor loses the fact
+                // that an assignment was attempted.
+                let resolved = assignee::resolve(self.record, &assignee);
+                let entry = match resolved.canonical() {
+                    Some(canonical) => {
+                        card.assignee = canonical.to_string();
+                        match note {
+                            Some(note) => format!("assigned to {assignee} — {note}"),
+                            None => format!("assigned to {assignee}"),
+                        }
+                    }
+                    None => format!(
+                        "could not assign to {assignee}: {}",
+                        resolved
+                            .rejection()
+                            .unwrap_or_else(|| "not on the roster".to_string())
+                    ),
+                };
                 card.note = Some(append_note(
                     card.note.as_deref(),
                     &self.orchestrator_id(),
-                    &match note {
-                        Some(note) => format!("assigned to {assignee} — {note}"),
-                        None => format!("assigned to {assignee}"),
-                    },
+                    &entry,
                 ));
                 // The column is untouched on purpose: dispatch fires from
                 // `CompanyRuntime::upsert_task`, which this port cannot reach.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -9,6 +9,11 @@
 //!   multi-company cases.
 //! - The [`journal`] backs at-most-once effects and the durable approval queue.
 
+/// Brain-agnostic resolution of a task card's `assignee` against the full
+/// roster — teammates, overlay teammates and desks (issue #205). Shared by the
+/// harness dispatch path and the REST write boundary so the board's assignee
+/// means one thing. See [`assignee`].
+pub mod assignee;
 pub mod builder;
 pub mod channel;
 pub mod cron;

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -20,9 +20,10 @@ use serde::{Deserialize, Serialize};
 use crate::AppState;
 use crate::company::steer::{InflightEntry, SteerAction, SteerError, cap_redirect};
 use crate::error::OpenCompanyError;
-use crate::ports::tasks::TaskRecord;
+use crate::ports::tasks::{BOARD_COLUMNS, COLUMN_BACKLOG, TaskRecord, is_board_column};
 use crate::ports::types::CompanyEvent;
 use crate::ports::{generate_id, now_millis};
+use crate::runtime::assignee;
 use crate::server::error::ApiError;
 use crate::server::ops::{ScopedCompany, scoped};
 
@@ -190,6 +191,56 @@ fn validate_parent(
     Ok(())
 }
 
+/// Rejects a `column` the board does not render (issue #205).
+///
+/// `column` is a free string on the wire, and nothing checked it: a typo'd
+/// `"in-progress"` was persisted verbatim, so the card disappeared from every
+/// rendered column *and* — since only the exact literal `in_progress`
+/// edge-fires a dispatch — silently never ran. Refusing at the write boundary
+/// is the cheap place to keep the board's five columns the only five.
+fn validate_column(column: &str) -> Result<(), ApiError> {
+    if is_board_column(column) {
+        return Ok(());
+    }
+    Err(ApiError(OpenCompanyError::InvalidRequest(format!(
+        "\"{column}\" is not a board column — use one of: {}",
+        BOARD_COLUMNS.join(", ")
+    ))))
+}
+
+/// Resolves an `assignee` against the company roster, returning the canonical
+/// id to store — and rejecting one that names nobody (issue #205).
+///
+/// The board's Assignee field is free text, so "Shane" — a name this company
+/// has never had — used to be persisted verbatim and then silently dispatched
+/// to the orchestrator. A teammate id, a desk (by id or name), and blank are
+/// all accepted; a desk with no members yet is accepted too, because assigning
+/// work to a desk you are about to staff is legitimate (dispatch is where that
+/// one is refused, and it says why).
+///
+/// What is stored is the **canonical** key rather than what was typed, so the
+/// board's assignee column is one namespace of real ids and every downstream
+/// reader matches on the same string.
+///
+/// A company whose record has not been persisted yet has no roster to check
+/// against, so the value passes through unvalidated rather than being guessed
+/// at — the same permissive stance the rest of the write plane takes toward an
+/// unsaved record.
+async fn resolve_assignee(company: &ScopedCompany, assignee: String) -> Result<String, ApiError> {
+    let Some(record) = company.runtime.store().load(company.id()).await? else {
+        return Ok(assignee);
+    };
+    let resolution = assignee::resolve(&record, &assignee);
+    match resolution.canonical() {
+        Some(canonical) => Ok(canonical.to_string()),
+        None => Err(ApiError(OpenCompanyError::InvalidRequest(
+            resolution
+                .rejection()
+                .unwrap_or_else(|| format!("\"{assignee}\" is not on this company's roster")),
+        ))),
+    }
+}
+
 async fn create_task(
     company: ScopedCompany,
     Json(body): Json<CreateTask>,
@@ -204,13 +255,19 @@ async fn create_task(
         // `None` child: the card does not exist yet, so it cannot be in a cycle.
         validate_parent(parent, None, &board)?;
     }
+    // Issue #205: validated before anything is written, so a bad column or a
+    // bad assignee is a `400` the operator sees rather than a card that lands
+    // somewhere the board cannot render or hands work to a name nobody answers to.
+    let column = body.column.unwrap_or_else(|| COLUMN_BACKLOG.to_string());
+    validate_column(&column)?;
+    let assignee = resolve_assignee(&company, body.assignee.unwrap_or_default()).await?;
     let record = TaskRecord {
         id: generate_id(),
         title: body.title,
         note: body.note,
-        column: body.column.unwrap_or_else(|| "backlog".to_string()),
+        column,
         priority: body.priority.unwrap_or_else(|| "medium".to_string()),
-        assignee: body.assignee.unwrap_or_default(),
+        assignee,
         updated_at_millis: now_millis(),
         origin_chat_id: None,
         parent_task_id: body.parent_task_id,
@@ -244,14 +301,19 @@ async fn patch_task(
     if let Some(note) = body.note {
         record.note = Some(note);
     }
+    // Issue #205: a patch is validated on the same terms as a create. `record`
+    // is a local clone that is only upserted once every field has been applied,
+    // so returning the `400` from here discards the partial edit rather than
+    // persisting half of it.
     if let Some(column) = body.column {
+        validate_column(&column)?;
         record.column = column;
     }
     if let Some(priority) = body.priority {
         record.priority = priority;
     }
     if let Some(assignee) = body.assignee {
-        record.assignee = assignee;
+        record.assignee = resolve_assignee(&company, assignee).await?;
     }
     if let Some(parent_task_id) = body.parent_task_id {
         validate_parent(&parent_task_id, Some(&task_id), &board)?;

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -162,6 +162,124 @@ async fn tasks_crud_round_trips_under_both_scopes() {
     tokio::fs::remove_dir_all(&home).await.ok();
 }
 
+/// #205: a card may only be assigned to somebody the company actually has.
+/// Before this the board's free-text Assignee field accepted anything, the bad
+/// value was persisted verbatim, and dispatch silently handed the work to the
+/// orchestrator instead.
+#[tokio::test]
+async fn task_writes_reject_an_off_roster_assignee() {
+    let home = home();
+    let state = state_with_company(&home).await;
+
+    let (status, body) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks",
+        Some(json!({"title": "Fetch my activity", "assignee": "Shane"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        body.to_string().contains("Shane"),
+        "the refusal must name what was typed: {body}"
+    );
+
+    // A roster teammate is fine, matched case-insensitively…
+    let (status, task) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks",
+        Some(json!({"title": "Q2 brief", "assignee": "CEO"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let id = task["id"].as_str().unwrap().to_string();
+
+    // …and so is blank — an unassigned card is not an error.
+    let (status, _) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks",
+        Some(json!({"title": "Unowned"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // The same rule on PATCH, and the rejected patch leaves the card untouched.
+    let (status, _) = send(
+        &state,
+        "PATCH",
+        &format!("/api/v1/company/tasks/{id}"),
+        Some(json!({"title": "Renamed", "assignee": "Shane"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let (_, board) = send(&state, "GET", "/api/v1/company/tasks", None).await;
+    let card = board
+        .as_array()
+        .expect("board")
+        .iter()
+        .find(|c| c["id"] == json!(id))
+        .expect("the card survives a rejected patch")
+        .clone();
+    assert_eq!(
+        card["assignee"], "ceo",
+        "the typed key is stored as the canonical roster id"
+    );
+    assert_eq!(
+        card["title"], "Q2 brief",
+        "a rejected patch must not persist the fields it did apply"
+    );
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+/// #205: a column the board does not render is refused too. A typo'd
+/// `in-progress` used to be persisted verbatim, hiding the card from every
+/// rendered column *and* — since only the exact literal `in_progress`
+/// edge-fires a dispatch — silently never running it.
+#[tokio::test]
+async fn task_writes_reject_a_column_the_board_cannot_render() {
+    let home = home();
+    let state = state_with_company(&home).await;
+
+    let (status, body) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks",
+        Some(json!({"title": "Typo'd", "column": "in-progress"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        body.to_string().contains("in_progress"),
+        "the refusal must list the columns that do exist: {body}"
+    );
+
+    let (status, task) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks",
+        Some(json!({"title": "Fine", "column": "paused"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let id = task["id"].as_str().unwrap().to_string();
+
+    let (status, _) = send(
+        &state,
+        "PATCH",
+        &format!("/api/v1/company/tasks/{id}"),
+        Some(json!({"column": "reviewing"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let (_, board) = send(&state, "GET", "/api/v1/company/tasks", None).await;
+    assert_eq!(board.as_array().expect("board")[0]["column"], "paused");
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
 #[tokio::test]
 async fn steer_task_validates_statuses_and_journals_acceptance() {
     let home = home();


### PR DESCRIPTION
## Summary

Fixes #205.

A task assigned to **"Shane"** — a name the company has never had — sat in `in_progress`, silently dispatched to the **orchestrator (CEO)**, and kept `assignee = "Shane"` on the board while the timeline read "reply from ceo". Nothing anywhere said the name was not a teammate. Cards the CEO *did* work kept `assignee = ""` for the same underlying reason: the working agent was never written back to the card.

`task_responder` (`brain.rs:427-435`) resolved the assignee against `manifest.agents` **only**, and fell back to `self.responder` on *every* miss — blank, an unknown name, an operator-overlay teammate, or a desk id — all through the same arm. Four very different situations were indistinguishable, so none of them could be reported, and the card's `assignee` was never written.

**Split them.** `src/runtime/assignee.rs` (new) is one brain-agnostic resolver over the **full** roster — manifest agents, operator-overlay teammates, and desks by id or case-insensitive name (`is_roster_agent` / `resolve_desk_id` / `effective_desk_members`) — returning which of the four cases it is. It is compiled in every build so the harness dispatch path and the REST write boundary share one answer.

On dispatch (`run_task`):

| assignee | before | now |
|---|---|---|
| blank | orchestrator runs it, card stays `assignee=""` | orchestrator runs it **and is written to the card** |
| roster teammate | ran it (exact-match only) | runs it; matched case-insensitively |
| **overlay teammate** | silently fell back to the CEO | runs it, and is linked to the card |
| **desk id** (what `delegate_to_desk` writes) | silently fell back to the CEO | the desk's **lead** runs it, and is linked to the card |
| **unknown name / empty desk** | silently fell back to the CEO | **refused** — no turn runs, card → `backlog`, reason on the note, on the task timeline, and relayed into the origin thread |

The link is persisted **before** the turn starts, so the board shows the card working under a real agent while it is in flight (via the plain store `upsert`, not `CompanyRuntime::upsert_task`, so it cannot re-fire the dispatch edge).

The same contract now holds at every write:

- `POST` / `PATCH /tasks` reject an off-roster assignee **and** a column the board cannot render, and store the **canonical** key rather than what was typed. A typo'd `"in-progress"` used to be persisted verbatim — hiding the card from every rendered column *and*, since only the exact literal `in_progress` edge-fires a dispatch, silently never running it.
- `assign_task`, whose `assignee` comes from an **LLM tool call** and is therefore just as capable of inventing a name, is held to it too: an unresolvable name never reaches the card, the previous owner stays, and the refusal is recorded in the orchestrator's voice.

Supporting cleanup: the board's five columns move to `ports::tasks` (`BOARD_COLUMNS`, `COLUMN_*`) so the write boundary, the dispatch edge (`company/runtime.rs`) and the harness lifecycle seam read one list — `harness::lifecycle` was `#[cfg(feature = "openhuman")]` and therefore invisible to the default build. `lifecycle` re-exports them, so every `lifecycle::COLUMN_*` path is unchanged. The journal tail of `run_task` is extracted to `journal_task_outcome` so the refusal path reuses it verbatim.

## API Or Behavior Changes

Yes — three, all deliberate:

1. **`POST` / `PATCH …/tasks` can now return `400`** for an assignee that names nobody on the roster, or a column outside `backlog|in_progress|paused|in_review|done`. The console already toasts `envelope.error` verbatim, so the operator sees the sentence with no frontend change.
2. **A dispatch with an unresolvable assignee no longer runs.** It previously produced CEO work on a card nobody had asked the CEO for; it now returns to `backlog` with the reason. This is the reported bug's core.
3. **`card.assignee` is written by dispatch.** A blank card gains the orchestrator's id; a desk-assigned card is relinked to the member that ran it. `assignment_matches` still surfaces such a card when the desk is addressed (it matches a desk's lead), so desk-addressed hand-off awareness is preserved.

Assignees are also stored canonically on write (`"Engineer"` → `engineer`, `"Engineering desk"` → `eng`). A **desk** assignment stays a desk assignment at the write boundary — picking the lead is dispatch's job.

No wire-shape change: `TaskCard` / `TaskRecord` fields are untouched, so no stored board needs migrating.

## Tests

Failing before, passing after. New coverage:

- `src/runtime/assignee.rs` — 9 unit tests: blank ≠ unknown, case-insensitive teammate, overlay teammate, desk → lead (by id and by name), overlay-led manifest-empty desk, empty desk is real-but-unworkable, `"Shane"` quoted back in the refusal, canonical storage key, desk-wins-a-key-collision.
- `src/harness/brain.rs` — `task_dispatch_off_roster_assignee_is_refused_not_silently_reassigned` (the reported bug: `backlog`, reason on note, and **no turn ran**), `task_dispatch_links_the_working_agent_to_an_unassigned_card`, `task_dispatch_routes_a_desk_assignee_to_its_lead_and_links_it`, `task_dispatch_routes_to_an_overlay_teammate`, `a_refused_dispatch_posts_the_reason_back_to_its_origin`, `assign_task_refuses_an_off_roster_assignee_and_keeps_the_current_owner`.
- `src/server/ops/write_test.rs` — `task_writes_reject_an_off_roster_assignee` (create + patch, incl. "a rejected patch persists none of the fields it did apply") and `task_writes_reject_a_column_the_board_cannot_render`.

Two existing tests used an off-roster `"maya"` assignee and would have passed for the wrong reason under the new behaviour; both now use a roster assignee, with a comment saying why.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 910 passed, 0 failed
- [x] `cargo test --features openhuman` — 1247 passed, 0 failed (the harness dispatch path only compiles under this feature, so the default lane cannot see the core of this change)

## Documentation

`docs/spec/runtime/ports.md` — the `TaskStore` section listed `column ∈ backlog|in_progress|in_review|done`, omitting `paused` (added with steering in #111). The code was right, so the doc is corrected, and the section now also records the assignee contract: what the field may name, that the write plane rejects anything else and stores the canonical key, and that dispatch refuses an unresolvable assignee and writes the working agent back.

Everything else is documented at its definition — `runtime::assignee`'s module docs carry the "why" for keeping the four cases distinct.

---

### Overlap with #204

**#204 (delegation reassignment) is a sibling bug in this same dispatch path** and will touch `src/harness/brain.rs` (`run_task`) and `src/runtime/delegation.rs`. I stayed out of its area deliberately: nothing here drains the delegation queue, and `delegate_to_desk` is untouched. The one shared file is `delegation.rs`, where this PR changes **only** the `Delegation::AssignTask` match arm.

When #204 reassigns a card to its delegate, it should write through `assignee::resolve(record, name).canonical()` — that is the seam it wants, and it is the reason this resolver is brain-agnostic rather than a private helper on `HarnessBrain`. The `run_task` edits here are confined to the head of the function (resolution + linking) and one extracted helper call in the tail, so a rebase should be mechanical.

Minor: `src/runtime/mod.rs` gains one `pub mod` declaration, which #211 and #212 also do — a trivial adjacent-line conflict at worst.

### Not in scope

The console's Assignee field is still free text. A roster picker is the real UX fix and would make an invalid name unreachable rather than merely rejected, but it is frontend scope this issue did not cover — worth a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `Paused` task-board column.
  * Task assignments now recognize teammates, overlay teammates, and desks, including desk leads.
  * Assignment names are standardized automatically when saved.
  * Task dispatch records the actual worker and returns unresolved tasks to the backlog.

* **Bug Fixes**
  * Invalid columns and unknown or ambiguous assignees are rejected with clear errors.
  * Failed task updates no longer partially save changes.
  * Desk and origin-thread dispatch behavior is now handled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->