### PR TITLE
fix(runtime): look up established correspondents without a page cap (#232)

### DIFF
--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -521,19 +521,24 @@ fn company_address(rt: &CompanyRuntime) -> String {
 /// `to` — an established thread, so replying is auto-allowed instead of
 /// parking for approval. Fails closed (`false`) on a missing mail handle or a
 /// store error, which routes the caller to the cold-recipient park path.
+///
+/// Delegates the lookup to [`has_inbound_from`](crate::ports::InboxStore::has_inbound_from)
+/// rather than scanning a page of
+/// [`messages`](crate::ports::InboxStore::messages): this answer decides
+/// an approval gate, and a gate built on a capped oldest-first page silently
+/// stops finding real correspondents once the inbox outgrows the cap — past
+/// that point every reply parks, and an approval queue full of legitimate mail
+/// is one operators learn to rubber-stamp (issue #232).
 async fn recipient_is_established(rt: &CompanyRuntime, to: &str) -> bool {
     let address = company_address(rt);
     if address.is_empty() {
         return false;
     }
     let key = crate::server::ops::smtp::local_part(&address);
-    let to = to.trim().to_ascii_lowercase();
-    match rt.inbox().messages(rt.id(), &key, 500, 0).await {
-        Ok(records) => records
-            .iter()
-            .any(|r| !r.outbound && r.from_email.trim().to_ascii_lowercase() == to),
-        Err(_) => false, // fail closed → parks for approval
-    }
+    rt.inbox()
+        .has_inbound_from(rt.id(), &key, to)
+        .await
+        .unwrap_or(false) // fail closed → parks for approval
 }
 
 /// The host the brain calls back into mid-cycle. Bridges tool, context, and
@@ -1920,6 +1925,83 @@ mod test {
             .unwrap();
         assert_eq!(res.output["status"], "sent");
         assert_eq!(sender.sent().len(), 1);
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    /// Issue #232: the established-correspondent gate must not weaken as the
+    /// inbox grows.
+    ///
+    /// [`InboxStore::messages`] returns **oldest-first**, so the old
+    /// `messages(.., 500, 0)` scan only ever saw the 500 *oldest* messages.
+    /// Past that size every newer correspondent read as unknown, and every
+    /// reply to a real thread parked for approval — an approval queue nobody
+    /// can distinguish from noise is an approval queue everyone rubber-stamps.
+    ///
+    /// So the correspondent here is filed **last**, past the old cap. Policy is
+    /// `full` (every effect executes) to isolate the flags on the effect from
+    /// the gate decision they feed: this asserts what the send path *believes*
+    /// about the recipient, not what the policy did with that belief.
+    #[tokio::test]
+    async fn established_recipient_past_the_old_page_cap_is_not_first_time() {
+        let home = tmp_home();
+        let sender = Arc::new(RecordingMailSender::new());
+        let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
+            .with_mail(CompanyMail {
+                sender: sender.clone(),
+                smtp: test_smtp("ceo@acme.test"),
+            })
+            .build()
+            .await
+            .unwrap();
+
+        let file = async |id: usize, from: &str| {
+            rt.inbox()
+                .append(
+                    rt.id(),
+                    &crate::ports::inbox::EmailRecord {
+                        id: format!("m{id}"),
+                        inbox: "ceo".into(),
+                        from_name: String::new(),
+                        from_email: from.to_string(),
+                        subject: "hi".into(),
+                        body: String::new(),
+                        at_millis: id as u64,
+                        read: false,
+                        outbound: false,
+                    },
+                )
+                .await
+                .unwrap();
+        };
+
+        // 501 older messages from other people, so the real correspondent lands
+        // at index 501 — one past the end of the old 500-message page.
+        for i in 0..501 {
+            file(i, &format!("filler{i}@ext.com")).await;
+        }
+        file(501, "known@ext.com").await;
+
+        let host = CycleHostImpl::new(rt.id().clone(), "cyc-deep".into(), &rt);
+        let res = host
+            .send_email(serde_json::json!({ "to": "known@ext.com", "subject": "s", "body": "b" }))
+            .await
+            .unwrap();
+        assert_eq!(res.output["status"], "sent");
+
+        let (executed, parked) = host.into_outcomes();
+        assert!(parked.is_empty(), "an established thread must not park");
+        let effect = executed
+            .iter()
+            .find(|e| e.kind == EMAIL_SEND_KIND)
+            .expect("the send path emitted an email.send effect");
+        assert!(
+            effect.established_thread,
+            "a correspondent who wrote in past message 500 is still established"
+        );
+        assert!(
+            !effect.first_time_counterparty,
+            "a correspondent who wrote in is never a first-time counterparty"
+        );
         tokio::fs::remove_dir_all(&home).await.ok();
     }
 


### PR DESCRIPTION
## Summary

The agent send path decided whether a recipient was an "established
correspondent" by scanning `InboxStore::messages(company, key, 500, 0)`.
That store method returns **oldest-first**, so the scan only ever saw the 500
*oldest* messages in the company inbox. Once an inbox outgrew that page, every
correspondent who wrote in after it read as unknown.

The failure mode is not a crash and not a hard denial — it is the approval gate
quietly ceasing to discriminate. Past message 500, replies to real, ongoing
threads park for approval alongside genuinely cold outreach. An approval queue
that fills with legitimate mail is one operators learn to clear on reflex, and a
gate everyone rubber-stamps no longer catches the cases it exists to catch. The
gate's value is that parking means something; a capped scan erodes exactly that.

This delegates the question to `InboxStore::has_inbound_from` (added in #226),
whose "correct at every inbox size" contract is pinned by the store conformance
suite, so all backends answer it the same way. The call keeps failing closed on
a store error, routing to the cold-recipient park path as before.

Closes #232

## API Or Behavior Changes

No public API change — `has_inbound_from` already exists on the `InboxStore`
port and is exercised by the conformance suite.

Behavior change, and the intended one: a recipient who has written in is now
recognised as an established thread regardless of where their message sits in
the inbox. Under the old code, that recognition depended on inbox size.

- Inboxes at or under 500 messages: **no observable change.**
- Inboxes over 500 messages: replies to established correspondents are
  auto-allowed instead of parking. Fewer approvals, and the ones that remain
  are the ones worth reading.
- Error and missing-mail-handle paths are unchanged — both still fail closed to
  the park path.

The local trim/lowercase of the recipient address was dropped from the call
site because `has_inbound_from` performs that same case-insensitive,
trimmed match itself, mirroring `normalize_email`. Matching semantics are
unchanged.

## Tests

New regression test in `src/runtime/cycle.rs`:
`established_recipient_past_the_old_page_cap_is_not_first_time`. It files 501
messages from unrelated senders and *then* files the real correspondent, so
that correspondent sits one past the end of the old 500-message page — the
exact position the old code could not see. It asserts the send path emits an
`email.send` effect with `established_thread` set and
`first_time_counterparty` clear, and that nothing parked. Policy is `full` so
the assertion is about what the send path *believes* about the recipient, not
about what the policy then did with that belief. The test fails on the previous
implementation and passes on this one.

Run locally on this branch, rebased onto current `main`:

- [x] `cargo fmt --all -- --check` — clean, exit 0
- [x] `cargo clippy --all-targets -- -D warnings` — clean, exit 0
- [x] `cargo build --all-targets` — exit 0
- [x] `cargo test` — 976 passed, 0 failed, 1 ignored (+6 passed in the second
      target)

Additionally, since CI on this repo builds default features only and compiles
none of the `openhuman`-gated code, the gated configuration was built and
tested locally as well:

- [x] `cargo check --features openhuman` — exit 0. The only warnings are the
      pre-existing `dead_code` ones for `toolkit_allowed` / `slug_toolkit` in
      `src/harness/composio.rs`, plus pre-existing `vendor/openhuman`
      warnings. Neither is touched by this change.
- [x] `cargo test --features openhuman` — 1347 passed, 0 failed, 1 ignored
      (+6 passed in the second target). The new test is present and passing in
      both the default and `openhuman` runs.

Not run, stated plainly: `cargo clippy --features openhuman`. That
configuration trips a pre-existing `large_enum_variant` in `vendor/tinyagents`
that is unrelated to this change and not mine to fix, so a pass/fail there
would say nothing about this diff. No other gate was skipped.

## Documentation

No separate docs update. The rationale lives with the code that has to keep
holding it: the doc comment on `recipient_is_established` now records *why* the
lookup is delegated rather than paginated — that this answer decides an
approval gate, and that a capped oldest-first page silently stops finding real
correspondents as the inbox grows. The regression test carries the same reason
in its own doc comment, so the next person to touch either sees the constraint
before they weaken it. The port-side contract for `has_inbound_from` was
already documented in #226.
