### PR TITLE
fix(deploy): refresh_all_tenants restart across namespaces

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -188,7 +188,16 @@ jobs:
           # deliberate, since restarting them interrupts live agent work.
           if [ "${REFRESH_ALL}" = "true" ]; then
             echo "Restarting all running tenants onto the new image (requested)..."
-            kubectl rollout restart statefulset -A -l app=opencompany
+            # `kubectl rollout restart` has no --all-namespaces/-A flag, so
+            # enumerate matching StatefulSets across namespaces and restart each
+            # in its own namespace.
+            kubectl get statefulset -A -l app=opencompany \
+              -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' \
+            | while read -r ns name; do
+                [ -n "${ns}" ] || continue
+                echo "  rollout restart statefulset/${name} in ${ns}"
+                kubectl -n "${ns}" rollout restart "statefulset/${name}"
+              done
           else
             echo "Running tenants keep their current image; re-run with refresh_all_tenants=true to roll them."
           fi


### PR DESCRIPTION
## Summary

`refresh_all_tenants=true` in `deploy-staging.yml` has never worked: it ran `kubectl rollout restart statefulset -A -l app=opencompany`, but `rollout restart` has **no** `--all-namespaces`/`-A` flag, so it aborts with `error: unknown shorthand flag: 'A'` and the deploy job fails after already rolling the manager.

## Problem

Observed on run 30639237477 (2026-07-31): manager rolled out fine, then the refresh step died on the bad flag — so no running tenant was ever restarted onto the new image, and the job reported failure.

## Solution

Enumerate matching StatefulSets with `kubectl get statefulset -A -l app=opencompany` (get *does* support `-A`) and `rollout restart` each in its own namespace.

## Submission Checklist

- [x] `rollout restart` no longer receives `-A`; namespaces resolved via `get -A` + per-namespace restart.
- [ ] Verified on a real `refresh_all_tenants=true` run (next dispatch after merge).

## Impact

`refresh_all_tenants=true` now actually restarts running tenants onto the freshly-rolled image. The non-refresh path (default) is unchanged.

## Related

Surfaced while rolling the full-toolbelt tenant image (#230) to staging.