### PR TITLE
ci: build, lint and test the openhuman/tinycortex feature sets (#202)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,102 @@ jobs:
 
       - name: Test
         run: cargo test
+
+  # Issue #202. The `Rust` job above builds DEFAULT FEATURES ONLY, so every line
+  # behind `openhuman` (`src/harness/**`, `src/workflows/**`, `src/runtime/`
+  # `delegation*`, and the `live_company_turn` example) and every line behind
+  # `tinycortex` (`src/store/tinycortex_engine.rs` plus its `src/store/select.rs`
+  # seam) is invisible to it — a green `Rust` check is not evidence for a diff
+  # whose lines are all feature-gated. That blind spot let a hard `E0062` in a
+  # test `HarnessDeps` literal and a failing harness test both sit on `main`.
+  # This job compiles, lints and tests that surface.
+  #
+  # Deliberately a SEPARATE job rather than extra steps on `rust`: the fast
+  # default check keeps its ~3-minute turnaround and its `Rust` check name (any
+  # branch-protection rule pinned to it is unaffected), and the two run in
+  # parallel.
+  #
+  # One combination, not a matrix. Cargo features are additive, and `tinycortex`
+  # adds no new compilation on top of an `openhuman` build — the crate is already
+  # an unconditional dependency of `openhuman_core` — so `openhuman,tinycortex`
+  # covers both rot areas in a single compile. A default/`openhuman`/
+  # `openhuman,tinycortex`/`--all-features` matrix would roughly triple CI
+  # compute for a sliver of extra coverage.
+  rust-gated:
+    name: Rust (openhuman, tinycortex)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          submodules: true
+
+      # Identical to the `rust` job's init, and for the same reason: `submodules:
+      # true` is not recursive. Keep it targeted — a plain `--recursive` over
+      # `vendor/openhuman` additionally drags in the desktop-only `tauri-cef`
+      # tree, which nothing in this build touches.
+      - name: Init vendored openhuman crate submodules
+        run: |
+          git -C vendor/openhuman submodule update --init --depth 1 \
+            vendor/tinyflows vendor/tinycortex vendor/tinyjuice \
+            vendor/tinychannels vendor/tinyplace
+          # tinycortex declares its own `tinyagents` path dependency, so its
+          # manifest must resolve too. Harmless for the default build; required
+          # for any `--features openhuman` build.
+          git -C vendor/openhuman/vendor/tinycortex submodule update --init --depth 1 \
+            vendor/tinyagents
+
+      # `--features openhuman` links system libraries the default build does not.
+      # Mirrors the builder stage of the repo `Dockerfile`: OpenSSL headers
+      # (native-tls → openssl-sys, via `motosan-ai-oauth` → `hyper-tls` in the
+      # vendored openhuman tree) and the X11 dev libs that openhuman's
+      # unconditional `rdev`/`arboard` deps link against even in a headless
+      # build. Pinning them here keeps the job immune to runner-image drift; the
+      # step is idempotent and costs well under a minute.
+      - name: Install system build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config libssl-dev \
+            libx11-dev libxi-dev libxtst-dev libxrandr-dev libxcb1-dev libxkbcommon-dev
+
+      # clippy only: `rustfmt` is feature-independent, so formatting stays fully
+      # covered by the `rust` job and re-running it here would buy nothing.
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      # Steps are ordered to fail fast and cheap: a compile break (the `E0062`
+      # class of bug that motivated this job) surfaces before the lint pass
+      # spends time on a tree that does not build.
+      - name: Build (openhuman, tinycortex)
+        run: cargo build --features openhuman,tinycortex --all-targets
+
+      # `--no-deps` is LOAD-BEARING — do not "simplify" it away. Cargo treats the
+      # vendored `[patch]` crates as local packages, so an unscoped `-D warnings`
+      # hard-fails on lints this repo neither owns nor can fix here (today:
+      # `large_enum_variant` in `vendor/tinyagents`), and the gate would never
+      # reach first-party code. Scoping to the primary package is what makes it
+      # meaningful.
+      - name: Clippy (openhuman, tinycortex)
+        run: cargo clippy --no-deps --features openhuman,tinycortex --all-targets -- -D warnings
+
+      # `--lib` is LOAD-BEARING — do not widen it to a bare `cargo test`. There
+      # is no `tests/` directory, and the only other runnable target the feature
+      # set unlocks is the `live_company_turn` example, which dials a real
+      # inference backend and needs a credential. The build step above already
+      # proves it compiles; this step must never try to run it.
+      - name: Test (openhuman, tinycortex)
+        run: cargo test --features openhuman,tinycortex --lib
+
+      # Catches the combination traps no single feature set can: most often a
+      # mandatory struct field constructed differently across feature arms.
+      # CHECK-ONLY BY DESIGN — `--all-features` enables `mcp`, which legitimately
+      # adds registry tools to the agent tool belt that a `harness::build` test
+      # pins for the openhuman-only set. This step must compile the combination
+      # without running its feature-sensitive tests.
+      - name: Check (--all-features)
+        run: cargo check --all-features

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -694,7 +694,6 @@ mod tests {
             workflow_runner: WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             approval_requests: ApprovalRequestQueue::default(),
-            approval_requests: ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: toolbelt::CapabilityFilter::AllowAll,

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -694,6 +694,7 @@ mod tests {
             workflow_runner: WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             approval_requests: ApprovalRequestQueue::default(),
+            approval_requests: ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
             capabilities: toolbelt::CapabilityFilter::AllowAll,

--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -181,6 +181,12 @@ impl TenantComposio {
 /// Whether a toolkit is admitted by an allowlist. An **empty** allowlist defers
 /// to the backend's server-enforced allowlist (open mode) and admits every
 /// toolkit; a non-empty allowlist admits only its members (case-insensitive).
+///
+/// Every call site is inside the `composio`-gated [`live`] module, so this is
+/// genuinely dead in an `openhuman`-without-`composio` build and is gated to
+/// match. A blanket `#[allow(dead_code)]` would say the same thing to the
+/// compiler while also hiding the day a real call site disappears.
+#[cfg(feature = "composio")]
 fn toolkit_allowed(allowlist: &[String], toolkit: &str) -> bool {
     allowlist.is_empty()
         || allowlist
@@ -190,6 +196,10 @@ fn toolkit_allowed(allowlist: &[String], toolkit: &str) -> bool {
 
 /// The toolkit a Composio action slug belongs to: the segment before the first
 /// `_`, lowercased (`GMAIL_SEND_EMAIL` → `gmail`). Empty slug → empty string.
+///
+/// Gated for the same reason as [`toolkit_allowed`]: both call sites live in
+/// the `composio`-gated [`live`] module.
+#[cfg(feature = "composio")]
 fn slug_toolkit(slug: &str) -> String {
     slug.split('_').next().unwrap_or("").to_ascii_lowercase()
 }
@@ -863,6 +873,10 @@ mod live {
 mod tests {
     use super::*;
 
+    // The three helper tests below follow their subjects behind the `composio`
+    // feature: `toolkit_allowed` / `slug_toolkit` do not exist in an
+    // `openhuman`-without-`composio` build.
+    #[cfg(feature = "composio")]
     #[test]
     fn toolkit_allowed_empty_defers_to_backend() {
         // Empty allowlist = open mode: every toolkit admitted.
@@ -870,6 +884,7 @@ mod tests {
         assert!(toolkit_allowed(&[], "anything"));
     }
 
+    #[cfg(feature = "composio")]
     #[test]
     fn toolkit_allowed_non_empty_narrows_case_insensitively() {
         let allow = vec!["gmail".to_string(), "github".to_string()];
@@ -879,6 +894,7 @@ mod tests {
         assert!(!toolkit_allowed(&allow, "slack"));
     }
 
+    #[cfg(feature = "composio")]
     #[test]
     fn slug_toolkit_extracts_lowercased_prefix() {
         assert_eq!(slug_toolkit("GMAIL_SEND_EMAIL"), "gmail");

--- a/src/harness/mcp_probe.rs
+++ b/src/harness/mcp_probe.rs
@@ -443,7 +443,7 @@ mod tests {
     use crate::company::mcp::{AuthMaterial, McpServerDecl, McpSource};
 
     fn anyhow_str(msg: &str) -> anyhow::Error {
-        anyhow::anyhow!("{}", msg.to_string())
+        anyhow::anyhow!("{msg}")
     }
 
     fn oauth_decl(name: &str, endpoint: &str, access_token: &str) -> McpServerDecl {

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -572,7 +572,7 @@ impl<'a> DelegationRunner<'a> {
                     // note, and `assigned to {assignee}` would record a
                     // sentence that trails off with nothing after it. Name the
                     // effect instead, so the timeline says what happened.
-                    Some(canonical) if canonical.is_empty() => {
+                    Some("") => {
                         card.assignee = String::new();
                         match note {
                             Some(note) => format!("cleared the assignee — {note}"),


### PR DESCRIPTION
## Summary

CI builds default features only, so everything behind `openhuman` (`src/harness/**`, `src/workflows/**`, the gated `src/runtime/delegation*` modules, the `live_company_turn` example) and everything behind `tinycortex` (`src/store/tinycortex_engine.rs` and its `src/store/select.rs` seam) is never compiled, linted or run. A green `Rust` check has therefore been non-evidence for any fully-gated diff — which is how a hard `E0062` and a failing harness test both sat on `main` this cycle.

Closes #202. Refs #188.

This adds a second, parallel job — **`Rust (openhuman, tinycortex)`** — that builds, clippies, tests and `--all-features`-checks that surface. It also fixes the four first-party lints that stood between the new clippy gate and green-on-arrival.

Four substantive commits, in dependency order:

| Commit | What |
|---|---|
| `1af0d9f` | gate `toolkit_allowed` / `slug_toolkit` (+ their 3 unit tests) behind `composio` |
| `e0a6847` | fold the redundant `is_empty()` delegation guard into the pattern |
| `b922dd1` | drop a redundant `.to_string()` in an `anyhow!` arg |
| `b14e607` | the `rust-gated` CI job |

Plus `ab5ee1a` / `dd1c671` — a deliberate defect and its revert, kept in history as the live proof that the new job bites (see [Negative controls](#negative-controls--the-point-of-the-pr)). The net tree is identical to `b14e607`.

### Design notes

**The existing `rust` job is byte-for-byte untouched.** The diff on `ci.yml` is purely additive, so its `Rust` check name — and any branch-protection rule pinned to it — is unaffected, and it keeps its ~3-minute turnaround.

**One combination, not a matrix.** Cargo features are additive and `tinycortex` adds no new compilation on top of an `openhuman` build (the crate is already an unconditional dependency of `openhuman_core`), so `openhuman,tinycortex` covers both rot areas in a single compile. The 4-cell matrix the issue floats would roughly triple CI compute for a sliver of extra coverage.

**Two flags are load-bearing and carry inline comments saying so**, because both look like clutter to a future editor:

- `--no-deps` on clippy. Cargo treats the vendored `[patch]` crates as local packages, so an unscoped `-D warnings` hard-fails on `vendor/tinyagents` (`large_enum_variant`) before ever reaching first-party code. Scoping to the primary package is what makes the gate meaningful — and first-party coverage still strictly increases, since none of this was linted before.
- `--lib` on test. There is no `tests/` directory, and the only other runnable target the feature set unlocks is `live_company_turn`, which dials a real inference backend and needs a credential. The build step proves it compiles; the test step must never try to run it.

**The `--all-features` step is check-only by design.** It exists for combination traps (a mandatory struct field constructed differently across feature arms). It must not *run* tests, because `--all-features` enables `mcp`, which legitimately adds registry tools to the belt that `harness::build::tests::dispatched_desk_agent_tool_belt_is_pinned` pins for the openhuman-only set.

### Why the four lints were invisible

`src/runtime/delegation.rs` is gated at its `mod` declaration (`src/runtime/mod.rs`, `#[cfg(feature = "openhuman")] pub mod delegation;`), so the default build never compiles the file at all — there is no subtlety about lint reachability *within* the file. Verified directly: with the pre-fix `Some(canonical) if canonical.is_empty()` restored, `cargo clippy --all-targets -- -D warnings` exits **0** while the gated run exits **101** on that exact line. The `src/harness/**` lints are invisible for the same structural reason (`#[cfg(feature = "openhuman")] pub mod harness;`).

The two `composio.rs` helpers are gated rather than `#[allow(dead_code)]`-ed deliberately: every call site is inside the `composio`-gated `live` module, so `cfg` states the actual truth, and an `allow` would additionally mask the day a real call site disappears. Their three unit tests are gated to match, since the subjects no longer exist in an `openhuman`-without-`composio` build.

## API Or Behavior Changes

**None.** No public API change and no runtime behaviour change.

- `Some(canonical) if canonical.is_empty()` → `Some("")` matches exactly the same `Unassigned` resolution (canonical form is the empty string).
- `anyhow!("{}", msg.to_string())` → `anyhow!("{msg}")` produces an identical message.
- The two `composio.rs` helpers were already unreachable without the `composio` feature; gating them changes nothing about any build that could call them.

## Tests

### Negative controls — the point of the PR

Green gates prove nothing here; the whole issue is that green was meaningless. Each control was introduced locally, the designated step was observed to fail, and the control was reverted. **Every one of them passes the existing `Rust` job**, which is precisely the blind spot being closed.

| # | Injected defect | `Rust` (default) | New job — step that caught it |
|---|---|---|---|
| 1 | duplicate `approval_requests` field in the `HarnessDeps` literal at `src/harness/build.rs:696` (the historical `E0062`) | **PASS** (exit 0) | **FAIL** — Build, `error[E0062]: field 'approval_requests' specified more than once` |
| 2 | flipped the expected desk id in `harness::brain::tests::task_dispatch_routes_a_desk_assignee_to_its_lead_but_keeps_the_desk` | **PASS** (exit 0) | **FAIL** — Test, one failed assertion |
| 3 | unused first-party fn added to `src/harness/mcp_probe.rs` | **PASS** (exit 0) | **FAIL** — Clippy, `error: function 'control3_orphan_helper' is never used` |
| 4 | dropped `overlay_desk_order` from the `CompanyRecord` literal in the **sqlite** arm (`src/store/sqlite.rs`) — a mandatory field one feature arm fails to construct | **PASS** (exit 0) | **FAIL** — only at Check `--all-features`, `error[E0063]: missing field 'overlay_desk_order'` |

Control 4 is the one that justifies the fourth step: it passes the existing job **and** the new job's Build, Clippy and Test steps, and is caught only by `cargo check --all-features`.

### Control 1, run live on this PR

Local runs are easy to mistrust, so control 1 was pushed as a real commit (`ab5ee1a`) and reverted (`dd1c671`). The evidence is clickable:

**Run [30699923529](https://github.com/tinyhumansai/opencompany/actions/runs/30699923529)**, head `ab5ee1a`:

| Job | Outcome | Duration |
|---|---|---|
| `Rust` | ✅ **success** | 2m27s |
| `Rust (openhuman, tinycortex)` | ❌ **failure** | 6m33s |

The failing step is `Build (openhuman, tinycortex)`:

```
error[E0062]: field `approval_requests` specified more than once
##[error]Process completed with exit code 101.
```

One commit, two jobs, opposite verdicts — the default gate green, the new gate red, on precisely the defect class that motivated the issue.

### Gates run (all green on the final head `dd1c671`)

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 986 + 6 passed, 0 failed

Plus the new job's own gates:

- [x] `cargo build --features openhuman,tinycortex --all-targets`
- [x] `cargo clippy --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --features openhuman,tinycortex --lib` — **1392 passed, 0 failed**
- [x] `cargo check --all-features`

Every one of these ran locally during development and again on CI at the final head. The branch was rebased onto `main` after #255 landed, so the counts above are from the rebased head — confirmed both locally and in run [30702467320](https://github.com/tinyhumansai/opencompany/actions/runs/30702467320) (default 986+6, gated 1392, identical numbers).

### Excluded pre-existing failures, each with its reason

| Failure | Disposition |
|---|---|
| `vendor/tinyagents` `large_enum_variant` (x2) | **Excluded** via `--no-deps`. Vendored, externally owned, and never compiled by CI before — scoping the gate to the primary package still strictly increases first-party coverage. |
| `harness::build::tests::dispatched_desk_agent_tool_belt_is_pinned` under `openhuman,mcp,telegram` | **Excluded.** `mcp` adds two registry tools to the belt and the test's doc pins the openhuman-only set by design. This job's combination does not enable `mcp`, and the `--all-features` step is check-only. |
| `harness::brain::tests::task_dispatch_routes_a_desk_assignee_to_its_lead_*` | **Nothing to do** — already fixed on `main` (renamed `..._but_keeps_the_desk`). Confirmed passing in the gated run. |
| `unused_imports` / `dead_code` warnings in `vendor/openhuman` (6) | **Excluded** — plain rustc warnings on a path dependency; `-D warnings` applies only to the primary package, so they are non-fatal. |

### CI cost

All three runs measured on this PR, from the GitHub Actions job timestamps:

| Run | `Rust` (default) | `Rust (openhuman, tinycortex)` |
|---|---|---|
| Cold green — [30699342565](https://github.com/tinyhumansai/opencompany/actions/runs/30699342565), empty cache | ✅ 2m52s | ✅ **16m35s** |
| Negative control — [30699923529](https://github.com/tinyhumansai/opencompany/actions/runs/30699923529), deliberate `E0062` | ✅ 2m27s | ❌ **6m33s** |
| Warm green — [30702467320](https://github.com/tinyhumansai/opencompany/actions/runs/30702467320), cache seeded | ✅ 3m14s | ✅ **11m59s** |

Two properties worth naming:

- **The fast check is unaffected.** `Rust` stays at ~2m30s–3m15s, so early signal on a PR does not regress. The two jobs run in parallel, so the wall-clock cost of a full green PR goes from ~3 min to ~12 min, and nobody waits longer for the default answer.
- **The gated job fails faster than it passes** — ~6.5 min red vs ~12 min green. Build is the first step, so a compile break kills the job before clippy and test ever start. The expensive path is the one where everything is fine.

Steady-state cost is the warm number: **~12 min** of parallel runner time per push, against the manual full-feature verification every harness/memory PR has been paying by hand this cycle.

### A different gap this batch surfaced (not fixed here)

Worth recording, because it is easy to conflate with the problem this PR solves and it is **not** the same thing.

While this branch was open, `main` went red with `E0599: no method named clone found for TempDir` at `src/runtime/cycle.rs:1950`. It was a **union break**: #252 changed `tmp_home()` to return a `TempDir`, #249 added a test written against the old `PathBuf` signature. Each PR was green on its own; only the merged combination broke. Fixed in #255.

That failure is **not** evidence for this PR. `src/runtime/cycle.rs` is not feature-gated — `src/runtime/mod.rs:23` declares `pub mod cycle;` unconditionally and its tests are a plain `#[cfg(test)] mod test` — so the *default* `Rust` job compiles it and caught the same error. No feature-gate blind spot was involved.

The real gap it points at is different: **no PR-vs-base CI on either job catches a break that only exists in the union of two green PRs.** Mitigating that means union-building related PRs before merge, or a merge-queue. Out of scope here; noted so the two problems stay separate.

## Documentation

No doc changes needed — this adds a CI job and fixes three lints, touching no public API, route, or module contract. The reasoning that would otherwise live in a doc is carried as inline YAML comments on the job itself, deliberately: the `--no-deps` and `--lib` flags are the two things a future editor is most likely to "simplify" away, so the *why* sits on the line rather than in a file nobody opens.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Reliability**
  - Improved validation across supported feature configurations and build targets.
  - Enhanced consistency when optional integrations are disabled.
  - Expanded automated checks to catch configuration-specific build and test issues earlier.

- **Bug Fixes**
  - Preserved correct delegation behavior when clearing an assignment.
  - Improved stability of optional integration test coverage across supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
