### PR TITLE
feat(workflows): one validation rule per field, on blur, with a cron preview (#260, #261, #262)

### DIFF
--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -46,7 +46,50 @@ address check for `{id}`, operator + `sole()` for the alias).
 | `domain` | `PUT …/domain`, `POST …/domain/verify` |
 | `smtp` | `PUT …/smtp`, `POST …/smtp/test` |
 | `connections` (feature `oauth`) | `POST …/connections/{provider}/start\|disconnect`, `GET /api/v1/oauth/callback` |
-| `workflows` | `POST …/workflows`, `GET …/workflows`, `GET …/workflows/{wid}`, `POST …/workflows/{wid}/run` |
+| `workflows` | `POST …/workflows`, `GET …/workflows`, `GET …/workflows/runs`, `POST …/workflows/cron/preview`, `GET …/workflows/{wid}`, `POST …/workflows/{wid}/run` |
+
+### Reading a trigger's cron back (issue #262)
+
+`POST …/workflows/cron/preview` answers what a 5-field expression means and when
+it next fires. It exists because a schedule's *dangerous* failure is the one
+that validates: `0 9 * * *` and `9 0 * * *` are both valid and nine hours apart,
+and the dialect is always UTC — so an author in IST who wants a 9am report
+writes `0 9 * * *` and gets one at 14:30 local. No validation can catch either
+mistake, because neither expression is wrong.
+
+```bash
+curl -X POST "$HOST/api/v1/company/workflows/cron/preview" \
+     -H "Authorization: Bearer $TOKEN" \
+     -H 'content-type: application/json' -d '{"expr":"0 9 * * MON"}'
+```
+
+```jsonc
+{ "description": "Every Mon at 09:00 UTC",
+  "next": [1786007000000, 1786611800000, 1787216600000] }
+```
+
+`description` is `null` for a shape the humaniser declines to paraphrase (a
+restricted month or day-of-month, say) — the fire times still state the schedule
+exactly, so a `null` description is a designed answer rather than a failure.
+`next` is epoch millis, which is what lets the console render each fire time in
+UTC *and* in the viewer's own zone from one number that cannot disagree with
+itself.
+
+**A malformed expression is a 200**, carrying the parser's message:
+
+```jsonc
+{ "error": "cron `every day` needs 5 fields (minute hour day month weekday), found 2" }
+```
+
+That is deliberate. The console previews while the author is still typing, so a
+half-written expression is the normal live state, not an exception — and the
+console's HTTP client throws on any non-2xx, so a 400 per keystroke would force
+`try`/`catch` as ordinary control flow. The rejection that matters is unchanged:
+`POST …/workflows` still validates the schedule and refuses to save a bad one.
+
+Optional `"after": <epoch millis>` pins the instant the fire times are counted
+from; it defaults to now and exists so tests need not assert against a moving
+clock.
 
 ### Workflow runs and report delivery
 

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -63,7 +63,15 @@ export interface WorkflowDestination {
   target?: string;
 }
 
