### PR TITLE
feat(workflows): delete a saved workflow, and replace one with conflict detection (#259)

### DIFF
--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -46,7 +46,88 @@ address check for `{id}`, operator + `sole()` for the alias).
 | `domain` | `PUT …/domain`, `POST …/domain/verify` |
 | `smtp` | `PUT …/smtp`, `POST …/smtp/test` |
 | `connections` (feature `oauth`) | `POST …/connections/{provider}/start\|disconnect`, `GET /api/v1/oauth/callback` |
-| `workflows` | `POST …/workflows`, `GET …/workflows`, `GET …/workflows/{wid}`, `POST …/workflows/{wid}/run` |
+| `workflows` | `POST …/workflows`, `GET …/workflows`, `GET …/workflows/{wid}`, `PUT …/workflows/{wid}`, `DELETE …/workflows/{wid}`, `POST …/workflows/{wid}/run`, `GET …/workflows/runs` |
+
+### Editing and removing a workflow (issue #259)
+
+A saved workflow used to be write-once: a typo'd cron or a node pointed at the
+wrong teammate was permanent, and the only recovery was to author a second
+workflow and leave the broken one firing. `PUT` replaces a graph wholesale and
+`DELETE` removes it.
+
+**Only overlay-backed graphs are writable.** A workflow defined by a file in the
+company source tree (`companies/<name>/workflows/<wid>.toml`), or enabled by
+name with no saved graph at all, answers `409` — it is not squeamishness about
+touching disk, it is the reader's rules restated. `load_workflow_union` gives a
+seed file precedence on an id collision, so an edit stored behind one would
+never be served; and `merge_enabled_workflows` re-derives `[workflows].enabled`
+from seed ids at boot, so a "delete" of a seed-backed workflow would come back
+on the next restart. The same invariant is what makes an overlay delete durable.
+
+The read routes project that predicate as `editable`, so the console can grey
+its buttons out instead of surfacing a 409 after the click.
+
+**The version token.** `GET …/workflows/{wid}` returns an opaque `version` for
+an editable graph. Echo it back — in the `PUT` body as `expectedVersion`, or on
+the `DELETE` as `?expectedVersion=` — and the write is refused with `409` if the
+graph moved in between, so one console cannot silently overwrite another's edit.
+The comparison happens under the same per-company write lock as the save, so it
+is a real guard rather than a check-then-act race. **Omitting it is an
+unconditional write**, which keeps `curl` usable without a read-modify-write
+dance; the console always sends it. Never parse the token — the contract is
+"echo back what the read returned", which is what lets the algorithm change
+without a client migration.
+
+**The id may not change.** A `PUT` whose body `id` differs from `{wid}` is a
+`400`. The id keys the union read path, the scheduler and every journalled run,
+so a rename would silently orphan all three. A rename is a create plus a delete.
+
+**Past runs are orphaned, not reaped.** A deleted workflow's
+`WorkflowRunFinished` entries stay in the company journal and keep coming back
+from `GET …/workflows/runs`. The journal is append-only and shared with chat and
+audit, so there is no per-workflow table to cascade; and what a workflow *did*
+stays true after the workflow is gone. Retention is a separate design.
+
+**No scheduler change is involved.** `WorkflowScheduler::tick` re-reads the
+company record and re-derives the schedule set from the overlay union every
+minute, so the tick *is* a continuous reconcile: a deleted workflow stops firing
+on the next tick and an edited cron takes effect on it, with no restart and no
+unbind call. There is no persisted registration to drift — which is why this
+needs no equivalent of OpenHuman's `reconcile_schedule_triggers_on_boot`, whose
+job is re-syncing cron rows that live in a second durable store.
+
+```bash
+# Read the graph and its concurrency token.
+curl -s "$HOST/api/v1/company/workflows/weekly_digest" \
+     -H "Authorization: Bearer $TOKEN"
+# → { "id": "weekly_digest", …, "editable": true, "version": "73e8ccc6…" }
+
+# Correct the schedule, conditional on nothing having changed since that read.
+curl -X PUT "$HOST/api/v1/company/workflows/weekly_digest" \
+     -H "Authorization: Bearer $TOKEN" \
+     -H 'content-type: application/json' -d '{
+  "id": "weekly_digest",
+  "name": "Weekly digest",
+  "nodes": [ { "id": "start", "kind": "trigger", "name": "Monday 10:00",
+               "schedule": "0 10 * * MON" },
+             { "id": "done", "kind": "output", "name": "Owner summary",
+               "destination": { "kind": "owner" } } ],
+  "edges": [ { "from": "start", "to": "done" } ],
+  "expectedVersion": "73e8ccc6…"
+}'
+# → 200 with the stored graph and a FRESH version; or 409 if it moved.
+
+# Remove it. 204 on success; past runs stay readable.
+curl -X DELETE "$HOST/api/v1/company/workflows/weekly_digest?expectedVersion=a60663c5…" \
+     -H "Authorization: Bearer $TOKEN"
+```
+
+**Deliberately not in #259**, each its own follow-up: revision history and
+rollback (OpenHuman keeps a bounded snapshot ring in a dedicated table; our
+overlay bodies live inside `CompanyRecord`, which is saved whole on every write,
+so a ring needs its own store surface); journal retention (see above); and
+enable/disable without deleting, which means first reversing this scheduler's
+deliberate decision not to gate on `[workflows].enabled`.
 
 ### Workflow runs and report delivery
 

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -10,6 +10,17 @@ export interface WorkflowSummary {
   id: string;
   name: string;
   description?: string;
+  /**
+   * Whether this workflow can be edited or deleted through the API (issue
+   * #259). `false` for a graph defined by a file in the company source tree,
+   * and for a name-only entry with no saved graph at all — the host refuses
+   * both with a 409, so the console greys the affordance out instead.
+   *
+   * **Optional on the type, not on the wire.** A host predating #259 sends no
+   * such field, and `undefined` must not read as "not editable" — treat only an
+   * explicit `false` as a refusal.
+   */
+  editable?: boolean;
 }
 
 /** A single graph node. `kind` is one of the tinyflows node kinds. */
