### PR TITLE
feat(company): grant the full tool belt to every tenant by default

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -51,10 +51,14 @@ env:
   ECR_REPOSITORY: tinyhumansai/opencompany-tenant
   K8S_NAMESPACE: opencompany-system
   MANAGER_DEPLOY: opencompany-manager
-  # The feature set the hosted tenant ships with. Kept verbatim from the
-  # pipeline this replaces — changing it changes what every tenant can do, so
-  # treat edits here as a product change, not a CI tweak.
-  TENANT_FEATURES: mongodb,openhuman,openhuman-rpc,tinyplace,github,smtp,dns,tinyhumans,webhooks,platform-jwt,export
+  # The feature set the hosted tenant ships with. Changing it changes what
+  # every tenant can do, so treat edits here as a product change, not a CI
+  # tweak. Full belt: adds mcp/media/composio (the credential/real-money tool
+  # families, fail-closed until their config exists), imap/telegram (channels),
+  # medulla (hosted brain transport), tinycortex (local memory backend), and
+  # sidecar. `sqlite` is intentionally omitted — its bundled rusqlite needs a C
+  # compiler the slim build image lacks, and it is redundant on a mongodb tenant.
+  TENANT_FEATURES: mongodb,openhuman,openhuman-rpc,tinyplace,github,smtp,dns,tinyhumans,webhooks,platform-jwt,export,mcp,media,composio,imap,telegram,medulla,tinycortex,sidecar
 
 jobs:
   deploy:

--- a/companies/agentic_software_company/company.toml
+++ b/companies/agentic_software_company/company.toml
@@ -8,9 +8,13 @@ output = "An entire SaaS product"
 human_role = "Product direction"
 
 [tools]
-# Composio integration tools (Gmail/Slack/GitHub). Fail-closed until a
-# per-company Composio bearer is set via the console.
-allow = ["composio"]
+# Full tool belt. `*` covers files/docs/shell/code/web/subagent; `media` and
+# `composio` are listed literally because `*` deliberately excludes those two
+# (real-money + per-tenant-credential) namespaces. media/composio/mcp also
+# require their Cargo features compiled into the tenant image, and each is
+# fail-closed at runtime until its credential/config is present (Composio
+# bearer, media backend, per-server MCP config).
+allow = ["*", "media", "composio"]
 
 [[agent]]
 id = "product_manager"

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -454,7 +454,12 @@ impl Default for Tools {
     fn default() -> Self {
         Self {
             provider: default_tool_provider(),
-            allow: Vec::new(),
+            // Grant the full tool belt by default: `*` covers files/docs/shell/
+            // code/web/subagent, and `media`/`composio` are listed literally
+            // because the `*` wildcard deliberately excludes those two
+            // (real-money + per-tenant-credential) namespaces. A company that
+            // wants a narrower belt overrides `[tools].allow` explicitly.
+            allow: vec!["*".into(), "media".into(), "composio".into()],
             web_allowed_domains: Vec::new(),
             composio: ComposioTools::default(),
         }


### PR DESCRIPTION
## Summary

Every company — and every hosted tenant — now gets the **full agent tool belt** by default: `files`, `docs`, `shell`, `code`, `web`, `subagent` (via the `*` wildcard) plus `media` and `composio` (listed literally, since `*` deliberately excludes those two credential/real-money namespaces) — and the tenant image is compiled with the feature set those grants need.

Three coupled changes, one repo:
1. default grants → full belt (`Tools::default`)
2. the hosted default company's explicit grants → full belt
3. `TENANT_FEATURES` → compile `mcp,media,composio,imap,telegram,medulla,tinycortex,sidecar` into the tenant image

## Problem

Grants were opt-in and almost nothing opted in: `Tools::default().allow` was empty, so a company with no `[tools]` section (19 of 21 bundled templates) gave its agents only the intrinsic memory tools — no shell/code/web/subagents. The hosted default company (`agentic_software_company`, what every tenant boots) granted only `["composio"]` — and the tenant image never even compiled the `composio` feature, so that grant was inert.

## Solution

- `src/company/types.rs` — `impl Default for Tools`: `allow` defaults to `["*", "media", "composio"]`. One place; covers every company with an absent/empty `[tools]`.
- `companies/agentic_software_company/company.toml` — `[tools].allow = ["*", "media", "composio"]`. This company has an explicit list, so it needs the direct edit; it is the manifest every hosted tenant boots, so this is the "every tenant" knob.
- `.github/workflows/deploy-staging.yml` — `TENANT_FEATURES` gains `mcp,media,composio,imap,telegram,medulla,tinycortex,sidecar` so the tenant image actually compiles the tool families the grants reference. `sqlite` omitted (bundled rusqlite needs a C compiler the slim build image lacks; redundant on a mongodb tenant).

Unchanged by design: `*` still does **not** cover `media`/`composio` (`grants_media_explicit`/`grants_composio_explicit`) — those stay literal-only. Grants remain workspace-sandboxed under `exec_security` + autonomy-tier + token-budget metered; this widens *which* namespaces are granted, not the sandbox or the gate.

**Security note:** this makes every tenant's agents able to run arbitrary shell/code in their workspace sandbox by default. That grant-gate was previously opt-in. Intended per product direction; flagging the blast radius explicitly.

**Runtime notes:** `media`/`composio`/`mcp` stay fail-closed until their credential/config is present (media backend, per-tenant Composio bearer, per-server MCP config). `web` is granted but `web_allowed_domains` stays empty — the SSRF domain allowlist is a separate per-company control, not opened here.

## Submission Checklist

- [x] Full tenant feature combo compiles: `cargo check --features mongodb,openhuman,openhuman-rpc,tinyplace,github,smtp,dns,tinyhumans,webhooks,platform-jwt,export,mcp,media,composio,imap,telegram,medulla,tinycortex,sidecar` — clean (only pre-existing vendored warnings).
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo test --lib company::types` — 6/0 (incl. the `*`-excludes-media/composio invariant).
- [x] `cargo test --features openhuman --lib harness::build` — 9/0.

## Impact

Existing tenants keep their old image until rebuilt+restarted (grants are a boot snapshot; no runtime edit path). A company can still narrow its belt by setting `[tools].allow` explicitly.

## Related

Full toolbelt direction (2026-07-24). Prior toolbelt wiring: #118. The staging deploy that ships this now lives in-repo (`deploy-staging.yml`, ECR/OIDC) after the microservice `#7` dropped the cross-repo tenant pipeline.