-/** The destination kinds the creator's picker offers, with prosumer labels. */
+/**
+ * The destination kinds the creator's picker offers, with prosumer labels.
+ *
+ * Kept in step with the host's `WORKFLOW_DESTINATION_KINDS` by
+ * `destination_kinds_match_the_console` in `src/company/workflow_file.rs`, which
+ * reads the `value:` entries out of this very block — so adding a kind on one
+ * side alone fails `cargo test` rather than shipping a picker the server rejects
+ * (or withholding one it accepts). Issue #260.
+ */
 export const DESTINATION_KINDS: { value: WorkflowDestination["kind"]; label: string }[] = [
   { value: "owner", label: "Owner — the company's admins" },
   { value: "email", label: "Email — a specific address" },

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -244,6 +244,55 @@ export function createWorkflow(
  * the creator doesn't offer them yet. All of these kinds still render on the
  * canvas and can be authored by hand in `workflows/<id>.toml`.
  */
+/**
+ * What a trigger's cron expression actually means, per the host's parser
+ * (issue #262).
+ *
+ * Exactly one of `error` or (`description`, `next`) is present — the host
+ * answers with two shapes, not one shape with half its fields null.
+ * `description` is `null` for a schedule the host declines to paraphrase; the
+ * fire times still say what it means.
+ */
+export interface CronPreview {
+  /** A plain-English gloss, or `null` when the shape is too gnarly for one. */
+  description?: string | null;
+  /**
+   * The next few fire times as epoch millis. The UTC reading and the viewer's
+   * local reading are BOTH rendered from these numbers, so the two can never
+   * disagree about the same instant — which is the entire point, since the
+   * schedule is UTC and the author is usually not.
+   */
+  next?: number[];
+  /** The parser's message, when the expression did not parse. */
+  error?: string;
+}
+
+/**
+ * Previews a cron expression (issue #262).
+ *
+ * **Answers 200 even for a malformed expression**, with the parser's message in
+ * `error`. The console calls this while the author is still typing, so a
+ * half-written expression is the normal state — and {@link OpenCompanyClient}
+ * throws on any non-2xx, so a 400 per keystroke would make an ordinary parse
+ * failure arrive as a thrown error. Callers still need a `catch` for genuine
+ * network failure; they should render nothing in that case rather than block
+ * authoring on a preview.
+ *
+ * `after` pins the instant the fire times are computed from; the host defaults
+ * to now.
+ */
+export function previewCron(
+  client: OpenCompanyClient,
+  company: string | null,
+  expr: string,
+  after?: number,
+): Promise<CronPreview> {
+  return client.post<CronPreview>(
+    `${client.scopeFor(company)}/workflows/cron/preview`,
+    { expr, after },
+  );
+}
+
 export const CREATABLE_NODE_KINDS: { value: string; label: string }[] = [
   { value: "trigger", label: "Trigger — starts the workflow" },
   { value: "agent", label: "Agent — a teammate performs a step" },

--- a/frontend/src/views/CronPreviewLine.tsx
+++ b/frontend/src/views/CronPreviewLine.tsx
@@ -1,0 +1,168 @@
+// Echoes back what a trigger's cron schedule actually means (issue #262).
+//
+// A schedule's failure modes split in two. The malformed one was already
+// handled — the host rejects it with the parser's message. The one that was
+// not is the SUCCESSFUL save: `0 9 * * *` and `9 0 * * *` are both valid and
+// nine hours apart, and the dialect is UTC, so an author in IST who wants a 9am
+// report writes `0 9 * * *` and gets one at 14:30 local. Neither mistake is
+// invalid, so no amount of validation catches either. Reading the schedule back
+// does.
+//
+// The parsing lives on the host: `CronExpr` is already the one dialect the
+// scheduler and the graph validator both speak, so a second parser here would
+// be exactly the duplicated-rule problem issue #260 is about. (OpenHuman
+// humanises cron client-side in `app/src/lib/flows/cron.ts` — a deliberate
+// divergence: it has no server round trip to spend, and no host-side cron
+// describer to reuse.)
+
+import { useEffect, useState } from "react";
+
+import { previewCron, type CronPreview } from "@/api/workflows";
+import type { OpenCompanyClient } from "@/api/client";
+
+/** How long the author must pause before a preview is fetched.
+ *
+ * Long enough that typing a 5-field expression is one request rather than one
+ * per character, short enough to feel live. The gate at the call site (a
+ * 5-field shape check) already keeps a half-written expression off the wire. */
+const PREVIEW_DEBOUNCE_MS = 350;
+
+/**
+ * The host's reading of `expr`, refreshed as the author types.
+ *
+ * Returns `null` while there is nothing to show — disabled, not yet fetched, or
+ * the request failed. A failure is deliberately indistinguishable from "no
+ * preview": this is a convenience, and a host that cannot answer must not turn
+ * into an error message on a field the author is still filling in.
+ */
+function useCronPreview(
+  client: OpenCompanyClient,
+  company: string | null,
+  expr: string,
+  enabled: boolean,
+): CronPreview | null {
+  const [preview, setPreview] = useState<CronPreview | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !expr.trim()) {
+      setPreview(null);
+      return;
+    }
+    // `live` guards against an out-of-order response overwriting a newer one:
+    // the author keeps typing, so several previews can be in flight, and the
+    // slowest must not win. Same shape as the dialog's roster load.
+    let live = true;
+    const timer = window.setTimeout(() => {
+      void (async () => {
+        try {
+          const result = await previewCron(client, company, expr);
+          if (live) setPreview(result);
+        } catch {
+          // Network failure, or a host predating this route. Show nothing —
+          // never block authoring on a preview.
+          if (live) setPreview(null);
+        }
+      })();
+    }, PREVIEW_DEBOUNCE_MS);
+
+    return () => {
+      live = false;
+      window.clearTimeout(timer);
+    };
+  }, [client, company, expr, enabled]);
+
+  return preview;
+}
+
+/** `Mon 3 Aug, 09:00` in UTC. */
+function formatUtc(ms: number): string {
+  return new Date(ms).toLocaleString(undefined, {
+    timeZone: "UTC",
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+/**
+ * The same instant in the viewer's own zone — `14:30`, or `Tue 14:30` when the
+ * offset pushes it onto a different day.
+ *
+ * Rendered from the SAME epoch millis as {@link formatUtc}, which is why the
+ * two readings cannot drift: they are one number formatted twice, not two
+ * computations that have to agree. The day is included only when it differs,
+ * because that is exactly when omitting it would mislead.
+ */
+function formatLocal(ms: number): string {
+  const at = new Date(ms);
+  const time = at.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  const sameDay =
+    at.toLocaleDateString(undefined, { timeZone: "UTC" }) === at.toLocaleDateString();
+  if (sameDay) return time;
+  return `${at.toLocaleDateString(undefined, { weekday: "short" })} ${time}`;
+}
+
+/**
+ * A one-line reading of `schedule`, under the cron field.
+ *
+ * Four states, all of them quiet:
+ *
+ * - the host describes the schedule → the description plus the next run in UTC
+ *   and in the viewer's zone;
+ * - the host declines to describe it → the next three fire times, which say the
+ *   same thing without paraphrasing;
+ * - the expression does not parse → the parser's message, in *informational*
+ *   styling and not a destructive alert, because a half-written expression is
+ *   the normal state of a field being typed into, not a failure;
+ * - nothing to show → nothing rendered.
+ *
+ * `suppressError` hides the third state while the field already carries a
+ * blur-time error (issue #261), so one mistake never produces two complaints
+ * stacked under one input.
+ */
+export function CronPreviewLine({
+  client,
+  company,
+  schedule,
+  suppressError = false,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+  schedule: string;
+  suppressError?: boolean;
+}) {
+  const preview = useCronPreview(client, company, schedule, true);
+  if (!preview) return null;
+
+  if (preview.error) {
+    if (suppressError) return null;
+    return (
+      <p className="text-[10px] leading-snug text-amber-600 dark:text-amber-400">
+        {preview.error}
+      </p>
+    );
+  }
+
+  const next = preview.next ?? [];
+  if (next.length === 0) return null;
+
+  return (
+    <p className="text-[10px] leading-snug text-muted-foreground">
+      {preview.description ? (
+        <>
+          <span className="text-foreground">{preview.description}</span> — next run{" "}
+          {formatUtc(next[0])} UTC ({formatLocal(next[0])} your time)
+        </>
+      ) : (
+        <>Next runs: {next.map((ms) => `${formatUtc(ms)} UTC`).join(" · ")}</>
+      )}
+    </p>
+  );
+}

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -111,6 +111,12 @@ function scheduleProblem(schedule: string): string | null {
  * and so have nothing to check.
  *
  * Same two-caller contract as {@link scheduleProblem}.
+ *
+ * Issue #260: each message ends with the SAME fix instruction the host's
+ * rejection ends with, and echoes the offending target the same way, so an
+ * author who trips the pre-flight and an author who trips the 400 are told the
+ * same thing. `destination_messages_match_the_console` in
+ * `src/company/workflow_file.rs` fails if either side is reworded alone.
  */
 function destinationTargetProblem(
   kind: DraftNode["destinationKind"],
@@ -118,12 +124,24 @@ function destinationTargetProblem(
 ): string | null {
   const value = target.trim();
   if (kind === "email" && !value.includes("@")) {
-    return "emails its report — give the recipient's full address.";
+    return `\`${value}\` is not an email address — give the recipient's full address.`;
   }
   if (kind === "channel" && !value) {
-    return "posts its report to a channel — name the channel.";
+    return "A channel destination needs a channel id — name the channel to post the report to.";
   }
   return null;
+}
+
+/** How a validation message names a node.
+ *
+ * Issue #260: the dialog reported `Node \`2\`` — the id, which on a row the
+ * author never renamed is whatever the form put there — while the author had
+ * typed a name. Prefer the name they chose; fall back to the id, and to a
+ * position-free phrase when the row is still blank (which the "needs an id"
+ * check above will have already reported).
+ */
+function nodeLabel(node: DraftNode): string {
+  return node.name.trim() || node.id.trim() || "this node";
 }
 
 interface DraftEdge {
@@ -282,15 +300,15 @@ export function WorkflowCreateDialog({
       if (!n.id.trim()) return "Every node needs an id.";
       if (ids.has(n.id.trim())) return `Node id \`${n.id}\` is used more than once.`;
       ids.add(n.id.trim());
-      if (!n.name.trim()) return `Node \`${n.id}\` needs a name.`;
+      if (!n.name.trim()) return `Node \`${nodeLabel(n)}\` needs a name.`;
       if (n.kind === "agent" && !n.agent.trim()) {
-        return `Node \`${n.id}\` is an agent node — pick who does it.`;
+        return `Node \`${nodeLabel(n)}\` is an agent node — pick who does it.`;
       }
       // Only fires for a node that IS a trigger, so this is a check on visible
       // state, never an off-kind trap.
       if (n.kind === "trigger") {
         const problem = scheduleProblem(n.schedule);
-        if (problem) return problem;
+        if (problem) return `Node \`${nodeLabel(n)}\`: ${problem}`;
       }
       // Mirrors the host's `destination` target rules so a wrong target is
       // caught here rather than after a round trip. There is deliberately NO
@@ -301,7 +319,7 @@ export function WorkflowCreateDialog({
         n.destinationKind,
         n.destinationTarget,
       );
-      if (destinationProblem) return `Node \`${n.id}\` ${destinationProblem}`;
+      if (destinationProblem) return `Node \`${nodeLabel(n)}\`: ${destinationProblem}`;
     }
     const triggerCount = nodes.filter((n) => n.kind === "trigger").length;
     if (triggerCount !== 1) {

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -17,6 +17,7 @@ import {
   type WorkflowNode,
 } from "@/api/workflows";
 import type { OpenCompanyClient } from "@/api/client";
+import { CronPreviewLine } from "@/views/CronPreviewLine";
 import type { TeamMemberDto } from "@/api/types";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -518,6 +519,8 @@ export function WorkflowCreateDialog({
               <NodeRow
                 key={n.key}
                 node={n}
+                client={client}
+                company={company}
                 roster={roster}
                 errors={{
                   schedule: fieldErrors[errorKey(n.key, "schedule")],
@@ -598,6 +601,8 @@ function FieldError({ id, message }: { id: string; message?: string }) {
 
 function NodeRow({
   node,
+  client,
+  company,
   roster,
   errors,
   onValidateField,
@@ -605,6 +610,10 @@ function NodeRow({
   onRemove,
 }: {
   node: DraftNode;
+  /** Threaded through solely so the trigger row's schedule field can ask the
+   * host what its cron means (issue #262). */
+  client: OpenCompanyClient;
+  company: string | null;
   roster: TeamMemberDto[];
   /** Blur-time problems for this row's validated fields, if any. */
   errors: Partial<Record<ValidatedField, string>>;
@@ -679,6 +688,8 @@ function NodeRow({
         />
         {node.kind === "trigger" && (
           <ScheduleField
+            client={client}
+            company={company}
             schedule={node.schedule}
             error={errors.schedule}
             onChange={(schedule) => onChange({ schedule })}
@@ -766,11 +777,15 @@ function NodeRow({
  * cover. Rendered only on the trigger node, mirroring how the teammate picker
  * appears only on agent nodes. */
 function ScheduleField({
+  client,
+  company,
   schedule,
   error,
   onChange,
   onBlurValidate,
 }: {
+  client: OpenCompanyClient;
+  company: string | null;
   schedule: string;
   /** The blur-time cron problem for this field, when there is one. */
   error?: string;
@@ -827,6 +842,19 @@ function ScheduleField({
         <p className="text-[10px] text-muted-foreground">
           5-field cron. Times are UTC.
         </p>
+      )}
+      {/* The hint above says the contract; this says what THIS expression means
+          under it (issue #262) — including for a preset, since "Daily — 09:00
+          UTC" is only obviously wrong once you see it land at 14:30 your time.
+          Gated on the same 5-field shape check the pre-flight uses, so nothing
+          goes on the wire until there is a whole expression to read. */}
+      {looksLikeCron(schedule) && (
+        <CronPreviewLine
+          client={client}
+          company={company}
+          schedule={schedule}
+          suppressError={Boolean(error)}
+        />
       )}
     </div>
   );

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -90,6 +90,42 @@ function looksLikeCron(cron: string): boolean {
   return cron.trim().split(/\s+/).length === 5;
 }
 
+/** What is wrong with `schedule`, or `null` when it is postable.
+ *
+ * One field, one message, no node context — so the same rule can answer both
+ * callers: `validate()` at submit (which prefixes the node it belongs to) and
+ * the field's own blur handler (which shows it under the input). An empty
+ * schedule is fine: "no schedule" is a real choice.
+ */
+function scheduleProblem(schedule: string): string | null {
+  if (!schedule.trim()) return null;
+  if (!looksLikeCron(schedule)) {
+    return "A schedule is a 5-field cron, e.g. `0 9 * * MON` (minute hour day month weekday).";
+  }
+  return null;
+}
+
+/** What is wrong with an output node's `destination.target` for `kind`, or
+ * `null` when it is postable. Mirrors the host's per-kind target contract in
+ * `src/company/workflow_file.rs`; `owner` and "no destination" carry no target
+ * and so have nothing to check.
+ *
+ * Same two-caller contract as {@link scheduleProblem}.
+ */
+function destinationTargetProblem(
+  kind: DraftNode["destinationKind"],
+  target: string,
+): string | null {
+  const value = target.trim();
+  if (kind === "email" && !value.includes("@")) {
+    return "emails its report — give the recipient's full address.";
+  }
+  if (kind === "channel" && !value) {
+    return "posts its report to a channel — name the channel.";
+  }
+  return null;
+}
+
 interface DraftEdge {
   key: string;
   from: string;
@@ -252,21 +288,20 @@ export function WorkflowCreateDialog({
       }
       // Only fires for a node that IS a trigger, so this is a check on visible
       // state, never an off-kind trap.
-      if (n.kind === "trigger" && n.schedule.trim() && !looksLikeCron(n.schedule)) {
-        return "A schedule is a 5-field cron, e.g. `0 9 * * MON` (minute hour day month weekday).";
+      if (n.kind === "trigger") {
+        const problem = scheduleProblem(n.schedule);
+        if (problem) return problem;
       }
       // Mirrors the host's `destination` target rules so a wrong target is
       // caught here rather than after a round trip. There is deliberately NO
       // "destination on a non-output node" check: `changeKind` makes that state
       // unreachable, and re-adding the check would only recreate the trap of an
       // error the author has no visible control to clear.
-      const target = n.destinationTarget.trim();
-      if (n.destinationKind === "email" && !target.includes("@")) {
-        return `Node \`${n.id}\` emails its report — give the recipient's full address.`;
-      }
-      if (n.destinationKind === "channel" && !target) {
-        return `Node \`${n.id}\` posts its report to a channel — name the channel.`;
-      }
+      const destinationProblem = destinationTargetProblem(
+        n.destinationKind,
+        n.destinationTarget,
+      );
+      if (destinationProblem) return `Node \`${n.id}\` ${destinationProblem}`;
     }
     const triggerCount = nodes.filter((n) => n.kind === "trigger").length;
     if (triggerCount !== 1) {

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -151,6 +151,21 @@ interface DraftEdge {
   label: string;
 }
 
+/** The node fields that validate on blur (issue #261) — the ones with a real
+ * contract, which are the ones authors get wrong. */
+type ValidatedField = "schedule" | "destinationTarget";
+
+/** The key a field's error is filed under.
+ *
+ * Deliberately `node.key`, the stable row key, and NOT `node.id`: the id is a
+ * text field the author edits, so keying on it would strand every error the
+ * moment they renamed a node — the error would still render, attached to
+ * nothing that can clear it.
+ */
+function errorKey(nodeKey: string, field: ValidatedField): string {
+  return `${nodeKey}:${field}`;
+}
+
 /** The "no destination" option's value. A Select item cannot carry an empty
  * string, so the sentinel stands in for `destinationKind: ""`. */
 const NO_DESTINATION = "__none__";
@@ -229,6 +244,11 @@ export function WorkflowCreateDialog({
   const [roster, setRoster] = useState<TeamMemberDto[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  /** Per-field problems raised on blur (issue #261), keyed by
+   * {@link errorKey}. Separate from `error`, the submit-time banner: this one
+   * is inline, scoped to the control that caused it, and never blocks Save on
+   * its own — `validate()` remains the gate. */
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const formId = useId();
 
   // Reload the roster (for the agent-node picker) and reset the draft each
@@ -241,6 +261,7 @@ export function WorkflowCreateDialog({
     setNodes(starterNodes());
     setEdges([]);
     setError(null);
+    setFieldErrors({});
     let live = true;
     (async () => {
       try {
@@ -263,11 +284,65 @@ export function WorkflowCreateDialog({
 
   function updateNode(key: string, fields: Partial<DraftNode>) {
     setNodes((rows) => rows.map((r) => (r.key === key ? { ...r, ...fields } : r)));
+    // Clear whatever the edit invalidated. This MUST stay in step with
+    // `changeKind`: that reset exists so the draft never holds a value whose
+    // control is off screen, and an error is a value too — leaving one behind
+    // would show a complaint about a field the author can no longer see, let
+    // alone fix. Same reasoning for `destinationKind`, which swaps which target
+    // contract (address vs channel id) applies.
+    setFieldErrors((prev) => {
+      const stale: ValidatedField[] = [];
+      if ("kind" in fields) stale.push("schedule", "destinationTarget");
+      if ("destinationKind" in fields) stale.push("destinationTarget");
+      // Typing in a field clears its own error: the author is already fixing
+      // it, and re-checking mid-word would fail on every prefix of a correct
+      // answer (`n`, `no`, `nop` on the way to an address).
+      if ("schedule" in fields) stale.push("schedule");
+      if ("destinationTarget" in fields) stale.push("destinationTarget");
+
+      const next = { ...prev };
+      let changed = false;
+      for (const field of stale) {
+        const k = errorKey(key, field);
+        if (k in next) {
+          delete next[k];
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }
+
+  /** Checks one field's own rule, on blur. Returns nothing — the result lands
+   * in `fieldErrors` — so the caller stays a one-liner on the control.
+   *
+   * An EMPTY field is never flagged here. "You haven't filled this in yet" is
+   * true of every field an author tabs past on the way to somewhere else;
+   * saying so is nagging, not feedback. Emptiness stays `validate()`'s business
+   * at submit, where it is actually a problem. */
+  function validateField(nodeKey: string, field: ValidatedField, value: string) {
+    if (!value.trim()) return;
+    const node = nodes.find((n) => n.key === nodeKey);
+    if (!node) return;
+    const problem =
+      field === "schedule"
+        ? scheduleProblem(value)
+        : destinationTargetProblem(node.destinationKind, value);
+    if (problem) {
+      setFieldErrors((prev) => ({ ...prev, [errorKey(nodeKey, field)]: problem }));
+    }
   }
 
   function removeNode(key: string) {
     const removed = nodes.find((n) => n.key === key);
     setNodes((rows) => rows.filter((r) => r.key !== key));
+    // The row is gone, so its errors have nothing left to point at.
+    setFieldErrors((prev) => {
+      const next = Object.fromEntries(
+        Object.entries(prev).filter(([k]) => !k.startsWith(`${key}:`)),
+      );
+      return Object.keys(next).length === Object.keys(prev).length ? prev : next;
+    });
     // Drop any edge that pointed at the removed node's id — a dangling
     // reference would just bounce back from the server as a 400.
     if (removed?.id) {
@@ -444,6 +519,11 @@ export function WorkflowCreateDialog({
                 key={n.key}
                 node={n}
                 roster={roster}
+                errors={{
+                  schedule: fieldErrors[errorKey(n.key, "schedule")],
+                  destinationTarget: fieldErrors[errorKey(n.key, "destinationTarget")],
+                }}
+                onValidateField={(field, value) => validateField(n.key, field, value)}
                 onChange={(fields) => updateNode(n.key, fields)}
                 onRemove={() => removeNode(n.key)}
               />
@@ -506,17 +586,34 @@ export function WorkflowCreateDialog({
   );
 }
 
+/** A one-line problem shown under the control that caused it (issue #261). */
+function FieldError({ id, message }: { id: string; message?: string }) {
+  if (!message) return null;
+  return (
+    <p id={id} className="text-[11px] leading-snug text-destructive">
+      {message}
+    </p>
+  );
+}
+
 function NodeRow({
   node,
   roster,
+  errors,
+  onValidateField,
   onChange,
   onRemove,
 }: {
   node: DraftNode;
   roster: TeamMemberDto[];
+  /** Blur-time problems for this row's validated fields, if any. */
+  errors: Partial<Record<ValidatedField, string>>;
+  onValidateField: (field: ValidatedField, value: string) => void;
   onChange: (fields: Partial<DraftNode>) => void;
   onRemove: () => void;
 }) {
+  const rowId = useId();
+  const targetErrorId = `${rowId}-target-error`;
   return (
     <div className="grid gap-2 rounded-lg border p-2 sm:grid-cols-[1fr_1fr_1.4fr_auto] sm:items-start">
       <div className="grid gap-1">
@@ -583,7 +680,9 @@ function NodeRow({
         {node.kind === "trigger" && (
           <ScheduleField
             schedule={node.schedule}
+            error={errors.schedule}
             onChange={(schedule) => onChange({ schedule })}
+            onBlurValidate={(value) => onValidateField("schedule", value)}
           />
         )}
         {/* Only an output node reports back, so only it can route that report
@@ -622,16 +721,22 @@ function NodeRow({
               </SelectContent>
             </Select>
             {(node.destinationKind === "email" || node.destinationKind === "channel") && (
-              <Input
-                value={node.destinationTarget}
-                onChange={(e) => onChange({ destinationTarget: e.target.value })}
-                placeholder={
-                  node.destinationKind === "email" ? "recipient@example.com" : "channel id"
-                }
-                aria-label={
-                  node.destinationKind === "email" ? "Recipient address" : "Channel id"
-                }
-              />
+              <>
+                <Input
+                  value={node.destinationTarget}
+                  onChange={(e) => onChange({ destinationTarget: e.target.value })}
+                  onBlur={(e) => onValidateField("destinationTarget", e.target.value)}
+                  aria-invalid={Boolean(errors.destinationTarget)}
+                  aria-describedby={errors.destinationTarget ? targetErrorId : undefined}
+                  placeholder={
+                    node.destinationKind === "email" ? "recipient@example.com" : "channel id"
+                  }
+                  aria-label={
+                    node.destinationKind === "email" ? "Recipient address" : "Channel id"
+                  }
+                />
+                <FieldError id={targetErrorId} message={errors.destinationTarget} />
+              </>
             )}
             {node.destinationKind === "email" && (
               <p className="text-[11px] leading-snug text-muted-foreground">
@@ -662,11 +767,18 @@ function NodeRow({
  * appears only on agent nodes. */
 function ScheduleField({
   schedule,
+  error,
   onChange,
+  onBlurValidate,
 }: {
   schedule: string;
+  /** The blur-time cron problem for this field, when there is one. */
+  error?: string;
   onChange: (schedule: string) => void;
+  onBlurValidate: (value: string) => void;
 }) {
+  const fieldId = useId();
+  const errorId = `${fieldId}-error`;
   // A non-empty value that isn't a preset means the operator typed their own.
   const custom = schedule !== "" && !isPresetSchedule(schedule);
   // Track "Custom is selected but nothing typed yet" so the input stays open.
@@ -703,10 +815,14 @@ function ScheduleField({
           className="h-8 font-mono text-xs"
           value={schedule}
           onChange={(e) => onChange(e.target.value)}
+          onBlur={(e) => onBlurValidate(e.target.value)}
+          aria-invalid={Boolean(error)}
+          aria-describedby={error ? errorId : undefined}
           placeholder="0 9 * * MON"
           aria-label="Custom cron schedule"
         />
       )}
+      <FieldError id={errorId} message={error} />
       {(showCustom || schedule) && (
         <p className="text-[10px] text-muted-foreground">
           5-field cron. Times are UTC.

--- a/frontend/test/e2e/workflow-dialog-feedback.spec.ts
+++ b/frontend/test/e2e/workflow-dialog-feedback.spec.ts
@@ -1,0 +1,243 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Issues #260 / #261 / #262: how the workflow create dialog validates input and
+ * gives feedback.
+ *
+ * These three are one behaviour seen from three sides — a rule stated once
+ * (#260), stated *early* (#261), and stated back in plain English (#262) — so
+ * they are pinned together, in the browser, against the live host.
+ *
+ * The browser is the only place two of these are real. Blur validation is a
+ * DOM event and a render, not a function call: the unit-testable part
+ * (`destinationTargetProblem`) was already correct before #261 and would stay
+ * green while the error rendered nowhere, or rendered under a control the
+ * author can no longer see. And the cron preview's whole job is to show a
+ * *round trip* — debounce, request, response, two clock renderings — which
+ * cannot be observed anywhere else.
+ *
+ * Runs against the live host the harness brings up (see `playwright.config.ts`).
+ */
+
+/**
+ * Dismisses the first-run tour if it is up — its overlay swallows pointer
+ * events, so without this every spec fails on an unrelated modal. Tolerates its
+ * absence; a company that has seen it never shows it again.
+ */
+async function dismissTour(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  try {
+    await skip.waitFor({ state: "visible", timeout: 10_000 });
+  } catch {
+    return;
+  }
+  await skip.click();
+  await expect(skip).toBeHidden();
+}
+
+/** Opens Workflows → New workflow and returns the dialog. */
+async function openCreateDialog(page: Page) {
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+  await page.getByRole("button", { name: "New workflow" }).click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByText("New workflow", { exact: true })).toBeVisible();
+  return dialog;
+}
+
+/**
+ * Turns the dialog's second node row into an `output` node routing to `email`,
+ * and returns its target Input.
+ *
+ * The starter draft holds one trigger row, so index 1 is the row this adds.
+ */
+async function emailOutputRow(page: Page) {
+  const dialog = await openCreateDialog(page);
+  await dialog.getByRole("button", { name: "Add node" }).click();
+
+  const kind = dialog.getByLabel("Node kind").nth(1);
+  await kind.click();
+  await page.getByRole("option", { name: /^Output/ }).click();
+
+  const destination = dialog.getByLabel("Send report to");
+  await destination.click();
+  await page.getByRole("option", { name: /^Email/ }).click();
+
+  return dialog.getByLabel("Recipient address");
+}
+
+test("a bad email target is reported on blur, and typing again clears it", async ({
+  page,
+}) => {
+  const target = await emailOutputRow(page);
+  const dialog = page.getByRole("dialog");
+
+  // Typing alone must NOT complain: `n` is not a valid address, and neither is
+  // `no`, so an author gets an error on the way to typing a correct one. #261
+  // rejects keystroke validation explicitly.
+  await target.fill("nope");
+  await expect(dialog.getByText(/is not an email address/)).toHaveCount(0);
+
+  // Blur is the moment the author has finished with the field.
+  await target.blur();
+  const error = dialog.getByText(/is not an email address/);
+  await expect(error).toBeVisible();
+  // #260: the message ends with the SAME fix instruction the host's 400 ends
+  // with, and echoes the offending target.
+  await expect(error).toContainText("`nope`");
+  await expect(error).toContainText("give the recipient's full address.");
+  await expect(target).toHaveAttribute("aria-invalid", "true");
+
+  // Typing again clears it — the author is already fixing it.
+  await target.fill("ada@example.com");
+  await expect(error).toHaveCount(0);
+  await expect(target).not.toHaveAttribute("aria-invalid", "true");
+
+  // A now-valid address stays quiet on blur.
+  await target.blur();
+  await expect(dialog.getByText(/is not an email address/)).toHaveCount(0);
+});
+
+test("an empty field is never nagged on blur — that stays submit's business", async ({
+  page,
+}) => {
+  const target = await emailOutputRow(page);
+  const dialog = page.getByRole("dialog");
+
+  // Tabbing straight through a fresh field must say nothing. "You haven't
+  // filled this in yet" is true of every field an author passes on the way
+  // somewhere else.
+  await target.click();
+  await target.blur();
+  await expect(dialog.getByText(/is not an email address/)).toHaveCount(0);
+});
+
+test("changing a node's kind clears the field AND its error, leaving no orphan", async ({
+  page,
+}) => {
+  const target = await emailOutputRow(page);
+  const dialog = page.getByRole("dialog");
+
+  await target.fill("nope");
+  await target.blur();
+  await expect(dialog.getByText(/is not an email address/)).toBeVisible();
+
+  // Switching the kind un-renders the destination controls (PR #226's
+  // `changeKind` reset). The error must go with them: an error about a field
+  // with no control left on screen is one the author cannot clear.
+  const kind = dialog.getByLabel("Node kind").nth(1);
+  await kind.click();
+  await page.getByRole("option", { name: /^Agent/ }).click();
+
+  await expect(dialog.getByLabel("Recipient address")).toHaveCount(0);
+  await expect(dialog.getByText(/is not an email address/)).toHaveCount(0);
+
+  // Switching back gives a clean field, not a resurrected value or error.
+  await kind.click();
+  await page.getByRole("option", { name: /^Output/ }).click();
+  await expect(dialog.getByLabel("Send report to")).toBeVisible();
+  await expect(dialog.getByText(/is not an email address/)).toHaveCount(0);
+});
+
+/** Opens the trigger row's custom-cron input. */
+async function customCronInput(page: Page) {
+  const dialog = page.getByRole("dialog");
+  await dialog.getByLabel("Schedule").click();
+  await page.getByRole("option", { name: "Custom cron…" }).click();
+  return dialog.getByLabel("Custom cron schedule");
+}
+
+test("a cron expression is read back in plain English, in UTC and local time", async ({
+  page,
+}) => {
+  await openCreateDialog(page);
+  const cron = await customCronInput(page);
+  const dialog = page.getByRole("dialog");
+
+  // **The issue #262 case.** `0 9 * * *` and `9 0 * * *` are two characters
+  // apart, both valid, and nine hours apart in meaning. Only the preview tells
+  // them apart before the report lands at the wrong time.
+  await cron.fill("0 9 * * *");
+  await expect(dialog.getByText("Every day at 09:00 UTC")).toBeVisible();
+  // The local gloss is the part that earns its keep: it is the only place the
+  // UTC contract becomes concrete rather than a hint the author skimmed.
+  await expect(dialog.getByText(/your time\)/)).toBeVisible();
+
+  await cron.fill("9 0 * * *");
+  await expect(dialog.getByText("Every day at 00:09 UTC")).toBeVisible();
+  await expect(dialog.getByText("Every day at 09:00 UTC")).toHaveCount(0);
+
+  // The UTC hint stays — the preview says what THIS expression means, it does
+  // not replace the statement of the contract.
+  await expect(dialog.getByText("5-field cron. Times are UTC.")).toBeVisible();
+});
+
+test("a schedule the humaniser won't paraphrase still previews its next runs", async ({
+  page,
+}) => {
+  await openCreateDialog(page);
+  const cron = await customCronInput(page);
+  const dialog = page.getByRole("dialog");
+
+  // A restricted day-of-month is left undescribed on purpose — a wrong
+  // paraphrase would be worse than none — but the fire times still state it.
+  await cron.fill("0 0 1 * *");
+  await expect(dialog.getByText(/^Next runs:/)).toBeVisible();
+});
+
+test("garbage in the cron field previews the parser's message without blocking", async ({
+  page,
+}) => {
+  await openCreateDialog(page);
+  const cron = await customCronInput(page);
+  const dialog = page.getByRole("dialog");
+
+  // Five fields, so the shape check passes and the request goes out; the hour
+  // is out of range, so the host's parser rejects it. That arrives as a 200
+  // with a message, not a thrown error, and it does not disable anything.
+  await cron.fill("0 99 * * *");
+  await expect(dialog.getByText(/value out of range/)).toBeVisible();
+  await expect(dialog.getByRole("button", { name: "Create workflow" })).toBeEnabled();
+
+  // Fewer than five fields never reaches the wire — the pre-flight shape check
+  // gates it — so the author sees the blur message, not a parser message.
+  await cron.fill("hourly");
+  await cron.blur();
+  await expect(dialog.getByText(/5-field cron, e\.g\./)).toBeVisible();
+  // And one mistake produces ONE complaint, not a blur error stacked on a
+  // preview error.
+  await expect(dialog.getByText(/value out of range/)).toHaveCount(0);
+});
+
+test("a valid workflow still saves", async ({ page }) => {
+  // The id AND the name must both be fresh: the host rejects a duplicate of
+  // either, so a fixed name would pass on a clean company and fail on the
+  // second run against the same one.
+  const stamp = Date.now();
+  await openCreateDialog(page);
+  const dialog = page.getByRole("dialog");
+
+  // `exact` matters: "Id" is also a substring of the row-level "Node id".
+  await dialog.getByLabel("Id", { exact: true }).fill(`e2e_feedback_${stamp}`);
+  await dialog.getByLabel("Name", { exact: true }).fill(`Feedback probe ${stamp}`);
+
+  // Trigger row: a preset schedule, which previews too.
+  await dialog.getByLabel("Node id").first().fill("start");
+  await dialog.getByLabel("Node name").first().fill("Start");
+  await dialog.getByLabel("Schedule").click();
+  await page.getByRole("option", { name: /^Daily/ }).click();
+  await expect(dialog.getByText("Every day at 09:00 UTC")).toBeVisible();
+
+  // Output row routing to the owner — no target to get wrong.
+  await dialog.getByRole("button", { name: "Add node" }).click();
+  await dialog.getByLabel("Node id").nth(1).fill("done");
+  await dialog.getByLabel("Node name").nth(1).fill("Ship it");
+  const kind = dialog.getByLabel("Node kind").nth(1);
+  await kind.click();
+  await page.getByRole("option", { name: /^Output/ }).click();
+  await dialog.getByLabel("Send report to").click();
+  await page.getByRole("option", { name: /^Owner/ }).click();
+
+  await dialog.getByRole("button", { name: "Create workflow" }).click();
+  await expect(dialog).toBeHidden({ timeout: 30_000 });
+});

--- a/frontend/test/e2e/workflow-dialog-feedback.spec.ts
+++ b/frontend/test/e2e/workflow-dialog-feedback.spec.ts
@@ -20,6 +20,16 @@ import { expect, test, type Page } from "@playwright/test";
  */
 
 /**
+ * Every cron-preview assertion waits on a round trip the other assertions in
+ * this file do not: a 350 ms debounce, then a request to the host, then a
+ * render. Playwright's default `expect` timeout is 5 s and the config's
+ * `timeout` governs the whole test, not each assertion — so on a slow host
+ * these are the assertions that flake first. Stated explicitly rather than
+ * inherited.
+ */
+const PREVIEW_TIMEOUT = 15_000;
+
+/**
  * Dismisses the first-run tour if it is up — its overlay swallows pointer
  * events, so without this every spec fails on an unrelated modal. Tolerates its
  * absence; a company that has seen it never shows it again.
@@ -158,14 +168,20 @@ test("a cron expression is read back in plain English, in UTC and local time", a
   // apart, both valid, and nine hours apart in meaning. Only the preview tells
   // them apart before the report lands at the wrong time.
   await cron.fill("0 9 * * *");
-  await expect(dialog.getByText("Every day at 09:00 UTC")).toBeVisible();
+  await expect(dialog.getByText("Every day at 09:00 UTC")).toBeVisible({
+    timeout: PREVIEW_TIMEOUT,
+  });
   // The local gloss is the part that earns its keep: it is the only place the
   // UTC contract becomes concrete rather than a hint the author skimmed.
-  await expect(dialog.getByText(/your time\)/)).toBeVisible();
+  await expect(dialog.getByText(/your time\)/)).toBeVisible({ timeout: PREVIEW_TIMEOUT });
 
   await cron.fill("9 0 * * *");
-  await expect(dialog.getByText("Every day at 00:09 UTC")).toBeVisible();
-  await expect(dialog.getByText("Every day at 09:00 UTC")).toHaveCount(0);
+  await expect(dialog.getByText("Every day at 00:09 UTC")).toBeVisible({
+    timeout: PREVIEW_TIMEOUT,
+  });
+  await expect(dialog.getByText("Every day at 09:00 UTC")).toHaveCount(0, {
+    timeout: PREVIEW_TIMEOUT,
+  });
 
   // The UTC hint stays — the preview says what THIS expression means, it does
   // not replace the statement of the contract.
@@ -182,7 +198,7 @@ test("a schedule the humaniser won't paraphrase still previews its next runs", a
   // A restricted day-of-month is left undescribed on purpose — a wrong
   // paraphrase would be worse than none — but the fire times still state it.
   await cron.fill("0 0 1 * *");
-  await expect(dialog.getByText(/^Next runs:/)).toBeVisible();
+  await expect(dialog.getByText(/^Next runs:/)).toBeVisible({ timeout: PREVIEW_TIMEOUT });
 });
 
 test("garbage in the cron field previews the parser's message without blocking", async ({
@@ -196,7 +212,9 @@ test("garbage in the cron field previews the parser's message without blocking",
   // is out of range, so the host's parser rejects it. That arrives as a 200
   // with a message, not a thrown error, and it does not disable anything.
   await cron.fill("0 99 * * *");
-  await expect(dialog.getByText(/value out of range/)).toBeVisible();
+  await expect(dialog.getByText(/value out of range/)).toBeVisible({
+    timeout: PREVIEW_TIMEOUT,
+  });
   await expect(dialog.getByRole("button", { name: "Create workflow" })).toBeEnabled();
 
   // Fewer than five fields never reaches the wire — the pre-flight shape check
@@ -206,7 +224,9 @@ test("garbage in the cron field previews the parser's message without blocking",
   await expect(dialog.getByText(/5-field cron, e\.g\./)).toBeVisible();
   // And one mistake produces ONE complaint, not a blur error stacked on a
   // preview error.
-  await expect(dialog.getByText(/value out of range/)).toHaveCount(0);
+  await expect(dialog.getByText(/value out of range/)).toHaveCount(0, {
+    timeout: PREVIEW_TIMEOUT,
+  });
 });
 
 test("a valid workflow still saves", async ({ page }) => {
@@ -226,7 +246,9 @@ test("a valid workflow still saves", async ({ page }) => {
   await dialog.getByLabel("Node name").first().fill("Start");
   await dialog.getByLabel("Schedule").click();
   await page.getByRole("option", { name: /^Daily/ }).click();
-  await expect(dialog.getByText("Every day at 09:00 UTC")).toBeVisible();
+  await expect(dialog.getByText("Every day at 09:00 UTC")).toBeVisible({
+    timeout: PREVIEW_TIMEOUT,
+  });
 
   // Output row routing to the owner — no target to get wrong.
   await dialog.getByRole("button", { name: "Add node" }).click();

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -2217,4 +2217,165 @@ to = "done"
         let ids: Vec<&str> = files.iter().map(|f| f.id.as_str()).collect();
         assert_eq!(ids, vec!["good"]);
     }
+
+    // -----------------------------------------------------------------------
+    // Console drift guard (issue #260)
+    // -----------------------------------------------------------------------
+    //
+    // The console pre-flights the destination and schedule rules client-side so
+    // a wrong target is caught without a round trip. That is worth keeping — it
+    // is the difference between instant feedback and a save that bounces — but
+    // it makes one rule live in two hand-written places, free to drift. Issue
+    // #260 reports the drift that already happened: two different messages for
+    // the same rule.
+    //
+    // These tests are the coupling. Each shared fragment is asserted TWICE —
+    // once against this module's live `validate()` output, so a server rewording
+    // fails here, and once against the console source, so a console rewording
+    // fails here too. Neither side can be reworded alone.
+    //
+    // This is a tripwire, not a proof. The fragment only has to APPEAR in the
+    // console source, so a stale copy left in a comment would false-pass, and
+    // nothing here checks that the console's rule FIRES in the same cases the
+    // host's does. What it does buy is that the specific failure #260 describes
+    // — one side reworded, the other silently asserting the old contract — can
+    // no longer happen quietly. Closing the rest means option 3 from the issue:
+    // the host exposing the destination contract as data.
+
+    /// The console's workflow creator, read at compile time so a file move is a
+    /// build error naming the path rather than a silently-skipped test.
+    const CONSOLE_DIALOG: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/frontend/src/views/WorkflowCreateDialog.tsx"
+    ));
+    const CONSOLE_DIALOG_PATH: &str = "frontend/src/views/WorkflowCreateDialog.tsx";
+
+    /// The console's workflow API module, which declares the picker's
+    /// destination kinds.
+    const CONSOLE_API: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/frontend/src/api/workflows.ts"
+    ));
+    const CONSOLE_API_PATH: &str = "frontend/src/api/workflows.ts";
+
+    /// How an `email` destination with a non-address target ends, on both sides.
+    const EMAIL_TARGET_TAIL: &str = "is not an email address — give the recipient's full address.";
+    /// How a `channel` destination with no target ends, on both sides.
+    const CHANNEL_TARGET_TAIL: &str = "name the channel to post the report to.";
+
+    /// A graph that trips both destination target rules at once.
+    const BAD_DESTINATIONS: &str = r#"
+        id = "wf"
+        name = "WF"
+
+        [[node]]
+        id = "start"
+        kind = "trigger"
+        name = "Start"
+
+        [[node]]
+        id = "mailer"
+        kind = "output"
+        name = "Mailer"
+        [node.destination]
+        kind = "email"
+        target = "nope"
+
+        [[node]]
+        id = "poster"
+        kind = "output"
+        name = "Poster"
+        [node.destination]
+        kind = "channel"
+    "#;
+
+    #[test]
+    fn destination_messages_match_the_console() {
+        let raw: RawWorkflow = toml::from_str(BAD_DESTINATIONS).expect("the fixture is valid TOML");
+        let problems = validate(&raw).join("\n");
+
+        for tail in [EMAIL_TARGET_TAIL, CHANNEL_TARGET_TAIL] {
+            assert!(
+                problems.contains(tail),
+                "the host stopped saying `{tail}` — if that rewording is deliberate, \
+                 update this const AND the matching message in {CONSOLE_DIALOG_PATH}, \
+                 so an author who trips the pre-flight and an author who trips the 400 \
+                 are still told the same thing.\nhost said:\n{problems}"
+            );
+            assert!(
+                CONSOLE_DIALOG.contains(tail),
+                "{CONSOLE_DIALOG_PATH} no longer says `{tail}` — the console's \
+                 client-side pre-flight has drifted from the host's rule (issue #260). \
+                 Reword both sides together, or drop the pre-flight and surface the \
+                 host's message on the failed save."
+            );
+        }
+    }
+
+    /// The picker's destination kinds, extracted from the console's own
+    /// `DESTINATION_KINDS` block. A kind added on one side alone is either a
+    /// picker option the host rejects or one the host accepts and the author
+    /// can never choose.
+    #[test]
+    fn destination_kinds_match_the_console() {
+        let start = CONSOLE_API.find("export const DESTINATION_KINDS").unwrap_or_else(|| {
+            panic!("`DESTINATION_KINDS` is gone from {CONSOLE_API_PATH} — it is what this test reads")
+        });
+        // Slice from the array opener, NOT from the declaration: the type
+        // annotation in between ends `WorkflowDestination["kind"];`, which
+        // contains a literal `"];` and would close the block before the first
+        // entry.
+        let block = &CONSOLE_API[start..];
+        let open = block.find("= [").unwrap_or_else(|| {
+            panic!("`DESTINATION_KINDS` in {CONSOLE_API_PATH} is no longer an array literal")
+        });
+        let block = &block[open..];
+        let end = block
+            .find("];")
+            .unwrap_or_else(|| panic!("`DESTINATION_KINDS` in {CONSOLE_API_PATH} has no `];`"));
+        let block = &block[..end];
+
+        // Scan for `value: "…"` entries. The type annotation on the same
+        // declaration carries a bare `value:` with no string, so keying on the
+        // opening quote is what keeps it out.
+        let needle = "value: \"";
+        let mut console = std::collections::BTreeSet::new();
+        let mut rest = block;
+        while let Some(at) = rest.find(needle) {
+            rest = &rest[at + needle.len()..];
+            let close = rest
+                .find('"')
+                .unwrap_or_else(|| panic!("unterminated `value:` in {CONSOLE_API_PATH}"));
+            console.insert(&rest[..close]);
+            rest = &rest[close..];
+        }
+
+        let host: std::collections::BTreeSet<&str> =
+            WORKFLOW_DESTINATION_KINDS.iter().copied().collect();
+        assert_eq!(
+            console, host,
+            "the console's DESTINATION_KINDS picker ({CONSOLE_API_PATH}) and the host's \
+             WORKFLOW_DESTINATION_KINDS disagree — one side offers a kind the other \
+             does not know (issue #260)"
+        );
+    }
+
+    /// The console's `looksLikeCron` pre-flight counts whitespace-separated
+    /// fields and accepts exactly five, so it is only correct while the host's
+    /// parser draws the line in the same place. Relaxing the host to accept a
+    /// 6-field (seconds) expression without touching the console would make the
+    /// console reject input the host now takes — the drift direction #260 says
+    /// bites, because the console is the stricter side by construction.
+    #[test]
+    fn cron_arity_matches_the_console_preflight() {
+        use crate::runtime::cron::CronExpr;
+        assert!(CronExpr::parse("0 9 * * MON").is_ok(), "5 fields");
+        assert!(CronExpr::parse("0 9 * *").is_err(), "4 fields");
+        assert!(CronExpr::parse("0 0 9 * * MON").is_err(), "6 fields");
+        assert!(
+            CONSOLE_DIALOG.contains("function looksLikeCron"),
+            "{CONSOLE_DIALOG_PATH} no longer defines `looksLikeCron` — this test \
+             exists to pin the arity that helper assumes"
+        );
+    }
 }

--- a/src/runtime/cron.rs
+++ b/src/runtime/cron.rs
@@ -49,6 +49,23 @@ impl FieldSet {
     fn contains(&self, value: u32) -> bool {
         value < 64 && self.mask & (1u64 << value) != 0
     }
+
+    /// The permitted values, ascending. Used only by [`CronExpr::describe`],
+    /// which reads the parsed masks rather than re-reading the source text —
+    /// so the description can never disagree with what [`CronExpr::matches`]
+    /// will actually do.
+    fn values(&self) -> Vec<u32> {
+        (0..64).filter(|v| self.contains(*v)).collect()
+    }
+
+    /// The single permitted value, when the set holds exactly one.
+    fn single(&self) -> Option<u32> {
+        let values = self.values();
+        match values.len() {
+            1 => Some(values[0]),
+            _ => None,
+        }
+    }
 }
 
 /// A parsed 5-field cron expression.
@@ -118,6 +135,151 @@ impl CronExpr {
             cursor += MINUTE_MS;
         }
         None
+    }
+
+    /// A plain-English gloss of this schedule, or `None` when the shape is
+    /// gnarlier than a one-liner can honestly state.
+    ///
+    /// Issue #262: cron is easy to write and hard to read — `0 9 * * *` and
+    /// `9 0 * * *` are both valid and only one is 9am — and the dialect is UTC,
+    /// so an author in IST who wants a 9am report gets one at 14:30 local.
+    /// Neither mistake is *invalid*, so validation can never catch them; the
+    /// only defence is echoing the parsed meaning back.
+    ///
+    /// Derived from the parsed field masks, never from the source string, so
+    /// this cannot drift from [`matches`](Self::matches). `None` is a first-class
+    /// answer, not a failure: it means "I will not paraphrase this", and the
+    /// caller still has the next fire times, which say the same thing without
+    /// any risk of a confidently wrong gloss. Widening the covered shapes is
+    /// safe by construction — anything not recognised keeps returning `None`.
+    ///
+    /// Recognised shapes (each optionally narrowed by a weekday field):
+    ///
+    /// | Expression | Description |
+    /// |---|---|
+    /// | `* * * * *` | `Every minute` |
+    /// | `*/15 * * * *` | `Every 15 minutes` |
+    /// | `5 * * * *` | `Every hour at :05` |
+    /// | `0 9 * * *` | `Every day at 09:00 UTC` |
+    /// | `0 9 * * MON` | `Every Mon at 09:00 UTC` |
+    /// | `0 9,17 * * 1-5` | `At 09:00 and 17:00 UTC on Mon-Fri` |
+    pub fn describe(&self) -> Option<String> {
+        // A restricted month or day-of-month ("the 3rd of every other month")
+        // takes more words to state than the expression takes to read, so it is
+        // left to the next-fire times.
+        if self.month.restricted || self.dom.restricted {
+            return None;
+        }
+        let days = self.describe_weekdays()?;
+        // `on Mon-Fri` / `` — appended to whichever body is built below.
+        let on_days = days
+            .as_deref()
+            .map(|d| format!(" on {d}"))
+            .unwrap_or_default();
+
+        // An unrestricted hour means the schedule repeats within every hour.
+        if !self.hour.restricted {
+            if !self.minute.restricted {
+                return Some(format!("Every minute{on_days}"));
+            }
+            if let Some(step) = self.minute_step() {
+                return Some(format!("Every {step} minutes{on_days}"));
+            }
+            let minute = self.minute.single()?;
+            return Some(format!("Every hour at :{minute:02}{on_days}"));
+        }
+
+        // A restricted hour with a wildcard (or multi-valued) minute fires many
+        // times inside the named hours — not a clean "at HH:MM".
+        let minute = self.minute.single()?;
+        let hours = self.hour.values();
+        // Beyond a handful of hours the list stops reading as a sentence.
+        if hours.len() > 4 {
+            return None;
+        }
+        let times: Vec<String> = hours
+            .iter()
+            .map(|hour| format!("{hour:02}:{minute:02}"))
+            .collect();
+        if let [only] = times.as_slice() {
+            // `Every day at 09:00 UTC` / `Every Mon at 09:00 UTC` — the weekday
+            // replaces "day" here rather than trailing, which is how the phrase
+            // is said out loud.
+            let subject = days.unwrap_or_else(|| "day".to_string());
+            return Some(format!("Every {subject} at {only} UTC"));
+        }
+        Some(format!("At {} UTC{on_days}", join_and(&times)))
+    }
+
+    /// The weekday phrase for this expression: `None` = every day (the field is
+    /// `*`, or names all seven days), `Some("Mon-Fri")` for a contiguous run,
+    /// `Some("Mon, Wed")` for a list. The outer `Option` is `None` when the
+    /// field is too long to read as a phrase.
+    fn describe_weekdays(&self) -> Option<Option<String>> {
+        if !self.dow.restricted {
+            return Some(None);
+        }
+        let days = self.dow.values();
+        if days.len() >= WEEKDAYS.len() {
+            return Some(None);
+        }
+        let names: Vec<&'static str> = days
+            .iter()
+            .map(|d| title_case_weekday(WEEKDAYS[*d as usize]))
+            .collect();
+        // A contiguous run reads as a range; anything else as a list. More than
+        // three scattered days is a list nobody parses at a glance.
+        let contiguous = days.windows(2).all(|w| w[1] == w[0] + 1);
+        if contiguous && days.len() > 2 {
+            return Some(Some(format!("{}-{}", names[0], names[names.len() - 1])));
+        }
+        if names.len() > 3 {
+            return None;
+        }
+        Some(Some(names.join(", ")))
+    }
+
+    /// The step of an evenly-spaced minute field starting at `0`, when it has
+    /// one — `*/15` → `Some(15)`.
+    ///
+    /// Requires the step to divide 60: `*/7` yields 0,7,…,56, and the 56 → 0
+    /// wrap is a 4-minute gap, so calling it "every 7 minutes" would be a lie
+    /// once an hour.
+    fn minute_step(&self) -> Option<u32> {
+        let values = self.minute.values();
+        if values.len() < 2 || values[0] != 0 {
+            return None;
+        }
+        let step = values[1];
+        if 60 % step != 0 || values.len() as u32 != 60 / step {
+            return None;
+        }
+        values
+            .windows(2)
+            .all(|w| w[1] - w[0] == step)
+            .then_some(step)
+    }
+}
+
+/// `MON` → `Mon`. The parser's tables are upper-case; a description is prose.
+fn title_case_weekday(name: &str) -> &'static str {
+    match name {
+        "SUN" => "Sun",
+        "MON" => "Mon",
+        "TUE" => "Tue",
+        "WED" => "Wed",
+        "THU" => "Thu",
+        "FRI" => "Fri",
+        _ => "Sat",
+    }
+}
+
+/// `["09:00", "17:00"]` → `"09:00 and 17:00"`; three or more use commas.
+fn join_and(parts: &[String]) -> String {
+    match parts {
+        [] => String::new(),
+        [only] => only.clone(),
+        [head @ .., last] => format!("{} and {last}", head.join(", ")),
     }
 }
 
@@ -254,6 +416,20 @@ impl CivilTime {
             minute,
             weekday,
         }
+    }
+
+    /// Unix milliseconds at the start of this civil minute — the inverse of
+    /// [`from_unix_millis`](Self::from_unix_millis), which discards everything
+    /// below the minute, so the round trip is lossless for any time this type
+    /// can hold.
+    ///
+    /// Public so a caller that computed a fire time with
+    /// [`CronExpr::next_after`] can hand it back as an instant: the cron
+    /// preview (issue #262) sends epoch millis to the console precisely so the
+    /// UTC reading and the viewer's local reading come from ONE number and
+    /// cannot disagree.
+    pub fn unix_millis(&self) -> u64 {
+        self.floor_to_minute_millis()
     }
 
     /// Unix milliseconds at the start of this civil minute.
@@ -413,6 +589,81 @@ mod test {
         // From 2025 (not a leap year) the next 29 Feb is 2028.
         let next = expr.next_after(&at(2025, 3, 1, 0, 0)).unwrap();
         assert_eq!((next.year, next.month, next.day), (2028, 2, 29));
+    }
+
+    /// The whole point of issue #262: `0 9 * * *` and `9 0 * * *` are both
+    /// valid, differ by two characters, and mean nine hours apart. Validation
+    /// cannot help — neither is wrong — so the description is the only thing
+    /// standing between an author and a report that arrives at the wrong time.
+    #[test]
+    fn describes_the_nine_am_versus_nine_past_midnight_confusion() {
+        assert_eq!(
+            CronExpr::parse("0 9 * * *").unwrap().describe().as_deref(),
+            Some("Every day at 09:00 UTC")
+        );
+        assert_eq!(
+            CronExpr::parse("9 0 * * *").unwrap().describe().as_deref(),
+            Some("Every day at 00:09 UTC")
+        );
+    }
+
+    #[test]
+    fn describes_the_common_shapes() {
+        let describe = |expr: &str| CronExpr::parse(expr).unwrap().describe();
+        assert_eq!(describe("* * * * *").as_deref(), Some("Every minute"));
+        assert_eq!(
+            describe("*/15 * * * *").as_deref(),
+            Some("Every 15 minutes")
+        );
+        assert_eq!(describe("5 * * * *").as_deref(), Some("Every hour at :05"));
+        assert_eq!(
+            describe("0 9 * * MON").as_deref(),
+            Some("Every Mon at 09:00 UTC")
+        );
+        assert_eq!(
+            describe("0 9,17 * * 1-5").as_deref(),
+            Some("At 09:00 and 17:00 UTC on Mon-Fri")
+        );
+        assert_eq!(
+            describe("*/30 * * * 1-5").as_deref(),
+            Some("Every 30 minutes on Mon-Fri")
+        );
+        assert_eq!(
+            describe("0 8,12,17 * * *").as_deref(),
+            Some("At 08:00, 12:00 and 17:00 UTC")
+        );
+        // Every preset the console's schedule picker offers must describe —
+        // an author who picks "Daily — 09:00 UTC" from a menu should not then
+        // see a blank preview.
+        assert_eq!(describe("0 * * * *").as_deref(), Some("Every hour at :00"));
+    }
+
+    /// `describe` returning `None` is a designed answer, not a bug: the caller
+    /// still shows the next fire times, which state the schedule exactly. A
+    /// wrong paraphrase would be worse than none.
+    #[test]
+    fn declines_to_describe_gnarlier_shapes() {
+        let describe = |expr: &str| CronExpr::parse(expr).unwrap().describe();
+        assert_eq!(describe("0 0 1 * *"), None); // day-of-month restricted
+        assert_eq!(describe("0 0 * JAN-MAR *"), None); // month restricted
+        assert_eq!(describe("* 9 * * *"), None); // every minute of one hour
+        assert_eq!(describe("0 1,3,5,7,9 * * *"), None); // too many hours to list
+        // `*/7` is 0,7,…,56 — the wrap back to 0 is a 4-minute gap, so "every
+        // 7 minutes" would be wrong once an hour.
+        assert_eq!(describe("*/7 * * * *"), None);
+    }
+
+    /// The preview hands the console epoch millis so the UTC reading and the
+    /// viewer's local reading are two renderings of ONE instant.
+    #[test]
+    fn unix_millis_round_trips_a_fire_time() {
+        let expr = CronExpr::parse("0 9 * * *").unwrap();
+        let next = expr.next_after(&at(2026, 8, 2, 12, 0)).unwrap();
+        let millis = next.unix_millis();
+        let back = CivilTime::from_unix_millis(millis);
+        assert_eq!(back, next);
+        assert_eq!((back.year, back.month, back.day), (2026, 8, 3));
+        assert_eq!((back.hour, back.minute), (9, 0));
     }
 
     #[test]

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -66,6 +66,7 @@ use crate::company::{
 };
 use crate::error::OpenCompanyError;
 use crate::ports::types::{CompanyEvent, CompanyRecord, EventSeq, OverlayWorkflow};
+use crate::runtime::cron::{CivilTime, CronExpr};
 use crate::runtime::record_run_finished;
 use crate::server::error::ApiError;
 use crate::server::ops::{ScopedCompany, scoped};
@@ -85,6 +86,9 @@ pub fn router() -> Router<AppState> {
         // read through this route. That is the same trade `tasks/inflight`
         // takes, and the history surface is worth more than the one reserved id.
         .merge(scoped("/workflows/runs", get(list_runs)))
+        // Same static-before-dynamic ordering as `/workflows/runs` above, for
+        // the same reason: `cron` is a syntactically valid `wid`.
+        .merge(scoped("/workflows/cron/preview", post(preview_cron)))
         .merge(scoped("/workflows/{wid}", get(get_workflow)))
         .merge(scoped("/workflows/{wid}/run", post(run_workflow)))
 }
@@ -578,6 +582,105 @@ async fn run_workflow(
         pending_approvals: run.pending_approvals,
         deliveries: run.deliveries,
     }))
+}
+
+// ---------------------------------------------------------------------------
+// Cron preview (issue #262)
+// ---------------------------------------------------------------------------
+
+/// How many upcoming fire times the preview returns. Three is enough to show
+/// the *interval* — one time tells you when, three tell you how often — without
+/// turning a one-line hint into a table.
+const CRON_PREVIEW_FIRES: usize = 3;
+
+/// The preview request: the expression as typed, plus an optional instant to
+/// compute the next fires from.
+#[derive(Debug, Deserialize)]
+struct PreviewCronBody {
+    expr: String,
+    /// Epoch millis to search forward from. Defaults to now; present so tests
+    /// can pin the answer instead of asserting against a moving clock.
+    #[serde(default)]
+    after: Option<u64>,
+}
+
+/// The preview response. Untagged, so the two outcomes are two shapes rather
+/// than one shape with half its fields null.
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum PreviewCronResponse {
+    /// A valid expression: what it means (`null` when the shape is one
+    /// [`CronExpr::describe`] declines to paraphrase) and when it next fires.
+    Parsed {
+        description: Option<String>,
+        /// Epoch millis, ascending. The console renders each one twice — UTC
+        /// and the viewer's local zone — from this single number, which is what
+        /// makes the two readings incapable of disagreeing.
+        next: Vec<u64>,
+    },
+    /// A malformed expression, carrying the parser's own message.
+    Invalid { error: String },
+}
+
+/// `POST …/workflows/cron/preview` (both scope forms).
+///
+/// Issue #262: a trigger's schedule is a bare cron field, and the failure that
+/// is NOT handled is the *successful* one — `0 9 * * *` saves cleanly whether or
+/// not the author meant 9am, and it is UTC whether or not they read the hint.
+/// Echoing the parsed meaning and the next fire times is the only thing that
+/// turns a silently-wrong schedule into an obviously-wrong one.
+///
+/// **Always answers 200**, including for a malformed expression. The console
+/// calls this while the author is still typing, so half-written garbage is the
+/// normal state, not an exception — and its HTTP client throws on any non-2xx,
+/// so a 400 per keystroke would make an ordinary parse failure arrive as a
+/// thrown error and force try/catch as control flow. The rejection that matters
+/// still happens: the create route validates the schedule and refuses to save a
+/// bad one.
+///
+/// Scoped (and so authenticated) like every other route in this module even
+/// though the computation touches no company state — an unauthenticated compute
+/// endpoint would be a new kind of surface here for no gain.
+async fn preview_cron(
+    _company: ScopedCompany,
+    Json(body): Json<PreviewCronBody>,
+) -> Json<PreviewCronResponse> {
+    let expr = match CronExpr::parse(&body.expr) {
+        Ok(expr) => expr,
+        Err(err) => {
+            return Json(PreviewCronResponse::Invalid {
+                error: err.to_string(),
+            });
+        }
+    };
+
+    let after = body.after.unwrap_or_else(now_millis);
+    let mut cursor = CivilTime::from_unix_millis(after);
+    let mut next = Vec::with_capacity(CRON_PREVIEW_FIRES);
+    for _ in 0..CRON_PREVIEW_FIRES {
+        // `next_after` is bounded and returns `None` only for an expression
+        // that can never fire, which a parsed one cannot be — but stopping
+        // early is still the right answer if that ever changes.
+        let Some(fire) = expr.next_after(&cursor) else {
+            break;
+        };
+        next.push(fire.unix_millis());
+        cursor = fire;
+    }
+
+    Json(PreviewCronResponse::Parsed {
+        description: expr.describe(),
+        next,
+    })
+}
+
+/// Wall-clock epoch millis. Saturates at the epoch rather than panicking on a
+/// clock set before 1970 — a preview is not worth a 500.
+fn now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 // ---------------------------------------------------------------------------
@@ -1813,6 +1916,115 @@ mod tests {
             // An array of outcomes, not a single graph object.
             let body = json_body(response).await;
             assert!(body.is_array(), "graph read shadowed the history: {body}");
+        }
+
+        // -------------------------------------------------------------------
+        // Cron preview (issue #262)
+        // -------------------------------------------------------------------
+
+        /// 2026-08-02 12:00 UTC, as epoch millis — the `after` pin every
+        /// preview test searches forward from, so the answers are fixed rather
+        /// than relative to whenever CI runs.
+        const AFTER: u64 = 1_785_672_000_000;
+
+        async fn preview(state: &AppState, expr: &str) -> serde_json::Value {
+            json_body(
+                router(state.clone())
+                    .oneshot(request(
+                        "POST",
+                        "/api/v1/company/workflows/cron/preview",
+                        Some(serde_json::json!({ "expr": expr, "after": AFTER })),
+                    ))
+                    .await
+                    .unwrap(),
+            )
+            .await
+        }
+
+        /// **The issue #262 pin.** `0 9 * * *` and `9 0 * * *` are two
+        /// characters apart, both valid, and nine hours different. The preview
+        /// is the only thing that tells them apart before the report arrives at
+        /// the wrong time, so the distinction is pinned end-to-end over HTTP,
+        /// not just in the matcher's unit tests.
+        #[tokio::test]
+        async fn cron_preview_distinguishes_nine_am_from_nine_past_midnight() {
+            let home_dir = home();
+            let (state, _store, _id) = hosted_state(home_dir.path()).await;
+
+            let morning = preview(&state, "0 9 * * *").await;
+            assert_eq!(morning["description"], "Every day at 09:00 UTC");
+            // 2026-08-02 12:00 UTC → the next 09:00 is the following morning.
+            assert_eq!(morning["next"][0], 1_785_747_600_000u64);
+            assert_eq!(morning["next"].as_array().unwrap().len(), 3);
+
+            let midnight = preview(&state, "9 0 * * *").await;
+            assert_eq!(midnight["description"], "Every day at 00:09 UTC");
+            assert_ne!(morning["next"][0], midnight["next"][0]);
+        }
+
+        /// A shape the humaniser declines to paraphrase still previews: the
+        /// description is `null` and the fire times carry the meaning. The
+        /// console shows "Next runs: …" rather than nothing.
+        #[tokio::test]
+        async fn cron_preview_returns_fires_without_a_description() {
+            let home_dir = home();
+            let (state, _store, _id) = hosted_state(home_dir.path()).await;
+
+            let body = preview(&state, "0 0 1 * *").await;
+            assert!(body["description"].is_null(), "{body}");
+            assert_eq!(body["next"].as_array().unwrap().len(), 3, "{body}");
+        }
+
+        /// **Malformed input answers 200, not 4xx.** The console previews while
+        /// the author is still typing, so a half-written expression is the
+        /// normal live state — and the console's client throws on any non-2xx,
+        /// which would turn every keystroke into a caught exception. The parser
+        /// message rides in the body instead.
+        #[tokio::test]
+        async fn cron_preview_reports_a_parse_error_as_a_200_body() {
+            let home_dir = home();
+            let (state, _store, _id) = hosted_state(home_dir.path()).await;
+
+            let response = router(state)
+                .oneshot(request(
+                    "POST",
+                    "/api/v1/company/workflows/cron/preview",
+                    Some(serde_json::json!({ "expr": "every day" })),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+
+            let body = json_body(response).await;
+            let error = body["error"].as_str().expect("an error message: {body}");
+            assert!(error.contains("5 fields"), "{body}");
+            assert!(body["next"].is_null(), "no fire times on a parse error");
+        }
+
+        /// **Route-ordering pin**, the same trade `/workflows/runs` takes:
+        /// `cron` is a syntactically valid `wid`, so the static preview path is
+        /// registered before `/workflows/{wid}`. A regression would route the
+        /// preview into the graph read and 404.
+        #[tokio::test]
+        async fn cron_preview_is_not_shadowed_by_the_graph_read() {
+            let home_dir = home();
+            let (state, _store, _id) = hosted_state(home_dir.path()).await;
+
+            let response = router(state)
+                .oneshot(request(
+                    "POST",
+                    "/api/v1/companies/acme/workflows/cron/preview",
+                    Some(serde_json::json!({ "expr": "0 9 * * MON" })),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::OK,
+                "the static /workflows/cron/preview must win over /workflows/{{wid}}"
+            );
+            let body = json_body(response).await;
+            assert_eq!(body["description"], "Every Mon at 09:00 UTC", "{body}");
         }
 
         /// Both scope forms serve the history — the platform

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1,7 +1,23 @@
 //! Workflow surfaces: create a graph (`POST /workflows`), read the company's
 //! saved graphs (`GET /workflows`, `GET /workflows/{wid}`), run one
-//! (`POST /workflows/{wid}/run`), and read back what past runs did
-//! (`GET /workflows/runs`) — under both scope forms.
+//! (`POST /workflows/{wid}/run`), read back what past runs did
+//! (`GET /workflows/runs`), and preview what a trigger's cron means
+//! (`POST /workflows/cron/preview`) — under both scope forms.
+//!
+//! ## Cron preview (issue #262)
+//!
+//! `POST /workflows/cron/preview` answers what a 5-field expression means and
+//! when it next fires. A schedule's dangerous failure is the one that
+//! *validates*: `0 9 * * *` and `9 0 * * *` are both valid and nine hours
+//! apart, and the dialect is always UTC, so nothing in the authoring flow
+//! contradicts an author who meant something else. Reading the parsed schedule
+//! back is the only defence, since neither expression is invalid.
+//!
+//! It is the only route here that answers **200 on bad input**, carrying the
+//! parser's message in the body — the console calls it while the author is
+//! still typing, so a half-written expression is the normal state rather than
+//! an error. See [`preview_cron`] for the full reasoning; `POST /workflows`
+//! still refuses to save a graph whose schedule does not parse.
 //!
 //! ## Run history (issue #228)
 //!


### PR DESCRIPTION
## Summary

Three facets of one thing — how the workflow create dialog validates input and tells you what it did.

Closes #260. Closes #261. Closes #262.

**#260 — the destination rules existed three times.** The host's `validate()`, a hand-copied pre-flight in the console, and a third copy of the closed kind list in `api/workflows.ts`. They had already drifted: for a channel destination the console said "name the channel." while the host said "name the channel to post the report to." Both message sets are now aligned on the host's fix instructions, and a Rust test pins them together — it asserts each fragment appears both in live `validate()` output and in the console source, plus set-equality between `DESTINATION_KINDS` and `WORKFLOW_DESTINATION_KINDS`.

**#261 — validation only ran on Save.** Typing `nope` into an email target gave no feedback until submit, and the resulting message named `Node \`2\`` rather than the name the author typed. Each rule is now a named predicate shared by submit and blur; errors appear under the offending field on blur, clear on the next keystroke, and name the node the author named.

**#262 — a valid cron saved silently.** `0 9 * * *` and `9 0 * * *` are both valid and only one is 9am, and the always-UTC contract lived only in hint text. A new preview line reads back what the expression means and when it next fires, in UTC and in the viewer's local time.

The cron humanising is deliberately **server-side**, in `CronExpr::describe()`, derived from the parsed field masks rather than re-parsing. A TypeScript cron parser would have been a fourth copy of exactly the rules #260 exists to collapse — including the parts that actually drift, like the day-of-month/day-of-week OR rule and `0`/`7` Sunday folding.

## API Or Behavior Changes

- **New route** `POST …/workflows/cron/preview`, merged before `/workflows/{wid}` so the static segment wins. Request `{ "expr": string, "after"?: epoch_millis }`. **Always responds 200** with a tagged body — `{ "description": string|null, "next": [ms, ms, ms] }` or `{ "error": "<parser message>" }`. Malformed input is the normal state while typing, and the console's client throws on non-2xx, so a 400-per-keystroke would force try/catch as control flow.
- `CronExpr::describe()` and `CivilTime::unix_millis()` are new public API. `floor_to_minute_millis` is unchanged and still private.
- Console destination validation messages reworded to match the host's. No wire-shape change.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 1020 passed / 0 failed

Also run: `cargo check --all-features` and `cargo check --features openhuman,mcp,telegram` (CI builds neither combo, and this touches `cron.rs` and `ops/workflows.rs` near feature boundaries); `npm ci && npm run typecheck && npm run build`.

**7 new Playwright specs**, all passing against a live host. Blur validation is a DOM event and the preview is a network round trip — neither is observable outside a browser. Note the suite is not run by CI (no `webServer`; it needs a live host), so it is repro-and-documentation rather than a gate.

**The drift guard was verified to bite**: reworded the console message and added a bogus `DESTINATION_KINDS` entry, watched both tests fail, reverted.

Manual: over curl, bad-email and missing-channel graphs return the host's messages ending in the same fix instructions the console now shows; `0 9 * * *` previews as `Every day at 09:00 UTC`, `9 0 * * *` as `Every day at 00:09 UTC`.

## Documentation

`docs/modules/server/README.md` gains the preview route. The module-doc header on `src/server/ops/workflows.rs` covers the route ordering constraint.

Worth stating plainly: the #260 guard is a **tripwire, not a proof** — it only asserts the shared fragments appear in the console source, so a stale copy inside a comment would pass. It is the strongest option available without a frontend test runner in CI. The real fix is the host exposing the destination contract as structured data; OpenHuman already returns node-addressed diagnostics (`FlowValidationError { code, message, node_id, field }`) and its own `AUDIT-n8n-gap.md` §4 names that as the wanted direction — though its console ignores them and regex-matches node ids out of prose. Adopting that here is the natural follow-on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live cron schedule previews with descriptions and upcoming run times in UTC and local time.
  * Added support for previewing five-field cron expressions with clear feedback for invalid schedules.
  * Improved workflow setup with destination and schedule validation, accessible inline errors, and clearer node labels.

* **Documentation**
  * Documented cron preview requests, responses, timing behavior, and error handling.

* **Tests**
  * Expanded coverage for workflow validation, cron previews, destination compatibility, and successful workflow creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->