### PR TITLE
feat(skills): add a call-debrief skill for post-call decisions and action items (#240)

### DIFF
--- a/frontend/src/lib/skills.ts
+++ b/frontend/src/lib/skills.ts
@@ -27,6 +27,6 @@ export const SKILL_REGISTRY: RegistrySkill[] = [
   { id: "weekly-report", name: "Weekly Report", description: "Compile the week's activity into a short report.", category: "Ops", publisher: "OpenCompany" },
   { id: "competitor-analysis", name: "Competitor Analysis", description: "Track rivals' launches, pricing, and positioning.", category: "Research", publisher: "OpenCompany" },
   { id: "social-scheduler", name: "Social Scheduler", description: "Plan and queue posts across social channels.", category: "Marketing", publisher: "OpenCompany" },
-  { id: "meeting-notes", name: "Meeting Notes", description: "Turn a transcript into decisions and action items.", category: "Content", publisher: "OpenCompany" },
+  { id: "call-debrief", name: "Call Debrief", description: "Distill a call transcript into decisions, action items with owners, and open questions so nothing agreed on the call is lost.", category: "Ops", publisher: "OpenCompany" },
   { id: "invoice-drafting", name: "Invoice Drafting", description: "Draft invoices from a scope and rate card.", category: "Finance", publisher: "OpenCompany" },
 ];

--- a/skills/README.md
+++ b/skills/README.md
@@ -20,6 +20,7 @@ Skills view against the `Marketing / Research / Ops / Content / Finance` set.
 | [competitor-scan](competitor-scan/SKILL.md) | Research | Profile competitors and surface where you can win. |
 | [deal-memo](deal-memo/SKILL.md) | Research | Turn diligence into a memo with a recommendation. |
 | [meeting-brief](meeting-brief/SKILL.md) | Ops | A one-page brief so the operator walks in ready. |
+| [call-debrief](call-debrief/SKILL.md) | Ops | Turn a call transcript into decisions and owned action items. |
 | [customer-followup](customer-followup/SKILL.md) | Ops | A timely, personal follow-up that moves a thread forward. |
 | [hiring-screen](hiring-screen/SKILL.md) | Ops | Screen a candidate against a role into a recommendation. |
 | [changelog-writer](changelog-writer/SKILL.md) | Content | Turn merged changes into a user-facing changelog. |

--- a/skills/call-debrief/SKILL.md
+++ b/skills/call-debrief/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: Call Debrief
+description: Distill a call transcript into decisions, action items with owners, and open questions so nothing agreed on the call is lost.
+category: Ops
+---
+
+# Call Debrief
+
+Turn a finished call into a record the work can run from — what was decided, who
+owes what by when, and what is still open.
+
+## When to use
+
+- Right after a client, partner, or candidate call, while it is still fresh.
+- Whenever a conversation produced commitments that need to outlive it.
+
+## Steps
+
+1. **Read** the transcript from the conversation — it has to be pasted in;
+   nothing fetches a recording or file for you.
+2. **Extract** every decision actually made, keeping decided separate from
+   merely discussed.
+3. **List** each action item with its owner, due date, and deliverable —
+   flagging whatever the call left unnamed.
+4. **Capture** the open questions and what each one blocks.
+5. **Draft** the follow-ups, and name any billable outcome so it can be invoiced.
+
+## Output
+
+A debrief in four parts: decisions; action items, each carrying an owner, a due
+date, and the deliverable; open questions; and drafted follow-ups. Anything the
+call left unowned or undated is flagged, never invented. Write each action item
+so it can be lifted straight into a task, and each billable outcome so an
+invoice can be drafted from it. Park the sends for the operator's approval.

--- a/skills/call-debrief/SKILL.md
+++ b/skills/call-debrief/SKILL.md
@@ -2,6 +2,7 @@
 name: Call Debrief
 description: Distill a call transcript into decisions, action items with owners, and open questions so nothing agreed on the call is lost.
 category: Ops
+version: 1.0.0
 ---
 
 # Call Debrief

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -935,6 +935,16 @@ mod tests {
         let first = state.skill_registry(&dir).expect("registry loads");
         assert!(first.iter().any(|skill| skill.slug == "web-research"));
         assert!(first.iter().any(|skill| skill.slug == "weekly-report"));
+        // The post-call half of the meeting pair (#240): its body must carry the
+        // full contract, not just the frontmatter description.
+        let debrief = first
+            .iter()
+            .find(|skill| skill.slug == "call-debrief")
+            .expect("call-debrief is in the shared library");
+        assert_eq!(debrief.name, "Call Debrief");
+        assert_eq!(debrief.category.as_deref(), Some("Ops"));
+        assert!(debrief.body.contains("## Steps"), "{}", debrief.body);
+        assert!(debrief.body.contains("## Output"), "{}", debrief.body);
 
         // A second call returns the same cached allocation, ignoring the path.
         let second = state


### PR DESCRIPTION
## Summary

Adds `skills/call-debrief/SKILL.md`, the missing post-call half of the meeting
pair. The shared library covered the run-up to a client call (`meeting-brief`)
and the invoice afterwards (`invoice-drafting`) with nothing in between, so the
decisions and commitments a call produces had no skill to land in.

The skill follows the house shape exactly — H1, framing line, `## When to use`,
five numbered bold-verb `## Steps`, `## Output` — and turns a transcript into
decisions, action items with owners, open questions, and drafted follow-ups.

Two things are deliberate:

- **Owners and dates are flagged, never invented.** Hallucinating an owner is
  the failure this skill exists to prevent, and instruction is the only lever a
  prose skill has, so "flag, never invent" is written into both the step and the
  output contract.
- **The handoffs are shaped for what comes next.** Each action item is written
  so it can be lifted straight into a task, and each billable outcome so
  `invoice-drafting` can pick it up.

Step 1 states the input assumption honestly: the transcript has to be pasted
into the conversation. Nothing fetches a recording or a file today.

Named `call-debrief`, not `meeting-notes`. Skill selection is model-chosen from
a flat one-line catalogue appended to the persona prompt — there is no
role→skill router — so the description is the only disambiguation lever, and
brief/debrief reads as a self-explanatory contrast beside `meeting-brief`.

**Known blocker — #239 guts this skill's body on install.** Verified live
against a running host below: the registry install path persists the skill's
*description* as its body, so `## Steps` and `## Output` never reach the agent.
The catalogue line is correct and the skill is selectable, but the procedure an
agent reads back is one repeated sentence. This PR is correct on disk and the
skill is only actually useful once #239 lands.

## API Or Behavior Changes

- New shared-library skill `call-debrief` (`Ops`). The `skillRegistry` query and
  the console Registry tab now list 15 skills instead of 14.
- Console registry (`frontend/src/lib/skills.ts`): the `meeting-notes` entry is
  **replaced** by `call-debrief`. `meeting-notes` was a phantom — it had no
  `SKILL.md` anywhere in the repo, so installing it produced a content-less
  skill, and its description ("Turn a transcript into decisions and action
  items") was this skill under a name the issue explicitly rejected. Leaving
  both would have put two near-identical entries side by side with the broken
  one first.
- No Rust behavior changes; the only Rust edit is a test assertion.

Note for reviewers: this console list is static and drifts from the on-disk
library in three more places (`competitor-analysis`, `social-scheduler` do not
exist — the real slugs are `competitor-scan`, `social-calendar` — and eight real
skills are missing from it). Out of scope here; worth its own issue.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 1009 passed, 0 failed
- [x] `npm run typecheck` and `npm run build` in `frontend/`

Added to `skill_registry_loads_the_repo_library_and_caches`: `call-debrief`
resolves out of the shared library with `name: Call Debrief`, `category: Ops`,
and a body carrying both `## Steps` and `## Output`. `load_dir_skills` hard-errors
on a malformed `SKILL.md`, so this also pins that the file parses via
`parse_skill_md`.

Verified against a running host (`serve --company companies/e2e_harness` on an
isolated `--home`), authenticated through the real magic-link flow:

- `skillRegistry` returns 15 skills, including `call-debrief` with its full
  name, description and category — discovery works end to end.
- Installing it through the console path returns the right metadata, but the
  persisted `customDoc` body is the description repeated, with no `## Steps` and
  no `## Output`. That is #239 reproduced on this skill.

## Documentation

`skills/README.md` gains a `call-debrief` row in the Ops group, directly under
`meeting-brief` so the before/after pair reads together.

`docs/plans/08-company-content.md` names the original ~12-skill target. Left
untouched — it is a record of what was planned, not a live catalog.

Closes #240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the **Call Debrief** skill to help extract decisions, owned and dated action items, open questions, follow-ups, and billable outcomes from call transcripts.
  * Highlights missing owners or dates without inventing details.
  * Keeps follow-up messages pending operator approval before sending.
  * Replaced the previous meeting-notes skill and categorized the new skill under **Ops**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->