### PR TITLE
fix(economy): draw the x402 authorization nonce from the OS CSPRNG (#253)

### DIFF
--- a/src/economy/x402.rs
+++ b/src/economy/x402.rs
@@ -22,13 +22,26 @@
 //!
 //! Isolated in [`canonical_bytes`] so it is a one-function change to reconcile
 //! with the real tiny.place server when reachable.
+//!
+//! ## The nonce comes from the OS CSPRNG
+//!
+//! `nonce` is documented as single-use and is signed into the payload above,
+//! so a counterparty's replay check is only as good as the value's
+//! unpredictability and uniqueness. It is therefore minted by [`mint_nonce`]
+//! from 256 bits of OS randomness through the same
+//! [`TokenSource`](crate::server::users::token::TokenSource) seam the user-auth
+//! secrets use — **not** from
+//! [`generate_id`](crate::ports::generate_id), whose epoch-millis-plus-counter
+//! shape is guessable from a prior value and repeats across processes that
+//! start in the same millisecond.
 
 use serde::{Deserialize, Serialize};
 
 use crate::Result;
 use crate::economy::signer::{LocalSigner, verify_b58};
 use crate::error::OpenCompanyError;
-use crate::ports::generate_id;
+use crate::server::platform_auth::b64url_encode;
+use crate::server::users::token::{OsTokens, TokenSource};
 
 /// The domain-separation tag pinning the x402 canonical layout version.
 pub const X402_DOMAIN: &str = "tiny.place-x402-v1";
@@ -88,13 +101,32 @@ pub struct X402Authorization {
     pub asset: String,
     /// The settlement network.
     pub network: String,
-    /// A single-use nonce.
+    /// A single-use nonce: 256 bits of OS randomness, base64url, 43 chars.
+    ///
+    /// Opaque to every reader — nothing parses, stores, or matches its shape —
+    /// so the counterparty only needs it to be unpredictable and unique. See
+    /// [`mint_nonce`].
     pub nonce: String,
     /// The authorization timestamp, epoch seconds.
     pub timestamp: i64,
     /// The base58 Ed25519 signature over [`canonical_bytes`].
     #[serde(rename = "signature")]
     pub signature_b58: String,
+}
+
+/// How many random bytes back an authorization nonce. 32 bytes = 256 bits,
+/// matching the user-auth secrets, so two mints colliding is not a scenario.
+const NONCE_BYTES: usize = 32;
+
+/// Mints an authorization nonce: 256 bits from `src`, base64url, 43 chars.
+///
+/// A pure function of the source bytes — no clock, no counter, no process
+/// state — which is the property that makes one nonce say nothing about the
+/// next, and makes two processes minting in the same millisecond differ.
+pub fn mint_nonce(src: &dyn TokenSource) -> String {
+    let mut bytes = [0u8; NONCE_BYTES];
+    src.fill(&mut bytes);
+    b64url_encode(&bytes)
 }
 
 /// Builds the canonical bytes an x402 authorization signs. See module docs.
@@ -136,7 +168,7 @@ fn authorize_amount(
     now: i64,
 ) -> X402Authorization {
     let agent_id = signer.agent_id();
-    let nonce = generate_id();
+    let nonce = mint_nonce(&OsTokens);
     let msg = canonical_bytes(
         &agent_id,
         &amount,
@@ -184,6 +216,8 @@ fn string_field(obj: &serde_json::Value, keys: &[&str]) -> Option<String> {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashSet;
+
     use super::*;
 
     fn sample_challenge() -> X402Challenge {
@@ -254,6 +288,99 @@ mod test {
         assert!(
             verify(&auth).is_err(),
             "changed amount must break the signature"
+        );
+    }
+
+    /// A deterministic source, for asserting minting is a pure function of its
+    /// bytes. Never use anything like this outside tests.
+    struct FixedTokens(u8);
+
+    impl TokenSource for FixedTokens {
+        fn fill(&self, out: &mut [u8]) {
+            out.fill(self.0);
+        }
+    }
+
+    #[test]
+    fn nonce_is_a_pure_function_of_the_source_bytes() {
+        // The property, not the encoding: the nonce is the CSPRNG's output and
+        // nothing else. If a clock or a counter were mixed in, two mints from
+        // the same bytes would differ.
+        assert_eq!(
+            mint_nonce(&FixedTokens(0xAB)),
+            mint_nonce(&FixedTokens(0xAB))
+        );
+        assert_ne!(
+            mint_nonce(&FixedTokens(0xAB)),
+            mint_nonce(&FixedTokens(0xCD))
+        );
+    }
+
+    #[test]
+    fn nonces_minted_in_the_same_millisecond_differ() {
+        let signer = LocalSigner::generate();
+        let ch = sample_challenge();
+        let mut seen = HashSet::new();
+        // A tight loop lands many mints inside one millisecond, which is
+        // exactly where a clock-prefixed id has only its counter left.
+        for _ in 0..1000 {
+            let auth = authorize(&signer, &ch, 1_700_000_000);
+            assert!(seen.insert(auth.nonce), "a nonce repeated");
+        }
+    }
+
+    #[test]
+    fn nonces_carry_no_monotonic_counter() {
+        let signer = LocalSigner::generate();
+        let ch = sample_challenge();
+        let minted: Vec<String> = (0..64)
+            .map(|_| authorize(&signer, &ch, 1_700_000_000).nonce)
+            .collect();
+
+        // An id built from a timestamp plus an incrementing counter sorts in
+        // mint order. Random values do not: 64 draws land sorted with
+        // probability 1/64!, so this failing means order leaked back in.
+        assert!(
+            minted.windows(2).any(|w| w[0] > w[1]),
+            "nonces arrived in ascending order, which implies a counter"
+        );
+
+        // And no shared structure: a common prefix is what a clock component
+        // would leave behind across mints in the same millisecond.
+        let first = minted[0].as_bytes();
+        assert!(
+            minted[1..]
+                .iter()
+                .any(|n| n.as_bytes().first() != first.first()),
+            "every nonce shared a leading byte, which implies a fixed prefix"
+        );
+    }
+
+    #[test]
+    fn nonce_is_url_safe_and_full_width() {
+        let auth = authorize(&LocalSigner::generate(), &sample_challenge(), 1_700_000_000);
+        // 32 bytes unpadded base64url.
+        assert_eq!(auth.nonce.len(), 43, "unexpected nonce: {}", auth.nonce);
+        assert!(
+            auth.nonce
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+            "nonce is not base64url: {}",
+            auth.nonce
+        );
+    }
+
+    #[test]
+    fn a_changed_nonce_breaks_the_signature() {
+        // The nonce is inside the signed payload, so replaying an
+        // authorization under a fresh nonce is not something a payer can do
+        // without the key.
+        let signer = LocalSigner::generate();
+        let mut auth = authorize(&signer, &sample_challenge(), 1_700_000_000);
+        auth.nonce = mint_nonce(&OsTokens);
+        assert!(
+            verify(&auth).is_err(),
+            "changed nonce must break the signature"
         );
     }
 

--- a/src/ports/ids.rs
+++ b/src/ports/ids.rs
@@ -35,6 +35,16 @@ pub fn now_millis() -> u64 {
 /// private path must take one from `tempfile` (`tempfile::Builder::new()
 /// .prefix("opencompany-…").tempdir()`), which asks the OS for a name no other
 /// process can hold, rather than deriving one from `generate_id`.
+///
+/// # Never where unpredictability is required
+///
+/// A minted id is fully guessable from a prior one: the counter steps by one
+/// and the prefix is the wall clock. It must not be used for a token, a
+/// secret, a capability URL, or a nonce — anything whose safety rests on a
+/// reader being unable to name the next value. Those come from the OS CSPRNG
+/// through [`TokenSource`](crate::server::users::token::TokenSource); see
+/// [`mint_session_token`](crate::server::users::token::mint_session_token) and
+/// the x402 authorization nonce for the two shapes already in the tree.
 pub fn generate_id() -> String {
     let millis = now_millis();
     let counter = COUNTER.fetch_add(1, Ordering::Relaxed);


### PR DESCRIPTION
## Summary

`src/economy/x402.rs` minted the authorization `nonce` with `generate_id()`. That helper is `format!("{millis:012x}-{counter:012x}")` — a wall-clock millisecond prefix plus a process-local `AtomicU64` that starts at zero in every process. `ports::ids` documents its output as "collision-safe in-process", which is the right guarantee for a record id and the wrong one for this field.

The field is documented as "a single-use nonce" and is signed into the canonical `tiny.place-x402-v1` payload, so a counterparty's replay check is only as good as the value being unpredictable and unique. It was neither:

- **Derivable.** The counter steps by one and the prefix is the clock, so a prior value names the next one.
- **Not unique across processes.** In shared-single-DB multi-tenant mode each tenant container runs its own process with its own counter from zero, so two containers signing their first authorization in the same millisecond emit an identical nonce.

The nonce now comes from 256 bits of OS randomness through the `TokenSource` / `OsTokens` seam that already mints the login-code and session secrets (`src/server/users/token.rs`) — the same seam whose module docs already say secrets must not come from `generate_id`. `generate_id()` itself is untouched; only its documentation gained a section saying it must not be used where unpredictability is required.

## API Or Behavior Changes

- **New public fn** `economy::x402::mint_nonce(&dyn TokenSource) -> String`. `authorize`, `authorize_upto`, `canonical_bytes`, and `verify` keep their existing signatures — the source is swapped inside `authorize_amount`, so no caller changes.
- **`X402Authorization.nonce` values change shape**: 25-char `{hex}-{hex}` → 43-char unpadded base64url. The JSON type is unchanged (a string) and the field stays opaque. Every reader was checked, not just the writer: the only ones are `canonical_bytes` (as signing input), `verify`, and `server::a2a::extract_payment` (whole-struct serde). Nothing parses, stores, indexes, echoes, or matches the value, so no persisted data and no wire contract moves.
- **No dependency change.** `getrandom` is already an unconditional dependency, so `Cargo.toml` and `Cargo.lock` are untouched.

Two open questions the issue raised are deliberately left out of this change, since both are behavior decisions rather than the entropy fix:

- **A bounded `seen` set in `x402::verify()`**, as `economy::siwx` keeps. Worth noting for whoever picks it up: the one inbound call site (`server::a2a`) already runs the SIWX `NonceCache` over the whole request — body hash included — before the payment is parsed, so a byte-identical replay is refused a layer above. A separate x402-level cache would cover a different case (the same authorization presented across differing requests) and should be scoped on its own.
- **A sweep of the other 44 `generate_id()` callers.** The identity-bearing ones were checked while grepping and want uniqueness rather than unpredictability — the closest is `runtime::delegation`'s in-flight registry `key`, which is an operator-facing CANCEL handle behind company-scoped auth, not a credential. The signed `state` value in `server::ops::connections` already uses an HMAC path and never touched `generate_id`.

## Tests

Five new tests in `economy::x402`, written against the property rather than the encoding:

- `nonce_is_a_pure_function_of_the_source_bytes` — mints through a deterministic `TokenSource` stub; two mints from the same bytes must match and different bytes must differ, which fails if a clock or counter is ever mixed back in.
- `nonces_minted_in_the_same_millisecond_differ` — 1000 mints in a tight loop, all distinct.
- `nonces_carry_no_monotonic_counter` — 64 mints must not arrive in ascending order (a timestamp-plus-counter id always does; 64 random draws land sorted with probability 1/64!) and must not all share a leading byte.
- `nonce_is_url_safe_and_full_width` — 43 chars, base64url alphabet only.
- `a_changed_nonce_breaks_the_signature` — pins that the nonce is inside the signed payload.

Commands run locally:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --features tinyplace --all-targets -- -D warnings` — `x402` is behind `tinyplace`, so the default-feature run does not lint it
- [x] `cargo test`
- [x] `cargo test --features tinyplace`
- [x] `cargo check --all-features`
- [x] `cargo check --features openhuman,mcp,telegram`
- [ ] `cargo build --all-targets` — not run; `cargo check` across the four feature sets above covers the same breakage

## Documentation

Rustdoc only, in the two files touched:

- `economy::x402` module docs gained a section on where the nonce comes from and why it is not `generate_id`.
- `X402Authorization::nonce` now states its width, encoding, and that it is opaque to every reader.
- `ports::ids::generate_id` gained a "Never where unpredictability is required" section naming tokens, secrets, capability URLs, and nonces, and pointing at `TokenSource` — the third acceptance criterion on the issue. Doc-only; the function is unchanged.

Closes #253.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Authorization nonces now use cryptographically secure, unpredictable randomness.
  * Nonces are URL-safe and consistently encoded for reliable use.
  * Updated guidance clarifies that predictable identifiers must not be used for security-sensitive values.
  * Added validation covering nonce uniqueness, format, unpredictability, and signature invalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->