### PR TITLE
fix(auth): stop the resend throttle blocking the echoed dev login code (#271)

### DIFF
--- a/docs/spec/runtime/users.md
+++ b/docs/spec/runtime/users.md
@@ -194,10 +194,14 @@ can send mail never echoes it.
 
 ## Abuse and exposure
 
-- **Resend throttle**: one link per address per minute. A throttled request
-  returns the same `202` as a sent one (or the throttle is itself a membership
-  oracle) and leaves the live code alone (or anyone could invalidate a victim's
-  link on demand).
+- **Resend throttle**: one *mailed* link per address per minute. A throttled
+  request returns the same `202` as a sent one (or the throttle is itself a
+  membership oracle) and leaves the live code alone (or anyone could invalidate
+  a victim's link on demand). It does not apply where the code is echoed rather
+  than mailed — a loopback-only bind with no transport wired. There is no
+  mailbox to spare there, only the plaintext's hash is stored (so a throttled
+  answer cannot re-echo the live code), and throttling would lock the sole local
+  sign-in path for a minute after every use.
 - **Login codes are never echoed** from a host that is reachable from anywhere
   else. `dev_code` appears only on a loopback-only bind with no mail
   transport. A routable host with broken mail lets nobody in rather than

--- a/frontend/test/e2e/global-setup.ts
+++ b/frontend/test/e2e/global-setup.ts
@@ -1,34 +1,129 @@
-import { expect, request, type FullConfig } from "@playwright/test";
+import {
+  request,
+  type APIRequestContext,
+  type APIResponse,
+  type FullConfig,
+} from "@playwright/test";
 
 const ADMIN_EMAIL = "harness-e2e@tinyhumans.ai";
+const REQUEST_PATH = "/api/v1/company/auth/request";
+const VERIFY_PATH = "/api/v1/company/auth/verify";
 
+/**
+ * Authenticates once and shares the session with every spec through Playwright
+ * storage state, so the suite signs in a single time.
+ *
+ * Every failure here aborts the whole run before a single spec executes, so the
+ * message has to carry enough to diagnose it without a second run: the endpoint,
+ * the status, and the body the host actually returned. `auth/request` answers
+ * `202 {"sent": true}` for *every* outcome by design — it refuses to say whether
+ * an address is a member — so a missing `dev_code` is otherwise indistinguishable
+ * from a broken host, which is exactly what issue #271 sent people chasing.
+ */
 export default async function globalSetup(config: FullConfig) {
   const storageState = process.env.PW_STORAGE_STATE;
   if (!storageState) return;
 
   const baseURL = config.projects[0]?.use.baseURL as string | undefined;
+  if (!baseURL) {
+    throw new Error(
+      "[e2e global-setup] no baseURL is configured. Set PW_BASE_URL to the " +
+        "running OpenCompany host, e.g. PW_BASE_URL=http://127.0.0.1:8080.",
+    );
+  }
+
   const context = await request.newContext({ baseURL });
   try {
-    const requested = await context.post("/api/v1/company/auth/request", {
-      data: { email: ADMIN_EMAIL },
+    const requested = await post(context, baseURL, REQUEST_PATH, {
+      email: ADMIN_EMAIL,
     });
-    expect(requested.ok()).toBeTruthy();
-    const requestedBody = await requested.json();
-    const devCode = requestedBody.dev_code as string | undefined;
-    expect(
-      devCode,
-      "auth/request must echo dev_code on a loopback bind",
-    ).toBeTruthy();
+    if (!requested.response.ok()) {
+      throw new Error(
+        `[e2e global-setup] ${describe(requested)}\n` +
+          "The host is reachable but rejected the sign-in request.",
+      );
+    }
 
-    const verified = await context.post("/api/v1/company/auth/verify", {
-      data: { code: devCode },
+    const devCode = readDevCode(requested);
+    if (!devCode) {
+      throw new Error(
+        `[e2e global-setup] ${describe(requested)}\n` +
+          `No dev_code came back, so the suite cannot sign in as ${ADMIN_EMAIL}.\n` +
+          "The host answers this route identically whatever happened, so check, " +
+          "in order:\n" +
+          `  1. The host serves a company whose [users] admins lists ${ADMIN_EMAIL} ` +
+          "(companies/e2e_harness). An address the host does not recognise gets " +
+          'this exact {"sent": true} answer.\n' +
+          `  2. The host binds loopback (127.0.0.1 / localhost) and has no ` +
+          "OPENCOMPANY_PUBLIC_URL set. A host that looks routable never echoes a " +
+          "login code, even with no mail configured.\n" +
+          "  3. No OPENCOMPANY_MAIL_* transport is configured. With one wired the " +
+          "code is mailed instead of echoed, and this bootstrap cannot read it " +
+          "at all — a throttled resend is not the difference, the mailing is.\n" +
+          "Re-running the suite inside 60s is NOT a cause: the resend throttle no " +
+          "longer applies where the code is echoed rather than mailed (issue #271, " +
+          "see RESEND_INTERVAL_MILLIS in src/server/users/routes.rs). If the host " +
+          "predates that fix, a second run within the minute does fail here.",
+      );
+    }
+
+    const verified = await post(context, baseURL, VERIFY_PATH, {
+      code: devCode,
     });
-    expect(
-      verified.ok(),
-      "auth/verify must accept the dev_code and set a session",
-    ).toBeTruthy();
+    if (!verified.response.ok()) {
+      throw new Error(
+        `[e2e global-setup] ${describe(verified)}\n` +
+          "The dev_code from auth/request was refused, so no session was minted. " +
+          "A login code is single-use and expires 15 minutes after it is minted; " +
+          "a 401 here means it was already spent or is stale.",
+      );
+    }
     await context.storageState({ path: storageState });
   } finally {
     await context.dispose();
+  }
+}
+
+/** A response paired with the request that produced it, for reporting. */
+type Attempt = {
+  method: string;
+  url: string;
+  response: APIResponse;
+  body: string;
+};
+
+async function post(
+  context: APIRequestContext,
+  baseURL: string,
+  path: string,
+  data: Record<string, unknown>,
+): Promise<Attempt> {
+  const response = await context.post(path, { data });
+  return {
+    method: "POST",
+    url: `${baseURL.replace(/\/$/, "")}${path}`,
+    response,
+    // Read as text, not JSON: an HTML error page or an empty body is exactly
+    // the case worth reporting verbatim, and `.json()` would throw over it.
+    body: await response.text().catch(() => "<body could not be read>"),
+  };
+}
+
+/** One line naming the request, its status, and what came back. */
+function describe(attempt: Attempt): string {
+  const { method, url, response, body } = attempt;
+  const shown = body.length > 500 ? `${body.slice(0, 500)}…` : body;
+  return `${method} ${url} → ${response.status()} ${response.statusText()}; body: ${shown || "<empty>"}`;
+}
+
+/** The echoed login code, if the body is JSON and carries one. */
+function readDevCode(attempt: Attempt): string | undefined {
+  try {
+    const parsed = JSON.parse(attempt.body) as { dev_code?: unknown };
+    return typeof parsed.dev_code === "string" && parsed.dev_code
+      ? parsed.dev_code
+      : undefined;
+  } catch {
+    return undefined;
   }
 }

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -54,6 +54,9 @@ const MANIFEST_INVITE_TTL_MILLIS: u64 = 30 * 24 * 60 * 60 * 1000;
 /// disturb the live code — otherwise the throttle would itself be the
 /// membership oracle the rest of this module refuses to be, and an attacker
 /// could invalidate a victim's link on demand.
+///
+/// It applies only where a mail can actually go out; see
+/// [`echoes_code_in_response`].
 const RESEND_INTERVAL_MILLIS: u64 = 60 * 1000;
 
 /// Builds the user-auth route fragment.
@@ -350,11 +353,19 @@ async fn request_code(
     // reaches a store read that an eligible one does — and answered with the
     // same 202, so the throttle is not itself an oracle. The live code is left
     // alone: replacing it here would let anyone kill a victim's link at will.
-    if let Some(previous) = runtime
-        .login_codes()
-        .latest_for_email(runtime.id(), &email)
-        .await
-        .map_err(|e| ApiError(e).into_response())?
+    //
+    // Skipped entirely where nothing is mailed and the code comes back in the
+    // response instead (issue #271). Only the plaintext's *hash* is stored, so
+    // a throttled response cannot re-echo the live code — it hands the caller
+    // an acknowledgement and no way in, for a minute after every single sign-in.
+    // On a loopback host with no transport that is not rate-limiting a mail
+    // cannon, it is the only sign-in path locking itself.
+    if !echoes_code_in_response(&state)
+        && let Some(previous) = runtime
+            .login_codes()
+            .latest_for_email(runtime.id(), &email)
+            .await
+            .map_err(|e| ApiError(e).into_response())?
         && now.saturating_sub(previous.created_at_millis) < RESEND_INTERVAL_MILLIS
     {
         tracing::debug!(company = %runtime.id(), "login link throttled");
@@ -420,8 +431,35 @@ async fn request_code(
     }))
 }
 
+/// Whether this host has a mail transport at all.
+///
+/// Not "will this send succeed" — a wired transport that errors still counts,
+/// because the attempt is what the resend throttle rate-limits.
+fn mail_transport_wired(state: &AppState) -> bool {
+    let connections = state.connections();
+    connections.mail.is_some() && connections.mail_credentials.is_some()
+}
+
+/// Whether a minted code comes back in the response instead of going to a
+/// mailbox.
+///
+/// Exactly the shape the dev echo is already gated on: a loopback bind, no
+/// `public_url`, and no mail transport wired. Nothing leaves the machine in
+/// that shape — there is no mailbox to flood and no remote caller to leak to —
+/// which is what makes skipping the resend throttle there safe. Any other host
+/// keeps the throttle.
+fn echoes_code_in_response(state: &AppState) -> bool {
+    state.config().is_local_only() && !mail_transport_wired(state)
+}
+
 /// Mails the magic link. Returns whether it was actually sent.
 async fn deliver_code(state: &AppState, runtime: &CompanyRuntime, email: &str, code: &str) -> bool {
+    // Asked through the shared predicate so "can this host mail at all" has one
+    // answer: the throttle and the dev echo both branch on it, and a second
+    // spelling here is how those three drift apart.
+    if !mail_transport_wired(state) {
+        return false;
+    }
     let connections = state.connections();
     let (Some(sender), Some(creds)) = (&connections.mail, &connections.mail_credentials) else {
         return false;

--- a/src/server/users/routes_test.rs
+++ b/src/server/users/routes_test.rs
@@ -34,6 +34,16 @@ fn manifest() -> CompanyManifest {
 }
 
 async fn state_with(home: &std::path::Path, connections: ConnectionsRuntime) -> AppState {
+    state_bound_to(home, &AppConfig::default().bind, connections).await
+}
+
+/// State on an explicit bind, for the tests that turn on whether the host looks
+/// reachable from anywhere but this machine.
+async fn state_bound_to(
+    home: &std::path::Path,
+    bind: &str,
+    connections: ConnectionsRuntime,
+) -> AppState {
     let store = crate::store::FsCompanyStore::new(home.to_path_buf());
     let id = CompanyId::new("acme");
     store
@@ -56,9 +66,12 @@ async fn state_with(home: &std::path::Path, connections: ConnectionsRuntime) -> 
         .build()
         .await
         .unwrap();
-    let state = AppState::new(AppConfig::default())
-        .with_home(home.to_path_buf())
-        .with_connections(connections);
+    let state = AppState::new(AppConfig {
+        bind: bind.to_string(),
+        ..AppConfig::default()
+    })
+    .with_home(home.to_path_buf())
+    .with_connections(connections);
     state.registry().insert(id, Arc::new(runtime));
     state
 }
@@ -1049,43 +1062,94 @@ async fn no_mail_transport_still_returns_202_and_echoes_for_dev() {
 async fn a_routable_host_never_echoes_the_code_even_with_no_mail() {
     let home_dir = home();
     let home = home_dir.path().to_path_buf();
-    let store = crate::store::FsCompanyStore::new(home.clone());
-    let id = CompanyId::new("acme");
-    store
-        .save(&CompanyRecord {
-            id: id.clone(),
-            manifest: manifest(),
-            ledger: Vec::new(),
-            lifecycle: "running".to_string(),
-            overlay_agents: Vec::new(),
-            overlay_desk_members: Vec::new(),
-            overlay_desk_order: Vec::new(),
-            overlay_desks: Vec::new(),
-            overlay_workflows: Vec::new(),
-            template_provenance: None,
-        })
-        .await
-        .unwrap();
-    let runtime = RuntimeBuilder::new(home.clone(), manifest())
-        .with_id(id.clone())
-        .build()
-        .await
-        .unwrap();
     // Routable bind, no mail transport: the code cannot be delivered — and it
     // must NOT come back in the response instead. Returning a credential to
     // whoever asked is worse than nobody being able to sign in.
-    let state = AppState::new(AppConfig {
-        bind: "0.0.0.0:8080".into(),
-        ..AppConfig::default()
-    })
-    .with_home(home.clone())
-    .with_connections(ConnectionsRuntime::new());
-    state.registry().insert(id, Arc::new(runtime));
+    let state = state_bound_to(&home, "0.0.0.0:8080", ConnectionsRuntime::new()).await;
 
     assert_eq!(
         request_dev_code(&state, "ada@example.com").await,
         None,
         "a routable host must never echo a login code"
+    );
+}
+
+#[tokio::test]
+async fn a_loopback_host_with_no_mail_reissues_inside_the_resend_window() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with(&home, ConnectionsRuntime::new()).await;
+
+    // Two sign-ins back to back, well inside the 60s resend window. Nothing is
+    // mailed here — the code is echoed — so there is no mailbox to spare, and
+    // the only thing a throttle could achieve is locking the sole local sign-in
+    // path for a minute after each use. That is issue #271: the console's
+    // Playwright bootstrap re-authenticates on every run and would fail on the
+    // second one within a minute, reporting a broken host.
+    let first = request_dev_code(&state, "ada@example.com")
+        .await
+        .expect("the first request must echo a code");
+    let second = request_dev_code(&state, "ada@example.com")
+        .await
+        .expect("a second request inside the window must still echo a code");
+    assert_ne!(first, second, "the second request must mint a fresh code");
+
+    // And the fresh one is the live one: one live code per address still holds,
+    // so the reissue invalidated its predecessor rather than leaving two open.
+    let app = router(state.clone());
+    let stale = app
+        .oneshot(post(
+            "/api/v1/companies/acme/auth/verify",
+            serde_json::json!({ "code": first }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        stale.status(),
+        StatusCode::UNAUTHORIZED,
+        "reissuing must invalidate the previous code"
+    );
+
+    let app = router(state.clone());
+    let live = app
+        .oneshot(post(
+            "/api/v1/companies/acme/auth/verify",
+            serde_json::json!({ "code": second }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(live.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn a_routable_host_still_throttles_even_with_no_mail() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    // No transport wired, but the host looks reachable from elsewhere. The
+    // reissue exemption is for the echo path only: this host echoes nothing, so
+    // it keeps the throttle and keeps the live code alone.
+    let state = state_bound_to(&home, "0.0.0.0:8080", ConnectionsRuntime::new()).await;
+    let id = CompanyId::new("acme");
+    let runtime = state.registry().get(&id).unwrap();
+
+    assert_eq!(request_dev_code(&state, "ada@example.com").await, None);
+    let minted = runtime
+        .login_codes()
+        .latest_for_email(&id, "ada@example.com")
+        .await
+        .unwrap()
+        .expect("the first request must have minted a code");
+
+    assert_eq!(request_dev_code(&state, "ada@example.com").await, None);
+    let after = runtime
+        .login_codes()
+        .latest_for_email(&id, "ada@example.com")
+        .await
+        .unwrap()
+        .expect("the throttled request must leave the live code in place");
+    assert_eq!(
+        minted.code_hash, after.code_hash,
+        "a throttled request must not replace the live code"
     );
 }
 


### PR DESCRIPTION
## Summary

The Playwright bootstrap did not fail intermittently — it failed **every time the
suite was run within 60 seconds of the previous run**, which is what an iterating
developer does. The 60s resend throttle on `POST …/auth/request` applied even on
a loopback host with no mail transport, where the login code is echoed in the
response rather than mailed. Because only the code's *hash* is stored, a
throttled answer cannot re-echo the still-live code: the caller gets
`202 {"sent": true}` and no way in, for a minute after every single sign-in.

The throttle exists to stop `auth/request` being a mail cannon aimed at an
invited mailbox. Where nothing is mailed there is no cannon — so it is now
skipped on exactly the shape the dev echo is already gated on (loopback bind, no
`public_url`, no mail transport wired). Every other host keeps it unchanged.

This is a root-cause fix, not a retry: no backoff loop was added, because after
the change there is nothing to retry around. First-run-on-a-fresh-host was never
the failing case (verified below), so there is no host-readiness race to defend
against either.

Separately, the bootstrap's failure message was actively misleading. It died on a
bare `expect(devCode).toBeTruthy()` with "must echo dev_code on a loopback bind",
which reads as a broken host. `auth/request` answers `202 {"sent": true}`
identically for an unknown address, a throttled resend, a routable host and a
mailing host — deliberately, so the route is not a membership oracle — so the
client cannot be told which happened and must say so. It now reports the
endpoint, the status and the verbatim body, then enumerates the conditions that
suppress the echo, in the order worth checking.

Closes #271

## API Or Behavior Changes

`POST …/auth/request` on a **loopback-only host with no mail transport** now
mints and echoes a fresh code on every request instead of returning
`{"sent": true}` with no code inside the 60s window. The reissue still
invalidates its predecessor, so "one live code per address" holds.

No change on any other host. A routable host, or a host with
`OPENCOMPANY_PUBLIC_URL` set, or a host with `OPENCOMPANY_MAIL_*` wired, keeps
the throttle exactly as before and still never echoes a code. The response shape
is unchanged, the generic-`202` rule is unchanged, and no new membership signal
is introduced — on a loopback/no-mail host the echo is already the oracle, by
design.

## Tests

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo build --all-targets` — clean
- `cargo test` — 1011 passed, 0 failed, 1 ignored
- `cd frontend && npm ci && npm run typecheck && npm run build` — clean

New Rust coverage in `src/server/users/routes_test.rs`:

- `a_loopback_host_with_no_mail_reissues_inside_the_resend_window` — two
  sign-ins back to back both get a code, the codes differ, the second verifies
  and the first is invalidated.
- `a_routable_host_still_throttles_even_with_no_mail` — the exemption is scoped
  to the echo path; a routable host keeps the throttle and leaves the live code
  in place.
- The existing `a_second_link_within_the_throttle_window_is_not_sent` (mail
  wired) is untouched and still green.

End-to-end verification, driving the real `global-setup.ts` against a live host
booted with an isolated `--home`:

| Host binary | Setup | Result |
|---|---|---|
| `upstream/main` | 12 consecutive runs, one fresh host | **1 / 12 passed** — run 1 OK, runs 2–12 all failed |
| `upstream/main` | 6 fresh hosts, 1 run each | 6 / 6 passed — the first run is never the failure |
| this branch | 12 consecutive runs, one fresh host | **12 / 12 passed** |
| this branch | 5 fresh hosts, 4 runs each | **20 / 20 passed** |

32 clean bootstrap runs after the change; the reproduction on `main` is
deterministic rather than intermittent once the trigger is understood.

## Documentation

`docs/spec/runtime/users.md` — the "Abuse and exposure" section now says the
resend throttle covers one *mailed* link per address per minute, and states why
it does not apply where the code is echoed instead.
