### PR TITLE
fix(console): refuse an inference save that would discard a typed key (#265)

### DIFF
--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -119,6 +119,9 @@ prompt = "Weekly review and operator digest"
   neither. The status route reports that state as `restartRequired` — a resolved
   config next to a non-harness `cognition` — and the console says "restart"
   instead of "next turn" for it (issue #266).
+  Saving `managed` from the console is a *revert* (`DELETE …/inference`) and
+  carries no credential, so the console refuses that save while a key is still
+  typed in the form rather than dropping it and reporting success (issue #265).
 - **`[channels.*]`** enables `ChannelAdapter`s. Unknown channels are a
   validation error; disabled OpenHuman means non-operator channels degrade
   with a boot warning, never a failure.

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { BrainCircuit, Check, Loader2, RotateCcw, Save, Zap } from "lucide-react";
+import { AlertTriangle, BrainCircuit, Check, Loader2, RotateCcw, Save, Zap } from "lucide-react";
 import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
@@ -136,6 +136,18 @@ export function InferenceSection({
 
   async function save() {
     if (busy) return;
+    // Managed is a revert, and a revert cannot carry a credential — so a key
+    // typed under a different provider and left behind by a switch would be
+    // dropped by the save below while the toast claimed success (issue #265).
+    // Refuse instead: a save that reports success must never have discarded
+    // what the operator typed. The Save button is disabled in this state; this
+    // is the guard that makes the invariant hold regardless of the button.
+    if (provider === "managed" && key.trim()) {
+      toast.error(
+        "Managed uses the platform credential and can't store a key. Choose OpenRouter or Custom (OpenAI-compatible) to save it, or discard it first.",
+      );
+      return;
+    }
     setBusy("save");
     try {
       // "Managed" means "use the platform default" — that's a revert, not a
@@ -219,6 +231,10 @@ export function InferenceSection({
   if (load === "unavailable") return null;
 
   const modelRows = status ? Object.entries(status.models) : [];
+  // A credential typed under a BYOK provider survives a switch to managed (the
+  // input is hidden, the state is not). Managed has nowhere to put it, so this
+  // is the one combination that would silently lose operator input on save.
+  const managedWouldDiscardKey = provider === "managed" && key.trim().length > 0;
 
   return (
     <section className="space-y-3">
@@ -357,7 +373,37 @@ export function InferenceSection({
                 )}
               </div>
 
-              {provider !== "managed" && (
+              {provider === "managed" ? (
+                <div className="space-y-2">
+                  <p className="text-xs text-muted-foreground" data-testid="inference-managed-note">
+                    Managed runs on the platform credential, so there is no key to paste here. To
+                    bring your own key, choose OpenRouter or Custom (OpenAI-compatible).
+                  </p>
+                  {managedWouldDiscardKey && (
+                    <div
+                      className="space-y-2 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+                      data-testid="inference-key-conflict"
+                    >
+                      <p className="flex items-start gap-1.5">
+                        <AlertTriangle className="mt-px size-3.5 shrink-0" />
+                        <span>
+                          You typed a key, and managed can&apos;t store one — saving now would throw
+                          it away. Choose OpenRouter or Custom (OpenAI-compatible) to save it, or
+                          discard it to stay on managed.
+                        </span>
+                      </p>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        data-testid="inference-discard-key"
+                        onClick={() => setKey("")}
+                      >
+                        Discard key
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              ) : (
                 <>
                   <div className="grid gap-2 sm:grid-cols-2">
                     {TIERS.map((tier) => (
@@ -393,7 +439,11 @@ export function InferenceSection({
               )}
 
               <div className="flex items-center gap-2">
-                <Button disabled={busy !== null} onClick={() => void save()}>
+                <Button
+                  data-testid="inference-save"
+                  disabled={busy !== null || managedWouldDiscardKey}
+                  onClick={() => void save()}
+                >
                   {busy === "save" ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
                   Save
                 </Button>

--- a/frontend/test/e2e/inference.spec.ts
+++ b/frontend/test/e2e/inference.spec.ts
@@ -97,7 +97,15 @@ test("a key typed for a BYOK provider does reach the host on save", async ({ pag
   await page.locator("#inference-key").fill(`pw-e2e-${Date.now()}`);
   await page.getByTestId("inference-save").click();
 
-  await expect(page.getByText("Inference updated.")).toBeVisible({ timeout: 30_000 });
+  // Either success wording is correct here, and which one shows is not this
+  // spec's business: a company that booted with no inference source is on the
+  // echo brain, so issue #266 makes the host report `restartRequired` for
+  // exactly this not-configured → configured save and the toast says "restart"
+  // instead of "next turn". What #265 asserts is that the save was *accepted*
+  // rather than refused — the stored-credential check below is the real proof.
+  await expect(
+    page.getByText(/Inference updated\.|Inference saved — restart the company/),
+  ).toBeVisible({ timeout: 30_000 });
   const status = await page.request.get("/api/v1/company/inference");
   expect(status.ok()).toBeTruthy();
   const body = await status.json();

--- a/frontend/test/e2e/inference.spec.ts
+++ b/frontend/test/e2e/inference.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Issue #265 — Connections → Inference must never report a successful save for
+ * a save that threw the operator's key away.
+ *
+ * The key input is rendered only for the bring-your-own-key providers, but the
+ * typed value lives in form state that survives a switch back to **managed**.
+ * Managed is a revert (`DELETE …/inference`) and carries no credential, so the
+ * old code dropped that pending key and still toasted "Inference updated".
+ *
+ * This spec drives the real browser against a live host. It is not part of CI
+ * (the Playwright config declares no `webServer`), so treat it as an executable
+ * reproduction plus documentation of the invariant, not a merge gate.
+ */
+
+const CONFLICT = "inference-key-conflict";
+
+type Page = import("@playwright/test").Page;
+
+/** Pick a provider from the base-ui select. */
+async function pickProvider(page: Page, label: string) {
+  await page.locator("#inference-provider").click();
+  await page.getByRole("option", { name: label, exact: true }).click();
+}
+
+/**
+ * A fresh browser context has no tour state, so the first-run welcome dialog
+ * opens over the console and swallows clicks. Skip it when it shows up.
+ */
+async function openConnections(page: Page) {
+  await page.goto("/#/connections");
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  await skip
+    .waitFor({ state: "visible", timeout: 10_000 })
+    .then(() => skip.click())
+    .catch(() => {
+      /* already seen in this context — nothing to dismiss */
+    });
+}
+
+test("a key typed for a BYOK provider is not discarded by switching to managed", async ({
+  page,
+}) => {
+  await openConnections(page);
+
+  // Managed is the default selection: no key input, and a line that says why.
+  await expect(page.getByTestId("inference-managed-note")).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator("#inference-key")).toHaveCount(0);
+  await expect(page.getByTestId(CONFLICT)).toHaveCount(0);
+
+  const before = await page.request.get("/api/v1/company/inference");
+  expect(before.ok()).toBeTruthy();
+  const keyConfiguredBefore = (await before.json()).keyConfigured;
+
+  // Type a key under a provider that can actually hold one.
+  await pickProvider(page, "OpenRouter");
+  const typed = `pw-e2e-${Date.now()}`;
+  await page.locator("#inference-key").fill(typed);
+
+  // Then switch back to managed — the input goes away but the value does not.
+  await pickProvider(page, "Managed (TinyHumans)");
+  await expect(page.locator("#inference-key")).toHaveCount(0);
+
+  // The regression: Save must be refused, loudly, instead of reverting and
+  // reporting success while the credential is dropped on the floor.
+  await expect(page.getByTestId(CONFLICT)).toBeVisible();
+  await expect(page.getByTestId("inference-save")).toBeDisabled();
+  await expect(page.getByText("Inference updated.")).toHaveCount(0);
+
+  // Nothing reached the host: the stored-credential flag is exactly as it was.
+  const after = await page.request.get("/api/v1/company/inference");
+  expect(after.ok()).toBeTruthy();
+  expect((await after.json()).keyConfigured).toBe(keyConfiguredBefore);
+
+  // Discarding is an explicit act, and it unblocks the managed save.
+  await page.getByTestId("inference-discard-key").click();
+  await expect(page.getByTestId(CONFLICT)).toHaveCount(0);
+  await expect(page.getByTestId("inference-save")).toBeEnabled();
+
+  // Going back to a BYOK provider offers an empty field, not the ghost value.
+  await pickProvider(page, "OpenRouter");
+  await expect(page.locator("#inference-key")).toHaveValue("");
+});
+
+test("a key typed for a BYOK provider does reach the host on save", async ({ page }) => {
+  // The guard above must not be a blanket block: the same input, saved under a
+  // provider that can store it, has to land server-side. The credential is
+  // write-only, so `keyConfigured` is the only observable — run this against a
+  // fresh `--home` for it to mean "this save stored it".
+  await openConnections(page);
+  await expect(page.getByTestId("inference-managed-note")).toBeVisible({ timeout: 30_000 });
+
+  await pickProvider(page, "Custom (OpenAI-compatible)");
+  await page.locator("#inference-base-url").fill("http://127.0.0.1:9/v1");
+  await page.locator("#inference-model-chat-v1").fill("pw-e2e-model");
+  await page.locator("#inference-key").fill(`pw-e2e-${Date.now()}`);
+  await page.getByTestId("inference-save").click();
+
+  await expect(page.getByText("Inference updated.")).toBeVisible({ timeout: 30_000 });
+  const status = await page.request.get("/api/v1/company/inference");
+  expect(status.ok()).toBeTruthy();
+  const body = await status.json();
+  expect(body.keyConfigured).toBe(true);
+  expect(body.provider).toBe("openai_compatible");
+
+  // Put the company back on the managed default for whatever runs next.
+  await page.getByRole("button", { name: "Reset to managed" }).click();
+  await expect(page.getByText("Reverted to the managed configuration.")).toBeVisible({
+    timeout: 30_000,
+  });
+});


### PR DESCRIPTION
## Summary

Connections → Inference could report a successful save that had thrown the operator's API key away.

The key input is rendered only for the bring-your-own-key providers, but the value the operator typed lives in form state that survives a switch back to **managed**. Managed means "use the platform default", so the save path takes the revert branch (`DELETE …/inference`), which carries no credential — the pending key was dropped and the toast still said `Inference updated. Agents use it on their next turn.` The operator walks away believing a credential is configured; `GET …/inference` still reports `keyConfigured: false`.

Of the three fixes the issue lists, this PR takes **"block the save with a validation message"**, and completes the "explain it in the form" half that was already partly there:

- The key input was **already** hidden for managed on `main`, so the issue's literal repro (typing into the field with managed selected) is not reachable — but hiding alone does not close the hole, because the state behind the hidden field is what gets discarded. The reachable path is: pick OpenRouter → type the key → switch back to managed → Save.
- Auto-switching the provider when a key is typed was rejected: it silently overrides an explicit dropdown choice, and this console never moves a control the operator set.
- Clearing the key on every provider switch was rejected too: it is the same silent discard, just moved earlier and hidden behind a field that disappears.

The invariant pinned here is that **a save which reports success must never have discarded operator input**. Managed now (a) says it runs on the platform credential and that a key needs a different provider, (b) flags a pending key with an explicit `Discard key` action, and (c) disables Save until the operator resolves it either way. `save()` carries the same guard, so the invariant holds even if the button state is bypassed.

Frontend-only — zero Rust diff.

## API Or Behavior Changes

No API change. The `…/inference` routes, request shapes, and the write-only key contract are untouched.

Console behavior, Connections → Inference:

- Selecting **managed** now shows a line explaining that it runs on the platform credential and that a key requires OpenRouter or Custom (OpenAI-compatible).
- With a key still pending from a previous provider selection, managed shows a warning with a `Discard key` button and **Save is disabled**. Clicking Save in that state (or reaching `save()` any other way) produces an error message, never a revert and never a success toast.
- Every other path is unchanged: managed with no pending key still saves as a revert, and BYOK saves still send the key exactly as before.
- Known and deliberately left alone: `Reset to managed` also clears a pending key while reporting success. Its label announces that it throws the in-progress configuration away, so it is an explicit act rather than a silent one — but it is the nearest sibling of this bug and worth a look if the maintainers disagree. Separately, a key typed under OpenRouter and then saved under **Ollama** (whose key field is also hidden) is *stored* rather than discarded — surprising, but no input is lost, so it is out of scope here.

## Tests

Frontend gates (`frontend/`):

- `npm ci && npm run typecheck` — clean.
- `npm run build` — clean (pre-existing chunk-size warning only).
- Note: the console has no lint or unit-test script; `typecheck` + `build` are the whole gate. The e2e specs are outside `tsconfig.app.json`'s `include`, so they are exercised by running them, not by `typecheck`.

Browser proof (`frontend/test/e2e/inference.spec.ts`, new). Playwright drives a real Chromium against a live host serving the built bundle, on an isolated `--home`. **This spec is not part of CI** — `playwright.config.ts` declares no `webServer`, so it is an executable reproduction plus documentation of the invariant, not a merge gate.

- Against the **unpatched** bundle, a scratch version of this flow reproduced the bug: the success toast appeared and `keyConfigured` stayed `false`.
- Against the patched bundle, both specs pass (`2 passed`): the blocked-save case (warning shown, Save disabled, stored-credential flag unchanged, `Discard key` unblocks it, and returning to a BYOK provider offers an empty field) and the positive case (the same key, saved under `openai_compatible`, does reach the host).

Rust gates — run despite the empty Rust diff:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — `1009 passed; 0 failed; 1 ignored`, plus the binary's `6 passed`

## Documentation

`docs/spec/runtime/manifest.md` — the `[inference]` bullet already described console-vs-manifest precedence; it now also records that saving `managed` from the console is a revert that carries no credential, and that the console refuses such a save while a key is typed rather than dropping it.

Closes #265
