### PR TITLE
fix(runtime): keep runtime-enabled workflows across a boot rebuild (#208)

### DIFF
--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -104,8 +104,23 @@ two sources — `load_workflow_union` / `list_workflows_union` in
 `src/company/workflow_file.rs` — with the committed seed file winning on an id
 collision, matching the manifest-first convention the desk resolvers use. The
 workflow scheduler (issue #169) reads through the same union, which is what
-makes a schedule on a console-created workflow survive a restart: the overlay
-bodies persist here, while the record's manifest is re-seeded on a boot rebuild.
+makes a schedule on a console-created workflow survive a restart.
+
+**A boot rebuild is not a plain re-seed** (issue #208). `RuntimeBuilder::build`
+persists the freshly-parsed seed manifest with exactly one field merged:
+`[workflows].enabled` becomes the seed's ids plus every surviving
+`overlay_workflows` id not already among them. `create_workflow` writes the graph
+body and the enabled id in one save, so overlay presence *is* the enablement
+invariant — deriving from the bodies carries a runtime enablement forward and
+re-heals records an earlier rebuild wiped, with no migration. Ids dropped from
+the seed, and enabled ids with no surviving body, do not survive.
+
+Every other manifest field is **seed-authoritative**; for `[tools]` and
+`[policy]` that is a security property, not a convention — a record-wins merge
+would let a runtime grant or a relaxed approval mode outlive the operator
+revoking it in version control. Runtime additions that must persist get their own
+overlay field instead (`overlay_agents`, `overlay_desks`, the `SecretStore` for
+console MCP credentials).
 
 ```rust
 // src/ports/store.rs

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -36,7 +36,9 @@ use crate::openhuman::{OpenHumanChannelAdapter, OpenHumanToolProvider};
 use crate::policy::ManifestApprovalGate;
 #[cfg(feature = "openhuman")]
 use crate::ports::WorkflowRunner;
-use crate::ports::types::{CompanyId, CompanyRecord, SecretValue, TemplateProvenance};
+use crate::ports::types::{
+    CompanyId, CompanyRecord, OverlayWorkflow, SecretValue, TemplateProvenance,
+};
 use crate::ports::{
     AgentEconomy, ArtifactStore, Brain, ChannelAdapter, CompanyStore, ContextStore, EventLog,
     FactStore, InboxStore, LoginCodeStore, MemoryStore, SecretStore, SessionStore, SkillStateStore,
@@ -137,6 +139,51 @@ fn dedup(grants: Vec<String>) -> Vec<String> {
         .into_iter()
         .filter(|grant| seen.insert(grant.clone()))
         .collect()
+}
+
+/// Issue #208: the rebuilt record's `[workflows].enabled` list — the seed
+/// manifest's ids first, in seed order, then every runtime-authored overlay
+/// workflow id not already among them, in overlay order.
+///
+/// **Why the persisted record's own `enabled` list is deliberately not an
+/// input.** `create_company_workflow` (the shared core behind the console's
+/// `POST …/workflows` route and the orchestrator's `create_workflow` tool)
+/// writes the graph body into `overlay_workflows` and pushes the id onto
+/// `[workflows].enabled` in **one** store save, so overlay presence *is* the
+/// runtime-enablement invariant — the overlay body is the durable half of a
+/// write that always carried both. Deriving from the bodies rather than from
+/// the old `enabled` list buys two things the old list cannot:
+///
+/// * **self-healing.** Every record written during the bug era has a surviving
+///   overlay body whose enabled id a past restart already wiped. Deriving from
+///   bodies re-enables those on the next boot with no migration.
+/// * **no zombies.** An `enabled` id whose body no longer exists (a seed entry
+///   the operator deleted from `company.toml`, or a graph removed at runtime)
+///   is dropped instead of being carried forward forever with nothing to run.
+///
+/// Seed-removed ids are dropped on purpose: the version-controlled
+/// `company.toml` stays authoritative for seed-authored entries, so deleting one
+/// there takes effect on the next boot exactly as an operator expects.
+///
+/// This is the **only** manifest field a rebuild merges. Every other field is
+/// seed-authoritative, and for two of them that is a security property rather
+/// than a convention: `[tools]` and `[policy]` must be seed-wins, because a
+/// record-wins merge would let a runtime write **outlive a seed rollback** —
+/// privilege persisting after the operator revoked it in version control.
+fn merge_enabled_workflows(seed_enabled: &[String], overlays: &[OverlayWorkflow]) -> Vec<String> {
+    let mut merged: Vec<String> = Vec::with_capacity(seed_enabled.len() + overlays.len());
+    let mut seen = std::collections::HashSet::new();
+    for id in seed_enabled {
+        if seen.insert(id.clone()) {
+            merged.push(id.clone());
+        }
+    }
+    for overlay in overlays {
+        if seen.insert(overlay.id.clone()) {
+            merged.push(overlay.id.clone());
+        }
+    }
+    merged
 }
 
 /// Builds one company's [`CompanyRuntime`] over a filesystem home.
@@ -1736,6 +1783,54 @@ mod test {
 
     fn parse(toml_src: &str) -> CompanyManifest {
         toml::from_str(toml_src).expect("valid manifest")
+    }
+
+    /// A bodiless overlay stub — `merge_enabled_workflows` only reads the id.
+    fn overlay(id: &str) -> OverlayWorkflow {
+        OverlayWorkflow {
+            id: id.to_string(),
+            toml: String::new(),
+        }
+    }
+
+    #[test]
+    fn merge_enabled_appends_overlay_only_ids() {
+        let merged = merge_enabled_workflows(
+            &["seed_one".to_string()],
+            &[overlay("console_made"), overlay("also_console")],
+        );
+        assert_eq!(merged, vec!["seed_one", "console_made", "also_console"]);
+    }
+
+    #[test]
+    fn merge_enabled_dedupes_at_the_seed_position() {
+        // `shared` is in both lists: it keeps its seed slot (first), and the
+        // overlay does not append a second copy at the end.
+        let merged = merge_enabled_workflows(
+            &["shared".to_string(), "seed_only".to_string()],
+            &[overlay("shared"), overlay("overlay_only")],
+        );
+        assert_eq!(merged, vec!["shared", "seed_only", "overlay_only"]);
+    }
+
+    #[test]
+    fn merge_enabled_first_boot_leaves_seed_unchanged() {
+        let seed = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        assert_eq!(merge_enabled_workflows(&seed, &[]), seed);
+    }
+
+    #[test]
+    fn merge_enabled_preserves_order_and_dedupes_within_each_list() {
+        let merged = merge_enabled_workflows(
+            &["b".to_string(), "a".to_string(), "b".to_string()],
+            &[overlay("z"), overlay("a"), overlay("z")],
+        );
+        assert_eq!(merged, vec!["b", "a", "z"]);
+    }
+
+    #[test]
+    fn merge_enabled_of_nothing_is_empty() {
+        assert!(merge_enabled_workflows(&[], &[]).is_empty());
     }
 
     #[test]

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -649,7 +649,7 @@ impl RuntimeBuilder {
 
     /// Assembles the runtime, materializing `company.toml` and replaying the
     /// journal to rebuild the approval queue.
-    pub async fn build(self) -> Result<CompanyRuntime> {
+    pub async fn build(mut self) -> Result<CompanyRuntime> {
         let home = self.home;
         let id = self.id;
 
@@ -852,6 +852,26 @@ impl RuntimeBuilder {
             .as_ref()
             .map(|r| r.overlay_workflows.clone())
             .unwrap_or_default();
+        // Issue #208: `[workflows].enabled` is the one manifest field a runtime
+        // write mutates (`create_company_workflow` pushes the new id alongside
+        // the overlay body, in the same save). Rebuilding the record from the
+        // freshly-parsed seed manifest therefore clobbered every console-created
+        // workflow's enablement on each boot, leaving an orphaned graph body the
+        // `list_workflows` route and the GraphQL `Company.workflows` resolver —
+        // both of which read this field — no longer reported.
+        //
+        // Fold the merged list into `self.manifest` ONCE, here, rather than at
+        // the two `CompanyRecord` construction sites below: both build their
+        // manifest from `self.manifest.clone()`, and one of them is inside the
+        // `openhuman`-gated harness arm that the default build never compiles.
+        // Mutating the source keeps the two records in agreement by construction
+        // instead of by a duplicated line only one CI job type-checks.
+        //
+        // Every other `self.manifest` reader in `build` (grants, tool provider,
+        // channels, inference, MCP, plan, policy gate, place) reads fields this
+        // merge never touches.
+        self.manifest.workflows.enabled =
+            merge_enabled_workflows(&self.manifest.workflows.enabled, &overlay_workflows);
         // Issue #85: carry an existing record's source-template provenance
         // forward across the rebuild (a rebuild never re-stamps it); on the very
         // first launch, stamp from the value the launch path recorded (a slug for
@@ -1177,10 +1197,19 @@ impl RuntimeBuilder {
         // Materialize the manifest so status/roster loads have a record to read.
         // The persisted overlays + provenance + ledger + lifecycle were read above
         // (before the brain was constructed, so the brain could be seeded from
-        // them); a rebuild never rewrites the version-controlled manifest, and must
-        // not drop the operator-added teammates, desk memberships, desk order,
-        // operator-created desks, runtime-authored workflow graphs, or the
-        // source-template provenance either.
+        // them), and must not be dropped here: not the operator-added teammates,
+        // desk memberships, desk order, operator-created desks, runtime-authored
+        // workflow graphs, nor the source-template provenance.
+        //
+        // The record's manifest is NOT simply the seed manifest (issue #208). A
+        // rebuild never rewrites the version-controlled `company.toml` *file* —
+        // that much has always held — but the manifest it *persists onto the
+        // record* is the seed manifest with `[workflows].enabled` merged against
+        // the surviving overlay bodies, so a workflow enabled at runtime is still
+        // enabled after a restart. Every other manifest field is seed-authoritative:
+        // the seed wins, and for `[tools]` / `[policy]` that is a security property
+        // — a record-wins merge would let a runtime grant outlive the operator
+        // revoking it in version control.
         store
             .save(&CompanyRecord {
                 id: id.clone(),

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1862,6 +1862,242 @@ mod test {
         assert!(merge_enabled_workflows(&[], &[]).is_empty());
     }
 
+    // --- Issue #208: two-build rebuild semantics over one home dir ----------
+
+    /// A seed manifest with the roster the create-path draft below references.
+    fn wf_manifest(extra: &str) -> CompanyManifest {
+        parse(&format!(
+            "[company]\nname=\"Acme\"\n[policy]\nmode=\"full\"\n\
+             [[agent]]\nid=\"assistant\"\nrole=\"Assistant\"\n{extra}"
+        ))
+    }
+
+    /// The minimal valid three-node graph the create path accepts, mirroring
+    /// `workflow_create`'s own `valid_draft`.
+    fn wf_draft(id: &str, name: &str) -> crate::company::RawWorkflow {
+        use crate::company::{RawEdge, RawNode, RawWorkflow};
+        let node = |id: &str, kind: &str, name: &str, agent: Option<&str>| RawNode {
+            id: id.to_string(),
+            kind: kind.to_string(),
+            name: name.to_string(),
+            summary: None,
+            agent: agent.map(str::to_string),
+            schedule: None,
+            config: None,
+            on_error: None,
+            retry: None,
+            requires_approval: None,
+            destination: None,
+        };
+        RawWorkflow {
+            id: id.to_string(),
+            name: name.to_string(),
+            description: Some("A tiny graph.".to_string()),
+            nodes: vec![
+                node("start", "trigger", "Start", None),
+                node("worker", "agent", "Worker", Some("assistant")),
+                node("done", "output", "Report", None),
+            ],
+            edges: vec![
+                RawEdge {
+                    from: "start".to_string(),
+                    to: "worker".to_string(),
+                    label: None,
+                },
+                RawEdge {
+                    from: "worker".to_string(),
+                    to: "done".to_string(),
+                    label: Some("ok".to_string()),
+                },
+            ],
+        }
+    }
+
+    /// Issue #208: a workflow created at runtime through the real create path
+    /// (console `POST …/workflows` / orchestrator `create_workflow`) is still
+    /// enabled after the runtime is rebuilt on the same home dir — and the
+    /// `enabled_workflow_ids` accessor both REST `list_workflows` and the
+    /// GraphQL `Company.workflows` resolver read still reports it.
+    #[tokio::test]
+    async fn runtime_created_workflow_stays_enabled_across_a_rebuild() {
+        let home_dir = tempfile::Builder::new()
+            .prefix("oc-wf-enabled-")
+            .tempdir()
+            .expect("tempdir");
+        let home = home_dir.path().to_path_buf();
+        let manifest = wf_manifest("[workflows]\nenabled=[\"seeded_pipeline\"]\n");
+        let id = CompanyId::new("acme");
+
+        let runtime = RuntimeBuilder::new(home.clone(), manifest.clone())
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        // The real writer: overlay body + enabled id in one save.
+        crate::company::create_company_workflow(
+            &id,
+            None,
+            runtime.store(),
+            None,
+            wf_draft("daily_digest", "Daily Digest"),
+        )
+        .await
+        .unwrap();
+        let created = runtime.store().load(&id).await.unwrap().unwrap();
+        assert_eq!(
+            created.manifest.workflows.enabled,
+            vec!["seeded_pipeline", "daily_digest"]
+        );
+        drop(runtime);
+
+        // Rebuild from the same seed manifest — the seed knows nothing about
+        // `daily_digest`, so this is exactly the boot that used to lose it.
+        let runtime = RuntimeBuilder::new(home.clone(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let rebuilt = runtime.store().load(&id).await.unwrap().unwrap();
+        assert_eq!(
+            rebuilt.manifest.workflows.enabled,
+            vec!["seeded_pipeline", "daily_digest"],
+            "the rebuild dropped the runtime-enabled workflow"
+        );
+        assert!(
+            rebuilt
+                .overlay_workflows
+                .iter()
+                .any(|w| w.id == "daily_digest"),
+            "the graph body should be untouched by this fix"
+        );
+        // What the REST + GraphQL workflow lists actually read.
+        assert_eq!(
+            runtime.enabled_workflow_ids().await.unwrap(),
+            vec!["seeded_pipeline", "daily_digest"]
+        );
+    }
+
+    /// Issue #208: a record written during the bug era — overlay graph body
+    /// intact, its enabled id already wiped by an earlier restart — is healed
+    /// by the next rebuild, with no migration.
+    #[tokio::test]
+    async fn rebuild_reenables_a_bug_era_orphaned_overlay_body() {
+        let home_dir = tempfile::Builder::new()
+            .prefix("oc-wf-heal-")
+            .tempdir()
+            .expect("tempdir");
+        let home = home_dir.path().to_path_buf();
+        let manifest = wf_manifest("");
+        let id = CompanyId::new("acme");
+
+        let runtime = RuntimeBuilder::new(home.clone(), manifest.clone())
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let store = runtime.store().clone();
+        let mut record = store.load(&id).await.unwrap().unwrap();
+        // Bug-era shape: body present, `enabled` clobbered back to the seed's.
+        record.overlay_workflows.push(OverlayWorkflow {
+            id: "orphaned".to_string(),
+            toml: "id = \"orphaned\"\n".to_string(),
+        });
+        record.manifest.workflows.enabled.clear();
+        store.save(&record).await.unwrap();
+        drop(runtime);
+
+        let runtime = RuntimeBuilder::new(home.clone(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        assert_eq!(
+            runtime.enabled_workflow_ids().await.unwrap(),
+            vec!["orphaned"],
+            "an orphaned bug-era overlay body was not re-enabled"
+        );
+    }
+
+    /// Issue #208: `[workflows].enabled` is the ONLY merged field. A
+    /// seed-authoritative field that diverged on the record — here a
+    /// runtime-granted tool, the case where record-wins would let privilege
+    /// outlive a seed rollback — is overwritten by the seed on rebuild.
+    #[tokio::test]
+    async fn rebuild_keeps_every_other_manifest_field_seed_authoritative() {
+        let home_dir = tempfile::Builder::new()
+            .prefix("oc-wf-seedwins-")
+            .tempdir()
+            .expect("tempdir");
+        let home = home_dir.path().to_path_buf();
+        let manifest = wf_manifest("[tools]\nallow=[\"memory.*\"]\n");
+        let id = CompanyId::new("acme");
+
+        let runtime = RuntimeBuilder::new(home.clone(), manifest.clone())
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let store = runtime.store().clone();
+        let mut record = store.load(&id).await.unwrap().unwrap();
+        record.manifest.tools.allow.push("email.*".to_string());
+        record.manifest.company.name = "Renamed At Runtime".to_string();
+        store.save(&record).await.unwrap();
+        drop(runtime);
+
+        let runtime = RuntimeBuilder::new(home.clone(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let rebuilt = runtime.store().load(&id).await.unwrap().unwrap();
+        assert_eq!(
+            rebuilt.manifest.tools.allow,
+            vec!["memory.*"],
+            "a runtime tool grant survived a seed rollback"
+        );
+        assert_eq!(rebuilt.manifest.company.name, "Acme");
+    }
+
+    /// Issue #208: an enabled id with no surviving graph body — a seed entry
+    /// the operator deleted from `company.toml` — is dropped rather than
+    /// carried forward forever with nothing to run.
+    #[tokio::test]
+    async fn rebuild_drops_an_enabled_id_with_no_body() {
+        let home_dir = tempfile::Builder::new()
+            .prefix("oc-wf-zombie-")
+            .tempdir()
+            .expect("tempdir");
+        let home = home_dir.path().to_path_buf();
+        let id = CompanyId::new("acme");
+
+        // First boot from a seed that enables `retired`.
+        let runtime = RuntimeBuilder::new(
+            home.clone(),
+            wf_manifest("[workflows]\nenabled=[\"retired\"]\n"),
+        )
+        .with_id(id.clone())
+        .build()
+        .await
+        .unwrap();
+        assert_eq!(
+            runtime.enabled_workflow_ids().await.unwrap(),
+            vec!["retired"]
+        );
+        drop(runtime);
+
+        // The operator removes it from the version-controlled seed. No overlay
+        // body was ever written for it, so nothing carries it forward.
+        let runtime = RuntimeBuilder::new(home.clone(), wf_manifest(""))
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        assert!(
+            runtime.enabled_workflow_ids().await.unwrap().is_empty(),
+            "a bodiless enabled id zombied past its removal from the seed"
+        );
+    }
+
     #[test]
     fn effective_grants_no_roster_is_company_allow() {
         let manifest = parse("[company]\nname=\"X\"\n[tools]\nallow=[\"email.*\",\"email.*\"]\n");

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -159,13 +159,18 @@ impl WorkflowScheduler {
     ///
     /// **Why the manifest's `[workflows].enabled` list is not a filter here.**
     /// A trigger `schedule` is itself the operator's explicit "run this on a
-    /// cron" statement, and the enabled list does not survive a restart today
-    /// (a boot rebuild overwrites the persisted record's manifest from the seed
-    /// `company.toml` — issue #208). Filtering on it would mean every scheduled
-    /// workflow silently stopped firing after a restart, which is the exact
-    /// failure this feature exists to prevent. The overlay graph bodies the
-    /// union reads *do* survive a rebuild, so enumeration through them is
-    /// restart-durable.
+    /// cron" statement — a graph that declares one has already said it wants to
+    /// fire, so re-asking the enabled list adds a second switch for the same
+    /// decision and a way to half-configure it. Enumeration therefore runs over
+    /// the union of seed files and overlay graph bodies, both of which survive a
+    /// rebuild.
+    ///
+    /// (An earlier version of this doc rested the argument partly on the enabled
+    /// list not surviving a restart. That was true — a boot rebuild re-seeded the
+    /// record's manifest from `company.toml` — but issue #208 fixed it: the
+    /// rebuild now merges runtime-enabled ids forward. Gating the scheduler on
+    /// `enabled` is a live design option again; it is deliberately not taken
+    /// here, on the argument above.)
     pub async fn tick(&mut self) -> usize {
         let now = self.clock.now_millis();
         let minute = now / MINUTE_MS;

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -687,11 +687,17 @@ async fn workflows_resolve_from_the_record_overlay_with_no_source_dir() {
 }
 
 /// Issue #168: a runtime-authored workflow with an **empty** manifest
-/// `[workflows].enabled` — the post-restart state on the fs backend, since the
-/// boot rebuild overwrites the record's manifest with the seed manifest — must
-/// still appear in `Company.workflows`. The resolver used to drive its id set
-/// off the enabled list alone, so this returned `[]` while `Company.workflow`
-/// happily returned the full graph.
+/// `[workflows].enabled` must still appear in `Company.workflows`. The resolver
+/// used to drive its id set off the enabled list alone, so this returned `[]`
+/// while `Company.workflow` happily returned the full graph.
+///
+/// This used to be the ordinary post-restart state on the fs backend, because a
+/// boot rebuild overwrote the record's manifest from the seed. Issue #208 fixed
+/// that — a rebuild now merges surviving overlay ids back into `enabled` — so
+/// the state is written here *after* the build instead. The resolver's guarantee
+/// is unchanged and still worth pinning: it enumerates graph bodies on their own
+/// evidence, whatever put the record in this shape (a hand-edited record, a
+/// store written by an older build, a future writer that adds a body first).
 ///
 /// Also pins REST/GraphQL agreement: both surfaces must report the same id set.
 #[tokio::test]
@@ -702,6 +708,22 @@ async fn workflows_summary_lists_an_overlay_workflow_with_no_enabled_entry() {
     // Nothing enabled in the manifest — the graph body is the only evidence.
     let manifest: CompanyManifest =
         toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n").unwrap();
+
+    let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest.clone())
+        .with_id(id.clone())
+        .build()
+        .await
+        .unwrap();
+    assert!(
+        runtime.source_dir().is_none(),
+        "no source dir in hosted mode"
+    );
+
+    // Write the enabled-less record AFTER the build. Since issue #208 a boot
+    // rebuild merges surviving overlay ids back into `[workflows].enabled`, so
+    // seeding this state before the build would be healed away — and this test
+    // is about the *resolver*, which must enumerate overlay bodies on their own
+    // evidence no matter how the record got into this shape.
     let store = FsCompanyStore::new(home.to_path_buf());
     store
         .save(&CompanyRecord {
@@ -724,15 +746,6 @@ async fn workflows_summary_lists_an_overlay_workflow_with_no_enabled_entry() {
         .await
         .unwrap();
 
-    let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
-        .with_id(id.clone())
-        .build()
-        .await
-        .unwrap();
-    assert!(
-        runtime.source_dir().is_none(),
-        "no source dir in hosted mode"
-    );
     let state = AppState::new(AppConfig::default()).with_home(home.to_path_buf());
     state.registry().insert(id, Arc::new(runtime));
     crate::server::test_support::seed_fixed_admin(&state, "acme").await;

--- a/src/server/graphql/workflows.rs
+++ b/src/server/graphql/workflows.rs
@@ -190,11 +190,16 @@ async fn overlays(runtime: &Arc<CompanyRuntime>) -> async_graphql::Result<Vec<Ov
 ///
 /// Driving this off the manifest's enabled list alone — as it used to — made a
 /// runtime-authored workflow invisible here while `Company.workflow(id)`
-/// returned its full graph. That gap is not hypothetical: the boot rebuild
-/// overwrites the persisted record's manifest with the seed manifest
-/// (`RuntimeBuilder`), so a runtime-added enabled id is gone after a restart and
-/// the graph body on the record is the only surviving evidence the workflow
-/// exists.
+/// returned its full graph. That gap was not hypothetical: a boot rebuild used
+/// to overwrite the persisted record's manifest from the seed
+/// (`RuntimeBuilder`), so a runtime-added enabled id was gone after a restart
+/// and the graph body was the only surviving evidence the workflow existed.
+///
+/// Issue #208 closed that hole at the source — a rebuild now merges surviving
+/// overlay ids back into `[workflows].enabled`, so `enabled` reads `true` again
+/// after a restart. Enumerating from bodies stays the right shape regardless:
+/// it is what keeps this resolver and the REST picker agreeing on the id set
+/// whatever put a record in a body-without-enabled-entry state.
 pub(crate) async fn resolve_summaries(
     _ctx: &Context<'_>,
     runtime: &Arc<CompanyRuntime>,


### PR DESCRIPTION
## Summary

Closes #208.

`RuntimeBuilder::build` carefully carries a persisted record forward across a
rebuild — lifecycle, ledger, all five overlays, template provenance — and then
rebuilds both `CompanyRecord`s with `manifest: self.manifest.clone()`, the
manifest freshly parsed from the seed `company.toml`. `[workflows].enabled` is
the one manifest field a runtime write mutates: `create_company_workflow` pushes
the new id onto it in the *same store save* that writes the graph body into
`overlay_workflows`. So every boot clobbered it, leaving an orphaned graph body
whose enablement was gone.

The store layer was never at fault (`FsCompanyStore` round-trips the manifest
faithfully); this was builder policy. The fix folds a merged enabled list into
`self.manifest` once, right after the record load, so both record sites inherit
it through their existing clones — including the `openhuman`-gated harness
record, which CI never compiles. Mutating the source once keeps the two records
in agreement by construction rather than by a duplicated line only one build
type-checks.

### Field authority on a rebuild

The merge raises the general question, so here is the answer in full. Every
manifest field is **seed-authoritative** except one:

| Field | Rebuild policy | Why |
|---|---|---|
| `[workflows].enabled` | **merge** (seed ∪ surviving overlay ids) | The only field a runtime write mutates, and the write that mutates it also writes an overlay body — durable evidence of the same decision. |
| `[tools]` | seed wins | **Security.** Record-wins would let a runtime-granted tool outlive a seed rollback — privilege persisting after the operator revoked it in version control. |
| `[policy]` | seed wins | **Security.** Same argument: a relaxed approval mode must not survive being reverted in `company.toml`. |
| `[[agent]]` | seed wins | Runtime roster additions have their own home by design — `overlay_agents`. |
| `[[group_chat]]` | seed wins | Runtime desks go to `overlay_desks` / `overlay_desk_members` / `overlay_desk_order`. |
| `[users]` | seed wins | The manifest is the root of trust for standing admin invites. |
| `[mcp_servers]` | seed wins | Console MCP writes go to the runtime index + `SecretStore`, never the manifest. |
| `[company]`, `[brain]`, `[inference]`, `[channels]`, `[place]`, `[budget]`, `[plan]`, `[schedules]`, `[connections]` | seed wins | No runtime writer touches them; the seed file is the definition. |

The pattern the table encodes: **a runtime write that must persist gets its own
overlay field, not a manifest mutation.** `[workflows].enabled` is the one place
that convention was broken, and the merge makes it behave like the rest without
reshaping `CompanyRecord`.

### Why the merge does not read the record's own `enabled` list

`merge_enabled_workflows(seed_enabled, overlays)` takes the seed ids and the
overlay **bodies** — deliberately not the persisted record's `enabled` list.
Overlay presence *is* the runtime-enablement invariant, since create writes both
halves in one save. Deriving from bodies buys two things the old list cannot:

- **Self-healing.** Every record written during the bug era has a surviving body
  whose enabled id a past restart already wiped. The next boot re-enables it,
  with no migration. Verified live below.
- **No zombies.** An enabled id with no body — a seed entry the operator deleted
  from `company.toml` — is dropped rather than carried forward forever with
  nothing to run.

Seed-removed ids are dropped on purpose: the version-controlled file stays
authoritative for seed-authored entries.

### Deliberately out of scope

- **Making the workflow scheduler filter on `enabled`.** Its doc cited #208's
  non-survival as one reason not to; that reason is now false, so the doc is
  rewritten to rest on the argument that still holds (a trigger `schedule` is
  itself the operator's explicit statement). Behavior unchanged — gating the
  scheduler is a separate design decision.
- **Moving enablement off the manifest into a record overlay field.**
  Architecturally cleaner, but it reshapes `CompanyRecord` across all three
  backends + conformance + every consumer, needs a data migration, and reverses
  shape decisions #226 just landed. This merge does not foreclose it.
- **Any store-backend or conformance change.** Save/load semantics are untouched.

### Related and coordination

Builds on #168 (`overlay_workflows`, the durable graph bodies this merge derives
from) and #226 (which set the current `CompanyRecord` shape this change
deliberately does not disturb). No file overlap with #250. #252 sweeps test-mod
temp helpers across `builder.rs`; the new tests here use `tempfile::TempDir` to
match that sweep's pattern and sit outside the line ranges it touches, so the
merge should be additive either way it lands.

## API Or Behavior Changes

- **Behavior**: after a restart, a workflow created at runtime is still listed in
  the record's `[workflows].enabled`, so GraphQL `Company.workflows[].enabled`
  reads `true` where it read `false`, and `enabled_workflow_ids()` reports it.
- **No shape changes.** `CompanyRecord` is untouched, as are the three store
  backends, the conformance suite, the GraphQL/REST resolvers and the frontend.
  `enabled_workflow_ids()`, the `Company.workflows` resolver and the REST picker
  all read the record fresh from the store, so they pick the surviving ids up
  automatically.
- **Scope note on operator visibility**: the console's workflow *list* was
  already restart-durable — #168 made both read surfaces enumerate overlay graph
  bodies, so the workflow itself never vanished from the picker. What was lost was
  the enablement flag and the manifest field, which is what
  `Company.workflows[].enabled` reports and what any future consumer — including
  a scheduler that decides to gate on it — would read.

## Tests

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo build --all-targets` — clean.
- [x] `cargo test` — `985 passed; 0 failed; 1 ignored`.

Two extra gates run locally beyond the checklist:

- `cargo check --features openhuman,mcp,telegram` — clean. **CI does not build
  this combination**, and one of the two `CompanyRecord` construction sites this
  fix corrects (the harness brain's in-memory record) is behind
  `#[cfg(feature = "openhuman")]`, so local is the only signal there. Also ran
  `cargo check --all-targets` under the same feature set so the new tests
  type-check in the gated build.
- `cargo check --all-features` — clean.

Pre-existing warnings under the gated feature sets (`dead_code` on
`toolkit_allowed` / `slug_toolkit` in `harness/composio.rs`, plus unused imports
in `vendor/openhuman`) are untouched here — #250 is fixing those.

### New tests

Five unit tests on `merge_enabled_workflows`: overlay-only id appended, id in
both lists deduped at its seed position, first boot leaves the seed unchanged,
order preserved with within-list dedup, empty case.

Four two-build integration tests over one home dir, following the
`template_provenance_stamped_at_launch_and_carried_forward` pattern:

- **regression** — a workflow created through the *real* `create_company_workflow`
  path survives a rebuild and is reported by `enabled_workflow_ids()`;
- **healing** — a bug-era record (overlay body intact, `enabled` already wiped)
  is re-enabled on the next boot;
- **seed authority** — a record whose `[tools].allow` gained a runtime grant and
  whose `[company].name` diverged is overwritten by the seed on rebuild;
- **no zombie** — an enabled id with no surviving body is dropped.

### One existing test changed

`server::graphql::test::workflows_summary_lists_an_overlay_workflow_with_no_enabled_entry`
seeded a record with an overlay body and an empty `enabled`, built a runtime over
it, and asserted `enabled == false`. That state is exactly what the fix now
heals, so the test was asserting the bug. Its actual subject is the **resolver** —
`Company.workflows` must enumerate graph bodies on their own evidence rather than
off the enabled list, and REST must agree on the id set. That guarantee is
unchanged, so the record is now written *after* the build instead of before; the
assertions themselves are untouched.

### Manual verification — both surfaces, on this branch

Ran `opencompany serve --company companies/e2e_harness` on a loopback bind,
authenticated through the real magic-link flow, and created a workflow through
the console's `POST …/workflows` route.

1. **After create**: record manifest `enabled = ["restart_probe"]`; REST
   `list_workflows` and GraphQL both report it.
2. **After restart (this branch)**: `enabled = ["restart_probe"]` survives;
   GraphQL reports `enabled: true`.
3. **Differential**: temporarily removed only the merge assignment, rebuilt, and
   restarted over the same data dir — `enabled = []`, GraphQL `enabled: false`.
   The bug, reproduced on demand.
4. **Healing, live**: restored the merge, rebuilt, restarted over that now-wiped
   record — `enabled = ["restart_probe"]` again, GraphQL back to `true`, no
   migration step.
5. **Console UI**: loaded the operator console against the restarted host and
   opened the Workflows view — the workflow is present with its graph rendered
   (`Start → Worker (Agent: ceo) → Report`).

## Documentation

- `docs/spec/runtime/ports.md` — replaced the claim that "the record's manifest
  is re-seeded on a boot rebuild" with the actual contract, including the security
  reason `[tools]` and `[policy]` must stay seed-authoritative.
- `src/runtime/builder.rs` — the save-site comment said a rebuild never rewrites
  the manifest. True of the *file* on disk, never true of the *record*; restated,
  and `merge_enabled_workflows` carries the field-authority rationale in its doc
  comment.
- `src/runtime/workflow_scheduler.rs` — the `tick` doc's "why `enabled` is not a
  filter" rationale partly rested on the enabled list not surviving a restart.
  Rewritten; behavior unchanged.
- `src/server/graphql/workflows.rs` — `resolve_summaries` cited the same loss as
  live justification. Restated as history; the body-first enumeration keeps its
  standing reason.
