### PR TITLE
fix(runtime): bind the cycle test home through TempDir::path

### DIFF
--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1945,7 +1945,8 @@ mod test {
     /// about the recipient, not what the policy did with that belief.
     #[tokio::test]
     async fn established_recipient_past_the_old_page_cap_is_not_first_time() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let sender = Arc::new(RecordingMailSender::new());
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .with_mail(CompanyMail {


### PR DESCRIPTION
## Summary

`main` does not compile under `--features openhuman`. One-line fix to the test that broke.

## Problem

Two PRs merged in sequence, each green on its own:

- **#252** (`db0f271`) changed `tmp_home()` in `src/runtime/cycle.rs` to return a `tempfile::TempDir` instead of a `PathBuf`, and updated every call site to bind through `home_dir.path().to_path_buf()`.
- **#249** (`c4fe3fb`) added `established_recipient_past_the_old_page_cap_is_not_first_time`, written against the old signature, binding `tmp_home()` straight to `home` and calling `home.clone()`.

Neither PR contained the break. Their union does:

```
error[E0599]: no method named `clone` found for struct `TempDir` in the current scope
    --> src/runtime/cycle.rs:1950:43
```

`cargo build --features openhuman,tinycortex --all-targets` fails; `cargo build` (default features) passes, because `src/runtime/cycle.rs`'s test module is only compiled under `openhuman`.

## Solution

Bind through `home_dir.path().to_path_buf()`, matching the pattern #252 established at all ~20 other call sites in the module. No behaviour change — the test's subject is the send path's `first_time_counterparty` flag, and every assertion is untouched.

## Submission Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --features openhuman --all-targets` — compiles clean (2 pre-existing `dead_code` warnings in `harness/composio.rs`, fixed separately by #250)
- [x] The affected test runs and passes: `runtime::cycle::test::established_recipient_past_the_old_page_cap_is_not_first_time ... ok`
- [ ] N/A: no new tests — this restores an existing test to compiling
- [ ] N/A: no documentation change — test-only, no public API affected

## Impact

Unblocks `main`. Also unblocks #250, whose new gated CI job builds the PR merge commit and therefore cannot go green while `main` is broken.

Test-only change. Nothing outside `#[cfg(test)]` is touched.

## Related

This is exactly the failure class #202 exists to catch, and it was found by #202's own job on its first real run — a break invisible to the default `Rust` check because the code is behind `openhuman`, which CI does not compile today. Two independently-green PRs producing a broken union is the recurring shape here; see also the union-build note in #250.

Related: #202, #249, #252, #250


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test cleanup and temporary-directory handling for more reliable runtime test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->