### PR TITLE
feat(tasks): To-do column and a To-do-only add button (#206)

### DIFF
--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -335,11 +335,20 @@ pub trait TaskStore: Send + Sync {
 `TaskRecord` carries `{id, title, note, column, priority, assignee,
 updated_at}`.
 
-`column` ∈ `backlog|in_progress|paused|in_review|done` — the `BOARD_COLUMNS`
+`column` ∈ `backlog|todo|in_progress|paused|in_review|done` — the `BOARD_COLUMNS`
 constant in `src/ports/tasks.rs`, which is the one authority the REST write
-boundary, the dispatch edge and the harness lifecycle seam all read. (`paused`
-arrived with steering, issue #111; this line used to omit it.) Entering
-`in_progress` is what dispatches the card; nothing dispatches out of `done`.
+boundary, the dispatch edge and the harness lifecycle seam all read, and which
+the console mirrors in the same order. (`paused` arrived with steering, issue
+#111; this line used to omit it.) Entering `in_progress` is what dispatches the
+card; nothing dispatches out of `done`.
+
+`backlog` and `todo` are both "not started", and the split is deliberate:
+`backlog` is the unqueued pool — and where the lifecycle returns work that needs
+another pass (a failed dispatch, an orchestrator `revise` verdict) — while
+`todo` is what has been queued up next. `todo` is the board's one manual-entry
+column: the console's `+` button lives there alone and `POST …/tasks` defaults
+to it (issue #206), so an operator cannot create a card straight into
+`in_progress` or a terminal column.
 
 `assignee` names a **roster teammate id, a desk, or nobody** (`""`), resolved by
 `crate::runtime::assignee` against the full roster — manifest agents, operator

--- a/frontend/src/lib/tasks-sample.ts
+++ b/frontend/src/lib/tasks-sample.ts
@@ -18,14 +18,36 @@ export interface TaskColumn {
   label: string;
 }
 
+/**
+ * The board's columns, left to right. Must stay in step with the backend's
+ * `BOARD_COLUMNS` (`src/ports/tasks.rs`), which is the source of truth — and
+ * which the REST write boundary rejects a card against, so a column that
+ * exists only here is one the host will refuse.
+ */
 export const TASK_COLUMNS: TaskColumn[] = [
+  // The unqueued pool, and where the lifecycle returns work that needs another
+  // pass (a failed dispatch, an orchestrator `revise` verdict).
   { id: "backlog", label: "Backlog" },
+  // Queued to be worked next (issue #206). The board's manual-entry column:
+  // `ADD_TASK_COLUMN` below restricts the `+` button to it, and it is what the
+  // host's `POST …/tasks` defaults to.
+  { id: "todo", label: "To-do" },
   { id: "in_progress", label: "In progress" },
   // Where a steered-to-pause run parks (issue #111); a card here offers Resume.
   { id: "paused", label: "Paused" },
   { id: "in_review", label: "In review" },
   { id: "done", label: "Done" },
 ];
+
+/**
+ * The one column that offers the "+" add-task button (issue #206).
+ *
+ * New work enters the board in exactly one place. Offering `+` on every column
+ * — as the board used to — let an operator create a card straight into
+ * `in_progress`, `in_review`, or `done`, which either skips the dispatch edge
+ * or fabricates a terminal state for work that never ran.
+ */
+export const ADD_TASK_COLUMN = "todo";
 
 const STRATEGY = { name: "Strategy desk", tone: "sky" };
 const CREATIVE = { name: "Creative studio", tone: "violet" };

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -26,7 +26,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { PRIORITY_STYLES, TASK_COLUMNS } from "@/lib/tasks-sample";
+import { ADD_TASK_COLUMN, PRIORITY_STYLES, TASK_COLUMNS } from "@/lib/tasks-sample";
 import { toast } from "sonner";
 import { TaskDetailView } from "./TaskDetailView";
 
@@ -230,13 +230,16 @@ export function TasksView({
                   <span className="text-sm font-medium">{col.label}</span>
                   <span className="text-xs text-muted-foreground">{items.length}</span>
                 </div>
-                <button
-                  className="text-muted-foreground hover:text-foreground"
-                  aria-label={`Add task to ${col.label}`}
-                  onClick={() => setCreatingIn(col.id)}
-                >
-                  <Plus className="size-4" />
-                </button>
+                {/* New work enters the board in one place only (issue #206). */}
+                {col.id === ADD_TASK_COLUMN && (
+                  <button
+                    className="text-muted-foreground hover:text-foreground"
+                    aria-label={`Add task to ${col.label}`}
+                    onClick={() => setCreatingIn(col.id)}
+                  >
+                    <Plus className="size-4" />
+                  </button>
+                )}
               </div>
               <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2 pb-2">
                 {loading && items.length === 0 ? (

--- a/src/ports/tasks.rs
+++ b/src/ports/tasks.rs
@@ -139,10 +139,16 @@ pub trait TaskStore: Send + Sync {
 mod test {
     use super::*;
 
-    /// The board's columns, in the order the console renders them. Pinned
-    /// because `frontend/src/lib/tasks-sample.ts` mirrors this list by hand: a
-    /// column added here and not there (or vice versa) files cards into a
-    /// column the operator cannot see.
+    /// Pins the **Rust** list's ids and their order against a literal, so a
+    /// reorder or a rename is a deliberate two-place edit rather than a
+    /// side effect.
+    ///
+    /// It does **not** protect against drift from the console's mirror in
+    /// `frontend/src/lib/tasks-sample.ts` — a Rust test cannot see the TS list,
+    /// so a column added on one side and not the other keeps this green.
+    /// Closing that gap means generating one list from the other (a build step
+    /// this crate does not have, across a separate npm build), so for now the
+    /// mirror is maintained by hand and the two lists are reviewed together.
     #[test]
     fn columns_are_ordered_and_unique() {
         assert_eq!(

--- a/src/ports/tasks.rs
+++ b/src/ports/tasks.rs
@@ -1,8 +1,8 @@
 //! The [`TaskStore`] port: the company's durable Kanban board.
 //!
-//! Tasks are the operator-visible work items the console's board renders
-//! (backlog / in-progress / in-review / done). They are hand-curated state, not
-//! cycle working memory — the brain's per-cycle task results live in
+//! Tasks are the operator-visible work items the console's board renders (see
+//! [`BOARD_COLUMNS`]). They are hand-curated state, not cycle working memory —
+//! the brain's per-cycle task results live in
 //! [`MemoryStore`](crate::ports::MemoryStore). Each record is keyed by a stable
 //! id within the company.
 
@@ -23,8 +23,13 @@ use crate::ports::types::CompanyId;
 // unchanged, and `CompanyRuntime`'s dispatch edge reads `COLUMN_IN_PROGRESS`
 // from here, so each literal exists in exactly one place.
 
-/// Where new work waits, and where a failed, cancelled or revised run returns.
+/// The unqueued pool: cards nobody has committed to yet, plus the ones a failed,
+/// cancelled or revised run returns.
 pub const COLUMN_BACKLOG: &str = "backlog";
+/// Queued to be worked next (issue #206). This is the board's manual-entry
+/// column — the `+` button lives here alone, and it is what `POST …/tasks`
+/// defaults to.
+pub const COLUMN_TODO: &str = "todo";
 /// The dispatch column: entering it hands the card to its assignee.
 pub const COLUMN_IN_PROGRESS: &str = "in_progress";
 /// Where a steered-to-pause run parks. Resume is a `column → in_progress` PATCH.
@@ -42,8 +47,16 @@ pub const COLUMN_DONE: &str = "done";
 /// card vanished from the board with no error, and — since only the exact
 /// literal `in_progress` edge-fires a dispatch — a typo'd `in-progress` also
 /// silently never ran. This list is what the write boundary checks against.
-pub const BOARD_COLUMNS: [&str; 5] = [
+///
+/// `backlog` and `todo` are both "not started", and the split is deliberate
+/// (issue #206): `backlog` is the pool — and where the lifecycle returns work
+/// that needs another pass — while `todo` is what has been picked up for the
+/// next stretch. `todo` therefore has to be in this list, not merely defined:
+/// `POST …/tasks` defaults a new card to it, so a write boundary that did not
+/// know the column would reject every card the board's `+` button creates.
+pub const BOARD_COLUMNS: [&str; 6] = [
     COLUMN_BACKLOG,
+    COLUMN_TODO,
     COLUMN_IN_PROGRESS,
     COLUMN_PAUSED,
     COLUMN_IN_REVIEW,
@@ -66,7 +79,7 @@ pub struct TaskRecord {
     /// An optional longer note.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
-    /// The board column (`backlog`, `in_progress`, `in_review`, `done`).
+    /// The board column — one of [`BOARD_COLUMNS`].
     pub column: String,
     /// The priority (`low`, `medium`, `high`).
     pub priority: String,
@@ -120,4 +133,51 @@ pub trait TaskStore: Send + Sync {
     async fn upsert(&self, company: &CompanyId, task: &TaskRecord) -> Result<()>;
     /// Deletes a task by id; returns whether a task was removed.
     async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool>;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// The board's columns, in the order the console renders them. Pinned
+    /// because `frontend/src/lib/tasks-sample.ts` mirrors this list by hand: a
+    /// column added here and not there (or vice versa) files cards into a
+    /// column the operator cannot see.
+    #[test]
+    fn columns_are_ordered_and_unique() {
+        assert_eq!(
+            BOARD_COLUMNS,
+            [
+                "backlog",
+                "todo",
+                "in_progress",
+                "paused",
+                "in_review",
+                "done"
+            ]
+        );
+        let mut sorted = BOARD_COLUMNS.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            sorted.len(),
+            BOARD_COLUMNS.len(),
+            "column ids must be unique"
+        );
+    }
+
+    #[test]
+    fn is_board_column_accepts_only_board_columns() {
+        for column in BOARD_COLUMNS {
+            assert!(is_board_column(column), "{column} is a board column");
+        }
+        // Issue #206 added To-do as a column of its own; Backlog stays.
+        assert!(is_board_column(COLUMN_TODO));
+        assert!(is_board_column(COLUMN_BACKLOG));
+        // Near-misses a typo'd client might send.
+        assert!(!is_board_column("to_do"));
+        assert!(!is_board_column("To-do"));
+        assert!(!is_board_column("inprogress"));
+        assert!(!is_board_column(""));
+    }
 }

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -650,7 +650,8 @@ type Task {
 	"""
 	note: String
 	"""
-	The board column: `backlog` | `in_progress` | `in_review` | `done`.
+	The board column: `backlog` | `todo` | `in_progress` | `paused` |
+	`in_review` | `done`.
 	"""
 	column: String!
 	"""

--- a/src/server/graphql/tasks.rs
+++ b/src/server/graphql/tasks.rs
@@ -18,7 +18,8 @@ pub struct TaskGql {
     pub title: String,
     /// An optional longer note.
     pub note: Option<String>,
-    /// The board column: `backlog` | `in_progress` | `in_review` | `done`.
+    /// The board column: `backlog` | `todo` | `in_progress` | `paused` |
+    /// `in_review` | `done`.
     pub column: String,
     /// The priority: `low` | `medium` | `high`.
     pub priority: String,

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use crate::AppState;
 use crate::company::steer::{InflightEntry, SteerAction, SteerError, cap_redirect};
 use crate::error::OpenCompanyError;
-use crate::ports::tasks::{BOARD_COLUMNS, COLUMN_BACKLOG, TaskRecord, is_board_column};
+use crate::ports::tasks::{BOARD_COLUMNS, COLUMN_TODO, TaskRecord, is_board_column};
 use crate::ports::types::CompanyEvent;
 use crate::ports::{generate_id, now_millis};
 use crate::runtime::assignee;
@@ -258,7 +258,12 @@ async fn create_task(
     // Issue #205: validated before anything is written, so a bad column or a
     // bad assignee is a `400` the operator sees rather than a card that lands
     // somewhere the board cannot render or hands work to a name nobody answers to.
-    let column = body.column.unwrap_or_else(|| COLUMN_BACKLOG.to_string());
+    // Issue #206: a card created here is manual entry — the board's `+` button,
+    // which now lives on To-do alone — so that is the default. It is
+    // deliberately NOT `backlog`: backlog is the unqueued pool and where the
+    // lifecycle returns work that needs another pass, so defaulting new work
+    // there mixed "nobody has picked this up" with "someone just asked for it".
+    let column = body.column.unwrap_or_else(|| COLUMN_TODO.to_string());
     validate_column(&column)?;
     let assignee = resolve_assignee(&company, body.assignee.unwrap_or_default()).await?;
     let record = TaskRecord {

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -118,7 +118,8 @@ async fn tasks_crud_round_trips_under_both_scopes() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(task["title"], "Q2 brief");
-    assert_eq!(task["column"], "backlog");
+    // Issue #206: manual entry lands in To-do, not the backlog pool.
+    assert_eq!(task["column"], "todo");
     let id = task["id"].as_str().unwrap().to_string();
 
     // Drag (PATCH column) via the {id} scope.
@@ -276,6 +277,37 @@ async fn task_writes_reject_a_column_the_board_cannot_render() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
     let (_, board) = send(&state, "GET", "/api/v1/company/tasks", None).await;
     assert_eq!(board.as_array().expect("board")[0]["column"], "paused");
+
+    tokio::fs::remove_dir_all(&home).await.ok();
+}
+
+/// Issue #206: `POST …/tasks` defaults a new card to To-do — the board's one
+/// manual-entry column — while an explicit `column` still wins, so the
+/// lifecycle paths that place a card themselves are untouched.
+#[tokio::test]
+async fn created_tasks_default_to_the_todo_column() {
+    let home = home();
+    let state = state_with_company(&home).await;
+
+    let (_, defaulted) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks",
+        Some(json!({"title": "queued work"})),
+    )
+    .await;
+    assert_eq!(defaulted["column"], crate::ports::tasks::COLUMN_TODO);
+
+    // An explicit column is still honored verbatim — `spawn_task`, the
+    // orchestrator's `revise`, and a failed run all place their own card.
+    let (_, explicit) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks",
+        Some(json!({"title": "parked", "column": "backlog"})),
+    )
+    .await;
+    assert_eq!(explicit["column"], crate::ports::tasks::COLUMN_BACKLOG);
 
     tokio::fs::remove_dir_all(&home).await.ok();
 }


### PR DESCRIPTION
## Summary

Closes #206. Rebased onto `main` after #214 landed; two commits.

### A To-do column, and it is the board's only entry point — `2738603`

New work had nowhere of its own to land. `backlog` served double duty — the unqueued pool *and* where the lifecycle returns work that needs another pass (a failed dispatch, an orchestrator `revise` verdict) — so "nobody has picked this up" and "someone just asked for it" sat in one column.

The issue asked to confirm Backlog vs To-do semantics with product. Resolved as the issue itself assumed, and now written into `docs/spec/runtime/ports.md`:

- **Backlog** — the unqueued pool, and the lifecycle's return column. Unchanged; every path that places a card there still does.
- **To-do** — queued next, sitting between Backlog and In progress. `POST …/tasks` defaults here, while an explicit `column` still wins, so `spawn_task`, `revise`, and a failed run keep placing their own card.

The `+` button now renders on To-do alone (`ADD_TASK_COLUMN`). That is not only tidiness: the old unconditional button let an operator create a card straight into `in_progress` — skipping the dispatch edge, since only the *transition* into that column fires it — or into `in_review`/`done`, fabricating a terminal for work that never ran.

### The column-order test says what it actually pins — `e586b43`

`columns_are_ordered_and_unique` claimed it existed because the console mirrors the list by hand, but it only asserts the Rust array against a Rust literal — it cannot read `tasks-sample.ts`, so the very drift it named as its reason keeps it green. The comment now states that it pins the Rust order only, that cross-language drift is unguarded, and that closing the gap needs codegen this crate has no build step for.

### Reconciliation with #214

This PR originally carried a second slice that resolved and wrote back a card's `assignee` on dispatch. #214 (#205) owns that, and now that it has merged, **this PR no longer touches `src/harness/brain.rs` at all**. Two things were reconciled rather than landed twice:

- **One owner for assignee resolution.** The `task_responder` extension here was dropped. It resolved a *desk* assignee to the desk's lead and the dispatch wrote that back, so a card the operator assigned to the Strategy desk silently became assigned to `engineer` on first dispatch and the desk assignment was gone from the board. `runtime::assignee::resolve` on `main` keeps desk ownership intact — its write-back is gated on `links_working_agent()`, true only for an unassigned card or a teammate assignment — and it *refuses* an assignee that names nobody instead of routing it to the orchestrator.
- **One column list, including `todo`.** Both PRs hoisted the column literals into `ports::tasks` under different names and different membership: `TASK_COLUMNS` with six entries here, `BOARD_COLUMNS` with five and no `todo` on #214, wired into `validate_column` at the REST write boundary. Each was green alone; together they were a live bug — `POST …/tasks` defaults a new card to `todo` while `validate_column` rejects `todo` as not a board column, so **every card creation 400s**. Confirmed by building the union locally before #214 merged: dropping `todo` from the list fails 5 write tests, `created_tasks_default_to_the_todo_column` and `tasks_crud_round_trips_under_both_scopes` among them. This PR now adds `COLUMN_TODO` to `main`'s `BOARD_COLUMNS` and keeps `is_board_column` as the single predicate, so the validator and the create default agree.

## API Or Behavior Changes

- **`POST …/tasks` with no `column` now returns `todo`, not `backlog`.** A client relying on the old default will see new cards in a new column. An explicit `column` is unaffected, and stored boards need no migration.
- **`todo` is a new value of `Task.column`** on both the REST and GraphQL read surfaces (SDL snapshot regenerated). Columns are now `backlog | todo | in_progress | paused | in_review | done`, and `todo` is accepted by the `validate_column` write boundary added in #214.
- The `+` add-task button no longer appears on Backlog, In progress, Paused, In review, or Done.
- No change to assignee resolution, dispatch, or the harness — that surface is entirely #214's.

Deliberately **not** changed: agent-spawned cards (`spawn_task`), operator-chat-opened cards (`operator.rs`), and the lifecycle return paths all still land in `backlog`. The issue scoped the change to the create default at `server/ops/tasks.rs`, and those three are documented #171/#186 decisions. Happy to move the operator-chat one to To-do as a follow-up if product wants it.

## Tests

2 new, 1 updated.

- `server::ops::write_test` — `created_tasks_default_to_the_todo_column` (the default, and that an explicit column still wins); `tasks_crud_round_trips_under_both_scopes` updated for the new default. Both now run in the same binary as #214's `task_writes_reject_a_column_the_board_cannot_render`, which is the union that would have 400'd every card creation had the lists not been reconciled.
- `ports::tasks` — `columns_are_ordered_and_unique` (pins the Rust order; see the commit note on what it does *not* pin), `is_board_column_accepts_only_board_columns` extended to cover `todo` and near-miss typos.

Commands run locally, on the rebased branch:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` (956 passed, 0 failed)
- [x] `cargo test --features openhuman` (1294 passed, 0 failed)
- [x] `cargo check --features openhuman`
- [x] `npm ci && npm run typecheck && npm run build` (frontend; this package has no lint or test script)
- [ ] `cargo clippy --all-targets --features openhuman -- -D warnings` — **fails on `main` too**, in vendored `tinyagents` (`vendor/tinyagents/src/harness/agent_loop/stream.rs:48`, `large size difference between variants`). This PR touches no vendored file.

## Documentation

- `docs/spec/runtime/ports.md` — the `TaskStore` section now lists `todo` in the column set and explains the Backlog-vs-To-do split and To-do's role as the single manual-entry column. #214's assignee-resolution paragraph is left as merged; it is the authority on that behaviour.
- Module docs for the column vocabulary live with the code in `src/ports/tasks.rs`.
