### PR TITLE
feat(workflows): output-node destinations with gated host-side delivery (#170)

### DIFF
--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -46,6 +46,33 @@ address check for `{id}`, operator + `sole()` for the alias).
 | `domain` | `PUT …/domain`, `POST …/domain/verify` |
 | `smtp` | `PUT …/smtp`, `POST …/smtp/test` |
 | `connections` (feature `oauth`) | `POST …/connections/{provider}/start\|disconnect`, `GET /api/v1/oauth/callback` |
+| `workflows` | `POST …/workflows`, `GET …/workflows`, `GET …/workflows/{wid}`, `POST …/workflows/{wid}/run` |
+
+### Workflow runs and report delivery
+
+A workflow's terminal `output` node may carry a `destination` — `owner`,
+`email`, or `channel` — saying where its report goes once the run finishes. It
+rides the create body and the read shape under the same key, and the model
+type is reused verbatim in both directions (`kind` / `target` are single words,
+so there is no camelCase mirror to drift from).
+
+Delivery itself is **not** a route concern. It runs host-side in the shared
+`WorkflowRunner` path (`src/workflows/delivery.rs`) once the engine returns,
+because the orchestrator's `run_workflow` tool and the trigger scheduler drive
+that same port — and a scheduled run is exactly the case where nobody is
+watching the console. The run response therefore carries `deliveries`: one row
+per attempt (`sent` / `skipped` / `denied` / `failed`) with an operator-readable
+reason. A delivery failure never fails the run, so that list is the only place
+an operator learns a report did not go out; an unwired runtime writes a loud
+`failed` row rather than skipping silently.
+
+The gating is fail-closed and differs per kind. `owner` resolves server-side to
+the company's active admins (the graph names nobody) and falls back to the
+`operator` channel. `channel` must name an adapter the deployment already
+wired. `email` is the only kind that can address an outsider, and it needs
+**both** an `email` grant in the manifest's `[tools].allow` **and** an
+established inbound thread from that address — the same rule the agent send
+path applies; a cold recipient is skipped and reported, never mailed.
 
 Every credential-shaped value written here lands in the `SecretStore`; the
 responses expose only non-secret status. The networked seams (DNS, SMTP, OAuth

--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -62,9 +62,54 @@ because the orchestrator's `run_workflow` tool and the trigger scheduler drive
 that same port — and a scheduled run is exactly the case where nobody is
 watching the console. The run response therefore carries `deliveries`: one row
 per attempt (`sent` / `skipped` / `denied` / `failed`) with an operator-readable
-reason. A delivery failure never fails the run, so that list is the only place
-an operator learns a report did not go out; an unwired runtime writes a loud
-`failed` row rather than skipping silently.
+reason. A delivery failure never fails the run, so that list is where an
+operator learns a report did not go out; an unwired runtime writes a loud
+`failed` row rather than skipping silently. A **scheduled** run has no response
+to carry those rows, so the scheduler logs each undelivered one instead — see
+`src/runtime/workflow_scheduler.rs`, which is also honest that a host log line
+is not the same as an operator-visible surface (issue #228).
+
+Authoring a destination and reading the result back:
+
+```bash
+# Create a graph whose output node reports to the company's admins.
+curl -X POST "$HOST/api/v1/company/workflows" -H 'content-type: application/json' -d '{
+  "id": "weekly_digest",
+  "name": "Weekly digest",
+  "nodes": [
+    { "id": "start", "kind": "trigger", "name": "Monday 09:00", "schedule": "0 9 * * MON" },
+    { "id": "write", "kind": "agent",  "name": "Draft it", "agent": "chief_of_staff" },
+    { "id": "done",  "kind": "output", "name": "Owner summary",
+      "destination": { "kind": "owner" } }
+  ],
+  "edges": [ { "from": "start", "to": "write" }, { "from": "write", "to": "done" } ]
+}'
+
+# Run it now. `deliveries` says what happened to the report.
+curl -X POST "$HOST/api/v1/company/workflows/weekly_digest/run" \
+     -H 'content-type: application/json' -d '{"input":{"request":"last week"}}'
+```
+
+```jsonc
+{
+  "output": { "nodes": { "done": { "items": [ { "json": { "text": "…" } } ] } } },
+  "pendingApprovals": [],
+  "deliveries": [
+    { "node": "done", "kind": "owner", "target": "ada@acme.test",
+      "status": "sent", "detail": "emailed the company's admin" }
+  ]
+}
+```
+
+Swap `{ "kind": "owner" }` for `{ "kind": "email", "target": "ada@example.com" }`
+and a recipient who has never written in comes back as
+`"status": "skipped"` with the reason, having sent nothing:
+
+```jsonc
+{ "node": "done", "kind": "email", "target": "ada@example.com",
+  "status": "skipped",
+  "detail": "this recipient has never written to the company, so a workflow may not open the conversation — send once from the inbox first" }
+```
 
 The gating is fail-closed and differs per kind. `owner` resolves server-side to
 the company's active admins (the graph names nobody) and falls back to the
@@ -72,7 +117,11 @@ the company's active admins (the graph names nobody) and falls back to the
 wired. `email` is the only kind that can address an outsider, and it needs
 **both** an `email` grant in the manifest's `[tools].allow` **and** an
 established inbound thread from that address — the same rule the agent send
-path applies; a cold recipient is skipped and reported, never mailed.
+path applies; a cold recipient is skipped and reported, never mailed. Note the
+grant half is satisfied by default: since #230 an unset `[tools].allow` defaults
+to `["*", "media", "composio"]` and `*` covers `email`, so on a
+default-configured company the established-thread rule is the gate actually
+holding the line. Narrow `[tools].allow` explicitly to close the first one.
 
 Every credential-shaped value written here lands in the `SecretStore`; the
 responses expose only non-secret status. The networked seams (DNS, SMTP, OAuth

--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -75,9 +75,14 @@ Surfacing those outcomes is issue #228; the durable record it needs is issue
 
 Authoring a destination and reading the result back:
 
+Both routes go through `ScopedCompany`, so both need an operator credential —
+`$TOKEN` below is the bearer token the `Authorization` header is parsed from.
+
 ```bash
 # Create a graph whose output node reports to the company's admins.
-curl -X POST "$HOST/api/v1/company/workflows" -H 'content-type: application/json' -d '{
+curl -X POST "$HOST/api/v1/company/workflows" \
+     -H "Authorization: Bearer $TOKEN" \
+     -H 'content-type: application/json' -d '{
   "id": "weekly_digest",
   "name": "Weekly digest",
   "nodes": [
@@ -91,6 +96,7 @@ curl -X POST "$HOST/api/v1/company/workflows" -H 'content-type: application/json
 
 # Run it now. `deliveries` says what happened to the report.
 curl -X POST "$HOST/api/v1/company/workflows/weekly_digest/run" \
+     -H "Authorization: Bearer $TOKEN" \
      -H 'content-type: application/json' -d '{"input":{"request":"last week"}}'
 ```
 

--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -60,14 +60,18 @@ Delivery itself is **not** a route concern. It runs host-side in the shared
 `WorkflowRunner` path (`src/workflows/delivery.rs`) once the engine returns,
 because the orchestrator's `run_workflow` tool and the trigger scheduler drive
 that same port — and a scheduled run is exactly the case where nobody is
-watching the console. The run response therefore carries `deliveries`: one row
-per attempt (`sent` / `skipped` / `denied` / `failed`) with an operator-readable
-reason. A delivery failure never fails the run, so that list is where an
-operator learns a report did not go out; an unwired runtime writes a loud
-`failed` row rather than skipping silently. A **scheduled** run has no response
-to carry those rows, so the scheduler logs each undelivered one instead — see
-`src/runtime/workflow_scheduler.rs`, which is also honest that a host log line
-is not the same as an operator-visible surface (issue #228).
+watching the console. An **on-demand** run's response therefore carries
+`deliveries`: one row per attempt (`sent` / `skipped` / `denied` / `failed`)
+with an operator-readable reason. A delivery failure never fails the run, so on
+that run the list is where an operator learns a report did not go out; an
+unwired runtime writes a loud `failed` row rather than skipping silently.
+
+A **scheduled** run is not persisted, so its delivery outcomes are not surfaced
+yet. The scheduler logs each undelivered report and drops the run value — see
+`src/runtime/workflow_scheduler.rs`. That makes a failed scheduled delivery
+diagnosable in the host's stdout, which is not the same as operator-visible.
+Giving a run a durable record to read those rows back from is issue #242
+(first-class `Run` records); #228 tracks this specific gap.
 
 Authoring a destination and reading the result back:
 

--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -70,8 +70,8 @@ A **scheduled** run is not persisted, so its delivery outcomes are not surfaced
 yet. The scheduler logs each undelivered report and drops the run value — see
 `src/runtime/workflow_scheduler.rs`. That makes a failed scheduled delivery
 diagnosable in the host's stdout, which is not the same as operator-visible.
-Surfacing those outcomes is issue #228; the durable record it needs is issue
-#242's first-class `Run`.
+Surfacing those outcomes is issue #228; the durable record it needs is the
+first-class `Run` tracked by issue #242.
 
 Authoring a destination and reading the result back:
 

--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -70,8 +70,8 @@ A **scheduled** run is not persisted, so its delivery outcomes are not surfaced
 yet. The scheduler logs each undelivered report and drops the run value — see
 `src/runtime/workflow_scheduler.rs`. That makes a failed scheduled delivery
 diagnosable in the host's stdout, which is not the same as operator-visible.
-Giving a run a durable record to read those rows back from is issue #242
-(first-class `Run` records); #228 tracks this specific gap.
+Surfacing those outcomes is issue #228; the durable record it needs is issue
+#242's first-class `Run`.
 
 Authoring a destination and reading the result back:
 

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -123,6 +123,7 @@ async fn main() -> anyhow::Result<()> {
         media: None,
         composio: None,
         steer: opencompany::company::steer::InflightRegistry::default(),
+        delivery: None,
     };
 
     let pool = HarnessPool::new();

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -44,7 +44,31 @@ export interface WorkflowNode {
   };
   /** Whether the node pauses for a human approval before proceeding. */
   requiresApproval?: boolean;
+  /** Where an `output` node's report goes when the run finishes. */
+  destination?: WorkflowDestination;
 }
+
+/**
+ * Where a terminal `output` node routes its report once the run completes.
+ *
+ * `owner` is resolved server-side from the company's admins and carries no
+ * target — the graph names nobody, which is what keeps it safe by construction.
+ * `email` names an address and only sends when the company grants `email` AND
+ * the recipient has already written in. `channel` must name a channel the
+ * deployment already wired.
+ */
+export interface WorkflowDestination {
+  kind: "owner" | "email" | "channel";
+  /** Required for `email` (an address) and `channel` (an id); absent for `owner`. */
+  target?: string;
+}
+
+/** The destination kinds the creator's picker offers, with prosumer labels. */
+export const DESTINATION_KINDS: { value: WorkflowDestination["kind"]; label: string }[] = [
+  { value: "owner", label: "Owner — the company's admins" },
+  { value: "email", label: "Email — a specific address" },
+  { value: "channel", label: "Channel — a wired chat channel" },
+];
 
 /** A directed edge between two node ids, with an optional branch label. */
 export interface WorkflowEdge {
@@ -62,12 +86,39 @@ export interface WorkflowGraph {
   edges: WorkflowEdge[];
 }
 
+/** What became of one attempt to deliver an output node's report. */
+export type DeliveryStatus = "sent" | "skipped" | "denied" | "failed";
+
+/**
+ * One attempt to route a reached `output` node's report to its destination.
+ *
+ * This is the ONLY place an operator learns a report was not delivered: a
+ * delivery failure never fails the run, so it has nowhere else to surface. An
+ * output node the run never reached contributes no row at all.
+ */
+export interface DeliveryReport {
+  /** The output node whose report this was. */
+  node: string;
+  /** The destination kind as authored. */
+  kind: string;
+  /** The address or channel actually addressed, when there was one. */
+  target?: string;
+  status: DeliveryStatus;
+  /** An operator-readable reason — populated even on success. */
+  detail: string;
+}
+
 /** The result of a run: the engine's final state and any pending approvals. */
 export interface WorkflowRunResult {
   /** The engine's final run state — a nested JSON payload. */
   output: unknown;
   /** Node ids left waiting on a human approval, if any. */
   pendingApprovals: string[];
+  /**
+   * One row per report-delivery attempt. Optional on the type (not the wire)
+   * so a response from a host predating issue #170 still parses.
+   */
+  deliveries?: DeliveryReport[];
 }
 
 export function listWorkflows(

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -9,7 +9,9 @@ import { Plus, Trash2 } from "lucide-react";
 
 import {
   CREATABLE_NODE_KINDS,
+  DESTINATION_KINDS,
   createWorkflow,
+  type WorkflowDestination,
   type WorkflowEdge,
   type WorkflowGraph,
   type WorkflowNode,
@@ -49,6 +51,11 @@ interface DraftNode {
   /** The trigger's cron expression (issue #169). Empty means "no schedule";
    * only ever set on the trigger node, which is where the host allows it. */
   schedule: string;
+  /** Output nodes only. `""` means "don't route this anywhere" — the pre-#170
+   * behaviour, where the report only shows in the run drawer. */
+  destinationKind: "" | WorkflowDestination["kind"];
+  /** The address (`email`) or channel id (`channel`). Unused for `owner`. */
+  destinationTarget: string;
 }
 
 /** "No schedule" — the workflow runs only when something starts it. A sentinel
@@ -90,24 +97,34 @@ interface DraftEdge {
   label: string;
 }
 
+/** The "no destination" option's value. A Select item cannot carry an empty
+ * string, so the sentinel stands in for `destinationKind: ""`. */
+const NO_DESTINATION = "__none__";
+
 let seq = 0;
 function nextKey(): string {
   seq += 1;
   return `row-${seq}`;
 }
 
+/** A blank node row, so every construction site stays in step as the shape grows. */
+function blankNode(fields: Partial<DraftNode> = {}): DraftNode {
+  return {
+    key: nextKey(),
+    id: "",
+    kind: "agent",
+    name: "",
+    summary: "",
+    agent: "",
+    schedule: "",
+    destinationKind: "",
+    destinationTarget: "",
+    ...fields,
+  };
+}
+
 function starterNodes(): DraftNode[] {
-  return [
-    {
-      key: nextKey(),
-      id: "start",
-      kind: "trigger",
-      name: "Start",
-      summary: "",
-      agent: "",
-      schedule: "",
-    },
-  ];
+  return [blankNode({ id: "start", kind: "trigger", name: "Start" })];
 }
 
 /** A safe on-disk id: only letters, digits, `_`, and `-` — a subset of what the
@@ -167,10 +184,7 @@ export function WorkflowCreateDialog({
   }, [open, client, company]);
 
   function addNode() {
-    setNodes((rows) => [
-      ...rows,
-      { key: nextKey(), id: "", kind: "agent", name: "", summary: "", agent: "", schedule: "" },
-    ]);
+    setNodes((rows) => [...rows, blankNode()]);
   }
 
   function updateNode(key: string, fields: Partial<DraftNode>) {
@@ -219,6 +233,20 @@ export function WorkflowCreateDialog({
       if (n.kind === "trigger" && n.schedule.trim() && !looksLikeCron(n.schedule)) {
         return "A schedule is a 5-field cron, e.g. `0 9 * * MON` (minute hour day month weekday).";
       }
+      // Mirrors the host's `destination` validation so a wrong target is caught
+      // here rather than after a round trip. Only output nodes carry one; the
+      // row that offers the control is already output-only, so this guards the
+      // case where the author picked a destination then changed the kind.
+      if (n.destinationKind && n.kind !== "output") {
+        return `Node \`${n.id}\` routes a report but isn't an output node — only output nodes report back.`;
+      }
+      const target = n.destinationTarget.trim();
+      if (n.destinationKind === "email" && !target.includes("@")) {
+        return `Node \`${n.id}\` emails its report — give the recipient's full address.`;
+      }
+      if (n.destinationKind === "channel" && !target) {
+        return `Node \`${n.id}\` posts its report to a channel — name the channel.`;
+      }
     }
     const triggerCount = nodes.filter((n) => n.kind === "trigger").length;
     if (triggerCount !== 1) {
@@ -256,6 +284,18 @@ export function WorkflowCreateDialog({
           // trigger's value is ever sent.
           schedule:
             n.kind === "trigger" && n.schedule.trim() ? n.schedule.trim() : undefined,
+          // Only output nodes route a report, and `owner` resolves server-side
+          // so it must carry no target — the host rejects one.
+          destination:
+            n.kind === "output" && n.destinationKind
+              ? {
+                  kind: n.destinationKind,
+                  target:
+                    n.destinationKind === "owner"
+                      ? undefined
+                      : n.destinationTarget.trim() || undefined,
+                }
+              : undefined,
         }),
       ),
       edges: edges.map(
@@ -468,6 +508,61 @@ function NodeRow({
             schedule={node.schedule}
             onChange={(schedule) => onChange({ schedule })}
           />
+        )}
+        {/* Only an output node reports back, so only it can route that report
+            somewhere. "Nowhere" stays the default: the result still shows in the
+            run drawer, which is all an output node did before. */}
+        {node.kind === "output" && (
+          <>
+            <Select
+              value={node.destinationKind || NO_DESTINATION}
+              onValueChange={(v) =>
+                onChange({
+                  destinationKind:
+                    !v || v === NO_DESTINATION
+                      ? ""
+                      : (v as WorkflowDestination["kind"]),
+                  // Switching to `owner` (or to no destination) clears the
+                  // target — the host rejects an `owner` that carries one.
+                  ...(v === "owner" || !v || v === NO_DESTINATION
+                    ? { destinationTarget: "" }
+                    : {}),
+                })
+              }
+            >
+              <SelectTrigger className="h-8" aria-label="Send report to">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NO_DESTINATION}>
+                  Send report to… nowhere (run result only)
+                </SelectItem>
+                {DESTINATION_KINDS.map((d) => (
+                  <SelectItem key={d.value} value={d.value}>
+                    {d.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {(node.destinationKind === "email" || node.destinationKind === "channel") && (
+              <Input
+                value={node.destinationTarget}
+                onChange={(e) => onChange({ destinationTarget: e.target.value })}
+                placeholder={
+                  node.destinationKind === "email" ? "recipient@example.com" : "channel id"
+                }
+                aria-label={
+                  node.destinationKind === "email" ? "Recipient address" : "Channel id"
+                }
+              />
+            )}
+            {node.destinationKind === "email" && (
+              <p className="text-[11px] leading-snug text-muted-foreground">
+                Only sends if this company grants email and the recipient has
+                already written in.
+              </p>
+            )}
+          </>
         )}
       </div>
       <Button

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -107,6 +107,26 @@ function nextKey(): string {
   return `row-${seq}`;
 }
 
+/** The field updates for changing a node's kind: the new kind, plus a reset of
+ * every field only the OLD kind's controls could edit.
+ *
+ * The rule is "draft state matches the visible controls", and it covers EVERY
+ * kind-conditional field — `agent` (agent nodes), `schedule` (trigger nodes),
+ * and the destination pair (output nodes). Clearing beats tolerating a stale
+ * value: `submit()` already drops fields that don't match the kind, but a stale
+ * `destinationKind` also had to pass validation, and there was no control left
+ * on screen to fix it with. `agent` and `schedule` never trapped the form that
+ * way; they are cleared so there is one rule here rather than three, and so
+ * that switching a node's kind and back doesn't silently resurrect a value the
+ * author can no longer see.
+ *
+ * Anything added to `DraftNode` behind a `node.kind === …` control belongs in
+ * this reset.
+ */
+function changeKind(kind: string): Partial<DraftNode> {
+  return { kind, agent: "", schedule: "", destinationKind: "", destinationTarget: "" };
+}
+
 /** A blank node row, so every construction site stays in step as the shape grows. */
 function blankNode(fields: Partial<DraftNode> = {}): DraftNode {
   return {
@@ -230,16 +250,16 @@ export function WorkflowCreateDialog({
       if (n.kind === "agent" && !n.agent.trim()) {
         return `Node \`${n.id}\` is an agent node — pick who does it.`;
       }
+      // Only fires for a node that IS a trigger, so this is a check on visible
+      // state, never an off-kind trap.
       if (n.kind === "trigger" && n.schedule.trim() && !looksLikeCron(n.schedule)) {
         return "A schedule is a 5-field cron, e.g. `0 9 * * MON` (minute hour day month weekday).";
       }
-      // Mirrors the host's `destination` validation so a wrong target is caught
-      // here rather than after a round trip. Only output nodes carry one; the
-      // row that offers the control is already output-only, so this guards the
-      // case where the author picked a destination then changed the kind.
-      if (n.destinationKind && n.kind !== "output") {
-        return `Node \`${n.id}\` routes a report but isn't an output node — only output nodes report back.`;
-      }
+      // Mirrors the host's `destination` target rules so a wrong target is
+      // caught here rather than after a round trip. There is deliberately NO
+      // "destination on a non-output node" check: `changeKind` makes that state
+      // unreachable, and re-adding the check would only recreate the trap of an
+      // error the author has no visible control to clear.
       const target = n.destinationTarget.trim();
       if (n.destinationKind === "email" && !target.includes("@")) {
         return `Node \`${n.id}\` emails its report — give the recipient's full address.`;
@@ -453,7 +473,11 @@ function NodeRow({
           placeholder="node id"
           aria-label="Node id"
         />
-        <Select value={node.kind} onValueChange={(v) => onChange({ kind: v ?? "" })}>
+        {/* Changing the kind clears every kind-conditional field, so the draft
+            never holds a value whose control is no longer on screen. Without
+            this, picking a destination and then changing the kind left the row
+            un-submittable with nothing visible to clear. */}
+        <Select value={node.kind} onValueChange={(v) => onChange(changeKind(v ?? ""))}>
           <SelectTrigger className="h-8" aria-label="Node kind">
             <SelectValue />
           </SelectTrigger>

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -19,6 +19,8 @@ import {
   getWorkflow,
   listWorkflows,
   runWorkflow,
+  type DeliveryReport,
+  type DeliveryStatus,
   type WorkflowGraph,
   type WorkflowNode as WorkflowNodeModel,
   type WorkflowRunResult,
@@ -405,18 +407,85 @@ function NodeDetailPanel({
           </DetailField>
         )}
 
+        {node.destination && (
+          <DetailField label="Destination">
+            <p className="text-sm leading-snug">{describeDestination(node.destination)}</p>
+          </DetailField>
+        )}
+
         {!node.summary &&
           !node.agent &&
           !hasConfig &&
           !node.onError &&
           !node.retry &&
           !node.schedule &&
+          !node.destination &&
           !node.requiresApproval && (
             <p className="text-xs text-muted-foreground">
               This node has no extra details beyond its kind and name.
             </p>
           )}
       </div>
+    </div>
+  );
+}
+
+/** Where an output node's report goes, in a sentence. `owner` deliberately has
+ * no target to show — it resolves to the company's admins server-side, which is
+ * exactly why an author can't point it at an outsider. */
+function describeDestination(destination: NonNullable<WorkflowNodeModel["destination"]>): string {
+  switch (destination.kind) {
+    case "owner":
+      return "Reports to the company's admins.";
+    case "email":
+      return `Emails ${destination.target ?? "(no address)"}.`;
+    case "channel":
+      return `Posts to the ${destination.target ?? "(unnamed)"} channel.`;
+    default:
+      return `${destination.kind}${destination.target ? ` → ${destination.target}` : ""}`;
+  }
+}
+
+/** Badge styling per delivery outcome. A report that did NOT go out must not
+ * look like one that did — `denied` and `failed` are the two an operator has to
+ * act on, so they get the loud treatment. */
+const DELIVERY_TONE: Record<DeliveryStatus, string> = {
+  sent: "border-emerald-500/40 bg-emerald-500/10",
+  skipped: "border-amber-500/40 bg-amber-500/10",
+  denied: "border-red-500/40 bg-red-500/10",
+  failed: "border-red-500/40 bg-red-500/10",
+};
+
+/** The delivery block of the run drawer: one line per attempt to route an
+ * output node's report. This is the ONLY place an operator learns a report
+ * didn't leave the building — a delivery failure never fails the run. */
+function DeliveryRows({ deliveries }: { deliveries: DeliveryReport[] }) {
+  const undelivered = deliveries.filter((d) => d.status !== "sent").length;
+  return (
+    <div className="mb-3 space-y-1.5 rounded-lg border bg-background/40 p-2">
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-medium">Report delivery</span>
+        {undelivered > 0 && (
+          <Badge variant="outline" className="h-4 px-1.5 text-[10px] font-normal border-red-500/40 bg-red-500/10">
+            {undelivered} not delivered
+          </Badge>
+        )}
+      </div>
+      {deliveries.map((d, i) => (
+        <div key={`${d.node}-${d.target ?? ""}-${i}`} className="flex flex-wrap items-baseline gap-1.5">
+          <Badge
+            variant="outline"
+            className={`h-4 px-1.5 text-[10px] font-normal ${DELIVERY_TONE[d.status] ?? ""}`}
+          >
+            {d.status}
+          </Badge>
+          <span className="font-mono text-[11px]">{d.node}</span>
+          <span className="text-[11px] text-muted-foreground">
+            → {d.kind}
+            {d.target ? ` ${d.target}` : ""} — {d.detail}
+          </span>
+        </div>
+      ))}
     </div>
   );
 }
@@ -453,12 +522,19 @@ function RunResultPanel({
     () => parseRunNodes(result.output, graph),
     [result.output, graph],
   );
+  const deliveries = result.deliveries ?? [];
+  const undeliveredCount = deliveries.filter((d) => d.status !== "sent").length;
 
   return (
     <div className="border-t bg-card/60">
       <div className="flex items-center justify-between px-4 py-2">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium">Run result</span>
+          {undeliveredCount > 0 && (
+            <Badge variant="outline" className="border-red-500/40 bg-red-500/10">
+              {undeliveredCount} report{undeliveredCount === 1 ? "" : "s"} not delivered
+            </Badge>
+          )}
           {result.pendingApprovals.length > 0 && (
             <Badge variant="outline" className="border-amber-500/40 bg-amber-500/10">
               {result.pendingApprovals.length} pending approval
@@ -481,6 +557,8 @@ function RunResultPanel({
             Waiting on: {result.pendingApprovals.join(", ")}
           </p>
         )}
+
+        {deliveries.length > 0 && <DeliveryRows deliveries={deliveries} />}
 
         {nodeResults && nodeResults.length > 0 ? (
           <div className="mb-2 space-y-2">

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -47,9 +47,9 @@ pub use types::{
     grants_media_explicit,
 };
 pub use workflow_file::{
-    WORKFLOW_NODE_KINDS, WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef, WorkflowNodeKind,
-    WorkflowRetryDef, list_source_workflows, list_workflows_union, load_company_workflows,
-    load_workflow_union, parse_workflow,
+    WORKFLOW_DESTINATION_KINDS, WORKFLOW_NODE_KINDS, WorkflowDestinationDef, WorkflowEdgeDef,
+    WorkflowFile, WorkflowNodeDef, WorkflowNodeKind, WorkflowRetryDef, list_source_workflows,
+    list_workflows_union, load_company_workflows, load_workflow_union, parse_workflow,
 };
 // Crate-internal only: the workflow creator (issue #69) builds a `RawWorkflow`
 // from its request body, renders it to TOML, and re-parses it through

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -480,6 +480,7 @@ to = "done"
                     on_error: None,
                     retry: None,
                     requires_approval: None,
+                    destination: None,
                 },
                 RawNode {
                     id: "worker".to_string(),
@@ -492,6 +493,7 @@ to = "done"
                     on_error: None,
                     retry: None,
                     requires_approval: None,
+                    destination: None,
                 },
                 RawNode {
                     id: "done".to_string(),
@@ -504,6 +506,7 @@ to = "done"
                     on_error: None,
                     retry: None,
                     requires_approval: None,
+                    destination: None,
                 },
             ],
             edges: vec![
@@ -770,6 +773,7 @@ to = "done"
                 on_error: None,
                 retry: None,
                 requires_approval: None,
+                destination: None,
             });
         }
         assert!(draft.nodes.len() > MAX_WORKFLOW_NODES);

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -203,6 +203,10 @@ pub struct WorkflowNodeDef {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct WorkflowDestinationDef {
     /// One of [`WORKFLOW_DESTINATION_KINDS`].
+    /// `#[serde(default)]` like every other field on the raw shapes: an omitted
+    /// `kind` becomes a prosumer-language validation problem rather than a raw
+    /// serde trace out of the TOML parser or the create route.
+    #[serde(default)]
     pub kind: String,
     /// The recipient address (`email`) or channel id (`channel`). Absent for
     /// `owner`, which the host resolves from the company's own directory.
@@ -738,6 +742,10 @@ fn validate(raw: &RawWorkflow) -> Vec<String> {
                         ));
                     }
                 }
+                "" => problems.push(format!(
+                    "{label} has a `destination` that names no `kind` — use one of {}.",
+                    WORKFLOW_DESTINATION_KINDS.join(", ")
+                )),
                 other => problems.push(format!(
                     "{label} has an unknown `destination.kind` `{other}` — use one of {}.",
                     WORKFLOW_DESTINATION_KINDS.join(", ")

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -1654,7 +1654,8 @@ to = "done"
         "#;
         let err = parse_workflow(src).unwrap_err();
         assert!(
-            err.to_string().contains("only `output` nodes route a report"),
+            err.to_string()
+                .contains("only `output` nodes route a report"),
             "{err}"
         );
     }

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -40,6 +40,13 @@ pub const WORKFLOW_NODE_KINDS: &[&str] = &[
     "sub_workflow",
 ];
 
+/// The destination kinds an `output` node may route its report to.
+///
+/// Deliberately closed: each kind has its own server-side resolution and its
+/// own policy gate (see [`crate::workflows::delivery`]), so a new kind is a
+/// deliberate addition, never a free-form string an author can invent.
+pub const WORKFLOW_DESTINATION_KINDS: &[&str] = &["owner", "email", "channel"];
+
 /// A node kind in a workflow graph.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WorkflowNodeKind {
@@ -169,6 +176,38 @@ pub struct WorkflowNodeDef {
     /// When `true`, the node pauses awaiting operator approval before it runs —
     /// the engine surfaces it on `WorkflowRun.pending_approvals`.
     pub requires_approval: Option<bool>,
+    /// Where this node's report is delivered once the run finishes — `output`
+    /// nodes only. `None` (every legacy graph) keeps the pre-#170 behaviour: the
+    /// value surfaces in the run-result drawer and goes nowhere else.
+    pub destination: Option<WorkflowDestinationDef>,
+}
+
+/// Where an `output` node's report goes when the run completes.
+///
+/// **The engine never sees this.** Delivery executes host-side, after
+/// `tinyflows::engine::run` returns, in
+/// [`deliver_outputs`](crate::workflows::delivery::deliver_outputs) — so this is
+/// not engine config and must not live in [`WorkflowNodeDef::config`], where it
+/// would be an inert key silently riding into the engine graph. It is first-class
+/// model data for the same reason [`WorkflowRetryDef`] is: the console and
+/// validation see exactly one shape.
+///
+/// Each `kind` carries a different target contract, enforced by
+/// [`validate`]:
+///
+/// | `kind`    | `target`                      | Who it reaches |
+/// |-----------|-------------------------------|----------------|
+/// | `owner`   | must be **absent**            | the company's active Admin users, else the operator channel |
+/// | `email`   | required, must contain `@`    | that address — **only** if the company grants `email` and the recipient is an established thread |
+/// | `channel` | required, a wired channel id  | that [`ChannelAdapter`](crate::ports::ChannelAdapter) |
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct WorkflowDestinationDef {
+    /// One of [`WORKFLOW_DESTINATION_KINDS`].
+    pub kind: String,
+    /// The recipient address (`email`) or channel id (`channel`). Absent for
+    /// `owner`, which the host resolves from the company's own directory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
 }
 
 /// A node's typed retry policy. Mirrors the free-form `retry.*` keys the
@@ -249,6 +288,10 @@ pub(crate) struct RawNode {
     pub(crate) retry: Option<WorkflowRetryDef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) requires_approval: Option<bool>,
+    /// Kept LAST in the struct: `toml::to_string` refuses to emit a scalar after
+    /// a table, so a table-valued field must not be followed by a scalar one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) destination: Option<WorkflowDestinationDef>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -320,6 +363,7 @@ pub fn parse_workflow(toml_src: &str) -> Result<WorkflowFile> {
                 on_error: node.on_error,
                 retry: node.retry,
                 requires_approval: node.requires_approval,
+                destination: node.destination,
             })
             .collect(),
         edges: raw
@@ -660,12 +704,62 @@ fn validate(raw: &RawWorkflow) -> Vec<String> {
             }
         }
 
+        // `destination` routes an `output` node's report to a person or a
+        // channel after the run finishes. Only `output` nodes report back, and
+        // each kind has its own target contract — an author who gets this wrong
+        // must hear about it here, not discover a silently undelivered report.
+        if let Some(destination) = &node.destination {
+            if kind != Some(WorkflowNodeKind::Output) {
+                problems.push(format!(
+                    "{label} sets `destination` but is a `{}` node — only `output` nodes route a report.",
+                    node.kind
+                ));
+            }
+            let target = destination.target.as_deref().map(str::trim).unwrap_or("");
+            match destination.kind.trim() {
+                "owner" => {
+                    if !target.is_empty() {
+                        problems.push(format!(
+                            "{label} sets a `target` on an `owner` destination — the owner is resolved from the company's own admins, so leave it out."
+                        ));
+                    }
+                }
+                "email" => {
+                    if !target.contains('@') {
+                        problems.push(format!(
+                            "{label} has an `email` destination whose `target` `{target}` is not an email address — give the recipient's full address."
+                        ));
+                    }
+                }
+                "channel" => {
+                    if target.is_empty() {
+                        problems.push(format!(
+                            "{label} has a `channel` destination with no `target` — name the channel to post the report to."
+                        ));
+                    }
+                }
+                other => problems.push(format!(
+                    "{label} has an unknown `destination.kind` `{other}` — use one of {}.",
+                    WORKFLOW_DESTINATION_KINDS.join(", ")
+                )),
+            }
+        }
+
         // Reserved config keys: the first-class fields above are written into
         // the engine config LAST, so a `config` entry naming one would be
-        // silently ignored — reject it as a footgun instead. `agent_ref` is
+        // silently ignored — reject it as a footgun instead. `destination` is
+        // reserved for a different reason: it is never engine config at all
+        // (delivery runs host-side), so a `config.destination` would ride into
+        // the engine graph as an inert key and deliver nothing. `agent_ref` is
         // reserved on `agent` nodes (translation binds it from `agent`).
         if let Some(toml::Value::Table(table)) = &node.config {
-            for reserved in ["on_error", "retry", "requires_approval", "schedule"] {
+            for reserved in [
+                "on_error",
+                "retry",
+                "requires_approval",
+                "schedule",
+                "destination",
+            ] {
                 if table.contains_key(reserved) {
                     problems.push(format!(
                         "{label} puts `{reserved}` inside `config` — set it as a first-class node field, not in `config`."
@@ -792,6 +886,7 @@ mod tests {
                     on_error: None,
                     retry: None,
                     requires_approval: None,
+                    destination: None,
                 },
                 RawNode {
                     id: "worker".to_string(),
@@ -804,6 +899,7 @@ mod tests {
                     on_error: None,
                     retry: None,
                     requires_approval: None,
+                    destination: None,
                 },
             ],
             edges: vec![RawEdge {
@@ -842,6 +938,7 @@ mod tests {
                 on_error: None,
                 retry: None,
                 requires_approval: None,
+                destination: None,
             }],
             edges: vec![],
         };
@@ -1446,6 +1543,224 @@ mod tests {
         assert!(start.on_error.is_none());
         assert!(start.retry.is_none());
         assert!(start.requires_approval.is_none());
+        assert!(start.destination.is_none());
+    }
+
+    // --- Output destination (issue #170) ------------------------------------
+
+    /// A graph with one `output` node carrying `destination` of `kind`, plus an
+    /// optional `target` line.
+    fn with_destination(kind: &str, target: Option<&str>) -> String {
+        let target_line = target
+            .map(|t| format!("target = \"{t}\"\n"))
+            .unwrap_or_default();
+        format!(
+            r#"
+id = "wf"
+name = "WF"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "done"
+kind = "output"
+name = "Report back"
+[node.destination]
+kind = "{kind}"
+{target_line}
+[[edge]]
+from = "start"
+to = "done"
+"#
+        )
+    }
+
+    /// Each of the three destination kinds parses onto the first-class field
+    /// with its target contract intact.
+    #[test]
+    fn output_destinations_parse_for_every_kind() {
+        let owner = parse_workflow(&with_destination("owner", None)).expect("owner parses");
+        let dest = owner.nodes[1].destination.as_ref().expect("present");
+        assert_eq!(dest.kind, "owner");
+        assert_eq!(dest.target, None);
+
+        let email = parse_workflow(&with_destination("email", Some("ada@example.com")))
+            .expect("email parses");
+        let dest = email.nodes[1].destination.as_ref().expect("present");
+        assert_eq!(dest.kind, "email");
+        assert_eq!(dest.target.as_deref(), Some("ada@example.com"));
+
+        let channel =
+            parse_workflow(&with_destination("channel", Some("operator"))).expect("channel parses");
+        let dest = channel.nodes[1].destination.as_ref().expect("present");
+        assert_eq!(dest.kind, "channel");
+        assert_eq!(dest.target.as_deref(), Some("operator"));
+    }
+
+    #[test]
+    fn unknown_destination_kind_is_rejected() {
+        let err = parse_workflow(&with_destination("carrier_pigeon", Some("x"))).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("unknown `destination.kind`"), "{message}");
+        // The message names what IS supported, not just what isn't.
+        assert!(message.contains("owner"), "{message}");
+    }
+
+    /// An `email` destination MUST name an address. This is the validation half
+    /// of the security boundary: a workflow cannot mail "somebody" — the
+    /// recipient is pinned in the graph, where a reviewer can see it.
+    #[test]
+    fn email_destination_without_an_address_is_rejected() {
+        let err = parse_workflow(&with_destination("email", Some("ada"))).unwrap_err();
+        assert!(err.to_string().contains("not an email address"), "{err}");
+        let err = parse_workflow(&with_destination("email", None)).unwrap_err();
+        assert!(err.to_string().contains("not an email address"), "{err}");
+    }
+
+    #[test]
+    fn channel_destination_without_a_target_is_rejected() {
+        let err = parse_workflow(&with_destination("channel", None)).unwrap_err();
+        assert!(err.to_string().contains("no `target`"), "{err}");
+    }
+
+    /// `owner` resolves server-side, so a target on it is a mistake worth
+    /// naming — otherwise an author writes an address there and quietly gets
+    /// the admins instead.
+    #[test]
+    fn owner_destination_with_a_target_is_rejected() {
+        let err = parse_workflow(&with_destination("owner", Some("ada@example.com"))).unwrap_err();
+        assert!(err.to_string().contains("`owner` destination"), "{err}");
+    }
+
+    /// Only `output` nodes report back, so a `destination` anywhere else is a
+    /// silent no-op waiting to happen.
+    #[test]
+    fn destination_on_a_non_output_node_is_rejected() {
+        let src = r#"
+            id = "wf"
+            name = "WF"
+            [[node]]
+            id = "start"
+            kind = "trigger"
+            name = "Start"
+            [[node]]
+            id = "worker"
+            kind = "agent"
+            name = "Worker"
+            agent = "ceo"
+            [node.destination]
+            kind = "owner"
+        "#;
+        let err = parse_workflow(src).unwrap_err();
+        assert!(
+            err.to_string().contains("only `output` nodes route a report"),
+            "{err}"
+        );
+    }
+
+    /// `destination` inside `config` would ride into the engine graph as an
+    /// inert key and deliver nothing — reject it like the other reserved keys.
+    #[test]
+    fn destination_inside_config_is_rejected() {
+        let src = r#"
+            id = "wf"
+            name = "WF"
+            [[node]]
+            id = "start"
+            kind = "trigger"
+            name = "Start"
+            [[node]]
+            id = "done"
+            kind = "output"
+            name = "Done"
+            [node.config]
+            destination = "owner"
+            [[edge]]
+            from = "start"
+            to = "done"
+        "#;
+        let err = parse_workflow(src).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("destination"), "{message}");
+        assert!(message.contains("inside `config`"), "{message}");
+    }
+
+    /// A destination-bearing graph renders back to TOML and re-parses to the
+    /// same model — the create route's persist path depends on this.
+    #[test]
+    fn destination_round_trips_through_render_and_parse() {
+        let raw = RawWorkflow {
+            id: "wf".to_string(),
+            name: "WF".to_string(),
+            description: None,
+            nodes: vec![
+                RawNode {
+                    id: "start".to_string(),
+                    kind: "trigger".to_string(),
+                    name: "Start".to_string(),
+                    summary: None,
+                    agent: None,
+                    config: None,
+                    on_error: None,
+                    retry: None,
+                    requires_approval: None,
+                    destination: None,
+                },
+                RawNode {
+                    id: "done".to_string(),
+                    kind: "output".to_string(),
+                    name: "Report".to_string(),
+                    summary: None,
+                    agent: None,
+                    config: None,
+                    on_error: None,
+                    retry: None,
+                    requires_approval: None,
+                    destination: Some(WorkflowDestinationDef {
+                        kind: "email".to_string(),
+                        target: Some("ada@example.com".to_string()),
+                    }),
+                },
+            ],
+            edges: vec![RawEdge {
+                from: "start".to_string(),
+                to: "done".to_string(),
+                label: None,
+            }],
+        };
+        let toml_src = render_workflow(&raw).expect("renders");
+        let file = parse_workflow(&toml_src).expect("re-parses");
+        let dest = file.nodes[1].destination.as_ref().expect("present");
+        assert_eq!(dest.kind, "email");
+        assert_eq!(dest.target.as_deref(), Some("ada@example.com"));
+    }
+
+    /// A legacy graph (no `destination` anywhere) renders byte-identically to
+    /// what it rendered before the field existed — `skip_serializing_if` is what
+    /// keeps an unchanged file from churning on every re-save.
+    #[test]
+    fn a_graph_without_a_destination_renders_no_destination_key() {
+        let raw = RawWorkflow {
+            id: "wf".to_string(),
+            name: "WF".to_string(),
+            description: None,
+            nodes: vec![RawNode {
+                id: "start".to_string(),
+                kind: "trigger".to_string(),
+                name: "Start".to_string(),
+                summary: None,
+                agent: None,
+                config: None,
+                on_error: None,
+                retry: None,
+                requires_approval: None,
+                destination: None,
+            }],
+            edges: Vec::new(),
+        };
+        let toml_src = render_workflow(&raw).expect("renders");
+        assert!(!toml_src.contains("destination"), "{toml_src}");
     }
 
     // --- trigger schedule (issue #169) --------------------------------------

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -1710,6 +1710,7 @@ to = "done"
                     name: "Start".to_string(),
                     summary: None,
                     agent: None,
+                    schedule: None,
                     config: None,
                     on_error: None,
                     retry: None,
@@ -1722,6 +1723,7 @@ to = "done"
                     name: "Report".to_string(),
                     summary: None,
                     agent: None,
+                    schedule: None,
                     config: None,
                     on_error: None,
                     retry: None,
@@ -1760,6 +1762,7 @@ to = "done"
                 name: "Start".to_string(),
                 summary: None,
                 agent: None,
+                schedule: None,
                 config: None,
                 on_error: None,
                 retry: None,
@@ -1794,6 +1797,7 @@ to = "done"
                     on_error: None,
                     retry: None,
                     requires_approval: None,
+                    destination: None,
                 },
                 RawNode {
                     id: "done".to_string(),
@@ -1806,6 +1810,7 @@ to = "done"
                     on_error: None,
                     retry: None,
                     requires_approval: None,
+                    destination: None,
                 },
             ],
             edges: vec![RawEdge {
@@ -2021,6 +2026,7 @@ to = "done"
                 on_error: None,
                 retry: None,
                 requires_approval: None,
+                destination: None,
             }],
             edges: Vec::new(),
         };
@@ -2052,6 +2058,7 @@ to = "done"
                     on_error: n.on_error.clone(),
                     retry: n.retry.clone(),
                     requires_approval: n.requires_approval,
+                    destination: n.destination.clone(),
                 })
                 .collect(),
             edges: Vec::new(),

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -1131,6 +1131,7 @@ description = "Runs Acme."
             media: None,
             composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
+            delivery: None,
         };
         HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record())
     }
@@ -1277,6 +1278,7 @@ description = "Builds it."
             media: None,
             composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
+            delivery: None,
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record_two()),
@@ -1341,6 +1343,7 @@ members = ["engineer"]
             media: None,
             composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
+            delivery: None,
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record_two()),
@@ -1982,6 +1985,7 @@ members = ["engineer"]
             media: None,
             composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
+            delivery: None,
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record),
@@ -2573,6 +2577,7 @@ members = ["eng1", "eng2"]
             media: None,
             composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
+            delivery: None,
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record());
 
@@ -2698,6 +2703,7 @@ members = ["eng1", "eng2"]
             media: None,
             composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
+            delivery: None,
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record());
 
@@ -2769,6 +2775,7 @@ members = ["eng1", "eng2"]
             media: None,
             composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
+            delivery: None,
         };
         HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record())
     }
@@ -3049,6 +3056,7 @@ members = ["eng1", "eng2"]
             media: None,
             composio: None,
             steer,
+            delivery: None,
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record()),
@@ -3355,6 +3363,7 @@ members = ["eng1", "eng2"]
             media: None,
             composio: None,
             steer,
