### PR TITLE
fix(ci): quote the tenant-image custom-columns argument

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -221,7 +221,7 @@ jobs:
             # patch took: a tenant scaled to zero has no pod to roll, so
             # `rollout status` would block forever on it.
             kubectl get statefulset -A -l app=opencompany \
-              -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,IMAGE:.spec.template.spec.containers[?(@.name=="opencompany")].image
+              -o 'custom-columns=NS:.metadata.namespace,NAME:.metadata.name,IMAGE:.spec.template.spec.containers[?(@.name=="opencompany")].image'
           else
             echo "Running tenants keep their current image; re-run with refresh_all_tenants=true to move them."
           fi


### PR DESCRIPTION
## Summary

Every staging deploy since #236 reports failure. The deploy itself succeeds — this is a shell quoting bug in the step that runs after it.

## Problem

`.github/workflows/deploy-staging.yml:224` passes an unquoted JSONPath to `kubectl`:

```
-o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,IMAGE:.spec.template.spec.containers[?(@.name=="opencompany")].image
```

Bash reads `[?(...)]` as a subshell and refuses the script:

```
bash: line 100: syntax error near unexpected token `('
##[error]Process completed with exit code 2
```

Two things make this worse than it looks:

- **Bash parses the entire heredoc before executing any of it**, so the step aborts regardless of whether `refresh_all_tenants` is set. The `else` branch never protected it.
- **The failure happens after the rollout succeeds.** Recent run logs show `deployment "opencompany-manager" successfully rolled out` immediately before the syntax error. So staging did receive each image, but every deploy since #236 has been marked red, and the `OCM_TENANT_IMAGE` verification line that follows has never run — the step that would confirm the manager is actually pointing where we think.

Affected runs (all `failure`, all with the rollout succeeding first): 10:55, 13:09, 13:11, 13:39, 14:39, 17:40 on 2026-08-01.

## Solution

Quote the argument. The sibling `kubectl` call on the next line already quotes its `-o jsonpath='...'`, which is why that one never broke — this just makes the two consistent.

## Submission Checklist

- [x] Reproduced locally: extracted the heredoc body and ran `bash -n` — fails on line 100 with the identical error before the change, parses clean after
- [x] Change is one line, quoting only; the JSONPath itself is unchanged
- [ ] N/A: no tests — this is a workflow shell fix, and the repo has no workflow-lint job. `bash -n` on the extracted body is the check that would have caught it
- [ ] N/A: no documentation change

## Impact

Staging deploys go green again, and the post-rollout verification output starts appearing. No change to what gets deployed or how — the rollout path was already working.

Worth considering separately: a `bash -n` lint over the heredoc bodies in this workflow would have caught this at PR time. Happy to file that if wanted.

## Related

Introduced by #236 (`cf67722`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tenant refresh status output formatting so custom column results display reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->