### PR TITLE
fix(console): dismiss the alert dialog when its action is confirmed (#268)

### DIFF
--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -139,14 +139,33 @@ function AlertDialogDescription({
   )
 }
 
+/**
+ * The confirm button. Like {@link AlertDialogCancel}, it renders the primitive's
+ * `Close` so confirming dismisses the dialog — otherwise the popup stays mounted
+ * and its inert backdrop swallows every later click on the app behind it.
+ *
+ * Base UI merges event handlers right-to-left, and the caller's `onClick` sits to
+ * the right of the primitive's own close handler, so the confirm handler runs
+ * *first* and the close runs after it. A handler that wants to keep the dialog
+ * open (a failed validation, say) can call `event.preventBaseUIHandler()`.
+ *
+ * That ordering is what keeps an async handler safe. Every confirm here is
+ * fire-and-forget (`onClick={() => void remove()}`), so it returns at its first
+ * `await` and the close still runs synchronously inside the same click — it can
+ * never be outrun by a continuation that later tears the dialog's owner down.
+ */
 function AlertDialogAction({
   className,
+  variant,
+  size,
   ...props
-}: React.ComponentProps<typeof Button>) {
+}: AlertDialogPrimitive.Close.Props &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
   return (
-    <Button
+    <AlertDialogPrimitive.Close
       data-slot="alert-dialog-action"
       className={cn(className)}
+      render={<Button variant={variant} size={size} />}
       {...props}
     />
   )

--- a/frontend/test/e2e/alert-dialog-confirm.spec.ts
+++ b/frontend/test/e2e/alert-dialog-confirm.spec.ts
@@ -1,0 +1,168 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+/**
+ * Regression proof for #268 — confirming an `AlertDialog` must dismiss it.
+ *
+ * `AlertDialogAction` used to render a plain `Button` while `AlertDialogCancel`
+ * rendered the primitive's `Close`, so only *cancelling* closed the dialog.
+ * Confirming ran the handler, the underlying action succeeded, and the popup
+ * stayed mounted — its backdrop marking the rest of the console inert and
+ * swallowing every subsequent click until a reload.
+ *
+ * Both tests hold the confirm handler's request open, because the interesting
+ * moment is the one *between* the click and the response. That window is where
+ * the bug lives, and holding it makes the assertion deterministic rather than a
+ * race: while the request is in flight the dialog must already be gone. It also
+ * removes the thing that used to mask the bug — on the delete path the console
+ * navigates away once the request lands, which unmounts the stuck dialog and
+ * makes a naive "is it hidden eventually?" assertion pass even on `main`.
+ *
+ * The dialog being *hidden* is only half of it. A popup that has animated out of
+ * sight but left an inert backdrop behind is the same bug, so each test also
+ * clicks its way back through the surface underneath with Playwright's
+ * actionability checks on: an intercepting backdrop fails that click rather than
+ * passing silently.
+ *
+ * Two of the three call sites on `main` are exercised, because the fix lives in
+ * the shared primitive (`components/ui/alert-dialog.tsx`) and not at any one
+ * call site: the task delete inside `TaskEditDialog`, and the lifecycle
+ * `ConfirmAction` in `SettingsView` (the same shape as `TaskDetailView`'s
+ * `ConfirmButton`, whose own confirm needs a live in-flight run to reach).
+ *
+ * Like the rest of `test/e2e`, this drives a *running* host and is not wired
+ * into CI — the Playwright config declares no `webServer`. It is a reproduction
+ * and a written-down contract, not a merge gate.
+ */
+
+/**
+ * The first-run product tour opens its own modal over a fresh console and would
+ * intercept every click below. Answer "already skipped" for whatever company id
+ * the host resolves to, rather than hard-coding the harness's.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+});
+
+const dialog = (page: Page) => page.locator('[data-slot="alert-dialog-content"]');
+const backdrop = (page: Page) => page.locator('[data-slot="alert-dialog-overlay"]');
+
+/** Sidebar navigation only succeeds if nothing is intercepting pointer events. */
+async function expectConsoleInteractive(page: Page) {
+  await page
+    .locator('[data-tour="nav-overview"]')
+    .getByRole("button")
+    .click({ timeout: 10_000 });
+  await expect(page).toHaveURL(/#\/overview$/);
+}
+
+/** The dialog, and the backdrop it made the console inert with, are both gone. */
+async function expectDismissed(page: Page) {
+  await expect(dialog(page)).toHaveCount(0, { timeout: 10_000 });
+  await expect(backdrop(page)).toHaveCount(0, { timeout: 10_000 });
+}
+
+/**
+ * Park every `method` request to `url` and hand back a `release` that decides
+ * their fate. Until it is called the confirm handler is stuck mid-await, which
+ * is exactly the window this spec is about.
+ */
+async function holdNextRequest(
+  page: Page,
+  url: RegExp,
+  method: string,
+): Promise<(outcome: "continue" | "abort") => void> {
+  let decide!: (outcome: "continue" | "abort") => void;
+  const decided = new Promise<"continue" | "abort">((resolve) => (decide = resolve));
+  await page.route(url, async (route: Route) => {
+    if (route.request().method() !== method) return route.fallback();
+    const outcome = await decided;
+    if (outcome === "abort") return route.abort();
+    return route.continue();
+  });
+  return decide;
+}
+
+test("confirming a task delete dismisses the dialog before the request lands", async ({
+  page,
+}) => {
+  await page.goto("/#/tasks");
+
+  // Create a card of our own so the test never deletes somebody else's row.
+  const title = `e2e confirm-closes ${Date.now()}`;
+  await page.getByRole("button", { name: "Add task to To-do" }).click();
+  await page.locator("#new-title").fill(title);
+  await page.getByRole("button", { name: "Create", exact: true }).click();
+
+  const card = page.locator('[role="button"]').filter({ hasText: title });
+  await expect(card).toBeVisible({ timeout: 30_000 });
+
+  // Open the card's detail screen, then its edit dialog, then ask to delete.
+  await card.click();
+  await page.getByRole("button", { name: "Edit", exact: true }).click();
+  await page.getByRole("button", { name: "Delete", exact: true }).click();
+  await expect(dialog(page)).toContainText("Delete");
+
+  const release = await holdNextRequest(page, /\/tasks\/[^/]+$/, "DELETE");
+
+  await dialog(page).getByRole("button", { name: "Delete task" }).click();
+
+  // The bug: the popup stayed mounted here, `data-open` still set, backdrop
+  // still covering the console — for as long as the delete took, and on this
+  // path for good if it failed.
+  await expectDismissed(page);
+
+  // The edit dialog this confirm was raised from is still open, and legitimately
+  // so — it closes when the delete lands. What must be true now is that it takes
+  // clicks again, which it cannot while the confirm's backdrop is over it. Close
+  // it by hand, and the console behind it is reachable too.
+  const editDialog = page.locator('[data-slot="dialog-content"]');
+  await editDialog.getByRole("button", { name: "Close" }).click();
+  await expect(editDialog).toHaveCount(0);
+  await expectConsoleInteractive(page);
+
+  // Let the delete through and confirm the handler really did run: closing the
+  // dialog must not have cost us the action.
+  release("continue");
+  await page.goto("/#/tasks");
+  await expect(page.locator('[role="button"]').filter({ hasText: title })).toHaveCount(
+    0,
+    { timeout: 30_000 },
+  );
+});
+
+test("confirming a lifecycle change dismisses the dialog from a second call site", async ({
+  page,
+}) => {
+  await page.goto("/#/settings");
+
+  const suspend = page.getByRole("button", { name: "Suspend", exact: true });
+  await expect(suspend).toBeVisible({ timeout: 30_000 });
+  await suspend.click();
+
+  // `SettingsView`'s shared `ConfirmAction` — same primitive, different caller.
+  await expect(dialog(page)).toContainText("Suspend this company?");
+
+  // Suspending for real ends the session, so the request is held and then
+  // failed: the console reports "couldn't suspend", the harness company stays
+  // running for the specs after this one, and the dialog's behaviour on confirm
+  // — the only thing under test — is unaffected either way.
+  const release = await holdNextRequest(page, /\/companies\/[^/]+\/suspend$/, "POST");
+
+  await dialog(page).getByRole("button", { name: "Suspend", exact: true }).click();
+
+  await expectDismissed(page);
+  await expectConsoleInteractive(page);
+
+  // Fail the held request, then confirm the company is still running — the
+  // specs after this one drive a live company.
+  release("abort");
+  await page.goto("/#/settings");
+  await expect(page.getByRole("button", { name: "Suspend", exact: true })).toBeVisible({
+    timeout: 30_000,
+  });
+});


### PR DESCRIPTION
## Summary

Confirming an `AlertDialog` left the modal mounted. `AlertDialogAction` rendered a plain `Button`, while `AlertDialogCancel` rendered `AlertDialogPrimitive.Close` — so only *cancelling* dismissed the dialog. Confirming ran the handler, the underlying action succeeded, and the popup stayed on screen with its backdrop marking the rest of the console inert. Every click after that went nowhere until a reload.

Fixed once in the shared primitive rather than three times at the call sites, since all three inherit the same component: `TaskDetailView`, `SettingsView`, `TaskEditDialog`.

Closes #268

## API Or Behavior Changes

**Behavior.** `AlertDialogAction` now dismisses the dialog when clicked, matching what its name has always implied and what `AlertDialogCancel` already did. No call site changes.

The props it accepts are unchanged in practice — `onClick`, `className`, `disabled`, and the `Button` `variant`/`size` all still reach the rendered button. Its type moves from `ComponentProps<typeof Button>` to `AlertDialogPrimitive.Close.Props & Pick<…, "variant" | "size">`, exactly mirroring `AlertDialogCancel`.

**Handler ordering, deliberately.** Base UI merges event handlers right-to-left and the caller's `onClick` sits to the right of the primitive's own close handler, so the confirm handler runs *first* and the close runs after it. Because every confirm on `main` is fire-and-forget (`onClick={() => void remove()}`), the handler returns at its first `await` and the close still runs synchronously inside the same click — it cannot be outrun by a continuation that later tears the dialog's owner down. The reverse direction is safe too: React batches state updates until the handler returns, so a synchronous unmount could not beat the close either. Nothing the handlers need is unmounted early; on the delete path the surrounding view unmounts only when the request lands, well after the dialog is gone. A handler that wants to *keep* the dialog open (a failed validation, say) can call `event.preventBaseUIHandler()`.

**No call site was working around this.** None of the three controls `open` itself. The one workaround that exists is on an unmerged branch — #279 controls `open`/`onOpenChange` locally in `WorkflowsView` for the same reason. This PR does not touch that file. Once both land the local control is redundant but harmless (the handler's `setConfirmOpen(false)` and the primitive's close drive the same state), so whoever merges second is looking at belt-and-braces, not a conflict. Removing it is a small follow-up, not something to do from here.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 1015 passed, 0 failed

Frontend: `npm ci && npm run typecheck && npm run build` — clean. There is no Rust diff in this PR; the Rust gates are run as a matter of course.

New Playwright spec, `frontend/test/e2e/alert-dialog-confirm.spec.ts`, driving a local host against the built console. It covers two of the three call sites — the task delete in `TaskEditDialog` and the lifecycle `ConfirmAction` in `SettingsView` — because the point is that one primitive serves all of them. (`TaskDetailView`'s `ConfirmButton` is the same shape but needs a live in-flight run to reach.)

Each test asserts both halves of the bug: the dialog is gone from the DOM, **and** the surface underneath takes clicks again. A popup that has animated out of sight but left an inert backdrop behind is the same bug, so the second assertion clicks through with actionability checks on rather than trusting a visibility check.

Both tests hold the confirm handler's request open, so the assertion lands in the window between the click and the response. That is where the bug lives, and holding it also removes what masked it: on the delete path the console navigates away once the request lands, unmounting the stuck dialog, so a naive "hidden eventually?" check passed even on `main`. The lifecycle test then *fails* its held request rather than releasing it, so the company is never actually suspended and later specs still find it running.

Ran the same spec both ways against a host on the default (offline) build:

| Console bundle | `alert-dialog-confirm.spec.ts` | Full suite |
| --- | --- | --- |
| `upstream/main`, unmodified | **2 failed** — `[data-slot="alert-dialog-content"]` expected 0, received 1, on both tests | 8 failed / 1 passed |
| this branch | **2 passed** | 6 failed / 3 passed |

The 6 failures common to both runs are environmental, not from this change: that host has no mocked LLM backend, which those specs need. They are identical before and after.

Not a CI gate — `playwright.config.ts` declares no `webServer`, so like the rest of `test/e2e` this needs a host brought up by hand. It is a reproduction and a written-down contract.

Also hit the known #271 global-setup flake (`auth/request` not echoing `dev_code`) several times; retried past it, and PR #284 is fixing it.

## Documentation

No doc file changes. Nothing under `docs/` or `frontend/ARCHITECTURE.md` describes the UI primitives — `ARCHITECTURE.md` is about which surfaces need which endpoints — so there was no stale sentence to correct. The contract instead lives as a doc comment on `AlertDialogAction` itself, next to the code that has to keep it, covering why it renders `Close` and why the handler ordering is what makes an async confirm safe. The issue notes this is easy to reintroduce because the component name reads as though it already closes; the comment is aimed squarely at that.