+            delivery: None,
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record_with_desk()),

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -702,6 +702,7 @@ mod tests {
             media: None,
             composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
+            delivery: None,
         }
     }
 

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -251,6 +251,19 @@ pub struct HarnessDeps {
     /// [`delegations`](Self::delegations)); the default is an empty registry,
     /// which simply lists nothing and rejects every steer as `not in flight`.
     pub steer: crate::company::steer::InflightRegistry,
+    /// Issue #170 — the ports an `output` node's `destination` needs to route a
+    /// finished workflow's report to a person or a channel (mail handle, inbox,
+    /// user directory, wired channels), bundled so this struct grows one field
+    /// rather than four.
+    ///
+    /// Read post-engine by
+    /// [`deliver_outputs`](crate::workflows::delivery::deliver_outputs) — never
+    /// by the engine, which knows nothing about destinations. `None` (the
+    /// default at every construction site but the production runtime builder)
+    /// **fails closed and loud**: nothing is sent and the run result carries a
+    /// `failed` row saying delivery is not wired, so an authored destination can
+    /// never quietly do nothing.
+    pub delivery: Option<crate::workflows::WorkflowDeliveryDeps>,
 }
 
 /// One live openhuman agent, keyed by its manifest id.
@@ -1547,6 +1560,7 @@ description = "Builds the product."
                 media: None,
                 composio: None,
                 steer: crate::company::steer::InflightRegistry::default(),
