### PR TITLE
feat(workflows): journal and read back what a workflow run did (#228)

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -121,6 +121,33 @@ export interface WorkflowRunResult {
   deliveries?: DeliveryReport[];
 }
 
+/**
+ * One finished workflow run, read back from the company's journal (issue #228).
+ *
+ * Before this, a run's outcome existed only in the moment: a manual run's
+ * `deliveries` lived in the run drawer until it was dismissed, and a scheduled
+ * run's reached only the host's stdout — which on a hosted tenant is the
+ * platform team, not the operator. This is the same information, durable, so it
+ * survives a console reload and a scheduled run nobody watched.
+ */
+export interface WorkflowRunOutcome {
+  /** The journal sequence position — a stable, monotonic row key. */
+  seq: number;
+  /** Epoch-millis the outcome was recorded. */
+  atMillis: number;
+  workflowId: string;
+  /** True when a cron started the run rather than an operator. */
+  scheduled: boolean;
+  /** A run correlation id, when the entry point minted one. */
+  runId?: string;
+  /** The same delivery rows a manual run's response carries. */
+  deliveries: DeliveryReport[];
+  /** Node ids the run left waiting on a human approval. */
+  pendingApprovals: string[];
+  /** Set when the run failed outright instead of finishing with rows. */
+  error?: string;
+}
+
 export function listWorkflows(
   client: OpenCompanyClient,
   company: string | null,
@@ -147,6 +174,28 @@ export function runWorkflow(
   return client.post<WorkflowRunResult>(
     `${client.scopeFor(company)}/workflows/${encodeURIComponent(wid)}/run`,
     { input: input ?? {} },
+  );
+}
+
+/**
+ * The company's finished workflow runs, **newest first** (issue #228).
+ *
+ * `workflow` narrows to one graph's runs; `limit` caps the page (the host
+ * defaults to a short recent list and clamps a large ask). A host predating this
+ * route answers 404 — callers should treat that as "no history yet" rather than
+ * an error, since the console still works without it.
+ */
+export function listWorkflowRuns(
+  client: OpenCompanyClient,
+  company: string | null,
+  options?: { workflow?: string; limit?: number },
+): Promise<WorkflowRunOutcome[]> {
+  const params = new URLSearchParams();
+  if (options?.workflow) params.set("workflow", options.workflow);
+  if (options?.limit) params.set("limit", String(options.limit));
+  const query = params.toString();
+  return client.get<WorkflowRunOutcome[]>(
+    `${client.scopeFor(company)}/workflows/runs${query ? `?${query}` : ""}`,
   );
 }
 

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -194,6 +194,10 @@ export function AppShell({
   // A monotonic nonce bumped on every task-lifecycle SSE event, so the
   // company-chat in-flight steer strip (issue #111) refetches live.
   const [taskEventTick, setTaskEventTick] = useState(0);
+  // Issue #228: bumped on every `workflow_run_finished` so the Workflows view
+  // refreshes its run history live. Same shape as `taskEventTick` — a counter,
+  // not the payload, so the view owns what it refetches.
+  const [workflowRunTick, setWorkflowRunTick] = useState(0);
   // The live tool timeline, per thread, built from the transient `tool_call` /
   // `tool_result` SSE frames while a turn runs (mirrors OpenHuman's live tool
   // rows). Cleared when the turn's final reply — carrying the authoritative
@@ -443,6 +447,7 @@ export function AppShell({
     onAgentReply: injectAgentReply,
     onTaskEvent: useCallback(() => setTaskEventTick((n) => n + 1), []),
     onTurnEvent,
+    onWorkflowRunEvent: useCallback(() => setWorkflowRunTick((n) => n + 1), []),
   });
 
   return (
@@ -575,7 +580,11 @@ export function AppShell({
                 </div>
               }
             >
-              <WorkflowsView client={client} company={company} />
+              <WorkflowsView
+                client={client}
+                company={company}
+                runEventTick={workflowRunTick}
+              />
             </Suspense>
           )}
           {view === "usage" && (

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
+import type { DeliveryReport } from "@/api/workflows";
 
 /**
  * One attention item off the company → operator SSE feed (issue #66). Mirrors
@@ -25,6 +26,21 @@ export type CompanyStreamEvent =
   | { type: "approval_resolved"; seq: number; atMillis: number; approvalId: string; verdict: string }
   | { type: "lifecycle_changed"; seq: number; atMillis: number; from: string; to: string }
   | { type: "payment_received"; seq: number; atMillis: number; amountUsd: number; memo: string }
+  // A workflow run finished (issue #228), from either entry point. The whole
+  // point is the *scheduled* case: nobody is watching a cron run, so without
+  // this an owner summary that failed to send would be silent until someone
+  // happened to open the history panel.
+  | {
+      type: "workflow_run_finished";
+      seq: number;
+      atMillis: number;
+      workflowId: string;
+      scheduled: boolean;
+      deliveries: DeliveryReport[];
+      pendingApprovals: string[];
+      /** Present only when the run failed outright. */
+      error?: string;
+    }
   // The transient live turn-progress frames (`src/turn_stream.rs`): a tool call
   // just started (status `running`) or finished (status `ok`/`error`). These are
   // ephemeral — never journaled — and drive the in-flight tool timeline the
@@ -90,6 +106,13 @@ interface Options {
    * the folded steps on the final reply.
    */
   onTurnEvent?: (event: CompanyStreamEvent) => void;
+  /**
+   * Called for each `workflow_run_finished` event (issue #228) so the Workflows
+   * view can refresh its run history live. Matters most for a *scheduled* run:
+   * it fires with the tab already open and nothing else would tell the view a
+   * new outcome exists.
+   */
+  onWorkflowRunEvent?: (event: CompanyStreamEvent) => void;
 }
 
 /**
@@ -104,7 +127,13 @@ interface Options {
 export function useEvents(
   client: OpenCompanyClient,
   company: string | null,
-  { pendingApprovals, onAgentReply, onTaskEvent, onTurnEvent }: Options,
+  {
+    pendingApprovals,
+    onAgentReply,
+    onTaskEvent,
+    onTurnEvent,
+    onWorkflowRunEvent,
+  }: Options,
 ): void {
   // Keep the latest callbacks without re-opening the stream when they change.
   const onAgentReplyRef = useRef(onAgentReply);
@@ -119,6 +148,10 @@ export function useEvents(
   useEffect(() => {
     onTurnEventRef.current = onTurnEvent;
   }, [onTurnEvent]);
+  const onWorkflowRunEventRef = useRef(onWorkflowRunEvent);
+  useEffect(() => {
+    onWorkflowRunEventRef.current = onWorkflowRunEvent;
+  }, [onWorkflowRunEvent]);
 
   // The rising-edge detector for pending approvals. Seeded with the current
   // value so we only toast on an *increase* observed while mounted, never on the
@@ -165,7 +198,13 @@ export function useEvents(
         console.debug("[events] dropping unparseable event", err);
         return;
       }
-      handleEvent(event, onAgentReplyRef.current, onTaskEventRef.current, onTurnEventRef.current);
+      handleEvent(
+        event,
+        onAgentReplyRef.current,
+        onTaskEventRef.current,
+        onTurnEventRef.current,
+        onWorkflowRunEventRef.current,
+      );
     };
 
     source.onerror = () => {
@@ -193,6 +232,7 @@ function handleEvent(
   onAgentReply?: (e: AgentReplyEvent) => void,
   onTaskEvent?: (e: CompanyStreamEvent) => void,
   onTurnEvent?: (e: CompanyStreamEvent) => void,
+  onWorkflowRunEvent?: (e: CompanyStreamEvent) => void,
 ): void {
   switch (event.type) {
     // Live turn frames drive the in-flight tool timeline — no toast, they render
@@ -237,6 +277,42 @@ function handleEvent(
         description: `$${event.amountUsd.toFixed(2)} — ${event.memo}`,
       });
       break;
+    // Issue #228. A run that went fine is not an attention signal — toasting
+    // every scheduled run would train the operator to ignore the ones that
+    // matter — so only a failure or an undelivered report speaks up. The view
+    // still refreshes either way, so a clean run shows up in the history.
+    case "workflow_run_finished": {
+      onWorkflowRunEvent?.(event);
+      if (event.error) {
+        toast.error("A workflow run failed", {
+          description: `${event.workflowId} — ${event.error}`,
+        });
+        break;
+      }
+      // `pending` is not a failure: it is a report parked for approval, and
+      // toasting it red would send the operator hunting for a bug that isn't
+      // there. Excluded from the count that speaks up.
+      //
+      // Compared through a widened `string` because `pending` joins
+      // `DeliveryStatus` in issue #227 — a literal would be a no-overlap type
+      // error against today's union, and the host can already send a status
+      // this console's type doesn't name yet.
+      const pendingStatus: string = "pending";
+      const undelivered = event.deliveries.filter(
+        (d) => d.status !== "sent" && d.status !== pendingStatus,
+      ).length;
+      if (undelivered > 0) {
+        toast.warning(
+          `${undelivered} report${undelivered === 1 ? "" : "s"} didn't go out`,
+          {
+            description: `${event.workflowId}${
+              event.scheduled ? " (scheduled run)" : ""
+            } — open Workflows for the reason.`,
+          },
+        );
+      }
+      break;
+    }
     default:
       // An unknown/forward event kind: ignore rather than surface noise.
       break;

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -10,19 +10,21 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useTheme } from "next-themes";
-import { Loader2, Play, Plus } from "lucide-react";
+import { History, Loader2, Play, Plus } from "lucide-react";
 import { toast } from "sonner";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import {
   getWorkflow,
+  listWorkflowRuns,
   listWorkflows,
   runWorkflow,
   type DeliveryReport,
   type DeliveryStatus,
   type WorkflowGraph,
   type WorkflowNode as WorkflowNodeModel,
+  type WorkflowRunOutcome,
   type WorkflowRunResult,
   type WorkflowSummary,
 } from "@/api/workflows";
@@ -59,9 +61,17 @@ const ROW_GAP = 150;
 export function WorkflowsView({
   client,
   company,
+  runEventTick = 0,
 }: {
   client: OpenCompanyClient;
   company: string | null;
+  /**
+   * Bumped by the shell on every `workflow_run_finished` SSE event (issue
+   * #228), so a run that finishes while this tab is open shows up without a
+   * reload. Matters most for a scheduled run — nothing else would tell this
+   * view a cron fired.
+   */
+  runEventTick?: number;
 }) {
   const { resolvedTheme } = useTheme();
   const [workflows, setWorkflows] = useState<WorkflowSummary[]>([]);
@@ -79,6 +89,17 @@ export function WorkflowsView({
   const [error, setError] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  // Issue #228: what past runs did, read back from the host's journal. This is
+  // the half that survives a reload — before it, a manual run's delivery rows
+  // vanished when the drawer was dismissed and a scheduled run's never reached
+  // the operator at all.
+  const [runs, setRuns] = useState<WorkflowRunOutcome[]>([]);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  // A host predating the runs route answers 404. That is not an error worth
+  // showing — the rest of the view works — so it just means "no history here".
+  const [historySupported, setHistorySupported] = useState(true);
+  // Bumped after a manual run so the history picks it up without a reload.
+  const [runsTick, setRunsTick] = useState(0);
 
   // Load the workflow list once, and auto-select the first entry.
   useEffect(() => {
@@ -136,6 +157,30 @@ export function WorkflowsView({
     };
   }, [client, company, selectedId]);
 
+  // Load the company's run history. Re-runs when the company changes, after a
+  // manual run, and on every `workflow_run_finished` the shell forwards — so a
+  // scheduled run that fires with this tab open lands here on its own.
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      try {
+        const rows = await listWorkflowRuns(client, company, { limit: 50 });
+        if (!live) return;
+        setRuns(rows);
+        setHistorySupported(true);
+      } catch (e) {
+        if (!live) return;
+        // Degrade quietly: an older host simply has no history to show.
+        console.debug("[WorkflowsView] run history unavailable", e);
+        setRuns([]);
+        setHistorySupported(false);
+      }
+    })();
+    return () => {
+      live = false;
+    };
+  }, [client, company, runsTick, runEventTick]);
+
   const run = useCallback(async () => {
     if (!selectedId) return;
     setRunning(true);
@@ -151,9 +196,15 @@ export function WorkflowsView({
       );
       setRanWith(asked);
       setResult(res);
+      // The run is journaled host-side (#228); pull the history forward so the
+      // chip and the panel reflect it immediately.
+      setRunsTick((n) => n + 1);
       toast.success("Workflow ran.");
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "could not run the workflow");
+      // A run that failed is journaled too (#228), and is the outcome most
+      // worth finding again later — so refresh the history on this path as well.
+      setRunsTick((n) => n + 1);
     } finally {
       setRunning(false);
     }
@@ -188,12 +239,23 @@ export function WorkflowsView({
     setSelectedNodeId(node.id);
   }, []);
 
+  // The selected workflow's runs, newest first (the host already orders them).
+  const selectedRuns = useMemo(
+    () => (selectedId ? runs.filter((r) => r.workflowId === selectedId) : []),
+    [runs, selectedId],
+  );
+  const lastRun = selectedRuns[0] ?? null;
+
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       <div className="flex flex-wrap items-center justify-between gap-2 border-b px-4 py-3">
         <div className="flex min-w-0 items-center gap-2">
           <h2 className="text-sm font-semibold">Workflows</h2>
           <Badge variant="secondary">{workflows.length}</Badge>
+          {/* Issue #228: the last run's outcome at a glance — including for a
+              scheduled run nobody watched, which is the case the issue is
+              about. Absent until this workflow has run at least once. */}
+          {lastRun && <LastRunChip run={lastRun} />}
           {selected?.description && (
             <p className="hidden truncate text-xs text-muted-foreground sm:block">
               {selected.description}
@@ -238,6 +300,22 @@ export function WorkflowsView({
             )}
             Run
           </Button>
+          {historySupported && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setHistoryOpen((open) => !open)}
+              aria-pressed={historyOpen}
+            >
+              <History className="mr-1.5 size-4" />
+              History
+              {selectedRuns.length > 0 && (
+                <Badge variant="secondary" className="ml-1.5 h-4 px-1.5 text-[10px] font-normal">
+                  {selectedRuns.length}
+                </Badge>
+              )}
+            </Button>
+          )}
           <Button size="sm" variant="outline" onClick={() => setCreateOpen(true)}>
             <Plus className="mr-1.5 size-4" />
             New workflow
@@ -299,6 +377,14 @@ export function WorkflowsView({
           graph={graph}
           request={ranWith}
           onClose={() => setResult(null)}
+        />
+      )}
+
+      {historyOpen && historySupported && (
+        <RunHistoryPanel
+          runs={selectedRuns}
+          workflowName={selected?.name ?? selectedId ?? ""}
+          onClose={() => setHistoryOpen(false)}
         />
       )}
 
@@ -486,6 +572,181 @@ function DeliveryRows({ deliveries }: { deliveries: DeliveryReport[] }) {
           </span>
         </div>
       ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Run history (issue #228)
+// ---------------------------------------------------------------------------
+
+/**
+ * The `pending` delivery status — a report parked for an operator's approval —
+ * is added to `DeliveryStatus` by issue #227. It is typed `string` rather than
+ * written as a literal so these comparisons compile both before and after that
+ * lands: against today's union TypeScript would reject the literal as a
+ * no-overlap comparison, and once the union widens this keeps behaving
+ * identically. The runtime check is what matters — the host can already send a
+ * status this console's type doesn't name yet.
+ */
+const PENDING_STATUS: string = "pending";
+
+/** Reports that did NOT reach their destination **and will not without a
+ * change** — the number worth acting on. `pending` is excluded on purpose: it
+ * is a report parked for an operator's approval, so counting it here would
+ * badge a working approvals queue as a failure. */
+function undeliveredCount(deliveries: DeliveryReport[]): number {
+  return deliveries.filter((d) => d.status !== "sent" && d.status !== PENDING_STATUS).length;
+}
+
+/** Reports waiting on an operator's verdict rather than on a fix. */
+function pendingCount(deliveries: DeliveryReport[]): number {
+  return deliveries.filter((d) => d.status === PENDING_STATUS).length;
+}
+
+/** A compact "N minutes ago" for a run timestamp — enough to tell last night's
+ * scheduled run from the one just clicked, without a date library. */
+function relativeTime(atMillis: number): string {
+  const seconds = Math.max(0, Math.round((Date.now() - atMillis) / 1000));
+  if (seconds < 60) return "just now";
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+/** The status dot for a whole run: red when it failed or lost a report, sky
+ * when something is parked for approval, green when everything landed. */
+function runTone(run: WorkflowRunOutcome): { dot: string; label: string } {
+  if (run.error) return { dot: "bg-red-500", label: "failed" };
+  if (undeliveredCount(run.deliveries) > 0) return { dot: "bg-red-500", label: "not delivered" };
+  if (pendingCount(run.deliveries) > 0) return { dot: "bg-sky-500", label: "awaiting approval" };
+  return { dot: "bg-emerald-500", label: "ok" };
+}
+
+/** The last-run chip beside the workflow title: a status dot, the undelivered
+ * count when there is one, and how long ago it ran. This is the at-a-glance
+ * answer to "did last night's scheduled run actually deliver?" — the question
+ * that had no answer at all before issue #228. */
+function LastRunChip({ run }: { run: WorkflowRunOutcome }) {
+  const tone = runTone(run);
+  const undelivered = undeliveredCount(run.deliveries);
+  const pending = pendingCount(run.deliveries);
+  return (
+    <Badge
+      variant="outline"
+      className="h-5 gap-1.5 px-2 text-[10px] font-normal"
+      title={
+        run.error
+          ? `Last run failed: ${run.error}`
+          : `Last ${run.scheduled ? "scheduled" : "manual"} run — ${tone.label}`
+      }
+    >
+      <span className={`size-1.5 rounded-full ${tone.dot}`} />
+      {run.scheduled ? "Scheduled" : "Manual"} run
+      {run.error
+        ? " failed"
+        : undelivered > 0
+          ? ` · ${undelivered} not delivered`
+          : pending > 0
+            ? ` · ${pending} awaiting approval`
+            : ""}
+      <span className="text-muted-foreground">· {relativeTime(run.atMillis)}</span>
+    </Badge>
+  );
+}
+
+/** The run-history drawer: one row per finished run of the selected workflow,
+ * newest first, each expanding to the very same {@link DeliveryRows} block the
+ * live run drawer shows.
+ *
+ * This is the durable half of issue #228. A manual run's delivery rows used to
+ * live only in the run drawer until it was dismissed, and a scheduled run's only
+ * on the host's stdout — which on a hosted tenant is the platform team, not the
+ * operator. These rows come back from the company's journal, so they survive a
+ * console reload and a run nobody was watching. */
+function RunHistoryPanel({
+  runs,
+  workflowName,
+  onClose,
+}: {
+  runs: WorkflowRunOutcome[];
+  workflowName: string;
+  onClose: () => void;
+}) {
+  return (
+    <div className="border-t bg-card/60">
+      <div className="flex items-center justify-between px-4 py-2">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">Run history</span>
+          {workflowName && (
+            <span className="truncate text-xs text-muted-foreground">{workflowName}</span>
+          )}
+          <Badge variant="secondary">{runs.length}</Badge>
+        </div>
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          Dismiss
+        </Button>
+      </div>
+      <div className="max-h-72 overflow-auto px-4 pb-3">
+        {runs.length === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            This workflow hasn't finished a run yet. Runs appear here once they
+            do — including scheduled ones that run while you're away.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {runs.map((run) => (
+              <RunHistoryRow key={run.seq} run={run} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** One finished run: a summary line, and its delivery rows underneath. */
+function RunHistoryRow({ run }: { run: WorkflowRunOutcome }) {
+  const tone = runTone(run);
+  return (
+    <div className="rounded-lg border bg-background/40 p-2">
+      <div className="mb-1 flex flex-wrap items-center gap-2">
+        <span className={`size-1.5 rounded-full ${tone.dot}`} />
+        <Badge variant="outline" className="h-4 px-1.5 text-[10px] font-normal">
+          {run.scheduled ? "scheduled" : "manual"}
+        </Badge>
+        <span className="text-[11px] text-muted-foreground">
+          {new Date(run.atMillis).toLocaleString()} · {relativeTime(run.atMillis)}
+        </span>
+        {run.pendingApprovals.length > 0 && (
+          <Badge
+            variant="outline"
+            className="h-4 px-1.5 text-[10px] font-normal border-amber-500/40 bg-amber-500/10"
+          >
+            {run.pendingApprovals.length} pending approval
+            {run.pendingApprovals.length === 1 ? "" : "s"}
+          </Badge>
+        )}
+      </div>
+      {run.error ? (
+        // The outcome that used to be quietest of all: a run that died left one
+        // host-stdout warning and nothing an operator could ever find.
+        <Alert variant="destructive" className="py-2">
+          <AlertDescription className="text-[11px]">
+            This run failed: {run.error}
+          </AlertDescription>
+        </Alert>
+      ) : run.deliveries.length > 0 ? (
+        // Deliberately the SAME component the live run drawer uses, so a report
+        // reads identically whether it's on screen now or a week old.
+        <DeliveryRows deliveries={run.deliveries} />
+      ) : (
+        <p className="text-[11px] text-muted-foreground">
+          Finished — this run routed no reports.
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -157,14 +157,35 @@ export function WorkflowsView({
     };
   }, [client, company, selectedId]);
 
-  // Load the company's run history. Re-runs when the company changes, after a
-  // manual run, and on every `workflow_run_finished` the shell forwards — so a
-  // scheduled run that fires with this tab open lands here on its own.
+  // Load the SELECTED workflow's run history. Re-runs when the selection or
+  // company changes, after a manual run, and on every `workflow_run_finished`
+  // the shell forwards — so a scheduled run that fires with this tab open lands
+  // here on its own.
+  //
+  // The `workflow` filter is not an optimization, it is the correctness of this
+  // read. The host applies `?workflow=` BEFORE the `limit` cut precisely so a
+  // rarely-run workflow still returns its own most recent runs. Fetching the
+  // company-wide page and filtering client-side would undo that: once other
+  // workflows produce `limit` more-recent runs, this workflow's history falls
+  // out of the page and the panel would claim it "hasn't finished a run yet"
+  // while the run sits journaled on the host — which is issue #228's own
+  // symptom, reappearing in the console.
   useEffect(() => {
+    // No selection yet (first render, or a company with no workflows): there is
+    // no history to ask for, and asking unfiltered is the bug described above.
+    // `historySupported` is deliberately left alone — nothing was learned about
+    // whether the host serves this route.
+    if (!selectedId) {
+      setRuns([]);
+      return;
+    }
     let live = true;
     (async () => {
       try {
-        const rows = await listWorkflowRuns(client, company, { limit: 50 });
+        const rows = await listWorkflowRuns(client, company, {
+          workflow: selectedId,
+          limit: 50,
+        });
         if (!live) return;
         setRuns(rows);
         setHistorySupported(true);
@@ -179,7 +200,7 @@ export function WorkflowsView({
     return () => {
       live = false;
     };
-  }, [client, company, runsTick, runEventTick]);
+  }, [client, company, selectedId, runsTick, runEventTick]);
 
   const run = useCallback(async () => {
     if (!selectedId) return;
@@ -239,12 +260,10 @@ export function WorkflowsView({
     setSelectedNodeId(node.id);
   }, []);
 
-  // The selected workflow's runs, newest first (the host already orders them).
-  const selectedRuns = useMemo(
-    () => (selectedId ? runs.filter((r) => r.workflowId === selectedId) : []),
-    [runs, selectedId],
-  );
-  const lastRun = selectedRuns[0] ?? null;
+  // `runs` already holds only the selected workflow's runs, newest first — the
+  // host filters and orders them. Re-filtering here would be a second source of
+  // truth that can only ever disagree with the first.
+  const lastRun = runs[0] ?? null;
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
@@ -306,12 +325,13 @@ export function WorkflowsView({
               variant="outline"
               onClick={() => setHistoryOpen((open) => !open)}
               aria-pressed={historyOpen}
+              data-testid="workflow-history-toggle"
             >
               <History className="mr-1.5 size-4" />
               History
-              {selectedRuns.length > 0 && (
+              {runs.length > 0 && (
                 <Badge variant="secondary" className="ml-1.5 h-4 px-1.5 text-[10px] font-normal">
-                  {selectedRuns.length}
+                  {runs.length}
                 </Badge>
               )}
             </Button>
@@ -382,7 +402,7 @@ export function WorkflowsView({
 
       {historyOpen && historySupported && (
         <RunHistoryPanel
-          runs={selectedRuns}
+          runs={runs}
           workflowName={selected?.name ?? selectedId ?? ""}
           onClose={() => setHistoryOpen(false)}
         />
@@ -637,6 +657,7 @@ function LastRunChip({ run }: { run: WorkflowRunOutcome }) {
     <Badge
       variant="outline"
       className="h-5 gap-1.5 px-2 text-[10px] font-normal"
+      data-testid="workflow-last-run-chip"
       title={
         run.error
           ? `Last run failed: ${run.error}`
@@ -676,7 +697,7 @@ function RunHistoryPanel({
   onClose: () => void;
 }) {
   return (
-    <div className="border-t bg-card/60">
+    <div className="border-t bg-card/60" data-testid="workflow-run-history">
       <div className="flex items-center justify-between px-4 py-2">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium">Run history</span>
@@ -711,7 +732,7 @@ function RunHistoryPanel({
 function RunHistoryRow({ run }: { run: WorkflowRunOutcome }) {
   const tone = runTone(run);
   return (
-    <div className="rounded-lg border bg-background/40 p-2">
+    <div className="rounded-lg border bg-background/40 p-2" data-testid="workflow-run-row">
       <div className="mb-1 flex flex-wrap items-center gap-2">
         <span className={`size-1.5 rounded-full ${tone.dot}`} />
         <Badge variant="outline" className="h-4 px-1.5 text-[10px] font-normal">

--- a/frontend/test/e2e/workflow-run-history.spec.ts
+++ b/frontend/test/e2e/workflow-run-history.spec.ts
@@ -1,0 +1,160 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Issue #228: the Workflows view reads a workflow's finished runs back from the
+ * host's journal, so a run's outcome survives the drawer being dismissed, the
+ * console being reloaded, and — for a scheduled run — nobody having watched.
+ *
+ * The load-bearing detail these specs pin is that the history read is **scoped
+ * to the selected workflow server-side**. The host applies `?workflow=` BEFORE
+ * its `limit` cut precisely so a rarely-run workflow still returns its own most
+ * recent runs. A console that fetched the company-wide page and filtered
+ * client-side would undo that: once other workflows produced `limit` more
+ * recent runs, the selected workflow's history would fall out of the fetched
+ * page and the panel would claim it "hasn't finished a run yet" while the run
+ * sat journaled on the host — which is issue #228's own symptom reappearing in
+ * the client. That regression is invisible on a small company, which is exactly
+ * why it is asserted on the request rather than left to eyeballing.
+ *
+ * Runs against the live host the harness brings up (see `playwright.config.ts`).
+ * The company must have at least one workflow saved.
+ */
+
+/**
+ * Dismisses the first-run "Welcome to your company" tour if it is up.
+ *
+ * A fresh company shows it over every view, and its overlay swallows pointer
+ * events — so without this the specs fail on an unrelated modal rather than on
+ * anything they are about. Tolerates its absence: a company that has already
+ * seen the tour never shows it again.
+ */
+async function dismissTour(page: import("@playwright/test").Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  // The dialog mounts a beat after navigation, so an instant visibility probe
+  // races it and leaves the overlay swallowing every later click. Wait a bounded
+  // moment for it, and treat "never appeared" as already dismissed.
+  try {
+    await skip.waitFor({ state: "visible", timeout: 10_000 });
+  } catch {
+    return;
+  }
+  await skip.click();
+  await expect(skip).toBeHidden();
+}
+
+/**
+ * The History toggle, once the view has settled.
+ *
+ * Waits for it rather than probing `count()` immediately: the button renders
+ * only after the workflow list resolves and a workflow is selected, so an
+ * instant check races the first paint and would silently skip on a host that
+ * DOES serve the route — turning a real failure into a green run. Only a
+ * genuine timeout means the host predates `…/workflows/runs`, and that is the
+ * one case worth skipping for.
+ */
+async function historyToggle(page: import("@playwright/test").Page) {
+  const toggle = page.getByTestId("workflow-history-toggle");
+  try {
+    await toggle.waitFor({ state: "visible", timeout: 30_000 });
+  } catch {
+    test.skip(true, "this host does not serve …/workflows/runs");
+  }
+  return toggle;
+}
+
+/** The host route these specs are about. */
+const RUNS_ROUTE = /\/workflows\/runs\b/;
+
+test("the console asks the host for the selected workflow's runs, not the whole company's", async ({
+  page,
+}) => {
+  // Capture every run-history request the view makes.
+  const requested: string[] = [];
+  page.on("request", (req) => {
+    if (RUNS_ROUTE.test(req.url())) requested.push(req.url());
+  });
+
+  await page.goto("/#/workflows");
+
+  // The view fetches history once a workflow is selected (the list auto-selects
+  // the first entry), so wait for the request rather than racing it.
+  await expect.poll(() => requested.length, { timeout: 30_000 }).toBeGreaterThan(0);
+
+  for (const url of requested) {
+    const params = new URL(url).searchParams;
+    expect(
+      params.get("workflow"),
+      `history must be scoped server-side, got: ${url}`,
+    ).toBeTruthy();
+  }
+});
+
+test("the run-history panel opens and shows only the selected workflow's runs", async ({
+  page,
+}) => {
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+
+  const toggle = await historyToggle(page);
+  await toggle.click();
+
+  const panel = page.getByTestId("workflow-run-history");
+  await expect(panel).toBeVisible();
+
+  // Either the workflow has runs, or the panel says so plainly. Both are
+  // correct; what must never happen is an error or an empty unexplained panel.
+  const rows = panel.getByTestId("workflow-run-row");
+  const count = await rows.count();
+  if (count === 0) {
+    await expect(panel.getByText(/hasn't finished a run yet/)).toBeVisible();
+  } else {
+    // Every row is a real outcome: it says how the run started.
+    await expect(rows.first().getByText(/^(scheduled|manual)$/)).toBeVisible();
+  }
+});
+
+test("running a workflow adds it to the durable history and it survives a reload", async ({
+  page,
+}) => {
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+
+  const toggle = await historyToggle(page);
+  await toggle.click();
+  const before = await page
+    .getByTestId("workflow-run-history")
+    .getByTestId("workflow-run-row")
+    .count();
+
+  // Run the selected workflow. The run may fail (an agent node with no
+  // inference source) — that is fine and in fact the more interesting case:
+  // a failed run is journaled too, and used to leave nothing behind at all.
+  await page.getByRole("button", { name: "Run", exact: true }).click();
+
+  await expect
+    .poll(
+      async () =>
+        page
+          .getByTestId("workflow-run-history")
+          .getByTestId("workflow-run-row")
+          .count(),
+      { timeout: 60_000 },
+    )
+    .toBeGreaterThan(before);
+
+  // The whole point of #228: reload the console and the outcome is still there,
+  // because it came from the journal rather than from component state.
+  await page.reload();
+  await dismissTour(page);
+  await page.getByTestId("workflow-history-toggle").click();
+  await expect
+    .poll(
+      async () =>
+        page
+          .getByTestId("workflow-run-history")
+          .getByTestId("workflow-run-row")
+          .count(),
+      { timeout: 30_000 },
+    )
+    .toBeGreaterThan(before);
+});

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -14,6 +14,7 @@ use crate::ports::types::{
     ChunkAddr, CompanyEvent, ContextChunk, ContextOp, ContextOpResult, Effect, EffectGroup,
     LedgerEntry, OutboundMessage, Verdict,
 };
+use crate::ports::workflow_runner::DeliveryStatus;
 
 use super::wire::{EffectFrame, Role, WireEvent};
 
@@ -152,6 +153,37 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("Steered task {task_id} ({action})"),
             "task.steered",
         ),
+        // A finished workflow run (#228). Counts and the failure reason only —
+        // NOT the per-row `target` or `detail`. A delivery row's target is a
+        // recipient's email address and its detail can quote one, and this body
+        // is wired out to the inference sidecar; the console reads the full
+        // rows from the journal instead, where they belong to the operator.
+        CompanyEvent::WorkflowRunFinished {
+            workflow_id,
+            scheduled,
+            deliveries,
+            pending_approvals,
+            error,
+            ..
+        } => {
+            let how = if *scheduled { "Scheduled" } else { "Manual" };
+            let body = match error {
+                Some(err) => format!("{how} run of workflow {workflow_id} failed: {err}"),
+                None => {
+                    let undelivered = deliveries
+                        .iter()
+                        .filter(|d| !matches!(d.status, DeliveryStatus::Sent))
+                        .count();
+                    format!(
+                        "{how} run of workflow {workflow_id} finished — {} report(s) routed, \
+                         {undelivered} not delivered, {} pending approval",
+                        deliveries.len(),
+                        pending_approvals.len(),
+                    )
+                }
+            };
+            (Role::System, "workflow".to_string(), body, "workflow.run")
+        }
     };
     WireEvent {
         seq,

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -464,6 +464,31 @@ fn summarize_event(event: &CompanyEvent) -> String {
         CompanyEvent::DeskTaskCompleted {
             task_id, column, ..
         } => format!("task completed ({column}): {task_id}"),
+        // A finished workflow run (#228). Counts only — never a delivery row's
+        // `target` (a recipient's email address) or its `detail`, which can
+        // quote one. This string is a non-sensitive one-liner for the insight
+        // surface; the operator reads the full rows in the console.
+        CompanyEvent::WorkflowRunFinished {
+            workflow_id,
+            scheduled,
+            deliveries,
+            error,
+            ..
+        } => {
+            let how = if *scheduled { "scheduled" } else { "manual" };
+            match error {
+                Some(_) => format!("{how} workflow run failed: {workflow_id}"),
+                None => {
+                    let undelivered = deliveries
+                        .iter()
+                        .filter(|d| !matches!(d.status, crate::ports::DeliveryStatus::Sent))
+                        .count();
+                    format!(
+                        "{how} workflow run finished: {workflow_id} ({undelivered} not delivered)"
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::company::CompanyManifest;
 use crate::ports::ids::{generate_id, now_millis};
+use crate::ports::workflow_runner::DeliveryReport;
 
 // ---------------------------------------------------------------------------
 // Identifiers
@@ -445,6 +446,64 @@ pub enum CompanyEvent {
         /// pause. Lets a reader tell a successful run from a stopped one
         /// without re-deriving it from `output`.
         column: String,
+    },
+    /// A workflow run finished (issue #228) — the durable record of what a run
+    /// actually did, journaled from **both** entry points: the console's Run
+    /// button and the cron [`WorkflowScheduler`](crate::runtime::WorkflowScheduler).
+    ///
+    /// Before this, a run's outcome existed only in the moment. A manual run's
+    /// [`DeliveryReport`] rows lived in the console drawer until it was
+    /// dismissed; a scheduled run's reached only host stdout, which on a hosted
+    /// tenant is the platform team rather than the tenant's operator. Nothing
+    /// wrote a run outcome anywhere the console could read it back — so a report
+    /// that did not leave the building was unfindable an hour later.
+    ///
+    /// This is **not** [issue #242's `RunRecord`](crate::ports::types) and does
+    /// not replace it. That record is a *task-attempt* record minted at the task
+    /// dispatch choke point, keyed to a board task with an attempt ordinal. A
+    /// workflow run enters through a different port entirely
+    /// ([`WorkflowRunner::run`](crate::ports::WorkflowRunner::run)) and produces
+    /// host-side delivery rows per output node; it has no task and no attempt
+    /// ordinal to be keyed on.
+    ///
+    /// Journaled **best-effort, after** the run returns, so it always records a
+    /// finished run and an append failure never disturbs the run path.
+    ///
+    /// Additive: old logs never carry it, and its presence doesn't change how
+    /// any existing variant serializes. Every optional/collection field carries
+    /// `#[serde(default)]` + `skip_serializing_if`, the same contract as
+    /// [`AgentReply`](Self::AgentReply)'s `task_id`, so a journal written before
+    /// this variant existed still loads and every already-persisted event stays
+    /// byte-identical.
+    WorkflowRunFinished {
+        /// The workflow graph that ran (its `workflows/<id>.toml` stem).
+        workflow_id: String,
+        /// Whether a cron schedule started this run rather than an operator.
+        /// The distinction is the point: a scheduled run is the
+        /// nobody-was-watching case this event exists for.
+        scheduled: bool,
+        /// A correlation id for the run, when the entry point minted one.
+        /// `None` today from both entry points — neither has a run id to give —
+        /// and kept `Option` so #242's first-class run, or any future
+        /// correlated entry point, needs no migration.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        run_id: Option<String>,
+        /// One row per attempt to route a reached `output` node's report to its
+        /// destination — the same rows a manual run hands back in its HTTP
+        /// response. Empty for a graph that routes nothing.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        deliveries: Vec<DeliveryReport>,
+        /// Node ids the run left waiting on a human approval.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        pending_approvals: Vec<String>,
+        /// The error that ended the run, when it failed outright rather than
+        /// finishing with rows.
+        ///
+        /// This is the field that closes the loudest hole: today a scheduled
+        /// run's `Err` arm only warns to host stdout, so **the worst outcome is
+        /// currently the quietest**. `None` on a run that completed.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
     },
 }
 
@@ -1486,6 +1545,7 @@ pub struct PaymentReceipt {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::ports::workflow_runner::DeliveryStatus;
 
     fn round_trip<T>(value: &T) -> T
     where
@@ -2344,6 +2404,111 @@ mod test {
         let json = serde_json::to_string(&blob).expect("serialize");
         let again = OverlayBlob::parse(&json).expect("reparse");
         assert_eq!(again.desks, blob.desks);
+    }
+
+    // ── Issue #228: a workflow run's outcome is journaled ───────────────────
+
+    fn delivery(node: &str, status: DeliveryStatus) -> DeliveryReport {
+        DeliveryReport {
+            node: node.to_string(),
+            kind: "owner".to_string(),
+            target: Some("ada@example.com".to_string()),
+            status,
+            detail: "emailed the company's admin".to_string(),
+        }
+    }
+
+    /// The full-bodied variant survives the JSONL round trip the journal puts
+    /// every event through — including the delivery rows, which are the whole
+    /// reason the event exists.
+    #[test]
+    fn workflow_run_finished_round_trips_with_every_field() {
+        let event = CompanyEvent::WorkflowRunFinished {
+            workflow_id: "digest".to_string(),
+            scheduled: true,
+            run_id: Some("run-1".to_string()),
+            deliveries: vec![
+                delivery("owner_summary", DeliveryStatus::Skipped),
+                delivery("also_sent", DeliveryStatus::Sent),
+            ],
+            pending_approvals: vec!["review".to_string()],
+            error: None,
+        };
+        assert_eq!(round_trip(&event), event);
+    }
+
+    /// The failed-run shape round-trips too. This is the arm that today only
+    /// warns to host stdout, so it is the one an operator most needs read back.
+    #[test]
+    fn workflow_run_finished_round_trips_a_failed_run() {
+        let event = CompanyEvent::WorkflowRunFinished {
+            workflow_id: "digest".to_string(),
+            scheduled: true,
+            run_id: None,
+            deliveries: Vec::new(),
+            pending_approvals: Vec::new(),
+            error: Some("agent node `worker` had no inference source".to_string()),
+        };
+        assert_eq!(round_trip(&event), event);
+    }
+
+    /// The additive contract, both halves.
+    ///
+    /// **Forward:** a minimal line — only the two required fields, exactly what
+    /// a future/older writer might emit — still loads, so no persisted journal
+    /// needs migrating.
+    ///
+    /// **Backward:** an empty run serializes to *only* those two fields. Every
+    /// optional/collection field is `skip_serializing_if`, which is what keeps
+    /// the wire form of an outcome-less run minimal rather than littered with
+    /// nulls and `[]`s.
+    #[test]
+    fn workflow_run_finished_omits_and_defaults_its_optional_fields() {
+        let json = r#"{"kind":"WorkflowRunFinished","workflow_id":"digest","scheduled":false}"#;
+        let event: CompanyEvent = serde_json::from_str(json).expect("minimal line loads");
+        assert_eq!(
+            event,
+            CompanyEvent::WorkflowRunFinished {
+                workflow_id: "digest".to_string(),
+                scheduled: false,
+                run_id: None,
+                deliveries: Vec::new(),
+                pending_approvals: Vec::new(),
+                error: None,
+            }
+        );
+        // …and serializing it back emits nothing extra.
+        let out = serde_json::to_string(&event).expect("serialize");
+        assert!(!out.contains("run_id"), "{out}");
+        assert!(!out.contains("deliveries"), "{out}");
+        assert!(!out.contains("pending_approvals"), "{out}");
+        assert!(!out.contains("error"), "{out}");
+    }
+
+    /// **The backcompat proof.** A journal written before this variant existed
+    /// still loads, line for line, and every one of those lines re-serializes
+    /// byte-identically — which is what "additive, no migration" actually
+    /// claims. Adding an enum variant cannot change how a sibling serializes,
+    /// but nothing else in the suite asserts it for the whole log, and a
+    /// regression here would corrupt an export/import round trip silently.
+    #[test]
+    fn a_journal_written_before_this_variant_still_loads_byte_identically() {
+        // Verbatim lines in the pre-#228 on-disk shapes, including the pre-`by`
+        // / pre-`chat` `OperatorMessage` and the pre-`steps` `AgentReply`.
+        let legacy = [
+            r#"{"kind":"OperatorMessage","text":"ship it"}"#,
+            r#"{"kind":"AgentReply","chat_id":"general","agent_id":"ceo","text":"on it"}"#,
+            r#"{"kind":"ScheduleFired","cron":"0 9 * * *","prompt":"daily"}"#,
+            r#"{"kind":"WorkflowCreated","workflow_id":"digest","name":"Digest"}"#,
+            r#"{"kind":"TaskDispatched","task_id":"t-1"}"#,
+            r#"{"kind":"DeskTaskCompleted","task_id":"t-1","desk":"ceo","output":"done","column":"in_review"}"#,
+        ];
+        for line in legacy {
+            let event: CompanyEvent = serde_json::from_str(line)
+                .unwrap_or_else(|e| panic!("pre-#228 journal line must still load: {line} — {e}"));
+            let again = serde_json::to_string(&event).expect("serialize");
+            assert_eq!(again, line, "pre-#228 line must re-serialize unchanged");
+        }
     }
 
     #[test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -45,6 +45,10 @@ pub mod scheduler;
 pub mod telegram_poller;
 pub mod tools;
 pub mod types;
+/// Issue #228: the single place a finished workflow run is journaled, shared by
+/// the console's run route and the cron [`WorkflowScheduler`] so a run's history
+/// is uniform no matter what started it. See [`workflow_outcome`].
+pub mod workflow_outcome;
 pub mod workflow_scheduler;
 
 pub use builder::{RuntimeBuilder, company_id_from_name};
@@ -55,6 +59,7 @@ pub use registry::CompanyRegistry;
 pub use scheduler::{Clock, CompanyScheduler, FakeClock, SystemClock};
 pub use tools::StubToolProvider;
 pub use types::{ApprovalSummary, CompanyStatus, CycleReport};
+pub use workflow_outcome::record_run_finished;
 pub use workflow_scheduler::WorkflowScheduler;
 
 // The assembly struct lives under `company/` to match the `ports.md` sketch

--- a/src/runtime/workflow_outcome.rs
+++ b/src/runtime/workflow_outcome.rs
@@ -1,0 +1,221 @@
+//! Issue #228: journal what a workflow run actually did, from every entry point.
+//!
+//! A workflow run's outcome used to exist only in the moment. A **manual** run's
+//! [`DeliveryReport`] rows lived in the console's run drawer until it was
+//! dismissed; a **scheduled** run's reached only host stdout, which on a hosted
+//! tenant is the platform team rather than the tenant's operator. Nothing wrote
+//! a run outcome anywhere the console could read back afterwards — so the exact
+//! thing an operator most needs to find later ("did last night's owner summary
+//! actually go out?") was unfindable an hour after the run.
+//!
+//! This module is the one place that writes
+//! [`CompanyEvent::WorkflowRunFinished`]. Both entry points — the console's
+//! `POST …/workflows/{wid}/run` route and the cron
+//! [`WorkflowScheduler`](super::WorkflowScheduler) — call
+//! [`record_run_finished`], so a run's history is uniform no matter what started
+//! it and the two call sites cannot drift apart in what they record.
+//!
+//! **Best-effort by construction.** The append happens *after* the run returns,
+//! so it always records a finished run, and a failure to append is logged and
+//! swallowed: journalling an outcome must never disturb the run path or fail a
+//! run whose work already happened.
+//!
+//! It deliberately does **not** replace the scheduler's log lines. Those remain
+//! the platform team's diagnostic on host stdout; this event is the *operator's*
+//! surface, read back through `GET …/workflows/runs`.
+
+use std::sync::Arc;
+
+use crate::ports::EventLog;
+use crate::ports::types::{CompanyEvent, CompanyId};
+use crate::ports::workflow_runner::{DeliveryReport, WorkflowRun};
+
+/// Journals a finished workflow run, best-effort.
+///
+/// `scheduled` says whether a cron started the run rather than an operator —
+/// the distinction is the point, since a scheduled run is the
+/// nobody-was-watching case this record exists for.
+///
+/// `outcome` is what the [`WorkflowRunner`](crate::ports::WorkflowRunner)
+/// returned, error included: a run that failed outright is recorded too, and is
+/// in fact the most important thing here — today's `Err` arm on the scheduled
+/// path only warns to host stdout, so **the worst outcome is currently the
+/// quietest**.
+pub async fn record_run_finished(
+    events: &Arc<dyn EventLog>,
+    company: &CompanyId,
+    workflow_id: &str,
+    scheduled: bool,
+    outcome: Result<&WorkflowRun, &str>,
+) {
+    let (deliveries, pending_approvals, error): (Vec<DeliveryReport>, Vec<String>, Option<String>) =
+        match outcome {
+            Ok(run) => (run.deliveries.clone(), run.pending_approvals.clone(), None),
+            Err(err) => (Vec::new(), Vec::new(), Some(err.to_string())),
+        };
+
+    let event = CompanyEvent::WorkflowRunFinished {
+        workflow_id: workflow_id.to_string(),
+        scheduled,
+        // Neither entry point mints a run id today. Kept on the event so #242's
+        // first-class run — or any future correlated entry point — needs no
+        // migration to start populating it.
+        run_id: None,
+        deliveries,
+        pending_approvals,
+        error,
+    };
+
+    if let Err(err) = events.append(company, event).await {
+        // Swallowed on purpose: the run already happened and its work is valid.
+        // Losing the record is worth a loud line, never a failed run.
+        tracing::warn!(
+            %company,
+            workflow = %workflow_id,
+            scheduled,
+            %err,
+            "workflow run outcome could not be journaled; the run itself was unaffected"
+        );
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use serde_json::Value;
+
+    use super::*;
+    use crate::ports::types::EventSeq;
+    use crate::ports::workflow_runner::DeliveryStatus;
+    use crate::store::FsEventLog;
+
+    /// The real filesystem journal over a temp home, not a test double: the
+    /// claim being made is that a run outcome survives to disk and reads back,
+    /// so the JSONL round trip is the thing under test.
+    fn log() -> (tempfile::TempDir, Arc<dyn EventLog>) {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-run-outcome-")
+            .tempdir()
+            .expect("tempdir");
+        let events: Arc<dyn EventLog> = Arc::new(FsEventLog::new(dir.path()));
+        (dir, events)
+    }
+
+    fn run_with(deliveries: Vec<DeliveryReport>, pending: Vec<String>) -> WorkflowRun {
+        WorkflowRun {
+            output: Value::Null,
+            pending_approvals: pending,
+            deliveries,
+        }
+    }
+
+    fn report(node: &str, status: DeliveryStatus) -> DeliveryReport {
+        DeliveryReport {
+            node: node.to_string(),
+            kind: "owner".to_string(),
+            target: Some("ada@example.com".to_string()),
+            status,
+            detail: "this recipient has never written to the company".to_string(),
+        }
+    }
+
+    async fn journaled(events: &Arc<dyn EventLog>, company: &CompanyId) -> Vec<CompanyEvent> {
+        events
+            .read_from(company, EventSeq::new(0), usize::MAX)
+            .await
+            .expect("read")
+            .into_iter()
+            .map(|s| s.event)
+            .collect()
+    }
+
+    /// A completed run records its delivery rows and pending approvals verbatim
+    /// — the rows are the whole reason the record exists.
+    #[tokio::test]
+    async fn a_completed_run_records_its_rows_and_approvals() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        let run = run_with(
+            vec![
+                report("owner_summary", DeliveryStatus::Skipped),
+                report("also_sent", DeliveryStatus::Sent),
+            ],
+            vec!["review".to_string()],
+        );
+
+        record_run_finished(&events, &company, "digest", true, Ok(&run)).await;
+
+        let events = journaled(&events, &company).await;
+        assert_eq!(events.len(), 1);
+        let CompanyEvent::WorkflowRunFinished {
+            workflow_id,
+            scheduled,
+            deliveries,
+            pending_approvals,
+            error,
+            ..
+        } = &events[0]
+        else {
+            panic!("expected a WorkflowRunFinished, got {:?}", events[0]);
+        };
+        assert_eq!(workflow_id, "digest");
+        assert!(*scheduled);
+        assert_eq!(deliveries.len(), 2);
+        assert_eq!(deliveries[0].node, "owner_summary");
+        assert_eq!(deliveries[0].status, DeliveryStatus::Skipped);
+        // The `detail` is the part that says what to fix, so it must survive.
+        assert!(deliveries[0].detail.contains("never written"));
+        assert_eq!(pending_approvals, &vec!["review".to_string()]);
+        assert!(error.is_none(), "a completed run carries no error");
+    }
+
+    /// The arm that matters most: a run that failed outright is recorded, with
+    /// the reason. Before this it only warned to host stdout.
+    #[tokio::test]
+    async fn a_failed_run_records_the_error() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+
+        record_run_finished(
+            &events,
+            &company,
+            "digest",
+            true,
+            Err("agent node `worker` had no inference source"),
+        )
+        .await;
+
+        let events = journaled(&events, &company).await;
+        let CompanyEvent::WorkflowRunFinished {
+            deliveries,
+            pending_approvals,
+            error,
+            ..
+        } = &events[0]
+        else {
+            panic!("expected a WorkflowRunFinished");
+        };
+        assert!(deliveries.is_empty());
+        assert!(pending_approvals.is_empty());
+        assert_eq!(
+            error.as_deref(),
+            Some("agent node `worker` had no inference source")
+        );
+    }
+
+    /// A manual run is recorded the same way, flagged as not scheduled — that
+    /// flag is what lets the console tell a cron run from a Run-button one.
+    #[tokio::test]
+    async fn a_manual_run_is_recorded_as_unscheduled() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        let run = run_with(Vec::new(), Vec::new());
+
+        record_run_finished(&events, &company, "digest", false, Ok(&run)).await;
+
+        let events = journaled(&events, &company).await;
+        let CompanyEvent::WorkflowRunFinished { scheduled, .. } = &events[0] else {
+            panic!("expected a WorkflowRunFinished");
+        };
+        assert!(!*scheduled);
+    }
+}

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -41,13 +41,23 @@
 //!
 //! **Be clear about the ceiling of that.** A log line reaches whoever can read
 //! the host's stdout. On a self-hosted deployment that is the operator; on a
-//! hosted tenant it is emphatically not — it is us. So this makes a failed
-//! scheduled delivery *diagnosable*, not *operator-visible*. Closing that gap
-//! needs somewhere durable an operator actually looks, and no such run-history
-//! surface exists for workflows yet (a manual run's deliveries are transient
-//! too — they live only in the drawer until it is dismissed). That is issue
-//! #228, and the durable record it needs is issue #242's first-class `Run`;
-//! this is the half that can be done without inventing a subsystem.
+//! hosted tenant it is emphatically not — it is us. So the log makes a failed
+//! scheduled delivery *diagnosable*, not *operator-visible*.
+//!
+//! Issue #228 closes that gap without inventing a subsystem: every finished run
+//! — this scheduler's and the console's Run button alike — is journaled as a
+//! [`CompanyEvent::WorkflowRunFinished`](crate::ports::types::CompanyEvent)
+//! through [`record_run_finished`], projected live onto the operator SSE stream,
+//! and read back durably from `GET …/workflows/runs`. The log lines below stay
+//! exactly as they were: they remain the platform team's diagnostic, and the
+//! event is the operator's surface. The two answer to different readers, so
+//! neither replaces the other.
+//!
+//! (A run outcome is deliberately *not* modelled as issue #242's first-class
+//! `RunRecord`. That is a task-attempt record minted at the task dispatch choke
+//! point and keyed to a board task with an attempt ordinal; a workflow run
+//! enters through the [`WorkflowRunner`] port, has no task, and produces
+//! host-side delivery rows per output node. The shapes don't meet.)
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
@@ -63,6 +73,7 @@ use crate::ports::{DeliveryReport, DeliveryStatus};
 use crate::runtime::CompanyRegistry;
 use crate::runtime::cron::{CivilTime, CronExpr};
 use crate::runtime::scheduler::{Clock, MINUTE_MS, millis_to_next_minute};
+use crate::runtime::workflow_outcome::record_run_finished;
 
 /// Identifies one schedulable workflow: which company, which graph.
 type WorkflowKey = (CompanyId, String);
@@ -273,6 +284,12 @@ impl WorkflowScheduler {
 
                 let runner = runner.clone();
                 let workflow = file;
+                // Cloned BEFORE the spawn: the task outlives this loop
+                // iteration (and this borrow of `runtime`), so the handle has to
+                // be moved in rather than reached for from inside. Issue #228 —
+                // this is what turns a scheduled run's outcome from a host-stdout
+                // line into something the tenant's own console can read back.
+                let events = runtime.events().clone();
                 // A FRESH TASK PER FIRE IS CORRECT HERE, and is not a hole in
                 // the `WORKFLOW_DEPTH` re-entry guard
                 // (`crate::workflows::runner`). That guard is a task-local
@@ -343,13 +360,34 @@ impl WorkflowScheduler {
                                 undelivered = counts.undelivered(),
                                 "workflow scheduler: scheduled run finished"
                             );
+                            // Issue #228: the operator-facing half. The log
+                            // lines above stay exactly as they are — they are
+                            // the platform team's diagnostic on host stdout,
+                            // which on a hosted tenant is emphatically not the
+                            // operator. This is the record the tenant's own
+                            // console reads back, after the fact, on reload.
+                            record_run_finished(&events, &company, &workflow_id, true, Ok(&run))
+                                .await;
                         }
-                        Err(err) => tracing::warn!(
-                            %company,
-                            workflow = %workflow_id,
-                            %err,
-                            "workflow scheduler: scheduled run failed"
-                        ),
+                        Err(err) => {
+                            tracing::warn!(
+                                %company,
+                                workflow = %workflow_id,
+                                %err,
+                                "workflow scheduler: scheduled run failed"
+                            );
+                            // The worst outcome was until now the quietest: a
+                            // run that died outright produced one host-stdout
+                            // warning and nothing an operator could ever find.
+                            record_run_finished(
+                                &events,
+                                &company,
+                                &workflow_id,
+                                true,
+                                Err(err.to_string().as_str()),
+                            )
+                            .await;
+                        }
                     }
                 });
                 fired += 1;
@@ -522,7 +560,7 @@ mod test {
 
     use super::*;
     use crate::company::CompanyManifest;
-    use crate::ports::types::{CompanyRecord, OverlayWorkflow};
+    use crate::ports::types::{CompanyEvent, CompanyRecord, EventSeq, OverlayWorkflow};
     use crate::ports::{WorkflowRun, WorkflowRunner};
     use crate::runtime::{FakeClock, RuntimeBuilder};
 
@@ -725,6 +763,38 @@ mod test {
                 pending_approvals: Vec::new(),
                 deliveries: self.deliveries.clone(),
             })
+        }
+    }
+
+    /// A [`WorkflowRunner`] whose every run fails, so a test can drive the
+    /// scheduler's `Err` arm — the outcome that used to leave nothing durable
+    /// behind at all (issue #228).
+    struct FailingRunner {
+        message: String,
+        attempts: Arc<AtomicUsize>,
+    }
+
+    impl FailingRunner {
+        fn new(message: &str) -> (Arc<Self>, Arc<AtomicUsize>) {
+            let attempts = Arc::new(AtomicUsize::new(0));
+            let runner = Arc::new(Self {
+                message: message.to_string(),
+                attempts: attempts.clone(),
+            });
+            (runner, attempts)
+        }
+    }
+
+    #[async_trait]
+    impl WorkflowRunner for FailingRunner {
+        async fn run(
+            &self,
+            _company: &CompanyId,
+            _workflow: &WorkflowFile,
+            _input: Value,
+        ) -> crate::Result<WorkflowRun> {
+            self.attempts.fetch_add(1, Ordering::SeqCst);
+            Err(crate::error::OpenCompanyError::Config(self.message.clone()))
         }
     }
 
@@ -1083,6 +1153,144 @@ to = "done"
         assert!(summary.contains("denied=0"), "{summary}");
         assert!(summary.contains("failed=0"), "{summary}");
         assert!(summary.contains("undelivered=0"), "{summary}");
+    }
+
+    // ── Issue #228: the run outcome reaches the journal, not just stdout ─────
+
+    /// Every `WorkflowRunFinished` journaled for `company`.
+    async fn run_outcomes(registry: &CompanyRegistry, company: &str) -> Vec<CompanyEvent> {
+        let id = CompanyId::new(company);
+        let runtime = registry.get(&id).expect("registered");
+        runtime
+            .events()
+            .read_from(&id, EventSeq::new(0), usize::MAX)
+            .await
+            .expect("read journal")
+            .into_iter()
+            .map(|s| s.event)
+            .filter(|e| matches!(e, CompanyEvent::WorkflowRunFinished { .. }))
+            .collect()
+    }
+
+    /// **The issue.** A scheduled run's delivery rows must land somewhere the
+    /// tenant's own console can read back — the log line only reaches whoever
+    /// reads host stdout, which on a hosted tenant is not the operator.
+    #[tokio::test]
+    async fn a_scheduled_run_journals_its_delivery_rows_and_approvals() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let company = "journal-delivery-co";
+        let (runner, completed) = RecordingRunner::with_deliveries(vec![
+            report(
+                "owner_summary",
+                DeliveryStatus::Skipped,
+                "this recipient has never written to the company",
+            ),
+            report("also_sent", DeliveryStatus::Sent, "emailed the recipient"),
+        ]);
+        let registry = company_with_overlays(
+            &home,
+            company,
+            vec![overlay("digest", Some("* * * * *"))],
+            Some(runner),
+            "running",
+        )
+        .await;
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry.clone(), clock);
+
+        assert_eq!(scheduler.tick().await, 1);
+        wait_for(|| completed.load(Ordering::SeqCst) == 1).await;
+        // The append happens after the run completes, so wait on the journal
+        // rather than racing it.
+        let outcomes = loop {
+            let outcomes = run_outcomes(&registry, company).await;
+            if !outcomes.is_empty() {
+                break outcomes;
+            }
+            tokio::task::yield_now().await;
+        };
+
+        assert_eq!(outcomes.len(), 1);
+        let CompanyEvent::WorkflowRunFinished {
+            workflow_id,
+            scheduled,
+            deliveries,
+            error,
+            ..
+        } = &outcomes[0]
+        else {
+            unreachable!("filtered above")
+        };
+        assert_eq!(workflow_id, "digest");
+        assert!(*scheduled, "a cron fire records itself as scheduled");
+        assert!(error.is_none());
+        assert_eq!(deliveries.len(), 2, "both rows, not just the failed one");
+        let skipped = deliveries
+            .iter()
+            .find(|d| d.node == "owner_summary")
+            .expect("the undelivered row");
+        assert_eq!(skipped.status, DeliveryStatus::Skipped);
+        // The `detail` is the part that says what to fix. The log line carries
+        // it too, but the log is not where the operator can look.
+        assert!(
+            skipped.detail.contains("never written to the company"),
+            "{skipped:?}"
+        );
+        // The journal is operator-scoped — unlike host stdout — so the resolved
+        // target rides it. This is the same field the manual run's HTTP response
+        // already ships to the console today.
+        assert_eq!(skipped.target.as_deref(), Some("ada@example.com"));
+    }
+
+    /// The arm that was quietest of all: a scheduled run that failed outright
+    /// produced one host-stdout warning and nothing durable. Now it records the
+    /// error where an operator can find it.
+    #[tokio::test]
+    async fn a_failed_scheduled_run_journals_the_error() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let company = "journal-failure-co";
+        let (runner, attempts) = FailingRunner::new("no inference source for agent node `worker`");
+        let registry = company_with_overlays(
+            &home,
+            company,
+            vec![overlay("digest", Some("* * * * *"))],
+            Some(runner),
+            "running",
+        )
+        .await;
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry.clone(), clock);
+
+        assert_eq!(scheduler.tick().await, 1);
+        wait_for(|| attempts.load(Ordering::SeqCst) == 1).await;
+        let outcomes = loop {
+            let outcomes = run_outcomes(&registry, company).await;
+            if !outcomes.is_empty() {
+                break outcomes;
+            }
+            tokio::task::yield_now().await;
+        };
+
+        assert_eq!(outcomes.len(), 1);
+        let CompanyEvent::WorkflowRunFinished {
+            scheduled,
+            deliveries,
+            error,
+            ..
+        } = &outcomes[0]
+        else {
+            unreachable!("filtered above")
+        };
+        assert!(*scheduled);
+        assert!(deliveries.is_empty(), "a run that died routed nothing");
+        assert!(
+            error
+                .as_deref()
+                .is_some_and(|e| e.contains("no inference source")),
+            "the failure reason must survive: {error:?}"
+        );
     }
 
     /// A workflow with no schedule is never fired by the scheduler — it stays

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -613,6 +613,9 @@ async fn company_events(
 /// unexpected (or secret-bearing) ever reaches the console. The actor (`by`) on
 /// `ApprovalResolved` / `LifecycleChanged` is intentionally omitted: the console
 /// renders the attention item without it, and it can carry a user id.
+///
+/// Adding a variant to [`CompanyEvent`] therefore drops it by default; it
+/// reaches the console only by being listed here on purpose.
 fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
     use serde_json::json;
 
@@ -735,6 +738,38 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             let mut o = envelope("task_steered");
             o["taskId"] = json!(task_id);
             o["action"] = json!(action);
+            o
+        }
+        // Issue #228: a finished workflow run, so the console can toast a
+        // report that did not go out *while it is happening* instead of only on
+        // the next reload of the history panel.
+        //
+        // This widens nothing. The projected fields are exactly what the run
+        // drawer already renders, and every one of them — `target` included —
+        // already reaches this same console in the manual run's HTTP response
+        // (see `RunWorkflowResponse` in `super::ops::workflows`). The stream is
+        // operator-authenticated and company-scoped, like that response.
+        //
+        // `runId` is deliberately not projected: it is always `None` today, so
+        // emitting it would put a permanently-null key on the wire.
+        CompanyEvent::WorkflowRunFinished {
+            workflow_id,
+            scheduled,
+            deliveries,
+            pending_approvals,
+            error,
+            ..
+        } => {
+            let mut o = envelope("workflow_run_finished");
+            o["workflowId"] = json!(workflow_id);
+            o["scheduled"] = json!(scheduled);
+            o["deliveries"] = json!(deliveries);
+            o["pendingApprovals"] = json!(pending_approvals);
+            // Omitted rather than null on a run that finished, so the console's
+            // "did this fail?" check is a presence check.
+            if let Some(error) = error {
+                o["error"] = json!(error);
+            }
             o
         }
         // Not an attention signal, or carries a raw payload we never put on the
@@ -2743,11 +2778,93 @@ mod test {
         assert_eq!(v["memo"], "invoice #1");
     }
 
+    // ---- issue #228: the workflow-run outcome projection ----
+
+    fn delivery_row(
+        node: &str,
+        status: crate::ports::DeliveryStatus,
+    ) -> crate::ports::DeliveryReport {
+        crate::ports::DeliveryReport {
+            node: node.into(),
+            kind: "email".into(),
+            target: Some("ada@example.com".into()),
+            status,
+            detail: "this recipient has never written to the company".into(),
+        }
+    }
+
+    /// The live half of #228: a finished run reaches the console as it happens,
+    /// carrying exactly the fields the run drawer already renders — so the
+    /// console can toast an undelivered report instead of waiting for a reload.
+    #[test]
+    fn projects_workflow_run_finished_with_the_fields_the_drawer_renders() {
+        let v = super::project_event(&stored(CompanyEvent::WorkflowRunFinished {
+            workflow_id: "digest".into(),
+            scheduled: true,
+            run_id: None,
+            deliveries: vec![
+                delivery_row("owner_summary", crate::ports::DeliveryStatus::Skipped),
+                delivery_row("also_sent", crate::ports::DeliveryStatus::Sent),
+            ],
+            pending_approvals: vec!["review".into()],
+            error: None,
+        }))
+        .expect("workflow_run_finished is an attention signal");
+        assert_eq!(v["type"], "workflow_run_finished");
+        assert_eq!(v["seq"], 7);
+        assert_eq!(v["workflowId"], "digest");
+        assert_eq!(v["scheduled"], true);
+        assert_eq!(v["pendingApprovals"][0], "review");
+
+        // Per-row node/kind/target/status/detail — the same shape the manual
+        // run's HTTP response already ships to this console.
+        let rows = v["deliveries"].as_array().expect("rows");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0]["node"], "owner_summary");
+        assert_eq!(rows[0]["kind"], "email");
+        assert_eq!(rows[0]["status"], "skipped");
+        assert_eq!(rows[0]["target"], "ada@example.com");
+        assert!(
+            rows[0]["detail"]
+                .as_str()
+                .unwrap()
+                .contains("never written"),
+            "the detail names the fix: {v}"
+        );
+
+        // A run that finished carries no `error` key, and `runId` — always
+        // `None` today — is never a permanently-null key on the wire.
+        assert!(v.get("error").is_none(), "{v}");
+        assert!(v.get("runId").is_none(), "{v}");
+    }
+
+    /// The failure arm reaches the console too — it is the outcome that used to
+    /// produce nothing but a host-stdout warning.
+    #[test]
+    fn projects_workflow_run_finished_with_the_failure_reason() {
+        let v = super::project_event(&stored(CompanyEvent::WorkflowRunFinished {
+            workflow_id: "digest".into(),
+            scheduled: true,
+            run_id: None,
+            deliveries: Vec::new(),
+            pending_approvals: Vec::new(),
+            error: Some("no inference source for agent node `worker`".into()),
+        }))
+        .expect("workflow_run_finished is an attention signal");
+        assert_eq!(v["error"], "no inference source for agent node `worker`");
+        assert_eq!(v["deliveries"].as_array().unwrap().len(), 0);
+    }
+
     #[test]
     fn drops_non_attention_and_raw_payload_events() {
         // The operator's own message, and every variant that carries a raw
         // third-party payload or is audit-only, is dropped so nothing unexpected
         // (or secret-bearing) ever reaches the console.
+        //
+        // This list is unchanged by #228: adding `workflow_run_finished` to the
+        // projection widened the wire by exactly one listed variant, and this
+        // test passing untouched is what proves the deny-by-default default
+        // still drops everything it dropped before.
         let dropped = [
             CompanyEvent::OperatorMessage {
                 text: "hi".into(),

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1,6 +1,18 @@
 //! Workflow surfaces: create a graph (`POST /workflows`), read the company's
-//! saved graphs (`GET /workflows`, `GET /workflows/{wid}`), and run one
-//! (`POST /workflows/{wid}/run`) — under both scope forms.
+//! saved graphs (`GET /workflows`, `GET /workflows/{wid}`), run one
+//! (`POST /workflows/{wid}/run`), and read back what past runs did
+//! (`GET /workflows/runs`) — under both scope forms.
+//!
+//! ## Run history (issue #228)
+//!
+//! A run's outcome used to exist only in the moment: a manual run's
+//! [`DeliveryReport`](crate::ports::DeliveryReport) rows lived in the console
+//! drawer until it was dismissed, and a scheduled run's reached only host
+//! stdout. The run route now journals every finished run through
+//! [`record_run_finished`] — the same helper the cron
+//! [`WorkflowScheduler`](crate::runtime::WorkflowScheduler) calls, so history is
+//! uniform whatever started the run — and `GET /workflows/runs` folds those
+//! events back out, newest first.
 //!
 //! A company's graphs come from two places, unioned by
 //! [`load_workflow_union`](crate::company::load_workflow_union) /
@@ -39,7 +51,7 @@
 use std::collections::HashSet;
 use std::path::Path as FsPath;
 
-use axum::extract::Path;
+use axum::extract::{Path, Query};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
@@ -53,7 +65,8 @@ use crate::company::{
     load_workflow_union,
 };
 use crate::error::OpenCompanyError;
-use crate::ports::types::{CompanyRecord, OverlayWorkflow};
+use crate::ports::types::{CompanyEvent, CompanyRecord, EventSeq, OverlayWorkflow};
+use crate::runtime::record_run_finished;
 use crate::server::error::ApiError;
 use crate::server::ops::{ScopedCompany, scoped};
 
@@ -61,6 +74,17 @@ use crate::server::ops::{ScopedCompany, scoped};
 /// run write.
 pub fn router() -> Router<AppState> {
     scoped("/workflows", post(create_workflow).get(list_workflows))
+        // The static `/workflows/runs` GET is registered BEFORE the dynamic
+        // `/workflows/{wid}`, mirroring `GET /tasks/inflight` in
+        // [`super::tasks`]. Axum prefers a static segment over a parameter, so
+        // the run-history read wins even though `runs` is a syntactically valid
+        // `wid`; `run_history_is_not_shadowed_by_the_graph_read` pins it,
+        // because a regression here would silently 404 the history panel.
+        //
+        // The cost is that a workflow whose id is literally `runs` cannot be
+        // read through this route. That is the same trade `tasks/inflight`
+        // takes, and the history surface is worth more than the one reserved id.
+        .merge(scoped("/workflows/runs", get(list_runs)))
         .merge(scoped("/workflows/{wid}", get(get_workflow)))
         .merge(scoped("/workflows/{wid}/run", post(run_workflow)))
 }
@@ -516,16 +540,163 @@ async fn run_workflow(
         })?;
 
     let input = body.map(|Json(b)| b.input).unwrap_or(Value::Null);
-    let run = runner
-        .run(company.id(), &file, input)
-        .await
-        .map_err(|e| ApiError(e).into_response())?;
+    let run = match runner.run(company.id(), &file, input).await {
+        Ok(run) => run,
+        Err(err) => {
+            // Issue #228: a manual run that dies is journaled too, before the
+            // error goes back. The caller sees the 5xx and may well close the
+            // tab; the record is what is still there tomorrow.
+            record_run_finished(
+                company.runtime.events(),
+                company.id(),
+                &wid,
+                false,
+                Err(err.to_string().as_str()),
+            )
+            .await;
+            return Err(ApiError(err).into_response());
+        }
+    };
+
+    // Issue #228: journal the outcome so a manual run's delivery rows stop being
+    // drawer-transient. Until now they lived in the console's run panel until it
+    // was dismissed and then existed nowhere — the operator could not answer
+    // "did that report actually go out?" an hour later. Recorded through the
+    // same helper the scheduler uses, so history is uniform whatever started the
+    // run. Best-effort: the response below is returned either way.
+    record_run_finished(
+        company.runtime.events(),
+        company.id(),
+        &wid,
+        false,
+        Ok(&run),
+    )
+    .await;
 
     Ok(Json(RunWorkflowResponse {
         output: run.output,
         pending_approvals: run.pending_approvals,
         deliveries: run.deliveries,
     }))
+}
+
+// ---------------------------------------------------------------------------
+// Run history (issue #228)
+// ---------------------------------------------------------------------------
+
+/// How many run outcomes `GET …/workflows/runs` returns when the caller names
+/// no `?limit=`, and the ceiling it clamps a larger one to. The console's
+/// history panel shows a short recent list; a bigger page would only make the
+/// journal fold slower for no one's benefit.
+const DEFAULT_RUN_LIMIT: usize = 20;
+const MAX_RUN_LIMIT: usize = 200;
+
+/// The `?workflow=` / `?limit=` selectors on the run-history read.
+#[derive(Debug, Deserialize)]
+struct RunsQuery {
+    /// Return only runs of this workflow id. Absent = every workflow.
+    workflow: Option<String>,
+    /// Cap the page. Clamped to [`MAX_RUN_LIMIT`]; `0` falls back to the
+    /// default rather than returning an empty page, which is never what a
+    /// caller means.
+    limit: Option<usize>,
+}
+
+/// One finished run as the console's history panel renders it (camelCase).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowRunOutcome {
+    /// The journal sequence position — a stable, monotonic row key.
+    seq: u64,
+    /// Epoch-millis the outcome was journaled.
+    at_millis: u64,
+    workflow_id: String,
+    /// Whether a cron started this run rather than an operator. The console
+    /// shows the distinction because a scheduled run is the one nobody watched.
+    scheduled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    run_id: Option<String>,
+    /// The same delivery rows a manual run's response carries — including
+    /// `target`, which the run response already ships to this same console.
+    deliveries: Vec<crate::ports::DeliveryReport>,
+    pending_approvals: Vec<String>,
+    /// Set when the run failed outright instead of finishing with rows.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+/// `GET …/workflows/runs?workflow=&limit=` — the company's finished workflow
+/// runs, **newest first** (issue #228).
+///
+/// This is the durable half of the issue: a manual run's delivery rows used to
+/// live only in the console drawer until it was dismissed, and a scheduled run's
+/// only on host stdout. Folding
+/// [`CompanyEvent::WorkflowRunFinished`](crate::ports::types::CompanyEvent) out
+/// of the journal makes both survive a console reload, which is the whole point.
+///
+/// The fold reads the company's whole event log
+/// (`read_from(0, MAX)`) — the same thing
+/// [`chat_history`](crate::server::chat_history) already does on every history
+/// GET. Following that precedent keeps this route from inventing an index the
+/// rest of the read plane doesn't have; if the journal scan ever becomes the
+/// bottleneck it should be fixed for both surfaces at once, not just here.
+async fn list_runs(
+    company: ScopedCompany,
+    Query(query): Query<RunsQuery>,
+) -> Result<Json<Vec<WorkflowRunOutcome>>, ApiError> {
+    let limit = match query.limit {
+        Some(0) | None => DEFAULT_RUN_LIMIT,
+        Some(n) => n.min(MAX_RUN_LIMIT),
+    };
+
+    let stored = company
+        .runtime
+        .events()
+        .read_from(company.id(), EventSeq::new(0), usize::MAX)
+        .await
+        .map_err(ApiError)?;
+
+    let mut runs: Vec<WorkflowRunOutcome> = stored
+        .into_iter()
+        .filter_map(|stored| {
+            let CompanyEvent::WorkflowRunFinished {
+                workflow_id,
+                scheduled,
+                run_id,
+                deliveries,
+                pending_approvals,
+                error,
+            } = stored.event
+            else {
+                return None;
+            };
+            // The `?workflow=` filter is applied here rather than after the
+            // `limit` cut, so asking for one workflow returns that workflow's
+            // most recent N — not "whichever of the last N happen to match".
+            if query
+                .workflow
+                .as_deref()
+                .is_some_and(|wanted| wanted != workflow_id)
+            {
+                return None;
+            }
+            Some(WorkflowRunOutcome {
+                seq: stored.seq.value(),
+                at_millis: stored.at_millis,
+                workflow_id,
+                scheduled,
+                run_id,
+                deliveries,
+                pending_approvals,
+                error,
+            })
+        })
+        .collect();
+
+    // Newest first: a history panel leads with the run that just happened.
+    runs.reverse();
+    runs.truncate(limit);
+    Ok(Json(runs))
 }
 
 #[cfg(test)]
@@ -1080,6 +1251,7 @@ mod tests {
         use axum::http::{Request, StatusCode};
         use tower::ServiceExt;
 
+        use super::super::{CompanyEvent, DEFAULT_RUN_LIMIT};
         use crate::company::CompanyManifest;
         use crate::ports::CompanyStore;
         use crate::ports::types::{CompanyId, CompanyRecord};
@@ -1374,6 +1546,272 @@ mod tests {
             assert_eq!(items.len(), 1, "body: {listed}");
             assert_eq!(items[0]["id"], "greeter");
             assert_eq!(items[0]["name"], "Greeter");
+        }
+
+        // ── Issue #228: the run-history read ────────────────────────────────
+
+        /// Journals a finished-run outcome directly on the company's event log,
+        /// the way both entry points do via `record_run_finished`.
+        async fn journal_run(
+            state: &AppState,
+            id: &CompanyId,
+            workflow_id: &str,
+            scheduled: bool,
+            deliveries: Vec<crate::ports::DeliveryReport>,
+            error: Option<&str>,
+        ) {
+            let runtime = state.registry().get(id).expect("registered");
+            runtime
+                .events()
+                .append(
+                    id,
+                    CompanyEvent::WorkflowRunFinished {
+                        workflow_id: workflow_id.to_string(),
+                        scheduled,
+                        run_id: None,
+                        deliveries,
+                        pending_approvals: Vec::new(),
+                        error: error.map(str::to_string),
+                    },
+                )
+                .await
+                .expect("append");
+        }
+
+        fn undelivered_row(node: &str) -> crate::ports::DeliveryReport {
+            crate::ports::DeliveryReport {
+                node: node.to_string(),
+                kind: "email".to_string(),
+                target: Some("ada@example.com".to_string()),
+                status: crate::ports::DeliveryStatus::Skipped,
+                detail: "this recipient has never written to the company".to_string(),
+            }
+        }
+
+        /// **The issue, at the HTTP boundary.** A run's delivery rows read back
+        /// after the fact, newest first — which is what survives a console
+        /// reload, and the reason #228 exists.
+        #[tokio::test]
+        async fn run_history_reads_back_newest_first_with_its_rows() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+
+            journal_run(
+                &state,
+                &id,
+                "digest",
+                true,
+                vec![undelivered_row("owner")],
+                None,
+            )
+            .await;
+            journal_run(&state, &id, "greeter", false, Vec::new(), None).await;
+
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = json_body(response).await;
+            let rows = body.as_array().expect("array");
+            assert_eq!(rows.len(), 2, "body: {body}");
+
+            // Newest first: the history panel leads with the run that just ran.
+            assert_eq!(rows[0]["workflowId"], "greeter");
+            assert_eq!(rows[0]["scheduled"], false);
+            assert_eq!(rows[1]["workflowId"], "digest");
+            assert_eq!(rows[1]["scheduled"], true);
+
+            // The delivery row — including the `detail` that names the fix, and
+            // the `target`, which the manual-run response already ships to this
+            // same console.
+            let deliveries = rows[1]["deliveries"].as_array().expect("deliveries");
+            assert_eq!(deliveries.len(), 1);
+            assert_eq!(deliveries[0]["node"], "owner");
+            assert_eq!(deliveries[0]["status"], "skipped");
+            assert_eq!(deliveries[0]["target"], "ada@example.com");
+            assert!(
+                deliveries[0]["detail"]
+                    .as_str()
+                    .unwrap()
+                    .contains("never written")
+            );
+            // A run that finished carries no `error` key at all.
+            assert!(rows[0].get("error").is_none(), "{body}");
+        }
+
+        /// A run that died outright reads back with its reason. This is the
+        /// outcome that previously left nothing behind but a host-stdout warning.
+        #[tokio::test]
+        async fn run_history_carries_a_failed_run_error() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+
+            journal_run(
+                &state,
+                &id,
+                "digest",
+                true,
+                Vec::new(),
+                Some("no inference source for agent node `worker`"),
+            )
+            .await;
+
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            assert_eq!(
+                body[0]["error"],
+                "no inference source for agent node `worker`"
+            );
+            assert_eq!(body[0]["deliveries"].as_array().unwrap().len(), 0);
+        }
+
+        /// `?workflow=` narrows to one graph, and does so BEFORE the limit cut —
+        /// otherwise asking for one workflow would return "whichever of the last
+        /// N happen to match", which for a busy company is usually none.
+        #[tokio::test]
+        async fn run_history_filters_by_workflow_before_the_limit_cut() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+
+            journal_run(&state, &id, "digest", true, Vec::new(), None).await;
+            for _ in 0..5 {
+                journal_run(&state, &id, "greeter", false, Vec::new(), None).await;
+            }
+
+            // Only ONE `digest` run exists, and it is the OLDEST of six. A
+            // filter applied after a `limit=2` cut would find nothing.
+            let response = router(state)
+                .oneshot(request(
+                    "GET",
+                    "/api/v1/company/workflows/runs?workflow=digest&limit=2",
+                    None,
+                ))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            let rows = body.as_array().expect("array");
+            assert_eq!(rows.len(), 1, "body: {body}");
+            assert_eq!(rows[0]["workflowId"], "digest");
+        }
+
+        /// `?limit=` caps the page from the newest end, defaults when absent or
+        /// zero, and clamps above the ceiling rather than folding the whole log.
+        #[tokio::test]
+        async fn run_history_limit_defaults_caps_and_clamps() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+
+            for i in 0..25 {
+                journal_run(&state, &id, &format!("wf-{i}"), false, Vec::new(), None).await;
+            }
+
+            let page = |uri: &'static str| {
+                let state = state.clone();
+                async move {
+                    json_body(
+                        router(state)
+                            .oneshot(request("GET", uri, None))
+                            .await
+                            .unwrap(),
+                    )
+                    .await
+                }
+            };
+
+            // Explicit cap, taken from the newest end.
+            let capped = page("/api/v1/company/workflows/runs?limit=3").await;
+            let rows = capped.as_array().expect("array");
+            assert_eq!(rows.len(), 3);
+            assert_eq!(rows[0]["workflowId"], "wf-24", "newest first: {capped}");
+
+            // No `limit` → the default page, not the whole 25.
+            let defaulted = page("/api/v1/company/workflows/runs").await;
+            assert_eq!(
+                defaulted.as_array().unwrap().len(),
+                DEFAULT_RUN_LIMIT,
+                "{defaulted}"
+            );
+
+            // `limit=0` means "I didn't really mean zero" — an empty page is
+            // never what a caller wants, so it falls back to the default.
+            let zero = page("/api/v1/company/workflows/runs?limit=0").await;
+            assert_eq!(zero.as_array().unwrap().len(), DEFAULT_RUN_LIMIT, "{zero}");
+
+            // Above the ceiling clamps; with only 25 rows that is all of them.
+            let huge = page("/api/v1/company/workflows/runs?limit=100000").await;
+            assert_eq!(huge.as_array().unwrap().len(), 25, "{huge}");
+        }
+
+        /// A company that has never run a workflow gets an empty list, not a
+        /// 404 — the history panel renders "nothing yet" rather than an error.
+        #[tokio::test]
+        async fn run_history_is_empty_before_any_run() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(json_body(response).await.as_array().unwrap().len(), 0);
+        }
+
+        /// **Route-ordering pin.** `runs` is a syntactically valid `wid`, so
+        /// `GET /workflows/runs` overlaps `GET /workflows/{wid}`. Axum prefers
+        /// the static segment; if that ever changed, the history panel would
+        /// silently 404 (there is no workflow named `runs`) instead of failing
+        /// loudly. Same trade, and same pin, as `GET /tasks/inflight`.
+        #[tokio::test]
+        async fn run_history_is_not_shadowed_by_the_graph_read() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+            journal_run(&state, &id, "digest", true, Vec::new(), None).await;
+
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::OK,
+                "the static /workflows/runs must win over /workflows/{{wid}}"
+            );
+            // An array of outcomes, not a single graph object.
+            let body = json_body(response).await;
+            assert!(body.is_array(), "graph read shadowed the history: {body}");
+        }
+
+        /// Both scope forms serve the history — the platform
+        /// `…/companies/{id}/…` address as well as the prosumer alias.
+        #[tokio::test]
+        async fn run_history_serves_both_scope_forms() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+            journal_run(&state, &id, "digest", true, Vec::new(), None).await;
+
+            let response = router(state)
+                .oneshot(request(
+                    "GET",
+                    "/api/v1/companies/acme/workflows/runs",
+                    None,
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = json_body(response).await;
+            assert_eq!(body[0]["workflowId"], "digest");
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #228.

A workflow run's outcome only existed in the moment. A **manual** run's `DeliveryReport` rows lived in the console's run drawer until it was dismissed; a **scheduled** run's reached only host stdout, which on a hosted tenant is the platform team rather than the tenant's operator. Nothing wrote a run outcome anywhere the console could read back — so "did last night's owner summary actually go out?" had no answer an hour later.

This journals one company event per finished run, from **both** entry points, projects it live on SSE, and reads it back durably in the Workflows view. Every surface it needs already existed: no new store, no new port, no migration.

- `CompanyEvent::WorkflowRunFinished { workflow_id, scheduled, run_id, deliveries, pending_approvals, error }`. Every optional/collection field is `#[serde(default)]` + `skip_serializing_if`, the same additive contract as `AgentReply.task_id`, so every already-persisted journal loads and pre-existing events stay byte-identical.
- Both the cron scheduler and the console's run route append it through one shared helper (`runtime::workflow_outcome::record_run_finished`), so the two entry points cannot drift in what they record. Best-effort: an append failure logs and never disturbs the run path.
- The `error` arm matters most. Today a run that dies outright produces one host-stdout warning and nothing durable — **the worst outcome is currently the quietest.**
- `GET {scope}/workflows/runs?workflow=&limit=` folds the events back out, newest first.
- The console gets a last-run chip, a run-history panel reusing the existing `DeliveryRows` component, and a toast when a run fails or loses a report.

### Why this is not #242's job

#242's `RunRecord` is a **task-attempt** record, minted at the task-dispatch choke point (`company/runtime.rs`), keyed to a board task with an attempt ordinal and traced via `TurnStep`s. A workflow run enters through a different port entirely (`WorkflowRunner::run`) and its delivery rows are produced host-side per output node — it has no task and no attempt ordinal to be keyed on. The words *workflow*, *delivery* and *DeliveryReport* appear nowhere in #242. Had #242 shipped as written, scheduled workflow runs would still persist nothing.

PR #226's scheduler log lines are kept **unchanged and deliberately**. They remain the platform team's diagnostic on host stdout; the event is the operator's surface. The two answer to different readers.

### Note for #256 (not merged yet)

Merges textually clean, and the console counts `pending` apart from `undelivered` so a parked report reads as awaiting approval rather than a failure — matching #256's `DELIVERY_TONE` treatment. The `pending` comparisons go through a widened `string` (commented at both sites) so they compile both before and after #256 widens `DeliveryStatus`.

The union build currently **fails, but not because of this branch** — see Tests.

## API Or Behavior Changes

- **New event variant** `CompanyEvent::WorkflowRunFinished`. Purely additive; no stored record changes shape.
- **New route** `GET {scope}/workflows/runs?workflow=<id>&limit=<n>` (both scope forms). Newest first; default page 20, clamped to 200; `limit=0` falls back to the default. Registered before `GET /workflows/{wid}` so the static segment wins — the same trade `GET /tasks/inflight` takes, pinned by a test, and it reserves `runs` as a workflow id.
- **New SSE frame** `workflow_run_finished`. This widens nothing: the projected fields are exactly what the run drawer already renders, and every one — `target` included — already reaches the same console in the manual run's HTTP response. `project_event` stays deny-by-default; the existing drop test passes untouched.
- No GraphQL SDL change (verified — the schema-drift test passes; `CompanyEvent` is not exposed in the SDL).
- No change to `DeliveryReport` / `DeliveryStatus`.

## Tests

Verbatim results:

- [x] `cargo fmt --all -- --check` — clean.
- [ ] `cargo clippy --all-targets -- -D warnings` — **clean on default features.** Under `--features openhuman` it aborts in `vendor/tinyagents` on a pre-existing `large_enum_variant`, before reaching this crate. Linting this crate alone (`cargo clippy --no-deps -p opencompany --features openhuman --all-targets`) surfaces only four pre-existing findings, all in files this branch never touches (`harness/composio.rs` dead code, `harness/mcp_probe.rs` `to_string_in_format_args`, `runtime/delegation.rs:575` `redundant_guards`) — all fixed by #250, in flight. **Zero new findings from this change.**
- [x] `cargo build --all-targets` — via `cargo test`.
- [x] `cargo test` — **1004 passed, 0 failed.**
- [x] `cargo test --features openhuman` — **1375 passed, 0 failed.** Worth noting: CI compiles none of `src/workflows/`, and this feature build is what caught a non-exhaustive match in `harness/orchestrator.rs` that default `cargo check` never sees.
- Frontend: `npm ci`, `npm run typecheck`, `npm run build` — all pass. There is **no lint or unit-test script** in this package, so neither is claimed. The package does have a Playwright e2e suite (`npm run e2e`, harness-driven, not wired into CI); the new spec there passes 3/3 against a live host.

New tests: `CompanyEvent` round trip (full, failed, and minimal shapes); a **backcompat test** asserting a journal of pre-#228 lines still loads *and re-serializes byte-identically*; the shared helper on completed / failed / manual runs against the real `FsEventLog`; scheduler appends on both the `Ok` and `Err` arms (the latter via a new `FailingRunner`); the read op's newest-first ordering, `?workflow=` filter applied *before* the limit cut, limit default/cap/clamp, empty case, both scope forms, and a route-ordering pin; and the `project_event` shape on both arms.

**PR #226's log-capture tests pass unchanged** — that is the proof the logging half wasn't disturbed.

### Union build against #256 — fails, and it is not this branch

Trial-merged `feat/227-workflow-cold-recipient-parking` and compiled under `--features openhuman`. It fails with 6 errors. Merging **#256 alone onto current `main`** produces **the identical 6 errors** (same files, same causes, line numbers offset only by this branch's added tests), so this branch contributes none of them.

Root cause: #256 branched at `e78ae50` and did not contain `83c46cb` — `fix(runtime): bind the cycle test home through TempDir::path (#255)`. Its test helpers still used the old `home.clone()` / `cleanup` idiom that #255 replaced.

**Resolved since:** #256 has been rebased onto `main` (head `46386e9`) with those six stale sites fixed, and now compiles. Nothing was needed here.

### Manual verification

Booted a real host (`--features openhuman`, console served from `frontend/dist`) with a company whose workflow is `trigger(schedule "* * * * *") → output(email → a recipient)`.

Legs that ran:
- **Scheduled run** fired on the cron, journaled, and read back from `GET .../workflows/runs` with the delivery row — node, kind, target, `skipped`, and the `detail` naming the reason.
- **Survives a restart** — the history read back identically after a full server restart, which is stronger than the console reload the issue asks about.
- **Manual run** journaled with `scheduled: false`, alongside the scheduled ones.
- **Failed run** (agent node, unreachable inference source): HTTP 500 to the caller, and the outcome journaled with the error — the case that previously left nothing behind.
- **Live SSE**: `workflow_run_finished` observed on the wire carrying `workflowId`, `scheduled`, `deliveries`, and `error`.
- **`?workflow=` filter** correctly separated the two workflows' histories.

- **The console UI**, via a new Playwright spec (`frontend/test/e2e/workflow-run-history.spec.ts`, **3 passed** against the live host): every history request carries `?workflow=`; the panel opens with real rows; and a run added to the history **is still there after a reload**. Visually confirmed too — the last-run chip reads "Scheduled run · 1 not delivered · just now" and the panel lists the journaled runs with their `skipped` rows and details, through the same `DeliveryRows` component the live drawer uses.

Leg that did **not** run, stated plainly:
- **The cold-recipient `detail` specifically** was not reached at runtime. The runner's delivery bundle only carries a mailbox when built with the `smtp` feature *and* a `TenantMailboxConfig` env whose local-part matches the company id; without it the email path stops at the earlier "no mailbox is configured" gate. So the undelivered row was exercised end to end, but via the mailbox gate rather than the established-thread gate. The cold-recipient gate is covered by the existing unit tests in `workflows/delivery.rs` and by this branch's tests, which carry the "never written" detail through the journal. Worth flagging: this also means #256's `Pending` is not reachable through this runtime path today.

#248 (transport-error `detail` text) is untouched and not made worse.

## Documentation

Module docs updated in place — `runtime/workflow_scheduler.rs` (its docs previously said this gap was unclosed and pointed at #242 for the durable record; corrected, with the reason the shapes don't meet), the new `runtime/workflow_outcome.rs`, and `server/ops/workflows.rs`. No separate doc file needed: the behavior is described where it lives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow run history with filtering, pagination, status summaries, delivery results, approvals, errors, and relative timestamps.
  * Workflow history now refreshes automatically after runs complete, including manual and scheduled runs.
  * Added notifications for workflow failures and undelivered results.
  * Workflow outcomes are recorded for successful and failed runs.
* **Bug Fixes**
  * Improved compatibility with older hosts that do not support workflow history.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