@@ -84,6 +95,19 @@ export interface WorkflowGraph {
   description?: string;
   nodes: WorkflowNode[];
   edges: WorkflowEdge[];
+  /** See {@link WorkflowSummary.editable}. Same "only `false` means no" rule. */
+  editable?: boolean;
+  /**
+   * The opaque optimistic-concurrency token for this graph (issue #259),
+   * present only when `editable`.
+   *
+   * **Echo it back, never parse it.** Pass it to {@link updateWorkflow} or
+   * {@link deleteWorkflow} and the host refuses the write with a 409 if the
+   * graph changed since this read — which is what stops one console silently
+   * overwriting another's edit. Absent from a host predating #259, in which case
+   * the write is unconditional and that protection simply does not exist.
+   */
+  version?: string;
 }
 
 /**
@@ -221,6 +245,71 @@ export function createWorkflow(
   graph: WorkflowGraph,
 ): Promise<WorkflowGraph> {
   return client.post<WorkflowGraph>(`${client.scopeFor(company)}/workflows`, graph);
+}
+
+/**
+ * Replaces a saved workflow graph wholesale (issue #259) — the fix for a
+ * workflow being write-once, so a typo'd cron or a node pointed at the wrong
+ * teammate can be corrected instead of abandoned.
+ *
+ * `graph.id` must equal `wid`: a workflow's id keys its saved graph, its
+ * schedule and its run history, so the host rejects a rename with a `400`. A
+ * rename is a create plus a delete.
+ *
+ * Pass `expectedVersion` — the `version` from the {@link getWorkflow} this edit
+ * was based on — to make the write conditional. If the graph moved in between,
+ * the host answers `409` and **nothing is written**; surface that to the
+ * operator with a reload rather than retrying without the token, which is the
+ * silent-overwrite the guard exists to prevent.
+ *
+ * Other rejections carry the same prosumer-language `ApiError` a create does:
+ * `400` for a bad graph, `404` for an unknown id, `409` for a source-defined
+ * workflow or a display name already taken.
+ *
+ * Returns the stored graph with a **fresh** `version`, so a second save needs no
+ * intervening read.
+ */
+export function updateWorkflow(
+  client: OpenCompanyClient,
+  company: string | null,
+  wid: string,
+  graph: WorkflowGraph,
+  expectedVersion?: string,
+): Promise<WorkflowGraph> {
+  return client.put<WorkflowGraph>(
+    `${client.scopeFor(company)}/workflows/${encodeURIComponent(wid)}`,
+    expectedVersion ? { ...graph, expectedVersion } : graph,
+  );
+}
+
+/**
+ * Removes a saved workflow (issue #259): the graph body and its entry in the
+ * company's enabled list, in one write, so it leaves the picker and stops
+ * firing on its schedule — and stays gone across a host restart.
+ *
+ * **Past runs are kept.** They record what the workflow did, which stays true
+ * after it is gone; {@link listWorkflowRuns} keeps serving them.
+ *
+ * `expectedVersion` makes the delete conditional in exactly the sense the
+ * operator means by clicking Delete on a graph they are looking at: if it
+ * changed underneath them, the host answers `409` and removes nothing.
+ *
+ * Follows the same runtime-vs-source contract as `deleteDesk`: a workflow
+ * defined by a file in the company source tree cannot be removed from the
+ * console and returns `409`; an unknown id is `404`.
+ */
+export function deleteWorkflow(
+  client: OpenCompanyClient,
+  company: string | null,
+  wid: string,
+  expectedVersion?: string,
+): Promise<void> {
+  const query = expectedVersion
+    ? `?expectedVersion=${encodeURIComponent(expectedVersion)}`
+    : "";
+  return client.del<void>(
+    `${client.scopeFor(company)}/workflows/${encodeURIComponent(wid)}${query}`,
+  );
 }
 
 /**

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -367,7 +367,16 @@ export function WorkflowsView({
             disabled={loadingList || workflows.length === 0}
           >
             <SelectTrigger className="h-8 w-56">
-              <SelectValue placeholder={loadingList ? "Loading…" : "Pick a workflow"} />
+              {/* The trigger renders the raw value unless told otherwise, and a
+                  workflow's id is not its name — the closed picker showed
+                  `e2e_conflict_1785687393855` where the popup showed "Conflict
+                  probe". Resolve it back through the list the popup is built
+                  from; fall back to the id if the list has not arrived yet. */}
+              <SelectValue placeholder={loadingList ? "Loading…" : "Pick a workflow"}>
+                {(selected) =>
+                  workflows.find((w) => w.id === selected)?.name ?? String(selected ?? "")
+                }
+              </SelectValue>
             </SelectTrigger>
             <SelectContent>
               {workflows.map((w) => (

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -10,12 +10,13 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useTheme } from "next-themes";
-import { History, Loader2, Play, Plus } from "lucide-react";
+import { History, Loader2, Play, Plus, RotateCw, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import {
+  deleteWorkflow,
   getWorkflow,
   listWorkflowRuns,
   listWorkflows,
@@ -29,6 +30,18 @@ import {
   type WorkflowSummary,
 } from "@/api/workflows";
 import type { OpenCompanyClient } from "@/api/client";
+import { ApiError } from "@/api/types";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -100,6 +113,17 @@ export function WorkflowsView({
   const [historySupported, setHistorySupported] = useState(true);
   // Bumped after a manual run so the history picks it up without a reload.
   const [runsTick, setRunsTick] = useState(0);
+  // Issue #259: a delete in flight, and the host's message when a write was
+  // refused because the graph moved under us.
+  const [deleting, setDeleting] = useState(false);
+  // A version conflict is deliberately NOT a toast. It means the operator is
+  // looking at a stale graph, so it has to persist next to the canvas with a way
+  // out (Reload) — a toast that auto-dismisses would leave them staring at the
+  // old graph believing the write landed.
+  const [conflict, setConflict] = useState<string | null>(null);
+  // Bumped by the conflict banner's Reload, to re-fetch the selected graph (and
+  // with it a fresh `version`) without changing the selection.
+  const [graphTick, setGraphTick] = useState(0);
 
   // Load the workflow list once, and auto-select the first entry.
   useEffect(() => {
@@ -144,6 +168,9 @@ export function WorkflowsView({
         if (!live) return;
         setGraph(g);
         setError(null);
+        // A successful re-read is exactly what clears a stale-graph warning:
+        // whatever `version` we now hold is current.
+        setConflict(null);
       } catch (e) {
         if (!live) return;
         setGraph(null);
@@ -155,7 +182,7 @@ export function WorkflowsView({
     return () => {
       live = false;
     };
-  }, [client, company, selectedId]);
+  }, [client, company, selectedId, graphTick]);
 
   // Load the SELECTED workflow's run history. Re-runs when the selection or
   // company changes, after a manual run, and on every `workflow_run_finished`
@@ -231,6 +258,42 @@ export function WorkflowsView({
     }
   }, [client, company, selectedId, request]);
 
+  // Issue #259: remove the selected workflow.
+  //
+  // The `version` from the graph we are looking at rides along, so this means
+  // "delete the thing on my screen" rather than "delete whatever is there now".
+  // If it changed underneath us the host refuses with a 409 and removes nothing,
+  // and we surface that instead of quietly deleting a graph the operator never
+  // saw.
+  const remove = useCallback(async () => {
+    if (!selectedId || !graph) return;
+    const removedName = graph.name;
+    setDeleting(true);
+    try {
+      await deleteWorkflow(client, company, selectedId, graph.version);
+      // Drop it locally rather than re-listing: the host has confirmed, and a
+      // re-list would flash an empty picker.
+      const remaining = workflows.filter((w) => w.id !== selectedId);
+      setWorkflows(remaining);
+      setSelectedId(remaining[0]?.id ?? null);
+      setGraph(null);
+      setResult(null);
+      setSelectedNodeId(null);
+      setConflict(null);
+      toast.success(`Deleted “${removedName}”.`);
+    } catch (e) {
+      // A 409 is the one failure the operator can actually act on, and acting
+      // on it means reloading — so it gets the persistent banner, not a toast.
+      if (e instanceof ApiError && e.status === 409) {
+        setConflict(e.message);
+      } else {
+        toast.error(e instanceof Error ? e.message : "could not delete the workflow");
+      }
+    } finally {
+      setDeleting(false);
+    }
+  }, [client, company, selectedId, graph, workflows]);
+
   // The creator posts the full graph back, so the new entry can be spliced
   // straight into the list and selected — no extra round trip to re-list.
   const handleCreated = useCallback((created: WorkflowGraph) => {
@@ -264,6 +327,16 @@ export function WorkflowsView({
   // host filters and orders them. Re-filtering here would be a second source of
   // truth that can only ever disagree with the first.
   const lastRun = runs[0] ?? null;
+
+  // Issue #259. `editable === false` is the host saying "PUT/DELETE on this id
+  // will 409" — a source-defined graph, or a name-only entry with no saved
+  // graph. A host predating #259 sends no field at all, and `undefined` must NOT
+  // read as a refusal, so only an explicit `false` disables the affordance.
+  const notEditable = graph?.editable === false;
+  const canDelete = !!graph && !notEditable && !deleting;
+  const notEditableReason = graph
+    ? `“${graph.name}” is defined by a file in the company source tree, so it can't be removed from the console. Edit workflows/${graph.id}.toml in the company repository instead.`
+    : undefined;
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
@@ -336,12 +409,81 @@ export function WorkflowsView({
               )}
             </Button>
           )}
+          {/* Issue #259. The wrapping span carries the explanation: a disabled
+              button swallows pointer events in most browsers, so a `title` on
+              the button itself would never show. */}
+          <span title={notEditable ? notEditableReason : undefined}>
+            <AlertDialog>
+              <AlertDialogTrigger
+                render={
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={!canDelete}
+                    aria-label="Delete workflow"
+                    data-testid="workflow-delete"
+                  >
+                    {deleting ? (
+                      <Loader2 className="mr-1.5 size-4 animate-spin" />
+                    ) : (
+                      <Trash2 className="mr-1.5 size-4" />
+                    )}
+                    Delete
+                  </Button>
+                }
+              />
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete “{graph?.name ?? selectedId}”?</AlertDialogTitle>
+                  {/* Say exactly what goes and what stays. "Stops its schedule"
+                      is the consequence an operator most needs spelled out, and
+                      "past runs stay" stops them hesitating over losing history. */}
+                  <AlertDialogDescription>
+                    This removes the workflow and stops it running on its schedule. Past runs stay
+                    in the run history. This can&apos;t be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Keep it</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => void remove()}
+                    className="bg-destructive text-white hover:bg-destructive/90"
+                    data-testid="workflow-delete-confirm"
+                  >
+                    Delete workflow
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </span>
           <Button size="sm" variant="outline" onClick={() => setCreateOpen(true)}>
             <Plus className="mr-1.5 size-4" />
             New workflow
           </Button>
         </div>
       </div>
+
+      {/* Issue #259: a write refused because the graph moved under us. Distinct
+          from `error` on purpose — this one is recoverable, and the recovery is
+          right here, so it must not be mistaken for a generic load failure. */}
+      {conflict && (
+        <div className="px-4 pt-3">
+          <Alert variant="destructive" data-testid="workflow-conflict">
+            <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
+              <span>{conflict}</span>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setGraphTick((n) => n + 1)}
+                data-testid="workflow-conflict-reload"
+              >
+                <RotateCw className="mr-1.5 size-4" />
+                Reload
+              </Button>
+            </AlertDescription>
+          </Alert>
+        </div>
+      )}
 
       {error && (
         <div className="px-4 pt-3">

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -116,6 +116,12 @@ export function WorkflowsView({
   // Issue #259: a delete in flight, and the host's message when a write was
   // refused because the graph moved under us.
   const [deleting, setDeleting] = useState(false);
+  // The confirm dialog is CONTROLLED on purpose. `AlertDialogAction` is a plain
+  // `Button`, not an `AlertDialogPrimitive.Close` (only `AlertDialogCancel` is),
+  // so confirming does not dismiss the dialog on its own — it stays up with its
+  // backdrop swallowing every pointer event, over a view whose workflow has just
+  // been deleted. Closing it explicitly in the confirm handler is the fix.
+  const [confirmOpen, setConfirmOpen] = useState(false);
   // A version conflict is deliberately NOT a toast. It means the operator is
   // looking at a stale graph, so it has to persist next to the canvas with a way
   // out (Reload) — a toast that auto-dismisses would leave them staring at the
@@ -413,7 +419,7 @@ export function WorkflowsView({
               button swallows pointer events in most browsers, so a `title` on
               the button itself would never show. */}
           <span title={notEditable ? notEditableReason : undefined}>
-            <AlertDialog>
+            <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
               <AlertDialogTrigger
                 render={
                   <Button
@@ -446,7 +452,13 @@ export function WorkflowsView({
                 <AlertDialogFooter>
                   <AlertDialogCancel>Keep it</AlertDialogCancel>
                   <AlertDialogAction
-                    onClick={() => void remove()}
+                    onClick={() => {
+                      // Close FIRST: `remove()` clears the selection, so a
+                      // dialog left mounted would re-render its title as
+                      // `Delete “”?` over a backdrop nothing can click past.
+                      setConfirmOpen(false);
+                      void remove();
+                    }}
                     className="bg-destructive text-white hover:bg-destructive/90"
                     data-testid="workflow-delete-confirm"
                   >

--- a/frontend/test/e2e/workflow-edit-delete.spec.ts
+++ b/frontend/test/e2e/workflow-edit-delete.spec.ts
@@ -1,0 +1,247 @@
+import { expect, test, type Page, type APIRequestContext } from "@playwright/test";
+
+/**
+ * Issue #259: a saved workflow used to be write-once. There was no `PUT` and no
+ * `DELETE`, so a typo'd cron or a node pointed at the wrong teammate was
+ * permanent — the only recovery was to author a second workflow and leave the
+ * broken one in the picker, still firing on its schedule.
+ *
+ * These specs cover the half that is only observable in a browser:
+ *
+ * * the Delete affordance is **disabled with an explanation** for a workflow
+ *   defined by a file in the company source tree (the host answers 409, and the
+ *   console must say so before the click, not after);
+ * * deleting is confirm-gated, and the confirm copy states both what goes (the
+ *   workflow, its schedule) and what stays (past runs);
+ * * a **version conflict surfaces distinctly and recoverably**. This is the one
+ *   that matters most: the console must never silently overwrite an edit it
+ *   never saw. The spec forces the race for real — it edits the graph
+ *   out-of-band over HTTP while the console holds a stale copy — rather than
+ *   trusting that the token is wired through.
+ *
+ * Runs against the live host the harness brings up (see `playwright.config.ts`).
+ * Not run by CI, which has no host.
+ */
+
+const COMPANY_SCOPE = "/api/v1/company";
+
+/**
+ * Dismisses the first-run tour if it is up. Its overlay swallows pointer
+ * events, so without this the specs fail on an unrelated modal. Tolerates its
+ * absence — a company that has seen it never shows it again.
+ */
+async function dismissTour(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  try {
+    await skip.waitFor({ state: "visible", timeout: 10_000 });
+  } catch {
+    return;
+  }
+  await skip.click();
+  await expect(skip).toBeHidden();
+}
+
+/** A minimal valid graph body: one trigger, one output, one edge. */
+function graphBody(id: string, name: string, schedule: string, description: string) {
+  return {
+    id,
+    name,
+    description,
+    nodes: [
+      { id: "start", kind: "trigger", name: "Start", schedule },
+      { id: "done", kind: "output", name: "Report" },
+    ],
+    edges: [{ from: "start", to: "done" }],
+  };
+}
+
+/** Creates a workflow over HTTP and returns its version token. */
+async function createWorkflow(
+  request: APIRequestContext,
+  id: string,
+  name: string,
+): Promise<string> {
+  const res = await request.post(`${COMPANY_SCOPE}/workflows`, {
+    data: graphBody(id, name, "0 9 * * *", "Created by the #259 e2e spec."),
+  });
+  expect(res.ok(), `create ${id}: ${res.status()} ${await res.text()}`).toBeTruthy();
+  const body = await res.json();
+  expect(body.editable, "a console-created workflow must be editable").toBe(true);
+  expect(body.version, "a console-created workflow must carry a version token").toBeTruthy();
+  return body.version as string;
+}
+
+/** Best-effort teardown so a failed spec does not poison the next run. */
+async function removeWorkflow(request: APIRequestContext, id: string) {
+  await request.delete(`${COMPANY_SCOPE}/workflows/${id}`).catch(() => undefined);
+}
+
+/**
+ * Selects the workflow named `name` in the picker and waits for the selection
+ * to settle.
+ *
+ * Picks by name (the listbox options render `name`) but *asserts* on `id`,
+ * because the closed trigger renders the workflow **id**: the picker binds
+ * `<SelectItem value={w.id}>` and Base UI's `SelectValue` renders the raw value
+ * rather than the item's children. That is pre-existing on `upstream/main` and
+ * untouched by #259 — worth its own issue, but keying this helper on the id is
+ * what makes these specs describe the console as it actually is.
+ */
+async function selectWorkflow(page: Page, id: string, name: string) {
+  await page.getByRole("combobox").first().click();
+  await page.getByRole("option", { name, exact: true }).click();
+  await expect(page.getByRole("combobox").first()).toContainText(id);
+}
+
+const DELETE = "workflow-delete";
+
+test("a source-defined workflow cannot be deleted, and the console says why", async ({
+  page,
+}) => {
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+
+  await selectWorkflow(page, "committed", "Committed flow");
+
+  const button = page.getByTestId(DELETE);
+  await expect(button).toBeVisible();
+  await expect(button, "a seed-backed workflow must not be deletable").toBeDisabled();
+
+  // The explanation lives on the wrapper (a disabled button swallows hover), and
+  // it must name the actual remedy, not just refuse.
+  const explanation = page.locator(`span:has([data-testid="${DELETE}"])`);
+  await expect(explanation).toHaveAttribute("title", /company source tree/);
+  await expect(explanation).toHaveAttribute("title", /workflows\/committed\.toml/);
+});
+
+test("deleting is confirm-gated, and the confirmation says what goes and what stays", async ({
+  page,
+  request,
+}) => {
+  const id = `e2e-confirm-${Date.now()}`;
+  const name = `Confirm probe ${Date.now()}`;
+  await createWorkflow(request, id, name);
+
+  try {
+    await page.goto("/#/workflows");
+    await dismissTour(page);
+    await selectWorkflow(page, id, name);
+
+    const button = page.getByTestId(DELETE);
+    await expect(button, "an overlay-backed workflow must be deletable").toBeEnabled();
+    await button.click();
+
+    const dialog = page.getByRole("alertdialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText(name);
+    // The two consequences an operator needs before committing.
+    await expect(dialog, "must say the schedule stops").toContainText(/stops it running on its schedule/);
+    await expect(dialog, "must say history is kept").toContainText(/Past runs stay/);
+
+    // Backing out leaves it alone — a confirm gate that deletes anyway is worse
+    // than none.
+    await dialog.getByRole("button", { name: "Keep it" }).click();
+    await expect(dialog).toBeHidden();
+    const still = await request.get(`${COMPANY_SCOPE}/workflows/${id}`);
+    expect(still.ok(), "cancelling must not delete").toBeTruthy();
+  } finally {
+    await removeWorkflow(request, id);
+  }
+});
+
+test("confirming the delete removes it from the picker and from the host", async ({
+  page,
+  request,
+}) => {
+  const id = `e2e-delete-${Date.now()}`;
+  const name = `Delete probe ${Date.now()}`;
+  await createWorkflow(request, id, name);
+
+  try {
+    await page.goto("/#/workflows");
+    await dismissTour(page);
+    await selectWorkflow(page, id, name);
+
+    await page.getByTestId(DELETE).click();
+    await page.getByTestId("workflow-delete-confirm").click();
+
+    // **Regression pin.** `AlertDialogAction` is a plain `Button`, not an
+    // `AlertDialogPrimitive.Close` — only `AlertDialogCancel` is — so
+    // confirming does NOT dismiss the dialog unless the view closes it
+    // explicitly. Without that, the modal stays up over a view whose workflow
+    // has just been deleted, rendering `Delete “”?`, with its backdrop
+    // swallowing every click on the console behind it. Caught here first.
+    await expect(
+      page.getByRole("alertdialog"),
+      "confirming must dismiss the dialog, not leave its backdrop blocking the app",
+    ).toBeHidden({ timeout: 15_000 });
+
+    // Gone from the picker: the selection moves off it and it is no longer an
+    // option.
+    await expect(page.getByRole("combobox").first()).not.toContainText(id, {
+      timeout: 15_000,
+    });
+
+    // And gone from the host — the console did not merely hide it.
+    await expect
+      .poll(async () => (await request.get(`${COMPANY_SCOPE}/workflows/${id}`)).status(), {
+        timeout: 15_000,
+      })
+      .toBe(404);
+  } finally {
+    await removeWorkflow(request, id);
+  }
+});
+
+test("a version conflict surfaces distinctly with a way out, and deletes nothing", async ({
+  page,
+  request,
+}) => {
+  const id = `e2e-conflict-${Date.now()}`;
+  const name = `Conflict probe ${Date.now()}`;
+  await createWorkflow(request, id, name);
+
+  try {
+    await page.goto("/#/workflows");
+    await dismissTour(page);
+    await selectWorkflow(page, id, name);
+
+    // Force the race for real: someone else edits the graph while this console
+    // holds the token it loaded a moment ago.
+    const edited = await request.put(`${COMPANY_SCOPE}/workflows/${id}`, {
+      data: graphBody(id, name, "0 11 * * *", "Edited out-of-band, after the console loaded it."),
+    });
+    expect(edited.ok(), `out-of-band edit: ${edited.status()}`).toBeTruthy();
+
+    await page.getByTestId(DELETE).click();
+    await page.getByTestId("workflow-delete-confirm").click();
+
+    // The conflict gets its own persistent banner — NOT a toast that fades and
+    // NOT the generic load error — because the operator has to act on it.
+    const banner = page.getByTestId("workflow-conflict");
+    await expect(banner, "a 409 must surface distinctly").toBeVisible({ timeout: 15_000 });
+    await expect(banner).toContainText(/changed since you loaded it/);
+    await expect(banner).toContainText(/[Rr]eload/);
+
+    // Nothing was deleted — this is the whole point of the guard.
+    const survived = await request.get(`${COMPANY_SCOPE}/workflows/${id}`);
+    expect(survived.ok(), "a refused delete must remove nothing").toBeTruthy();
+    expect((await survived.json()).nodes[0].schedule).toBe("0 11 * * *");
+
+    // The way out works: Reload re-reads the graph (and a fresh token), and the
+    // banner clears.
+    await banner.getByTestId("workflow-conflict-reload").click();
+    await expect(banner).toBeHidden({ timeout: 15_000 });
+
+    // …and now the delete goes through, so the loop actually terminates.
+    await page.getByTestId(DELETE).click();
+    await page.getByTestId("workflow-delete-confirm").click();
+    await expect
+      .poll(async () => (await request.get(`${COMPANY_SCOPE}/workflows/${id}`)).status(), {
+        timeout: 15_000,
+      })
+      .toBe(404);
+  } finally {
+    await removeWorkflow(request, id);
+  }
+});

--- a/frontend/test/e2e/workflow-edit-delete.spec.ts
+++ b/frontend/test/e2e/workflow-edit-delete.spec.ts
@@ -80,17 +80,15 @@ async function removeWorkflow(request: APIRequestContext, id: string) {
  * Selects the workflow named `name` in the picker and waits for the selection
  * to settle.
  *
- * Picks by name (the listbox options render `name`) but *asserts* on `id`,
- * because the closed trigger renders the workflow **id**: the picker binds
- * `<SelectItem value={w.id}>` and Base UI's `SelectValue` renders the raw value
- * rather than the item's children. That is pre-existing on `upstream/main` and
- * untouched by #259 — worth its own issue, but keying this helper on the id is
- * what makes these specs describe the console as it actually is.
+ * Asserts the trigger shows the **name**. It used to show the raw id — the
+ * picker binds `<SelectItem value={w.id}>` and Base UI's `SelectValue` renders
+ * the value, not the item's children — which is #270, fixed on this branch
+ * because it is the same picker this issue's Delete affordance sits next to.
  */
-async function selectWorkflow(page: Page, id: string, name: string) {
+async function selectWorkflow(page: Page, name: string) {
   await page.getByRole("combobox").first().click();
   await page.getByRole("option", { name, exact: true }).click();
-  await expect(page.getByRole("combobox").first()).toContainText(id);
+  await expect(page.getByRole("combobox").first()).toContainText(name);
 }
 
 const DELETE = "workflow-delete";
@@ -101,7 +99,7 @@ test("a source-defined workflow cannot be deleted, and the console says why", as
   await page.goto("/#/workflows");
   await dismissTour(page);
 
-  await selectWorkflow(page, "committed", "Committed flow");
+  await selectWorkflow(page, "Committed flow");
 
   const button = page.getByTestId(DELETE);
   await expect(button).toBeVisible();
@@ -125,7 +123,7 @@ test("deleting is confirm-gated, and the confirmation says what goes and what st
   try {
     await page.goto("/#/workflows");
     await dismissTour(page);
-    await selectWorkflow(page, id, name);
+    await selectWorkflow(page, name);
 
     const button = page.getByTestId(DELETE);
     await expect(button, "an overlay-backed workflow must be deletable").toBeEnabled();
@@ -160,7 +158,7 @@ test("confirming the delete removes it from the picker and from the host", async
   try {
     await page.goto("/#/workflows");
     await dismissTour(page);
-    await selectWorkflow(page, id, name);
+    await selectWorkflow(page, name);
 
     await page.getByTestId(DELETE).click();
     await page.getByTestId("workflow-delete-confirm").click();
@@ -178,7 +176,7 @@ test("confirming the delete removes it from the picker and from the host", async
 
     // Gone from the picker: the selection moves off it and it is no longer an
     // option.
-    await expect(page.getByRole("combobox").first()).not.toContainText(id, {
+    await expect(page.getByRole("combobox").first()).not.toContainText(name, {
       timeout: 15_000,
     });
 
@@ -204,7 +202,7 @@ test("a version conflict surfaces distinctly with a way out, and deletes nothing
   try {
     await page.goto("/#/workflows");
     await dismissTour(page);
-    await selectWorkflow(page, id, name);
+    await selectWorkflow(page, name);
 
     // Force the race for real: someone else edits the graph while this console
     // holds the token it loaded a moment ago.

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -144,6 +144,25 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("Created workflow {name} ({workflow_id})"),
             "workflow.created",
         ),
+        // Issue #259. Id + name only, exactly like the create arm above — the
+        // variant carries no graph body precisely so this wire-out to the
+        // inference sidecar cannot leak one.
+        CompanyEvent::WorkflowUpdated {
+            workflow_id, name, ..
+        } => (
+            Role::System,
+            "workflow".to_string(),
+            format!("Updated workflow {name} ({workflow_id})"),
+            "workflow.updated",
+        ),
+        CompanyEvent::WorkflowDeleted {
+            workflow_id, name, ..
+        } => (
+            Role::System,
+            "workflow".to_string(),
+            format!("Deleted workflow {name} ({workflow_id})"),
+            "workflow.deleted",
+        ),
         // Action-only body: the operator's redirect instruction is never wired.
         CompanyEvent::TaskSteered {
             task_id, action, ..

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -59,7 +59,9 @@ pub(crate) use workflow_file::{RawEdge, RawNode, RawWorkflow, render_workflow};
 // REST `POST …/workflows` route and the orchestrator `create_workflow` tool run.
 // Ungated: the REST route is in the default build, so gating this behind
 // `openhuman` is what let the two surfaces drift apart (issue #168).
-pub(crate) use workflow_create::create_company_workflow;
+pub(crate) use workflow_create::{
+    create_company_workflow, delete_company_workflow, update_company_workflow, workflow_version,
+};
 pub use workspace_seed::{NodeKind, SeedNode, extract_wikilinks, walk_workspace};
 
 use crate::{Result, VERSION};

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -60,7 +60,8 @@ pub(crate) use workflow_file::{RawEdge, RawNode, RawWorkflow, render_workflow};
 // Ungated: the REST route is in the default build, so gating this behind
 // `openhuman` is what let the two surfaces drift apart (issue #168).
 pub(crate) use workflow_create::{
-    create_company_workflow, delete_company_workflow, update_company_workflow, workflow_version,
+    create_company_workflow, delete_company_workflow, seed_file_exists, update_company_workflow,
+    workflow_version,
 };
 pub use workspace_seed::{NodeKind, SeedNode, extract_wikilinks, walk_workspace};
 

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -214,12 +214,7 @@ pub(crate) async fn create_company_workflow(
     // The seed side is checked by path rather than by scanning: a *malformed*
     // seed file still owns its id (it would shadow the overlay body on read),
     // and a scan would silently skip it.
-    let seed_file_exists = source_dir.is_some_and(|dir| {
-        dir.join("workflows")
-            .join(format!("{}.toml", draft.id))
-            .is_file()
-    });
-    let id_taken = seed_file_exists
+    let id_taken = seed_file_exists(source_dir, &draft.id)
         || record.overlay_workflows.iter().any(|w| w.id == draft.id)
         || record
             .manifest
@@ -389,11 +384,15 @@ pub(crate) fn workflow_version(toml: &str) -> String {
 
 /// Whether `wid` is backed by a **seed file** in the company source tree.
 ///
-/// Checked by path rather than by scanning, for the same reason
-/// [`create_company_workflow`]'s id-uniqueness probe is: a *malformed* seed file
-/// still owns its id — it would shadow an overlay body on read — and a scan that
-/// parses would silently skip it.
-fn seed_file_exists(source_dir: Option<&Path>, wid: &str) -> bool {
+/// Checked by path rather than by scanning: a *malformed* seed file still owns
+/// its id — it would shadow an overlay body on read — and a scan that parses
+/// would silently skip it.
+///
+/// This is the one probe behind three answers that must agree: create's
+/// id-uniqueness 409, update/delete's "not editable from the console" 409, and
+/// the read routes' `editable` flag. Duplicating it is how the console ends up
+/// offering an Edit button for a graph the host will refuse.
+pub(crate) fn seed_file_exists(source_dir: Option<&Path>, wid: &str) -> bool {
     source_dir.is_some_and(|dir| dir.join("workflows").join(format!("{wid}.toml")).is_file())
 }
 

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -46,10 +46,74 @@
 //!
 //! Compiled in the default build (no harness imports) so the REST route reaches
 //! it without any feature gate.
+//!
+//! # Editing and removing (issue #259)
+//!
+//! [`update_company_workflow`] and [`delete_company_workflow`] complete the
+//! write lifecycle. Both run the same validation and hold the same
+//! [`company_write_lock`] as create, and both are **overlay-only**: they refuse
+//! (with a [`Conflict`](OpenCompanyError::Conflict)) to touch an id backed by a
+//! seed file or by a bodiless manifest-`enabled` entry. That is not squeamishness
+//! about writing to disk, it is the only shape that is honest about what the
+//! reader will do:
+//!
+//! * [`load_workflow_union`](crate::company::load_workflow_union) gives the
+//!   **seed file precedence** on an id collision, so persisting an overlay edit
+//!   for a seed-backed id would store a graph the read path never serves — the
+//!   operator's change would appear to save and then silently not exist.
+//! * `merge_enabled_workflows` (`src/runtime/builder.rs`, issue #208) rebuilds
+//!   `[workflows].enabled` at boot from seed ids ∪ surviving overlay ids, so a
+//!   "deleted" seed workflow would come back on the next restart.
+//!
+//! The same invariant is what makes an overlay delete *durable*: with no overlay
+//! body left, the boot merge has nothing to re-enable.
+//!
+//! ## The version token
+//!
+//! [`workflow_version`] hashes the stored overlay TOML. `GET …/workflows/{wid}`
+//! hands it out, a `PUT`/`DELETE` may hand it back, and the comparison happens
+//! **inside** the write lock immediately before the mutation — so it is a real
+//! optimistic-concurrency guard, not a check-then-act race. The token is opaque
+//! on the wire (the contract is "echo back what the read returned"), so the
+//! algorithm can change without a client migration.
+//!
+//! Passing no token is an unconditional write. That mirrors OpenHuman's
+//! `flows_update`, whose `expected_version` is likewise `Option`: it keeps a
+//! `curl` caller usable without a read-modify-write dance, while the console —
+//! which has a stale-tab problem — always sends one.
+//!
+//! ## What is deliberately not here
+//!
+//! * **No revision history.** OpenHuman keeps a bounded snapshot ring in a
+//!   dedicated `flow_revisions` table; our overlay bodies live inside
+//!   `CompanyRecord`, which is loaded and saved *whole* on every write, so a ring
+//!   per workflow would bloat that hot path. It needs its own store surface.
+//! * **No run-history reaping.** Past runs are
+//!   [`WorkflowRunFinished`](CompanyEvent::WorkflowRunFinished) entries on the
+//!   company's single append-only journal, interleaved with chat and audit. What
+//!   a workflow did stays true after the workflow is gone, and `GET
+//!   …/workflows/runs` keeps serving those rows.
+//! * **No schedule re-registration.** Nothing to re-register:
+//!   [`WorkflowScheduler::tick`](crate::runtime::WorkflowScheduler) re-reads the
+//!   record and re-derives the schedule set from the overlay union every minute,
+//!   so the tick *is* a continuous reconcile. OpenHuman needs
+//!   `reconcile_schedule_triggers_on_boot` because a bound cron job lives in a
+//!   second durable store (`cron.db`) that can drift from `flows.db`; we persist
+//!   no registration at all, so that class of bug cannot arise here.
+//! * **No disarm-on-edit.** OpenHuman forces `enabled = false` when an edit turns
+//!   a manual trigger into an automatic one, so a schedule cannot go live
+//!   unreviewed. That rule has no lever here yet: our scheduler deliberately does
+//!   not gate on `[workflows].enabled` at all (see `workflow_scheduler.rs`), so
+//!   writing `false` would stop nothing. Note this makes update no riskier than
+//!   create, which already persists a live schedule the same way. Reversing the
+//!   scheduler decision and adopting the disarm rule for create and update
+//!   together is one follow-up, not two.
 
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
+
+use sha2::{Digest, Sha256};
 
 use crate::company::{
     RawWorkflow, WorkflowFile, list_workflows_union, parse_workflow, render_workflow,
@@ -58,7 +122,7 @@ use crate::error::{OpenCompanyError, Result};
 use crate::ports::CompanyStore;
 use crate::ports::events::EventLog;
 use crate::ports::store::company_write_lock;
-use crate::ports::types::{CompanyEvent, CompanyId, OverlayWorkflow};
+use crate::ports::types::{CompanyEvent, CompanyId, CompanyRecord, OverlayWorkflow};
 use crate::server::ops::language;
 
 /// Max nodes a freshly authored graph may declare. A larger graph is refused
@@ -98,44 +162,7 @@ pub(crate) async fn create_company_workflow(
     draft: RawWorkflow,
 ) -> Result<WorkflowFile> {
     // --- Input validation (no lock; pure function of the draft) -------------
-
-    if !is_safe_workflow_id(&draft.id) {
-        return Err(OpenCompanyError::InvalidRequest(
-            language::WORKFLOW_ID_INVALID.to_string(),
-        ));
-    }
-    if draft.id.len() > MAX_WORKFLOW_ID_LEN {
-        return Err(OpenCompanyError::InvalidRequest(format!(
-            "a workflow id can be at most {MAX_WORKFLOW_ID_LEN} characters."
-        )));
-    }
-    if draft.name.trim().len() > MAX_WORKFLOW_NAME_LEN {
-        return Err(OpenCompanyError::InvalidRequest(format!(
-            "a workflow name can be at most {MAX_WORKFLOW_NAME_LEN} characters."
-        )));
-    }
-    if draft.nodes.len() > MAX_WORKFLOW_NODES {
-        return Err(OpenCompanyError::InvalidRequest(format!(
-            "a workflow can have at most {MAX_WORKFLOW_NODES} nodes (this one has {}).",
-            draft.nodes.len()
-        )));
-    }
-    if draft.edges.len() > MAX_WORKFLOW_EDGES {
-        return Err(OpenCompanyError::InvalidRequest(format!(
-            "a workflow can have at most {MAX_WORKFLOW_EDGES} edges (this one has {}).",
-            draft.edges.len()
-        )));
-    }
-
-    // `parse_workflow` only rejects zero triggers (a saved graph may legally
-    // have more than one entry point); the creator is stricter — a freshly
-    // authored graph must name exactly one starting point.
-    let trigger_count = draft.nodes.iter().filter(|n| n.kind == "trigger").count();
-    if trigger_count != 1 {
-        return Err(OpenCompanyError::InvalidRequest(format!(
-            "a workflow needs exactly one `trigger` node to say what starts it (found {trigger_count})."
-        )));
-    }
+    validate_draft_shape(&draft)?;
 
     // --- Serialized write section -------------------------------------------
     // Load record → roster check → id/name uniqueness → save record all under
@@ -288,6 +315,372 @@ pub(crate) async fn create_company_workflow(
     }
 
     Ok(file)
+}
+
+/// The validation that is a pure function of the draft — safe id, size caps,
+/// exactly one `trigger` — shared verbatim by [`create_company_workflow`] and
+/// [`update_company_workflow`] so a bad edit is refused on exactly the same
+/// terms as a bad create. Runs before any lock is taken: nothing here reads the
+/// company record.
+fn validate_draft_shape(draft: &RawWorkflow) -> Result<()> {
+    if !is_safe_workflow_id(&draft.id) {
+        return Err(OpenCompanyError::InvalidRequest(
+            language::WORKFLOW_ID_INVALID.to_string(),
+        ));
+    }
+    if draft.id.len() > MAX_WORKFLOW_ID_LEN {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "a workflow id can be at most {MAX_WORKFLOW_ID_LEN} characters."
+        )));
+    }
+    if draft.name.trim().len() > MAX_WORKFLOW_NAME_LEN {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "a workflow name can be at most {MAX_WORKFLOW_NAME_LEN} characters."
+        )));
+    }
+    if draft.nodes.len() > MAX_WORKFLOW_NODES {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "a workflow can have at most {MAX_WORKFLOW_NODES} nodes (this one has {}).",
+            draft.nodes.len()
+        )));
+    }
+    if draft.edges.len() > MAX_WORKFLOW_EDGES {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "a workflow can have at most {MAX_WORKFLOW_EDGES} edges (this one has {}).",
+            draft.edges.len()
+        )));
+    }
+
+    // `parse_workflow` only rejects zero triggers (a saved graph may legally
+    // have more than one entry point); the author-time path is stricter — a
+    // graph written from the console must name exactly one starting point.
+    let trigger_count = draft.nodes.iter().filter(|n| n.kind == "trigger").count();
+    if trigger_count != 1 {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "a workflow needs exactly one `trigger` node to say what starts it (found {trigger_count})."
+        )));
+    }
+
+    Ok(())
+}
+
+/// An opaque version token for a stored overlay body: the hex SHA-256 of the
+/// TOML exactly as persisted.
+///
+/// The wire contract is "echo back what the read handed you" — callers must not
+/// parse it, derive it, or compare it to anything but another token from the
+/// same route. That is what lets the algorithm change later without a client
+/// migration.
+///
+/// Hashing the body rather than stamping a counter or a timestamp means the
+/// token is a pure function of what is stored: it needs no extra field on
+/// [`OverlayWorkflow`], it is stable across a save that rewrites the record for
+/// unrelated reasons, and two writers who happen to persist byte-identical TOML
+/// do not conflict — because there is nothing to lose between them.
+pub(crate) fn workflow_version(toml: &str) -> String {
+    let digest = Sha256::digest(toml.as_bytes());
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+/// Whether `wid` is backed by a **seed file** in the company source tree.
+///
+/// Checked by path rather than by scanning, for the same reason
+/// [`create_company_workflow`]'s id-uniqueness probe is: a *malformed* seed file
+/// still owns its id — it would shadow an overlay body on read — and a scan that
+/// parses would silently skip it.
+fn seed_file_exists(source_dir: Option<&Path>, wid: &str) -> bool {
+    source_dir.is_some_and(|dir| dir.join("workflows").join(format!("{wid}.toml")).is_file())
+}
+
+/// Resolves `wid` to the record's overlay body, or explains why it can't be
+/// written to. Shared by update and delete so the two answer identically.
+///
+/// * seed-backed → [`Conflict`](OpenCompanyError::Conflict): the read path would
+///   keep serving the seed, and a boot rebuild would resurrect it;
+/// * enabled but bodiless → [`Conflict`](OpenCompanyError::Conflict): a
+///   provisioned id with no graph in either source, so there is nothing to
+///   replace or remove;
+/// * unknown → [`CompanyNotFound`](OpenCompanyError::CompanyNotFound) (404).
+///
+/// Returns the index into `record.overlay_workflows`, so the caller can replace
+/// the body **in place** and keep the picker's order stable across an edit.
+fn locate_editable_overlay(
+    record: &CompanyRecord,
+    source_dir: Option<&Path>,
+    wid: &str,
+) -> Result<usize> {
+    if seed_file_exists(source_dir, wid) {
+        return Err(OpenCompanyError::Conflict(format!(
+            "Workflow `{wid}` is defined by a file in the company source tree, so it can't be \
+             changed or removed from the console. Edit `workflows/{wid}.toml` in the company \
+             repository instead."
+        )));
+    }
+
+    if let Some(index) = record.overlay_workflows.iter().position(|w| w.id == wid) {
+        return Ok(index);
+    }
+
+    if record.manifest.workflows.enabled.iter().any(|id| id == wid) {
+        return Err(OpenCompanyError::Conflict(format!(
+            "Workflow `{wid}` is enabled for this company but has no saved graph to change or \
+             remove — it was provisioned by name only."
+        )));
+    }
+
+    Err(OpenCompanyError::CompanyNotFound(format!("workflow {wid}")))
+}
+
+/// Fails with a [`Conflict`](OpenCompanyError::Conflict) when the caller's
+/// `expected` token disagrees with what is actually stored.
+///
+/// Called **inside** the write lock, immediately before the mutation — the whole
+/// point is that the compare and the save are one critical section, so a writer
+/// that lands in between cannot be overwritten. `None` is an unconditional
+/// write; see the module docs for why that stays allowed.
+fn check_expected_version(expected: Option<&str>, current_toml: &str) -> Result<()> {
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    let current = workflow_version(current_toml);
+    if expected != current {
+        return Err(OpenCompanyError::Conflict(format!(
+            "This workflow changed since you loaded it (current version `{current}`). Reload it \
+             to see the latest, then reapply your change."
+        )));
+    }
+    Ok(())
+}
+
+/// Replaces an existing workflow graph wholesale, returning the parsed
+/// [`WorkflowFile`] the union read path will now serve.
+///
+/// Runs [`create_company_workflow`]'s validation with three deltas:
+///
+/// 1. the id must resolve to an **overlay body** that is not shadowed by a seed
+///    file (see [`locate_editable_overlay`]) — 409 if it is source-defined or
+///    body-less, 404 if it is unknown;
+/// 2. display-name uniqueness excludes this workflow's own current name, so
+///    re-saving without renaming isn't a self-conflict;
+/// 3. `expected_version`, when supplied, must match what is stored — compared
+///    under the same lock as the save.
+///
+/// The overlay is replaced **in place** (order preserved, so the picker doesn't
+/// reshuffle on an edit) and `[workflows].enabled` is left exactly as it was: a
+/// workflow that was enabled stays enabled across an edit, and one that somehow
+/// wasn't is not silently armed by saving it.
+pub(crate) async fn update_company_workflow(
+    company: &CompanyId,
+    source_dir: Option<&Path>,
+    store: &Arc<dyn CompanyStore>,
+    events: Option<&Arc<dyn EventLog>>,
+    draft: RawWorkflow,
+    expected_version: Option<&str>,
+) -> Result<WorkflowFile> {
+    // --- Input validation (no lock; pure function of the draft) -------------
+    validate_draft_shape(&draft)?;
+
+    // --- Serialized write section -------------------------------------------
+    let write_lock = company_write_lock(company);
+    let _lock = write_lock.lock().await;
+
+    let mut record = store
+        .load(company)
+        .await?
+        .ok_or_else(|| OpenCompanyError::CompanyNotFound(company.to_string()))?;
+
+    // Which overlay body are we replacing — and may we replace it at all?
+    let index = locate_editable_overlay(&record, source_dir, &draft.id)?;
+
+    // Optimistic concurrency, inside the lock and before any mutation.
+    check_expected_version(expected_version, &record.overlay_workflows[index].toml)?;
+
+    // Same roster cross-check as create: `parse_workflow` validates the graph's
+    // own shape but has no roster to check `agent` node names against.
+    let roster: HashSet<&str> = record
+        .manifest
+        .agents
+        .iter()
+        .map(|a| a.id.as_str())
+        .chain(record.overlay_agents.iter().map(|a| a.id.as_str()))
+        .collect();
+    for node in &draft.nodes {
+        if node.kind != "agent" {
+            continue;
+        }
+        match node.agent.as_deref() {
+            Some(agent_id) if roster.contains(agent_id) => {}
+            Some(agent_id) => {
+                return Err(OpenCompanyError::InvalidRequest(format!(
+                    "node `{}` names teammate `{agent_id}`, which is not on this company's roster.",
+                    node.id
+                )));
+            }
+            None => {
+                return Err(OpenCompanyError::InvalidRequest(format!(
+                    "node `{}` is an agent node but names no teammate.",
+                    node.id
+                )));
+            }
+        }
+    }
+
+    // Display-name uniqueness, MINUS this workflow's own current name — a
+    // re-save that doesn't rename must not collide with itself. Every other
+    // workflow's name is still guarded, so an edit can't take a sibling's name.
+    let mut existing_names = existing_workflow_names(
+        source_dir,
+        &record.overlay_workflows,
+        &record.manifest.workflows.enabled,
+    );
+    // A body that no longer parses contributes no name to the set above either
+    // (the union scan skips it), so the two stay consistent.
+    if let Ok(current) = parse_workflow(&record.overlay_workflows[index].toml) {
+        existing_names.remove(&current.name.trim().to_ascii_lowercase());
+    }
+    if existing_names.contains(&draft.name.trim().to_ascii_lowercase()) {
+        return Err(OpenCompanyError::Conflict(format!(
+            "A workflow named `{}` already exists. Pick a different name.",
+            draft.name.trim()
+        )));
+    }
+
+    // Render and re-parse through the same structural validation a hand-authored
+    // file passes, so a bad edit is a 400 rather than a persisted graph that
+    // breaks the read routes.
+    let toml_src = render_workflow(&draft)?;
+    if toml_src.len() > MAX_WORKFLOW_TOML_BYTES {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "the rendered workflow is {} bytes, over the {MAX_WORKFLOW_TOML_BYTES}-byte limit.",
+            toml_src.len()
+        )));
+    }
+    let file = parse_workflow(&toml_src).map_err(|err| match err {
+        OpenCompanyError::DataInvalid { problems, .. } => {
+            OpenCompanyError::InvalidRequest(problems.join(" "))
+        }
+        OpenCompanyError::DataParse { message, .. } => OpenCompanyError::InvalidRequest(message),
+        other => other,
+    })?;
+
+    // Replace in place: same slot, same order, so the picker doesn't reshuffle.
+    record.overlay_workflows[index] = OverlayWorkflow {
+        id: file.id.clone(),
+        toml: toml_src,
+    };
+    store.save(&record).await?;
+
+    drop(_lock);
+
+    // Best-effort audit journal — id and name only, never the body.
+    if let Some(log) = events
+        && let Err(err) = log
+            .append(
+                company,
+                CompanyEvent::WorkflowUpdated {
+                    workflow_id: file.id.clone(),
+                    name: file.name.clone(),
+                    by: None,
+                },
+            )
+            .await
+    {
+        tracing::warn!(
+            company = %company,
+            workflow = %file.id,
+            error = %err,
+            "workflow updated but audit journal append failed"
+        );
+    }
+
+    Ok(file)
+}
+
+/// Removes a workflow: its overlay body **and** its id in
+/// `[workflows].enabled`, in one save.
+///
+/// Both halves matter. Dropping only the body would leave an enabled id the
+/// picker still lists (under the id as its name, per `list_workflows`'s
+/// fallback); dropping only the enabled id would leave a body the union read
+/// path still serves and the scheduler still fires. One atomic save means there
+/// is no window where a half-deleted workflow exists.
+///
+/// Gated exactly like [`update_company_workflow`] — source-defined and bodiless
+/// ids are refused rather than half-removed — and honours the same optional
+/// version token, so "delete the thing I was looking at" can't remove something
+/// that changed underneath the operator.
+///
+/// Returns the removed workflow's display name for the audit journal (falling
+/// back to the id when the stored body no longer parses).
+pub(crate) async fn delete_company_workflow(
+    company: &CompanyId,
+    source_dir: Option<&Path>,
+    store: &Arc<dyn CompanyStore>,
+    events: Option<&Arc<dyn EventLog>>,
+    wid: &str,
+    expected_version: Option<&str>,
+) -> Result<String> {
+    if !is_safe_workflow_id(wid) {
+        return Err(OpenCompanyError::InvalidRequest(
+            language::WORKFLOW_ID_INVALID.to_string(),
+        ));
+    }
+
+    let write_lock = company_write_lock(company);
+    let _lock = write_lock.lock().await;
+
+    let mut record = store
+        .load(company)
+        .await?
+        .ok_or_else(|| OpenCompanyError::CompanyNotFound(company.to_string()))?;
+
+    let index = locate_editable_overlay(&record, source_dir, wid)?;
+    check_expected_version(expected_version, &record.overlay_workflows[index].toml)?;
+
+    // The display name, read before the body goes away, so the journal entry can
+    // name what was removed. A body that no longer parses still deletes — it is
+    // exactly the kind an operator most wants gone — it just journals under its
+    // id.
+    let name = parse_workflow(&record.overlay_workflows[index].toml)
+        .map(|f| f.name)
+        .unwrap_or_else(|_| wid.to_string());
+
+    // Body and enabled id, one save. `merge_enabled_workflows` (#208) rebuilds
+    // `enabled` at boot from seed ids ∪ surviving overlay ids — with the body
+    // gone there is nothing left to re-enable, which is what makes this durable
+    // across a restart.
+    record.overlay_workflows.remove(index);
+    record.manifest.workflows.enabled.retain(|id| id != wid);
+    store.save(&record).await?;
+
+    drop(_lock);
+
+    if let Some(log) = events
+        && let Err(err) = log
+            .append(
+                company,
+                CompanyEvent::WorkflowDeleted {
+                    workflow_id: wid.to_string(),
+                    name: name.clone(),
+                    by: None,
+                },
+            )
+            .await
+    {
+        tracing::warn!(
+            company = %company,
+            workflow = %wid,
+            error = %err,
+            "workflow deleted but audit journal append failed"
+        );
+    }
+
+    Ok(name)
 }
 
 /// The set of existing workflow display names (trimmed, lowercased) for a
@@ -990,6 +1383,526 @@ to = "done"
         assert!(
             matches!(err, OpenCompanyError::CompanyNotFound(_)),
             "{err:?}"
+        );
+    }
+
+    // --- #259: update ------------------------------------------------------
+
+    /// Seeds a company with one created workflow and hands back the store plus
+    /// the version token a `GET` would have returned for it.
+    async fn with_one_workflow(
+        company: &CompanyId,
+        id: &str,
+        name: &str,
+    ) -> (Arc<dyn CompanyStore>, String) {
+        let store = store_of(MemStore::seeded(record(company, manifest_with_assistant())));
+        create_company_workflow(company, None, &store, None, valid_draft(id, name))
+            .await
+            .expect("seed create");
+        let record = store.load(company).await.unwrap().unwrap();
+        let version = workflow_version(&record.overlay_workflows[0].toml);
+        (store, version)
+    }
+
+    #[tokio::test]
+    async fn updates_the_body_in_place_and_journals() {
+        let company = CompanyId::new("acme");
+        let (store, version) = with_one_workflow(&company, "greeter", "Greeter").await;
+        let log = Arc::new(MemLog::default());
+        let log_dyn: Arc<dyn EventLog> = log.clone();
+
+        let mut draft = valid_draft("greeter", "Greeter");
+        draft.nodes[0].schedule = Some("0 9 * * *".to_string());
+        draft.description = Some("Now on a cron.".to_string());
+
+        let file = update_company_workflow(
+            &company,
+            None,
+            &store,
+            Some(&log_dyn),
+            draft,
+            Some(&version),
+        )
+        .await
+        .expect("updates");
+        assert_eq!(file.nodes[0].schedule.as_deref(), Some("0 9 * * *"));
+
+        let record = store.load(&company).await.unwrap().unwrap();
+        // Replaced, not appended — an edit must never fork the graph in two.
+        assert_eq!(record.overlay_workflows.len(), 1);
+        assert_eq!(record.overlay_workflows[0].id, "greeter");
+        // Still enabled: an edit leaves the arming decision alone.
+        assert_eq!(record.manifest.workflows.enabled, vec!["greeter"]);
+
+        // What the union read path serves is what we returned.
+        let reloaded = load_workflow_union(None, &record.overlay_workflows, "greeter")
+            .expect("reloads")
+            .expect("present");
+        assert_eq!(reloaded, file);
+
+        let events = log.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            CompanyEvent::WorkflowUpdated {
+                workflow_id, name, ..
+            } => {
+                assert_eq!(workflow_id, "greeter");
+                assert_eq!(name, "Greeter");
+            }
+            other => panic!("expected WorkflowUpdated, got {other:?}"),
+        }
+    }
+
+    /// The version token is what makes concurrent edits safe. A caller holding a
+    /// token from before someone else's write must be refused, not silently win.
+    #[tokio::test]
+    async fn a_stale_version_is_refused_and_changes_nothing() {
+        let company = CompanyId::new("acme");
+        let (store, stale) = with_one_workflow(&company, "greeter", "Greeter").await;
+
+        // Someone else edits first, unconditionally.
+        let mut theirs = valid_draft("greeter", "Greeter");
+        theirs.description = Some("Theirs landed first.".to_string());
+        update_company_workflow(&company, None, &store, None, theirs, None)
+            .await
+            .expect("first writer wins");
+
+        // Our stale token is now wrong.
+        let mut ours = valid_draft("greeter", "Greeter");
+        ours.description = Some("Ours would clobber.".to_string());
+        let err = update_company_workflow(&company, None, &store, None, ours, Some(&stale))
+            .await
+            .expect_err("stale version must be refused");
+        assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
+
+        // And the other writer's edit is intact — the refusal is not partial.
+        let record = store.load(&company).await.unwrap().unwrap();
+        let current = load_workflow_union(None, &record.overlay_workflows, "greeter")
+            .unwrap()
+            .unwrap();
+        assert_eq!(current.description.as_deref(), Some("Theirs landed first."));
+    }
+
+    /// The fresh token from the *previous* write is accepted, so the
+    /// reload-and-retry loop the console offers actually terminates.
+    #[tokio::test]
+    async fn a_fresh_version_is_accepted() {
+        let company = CompanyId::new("acme");
+        let (store, first) = with_one_workflow(&company, "greeter", "Greeter").await;
+
+        let mut once = valid_draft("greeter", "Greeter");
+        once.description = Some("One.".to_string());
+        update_company_workflow(&company, None, &store, None, once, Some(&first))
+            .await
+            .expect("first conditional write");
+
+        let record = store.load(&company).await.unwrap().unwrap();
+        let second = workflow_version(&record.overlay_workflows[0].toml);
+        assert_ne!(second, first, "the token must move when the body does");
+
+        let mut twice = valid_draft("greeter", "Greeter");
+        twice.description = Some("Two.".to_string());
+        update_company_workflow(&company, None, &store, None, twice, Some(&second))
+            .await
+            .expect("refreshed token is accepted");
+    }
+
+    /// No token at all is an unconditional write — the `curl` contract.
+    #[tokio::test]
+    async fn no_version_is_an_unconditional_write() {
+        let company = CompanyId::new("acme");
+        let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
+        let mut draft = valid_draft("greeter", "Greeter");
+        draft.description = Some("No token needed.".to_string());
+        update_company_workflow(&company, None, &store, None, draft, None)
+            .await
+            .expect("unconditional write");
+    }
+
+    /// Re-saving without renaming must not collide with the workflow's own name.
+    #[tokio::test]
+    async fn keeping_the_same_name_is_not_a_self_conflict() {
+        let company = CompanyId::new("acme");
+        let (store, version) = with_one_workflow(&company, "greeter", "Greeter").await;
+        let mut draft = valid_draft("greeter", "  greeter  ");
+        draft.description = Some("Same name, different case and padding.".to_string());
+        update_company_workflow(&company, None, &store, None, draft, Some(&version))
+            .await
+            .expect("own name must not conflict with itself");
+    }
+
+    /// …but a *sibling's* name is still guarded.
+    #[tokio::test]
+    async fn taking_another_workflows_name_is_a_conflict() {
+        let company = CompanyId::new("acme");
+        let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
+        create_company_workflow(&company, None, &store, None, valid_draft("other", "Other"))
+            .await
+            .expect("second workflow");
+
+        let err = update_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            valid_draft("greeter", "OTHER"),
+            None,
+        )
+        .await
+        .expect_err("sibling name is taken");
+        assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
+    }
+
+    /// An edit runs the same shape validation a create does.
+    #[tokio::test]
+    async fn a_bad_edit_is_refused_on_the_same_terms_as_a_bad_create() {
+        let company = CompanyId::new("acme");
+        let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
+
+        // Zero triggers.
+        let mut no_trigger = valid_draft("greeter", "Greeter");
+        no_trigger.nodes[0].kind = "output".to_string();
+        let err = update_company_workflow(&company, None, &store, None, no_trigger, None)
+            .await
+            .expect_err("no trigger");
+        assert!(err.to_string().contains("exactly one `trigger`"), "{err}");
+
+        // Off-roster teammate.
+        let mut ghost = valid_draft("greeter", "Greeter");
+        ghost.nodes[1].agent = Some("ghost".to_string());
+        let err = update_company_workflow(&company, None, &store, None, ghost, None)
+            .await
+            .expect_err("off-roster teammate");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+
+        // And nothing was persisted by either attempt.
+        let record = store.load(&company).await.unwrap().unwrap();
+        assert_eq!(record.overlay_workflows.len(), 1);
+        let current = load_workflow_union(None, &record.overlay_workflows, "greeter")
+            .unwrap()
+            .unwrap();
+        assert_eq!(current.nodes.len(), 3);
+    }
+
+    /// **The core overlay-only rule for update.** A seed-backed id is refused,
+    /// because `load_workflow_union` gives the seed file precedence — persisting
+    /// the edit would store a graph the read path never serves.
+    #[tokio::test]
+    async fn updating_a_seed_backed_workflow_is_a_conflict() {
+        let dir = tempfile::tempdir().unwrap();
+        let workflows = dir.path().join("workflows");
+        std::fs::create_dir_all(&workflows).unwrap();
+        std::fs::write(workflows.join("seeded.toml"), SEED_TOML).unwrap();
+
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        let err = update_company_workflow(
+            &company,
+            Some(dir.path()),
+            &store,
+            None,
+            valid_draft("seeded", "Seeded flow"),
+            None,
+        )
+        .await
+        .expect_err("a source-defined workflow is not editable");
+        assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
+        assert!(err.to_string().contains("source tree"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn updating_an_unknown_workflow_is_not_found() {
+        let company = CompanyId::new("acme");
+        let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
+        let err = update_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            valid_draft("ghost", "Ghost"),
+            None,
+        )
+        .await
+        .expect_err("unknown id");
+        assert!(
+            matches!(err, OpenCompanyError::CompanyNotFound(_)),
+            "{err:?}"
+        );
+    }
+
+    /// A manifest-`enabled` id with no body in either source has nothing to
+    /// replace — a 409 that says so beats a 404 that implies it never existed.
+    #[tokio::test]
+    async fn updating_a_bodiless_enabled_id_is_a_conflict() {
+        let company = CompanyId::new("acme");
+        let mut rec = record(&company, manifest_with_assistant());
+        rec.manifest.workflows.enabled.push("legacy".to_string());
+        let store = store_of(MemStore::seeded(rec));
+
+        let err = update_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            valid_draft("legacy", "Legacy"),
+            None,
+        )
+        .await
+        .expect_err("no body to replace");
+        assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
+    }
+
+    /// An edit must not reshuffle the picker.
+    #[tokio::test]
+    async fn an_edit_preserves_overlay_order() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        for (id, name) in [("a", "Alpha"), ("b", "Bravo"), ("c", "Charlie")] {
+            create_company_workflow(&company, None, &store, None, valid_draft(id, name))
+                .await
+                .expect("seed");
+        }
+
+        let mut draft = valid_draft("a", "Alpha");
+        draft.description = Some("Edited.".to_string());
+        update_company_workflow(&company, None, &store, None, draft, None)
+            .await
+            .expect("edit the first");
+
+        let record = store.load(&company).await.unwrap().unwrap();
+        let ids: Vec<&str> = record
+            .overlay_workflows
+            .iter()
+            .map(|w| w.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["a", "b", "c"], "an edit must not reorder");
+    }
+
+    // --- #259: delete ------------------------------------------------------
+
+    #[tokio::test]
+    async fn deletes_the_body_and_the_enabled_id_and_journals() {
+        let company = CompanyId::new("acme");
+        let (store, version) = with_one_workflow(&company, "greeter", "Greeter").await;
+        let log = Arc::new(MemLog::default());
+        let log_dyn: Arc<dyn EventLog> = log.clone();
+
+        let name = delete_company_workflow(
+            &company,
+            None,
+            &store,
+            Some(&log_dyn),
+            "greeter",
+            Some(&version),
+        )
+        .await
+        .expect("deletes");
+        assert_eq!(name, "Greeter");
+
+        let record = store.load(&company).await.unwrap().unwrap();
+        // BOTH halves gone, in one save. Either alone would leave a workflow
+        // that is half-present: a listed id with no graph, or a graph the
+        // scheduler still fires.
+        assert!(record.overlay_workflows.is_empty(), "body must be gone");
+        assert!(
+            record.manifest.workflows.enabled.is_empty(),
+            "enabled id must be gone"
+        );
+        assert!(
+            load_workflow_union(None, &record.overlay_workflows, "greeter")
+                .unwrap()
+                .is_none(),
+            "the union read path must no longer serve it"
+        );
+
+        let events = log.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            CompanyEvent::WorkflowDeleted {
+                workflow_id, name, ..
+            } => {
+                assert_eq!(workflow_id, "greeter");
+                assert_eq!(name, "Greeter");
+            }
+            other => panic!("expected WorkflowDeleted, got {other:?}"),
+        }
+    }
+
+    /// The delete is durable across the #208 boot rebuild *because* the overlay
+    /// body is gone: `merge_enabled_workflows` re-derives `enabled` from seed
+    /// ids ∪ surviving overlay ids, so there is nothing left to resurrect. This
+    /// pins the invariant the delete's correctness rests on.
+    #[tokio::test]
+    async fn a_deleted_workflow_has_nothing_left_for_the_boot_merge_to_re_enable() {
+        let company = CompanyId::new("acme");
+        let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
+        delete_company_workflow(&company, None, &store, None, "greeter", None)
+            .await
+            .expect("deletes");
+
+        let record = store.load(&company).await.unwrap().unwrap();
+        let surviving: Vec<&str> = record
+            .overlay_workflows
+            .iter()
+            .map(|w| w.id.as_str())
+            .collect();
+        assert!(
+            !surviving.contains(&"greeter"),
+            "no overlay body means the boot merge cannot re-enable it"
+        );
+        assert!(list_workflows_union(None, &record.overlay_workflows).is_empty());
+    }
+
+    #[tokio::test]
+    async fn deleting_with_a_stale_version_is_refused_and_keeps_the_workflow() {
+        let company = CompanyId::new("acme");
+        let (store, stale) = with_one_workflow(&company, "greeter", "Greeter").await;
+
+        let mut theirs = valid_draft("greeter", "Greeter");
+        theirs.description = Some("Edited after you loaded it.".to_string());
+        update_company_workflow(&company, None, &store, None, theirs, None)
+            .await
+            .expect("someone edits first");
+
+        let err = delete_company_workflow(&company, None, &store, None, "greeter", Some(&stale))
+            .await
+            .expect_err("stale delete must be refused");
+        assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
+
+        let record = store.load(&company).await.unwrap().unwrap();
+        assert_eq!(record.overlay_workflows.len(), 1, "nothing was removed");
+    }
+
+    /// Deleting a source-defined workflow is refused: `merge_enabled_workflows`
+    /// would re-enable it from the seed id on the next boot, so the console
+    /// would be promising a removal it cannot keep.
+    #[tokio::test]
+    async fn deleting_a_seed_backed_workflow_is_a_conflict() {
+        let dir = tempfile::tempdir().unwrap();
+        let workflows = dir.path().join("workflows");
+        std::fs::create_dir_all(&workflows).unwrap();
+        std::fs::write(workflows.join("seeded.toml"), SEED_TOML).unwrap();
+
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+
+        let err = delete_company_workflow(&company, Some(dir.path()), &store, None, "seeded", None)
+            .await
+            .expect_err("a source-defined workflow is not deletable");
+        assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
+        assert!(err.to_string().contains("source tree"), "{err}");
+        // And the seed file is untouched — this path never writes to the tree.
+        assert!(workflows.join("seeded.toml").is_file());
+    }
+
+    #[tokio::test]
+    async fn deleting_an_unknown_workflow_is_not_found() {
+        let company = CompanyId::new("acme");
+        let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
+        let err = delete_company_workflow(&company, None, &store, None, "ghost", None)
+            .await
+            .expect_err("unknown id");
+        assert!(
+            matches!(err, OpenCompanyError::CompanyNotFound(_)),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn deleting_a_traversal_id_is_invalid() {
+        let company = CompanyId::new("acme");
+        let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
+        let err = delete_company_workflow(&company, None, &store, None, "../secrets", None)
+            .await
+            .expect_err("traversal id");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+    }
+
+    /// Only the named workflow goes; siblings keep their bodies and their
+    /// enabled ids.
+    #[tokio::test]
+    async fn deleting_one_leaves_the_others_alone() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        for (id, name) in [("a", "Alpha"), ("b", "Bravo"), ("c", "Charlie")] {
+            create_company_workflow(&company, None, &store, None, valid_draft(id, name))
+                .await
+                .expect("seed");
+        }
+
+        delete_company_workflow(&company, None, &store, None, "b", None)
+            .await
+            .expect("deletes the middle one");
+
+        let record = store.load(&company).await.unwrap().unwrap();
+        let ids: Vec<&str> = record
+            .overlay_workflows
+            .iter()
+            .map(|w| w.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["a", "c"]);
+        assert_eq!(record.manifest.workflows.enabled, vec!["a", "c"]);
+    }
+
+    /// A save failure leaves the record exactly as it was — the same one-save
+    /// atomicity create relies on.
+    #[tokio::test]
+    async fn a_failing_save_leaves_the_workflow_in_place() {
+        let company = CompanyId::new("acme");
+        let mut rec = record(&company, manifest_with_assistant());
+        rec.overlay_workflows.push(OverlayWorkflow {
+            id: "greeter".to_string(),
+            toml: render_workflow(&valid_draft("greeter", "Greeter")).unwrap(),
+        });
+        rec.manifest.workflows.enabled.push("greeter".to_string());
+        let store = store_of(MemStore::failing(rec));
+
+        delete_company_workflow(&company, None, &store, None, "greeter", None)
+            .await
+            .expect_err("save fails");
+
+        let record = store.load(&company).await.unwrap().unwrap();
+        assert_eq!(record.overlay_workflows.len(), 1, "nothing was removed");
+        assert_eq!(record.manifest.workflows.enabled, vec!["greeter"]);
+    }
+
+    // --- #259: the version token itself ------------------------------------
+
+    #[test]
+    fn the_version_token_is_stable_and_body_derived() {
+        let a = workflow_version("id = \"x\"\n");
+        assert_eq!(a, workflow_version("id = \"x\"\n"), "must be deterministic");
+        assert_ne!(
+            a,
+            workflow_version("id = \"y\"\n"),
+            "a different body must produce a different token"
+        );
+        // Hex sha256: 64 lowercase hex characters, so it is safe in a URL query
+        // without escaping (the DELETE route passes it as `?expectedVersion=`).
+        assert_eq!(a.len(), 64, "{a}");
+        assert!(
+            a.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()),
+            "{a}"
         );
     }
 }

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -458,6 +458,12 @@ fn summarize_event(event: &CompanyEvent) -> String {
         CompanyEvent::WorkflowCreated {
             workflow_id, name, ..
         } => format!("workflow created: {name} ({workflow_id})"),
+        CompanyEvent::WorkflowUpdated {
+            workflow_id, name, ..
+        } => format!("workflow updated: {name} ({workflow_id})"),
+        CompanyEvent::WorkflowDeleted {
+            workflow_id, name, ..
+        } => format!("workflow deleted: {name} ({workflow_id})"),
         CompanyEvent::TaskSteered {
             task_id, action, ..
         } => format!("task steered ({action}): {task_id}"),

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -389,6 +389,53 @@ pub enum CompanyEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         by: Option<Actor>,
     },
+    /// An existing workflow graph was replaced wholesale (issue #259), from the
+    /// console's `PUT …/workflows/{wid}` route. Journaled best-effort **after**
+    /// the new body is persisted, so it records a completed edit — a journal
+    /// failure never rolls the update back. Additive, same contract as
+    /// [`WorkflowCreated`](Self::WorkflowCreated).
+    ///
+    /// **The graph body is deliberately NOT carried.** A company's journal is
+    /// one append-only log shared by chat, audit and run history, and it is read
+    /// by the operator SSE projection and wired to the inference sidecar — a
+    /// TOML body on it would put the graph's full contents (agent prompts,
+    /// destination addresses) somewhere none of those readers need it. The id
+    /// and name are what an audit reader needs; the body is read from the record.
+    WorkflowUpdated {
+        /// The edited workflow's id. Never changes across an update — a rename
+        /// through `PUT` is rejected, because the id keys the union read path,
+        /// the scheduler and the run history.
+        workflow_id: String,
+        /// The workflow's display name **after** the edit (the name may change
+        /// even though the id may not).
+        name: String,
+        /// Who edited it, when known. `None` from the current unattributed
+        /// surfaces; same forward-compatible shape as
+        /// [`WorkflowCreated`](Self::WorkflowCreated)'s `by`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        by: Option<Actor>,
+    },
+    /// A workflow graph was removed (issue #259), from the console's
+    /// `DELETE …/workflows/{wid}` route. Journaled best-effort **after** the
+    /// overlay body and the manifest-enabled id are both gone, so it records a
+    /// completed delete. Additive, same contract as
+    /// [`WorkflowCreated`](Self::WorkflowCreated).
+    ///
+    /// Past [`WorkflowRunFinished`](Self::WorkflowRunFinished) entries for this
+    /// id are deliberately left in place — the journal is append-only, and what
+    /// a workflow *did* stays true after the workflow is gone. `GET
+    /// …/workflows/runs` keeps serving them.
+    WorkflowDeleted {
+        /// The removed workflow's id.
+        workflow_id: String,
+        /// Its display name at the moment it was removed, so a journal reader
+        /// need not resolve an id that no longer exists.
+        name: String,
+        /// Who removed it, when known. `None` from the current unattributed
+        /// surfaces.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        by: Option<Actor>,
+    },
     /// An operator steered an in-flight run — paused, cancelled, or redirected a
     /// dispatched task (or cancelled a delegation) from chat (issue #111).
     /// Journaled best-effort **after** the steer is accepted by the in-flight
@@ -2483,6 +2530,57 @@ mod test {
         assert!(!out.contains("deliveries"), "{out}");
         assert!(!out.contains("pending_approvals"), "{out}");
         assert!(!out.contains("error"), "{out}");
+    }
+
+    /// Issue #259's two variants pin their wire shape the same way
+    /// `WorkflowCreated` does: `kind` + `workflow_id` + `name`, with `by`
+    /// omitted entirely when absent so the common unattributed line stays the
+    /// short one.
+    #[test]
+    fn workflow_updated_and_deleted_pin_their_wire_shape() {
+        let updated = CompanyEvent::WorkflowUpdated {
+            workflow_id: "digest".to_string(),
+            name: "Daily digest".to_string(),
+            by: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&updated).expect("serialize"),
+            r#"{"kind":"WorkflowUpdated","workflow_id":"digest","name":"Daily digest"}"#
+        );
+
+        let deleted = CompanyEvent::WorkflowDeleted {
+            workflow_id: "digest".to_string(),
+            name: "Daily digest".to_string(),
+            by: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&deleted).expect("serialize"),
+            r#"{"kind":"WorkflowDeleted","workflow_id":"digest","name":"Daily digest"}"#
+        );
+
+        // Both round-trip.
+        for event in [updated, deleted] {
+            let line = serde_json::to_string(&event).expect("serialize");
+            let back: CompanyEvent = serde_json::from_str(&line).expect("deserialize");
+            assert_eq!(back, event);
+        }
+    }
+
+    /// The graph body must never reach the journal — see the variant docs. A
+    /// reader of the shared append-only log (operator SSE, the inference
+    /// sidecar) has no business seeing agent prompts or destination addresses,
+    /// and the only way a body could leak here is someone adding a field.
+    #[test]
+    fn workflow_updated_carries_no_graph_body() {
+        let line = serde_json::to_string(&CompanyEvent::WorkflowUpdated {
+            workflow_id: "digest".to_string(),
+            name: "Daily digest".to_string(),
+            by: None,
+        })
+        .expect("serialize");
+        assert!(!line.contains("toml"), "{line}");
+        assert!(!line.contains("node"), "{line}");
+        assert!(!line.contains("graph"), "{line}");
     }
 
     /// **The backcompat proof.** A journal written before this variant existed

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -1809,4 +1809,164 @@ to = "done"
         let mut scheduler = WorkflowScheduler::new(CompanyRegistry::new(), clock);
         assert_eq!(scheduler.tick().await, 0);
     }
+
+    // ── Issue #259: the tick IS the reconcile ───────────────────────────────
+    //
+    // Editing or removing a workflow deliberately ships NO scheduler change.
+    // The two tests below are why that is safe rather than an omission, and
+    // they are the pin: if someone ever caches the schedule set across ticks —
+    // an obvious-looking optimisation, since the record load is per-minute
+    // per-company — these fail, instead of a deleted workflow quietly firing
+    // forever in production.
+    //
+    // OpenHuman needs `reconcile_schedule_triggers_on_boot` precisely because
+    // it *does* persist a registration: a schedule-trigger flow binds a row in
+    // a separate `cron.db`, which can drift from `flows.db` and must be
+    // re-synced. We persist no registration at all, so there is nothing to
+    // drift and nothing to reconcile.
+
+    /// Replaces a registered company's overlay bodies, standing in for the
+    /// `PUT`/`DELETE` routes' record write.
+    async fn rewrite_overlays(
+        registry: &CompanyRegistry,
+        id: &str,
+        overlays: Vec<OverlayWorkflow>,
+    ) {
+        let company = CompanyId::new(id);
+        let runtime = registry.get(&company).expect("registered");
+        let store = runtime.store().clone();
+        let mut record: CompanyRecord = store.load(&company).await.unwrap().unwrap();
+        record.overlay_workflows = overlays;
+        store.save(&record).await.unwrap();
+    }
+
+    /// **Delete needs no scheduler teardown.** The workflow fires, is removed
+    /// from the record, and never fires again — no restart, no unbind call.
+    #[tokio::test]
+    async fn a_deleted_workflow_stops_firing_on_the_very_next_tick() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (runner, started, _completed) = RecordingRunner::new();
+        let registry = company_with_overlays(
+            &home,
+            "acme",
+            vec![overlay("digest", Some("0 9 * * *"))],
+            Some(runner),
+            "running",
+        )
+        .await;
+
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry.clone(), clock.clone());
+
+        // It fires while it exists.
+        assert_eq!(scheduler.tick().await, 1);
+        wait_for(|| started.lock().unwrap().len() == 1).await;
+        drain(&scheduler).await;
+
+        // The operator deletes it (the route drops the overlay body).
+        rewrite_overlays(&registry, "acme", Vec::new()).await;
+
+        // Next matching minute: nothing. No process restart in between.
+        clock.set(millis_at(2026, 7, 14, 9, 0));
+        assert_eq!(
+            scheduler.tick().await,
+            0,
+            "a deleted workflow must not keep firing"
+        );
+        assert_eq!(started.lock().unwrap().len(), 1);
+    }
+
+    /// **Edit needs no rebinding.** A corrected cron takes effect on the next
+    /// tick: the old expression stops matching and the new one starts. This is
+    /// the issue's own example — a typo'd schedule that used to be permanent.
+    #[tokio::test]
+    async fn an_edited_schedule_takes_effect_without_rebinding() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (runner, started, _completed) = RecordingRunner::new();
+        let registry = company_with_overlays(
+            &home,
+            "acme",
+            vec![overlay("digest", Some("0 9 * * *"))],
+            Some(runner),
+            "running",
+        )
+        .await;
+
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry.clone(), clock.clone());
+
+        assert_eq!(scheduler.tick().await, 1);
+        wait_for(|| started.lock().unwrap().len() == 1).await;
+        drain(&scheduler).await;
+
+        // The operator corrects 09:00 → 10:00.
+        rewrite_overlays(
+            &registry,
+            "acme",
+            vec![overlay("digest", Some("0 10 * * *"))],
+        )
+        .await;
+
+        // The OLD cadence is dead…
+        clock.set(millis_at(2026, 7, 14, 9, 0));
+        assert_eq!(
+            scheduler.tick().await,
+            0,
+            "the replaced schedule must stop firing"
+        );
+
+        // …and the NEW one is live, with no restart and no rebind call.
+        clock.set(millis_at(2026, 7, 14, 10, 0));
+        assert_eq!(
+            scheduler.tick().await,
+            1,
+            "the corrected schedule must start firing"
+        );
+        wait_for(|| started.lock().unwrap().len() == 2).await;
+        drain(&scheduler).await;
+    }
+
+    /// Adding a schedule to a previously manual workflow arms it on the next
+    /// tick — no `enabled` toggle involved, because this scheduler deliberately
+    /// does not gate on `[workflows].enabled` (see [`WorkflowScheduler::tick`]).
+    ///
+    /// This is also the honest record of what #259 does NOT ship: OpenHuman's
+    /// `flows_update` forces `enabled = false` on exactly this manual→automatic
+    /// transition so a schedule cannot go live unreviewed. That rule has no
+    /// lever here yet — writing `enabled = false` would stop nothing — and note
+    /// that create already behaves identically, so an edit is no riskier than
+    /// authoring the same graph fresh. Adopting the disarm rule means first
+    /// reversing the gating decision, for create and update together.
+    #[tokio::test]
+    async fn adding_a_schedule_by_edit_arms_the_workflow_on_the_next_tick() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (runner, started, _completed) = RecordingRunner::new();
+        let registry = company_with_overlays(
+            &home,
+            "acme",
+            vec![overlay("digest", None)], // manual-run only
+            Some(runner),
+            "running",
+        )
+        .await;
+
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry.clone(), clock.clone());
+        assert_eq!(scheduler.tick().await, 0, "no schedule, no fire");
+
+        rewrite_overlays(
+            &registry,
+            "acme",
+            vec![overlay("digest", Some("0 9 * * *"))],
+        )
+        .await;
+
+        clock.set(millis_at(2026, 7, 14, 9, 0));
+        assert_eq!(scheduler.tick().await, 1);
+        wait_for(|| started.lock().unwrap().len() == 1).await;
+        drain(&scheduler).await;
+    }
 }

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -728,6 +728,27 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             o["name"] = json!(name);
             o
         }
