### PR TITLE
fix(ci): restart tenants per namespace + declare Composio toolkits so the Connections tab is usable

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -188,7 +188,17 @@ jobs:
           # deliberate, since restarting them interrupts live agent work.
           if [ "${REFRESH_ALL}" = "true" ]; then
             echo "Restarting all running tenants onto the new image (requested)..."
-            kubectl rollout restart statefulset -A -l app=opencompany
+            # `kubectl rollout restart` has no -A/--all-namespaces (only `get`
+            # does), so enumerate first and restart per namespace. Each tenant
+            # lives in its own namespace, so this is the only way to reach them
+            # all in one pass.
+            kubectl get statefulset -A -l app=opencompany \
+              -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' \
+            | while read -r ns name; do
+                [ -n "${ns}" ] || continue
+                echo "  restarting ${ns}/${name}"
+                kubectl -n "${ns}" rollout restart "statefulset/${name}"
+              done
           else
             echo "Running tenants keep their current image; re-run with refresh_all_tenants=true to roll them."
           fi

--- a/companies/agentic_software_company/company.toml
+++ b/companies/agentic_software_company/company.toml
@@ -16,6 +16,21 @@ human_role = "Product direction"
 # bearer, media backend, per-server MCP config).
 allow = ["*", "media", "composio"]
 
+# The Composio toolkits this company may reach. Two effects, and the second is
+# the reason this is set rather than left empty:
+#
+#  1. Runtime narrowing — a toolkit outside this list is rejected client-side,
+#     before any network call. Empty would defer to the backend's own
+#     server-enforced allowlist ("open mode"), which is not unsafe, just wider.
+#  2. The console's per-provider "Sign in" list renders from THIS list. With it
+#     empty the Connections tab shows no provider rows at all, so an operator has
+#     no way to start an OAuth handoff from the UI.
+#
+# Keep it to the toolkits a company is actually expected to use; adding one here
+# is what makes it appear in the Connections tab.
+[tools.composio]
+toolkits = ["gmail", "slack", "github"]
+
 [[agent]]
 id = "product_manager"
 role = "Product Manager"


### PR DESCRIPTION
## Summary

Two changes needed before the Connections tab can actually be used:

1. **Fix the tenant-refresh path**, which fails outright — so a running tenant cannot be moved onto a new image.
2. **Declare the Composio toolkits** for `agentic_software_company`, without which the console renders no provider rows to sign in with.

## API Or Behavior Changes

**`refresh_all_tenants` now works.** It was failing with:

```
error: unknown shorthand flag: 'A' in -A
See 'kubectl rollout restart --help' for usage.
```

`kubectl rollout restart` has no `-A`/`--all-namespaces` — only `get` does. The line came over verbatim from the pipeline #200 replaced, where it had never been exercised because that workflow never completed a run (it died at checkout on a missing `SUBMODULES_PAT`). So this is a latent bug that only surfaced once the pipeline started working. Note the failure happened **after** `OCM_TENANT_IMAGE` was already set, so the env change landed and only the restart was lost.

Now the StatefulSets are enumerated first and restarted per namespace. Verified against staging — the enumeration resolves all three tenants:

```
tenant-john opencompany
tenant-smoke1 opencompany
tenant-tinyhumans-marketing opencompany
```

**`[tools.composio].toolkits` is now declared** as `["gmail", "slack", "github"]`. Two effects, and the second is the reason:

- Runtime narrowing: a toolkit outside the list is rejected client-side before any network call. Empty was **not unsafe** — it defers to the backend's own server-enforced allowlist ("open mode") — just wider.
- The console's per-provider "Sign in" list renders from this list; `showProviders` is gated on `status.toolkits.length > 0`. With it empty, the Connections tab shows **no provider rows at all**, so an operator has no way to start an OAuth handoff from the UI.

No Rust behaviour changes: `composio` was already added to `TENANT_FEATURES` by #230, so the tools are compiled into the image already.

## Tests

- `cargo test --lib company::` — **172 passed**, 0 failed (covers manifest deserialization, which is what the new TOML block exercises).
- `company.toml` parses, and `tools.composio.toolkits` round-trips as `["gmail", "slack", "github"]`.
- Workflow parses as valid YAML.
- The fixed `kubectl get` enumeration was run against the live staging cluster (read-only) and returns the three tenants above. The `rollout restart` half is not exercised until a run uses `refresh_all_tenants=true`.

## Documentation

Both changes carry inline comments explaining the *why* rather than the what — specifically that `rollout restart` lacks `-A`, and that the toolkit list drives the console's provider rows (the non-obvious coupling that made an empty list look harmless).

## Notes for review

Worth deciding deliberately: declaring toolkits narrows this company to those three. If the intent is for companies to reach anything the backend allows, the better long-term fix is for the console to render provider rows from the backend's allowlist instead of the manifest, and leave `toolkits` empty. That would be a frontend change; this PR takes the smaller path so the tab becomes usable now.

`#230` granted the full tool belt by default, so `composio` is already in `allow` for this company — no grant change needed here.

## Related

Unblocks the Connections work: with the image already carrying `composio` (#230) and the provider rows now rendering, what remains is activating attestation (`OCM_ATTESTATION_AUDIENCE` on the manager, then the backend's `OPENCOMPANY_CLUSTER_ISSUER` / `OPENCOMPANY_ATTESTATION_AUDIENCE`) so the credential comes from platform identity rather than a pasted token.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tenant refresh reliability by restarting each applicable service individually across namespaces.

- **New Features**
  - Added Gmail, Slack, and GitHub integrations.
  - Made these integrations available through the Connections interface.
  - Documented runtime options for limiting available integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->