### PR TITLE
feat(workflows): park a cold email recipient for approval instead of dropping the report (#227)

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -86,8 +86,16 @@ export interface WorkflowGraph {
   edges: WorkflowEdge[];
 }
 
-/** What became of one attempt to deliver an output node's report. */
-export type DeliveryStatus = "sent" | "skipped" | "denied" | "failed";
+/**
+ * What became of one attempt to deliver an output node's report.
+ *
+ * `pending` means the send was parked for operator approval (a cold email
+ * recipient a workflow may not open a conversation with on its own). It is a
+ * SNAPSHOT taken when the run finished: runs are not persisted, so nothing ever
+ * comes back to flip the row to `sent`. The Approvals view is the live source of
+ * truth — approving there actually sends the mail.
+ */
+export type DeliveryStatus = "sent" | "pending" | "skipped" | "denied" | "failed";
 
 /**
  * One attempt to route a reached `output` node's report to its destination.

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -448,9 +448,11 @@ function describeDestination(destination: NonNullable<WorkflowNodeModel["destina
 
 /** Badge styling per delivery outcome. A report that did NOT go out must not
  * look like one that did — `denied` and `failed` are the two an operator has to
- * act on, so they get the loud treatment. */
+ * act on, so they get the loud treatment. `pending` is neither: the report is
+ * waiting in Approvals, so it reads as informational, not as a failure. */
 const DELIVERY_TONE: Record<DeliveryStatus, string> = {
   sent: "border-emerald-500/40 bg-emerald-500/10",
+  pending: "border-sky-500/40 bg-sky-500/10",
   skipped: "border-amber-500/40 bg-amber-500/10",
   denied: "border-red-500/40 bg-red-500/10",
   failed: "border-red-500/40 bg-red-500/10",
@@ -460,11 +462,22 @@ const DELIVERY_TONE: Record<DeliveryStatus, string> = {
  * output node's report. This is the ONLY place an operator learns a report
  * didn't leave the building — a delivery failure never fails the run. */
 function DeliveryRows({ deliveries }: { deliveries: DeliveryReport[] }) {
-  const undelivered = deliveries.filter((d) => d.status !== "sent").length;
+  // Two counters, not one. A parked report is waiting on the operator, not
+  // broken — badging it red alongside a transport failure would send them
+  // hunting for a bug when the fix is a click in Approvals.
+  const pending = deliveries.filter((d) => d.status === "pending").length;
+  const undelivered = deliveries.filter(
+    (d) => d.status !== "sent" && d.status !== "pending",
+  ).length;
   return (
     <div className="mb-3 space-y-1.5 rounded-lg border bg-background/40 p-2">
       <div className="flex items-center gap-2">
         <span className="text-xs font-medium">Report delivery</span>
+        {pending > 0 && (
+          <Badge variant="outline" className="h-4 px-1.5 text-[10px] font-normal border-sky-500/40 bg-sky-500/10">
+            {pending} awaiting approval
+          </Badge>
+        )}
         {undelivered > 0 && (
           <Badge variant="outline" className="h-4 px-1.5 text-[10px] font-normal border-red-500/40 bg-red-500/10">
             {undelivered} not delivered
@@ -523,13 +536,21 @@ function RunResultPanel({
     [result.output, graph],
   );
   const deliveries = result.deliveries ?? [];
-  const undeliveredCount = deliveries.filter((d) => d.status !== "sent").length;
+  const pendingDeliveryCount = deliveries.filter((d) => d.status === "pending").length;
+  const undeliveredCount = deliveries.filter(
+    (d) => d.status !== "sent" && d.status !== "pending",
+  ).length;
 
   return (
     <div className="border-t bg-card/60">
       <div className="flex items-center justify-between px-4 py-2">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium">Run result</span>
+          {pendingDeliveryCount > 0 && (
+            <Badge variant="outline" className="border-sky-500/40 bg-sky-500/10">
+              {pendingDeliveryCount} report{pendingDeliveryCount === 1 ? "" : "s"} awaiting approval
+            </Badge>
+          )}
           {undeliveredCount > 0 && (
             <Badge variant="outline" className="border-red-500/40 bg-red-500/10">
               {undeliveredCount} report{undeliveredCount === 1 ? "" : "s"} not delivered

--- a/src/ports/workflow_runner.rs
+++ b/src/ports/workflow_runner.rs
@@ -48,9 +48,22 @@ pub struct WorkflowRun {
 pub enum DeliveryStatus {
     /// The transport accepted the report.
     Sent,
-    /// Deliberately not attempted — a policy precondition was unmet (a cold
-    /// email recipient, no mailbox configured). Not an error; the report simply
-    /// was not owed to that address under the current rules.
+    /// Parked for operator approval and not sent — the destination needs a
+    /// human verdict before anything leaves the process (a cold email
+    /// recipient, which a workflow may not cold-open by itself).
+    ///
+    /// **This row is a snapshot taken at run time, not a live status.** A
+    /// workflow run is not persisted, so nothing ever comes back to flip this
+    /// row to `Sent` once the operator approves. The approvals queue is the
+    /// live source of truth: the parked effect is journal-backed, survives a
+    /// restart, and executes on approval through the same path an agent's
+    /// `email.send` does. Read this row as "an approval was opened for this",
+    /// then look at Approvals for what became of it.
+    Pending,
+    /// Deliberately not attempted — a policy precondition was unmet (no mailbox
+    /// configured, or a cold recipient on a runtime that cannot park). Not an
+    /// error; the report simply was not owed to that address under the current
+    /// rules.
     Skipped,
     /// Refused by policy: the company does not grant what the destination needs.
     Denied,

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -794,6 +794,31 @@ impl RuntimeBuilder {
             }
         };
 
+        // Boot replay: load the journal and rehydrate parked approvals into the
+        // gate so approvals survive a restart with their original ids.
+        //
+        // **Constructed here, above the brain, on purpose (issue #227).** These
+        // two used to be built after the brain, just before `CompanyRuntime::new`
+        // — which put them out of reach of the `HarnessDeps` built inside the
+        // brain arm, and that is precisely why workflow delivery could not park
+        // a cold email recipient the way the agent path does. The block depends
+        // on nothing but `home`, `id`, `self.approvals` and
+        // `self.manifest.policy`, none of which the code it used to sit below
+        // produces or mutates, so hoisting it is a pure move. The same two
+        // `Arc`s go to the delivery deps and to the runtime — one gate, one
+        // journal, one approvals queue.
+        let journal = Arc::new(RuntimeJournal::new(
+            Bundle::new(home.clone(), &id).journal_jsonl(),
+        ));
+        journal.load().await?;
+
+        let gate = self
+            .approvals
+            .unwrap_or_else(|| Arc::new(ManifestApprovalGate::new(self.manifest.policy.clone())));
+        for pending in journal.pending() {
+            gate.rehydrate(pending.id, pending.effect, pending.at_millis);
+        }
+
         // Brain selection, in precedence order:
         //   1. an explicit brain (test injection) always wins;
         //   2. under the `openhuman` feature, an attached harness pool + a
@@ -1224,20 +1249,6 @@ impl RuntimeBuilder {
                 template_provenance,
             })
             .await?;
-
-        // Boot replay: load the journal and rehydrate parked approvals into the
-        // gate so approvals survive a restart with their original ids.
-        let journal = Arc::new(RuntimeJournal::new(
-            Bundle::new(home.clone(), &id).journal_jsonl(),
-        ));
-        journal.load().await?;
-
-        let gate = self
-            .approvals
-            .unwrap_or_else(|| Arc::new(ManifestApprovalGate::new(self.manifest.policy.clone())));
-        for pending in journal.pending() {
-            gate.rehydrate(pending.id, pending.effect, pending.at_millis);
-        }
 
         // Economy: an injected economy wins; otherwise the `tinyplace` feature
         // auto-wires one for a discoverable company with a handle. Going-public

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1121,6 +1121,17 @@ impl RuntimeBuilder {
                                     inbox: inbox.clone(),
                                     users: ops.users.clone(),
                                     channels: channels.clone(),
+                                    // Issue #227: the same gate and journal the
+                                    // runtime gets below — one approvals queue,
+                                    // so a report parked by a workflow lands in
+                                    // the operator's list beside one parked by
+                                    // an agent, and rehydrates on restart with
+                                    // its original id. Both halves or neither,
+                                    // by construction.
+                                    parking: Some(crate::workflows::DeliveryParking {
+                                        approvals: gate.clone(),
+                                        journal: journal.clone(),
+                                    }),
                                 }),
                             };
                             let record = CompanyRecord {

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1773,7 +1773,8 @@ mod test {
     /// deciding to park. It was parked directly, exactly as delivery parks it.
     #[tokio::test]
     async fn a_directly_parked_email_send_is_mailed_when_approved() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let sender = Arc::new(RecordingMailSender::new());
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .with_mail(CompanyMail {
@@ -1836,7 +1837,8 @@ mod test {
     /// queue. A parked report must not leak out on a refusal.
     #[tokio::test]
     async fn a_directly_parked_email_send_is_not_mailed_when_denied() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let sender = Arc::new(RecordingMailSender::new());
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .with_mail(CompanyMail {
@@ -1888,7 +1890,8 @@ mod test {
     /// `pending` row honest even though the run itself is not persisted.
     #[tokio::test]
     async fn a_parked_email_send_survives_a_restart_and_still_sends() {
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let effect = Effect {
             kind: EMAIL_SEND_KIND.into(),
             group: EffectGroup::Send,

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1758,6 +1758,188 @@ mod test {
         assert!(inbox.iter().any(|r| r.outbound && r.subject == "Hi"));
     }
 
+    /// **The acceptance bar for issue #227.** Parking a cold recipient's report
+    /// is only worth doing if approving it actually sends the mail — otherwise
+    /// `pending` is a nicer-looking way to drop the report.
+    ///
+    /// This parks an `email.send` effect the way
+    /// [`crate::workflows::delivery`] does — straight onto the gate + journal,
+    /// with no cycle running and no brain involved — then resolves it the way
+    /// the HTTP handler does. The mail must go out and leave the outbound audit
+    /// record, through `resolve_approval` → `execute_effect_once` →
+    /// `perform_effect` → `send_company_email`.
+    ///
+    /// Policy mode is `full` on purpose: nothing here relies on the gate
+    /// deciding to park. It was parked directly, exactly as delivery parks it.
+    #[tokio::test]
+    async fn a_directly_parked_email_send_is_mailed_when_approved() {
+        let home = tmp_home();
+        let sender = Arc::new(RecordingMailSender::new());
+        let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
+            .with_mail(CompanyMail {
+                sender: sender.clone(),
+                smtp: test_smtp("ceo@acme.test"),
+            })
+            .build()
+            .await
+            .unwrap();
+
+        // What `park_cold_recipient` builds, field for field.
+        let effect = Effect {
+            kind: EMAIL_SEND_KIND.into(),
+            group: EffectGroup::Send,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: true,
+            payload: serde_json::json!({
+                "to": "stranger@ext.com",
+                "subject": "[Acme] Report flow — Owner summary",
+                "body": "Q3 is up 12%.",
+            }),
+        };
+        let approval_id = rt.approvals.park(rt.id(), effect.clone()).await.unwrap();
+        rt.journal
+            .record_parked(&approval_id, &effect, now_millis())
+            .await
+            .unwrap();
+
+        // It reaches the operator's queue — the same list a workflow's park
+        // shows up in, since it is the same journal.
+        assert_eq!(rt.pending_approvals().len(), 1);
+        assert_eq!(rt.pending_approvals()[0].kind, EMAIL_SEND_KIND);
+        assert!(sender.sent().is_empty(), "parked means not yet sent");
+
+        rt.resolve_approval(&approval_id, Verdict::Approve, operator())
+            .await
+            .unwrap();
+
+        // Approving SENDS.
+        assert_eq!(sender.sent().len(), 1, "approving must mail the report");
+        assert_eq!(sender.sent()[0].1.to, "stranger@ext.com");
+        assert!(sender.sent()[0].1.body.contains("Q3 is up 12%."));
+        // From the company's own address, never anything the payload named.
+        assert_eq!(sender.sent()[0].0, "ceo@acme.test");
+        // …and leaves the outbound audit record, which also makes the recipient
+        // an established thread for next time.
+        let inbox = rt.inbox().messages(rt.id(), "ceo", 10, 0).await.unwrap();
+        assert!(
+            inbox
+                .iter()
+                .any(|r| r.outbound && r.subject.contains("Owner summary")),
+            "{inbox:?}"
+        );
+        assert!(rt.pending_approvals().is_empty(), "the queue drains");
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    /// The other half of the same bar: DENYING sends nothing and drains the
+    /// queue. A parked report must not leak out on a refusal.
+    #[tokio::test]
+    async fn a_directly_parked_email_send_is_not_mailed_when_denied() {
+        let home = tmp_home();
+        let sender = Arc::new(RecordingMailSender::new());
+        let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
+            .with_mail(CompanyMail {
+                sender: sender.clone(),
+                smtp: test_smtp("ceo@acme.test"),
+            })
+            .build()
+            .await
+            .unwrap();
+
+        let effect = Effect {
+            kind: EMAIL_SEND_KIND.into(),
+            group: EffectGroup::Send,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: true,
+            payload: serde_json::json!({
+                "to": "stranger@ext.com",
+                "subject": "[Acme] Report flow — Owner summary",
+                "body": "Q3 is up 12%.",
+            }),
+        };
+        let approval_id = rt.approvals.park(rt.id(), effect.clone()).await.unwrap();
+        rt.journal
+            .record_parked(&approval_id, &effect, now_millis())
+            .await
+            .unwrap();
+
+        rt.resolve_approval(&approval_id, Verdict::Deny, operator())
+            .await
+            .unwrap();
+
+        assert!(sender.sent().is_empty(), "a denied report must not go out");
+        assert!(
+            rt.inbox()
+                .messages(rt.id(), "ceo", 10, 0)
+                .await
+                .unwrap()
+                .iter()
+                .all(|r| !r.outbound),
+            "nothing was sent, so there is no outbound record"
+        );
+        assert!(rt.pending_approvals().is_empty());
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
+    /// **Restart durability.** A parked report survives a process restart with
+    /// its original id and still sends on approval — the property that makes a
+    /// `pending` row honest even though the run itself is not persisted.
+    #[tokio::test]
+    async fn a_parked_email_send_survives_a_restart_and_still_sends() {
+        let home = tmp_home();
+        let effect = Effect {
+            kind: EMAIL_SEND_KIND.into(),
+            group: EffectGroup::Send,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: true,
+            payload: serde_json::json!({
+                "to": "stranger@ext.com",
+                "subject": "[Acme] Report flow — Owner summary",
+                "body": "Q3 is up 12%.",
+            }),
+        };
+        let approval_id = {
+            let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
+                .build()
+                .await
+                .unwrap();
+            let id = rt.approvals.park(rt.id(), effect.clone()).await.unwrap();
+            rt.journal
+                .record_parked(&id, &effect, now_millis())
+                .await
+                .unwrap();
+            id
+        };
+
+        // Fresh runtime over the same home: boot replay rehydrates the card.
+        let sender = Arc::new(RecordingMailSender::new());
+        let rt2 = RuntimeBuilder::new(home.clone(), manifest("full"))
+            .with_mail(CompanyMail {
+                sender: sender.clone(),
+                smtp: test_smtp("ceo@acme.test"),
+            })
+            .build()
+            .await
+            .unwrap();
+        let pending = rt2.pending_approvals();
+        assert_eq!(pending.len(), 1, "{pending:?}");
+        assert_eq!(pending[0].id, approval_id, "the ORIGINAL id, not a new one");
+
+        rt2.resolve_approval(&approval_id, Verdict::Approve, operator())
+            .await
+            .unwrap();
+        assert_eq!(
+            sender.sent().len(),
+            1,
+            "a card approved after a restart must still mail"
+        );
+        assert_eq!(sender.sent()[0].1.to, "stranger@ext.com");
+        tokio::fs::remove_dir_all(&home).await.ok();
+    }
+
     #[tokio::test]
     async fn email_send_effect_without_mail_errors() {
         let home_dir = tmp_home();

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -48,9 +48,14 @@ use crate::server::ops::mailer::{MailCredentials, OutboundEmail};
 const HISTORY_LIMIT: usize = 32;
 
 /// The `Effect::kind` for an outbound email send. Shared between where the
-/// effect is built (`CycleHostImpl::send_email`) and where it is executed
-/// (`perform_effect`) so the two can't drift apart.
-const EMAIL_SEND_KIND: &str = "email.send";
+/// effect is built (`CycleHostImpl::send_email`, and the workflow delivery path
+/// in [`crate::workflows::delivery`]) and where it is executed
+/// (`perform_effect`) so they can't drift apart.
+///
+/// `pub(crate)` because delivery parks an effect this same executor has to
+/// recognise on approval: a duplicated `"email.send"` literal over there would
+/// park cards that silently do nothing when approved.
+pub(crate) const EMAIL_SEND_KIND: &str = "email.send";
 
 /// Drives cycles for one [`CompanyRuntime`].
 pub struct CycleRunner<'a> {

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -70,9 +70,15 @@ type WorkflowKey = (CompanyId, String);
 /// How a scheduled run's report deliveries came out, folded for one log line.
 ///
 /// A count per status rather than a bare total: `skipped` and `denied` mean
-/// policy refused to send (a cold recipient, a missing `email` grant) while
-/// `failed` means something broke, and an operator reading a scheduled run's
-/// outcome needs to tell those apart before deciding whether to act.
+/// policy refused to send (a missing `email` grant, no mailbox) while `failed`
+/// means something broke, and an operator reading a scheduled run's outcome
+/// needs to tell those apart before deciding whether to act.
+///
+/// `pending` is the fourth thing entirely, and the reason this line matters
+/// most on the scheduled path: the report is not lost and nothing is broken —
+/// it is sitting in the approvals queue waiting for a human. A scheduled run
+/// is exactly the nobody-is-watching case, so without this count an operator
+/// would have no signal that a card is waiting for them.
 #[derive(Debug, Default, PartialEq, Eq)]
 struct DeliveryCounts {
     sent: usize,
@@ -97,7 +103,12 @@ impl DeliveryCounts {
         counts
     }
 
-    /// Reports that did NOT reach their destination, whatever the reason.
+    /// Reports that did NOT reach their destination **and never will without a
+    /// change** — the number worth alerting on.
+    ///
+    /// `pending` is deliberately excluded: it is awaiting a verdict, not a fix,
+    /// and folding it in here would page someone for a queue that is working as
+    /// designed. It gets its own count on the summary line.
     fn undelivered(&self) -> usize {
         self.skipped + self.denied + self.failed
     }
@@ -315,6 +326,23 @@ impl WorkflowScheduler {
                                 if report.status == DeliveryStatus::Sent {
                                     continue;
                                 }
+                                // A parked report is not a failure and must not
+                                // be logged as one — it is a card waiting in
+                                // the approvals queue. Say where to go, at
+                                // info, and move on.
+                                if report.status == DeliveryStatus::Pending {
+                                    tracing::info!(
+                                        %company,
+                                        workflow = %workflow_id,
+                                        node = %report.node,
+                                        kind = %report.kind,
+                                        // Same reason as the warn below: never
+                                        // the recipient's address in a host log.
+                                        target_configured = report.target.is_some(),
+                                        "workflow scheduler: a scheduled run's report is parked for operator approval — see the Approvals view"
+                                    );
+                                    continue;
+                                }
                                 tracing::warn!(
                                     %company,
                                     workflow = %workflow_id,
@@ -337,6 +365,9 @@ impl WorkflowScheduler {
                                 workflow = %workflow_id,
                                 pending_approvals = run.pending_approvals.len(),
                                 sent = counts.sent,
+                                // Awaiting a human, not a fix — counted apart
+                                // from `undelivered` for exactly that reason.
+                                pending_approval = counts.pending,
                                 skipped = counts.skipped,
                                 denied = counts.denied,
                                 failed = counts.failed,
@@ -926,24 +957,28 @@ to = "done"
     /// The fold behind the summary line counts each status separately, because
     /// "policy refused to send" and "something broke" are different problems.
     #[test]
-    fn delivery_counts_separate_the_four_outcomes() {
+    fn delivery_counts_separate_the_five_outcomes() {
         let counts = DeliveryCounts::of(&[
             report("a", DeliveryStatus::Sent, ""),
             report("b", DeliveryStatus::Sent, ""),
             report("c", DeliveryStatus::Skipped, ""),
             report("d", DeliveryStatus::Denied, ""),
             report("e", DeliveryStatus::Failed, ""),
+            report("f", DeliveryStatus::Pending, ""),
         ]);
         assert_eq!(
             counts,
             DeliveryCounts {
                 sent: 2,
-                pending: 0,
+                pending: 1,
                 skipped: 1,
                 denied: 1,
                 failed: 1,
             }
         );
+        // A parked report awaits a verdict, not a fix: it must NOT inflate the
+        // number an operator alerts on, or a working approvals queue would page
+        // someone every scheduled minute.
         assert_eq!(counts.undelivered(), 3);
         // The common case: nothing routed anywhere.
         assert_eq!(DeliveryCounts::of(&[]), DeliveryCounts::default());
@@ -1034,7 +1069,69 @@ to = "done"
         assert!(summary.contains("skipped=1"), "{summary}");
         assert!(summary.contains("denied=0"), "{summary}");
         assert!(summary.contains("failed=0"), "{summary}");
+        assert!(summary.contains("pending_approval=0"), "{summary}");
         assert!(summary.contains("undelivered=1"), "{summary}");
+    }
+
+    /// Issue #227: a scheduled run whose report was parked for approval is the
+    /// nobody-is-watching case squared — there is no drawer AND the operator
+    /// has to be told a card is waiting for them. It must be said, but not as a
+    /// failure: no `was NOT delivered` warning, and it must not inflate the
+    /// `undelivered` number an alert keys on.
+    #[tokio::test]
+    async fn a_scheduled_run_reports_a_parked_report_without_crying_wolf() {
+        let sink = captured_logs();
+        let home = tmp_home();
+        let company = "parked-delivery-co";
+        let (runner, completed) = RecordingRunner::with_deliveries(vec![report(
+            "owner_summary",
+            DeliveryStatus::Pending,
+            "parked for operator approval",
+        )]);
+        let registry = company_with_overlays(
+            &home,
+            company,
+            vec![overlay("digest", Some("* * * * *"))],
+            Some(runner),
+            "running",
+        )
+        .await;
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry, clock);
+
+        assert_eq!(scheduler.tick().await, 1);
+        wait_for(|| completed.load(Ordering::SeqCst) == 1).await;
+        wait_for(|| captured_text(&sink).contains("scheduled run finished")).await;
+
+        let logs = captured_text(&sink);
+        // Said, and pointed at the place the operator has to go.
+        let line = logs
+            .lines()
+            .find(|l| l.contains(company) && l.contains("parked for operator approval"))
+            .unwrap_or_else(|| panic!("no parked-report line for {company}: {logs}"));
+        assert!(line.contains("owner_summary"), "names the node: {line}");
+        assert!(line.contains("Approvals view"), "says where to go: {line}");
+        // Never the recipient's address on host stdout, same as the warn path.
+        assert!(
+            !line.contains("ada@example.com"),
+            "must not leak the recipient address to host stdout: {line}"
+        );
+        // Not cried wolf about.
+        assert!(
+            !logs
+                .lines()
+                .any(|l| l.contains(company) && l.contains("was NOT delivered")),
+            "a parked report is not a failed delivery: {logs}"
+        );
+        let summary = logs
+            .lines()
+            .find(|l| l.contains(company) && l.contains("scheduled run finished"))
+            .unwrap_or_else(|| panic!("no summary line for {company}: {logs}"));
+        assert!(summary.contains("pending_approval=1"), "{summary}");
+        assert!(summary.contains("undelivered=0"), "{summary}");
+        assert!(summary.contains("sent=0"), "{summary}");
+
+        cleanup(&home).await;
     }
 
     /// A scheduled run that delivered everything says so without crying wolf:

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -76,6 +76,7 @@ type WorkflowKey = (CompanyId, String);
 #[derive(Debug, Default, PartialEq, Eq)]
 struct DeliveryCounts {
     sent: usize,
+    pending: usize,
     skipped: usize,
     denied: usize,
     failed: usize,
@@ -87,6 +88,7 @@ impl DeliveryCounts {
         for report in reports {
             match report.status {
                 DeliveryStatus::Sent => counts.sent += 1,
+                DeliveryStatus::Pending => counts.pending += 1,
                 DeliveryStatus::Skipped => counts.skipped += 1,
                 DeliveryStatus::Denied => counts.denied += 1,
                 DeliveryStatus::Failed => counts.failed += 1,
@@ -936,6 +938,7 @@ to = "done"
             counts,
             DeliveryCounts {
                 sent: 2,
+                pending: 0,
                 skipped: 1,
                 denied: 1,
                 failed: 1,

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -1081,7 +1081,8 @@ to = "done"
     #[tokio::test]
     async fn a_scheduled_run_reports_a_parked_report_without_crying_wolf() {
         let sink = captured_logs();
-        let home = tmp_home();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
         let company = "parked-delivery-co";
         let (runner, completed) = RecordingRunner::with_deliveries(vec![report(
             "owner_summary",
@@ -1130,8 +1131,6 @@ to = "done"
         assert!(summary.contains("pending_approval=1"), "{summary}");
         assert!(summary.contains("undelivered=0"), "{summary}");
         assert!(summary.contains("sent=0"), "{summary}");
-
-        cleanup(&home).await;
     }
 
     /// A scheduled run that delivered everything says so without crying wolf:

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -1023,7 +1023,19 @@ to = "done"
         wait_for(|| completed.load(Ordering::SeqCst) == 1).await;
         // The run task logs after `completed` is bumped, so wait for the line
         // itself rather than racing it.
-        wait_for(|| captured_text(&sink).contains("owner_summary")).await;
+        //
+        // Qualified by BOTH this company and the marker, and scanned per line:
+        // `CAPTURE` is shared across every test in the binary, and
+        // `owner_summary` is the node name three tests in this module use — an
+        // unqualified `contains` could be satisfied by a sibling's line before
+        // this run has logged anything, and the lookup below would then fail
+        // intermittently.
+        wait_for(|| {
+            captured_text(&sink)
+                .lines()
+                .any(|l| l.contains(company) && l.contains("was NOT delivered"))
+        })
+        .await;
 
         let logs = captured_text(&sink);
         let line = logs
@@ -1102,7 +1114,17 @@ to = "done"
 
         assert_eq!(scheduler.tick().await, 1);
         wait_for(|| completed.load(Ordering::SeqCst) == 1).await;
-        wait_for(|| captured_text(&sink).contains("scheduled run finished")).await;
+        // Qualified by BOTH this company and the marker, and scanned per line:
+        // `CAPTURE` is shared across every test in the binary, so an
+        // unqualified `contains("scheduled run finished")` is satisfied by any
+        // sibling test's summary line — including one logged before this run
+        // finished — and the lookups below would then fail intermittently.
+        wait_for(|| {
+            captured_text(&sink)
+                .lines()
+                .any(|l| l.contains(company) && l.contains("scheduled run finished"))
+        })
+        .await;
 
         let logs = captured_text(&sink);
         // Said, and pointed at the place the operator has to go.

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1033,6 +1033,29 @@ mod tests {
         assert!(json["pendingApprovals"].is_array());
     }
 
+    /// Issue #227: a parked report rides the run response as `"pending"`. The
+    /// console's `DeliveryStatus` union is spelled in lowercase strings, so the
+    /// wire word is the contract — a rename here silently drops the row into
+    /// the frontend's fallback tone.
+    #[test]
+    fn run_response_serializes_a_parked_delivery_as_pending() {
+        use crate::ports::{DeliveryReport, DeliveryStatus};
+
+        let json = serde_json::to_value(RunWorkflowResponse {
+            output: serde_json::json!({ "nodes": {} }),
+            pending_approvals: Vec::new(),
+            deliveries: vec![DeliveryReport {
+                node: "done".into(),
+                kind: "email".into(),
+                target: Some("stranger@example.com".into()),
+                status: DeliveryStatus::Pending,
+                detail: "waiting for you in Approvals".into(),
+            }],
+        })
+        .unwrap();
+        assert_eq!(json["deliveries"][0]["status"], "pending");
+    }
+
     /// A graph that routes nothing serializes an empty list, not a missing key —
     /// the console can render "no deliveries" without a null check.
     #[test]

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -42,17 +42,37 @@
 //!   2. the recipient must be an **established thread** — the company's inbox
 //!      must already hold inbound mail from that address. This is the rule
 //!      ported verbatim from the agent send path
-//!      ([`crate::runtime::cycle`]); a cold recipient is **skipped and
-//!      reported**, never sent to.
+//!      ([`crate::runtime::cycle`]); a cold recipient is **parked for operator
+//!      approval**, never sent to on the workflow's own authority.
 //! * **`channel`** — the target must match a [`ChannelAdapter`] the deployment
 //!   already wired. A graph cannot conjure a channel; it can only address one an
 //!   operator installed. Constrained by construction, like `owner`.
 //!
-//! A cold `email` recipient is a real product gap, not a design end-state: the
-//! agent path parks such a send for operator approval, but the engine's approval
-//! pause has no resume path today, so gating delivery on it would dead-end the
-//! report instead of delaying it. Skipping loudly is the honest behaviour until
-//! a resume path exists.
+//! # A cold recipient is delayed, not dropped (issue #227)
+//!
+//! A cold `email` recipient used to end the report's life: a `skipped` row and
+//! nothing else, while a teammate emailing the same new contact got an approval
+//! card. Delivery now parks the send the same way the agent path does, so the
+//! two paths refuse identically and both refusals are recoverable.
+//!
+//! **This does not resume the run, and does not need to.** Delivery is
+//! post-engine by design: by the time a destination is refused,
+//! `tinyflows::engine::run` has already returned and the run is complete —
+//! there is nothing to resume. What is parked is the *send*, not the run, and
+//! approving it executes through the same
+//! [`perform_effect`](crate::runtime::cycle) path that mails an agent's
+//! approved `email.send` from an HTTP handler outside any live cycle.
+//!
+//! One consequence to be honest about: a workflow run is not persisted, so a
+//! `pending` row is a **snapshot** taken at delivery time and can never later
+//! flip to `sent`. The approvals queue is the live source of truth — it is
+//! journal-backed and survives a restart; the row only points at it.
+//!
+//! The park is **direct**, never routed through
+//! [`ApprovalGate::evaluate`](crate::ports::ApprovalGate): under `full` policy
+//! mode that returns `Allow` for a `Send` effect, which would auto-send cold
+//! workflow mail on most companies and turn the established-thread gate into a
+//! suggestion. See [`park_cold_recipient`].
 //!
 //! # Failure is reported, never fatal
 //!
@@ -76,11 +96,13 @@ use serde_json::Value;
 use crate::company::WorkflowFile;
 use crate::company::runtime::CompanyMail;
 use crate::company::{WorkflowDestinationDef, WorkflowNodeKind};
-use crate::ports::types::{CompanyId, CompanyRecord, OutboundMessage};
+use crate::ports::types::{CompanyId, CompanyRecord, Effect, EffectGroup, OutboundMessage};
 use crate::ports::{
-    ChannelAdapter, DeliveryReport, DeliveryStatus, EmailRecord, InboxStore, UserRole, UserStatus,
-    UserStore, generate_id, now_millis,
+    ApprovalGate, ChannelAdapter, DeliveryReport, DeliveryStatus, EmailRecord, InboxStore,
+    UserRole, UserStatus, UserStore, generate_id, now_millis,
 };
+use crate::runtime::cycle::EMAIL_SEND_KIND;
+use crate::runtime::journal::RuntimeJournal;
 use crate::server::ops::mailer::{MailCredentials, OutboundEmail};
 use crate::server::ops::smtp::local_part;
 
@@ -118,6 +140,29 @@ pub struct WorkflowDeliveryDeps {
     pub users: Arc<dyn UserStore>,
     /// Every wired channel adapter, including the always-present `operator`.
     pub channels: Vec<Arc<dyn ChannelAdapter>>,
+    /// What a cold `email` recipient is parked on (issue #227). `None` fails
+    /// closed to the pre-#227 behaviour: the report is `skipped`, never a
+    /// `pending` row no queue is backing.
+    pub parking: Option<DeliveryParking>,
+}
+
+/// The approval queue's two halves, bundled so a delivery can only ever hold
+/// **both or neither**.
+///
+/// Deliberately one field rather than two `Option`s. Parking on the gate
+/// without journaling would produce an approval that is invisible to
+/// `/approvals` (which reads the journal, not the gate) and gone on the next
+/// restart — a card the operator can neither see nor approve, backing a
+/// `pending` row that promises one exists. Making that state unrepresentable is
+/// cheaper than remembering not to build it.
+#[derive(Clone)]
+pub struct DeliveryParking {
+    /// Where the effect is parked, yielding the [`ApprovalId`] the operator
+    /// later resolves.
+    pub approvals: Arc<dyn ApprovalGate>,
+    /// The durable record of the park. This is what `/approvals` lists and what
+    /// boot replay rehydrates, so it is what makes the card survive a restart.
+    pub journal: Arc<RuntimeJournal>,
 }
 
 impl std::fmt::Debug for WorkflowDeliveryDeps {
@@ -126,6 +171,7 @@ impl std::fmt::Debug for WorkflowDeliveryDeps {
         // whose derived `Debug` prints the password (see `mailer::test`).
         f.debug_struct("WorkflowDeliveryDeps")
             .field("mail", &self.mail.is_some())
+            .field("parking", &self.parking.is_some())
             .field(
                 "channels",
                 &self
@@ -339,18 +385,10 @@ async fn deliver_one(
             )
             .await
             {
-                tracing::warn!(
-                    company = %record.id,
-                    node = %node_id,
-                    "workflow delivery: skipped an email destination — the recipient is not an established thread"
+                reports.push(
+                    park_cold_recipient(delivery, record, node_id, target, subject, text, row)
+                        .await,
                 );
-                reports.push(row(
-                    Some(target.to_string()),
-                    DeliveryStatus::Skipped,
-                    "this recipient has never written to the company, so a workflow may not open \
-                     the conversation — send once from the inbox first"
-                        .to_string(),
-                ));
                 return;
             }
             reports.push(
@@ -392,6 +430,134 @@ async fn deliver_one(
             format!("`{other}` is not a destination kind this runtime knows how to deliver to"),
         )),
     }
+}
+
+/// Parks a cold `email` recipient's report for operator approval, returning the
+/// row that says so (issue #227).
+///
+/// # Why this parks DIRECTLY instead of asking the gate
+///
+/// The obvious shape — evaluate the effect, then act on the decision — is
+/// wrong here, and dangerously so.
+/// [`ManifestApprovalGate::evaluate`](crate::policy::ManifestApprovalGate)
+/// returns `Allow` for a `Send` effect under `full` policy mode, and
+/// `email.send` is not in the always-approve list. Routing through it would
+/// therefore **auto-send** this mail on every full-mode company — which is most
+/// of them — quietly converting the established-thread rule from a gate into a
+/// suggestion. The refusal is already decided by the time we get here; the only
+/// question is whether the report is dropped or recoverable. So this takes the
+/// same already-decided path [`CycleHost::park_effect`](crate::ports::brain::CycleHost)
+/// does on the agent side: park, journal, done.
+///
+/// **The invariant: a cold recipient never auto-sends.** With no parking wired
+/// the report degrades to the pre-#227 `skipped` row; if parking itself errors
+/// it degrades to `skipped` too. Nothing about a cold recipient reaches a
+/// transport without a human verdict.
+async fn park_cold_recipient(
+    delivery: &WorkflowDeliveryDeps,
+    record: &CompanyRecord,
+    node_id: &str,
+    target: &str,
+    subject: &str,
+    text: &str,
+    row: impl Fn(Option<String>, DeliveryStatus, String) -> DeliveryReport,
+) -> DeliveryReport {
+    let Some(parking) = &delivery.parking else {
+        // Fail closed to the pre-#227 behaviour. A `pending` row on a runtime
+        // with no approvals queue would point the operator at a card that does
+        // not exist.
+        tracing::warn!(
+            company = %record.id,
+            node = %node_id,
+            "workflow delivery: skipped an email destination — the recipient is not an established \
+             thread and this runtime has no approvals queue to park it on"
+        );
+        return row(
+            Some(target.to_string()),
+            DeliveryStatus::Skipped,
+            "this recipient has never written to the company, so a workflow may not open the \
+             conversation — send once from the inbox first"
+                .to_string(),
+        );
+    };
+
+    // The same effect shape the agent path builds in `CycleHostImpl::send_email`
+    // — same kind, same group, same counterparty flags, same payload keys — so
+    // the operator sees one kind of card and `perform_effect` executes it on
+    // approval through the code that already ships.
+    let effect = Effect {
+        kind: EMAIL_SEND_KIND.into(),
+        group: EffectGroup::Send,
+        amount_usd: None,
+        established_thread: false,
+        first_time_counterparty: true,
+        payload: serde_json::json!({
+            "to": target,
+            "subject": subject,
+            // Already truncated by `report_text`.
+            "body": text,
+        }),
+    };
+
+    match park_effect(parking, &record.id, effect).await {
+        Ok(()) => {
+            tracing::info!(
+                company = %record.id,
+                node = %node_id,
+                "workflow delivery: parked an email destination for operator approval — the \
+                 recipient is not an established thread"
+            );
+            row(
+                Some(target.to_string()),
+                DeliveryStatus::Pending,
+                "this recipient has never written to the company, so a workflow may not open the \
+                 conversation on its own — the report is waiting for you in Approvals, and \
+                 approving it sends the mail"
+                    .to_string(),
+            )
+        }
+        Err(err) => {
+            // The queue is the only thing that failed; the refusal itself still
+            // holds. Report the pre-#227 outcome and say why it was not parked.
+            //
+            // `err` is deliberately the only thing interpolated: this line goes
+            // to host stdout, which on a hosted tenant is us and not the
+            // operator, so the recipient's address must not ride it (issue
+            // #248). The row the operator reads names the target; the log does
+            // not.
+            tracing::warn!(
+                company = %record.id,
+                node = %node_id,
+                error = %err,
+                "workflow delivery: could not park a cold email destination for approval; the \
+                 report was NOT sent"
+            );
+            row(
+                Some(target.to_string()),
+                DeliveryStatus::Skipped,
+                "this recipient has never written to the company, and this report could not be \
+                 queued for your approval either — send once from the inbox first"
+                    .to_string(),
+            )
+        }
+    }
+}
+
+/// Parks `effect` on the gate and journals it, in that order.
+///
+/// Both halves or neither: a park the journal never recorded is invisible to
+/// `/approvals` and gone on the next restart, so a journal write failure has to
+/// surface as a failure to park rather than as a card nobody can find.
+async fn park_effect(
+    parking: &DeliveryParking,
+    company: &CompanyId,
+    effect: Effect,
+) -> Result<(), crate::error::OpenCompanyError> {
+    let approval_id = parking.approvals.park(company, effect.clone()).await?;
+    parking
+        .journal
+        .record_parked(&approval_id, &effect, now_millis())
+        .await
 }
 
 /// The active admins' email addresses, in store order. An unreadable user store
@@ -760,6 +926,7 @@ allow = [{allow}]
                     inbox: inbox.clone(),
                     users: users.clone(),
                     channels,
+                    parking: None,
                 },
                 mail,
                 channel,

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -96,7 +96,9 @@ use serde_json::Value;
 use crate::company::WorkflowFile;
 use crate::company::runtime::CompanyMail;
 use crate::company::{WorkflowDestinationDef, WorkflowNodeKind};
-use crate::ports::types::{CompanyId, CompanyRecord, Effect, EffectGroup, OutboundMessage};
+use crate::ports::types::{
+    Actor, ActorKind, CompanyId, CompanyRecord, Effect, EffectGroup, OutboundMessage, Verdict,
+};
 use crate::ports::{
     ApprovalGate, ChannelAdapter, DeliveryReport, DeliveryStatus, EmailRecord, InboxStore,
     UserRole, UserStatus, UserStore, generate_id, now_millis,
@@ -544,21 +546,85 @@ async fn park_cold_recipient(
     }
 }
 
-/// Parks `effect` on the gate and journals it, in that order.
+/// Parks `effect` on the gate and journals it — **both halves or neither**.
 ///
-/// Both halves or neither: a park the journal never recorded is invisible to
-/// `/approvals` and gone on the next restart, so a journal write failure has to
-/// surface as a failure to park rather than as a card nobody can find.
+/// The gate is in-memory; the journal is the durable record `/approvals` reads
+/// and boot replay rehydrates. A gate entry the journal never recorded is the
+/// worst of the three possible outcomes: it shows up in the operator's queue
+/// now, vanishes on the next restart, and backs a `pending` row that promises a
+/// card which no longer exists.
+///
+/// Bundling the two handles in [`DeliveryParking`] makes the *mis-wiring* of
+/// that state unrepresentable, but it does nothing about a **partial failure at
+/// runtime** — `park` succeeding and `record_parked` erroring (a full disk, a
+/// read-only volume, a serialization fault). So the journal write is treated as
+/// the commit point: if it fails, the gate entry is retracted before returning
+/// the error, and the caller degrades to the `skipped` row it already emits for
+/// a parking failure.
+///
+/// Retraction has to undo **two** things, because a failed `record_parked` has
+/// already mutated the journal's in-memory queue (it inserts before it appends,
+/// so the entry is live even though nothing reached disk):
+///
+/// 1. [`ApprovalGate::resolve`] with [`Verdict::Deny`] — the trait's only
+///    removal verb, and the honest one: this effect must never execute. It is
+///    attributed to [`ActorKind::System`](crate::ports::types::ActorKind::System)
+///    (the runtime itself, as boot replay and the TTL sweep are) rather than to
+///    an operator who made no such decision.
+/// 2. [`RuntimeJournal::record_resolved`] — which also removes before it
+///    appends, so it clears the in-memory queue entry that would otherwise show
+///    the operator a card `/approvals` lists but the gate can no longer
+///    execute. Its own append will usually fail for the same reason the first
+///    one did; that is fine and expected, since there is no `ApprovalParked`
+///    line on disk for it to pair with anyway.
+///
+/// The ordering cannot simply be inverted to dodge this: `record_parked` needs
+/// the [`ApprovalId`](crate::ports::types::ApprovalId) that `park` mints, so the
+/// gate write must come first.
+///
+/// Both rollback steps deliberately ignore their own errors and the **original**
+/// journal error propagates — the report is reported unsent either way, and
+/// losing the real cause behind a cleanup error would make the failure harder to
+/// diagnose, not easier.
 async fn park_effect(
     parking: &DeliveryParking,
     company: &CompanyId,
     effect: Effect,
 ) -> Result<(), crate::error::OpenCompanyError> {
     let approval_id = parking.approvals.park(company, effect.clone()).await?;
-    parking
+    if let Err(err) = parking
         .journal
         .record_parked(&approval_id, &effect, now_millis())
         .await
+    {
+        // Roll back to "never parked". Both steps deliberately swallow their own
+        // errors — `err` below is the one worth surfacing.
+        if let Err(rollback) = parking
+            .approvals
+            .resolve(
+                &approval_id,
+                Verdict::Deny,
+                Actor {
+                    kind: ActorKind::System,
+                    id: "workflow-delivery".to_string(),
+                },
+            )
+            .await
+        {
+            tracing::error!(
+                company = %company,
+                error = %rollback,
+                "workflow delivery: a parked effect could not be journaled AND could not be \
+                 retracted from the approval gate; it may linger in the queue until restart"
+            );
+        }
+        // Clears the in-memory queue entry `record_parked` inserted before it
+        // failed to write. Its append will usually fail too — expected, and
+        // ignored: there is no `ApprovalParked` line on disk to pair with.
+        let _ = parking.journal.record_resolved(&approval_id).await;
+        return Err(err);
+    }
+    Ok(())
 }
 
 /// The active admins' email addresses, in store order. An unreadable user store
@@ -968,6 +1034,30 @@ allow = [{allow}]
             self
         }
 
+        /// Wires a gate plus a journal whose every write **fails**, for the
+        /// partial-failure case.
+        ///
+        /// The failure is induced by pointing the journal at a path that is
+        /// already a *directory*: `append` creates the parent fine and then
+        /// `OpenOptions::open` returns `EISDIR`. Deterministic, cross-platform,
+        /// and it fails at the real I/O boundary rather than at a mock, so the
+        /// test exercises the same error path a full disk would.
+        fn with_failing_journal(mut self, dir: &std::path::Path, policy_mode: &str) -> Self {
+            let policy = toml::from_str(&format!("mode = \"{policy_mode}\"\n"))
+                .expect("valid [policy] block");
+            let gate = Arc::new(ManifestApprovalGate::new(policy));
+            let blocked = dir.join("unwritable-journal.jsonl");
+            std::fs::create_dir_all(&blocked).expect("journal path occupied by a directory");
+            let journal = Arc::new(RuntimeJournal::new(blocked));
+            self.deps.parking = Some(DeliveryParking {
+                approvals: gate.clone(),
+                journal: journal.clone(),
+            });
+            self.gate = Some(gate);
+            self.journal = Some(journal);
+            self
+        }
+
         /// Adds an active admin with `email` to the company directory.
         async fn add_admin(&self, id: &str, email: &str) {
             self.users
@@ -1356,6 +1446,61 @@ allow = [{allow}]
             .expect("the gate holds the same id the journal recorded");
         assert_eq!(parked.payload, effect.payload);
         assert_eq!(parked.kind, effect.kind);
+    }
+
+    /// **Data integrity (PR #256 review).** A journal write that fails AFTER the
+    /// gate accepted the park must leave **no gate entry behind**.
+    ///
+    /// The half-wired state the bundled [`DeliveryParking`] makes unrepresentable
+    /// is a *construction* mistake; this is the *runtime* version of it, and
+    /// bundling does nothing for it. An orphaned gate entry is the worst of the
+    /// three outcomes: an executable effect sitting in the queue with no durable
+    /// record, visible now and gone on the next restart, backing a row that
+    /// promises a card which will not survive.
+    ///
+    /// Asserts all four halves of the rollback: `skipped` (not `pending`), no
+    /// gate entry, no in-memory queue entry, and nothing sent.
+    #[tokio::test]
+    async fn a_failed_journal_write_leaves_no_orphaned_gate_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true).with_failing_journal(dir.path(), "full");
+        h.receive_from("someone-else@example.com").await;
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["*"]),
+            &graph("email", Some("stranger@example.com")),
+            &reached_output(),
+        )
+        .await;
+
+        // Degrades to the pre-#227 row, never `pending`: there is no durable
+        // card to point the operator at.
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(
+            reports[0].status,
+            DeliveryStatus::Skipped,
+            "a park that could not be journaled is not pending: {reports:?}"
+        );
+        assert!(
+            reports[0].detail.contains("could not be queued"),
+            "{reports:?}"
+        );
+
+        // THE FINDING: the gate must not still hold the effect.
+        assert!(
+            h.gate.as_ref().unwrap().parked_ids().is_empty(),
+            "a journal write failure must retract the gate entry, not orphan it"
+        );
+        // …and the operator's queue must not list a card the gate can no longer
+        // execute. `record_parked` inserts before it appends, so this only holds
+        // because the rollback clears it too.
+        assert!(
+            h.journal.as_ref().unwrap().pending().is_empty(),
+            "no phantom card may be left in the approvals queue"
+        );
+        // The refusal still held throughout.
+        assert!(h.mail.sent().is_empty(), "nothing may leave the process");
     }
 
     /// **Fail-closed (issue #227).** With no approvals queue wired, delivery

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -72,7 +72,7 @@
 //! [`ApprovalGate::evaluate`](crate::ports::ApprovalGate): under `full` policy
 //! mode that returns `Allow` for a `Send` effect, which would auto-send cold
 //! workflow mail on most companies and turn the established-thread gate into a
-//! suggestion. See [`park_cold_recipient`].
+//! suggestion. See `park_cold_recipient` below.
 //!
 //! # Failure is reported, never fatal
 //!
@@ -157,8 +157,9 @@ pub struct WorkflowDeliveryDeps {
 /// cheaper than remembering not to build it.
 #[derive(Clone)]
 pub struct DeliveryParking {
-    /// Where the effect is parked, yielding the [`ApprovalId`] the operator
-    /// later resolves.
+    /// Where the effect is parked, yielding the
+    /// [`ApprovalId`](crate::ports::types::ApprovalId) the operator later
+    /// resolves.
     pub approvals: Arc<dyn ApprovalGate>,
     /// The durable record of the park. This is what `/approvals` lists and what
     /// boot replay rehydrates, so it is what makes the card survive a restart.

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -785,6 +785,7 @@ mod tests {
 
     use crate::company::parse_workflow;
     use crate::error::OpenCompanyError;
+    use crate::policy::ManifestApprovalGate;
     use crate::ports::UserRecord;
     use crate::ports::types::CompanyId;
     use crate::runtime::channel::{OPERATOR_CHANNEL, OperatorChannel};
@@ -904,6 +905,12 @@ allow = [{allow}]
         inbox: Arc<FsInboxStore>,
         users: Arc<FsOps>,
         company: CompanyId,
+        /// The approvals queue, when [`with_parking`](Harness::with_parking)
+        /// wired one. The real gate and a real on-disk journal, not fakes: the
+        /// point of these tests is that a workflow's park lands in the same
+        /// queue an agent's does.
+        gate: Option<Arc<ManifestApprovalGate>>,
+        journal: Option<Arc<RuntimeJournal>>,
     }
 
     impl Harness {
@@ -933,7 +940,31 @@ allow = [{allow}]
                 inbox,
                 users,
                 company: CompanyId::new("acme"),
+                gate: None,
+                journal: None,
             }
+        }
+
+        /// Wires the approvals queue the production builder wires: a real
+        /// [`ManifestApprovalGate`] over `policy_mode` and a real
+        /// [`RuntimeJournal`] on disk under `dir`.
+        ///
+        /// `policy_mode` is a parameter because `full` is the interesting one:
+        /// it is the mode under which `evaluate` would return `Allow` for a
+        /// `Send` effect, so a test that parks under `full` is the one that
+        /// proves delivery does not route through `evaluate`.
+        fn with_parking(mut self, dir: &std::path::Path, policy_mode: &str) -> Self {
+            let policy = toml::from_str(&format!("mode = \"{policy_mode}\"\n"))
+                .expect("valid [policy] block");
+            let gate = Arc::new(ManifestApprovalGate::new(policy));
+            let journal = Arc::new(RuntimeJournal::new(dir.join("journal.jsonl")));
+            self.deps.parking = Some(DeliveryParking {
+                approvals: gate.clone(),
+                journal: journal.clone(),
+            });
+            self.gate = Some(gate);
+            self.journal = Some(journal);
+            self
         }
 
         /// Adds an active admin with `email` to the company directory.
@@ -1221,6 +1252,211 @@ allow = [{allow}]
             h.mail.sent().is_empty(),
             "a cold recipient must not be mailed"
         );
+    }
+
+    // --- email: cold recipients park (issue #227) ----------------------------
+
+    /// **Issue #227, the headline.** Cold and granted, with an approvals queue
+    /// wired: the report is PARKED rather than dropped. One `pending` row,
+    /// nothing mailed, and a real card in the journal the operator's
+    /// `/approvals` list reads.
+    ///
+    /// Note the policy mode: `full`. That is deliberately the mode under which
+    /// `ApprovalGate::evaluate` returns `Allow` for a `Send` effect, so if this
+    /// path ever grew an evaluate-then-dispatch step the mail would go out here
+    /// and this test would fail on `sent()`.
+    #[tokio::test]
+    async fn a_cold_recipient_is_parked_for_approval_and_nothing_is_sent() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true).with_parking(dir.path(), "full");
+        h.receive_from("someone-else@example.com").await;
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["*"]),
+            &graph("email", Some("stranger@example.com")),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Pending, "{reports:?}");
+        assert_eq!(
+            reports[0].target.as_deref(),
+            Some("stranger@example.com"),
+            "{reports:?}"
+        );
+        // The row has to point somewhere, or `pending` is just a nicer word for
+        // dropped.
+        assert!(reports[0].detail.contains("Approvals"), "{reports:?}");
+        // THE INVARIANT: a cold recipient never auto-sends.
+        assert!(
+            h.mail.sent().is_empty(),
+            "a cold recipient must not be mailed, parked or not"
+        );
+        assert!(
+            h.inbox_messages().await.iter().all(|m| !m.outbound),
+            "nothing was sent, so there is no outbound record to leave"
+        );
+
+        // And the card really is in the durable queue — this is what
+        // `/approvals` lists and what boot replay rehydrates.
+        let pending = h.journal.as_ref().unwrap().pending();
+        assert_eq!(pending.len(), 1, "{pending:?}");
+        assert_eq!(pending[0].effect.kind, EMAIL_SEND_KIND);
+    }
+
+    /// The parked effect must have the **same shape as the agent path's**
+    /// (`CycleHostImpl::send_email`), field for field. Not cosmetic: the
+    /// operator sees one kind of card either way, and `perform_effect` keys on
+    /// `kind` plus the `to`/`subject`/`body` payload to actually mail it on
+    /// approval. A drift here parks cards that do nothing when approved.
+    #[tokio::test]
+    async fn the_parked_effect_matches_the_agent_paths_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true).with_parking(dir.path(), "full");
+
+        deliver_outputs(
+            Some(&h.deps),
+            &record(&["*"]),
+            &graph("email", Some("stranger@example.com")),
+            &reached_output(),
+        )
+        .await;
+
+        let pending = h.journal.as_ref().unwrap().pending();
+        let effect = &pending[0].effect;
+        assert_eq!(effect.kind, EMAIL_SEND_KIND, "same kind constant");
+        assert_eq!(effect.group, EffectGroup::Send);
+        assert_eq!(effect.amount_usd, None, "a send costs nothing to gate on");
+        // The two flags that say *why* this parked: cold counterparty.
+        assert!(!effect.established_thread);
+        assert!(effect.first_time_counterparty);
+        // The payload `perform_effect` reads.
+        assert_eq!(effect.payload["to"], "stranger@example.com");
+        assert!(
+            effect.payload["subject"].as_str().unwrap().contains("Acme"),
+            "{effect:?}"
+        );
+        assert!(
+            effect.payload["body"]
+                .as_str()
+                .unwrap()
+                .contains("Q3 is up 12%."),
+            "the report itself is the body, or approving sends an empty mail: {effect:?}"
+        );
+        // The gate holds the identical effect under the same id, so resolving
+        // the approval returns something executable.
+        let parked = h
+            .gate
+            .as_ref()
+            .unwrap()
+            .parked_effect(&pending[0].id)
+            .expect("the gate holds the same id the journal recorded");
+        assert_eq!(parked.payload, effect.payload);
+        assert_eq!(parked.kind, effect.kind);
+    }
+
+    /// **Fail-closed (issue #227).** With no approvals queue wired, delivery
+    /// degrades to the pre-#227 `skipped` row rather than promising a `pending`
+    /// card that nothing is backing. A `pending` row on a runtime with no queue
+    /// would send the operator to an empty Approvals list.
+    #[tokio::test]
+    async fn a_cold_recipient_without_a_queue_falls_back_to_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        // No `with_parking`: exactly the shape every non-production
+        // construction site builds.
+        let h = Harness::new(dir.path(), true, true);
+        assert!(h.deps.parking.is_none());
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["*"]),
+            &graph("email", Some("stranger@example.com")),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(
+            reports[0].status,
+            DeliveryStatus::Skipped,
+            "never `pending` with no queue to back it: {reports:?}"
+        );
+        assert!(reports[0].detail.contains("never written"), "{reports:?}");
+        assert!(h.mail.sent().is_empty());
+    }
+
+    /// The established-thread gate is unchanged by #227: a recipient who DID
+    /// write in still sends immediately, and parks nothing. Parking is what
+    /// happens to the refusal, not a new hurdle in front of a legitimate send.
+    #[tokio::test]
+    async fn an_established_recipient_still_sends_without_parking() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true).with_parking(dir.path(), "full");
+        h.receive_from("ada@example.com").await;
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["*"]),
+            &graph("email", Some("ada@example.com")),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports[0].status, DeliveryStatus::Sent, "{reports:?}");
+        assert_eq!(h.mail.sent().len(), 1);
+        assert!(
+            h.journal.as_ref().unwrap().pending().is_empty(),
+            "an established send must not clutter the approvals queue"
+        );
+    }
+
+    /// The grant gate is unchanged by #227 too, and still runs FIRST: an
+    /// ungranted company's cold send is `denied` outright, never parked. Parking
+    /// an effect the company has no grant for would put a card in front of the
+    /// operator that policy already refused — approving it would be an end-run
+    /// around `[tools].allow`.
+    #[tokio::test]
+    async fn an_ungranted_cold_recipient_is_denied_not_parked() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true).with_parking(dir.path(), "full");
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["docs.*"]),
+            &graph("email", Some("stranger@example.com")),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports[0].status, DeliveryStatus::Denied, "{reports:?}");
+        assert!(
+            h.journal.as_ref().unwrap().pending().is_empty(),
+            "a denied destination must not reach the approvals queue"
+        );
+        assert!(h.mail.sent().is_empty());
+    }
+
+    /// A company with no mailbox is still `skipped`, not parked: there is
+    /// nothing to send from, so approving a card would fail at the transport.
+    /// That arm is checked before the thread gate and #227 does not move it.
+    #[tokio::test]
+    async fn a_company_without_a_mailbox_is_skipped_not_parked() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), false, true).with_parking(dir.path(), "full");
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["*"]),
+            &graph("email", Some("stranger@example.com")),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports[0].status, DeliveryStatus::Skipped, "{reports:?}");
+        assert!(reports[0].detail.contains("no mailbox"), "{reports:?}");
+        assert!(h.journal.as_ref().unwrap().pending().is_empty());
     }
 
     /// **Regression (PR #226 review).** A busy company's inbox must not lose an

--- a/src/workflows/mod.rs
+++ b/src/workflows/mod.rs
@@ -19,7 +19,7 @@ pub mod runner;
 pub mod translate;
 
 pub use caps::{HarnessAgentRunner, build_capabilities};
-pub use delivery::{WorkflowDeliveryDeps, deliver_outputs};
+pub use delivery::{DeliveryParking, WorkflowDeliveryDeps, deliver_outputs};
 pub use runner::{HarnessWorkflowRunner, run_workflow};
 pub use translate::translate;
 

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -431,6 +431,8 @@ to = "done"
             inbox: Arc::new(crate::store::FsInboxStore::new(dir.path())),
             users: Arc::new(FsOps::new(dir.path())),
             channels: vec![Arc::new(channel.clone())],
+            // This case delivers to a channel, which never parks.
+            parking: None,
         });
 
         let file = parse_workflow(REPORT_TO_OPERATOR).expect("parses");


### PR DESCRIPTION
## Summary

A workflow that emails a report to an address which has never written in used to get a `skipped` row and nothing else — the report's life ended there. A teammate emailing that same new contact got an approval card. Same refusal, two different fates.

Delivery now **parks** the cold send the way the agent path does, so both paths refuse identically and both refusals are recoverable. Approving the card actually sends the mail, through code that already ships.

**Neither gate moved.** The `[tools].allow` grant check and the established-thread rule both stand exactly where they were. This is only about what happens to the refusal.

### The trap this deliberately avoids

The obvious implementation — evaluate the effect, then act on the decision — would have been a security regression. `ManifestApprovalGate::evaluate` returns `Allow` for a `Send` effect under `full` policy mode, and `email.send` is not in `DEFAULT_ALWAYS_APPROVE`. Evaluate-then-dispatch would therefore have **auto-sent cold workflow mail on every full-mode company**, quietly demoting the established-thread rule from a gate to a suggestion.

So the park is **direct** — `park` + `record_parked`, mirroring the already-decided `CycleHost::park_effect` path. The refusal is already decided by the time delivery gets there; the only open question is whether the report is dropped or recoverable. The invariant held throughout: **a cold recipient never auto-sends.** The E2E below runs on a `full`-mode company precisely so that a regression here would show up as a real mail leaving the process.

### Why delivery-side parking rather than engine resume

Resume would be a category error. The refusal happens in `deliver_outputs`, **after** `tinyflows::engine::run` has returned — the run is complete, there is nothing left to resume. Resume would mean touching the vendored engine, inventing persisted paused-run state (runs are not persisted at all today), a resume API and a console surface — and would *still* need delivery-side parking, because delivery is host-side and post-engine by design.

Delivery-side parking instead reuses machinery that already works end to end: the approvals queue is journal-backed, boot replay rehydrates parked effects, and `resolve_approval` already executes an approved `email.send` from an HTTP handler outside any live cycle.

### An honest limitation

A workflow run is not persisted, so a `pending` row is a **snapshot** taken at delivery time. It can never later flip to `sent`. The row says "an approval was opened for this, go look at Approvals" — and the approvals queue *is* live and restart-safe. The variant's docs, the console type, and the row's own text all say this rather than implying a status that will update itself.

### Shape of the change

- `DeliveryStatus::Pending` (serde `"pending"`), documented as a snapshot.
- `EMAIL_SEND_KIND` promoted to `pub(crate)` so delivery builds the identical effect kind rather than duplicating a literal that could drift from what `perform_effect` executes.
- `WorkflowDeliveryDeps.parking: Option<DeliveryParking>` — gate and journal bundled in **one** field, not two. A gate-park without the journal write would be invisible on `/approvals` and gone on restart; making that half-wired state unrepresentable is cheaper than remembering not to build it. `None` fails closed to today's `skipped` row, so there is never a `pending` row that no queue is backing.
- `builder.rs`: the journal + gate construction block is hoisted above the brain arm — a pure move (it depends only on `home`, `id`, `self.approvals`, `self.manifest.policy`, none of which the intervening code produces or mutates). It previously sat *after* the brain, which is exactly why the delivery deps built inside the brain arm had nothing to park on.
- Scheduler: `pending` counted separately and logged at info pointing at Approvals — never folded into `undelivered`, which is the number an alert keys on. Awaiting a verdict is not awaiting a fix.
- Console: `pending` badges sky "awaiting approval"; the two "not sent" counters split so a parked report no longer badges red beside a transport failure.

**The Approvals view needed no changes** — verified, not assumed: `/approvals` reads `journal.pending()`, which is the same journal delivery now parks into, and `ApprovalsView`'s `KIND_ICONS` already maps `email.send` to its Mail icon.

## API Or Behavior Changes

- **`DeliveryStatus` gains `pending`.** Additive. Existing values unchanged. It rides the run response (`POST …/workflows/{id}/run` → `deliveries[].status`) and the console's `DeliveryStatus` union.
- **A cold `email` destination now yields `pending` instead of `skipped`** when the runtime has an approvals queue (the production builder always does), and parks a real `email.send` card on `/approvals`. With no queue wired, behaviour is byte-for-byte the old `skipped` row.
- **No change to either gate.** Ungranted → still `Denied`, never parked (parking an effect policy already refused would let approval end-run `[tools].allow`). No mailbox → still `Skipped`. Established recipient → still sends immediately, parks nothing.
- Scheduler log line gains `pending_approval=N`; `undelivered` deliberately excludes it.

## Tests

Run locally from the worktree:

- [x] `cargo fmt --all -- --check` — clean, no output.
- [x] `cargo clippy --all-targets -- -D warnings` — clean, `Finished dev profile`.
- [x] `cargo build --all-targets` — clean.
- [x] `cargo test` — `991 passed; 0 failed; 1 ignored`.
- [x] `cargo test --features openhuman` — `1366 passed; 0 failed; 1 ignored`.
- [x] `npm ci`, `npm run typecheck`, `npm run build` in `frontend/` — all clean. (No lint or test script exists in this package; neither is claimed.)

**CI compiles none of `src/workflows/`.** CI builds default features only, so it type-checks the ports / scheduler / frontend-facing parts of this change but not the core of it. The local `--features openhuman` run is the only real signal for the parking path itself. Please weight it accordingly.

Clippy note: under `--features openhuman`, clippy fails inside vendored submodules (`large_enum_variant` in `vendor/tinyagents`) before it reaches this crate. Linted this crate separately to confirm it is clean — the only warnings in `src/` are the four known pre-existing ones (`toolkit_allowed` / `slug_toolkit` dead code, `to_string_in_format_args`, `redundant_guards`), all of which PR #250 is fixing and none of which are touched here.

### New coverage

Delivery (`src/workflows/delivery.rs`):
- cold + queue wired → exactly one `pending` row, nothing mailed, no outbound record, and a real card in `journal.pending()` — run under `full` policy so the evaluate-trap would fail it
- the parked effect matches the agent path's shape field for field (kind / group / `amount_usd` / both counterparty flags / `to`+`subject`+`body`), and the gate holds the identical effect under the id the journal recorded
- cold + no queue → the old `skipped` row
- established still sends and parks nothing; ungranted still denies and parks nothing; no-mailbox still skips and parks nothing

Cycle (`src/runtime/cycle.rs`) — the acceptance bar:
- an effect parked the way delivery parks it is **actually mailed** by `resolve_approval`, from the company's own address, leaving the outbound audit record
- denying sends nothing and drains the queue
- a parked send survives a restart under its **original** id and still sends on approval

Scheduler + REST: `pending` folds into the summary line, is logged at info rather than as a failed delivery, stays out of `undelivered`; and serializes as `"pending"` on the run response.

The 22 pre-existing delivery tests are **untouched** and pass — that is itself the evidence neither gate moved.

### Manual E2E — both surfaces, on a real running host

**Precondition, and it is a sharp one.** The `pending` row is only reachable when the runtime actually carries a mailbox. `CompanyMail` is wired at build time from `TenantMailboxConfig::from_env`, which needs the **`smtp` feature** *and* `OPENCOMPANY_MAIL_*` env whose address local-part **matches the company id**. Without all of that, the `email` arm stops at the earlier "no mailbox configured" gate and returns `Skipped` — the cold-recipient branch is never reached at all. #228's agent hit exactly this while union-building against this branch and correctly observed that `Pending` was unreachable in their environment.

So: this run was done with `--features openhuman,smtp`, a company id of `wf227`, and `OPENCOMPANY_MAIL_ADDRESS=wf227@opencompany.test` — which is what makes the branch reachable. Anyone reproducing without that combination will see `Skipped` and should not read it as a contradiction.

**Which path was driven:** the **on-demand run route** (`POST …/workflows/{id}/run`), through the real console and through the API. The **cron/scheduler path was not exercised end-to-end** — the scheduler's `pending_approval=N` summary line and its info-level parked-report line are covered by unit tests only.

Drove the real console (Playwright + Chromium, real magic-link session) as well as the API.

| Leg | Result |
|---|---|
| Run the workflow from the console (on-demand route) | Run drawer: **"1 report awaiting approval"** + `pending` row badge, sky — **not** the red "not delivered" |
| Approvals view | **"1 thing needs your approval" → "Send an email"** card with Decline / Approve, Mail icon, zero frontend changes |
| Nothing auto-sent under `full` policy | SMTP sink **empty** — the evaluate-trap, disproven live |
| Restart the serve process between park and approve | Card survives with its **original id**, journal replay verified on disk |
| Approve | Reaches the real SMTP transport (fails only at STARTTLS, which my plaintext sink cannot speak) |
| Deny | Queue drains, nothing sent, no outbound audit record |

**Legs covered by tests only, not by this run:** the scheduled/cron path (the scheduler log line), and — see below — the final SMTP byte delivery.

**One leg I could not run:** the final byte-delivery over SMTP. The tenant-mailbox env path derives STARTTLS/TLS from the port, so a plaintext local sink cannot complete the handshake — approving demonstrably *reaches* the transport with the parked payload, but I did not watch the bytes land in a mailbox. That last inch is covered by `a_directly_parked_email_send_is_mailed_when_approved`, which drives the same `resolve_approval → execute_effect_once → perform_effect → send_company_email` chain with a recording sender and asserts recipient, body, from-address and the outbound audit record. No new code sits on that segment.

## Review round 1 (CodeRabbit)

All three threads addressed, one commit each.

**Data integrity — an orphaned gate entry on a failed journal write.** The real finding of the three. Bundling the gate and journal into one `DeliveryParking` makes the half-wired state unrepresentable *at construction*; it does nothing about a partial failure *at runtime*. `park()` succeeding and `record_parked()` erroring left an executable effect in the queue with no durable record — visible now, gone on the next restart, backing a `pending` row promising a card that would not survive.

The journal write is now the commit point. On failure both halves are rolled back: `ApprovalGate::resolve(Deny, ActorKind::System)` retracts the gate entry (the trait's only removal verb, and the honest one — the effect must never execute), and `record_resolved` clears the in-memory queue entry that `record_parked` inserts *before* it appends. Without that second step the operator would still see a phantom card `/approvals` lists but the gate can no longer execute. The ordering cannot be inverted to dodge this: `record_parked` needs the `ApprovalId` that `park` mints. Both rollback steps swallow their own errors so the original journal error is what propagates, and the caller degrades to the `skipped` row it already emits.

The regression test induces a genuine `EISDIR` at the real I/O boundary (journal path occupied by a directory) rather than mocking a failing journal, and asserts all four halves: `skipped` not `pending`, no gate entry, no queue entry, nothing sent. Verified it fails on the exact orphaned-gate assertion when the rollback is removed.

**Test flake — unqualified log-wait predicate.** Fixed in **both** places, not only the one flagged. `CAPTURE` is shared across the whole test binary, so an unqualified `contains()` can be satisfied by a sibling's line before this run has logged anything. The pre-existing undelivered-report test had the same defect via `owner_summary`, which is the node name three tests in this module share. Both now scan per line for the company **and** the marker — the form `a_clean_scheduled_run_logs_no_delivery_warning` already used. Ran the scheduler suite 5× clean.

**Unresolvable rustdoc link.** `ApprovalId` is not in scope from this module; now uses the full crate path. Also dropped the module-header intra-doc link to the private `park_cold_recipient`, which warned for the same class of reason. Confirmed against `cargo doc`: no `delivery.rs` entry remains in the unresolved-link list.

## Documentation

The `src/workflows/delivery.rs` module docs carried a paragraph this change makes false — "the engine's approval pause has no resume path today, so gating delivery on it would dead-end the report… Skipping loudly is the honest behaviour until a resume path exists." Replaced with a section explaining why parking needs no resume (delivery is post-engine, the *send* is parked, not the run), the snapshot limitation of a `pending` row, and why the park must not route through `evaluate`. The security-boundary bullet for `email` is updated from "skipped and reported" to "parked for operator approval".

No `docs/` change: this alters the fate of a refusal within an already-documented gate, not the architecture or any documented route shape.

Closes #227


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workflow email deliveries awaiting operator approval now appear with a distinct **Pending** status.
  - Pending deliveries can be approved or denied before sending.
  - Approval status is preserved across runtime restarts.
  - Workflow run summaries now show separate approval-pending counts.

- **Bug Fixes**
  - Pending deliveries are no longer incorrectly reported as failed or undelivered.
  - Approved and denied parked deliveries now execute or remain unsent as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