+        // Issue #259: an edited or removed workflow, so a console holding the
+        // Workflows tab open re-reads the picker instead of offering a graph
+        // that changed under it (or one that no longer exists). Same two fields
+        // and same deny-by-default actor omission as `workflow_created` — and,
+        // as the variant docs spell out, there is no graph body to leak here.
+        CompanyEvent::WorkflowUpdated {
+            workflow_id, name, ..
+        } => {
+            let mut o = envelope("workflow_updated");
+            o["workflowId"] = json!(workflow_id);
+            o["name"] = json!(name);
+            o
+        }
+        CompanyEvent::WorkflowDeleted {
+            workflow_id, name, ..
+        } => {
+            let mut o = envelope("workflow_deleted");
+            o["workflowId"] = json!(workflow_id);
+            o["name"] = json!(name);
+            o
+        }
         // Issue #111: surface an accepted operator steer so the console's
         // in-flight strip can refresh live. Only the task id + action word go on
         // the wire — the actor (`by`) and the operator's redirect `instruction`
@@ -2744,6 +2765,40 @@ mod test {
         }))
         .expect("workflow_created is an attention signal");
         assert_eq!(v["type"], "workflow_created");
+        assert_eq!(v["workflowId"], "greeter");
+        assert_eq!(v["name"], "Greeter");
+        assert!(!v.to_string().contains("secret-user-id"));
+    }
+
+    /// Issue #259: the edit and delete signals project the same two fields and
+    /// drop the actor, exactly like `workflow_created` above.
+    #[test]
+    fn projects_workflow_updated_and_deleted_without_the_actor() {
+        let actor = || {
+            Some(Actor {
+                kind: ActorKind::User,
+                id: "secret-user-id".into(),
+            })
+        };
+
+        let v = super::project_event(&stored(CompanyEvent::WorkflowUpdated {
+            workflow_id: "greeter".into(),
+            name: "Greeter v2".into(),
+            by: actor(),
+        }))
+        .expect("workflow_updated is an attention signal");
+        assert_eq!(v["type"], "workflow_updated");
+        assert_eq!(v["workflowId"], "greeter");
+        assert_eq!(v["name"], "Greeter v2");
+        assert!(!v.to_string().contains("secret-user-id"));
+
+        let v = super::project_event(&stored(CompanyEvent::WorkflowDeleted {
+            workflow_id: "greeter".into(),
+            name: "Greeter".into(),
+            by: actor(),
+        }))
+        .expect("workflow_deleted is an attention signal");
+        assert_eq!(v["type"], "workflow_deleted");
         assert_eq!(v["workflowId"], "greeter");
         assert_eq!(v["name"], "Greeter");
         assert!(!v.to_string().contains("secret-user-id"));

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -52,6 +52,7 @@ use std::collections::HashSet;
 use std::path::Path as FsPath;
 
 use axum::extract::{Path, Query};
+use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
@@ -61,8 +62,9 @@ use serde_json::Value;
 use crate::AppState;
 use crate::company::{
     RawEdge, RawNode, RawWorkflow, WorkflowDestinationDef, WorkflowEdgeDef, WorkflowFile,
-    WorkflowNodeDef, WorkflowRetryDef, create_company_workflow, list_workflows_union,
-    load_workflow_union,
+    WorkflowNodeDef, WorkflowRetryDef, create_company_workflow, delete_company_workflow,
+    list_workflows_union, load_workflow_union, seed_file_exists, update_company_workflow,
+    workflow_version,
 };
 use crate::error::OpenCompanyError;
 use crate::ports::types::{CompanyEvent, CompanyRecord, EventSeq, OverlayWorkflow};
@@ -85,7 +87,17 @@ pub fn router() -> Router<AppState> {
         // read through this route. That is the same trade `tasks/inflight`
         // takes, and the history surface is worth more than the one reserved id.
         .merge(scoped("/workflows/runs", get(list_runs)))
-        .merge(scoped("/workflows/{wid}", get(get_workflow)))
+        // Issue #259: read, replace, remove — all on the same id. `PUT` is a
+        // full replace rather than a `PATCH` merge because a workflow *is* its
+        // graph: a partial node/edge merge has no well-defined meaning (which
+        // half of a rewired edge set wins?), and the console always holds the
+        // whole graph anyway.
+        .merge(scoped(
+            "/workflows/{wid}",
+            get(get_workflow)
+                .put(update_workflow)
+                .delete(delete_workflow),
+        ))
         .merge(scoped("/workflows/{wid}/run", post(run_workflow)))
 }
 
@@ -97,14 +109,20 @@ struct WorkflowSummary {
     name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
+    /// Whether `PUT`/`DELETE` on this id will be accepted (issue #259) — see
+    /// [`is_editable`]. The console disables its Edit/Delete affordances on a
+    /// `false`, so an operator is told *before* clicking rather than by a 409
+    /// after.
+    editable: bool,
 }
 
-impl From<WorkflowFile> for WorkflowSummary {
-    fn from(f: WorkflowFile) -> Self {
+impl WorkflowSummary {
+    fn new(f: WorkflowFile, editable: bool) -> Self {
         Self {
             id: f.id,
             name: f.name,
             description: f.description,
+            editable,
         }
     }
 }
@@ -119,16 +137,31 @@ struct WorkflowGraph {
     description: Option<String>,
     nodes: Vec<WorkflowNode>,
     edges: Vec<WorkflowEdge>,
+    /// Whether this graph can be replaced or removed through the API — see
+    /// [`is_editable`].
+    editable: bool,
+    /// The opaque optimistic-concurrency token for this graph (issue #259),
+    /// present only when `editable` (a source-defined graph has nothing to
+    /// version, and a token for an overlay body the read path does not even
+    /// serve would be actively misleading).
+    ///
+    /// The contract is **echo it back**: hand it to `PUT` in the body or to
+    /// `DELETE` as `?expectedVersion=`, and the write is refused with a `409` if
+    /// the graph moved in between. Never parse or derive it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
 }
 
-impl From<WorkflowFile> for WorkflowGraph {
-    fn from(f: WorkflowFile) -> Self {
+impl WorkflowGraph {
+    fn new(f: WorkflowFile, editable: bool, version: Option<String>) -> Self {
         Self {
             id: f.id,
             name: f.name,
             description: f.description,
             nodes: f.nodes.into_iter().map(WorkflowNode::from).collect(),
             edges: f.edges.into_iter().map(WorkflowEdge::from).collect(),
+            editable,
+            version,
         }
     }
 }
@@ -233,6 +266,32 @@ impl From<WorkflowEdgeDef> for WorkflowEdge {
 /// live record. A company with no persisted record contributes none — the read
 /// routes stay tolerant (they still serve the seed files), and the create route
 /// re-loads the record under its write lock and 404s properly there.
+/// Whether `wid` can be replaced or removed through `PUT`/`DELETE` (issue #259):
+/// it is backed by a **record overlay body** and is **not shadowed by a seed
+/// file**.
+///
+/// Both halves are the reader's rules, restated. `load_workflow_union` gives a
+/// seed file precedence on an id collision, so an edit to a seed-shadowed id
+/// would persist a graph nothing serves; and `merge_enabled_workflows` (#208)
+/// re-derives `[workflows].enabled` from seed ids at boot, so a "delete" of a
+/// seed-backed workflow would undo itself on restart. The write core enforces
+/// exactly this and answers `409` — this flag is the same predicate, projected
+/// so the console can grey the button instead of surfacing that 409.
+///
+/// The seed probe is [`seed_file_exists`], shared with the create path's
+/// id-uniqueness check, so the flag and the host's actual answer cannot drift.
+fn is_editable(source_dir: Option<&FsPath>, overlays: &[OverlayWorkflow], wid: &str) -> bool {
+    overlays.iter().any(|w| w.id == wid) && !seed_file_exists(source_dir, wid)
+}
+
+/// The stored overlay TOML for `wid`, when the record has one.
+fn overlay_toml<'a>(overlays: &'a [OverlayWorkflow], wid: &str) -> Option<&'a str> {
+    overlays
+        .iter()
+        .find(|w| w.id == wid)
+        .map(|w| w.toml.as_str())
+}
+
 async fn overlay_workflows(company: &ScopedCompany) -> Result<Vec<OverlayWorkflow>, ApiError> {
     let record: Option<CompanyRecord> = company
         .runtime
@@ -255,10 +314,16 @@ async fn overlay_workflows(company: &ScopedCompany) -> Result<Vec<OverlayWorkflo
 /// than a failure.
 async fn list_workflows(company: ScopedCompany) -> Result<Json<Vec<WorkflowSummary>>, ApiError> {
     let overlays = overlay_workflows(&company).await?;
-    let files = list_workflows_union(company.runtime.source_dir(), &overlays);
+    let source_dir = company.runtime.source_dir();
+    let files = list_workflows_union(source_dir, &overlays);
     let mut seen: HashSet<String> = files.iter().map(|f| f.id.clone()).collect();
-    let mut summaries: Vec<WorkflowSummary> =
-        files.into_iter().map(WorkflowSummary::from).collect();
+    let mut summaries: Vec<WorkflowSummary> = files
+        .into_iter()
+        .map(|f| {
+            let editable = is_editable(source_dir, &overlays, &f.id);
+            WorkflowSummary::new(f, editable)
+        })
+        .collect();
 
     let enabled_ids = company
         .runtime
@@ -275,6 +340,10 @@ async fn list_workflows(company: ScopedCompany) -> Result<Json<Vec<WorkflowSumma
             id: id.clone(),
             name: id,
             description: None,
+            // A manifest-`enabled` id with no body in either source: there is
+            // nothing to replace or remove, and the write core says so with a
+            // 409. Never editable.
+            editable: false,
         });
     }
 
@@ -297,11 +366,19 @@ async fn get_workflow(
             "workflow {wid}"
         ))));
     }