+                delivery: None,
             },
             store,
             meter,
@@ -1606,6 +1620,7 @@ description = "Builds the product."
             media: None,
             composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
+            delivery: None,
         };
 
         let roster = build_roster(&record(), &deps, &[]).expect("roster builds with skills");
@@ -1890,6 +1905,7 @@ description = "Builds the product."
             media: None,
             composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
+            delivery: None,
         };
         let roster = build_roster(&record(), &deps, &[]).expect("roster");
         // Keep the tempdir alive for the agent's workspace by leaking it into the
@@ -2046,6 +2062,7 @@ description = "Builds the product."
             media: None,
             composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
+            delivery: None,
         };
         let pool = HarnessPool::new();
         let rec = record();
@@ -2354,6 +2371,7 @@ description = "Builds the product."
             media: None,
             composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
+            delivery: None,
         };
         let pool = HarnessPool::new();
 
@@ -2506,6 +2524,7 @@ description = "Sets direction."
             media: None,
             composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
+            delivery: None,
         };
         let pool = HarnessPool::new();
         let rec = granting_record();
@@ -2643,6 +2662,7 @@ description = "Sets direction."
             composio: None,
             artifacts: None,
             steer: crate::company::steer::InflightRegistry::default(),
+            delivery: None,
         }
     }
 

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -1974,6 +1974,7 @@ name = "Morning"
             Self::new(WorkflowRun {
                 output: Value::Null,
                 pending_approvals: Vec::new(),
+                deliveries: Vec::new(),
             })
         }
     }
@@ -2059,6 +2060,7 @@ name = "Morning"
                 "nodes": { "worker": { "items": ["did the thing"] }, "done": { "items": [] } }
             }),
             pending_approvals: Vec::new(),
+            deliveries: Vec::new(),
         });
         let calls = runner_impl.calls.clone();
         let runner: Arc<dyn WorkflowRunner> = Arc::new(runner_impl);
