### PR TITLE
fix(ci): refresh tenants by patching the image, not restarting them

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -221,7 +221,7 @@ jobs:
             # patch took: a tenant scaled to zero has no pod to roll, so
             # `rollout status` would block forever on it.
             kubectl get statefulset -A -l app=opencompany \
-              -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,IMAGE:.spec.template.spec.containers[0].image
+              -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,IMAGE:.spec.template.spec.containers[?(@.name=="opencompany")].image
           else
             echo "Running tenants keep their current image; re-run with refresh_all_tenants=true to move them."
           fi

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -163,7 +163,21 @@ jobs:
           # `ctr`, which defaults to `default`), but naming it means this does not
           # silently break if that wrapper default ever changes.
           k3s ctr -n k8s.io images pull --user "${PULL_USER}:${PULL_PW}" "${IMAGE}"
-          k3s ctr -n k8s.io images ls -q | grep -Fqx "${IMAGE}" \
+
+          # Retry the check: `images ls` can lag a just-finished pull by a beat
+          # while containerd commits the record (observed failing 147ms after a
+          # successful pull, with layers still reporting `extracted`). The
+          # assertion is worth keeping — a silent pull failure would leave tenants
+          # unable to start — but it must not fail the deploy on that race.
+          present=no
+          for _ in 1 2 3 4 5 6 7 8 9 10; do
+            if k3s ctr -n k8s.io images ls -q | grep -Fqx "${IMAGE}"; then
+              present=yes
+              break
+            fi
+            sleep 2
+          done
+          [ "${present}" = yes ] \
             || { echo "ERROR: ${IMAGE} is not in the k8s.io containerd namespace after pull" >&2; exit 1; }
 
           # Tenant pods pin imagePullPolicy: IfNotPresent, so a moving tag is not

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -183,24 +183,33 @@ jobs:
             exit 1
           fi
 
-          # New and woken tenants boot on the new image from here. ALREADY
-          # RUNNING tenants keep their current image until recreated — that is
-          # deliberate, since restarting them interrupts live agent work.
+          # OCM_TENANT_IMAGE only reaches a tenant when the manager PROVISIONS
+          # it — `ensure_running` calls `provision()` only when the StatefulSet is
+          # missing, and the reconciler does not re-apply manifests. So an
+          # existing tenant keeps its original image indefinitely, across
+          # scale-to-zero and wake alike; only a brand-new tenant picks this up.
+          #
+          # A `rollout restart` therefore does NOT move a tenant to a new image:
+          # it recreates the pod from the same spec. Refreshing means patching the
+          # image on the StatefulSet itself.
           if [ "${REFRESH_ALL}" = "true" ]; then
-            echo "Restarting all running tenants onto the new image (requested)..."
-            # `kubectl rollout restart` has no -A/--all-namespaces (only `get`
-            # does), so enumerate first and restart per namespace. Each tenant
-            # lives in its own namespace, so this is the only way to reach them
-            # all in one pass.
+            echo "Moving all tenants onto ${IMAGE} (requested)..."
+            # `kubectl set image` has no -A/--all-namespaces (only `get` does), so
+            # enumerate first and patch each in its own namespace.
             kubectl get statefulset -A -l app=opencompany \
               -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' \
             | while read -r ns name; do
                 [ -n "${ns}" ] || continue
-                echo "  restarting ${ns}/${name}"
-                kubectl -n "${ns}" rollout restart "statefulset/${name}"
+                echo "  ${ns}/${name} -> ${IMAGE}"
+                kubectl -n "${ns}" set image "statefulset/${name}" "opencompany=${IMAGE}"
               done
+            # Report where each tenant actually landed rather than assuming the
+            # patch took: a tenant scaled to zero has no pod to roll, so
+            # `rollout status` would block forever on it.
+            kubectl get statefulset -A -l app=opencompany \
+              -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,IMAGE:.spec.template.spec.containers[0].image
           else
-            echo "Running tenants keep their current image; re-run with refresh_all_tenants=true to roll them."
+            echo "Running tenants keep their current image; re-run with refresh_all_tenants=true to move them."
           fi
 
           kubectl -n "${K8S_NAMESPACE}" get deploy "${MANAGER_DEPLOY}" \


### PR DESCRIPTION
## Summary

`refresh_all_tenants` did not move tenants onto a new image. #234 made the step *run* (it was failing on `kubectl rollout restart -A`, which does not exist); this makes it *work*.

## API Or Behavior Changes

`refresh_all_tenants=true` now patches the image on each tenant StatefulSet instead of restarting it.

## Problem

A `rollout restart` recreates pods from the **same spec**, so it recreated tenants on the **same image**.

`OCM_TENANT_IMAGE` only reaches a tenant when the manager *provisions* it:

```rust
// Provision on first touch, mirroring DockerRuntime's create-on-missing.
if stateful_sets.get_opt(manifests::APP_NAME).await?.is_none() {
    self.provision(tenant).await?;
}
```

and the reconciler does not re-apply manifests — *"provisioning happens on demand in the wake-on-request path"*. So an existing tenant keeps its original image **indefinitely**, across scale-to-zero and wake alike. Only a brand-new tenant picks up a new value.

That also makes the inherited documentation wrong: it claimed *"New / restarted tenants boot on the new image immediately"*. The **restarted** half was never true. Observed directly — a tenant on a stale image had to have its StatefulSet image patched by hand; restarting it changed nothing.

## Solution

Enumerate the tenant StatefulSets (`kubectl set image` has no `-A` either, same as `rollout restart`) and patch each in its own namespace, then print where every tenant actually landed instead of asserting success.

No `rollout status`, deliberately: a tenant scaled to zero has no pod to roll, so waiting on it would block until timeout. The printed image column is the verification.

## Tests

- Workflow parses as valid YAML.
- Enumeration verified against staging (read-only): resolves `tenant-john`, `tenant-smoke1`, `tenant-tinyhumans-marketing`.
- Container name confirmed as `opencompany` (`APP_NAME` in `kube_manifests.rs`) and matches the live StatefulSets.
- The patch path itself is exercised the first time a run uses `refresh_all_tenants=true`.

## Documentation

The step carries the `provision()`-only explanation inline, so the next person does not re-derive why a restart is insufficient.

## Notes for review

**This belongs in the manager, not CI.** Having a CI job reach into tenant StatefulSets is a workaround for the manager not converging tenants onto the configured image on wake. The better fix is for `ensure_running` to re-apply the image from `OCM_TENANT_IMAGE`, after which this step could go away entirely. Happy to file that against `opencompany-microservice` if you want it tracked.

## Related

- #234 — fixed the `-A` flag so this step ran at all.
- #200 / #209 — the pipeline this completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Staging deployments now retry image verification to handle brief availability delays.
  * Refresh-all deployments apply the new image to every tenant, including tenants scaled to zero.
  * Existing tenant images remain unchanged when refresh-all is disabled.
  * Deployment results now report the image assigned to each tenant without waiting for rollout completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->