### PR TITLE
fix(runtime): give test temp paths OS-guaranteed unique names (#235)

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -725,9 +725,11 @@ mod test {
     fn projected_token_file_alone_enables_cycles() {
         // The path must actually exist: the projected tier is selected on
         // existence, not on the variable merely being set.
-        let dir = std::env::temp_dir().join(format!("oc-cfg-{}", crate::ports::generate_id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("token");
+        let dir = tempfile::Builder::new()
+            .prefix("oc-cfg-")
+            .tempdir()
+            .expect("tempdir");
+        let path = dir.path().join("token");
         std::fs::write(&path, "projected-token").unwrap();
 
         let env = MapEnv::new([(
@@ -745,8 +747,6 @@ mod test {
             crate::company::CredentialSource::Attested
         );
         assert_eq!(prov.layer("tinyhumans_token_file"), Some(ConfigLayer::Env));
-
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The docker case: a leftover `TINYHUMANS_TOKEN_FILE` naming a path nothing
@@ -757,8 +757,13 @@ mod test {
     /// `TinyhumansTokenSource::from_env`.
     #[test]
     fn a_token_file_that_does_not_exist_is_not_attested() {
-        let missing =
-            std::env::temp_dir().join(format!("oc-absent-{}", crate::ports::generate_id()));
+        // A real directory, but the token path inside it is never created: the
+        // fixture must name something that does not exist.
+        let dir = tempfile::Builder::new()
+            .prefix("oc-absent-")
+            .tempdir()
+            .expect("tempdir");
+        let missing = dir.path().join("token");
         assert!(!missing.exists(), "fixture path must not exist");
 
         let env = MapEnv::new([(
@@ -780,8 +785,13 @@ mod test {
     /// the static tier rather than to `none`, matching `from_env`'s fallback.
     #[test]
     fn a_missing_token_file_degrades_to_the_static_tier() {
-        let missing =
-            std::env::temp_dir().join(format!("oc-absent-{}", crate::ports::generate_id()));
+        // A real directory, but the token path inside it is never created: the
+        // fixture must name something that does not exist.
+        let dir = tempfile::Builder::new()
+            .prefix("oc-absent-")
+            .tempdir()
+            .expect("tempdir");
+        let missing = dir.path().join("token");
         let env = MapEnv::new([
             (
                 crate::company::credentials::TOKEN_FILE_ENV,
@@ -801,9 +811,11 @@ mod test {
     /// Precedence: a projected file that exists outranks a leftover static key.
     #[test]
     fn projected_file_outranks_a_static_key_for_the_source() {
-        let dir = std::env::temp_dir().join(format!("oc-cfg-{}", crate::ports::generate_id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("token");
+        let dir = tempfile::Builder::new()
+            .prefix("oc-cfg-")
+            .tempdir()
+            .expect("tempdir");
+        let path = dir.path().join("token");
         std::fs::write(&path, "projected-token").unwrap();
 
         let env = MapEnv::new([
@@ -818,7 +830,6 @@ mod test {
             cfg.credential_source(),
             crate::company::CredentialSource::Attested
         );
-        std::fs::remove_dir_all(&dir).ok();
 
         // Docker development keeps working on the static tier alone.
         let static_only = MapEnv::new([(crate::company::credentials::API_KEY_ENV, "th_static")]);

--- a/src/app/doctor.rs
+++ b/src/app/doctor.rs
@@ -237,9 +237,11 @@ mod test {
     fn projected_token_file_reports_the_attested_tier() {
         // A real file: the attested tier is selected on the path existing, not on
         // the variable being set, so a fixture path would report `none` here.
-        let dir = std::env::temp_dir().join(format!("oc-doctor-{}", crate::ports::generate_id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("token");
+        let dir = tempfile::Builder::new()
+            .prefix("oc-doctor-")
+            .tempdir()
+            .expect("tempdir");
+        let path = dir.path().join("token");
         std::fs::write(&path, "projected-token").unwrap();
 
         let env = MapEnv::new([(
@@ -256,8 +258,6 @@ mod test {
             value(&report, "tinyhumans_token_file"),
             path.to_str().unwrap()
         );
-
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// A leftover `TINYHUMANS_TOKEN_FILE` naming an unmounted path must not tell
@@ -266,8 +266,13 @@ mod test {
     /// worse than an honest `none`.
     #[test]
     fn a_token_file_that_does_not_exist_does_not_report_attested() {
-        let missing =
-            std::env::temp_dir().join(format!("oc-doctor-absent-{}", crate::ports::generate_id()));
+        // A real directory, but the token path inside it is never created: the
+        // fixture must name something that does not exist.
+        let dir = tempfile::Builder::new()
+            .prefix("oc-doctor-absent-")
+            .tempdir()
+            .expect("tempdir");
+        let missing = dir.path().join("token");
         let env = MapEnv::new([(
             crate::company::credentials::TOKEN_FILE_ENV,
             missing.to_str().unwrap(),

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -845,12 +845,16 @@ mod tests {
     /// file (mounted at `/var/run/secrets/tinyhumans.ai/token` in production).
     /// The tier is only selected when the path exists, so the test needs a real
     /// one.
-    fn projected_token_file() -> PathBuf {
-        let dir = std::env::temp_dir().join(format!("oc-appcfg-{}", crate::ports::generate_id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("token");
+    /// Returns the directory handle alongside the path: dropping it removes the
+    /// fixture, and holding it is what keeps the file alive for the assertions.
+    fn projected_token_file() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-appcfg-")
+            .tempdir()
+            .expect("tempdir");
+        let path = dir.path().join("token");
         std::fs::write(&path, "projected-token").unwrap();
-        path
+        (dir, path)
     }
 
     /// The hosted shape: no static secret at all, just a projected token file.
@@ -858,7 +862,7 @@ mod tests {
     #[test]
     fn a_projected_token_file_alone_enables_cycles() {
         use crate::app::config::MapEnv;
-        let path = projected_token_file();
+        let (_dir, path) = projected_token_file();
         let env = MapEnv::new([(
             crate::company::credentials::TOKEN_FILE_ENV,
             path.display().to_string(),
@@ -898,7 +902,7 @@ mod tests {
             CredentialSource::Static
         );
 
-        let path = projected_token_file();
+        let (_dir, path) = projected_token_file();
         let projected = MapEnv::new([(
             crate::company::credentials::TOKEN_FILE_ENV,
             path.display().to_string(),

--- a/src/brain/hosted/test.rs
+++ b/src/brain/hosted/test.rs
@@ -466,11 +466,11 @@ use crate::company::CompanyManifest;
 use crate::ports::types::{Actor, ActorKind};
 use crate::runtime::RuntimeBuilder;
 
-fn tmp_home() -> std::path::PathBuf {
-    std::env::temp_dir().join(format!(
-        "opencompany-hosted-{}",
-        crate::ports::generate_id()
-    ))
+fn tmp_home() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix("opencompany-hosted-")
+        .tempdir()
+        .expect("tempdir")
 }
 
 fn manifest(policy_mode: &str) -> CompanyManifest {
@@ -500,7 +500,8 @@ fn runtime_cid() -> String {
 
 #[tokio::test]
 async fn e2e_operator_message_drives_tool_call_and_gated_send_dm() {
-    let home = tmp_home();
+    let home_dir = tmp_home();
+    let home = home_dir.path().to_path_buf();
     let transport = Arc::new(MockTransport::new());
     transport.script_cycle(
         runtime_cid(),
@@ -546,13 +547,12 @@ async fn e2e_operator_message_drives_tool_call_and_gated_send_dm() {
     // A compressed trace was persisted to the fs-backed MemoryStore.
     let traces = rt.memory.recent_traces(rt.id(), 10).await.unwrap();
     assert!(!traces.is_empty());
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn e2e_supervised_effect_parks_and_acks_not_ok() {
-    let home = tmp_home();
+    let home_dir = tmp_home();
+    let home = home_dir.path().to_path_buf();
     let transport = Arc::new(MockTransport::new());
     transport.script_cycle(
         runtime_cid(),
@@ -607,15 +607,14 @@ async fn e2e_supervised_effect_parks_and_acks_not_ok() {
     .await
     .unwrap();
     assert!(rt.pending_approvals().is_empty());
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// Issue #174 end to end: a real runtime on the hosted brain records the tokens
 /// and cost the wire reported, so the console's Usage view stops reading zero.
 #[tokio::test]
 async fn e2e_reported_usage_lands_on_the_usage_meter() {
-    let home = tmp_home();
+    let home_dir = tmp_home();
+    let home = home_dir.path().to_path_buf();
     let transport = Arc::new(MockTransport::new());
     // `cid()` and `runtime_cid()` are the same deterministic id: company `acme`,
     // first event at seq 0.
@@ -663,8 +662,6 @@ async fn e2e_reported_usage_lands_on_the_usage_meter() {
             .iter()
             .any(|e| e.kind == crate::metering::INFERENCE_SPEND_KIND && e.amount_usd == 0.042)
     );
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 // ---------------------------------------------------------------------------
@@ -711,7 +708,8 @@ fn desk_manifest() -> CompanyManifest {
 /// orchestrator can actually delegate.
 #[tokio::test]
 async fn e2e_hosted_catalog_advertises_delegation_tools() {
-    let home = tmp_home();
+    let home_dir = tmp_home();
+    let home = home_dir.path().to_path_buf();
     let transport = Arc::new(MockTransport::new());
     let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
         .with_brain_mode(BrainMode::Hosted)
@@ -741,15 +739,14 @@ async fn e2e_hosted_catalog_advertises_delegation_tools() {
         names.contains(&"delegate_to_desk"),
         "delegate_to_desk advertised: {names:?}"
     );
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// Medulla emitting a `spawn_task` tool-call on the hosted path opens a durable
 /// board card device-side and answers ok — no local cognition needed.
 #[tokio::test]
 async fn e2e_spawn_task_tool_call_opens_a_board_card() {
-    let home = tmp_home();
+    let home_dir = tmp_home();
+    let home = home_dir.path().to_path_buf();
     let transport = Arc::new(MockTransport::new());
     transport.script_cycle(
         runtime_cid(),
@@ -787,8 +784,6 @@ async fn e2e_spawn_task_tool_call_opens_a_board_card() {
     assert_eq!(cards[0].title, "Ship the invoice flow");
     assert_eq!(cards[0].assignee, "eng");
     assert_eq!(cards[0].column, "backlog");
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// Medulla emitting a `delegate_to_desk` tool-call resolves the desk and records
@@ -796,7 +791,8 @@ async fn e2e_spawn_task_tool_call_opens_a_board_card() {
 /// is asked directly). An unknown desk is a clean tool error, not a lost card.
 #[tokio::test]
 async fn e2e_delegate_to_desk_tool_call_writes_a_handoff_card() {
-    let home = tmp_home();
+    let home_dir = tmp_home();
+    let home = home_dir.path().to_path_buf();
     let transport = Arc::new(MockTransport::new());
     transport.script_cycle(
         runtime_cid(),
@@ -851,15 +847,14 @@ async fn e2e_delegate_to_desk_tool_call_writes_a_handoff_card() {
         note.contains("build the invoice importer"),
         "note carries the instruction"
     );
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// The same company with no usage frame on the wire: an honest zero, and no
 /// fabricated sample.
 #[tokio::test]
 async fn e2e_a_cycle_without_usage_frames_meters_nothing() {
-    let home = tmp_home();
+    let home_dir = tmp_home();
+    let home = home_dir.path().to_path_buf();
     let transport = Arc::new(MockTransport::new());
     transport.script_cycle(
         runtime_cid(),
@@ -883,5 +878,4 @@ async fn e2e_a_cycle_without_usage_frames_meters_nothing() {
     .unwrap();
 
     assert!(rt.usage().query(rt.id(), 0).await.unwrap().is_empty());
-    tokio::fs::remove_dir_all(&home).await.ok();
 }

--- a/src/brain/sidecar/test.rs
+++ b/src/brain/sidecar/test.rs
@@ -438,11 +438,11 @@ use crate::company::CompanyManifest;
 use crate::ports::types::{Actor, ActorKind, Verdict};
 use crate::runtime::RuntimeBuilder;
 
-fn tmp_home() -> std::path::PathBuf {
-    std::env::temp_dir().join(format!(
-        "opencompany-sidecar-{}",
-        crate::ports::generate_id()
-    ))
+fn tmp_home() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix("opencompany-sidecar-")
+        .tempdir()
+        .expect("tempdir")
 }
 
 fn manifest(policy_mode: &str) -> CompanyManifest {
@@ -487,7 +487,8 @@ fn sidecar_brain_for(
 
 #[tokio::test]
 async fn e2e_inference_then_gated_send_dm_drives_a_channel_response() {
-    let home = tmp_home();
+    let home_dir = tmp_home();
+    let home = home_dir.path().to_path_buf();
     let transport = Arc::new(MockSidecarTransport::new());
     transport.script_cycle(
         runtime_cid(),
@@ -534,13 +535,12 @@ async fn e2e_inference_then_gated_send_dm_drives_a_channel_response() {
     // A compressed trace was persisted to the fs-backed MemoryStore.
     let traces = rt.memory.recent_traces(rt.id(), 10).await.unwrap();
     assert!(!traces.is_empty());
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn e2e_supervised_effect_parks_through_the_real_gate() {
-    let home = tmp_home();
+    let home_dir = tmp_home();
+    let home = home_dir.path().to_path_buf();
     let transport = Arc::new(MockSidecarTransport::new());
     transport.script_cycle(
         runtime_cid(),
@@ -587,6 +587,4 @@ async fn e2e_supervised_effect_parks_through_the_real_gate() {
     .await
     .unwrap();
     assert!(rt.pending_approvals().is_empty());
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }

--- a/src/company/credentials.rs
+++ b/src/company/credentials.rs
@@ -584,17 +584,22 @@ mod tests {
         SystemTime::UNIX_EPOCH + Duration::from_secs(secs)
     }
 
-    fn temp_file(name: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!("oc-tokensrc-{}", crate::ports::generate_id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        dir.join(name)
+    /// The caller must hold the returned handle: it owns the enclosing
+    /// directory and removes it on drop.
+    fn temp_file(name: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-tokensrc-")
+            .tempdir()
+            .expect("tempdir");
+        let path = dir.path().join(name);
+        (dir, path)
     }
 
     // ---- tier precedence ---------------------------------------------------
 
     #[test]
     fn projected_file_beats_static_key() {
-        let path = temp_file("token");
+        let (_path_dir, path) = temp_file("token");
         std::fs::write(&path, "projected").unwrap();
         let env = MapEnv::new([
             (TOKEN_FILE_ENV, path.display().to_string()),
@@ -663,7 +668,7 @@ mod tests {
     /// cache here is the latent outage this tier exists to avoid.
     #[tokio::test]
     async fn projected_file_picks_up_an_in_place_rotation() {
-        let path = temp_file("token");
+        let (_path_dir, path) = temp_file("token");
         // exp 1000s out at t=0 → window = min(0.8 * 1000, 60) = 60s.
         std::fs::write(&path, jwt(serde_json::json!({ "exp": 1000 }))).unwrap();
         let first = std::fs::read_to_string(&path).unwrap();
@@ -717,7 +722,7 @@ mod tests {
     /// sends the next call straight back to the file.
     #[tokio::test]
     async fn invalidate_forces_a_re_read_inside_the_cache_window() {
-        let path = temp_file("token");
+        let (_path_dir, path) = temp_file("token");
         std::fs::write(&path, jwt(serde_json::json!({ "exp": 1000 }))).unwrap();
         let first = std::fs::read_to_string(&path).unwrap();
         let source = TinyhumansTokenSource::projected_file(&path);
@@ -738,7 +743,7 @@ mod tests {
     /// but it can never serve a credential the platform already rotated away.
     #[tokio::test]
     async fn an_undatable_token_is_never_cached() {
-        let path = temp_file("token");
+        let (_path_dir, path) = temp_file("token");
         std::fs::write(&path, "opaque-not-a-jwt").unwrap();
         let source = TinyhumansTokenSource::projected_file(&path);
         assert_eq!(
@@ -760,7 +765,7 @@ mod tests {
     /// locally would turn a recoverable 401 into an outage — but never cached.
     #[tokio::test]
     async fn an_expired_token_is_served_but_not_cached() {
-        let path = temp_file("token");
+        let (_path_dir, path) = temp_file("token");
         std::fs::write(&path, jwt(serde_json::json!({ "exp": 50 }))).unwrap();
         let stale = std::fs::read_to_string(&path).unwrap();
         let source = TinyhumansTokenSource::projected_file(&path);
@@ -783,7 +788,7 @@ mod tests {
         let err = missing.current().await.expect_err("unreadable");
         assert_eq!(err.code(), "config_error");
 
-        let path = temp_file("token");
+        let (_path_dir, path) = temp_file("token");
         std::fs::write(&path, "   \n").unwrap();
         let empty = TinyhumansTokenSource::projected_file(&path);
         assert_eq!(
@@ -897,7 +902,7 @@ mod tests {
             Some("pasted-token")
         );
 
-        let path = temp_file("token");
+        let (_path_dir, path) = temp_file("token");
         std::fs::write(&path, "projected-token").unwrap();
         let source =
             Credential::from_source(Arc::new(TinyhumansTokenSource::projected_file(&path)));

--- a/src/feedback/store.rs
+++ b/src/feedback/store.rs
@@ -140,9 +140,15 @@ mod test {
     use crate::feedback::types::{ConsentMode, FeedbackCategory, FeedbackInput, FeedbackItem};
     use crate::ports::types::CompanyId;
 
-    fn tmp_bundle() -> Bundle {
-        let root = std::env::temp_dir().join(format!("oc-feedback-{}", generate_id()));
-        Bundle::new(root, &CompanyId::new("acme"))
+    /// The caller must hold the returned handle: it owns the bundle's root and
+    /// removes it on drop.
+    fn tmp_bundle() -> (tempfile::TempDir, Bundle) {
+        let root = tempfile::Builder::new()
+            .prefix("oc-feedback-")
+            .tempdir()
+            .expect("tempdir");
+        let bundle = Bundle::new(root.path().to_path_buf(), &CompanyId::new("acme"));
+        (root, bundle)
     }
 
     fn item(note: &str) -> FeedbackItem {
@@ -161,7 +167,7 @@ mod test {
 
     #[tokio::test]
     async fn append_and_list_round_trips() {
-        let bundle = tmp_bundle();
+        let (_root, bundle) = tmp_bundle();
         let store = FeedbackStore::new(&bundle);
         assert!(store.list().await.unwrap().is_empty());
 
@@ -176,7 +182,7 @@ mod test {
 
     #[tokio::test]
     async fn update_status_records_url_without_losing_others() {
-        let bundle = tmp_bundle();
+        let (_root, bundle) = tmp_bundle();
         let store = FeedbackStore::new(&bundle);
         let a = item("a");
         let b = item("b");
@@ -213,7 +219,7 @@ mod test {
     /// `store::fs::test::concurrent_appends_stay_one_record_per_line` (PR #43).
     #[tokio::test]
     async fn concurrent_appends_stay_one_record_per_line() {
-        let bundle = tmp_bundle();
+        let (_root, bundle) = tmp_bundle();
         let store = std::sync::Arc::new(FeedbackStore::new(&bundle));
 
         const N: usize = 32;

--- a/src/feedback/tool.rs
+++ b/src/feedback/tool.rs
@@ -175,28 +175,33 @@ mod test {
     use crate::store::FsEventLog;
     use crate::store::paths::Bundle;
 
-    fn wiring() -> (BuiltinToolProvider, Arc<FeedbackStore>, std::path::PathBuf) {
-        let root = std::env::temp_dir().join(format!("oc-btool-{}", crate::ports::generate_id()));
+    /// The caller must hold the returned handle: it owns the bundle root and
+    /// removes it on drop.
+    fn wiring() -> (BuiltinToolProvider, Arc<FeedbackStore>, tempfile::TempDir) {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-btool-")
+            .tempdir()
+            .expect("tempdir");
+        let root = dir.path().to_path_buf();
         let bundle = Bundle::new(root.clone(), &CompanyId::new("acme"));
         let feedback = Arc::new(FeedbackStore::new(&bundle));
         let events: Arc<dyn EventLog> = Arc::new(FsEventLog::new(root.clone()));
         let inner: Arc<dyn ToolProvider> = Arc::new(StubToolProvider::new(vec!["email.*".into()]));
         let provider =
             BuiltinToolProvider::new(inner, feedback.clone(), events, ConsentMode::Manual);
-        (provider, feedback, root)
+        (provider, feedback, dir)
     }
 
     #[tokio::test]
     async fn catalog_includes_feedback_tool() {
-        let (provider, _fb, root) = wiring();
+        let (provider, _fb, _root) = wiring();
         let catalog = provider.catalog(&CompanyId::new("acme")).await.unwrap();
         assert!(catalog.iter().any(|t| t.name == FEEDBACK_TOOL));
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn catalog_advertises_send_email() {
-        let (provider, _fb, root) = wiring();
+        let (provider, _fb, _root) = wiring();
         let specs = provider.catalog(&CompanyId::new("acme")).await.unwrap();
         let spec = specs
             .iter()
@@ -204,12 +209,11 @@ mod test {
             .expect("send_email advertised");
         let req = &spec.input_schema["required"];
         assert!(req.as_array().unwrap().iter().any(|v| v == "to"));
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn feedback_tool_captures_without_grant() {
-        let (provider, feedback, root) = wiring();
+        let (provider, feedback, _root) = wiring();
         let result = provider
             .invoke(
                 &CompanyId::new("acme"),
@@ -226,12 +230,11 @@ mod test {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].operator_words, "route broke");
         assert_eq!(items[0].category, FeedbackCategory::Bug);
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn non_feedback_tool_delegates_and_enforces_grants() {
-        let (provider, _fb, root) = wiring();
+        let (provider, _fb, _root) = wiring();
         // Ungranted tool is still rejected by the inner provider.
         let err = provider
             .invoke(
@@ -244,6 +247,5 @@ mod test {
             .await
             .unwrap_err();
         assert!(matches!(err, crate::OpenCompanyError::ToolNotGranted(t) if t == "payment.send"));
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 }

--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -925,9 +925,11 @@ mod tests {
         use crate::ports::types::{CompanyId, SecretValue};
         use crate::store::FsSecretStore;
 
-        let dir =
-            std::env::temp_dir().join(format!("oc-composio-res-{}", crate::ports::generate_id()));
-        let secrets = FsSecretStore::new(&dir);
+        let dir = tempfile::Builder::new()
+            .prefix("oc-composio-res-")
+            .tempdir()
+            .expect("tempdir");
+        let secrets = FsSecretStore::new(dir.path());
         let company = CompanyId::new("acme");
         let source = || Arc::new(TinyhumansTokenSource::static_key("platform-identity"));
 
@@ -1017,7 +1019,6 @@ mod tests {
         assert_eq!(staged.backend_url, "https://staging-api.tinyhumans.ai");
 
         unsafe { std::env::remove_var("TINYHUMANS_API_KEY") };
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// The bearer a config would present right now.
@@ -1039,10 +1040,11 @@ mod tests {
     /// changed *stored* token must still move it.
     #[tokio::test]
     async fn fingerprint_is_stable_across_a_projected_rotation() {
-        let dir =
-            std::env::temp_dir().join(format!("oc-composio-fp-{}", crate::ports::generate_id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("token");
+        let dir = tempfile::Builder::new()
+            .prefix("oc-composio-fp-")
+            .tempdir()
+            .expect("tempdir");
+        let path = dir.path().join("token");
         std::fs::write(&path, "token-before").unwrap();
 
         let projected = config_with(Credential::from_source(Arc::new(
@@ -1069,11 +1071,9 @@ mod tests {
 
         // A different projected path is a different identity.
         let other = config_with(Credential::from_source(Arc::new(
-            TinyhumansTokenSource::projected_file(dir.join("other")),
+            TinyhumansTokenSource::projected_file(dir.path().join("other")),
         )));
         assert_ne!(TenantComposio::fingerprint(&other), before);
-
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
@@ -1396,10 +1396,11 @@ mod isolation_tests {
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
-        let dir =
-            std::env::temp_dir().join(format!("oc-composio-rot-{}", crate::ports::generate_id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("token");
+        let dir = tempfile::Builder::new()
+            .prefix("oc-composio-rot-")
+            .tempdir()
+            .expect("tempdir");
+        let path = dir.path().join("token");
         std::fs::write(&path, "projected-secret-before").unwrap();
 
         // ONE config, built once — exactly what a roster holds across turns.
@@ -1436,8 +1437,6 @@ mod isolation_tests {
             ],
             "each call must carry the token the file held at that moment: {seen:?}"
         );
-
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// A mock backend that echoes the caller's bearer inside an error body; the

--- a/src/harness/provider.rs
+++ b/src/harness/provider.rs
@@ -1006,9 +1006,11 @@ mod tests {
     /// harness must still resolve a managed brain, reading the file per request.
     #[tokio::test]
     async fn env_config_resolves_a_projected_token_file() {
-        let dir = std::env::temp_dir().join(format!("oc-prov-{}", crate::ports::generate_id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("token");
+        let dir = tempfile::Builder::new()
+            .prefix("oc-prov-")
+            .tempdir()
+            .expect("tempdir");
+        let path = dir.path().join("token");
         std::fs::write(&path, "projected-token").unwrap();
 
         let env = MapEnv::new([(
@@ -1035,8 +1037,6 @@ mod tests {
         ]);
         let (cfg, _) = harness_inference_from_env(&both).expect("configured");
         assert_eq!(bearer_of(&cfg).await.as_deref(), Some("projected-token"));
-
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     // ---- media backend (issue #109) ---------------------------------------
@@ -1360,9 +1360,11 @@ mod tests {
     #[tokio::test]
     async fn hosted_provider_resolves_the_bearer_per_request() {
         let (url, seen) = spawn_auth_recorder().await;
-        let dir = std::env::temp_dir().join(format!("oc-prov-rot-{}", crate::ports::generate_id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("token");
+        let dir = tempfile::Builder::new()
+            .prefix("oc-prov-rot-")
+            .tempdir()
+            .expect("tempdir");
+        let path = dir.path().join("token");
         // No `exp` to read ⇒ never cached ⇒ every request re-reads the file.
         std::fs::write(&path, "token-before-rotation").unwrap();
 
@@ -1387,8 +1389,6 @@ mod tests {
             ],
             "the bearer must be resolved per request, not captured at build time"
         );
-
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// With no credential at all the header is omitted rather than sent empty.
@@ -1452,9 +1452,11 @@ mod tests {
             let _ = axum::serve(listener, app).await;
         });
 
-        let dir = std::env::temp_dir().join(format!("oc-prov-401-{}", crate::ports::generate_id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("token");
+        let dir = tempfile::Builder::new()
+            .prefix("oc-prov-401-")
+            .tempdir()
+            .expect("tempdir");
+        let path = dir.path().join("token");
         // A long-lived `exp` ⇒ the window would normally hold this read for the
         // full cap, so only invalidation can explain the second value going out.
         let long_lived = jwt_with_exp(60 * 60 * 24 * 365 * 100);
@@ -1482,8 +1484,6 @@ mod tests {
             headers[1].starts_with("Bearer rotated-"),
             "a 401 must send the next turn back to the file: {headers:?}"
         );
-
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// An unreadable projected file fails the turn with a model error that names

--- a/src/harness/toolbelt.rs
+++ b/src/harness/toolbelt.rs
@@ -724,10 +724,15 @@ mod tests {
 
     #[tokio::test]
     async fn apply_patch_denied_outside_workspace() {
-        let ws = std::env::temp_dir().join("oc-toolbelt-escape");
-        let _ = tokio::fs::remove_dir_all(&ws).await;
-        tokio::fs::create_dir_all(&ws).await.unwrap();
-        let security = test_security(&ws, PolicyMode::Full);
+        // A private workspace root, not a fixed `/tmp` name: the old fixed name
+        // made two concurrent runs of this test tear down each other's
+        // directory between the create and the assertion.
+        let ws_dir = tempfile::Builder::new()
+            .prefix("oc-toolbelt-escape-")
+            .tempdir()
+            .expect("tempdir");
+        let ws = ws_dir.path();
+        let security = test_security(ws, PolicyMode::Full);
         let tool = ApplyPatchTool::new(security);
         // A path escaping the workspace root must be refused by the policy.
         let result = tool
@@ -743,7 +748,6 @@ mod tests {
             "workspace escape must be denied: {}",
             result.output()
         );
-        let _ = tokio::fs::remove_dir_all(&ws).await;
     }
 
     #[test]

--- a/src/ports/ids.rs
+++ b/src/ports/ids.rs
@@ -25,6 +25,16 @@ pub fn now_millis() -> u64 {
 ///
 /// The counter is strictly increasing, so two calls always differ and — given
 /// a non-decreasing clock — sort in mint order.
+///
+/// # Uniqueness is process-local
+///
+/// `COUNTER` starts at zero in every process and the millis prefix has
+/// millisecond resolution, so two processes that start within the same
+/// millisecond mint *identical* ids. Never use a minted id to name an entry in
+/// a directory other processes share — `/tmp` above all. Tests that need a
+/// private path must take one from `tempfile` (`tempfile::Builder::new()
+/// .prefix("opencompany-…").tempdir()`), which asks the OS for a name no other
+/// process can hold, rather than deriving one from `generate_id`.
 pub fn generate_id() -> String {
     let millis = now_millis();
     let counter = COUNTER.fetch_add(1, Ordering::Relaxed);

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1512,6 +1512,13 @@ mod test {
     use crate::openhuman::MockOpenHumanRpc;
     use crate::ports::types::ToolCall;
 
+    fn tmp_home(prefix: &str) -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix(prefix)
+            .tempdir()
+            .expect("tempdir")
+    }
+
     #[test]
     fn slugifies_display_names() {
         assert_eq!(company_id_from_name("Acme Co!").as_ref(), "acme-co");
@@ -1525,7 +1532,8 @@ mod test {
             InviteRecord, LoginCodeRecord, SessionRecord, UserRecord, UserRole, UserStatus,
         };
 
-        let home = std::env::temp_dir().join(format!("oc-users-{}", crate::ports::generate_id()));
+        let home_dir = tmp_home("oc-users-");
+        let home = home_dir.path().to_path_buf();
         let manifest = parse("[company]\nname=\"Acme\"\n[policy]\nmode=\"full\"\n");
         let id = CompanyId::new("acme");
         // No with_users/with_sessions/with_login_codes override: the builder must
@@ -1631,13 +1639,12 @@ mod test {
                 .unwrap()
                 .is_some()
         );
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn workspace_seeds_once_and_operator_deletions_stick() {
-        let home = std::env::temp_dir().join(format!("oc-seed-{}", crate::ports::generate_id()));
+        let home_dir = tmp_home("oc-seed-");
+        let home = home_dir.path().to_path_buf();
         // A company definition dir with a workspace subtree.
         let seed_dir = home.join("def");
         std::fs::create_dir_all(seed_dir.join("workspace/Brand")).unwrap();
@@ -1678,8 +1685,6 @@ mod test {
         assert!(!tree.iter().any(|n| n.name == "voice.md"));
         // Sanity: the record store still loads.
         assert!(runtime.store().load(&id).await.unwrap().is_some());
-
-        std::fs::remove_dir_all(&home).ok();
     }
 
     /// Issue #85: the launch path's template provenance is stamped onto the
@@ -1687,7 +1692,8 @@ mod test {
     /// (carried forward), and a company built with no provenance records `None`.
     #[tokio::test]
     async fn template_provenance_stamped_at_launch_and_carried_forward() {
-        let home = std::env::temp_dir().join(format!("oc-prov-{}", crate::ports::generate_id()));
+        let home_dir = tmp_home("oc-prov-");
+        let home = home_dir.path().to_path_buf();
         let manifest = parse("[company]\nname=\"Acme\"\n[policy]\nmode=\"full\"\n");
         let id = CompanyId::new("acme");
         let provenance = TemplateProvenance {
@@ -1730,8 +1736,6 @@ mod test {
             .unwrap();
         let raw = runtime.store().load(&other).await.unwrap().unwrap();
         assert!(raw.template_provenance.is_none());
-
-        std::fs::remove_dir_all(&home).ok();
     }
 
     fn parse(toml_src: &str) -> CompanyManifest {
@@ -1952,8 +1956,8 @@ mod test {
         use crate::ports::types::{CompanyEvent, OverlayDeskOrder};
         use crate::store::{FsCompanyStore, FsContextStore};
 
-        let home =
-            std::env::temp_dir().join(format!("oc-seed-order-{}", crate::ports::generate_id()));
+        let home_dir = tmp_home("oc-seed-order-");
+        let home = home_dir.path().to_path_buf();
         let id = CompanyId::new("order-co");
 
         // A desk `eng` whose blueprint lead is `eng1` (declared first).
@@ -2043,7 +2047,5 @@ mod test {
             !labels.contains(&"task-outcome/eng1"),
             "desk turn routed to the blueprint lead eng1 — the builder dropped the operator desk order; saw {labels:?}"
         );
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 }

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -890,8 +890,11 @@ mod test {
     use crate::server::ops::smtp::{SmtpCredentials, SmtpSecurity};
     use crate::store::paths::Bundle;
 
-    fn tmp_home() -> std::path::PathBuf {
-        std::env::temp_dir().join(format!("opencompany-cycle-{}", crate::ports::generate_id()))
+    fn tmp_home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("opencompany-cycle-")
+            .tempdir()
+            .expect("tempdir")
     }
 
     fn manifest(policy_mode: &str) -> CompanyManifest {
@@ -1018,7 +1021,8 @@ mod test {
     /// still receiving the orchestrator's.
     #[tokio::test]
     async fn a_reply_addressed_by_agent_id_reaches_the_operator_channel() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let operator_channel = OperatorChannel::new();
         let channels: Vec<Arc<dyn ChannelAdapter>> = vec![Arc::new(operator_channel.clone())];
         let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
@@ -1052,7 +1056,8 @@ mod test {
 
     #[tokio::test]
     async fn end_to_end_operator_message_echoes_and_persists() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let rt = RuntimeBuilder::fs_defaults(home.clone(), manifest("full"))
             .await
             .unwrap();
@@ -1090,12 +1095,12 @@ mod test {
         // (c) a compressed trace was persisted.
         let traces = rt.memory.recent_traces(rt.id(), 10).await.unwrap();
         assert!(!traces.is_empty());
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn effect_executes_at_most_once_across_reload() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let rt = RuntimeBuilder::fs_defaults(home.clone(), manifest("full"))
             .await
             .unwrap();
@@ -1125,12 +1130,12 @@ mod test {
         execute_effect_once(&rt2, "k1", &effect).await.unwrap();
         let record = rt2.store.load(rt2.id()).await.unwrap().unwrap();
         assert_eq!(record.ledger.len(), 1);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn supervised_effect_parks_then_resolves() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let sign_effect = Effect {
             kind: "filing.submit".into(),
             group: EffectGroup::Sign,
@@ -1168,7 +1173,6 @@ mod test {
             .unwrap();
         assert!(follow_up.parked.is_empty());
         assert!(rt.pending_approvals().is_empty());
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// Issue #172: an already-decided approval request parks and reaches the
@@ -1181,7 +1185,8 @@ mod test {
     /// to disappear before ever reaching the Approvals page.
     #[tokio::test]
     async fn a_decided_request_parks_without_being_re_evaluated() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let tool_effect = Effect {
             kind: "composio_execute".into(),
             group: EffectGroup::Other,
@@ -1229,13 +1234,12 @@ mod test {
             .await
             .unwrap();
         assert_eq!(rt2.pending_approvals().len(), 1);
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn approval_survives_runtime_restart() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let sign_effect = Effect {
             kind: "filing.submit".into(),
             group: EffectGroup::Sign,
@@ -1277,12 +1281,12 @@ mod test {
             .await
             .unwrap();
         assert!(rt2.pending_approvals().is_empty());
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn amend_then_approve_executes_edited_effect() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         // A parked Sign effect whose payload the operator will overwrite so the
         // executed effect routes an amended message to the operator channel.
         let sign_effect = Effect {
@@ -1343,12 +1347,12 @@ mod test {
         assert!(raw.contains("ApprovalParked"));
         assert!(raw.contains("ApprovalAmended"));
         assert!(raw.contains("AMENDED"));
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn sweep_expires_parked_approval_to_deny() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let sign_effect = Effect {
             kind: "filing.submit".into(),
             group: EffectGroup::Sign,
@@ -1390,7 +1394,6 @@ mod test {
             .await
             .unwrap();
         assert!(raw.contains("ApprovalExpired"));
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     // ── Issue #174: the generic cycle seam meters inference usage ────────────
@@ -1449,7 +1452,8 @@ mod test {
     /// and the cycle loop dropped it, so the Usage view read zero forever.
     #[tokio::test]
     async fn reported_cycle_usage_reaches_the_usage_meter() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .with_brain(Arc::new(MeteredBrain::per_cycle(reported_usage(0.031))))
             .build()
@@ -1484,15 +1488,14 @@ mod test {
             .collect();
         assert_eq!(spend.len(), 1);
         assert_eq!(spend[0].amount_usd, 0.031);
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// Tokens without USD (the managed passthrough bills backend-side) still
     /// count on the Usage surface, but must not post a `$0.00` spend line.
     #[tokio::test]
     async fn token_only_usage_meters_without_a_ledger_entry() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .with_brain(Arc::new(MeteredBrain::per_cycle(reported_usage(0.0))))
             .build()
@@ -1509,14 +1512,14 @@ mod test {
                 .iter()
                 .any(|e| e.kind == crate::metering::INFERENCE_SPEND_KIND)
         );
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// A cycle that spent nothing writes nothing — an idle cycle or the offline
     /// echo brain must not mint an empty sample.
     #[tokio::test]
     async fn a_zero_usage_cycle_writes_no_sample() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .with_brain(Arc::new(MeteredBrain::per_cycle(TokenUsage::default())))
             .build()
@@ -1526,7 +1529,6 @@ mod test {
         rt.run_cycle(Vec::new()).await.unwrap();
 
         assert!(rt.usage().query(rt.id(), 0).await.unwrap().is_empty());
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// The openhuman harness meters every turn itself, so the cycle seam must
@@ -1534,7 +1536,8 @@ mod test {
     /// than charged a second time.
     #[tokio::test]
     async fn a_self_metering_brain_is_not_metered_twice() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .with_brain(Arc::new(MeteredBrain {
                 usage: reported_usage(9.99),
@@ -1554,7 +1557,6 @@ mod test {
                 .iter()
                 .any(|e| e.kind == crate::metering::INFERENCE_SPEND_KIND)
         );
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// `UsageMetering::None` means "no model runs on this path", so the cycle
@@ -1563,7 +1565,8 @@ mod test {
     /// would post a `provider: "none"` row into `byProvider`.
     #[tokio::test]
     async fn a_brain_that_runs_no_model_is_not_metered() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .with_brain(Arc::new(MeteredBrain {
                 usage: reported_usage(4.2),
@@ -1583,14 +1586,14 @@ mod test {
                 .iter()
                 .any(|e| e.kind == crate::metering::INFERENCE_SPEND_KIND)
         );
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// Every cycle meters independently, so a multi-turn conversation
     /// accumulates rather than overwriting.
     #[tokio::test]
     async fn each_cycle_meters_its_own_usage() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .with_brain(Arc::new(MeteredBrain::per_cycle(reported_usage(0.01))))
             .build()
@@ -1605,7 +1608,6 @@ mod test {
         assert_eq!(samples.len(), 3);
         let total: u64 = samples.iter().map(|s| s.input_tokens).sum();
         assert_eq!(total, 3_600);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// A brain that tracks the peak number of concurrently-active cycles.
@@ -1632,7 +1634,8 @@ mod test {
 
     #[tokio::test]
     async fn cycles_are_serial_per_company() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let peak = Arc::new(AtomicUsize::new(0));
         let brain = Arc::new(ConcurrencyBrain {
             active: Arc::new(AtomicUsize::new(0)),
@@ -1659,12 +1662,12 @@ mod test {
 
         // The serial lock kept the two cycles from overlapping.
         assert_eq!(peak.load(Ordering::SeqCst), 1);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn distinct_companies_run_concurrently() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let one = RuntimeBuilder::new(home.clone(), manifest("full"))
             .with_id(CompanyId::new("one"))
             .build()
@@ -1690,7 +1693,6 @@ mod test {
         );
         assert_eq!(ra.unwrap().responses.len(), 1);
         assert_eq!(rb.unwrap().responses.len(), 1);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     fn test_smtp(from_email: &str) -> SmtpCredentials {
@@ -1707,7 +1709,8 @@ mod test {
 
     #[tokio::test]
     async fn email_send_effect_sends_and_records() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let sender = Arc::new(RecordingMailSender::new());
         let email_effect = Effect {
             kind: "email.send".into(),
@@ -1743,12 +1746,12 @@ mod test {
         assert_eq!(sender.sent()[0].0, "ceo@acme.test");
         let inbox = rt.inbox().messages(rt.id(), "ceo", 10, 0).await.unwrap();
         assert!(inbox.iter().any(|r| r.outbound && r.subject == "Hi"));
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn email_send_effect_without_mail_errors() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let email_effect = Effect {
             kind: "email.send".into(),
             group: EffectGroup::Send,
@@ -1779,12 +1782,12 @@ mod test {
         .await
         .unwrap_err();
         assert!(err.to_string().contains("email is not configured"));
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn established_true_only_after_inbound_from_recipient() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .with_mail(CompanyMail {
                 sender: Arc::new(RecordingMailSender::new()),
@@ -1815,12 +1818,12 @@ mod test {
             .unwrap();
 
         assert!(recipient_is_established(&rt, "X@EXT.COM").await);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn send_email_without_mail_returns_clean_error() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         // No `.with_mail(..)`: the company has no mailbox wired at all.
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .build()
@@ -1839,12 +1842,12 @@ mod test {
                 .unwrap_or_default()
                 .contains("not configured")
         );
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn send_email_bad_args_missing_to_yields_no_effect() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
             .build()
             .await
@@ -1857,12 +1860,12 @@ mod test {
             .unwrap();
         assert!(!res.ok);
         assert!(res.output["error"].is_string());
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn send_email_parks_for_new_recipient() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let sender = Arc::new(RecordingMailSender::new());
         let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
             .with_mail(CompanyMail {
@@ -1880,12 +1883,12 @@ mod test {
             .unwrap();
         assert_eq!(res.output["status"], "pending_approval");
         assert_eq!(sender.sent().len(), 0);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn send_email_sends_for_established_recipient() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let sender = Arc::new(RecordingMailSender::new());
         let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
             .with_mail(CompanyMail {
@@ -1920,7 +1923,6 @@ mod test {
             .unwrap();
         assert_eq!(res.output["status"], "sent");
         assert_eq!(sender.sent().len(), 1);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     // -----------------------------------------------------------------------
@@ -1979,7 +1981,8 @@ mod test {
 
     #[tokio::test]
     async fn spawn_task_arm_opens_a_board_card() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .build()
             .await
@@ -2005,12 +2008,12 @@ mod test {
             .unwrap();
         assert!(!bad.ok);
         assert_eq!(rt.tasks().list(rt.id()).await.unwrap().len(), 1);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn delegate_to_desk_arm_records_handoff_and_rejects_unknown_desk() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let rt = RuntimeBuilder::new(home.clone(), desk_manifest())
             .build()
             .await
@@ -2039,12 +2042,12 @@ mod test {
         let cards = rt.tasks().list(rt.id()).await.unwrap();
         assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].assignee, "eng");
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn call_tool_dispatches_delegation_tools() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .build()
             .await
@@ -2061,12 +2064,12 @@ mod test {
             .unwrap();
         assert!(res.ok);
         assert_eq!(rt.tasks().list(rt.id()).await.unwrap().len(), 1);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn handed_task_awareness_surfaces_open_cards_on_a_direct_query() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let seen = Arc::new(StdMutex::new(Vec::new()));
         let rt = RuntimeBuilder::new(home.clone(), desk_manifest())
             .with_brain(Arc::new(CapturingBrain { seen: seen.clone() }))
@@ -2125,12 +2128,12 @@ mod test {
             "unaddressed query has no desk briefing: {:?}",
             seen[1]
         );
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn awareness_skips_done_cards() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let seen = Arc::new(StdMutex::new(Vec::new()));
         let rt = RuntimeBuilder::new(home.clone(), desk_manifest())
             .with_brain(Arc::new(CapturingBrain { seen: seen.clone() }))
@@ -2167,6 +2170,5 @@ mod test {
             "done cards are not surfaced as open work: {:?}",
             seen[0]
         );
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 }

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -95,6 +95,11 @@ struct State {
 
 /// A per-company append-only journal backing at-most-once effects and the
 /// durable approval queue.
+///
+/// Exactly one process may write a given journal file. [`append`](Self::append)
+/// emits the record and its newline as two separate writes under an in-process
+/// lock, so a second writer on the same path can interleave between them and
+/// leave two records on one line, which then fails to parse on replay.
 pub struct RuntimeJournal {
     path: PathBuf,
     state: StdMutex<State>,
@@ -319,16 +324,24 @@ mod test {
         }
     }
 
-    fn tmp_path() -> PathBuf {
-        std::env::temp_dir().join(format!(
-            "opencompany-journal-{}.jsonl",
-            crate::ports::generate_id()
-        ))
+    /// A private directory for one test's journal file.
+    ///
+    /// The name comes from the OS, not from [`crate::ports::generate_id`] —
+    /// minted ids are unique only within a process, so two test processes
+    /// sharing `/tmp` could otherwise land on the same journal path and
+    /// interleave their appends into an unparseable line. Dropping the
+    /// returned handle removes the directory, including after a failed assert.
+    fn tmp_dir() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("opencompany-journal-")
+            .tempdir()
+            .expect("tempdir")
     }
 
     #[tokio::test]
     async fn effect_key_commits_once_and_survives_reload() {
-        let path = tmp_path();
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
         let journal = RuntimeJournal::new(&path);
 
         assert!(!journal.is_executed("cyc:0"));
@@ -344,12 +357,12 @@ mod test {
 
         let raw = tokio::fs::read_to_string(&path).await.unwrap();
         assert_eq!(raw.lines().filter(|l| !l.trim().is_empty()).count(), 1);
-        tokio::fs::remove_file(&path).await.ok();
     }
 
     #[tokio::test]
     async fn parked_approvals_rehydrate_and_resolve() {
-        let path = tmp_path();
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
         let journal = RuntimeJournal::new(&path);
         let id = ApprovalId::new("appr-1");
         journal
@@ -371,12 +384,12 @@ mod test {
         let after = RuntimeJournal::new(&path);
         after.load().await.unwrap();
         assert!(after.pending().is_empty());
-        tokio::fs::remove_file(&path).await.ok();
     }
 
     #[tokio::test]
     async fn expired_record_removes_parked_and_survives_reload() {
-        let path = tmp_path();
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
         let journal = RuntimeJournal::new(&path);
         let id = ApprovalId::new("appr-exp");
         journal
@@ -395,12 +408,12 @@ mod test {
 
         let raw = tokio::fs::read_to_string(&path).await.unwrap();
         assert!(raw.contains("ApprovalExpired"));
-        tokio::fs::remove_file(&path).await.ok();
     }
 
     #[tokio::test]
     async fn amended_record_is_audit_only_and_round_trips() {
-        let path = tmp_path();
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
         let journal = RuntimeJournal::new(&path);
         let id = ApprovalId::new("appr-amend");
         journal
@@ -427,7 +440,6 @@ mod test {
         let raw = tokio::fs::read_to_string(&path).await.unwrap();
         assert!(raw.contains("ApprovalAmended"));
         assert!(raw.contains("\"edited\":true"));
-        tokio::fs::remove_file(&path).await.ok();
     }
 
     #[test]

--- a/src/runtime/mailbox_poller.rs
+++ b/src/runtime/mailbox_poller.rs
@@ -126,8 +126,11 @@ mod tests {
     use crate::server::ops::mailer::{FetchedEmail, InboundEmail, RecordingMailReceiver};
     use crate::store::FsInboxStore;
 
-    fn tmp_home() -> std::path::PathBuf {
-        std::env::temp_dir().join(format!("opencompany-mailpoll-{}", generate_id()))
+    fn tmp_home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("opencompany-mailpoll-")
+            .tempdir()
+            .expect("tempdir")
     }
 
     fn manifest() -> CompanyManifest {
@@ -147,7 +150,8 @@ mod tests {
 
     #[tokio::test]
     async fn tick_files_and_notifies_each_message() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let runtime = Arc::new(
             RuntimeBuilder::fs_defaults(home.clone(), manifest())
                 .await
@@ -203,7 +207,6 @@ mod tests {
         );
         // Both durably filed, so both UIDs — and only those UIDs — are acked.
         assert_eq!(rx.marked(), vec![10, 11]);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// A wrapper [`InboxStore`] delegating to a real `FsInboxStore`, except
@@ -258,7 +261,8 @@ mod tests {
 
     #[tokio::test]
     async fn tick_continues_past_one_filing_failure_and_only_marks_seen_the_filed_uid() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let inbox = Arc::new(NthAppendFailsInbox {
             inner: FsInboxStore::new(home.clone()),
             fail_on_call: 2,
@@ -333,12 +337,12 @@ mod tests {
         // Only the successfully-filed UIDs are acked — 21 must never appear,
         // or it would be lost forever (marked seen without ever being filed).
         assert_eq!(rx.marked(), vec![20, 22]);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn tick_skips_while_not_running() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let runtime = Arc::new(
             RuntimeBuilder::fs_defaults(home.clone(), manifest())
                 .await
@@ -378,6 +382,5 @@ mod tests {
         let n = poller.tick().await.unwrap();
         assert_eq!(n, 0);
         assert_eq!(rx.calls(), 0);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 }

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -104,6 +104,13 @@ mod test {
         toml::from_str(&format!("[company]\nname = \"{name}\"\n")).unwrap()
     }
 
+    fn tmp_home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("opencompany-reg-")
+            .tempdir()
+            .expect("tempdir")
+    }
+
     async fn runtime(home: &std::path::Path, id: &str) -> Arc<CompanyRuntime> {
         Arc::new(
             RuntimeBuilder::new(home.to_path_buf(), manifest(id))
@@ -116,8 +123,8 @@ mod test {
 
     #[tokio::test]
     async fn sole_returns_the_only_company() {
-        let home =
-            std::env::temp_dir().join(format!("opencompany-reg-{}", crate::ports::generate_id()));
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let registry = CompanyRegistry::new();
         assert!(registry.is_empty());
         assert!(registry.sole().is_none());
@@ -131,13 +138,12 @@ mod test {
         assert!(registry.sole().is_none());
         assert_eq!(registry.len(), 2);
         assert!(registry.get(&CompanyId::new("globex")).is_some());
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn remove_unregisters_the_company() {
-        let home =
-            std::env::temp_dir().join(format!("opencompany-reg-{}", crate::ports::generate_id()));
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let registry = CompanyRegistry::new();
         registry.insert(CompanyId::new("acme"), runtime(&home, "acme").await);
         assert!(registry.get(&CompanyId::new("acme")).is_some());
@@ -146,6 +152,5 @@ mod test {
         assert!(removed.is_some());
         assert!(registry.get(&CompanyId::new("acme")).is_none());
         assert!(registry.remove(&CompanyId::new("acme")).is_none());
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 }

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -230,8 +230,11 @@ mod test {
     use crate::runtime::RuntimeBuilder;
     use crate::runtime::cron::CivilTime;
 
-    fn tmp_home() -> std::path::PathBuf {
-        std::env::temp_dir().join(format!("opencompany-sched-{}", crate::ports::generate_id()))
+    fn tmp_home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("opencompany-sched-")
+            .tempdir()
+            .expect("tempdir")
     }
 
     fn manifest(policy_mode: &str) -> CompanyManifest {
@@ -320,7 +323,8 @@ mod test {
 
     #[tokio::test]
     async fn fires_once_per_matching_minute_and_dedupes() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let manifest = scheduled_manifest();
         let schedules = manifest.schedules.clone();
         let rt = Arc::new(
@@ -367,12 +371,12 @@ mod test {
             .await
             .unwrap();
         assert_eq!(events.len(), 2);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn non_matching_minute_never_fires() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let manifest = scheduled_manifest();
         let schedules = manifest.schedules.clone();
         let rt = Arc::new(
@@ -386,12 +390,12 @@ mod test {
         let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 14, 9, 0)));
         let mut scheduler = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
         assert_eq!(scheduler.tick().await.unwrap(), 0);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn empty_schedule_set_is_a_noop() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let rt = Arc::new(
             RuntimeBuilder::fs_defaults(home.clone(), manifest("full"))
                 .await
@@ -401,12 +405,12 @@ mod test {
         let mut scheduler = CompanyScheduler::new(rt, &[], clock).unwrap();
         assert!(scheduler.is_empty());
         assert_eq!(scheduler.tick().await.unwrap(), 0);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn tick_maintenance_expires_parked_approval() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         // A brain that parks a Sign effect so there is something to expire.
         struct ParkBrain;
         #[async_trait]
@@ -461,7 +465,6 @@ mod test {
         let expired = scheduler.tick_maintenance().await.unwrap();
         assert_eq!(expired.len(), 1);
         assert!(rt.pending_approvals().is_empty());
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     fn scheduled_manifest_supervised() -> CompanyManifest {
@@ -525,7 +528,8 @@ mod test {
     /// The 5s bound only caps how long the failing case takes to report.
     #[tokio::test]
     async fn shutdown_during_a_tick_stops_the_loop() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let manifest = scheduled_manifest();
         let schedules = manifest.schedules.clone();
         let (started_tx, started_rx) = tokio::sync::oneshot::channel();
@@ -558,8 +562,6 @@ mod test {
             .await
             .expect("scheduler kept running after a shutdown delivered mid-tick")
             .expect("scheduler task panicked");
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
@@ -569,7 +571,8 @@ mod test {
             cron: "not a cron".into(),
             prompt: "x".into(),
         }];
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let rt = Arc::new(
             RuntimeBuilder::fs_defaults(home.clone(), manifest("full"))
                 .await
@@ -577,7 +580,6 @@ mod test {
         );
         let clock = Arc::new(FakeClock::new(0));
         assert!(CompanyScheduler::new(rt, &bad, clock).is_err());
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[test]

--- a/src/runtime/telegram_poller.rs
+++ b/src/runtime/telegram_poller.rs
@@ -295,14 +295,16 @@ mod tests {
 
     use crate::company::CompanyManifest;
     use crate::company::telegram::RecordingTelegramApi;
-    use crate::ports::generate_id;
     use crate::ports::types::SecretValue;
     use crate::runtime::RuntimeBuilder;
 
     const TOKEN: &str = "7654321:AAExampleBotTokenNeverLeaks";
 
-    fn tmp_home() -> std::path::PathBuf {
-        std::env::temp_dir().join(format!("opencompany-tgpoll-{}", generate_id()))
+    fn tmp_home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("opencompany-tgpoll-")
+            .tempdir()
+            .expect("tempdir")
     }
 
     fn manifest() -> CompanyManifest {
@@ -356,7 +358,8 @@ mod tests {
     /// public URL, no `setWebhook` — is enough to receive a DM and answer it.
     #[tokio::test]
     async fn polls_updates_and_replies_without_any_webhook() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let runtime = company(&home).await;
         store_token(&runtime, TOKEN).await;
 
@@ -377,8 +380,6 @@ mod tests {
         // A second tick carries the ack forward even with nothing to fetch.
         assert_eq!(poller.tick().await.unwrap(), PollOutcome::Polled(0));
         assert_eq!(api.poll_offsets(), vec![None, Some(42)]);
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// Issue #203's broken state: a webhook is registered against a URL Telegram
@@ -386,7 +387,8 @@ mod tests {
     /// poller must clear it and take over rather than 409-loop.
     #[tokio::test]
     async fn clears_an_unreachable_webhook_and_takes_over_inbound() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let runtime = company(&home).await;
         store_token(&runtime, TOKEN).await;
 
@@ -399,8 +401,6 @@ mod tests {
         assert_eq!(poller.tick().await.unwrap(), PollOutcome::Polled(1));
         assert_eq!(api.delete_webhook_calls(), 1, "stale webhook was cleared");
         assert_eq!(api.sent().len(), 1, "the parked DM got answered");
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// On a host Telegram *can* reach, a registered webhook is a deliberate
@@ -408,7 +408,8 @@ mod tests {
     /// updates — and must re-check, so unregistering resumes polling.
     #[tokio::test]
     async fn stands_by_for_a_webhook_on_a_publicly_reachable_host() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let runtime = company(&home).await;
         store_token(&runtime, TOKEN).await;
 
@@ -426,15 +427,14 @@ mod tests {
         api.delete_webhook(TOKEN).await.unwrap();
         assert_eq!(poller.tick().await.unwrap(), PollOutcome::Polled(1));
         assert_eq!(api.sent().len(), 1);
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// No token stored is idle, not an error — and a token pasted later is
     /// picked up on the very next tick, with no restart.
     #[tokio::test]
     async fn idles_without_a_token_then_picks_one_up_live() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let runtime = company(&home).await;
 
         let api = Arc::new(RecordingTelegramApi::new());
@@ -452,15 +452,14 @@ mod tests {
         store_token(&runtime, "").await;
         assert_eq!(poller.tick().await.unwrap(), PollOutcome::Idle);
         assert_eq!(poller.offset, None);
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// Scale-to-zero: a paused company polls nothing. Updates wait on
     /// Telegram's side and arrive on the first tick after wake.
     #[tokio::test]
     async fn skips_while_the_company_is_not_running() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let runtime = company(&home).await;
         store_token(&runtime, TOKEN).await;
         let mut record = runtime.store.load(runtime.id()).await.unwrap().unwrap();
@@ -473,15 +472,14 @@ mod tests {
 
         assert_eq!(poller.tick().await.unwrap(), PollOutcome::Idle);
         assert!(api.poll_offsets().is_empty());
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// A poll failure must never echo the bot token, and must re-arm the
     /// handshake so a mid-flight webhook registration is noticed.
     #[tokio::test]
     async fn poll_errors_are_scrubbed_and_rearm_the_handshake() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let runtime = company(&home).await;
         store_token(&runtime, TOKEN).await;
 
@@ -499,15 +497,14 @@ mod tests {
 
         // Re-handshaking resolves it: the webhook owns inbound, so stand by.
         assert_eq!(poller.tick().await.unwrap(), PollOutcome::Idle);
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// Changing the bot token discards the previous bot's offset — update ids
     /// are per-bot, so carrying one over would ack the wrong updates.
     #[tokio::test]
     async fn a_new_token_resets_the_offset() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let runtime = company(&home).await;
         store_token(&runtime, TOKEN).await;
 
@@ -524,7 +521,5 @@ mod tests {
             vec![None, None],
             "the second bot is asked cold, not at the first bot's offset"
         );
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 }

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -599,11 +599,11 @@ mod test {
         String::from_utf8_lossy(&sink.lock().unwrap()).to_string()
     }
 
-    fn tmp_home() -> std::path::PathBuf {
-        std::env::temp_dir().join(format!(
-            "opencompany-wfsched-{}",
-            crate::ports::generate_id()
-        ))
+    fn tmp_home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("opencompany-wfsched-")
+            .tempdir()
+            .expect("tempdir")
     }
 
     fn manifest() -> CompanyManifest {
@@ -826,17 +826,14 @@ to = "done"
         wait_for(|| !scheduler.is_running_any()).await;
     }
 
-    async fn cleanup(home: &std::path::Path) {
-        tokio::fs::remove_dir_all(home).await.ok();
-    }
-
     /// The headline: a workflow that exists ONLY as a record overlay (no source
     /// file — the console-created shape #168 introduced) is picked up and fired
     /// on a matching minute, once. It does not re-fire in the same minute, stays
     /// silent on a non-matching minute, and fires again on the next match.
     #[tokio::test]
     async fn fires_an_overlay_only_workflow_once_per_matching_minute() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let (runner, started, _completed) = RecordingRunner::new();
         let registry = company_with_overlays(
             &home,
@@ -871,15 +868,14 @@ to = "done"
         clock.set(millis_at(2026, 7, 20, 9, 0));
         assert_eq!(scheduler.tick().await, 1);
         wait_for(|| started.lock().unwrap().len() == 2).await;
-
-        cleanup(&home).await;
     }
 
     /// The seeded input tells the run — and every agent turn inside it — that a
     /// schedule started it. `request` is the key `run_request_text` reads.
     #[tokio::test]
     async fn the_seeded_input_marks_the_run_as_scheduled() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let (runner, started, _completed) = RecordingRunner::new();
         let registry = company_with_overlays(
             &home,
@@ -906,8 +902,6 @@ to = "done"
         assert!(request.contains("Scheduled run"), "{request}");
         assert!(request.contains("* * * * *"), "{request}");
         assert!(!request.trim().is_empty());
-
-        cleanup(&home).await;
     }
 
     // --- report delivery on a scheduled run (issue #170) ---------------------
@@ -957,7 +951,8 @@ to = "done"
     #[tokio::test]
     async fn a_scheduled_run_reports_an_undelivered_report() {
         let sink = captured_logs();
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         // A company id unique to this test: the capture buffer is shared with
         // every other test in the binary, so this is what makes the assertions
         // about *this* run rather than about whatever else logged.
@@ -1032,8 +1027,6 @@ to = "done"
         assert!(summary.contains("denied=0"), "{summary}");
         assert!(summary.contains("failed=0"), "{summary}");
         assert!(summary.contains("undelivered=1"), "{summary}");
-
-        cleanup(&home).await;
     }
 
     /// A scheduled run that delivered everything says so without crying wolf:
@@ -1041,7 +1034,8 @@ to = "done"
     #[tokio::test]
     async fn a_clean_scheduled_run_logs_no_delivery_warning() {
         let sink = captured_logs();
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let company = "clean-delivery-co";
         let (runner, completed) = RecordingRunner::with_deliveries(vec![report(
             "owner_summary",
@@ -1084,15 +1078,14 @@ to = "done"
         assert!(summary.contains("denied=0"), "{summary}");
         assert!(summary.contains("failed=0"), "{summary}");
         assert!(summary.contains("undelivered=0"), "{summary}");
-
-        cleanup(&home).await;
     }
 
     /// A workflow with no schedule is never fired by the scheduler — it stays
     /// manual-run only.
     #[tokio::test]
     async fn an_unscheduled_workflow_never_fires() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let (runner, started, _completed) = RecordingRunner::new();
         let registry = company_with_overlays(
             &home,
@@ -1107,15 +1100,14 @@ to = "done"
 
         assert_eq!(scheduler.tick().await, 0);
         assert!(started.lock().unwrap().is_empty());
-
-        cleanup(&home).await;
     }
 
     /// A paused company fires nothing — the same `ensure_running` guard the
     /// manifest cron scheduler uses, so schedules resume on unpause.
     #[tokio::test]
     async fn a_paused_company_is_skipped() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let (runner, started, _completed) = RecordingRunner::new();
         let registry = company_with_overlays(
             &home,
@@ -1130,8 +1122,6 @@ to = "done"
 
         assert_eq!(scheduler.tick().await, 0);
         assert!(started.lock().unwrap().is_empty());
-
-        cleanup(&home).await;
     }
 
     /// No runner wired (the default build) is a clean no-op, not an error — the
@@ -1141,7 +1131,8 @@ to = "done"
     /// signal it is raising.
     #[tokio::test]
     async fn no_runner_wired_is_a_noop_and_warns_once() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let registry = company_with_overlays(
             &home,
             "acme",
@@ -1165,15 +1156,14 @@ to = "done"
             scheduler.unwired_warnings, 1,
             "the warning must not repeat every tick"
         );
-
-        cleanup(&home).await;
     }
 
     /// A company with no runner AND no scheduled workflows is not
     /// misconfigured — it simply has nothing to run, so it stays silent.
     #[tokio::test]
     async fn no_runner_and_no_schedules_does_not_warn() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let registry = company_with_overlays(
             &home,
             "acme",
@@ -1190,8 +1180,6 @@ to = "done"
             scheduler.unwired_warnings, 0,
             "a company with nothing scheduled deserves silence"
         );
-
-        cleanup(&home).await;
     }
 
     /// The latch is re-armed when the situation changes: a schedule saved onto a
@@ -1199,7 +1187,8 @@ to = "done"
     /// that company unwired (with nothing scheduled) and said nothing.
     #[tokio::test]
     async fn a_schedule_added_later_still_warns() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let company = CompanyId::new("acme");
         let registry = company_with_overlays(
             &home,
@@ -1228,15 +1217,14 @@ to = "done"
             scheduler.unwired_warnings, 1,
             "a schedule saved onto an unwired company must be reported"
         );
-
-        cleanup(&home).await;
     }
 
     /// A malformed graph body skips only itself: the healthy scheduled workflow
     /// beside it still fires.
     #[tokio::test]
     async fn a_malformed_graph_skips_only_itself() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let (runner, started, _completed) = RecordingRunner::new();
         let registry = company_with_overlays(
             &home,
@@ -1258,15 +1246,14 @@ to = "done"
         assert_eq!(scheduler.tick().await, 1);
         wait_for(|| started.lock().unwrap().len() == 1).await;
         assert_eq!(started.lock().unwrap()[0].workflow, "healthy");
-
-        cleanup(&home).await;
     }
 
     /// A scheduled run still executing suppresses the next fire; once it
     /// completes, the workflow becomes schedulable again.
     #[tokio::test]
     async fn an_in_flight_run_suppresses_the_next_fire() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let gate = Arc::new(Semaphore::new(0));
         let (runner, started, completed) = RecordingRunner::gated(gate.clone());
         let registry = company_with_overlays(
@@ -1304,8 +1291,6 @@ to = "done"
             "the workflow must be schedulable once its run completed"
         );
         wait_for(|| started.lock().unwrap().len() == 2).await;
-
-        cleanup(&home).await;
     }
 
     /// A company removed from the registry (archived) is swept out of the
@@ -1314,7 +1299,8 @@ to = "done"
     /// its entry would be orphaned for the life of the process.
     #[tokio::test]
     async fn a_removed_company_is_swept_from_the_warning_latch() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let company = CompanyId::new("acme");
         let registry = company_with_overlays(
             &home,
@@ -1340,8 +1326,6 @@ to = "done"
             scheduler.warned_unwired.is_empty(),
             "a company that no longer exists must not be held in the latch"
         );
-
-        cleanup(&home).await;
     }
 
     /// The dedupe map keeps only the current minute. Anything older can never
@@ -1349,7 +1333,8 @@ to = "done"
     /// (company, workflow) ever fired, including deleted ones.
     #[tokio::test]
     async fn the_dedupe_map_does_not_grow_without_bound() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let (runner, started, _completed) = RecordingRunner::new();
         let registry = company_with_overlays(
             &home,
@@ -1380,8 +1365,6 @@ to = "done"
             assert_eq!(scheduler.last_fired.len(), 1, "minute {minute}");
         }
         wait_for(|| started.lock().unwrap().len() == 10).await;
-
-        cleanup(&home).await;
     }
 
     /// A runner that panics must not strand the in-flight claim. Releasing the
@@ -1407,7 +1390,8 @@ to = "done"
             }
         }
 
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let calls = Arc::new(AtomicUsize::new(0));
         let runner = Arc::new(PanickingRunner {
             calls: calls.clone(),
@@ -1438,15 +1422,14 @@ to = "done"
             "a panicking run must not retire the schedule"
         );
         wait_for(|| calls.load(Ordering::SeqCst) == 2).await;
-
-        cleanup(&home).await;
     }
 
     /// A workflow committed as a seed file (not an overlay) is scheduled too, so
     /// the union really is the read path.
     #[tokio::test]
     async fn a_seed_file_workflow_is_scheduled() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let source = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(source.path().join("workflows")).unwrap();
         std::fs::write(
@@ -1472,8 +1455,6 @@ to = "done"
         assert_eq!(scheduler.tick().await, 1);
         wait_for(|| started.lock().unwrap().len() == 1).await;
         assert_eq!(started.lock().unwrap()[0].workflow, "seeded");
-
-        cleanup(&home).await;
     }
 
     /// The helper reads the first scheduled trigger and ignores everything else.

--- a/src/server/feedback.rs
+++ b/src/server/feedback.rs
@@ -170,11 +170,11 @@ mod test {
     use crate::store::FsSecretStore;
     use crate::{AppConfig, AppState};
 
-    fn home() -> std::path::PathBuf {
-        std::env::temp_dir().join(format!(
-            "opencompany-feedback-{}",
-            crate::ports::generate_id()
-        ))
+    fn home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("opencompany-feedback-")
+            .tempdir()
+            .expect("tempdir")
     }
 
     fn manifest() -> CompanyManifest {
@@ -273,7 +273,8 @@ mod test {
     // redacted) → preview → mock-file with dedupe.
     #[tokio::test]
     async fn capture_scrub_preview_file_and_dedupe() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let github = Arc::new(MockGitHubClient::new());
         let state = state_with_company(&home, github.clone()).await;
         let app = router(state);
@@ -338,15 +339,14 @@ mod test {
         assert_eq!(value["deduped"], true);
         assert_eq!(github.created().len(), 1);
         assert_eq!(github.comments().len(), 1);
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     // A provisioned instance forwards to the hub instead of filing, and what
     // crosses the boundary is the scrubbed body — not the operator's raw words.
     #[tokio::test]
     async fn provisioned_instance_forwards_scrubbed_body_and_files_nothing() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let github = Arc::new(MockGitHubClient::new());
         let hub = Arc::new(MockTinyHumansClient::new());
         let state = state_with_clients(&home, github.clone(), Some(hub.clone())).await;
@@ -377,15 +377,14 @@ mod test {
         assert_eq!(sent.origin, "acme");
         assert_eq!(sent.wire_type(), "bug");
         assert!(!sent.external_ref.is_empty());
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     // The scrub gate runs before the destination choice, so a secret is blocked
     // rather than forwarded.
     #[tokio::test]
     async fn scrub_abort_blocks_before_forwarding() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let github = Arc::new(MockGitHubClient::new());
         let hub = Arc::new(MockTinyHumansClient::new());
         let state = state_with_clients(&home, github, Some(hub.clone())).await;
@@ -404,15 +403,14 @@ mod test {
             hub.forwarded().is_empty(),
             "a blocked report must not leave"
         );
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     // An unreachable hub is a degraded success: the note is already stored, so
     // the operator gets a reason rather than a failed request.
     #[tokio::test]
     async fn unreachable_hub_degrades_to_local() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let github = Arc::new(MockGitHubClient::new());
         let hub = Arc::new(MockTinyHumansClient::new().with_failure("connection refused"));
         let state = state_with_clients(&home, github.clone(), Some(hub)).await;
@@ -430,14 +428,13 @@ mod test {
         assert!(value["reason"].is_string());
         // It must not silently fall back to filing an issue instead.
         assert!(github.created().is_empty());
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     // Moderation rejection is reported as such, not as a transport failure.
     #[tokio::test]
     async fn hub_moderation_rejection_is_reported() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let github = Arc::new(MockGitHubClient::new());
         let hub = Arc::new(
             MockTinyHumansClient::new().with_outcome(IngestOutcome::Rejected {
@@ -457,14 +454,13 @@ mod test {
         assert_eq!(value["filed"], false);
         assert_eq!(value["destination"], "tinyhumans");
         assert_eq!(value["reason"], "off-topic");
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     // Without a credential the original GitHub path is untouched.
     #[tokio::test]
     async fn unprovisioned_instance_still_files_to_github() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let github = Arc::new(MockGitHubClient::new());
         let state = state_with_company(&home, github.clone()).await;
         let app = router(state);
@@ -479,15 +475,14 @@ mod test {
         assert_eq!(value["filed"], true);
         assert_eq!(value["destination"], "github");
         assert_eq!(github.created().len(), 1);
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     // The reports list shows what was reported and where it went, and never the
     // operator's own words.
     #[tokio::test]
     async fn list_returns_summaries_without_operator_words() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let github = Arc::new(MockGitHubClient::new());
         let state = state_with_company(&home, github).await;
         let app = router(state);
@@ -513,15 +508,14 @@ mod test {
         assert!(!raw.contains("payroll run crashed"), "got {raw}");
         assert!(!raw.contains("operator_words"), "got {raw}");
         assert!(!raw.contains("context_excerpt"), "got {raw}");
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     // A forwarded report stores the hub's id, which is not a URL — the list must
     // not offer it as a link.
     #[tokio::test]
     async fn list_omits_a_non_url_reference_for_forwarded_reports() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let github = Arc::new(MockGitHubClient::new());
         let hub = Arc::new(MockTinyHumansClient::new());
         let state = state_with_clients(&home, github, Some(hub)).await;
@@ -539,13 +533,12 @@ mod test {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0]["issue_status"], "forwarded");
         assert!(items[0]["filed_issue_url"].is_null());
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn feedback_for_unknown_company_is_404() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let github = Arc::new(MockGitHubClient::new());
         let state = state_with_company(&home, github).await;
         let app = router(state);
@@ -559,6 +552,5 @@ mod test {
         // 401, not 404: authentication precedes existence, so an unauthenticated
         // caller cannot enumerate which companies this host runs.
         assert_eq!(status, StatusCode::UNAUTHORIZED);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 }

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -15,8 +15,11 @@ use crate::server::router;
 use crate::store::FsCompanyStore;
 use crate::{AppConfig, AppState};
 
-pub(crate) fn home() -> std::path::PathBuf {
-    std::env::temp_dir().join(format!("opencompany-gql-{}", crate::ports::generate_id()))
+pub(crate) fn home() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix("opencompany-gql-")
+        .tempdir()
+        .expect("tempdir")
 }
 
 pub(crate) fn manifest() -> CompanyManifest {
@@ -74,7 +77,8 @@ pub(crate) async fn query(app: axum::Router, body: &str) -> serde_json::Value {
 
 #[tokio::test]
 async fn companies_query_lists_the_company() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let app = router(state_with_company(&home).await);
     let value = query(
         app,
@@ -84,12 +88,12 @@ async fn companies_query_lists_the_company() {
     assert_eq!(value["data"]["companies"][0]["id"], "acme");
     assert_eq!(value["data"]["companies"][0]["name"], "Acme");
     assert_eq!(value["data"]["companies"][0]["lifecycle"], "running");
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn company_query_by_id_resolves() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let app = router(state_with_company(&home).await);
     let value = query(
         app,
@@ -97,30 +101,30 @@ async fn company_query_by_id_resolves() {
     )
     .await;
     assert_eq!(value["data"]["company"]["id"], "acme");
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn company_query_without_id_resolves_the_sole_company() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let app = router(state_with_company(&home).await);
     let value = query(app, r#"{"query":"{ company { id } }"}"#).await;
     assert_eq!(value["data"]["company"]["id"], "acme");
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn unknown_company_query_is_null() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let app = router(state_with_company(&home).await);
     let value = query(app, r#"{"query":"{ company(id: \"ghost\") { id } }"}"#).await;
     assert!(value["data"]["company"].is_null());
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn approvals_field_is_empty_before_any_park() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let app = router(state_with_company(&home).await);
     let value = query(
         app,
@@ -134,7 +138,6 @@ async fn approvals_field_is_empty_before_any_park() {
             .len(),
         0
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 // ---------------------------------------------------------------------------
@@ -198,7 +201,8 @@ async fn state_with_rich_company(home: &std::path::Path) -> AppState {
 
 #[tokio::test]
 async fn team_lists_manifest_teammates() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let app = router(state_with_rich_company(&home).await);
     let value = query(
         app,
@@ -210,12 +214,12 @@ async fn team_lists_manifest_teammates() {
     assert_eq!(team[0]["id"], "maya");
     assert_eq!(team[0]["role"], "Marketing Lead");
     assert!(team[0]["name"].is_null());
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn chats_list_the_manifest_desks() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let app = router(state_with_rich_company(&home).await);
     let value = query(
         app,
@@ -226,7 +230,6 @@ async fn chats_list_the_manifest_desks() {
     assert_eq!(chats.len(), 1);
     assert_eq!(chats[0]["id"], "general");
     assert_eq!(chats[0]["members"][0], "maya");
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// Issue #65: `AgentReply`s answering the console's default thread are
@@ -236,7 +239,8 @@ async fn chats_list_the_manifest_desks() {
 /// transcript is never split by which id a given turn happened to use.
 #[tokio::test]
 async fn chat_history_finds_agent_replies_under_general_and_main() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_rich_company(&home).await;
     let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
     runtime
@@ -285,12 +289,12 @@ async fn chat_history_finds_agent_replies_under_general_and_main() {
         texts.contains(&"console default-thread id"),
         "missing: {texts:?}"
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn connections_reflect_manifest_intent_disconnected() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let app = router(state_with_rich_company(&home).await);
     let value = query(
         app,
@@ -302,13 +306,13 @@ async fn connections_reflect_manifest_intent_disconnected() {
     assert_eq!(conns[0]["provider"], "slack");
     assert_eq!(conns[0]["connected"], false);
     assert_eq!(conns[0]["reason"], "Post updates.");
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn tasks_page_reflects_upserts_and_column_filter() {
     use crate::ports::tasks::TaskRecord;
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_rich_company(&home).await;
     let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
     runtime
@@ -345,13 +349,13 @@ async fn tasks_page_reflects_upserts_and_column_filter() {
     )
     .await;
     assert_eq!(none["data"]["company"]["tasks"]["total"], 0);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn memory_page_reflects_upserts() {
     use crate::ports::facts::{FactKind, FactRecord};
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_rich_company(&home).await;
     let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
     runtime
@@ -386,12 +390,12 @@ async fn memory_page_reflects_upserts() {
             .unwrap()
             .starts_with("2023-")
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn empty_surfaces_resolve_to_empty_lists() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let app = router(state_with_rich_company(&home).await);
     let value = query(
         app,
@@ -403,12 +407,12 @@ async fn empty_surfaces_resolve_to_empty_lists() {
     assert_eq!(company["inboxes"].as_array().unwrap().len(), 0);
     assert_eq!(company["skills"].as_array().unwrap().len(), 0);
     assert_eq!(company["workflows"].as_array().unwrap().len(), 0);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn smtp_status_is_unconfigured_without_credentials() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let app = router(state_with_rich_company(&home).await);
     let value = query(
         app,
@@ -418,12 +422,12 @@ async fn smtp_status_is_unconfigured_without_credentials() {
     assert_eq!(value["data"]["company"]["smtp"]["configured"], false);
     assert_eq!(value["data"]["company"]["smtp"]["host"], "");
     assert!(value["data"]["company"]["domain"].is_null());
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn usage_is_empty_without_samples() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let app = router(state_with_rich_company(&home).await);
     let value = query(
         app,
@@ -435,13 +439,13 @@ async fn usage_is_empty_without_samples() {
     assert_eq!(usage["totals"]["connections"], 0);
     // D7 still yields a zero-filled 7-day series.
     assert_eq!(usage["series"].as_array().unwrap().len(), 7);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn usage_reflects_recorded_samples() {
     use crate::ports::usage::{SampleKind, UsageSample};
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_rich_company(&home).await;
     let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
     let now = super::now_millis();
@@ -473,13 +477,13 @@ async fn usage_reflects_recorded_samples() {
     assert_eq!(usage["totals"]["tokens"], 140.0);
     assert_eq!(usage["totals"]["costUsd"], 0.5);
     assert_eq!(usage["byAgent"][0]["tokens"], 140.0);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn finances_fold_the_ledger() {
     use crate::ports::types::LedgerEntry;
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_rich_company(&home).await;
     let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
     let now = super::now_millis();
@@ -520,7 +524,6 @@ async fn finances_fold_the_ledger() {
     assert_eq!(fin["revenueUsd"], 10.0);
     assert_eq!(fin["netUsd"], 8.0);
     assert_eq!(fin["transactions"].as_array().unwrap().len(), 2);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// On the serve path a company has an on-disk source dir; `Company.skills`,
@@ -528,7 +531,8 @@ async fn finances_fold_the_ledger() {
 /// from it (and the repo-level `skills/` root) rather than the empty bundle.
 #[tokio::test]
 async fn skills_and_workflows_resolve_from_source_dir() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let id = CompanyId::new("acme");
 
     // A company source directory with a committed skill and workflow.
@@ -613,8 +617,6 @@ async fn skills_and_workflows_resolve_from_source_dir() {
     // skillRegistry reads the repo-level shared library.
     let registry = value["data"]["skillRegistry"].as_array().unwrap();
     assert!(registry.iter().any(|s| s["id"] == "web-research"));
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// Issue #168: a hosted tenant has no source directory, so its workflows live
@@ -623,7 +625,8 @@ async fn skills_and_workflows_resolve_from_source_dir() {
 /// must return the full graph.
 #[tokio::test]
 async fn workflows_resolve_from_the_record_overlay_with_no_source_dir() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let id = CompanyId::new("acme");
 
     let manifest: CompanyManifest = toml::from_str(
@@ -682,8 +685,6 @@ async fn workflows_resolve_from_the_record_overlay_with_no_source_dir() {
     assert_eq!(company["workflow"]["name"], "Hosted Flow");
     assert_eq!(company["workflow"]["nodes"].as_array().unwrap().len(), 2);
     assert_eq!(company["workflow"]["edges"].as_array().unwrap().len(), 1);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// Issue #168: a runtime-authored workflow with an **empty** manifest
@@ -696,7 +697,8 @@ async fn workflows_resolve_from_the_record_overlay_with_no_source_dir() {
 /// Also pins REST/GraphQL agreement: both surfaces must report the same id set.
 #[tokio::test]
 async fn workflows_summary_lists_an_overlay_workflow_with_no_enabled_entry() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let id = CompanyId::new("acme");
 
     // Nothing enabled in the manifest — the graph body is the only evidence.
@@ -781,8 +783,6 @@ async fn workflows_summary_lists_an_overlay_workflow_with_no_enabled_entry() {
         .map(|row| row["id"].as_str().unwrap())
         .collect();
     assert_eq!(rest_ids, gql_ids, "REST and GraphQL disagree on the id set");
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// The committed SDL snapshot freezes the read contract. Regenerate with

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1279,8 +1279,11 @@ mod test {
     use crate::store::FsCompanyStore;
     use crate::{AppConfig, AppState};
 
-    fn home() -> std::path::PathBuf {
-        std::env::temp_dir().join(format!("opencompany-http-{}", crate::ports::generate_id()))
+    fn home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("opencompany-http-")
+            .tempdir()
+            .expect("tempdir")
     }
 
     fn manifest() -> CompanyManifest {
@@ -1325,7 +1328,8 @@ mod test {
 
     #[tokio::test]
     async fn chat_returns_echoed_response() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home, "running").await;
         let app = router(state);
 
@@ -1347,7 +1351,6 @@ mod test {
         let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(value["responses"][0]["text"], "You said: hi");
         assert_eq!(value["responses"][0]["channel"], "operator");
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// An actionable operator chat opens exactly one `backlog` task card on the
@@ -1356,7 +1359,8 @@ mod test {
     /// the handler-level wiring, not model behaviour.
     #[tokio::test]
     async fn actionable_chat_opens_a_backlog_task_card() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home, "running").await;
         let id = CompanyId::new("acme");
         let runtime = state.registry().get(&id).unwrap();
@@ -1393,8 +1397,6 @@ mod test {
         assert_eq!(r.status(), StatusCode::OK);
         let tasks = runtime.tasks().list(&id).await.unwrap();
         assert_eq!(tasks.len(), 1, "a greeting must not open a card");
-
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// End-to-end proof of the WS4 wire: with a [`HarnessBrain`] as the runtime's
@@ -1410,7 +1412,8 @@ mod test {
         use crate::ports::CompanyStore;
         use crate::store::{FsContextStore, FsOps};
 
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let id = CompanyId::new("acme");
         let manifest: CompanyManifest = toml::from_str(
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
@@ -1505,7 +1508,6 @@ mod test {
         );
         assert_ne!(text, "You said: hi", "still routing through the echo brain");
         assert_eq!(value["responses"][0]["channel"], "operator");
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// A manifest with two agents and one desk (`studio`, led by `ceo`), used by
@@ -1572,7 +1574,8 @@ mod test {
     /// both an effective member and a removable overlay member.
     #[tokio::test]
     async fn add_desk_member_persists_and_shows_in_list() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(&home, desk_manifest()).await;
         let app = router(state);
         let cookie = crate::server::test_support::fixed_cookie("acme");
@@ -1598,14 +1601,14 @@ mod test {
         assert_eq!(desks[0]["members"][0], "ceo");
         assert_eq!(desks[0]["members"][1], "eng");
         assert_eq!(desks[0]["overlayMembers"][0], "eng");
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// Removing an overlay member drops it from the merged view; a manifest
     /// member cannot be removed (409), and an unknown overlay member is a 404.
     #[tokio::test]
     async fn remove_desk_member_drops_overlay_and_guards_manifest() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(&home, desk_manifest()).await;
         let app = router(state);
         let cookie = crate::server::test_support::fixed_cookie("acme");
@@ -1672,7 +1675,6 @@ mod test {
             .await
             .unwrap();
         assert_eq!(gone.status(), StatusCode::NOT_FOUND);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// Creating a desk persists it as an overlay and surfaces it in `list_desks`
@@ -1680,7 +1682,8 @@ mod test {
     /// first. The manifest is never rewritten.
     #[tokio::test]
     async fn create_desk_persists_and_appears_in_list() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(&home, desk_manifest()).await;
         let app = router(state);
         let cookie = crate::server::test_support::fixed_cookie("acme");
@@ -1717,14 +1720,14 @@ mod test {
         assert_eq!(arr[0]["id"], "studio"); // manifest desk first
         assert_eq!(arr[1]["id"], "growth_desk");
         assert_eq!(arr[1]["overlayCreated"], true);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// Create-desk validation: an empty name is 400, an id colliding with a
     /// manifest desk is 409, and an unknown member is 400.
     #[tokio::test]
     async fn create_desk_validates_name_id_and_members() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(&home, desk_manifest()).await;
         let app = router(state);
         let cookie = crate::server::test_support::fixed_cookie("acme");
@@ -1753,14 +1756,14 @@ mod test {
                 .unwrap();
             assert_eq!(response.status(), want, "body {body}");
         }
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// Deleting an operator-created desk drops it (and any of its overlay
     /// members); a manifest desk cannot be deleted (409); an unknown id is 404.
     #[tokio::test]
     async fn delete_desk_removes_overlay_and_guards_manifest() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(&home, desk_manifest()).await;
         let app = router(state);
         let cookie = crate::server::test_support::fixed_cookie("acme");
@@ -1827,14 +1830,14 @@ mod test {
             .await
             .unwrap();
         assert_eq!(gone.status(), StatusCode::NOT_FOUND);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// Add-member validation: an unknown desk is 404, an unknown teammate is
     /// 400, and a teammate already on the desk is 409.
     #[tokio::test]
     async fn add_desk_member_validates_desk_agent_and_duplicates() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(&home, desk_manifest()).await;
         let app = router(state);
         let cookie = crate::server::test_support::fixed_cookie("acme");
@@ -1873,7 +1876,6 @@ mod test {
                 .unwrap();
             assert_eq!(response.status(), want, "{uri} {body}");
         }
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// Seeds `eng` as an overlay member of `studio` so a desk has two members to
@@ -1920,7 +1922,8 @@ mod test {
     /// as the new `members` order (the hierarchy), and an empty body resets it.
     #[tokio::test]
     async fn set_desk_order_reorders_and_resets() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(&home, desk_manifest()).await;
         let app = router(state);
         let cookie = crate::server::test_support::fixed_cookie("acme");
@@ -1950,7 +1953,6 @@ mod test {
         let desks = get_desks(&app, &cookie).await;
         assert_eq!(desks[0]["members"][0], "ceo");
         assert_eq!(desks[0]["members"][1], "eng");
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// An operator-created (overlay) desk can be reordered too — the set-order
@@ -1958,7 +1960,8 @@ mod test {
     /// not just manifest group chats. A manifest-only check used to 404 here (#133).
     #[tokio::test]
     async fn set_desk_order_reorders_an_overlay_created_desk() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(&home, desk_manifest()).await;
         let app = router(state);
         let cookie = crate::server::test_support::fixed_cookie("acme");
@@ -2001,14 +2004,14 @@ mod test {
             .expect("overlay desk present");
         assert_eq!(growth["members"][0], "eng");
         assert_eq!(growth["members"][1], "ceo");
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// Set-order validation: an unknown desk is 404, an unknown member id is 400,
     /// and a duplicate id is 400.
     #[tokio::test]
     async fn set_desk_order_validates_desk_members_and_duplicates() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(&home, desk_manifest()).await;
         let app = router(state);
         let cookie = crate::server::test_support::fixed_cookie("acme");
@@ -2041,14 +2044,14 @@ mod test {
             .await,
             StatusCode::BAD_REQUEST
         );
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// Removing an overlay member prunes it from the desk's order overlay, so the
     /// remaining members keep the operator's relative order without a stale id.
     #[tokio::test]
     async fn remove_desk_member_prunes_the_order_entry() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(&home, desk_manifest()).await;
         let app = router(state);
         let cookie = crate::server::test_support::fixed_cookie("acme");
@@ -2084,14 +2087,14 @@ mod test {
         let desks = get_desks(&app, &cookie).await;
         assert_eq!(desks[0]["members"].as_array().unwrap().len(), 1);
         assert_eq!(desks[0]["members"][0], "ceo");
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn desks_route_returns_the_company_desks() {
         // The default test manifest defines no group chats, so the route answers
         // 200 with an empty list (the console then falls back to its defaults).
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home, "running").await;
         let app = router(state);
 
@@ -2109,7 +2112,6 @@ mod test {
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(value.as_array().unwrap().len(), 0);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// Issue #65: the console's default thread addresses sends with
@@ -2119,7 +2121,8 @@ mod test {
     /// the REST route with no `?desk=` selector (the console's default read).
     #[tokio::test]
     async fn chat_history_route_reunifies_general_and_main_transcripts() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home, "running").await;
         let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
 
@@ -2179,7 +2182,6 @@ mod test {
             texts.contains(&"reply under main"),
             "missing main-id reply: {texts:?}"
         );
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// Regression: a reply's tool-call timeline must survive a history reload —
@@ -2188,7 +2190,8 @@ mod test {
     /// `AgentReply` and projected back through the DTO.
     #[tokio::test]
     async fn chat_history_route_rehydrates_reply_steps() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home, "running").await;
         let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
 
@@ -2239,7 +2242,6 @@ mod test {
         );
         assert_eq!(reply["steps"][0]["status"], "ok");
         assert_eq!(reply["steps"][0]["elapsedMs"], 9);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     /// A desk id with no `?desk=` selector defaults to the operator/General
@@ -2247,7 +2249,8 @@ mod test {
     /// nor the General desk reads back empty rather than erroring.
     #[tokio::test]
     async fn chat_history_route_unknown_desk_is_empty_not_an_error() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home, "running").await;
         let app = router(state);
 
@@ -2265,12 +2268,12 @@ mod test {
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(value.as_array().unwrap().len(), 0);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn chat_by_id_matches_registered_company() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home, "running").await;
         let app = router(state);
 
@@ -2287,12 +2290,12 @@ mod test {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn unknown_company_is_404() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home, "running").await;
         let app = router(state);
 
@@ -2313,12 +2316,12 @@ mod test {
         // unauthenticated caller would let anyone enumerate which companies a
         // host runs. A user of `ghost` gets a real 404.
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn paused_company_chat_is_409() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home, "paused").await;
         let app = router(state);
 
@@ -2335,12 +2338,12 @@ mod test {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::CONFLICT);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn list_and_status_routes_report_the_company() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home, "running").await;
         let app = router(state);
 
@@ -2375,12 +2378,12 @@ mod test {
         let bytes = to_bytes(status.into_body(), usize::MAX).await.unwrap();
         let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(value["id"], "acme");
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn approvals_list_is_empty_before_any_park() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home, "running").await;
         let app = router(state);
 
@@ -2398,12 +2401,12 @@ mod test {
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(value.as_array().unwrap().len(), 0);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn amended_approve_resolves_and_returns_responses() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home, "running").await;
         let app = router(state);
 
@@ -2428,12 +2431,12 @@ mod test {
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert!(value["responses"].is_array());
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn deny_with_amended_payload_is_400() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home, "running").await;
         let app = router(state);
 
@@ -2455,7 +2458,6 @@ mod test {
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(value["code"], "invalid_request");
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
@@ -2463,7 +2465,8 @@ mod test {
         // Replaces `operator_token_guards_routes`. That token could never be
         // set, so the test only ever proved the guard worked in a state no
         // deployment could reach; every real host served this route to anyone.
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = build_state(&home, "running", AppConfig::default()).await;
 
         // No credential at all: closed.
@@ -2506,7 +2509,6 @@ mod test {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     // ---- issue #66: the operator attention SSE feed ----
@@ -2781,7 +2783,8 @@ mod test {
 
     #[tokio::test]
     async fn events_route_streams_text_event_stream() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home, "running").await;
         let app = router(state);
 
@@ -2805,12 +2808,12 @@ mod test {
                 .and_then(|v| v.to_str().ok()),
             Some("text/event-stream")
         );
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 
     #[tokio::test]
     async fn events_route_requires_a_session() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home, "running").await;
         let app = router(state);
 
@@ -2824,6 +2827,5 @@ mod test {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-        tokio::fs::remove_dir_all(&home).await.ok();
     }
 }

--- a/src/server/ops/capabilities.rs
+++ b/src/server/ops/capabilities.rs
@@ -263,8 +263,11 @@ mod tests {
     use crate::store::FsCompanyStore;
     use crate::{AppConfig, AppState};
 
-    fn home() -> std::path::PathBuf {
-        std::env::temp_dir().join(format!("oc-capabilities-{}", crate::ports::generate_id()))
+    fn home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("oc-capabilities-")
+            .tempdir()
+            .expect("tempdir")
     }
 
     async fn state_with_manifest(home: &std::path::Path, manifest_toml: &str) -> AppState {
@@ -318,7 +321,8 @@ mod tests {
 
     #[tokio::test]
     async fn reports_unconfigured_without_a_plan() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(
             &home,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n",
@@ -333,8 +337,6 @@ mod tests {
             "no tiers when unconfigured: {dto}"
         );
         assert!(dto.get("plan").is_none());
-
-        std::fs::remove_dir_all(&home).ok();
     }
 
     /// Media generation (issue #109): the route surfaces `mediaGranted` from the
@@ -342,7 +344,8 @@ mod tests {
     #[tokio::test]
     async fn reports_media_granted_from_explicit_grant_only() {
         // Explicit `media` grant, no `[plan]` → unconfigured but mediaGranted.
-        let home_a = home();
+        let home_a_dir = home();
+        let home_a = home_a_dir.path().to_path_buf();
         let state = state_with_manifest(
             &home_a,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"media\"]\n",
@@ -355,10 +358,10 @@ mod tests {
         // The flags are always present so the console can render every state.
         assert!(dto.get("mediaInBuild").is_some(), "{dto}");
         assert!(dto.get("mediaCredentialConfigured").is_some(), "{dto}");
-        std::fs::remove_dir_all(&home_a).ok();
 
         // A `*` wildcard grant must NOT count as a media grant.
-        let home_b = home();
+        let home_b_dir = home();
+        let home_b = home_b_dir.path().to_path_buf();
         let state2 = state_with_manifest(
             &home_b,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"*\"]\n",
@@ -369,7 +372,6 @@ mod tests {
             dto2["mediaGranted"], false,
             "the `*` wildcard must not grant the real-money media family: {dto2}"
         );
-        std::fs::remove_dir_all(&home_b).ok();
     }
 
     /// Per-tenant Composio (issue #110): the route surfaces `composioGranted`
@@ -377,7 +379,8 @@ mod tests {
     /// `[plan]`.
     #[tokio::test]
     async fn reports_composio_flags_from_explicit_grant_only() {
-        let home_a = home();
+        let home_a_dir = home();
+        let home_a = home_a_dir.path().to_path_buf();
         let state = state_with_manifest(
             &home_a,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"composio\"]\n",
@@ -388,10 +391,10 @@ mod tests {
         assert_eq!(dto["composioGranted"], true, "{dto}");
         assert_eq!(dto["composioTokenConfigured"], false, "no token yet: {dto}");
         assert!(dto.get("composioInBuild").is_some(), "{dto}");
-        std::fs::remove_dir_all(&home_a).ok();
 
         // A `*` wildcard grant must NOT count as a composio grant.
-        let home_b = home();
+        let home_b_dir = home();
+        let home_b = home_b_dir.path().to_path_buf();
         let state2 = state_with_manifest(
             &home_b,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"*\"]\n",
@@ -402,12 +405,12 @@ mod tests {
             dto2["composioGranted"], false,
             "the `*` wildcard must not grant composio: {dto2}"
         );
-        std::fs::remove_dir_all(&home_b).ok();
     }
 
     #[tokio::test]
     async fn reports_tiers_and_exhaustion_for_a_configured_plan() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(
             &home,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[plan]\nname = \"starter\"\n",
@@ -455,8 +458,6 @@ mod tests {
             dto.get("total").is_none(),
             "no total ceiling configured: {dto}"
         );
-
-        std::fs::remove_dir_all(&home).ok();
     }
 
     /// The plan-level total token ceiling (issue #188) surfaces its own `total`
@@ -464,7 +465,8 @@ mod tests {
     /// tiers, and reports `exhausted` once period spend crosses it.
     #[tokio::test]
     async fn reports_total_ceiling_row_when_configured() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(
             &home,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[plan]\nname = \"starter\"\ntotal_tokens = 300000\n",
@@ -500,7 +502,5 @@ mod tests {
         assert_eq!(total["spentTokens"], 250_000);
         assert_eq!(total["remainingTokens"], 50_000);
         assert_eq!(total["exhausted"], false, "250k < 300k is under budget");
-
-        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -345,8 +345,11 @@ mod tests {
 
     const TOKEN: &str = "composio-tenant-bearer-SECRET-xyz";
 
-    fn home() -> std::path::PathBuf {
-        std::env::temp_dir().join(format!("oc-composio-{}", crate::ports::generate_id()))
+    fn home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("oc-composio-")
+            .tempdir()
+            .expect("tempdir")
     }
 
     async fn state_with_manifest(home: &std::path::Path, manifest_toml: &str) -> AppState {
@@ -415,7 +418,8 @@ mod tests {
     /// credential in play: `none` → `static` → `none`.
     #[tokio::test]
     async fn credential_source_tracks_the_byo_token_and_never_carries_it() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(
             &home,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"composio\"]\n[tools.composio]\ntoolkits = [\"gmail\", \"github\"]\n",
@@ -464,8 +468,6 @@ mod tests {
         )
         .await;
         assert_eq!(resp["status"]["credentialSource"], "none");
-
-        std::fs::remove_dir_all(&home).ok();
     }
 
     /// The hosted shape, driven through the env seam (no process mutation): a
@@ -475,9 +477,11 @@ mod tests {
     fn credential_source_matrix_follows_the_resolver_precedence() {
         use crate::app::config::MapEnv;
 
-        let dir = std::env::temp_dir().join(format!("oc-dto-{}", crate::ports::generate_id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("token");
+        let dir = tempfile::Builder::new()
+            .prefix("oc-dto-")
+            .tempdir()
+            .expect("tempdir");
+        let path = dir.path().join("token");
         std::fs::write(&path, "projected-instance-token").unwrap();
         let projected = MapEnv::new([(
             crate::company::credentials::TOKEN_FILE_ENV,
@@ -543,7 +547,8 @@ mod tests {
     /// route (mirrors the harness build gate).
     #[tokio::test]
     async fn wildcard_grant_does_not_count_as_composio() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(
             &home,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"*\"]\n",
@@ -551,7 +556,6 @@ mod tests {
         .await;
         let (_, dto, _) = send(&state, "GET", "/api/v1/company/composio", None).await;
         assert_eq!(dto["granted"], false, "{dto}");
-        std::fs::remove_dir_all(&home).ok();
     }
 
     /// The OAuth sign-in plane is always wired into the route table (like the
@@ -562,7 +566,8 @@ mod tests {
     /// non-404 signal rather than a missing route.
     #[tokio::test]
     async fn authorize_route_conflicts_without_build_or_token() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(
             &home,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"composio\"]\n[tools.composio]\ntoolkits = [\"gmail\"]\n",
@@ -578,15 +583,14 @@ mod tests {
         .await;
         assert_eq!(status, StatusCode::CONFLICT, "{raw}");
         assert_eq!(body["code"], "conflict", "{body}");
-
-        std::fs::remove_dir_all(&home).ok();
     }
 
     /// `GET …/composio/connections` is likewise always wired and conflicts
     /// (`409`) when there is no usable client — no build feature or no token.
     #[tokio::test]
     async fn connections_route_conflicts_without_build_or_token() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(
             &home,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"composio\"]\n[tools.composio]\ntoolkits = [\"gmail\"]\n",
@@ -597,7 +601,5 @@ mod tests {
             send(&state, "GET", "/api/v1/company/composio/connections", None).await;
         assert_eq!(status, StatusCode::CONFLICT, "{raw}");
         assert_eq!(body["code"], "conflict", "{body}");
-
-        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/server/ops/connections.rs
+++ b/src/server/ops/connections.rs
@@ -540,11 +540,17 @@ mod test {
     use crate::runtime::RuntimeBuilder;
 
     /// Builds an isolated in-memory company runtime for disconnect tests.
-    async fn test_runtime() -> (Arc<CompanyRuntime>, std::path::PathBuf) {
-        let home = std::env::temp_dir().join(format!("oc-disc-{}", crate::ports::generate_id()));
+    ///
+    /// The caller must hold the returned handle for the life of the test: it
+    /// owns the runtime's home directory and removes it on drop.
+    async fn test_runtime() -> (Arc<CompanyRuntime>, tempfile::TempDir) {
+        let home = tempfile::Builder::new()
+            .prefix("oc-disc-")
+            .tempdir()
+            .expect("tempdir");
         let manifest: CompanyManifest =
             toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n").unwrap();
-        let runtime = RuntimeBuilder::new(home.clone(), manifest)
+        let runtime = RuntimeBuilder::new(home.path().to_path_buf(), manifest)
             .with_id(CompanyId::new("acme"))
             .build()
             .await
@@ -587,15 +593,13 @@ mod test {
     /// remote to revoke, but the disconnect must still blank the local secret.
     #[tokio::test]
     async fn disconnect_blanks_secret_without_revoke_config() {
-        let (runtime, home) = test_runtime().await;
+        let (runtime, _home) = test_runtime().await;
         let provider = unique_provider();
         store_token(&runtime, &provider, "CANARY-should-never-leak").await;
 
         let resp = do_disconnect(runtime.clone(), &provider).await.unwrap();
         assert_eq!(resp.0["connected"], false);
         assert!(is_blanked(&runtime, &provider).await, "secret not blanked");
-
-        std::fs::remove_dir_all(&home).ok();
     }
 
     /// The best-effort revoke path is invoked: with app credentials + a revoke
@@ -621,7 +625,7 @@ mod test {
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
-        let (runtime, home) = test_runtime().await;
+        let (runtime, _home) = test_runtime().await;
         let provider = unique_provider();
         let key = provider.to_ascii_uppercase();
         // SAFETY: unique per-test provider name → no cross-test env collision.
@@ -656,7 +660,6 @@ mod test {
                 std::env::remove_var(format!("OPENCOMPANY_OAUTH_{key}_{suffix}"));
             }
         }
-        std::fs::remove_dir_all(&home).ok();
     }
 
     /// A revoke endpoint that refuses the connection must not fail the
@@ -668,7 +671,7 @@ mod test {
         let dead_addr = dead.local_addr().unwrap();
         drop(dead);
 
-        let (runtime, home) = test_runtime().await;
+        let (runtime, _home) = test_runtime().await;
         let provider = unique_provider();
         let key = provider.to_ascii_uppercase();
         // SAFETY: unique per-test provider name → no cross-test env collision.
@@ -696,6 +699,5 @@ mod test {
                 std::env::remove_var(format!("OPENCOMPANY_OAUTH_{key}_{suffix}"));
             }
         }
-        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/server/ops/connections_read.rs
+++ b/src/server/ops/connections_read.rs
@@ -102,8 +102,11 @@ mod tests {
     use crate::store::FsCompanyStore;
     use crate::{AppConfig, AppState};
 
-    fn home() -> std::path::PathBuf {
-        std::env::temp_dir().join(format!("oc-connections-{}", crate::ports::generate_id()))
+    fn home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("oc-connections-")
+            .tempdir()
+            .expect("tempdir")
     }
 
     async fn state_with_manifest(home: &std::path::Path, manifest_toml: &str) -> AppState {
@@ -160,7 +163,8 @@ mod tests {
     /// to flip from "unavailable" to live buttons.
     #[tokio::test]
     async fn projects_connected_and_not_connected() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(
             &home,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
@@ -253,8 +257,6 @@ mod tests {
             !body.to_string().contains("access_token"),
             "token field leaked into the connections response: {body}"
         );
-
-        std::fs::remove_dir_all(&home).ok();
     }
 
     /// A company with no `[[connection]]` entries returns an empty list (200),
@@ -262,7 +264,8 @@ mod tests {
     /// than the "unavailable" fallback.
     #[tokio::test]
     async fn empty_when_no_connections_declared() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(
             &home,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n",
@@ -272,7 +275,5 @@ mod tests {
         let (status, body) = get_connections(&state).await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body, serde_json::json!([]), "empty array: {body}");
-
-        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/server/ops/finances.rs
+++ b/src/server/ops/finances.rs
@@ -73,8 +73,11 @@ mod tests {
     use crate::store::FsCompanyStore;
     use crate::{AppConfig, AppState};
 
-    fn home() -> std::path::PathBuf {
-        std::env::temp_dir().join(format!("oc-finances-{}", crate::ports::generate_id()))
+    fn home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("oc-finances-")
+            .tempdir()
+            .expect("tempdir")
     }
 
     /// Builds a runtime under `manifest_toml`, then appends `ledger` through the
@@ -140,7 +143,8 @@ mod tests {
     /// still read from the manifest `[budget]`.
     #[tokio::test]
     async fn empty_ledger_projects_zeroes_with_budget() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_ledger(
             &home,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[budget]\nmonthly_usd = 2000.0\n",
@@ -156,15 +160,14 @@ mod tests {
         assert_eq!(dto["netUsd"], 0.0);
         assert!(dto["byCategory"].as_array().unwrap().is_empty(), "{dto}");
         assert!(dto["transactions"].as_array().unwrap().is_empty(), "{dto}");
-
-        std::fs::remove_dir_all(&home).ok();
     }
 
     /// A ledger with a spend and a revenue entry this month projects the
     /// expected budget / spend / revenue / net, by-category, and journal.
     #[tokio::test]
     async fn ledger_projects_spend_revenue_and_journal() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         // Timestamp entries "now" so they land in the current UTC month.
         let now = crate::ports::now_millis();
         let ledger = vec![
@@ -218,7 +221,5 @@ mod tests {
             .map(|t| t["direction"].as_str().unwrap())
             .collect();
         assert!(dirs.contains(&"in") && dirs.contains(&"out"), "{dto}");
-
-        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -287,8 +287,11 @@ mod tests {
 
     const TOKEN: &str = "sk-super-secret-inference-token-XYZ";
 
-    fn home() -> std::path::PathBuf {
-        std::env::temp_dir().join(format!("oc-inference-{}", crate::ports::generate_id()))
+    fn home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("oc-inference-")
+            .tempdir()
+            .expect("tempdir")
     }
 
     fn manifest() -> CompanyManifest {
@@ -356,7 +359,8 @@ mod tests {
 
     #[tokio::test]
     async fn status_defaults_to_managed_then_switches_to_runtime() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home).await;
 
         // A company with no manifest/runtime inference reports the managed default.
@@ -397,13 +401,12 @@ mod tests {
         assert_eq!(dto["source"], "runtime");
         assert_eq!(dto["keyConfigured"], true);
         assert!(!raw.contains(TOKEN), "GET status leaked the token: {raw}");
-
-        std::fs::remove_dir_all(&home).ok();
     }
 
     #[tokio::test]
     async fn revert_clears_the_runtime_override() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home).await;
 
         send(
@@ -418,13 +421,12 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(resp["status"]["provider"], "managed");
         assert_eq!(resp["status"]["source"], "managed");
-
-        std::fs::remove_dir_all(&home).ok();
     }
 
     #[tokio::test]
     async fn invalid_provider_config_is_rejected() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home).await;
 
         // Ollama requires a base_url.
@@ -443,13 +445,12 @@ mod tests {
                 .contains("base_url"),
             "{err}"
         );
-
-        std::fs::remove_dir_all(&home).ok();
     }
 
     #[tokio::test]
     async fn key_never_leaks_across_any_response() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home).await;
 
         let (_, _, put_raw) = send(
@@ -467,7 +468,5 @@ mod tests {
         for raw in [put_raw, get_raw, test_raw] {
             assert!(!raw.contains(TOKEN), "a response leaked the token: {raw}");
         }
-
-        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/server/ops/test.rs
+++ b/src/server/ops/test.rs
@@ -24,8 +24,11 @@ use crate::server::webhook::DefaultHashSigner;
 use crate::server::webhook::WebhookSigner;
 use crate::{AppConfig, AppState};
 
-fn home() -> std::path::PathBuf {
-    std::env::temp_dir().join(format!("opencompany-ops-{}", crate::ports::generate_id()))
+fn home() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix("opencompany-ops-")
+        .tempdir()
+        .expect("tempdir")
 }
 
 fn manifest() -> CompanyManifest {
@@ -71,7 +74,8 @@ async fn body_json(response: axum::response::Response) -> serde_json::Value {
 
 #[tokio::test]
 async fn put_domain_returns_records() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with(&home, ConnectionsRuntime::new()).await;
     let app = router(state);
 
@@ -92,12 +96,12 @@ async fn put_domain_returns_records() {
     assert_eq!(value["domain"], "acme.com");
     assert_eq!(value["verified"], false);
     assert_eq!(value["records"].as_array().unwrap().len(), 5);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn verify_without_resolver_is_404_not_wired() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with(&home, ConnectionsRuntime::new()).await;
     let app = router(state);
 
@@ -129,12 +133,12 @@ async fn verify_without_resolver_is_404_not_wired() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     let value = body_json(response).await;
     assert_eq!(value["code"], "not_wired");
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn verify_with_resolver_marks_verified() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let resolver = Arc::new(StaticDnsResolver::fully_verifying("acme.com"));
     let state = state_with(&home, ConnectionsRuntime::new().with_dns(resolver)).await;
     let app = router(state);
@@ -166,12 +170,12 @@ async fn verify_with_resolver_marks_verified() {
     assert_eq!(response.status(), StatusCode::OK);
     let value = body_json(response).await;
     assert_eq!(value["verified"], true);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn put_smtp_hides_password() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with(&home, ConnectionsRuntime::new()).await;
     let app = router(state);
 
@@ -196,12 +200,12 @@ async fn put_smtp_hides_password() {
     let value: serde_json::Value = serde_json::from_str(&text).unwrap();
     assert_eq!(value["configured"], true);
     assert_eq!(value["host"], "smtp.acme.test");
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn smtp_test_without_sender_is_404() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with(&home, ConnectionsRuntime::new()).await;
     let app = router(state);
 
@@ -217,12 +221,12 @@ async fn smtp_test_without_sender_is_404() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn smtp_test_sends_and_records_outbound() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let sender = Arc::new(RecordingMailSender::new());
     let state = state_with(&home, ConnectionsRuntime::new().with_mail(sender.clone())).await;
     let app = router(state);
@@ -260,12 +264,12 @@ async fn smtp_test_sends_and_records_outbound() {
     assert_eq!(value["ok"], true);
     assert_eq!(sender.sent().len(), 1);
     assert_eq!(sender.sent()[0].1.to, "ops@acme.test");
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn ingest_bad_hmac_is_401_and_no_mail() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with(&home, ConnectionsRuntime::new()).await;
     // Seed the ingest secret.
     let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
@@ -305,12 +309,12 @@ async fn ingest_bad_hmac_is_401_and_no_mail() {
             .unwrap()
             .is_empty()
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn ingest_good_hmac_files_mail() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with(&home, ConnectionsRuntime::new()).await;
     let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
     runtime
@@ -358,5 +362,4 @@ async fn ingest_good_hmac_files_mail() {
     assert_eq!(mail.len(), 1);
     assert_eq!(mail[0].from_email, "a@x.test");
     assert!(!mail[0].outbound);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }

--- a/src/server/ops/usage.rs
+++ b/src/server/ops/usage.rs
@@ -134,8 +134,11 @@ mod tests {
     use crate::store::FsCompanyStore;
     use crate::{AppConfig, AppState};
 
-    fn home() -> std::path::PathBuf {
-        std::env::temp_dir().join(format!("oc-usage-{}", crate::ports::generate_id()))
+    fn home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("oc-usage-")
+            .tempdir()
+            .expect("tempdir")
     }
 
     async fn state_with_manifest(home: &std::path::Path, manifest_toml: &str) -> AppState {
@@ -190,7 +193,8 @@ mod tests {
     /// An empty meter zero-fills the series to the range length and totals zero.
     #[tokio::test]
     async fn empty_meter_projects_a_zero_filled_series() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(
             &home,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n",
@@ -204,15 +208,14 @@ mod tests {
         assert_eq!(dto["totals"]["connections"], 0);
         assert!(dto["byAgent"].as_array().unwrap().is_empty(), "{dto}");
         assert!(dto["byProvider"].as_array().unwrap().is_empty(), "{dto}");
-
-        std::fs::remove_dir_all(&home).ok();
     }
 
     /// A couple of recorded samples project the expected DTO: totals sum, the
     /// series carries the day's tokens, and `byAgent` resolves the roster role.
     #[tokio::test]
     async fn recorded_samples_project_totals_series_and_by_desk() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(
             &home,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
@@ -265,14 +268,13 @@ mod tests {
         assert_eq!(by_agent.len(), 1, "{dto}");
         assert_eq!(by_agent[0]["name"], "Chief Executive");
         assert_eq!(by_agent[0]["tokens"], 165.0);
-
-        std::fs::remove_dir_all(&home).ok();
     }
 
     /// An absent / unknown `?range=` defaults to the 30-day window.
     #[tokio::test]
     async fn range_defaults_to_thirty_days() {
-        let home = home();
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
         let state = state_with_manifest(
             &home,
             "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n",
@@ -283,7 +285,5 @@ mod tests {
         assert_eq!(dto["series"].as_array().unwrap().len(), 30, "{dto}");
         let (_, dto_bad) = get_usage(&state, "?range=nonsense").await;
         assert_eq!(dto_bad["series"].as_array().unwrap().len(), 30, "{dto_bad}");
-
-        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1088,11 +1088,11 @@ mod tests {
         use crate::store::FsCompanyStore;
         use crate::{AppConfig, AppState};
 
-        fn home() -> std::path::PathBuf {
-            std::env::temp_dir().join(format!(
-                "oc-workflows-hosted-{}",
-                crate::ports::generate_id()
-            ))
+        fn home() -> tempfile::TempDir {
+            tempfile::Builder::new()
+                .prefix("oc-workflows-hosted-")
+                .tempdir()
+                .expect("tempdir")
         }
 
         /// A manifest declaring one enabled workflow — mirrors what a
@@ -1144,7 +1144,8 @@ mod tests {
 
         #[tokio::test]
         async fn manifest_enabled_workflow_lists_with_no_source_dir() {
-            let home = home();
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
             let state = state_with_hosted_company(&home).await;
 
             let response = router(state)
@@ -1172,8 +1173,6 @@ mod tests {
             // name — same fallback the GraphQL `Company.workflows` resolver
             // uses for the same case.
             assert_eq!(items[0]["name"], "demo");
-
-            std::fs::remove_dir_all(&home).ok();
         }
 
         /// A hosted tenant's record with no manifest-enabled workflows — the
@@ -1273,7 +1272,8 @@ mod tests {
         /// name, and the full body reads back.
         #[tokio::test]
         async fn create_persists_and_reads_back_with_no_source_dir() {
-            let home = home();
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
             let (state, _store, _id) = hosted_state(&home).await;
 
             // POST → 200 with the graph echoed back.
@@ -1312,15 +1312,14 @@ mod tests {
             let graph = json_body(response).await;
             assert_eq!(graph["id"], "greeter");
             assert_eq!(graph["edges"][0]["label"], "ok");
-
-            std::fs::remove_dir_all(&home).ok();
         }
 
         /// A duplicate id is a clean 409, not a 500 — the id-uniqueness check
         /// that replaced the filesystem's `create_new(true)`.
         #[tokio::test]
         async fn duplicate_create_is_a_conflict() {
-            let home = home();
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
             let (state, _store, _id) = hosted_state(&home).await;
 
             let first = router(state.clone())
@@ -1342,8 +1341,6 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(second.status(), StatusCode::CONFLICT);
-
-            std::fs::remove_dir_all(&home).ok();
         }
 
         /// Restart survival: a workflow created through the API is still listed
@@ -1351,7 +1348,8 @@ mod tests {
         /// the body is durable, not process-local.
         #[tokio::test]
         async fn a_created_workflow_survives_a_state_rebuild() {
-            let home = home();
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
             let (state, _store, id) = hosted_state(&home).await;
 
             let response = router(state)
@@ -1376,8 +1374,6 @@ mod tests {
             assert_eq!(items.len(), 1, "body: {listed}");
             assert_eq!(items[0]["id"], "greeter");
             assert_eq!(items[0]["name"], "Greeter");
-
-            std::fs::remove_dir_all(&home).ok();
         }
     }
 }

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -17,8 +17,11 @@ use crate::server::router;
 use crate::store::FsCompanyStore;
 use crate::{AppConfig, AppState};
 
-fn home() -> std::path::PathBuf {
-    std::env::temp_dir().join(format!("opencompany-ops-{}", crate::ports::generate_id()))
+fn home() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix("opencompany-ops-")
+        .tempdir()
+        .expect("tempdir")
 }
 
 fn manifest() -> CompanyManifest {
@@ -105,7 +108,8 @@ async fn send_auth(
 
 #[tokio::test]
 async fn tasks_crud_round_trips_under_both_scopes() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     // Create via the single-company alias.
@@ -159,8 +163,6 @@ async fn tasks_crud_round_trips_under_both_scopes() {
     )
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// #205: a card may only be assigned to somebody the company actually has.
@@ -169,7 +171,8 @@ async fn tasks_crud_round_trips_under_both_scopes() {
 /// orchestrator instead.
 #[tokio::test]
 async fn task_writes_reject_an_off_roster_assignee() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     let (status, body) = send(
@@ -231,8 +234,6 @@ async fn task_writes_reject_an_off_roster_assignee() {
         card["title"], "Q2 brief",
         "a rejected patch must not persist the fields it did apply"
     );
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// #205: a column the board does not render is refused too. A typo'd
@@ -241,7 +242,8 @@ async fn task_writes_reject_an_off_roster_assignee() {
 /// edge-fires a dispatch — silently never running it.
 #[tokio::test]
 async fn task_writes_reject_a_column_the_board_cannot_render() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     let (status, body) = send(
@@ -277,8 +279,6 @@ async fn task_writes_reject_a_column_the_board_cannot_render() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
     let (_, board) = send(&state, "GET", "/api/v1/company/tasks", None).await;
     assert_eq!(board.as_array().expect("board")[0]["column"], "paused");
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// Issue #206: `POST …/tasks` defaults a new card to To-do — the board's one
@@ -286,7 +286,8 @@ async fn task_writes_reject_a_column_the_board_cannot_render() {
 /// lifecycle paths that place a card themselves are untouched.
 #[tokio::test]
 async fn created_tasks_default_to_the_todo_column() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     let (_, defaulted) = send(
@@ -308,13 +309,12 @@ async fn created_tasks_default_to_the_todo_column() {
     )
     .await;
     assert_eq!(explicit["column"], crate::ports::tasks::COLUMN_BACKLOG);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn steer_task_validates_statuses_and_journals_acceptance() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
     let company = CompanyId::new("acme");
     let runtime = state.registry().get(&company).unwrap();
@@ -421,13 +421,12 @@ async fn steer_task_validates_statuses_and_journals_acceptance() {
             ..
         } if task_id == "active" && action == "redirect" && instruction == "focus on the API"
     )));
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn memory_create_and_delete_journals_event() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     let (status, fact) = send(
@@ -449,13 +448,12 @@ async fn memory_create_and_delete_journals_event() {
     )
     .await;
     assert_eq!(status, StatusCode::NO_CONTENT);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn memory_list_filters_stats_and_dual_write() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
     let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
 
@@ -552,8 +550,6 @@ async fn memory_list_filters_stats_and_dual_write() {
     assert_eq!(stats["facts"], 4);
     assert_eq!(stats["agentChunks"], 1);
     assert_eq!(stats["taskOutcomes"], 0);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// The Brain's "Last updated" stat must move when *agents* write memory, not
@@ -565,7 +561,8 @@ async fn memory_list_filters_stats_and_dual_write() {
 /// never added a fact, showed "—" forever.
 #[tokio::test]
 async fn memory_stats_last_updated_covers_agent_written_context() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
     let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
 
@@ -652,8 +649,6 @@ async fn memory_stats_last_updated_covers_agent_written_context() {
             .all(|r| r["updatedAt"].as_u64().unwrap() >= before),
         "each agent-written row carries the time it was stored"
     );
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// End-to-end proof that the dual-write closes the manual-ingest loop: an
@@ -665,7 +660,8 @@ async fn memory_stats_last_updated_covers_agent_written_context() {
 async fn memory_operator_fact_is_injected_into_the_agent_turn() {
     use crate::harness::memory_loop;
 
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
     let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
 
@@ -694,8 +690,6 @@ async fn memory_operator_fact_is_injected_into_the_agent_turn() {
     assert!(augmented.contains("Relevant prior work"));
     assert!(augmented.contains("we ship on Friday at noon"));
     assert!(augmented.trim_end().ends_with("when do we ship?"));
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// Two-company isolation over HTTP: company B never sees company A's facts, and
@@ -708,7 +702,8 @@ async fn memory_is_isolated_between_companies() {
     };
     use std::collections::HashSet;
 
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let verifier = std::sync::Arc::new(StaticPlatformVerifier::new("plat-secret"));
     let state = AppState::new(AppConfig::default())
         .with_home(home.clone())
@@ -780,13 +775,12 @@ async fn memory_is_isolated_between_companies() {
     )
     .await;
     assert_eq!(status, StatusCode::FORBIDDEN);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn workspace_create_write_move_and_cycle_rejection() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     let (_, folder) = send(
@@ -861,13 +855,12 @@ async fn workspace_create_write_move_and_cycle_rejection() {
     )
     .await;
     assert_eq!(status, StatusCode::NO_CONTENT);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn skills_install_toggle_custom_and_builtin_uninstall_conflict() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     // Install from registry, carrying the entry's metadata so the host persists
@@ -951,13 +944,12 @@ async fn skills_install_toggle_custom_and_builtin_uninstall_conflict() {
     assert_eq!(my_skill["source"], "custom");
     assert_eq!(my_skill["name"], "My Skill");
     assert!(!my_skill["enabled"].as_bool().unwrap());
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn team_overlay_add_delete_and_manifest_delete_conflict() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     // The manifest teammate shows up on the read side before any overlay add,
@@ -1023,14 +1015,13 @@ async fn team_overlay_add_delete_and_manifest_delete_conflict() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(ack["key"], "ceo");
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn inbox_read_marks_and_reports_unread() {
     use crate::ports::inbox::EmailRecord;
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
     let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
     for i in 0..2 {
@@ -1069,8 +1060,6 @@ async fn inbox_read_marks_and_reports_unread() {
     let (status, body) = send(&state, "POST", "/api/v1/company/inboxes/ceo/read", None).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["unread"], 0);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// Appends one received email to `inbox`, for the read-surface tests below.
@@ -1108,7 +1097,8 @@ async fn append_mail(
 /// reachable over REST at all.
 #[tokio::test]
 async fn inbox_reads_are_per_agent_and_never_shared() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
     let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
 
@@ -1159,8 +1149,6 @@ async fn inbox_reads_are_per_agent_and_never_shared() {
     assert_eq!(items[0]["subject"], "on-call rotation");
     assert_eq!(items[0]["fromEmail"], "cto-sender@x.test");
     assert_eq!(items[0]["inbox"], "cto");
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// An inbox nobody has mail in — or that does not exist at all — reads as an
@@ -1168,7 +1156,8 @@ async fn inbox_reads_are_per_agent_and_never_shared() {
 /// state, and the console must render it as such rather than as an error.
 #[tokio::test]
 async fn inbox_messages_soft_fail_on_unknown_key() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
     let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
     append_mail(&runtime, "ceo", "m0", "mail 0", 1).await;
@@ -1186,8 +1175,6 @@ async fn inbox_messages_soft_fail_on_unknown_key() {
     // …and the inbox that *does* hold mail is unaffected by that read.
     let (_, body) = send(&state, "GET", "/api/v1/company/inboxes/ceo/messages", None).await;
     assert_eq!(body.as_array().unwrap().len(), 1);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// An inbox switched on but never written to is still listed, so the console can
@@ -1195,7 +1182,8 @@ async fn inbox_messages_soft_fail_on_unknown_key() {
 /// enabled state, so the toggle isn't a client-side guess.
 #[tokio::test]
 async fn team_read_reports_inbox_enabled_and_empty_inbox_is_listed() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     // Before the toggle: no inbox on the roster, and nothing listed.
@@ -1253,15 +1241,14 @@ async fn team_read_reports_inbox_enabled_and_empty_inbox_is_listed() {
     assert_eq!(status, StatusCode::OK);
     let (_, body) = send(&state, "GET", "/api/v1/company/inboxes", None).await;
     assert_eq!(body.as_array().unwrap()[0]["enabled"], false);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// Mail that arrives through the ingest webhook is exactly what the console's
 /// read surface returns — the end-to-end path issue #173's repro step 4 walked.
 #[tokio::test]
 async fn ingested_mail_shows_up_on_the_console_read_surface() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
     let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
 
@@ -1289,14 +1276,13 @@ async fn ingested_mail_shows_up_on_the_console_read_surface() {
     assert_eq!(body["unread"], 0);
     let (_, body) = send(&state, "GET", "/api/v1/company/inboxes", None).await;
     assert_eq!(body.as_array().unwrap()[0]["unread"], 0);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn inbox_list_and_messages_project_store() {
     use crate::ports::inbox::EmailRecord;
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
     let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
     // One inbound (unread) + one outbound reply in inbox "ceo".
@@ -1356,13 +1342,12 @@ async fn inbox_list_and_messages_project_store() {
     assert_eq!(msgs[0]["id"], "in1");
     assert_eq!(msgs[0]["fromEmail"], "p@x.test");
     assert_eq!(msgs[1]["outbound"], true);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn chat_accepts_desk_id_and_replies() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     let (status, body) = send(
@@ -1374,8 +1359,6 @@ async fn chat_accepts_desk_id_and_replies() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert!(body["responses"].is_array());
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
@@ -1385,7 +1368,8 @@ async fn credential_route_rejects_foreign_tenant() {
     };
     use std::collections::HashSet;
 
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     // Platform mode: `acme` is owned by `tenant:acme`.
     let verifier = std::sync::Arc::new(StaticPlatformVerifier::new("plat-secret"));
     let state = AppState::new(AppConfig::default())
@@ -1431,13 +1415,12 @@ async fn credential_route_rejects_foreign_tenant() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn unknown_company_scope_is_404() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
     let (status, _) = send(
         &state,
@@ -1447,7 +1430,6 @@ async fn unknown_company_scope_is_404() {
     )
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 // ---------------------------------------------------------------------------
@@ -1497,7 +1479,8 @@ async fn state_with_manifest(home: &std::path::Path, manifest: CompanyManifest) 
 
 #[tokio::test]
 async fn mcp_servers_crud_round_trips_and_token_is_write_only() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     // Cold: no servers.
@@ -1580,13 +1563,12 @@ async fn mcp_servers_crud_round_trips_and_token_is_write_only() {
     assert_eq!(status, StatusCode::NO_CONTENT);
     let (_, list) = send(&state, "GET", "/api/v1/company/mcp/servers", None).await;
     assert_eq!(list.as_array().unwrap().len(), 0);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn mcp_manifest_server_cannot_be_deleted_but_can_be_overridden() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_manifest(&home, mcp_manifest()).await;
 
     // The manifest server shows up as `manifest`.
@@ -1610,8 +1592,6 @@ async fn mcp_manifest_server_cannot_be_deleted_but_can_be_overridden() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(updated["server"]["source"], "manifest");
     assert_eq!(updated["server"]["enabled"], false);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// Without the `openhuman` feature there is no MCP transport, so live discovery
@@ -1619,7 +1599,8 @@ async fn mcp_manifest_server_cannot_be_deleted_but_can_be_overridden() {
 #[cfg(not(feature = "openhuman"))]
 #[tokio::test]
 async fn mcp_discovery_is_not_wired_without_the_feature() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_manifest(&home, mcp_manifest()).await;
     let (status, body) = send(
         &state,
@@ -1630,14 +1611,14 @@ async fn mcp_discovery_is_not_wired_without_the_feature() {
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
     assert_eq!(body["code"], "not_wired");
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// A `user:pass@host` endpoint smuggles a credential into the URL — rejected as
 /// a 400 (the error-hardening cell's validate-on-add).
 #[tokio::test]
 async fn mcp_userinfo_endpoint_is_rejected() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
     let (status, _) = send(
         &state,
@@ -1647,7 +1628,6 @@ async fn mcp_userinfo_endpoint_is_rejected() {
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// A query-parameter credential (BrowserBase style) round-trips write-only:
@@ -1655,7 +1635,8 @@ async fn mcp_userinfo_endpoint_is_rejected() {
 /// non-secret id left in the endpoint URL raises the non-blocking advisory.
 #[tokio::test]
 async fn mcp_query_param_auth_round_trips_write_only_with_advisory() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     let (status, added) = send(
@@ -1700,7 +1681,6 @@ async fn mcp_query_param_auth_round_trips_write_only_with_advisory() {
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 // ---------------------------------------------------------------------------
@@ -1769,7 +1749,8 @@ fn workflow_body(id: &str) -> Value {
 /// both read routes serve it from there.
 #[tokio::test]
 async fn workflow_create_persists_on_the_record_appends_enabled_and_is_listed() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let seed_dir = home.join("seed");
     std::fs::create_dir_all(&seed_dir).unwrap();
     let state = state_with_source_dir(&home, &seed_dir, manifest()).await;
@@ -1813,13 +1794,12 @@ async fn workflow_create_persists_on_the_record_appends_enabled_and_is_listed() 
     let (status, graph) = send(&state, "GET", "/api/v1/company/workflows/greet", None).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(graph["name"], "greet");
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn workflow_create_duplicate_id_is_conflict() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let seed_dir = home.join("seed");
     std::fs::create_dir_all(&seed_dir).unwrap();
     let state = state_with_source_dir(&home, &seed_dir, manifest()).await;
@@ -1842,13 +1822,12 @@ async fn workflow_create_duplicate_id_is_conflict() {
     .await;
     assert_eq!(status, StatusCode::CONFLICT);
     assert_eq!(body["code"], "conflict");
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn workflow_create_rejects_bad_edges_missing_agent_and_no_trigger() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let seed_dir = home.join("seed");
     std::fs::create_dir_all(&seed_dir).unwrap();
     let state = state_with_source_dir(&home, &seed_dir, manifest()).await;
@@ -1913,13 +1892,12 @@ async fn workflow_create_rejects_bad_edges_missing_agent_and_no_trigger() {
                 .unwrap_or(true)
         }
     );
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn workflow_create_without_source_dir_succeeds() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     // `state_with_company` boots with no `seed_dir`, so the company has no
     // source directory at all — the platform-provisioned-mode case. Issue #168:
     // creation used to be refused here with a 400; the body now lands on the
@@ -1939,15 +1917,14 @@ async fn workflow_create_without_source_dir_succeeds() {
     let (status, graph) = send(&state, "GET", "/api/v1/company/workflows/greet", None).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(graph["nodes"].as_array().unwrap().len(), 3);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// Without the `openhuman` feature the on-demand Test route is "not wired".
 #[cfg(not(feature = "openhuman"))]
 #[tokio::test]
 async fn mcp_test_route_is_not_wired_without_the_feature() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
     send(
         &state,
@@ -1965,7 +1942,6 @@ async fn mcp_test_route_is_not_wired_without_the_feature() {
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
     assert_eq!(body["code"], "not_wired");
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// Under the `openhuman` feature, adding a server probes it — and a probe that
@@ -1974,7 +1950,8 @@ async fn mcp_test_route_is_not_wired_without_the_feature() {
 #[cfg(feature = "openhuman")]
 #[tokio::test]
 async fn mcp_add_probes_without_rollback_and_persists_health() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     // A syntactically valid but unreachable endpoint (nothing listening).
@@ -2015,8 +1992,6 @@ async fn mcp_add_probes_without_rollback_and_persists_health() {
         health["status"].is_string(),
         "test returns health: {health}"
     );
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 // -- Telegram channel (issue #31) -------------------------------------------
@@ -2117,7 +2092,8 @@ fn telegram_update(chat_id: i64, text: &str) -> Value {
 
 #[tokio::test]
 async fn telegram_config_is_write_only_and_status_reads_back() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     // Nothing configured yet. This host binds loopback with no `public_url`, so
@@ -2169,13 +2145,12 @@ async fn telegram_config_is_write_only_and_status_reads_back() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(cfg["configured"], false);
     assert_eq!(cfg["tokenSet"], false);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn telegram_webhook_rejects_an_unverified_post() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
     send(
         &state,
@@ -2192,13 +2167,12 @@ async fn telegram_webhook_rejects_an_unverified_post() {
     // Wrong secret.
     let (status, _, _) = telegram_hook(&state, Some("nope"), telegram_update(1, "hi")).await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn telegram_inbound_runs_a_turn_and_delivers_the_reply_back() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let api = RecordingTelegramApi::new();
     let state = state_with_telegram(&home, api.clone()).await;
     send(
@@ -2226,13 +2200,12 @@ async fn telegram_inbound_runs_a_turn_and_delivers_the_reply_back() {
         !raw.contains(BOT_TOKEN),
         "token leaked into webhook response"
     );
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn telegram_set_webhook_registers_the_public_url() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let api = RecordingTelegramApi::new();
     // The hosted shape: a real public https URL Telegram can deliver to.
     let state = state_with_telegram_at(&home, api.clone(), Some("https://acme.example")).await;
@@ -2263,8 +2236,6 @@ async fn telegram_set_webhook_registers_the_public_url() {
     let webhooks = api.webhooks();
     assert_eq!(webhooks.len(), 1);
     assert_eq!(webhooks[0], "https://acme.example/hooks/acme/telegram");
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// Issue #203: on a host with no public https URL, registering a webhook is
@@ -2273,7 +2244,8 @@ async fn telegram_set_webhook_registers_the_public_url() {
 /// would take down the one inbound path that does work.
 #[tokio::test]
 async fn telegram_set_webhook_is_refused_on_a_host_telegram_cannot_reach() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let api = RecordingTelegramApi::new();
     let state = state_with_telegram(&home, api.clone()).await;
     send(
@@ -2300,15 +2272,14 @@ async fn telegram_set_webhook_is_refused_on_a_host_telegram_cannot_reach() {
         api.webhooks().is_empty(),
         "no loopback URL was ever handed to Telegram"
     );
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// The channel is usable with a bot token alone: no webhook secret, no public
 /// URL, no `setWebhook` — the polling listener covers inbound.
 #[tokio::test]
 async fn telegram_is_configured_by_a_bot_token_alone() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let api = RecordingTelegramApi::new();
     let state = state_with_telegram(&home, api).await;
 
@@ -2325,13 +2296,12 @@ async fn telegram_is_configured_by_a_bot_token_alone() {
     assert!(cfg["webhookUrl"].is_null());
     // The host has a transport wired, so it long-polls for inbound.
     assert_eq!(cfg["polling"], true);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn telegram_token_never_leaks_even_when_delivery_fails() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     // A transport that fails with an error embedding the bot token.
     let api = RecordingTelegramApi::failing_with_token_echo();
     let state = state_with_telegram(&home, api).await;
@@ -2353,8 +2323,6 @@ async fn telegram_token_never_leaks_even_when_delivery_fails() {
         !raw.contains(BOT_TOKEN),
         "token leaked on a failed delivery"
     );
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// #187: the Artifacts tab's full loop — an agent draft, a human edit appended
@@ -2366,7 +2334,8 @@ async fn telegram_token_never_leaks_even_when_delivery_fails() {
 /// having destroyed the one datum the epic wants.
 #[tokio::test]
 async fn artifact_versions_capture_the_human_edit_and_diff() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     // The agent's draft.
@@ -2437,8 +2406,6 @@ async fn artifact_versions_capture_the_human_edit_and_diff() {
     )
     .await;
     assert_eq!(empty.as_array().unwrap().len(), 0);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// #185: `GET …/tasks/{id}` assembles the header, the per-task timeline, and
@@ -2452,7 +2419,8 @@ async fn artifact_versions_capture_the_human_edit_and_diff() {
 async fn task_detail_assembles_timeline_and_lineage() {
     use crate::ports::types::CompanyEvent;
 
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
     let company = CompanyId::new("acme");
     let runtime = state.registry().get(&company).unwrap();
@@ -2543,14 +2511,13 @@ async fn task_detail_assembles_timeline_and_lineage() {
     // An unknown id 404s, matching PATCH/DELETE.
     let (status, _) = send(&state, "GET", "/api/v1/company/tasks/nope", None).await;
     assert_eq!(status, StatusCode::NOT_FOUND);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// #187: the diff route's argument contract, and the 404s.
 #[tokio::test]
 async fn artifact_diff_rejects_a_half_specified_range() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     let (_, created) = send(
@@ -2606,8 +2573,6 @@ async fn artifact_diff_rejects_a_half_specified_range() {
     assert_eq!(status, StatusCode::NOT_FOUND);
     let (status, _) = send(&state, "DELETE", "/api/v1/company/artifacts/nope", None).await;
     assert_eq!(status, StatusCode::NOT_FOUND);
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// #185 gave `GET …/tasks/{task_id}` a handler, which now overlaps the static
@@ -2621,7 +2586,8 @@ async fn artifact_diff_rejects_a_half_specified_range() {
 /// in ordinary use.
 #[tokio::test]
 async fn inflight_read_is_not_shadowed_by_task_detail() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     // The strip's read still resolves to the inflight handler: an array, not
@@ -2632,8 +2598,6 @@ async fn inflight_read_is_not_shadowed_by_task_detail() {
         body.is_array(),
         "GET /tasks/inflight must hit list_inflight, not task_detail: {body}"
     );
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// #185 review follow-up: pin the two timeline branches the first test skipped —
@@ -2648,7 +2612,8 @@ async fn inflight_read_is_not_shadowed_by_task_detail() {
 async fn task_timeline_scopes_approvals_to_the_run_window() {
     use crate::ports::types::{Actor, ActorKind, ApprovalId, CompanyEvent, Verdict};
 
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
     let company = CompanyId::new("acme");
     let runtime = state.registry().get(&company).unwrap();
@@ -2728,8 +2693,6 @@ async fn task_timeline_scopes_approvals_to_the_run_window() {
     let raw = serde_json::to_string(&body["timeline"]).unwrap();
     assert!(raw.contains("needs auth"));
     assert!(!raw.contains("u-1"), "operator identity leaked: {raw}");
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// #185 review follow-up: the lineage forest is enforced at the write boundary.
@@ -2739,7 +2702,8 @@ async fn task_timeline_scopes_approvals_to_the_run_window() {
 /// close a `t1 → t2 → t1` loop — all persisted silently.
 #[tokio::test]
 async fn parent_task_id_rejects_self_unknown_and_cycles() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
     let create = |title: &str| {
@@ -2808,8 +2772,6 @@ async fn parent_task_id_rejects_self_unknown_and_cycles() {
         StatusCode::BAD_REQUEST,
         "A → B → A must be rejected"
     );
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 /// #185 review follow-up: validation is only as good as its atomicity.
@@ -2825,7 +2787,8 @@ async fn parent_task_id_rejects_self_unknown_and_cycles() {
 /// rejected — so the assertion is *exactly* one success, not "usually one".
 #[tokio::test]
 async fn concurrent_reparents_cannot_race_a_cycle_onto_the_board() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = std::sync::Arc::new(state_with_company(&home).await);
 
     let mut ids = Vec::new();
@@ -2883,6 +2846,4 @@ async fn concurrent_reparents_cannot_race_a_cycle_onto_the_board() {
         .filter(|c| c["parentTaskId"].is_string())
         .count();
     assert_eq!(parented, 1, "a cycle reached the board: {board}");
-
-    tokio::fs::remove_dir_all(&home).await.ok();
 }

--- a/src/server/provision/test.rs
+++ b/src/server/provision/test.rs
@@ -27,8 +27,11 @@ const PLATFORM_SECRET: &str = "plat-secret";
 
 const ACME_TOML: &str = "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n";
 
-fn home() -> std::path::PathBuf {
-    std::env::temp_dir().join(format!("oc-provision-{}", crate::ports::generate_id()))
+fn home() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix("oc-provision-")
+        .tempdir()
+        .expect("tempdir")
 }
 
 fn platform_state(home: &std::path::Path, max_per_tenant: Option<usize>) -> AppState {
@@ -118,7 +121,8 @@ async fn json_body(response: axum::response::Response) -> serde_json::Value {
 
 #[tokio::test]
 async fn provision_then_list_then_status() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = platform_state(&home, None);
     let app = router(state);
 
@@ -150,12 +154,12 @@ async fn provision_then_list_then_status() {
         .unwrap();
     assert_eq!(status.status(), StatusCode::OK);
     assert_eq!(json_body(status).await["id"], "acme");
-    std::fs::remove_dir_all(&home).ok();
 }
 
 #[tokio::test]
 async fn provision_accepts_json_envelope_with_explicit_id() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = platform_state(&home, None);
     let app = router(state);
 
@@ -171,12 +175,12 @@ async fn provision_accepts_json_envelope_with_explicit_id() {
     let response = app.oneshot(req).await.unwrap();
     assert_eq!(response.status(), StatusCode::CREATED);
     assert_eq!(json_body(response).await["id"], "custom-id");
-    std::fs::remove_dir_all(&home).ok();
 }
 
 #[tokio::test]
 async fn provision_requires_platform_scope() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = platform_state(&home, None);
     let app = router(state);
 
@@ -196,12 +200,12 @@ async fn provision_requires_platform_scope() {
         .unwrap();
     assert_eq!(forbidden.status(), StatusCode::FORBIDDEN);
     assert_eq!(json_body(forbidden).await["code"], "forbidden");
-    std::fs::remove_dir_all(&home).ok();
 }
 
 #[tokio::test]
 async fn invalid_manifest_is_400() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = platform_state(&home, None);
     let app = router(state);
 
@@ -213,12 +217,12 @@ async fn invalid_manifest_is_400() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(json_body(response).await["code"], "manifest_invalid");
-    std::fs::remove_dir_all(&home).ok();
 }
 
 #[tokio::test]
 async fn quota_rejects_when_exceeded() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = platform_state(&home, Some(1));
     let app = router(state);
 
@@ -236,12 +240,12 @@ async fn quota_rejects_when_exceeded() {
         .unwrap();
     assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
     assert_eq!(json_body(second).await["code"], "quota_exceeded");
-    std::fs::remove_dir_all(&home).ok();
 }
 
 #[tokio::test]
 async fn duplicate_id_conflicts() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = platform_state(&home, None);
     let app = router(state);
 
@@ -258,12 +262,12 @@ async fn duplicate_id_conflicts() {
         .unwrap();
     assert_eq!(dup.status(), StatusCode::CONFLICT);
     assert_eq!(json_body(dup).await["code"], "company_exists");
-    std::fs::remove_dir_all(&home).ok();
 }
 
 #[tokio::test]
 async fn provision_namespaces_id_by_workload_tenant() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     // Workload tenant is `tenant-a`.
     let state = namespaced_state(&home, "tenant-a");
     // Keep a handle on the shared ownership map to inspect what boot hydration
@@ -286,7 +290,6 @@ async fn provision_namespaces_id_by_workload_tenant() {
     // hydration filters on — so the company survives a restart.
     let id = CompanyId::new("tenant-a--acme");
     assert_eq!(observed.owner_of(&id).as_deref(), Some("tenant-a"));
-    std::fs::remove_dir_all(&home).ok();
 }
 
 #[tokio::test]
@@ -295,7 +298,8 @@ async fn same_template_under_two_tenant_workloads_does_not_conflict() {
     // `OPENCOMPANY_TENANT_ID`, writing to one shared logical database. In a
     // shared DB the derived id `acme` used to collide; per-workload namespacing
     // keeps them distinct.
-    let home_a = home();
+    let home_a_dir = home();
+    let home_a = home_a_dir.path().to_path_buf();
     let app_a = router(namespaced_state(&home_a, "tenant-a"));
     let a = tenant_token("tenant-a", &["platform", "operator"]);
     let first = app_a
@@ -305,7 +309,8 @@ async fn same_template_under_two_tenant_workloads_does_not_conflict() {
     assert_eq!(first.status(), StatusCode::CREATED);
     assert_eq!(json_body(first).await["id"], "tenant-a--acme");
 
-    let home_b = home();
+    let home_b_dir = home();
+    let home_b = home_b_dir.path().to_path_buf();
     let app_b = router(namespaced_state(&home_b, "tenant-b"));
     let b = tenant_token("tenant-b", &["platform", "operator"]);
     let second = app_b
@@ -314,9 +319,6 @@ async fn same_template_under_two_tenant_workloads_does_not_conflict() {
         .unwrap();
     assert_eq!(second.status(), StatusCode::CREATED);
     assert_eq!(json_body(second).await["id"], "tenant-b--acme");
-
-    std::fs::remove_dir_all(&home_a).ok();
-    std::fs::remove_dir_all(&home_b).ok();
 }
 
 #[tokio::test]
@@ -324,7 +326,8 @@ async fn claim_shaped_tenant_manages_namespaced_company() {
     // Shared-single-DB workload for tenant slug `acme` (its bare
     // `OPENCOMPANY_TENANT_ID`). A full-platform token provisions the company; it
     // is namespaced `acme--acme` and its owner is recorded under the bare slug.
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = namespaced_state(&home, "acme");
     let observed = state.clone();
     let app = router(state);
@@ -370,7 +373,6 @@ async fn claim_shaped_tenant_manages_namespaced_company() {
         .await
         .unwrap();
     assert_eq!(denied.status(), StatusCode::FORBIDDEN);
-    std::fs::remove_dir_all(&home).ok();
 }
 
 // ---------------------------------------------------------------------------
@@ -379,7 +381,8 @@ async fn claim_shaped_tenant_manages_namespaced_company() {
 
 #[tokio::test]
 async fn pause_toggles_and_chat_409() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = platform_state(&home, None);
     let app = router(state);
 
@@ -433,12 +436,12 @@ async fn pause_toggles_and_chat_409() {
         .await
         .unwrap();
     assert_eq!(ok.status(), StatusCode::OK);
-    std::fs::remove_dir_all(&home).ok();
 }
 
 #[tokio::test]
 async fn suspend_requires_platform_scope_and_blocks_chat() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = platform_state(&home, None);
     let app = router(state);
 
@@ -478,12 +481,12 @@ async fn suspend_requires_platform_scope_and_blocks_chat() {
         .await
         .unwrap();
     assert_eq!(conflict.status(), StatusCode::CONFLICT);
-    std::fs::remove_dir_all(&home).ok();
 }
 
 #[tokio::test]
 async fn foreign_tenant_cannot_file_feedback() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = platform_state(&home, None);
     let app = router(state);
 
@@ -505,12 +508,12 @@ async fn foreign_tenant_cannot_file_feedback() {
         .unwrap();
     let denied = app.oneshot(req).await.unwrap();
     assert_eq!(denied.status(), StatusCode::FORBIDDEN);
-    std::fs::remove_dir_all(&home).ok();
 }
 
 #[tokio::test]
 async fn owner_cannot_resume_a_platform_suspension() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = platform_state(&home, None);
     let app = router(state);
 
@@ -549,12 +552,12 @@ async fn owner_cannot_resume_a_platform_suspension() {
         .unwrap();
     assert_eq!(resumed.status(), StatusCode::OK);
     assert_eq!(json_body(resumed).await["lifecycle"], "running");
-    std::fs::remove_dir_all(&home).ok();
 }
 
 #[tokio::test]
 async fn archive_removes_from_registry() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = platform_state(&home, None);
     let app = router(state);
 
@@ -591,12 +594,12 @@ async fn archive_removes_from_registry() {
         .await
         .unwrap();
     assert_eq!(chat.status(), StatusCode::NOT_FOUND);
-    std::fs::remove_dir_all(&home).ok();
 }
 
 #[tokio::test]
 async fn cross_tenant_access_forbidden() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = platform_state(&home, None);
     let app = router(state);
 
@@ -616,12 +619,12 @@ async fn cross_tenant_access_forbidden() {
         .await
         .unwrap();
     assert_eq!(forbidden.status(), StatusCode::FORBIDDEN);
-    std::fs::remove_dir_all(&home).ok();
 }
 
 #[tokio::test]
 async fn lifecycle_transition_recorded_as_event() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = platform_state(&home, None);
     let app = router(state);
 
@@ -649,7 +652,6 @@ async fn lifecycle_transition_recorded_as_event() {
         )
     });
     assert!(found, "expected a LifecycleChanged event, got {stored:?}");
-    std::fs::remove_dir_all(&home).ok();
 }
 
 // ---------------------------------------------------------------------------
@@ -692,7 +694,8 @@ impl Brain for EffectBrain {
 
 #[tokio::test]
 async fn webhook_emitted_on_approval_requested() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     // Prosumer mode (no platform_auth) plus a recording webhook sink.
     let (webhook, sink) = WebhookConfig::recording("tenant-secret");
     let state = AppState::new(AppConfig::default())
@@ -738,5 +741,4 @@ async fn webhook_emitted_on_approval_requested() {
     // The delivery carries a non-empty signature header value.
     assert!(!approval.1.is_empty());
     assert!(approval.1.starts_with("kh1="));
-    std::fs::remove_dir_all(&home).ok();
 }

--- a/src/server/users/auth_test.rs
+++ b/src/server/users/auth_test.rs
@@ -21,8 +21,11 @@ use crate::server::users::cookie::session_cookie_name;
 use crate::server::users::token::{OsTokens, mint_session_token, sha256_hex};
 use crate::{AppConfig, AppState};
 
-fn home() -> std::path::PathBuf {
-    std::env::temp_dir().join(format!("oc-userauth-{}", crate::ports::generate_id()))
+fn home() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix("oc-userauth-")
+        .tempdir()
+        .expect("tempdir")
 }
 
 fn manifest() -> CompanyManifest {
@@ -128,7 +131,8 @@ fn headers_with_cookie(company: &str, token: &str) -> axum::http::HeaderMap {
 
 #[tokio::test]
 async fn a_session_cookie_resolves_to_a_user_of_that_company() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with(&home, &["acme"]).await;
     let token = seed_session(&state, "acme", UserRole::Member, UserStatus::Active).await;
 
@@ -145,12 +149,12 @@ async fn a_session_cookie_resolves_to_a_user_of_that_company() {
         }
         other => panic!("expected a user principal, got {other:?}"),
     }
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn a_session_for_one_company_is_refused_for_another() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with(&home, &["acme", "globex"]).await;
     let token = seed_session(&state, "acme", UserRole::Admin, UserStatus::Active).await;
 
@@ -177,12 +181,12 @@ async fn a_session_for_one_company_is_refused_for_another() {
             .is_err(),
         "a token from another company's partition must not resolve"
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn a_user_may_address_only_their_own_company() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with(&home, &["acme", "globex"]).await;
     let token = seed_session(&state, "acme", UserRole::Admin, UserStatus::Active).await;
 
@@ -198,12 +202,12 @@ async fn a_user_may_address_only_their_own_company() {
     );
     // A user cannot even learn that other companies exist on this host.
     assert_eq!(auth.visible_companies(&state), vec![acme]);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn a_suspended_users_live_session_stops_working_immediately() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with(&home, &["acme"]).await;
     let token = seed_session(&state, "acme", UserRole::Member, UserStatus::Active).await;
     let acme = CompanyId::new("acme");
@@ -225,12 +229,12 @@ async fn a_suspended_users_live_session_stops_working_immediately() {
             .is_err(),
         "suspension must take effect on the next request, not at cookie expiry"
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn an_expired_session_does_not_resolve() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with(&home, &["acme"]).await;
     let acme = CompanyId::new("acme");
     let runtime = state.registry().get(&acme).unwrap();
@@ -277,12 +281,12 @@ async fn an_expired_session_does_not_resolve() {
             .is_err(),
         "an expired session must not resolve"
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn a_stale_or_garbage_cookie_falls_through_to_the_platform_bearer() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     // Platform mode: the hosting layer's machine credential.
     let state = AppState::new(AppConfig {
         platform_auth: Some(crate::server::platform_auth::PlatformAuthConfig::new(
@@ -320,7 +324,6 @@ async fn a_stale_or_garbage_cookie_falls_through_to_the_platform_bearer() {
         matches!(auth, GqlAuth::Platform(_)),
         "a bad cookie must degrade to the bearer path, not fail the request"
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
@@ -328,7 +331,8 @@ async fn an_anonymous_request_reaches_nothing() {
     // What used to be dev mode. With no principal at all, a write route is
     // simply closed — previously this was a 200 on every deployment, because
     // the operator token that would have guarded it could not be set.
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with(&home, &["acme"]).await;
 
     let app = router(state.clone());
@@ -344,14 +348,14 @@ async fn an_anonymous_request_reaches_nothing() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn a_users_session_now_reaches_their_own_companys_write_plane() {
     // The point of the change: humans are the prosumer auth story, so a member
     // of the company can drive its console surfaces.
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with(&home, &["acme"]).await;
     let token = seed_session(&state, "acme", UserRole::Member, UserStatus::Active).await;
 
@@ -373,7 +377,6 @@ async fn a_users_session_now_reaches_their_own_companys_write_plane() {
         "a member must be able to use their own company, got {}",
         response.status()
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
@@ -382,7 +385,8 @@ async fn a_session_cookie_cannot_reach_the_platform_plane() {
     // suspension resolve through `resolve_claims`, which cannot produce a User,
     // so no session — however admin — can create or destroy companies across
     // tenants.
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with(&home, &["acme"]).await;
     let token = seed_session(&state, "acme", UserRole::Admin, UserStatus::Active).await;
 
@@ -423,14 +427,14 @@ async fn a_session_cookie_cannot_reach_the_platform_plane() {
         StatusCode::UNAUTHORIZED,
         "an admin user's session must not suspend a company"
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn without_an_addressed_company_a_lone_cookie_selects_its_own() {
     // The GraphQL path: the company lives in the request body, so the cookie
     // name is the only signal.
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with(&home, &["acme"]).await;
     let token = seed_session(&state, "acme", UserRole::Member, UserStatus::Active).await;
 
@@ -441,14 +445,14 @@ async fn without_an_addressed_company_a_lone_cookie_selects_its_own() {
         GqlAuth::User(u) => assert_eq!(u.company, CompanyId::new("acme")),
         other => panic!("expected a user, got {other:?}"),
     }
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn without_an_addressed_company_ambiguous_cookies_resolve_no_user() {
     // Two companies' sessions in one jar (only reachable in local dev). Picking
     // one would be a guess; degrade instead.
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let state = state_with(&home, &["acme", "globex"]).await;
     let acme_token = seed_session(&state, "acme", UserRole::Member, UserStatus::Active).await;
     let globex_token = seed_session(&state, "globex", UserRole::Member, UserStatus::Active).await;
@@ -468,5 +472,4 @@ async fn without_an_addressed_company_ambiguous_cookies_resolve_no_user() {
         resolve_principal(&headers, &state, None).await.is_err(),
         "an ambiguous jar must not silently pick a company"
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }

--- a/src/server/users/routes_test.rs
+++ b/src/server/users/routes_test.rs
@@ -16,8 +16,11 @@ use crate::server::ops::smtp::{SmtpCredentials, SmtpSecurity};
 use crate::server::router;
 use crate::{AppConfig, AppState};
 
-fn home() -> std::path::PathBuf {
-    std::env::temp_dir().join(format!("oc-routes-{}", crate::ports::generate_id()))
+fn home() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix("oc-routes-")
+        .tempdir()
+        .expect("tempdir")
 }
 
 /// A manifest whose `[users] admins` bootstraps `ada` — deliberately spelled
@@ -203,7 +206,8 @@ async fn user_id(state: &AppState, admin: &str, email: &str) -> String {
 
 #[tokio::test]
 async fn auth_request_answers_identically_for_everyone() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, sender) = state_with_mail(&home).await;
 
     // An eligible admin, a stranger, and malformed input must be
@@ -233,12 +237,12 @@ async fn auth_request_answers_identically_for_everyone() {
     let sent = sender.sent();
     assert_eq!(sent.len(), 1, "mail went to someone it shouldn't have");
     assert_eq!(sent[0].1.to, "ada@example.com");
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn every_verify_failure_is_the_same_401() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, _) = state_with_mail(&home).await;
 
     let mut seen = Vec::new();
@@ -264,12 +268,12 @@ async fn every_verify_failure_is_the_same_401() {
         assert_eq!(*entry, first, "verify failures must be byte-identical");
         assert_eq!(entry.1["code"], "invalid_login");
     }
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn every_password_login_failure_is_the_same_401() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, sender) = state_with_mail(&home).await;
     // Give ada an account and a password first.
     let cookie = login_via_link(&state, &sender, "ada@example.com").await;
@@ -309,7 +313,6 @@ async fn every_password_login_failure_is_the_same_401() {
         assert_eq!(entry.0, StatusCode::UNAUTHORIZED);
         assert_eq!(*entry, first, "login failures must be byte-identical");
     }
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 // ---------------------------------------------------------------------------
@@ -318,7 +321,8 @@ async fn every_password_login_failure_is_the_same_401() {
 
 #[tokio::test]
 async fn a_manifest_admin_can_log_in_and_is_an_admin() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, sender) = state_with_mail(&home).await;
     // The manifest spells it "Ada@Example.com"; normalization must match.
     let cookie = login_via_link(&state, &sender, "ada@example.com").await;
@@ -334,12 +338,12 @@ async fn a_manifest_admin_can_log_in_and_is_an_admin() {
     assert_eq!(me["role"], "admin", "the manifest bootstraps an admin");
     assert_eq!(me["company"], "acme");
     assert_eq!(me["hasPassword"], false);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn a_link_is_single_use() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, sender) = state_with_mail(&home).await;
     let code = request_code(&state, &sender, "ada@example.com").await;
 
@@ -363,12 +367,12 @@ async fn a_link_is_single_use() {
         .await
         .unwrap();
     assert_eq!(second.status(), StatusCode::UNAUTHORIZED);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn a_second_link_within_the_throttle_window_is_not_sent() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, sender) = state_with_mail(&home).await;
     let first_code = request_code(&state, &sender, "ada@example.com").await;
 
@@ -401,14 +405,14 @@ async fn a_second_link_within_the_throttle_window_is_not_sent() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn once_the_window_passes_a_new_link_invalidates_the_previous_one() {
     use crate::ports::LoginCodeRecord;
 
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, sender) = state_with_mail(&home).await;
     let id = CompanyId::new("acme");
     let runtime = state.registry().get(&id).unwrap();
@@ -462,12 +466,12 @@ async fn once_the_window_passes_a_new_link_invalidates_the_previous_one() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn setting_a_password_enables_password_login() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, sender) = state_with_mail(&home).await;
     let cookie = login_via_link(&state, &sender, "ada@example.com").await;
 
@@ -496,12 +500,12 @@ async fn setting_a_password_enables_password_login() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     assert!(!session_cookie(&response).is_empty());
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn a_weak_password_is_refused() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, sender) = state_with_mail(&home).await;
     let cookie = login_via_link(&state, &sender, "ada@example.com").await;
 
@@ -515,12 +519,12 @@ async fn a_weak_password_is_refused() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn setting_a_password_requires_a_session() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, _) = state_with_mail(&home).await;
     let app = router(state.clone());
     let response = app
@@ -531,12 +535,12 @@ async fn setting_a_password_requires_a_session() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn the_session_cookie_is_defended() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, sender) = state_with_mail(&home).await;
     let code = request_code(&state, &sender, "ada@example.com").await;
     let app = router(state.clone());
@@ -563,12 +567,12 @@ async fn the_session_cookie_is_defended() {
         !set.contains("Secure"),
         "http dev must not set Secure or the cookie is dropped: {set}"
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn a_https_deployment_marks_the_cookie_secure() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let sender = RecordingMailSender::new();
     let store = crate::store::FsCompanyStore::new(home.clone());
     let id = CompanyId::new("acme");
@@ -633,12 +637,12 @@ async fn a_https_deployment_marks_the_cookie_secure() {
         set.contains("Secure"),
         "an https host must set Secure: {set}"
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn logout_revokes_the_session_not_just_the_cookie() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, sender) = state_with_mail(&home).await;
     let cookie = login_via_link(&state, &sender, "ada@example.com").await;
 
@@ -670,7 +674,6 @@ async fn logout_revokes_the_session_not_just_the_cookie() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 // ---------------------------------------------------------------------------
@@ -679,7 +682,8 @@ async fn logout_revokes_the_session_not_just_the_cookie() {
 
 #[tokio::test]
 async fn only_an_admin_can_invite() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, sender) = state_with_mail(&home).await;
     let admin = login_via_link(&state, &sender, "ada@example.com").await;
 
@@ -723,12 +727,12 @@ async fn only_an_admin_can_invite() {
         StatusCode::FORBIDDEN,
         "a member must not be able to invite"
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn an_uninvited_address_cannot_log_in() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, _) = state_with_mail(&home).await;
     // Not invited, not in the manifest: no code is minted at all.
     assert_eq!(
@@ -736,12 +740,12 @@ async fn an_uninvited_address_cannot_log_in() {
         None,
         "an uninvited address must not receive a code"
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn suspending_a_user_kills_their_session_at_once() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, sender) = state_with_mail(&home).await;
     let admin = login_via_link(&state, &sender, "ada@example.com").await;
 
@@ -784,12 +788,12 @@ async fn suspending_a_user_kills_their_session_at_once() {
 
     // And he cannot get a new link either.
     assert_eq!(request_dev_code(&state, "bob@example.com").await, None);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn the_last_admin_cannot_be_demoted() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, sender) = state_with_mail(&home).await;
     let admin = login_via_link(&state, &sender, "ada@example.com").await;
     let ada_id = user_id(&state, &admin, "ada@example.com").await;
@@ -810,12 +814,12 @@ async fn the_last_admin_cannot_be_demoted() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::CONFLICT);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn an_admin_reset_forces_a_change_and_kills_sessions() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, sender) = state_with_mail(&home).await;
     let admin = login_via_link(&state, &sender, "ada@example.com").await;
 
@@ -888,12 +892,12 @@ async fn an_admin_reset_forces_a_change_and_kills_sessions() {
         .await
         .unwrap();
     assert_eq!(body_json(response).await["mustChangePassword"], false);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn a_temporary_password_is_a_boundary_not_a_suggestion() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, sender) = state_with_mail(&home).await;
     let admin = login_via_link(&state, &sender, "ada@example.com").await;
 
@@ -998,12 +1002,12 @@ async fn a_temporary_password_is_a_boundary_not_a_suggestion() {
         "the flag must clear once the password is replaced, got {}",
         response.status()
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn a_manifest_admin_invite_cannot_be_revoked_through_the_api() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, sender) = state_with_mail(&home).await;
     let admin = login_via_link(&state, &sender, "ada@example.com").await;
 
@@ -1022,7 +1026,6 @@ async fn a_manifest_admin_invite_cannot_be_revoked_through_the_api() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 // ---------------------------------------------------------------------------
@@ -1031,7 +1034,8 @@ async fn a_manifest_admin_invite_cannot_be_revoked_through_the_api() {
 
 #[tokio::test]
 async fn no_mail_transport_still_returns_202_and_echoes_for_dev() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     // No mail wired at all — the default offline build, on the default
     // loopback bind.
     let state = state_with(&home, ConnectionsRuntime::new()).await;
@@ -1039,12 +1043,12 @@ async fn no_mail_transport_still_returns_202_and_echoes_for_dev() {
         request_dev_code(&state, "ada@example.com").await.is_some(),
         "without a transport the code must be echoed so local dev works"
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn a_routable_host_never_echoes_the_code_even_with_no_mail() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let store = crate::store::FsCompanyStore::new(home.clone());
     let id = CompanyId::new("acme");
     store
@@ -1083,12 +1087,12 @@ async fn a_routable_host_never_echoes_the_code_even_with_no_mail() {
         None,
         "a routable host must never echo a login code"
     );
-    tokio::fs::remove_dir_all(&home).await.ok();
 }
 
 #[tokio::test]
 async fn with_mail_wired_the_code_is_never_echoed() {
-    let home = home();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
     let (state, sender) = state_with_mail(&home).await;
     assert_eq!(
         request_dev_code(&state, "ada@example.com").await,
@@ -1099,5 +1103,4 @@ async fn with_mail_wired_the_code_is_never_echoed() {
     let sent = sender.sent();
     assert_eq!(sent.len(), 1);
     assert!(sent[0].1.body.contains("/login?company=acme&code="));
-    tokio::fs::remove_dir_all(&home).await.ok();
 }

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -810,8 +810,11 @@ mod test {
     use crate::store::conformance;
     use futures::StreamExt;
 
-    fn tmp_root() -> PathBuf {
-        std::env::temp_dir().join(format!("opencompany-test-{}", generate_id()))
+    fn tmp_root() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("opencompany-test-")
+            .tempdir()
+            .expect("tempdir")
     }
 
     #[tokio::test]
@@ -821,7 +824,8 @@ mod test {
         // `read_jsonl` reports as a "trailing characters" parse error). The
         // single-write `append_line` makes each record one atomic O_APPEND
         // write, so this holds deterministically.
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         tokio::fs::create_dir_all(&root).await.unwrap();
         let path = root.join("log.jsonl");
 
@@ -844,8 +848,6 @@ mod test {
         let mut seen: Vec<u64> = rows.iter().map(|r| r["i"].as_u64().unwrap()).collect();
         seen.sort_unstable();
         assert_eq!(seen, (0..N).collect::<Vec<_>>(), "all records intact");
-
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     // The fs backend runs the identical port-conformance suite the sqlite
@@ -853,7 +855,8 @@ mod test {
     // stores start empty.
     #[tokio::test]
     async fn conformance_isolation_by_company() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         conformance::assert_isolation_by_company(
             Arc::new(FsCompanyStore::new(&root)),
             Arc::new(FsEventLog::new(&root)),
@@ -861,39 +864,38 @@ mod test {
             Arc::new(FsContextStore::new(&root)),
         )
         .await;
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn conformance_append_only_event_and_ledger() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         conformance::assert_append_only_event_and_ledger(
             Arc::new(FsCompanyStore::new(&root)),
             Arc::new(FsEventLog::new(&root)),
         )
         .await;
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn conformance_monotonic_event_seq() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         conformance::assert_monotonic_event_seq(Arc::new(FsEventLog::new(&root))).await;
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn conformance_inbox_store() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         conformance::assert_inbox_store(Arc::new(FsInboxStore::new(&root))).await;
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn conformance_context_chunk_stamps() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         conformance::assert_context_chunk_stamps(Arc::new(FsContextStore::new(&root))).await;
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     /// The fs backend's migration path: index lines written before
@@ -912,7 +914,8 @@ mod test {
 
     #[tokio::test]
     async fn conformance_export_totality() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         conformance::assert_export_totality(
             Arc::new(FsCompanyStore::new(&root)),
             Arc::new(FsEventLog::new(&root)),
@@ -920,7 +923,6 @@ mod test {
             Arc::new(FsContextStore::new(&root)),
         )
         .await;
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     fn sample_manifest() -> crate::company::CompanyManifest {
@@ -941,7 +943,8 @@ mod test {
 
     #[tokio::test]
     async fn company_store_saves_and_loads() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         let store = FsCompanyStore::new(&root);
         let id = CompanyId::new("acme");
         let record = CompanyRecord {
@@ -974,12 +977,12 @@ mod test {
                 .unwrap()
                 .is_none()
         );
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn append_ledger_grows_without_rewrite() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         let store = FsCompanyStore::new(&root);
         let id = CompanyId::new("acme");
         store
@@ -1015,12 +1018,12 @@ mod test {
         let loaded = store.load(&id).await.unwrap().unwrap();
         assert_eq!(loaded.ledger.len(), 3);
         assert_eq!(loaded.ledger[2].memo, "entry 2");
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn event_log_assigns_monotonic_seqs_and_resumes() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         let log = FsEventLog::new(&root);
         let id = CompanyId::new("acme");
 
@@ -1054,12 +1057,12 @@ mod test {
         let from_one = log.read_from(&id, EventSeq::new(1), 10).await.unwrap();
         assert_eq!(from_one.len(), 1);
         assert_eq!(from_one[0].seq, EventSeq::new(1));
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn event_log_subscribe_delivers_new_event() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         let log = FsEventLog::new(&root);
         let id = CompanyId::new("acme");
         let mut stream = log.subscribe(&id);
@@ -1083,12 +1086,12 @@ mod test {
                 chat: None
             }
         );
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn memory_store_traces_tail_and_evict() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         let mem = FsMemoryStore::new(&root);
         let id = CompanyId::new("acme");
         for i in 0..5 {
@@ -1106,12 +1109,12 @@ mod test {
             .unwrap();
         assert_eq!(removed, 4);
         assert_eq!(mem.recent_traces(&id, 10).await.unwrap().len(), 1);
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn context_store_put_peek_search() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         let ctx = FsContextStore::new(&root);
         let id = CompanyId::new("acme");
         let addr = ctx
@@ -1137,12 +1140,12 @@ mod test {
         let hits = ctx.search(&id, "brown", 5).await.unwrap();
         assert_eq!(hits.len(), 1);
         assert!(hits[0].snippet.contains("brown"));
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn secret_store_isolates_companies() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         let secrets = FsSecretStore::new(&root);
         let a = CompanyId::new("company-a");
         let b = CompanyId::new("company-b");
@@ -1157,6 +1160,5 @@ mod test {
         );
         // Company B cannot see company A's secret.
         assert_eq!(secrets.get(&b, "github_token").await.unwrap(), None);
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 }

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -951,77 +951,81 @@ mod test {
     use crate::store::conformance;
     use std::sync::Arc;
 
-    fn tmp_root() -> PathBuf {
-        std::env::temp_dir().join(format!("opencompany-fsops-{}", crate::ports::generate_id()))
+    fn tmp_root() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("opencompany-fsops-")
+            .tempdir()
+            .expect("tempdir")
     }
 
     #[tokio::test]
     async fn conformance_task_store() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         conformance::assert_task_store(Arc::new(FsOps::new(&root))).await;
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn conformance_user_store() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         conformance::assert_user_store(Arc::new(FsOps::new(&root))).await;
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn conformance_session_store() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         conformance::assert_session_store(Arc::new(FsOps::new(&root))).await;
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn conformance_login_code_store() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         conformance::assert_login_code_store(Arc::new(FsOps::new(&root))).await;
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn conformance_fact_store() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         conformance::assert_fact_store(Arc::new(FsOps::new(&root))).await;
         conformance::assert_artifact_store(Arc::new(FsOps::new(&root))).await;
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn conformance_usage_meter() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         conformance::assert_usage_meter(Arc::new(FsOps::new(&root))).await;
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn conformance_usage_retention() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         conformance::assert_usage_retention(Arc::new(FsOps::new(&root))).await;
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn conformance_skill_state_store() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         conformance::assert_skill_state_store(Arc::new(FsOps::new(&root))).await;
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn conformance_workspace_store() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         conformance::assert_workspace_store(Arc::new(FsOps::new(&root))).await;
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 
     #[tokio::test]
     async fn workspace_files_land_on_disk_under_folders() {
-        let root = tmp_root();
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
         let ops = FsOps::new(&root);
         let company = CompanyId::new("acme");
         let now = now_millis();
@@ -1067,6 +1071,5 @@ mod test {
         assert!(!tokio::fs::try_exists(&disk).await.unwrap());
 
         let _ = (FactKind::Fact, SkillSource::Company, SampleKind::Inference);
-        tokio::fs::remove_dir_all(&root).await.ok();
     }
 }


### PR DESCRIPTION
## Summary

`runtime::journal::test::expired_record_removes_parked_and_survives_reload` flakes with a `trailing characters` parse error. Test journal paths were built from `std::env::temp_dir()` plus a `crate::ports::generate_id()` name, and that id is unique **only within one process**: `COUNTER` in `src/ports/ids.rs` is a plain `AtomicU64` starting at zero in every process, and the millis prefix has millisecond resolution. Two processes that start within the same millisecond mint the same id, so both land on the same journal file in the shared temp directory.

Once they share the file, `RuntimeJournal::append` does the rest. It writes the JSON line and the `\n` as two separate `write_all` calls on an `O_APPEND` handle, serialized by an in-process mutex only, so the other process's record can land between them. The reader then sees two records on one line and fails. A serialized `ApprovalParked` carrying the test fixture is ~210 bytes, which matches the reported `column: 211`.

**Correction to the issue text.** The issue blames "two test binaries in the same millisecond in CI". CI cannot race itself: `ci.yml` runs a plain `cargo test` on a fresh VM, and cargo runs test binaries serially. The real trigger is any two concurrent test *processes* sharing one machine's temp directory — parallel worktree sessions, or `cargo test` and `cargo test --features openhuman` in two shells, both routine here. I have not identified which pair produced the reported failure, and the fix does not depend on knowing: it removes the shared-name assumption entirely.

Every test path now comes from `tempfile`, which asks the OS for a name no other process can hold. **That is the proof.** The flake is not reproducible on demand — it needs two processes to align on both the millisecond and the counter — so a green run proves nothing on its own. What can be checked is the invariant: uniqueness is now enforced by the OS at creation time rather than inferred from id semantics that never guaranteed it.

Since a `TempDir` cleans up on drop, the trailing manual `remove_file` / `remove_dir_all` calls are gone. That also fixes a leak: those calls sat after the assertions, so every failing test leaked its directory.

## API Or Behavior Changes

None. Every code change is inside `#[cfg(test)]` modules or `*_test.rs` files, except two doc comments:

- `RuntimeJournal` now records that exactly one process may write a given journal file, and why (the two-write append is only in-process-atomic).
- `generate_id` now spells out that its ids are process-unique only and must never name an entry in a shared directory, pointing test authors at `tempfile`. This is the durable lever against the pattern respreading.

`tempfile` was already a dev-dependency and dev-deps are not feature-gated, so `Cargo.toml` is untouched.

Scope: 51 sites across 38 files. Deliberately left alone:

- pid-named temp paths (`app/config.rs`, `bin/opencompany.rs`, `company/{workspace_seed,manifest}.rs`, `store/layout.rs`) — a pid is unique among concurrently live processes, so this race cannot fire.
- `store/export.rs`'s `tmp_root`, which is pid-and-millis named rather than `generate_id` named. Safe for the same reason; left as-is.
- the production atomic-write temps in `store/fs.rs` and `feedback/store.rs` — colliding needs two processes writing the same store path in the same millisecond, outside the one-process-per-company design.
- `harness/toolbelt.rs`'s two bare `temp_dir()` reads (nothing is written) and `workspace_seed.rs`'s fixed name that is never created.

One site was worse than the rest and is fixed here too: `harness/toolbelt.rs`'s `apply_patch_denied_outside_workspace` used the *fixed* name `oc-toolbelt-escape` with `remove_dir_all` followed by create, so two concurrent runs tore down each other's workspace between the create and the assertion.

No cross-process stress test is added. A timing-dependent test would itself be a flake.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets` — N/A: covered by the clippy and test runs above, not run as a separate invocation
- [x] `cargo test` — 976 passed, 0 failed, 1 ignored
- [x] `cargo test --features openhuman` — 1347 passed, 0 failed, 1 ignored

The feature run matters here: CI builds default features only and compiles none of the `openhuman`-gated test modules, so `brain/` and `harness/` are covered by that run alone.

`cargo clippy --all-targets --features openhuman` was run but is **not** ticked as clean. It reports four pre-existing warnings in this crate, none of them from this change and none in code it touches: dead `toolkit_allowed` / `slug_toolkit` in `harness/composio.rs`, `to_string_in_format_args` in `harness/mcp_probe.rs`, and a `redundant_guards` in `runtime/delegation.rs`. Everything else it reports is vendored.

Two extra checks beyond the gates:

- **Leak check.** Snapshotted the temp directory, ran both full suites, diffed: zero new leftovers. Separately forced one journal assertion to fail and confirmed its directory was still removed — the old code leaked one per failure.
- **Concurrency smoke.** Ran two instances of the prebuilt lib test binary filtered to `runtime::journal` against a shared temp directory, 60 paired runs (120 processes): no failures, no leftovers. Consistent with the fix, but as noted above it is not the proof — the invariant is.

## Documentation

No user-facing docs affected. The two doc comments described above are the documentation change: they record the journal's single-writer contract and the uniqueness limit of `generate_id`, which is what stops this class of bug being reintroduced.

Closes #235


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated filesystem, runtime, server, and integration tests to use isolated temporary directories.
  * Added automatic cleanup for test-generated files and directories, reducing leftover test artifacts and cross-test interference.
  * Preserved existing test behavior and assertions across credential, workflow, storage, and service coverage.

* **Documentation**
  * Clarified that generated IDs are process-local and may collide across processes.
  * Documented the single-writer requirement for runtime journal files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->