@@ -2092,6 +2094,7 @@ name = "Morning"
         let runner: Arc<dyn WorkflowRunner> = Arc::new(StubRunner::new(WorkflowRun {
             output: json!({ "nodes": { "worker": { "items": [] } } }),
             pending_approvals: vec!["worker".to_string()],
+            deliveries: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -2266,6 +2269,7 @@ name = "Morning"
         let runner: Arc<dyn WorkflowRunner> = Arc::new(StubRunner::new(WorkflowRun {
             output: json!({ "nodes": { "worker": { "items": ["hi"] } } }),
             pending_approvals: Vec::new(),
+            deliveries: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -2342,6 +2346,7 @@ name = "Morning"
         let runner: Arc<dyn WorkflowRunner> = Arc::new(StubRunner::new(WorkflowRun {
             output: json!({ "nodes": { "done": { "items": ["ok"] } } }),
             pending_approvals: Vec::new(),
+            deliveries: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -1325,6 +1325,7 @@ impl From<CreateWorkflowArgs> for RawWorkflow {
                     on_error: None,
                     retry: None,
                     requires_approval: None,
+                    destination: None,
                 })
                 .collect(),
             edges: args

--- a/src/ports/inbox.rs
+++ b/src/ports/inbox.rs
@@ -73,6 +73,42 @@ pub trait InboxStore: Send + Sync {
         limit: usize,
         offset: usize,
     ) -> Result<Vec<EmailRecord>>;
+    /// Whether `key` holds any **inbound** mail from `from_email` — i.e. whether
+    /// that address is an established correspondent.
+    ///
+    /// A first-class port method rather than a caller-side scan because callers
+    /// use it as a *security* gate (a workflow may only email an address that
+    /// has written in first), and a gate built on a paginated read silently
+    /// weakens as the inbox grows: [`messages`](Self::messages) returns
+    /// oldest-first, so any capped page stops covering the newest mail. This
+    /// question has one right answer at every inbox size, so the port answers it.
+    ///
+    /// The default implementation reads the whole inbox, which is correct
+    /// everywhere and cheap on the append-only file backend (whose `messages`
+    /// already parses the entire log on any call). A backend that can index
+    /// `from_email` should override this with a single indexed lookup rather
+    /// than materialising the mailbox.
+    ///
+    /// Matching is case-insensitive on a trimmed address, mirroring
+    /// [`normalize_email`](crate::ports::normalize_email). A blank `from_email`
+    /// is `false`, never a match-anything.
+    async fn has_inbound_from(
+        &self,
+        company: &CompanyId,
+        key: &str,
+        from_email: &str,
+    ) -> Result<bool> {
+        let needle = from_email.trim().to_ascii_lowercase();
+        if needle.is_empty() {
+            return Ok(false);
+        }
+        Ok(self
+            .messages(company, key, usize::MAX, 0)
+            .await?
+            .iter()
+            .any(|r| !r.outbound && r.from_email.trim().to_ascii_lowercase() == needle))
+    }
+
     /// Appends one email to its addressed inbox.
     async fn append(&self, company: &CompanyId, msg: &EmailRecord) -> Result<()>;
     /// Marks messages in `key` as read — the given `ids`, or every message when

--- a/src/ports/inbox.rs
+++ b/src/ports/inbox.rs
@@ -83,11 +83,15 @@ pub trait InboxStore: Send + Sync {
     /// oldest-first, so any capped page stops covering the newest mail. This
     /// question has one right answer at every inbox size, so the port answers it.
     ///
-    /// The default implementation reads the whole inbox, which is correct
-    /// everywhere and cheap on the append-only file backend (whose `messages`
-    /// already parses the entire log on any call). A backend that can index
-    /// `from_email` should override this with a single indexed lookup rather
-    /// than materialising the mailbox.
+    /// The default implementation reads the whole inbox. That is correct at any
+    /// size, and it is what **every** backend does today: `fs` parses its entire
+    /// append-only log on any `messages` call regardless of limit, and the
+    /// `sqlite`/`mongodb` backends store each message as an opaque
+    /// `record_json` blob with no queryable sender column, so neither can
+    /// answer this from an index without a schema migration. Overriding with a
+    /// real indexed lookup (`… WHERE from_email = ? AND NOT outbound LIMIT 1`)
+    /// is worth doing when that migration happens — correctness is not the
+    /// reason to wait, cost is.
     ///
     /// Matching is case-insensitive on a trimmed address, mirroring
     /// [`normalize_email`](crate::ports::normalize_email). A blank `from_email`

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -55,7 +55,7 @@ pub use tools::ToolProvider;
 pub use types::*;
 pub use usage::{SampleKind, UsageMeter, UsageSample};
 pub use users::{InviteRecord, UserRecord, UserRole, UserStatus, UserStore, normalize_email};
-pub use workflow_runner::{WorkflowRun, WorkflowRunner};
+pub use workflow_runner::{DeliveryReport, DeliveryStatus, WorkflowRun, WorkflowRunner};
 pub use workspace::{NodeKind, WorkspaceNode, WorkspaceStore};
 
 #[cfg(test)]

--- a/src/ports/workflow_runner.rs
+++ b/src/ports/workflow_runner.rs
@@ -64,7 +64,7 @@ pub enum DeliveryStatus {
 /// On an on-demand run these rows ride the run response into the console's
 /// run-result panel, so an operator can tell a delivered report from an
 /// undelivered one without reading a log. A scheduled run is not persisted, so
-/// its rows reach only the scheduler's log until issue #242 lands.
+/// its rows reach only the scheduler's log until issue #228 lands.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeliveryReport {

--- a/src/ports/workflow_runner.rs
+++ b/src/ports/workflow_runner.rs
@@ -27,6 +27,59 @@ pub struct WorkflowRun {
     /// Node ids that paused the run awaiting human approval. Empty for a run
     /// that reached its terminal node(s) without gating.
     pub pending_approvals: Vec<String>,
+    /// One row per attempt to route a reached `output` node's report to its
+    /// configured destination (issue #170), in graph order.
+    ///
+    /// Empty for a graph whose `output` nodes name no destination — the
+    /// pre-#170 shape — which is why it is `#[serde(default)]`: a `WorkflowRun`
+    /// deserialized from an older payload still loads.
+    ///
+    /// A delivery failure is reported here rather than failing the run: the work
+    /// the run did is still valid. An output node the run never reached
+    /// contributes no row at all, so an absent row means "not reached", never
+    /// "silently dropped".
+    #[serde(default)]
+    pub deliveries: Vec<DeliveryReport>,
+}
+
+/// What became of one attempt to deliver an `output` node's report.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DeliveryStatus {
+    /// The transport accepted the report.
+    Sent,
+    /// Deliberately not attempted — a policy precondition was unmet (a cold
+    /// email recipient, no mailbox configured). Not an error; the report simply
+    /// was not owed to that address under the current rules.
+    Skipped,
+    /// Refused by policy: the company does not grant what the destination needs.
+    Denied,
+    /// Attempted (or attemptable) and did not work — a transport error, an
+    /// unwired channel, or a runtime with no delivery ports at all.
+    Failed,
+}
+
+/// One attempt to route a reached `output` node's report somewhere.
+///
+/// Rides the run response into the console's run-result panel, so an operator
+/// can tell a delivered report from an undelivered one without reading a log.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeliveryReport {
+    /// The `output` node whose report this was.
+    pub node: String,
+    /// The destination kind as authored (`owner` / `email` / `channel`).
+    pub kind: String,
+    /// The address or channel actually addressed. For `owner` this is the
+    /// server-resolved recipient, not something the graph named.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    /// What became of the attempt.
+    pub status: DeliveryStatus,
+    /// An operator-readable reason, always populated — including on success, so
+    /// a `sent` row still says *how* it was sent (which matters for `owner`,
+    /// whose recipient the graph never named).
+    pub detail: String,
 }
 
 /// Runs a company's workflow graph to completion.

--- a/src/ports/workflow_runner.rs
+++ b/src/ports/workflow_runner.rs
@@ -61,8 +61,10 @@ pub enum DeliveryStatus {
 
 /// One attempt to route a reached `output` node's report somewhere.
 ///
-/// Rides the run response into the console's run-result panel, so an operator
-/// can tell a delivered report from an undelivered one without reading a log.
+/// On an on-demand run these rows ride the run response into the console's
+/// run-result panel, so an operator can tell a delivered report from an
+/// undelivered one without reading a log. A scheduled run is not persisted, so
+/// its rows reach only the scheduler's log until issue #242 lands.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeliveryReport {

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1013,6 +1013,23 @@ impl RuntimeBuilder {
                                 // never an env/platform key). `None` fails closed.
                                 composio: composio_config,
                                 steer,
+                                // Issue #170: the ports an `output` node's
+                                // `destination` needs. This is the ONLY site
+                                // that wires them — every other `HarnessDeps`
+                                // construction leaves `None`, which fails closed
+                                // with a loud "not wired" row on the run result.
+                                // All four are already resolved above: the
+                                // company's own mailbox handle, its inboxes (for
+                                // the established-thread gate and the outbound
+                                // audit record), its user directory (how `owner`
+                                // resolves server-side), and the wired channel
+                                // adapters (always at least `operator`).
+                                delivery: Some(crate::workflows::WorkflowDeliveryDeps {
+                                    mail: self.mail.clone(),
+                                    inbox: inbox.clone(),
+                                    users: ops.users.clone(),
+                                    channels: channels.clone(),
+                                }),
                             };
                             let record = CompanyRecord {
                                 id: id.clone(),

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -46,7 +46,8 @@
 //! needs somewhere durable an operator actually looks, and no such run-history
 //! surface exists for workflows yet (a manual run's deliveries are transient
 //! too — they live only in the drawer until it is dismissed). That is issue
-//! #228; this is the half that can be done without inventing a subsystem.
+//! #228, and the durable record it needs is issue #242's first-class `Run`;
+//! this is the half that can be done without inventing a subsystem.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -528,6 +528,7 @@ mod test {
             Ok(WorkflowRun {
                 output: Value::Null,
                 pending_approvals: Vec::new(),
+                deliveries: Vec::new(),
             })
         }
     }

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -29,6 +29,24 @@
 //!
 //! Missed runs are skipped, never caught up — identical to the manifest cron
 //! scheduler, so a restart after downtime does not burst.
+//!
+//! ## Report delivery on a scheduled run
+//!
+//! An `output` node may route its report to a person or a channel (issue #170).
+//! The runner delivers it either way — the scheduler drives the same
+//! [`WorkflowRunner`] port the console's Run button does — but only a manual run
+//! gets the [`WorkflowRun::deliveries`](crate::ports::WorkflowRun) rows back in
+//! an HTTP response for the console to render. A scheduled run has no response
+//! and no one watching, so this module logs them instead.
+//!
+//! **Be clear about the ceiling of that.** A log line reaches whoever can read
+//! the host's stdout. On a self-hosted deployment that is the operator; on a
+//! hosted tenant it is emphatically not — it is us. So this makes a failed
+//! scheduled delivery *diagnosable*, not *operator-visible*. Closing that gap
+//! needs somewhere durable an operator actually looks, and no such run-history
+//! surface exists for workflows yet (a manual run's deliveries are transient
+//! too — they live only in the drawer until it is dismissed). That is issue
+//! #228; this is the half that can be done without inventing a subsystem.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
@@ -40,12 +58,47 @@ use tokio::task::JoinHandle;
 
 use crate::company::{WorkflowFile, list_workflows_union};
 use crate::ports::types::CompanyId;
+use crate::ports::{DeliveryReport, DeliveryStatus};
 use crate::runtime::CompanyRegistry;
 use crate::runtime::cron::{CivilTime, CronExpr};
 use crate::runtime::scheduler::{Clock, MINUTE_MS, millis_to_next_minute};
 
 /// Identifies one schedulable workflow: which company, which graph.
 type WorkflowKey = (CompanyId, String);
+
+/// How a scheduled run's report deliveries came out, folded for one log line.
+///
+/// A count per status rather than a bare total: `skipped` and `denied` mean
+/// policy refused to send (a cold recipient, a missing `email` grant) while
+/// `failed` means something broke, and an operator reading a scheduled run's
+/// outcome needs to tell those apart before deciding whether to act.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct DeliveryCounts {
+    sent: usize,
+    skipped: usize,
+    denied: usize,
+    failed: usize,
+}
+
+impl DeliveryCounts {
+    fn of(reports: &[DeliveryReport]) -> Self {
+        let mut counts = Self::default();
+        for report in reports {
+            match report.status {
+                DeliveryStatus::Sent => counts.sent += 1,
+                DeliveryStatus::Skipped => counts.skipped += 1,
+                DeliveryStatus::Denied => counts.denied += 1,
+                DeliveryStatus::Failed => counts.failed += 1,
+            }
+        }
+        counts
+    }
+
+    /// Reports that did NOT reach their destination, whatever the reason.
+    fn undelivered(&self) -> usize {
+        self.skipped + self.denied + self.failed
+    }
+}
 
 /// Drives the cron schedules authored on saved workflow graphs.
 pub struct WorkflowScheduler {
@@ -238,12 +291,44 @@ impl WorkflowScheduler {
                     let _claim = claim;
                     let (company, workflow_id) = key;
                     match runner.run(&company, &workflow, input).await {
-                        Ok(run) => tracing::info!(
-                            %company,
-                            workflow = %workflow_id,
-                            pending_approvals = run.pending_approvals.len(),
-                            "workflow scheduler: scheduled run finished"
-                        ),
+                        Ok(run) => {
+                            // A manual run hands `deliveries` back in the HTTP
+                            // response and the console renders it. A scheduled
+                            // run has no response and nobody watching, so
+                            // without this the exact case the operator most
+                            // needs to know about — the owner summary that did
+                            // NOT go out — would be the quietest thing the
+                            // system does.
+                            let counts = DeliveryCounts::of(&run.deliveries);
+                            // One line per undelivered report: a count alone
+                            // says something is wrong without saying what to
+                            // fix, and `detail` is the part that names the fix.
+                            for report in &run.deliveries {
+                                if report.status == DeliveryStatus::Sent {
+                                    continue;
+                                }
+                                tracing::warn!(
+                                    %company,
+                                    workflow = %workflow_id,
+                                    node = %report.node,
+                                    kind = %report.kind,
+                                    target = report.target.as_deref().unwrap_or("-"),
+                                    status = ?report.status,
+                                    detail = %report.detail,
+                                    "workflow scheduler: a scheduled run's report was NOT delivered"
+                                );
+                            }
+                            tracing::info!(
+                                %company,
+                                workflow = %workflow_id,
+                                pending_approvals = run.pending_approvals.len(),
+                                sent = counts.sent,
+                                skipped = counts.skipped,
+                                denied = counts.denied,
+                                failed = counts.failed,
+                                "workflow scheduler: scheduled run finished"
+                            );
+                        }
                         Err(err) => tracing::warn!(
                             %company,
                             workflow = %workflow_id,
@@ -426,6 +511,84 @@ mod test {
     use crate::ports::{WorkflowRun, WorkflowRunner};
     use crate::runtime::{FakeClock, RuntimeBuilder};
 
+    // --- tracing capture -----------------------------------------------------
+    //
+    // The scheduler's only channel for a failed scheduled delivery IS a log
+    // line (see the module docs), so proving it is "observable rather than
+    // silent" means reading what it actually emitted. The run happens on a
+    // spawned task, and a thread-local subscriber does not reach one, so the
+    // capture is installed process-wide exactly once. Every test in this binary
+    // therefore shares one buffer — assertions must key on something unique to
+    // their own company id, never on "the buffer contains one line".
+
+    /// The shared capture buffer. `None` until `captured_logs()` installs it.
+    static CAPTURE: std::sync::OnceLock<Arc<Mutex<Vec<u8>>>> = std::sync::OnceLock::new();
+
+    /// A writer that accumulates one event and appends it to the shared buffer
+    /// in a single locked write on drop, so events from concurrent tests
+    /// interleave whole-line rather than mid-line.
+    struct CaptureWriter {
+        buf: Vec<u8>,
+        sink: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl std::io::Write for CaptureWriter {
+        fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+            self.buf.extend_from_slice(data);
+            Ok(data.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl Drop for CaptureWriter {
+        fn drop(&mut self) {
+            if !self.buf.is_empty() {
+                self.sink.lock().unwrap().extend_from_slice(&self.buf);
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct MakeCapture(Arc<Mutex<Vec<u8>>>);
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for MakeCapture {
+        type Writer = CaptureWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            CaptureWriter {
+                buf: Vec::new(),
+                sink: self.0.clone(),
+            }
+        }
+    }
+
+    /// Installs the process-wide capture on first call and returns the buffer.
+    fn captured_logs() -> Arc<Mutex<Vec<u8>>> {
+        CAPTURE
+            .get_or_init(|| {
+                let sink = Arc::new(Mutex::new(Vec::new()));
+                let subscriber = tracing_subscriber::fmt()
+                    .with_writer(MakeCapture(sink.clone()))
+                    .with_max_level(tracing::Level::INFO)
+                    .with_ansi(false)
+                    .finish();
+                // Only this module installs one, so it cannot lose the race to
+                // another test; if some future test adds a subscriber, this
+                // returns Err and the capture tests would fail loudly rather
+                // than silently asserting on an empty buffer.
+                tracing::subscriber::set_global_default(subscriber)
+                    .expect("no other global tracing subscriber in the test binary");
+                sink
+            })
+            .clone()
+    }
+
+    /// The captured log text so far.
+    fn captured_text(sink: &Arc<Mutex<Vec<u8>>>) -> String {
+        String::from_utf8_lossy(&sink.lock().unwrap()).to_string()
+    }
+
     fn tmp_home() -> std::path::PathBuf {
         std::env::temp_dir().join(format!(
             "opencompany-wfsched-{}",
@@ -481,6 +644,9 @@ mod test {
         completed: Arc<AtomicUsize>,
         /// When set, a run parks until the test adds a permit.
         gate: Option<Arc<Semaphore>>,
+        /// The delivery rows every run reports back, so a test can drive the
+        /// scheduler's undelivered-report path.
+        deliveries: Vec<DeliveryReport>,
     }
 
     impl RecordingRunner {
@@ -491,6 +657,7 @@ mod test {
                 started: started.clone(),
                 completed: completed.clone(),
                 gate: None,
+                deliveries: Vec::new(),
             });
             (runner, started, completed)
         }
@@ -502,8 +669,21 @@ mod test {
                 started: started.clone(),
                 completed: completed.clone(),
                 gate: Some(gate),
+                deliveries: Vec::new(),
             });
             (runner, started, completed)
+        }
+
+        /// A runner whose every run reports `deliveries` back.
+        fn with_deliveries(deliveries: Vec<DeliveryReport>) -> (Arc<Self>, Arc<AtomicUsize>) {
+            let completed = Arc::new(AtomicUsize::new(0));
+            let runner = Arc::new(Self {
+                started: Arc::new(Mutex::new(Vec::new())),
+                completed: completed.clone(),
+                gate: None,
+                deliveries,
+            });
+            (runner, completed)
         }
     }
 
@@ -528,7 +708,7 @@ mod test {
             Ok(WorkflowRun {
                 output: Value::Null,
                 pending_approvals: Vec::new(),
-                deliveries: Vec::new(),
+                deliveries: self.deliveries.clone(),
             })
         }
     }
@@ -716,6 +896,166 @@ to = "done"
         assert!(request.contains("Scheduled run"), "{request}");
         assert!(request.contains("* * * * *"), "{request}");
         assert!(!request.trim().is_empty());
+
+        cleanup(&home).await;
+    }
+
+    // --- report delivery on a scheduled run (issue #170) ---------------------
+
+    fn report(node: &str, status: DeliveryStatus, detail: &str) -> DeliveryReport {
+        DeliveryReport {
+            node: node.to_string(),
+            kind: "email".to_string(),
+            target: Some("ada@example.com".to_string()),
+            status,
+            detail: detail.to_string(),
+        }
+    }
+
+    /// The fold behind the summary line counts each status separately, because
+    /// "policy refused to send" and "something broke" are different problems.
+    #[test]
+    fn delivery_counts_separate_the_four_outcomes() {
+        let counts = DeliveryCounts::of(&[
+            report("a", DeliveryStatus::Sent, ""),
+            report("b", DeliveryStatus::Sent, ""),
+            report("c", DeliveryStatus::Skipped, ""),
+            report("d", DeliveryStatus::Denied, ""),
+            report("e", DeliveryStatus::Failed, ""),
+        ]);
+        assert_eq!(
+            counts,
+            DeliveryCounts {
+                sent: 2,
+                skipped: 1,
+                denied: 1,
+                failed: 1,
+            }
+        );
+        assert_eq!(counts.undelivered(), 3);
+        // The common case: nothing routed anywhere.
+        assert_eq!(DeliveryCounts::of(&[]), DeliveryCounts::default());
+        assert_eq!(DeliveryCounts::of(&[]).undelivered(), 0);
+    }
+
+    /// **The finding CodeRabbit raised.** A scheduled run whose report did not
+    /// go out must not be silent. There is no HTTP response and no drawer, so
+    /// the log line is the whole channel — this reads what the scheduler
+    /// actually emitted and asserts the operator-actionable parts are in it:
+    /// which company, which workflow, which node, and the `detail` that says
+    /// what to do about it.
+    #[tokio::test]
+    async fn a_scheduled_run_reports_an_undelivered_report() {
+        let sink = captured_logs();
+        let home = tmp_home();
+        // A company id unique to this test: the capture buffer is shared with
+        // every other test in the binary, so this is what makes the assertions
+        // about *this* run rather than about whatever else logged.
+        let company = "undelivered-co";
+        let (runner, completed) = RecordingRunner::with_deliveries(vec![
+            report(
+                "owner_summary",
+                DeliveryStatus::Skipped,
+                "this recipient has never written to the company",
+            ),
+            report("also_sent", DeliveryStatus::Sent, "emailed the recipient"),
+        ]);
+        let registry = company_with_overlays(
+            &home,
+            company,
+            vec![overlay("digest", Some("* * * * *"))],
+            Some(runner),
+            "running",
+        )
+        .await;
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry, clock);
+
+        assert_eq!(scheduler.tick().await, 1);
+        wait_for(|| completed.load(Ordering::SeqCst) == 1).await;
+        // The run task logs after `completed` is bumped, so wait for the line
+        // itself rather than racing it.
+        wait_for(|| captured_text(&sink).contains("owner_summary")).await;
+
+        let logs = captured_text(&sink);
+        let line = logs
+            .lines()
+            .find(|l| l.contains(company) && l.contains("was NOT delivered"))
+            .unwrap_or_else(|| panic!("no undelivered-report line for {company}: {logs}"));
+        assert!(line.contains("digest"), "names the workflow: {line}");
+        assert!(line.contains("owner_summary"), "names the node: {line}");
+        assert!(line.contains("Skipped"), "names the status: {line}");
+        assert!(
+            line.contains("never written to the company"),
+            "carries the detail, which is the part that says what to fix: {line}"
+        );
+
+        // The delivery that DID land gets no warning of its own — otherwise a
+        // healthy run would look broken.
+        assert_eq!(
+            logs.lines()
+                .filter(|l| l.contains(company) && l.contains("was NOT delivered"))
+                .count(),
+            1,
+            "{logs}"
+        );
+        // …and the run's own summary still reports the split.
+        let summary = logs
+            .lines()
+            .find(|l| l.contains(company) && l.contains("scheduled run finished"))
+            .unwrap_or_else(|| panic!("no summary line for {company}: {logs}"));
+        assert!(summary.contains("sent=1"), "{summary}");
+        assert!(summary.contains("skipped=1"), "{summary}");
+
+        cleanup(&home).await;
+    }
+
+    /// A scheduled run that delivered everything says so without crying wolf:
+    /// no warning line, and a summary that still accounts for what went out.
+    #[tokio::test]
+    async fn a_clean_scheduled_run_logs_no_delivery_warning() {
+        let sink = captured_logs();
+        let home = tmp_home();
+        let company = "clean-delivery-co";
+        let (runner, completed) = RecordingRunner::with_deliveries(vec![report(
+            "owner_summary",
+            DeliveryStatus::Sent,
+            "emailed the company's admin",
+        )]);
+        let registry = company_with_overlays(
+            &home,
+            company,
+            vec![overlay("digest", Some("* * * * *"))],
+            Some(runner),
+            "running",
+        )
+        .await;
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry, clock);
+
+        assert_eq!(scheduler.tick().await, 1);
+        wait_for(|| completed.load(Ordering::SeqCst) == 1).await;
+        wait_for(|| {
+            captured_text(&sink)
+                .lines()
+                .any(|l| l.contains(company) && l.contains("scheduled run finished"))
+        })
+        .await;
+
+        let logs = captured_text(&sink);
+        assert!(
+            !logs
+                .lines()
+                .any(|l| l.contains(company) && l.contains("was NOT delivered")),
+            "a fully delivered run must not warn: {logs}"
+        );
+        let summary = logs
+            .lines()
+            .find(|l| l.contains(company) && l.contains("scheduled run finished"))
+            .expect("a summary line");
+        assert!(summary.contains("sent=1"), "{summary}");
+        assert!(summary.contains("skipped=0"), "{summary}");
+        assert!(summary.contains("failed=0"), "{summary}");
 
         cleanup(&home).await;
     }

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -326,6 +326,9 @@ impl WorkflowScheduler {
                                 skipped = counts.skipped,
                                 denied = counts.denied,
                                 failed = counts.failed,
+                                // The one number worth alerting on, so a log
+                                // query need not sum the three refusal kinds.
+                                undelivered = counts.undelivered(),
                                 "workflow scheduler: scheduled run finished"
                             );
                         }
@@ -1006,6 +1009,7 @@ to = "done"
             .unwrap_or_else(|| panic!("no summary line for {company}: {logs}"));
         assert!(summary.contains("sent=1"), "{summary}");
         assert!(summary.contains("skipped=1"), "{summary}");
+        assert!(summary.contains("undelivered=1"), "{summary}");
 
         cleanup(&home).await;
     }
@@ -1056,6 +1060,7 @@ to = "done"
         assert!(summary.contains("sent=1"), "{summary}");
         assert!(summary.contains("skipped=0"), "{summary}");
         assert!(summary.contains("failed=0"), "{summary}");
+        assert!(summary.contains("undelivered=0"), "{summary}");
 
         cleanup(&home).await;
     }

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -313,7 +313,13 @@ impl WorkflowScheduler {
                                     workflow = %workflow_id,
                                     node = %report.node,
                                     kind = %report.kind,
-                                    target = report.target.as_deref().unwrap_or("-"),
+                                    // NOT the target itself: for an `email`
+                                    // destination that is the recipient's
+                                    // address, and this line goes to host
+                                    // stdout — which on a hosted tenant is us,
+                                    // not the operator. Whether one resolved is
+                                    // the part with diagnostic value anyway.
+                                    target_configured = report.target.is_some(),
                                     status = ?report.status,
                                     detail = %report.detail,
                                     "workflow scheduler: a scheduled run's report was NOT delivered"
@@ -992,6 +998,17 @@ to = "done"
         assert!(
             line.contains("never written to the company"),
             "carries the detail, which is the part that says what to fix: {line}"
+        );
+        // …but NOT the recipient's address. This line lands on host stdout,
+        // which on a hosted tenant is us rather than the operator, so the
+        // address must never ride it — only whether one resolved at all.
+        assert!(
+            !line.contains("ada@example.com"),
+            "must not leak the recipient address to host stdout: {line}"
+        );
+        assert!(
+            line.contains("target_configured=true"),
+            "keeps the non-sensitive half of the diagnostic: {line}"
         );
 
         // The delivery that DID land gets no warning of its own — otherwise a

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -1025,8 +1025,12 @@ to = "done"
             .lines()
             .find(|l| l.contains(company) && l.contains("scheduled run finished"))
             .unwrap_or_else(|| panic!("no summary line for {company}: {logs}"));
+        // Every count, including the zeroes: asserting only the non-zero ones
+        // lets a regression that stops emitting `denied` or `failed` pass.
         assert!(summary.contains("sent=1"), "{summary}");
         assert!(summary.contains("skipped=1"), "{summary}");
+        assert!(summary.contains("denied=0"), "{summary}");
+        assert!(summary.contains("failed=0"), "{summary}");
         assert!(summary.contains("undelivered=1"), "{summary}");
 
         cleanup(&home).await;
@@ -1077,6 +1081,7 @@ to = "done"
             .expect("a summary line");
         assert!(summary.contains("sent=1"), "{summary}");
         assert!(summary.contains("skipped=0"), "{summary}");
+        assert!(summary.contains("denied=0"), "{summary}");
         assert!(summary.contains("failed=0"), "{summary}");
         assert!(summary.contains("undelivered=0"), "{summary}");
 

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -920,6 +920,14 @@ type WorkflowNode {
 	Whether the node pauses awaiting operator approval before it runs.
 	"""
 	requiresApproval: Boolean
+	"""
+	Where an `output` node's report is routed once the run finishes (issue
+	#170), as a JSON scalar: `{"kind": "owner"|"email"|"channel",
+	"target"?: "…"}`. Exposed for the same reason `config` is — so
+	`Company.workflow(id)` does not drop model data. Both keys are single
+	words, so the model shape needs no camelCase mirror the way `retry` does.
+	"""
+	destination: JSON
 }
 
 """

--- a/src/server/graphql/workflows.rs
+++ b/src/server/graphql/workflows.rs
@@ -73,6 +73,12 @@ pub struct WorkflowNodeGql {
     pub retry: Option<async_graphql::Json<RetryGql>>,
     /// Whether the node pauses awaiting operator approval before it runs.
     pub requires_approval: Option<bool>,
+    /// Where an `output` node's report is routed once the run finishes (issue
+    /// #170), as a JSON scalar: `{"kind": "owner"|"email"|"channel",
+    /// "target"?: "…"}`. Exposed for the same reason `config` is — so
+    /// `Company.workflow(id)` does not drop model data. Both keys are single
+    /// words, so the model shape needs no camelCase mirror the way `retry` does.
+    pub destination: Option<async_graphql::Json<crate::company::WorkflowDestinationDef>>,
 }
 
 /// The camelCase retry shape the console reads back over GraphQL, mirroring the
@@ -129,6 +135,7 @@ impl From<WorkflowFile> for WorkflowGql {
                     on_error: node.on_error,
                     retry: node.retry.map(|r| async_graphql::Json(RetryGql::from(r))),
                     requires_approval: node.requires_approval,
+                    destination: node.destination.map(async_graphql::Json),
                 })
                 .collect(),
             edges: file
@@ -273,6 +280,67 @@ mod tests {
                 "backoffMs": 250,
                 "backoff": "exponential"
             })
+        );
+        // A node with no destination carries none.
+        assert!(node.destination.is_none());
+    }
+
+    /// An `output` node's destination reaches the GraphQL read shape too — the
+    /// console's REST path is not the only reader, and a resolver that dropped
+    /// it would report the graph as routing nowhere (issue #170).
+    #[test]
+    fn node_conversion_preserves_the_output_destination() {
+        let file = parse_workflow(
+            r#"
+            id = "wf"
+            name = "Workflow"
+            [[node]]
+            id = "start"
+            kind = "trigger"
+            name = "Start"
+            [[node]]
+            id = "done"
+            kind = "output"
+            name = "Report"
+            [node.destination]
+            kind = "email"
+            target = "ada@example.com"
+            [[edge]]
+            from = "start"
+            to = "done"
+            "#,
+        )
+        .expect("workflow parses");
+
+        let gql = WorkflowGql::from(file);
+        let done = gql.nodes.iter().find(|n| n.id.as_str() == "done").unwrap();
+        assert_eq!(
+            serde_json::to_value(&done.destination.as_ref().unwrap().0).unwrap(),
+            json!({ "kind": "email", "target": "ada@example.com" })
+        );
+        // `owner` carries no target, and the key stays absent rather than null.
+        let owner = parse_workflow(
+            r#"
+            id = "wf2"
+            name = "Workflow 2"
+            [[node]]
+            id = "start"
+            kind = "trigger"
+            name = "Start"
+            [[node]]
+            id = "done"
+            kind = "output"
+            name = "Report"
+            [node.destination]
+            kind = "owner"
+            "#,
+        )
+        .expect("parses");
+        let gql = WorkflowGql::from(owner);
+        let done = gql.nodes.iter().find(|n| n.id.as_str() == "done").unwrap();
+        assert_eq!(
+            serde_json::to_value(&done.destination.as_ref().unwrap().0).unwrap(),
+            json!({ "kind": "owner" })
         );
     }
 }

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1462,6 +1462,7 @@ mod test {
             media: None,
             composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
+            delivery: None,
         };
         let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record);
 

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -383,6 +383,7 @@ impl TryFrom<CreateWorkflowBody> for RawWorkflow {
                 on_error: n.on_error,
                 retry: n.retry.map(WorkflowRetryDef::from),
                 requires_approval: n.requires_approval,
+                destination: None,
             });
         }
         Ok(Self {
@@ -642,6 +643,7 @@ mod tests {
                     backoff: Some("exponential".into()),
                 }),
                 requires_approval: Some(true),
+                destination: None,
             }],
             edges: Vec::new(),
         };

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -48,8 +48,9 @@ use serde_json::Value;
 
 use crate::AppState;
 use crate::company::{
-    RawEdge, RawNode, RawWorkflow, WorkflowEdgeDef, WorkflowFile, WorkflowNodeDef,
-    WorkflowRetryDef, create_company_workflow, list_workflows_union, load_workflow_union,
+    RawEdge, RawNode, RawWorkflow, WorkflowDestinationDef, WorkflowEdgeDef, WorkflowFile,
+    WorkflowNodeDef, WorkflowRetryDef, create_company_workflow, list_workflows_union,
+    load_workflow_union,
 };
 use crate::error::OpenCompanyError;
 use crate::ports::types::{CompanyRecord, OverlayWorkflow};