+    let source_dir = company.runtime.source_dir();
     let overlays = overlay_workflows(&company).await?;
-    let file = load_workflow_union(company.runtime.source_dir(), &overlays, &wid)
+    let file = load_workflow_union(source_dir, &overlays, &wid)
         .map_err(ApiError)?
         .ok_or_else(|| ApiError(OpenCompanyError::CompanyNotFound(format!("workflow {wid}"))))?;
-    Ok(Json(WorkflowGraph::from(file)))
+    // Issue #259: the version token rides out with the graph, so the console
+    // gets it for free on the same read it renders from — there is no second
+    // round trip for a caller to skip and thereby lose the concurrency guard.
+    let editable = is_editable(source_dir, &overlays, &wid);
+    let version = editable
+        .then(|| overlay_toml(&overlays, &wid).map(workflow_version))
+        .flatten();
+    Ok(Json(WorkflowGraph::new(file, editable, version)))
 }
 
 /// The create-workflow body — the same camelCase graph shape the GET routes
@@ -470,7 +547,144 @@ async fn create_workflow(
     )
     .await
     .map_err(ApiError)?;
-    Ok(Json(WorkflowGraph::from(file)))
+    // A freshly created graph is always an overlay body and, since create
+    // refuses a seed-colliding id, never seed-shadowed — so it is editable, and
+    // its version token goes back on the create response. That lets the console
+    // hold a valid token from the moment it creates a workflow, without a
+    // follow-up GET.
+    Ok(Json(graph_with_version(&company, file).await?))
+}
+
+/// Re-reads the just-written overlay body to attach the current `editable` flag
+/// and version token to a write response.
+///
+/// The re-read is deliberate rather than derived from the value we just
+/// rendered: the token must be the hash of what is *stored*, so that echoing it
+/// back is guaranteed to match. Computing it from an in-memory copy would work
+/// right up until the persist path ever normalizes the TOML, and then fail as a
+/// mysterious permanent 409.
+async fn graph_with_version(
+    company: &ScopedCompany,
+    file: WorkflowFile,
+) -> Result<WorkflowGraph, ApiError> {
+    let source_dir = company.runtime.source_dir();
+    let overlays = overlay_workflows(company).await?;
+    let editable = is_editable(source_dir, &overlays, &file.id);
+    let version = editable
+        .then(|| overlay_toml(&overlays, &file.id).map(workflow_version))
+        .flatten();
+    Ok(WorkflowGraph::new(file, editable, version))
+}
+
+/// The `PUT …/workflows/{wid}` body: the same camelCase graph shape the read and
+/// create routes speak, plus the optional concurrency token.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateWorkflowBody {
+    #[serde(flatten)]
+    graph: CreateWorkflowBody,
+    /// The token from the `GET`/`PUT` this edit was based on. Omit for an
+    /// unconditional write (the `curl` path); the console always sends it.
+    #[serde(default)]
+    expected_version: Option<String>,
+}
+
+/// `PUT …/workflows/{wid}` — replaces a saved workflow graph wholesale (issue
+/// #259).
+///
+/// Before this, a workflow was write-once: a typo in a cron expression or a
+/// node pointed at the wrong teammate was permanent, and the only recovery was
+/// to author a second workflow and leave the broken one firing forever.
+///
+/// The body's `id` **must equal** `wid`. Renaming an id through `PUT` is
+/// deliberately rejected rather than quietly supported: the id keys the union
+/// read path, the scheduler's per-workflow fire bookkeeping, and every
+/// journalled run in the history — a rename would silently orphan all three. A
+/// rename is a create plus a delete, and the operator should say so.
+///
+/// Statuses: `400` (bad graph, or `id` ≠ `wid`), `404` (unknown id), `409`
+/// (source-defined, body-less, name taken, or a stale `expectedVersion`).
+async fn update_workflow(
+    company: ScopedCompany,
+    Path(WorkflowPath { wid }): Path<WorkflowPath>,
+    Json(body): Json<UpdateWorkflowBody>,
+) -> Result<Json<WorkflowGraph>, ApiError> {
+    if !safe_wid(&wid) {
+        return Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
+            "workflow {wid}"
+        ))));
+    }
+    if body.graph.id != wid {
+        return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
+            "this request would change the workflow's id from `{wid}` to `{}`. A workflow's id \
+             can't change — it keys the saved graph, its schedule and its run history. Create a \
+             new workflow under the new id and delete this one instead.",
+            body.graph.id
+        ))));
+    }
+
+    let expected = body.expected_version.clone();
+    let draft = RawWorkflow::try_from(body.graph)?;
+    let file = update_company_workflow(
+        company.id(),
+        company.runtime.source_dir(),
+        company.runtime.store(),
+        Some(company.runtime.events()),
+        draft,
+        expected.as_deref(),
+    )
+    .await
+    .map_err(ApiError)?;
+    // The response carries the NEW token, so a console can save twice in a row
+    // without a re-read in between.
+    Ok(Json(graph_with_version(&company, file).await?))
+}
+
+/// The optional `?expectedVersion=` query on `DELETE …/workflows/{wid}`.
+///
+/// A query param rather than a body because a `DELETE` with a body is poorly
+/// supported by intermediaries and by `fetch`; the token is 64 hex characters,
+/// so it is URL-safe without escaping.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DeleteWorkflowQuery {
+    #[serde(default)]
+    expected_version: Option<String>,
+}
+
+/// `DELETE …/workflows/{wid}` — removes a saved workflow (issue #259).
+///
+/// Drops the graph body **and** the id from `[workflows].enabled` in one save,
+/// so the workflow stops appearing in the picker and stops firing on its
+/// schedule, and stays gone across a restart.
+///
+/// **Past runs are deliberately kept.** They are journal entries recording what
+/// the workflow did, and that stays true after it is gone — `GET
+/// …/workflows/runs` keeps serving them. See the module doc.
+///
+/// `204` on success. `404` for an unknown id; `409` for a source-defined or
+/// body-less id, or a stale `expectedVersion`.
+async fn delete_workflow(
+    company: ScopedCompany,
+    Path(WorkflowPath { wid }): Path<WorkflowPath>,
+    Query(query): Query<DeleteWorkflowQuery>,
+) -> Result<StatusCode, ApiError> {
+    if !safe_wid(&wid) {
+        return Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
+            "workflow {wid}"
+        ))));
+    }
+    delete_company_workflow(
+        company.id(),
+        company.runtime.source_dir(),
+        company.runtime.store(),
+        Some(company.runtime.events()),
+        &wid,
+        query.expected_version.as_deref(),
+    )
+    .await
+    .map_err(ApiError)?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// Whether `wid` is a single safe on-disk filename stem — no path separators,
@@ -740,12 +954,45 @@ mod tests {
         dir
     }
 
