### PR TITLE
feat(tasks): pick an assignee from the roster instead of typing it (#263)

### DIFF
--- a/frontend/src/views/AssigneeSelect.tsx
+++ b/frontend/src/views/AssigneeSelect.tsx
@@ -18,6 +18,7 @@
 //      its own labelled row saying what it does.
 
 import { useEffect, useMemo, useState } from "react";
+import { AlertCircle } from "lucide-react";
 
 import type { OpenCompanyClient } from "@/api/client";
 import type { DeskDto, TeamMemberDto } from "@/api/types";
@@ -171,16 +172,37 @@ export function AssigneeSelect({
     };
   }, [value, deskOptions, teamOptions, loaded, desks.length, team.length]);
 
-  /** The trigger's one-line rendering of a wire value. */
-  const labelFor = useMemo(() => {
+  /**
+   * The trigger's rendering of a wire value.
+   *
+   * The off-roster warning is an icon here, not the words — the trigger is
+   * often a third of a dialog row and an overlay teammate id already fills it,
+   * so spelling it out would truncate the id away and leave a warning with no
+   * subject. The icon keeps both visible; the words stay on the popup row
+   * (which has the width) and in an `sr-only` span, so screen readers and text
+   * assertions still get them.
+   */
+  const renderValue = useMemo(() => {
     const byValue = new Map<string, Option>();
     for (const option of [...deskOptions, ...teamOptions]) byValue.set(option.value, option);
     if (stale) byValue.set(stale.value, stale);
-    return (wire: string): string => {
-      if (!wire) return UNASSIGNED_LABEL;
+    return (wire: string) => {
+      if (!wire) return <span className="min-w-0 truncate">{UNASSIGNED_LABEL}</span>;
       const option = byValue.get(wire);
-      if (!option) return wire;
-      return option.offRoster ? `${option.label} (not on roster)` : option.label;
+      return (
+        <>
+          {option?.offRoster && (
+            <>
+              <AlertCircle
+                className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400"
+                aria-hidden
+              />
+              <span className="sr-only">not on roster:</span>
+            </>
+          )}
+          <span className="min-w-0 truncate">{option?.label ?? wire}</span>
+        </>
+      );
     };
   }, [deskOptions, teamOptions, stale]);
 
@@ -192,12 +214,20 @@ export function AssigneeSelect({
       onValueChange={(next) => onChange(next == null || next === UNASSIGNED ? "" : String(next))}
       disabled={disabled}
     >
-      <SelectTrigger id={id} className={cn("w-full", className)}>
+      {/* `min-w-0` matters: the trigger's content is `whitespace-nowrap`, and a
+          long overlay-teammate id would otherwise set the min-content width of
+          whatever grid or flex track holds this control — squashing its
+          neighbours (the edit dialog's Column and Priority) to nothing. */}
+      <SelectTrigger id={id} className={cn("w-full min-w-0", className)}>
         <SelectValue>
-          {(selected) => labelFor(selected === UNASSIGNED ? "" : String(selected ?? ""))}
+          {(selected) => renderValue(selected === UNASSIGNED ? "" : String(selected ?? ""))}
         </SelectValue>
       </SelectTrigger>
-      <SelectContent className="max-h-72">
+      {/* The popup defaults to the trigger's width, which clips the trailing
+          hints ("— hand it to the orchestrator", "— 2 teammates"). Let it grow
+          to its content instead, bounded so a long role cannot run off-screen —
+          the label truncates first. */}
+      <SelectContent className="max-h-72 w-auto min-w-(--anchor-width) max-w-[min(26rem,90vw)]">
         <SelectGroup>
           <SelectItem value={UNASSIGNED}>
             <OptionRow label={UNASSIGNED_LABEL} hint="hand it to the orchestrator" />
@@ -209,7 +239,7 @@ export function AssigneeSelect({
             <SelectSeparator />
             <SelectGroup>
               <SelectItem value={stale.value}>
-                <OptionRow label={stale.label} hint={stale.hint} />
+                <OptionRow label={stale.label} hint={stale.hint} warn={stale.offRoster} />
               </SelectItem>
             </SelectGroup>
           </>
@@ -247,10 +277,16 @@ export function AssigneeSelect({
   );
 }
 
-function OptionRow({ label, hint }: { label: string; hint?: string }) {
+function OptionRow({ label, hint, warn }: { label: string; hint?: string; warn?: boolean }) {
   return (
     <>
-      <span className="truncate">{label}</span>
+      {warn && (
+        <AlertCircle
+          className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400"
+          aria-hidden
+        />
+      )}
+      <span className="min-w-0 truncate">{label}</span>
       {hint && <span className="shrink-0 text-xs text-muted-foreground">— {hint}</span>}
     </>
   );

--- a/frontend/src/views/AssigneeSelect.tsx
+++ b/frontend/src/views/AssigneeSelect.tsx
@@ -1,0 +1,257 @@
+// The task assignee picker (#263). The roster is a closed set — the company's
+// desks and its teammates — and the host already enforces it at the write
+// boundary (`src/runtime/assignee.rs`, reached from `server::ops::tasks`). A
+// free-text field therefore turned a pick into a spelling test whose only
+// feedback was a rejected submit. This is the one control every task surface
+// uses instead: the board's create dialog, the edit dialog, and the detail
+// screen's reassign row.
+//
+// Two invariants this component must not break, both from #205/#214:
+//
+//   1. **A desk assignment stays a desk.** `AssigneeResolution::links_working_agent`
+//      is true only for `Unassigned | Agent(_)`, precisely so a card assigned to
+//      a desk is never silently rewritten to that desk's lead. So the picker
+//      submits the id it was given, verbatim, and never resolves a desk to its
+//      lead here.
+//   2. **Blank is a real choice**, not the absence of one — it hands the card to
+//      the orchestrator (`resolve("") -> Unassigned -> canonical ""`). It gets
+//      its own labelled row saying what it does.
+
+import { useEffect, useMemo, useState } from "react";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { DeskDto, TeamMemberDto } from "@/api/types";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+/**
+ * The select's stand-in for the unassigned wire value.
+ *
+ * Base UI reads a value that stringifies to `""` as "nothing selected"
+ * (`SelectRoot`'s `hasSelectedValue`), so binding the empty string directly
+ * would put the trigger in its placeholder state and leave the Unassigned row
+ * unticked — the deliberate choice would look like no choice at all. The
+ * sentinel is mapped back at this component's edge, so consumers only ever see
+ * the wire value: `""`, a desk id, or a teammate id.
+ *
+ * The leading space is what makes it uncollidable: `assignee::resolve` trims
+ * its input before matching, so no canonical id the host stores can begin with
+ * one.
+ */
+const UNASSIGNED = " unassigned";
+
+const UNASSIGNED_LABEL = "Unassigned";
+
+/** One pickable row, reduced to what the trigger and the list render. */
+interface Option {
+  /** React key — namespaced, because a desk id and a teammate id can collide. */
+  key: string;
+  /** The **wire** value, submitted verbatim: a desk id or a teammate id. */
+  value: string;
+  /** The primary label. */
+  label: string;
+  /** The muted trailing note (member count, role, or why it is unrecognised). */
+  hint?: string;
+  /** Set on the synthesised row for a value the roster no longer contains. */
+  offRoster?: boolean;
+}
+
+export function AssigneeSelect({
+  client,
+  company,
+  value,
+  onChange,
+  id,
+  disabled,
+  className,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+  /** The current wire value: `""` (unassigned), a desk id, or a teammate id. */
+  value: string;
+  /** Receives the next wire value, verbatim — never resolved client-side. */
+  onChange: (next: string) => void;
+  /** Forwarded to the trigger so a `<Label htmlFor>` points at it. */
+  id?: string;
+  disabled?: boolean;
+  className?: string;
+}) {
+  const [desks, setDesks] = useState<DeskDto[]>([]);
+  const [team, setTeam] = useState<TeamMemberDto[]>([]);
+  // Distinguishes "the roster has not arrived yet" from "the roster arrived and
+  // this value is not on it". Without it, every assigned card would flash as
+  // off-roster on the first paint.
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoaded(false);
+    // Both halves are best-effort, the stance `DesksView` already takes: a host
+    // that does not serve one of these surfaces still gets a usable picker
+    // rather than a dialog that fails to render.
+    void Promise.all([
+      client.listDesks(company).catch(() => [] as DeskDto[]),
+      client.listTeam(company).catch(() => [] as TeamMemberDto[]),
+    ]).then(([desksRes, teamRes]) => {
+      if (cancelled) return;
+      setDesks(desksRes);
+      setTeam(teamRes);
+      setLoaded(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [client, company]);
+
+  const deskOptions = useMemo<Option[]>(
+    () =>
+      desks.map((desk) => ({
+        key: `desk:${desk.id}`,
+        value: desk.id,
+        label: desk.name,
+        // An empty desk stays listed on purpose: `AssigneeResolution::EmptyDesk`
+        // is `names_something_real()`, so assigning work to a desk you are about
+        // to staff is a legitimate write. Say that it is empty; don't hide it.
+        hint:
+          desk.members.length === 0
+            ? "no members yet"
+            : `${desk.members.length} teammate${desk.members.length === 1 ? "" : "s"}`,
+      })),
+    [desks],
+  );
+
+  const teamOptions = useMemo<Option[]>(() => {
+    const deskIds = new Set(desks.map((d) => d.id));
+    return (
+      team
+        // Desks resolve first (`assignee::resolve`), so on an id collision the
+        // bare string can only ever come back as the desk. Offering the
+        // teammate row would promise an assignment the host cannot honour.
+        .filter((member) => !deskIds.has(member.id))
+        .map((member) => ({
+          key: `agent:${member.id}`,
+          // Always the canonical id: the resolver matches the id namespace
+          // before any display name, so this is the one key that can never be
+          // shadowed by another teammate or come back ambiguous.
+          value: member.id,
+          // Manifest agents carry no `name`, so the id *is* the handle
+          // operators know them by.
+          label: member.name ?? member.id,
+          hint: member.role,
+        }))
+    );
+  }, [team, desks]);
+
+  // A value the roster does not contain — a teammate since removed, a desk
+  // since deleted, or something typed before this picker existed. It gets its
+  // own row so the control renders what the card actually holds instead of
+  // silently showing something else.
+  const stale = useMemo<Option | null>(() => {
+    if (!value) return null;
+    if (deskOptions.some((o) => o.value === value)) return null;
+    if (teamOptions.some((o) => o.value === value)) return null;
+    // Only claim it is off-roster once a roster actually came back: a host that
+    // served neither surface tells us nothing about this value.
+    const known = loaded && (desks.length > 0 || team.length > 0);
+    return {
+      key: `stale:${value}`,
+      value,
+      label: value,
+      hint: known ? "not on roster" : undefined,
+      offRoster: known,
+    };
+  }, [value, deskOptions, teamOptions, loaded, desks.length, team.length]);
+
+  /** The trigger's one-line rendering of a wire value. */
+  const labelFor = useMemo(() => {
+    const byValue = new Map<string, Option>();
+    for (const option of [...deskOptions, ...teamOptions]) byValue.set(option.value, option);
+    if (stale) byValue.set(stale.value, stale);
+    return (wire: string): string => {
+      if (!wire) return UNASSIGNED_LABEL;
+      const option = byValue.get(wire);
+      if (!option) return wire;
+      return option.offRoster ? `${option.label} (not on roster)` : option.label;
+    };
+  }, [deskOptions, teamOptions, stale]);
+
+  return (
+    <Select
+      value={value === "" ? UNASSIGNED : value}
+      // `null` arrives when Base UI clears the selection; it and the sentinel
+      // mean the same wire value.
+      onValueChange={(next) => onChange(next == null || next === UNASSIGNED ? "" : String(next))}
+      disabled={disabled}
+    >
+      <SelectTrigger id={id} className={cn("w-full", className)}>
+        <SelectValue>
+          {(selected) => labelFor(selected === UNASSIGNED ? "" : String(selected ?? ""))}
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent className="max-h-72">
+        <SelectGroup>
+          <SelectItem value={UNASSIGNED}>
+            <OptionRow label={UNASSIGNED_LABEL} hint="hand it to the orchestrator" />
+          </SelectItem>
+        </SelectGroup>
+
+        {stale && (
+          <>
+            <SelectSeparator />
+            <SelectGroup>
+              <SelectItem value={stale.value}>
+                <OptionRow label={stale.label} hint={stale.hint} />
+              </SelectItem>
+            </SelectGroup>
+          </>
+        )}
+
+        {deskOptions.length > 0 && (
+          <>
+            <SelectSeparator />
+            <SelectGroup>
+              <SelectLabel>Desks</SelectLabel>
+              {deskOptions.map((option) => (
+                <SelectItem key={option.key} value={option.value}>
+                  <OptionRow label={option.label} hint={option.hint} />
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </>
+        )}
+
+        {teamOptions.length > 0 && (
+          <>
+            <SelectSeparator />
+            <SelectGroup>
+              <SelectLabel>Teammates</SelectLabel>
+              {teamOptions.map((option) => (
+                <SelectItem key={option.key} value={option.value}>
+                  <OptionRow label={option.label} hint={option.hint} />
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </>
+        )}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function OptionRow({ label, hint }: { label: string; hint?: string }) {
+  return (
+    <>
+      <span className="truncate">{label}</span>
+      {hint && <span className="shrink-0 text-xs text-muted-foreground">— {hint}</span>}
+    </>
+  );
+}

--- a/frontend/src/views/AssigneeSelect.tsx
+++ b/frontend/src/views/AssigneeSelect.tsx
@@ -96,6 +96,12 @@ export function AssigneeSelect({
   useEffect(() => {
     let cancelled = false;
     setLoaded(false);
+    // Drop the previous company's roster with it. `loaded` alone only stops the
+    // off-roster marker from flashing; the option lists would keep rendering
+    // the old company's desks and teammates until the new fetch resolves, and a
+    // pick made in that window would name something that does not exist here.
+    setDesks([]);
+    setTeam([]);
     // Both halves are best-effort, the stance `DesksView` already takes: a host
     // that does not serve one of these surfaces still gets a usable picker
     // rather than a dialog that fails to render.

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -471,7 +471,11 @@ function ControlBar({
 
   async function saveAssignee() {
     const next = assignee.trim();
-    if (!next || next === task.assignee) {
+    // Only an unchanged value is a no-op. Blank used to short-circuit here too,
+    // which made the one deliberate way to hand a card back to the orchestrator
+    // unreachable from this screen — the host accepts it happily
+    // (`resolve("") -> Unassigned -> canonical ""`), the row just never sent it.
+    if (next === task.assignee) {
       setReassigning(false);
       return;
     }

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -614,7 +614,7 @@ function ControlBar({
             value={assignee}
             onChange={setAssignee}
             disabled={busy}
-            className="h-8"
+            className="h-8 min-w-0 flex-1"
           />
           <Button size="sm" className="h-8" disabled={busy} onClick={() => void saveAssignee()}>
             Save

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -61,6 +61,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { PRIORITY_STYLES, TASK_COLUMNS } from "@/lib/tasks-sample";
 import { toast } from "sonner";
+import { AssigneeSelect } from "./AssigneeSelect";
 import { TaskEditDialog } from "./TaskEditDialog";
 
 /** How often to re-poll the detail while the screen is open (visibility-gated). */
@@ -604,16 +605,16 @@ function ControlBar({
 
       {reassigning && (
         <div className="mt-2 flex items-center gap-2">
-          <Input
-            autoFocus
+          {/* Issue #263: the same roster picker the create and edit dialogs use.
+              Unassigned is a row here rather than an empty field, so handing the
+              card back to the orchestrator is something you can see and choose. */}
+          <AssigneeSelect
+            client={client}
+            company={company}
             value={assignee}
-            placeholder="agent id"
-            className="h-8"
+            onChange={setAssignee}
             disabled={busy}
-            onChange={(e) => setAssignee(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") void saveAssignee();
-            }}
+            className="h-8"
           />
           <Button size="sm" className="h-8" disabled={busy} onClick={() => void saveAssignee()}>
             Save

--- a/frontend/src/views/TaskEditDialog.tsx
+++ b/frontend/src/views/TaskEditDialog.tsx
@@ -40,6 +40,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { TASK_COLUMNS } from "@/lib/tasks-sample";
 import { toast } from "sonner";
+import { AssigneeSelect } from "./AssigneeSelect";
 
 const PRIORITIES = ["low", "medium", "high"] as const;
 
@@ -211,11 +212,15 @@ export function TaskEditDialog({
             </div>
             <div className="grid gap-1.5">
               <Label htmlFor="task-assignee">Assignee</Label>
-              <Input
+              {/* Issue #263: picked from the roster, not typed. An assignee the
+                  roster no longer carries still renders — flagged — so a save
+                  that does not touch it can never quietly rewrite it. */}
+              <AssigneeSelect
                 id="task-assignee"
+                client={client}
+                company={company}
                 value={draft.assignee ?? ""}
-                placeholder="agent id"
-                onChange={(e) => setDraft((d) => ({ ...d, assignee: e.target.value }))}
+                onChange={(next) => setDraft((d) => ({ ...d, assignee: next }))}
               />
             </div>
           </div>

--- a/frontend/src/views/TaskEditDialog.tsx
+++ b/frontend/src/views/TaskEditDialog.tsx
@@ -81,11 +81,44 @@ export function TaskEditDialog({
 
   if (!task) return null;
 
+  /**
+   * The fields the operator actually changed, and only those.
+   *
+   * A `PatchTask` is applied field-by-field on the host, and every field it
+   * *receives* is re-validated — `assignee` included, which re-runs
+   * `assignee::resolve` against the current roster. Sending the whole seeded
+   * draft therefore made a card uneditable the moment its stored assignee left
+   * the roster (a teammate removed, a desk deleted): renaming the title
+   * resubmitted the stale assignee, which came back `Unknown`, and the save
+   * failed with a `400` about a field the operator never touched. Diffing means
+   * an untouched field is never re-validated, so the only assignee the host is
+   * ever asked to resolve is one just picked from the roster.
+   */
+  function changedFields(current: Task): PatchTask {
+    const patch: PatchTask = {};
+    if ((draft.title ?? "") !== current.title) patch.title = draft.title ?? "";
+    if ((draft.note ?? "") !== (current.note ?? "")) patch.note = draft.note ?? "";
+    if (draft.column !== undefined && draft.column !== current.column) patch.column = draft.column;
+    if (draft.priority !== undefined && draft.priority !== current.priority) {
+      patch.priority = draft.priority;
+    }
+    if ((draft.assignee ?? "") !== current.assignee) patch.assignee = draft.assignee ?? "";
+    return patch;
+  }
+
   async function save() {
     if (!task) return;
+    const patch = changedFields(task);
+    if (Object.keys(patch).length === 0) {
+      // Nothing to write. Saying so beats a round-trip that reports "Saved."
+      // for an edit that never happened.
+      toast.success("No changes to save.");
+      onSaved(task);
+      return;
+    }
     setBusy(true);
     try {
-      const saved = await patchTask(client, company, task.id, draft);
+      const saved = await patchTask(client, company, task.id, patch);
       onSaved(saved);
       toast.success("Saved.");
     } catch (e) {

--- a/frontend/src/views/TaskEditDialog.tsx
+++ b/frontend/src/views/TaskEditDialog.tsx
@@ -176,12 +176,25 @@ export function TaskEditDialog({
           <div className="grid grid-cols-3 gap-3">
             <div className="grid gap-1.5">
               <Label htmlFor="task-column">Column</Label>
+              {/* Fall back to the card's own value rather than `undefined`.
+                  `draft` starts empty and is seeded a tick later by the effect
+                  above, so a bare `draft.column` hands Base UI `undefined` on
+                  the first render — which latches the select as *uncontrolled*
+                  and makes it ignore the seeded value, leaving the trigger
+                  blank for the whole life of the dialog. */}
               <Select
-                value={draft.column}
+                value={draft.column ?? task.column}
                 onValueChange={(v) => setDraft((d) => ({ ...d, column: v ?? undefined }))}
               >
                 <SelectTrigger id="task-column">
-                  <SelectValue />
+                  {/* The trigger renders the raw value unless told otherwise,
+                      and a column's id is not its label (`in_progress` vs "In
+                      progress"). */}
+                  <SelectValue>
+                    {(selected) =>
+                      TASK_COLUMNS.find((c) => c.id === selected)?.label ?? String(selected ?? "")
+                    }
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   {TASK_COLUMNS.map((c) => (
@@ -194,12 +207,14 @@ export function TaskEditDialog({
             </div>
             <div className="grid gap-1.5">
               <Label htmlFor="task-priority">Priority</Label>
+              {/* Same seeding hazard as Column above. A priority is its own
+                  label, so only the casing the items carry needs restating. */}
               <Select
-                value={draft.priority}
+                value={draft.priority ?? task.priority}
                 onValueChange={(v) => setDraft((d) => ({ ...d, priority: v ?? undefined }))}
               >
                 <SelectTrigger id="task-priority">
-                  <SelectValue />
+                  <SelectValue className="capitalize" />
                 </SelectTrigger>
                 <SelectContent>
                   {PRIORITIES.map((p) => (

--- a/frontend/src/views/TaskEditDialog.tsx
+++ b/frontend/src/views/TaskEditDialog.tsx
@@ -210,7 +210,10 @@ export function TaskEditDialog({
                 </SelectContent>
               </Select>
             </div>
-            <div className="grid gap-1.5">
+            {/* `min-w-0`: a grid item's automatic minimum size is its content's
+                min-content width, so the assignee's long ids would otherwise
+                widen this track and squeeze Column and Priority away. */}
+            <div className="grid min-w-0 gap-1.5">
               <Label htmlFor="task-assignee">Assignee</Label>
               {/* Issue #263: picked from the roster, not typed. An assignee the
                   roster no longer carries still renders — flagged — so a save

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -28,6 +28,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { ADD_TASK_COLUMN, PRIORITY_STYLES, TASK_COLUMNS } from "@/lib/tasks-sample";
 import { toast } from "sonner";
+import { AssigneeSelect } from "./AssigneeSelect";
 import { TaskDetailView } from "./TaskDetailView";
 
 /**
@@ -469,11 +470,14 @@ function CreateTaskDialog({
             </div>
             <div className="grid gap-1.5">
               <Label htmlFor="new-assignee">Assignee</Label>
-              <Input
+              {/* Issue #263: the roster is a closed set the host enforces, so it
+                  is picked, not typed. Blank is its own labelled row. */}
+              <AssigneeSelect
                 id="new-assignee"
+                client={client}
+                company={company}
                 value={assignee}
-                placeholder="agent id"
-                onChange={(e) => setAssignee(e.target.value)}
+                onChange={setAssignee}
               />
             </div>
           </div>

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -468,7 +468,9 @@ function CreateTaskDialog({
                 </SelectContent>
               </Select>
             </div>
-            <div className="grid gap-1.5">
+            {/* `min-w-0` so a long teammate id cannot widen this grid track
+                and squeeze the Priority select beside it. */}
+            <div className="grid min-w-0 gap-1.5">
               <Label htmlFor="new-assignee">Assignee</Label>
               {/* Issue #263: the roster is a closed set the host enforces, so it
                   is picked, not typed. Blank is its own labelled row. */}

--- a/frontend/test/e2e/assignee-picker.spec.ts
+++ b/frontend/test/e2e/assignee-picker.spec.ts
@@ -1,0 +1,226 @@
+import { expect, test, type Page, type Request } from "@playwright/test";
+
+/**
+ * Issue #263 — the task assignee is picked from the company roster, not typed.
+ *
+ * These run against a live host serving the built console, with the
+ * `e2e_harness` company: desks `engineering` / `content` and manifest agents
+ * `ceo` / `engineer` / `writer`.
+ *
+ * The load-bearing assertion is the desk one. `AssigneeResolution` keeps a desk
+ * assignment a *desk* (`links_working_agent()` is false for `Desk`), so a card
+ * assigned to "Engineering desk" must persist `engineering` — never its lead
+ * `engineer`. A picker that resolved the desk client-side would break the
+ * invariant #214 exists to hold, and nothing else in the console would notice.
+ */
+
+const API = "/api/v1/company";
+
+/**
+ * The first-run product tour opens a modal over the board and would swallow
+ * every click. `src/tour/state.ts` keys "seen" per company in localStorage, so
+ * pre-seed every key this host could use before the app boots, and click the
+ * dialog away if one still slips through.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const seen = JSON.stringify({ skipped: true, seenAt: Date.now() });
+    for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
+      window.localStorage.setItem(key, seen);
+    }
+  });
+});
+
+async function dismissTour(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    if (!(await skip.isVisible().catch(() => false))) return;
+    await skip.click({ force: true }).catch(() => {});
+    await page.waitForTimeout(300);
+  }
+  await expect(skip).toHaveCount(0);
+}
+
+async function openCreateDialog(page: Page) {
+  await page.goto("/#/tasks");
+  await dismissTour(page);
+  await page.getByRole("button", { name: "Add task to To-do" }).click();
+  await expect(page.getByRole("heading", { name: "New task" })).toBeVisible();
+}
+
+/** Opens the assignee select and picks the option with this exact-ish name. */
+async function pickAssignee(page: Page, trigger: string, option: RegExp | string) {
+  await page.locator(`#${trigger}`).click();
+  await page.getByRole("option", { name: option }).click();
+}
+
+/** The board card whose title matches, once the board has rendered it. */
+function card(page: Page, title: string) {
+  return page.locator("div[draggable=true]").filter({ hasText: title }).first();
+}
+
+test("the create dialog offers Unassigned, desks and teammates instead of a text field", async ({
+  page,
+}) => {
+  await openCreateDialog(page);
+
+  // It is a select, not a free-text input: typing a name is no longer possible.
+  await expect(page.locator("input#new-assignee")).toHaveCount(0);
+
+  await page.locator("#new-assignee").click();
+
+  // Blank is a labelled choice that says what it does, not an empty field.
+  await expect(page.getByRole("option", { name: /Unassigned/ })).toBeVisible();
+  await expect(page.getByText("hand it to the orchestrator")).toBeVisible();
+
+  // Desks first, then teammates — the two kinds are separated, and in that
+  // order. (Scoped to the popup's own group labels: the sidebar also has a
+  // "Desks" nav item.)
+  const groups = page.locator('[data-slot="select-label"]');
+  await expect(groups).toHaveText(["Desks", "Teammates"]);
+
+  await expect(page.getByRole("option", { name: /Engineering desk/ })).toBeVisible();
+  await expect(page.getByRole("option", { name: /Content desk/ })).toBeVisible();
+
+  // Manifest agents carry no display name, so the id is the handle shown, with
+  // the role as the hint.
+  await expect(page.getByRole("option", { name: /^engineer —/ })).toBeVisible();
+  await expect(page.getByRole("option", { name: /^writer —/ })).toBeVisible();
+  await expect(page.getByRole("option", { name: /^ceo —/ })).toBeVisible();
+
+  // A desk with nobody on it stays assignable (EmptyDesk is real), and says so.
+  await expect(page.getByRole("option", { name: /Legal — no members yet/ })).toBeVisible();
+  // A staffed desk shows its headcount.
+  await expect(page.getByRole("option", { name: /Engineering desk — 1 teammate/ })).toBeVisible();
+});
+
+test("a card assigned to a desk keeps the desk, not the desk's lead", async ({ page }) => {
+  const title = `e2e desk card ${Date.now()}`;
+  await openCreateDialog(page);
+  await page.locator("#new-title").fill(title);
+  await pickAssignee(page, "new-assignee", /Engineering desk/);
+  await page.getByRole("button", { name: "Create" }).click();
+
+  const created = card(page, title);
+  await expect(created).toBeVisible({ timeout: 15_000 });
+  // The whole point: `engineering` (the desk), never `engineer` (its lead).
+  await expect(created).toContainText("engineering");
+  await expect(created).not.toContainText(/\bengineer\b(?!ing)/);
+});
+
+test("a card can be created for a teammate and for nobody at all", async ({ page }) => {
+  const forWriter = `e2e writer card ${Date.now()}`;
+  await openCreateDialog(page);
+  await page.locator("#new-title").fill(forWriter);
+  await pickAssignee(page, "new-assignee", /^writer —/);
+  await page.getByRole("button", { name: "Create" }).click();
+  await expect(card(page, forWriter)).toContainText("writer", { timeout: 15_000 });
+
+  const forNobody = `e2e unassigned card ${Date.now()}`;
+  await openCreateDialog(page);
+  await page.locator("#new-title").fill(forNobody);
+  // Unassigned is the default, but choose it explicitly so the round-trip is real.
+  await pickAssignee(page, "new-assignee", /Unassigned/);
+  await page.getByRole("button", { name: "Create" }).click();
+
+  const nobody = card(page, forNobody);
+  await expect(nobody).toBeVisible({ timeout: 15_000 });
+  // No assignee row rendered at all.
+  await expect(nobody.locator("span.truncate")).toHaveCount(0);
+});
+
+test("renaming a card does not resubmit its assignee", async ({ page, request }) => {
+  // Seed a card assigned to a teammate through the API, so the edit is the only
+  // thing under test.
+  const title = `e2e rename ${Date.now()}`;
+  const created = await request.post(`${API}/tasks`, {
+    data: { title, assignee: "writer" },
+  });
+  expect(created.ok()).toBeTruthy();
+  const id = (await created.json()).id as string;
+
+  const patches: Array<Record<string, unknown>> = [];
+  page.on("request", (req: Request) => {
+    if (req.method() === "PATCH" && req.url().includes("/tasks/")) {
+      patches.push(JSON.parse(req.postData() ?? "{}"));
+    }
+  });
+
+  await page.goto(`/#/tasks/${id}`);
+  await dismissTour(page);
+  await page.getByRole("button", { name: "Edit" }).click();
+  await expect(page.getByRole("heading", { name: "Edit task" })).toBeVisible();
+  await page.locator("#task-title").fill(`${title} renamed`);
+  await page.getByRole("button", { name: "Save" }).click();
+
+  await expect.poll(() => patches.length, { timeout: 15_000 }).toBeGreaterThan(0);
+  // Only the field that changed is sent. Sending `assignee` too is what made a
+  // card with an off-roster assignee permanently uneditable: the host
+  // re-resolves every assignee it receives.
+  expect(patches[0]).toEqual({ title: `${title} renamed` });
+  expect(patches[0]).not.toHaveProperty("assignee");
+});
+
+test("the detail screen can hand a card back to the orchestrator", async ({ page, request }) => {
+  const title = `e2e unassign ${Date.now()}`;
+  const created = await request.post(`${API}/tasks`, {
+    data: { title, assignee: "engineer" },
+  });
+  const id = (await created.json()).id as string;
+
+  await page.goto(`/#/tasks/${id}`);
+  await dismissTour(page);
+  await expect(page.getByRole("heading", { name: title })).toBeVisible();
+  await page.getByRole("button", { name: "Reassign" }).click();
+
+  // The reassign row is the same picker; Unassigned is reachable from it, which
+  // it was not while the row early-returned on an empty string.
+  await page.getByRole("combobox").last().click();
+  await page.getByRole("option", { name: /Unassigned/ }).click();
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+
+  await expect
+    .poll(
+      async () => (await (await request.get(`${API}/tasks/${id}`)).json()).task.assignee,
+      { timeout: 15_000 },
+    )
+    .toBe("");
+});
+
+test("an assignee the roster no longer carries still renders, and the card stays editable", async ({
+  page,
+  request,
+}) => {
+  // Assign to an overlay teammate, then remove the teammate. The card now holds
+  // an id that resolves to nothing.
+  const ghost = await request.post(`${API}/team`, {
+    data: { name: `Ghost ${Date.now()}`, role: "Tester" },
+  });
+  const ghostId = (await ghost.json()).id as string;
+  const title = `e2e stale ${Date.now()}`;
+  const created = await request.post(`${API}/tasks`, {
+    data: { title, assignee: ghostId },
+  });
+  const id = (await created.json()).id as string;
+  expect((await request.delete(`${API}/team/${ghostId}`)).status()).toBe(204);
+
+  await page.goto(`/#/tasks/${id}`);
+  await dismissTour(page);
+  await page.getByRole("button", { name: "Edit" }).click();
+
+  // Flagged, not silently dropped and not silently replaced by something else.
+  await expect(page.locator("#task-assignee")).toContainText("not on roster", {
+    timeout: 15_000,
+  });
+  await expect(page.locator("#task-assignee")).toContainText(ghostId);
+
+  // And a save that does not touch the assignee still succeeds.
+  await page.locator("#task-title").fill(`${title} renamed`);
+  await page.getByRole("button", { name: "Save" }).click();
+  await expect(page.getByText("could not save")).toHaveCount(0);
+  await expect
+    .poll(async () => (await (await request.get(`${API}/tasks/${id}`)).json()).task.title, {
+      timeout: 15_000,
+    })
+    .toBe(`${title} renamed`);
+});


### PR DESCRIPTION
## Summary

Closes #263. Closes #269.

The assignee was free text in three places — the create dialog, the edit dialog, and the reassign row on card detail — while the host enforces a closed roster at the write boundary. A typo was only discoverable as a rejected submit.

All three now share one `AssigneeSelect`: an Unassigned row labelled for what it actually does (hand the card to the orchestrator), a Desks group with member counts, then a Teammates group. It submits ids verbatim and **never resolves a desk to its lead**, which is the invariant from #214 — a desk assignment has to stay a desk or the desk disappears from the board. An empty desk stays listed rather than being filtered, because the host deliberately makes `EmptyDesk` assignable. An assignee no longer on the roster renders flagged rather than vanishing.

Zero Rust diff — the roster endpoints already existed and the host already validated.

**Two latent bugs fixed along the way, both reproduced live rather than inferred:**

**A card could become permanently uneditable.** The edit dialog always sent `assignee`, and the host re-resolves any assignee it receives. So if a card's assignee had since left the roster, changing only the *title* returned 400 and the card could never be edited again. Reproduced end to end: added an overlay teammate → assigned a card → `DELETE /team/<id>` (204) → `PATCH {title, assignee:<stale>}` → **400**; `PATCH {title}` alone → **200**. Fixed by diffing the draft against the seeded task and sending only what changed.

**Unassigning was unreachable from card detail.** `saveAssignee` early-returned on an empty value, so the deliberate hand-to-the-orchestrator path could not be triggered from that view. `PATCH {"assignee":""}` was always accepted by the host — the UI simply never sent it.

**A third bug, folded in because it lives in the same dialog (#269).** `TaskEditDialog`'s Column and Priority selects rendered blank on every open. `draft` starts empty and is seeded a tick later by an effect, so a bare `draft.column` handed Base UI `undefined` on the first render — which latches the select as *uncontrolled* and makes it ignore the seeded value for the life of the dialog. The assignee select was immune only because it binds `draft.assignee ?? ""`. Both now bind through the card's own value, and Column renders its label rather than its id (`In progress`, not `in_progress`).

## API Or Behavior Changes

None on the wire. Three console behaviour changes:

- assignee is picked from the roster rather than typed
- the edit dialog PATCHes only changed fields (previously always sent `assignee`)
- card detail can now unassign
- the edit dialog's Column and Priority controls show the card's current values instead of rendering blank

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 1009 passed / 0 failed (+6)

Rust is run as pure regression proof given the zero-line Rust diff — the `assignee.rs` and `ops/tasks.rs` contract tests are the net. Frontend: `npm ci && npm run typecheck && npm run build`.

**6 new Playwright specs**, passing in a real browser against a live host — including the load-bearing one: a card created via "Engineering desk" persists `engineering`, never the lead `engineer`. That invariant had review but no test until now. The suite is not run by CI (no `webServer`).

curl parity: desk id → 200 storing `engineering`; desk *name* → canonicalised; `""` → 200; empty desk → 200; garbage → 400. Note create returns **200**, not 201.

## Documentation

No doc changes — this replaces an input control with a picker over data the host already published, and adds no new route or config.

One thing found and deliberately **not** fixed here: confirming an `AlertDialog` leaves the modal mounted and blocks the console (#268), including at `TaskEditDialog.tsx:192`. The cause is in the shared `AlertDialogAction` primitive rather than at any call site, so it is fixed once in `components/ui/alert-dialog.tsx` on its own branch instead of three times here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