@@ -134,6 +135,12 @@ struct WorkflowNode {
     retry: Option<WorkflowRetryOut>,
     #[serde(skip_serializing_if = "Option::is_none")]
     requires_approval: Option<bool>,
+    /// Where an `output` node's report is routed once the run finishes (issue
+    /// #170). The model shape is reused verbatim in both directions: its two
+    /// fields (`kind` / `target`) are single words, so there is no snake_case →
+    /// camelCase gap to bridge and no second shape to drift from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    destination: Option<WorkflowDestinationDef>,
 }
 
 /// The camelCase retry policy shape the console reads back (`maxAttempts` /
@@ -173,6 +180,7 @@ impl From<WorkflowNodeDef> for WorkflowNode {
             on_error: n.on_error,
             retry: n.retry.map(WorkflowRetryOut::from),
             requires_approval: n.requires_approval,
+            destination: n.destination,
         }
     }
 }
@@ -320,6 +328,12 @@ struct CreateNode {
     /// When `true`, the node pauses awaiting operator approval before it runs.
     #[serde(default)]
     requires_approval: Option<bool>,
+    /// Where an `output` node's report goes once the run finishes:
+    /// `{"kind": "owner"|"email"|"channel", "target"?: "…"}`. Rejected on any
+    /// other node kind, and each kind's target contract is enforced by
+    /// `parse_workflow` before anything is persisted.
+    #[serde(default)]
+    destination: Option<WorkflowDestinationDef>,
 }
 
 /// The camelCase retry policy the create body carries (`maxAttempts` /
@@ -383,7 +397,7 @@ impl TryFrom<CreateWorkflowBody> for RawWorkflow {
                 on_error: n.on_error,
                 retry: n.retry.map(WorkflowRetryDef::from),
                 requires_approval: n.requires_approval,
-                destination: None,
+                destination: n.destination,
             });
         }
         Ok(Self {
@@ -464,6 +478,11 @@ struct RunWorkflowBody {
 struct RunWorkflowResponse {
     output: Value,
     pending_approvals: Vec<String>,
+    /// One row per attempt to route a reached `output` node's report to its
+    /// destination (issue #170). Empty for a graph that routes nothing. This is
+    /// where an operator learns a report was NOT delivered — a delivery failure
+    /// never fails the run, so it has nowhere else to surface.
+    deliveries: Vec<crate::ports::DeliveryReport>,
 }
 
 /// `POST …/workflows/{wid}/run` (both scope forms).
@@ -505,6 +524,7 @@ async fn run_workflow(
     Ok(Json(RunWorkflowResponse {
         output: run.output,
         pending_approvals: run.pending_approvals,
+        deliveries: run.deliveries,
     }))
 }
 
@@ -830,6 +850,7 @@ mod tests {
                     on_error: None,
                     retry: None,
                     requires_approval: None,
+                    destination: None,
                 },
                 WorkflowNodeDef {
                     id: "done".into(),
@@ -842,6 +863,7 @@ mod tests {
                     on_error: None,
                     retry: None,
                     requires_approval: None,
+                    destination: None,
                 },
             ],
             edges: Vec::new(),
@@ -864,6 +886,164 @@ mod tests {
         .unwrap();
         let raw = RawWorkflow::try_from(body).expect("converts");
         assert!(raw.nodes[0].schedule.is_none());
+    }
+
+    // --- Output destination on the wire (issue #170) ------------------------
+
+    /// A create body's `destination` survives the render → parse pipeline the
+    /// endpoint runs before persisting, and comes back out on the GET shape
+    /// under the same key — so the console can post exactly what it reads.
+    #[test]
+    fn create_body_round_trips_an_output_destination() {
+        let body: CreateWorkflowBody = serde_json::from_value(serde_json::json!({
+            "id": "wf",
+            "name": "WF",
+            "nodes": [
+                { "id": "start", "kind": "trigger", "name": "Start" },
+                {
+                    "id": "done", "kind": "output", "name": "Report",
+                    "destination": { "kind": "email", "target": "ada@example.com" }
+                }
+            ],
+            "edges": [ { "from": "start", "to": "done" } ]
+        }))
+        .expect("body deserializes");
+
+        let raw = RawWorkflow::try_from(body).expect("converts");
+        let toml_src = crate::company::render_workflow(&raw).expect("renders");
+        let file = crate::company::parse_workflow(&toml_src).expect("re-parses");
+
+        let done = file.nodes.iter().find(|n| n.id == "done").unwrap();
+        let dest = done.destination.as_ref().expect("destination survived");
+        assert_eq!(dest.kind, "email");
+        assert_eq!(dest.target.as_deref(), Some("ada@example.com"));
+
+        // …and back out on the read shape, under the same key.
+        let json = serde_json::to_value(WorkflowGraph::from(file)).unwrap();
+        let node = json["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|n| n["id"] == "done")
+            .unwrap()
+            .clone();
+        assert_eq!(node["destination"]["kind"], "email");
+        assert_eq!(node["destination"]["target"], "ada@example.com");
+    }
+
+    /// An `owner` destination carries no target, and the key is omitted rather
+    /// than serialized as `null`.
+    #[test]
+    fn an_owner_destination_omits_the_target_key() {
+        let body: CreateWorkflowBody = serde_json::from_value(serde_json::json!({
+            "id": "wf",
+            "name": "WF",
+            "nodes": [
+                { "id": "start", "kind": "trigger", "name": "Start" },
+                {
+                    "id": "done", "kind": "output", "name": "Report",
+                    "destination": { "kind": "owner" }
+                }
+            ],
+            "edges": [ { "from": "start", "to": "done" } ]
+        }))
+        .unwrap();
+        let raw = RawWorkflow::try_from(body).expect("converts");
+        let file = crate::company::parse_workflow(
+            &crate::company::render_workflow(&raw).expect("renders"),
+        )
+        .expect("re-parses");
+        let json = serde_json::to_value(WorkflowGraph::from(file)).unwrap();
+        let node = &json["nodes"][1];
+        assert_eq!(node["destination"]["kind"], "owner");
+        assert!(node["destination"].get("target").is_none());
+    }
+
+    /// A node with no destination omits the key entirely — the pre-#170 read
+    /// shape is byte-identical for every existing graph.
+    #[test]
+    fn a_node_without_a_destination_omits_the_key() {
+        let dir = seed_demo();
+        let file = load_workflow_union(Some(dir.path()), &[], "demo")
+            .unwrap()
+            .unwrap();
+        let json = serde_json::to_value(WorkflowGraph::from(file)).unwrap();
+        for node in json["nodes"].as_array().unwrap() {
+            assert!(node.get("destination").is_none(), "{node}");
+        }
+    }
+
+    /// A destination the host cannot honour is rejected before anything is
+    /// persisted — the create route surfaces the same prosumer-language problem
+    /// a hand-authored file gets.
+    #[test]
+    fn create_body_with_a_bad_destination_is_rejected_at_validation() {
+        for (dest, expected) in [
+            (
+                serde_json::json!({ "kind": "email", "target": "ada" }),
+                "not an email address",
+            ),
+            (
+                serde_json::json!({ "kind": "carrier_pigeon" }),
+                "unknown `destination.kind`",
+            ),
+            (serde_json::json!({ "kind": "channel" }), "no `target`"),
+        ] {
+            let body: CreateWorkflowBody = serde_json::from_value(serde_json::json!({
+                "id": "wf",
+                "name": "WF",
+                "nodes": [
+                    { "id": "start", "kind": "trigger", "name": "Start" },
+                    { "id": "done", "kind": "output", "name": "Report", "destination": dest }
+                ],
+                "edges": [ { "from": "start", "to": "done" } ]
+            }))
+            .unwrap();
+            let raw = RawWorkflow::try_from(body).expect("converts");
+            let toml_src = crate::company::render_workflow(&raw).expect("renders");
+            let err = crate::company::parse_workflow(&toml_src)
+                .expect_err("an unhonourable destination must not persist");
+            assert!(err.to_string().contains(expected), "{err}");
+        }
+    }
+
+    /// The run response carries `deliveries` in camelCase — this is the ONLY
+    /// place an operator learns a report was not delivered, since a delivery
+    /// failure never fails the run.
+    #[test]
+    fn run_response_serializes_delivery_rows_in_camelcase() {
+        use crate::ports::{DeliveryReport, DeliveryStatus};
+
+        let json = serde_json::to_value(RunWorkflowResponse {
+            output: serde_json::json!({ "nodes": {} }),
+            pending_approvals: Vec::new(),
+            deliveries: vec![DeliveryReport {
+                node: "done".into(),
+                kind: "email".into(),
+                target: Some("ada@example.com".into()),
+                status: DeliveryStatus::Skipped,
+                detail: "never written in".into(),
+            }],
+        })
+        .unwrap();
+        assert_eq!(json["deliveries"][0]["node"], "done");
+        assert_eq!(json["deliveries"][0]["status"], "skipped");
+        assert_eq!(json["deliveries"][0]["target"], "ada@example.com");
+        assert_eq!(json["deliveries"][0]["detail"], "never written in");
+        assert!(json["pendingApprovals"].is_array());
+    }
+
+    /// A graph that routes nothing serializes an empty list, not a missing key —
+    /// the console can render "no deliveries" without a null check.
+    #[test]
+    fn run_response_with_no_deliveries_is_an_empty_list() {
+        let json = serde_json::to_value(RunWorkflowResponse {
+            output: Value::Null,
+            pending_approvals: Vec::new(),
+            deliveries: Vec::new(),
+        })
+        .unwrap();
+        assert_eq!(json["deliveries"], serde_json::json!([]));
     }
 
     #[test]

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -557,6 +557,70 @@ pub async fn assert_inbox_store(inbox: Arc<dyn InboxStore>) {
             .unwrap()
             .is_empty()
     );
+
+    // --- has_inbound_from: the established-correspondent gate ---------------
+    //
+    // Callers use this as a SECURITY gate (a workflow may only email an address
+    // that has written in first), so the contract is asserted here rather than
+    // left to whichever backend happens to be wired. A backend that overrides
+    // the default with an indexed lookup must still satisfy every case below.
+    let from = |id: &str, mailbox: &str, sender: &str, outbound: bool| EmailRecord {
+        from_email: sender.to_string(),
+        ..email(id, mailbox, outbound, 10)
+    };
+    inbox
+        .append(&alpha, &from("c1", "ops", "ada@example.com", false))
+        .await
+        .unwrap();
+    // `grace` only ever RECEIVED mail from this company — never wrote in.
+    inbox
+        .append(&alpha, &from("c2", "ops", "grace@example.com", true))
+        .await
+        .unwrap();
+
+    assert!(
+        inbox
+            .has_inbound_from(&alpha, "ops", "ada@example.com")
+            .await
+            .unwrap(),
+        "an address that wrote in is an established correspondent"
+    );
+    assert!(
+        !inbox
+            .has_inbound_from(&alpha, "ops", "grace@example.com")
+            .await
+            .unwrap(),
+        "OUTBOUND mail must not establish a correspondent — otherwise one send \
+         would authorize the next"
+    );
+    assert!(
+        !inbox
+            .has_inbound_from(&alpha, "ops", "stranger@example.com")
+            .await
+            .unwrap()
+    );
+    // Case and surrounding whitespace do not change who someone is.
+    assert!(
+        inbox
+            .has_inbound_from(&alpha, "ops", "  Ada@EXAMPLE.com ")
+            .await
+            .unwrap()
+    );
+    // A blank needle matches nobody, rather than matching anybody.
+    assert!(!inbox.has_inbound_from(&alpha, "ops", "   ").await.unwrap());
+    // Wrong mailbox, and wrong company, both miss.
+    assert!(
+        !inbox
+            .has_inbound_from(&alpha, "ceo", "ada@example.com")
+            .await
+            .unwrap()
+    );
+    assert!(
+        !inbox
+            .has_inbound_from(&beta, "ops", "ada@example.com")
+            .await
+            .unwrap()
+    );
 }
 
 /// Asserts the [`TaskStore`] contract: per-company isolation, upsert semantics,

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -1,0 +1,619 @@
+//! Route an `output` node's report to a person or a channel (issue #170).
+//!
+//! An `output` node is a workflow's terminal "report back". Before this module
+//! existed it produced a value that surfaced only in the console's transient
+//! run-result drawer — so a workflow could compute an owner summary and had no
+//! way to send it anywhere. A node's
+//! [`destination`](crate::company::WorkflowDestinationDef) closes that gap.
+//!
+//! # Where this runs, and why here
+//!
+//! Delivery is **host-side and post-engine**: [`deliver_outputs`] is called from
+//! [`run_workflow_inner`](super::runner) once `tinyflows::engine::run` has
+//! returned, NOT from the HTTP handler. Three callers drive the same
+//! [`WorkflowRunner`](crate::ports::WorkflowRunner) port — the console's run
+//! route, the orchestrator's `run_workflow` tool, and the trigger scheduler —
+//! and a *scheduled* run is precisely the case where nobody is watching the
+//! drawer. Putting delivery in the handler would give the console the only
+//! working destination.
+//!
+//! The engine never sees a destination. That is why it is a first-class model
+//! field rather than node `config`: config is lowered into the engine graph, and
+//! an inert key riding into the engine is exactly what the reserved-key
+//! validation exists to prevent.
+//!
+//! # The security boundary
+//!
+//! **No path here may let a workflow email an arbitrary external address without
+//! an explicit company grant.** The three destination kinds are gated
+//! differently because they carry different risk:
+//!
+//! * **`owner`** — recipients are resolved *server-side* from the company's own
+//!   [`UserStore`](crate::ports::UserStore) (active `Admin` users). The graph
+//!   names no address, so an author cannot point it at an outsider. Constrained
+//!   by construction; no grant needed. With no admin address (or no mailbox) it
+//!   falls back to the always-present `operator` channel rather than becoming a
+//!   silent no-op.
+//! * **`email`** — the graph names an arbitrary address, so it is the dangerous
+//!   one and carries **two independent gates**, both fail-closed:
+//!   1. the company's `[tools].allow` must cover the `email` namespace (the same
+//!      [`grants_cover`](crate::harness::build::grants_cover) matcher that gates
+//!      an agent's `email.send` effect and a workflow `tool_call`), and
+//!   2. the recipient must be an **established thread** — the company's inbox
+//!      must already hold inbound mail from that address. This is the rule
+//!      ported verbatim from the agent send path
+//!      ([`crate::runtime::cycle`]); a cold recipient is **skipped and
+//!      reported**, never sent to.
+//! * **`channel`** — the target must match a [`ChannelAdapter`] the deployment
+//!   already wired. A graph cannot conjure a channel; it can only address one an
+//!   operator installed. Constrained by construction, like `owner`.
+//!
+//! A cold `email` recipient is a real product gap, not a design end-state: the
+//! agent path parks such a send for operator approval, but the engine's approval
+//! pause has no resume path today, so gating delivery on it would dead-end the
+//! report instead of delaying it. Skipping loudly is the honest behaviour until
+//! a resume path exists.
+//!
+//! # Failure is reported, never fatal
+//!
+//! A delivery failure must not fail a run that already did its work. Every
+//! attempt yields a [`DeliveryReport`] row on
+//! [`WorkflowRun::deliveries`](crate::ports::WorkflowRun), which rides the run
+//! response into the console's run-result panel — so an operator can tell a
+//! delivered report from an undelivered one **without reading a log**. There is
+//! one attempt per recipient and no retry: a workflow run is not a mail queue.
+//!
+//! An output node the run never reached (an untaken branch, or a path that
+//! paused for approval) gets no attempt and no row — an absent row means "not
+//! reached", never "silently dropped".
+
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use crate::company::WorkflowFile;
+use crate::company::runtime::CompanyMail;
+use crate::company::{WorkflowDestinationDef, WorkflowNodeKind};
+use crate::ports::types::{CompanyId, CompanyRecord, OutboundMessage};
+use crate::ports::{
+    ChannelAdapter, DeliveryReport, DeliveryStatus, EmailRecord, InboxStore, UserRole, UserStatus,
+    UserStore, generate_id, now_millis,
+};
+use crate::server::ops::mailer::{MailCredentials, OutboundEmail};
+use crate::server::ops::smtp::local_part;
+
+/// How much report text one delivery carries. A workflow can emit an arbitrarily
+/// large payload; an email or chat message that large helps nobody and may be
+/// refused by the transport, so the body is truncated (on a **character**
+/// boundary — never a byte slice, which panics mid-codepoint) with a visible
+/// marker so the reader knows the text was cut.
+const MAX_REPORT_CHARS: usize = 16_000;
+
+/// The marker appended when a report is truncated at [`MAX_REPORT_CHARS`].
+const TRUNCATION_MARKER: &str = "\n\n… (report truncated)";
+
+/// How many inbox messages the established-thread check scans. Mirrors the
+/// agent send path in [`crate::runtime::cycle`] so the two cannot disagree about
+/// what "established" means.
+const ESTABLISHED_SCAN_LIMIT: usize = 500;
+
+/// The ports an output destination needs, bundled so [`HarnessDeps`] grows one
+/// optional field rather than four.
+///
+/// [`HarnessDeps::delivery`](crate::harness::HarnessDeps) is `Option<Self>` and
+/// defaults to `None` at every construction site except the production runtime
+/// builder. `None` **fails closed and loud**: [`deliver_outputs`] attempts
+/// nothing and writes a `failed` row naming the gap, so an operator sees "this
+/// build cannot deliver" in the run result instead of an authored destination
+/// quietly doing nothing.
+#[derive(Clone)]
+pub struct WorkflowDeliveryDeps {
+    /// The company's own outbound-mail handle (sender + its SMTP credentials).
+    /// `None` when the company has no mailbox: `owner` then falls back to the
+    /// operator channel, and `email` is reported `skipped`.
+    pub mail: Option<CompanyMail>,
+    /// The company's inboxes — both the established-thread check and the
+    /// outbound audit record go through this port.
+    pub inbox: Arc<dyn InboxStore>,
+    /// The company's user directory: how an `owner` destination resolves to
+    /// actual addresses, server-side.
+    pub users: Arc<dyn UserStore>,
+    /// Every wired channel adapter, including the always-present `operator`.
+    pub channels: Vec<Arc<dyn ChannelAdapter>>,
+}
+
+impl std::fmt::Debug for WorkflowDeliveryDeps {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never the mail handle itself — `CompanyMail` carries `SmtpCredentials`,
+        // whose derived `Debug` prints the password (see `mailer::test`).
+        f.debug_struct("WorkflowDeliveryDeps")
+            .field("mail", &self.mail.is_some())
+            .field(
+                "channels",
+                &self
+                    .channels
+                    .iter()
+                    .map(|c| c.channel_id().to_string())
+                    .collect::<Vec<_>>(),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+/// Delivers every reached `output` node's report to its configured destination,
+/// returning one [`DeliveryReport`] per attempt.
+///
+/// Never returns an error: a delivery problem is data on the run result, not a
+/// failed run (see the module docs). Nodes with no `destination`, and nodes the
+/// run never reached, produce no rows at all.
+pub async fn deliver_outputs(
+    delivery: Option<&WorkflowDeliveryDeps>,
+    record: &CompanyRecord,
+    workflow: &WorkflowFile,
+    output: &Value,
+) -> Vec<DeliveryReport> {
+    let mut reports = Vec::new();
+
+    for node in &workflow.nodes {
+        // Only `output` nodes report back. Validation already rejects a
+        // `destination` on any other kind; this is the belt to that braces, so a
+        // graph loaded from an older/looser source can never deliver from, say,
+        // an agent node.
+        if node.kind != WorkflowNodeKind::Output {
+            continue;
+        }
+        let Some(destination) = &node.destination else {
+            continue;
+        };
+        // An output node the run never reached (untaken branch, or a path that
+        // paused for approval) is not a delivery that failed — it is a delivery
+        // that was never owed. No attempt, no row.
+        if !node_was_reached(output, &node.id) {
+            tracing::debug!(
+                company = %record.id,
+                workflow = %workflow.id,
+                node = %node.id,
+                "workflow delivery: output node not reached; nothing to deliver"
+            );
+            continue;
+        }
+
+        let text = report_text(output, &node.id);
+        let subject = subject_for(record, workflow, &node.name);
+
+        let Some(delivery) = delivery else {
+            // The #169 lesson: a silent skip is indistinguishable from a working
+            // destination. Say it where the operator actually looks — the run
+            // result — and in the log.
+            tracing::warn!(
+                company = %record.id,
+                workflow = %workflow.id,
+                node = %node.id,
+                kind = %destination.kind,
+                "workflow delivery: this build has no delivery ports wired; the report was NOT sent"
+            );
+            reports.push(DeliveryReport {
+                node: node.id.clone(),
+                kind: destination.kind.clone(),
+                target: destination.target.clone(),
+                status: DeliveryStatus::Failed,
+                detail: "report delivery is not wired on this runtime — the workflow ran and its \
+                         result is in this run, but nothing was sent"
+                    .to_string(),
+            });
+            continue;
+        };
+
+        deliver_one(
+            delivery,
+            record,
+            &node.id,
+            destination,
+            &subject,
+            &text,
+            &mut reports,
+        )
+        .await;
+    }
+
+    reports
+}
+
+/// Dispatches one node's destination, appending every attempt's row to
+/// `reports`. `owner` can fan out to several admins, so this appends rather than
+/// returning a single report.
+async fn deliver_one(
+    delivery: &WorkflowDeliveryDeps,
+    record: &CompanyRecord,
+    node_id: &str,
+    destination: &WorkflowDestinationDef,
+    subject: &str,
+    text: &str,
+    reports: &mut Vec<DeliveryReport>,
+) {
+    let row = |target: Option<String>, status: DeliveryStatus, detail: String| DeliveryReport {
+        node: node_id.to_string(),
+        kind: destination.kind.clone(),
+        target,
+        status,
+        detail,
+    };
+    let target = destination.target.as_deref().map(str::trim).unwrap_or("");
+
+    match destination.kind.trim() {
+        // --- owner: resolved server-side; the graph names nobody -------------
+        "owner" => {
+            let admins = admin_emails(delivery.users.as_ref(), &record.id).await;
+            match (&delivery.mail, admins.is_empty()) {
+                (Some(mail), false) => {
+                    for address in admins {
+                        let result =
+                            send_email(delivery, mail, &record.id, &address, subject, text).await;
+                        reports.push(match result {
+                            Ok(()) => row(
+                                Some(address),
+                                DeliveryStatus::Sent,
+                                "emailed the company's admin".to_string(),
+                            ),
+                            Err(err) => row(
+                                Some(address),
+                                DeliveryStatus::Failed,
+                                format!("the mail transport refused the message: {err}"),
+                            ),
+                        });
+                    }
+                }
+                // No mailbox, or no admin has an address: fall back to the
+                // always-present operator channel so the owner still hears about
+                // it. Never a silent no-op.
+                _ => {
+                    let why = if delivery.mail.is_none() {
+                        "no mailbox is configured for this company"
+                    } else {
+                        "no active admin has an email address"
+                    };
+                    reports.push(
+                        post_to_channel(
+                            delivery,
+                            crate::runtime::channel::OPERATOR_CHANNEL,
+                            subject,
+                            text,
+                        )
+                        .await
+                        .map(|()| {
+                            row(
+                                Some(crate::runtime::channel::OPERATOR_CHANNEL.to_string()),
+                                DeliveryStatus::Sent,
+                                format!("{why}, so the report went to the operator channel"),
+                            )
+                        })
+                        .unwrap_or_else(|detail| {
+                            row(
+                                Some(crate::runtime::channel::OPERATOR_CHANNEL.to_string()),
+                                DeliveryStatus::Failed,
+                                format!(
+                                    "{why}, and the operator channel fallback failed: {detail}"
+                                ),
+                            )
+                        }),
+                    );
+                }
+            }
+        }
+
+        // --- email: the graph names an address, so it is double-gated --------
+        "email" => {
+            // GATE 1 — the company must grant the `email` namespace. Checked
+            // FIRST and independently of whether mail is even wired, so a
+            // missing grant is always reported as a denial rather than being
+            // masked by an unrelated configuration gap.
+            if !crate::harness::build::grants_cover(&record.manifest.tools.allow, "email") {
+                tracing::warn!(
+                    company = %record.id,
+                    node = %node_id,
+                    "workflow delivery: refused an email destination — the company does not grant `email`"
+                );
+                reports.push(row(
+                    Some(target.to_string()),
+                    DeliveryStatus::Denied,
+                    "this company's [tools].allow does not grant `email`, so a workflow may not \
+                     send mail to a named address"
+                        .to_string(),
+                ));
+                return;
+            }
+            let Some(mail) = &delivery.mail else {
+                reports.push(row(
+                    Some(target.to_string()),
+                    DeliveryStatus::Skipped,
+                    "no mailbox is configured for this company, so there is nothing to send from"
+                        .to_string(),
+                ));
+                return;
+            };
+            // GATE 2 — the established-thread rule, ported from the agent send
+            // path. Fails closed: an inbox read error counts as "cold".
+            if !recipient_is_established(
+                delivery.inbox.as_ref(),
+                &record.id,
+                &mail.smtp.from_email,
+                target,
+            )
+            .await
+            {
+                tracing::warn!(
+                    company = %record.id,
+                    node = %node_id,
+                    "workflow delivery: skipped an email destination — the recipient is not an established thread"
+                );
+                reports.push(row(
+                    Some(target.to_string()),
+                    DeliveryStatus::Skipped,
+                    "this recipient has never written to the company, so a workflow may not open \
+                     the conversation — send once from the inbox first"
+                        .to_string(),
+                ));
+                return;
+            }
+            reports.push(
+                match send_email(delivery, mail, &record.id, target, subject, text).await {
+                    Ok(()) => row(
+                        Some(target.to_string()),
+                        DeliveryStatus::Sent,
+                        "emailed the named recipient on an established thread".to_string(),
+                    ),
+                    Err(err) => row(
+                        Some(target.to_string()),
+                        DeliveryStatus::Failed,
+                        format!("the mail transport refused the message: {err}"),
+                    ),
+                },
+            );
+        }
+
+        // --- channel: only a channel the deployment already wired ------------
+        "channel" => {
+            reports.push(
+                match post_to_channel(delivery, target, subject, text).await {
+                    Ok(()) => row(
+                        Some(target.to_string()),
+                        DeliveryStatus::Sent,
+                        "posted to the channel".to_string(),
+                    ),
+                    Err(detail) => row(Some(target.to_string()), DeliveryStatus::Failed, detail),
+                },
+            );
+        }
+
+        // Unreachable through `parse_workflow`, which rejects an unknown kind.
+        // Reported rather than ignored so a graph that somehow bypassed
+        // validation cannot deliver nowhere in silence.
+        other => reports.push(row(
+            destination.target.clone(),
+            DeliveryStatus::Failed,
+            format!("`{other}` is not a destination kind this runtime knows how to deliver to"),
+        )),
+    }
+}
+
+/// The active admins' email addresses, in store order. An unreadable user store
+/// yields none (which routes `owner` to the operator-channel fallback) rather
+/// than failing the run.
+async fn admin_emails(users: &dyn UserStore, company: &CompanyId) -> Vec<String> {
+    match users.list_users(company).await {
+        Ok(list) => list
+            .into_iter()
+            .filter(|u| u.role == UserRole::Admin && u.status == UserStatus::Active)
+            .map(|u| u.email)
+            .filter(|email| email.contains('@'))
+            .collect(),
+        Err(err) => {
+            tracing::warn!(
+                company = %company,
+                error = %err,
+                "workflow delivery: could not read the user directory; falling back to the operator channel"
+            );
+            Vec::new()
+        }
+    }
+}
+
+/// Sends one email through the company's own mail handle and mirrors it into the
+/// company inbox as outbound (the same audit trail the agent send path and the
+/// console's test-send leave, and what makes the thread "established" for a
+/// later reply).
+async fn send_email(
+    delivery: &WorkflowDeliveryDeps,
+    mail: &CompanyMail,
+    company: &CompanyId,
+    to: &str,
+    subject: &str,
+    body: &str,
+) -> Result<(), crate::error::OpenCompanyError> {
+    let email = OutboundEmail {
+        to: to.to_string(),
+        subject: subject.to_string(),
+        body: body.to_string(),
+    };
+    mail.sender
+        .send(&MailCredentials::Smtp(mail.smtp.clone()), &email)
+        .await?;
+    record_outbound(delivery.inbox.as_ref(), company, mail, &email).await;
+    Ok(())
+}
+
+/// Appends a sent email to the sending inbox so the console shows it alongside
+/// inbound mail. Mirrors [`crate::server::ops::smtp::record_outbound`], which
+/// takes a whole `CompanyRuntime` this path does not have.
+async fn record_outbound(
+    inbox: &dyn InboxStore,
+    company: &CompanyId,
+    mail: &CompanyMail,
+    email: &OutboundEmail,
+) {
+    let record = EmailRecord {
+        id: generate_id(),
+        inbox: local_part(&mail.smtp.from_email),
+        from_name: mail.smtp.from_name.clone(),
+        from_email: mail.smtp.from_email.clone(),
+        subject: email.subject.clone(),
+        body: email.body.clone(),
+        at_millis: now_millis(),
+        read: true,
+        outbound: true,
+    };
+    if let Err(err) = inbox.append(company, &record).await {
+        tracing::warn!(
+            company = %company,
+            error = %err,
+            "workflow delivery: failed to record the outbound email"
+        );
+    }
+}
+
+/// Whether the company's inbox already holds **inbound** mail from `to` — an
+/// established thread.
+///
+/// Fails closed (`false`) on a missing sending address or an inbox read error,
+/// which routes the caller to the cold-recipient skip. Byte-for-byte the same
+/// rule as `recipient_is_established` in [`crate::runtime::cycle`].
+async fn recipient_is_established(
+    inbox: &dyn InboxStore,
+    company: &CompanyId,
+    company_address: &str,
+    to: &str,
+) -> bool {
+    if company_address.trim().is_empty() {
+        return false;
+    }
+    let key = local_part(company_address);
+    let to = to.trim().to_ascii_lowercase();
+    if to.is_empty() {
+        return false;
+    }
+    match inbox
+        .messages(company, &key, ESTABLISHED_SCAN_LIMIT, 0)
+        .await
+    {
+        Ok(records) => records
+            .iter()
+            .any(|r| !r.outbound && r.from_email.trim().to_ascii_lowercase() == to),
+        Err(_) => false, // fail closed → the cold-recipient skip
+    }
+}
+
+/// Posts a report to the wired channel adapter with id `channel_id`.
+///
+/// `Err(detail)` carries an operator-readable reason: an unwired id names what
+/// *is* wired, so the fix is obvious from the run result alone.
+async fn post_to_channel(
+    delivery: &WorkflowDeliveryDeps,
+    channel_id: &str,
+    subject: &str,
+    text: &str,
+) -> Result<(), String> {
+    let Some(adapter) = delivery
+        .channels
+        .iter()
+        .find(|c| c.channel_id() == channel_id)
+    else {
+        let wired: Vec<&str> = delivery
+            .channels
+            .iter()
+            .map(|c| c.channel_id())
+            .collect::<Vec<_>>();
+        return Err(if wired.is_empty() {
+            format!("`{channel_id}` is not wired on this runtime, which has no channels at all")
+        } else {
+            format!(
+                "`{channel_id}` is not a wired channel — this runtime has: {}",
+                wired.join(", ")
+            )
+        });
+    };
+    adapter
+        .send(OutboundMessage {
+            channel: channel_id.to_string(),
+            text: format!("{subject}\n\n{text}"),
+            steps: Vec::new(),
+            reply_to: None,
+        })
+        .await
+        .map_err(|err| format!("the channel refused the message: {err}"))
+}
+
+/// Whether the run's output carries an entry for `node_id` — i.e. the engine
+/// actually reached that node.
+fn node_was_reached(output: &Value, node_id: &str) -> bool {
+    !output
+        .get("nodes")
+        .and_then(|nodes| nodes.get(node_id))
+        .unwrap_or(&Value::Null)
+        .is_null()
+}
+
+/// The report body for one output node: every item's text, in order.
+///
+/// The engine emits items as `{"json": {...}}`, and the `text` an agent node
+/// produced sometimes sits one level deeper (`json.json.text`) — the same
+/// double-wrapping the console's run-result parser handles, so the outer value
+/// wins here too. An item carrying no readable text falls back to its compact
+/// JSON, so a data-shaped report is delivered rather than dropped.
+fn report_text(output: &Value, node_id: &str) -> String {
+    let items = output
+        .get("nodes")
+        .and_then(|nodes| nodes.get(node_id))
+        .and_then(|node| node.get("items"))
+        .and_then(Value::as_array);
+    let Some(items) = items else {
+        return "(this workflow step produced no output)".to_string();
+    };
+
+    let mut parts: Vec<String> = Vec::new();
+    for item in items {
+        let json = item.get("json").unwrap_or(item);
+        if let Some(text) = read_nested_str(json, "text") {
+            parts.push(text.to_string());
+        } else {
+            parts.push(json.to_string());
+        }
+    }
+    if parts.is_empty() {
+        return "(this workflow step produced no output)".to_string();
+    }
+    truncate_chars(&parts.join("\n\n"), MAX_REPORT_CHARS)
+}
+
+/// Reads a string field from an item's `json`, preferring the outermost value
+/// and falling back to the nested `json.json.<key>` the engine sometimes emits.
+fn read_nested_str<'a>(json: &'a Value, key: &str) -> Option<&'a str> {
+    let non_empty = |v: &'a Value| v.as_str().filter(|s| !s.trim().is_empty());
+    if let Some(outer) = json.get(key).and_then(non_empty) {
+        return Some(outer);
+    }
+    json.get("json")
+        .and_then(|inner| inner.get(key))
+        .and_then(non_empty)
+}
+
+/// Truncates `text` to at most `max` characters, appending a visible marker when
+/// it actually cut something.
+///
+/// Character-indexed on purpose: slicing a `String` by byte offset panics when
+/// the offset lands mid-codepoint, and a report can carry any UTF-8 the run
+/// produced.
+fn truncate_chars(text: &str, max: usize) -> String {
+    match text.char_indices().nth(max) {
+        None => text.to_string(),
+        Some((byte_index, _)) => format!("{}{TRUNCATION_MARKER}", &text[..byte_index]),
+    }
+}
+
+/// The subject line one report carries: the company, the workflow, and which
+/// step reported.
+fn subject_for(record: &CompanyRecord, workflow: &WorkflowFile, node_name: &str) -> String {
+    format!(
+        "[{}] {} — {}",
+        record.manifest.company.name, workflow.name, node_name
+    )
+}

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -62,8 +62,8 @@
 //! run those rows ride the run response into the console's run-result panel, so
 //! an operator can tell a delivered report from an undelivered one without
 //! reading a log. A **scheduled** run is not persisted, so its rows reach only
-//! the scheduler's log until issue #242 gives a run a durable record. There is
-//! one attempt per recipient and no retry: a workflow run is not a mail queue.
+//! the scheduler's log until issue #228 surfaces them. There is one attempt per
+//! recipient and no retry: a workflow run is not a mail queue.
 //!
 //! An output node the run never reached (an untaken branch, or a path that
 //! paused for approval) gets no attempt and no row — an absent row means "not

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -1093,6 +1093,53 @@ allow = [{allow}]
         assert_eq!(h.mail.sent().len(), 1);
     }
 
+    /// **The default-configuration case (after #230).** A company with no
+    /// `[tools]` section at all now defaults to `["*", "media", "composio"]`,
+    /// and `*` satisfies the `email` grant — so on the majority of tenants the
+    /// grant gate is open and the established-thread gate is the one actually
+    /// holding the line. Pin that it does: a default-configured company still
+    /// cannot cold-email a stranger.
+    #[tokio::test]
+    async fn a_default_configured_company_still_cannot_cold_email() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+        let manifest = toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+"#,
+        )
+        .expect("valid manifest");
+        let mut rec = record(&[]);
+        rec.manifest = manifest;
+        // Sanity: the default really does grant `email` — if this ever stops
+        // being true the test below would pass for the wrong reason.
+        assert!(
+            crate::harness::build::grants_cover(&rec.manifest.tools.allow, "email"),
+            "expected the post-#230 default belt to cover `email`, got {:?}",
+            rec.manifest.tools.allow
+        );
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &rec,
+            &graph("email", Some("stranger@example.com")),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(
+            reports[0].status,
+            DeliveryStatus::Skipped,
+            "the established-thread gate must still refuse a stranger: {reports:?}"
+        );
+        assert!(h.mail.sent().is_empty(), "nothing may leave the process");
+    }
+
     /// The company's OWN prior outbound mail to an address does not make that
     /// address established — otherwise one send would bootstrap the next.
     #[tokio::test]

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -92,8 +92,9 @@ const MAX_REPORT_CHARS: usize = 16_000;
 /// The marker appended when a report is truncated at [`MAX_REPORT_CHARS`].
 const TRUNCATION_MARKER: &str = "\n\n… (report truncated)";
 