+    /// **The `editable` predicate, including the case the route harness can't
+    /// reach** (its runtimes are hosted, so they have no source directory).
+    ///
+    /// A seed file wins the union read, so an overlay body sitting behind one is
+    /// not editable even though a body exists — persisting an edit there would
+    /// store a graph nothing serves. This is the same predicate the write core
+    /// enforces with a 409; if the two ever disagree the console offers a button
+    /// that cannot work.
+    #[test]
+    fn editable_is_overlay_backed_and_not_seed_shadowed() {
+        let dir = seed_demo(); // writes workflows/demo.toml
+        let source = Some(dir.path());
+        let overlay = |id: &str| OverlayWorkflow {
+            id: id.to_string(),
+            toml: DEMO.to_string(),
+        };
+
+        // Overlay body, no seed file → editable.
+        assert!(is_editable(source, &[overlay("mine")], "mine"));
+        // Overlay body shadowed by a seed file of the same id → NOT editable.
+        assert!(!is_editable(source, &[overlay("demo")], "demo"));
+        // Seed file only → not editable.
+        assert!(!is_editable(source, &[], "demo"));
+        // Nothing at all → not editable.
+        assert!(!is_editable(source, &[], "ghost"));
+        // No source tree (the hosted shape): an overlay body is editable, and a
+        // seed id that no longer has a tree behind it simply isn't there.
+        assert!(is_editable(None, &[overlay("mine")], "mine"));
+        assert!(!is_editable(None, &[], "demo"));
+    }
+
     #[test]
     fn list_returns_a_summary_per_saved_workflow() {
         let dir = seed_demo();
         let files = list_workflows_union(Some(dir.path()), &[]);
-        let summaries: Vec<WorkflowSummary> =
-            files.into_iter().map(WorkflowSummary::from).collect();
+        let summaries: Vec<WorkflowSummary> = files
+            .into_iter()
+            .map(|f| WorkflowSummary::new(f, false))
+            .collect();
         assert_eq!(summaries.len(), 1);
         assert_eq!(summaries[0].id, "demo");
         assert_eq!(summaries[0].name, "Demo flow");
@@ -761,7 +1008,7 @@ mod tests {
         let file = load_workflow_union(Some(dir.path()), &[], "demo")
             .expect("loads")
             .expect("one file");
-        let graph = WorkflowGraph::from(file);
+        let graph = WorkflowGraph::new(file, false, None);
 
         assert_eq!(graph.id, "demo");
         assert_eq!(graph.nodes.len(), 3);
@@ -798,7 +1045,7 @@ mod tests {
         let file = load_workflow_union(Some(dir.path()), &[], "demo")
             .unwrap()
             .unwrap();
-        let json = serde_json::to_value(WorkflowGraph::from(file)).unwrap();
+        let json = serde_json::to_value(WorkflowGraph::new(file, false, None)).unwrap();
         // A node with no summary/agent omits those keys entirely.
         let done = json["nodes"]
             .as_array()
@@ -838,7 +1085,7 @@ mod tests {
             }],
             edges: Vec::new(),
         };
-        let json = serde_json::to_value(WorkflowGraph::from(file)).unwrap();
+        let json = serde_json::to_value(WorkflowGraph::new(file, false, None)).unwrap();
         let node = &json["nodes"][0];
         assert_eq!(node["config"]["slug"], "csv_export");
         assert_eq!(node["onError"], "continue");
@@ -1039,7 +1286,7 @@ mod tests {
             ],
             edges: Vec::new(),
         };