-/// The ports an output destination needs, bundled so [`HarnessDeps`] grows one
-/// optional field rather than four.
+/// The ports an output destination needs, bundled so
+/// [`HarnessDeps`](crate::harness::HarnessDeps) grows one optional field rather
+/// than four.
 ///
 /// [`HarnessDeps::delivery`](crate::harness::HarnessDeps) is `Option<Self>` and
 /// defaults to `None` at every construction site except the production runtime

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -617,3 +617,706 @@ fn subject_for(record: &CompanyRecord, workflow: &WorkflowFile, node_name: &str)
         record.manifest.company.name, workflow.name, node_name
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use async_trait::async_trait;
+
+    use crate::company::parse_workflow;
+    use crate::error::OpenCompanyError;
+    use crate::ports::UserRecord;
+    use crate::ports::types::CompanyId;
+    use crate::runtime::channel::{OPERATOR_CHANNEL, OperatorChannel};
+    use crate::server::ops::mailer::{MailSender, RecordingMailSender};
+    use crate::server::ops::smtp::{SmtpCredentials, SmtpSecurity};
+    use crate::store::{FsInboxStore, FsOps};
+
+    /// The company's own sending address in every test below.
+    const COMPANY_ADDRESS: &str = "acme@opencompany.test";
+
+    /// A graph whose single `output` node carries `destination`, wired
+    /// `trigger → done`. `target` is omitted when `None`.
+    fn graph(kind: &str, target: Option<&str>) -> WorkflowFile {
+        let target_line = target
+            .map(|t| format!("target = \"{t}\"\n"))
+            .unwrap_or_default();
+        let src = format!(
+            r#"
+id = "report_flow"
+name = "Report flow"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "done"
+kind = "output"
+name = "Owner summary"
+[node.destination]
+kind = "{kind}"
+{target_line}
+[[edge]]
+from = "start"
+to = "done"
+"#
+        );
+        parse_workflow(&src).expect("test graph is valid")
+    }
+
+    /// A run output in which `done` produced one text item — the reached case.
+    fn reached_output() -> Value {
+        serde_json::json!({
+            "nodes": {
+                "start": { "items": [{ "json": { "seed": 1 } }] },
+                "done": { "items": [{ "json": { "text": "Q3 is up 12%." } }] },
+            }
+        })
+    }
+
+    /// A company record whose `[tools].allow` is exactly `grants`.
+    fn record(grants: &[&str]) -> CompanyRecord {
+        let allow = grants
+            .iter()
+            .map(|g| format!("\"{g}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let manifest = toml::from_str(&format!(
+            r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+
+[tools]
+allow = [{allow}]
+"#
+        ))
+        .expect("valid manifest");
+        CompanyRecord {
+            id: CompanyId::new("acme"),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            template_provenance: None,
+        }
+    }
+
+    fn smtp_creds() -> SmtpCredentials {
+        SmtpCredentials {
+            host: "smtp.example.test".into(),
+            port: 587,
+            security: SmtpSecurity::Starttls,
+            username: "acme".into(),
+            password: "hunter2".into(),
+            from_name: "Acme".into(),
+            from_email: COMPANY_ADDRESS.into(),
+        }
+    }
+
+    /// A [`MailSender`] that always refuses, for the "a send failure does not
+    /// fail the run" case.
+    struct RefusingMailSender;
+
+    #[async_trait]
+    impl MailSender for RefusingMailSender {
+        async fn send(
+            &self,
+            _creds: &MailCredentials,
+            _email: &OutboundEmail,
+        ) -> Result<(), OpenCompanyError> {
+            Err(OpenCompanyError::Config("smtp said no".into()))
+        }
+    }
+
+    /// The offline delivery bundle: a recording mail sender (or none), tempdir
+    /// inbox + user stores, and the built-in operator channel.
+    struct Harness {
+        deps: WorkflowDeliveryDeps,
+        mail: RecordingMailSender,
+        channel: OperatorChannel,
+        inbox: Arc<FsInboxStore>,
+        users: Arc<FsOps>,
+        company: CompanyId,
+    }
+
+    impl Harness {
+        fn new(dir: &std::path::Path, with_mail: bool, with_channel: bool) -> Self {
+            let mail = RecordingMailSender::new();
+            let inbox = Arc::new(FsInboxStore::new(dir));
+            let users = Arc::new(FsOps::new(dir));
+            let channel = OperatorChannel::new();
+            let channels: Vec<Arc<dyn ChannelAdapter>> = if with_channel {
+                vec![Arc::new(channel.clone())]
+            } else {
+                Vec::new()
+            };
+            Self {
+                deps: WorkflowDeliveryDeps {
+                    mail: with_mail.then(|| CompanyMail {
+                        sender: Arc::new(mail.clone()),
+                        smtp: smtp_creds(),
+                    }),
+                    inbox: inbox.clone(),
+                    users: users.clone(),
+                    channels,
+                },
+                mail,
+                channel,
+                inbox,
+                users,
+                company: CompanyId::new("acme"),
+            }
+        }
+
+        /// Adds an active admin with `email` to the company directory.
+        async fn add_admin(&self, id: &str, email: &str) {
+            self.users
+                .upsert_user(
+                    &self.company,
+                    &UserRecord {
+                        id: id.to_string(),
+                        email: email.to_string(),
+                        display_name: None,
+                        role: UserRole::Admin,
+                        status: UserStatus::Active,
+                        password_hash: None,
+                        must_change_password: false,
+                        created_at_millis: 1,
+                        last_seen_at_millis: None,
+                        updated_at_millis: 1,
+                    },
+                )
+                .await
+                .expect("user upserted");
+        }
+
+        /// Files an INBOUND email from `from`, which is what makes that address
+        /// an established thread.
+        async fn receive_from(&self, from: &str) {
+            self.inbox
+                .append(
+                    &self.company,
+                    &EmailRecord {
+                        id: generate_id(),
+                        inbox: local_part(COMPANY_ADDRESS),
+                        from_name: String::new(),
+                        from_email: from.to_string(),
+                        subject: "hello".to_string(),
+                        body: "hi".to_string(),
+                        at_millis: 1,
+                        read: false,
+                        outbound: false,
+                    },
+                )
+                .await
+                .expect("inbound filed");
+        }
+
+        /// Every message in the company's own inbox.
+        async fn inbox_messages(&self) -> Vec<EmailRecord> {
+            self.inbox
+                .messages(&self.company, &local_part(COMPANY_ADDRESS), 100, 0)
+                .await
+                .expect("inbox readable")
+        }
+    }
+
+    // --- owner ---------------------------------------------------------------
+
+    /// `owner` resolves to the company's active admins server-side and emails
+    /// each of them. The graph named nobody — that is the whole point.
+    #[tokio::test]
+    async fn owner_emails_every_active_admin() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+        h.add_admin("u1", "ada@acme.test").await;
+        h.add_admin("u2", "grace@acme.test").await;
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("owner", None),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 2, "{reports:?}");
+        assert!(reports.iter().all(|r| r.status == DeliveryStatus::Sent));
+        let mut addressed: Vec<String> = h.mail.sent().into_iter().map(|(_, e)| e.to).collect();
+        addressed.sort();
+        assert_eq!(addressed, vec!["ada@acme.test", "grace@acme.test"]);
+        // The report body is the output node's text, and the subject names the
+        // company, the workflow, and the step.
+        let (_, email) = &h.mail.sent()[0];
+        assert!(email.body.contains("Q3 is up 12%."), "{}", email.body);
+        assert!(email.subject.contains("Acme"), "{}", email.subject);
+        assert!(email.subject.contains("Report flow"), "{}", email.subject);
+        // `owner` needs no grant: this record grants nothing at all.
+    }
+
+    /// A suspended admin and a plain member are not the owner. Only active
+    /// admins are.
+    #[tokio::test]
+    async fn owner_ignores_suspended_admins_and_members() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+        h.add_admin("u1", "ada@acme.test").await;
+        for (id, email, role, status) in [
+            (
+                "u2",
+                "sus@acme.test",
+                UserRole::Admin,
+                UserStatus::Suspended,
+            ),
+            ("u3", "mem@acme.test", UserRole::Member, UserStatus::Active),
+        ] {
+            h.users
+                .upsert_user(
+                    &h.company,
+                    &UserRecord {
+                        id: id.to_string(),
+                        email: email.to_string(),
+                        display_name: None,
+                        role,
+                        status,
+                        password_hash: None,
+                        must_change_password: false,
+                        created_at_millis: 1,
+                        last_seen_at_millis: None,
+                        updated_at_millis: 1,
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("owner", None),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(h.mail.sent().len(), 1);
+        assert_eq!(h.mail.sent()[0].1.to, "ada@acme.test");
+    }
+
+    /// With no mailbox wired, `owner` falls back to the always-present operator
+    /// channel rather than becoming a silent no-op.
+    #[tokio::test]
+    async fn owner_falls_back_to_the_operator_channel_without_mail() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), false, true);
+        h.add_admin("u1", "ada@acme.test").await;
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("owner", None),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Sent);
+        assert_eq!(reports[0].target.as_deref(), Some(OPERATOR_CHANNEL));
+        assert!(reports[0].detail.contains("no mailbox"), "{reports:?}");
+        let sent = h.channel.sent();
+        assert_eq!(sent.len(), 1);
+        assert!(sent[0].text.contains("Q3 is up 12%."), "{}", sent[0].text);
+    }
+
+    /// A company with a mailbox but no admin address also falls back — the owner
+    /// still hears about it.
+    #[tokio::test]
+    async fn owner_falls_back_when_no_admin_has_an_address() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("owner", None),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Sent);
+        assert!(reports[0].detail.contains("no active admin"), "{reports:?}");
+        assert!(h.mail.sent().is_empty(), "nothing should have been emailed");
+        assert_eq!(h.channel.sent().len(), 1);
+    }
+
+    /// Both fallbacks unavailable: no mail, no operator channel. Still a row —
+    /// `failed`, naming the gap — never silence.
+    #[tokio::test]
+    async fn owner_with_neither_mail_nor_a_channel_reports_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), false, false);
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("owner", None),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Failed);
+        assert!(reports[0].detail.contains("operator"), "{reports:?}");
+    }
+
+    // --- email ---------------------------------------------------------------
+
+    /// The happy path: granted AND established. The mail goes out and is
+    /// mirrored into the company inbox as outbound, for audit.
+    #[tokio::test]
+    async fn email_granted_and_established_sends_and_records_outbound() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+        h.receive_from("ada@example.com").await;
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["email.send"]),
+            &graph("email", Some("ada@example.com")),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Sent);
+        assert_eq!(h.mail.sent().len(), 1);
+        assert_eq!(h.mail.sent()[0].1.to, "ada@example.com");
+
+        let messages = h.inbox_messages().await;
+        let outbound: Vec<&EmailRecord> = messages.iter().filter(|m| m.outbound).collect();
+        assert_eq!(outbound.len(), 1, "the send must leave an audit record");
+        assert!(outbound[0].body.contains("Q3 is up 12%."));
+    }
+
+    /// **The security boundary.** With no `email` grant the send is REFUSED
+    /// outright — before the mailbox, before the thread check — and nothing
+    /// leaves the process.
+    #[tokio::test]
+    async fn email_without_the_grant_is_denied_and_nothing_is_sent() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+        // Established thread AND a wired mailbox: the ONLY thing missing is the
+        // grant, so a pass here could only come from the grant check.
+        h.receive_from("ada@example.com").await;
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["docs.*", "web"]),
+            &graph("email", Some("ada@example.com")),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Denied);
+        assert!(reports[0].detail.contains("[tools].allow"), "{reports:?}");
+        assert!(h.mail.sent().is_empty(), "a denied send must not go out");
+        assert!(
+            h.inbox_messages().await.iter().all(|m| !m.outbound),
+            "a denied send must leave no outbound record"
+        );
+    }
+
+    /// **The security boundary, second gate.** Granted but COLD: the company's
+    /// inbox holds nothing from this address, so the workflow may not open the
+    /// conversation. Skipped and reported — never sent.
+    #[tokio::test]
+    async fn email_to_a_cold_recipient_is_skipped_and_nothing_is_sent() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+        // A different address wrote in; the target never did.
+        h.receive_from("someone-else@example.com").await;
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["*"]),
+            &graph("email", Some("stranger@example.com")),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Skipped);
+        assert!(reports[0].detail.contains("never written"), "{reports:?}");
+        assert!(
+            h.mail.sent().is_empty(),
+            "a cold recipient must not be mailed"
+        );
+    }
+
+    /// The company's OWN prior outbound mail to an address does not make that
+    /// address established — otherwise one send would bootstrap the next.
+    #[tokio::test]
+    async fn a_prior_outbound_does_not_establish_a_thread() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+        h.inbox
+            .append(
+                &h.company,
+                &EmailRecord {
+                    id: generate_id(),
+                    inbox: local_part(COMPANY_ADDRESS),
+                    from_name: String::new(),
+                    from_email: "stranger@example.com".to_string(),
+                    subject: "earlier".to_string(),
+                    body: "earlier".to_string(),
+                    at_millis: 1,
+                    read: true,
+                    outbound: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["*"]),
+            &graph("email", Some("stranger@example.com")),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports[0].status, DeliveryStatus::Skipped);
+        assert!(h.mail.sent().is_empty());
+    }
+
+    /// Granted and established, but the company has no mailbox: skipped, with a
+    /// reason distinct from the cold-recipient one.
+    #[tokio::test]
+    async fn email_without_a_mailbox_is_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), false, true);
+        h.receive_from("ada@example.com").await;
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["*"]),
+            &graph("email", Some("ada@example.com")),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports[0].status, DeliveryStatus::Skipped);
+        assert!(reports[0].detail.contains("no mailbox"), "{reports:?}");
+    }
+
+    /// A transport refusal is reported as `failed` — and, critically,
+    /// `deliver_outputs` still returns normally, because the run's work is done
+    /// and must not be thrown away over a mail hiccup.
+    #[tokio::test]
+    async fn a_send_failure_is_reported_and_does_not_abort_delivery() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut h = Harness::new(dir.path(), true, true);
+        h.deps.mail = Some(CompanyMail {
+            sender: Arc::new(RefusingMailSender),
+            smtp: smtp_creds(),
+        });
+        h.receive_from("ada@example.com").await;
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["*"]),
+            &graph("email", Some("ada@example.com")),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Failed);
+        assert!(reports[0].detail.contains("smtp said no"), "{reports:?}");
+        // A refused send leaves no outbound audit record — the mail never went.
+        assert!(h.inbox_messages().await.iter().all(|m| !m.outbound));
+    }
+
+    // --- channel -------------------------------------------------------------
+
+    #[tokio::test]
+    async fn channel_posts_to_the_wired_adapter() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("channel", Some(OPERATOR_CHANNEL)),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Sent);
+        let sent = h.channel.sent();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0].channel, OPERATOR_CHANNEL);
+        assert!(sent[0].text.contains("Q3 is up 12%."));
+    }
+
+    /// A channel the deployment never wired cannot be conjured by a graph. The
+    /// failure names what IS wired, so the fix is obvious from the run result.
+    #[tokio::test]
+    async fn channel_that_is_not_wired_fails_with_the_wired_list() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["*"]),
+            &graph("channel", Some("telegram")),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Failed);
+        assert!(
+            reports[0].detail.contains("not a wired channel"),
+            "{reports:?}"
+        );
+        assert!(reports[0].detail.contains(OPERATOR_CHANNEL), "{reports:?}");
+        assert!(h.channel.sent().is_empty());
+    }
+
+    // --- reachability & wiring ----------------------------------------------
+
+    /// An `output` node on a branch the run never took gets no attempt and NO
+    /// ROW. An absent row means "not reached", never "silently dropped".
+    #[tokio::test]
+    async fn an_unreached_output_node_produces_no_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+        h.add_admin("u1", "ada@acme.test").await;
+        // The engine reached `start` but never `done`.
+        let output = serde_json::json!({
+            "nodes": { "start": { "items": [{ "json": { "seed": 1 } }] } }
+        });
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["*"]),
+            &graph("owner", None),
+            &output,
+        )
+        .await;
+
+        assert!(reports.is_empty(), "{reports:?}");
+        assert!(h.mail.sent().is_empty());
+        assert!(h.channel.sent().is_empty());
+    }
+
+    /// An `output` node with no `destination` is the pre-#170 shape: it still
+    /// shows in the run drawer and produces no delivery row.
+    #[tokio::test]
+    async fn an_output_node_without_a_destination_produces_no_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+        let plain = parse_workflow(
+            r#"
+id = "plain"
+name = "Plain"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+[[edge]]
+from = "start"
+to = "done"
+"#,
+        )
+        .expect("parses");
+
+        let reports =
+            deliver_outputs(Some(&h.deps), &record(&["*"]), &plain, &reached_output()).await;
+        assert!(reports.is_empty(), "{reports:?}");
+    }
+
+    /// The #169 lesson: an unwired delivery bundle must be LOUD. It writes a
+    /// `failed` row onto the run result — where an operator actually looks —
+    /// rather than skipping in a debug log.
+    #[tokio::test]
+    async fn unwired_delivery_reports_loudly_instead_of_skipping() {
+        let reports = deliver_outputs(
+            None,
+            &record(&["*"]),
+            &graph("owner", None),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Failed);
+        assert_eq!(reports[0].node, "done");
+        assert_eq!(reports[0].kind, "owner");
+        assert!(reports[0].detail.contains("not wired"), "{reports:?}");
+        assert!(
+            reports[0].detail.contains("nothing was sent"),
+            "{reports:?}"
+        );
+    }
+
+    // --- report extraction ---------------------------------------------------
+
+    /// Several items concatenate in order; the doubly-wrapped `json.json.text`
+    /// the engine sometimes emits is read too, with the outer value winning.
+    #[test]
+    fn report_text_reads_plain_and_doubly_wrapped_items() {
+        let output = serde_json::json!({
+            "nodes": { "done": { "items": [
+                { "json": { "text": "first" } },
+                { "json": { "json": { "text": "second" } } },
+                { "json": { "text": "outer", "json": { "text": "inner" } } },
+            ] } }
+        });
+        assert_eq!(report_text(&output, "done"), "first\n\nsecond\n\nouter");
+    }
+
+    /// A data-shaped item with no `text` is delivered as JSON rather than
+    /// dropped — an empty report would be worse than an ugly one.
+    #[test]
+    fn report_text_falls_back_to_json_for_a_textless_item() {
+        let output = serde_json::json!({
+            "nodes": { "done": { "items": [{ "json": { "revenue": 12 } }] } }
+        });
+        assert!(report_text(&output, "done").contains("revenue"));
+    }
+
+    #[test]
+    fn report_text_of_a_node_with_no_items_says_so() {
+        let output = serde_json::json!({ "nodes": { "done": { "items": [] } } });
+        assert!(report_text(&output, "done").contains("no output"));
+    }
+
+    /// Truncation is character-indexed: a byte slice here would panic
+    /// mid-codepoint on any multi-byte report.
+    #[test]
+    fn truncation_never_splits_a_codepoint() {
+        let text = "é".repeat(50);
+        let cut = truncate_chars(&text, 10);
+        assert!(cut.starts_with(&"é".repeat(10)));
+        assert!(cut.ends_with(TRUNCATION_MARKER));
+        // Untouched when it fits.
+        assert_eq!(truncate_chars("short", 10), "short");
+    }
+}

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -58,9 +58,11 @@
 //!
 //! A delivery failure must not fail a run that already did its work. Every
 //! attempt yields a [`DeliveryReport`] row on
-//! [`WorkflowRun::deliveries`](crate::ports::WorkflowRun), which rides the run
-//! response into the console's run-result panel — so an operator can tell a
-//! delivered report from an undelivered one **without reading a log**. There is
+//! [`WorkflowRun::deliveries`](crate::ports::WorkflowRun). On an **on-demand**
+//! run those rows ride the run response into the console's run-result panel, so
+//! an operator can tell a delivered report from an undelivered one without
+//! reading a log. A **scheduled** run is not persisted, so its rows reach only
+//! the scheduler's log until issue #242 gives a run a durable record. There is
 //! one attempt per recipient and no retry: a workflow run is not a mail queue.
 //!
 //! An output node the run never reached (an untaken branch, or a path that

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -92,11 +92,6 @@ const MAX_REPORT_CHARS: usize = 16_000;
 /// The marker appended when a report is truncated at [`MAX_REPORT_CHARS`].
 const TRUNCATION_MARKER: &str = "\n\n… (report truncated)";
 
-/// How many inbox messages the established-thread check scans. Mirrors the
-/// agent send path in [`crate::runtime::cycle`] so the two cannot disagree about
-/// what "established" means.
-const ESTABLISHED_SCAN_LIMIT: usize = 500;
-
 /// The ports an output destination needs, bundled so [`HarnessDeps`] grows one
 /// optional field rather than four.
 ///
@@ -475,8 +470,12 @@ async fn record_outbound(
 /// established thread.
 ///
 /// Fails closed (`false`) on a missing sending address or an inbox read error,
-/// which routes the caller to the cold-recipient skip. Byte-for-byte the same
-/// rule as `recipient_is_established` in [`crate::runtime::cycle`].
+/// which routes the caller to the cold-recipient skip.
+///
+/// Delegates the lookup to [`InboxStore::has_inbound_from`] rather than scanning
+/// a page of [`messages`](InboxStore::messages): this is a security gate, and a
+/// gate built on a capped oldest-first page silently stops finding real
+/// correspondents once a company's inbox outgrows the cap (PR #226 review).
 async fn recipient_is_established(
     inbox: &dyn InboxStore,
     company: &CompanyId,
@@ -487,19 +486,10 @@ async fn recipient_is_established(
         return false;
     }
     let key = local_part(company_address);
-    let to = to.trim().to_ascii_lowercase();
-    if to.is_empty() {
-        return false;
-    }
-    match inbox
-        .messages(company, &key, ESTABLISHED_SCAN_LIMIT, 0)
+    inbox
+        .has_inbound_from(company, &key, to)
         .await
-    {
-        Ok(records) => records
-            .iter()
-            .any(|r| !r.outbound && r.from_email.trim().to_ascii_lowercase() == to),
-        Err(_) => false, // fail closed → the cold-recipient skip
-    }
+        .unwrap_or(false) // fail closed → the cold-recipient skip
 }
 
 /// Posts a report to the wired channel adapter with id `channel_id`.
@@ -1061,6 +1051,45 @@ allow = [{allow}]
             h.mail.sent().is_empty(),
             "a cold recipient must not be mailed"
         );
+    }
+
+    /// **Regression (PR #226 review).** A busy company's inbox must not lose an
+    /// established recipient. `InboxStore::messages` returns oldest-first, so a
+    /// capped read takes the OLDEST page — and an inbox that outgrows the cap
+    /// silently stops finding anyone whose mail arrived after it. The failure
+    /// is fail-closed (never a wrong send) but it is still wrong, and it bites
+    /// exactly the longest-lived tenants.
+    ///
+    /// Note the direction: the sender's message must be buried *past* the cap,
+    /// i.e. among the NEWEST mail. A sender whose message is the oldest sits at
+    /// index 0 and was always found, cap or no cap.
+    #[tokio::test]
+    async fn an_established_sender_is_found_past_the_old_scan_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+        // 600 older messages from other people fill the first page…
+        for i in 0..600 {
+            h.receive_from(&format!("filler{i}@example.com")).await;
+        }
+        // …so the real correspondent's mail lands well past a 500-message cap.
+        h.receive_from("ada@example.com").await;
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["*"]),
+            &graph("email", Some("ada@example.com")),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(
+            reports[0].status,
+            DeliveryStatus::Sent,
+            "a correspondent buried past the scan cap is still an established \
+             thread: {reports:?}"
+        );
+        assert_eq!(h.mail.sent().len(), 1);
     }
 
     /// The company's OWN prior outbound mail to an address does not make that