-        let json = serde_json::to_value(WorkflowGraph::from(file)).unwrap();
+        let json = serde_json::to_value(WorkflowGraph::new(file, false, None)).unwrap();
         assert_eq!(json["nodes"][0]["schedule"], "0 * * * *");
         assert!(json["nodes"][1].get("schedule").is_none());
     }
@@ -1090,7 +1337,7 @@ mod tests {
         assert_eq!(dest.target.as_deref(), Some("ada@example.com"));
 
         // …and back out on the read shape, under the same key.
-        let json = serde_json::to_value(WorkflowGraph::from(file)).unwrap();
+        let json = serde_json::to_value(WorkflowGraph::new(file, false, None)).unwrap();
         let node = json["nodes"]
             .as_array()
             .unwrap()
@@ -1124,7 +1371,7 @@ mod tests {
             &crate::company::render_workflow(&raw).expect("renders"),
         )
         .expect("re-parses");
-        let json = serde_json::to_value(WorkflowGraph::from(file)).unwrap();
+        let json = serde_json::to_value(WorkflowGraph::new(file, false, None)).unwrap();
         let node = &json["nodes"][1];
         assert_eq!(node["destination"]["kind"], "owner");
         assert!(node["destination"].get("target").is_none());
@@ -1138,7 +1385,7 @@ mod tests {
         let file = load_workflow_union(Some(dir.path()), &[], "demo")
             .unwrap()
             .unwrap();
-        let json = serde_json::to_value(WorkflowGraph::from(file)).unwrap();
+        let json = serde_json::to_value(WorkflowGraph::new(file, false, None)).unwrap();
         for node in json["nodes"].as_array().unwrap() {
             assert!(node.get("destination").is_none(), "{node}");
         }
@@ -1835,6 +2082,463 @@ mod tests {
             assert_eq!(response.status(), StatusCode::OK);
             let body = json_body(response).await;
             assert_eq!(body[0]["workflowId"], "digest");
+        }
+
+        // ── Issue #259: edit + delete at the HTTP boundary ──────────────────
+
+        /// Creates `greeter` and returns its current version token.
+        async fn create_greeter(state: &AppState) -> String {
+            let response = router(state.clone())
+                .oneshot(request(
+                    "POST",
+                    "/api/v1/company/workflows",
+                    Some(create_body()),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let created = json_body(response).await;
+            // A freshly created overlay graph is editable and carries a token.
+            assert_eq!(created["editable"], true, "{created}");
+            created["version"]
+                .as_str()
+                .unwrap_or_else(|| panic!("create must return a version token: {created}"))
+                .to_string()
+        }
+
+        /// `create_body()` with a schedule on the trigger and a changed
+        /// description — the exact "I typo'd my cron" edit the issue is about.
+        fn edited_body(expected_version: Option<&str>) -> serde_json::Value {
+            let mut body = serde_json::json!({
+                "id": "greeter",
+                "name": "Greeter",
+                "description": "Say hi, every morning.",
+                "nodes": [
+                    { "id": "start", "kind": "trigger", "name": "Start", "schedule": "0 9 * * *" },
+                    { "id": "done", "kind": "output", "name": "Report" }
+                ],
+                "edges": [ { "from": "start", "to": "done", "label": "ok" } ]
+            });
+            if let Some(v) = expected_version {
+                body["expectedVersion"] = serde_json::json!(v);
+            }
+            body
+        }
+
+        /// **The issue, at the HTTP boundary.** A saved workflow's cron was
+        /// permanent; now it can be corrected and the correction reads back.
+        #[tokio::test]
+        async fn edit_replaces_the_graph_and_reads_back() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+            let version = create_greeter(&state).await;
+
+            let response = router(state.clone())
+                .oneshot(request(
+                    "PUT",
+                    "/api/v1/company/workflows/greeter",
+                    Some(edited_body(Some(&version))),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let updated = json_body(response).await;
+            assert_eq!(updated["nodes"][0]["schedule"], "0 9 * * *");
+            // The response carries the NEW token, so a second save needs no
+            // intervening read.
+            let next = updated["version"].as_str().expect("new token").to_string();
+            assert_ne!(next, version, "the token must move with the body");
+
+            // And a fresh read agrees — the edit is what the read path serves.
+            let response = router(state.clone())
+                .oneshot(request("GET", "/api/v1/company/workflows/greeter", None))
+                .await
+                .unwrap();
+            let graph = json_body(response).await;
+            assert_eq!(graph["nodes"][0]["schedule"], "0 9 * * *");
+            assert_eq!(graph["description"], "Say hi, every morning.");
+            assert_eq!(graph["version"], next.as_str());
+
+            // Still exactly one workflow — an edit replaces, never forks.
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows", None))
+                .await
+                .unwrap();
+            let items = json_body(response).await;
+            assert_eq!(items.as_array().unwrap().len(), 1, "{items}");
+        }
+
+        /// **The silent-overwrite guard.** Two consoles hold the same graph; one
+        /// saves, then the other saves its stale copy. The second must be
+        /// refused, not silently win.
+        #[tokio::test]
+        async fn a_stale_expected_version_is_a_conflict() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+            let stale = create_greeter(&state).await;
+
+            // Console A saves first.
+            let first = router(state.clone())
+                .oneshot(request(
+                    "PUT",
+                    "/api/v1/company/workflows/greeter",
+                    Some(edited_body(Some(&stale))),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(first.status(), StatusCode::OK);
+
+            // Console B saves with the token it loaded before A's write.
+            let second = router(state.clone())
+                .oneshot(request(
+                    "PUT",
+                    "/api/v1/company/workflows/greeter",
+                    Some(edited_body(Some(&stale))),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(second.status(), StatusCode::CONFLICT);
+            // The message must tell the operator what to do, not just say no.
+            let body = json_body(second).await;
+            let message = body["error"].as_str().unwrap_or_default().to_lowercase();
+            assert!(message.contains("reload"), "unhelpful 409: {body}");
+
+            // A's edit is intact — the refusal changed nothing.
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/greeter", None))
+                .await
+                .unwrap();
+            let graph = json_body(response).await;
+            assert_eq!(graph["description"], "Say hi, every morning.");
+        }
+
+        /// Omitting the token is an unconditional write — the `curl` contract.
+        #[tokio::test]
+        async fn an_edit_without_a_token_is_unconditional() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+            create_greeter(&state).await;
+
+            let response = router(state)
+                .oneshot(request(
+                    "PUT",
+                    "/api/v1/company/workflows/greeter",
+                    Some(edited_body(None)),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+
+        /// A `PUT` that would rename the id is a 400, not a silent create — the
+        /// id keys the saved graph, its schedule and its run history.
+        #[tokio::test]
+        async fn an_id_mismatch_is_a_bad_request() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+            create_greeter(&state).await;
+
+            let mut body = edited_body(None);
+            body["id"] = serde_json::json!("greeter-v2");
+            let response = router(state.clone())
+                .oneshot(request(
+                    "PUT",
+                    "/api/v1/company/workflows/greeter",
+                    Some(body),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+            // Nothing was created under the new id.
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows", None))
+                .await
+                .unwrap();
+            let items = json_body(response).await;
+            assert_eq!(items.as_array().unwrap().len(), 1, "{items}");
+            assert_eq!(items[0]["id"], "greeter");
+        }
+
+        #[tokio::test]
+        async fn editing_an_unknown_workflow_is_not_found() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+
+            let mut body = edited_body(None);
+            body["id"] = serde_json::json!("ghost");
+            let response = router(state)
+                .oneshot(request(
+                    "PUT",
+                    "/api/v1/company/workflows/ghost",
+                    Some(body),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        }
+
+        /// A bad edit is refused on the same terms as a bad create — the shared
+        /// validation, at the HTTP boundary.
+        #[tokio::test]
+        async fn a_structurally_invalid_edit_is_a_bad_request() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+            create_greeter(&state).await;
+
+            // No trigger node at all.
+            let body = serde_json::json!({
+                "id": "greeter",
+                "name": "Greeter",
+                "nodes": [ { "id": "done", "kind": "output", "name": "Report" } ],
+                "edges": []
+            });
+            let response = router(state)
+                .oneshot(request(
+                    "PUT",
+                    "/api/v1/company/workflows/greeter",
+                    Some(body),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+
+        /// **The delete, and its durability.** A removed workflow leaves the
+        /// picker AND stays gone across a full state rebuild — the property that
+        /// matters, because `merge_enabled_workflows` (#208) re-derives the
+        /// enabled list at boot and would resurrect a half-delete.
+        #[tokio::test]
+        async fn delete_removes_it_from_the_picker_and_survives_a_rebuild() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+            let version = create_greeter(&state).await;
+
+            let response = router(state.clone())
+                .oneshot(request(
+                    "DELETE",
+                    &format!("/api/v1/company/workflows/greeter?expectedVersion={version}"),
+                    None,
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+            // Gone from the picker…
+            let response = router(state.clone())
+                .oneshot(request("GET", "/api/v1/company/workflows", None))
+                .await
+                .unwrap();
+            let items = json_body(response).await;
+            assert_eq!(items.as_array().unwrap().len(), 0, "{items}");
+
+            // …and from the graph read.
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/greeter", None))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+            // Rebuild everything from the same durable store: still gone.
+            let rebuilt = state_over(&home, &id, false).await;
+            let response = router(rebuilt)
+                .oneshot(request("GET", "/api/v1/company/workflows", None))
+                .await
+                .unwrap();
+            let items = json_body(response).await;
+            assert_eq!(
+                items.as_array().unwrap().len(),
+                0,
+                "a deleted workflow must not come back on restart: {items}"
+            );
+        }
+
+        /// **Run history is orphaned, not reaped.** What a workflow did stays
+        /// true after the workflow is gone, and the journal is append-only.
+        #[tokio::test]
+        async fn deleting_a_workflow_keeps_its_run_history() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+            create_greeter(&state).await;
+            journal_run(
+                &state,
+                &id,
+                "greeter",
+                true,
+                vec![undelivered_row("done")],
+                None,
+            )
+            .await;
+
+            let response = router(state.clone())
+                .oneshot(request("DELETE", "/api/v1/company/workflows/greeter", None))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+            let response = router(state)
+                .oneshot(request(
+                    "GET",
+                    "/api/v1/company/workflows/runs?workflow=greeter",
+                    None,
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let rows = json_body(response).await;
+            assert_eq!(
+                rows.as_array().unwrap().len(),
+                1,
+                "past runs must outlive the workflow: {rows}"
+            );
+            assert_eq!(rows[0]["workflowId"], "greeter");
+        }
+
+        #[tokio::test]
+        async fn deleting_with_a_stale_version_is_a_conflict() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+            let stale = create_greeter(&state).await;
+
+            // Someone edits after the console loaded the graph.
+            let edited = router(state.clone())
+                .oneshot(request(
+                    "PUT",
+                    "/api/v1/company/workflows/greeter",
+                    Some(edited_body(None)),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(edited.status(), StatusCode::OK);
+
+            let response = router(state.clone())
+                .oneshot(request(
+                    "DELETE",
+                    &format!("/api/v1/company/workflows/greeter?expectedVersion={stale}"),
+                    None,
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::CONFLICT);
+
+            // Still there.
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/greeter", None))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn deleting_an_unknown_workflow_is_not_found() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+
+            let response = router(state)
+                .oneshot(request("DELETE", "/api/v1/company/workflows/ghost", None))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        }
+
+        /// The write verbs are reachable under the platform scope form too, not
+        /// just the prosumer alias.
+        #[tokio::test]
+        async fn edit_and_delete_serve_both_scope_forms() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+            create_greeter(&state).await;
+
+            let response = router(state.clone())
+                .oneshot(request(
+                    "PUT",
+                    "/api/v1/companies/acme/workflows/greeter",
+                    Some(edited_body(None)),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+
+            let response = router(state)
+                .oneshot(request(
+                    "DELETE",
+                    "/api/v1/companies/acme/workflows/greeter",
+                    None,
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        }
+
+        /// A manifest-`enabled` id with no saved graph is listed but NOT
+        /// editable — there is nothing to replace or remove, and the console
+        /// must not offer a button that can only 409.
+        #[tokio::test]
+        async fn a_bodiless_enabled_id_is_listed_but_not_editable() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let store = FsCompanyStore::new(home.clone());
+            let id = CompanyId::new("acme");
+            let mut manifest = empty_manifest();
+            manifest.workflows.enabled.push("legacy".to_string());
+            store
+                .save(&CompanyRecord {
+                    id: id.clone(),
+                    manifest: manifest.clone(),
+                    ledger: Vec::new(),
+                    lifecycle: "running".to_string(),
+                    overlay_agents: Vec::new(),
+                    overlay_desk_members: Vec::new(),
+                    overlay_desk_order: Vec::new(),
+                    overlay_desks: Vec::new(),
+                    overlay_workflows: Vec::new(),
+                    template_provenance: None,
+                })
+                .await
+                .unwrap();
+            // The runtime carries its own manifest — the enabled list the list
+            // route reads comes from there, not from the record we just saved.
+            let runtime = RuntimeBuilder::new(home.clone(), manifest)
+                .with_id(id.clone())
+                .build()
+                .await
+                .unwrap();
+            let state = AppState::new(AppConfig::default());
+            state
+                .registry()
+                .insert(id.clone(), std::sync::Arc::new(runtime));
+            crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+
+            let response = router(state.clone())
+                .oneshot(request("GET", "/api/v1/company/workflows", None))
+                .await
+                .unwrap();
+            let items = json_body(response).await;
+            let legacy = items
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|i| i["id"] == "legacy")
+                .expect("listed under its id");
+            assert_eq!(legacy["editable"], false, "{items}");
+
+            // And the host agrees when actually asked to delete it.
+            let response = router(state)
+                .oneshot(request("DELETE", "/api/v1/company/workflows/legacy", None))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::CONFLICT);
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #270. Advances #259 — a saved workflow could not be edited or deleted, so a mistyped cron fired forever and the only recovery was authoring a second workflow beside the broken one.

This lands the whole backend, the API client, and **Delete** in the console. **Edit's button is deliberately not in this PR** — it needs the create dialog's edit mode, which collides with #277 (`WorkflowCreateDialog.tsx`); a visibly broken Edit is worse than none. `PUT` is fully built and tested at the API level, and `editable` plus the conflict banner are live and exercised *through* Delete, so nothing here is dead code waiting on a follow-up. The dialog commit adds a button and one `updateWorkflow` call.

**Conflict detection, not last-write-wins.** `GET` returns a `version` — a hash of the stored graph — and `PUT`/`DELETE` accept it back. Mismatched means someone else changed the workflow since you loaded it, answered 409 with a reload-and-reapply message. The comparison happens inside the same write lock as the save, so it is race-free. Omitting the token writes unconditionally, which keeps curl usable; the console always sends it. This follows OpenHuman's `flows_update`, which takes an optional `expected_version` and enforces it in a guarded UPDATE — reading that is what overturned an earlier plan that had settled for last-write-wins on the grounds that versioning would ripple through three storage backends. A content hash needs no schema change at all.

**Only console-created workflows are editable.** Ones defined in a company's source tree answer 409 with an actionable message, and render disabled with a tooltip. The seed file wins the read union, so an edit would persist and never display; and the boot rebuild reconstructs `enabled` from seed ids, so a delete would resurrect on restart. Rejecting cleanly beats half-working.

**Deleting keeps run history.** The `EventLog` port has no delete across any of its three backends, and run outcomes are interleaved with chat and audit in one append-only journal. Filed as #275 rather than bodged.

**The scheduler needs no changes**, and that is now proven rather than assumed. OpenHuman needs `reconcile_schedule_triggers_on_boot` because a scheduled flow binds a row in a separate `cron.db` that can drift from `flows.db`. We persist no registration at all — the tick re-reads the record and re-derives the schedule set every minute, so the tick *is* the reconcile. Three tests pin it.

Follow-ups filed: #274 revision history and rollback · #275 journal retention · #276 enable/disable plus disarm-on-edit.

## API Or Behavior Changes

- **New** `PUT /workflows/{wid}` — full replace, same validation as create. Optional `expectedVersion` in the body. `body.id` must equal `{wid}`; rename via PUT is rejected 400, since the id keys the read union, the scheduler and run history. Unknown 404, seed-backed 409, stale token 409.
- **New** `DELETE /workflows/{wid}` — 204. Optional `?expectedVersion=`. Removes the overlay body and the id from `[workflows].enabled` in one save.
- `WorkflowSummary` and `WorkflowGraph` gain `editable: bool`; `WorkflowGraph` also gains `version: String` when overlay-backed. Both additive.
- **New events** `CompanyEvent::WorkflowUpdated` / `WorkflowDeleted`, carrying id and name only. A test asserts no graph body can reach the shared journal.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 1048 passed / 0 failed (+6)

Also `cargo check --all-features` and `cargo check --features openhuman,mcp,telegram` — the new event variants cross feature boundaries, and `--all-features` is what located all three gated match sites; the default combos surface none. Frontend: `npm ci && npm run typecheck && npm run build`.

Live curl over every path: PUT happy / stale-409 / id-mismatch-400, DELETE happy-204 / stale-409 / unknown-404, the token moving on each write, a real seed-backed workflow refusing both writes, and **restart survival** — a deleted workflow did not resurrect.

**4 new Playwright specs, 4/4**, including forcing a genuine conflict by editing out-of-band over HTTP while the console held a stale token. Not run by CI (no `webServer`).

**One gate not completed:** the full-suite regression baseline. Playwright's `global-setup` intermittently gets no `dev_code` while curl to the same host succeeds seconds later. The 60s resend throttle was the obvious suspect and was disproved — it still failed after 75s of quiet on a brand-new `--home`. Filed as #271 rather than papered over.

## Documentation

`docs/modules/` workflow page and the `src/server/ops/workflows.rs` module header cover the PUT/DELETE contract, the version token, the seed-vs-overlay rule, and that run history is orphaned rather than reaped.

**#270 is now fixed here too.** The Workflows picker rendered the raw id in its closed trigger while the popup showed the name — `<SelectItem value={w.id}>` with a bare `<SelectValue />`, which renders the value rather than the item's children. It is the same picker this PR's Delete affordance sits next to, and the delete specs had to key on the id to describe the console honestly; both now read the name.

One pre-existing bug found and filed, **not** fixed here: confirming an `AlertDialog` leaves the modal mounted (#268). This PR's own delete flow works around it by controlling `open`, but the cause is in the shared `AlertDialogAction` primitive and the same pattern is at three more sites on `main` — so it is fixed once at the primitive on its own branch. Whichever merges second, the local workaround here is belt-and-braces, not a conflict.

One gap worth naming: OpenHuman's `flows_update` enforces that an edit turning a manual trigger automatic forces `enabled = false`, so a schedule cannot go live unreviewed. **We have no lever for that** — our scheduler deliberately does not gate on `enabled`, so writing `false` would stop nothing. Not a regression, since create already behaves identically, but it is documented, pinned by a test, and folded into #276.