--- a/src/workflows/mod.rs
+++ b/src/workflows/mod.rs
@@ -14,10 +14,12 @@
 //! epic. The default build links none of it.
 
 pub mod caps;
+pub mod delivery;
 pub mod runner;
 pub mod translate;
 
 pub use caps::{HarnessAgentRunner, build_capabilities};
+pub use delivery::{WorkflowDeliveryDeps, deliver_outputs};
 pub use runner::{HarnessWorkflowRunner, run_workflow};
 pub use translate::translate;
 

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -391,6 +391,105 @@ to = "done"
         assert!(output.contains("hello-marker"), "{output}");
     }
 
+    // --- Output destinations, end to end (issue #170) ------------------------
+
+    /// A graph whose terminal `output` node routes its report to the operator
+    /// channel. `trigger → output` only, so it needs no roster.
+    const REPORT_TO_OPERATOR: &str = r#"
+id = "report"
+name = "Report"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "done"
+kind = "output"
+name = "Owner summary"
+[node.destination]
+kind = "channel"
+target = "operator"
+[[edge]]
+from = "start"
+to = "done"
+"#;
+
+    /// The end-to-end proof that the RUNNER (not the HTTP handler) delivers: a
+    /// run driven straight through `run_workflow` with a wired delivery bundle
+    /// posts the report and reports the send on the run result. The
+    /// orchestrator's `run_workflow` tool and the trigger scheduler reach this
+    /// same function, which is why delivery lives here.
+    #[tokio::test]
+    async fn a_run_delivers_its_output_report_through_the_runner() {
+        use crate::runtime::channel::OperatorChannel;
+
+        let dir = tempfile::tempdir().unwrap();
+        let channel = OperatorChannel::new();
+        let mut deps = deps(dir.path());
+        deps.delivery = Some(crate::workflows::WorkflowDeliveryDeps {
+            mail: None,
+            inbox: Arc::new(crate::store::FsInboxStore::new(dir.path())),
+            users: Arc::new(FsOps::new(dir.path())),
+            channels: vec![Arc::new(channel.clone())],
+        });
+
+        let file = parse_workflow(REPORT_TO_OPERATOR).expect("parses");
+        let run = run_workflow(
+            Arc::new(HarnessPool::new()),
+            deps,
+            &record(),
+            &file,
+            serde_json::json!({ "brief": "quarterly numbers" }),
+        )
+        .await
+        .expect("workflow runs");
+
+        assert_eq!(run.deliveries.len(), 1, "{:?}", run.deliveries);
+        assert_eq!(
+            run.deliveries[0].status,
+            crate::ports::DeliveryStatus::Sent,
+            "{:?}",
+            run.deliveries
+        );
+        assert_eq!(run.deliveries[0].node, "done");
+        assert_eq!(
+            channel.sent().len(),
+            1,
+            "the report should have been posted"
+        );
+    }
+
+    /// The #169 lesson, at the run level: with no delivery ports wired the run
+    /// still SUCCEEDS (its work is valid) but the result carries a loud `failed`
+    /// row — an operator can tell a working destination from a broken one
+    /// without reading a log. Every other `deps()` in this suite is unwired, so
+    /// this is the default-build shape.
+    #[tokio::test]
+    async fn an_unwired_runtime_still_runs_but_says_the_report_was_not_sent() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = parse_workflow(REPORT_TO_OPERATOR).expect("parses");
+        let run = run_workflow(
+            Arc::new(HarnessPool::new()),
+            deps(dir.path()),
+            &record(),
+            &file,
+            serde_json::json!({}),
+        )
+        .await
+        .expect("an undeliverable report must not fail the run");
+
+        assert_eq!(run.deliveries.len(), 1, "{:?}", run.deliveries);
+        assert_eq!(
+            run.deliveries[0].status,
+            crate::ports::DeliveryStatus::Failed
+        );
+        assert!(
+            run.deliveries[0].detail.contains("not wired"),
+            "{:?}",
+            run.deliveries
+        );
+    }
+
     /// The port implementation ensures the roster itself, so a caller need not
     /// pre-`ensure`.
     #[tokio::test]

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -116,16 +116,30 @@ async fn run_workflow_inner(
     // message carries the topic — a node's authored `prompt` is the same on
     // every run and cannot say what was asked this time.
     let run_request = super::caps::run_request_text(&input);
+    // Issue #170: the delivery ports are read off `deps` BEFORE it moves into
+    // the capability bundle. Delivery is host-side and post-engine, so it is not
+    // a capability — the engine never learns a report has a destination.
+    let delivery = deps.delivery.clone();
     let capabilities =
         super::caps::build_capabilities(pool, deps, record, &workflow.id, &run_id, run_request)
             .await;
     let outcome = tinyflows::engine::run(&compiled, input, &capabilities)
         .await
         .map_err(map_engine_error)?;
+
+    // Route every reached `output` node's report to its configured destination.
+    // Deliberately here rather than in the HTTP handler: the orchestrator's
+    // `run_workflow` tool and the trigger scheduler drive this same path, and a
+    // scheduled run is exactly the case where nobody is watching the console's
+    // run-result drawer. Never fails the run — each attempt is reported instead.
+    let deliveries =
+        super::delivery::deliver_outputs(delivery.as_ref(), record, workflow, &outcome.output)
+            .await;
+
     Ok(WorkflowRun {
         output: outcome.output,
         pending_approvals: outcome.pending_approvals,
-        deliveries: Vec::new(),
+        deliveries,
     })
 }
 
@@ -248,6 +262,7 @@ description = "Runs Acme."
             media: None,
             composio: None,
             steer: crate::company::steer::InflightRegistry::default(),
+            delivery: None,
         }
     }
 

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -125,6 +125,7 @@ async fn run_workflow_inner(
     Ok(WorkflowRun {
         output: outcome.output,
         pending_approvals: outcome.pending_approvals,
+        deliveries: Vec::new(),
     })
 }
 

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -413,6 +413,7 @@ to = "done"
                 on_error: None,
                 retry: None,
                 requires_approval: None,
+                destination: None,
             }],
             edges: Vec::new(),
         };

--- a/src/workflows/translate.rs
+++ b/src/workflows/translate.rs
@@ -22,8 +22,8 @@
 //! returns (see [`super::delivery`]), so the engine has no use for it and a
 //! `destination` key in node config would be inert cargo. A destination-bearing
 //! `output` node therefore lowers to exactly the same bare pass-through
-//! `Transform` as one without — pinned by
-//! [`an_output_destination_never_reaches_the_engine_graph`](tests).
+//! `Transform` as one without — pinned by the
+//! `an_output_destination_never_reaches_the_engine_graph` test below.
 //!
 //! An **agent** node's roster teammate id becomes the tinyflows `agent_ref` in
 //! node config, which the engine's `agent` node routes to the injected

--- a/src/workflows/translate.rs
+++ b/src/workflows/translate.rs
@@ -17,6 +17,14 @@
 //!   so an edge leaving a condition node maps its label to a `true`/`false`
 //!   port. Every other edge stays on the default `"main"` port.
 //!
+//! An `output` node's [`destination`](crate::company::WorkflowDestinationDef)
+//! is deliberately **not** translated. Delivery runs host-side after the engine
+//! returns (see [`super::delivery`]), so the engine has no use for it and a
+//! `destination` key in node config would be inert cargo. A destination-bearing
+//! `output` node therefore lowers to exactly the same bare pass-through
+//! `Transform` as one without — pinned by
+//! [`an_output_destination_never_reaches_the_engine_graph`](tests).
+//!
 //! An **agent** node's roster teammate id becomes the tinyflows `agent_ref` in
 //! node config, which the engine's `agent` node routes to the injected
 //! `AgentRunner` — that is how a step lands on the harness pool (see
@@ -671,6 +679,73 @@ mod tests {
         assert_eq!(port("paid").as_deref(), Some("paid"));
         assert_eq!(port("error_case").as_deref(), Some("error"));
         assert_eq!(port("fallthrough").as_deref(), Some("default"));
+    }
+
+    /// **The delivery invariant (issue #170).** An `output` node's
+    /// `destination` is host-side routing, not engine config: it must NOT reach
+    /// the compiled graph. A destination-bearing output node lowers to exactly
+    /// the same bare pass-through `Transform` it lowered to before the field
+    /// existed — so translation of a graph is unaffected by where its report
+    /// goes, and the engine never gains an inert key it does not understand.
+    #[test]
+    fn an_output_destination_never_reaches_the_engine_graph() {
+        let with_destination = crate::company::parse_workflow(
+            r#"
+id = "wf"
+name = "WF"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "done"
+kind = "output"
+name = "Report"
+[node.destination]
+kind = "email"
+target = "ada@example.com"
+[[edge]]
+from = "start"
+to = "done"
+"#,
+        )
+        .expect("parses");
+        let without = crate::company::parse_workflow(
+            r#"
+id = "wf"
+name = "WF"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "done"
+kind = "output"
+name = "Report"
+[[edge]]
+from = "start"
+to = "done"
+"#,
+        )
+        .expect("parses");
+
+        let done = |file: &crate::company::WorkflowFile| {
+            translate(file)
+                .nodes
+                .into_iter()
+                .find(|n| n.id == "done")
+                .expect("output node lowered")
+        };
+        let with = done(&with_destination);
+        let plain = done(&without);
+
+        assert_eq!(with.kind, NodeKind::Transform, "output lowers to transform");
+        // A bare pass-through: no `set` bindings, and above all no destination.
+        assert_eq!(with.config, json!({}));
+        assert_eq!(
+            with.config, plain.config,
+            "a destination must not change the engine config"
+        );
     }
 
     fn node_stub(id: &str) -> crate::company::WorkflowNodeDef {

--- a/src/workflows/translate.rs
+++ b/src/workflows/translate.rs
@@ -437,6 +437,7 @@ mod tests {
                 on_error: None,
                 retry: None,
                 requires_approval: None,
+                destination: None,
             }],
             edges: Vec::new(),
         };
@@ -553,6 +554,7 @@ mod tests {
                     on_error: Some("route".into()),
                     retry: None,
                     requires_approval: None,
+                    destination: None,
                 },
                 node_stub("yes_path"),
                 node_stub("no_path"),
@@ -615,6 +617,7 @@ mod tests {
                     on_error: None,
                     retry: None,
                     requires_approval: None,
+                    destination: None,
                 }],
                 edges: Vec::new(),
             };
@@ -643,6 +646,7 @@ mod tests {
                     on_error: None,
                     retry: None,
                     requires_approval: None,
+                    destination: None,
                 },
                 node_stub("paid"),
                 node_stub("error_case"),
@@ -681,6 +685,7 @@ mod tests {
             on_error: None,
             retry: None,
             requires_approval: None,
+            destination: None,
         }
     }
 


### PR DESCRIPTION
## Summary

The terminal `output` node ("owner summary" report-back) had nowhere to send its report. There was no destination in the model and no selector in the console, so an authored output node could only produce a value that surfaced in the transient run-result drawer and then vanished.

Output nodes now carry a first-class `destination` — `owner`, `email`, or `channel` — and the runner delivers the report to it after a run, reporting per-destination outcomes on the run result.

Closes #170.

## Problem

`WorkflowNodeDef` had no destination field; an output node was id/name/summary. The create form rendered no control for it, the inspector showed nothing, and `WorkflowRun { output, pending_approvals }` was consumed only by the ephemeral run drawer. No delivery ever happened.

Worth correcting the issue text: its suggested reuse targets are wrong. `ops/mail.rs` is inbox *reads* and `ops/channels.rs` is Telegram *config*. The real outbound primitives are `CompanyMail`/`MailSender`, the `email.send` effect path in `runtime/cycle.rs`, and the `ChannelAdapter` port with its always-present `operator` channel.

## Solution

**Model** — `destination { kind, target? }` as a typed field on output nodes, following the `WorkflowRetryDef` precedent rather than the free-form `config` blob. Destination is not engine config — the engine never sees it — so putting it in `config` would leak inert keys into the graph, which is what the reserved-key mechanism exists to prevent. `destination` is reserved inside `config` for the same reason. Validation enforces output-only, the kind whitelist, an `@`-containing target for `email`, a target for `channel`, and **no** target for `owner`. Legacy graphs re-render byte-identically.

**Delivery runs host-side, post-engine, in `run_workflow_inner`** — not in the HTTP handler. The orchestrator's `run_workflow` tool and #169's scheduler both drive the same `WorkflowRunner` port, and a scheduled run is precisely the case where nobody is watching the drawer. Dependencies arrive as one optional `WorkflowDeliveryDeps` on `HarnessDeps`, wired at exactly one production site; every other construction leaves `None`, which is fail-closed **and loud** — the run result carries a `failed` row saying delivery is not wired, rather than skipping in silence.

**Delivery failure never fails the run.** The run succeeded; erroring would discard the output. Each attempt yields a `DeliveryReport { node, kind, target, status, detail }` on `WorkflowRun.deliveries`, and successful sends are mirrored into the company inbox for audit. Output nodes on untaken branches or approval-paused paths attempt nothing and produce no row.

**Console** — a destination picker on output rows in the create dialog, a Destination line in the node inspector, and per-delivery status lines in the run drawer.

## API Or Behavior Changes

A workflow can now cause an email to leave the system, so the gating is the substance of this PR. There is exactly **one** transport call site (`send_email` in `src/workflows/delivery.rs`), reached from exactly **two** places:

- **`owner`** — recipients come from the company's own user store (Admin + Active + has an address). The graph names nobody: validation rejects a `target` on `owner`, and the owner arm never reads one. With no mailbox or no addressable admin it falls back to the operator channel, so the owner always hears about it and it is never a silent no-op.
- **`email`** — three sequential fail-closed guards, each returning early. First the company's `[tools].allow` must cover the `email` namespace, via the same `grants_cover` matcher that gates an agent's exec tools. Then a mailbox must exist. Then the recipient must be an **established thread** — the company inbox must already hold inbound mail from that address — ported from the agent send path. A cold recipient is skipped and reported, never sent. The thread check fails closed on an empty sender, an empty target, or an inbox read error, and a prior *outbound* to that address does not bootstrap the next one.

  > **Correction, and it matters.** An earlier version of this description called the grant and the thread rule "two independent gates". Since #230 that is no longer true of a default-configured company: the default `[tools].allow` is now `["*", "media", "composio"]` (`src/company/types.rs:462`), and `grants_cover(&["*"], "email")` is `true`. So on any company without an explicit `[tools]` section — the default, including hosted — **the grant gate is already open**, and the established-thread rule is the only thing holding the line. Nothing here is wrong or inconsistent: `*` means everything, uniformly, across `tool_call` and agent exec tools too. But the protection should be described as one load-bearing gate plus one that most deployments will not exercise, not two independent ones. A test pins the remaining guarantee for a default-configured company (`a_default_configured_company_still_cannot_cold_email`), including an assertion that the default belt really does cover `email` so it cannot pass for the wrong reason later.
  >
  > Worth a maintainer's opinion separately: `*` deliberately excludes `media` and `composio` as real-money / per-tenant-credential namespaces. `email` is an outbound-send namespace with real-world reach, and there is a case that it belongs in the same excluded set. That is a decision about #230's default, not something this PR should change unilaterally.

- **`channel`** — resolves against wired `ChannelAdapter`s, which come from the company manifest's own `[channels]` declarations. A miss posts nothing and names the wired ids.

**One asymmetry a reviewer should weigh deliberately**: `email` requires a manifest grant, `channel` does not. The argument for it is that channel adapters are per-company manifest declarations rather than ambient, and that channels are not a tool namespace anywhere else in the platform either — so requiring a grant here would be novel rather than consistent. If the team wants parity, adding a `channels` grant is a small change, but it should be a decision rather than a default.

Not forcing `requires_approval` on delivery: the engine's approval pause has no resume path today, so gating on it would dead-end the report instead of delaying it. That leaves a real gap — an agent emailing a new contact gets an approval card, a workflow gets a `skipped` row — filed as a follow-up (linked below) rather than papered over.

Other shape changes: `WorkflowRun` gains `deliveries` (`#[serde(default)]`); `HarnessDeps` gains `delivery: Option<WorkflowDeliveryDeps>`; the GraphQL `WorkflowNode` gains `destination` as a JSON scalar, with the committed SDL snapshot regenerated.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — 0 errors
- [x] `cargo build --all-targets`
- [x] `cargo test` — 943 passed, 0 failed

Also run: `cargo test --features openhuman` (1300 passed, 0 failed), `cargo check --all-features`, `cargo check --features openhuman,mcp,telegram`, and frontend `npm ci` + `typecheck` + `build`.

Delivery coverage is offline via the existing fakes: owner→admin email, owner→operator-channel fallback (both the no-mailbox and no-addressable-admin reasons), email granted + established (sent, and the outbound audit record written), email cold (skipped, nothing sent, no audit record), email ungranted (denied even with mailbox and thread present, so the grant is provably the refusing gate), a prior outbound not establishing a thread, channel hit and miss, output node on an untaken branch (no row), delivery not wired (loud row, run still `Ok`), and a refusing transport (reported, run unaffected, no audit record). Plus model round-trip and validation arms, the translate invariant that a destination-bearing output node still lowers to a pass-through `Transform`, REST create/GET/run wire, and two GraphQL reads.

`cargo test --features openhuman,mcp,telegram` shows 1285 passed / 1 failed — `harness::build::tests::dispatched_desk_agent_tool_belt_is_pinned`, the pre-existing combo failure, untouched by this branch.

**Not verified**: no message has crossed a real SMTP wire (every send test uses a recording sender), and the console controls were type-checked and built but never driven in a browser — this repo has no frontend test harness. Both are called out rather than implied.


### Rebased onto `main` after #211 merged

#169 (trigger schedules) landed first and touched the same seams, so this branch was rebased rather than merged. Every conflict was additive and resolved as keep-both: the reserved-config-key list, four DTO seams in `ops/workflows.rs`, six hunks in the create dialog, the inspector's "no extra details" guard, and the exhaustive struct literals each side was missing from the other.

Two resolutions worth naming, because both are places a rebase quietly loses work:

- Both PRs appended a test block at the same point in `ops/workflows.rs`, so git interleaved two unrelated suites line-by-line with `#[test]` attributes spliced across each other. Rather than hand-merge that, each block was extracted verbatim from its own side and spliced back to back.
- The SDL snapshot auto-merged without conflict, which is exactly the case not to trust. It was regenerated from the resolved Rust and came out byte-identical — verified rather than assumed.
- `changeKind` (the helper that clears kind-conditional fields) predated #169's `schedule`, so after the rebase it cleared `agent` and the destination fields but not `schedule`. Switching a node away from `trigger` and back would have silently restored a cron the author could not see in between. Now covered, with the doc comment restated as a rule about *every* kind-conditional field.

No test was lost in the resolution, checked by name rather than by count: the union of tests on both sides was diffed against the rebased branch, and the only difference is the one test deliberately added (`a_default_configured_company_still_cannot_cold_email`).

A scheduled run picks up delivery automatically — the scheduler drives the same `WorkflowRunner` port — which is why delivery lives in the runner rather than the HTTP handler. The scheduler still discards `run.deliveries`; that is #228 and is deliberately not fixed here.

## Documentation

`docs/modules/server/README.md` gains a `workflows` row in the ops routes table (it had none) plus a delivery section. Module docs on `workflow_file.rs` and the new `delivery.rs` describe the destination shape and every gate.

## Related

- Builds on #168 / PR #207 — a destination round-trips through the record overlay like any other node field.
- Stacks conceptually with #169 / PR #211 (trigger schedules). The two touch the same model file, REST DTOs, GraphQL node shape and SDL snapshot, and create-form node row; conflicts are additive and resolve as *keep both*, regenerating the SDL snapshot rather than hand-merging.
- **Follow-up owed once both land**: #169's scheduler discards the `WorkflowRun` it receives, and delivery outcomes now live on that value — so a scheduled report that failed to send would be invisible. Neither branch can fix this alone, since the field does not exist on #169's branch. Tracked as a separate issue.
- Cold-send approval gap: linked follow-up issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow output reports can be routed to an owner, email address, or channel.
  * Workflow creation supports destination selection and target validation.
  * Run results show delivery attempts, statuses, undelivered counts, and details.
  * Destination settings and delivery reports are available through workflow APIs and GraphQL.

* **Bug Fixes**
  * Delivery failures, skips, and authorization issues no longer fail workflow runs.
  * Invalid or unauthorized destinations are safely rejected.

* **Documentation**
  * Added documentation covering report delivery behavior and safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->