### PR TITLE
fix(store): make OPENCOMPANY_DATA_DIR place the whole instance, not half of it (#273)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,12 @@ injects its environment. When developing hosted behavior, know the seams:
 
 - The manager injects `OPENCOMPANY_COMPANY`, `OPENCOMPANY_BIND=0.0.0.0:8080`,
   `OPENCOMPANY_DATA_DIR=/data`, and `OPENCOMPANY_PUBLIC_URL` into every
-  tenant container, plus — when database-per-tenant storage is enabled —
+  tenant container. `OPENCOMPANY_DATA_DIR` is the instance data root for
+  **both** the workspace layout and the company-bundle home; `docker/entrypoint.sh`
+  additionally forwards it as `--home "$OPENCOMPANY_DATA_DIR"`, which resolves
+  identically (the flag outranks the variable). Locally it is the only knob that
+  isolates two `serve` processes from each other — see
+  `docs/spec/runtime/storage.md`. Plus — when database-per-tenant storage is enabled —
   `OPENCOMPANY_STORAGE=mongodb`, `OPENCOMPANY_MONGODB_URI` (credentials
   scoped to that tenant's database only), and `OPENCOMPANY_MONGODB_DB`.
 - In the alternative **shared-single-DB** mode (all tenants on one logical

--- a/docs/spec/runtime/config.md
+++ b/docs/spec/runtime/config.md
@@ -83,7 +83,7 @@ layer set it, and what is missing for each optional capability.
 | `TINYHUMANS_API_KEY` | — (required for cycles when no token file) | Static TinyHumans credential (JWT or API key) |
 | `TINYHUMANS_API_URL` | `https://api.tinyhumans.ai` | Backend base URL |
 | `OPENCOMPANY_BIND` | `127.0.0.1:8080` | HTTP bind address |
-| `OPENCOMPANY_DATA_DIR` | `~/.opencompany` | Bundle root for fs stores |
+| `OPENCOMPANY_DATA_DIR` | `~/.opencompany` (workspace) / `~/.opencompany/companies` (bundle home) | The instance data root: both the workspace layout and the company-bundle home. `--home` outranks it. The only knob that isolates two hosts from each other — see [storage](storage.md#choosing-the-root-srcstorepathsrs) |
 | `OPENCOMPANY_BRAIN_MODE` | `hosted` | `hosted` \| `sidecar` (overrides `[brain].mode`) |
 | `OPENCOMPANY_OPENHUMAN_URL` | — | Attach to a running `openhuman-core serve` instead of launching |
 | `OPENCOMPANY_INFERENCE_KEY` | `TINYHUMANS_API_KEY` | Harness-brain credential (`openhuman` feature). Per-tenant override of the platform key |

--- a/docs/spec/runtime/config.md
+++ b/docs/spec/runtime/config.md
@@ -83,7 +83,7 @@ layer set it, and what is missing for each optional capability.
 | `TINYHUMANS_API_KEY` | — (required for cycles when no token file) | Static TinyHumans credential (JWT or API key) |
 | `TINYHUMANS_API_URL` | `https://api.tinyhumans.ai` | Backend base URL |
 | `OPENCOMPANY_BIND` | `127.0.0.1:8080` | HTTP bind address |
-| `OPENCOMPANY_DATA_DIR` | `~/.opencompany` (workspace) / `~/.opencompany/companies` (bundle home) | The instance data root: both the workspace layout and the company-bundle home. `--home` outranks it. The only knob that isolates two hosts from each other — see [storage](storage.md#choosing-the-root-srcstorepathsrs) |
+| `OPENCOMPANY_DATA_DIR` | `~/.opencompany` (workspace) / `~/.opencompany/companies` (bundle home) | The instance data root: both the workspace layout and the company-bundle home. `--home` outranks it for the bundle home **only** — the workspace (`memory/`, `store/`, `files/`, `logs/`, `tmp/`) still resolves under this variable, so `--home` alone does not move a whole instance. The only knob that isolates two hosts from each other — see [storage](storage.md#choosing-the-root-srcstorepathsrs) |
 | `OPENCOMPANY_BRAIN_MODE` | `hosted` | `hosted` \| `sidecar` (overrides `[brain].mode`) |
 | `OPENCOMPANY_OPENHUMAN_URL` | — | Attach to a running `openhuman-core serve` instead of launching |
 | `OPENCOMPANY_INFERENCE_KEY` | `TINYHUMANS_API_KEY` | Harness-brain credential (`openhuman` feature). Per-tenant override of the platform key |

--- a/docs/spec/runtime/storage.md
+++ b/docs/spec/runtime/storage.md
@@ -65,6 +65,62 @@ the shared subdirectories and — unless `[workspace].clear_tmp_on_startup` is
 own `OPENCOMPANY_DATA_DIR`, this root *is* the per-tenant workspace — no separate
 per-tenant path prefix is needed.
 
+### Choosing the root (`src/store/paths.rs`)
+
+`OPENCOMPANY_DATA_DIR` is the **only** environment knob that places an instance.
+`opencompany serve` (and `export` / `import`) resolve the root every company
+bundle hangs off through `store::resolve_home`, in this order:
+
+| Precedence | Source | Resolves to |
+| --- | --- | --- |
+| 1 | `--home <DIR>` | `<DIR>` verbatim — an explicit flag is never overridden by the environment |
+| 2 | `OPENCOMPANY_DATA_DIR` | its value verbatim, so bundles land at `<root>/companies/<slug>` — exactly the layout above |
+| 3 | neither | `$HOME/.opencompany/companies` (the legacy default; see below) |
+
+An empty `OPENCOMPANY_DATA_DIR` counts as unset — it would otherwise root the
+instance at the process working directory.
+
+Two consequences worth knowing:
+
+- **The legacy default is one level deeper than the layout above.** With neither
+  the flag nor the variable set, the home is `$HOME/.opencompany/companies` and
+  `Bundle` appends a `companies/` of its own, so bundles sit at
+  `~/.opencompany/companies/companies/<slug>` while `DataLayout` materializes
+  `~/.opencompany/{memory,store,files,logs,tmp}`. That extra level is a wart kept
+  for compatibility with existing local installs rather than silently relocating
+  their data. Setting `OPENCOMPANY_DATA_DIR` gives the canonical single-root
+  layout.
+- **`--home` moves the bundles but not the workspace.** It places company
+  bundles only; `memory/`, `store/`, `files/`, `logs/` and `tmp/` always follow
+  `OPENCOMPANY_DATA_DIR`. So two hosts isolated by `--home` alone still share one
+  workspace. `serve` prints an operator-visible warning naming both roots
+  whenever they are not aligned. Prefer `OPENCOMPANY_DATA_DIR`, which moves the
+  whole instance. A hosted tenant sets both to the same value
+  (`docker/entrypoint.sh` passes `--home "$OPENCOMPANY_DATA_DIR"`), so it never
+  warns — nor does the untouched local default.
+
+`OPENCOMPANY_HOME` is **not** a synonym and is not read. It was never wired to
+anything, so setting it was silently ignored; `serve` now aborts with an error
+naming `OPENCOMPANY_DATA_DIR` instead.
+
+#### Running two hosts side by side
+
+Because a bundle store is shared by every process that resolves the same root,
+two `serve` processes on different ports with no isolation write to one another's
+companies — teammates and desks created on one appear on the other. Give each its
+own root:
+
+```sh
+OPENCOMPANY_DATA_DIR=/tmp/oc-a opencompany serve \
+  --company companies/e2e_harness --bind 127.0.0.1:8095 &
+OPENCOMPANY_DATA_DIR=/tmp/oc-b opencompany serve \
+  --company companies/e2e_harness --bind 127.0.0.1:8096 &
+```
+
+`--home /tmp/oc-a` places the bundles the same way and takes precedence, but it
+does **not** move the shared workspace — prefer the variable for side-by-side
+hosts.
+
 The `[workspace]` section of `config.toml` (in the data dir) tunes the lifecycle:
 
 ```toml

--- a/docs/spec/runtime/storage.md
+++ b/docs/spec/runtime/storage.md
@@ -99,9 +99,12 @@ Two consequences worth knowing:
   (`docker/entrypoint.sh` passes `--home "$OPENCOMPANY_DATA_DIR"`), so it never
   warns — nor does the untouched local default.
 
-`OPENCOMPANY_HOME` is **not** a synonym and is not read. It was never wired to
-anything, so setting it was silently ignored; `serve` now aborts with an error
-naming `OPENCOMPANY_DATA_DIR` instead.
+`OPENCOMPANY_HOME` is **not** a synonym and is **not supported**. It was never
+wired to anything, so setting it used to be ignored silently. The resolver now
+reads it solely to reject it: `serve`, `export`, and `import` abort with an error
+naming `OPENCOMPANY_DATA_DIR` instead. The rejection is checked before `--home`,
+so passing the flag does not suppress it — a stale entrypoint that still exports
+the variable fails loudly rather than half-placing a store.
 
 #### Running two hosts side by side
 

--- a/gitbooks/developers/cli.md
+++ b/gitbooks/developers/cli.md
@@ -24,7 +24,7 @@ opencompany serve --company companies/agentic_marketing_agency
 | --- | --- |
 | `--bind <ADDR>` | Address to bind. Default `127.0.0.1:8080`. |
 | `--company <DIR>` | A company to load at boot — a manifest file or a directory containing one. **Repeatable** for multi-company hosting. |
-| `--home <DIR>` | OpenCompany home holding company bundles. Default `$HOME/.opencompany/companies`. |
+| `--home <DIR>` | OpenCompany home holding company bundles. Falls back to `OPENCOMPANY_DATA_DIR`, then to `$HOME/.opencompany/companies`. |
 | `--discoverable` | Opt every loaded company into going public on [tiny.place](../overview/tiny-place.md), regardless of each manifest's `[place].discoverable`. Needs the `tinyplace` feature to reach the network. |
 | `--openhuman_root <PATH>` | Optional OpenHuman checkout path to report in `/spec`. |
 
@@ -65,7 +65,22 @@ opencompany import ./backup
 
 `export` excludes `secrets/` and `keys/` unless `--include-secrets` is passed.
 With `--features export` the output is a single `.tar`; otherwise an unpacked
-bundle directory. Both accept `--home <DIR>`.
+bundle directory. Both accept `--home <DIR>`, and both fall back to
+`OPENCOMPANY_DATA_DIR` the same way `serve` does.
+
+## Where state lives
+
+Every subcommand that touches company bundles resolves one root, highest
+precedence first:
+
+1. `--home <DIR>` — an explicit flag always wins.
+2. `OPENCOMPANY_DATA_DIR` — the instance data root. Set it to run two hosts side
+   by side; without isolation they share one company store and each one's
+   teammates and desks show up in the other.
+3. `$HOME/.opencompany/companies` — the default when neither is set.
+
+`OPENCOMPANY_HOME` is not read. It never was, so setting it used to do nothing
+silently; commands now abort and point at `OPENCOMPANY_DATA_DIR`.
 
 ## `open-human`
 

--- a/gitbooks/developers/cli.md
+++ b/gitbooks/developers/cli.md
@@ -73,14 +73,16 @@ bundle directory. Both accept `--home <DIR>`, and both fall back to
 Every subcommand that touches company bundles resolves one root, highest
 precedence first:
 
-1. `--home <DIR>` — an explicit flag always wins.
+1. `--home <DIR>` — an explicit flag outranks both entries below.
 2. `OPENCOMPANY_DATA_DIR` — the instance data root. Set it to run two hosts side
    by side; without isolation they share one company store and each one's
    teammates and desks show up in the other.
 3. `$HOME/.opencompany/companies` — the default when neither is set.
 
-`OPENCOMPANY_HOME` is not read. It never was, so setting it used to do nothing
-silently; commands now abort and point at `OPENCOMPANY_DATA_DIR`.
+`OPENCOMPANY_HOME` is not supported. It never was, so setting it used to do
+nothing silently; `serve`, `export`, and `import` now abort and point at
+`OPENCOMPANY_DATA_DIR`. The check runs before `--home`, so passing the flag does
+not silence it.
 
 ## `open-human`
 

--- a/gitbooks/developers/configuration.md
+++ b/gitbooks/developers/configuration.md
@@ -27,7 +27,7 @@ live cognition is gated.
 | --- | --- |
 | `OPENCOMPANY_COMPANY` | The company to load (used by container images). |
 | `OPENCOMPANY_BIND` | Bind address; the platform harness injects `0.0.0.0:8080`. |
-| `OPENCOMPANY_DATA_DIR` | Where durable state lives; defaults to a local folder. Set it to run two hosts side by side without them sharing one company store — the `--home` flag overrides it. |
+| `OPENCOMPANY_DATA_DIR` | Where durable state lives; defaults to a local folder. Set it to run two hosts side by side without them sharing one company store. The `--home` flag overrides it for company bundles only — the shared workspace directories still follow this variable, so isolating two hosts with `--home` alone only half-works. |
 | `OPENCOMPANY_PUBLIC_URL` | The externally reachable URL, used for discovery. |
 
 The CLI mirrors several of these as flags — see the [CLI reference](cli.md).

--- a/gitbooks/developers/configuration.md
+++ b/gitbooks/developers/configuration.md
@@ -27,7 +27,7 @@ live cognition is gated.
 | --- | --- |
 | `OPENCOMPANY_COMPANY` | The company to load (used by container images). |
 | `OPENCOMPANY_BIND` | Bind address; the platform harness injects `0.0.0.0:8080`. |
-| `OPENCOMPANY_DATA_DIR` | Where durable state lives; defaults to a local folder. |
+| `OPENCOMPANY_DATA_DIR` | Where durable state lives; defaults to a local folder. Set it to run two hosts side by side without them sharing one company store — the `--home` flag overrides it. |
 | `OPENCOMPANY_PUBLIC_URL` | The externally reachable URL, used for discovery. |
 
 The CLI mirrors several of these as flags — see the [CLI reference](cli.md).

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -130,15 +130,6 @@ impl From<ModeArg> for LaunchMode {
     }
 }
 
-/// The default OpenCompany home: `$HOME/.opencompany/companies`, falling back
-/// to a relative path when `$HOME` is unset.
-fn default_home() -> PathBuf {
-    match std::env::var_os("HOME") {
-        Some(home) => PathBuf::from(home).join(".opencompany").join("companies"),
-        None => PathBuf::from(".opencompany").join("companies"),
-    }
-}
-
 /// Resolves a `--company` argument to its source *directory*. `--company`
 /// accepts either the company directory (`companies/<name>`) or the manifest
 /// file inside it (`companies/<name>/company.toml`); the file form is normalized
@@ -611,7 +602,7 @@ async fn run_export(
     include_secrets: bool,
     home: Option<PathBuf>,
 ) -> Result<()> {
-    let home = home.unwrap_or_else(default_home);
+    let home = opencompany::store::resolve_home(home)?;
     let id = CompanyId::new(company);
     let dest = out.unwrap_or_else(|| PathBuf::from(format!("{}-bundle", id.as_ref())));
     export_to_dir(&home, &id, include_secrets, &dest).await?;
@@ -632,7 +623,7 @@ async fn run_export(
 ) -> Result<()> {
     use opencompany::store::export::pack_tar;
 
-    let home = home.unwrap_or_else(default_home);
+    let home = opencompany::store::resolve_home(home)?;
     let id = CompanyId::new(company);
     let out = out.unwrap_or_else(|| PathBuf::from(format!("{}.tar", id.as_ref())));
 
@@ -689,7 +680,7 @@ async fn import_from_dir(dir: &std::path::Path, home: Option<PathBuf>) -> Result
     use opencompany::store::export::{find_bundle_root, import_bundle, restore_fs_artifacts};
     use opencompany::store::paths::Bundle;
 
-    let home = home.unwrap_or_else(default_home);
+    let home = opencompany::store::resolve_home(home)?;
     let root = find_bundle_root(dir)?;
     let (store, events, memory, context) = fs_ports(&home);
     let id = import_bundle(&root, store, events, memory, context).await?;
@@ -712,12 +703,21 @@ async fn main() -> Result<()> {
             home,
             discoverable,
         }) => {
-            let home = home.unwrap_or_else(default_home);
+            // `--home` > OPENCOMPANY_DATA_DIR > $HOME/.opencompany/companies.
+            let home = opencompany::store::resolve_home(home)?;
             // Materialize the canonical data-dir workspace layout and empty the
             // ephemeral `tmp/` scratch so nothing stale survives a restart. The
             // `[workspace]` section of `config.toml` (in the data dir) toggles
             // the tmp clear; absent config keeps the default (clear on startup).
             let data_root = opencompany::app::config::data_dir_from_env();
+            // An explicit `--home` pointing away from the data root splits one
+            // instance in two: bundles here, shared workspace there. Printed
+            // rather than `warn!`d — the default `EnvFilter` drops warnings
+            // unless RUST_LOG is set, so a `warn!` would be exactly as silent
+            // as the bug it reports.
+            if let Some(warning) = opencompany::store::home_divergence_warning(&home, &data_root) {
+                eprintln!("opencompany: {warning}");
+            }
             let workspace_cfg = ConfigFile::load(&data_root)?
                 .map(|c| c.workspace.resolve())
                 .unwrap_or_default();
@@ -1000,10 +1000,15 @@ mod test {
     use super::*;
 
     #[test]
-    fn default_home_lands_under_opencompany() {
-        let home = default_home();
-        assert!(home.ends_with("companies"));
-        assert!(home.to_string_lossy().contains(".opencompany"));
+    fn the_home_flag_is_taken_verbatim() {
+        // The binary owns no home policy of its own: it delegates to
+        // `store::resolve_home`, whose precedence chain (flag >
+        // OPENCOMPANY_DATA_DIR > $HOME/.opencompany/companies) is covered in
+        // `src/store/paths.rs`. This only pins the wiring.
+        assert_eq!(
+            opencompany::store::resolve_home(Some(PathBuf::from("/flag"))).unwrap(),
+            PathBuf::from("/flag")
+        );
     }
 
     #[tokio::test]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -75,7 +75,7 @@ pub use fs::{
 };
 pub use fs_ops::FsOps;
 pub use layout::DataLayout;
-pub use paths::{Bundle, default_home};
+pub use paths::{Bundle, DATA_DIR_ENV, home_divergence_warning, resolve_home};
 pub use select::{
     MemoryBackend, MemoryOverlay, StorageHandles, StorageKind, StorageSettings,
     open_memory_overlay, open_storage,

--- a/src/store/paths.rs
+++ b/src/store/paths.rs
@@ -51,8 +51,10 @@ const LEGACY_DEFAULT_LEAF: &str = "companies";
 ///
 /// Precedence, highest first:
 ///
-/// 1. **`--home`** (`flag`). An explicit flag always wins; no environment
-///    variable may override it.
+/// 1. **`--home`** (`flag`). Outranks [`DATA_DIR_ENV`] and the legacy default
+///    below. It does not suppress the [`REMOVED_HOME_ENV`] rejection, which is
+///    checked ahead of every branch — see [Errors](#errors) — so `--home` wins
+///    the *choice* of root but never skips that validation.
 /// 2. **`OPENCOMPANY_DATA_DIR`** ([`DATA_DIR_ENV`]), used verbatim. This is the
 ///    same value a hosted tenant's entrypoint already forwards as
 ///    `--home "$OPENCOMPANY_DATA_DIR"`, so the flag and the variable resolve
@@ -68,10 +70,13 @@ const LEGACY_DEFAULT_LEAF: &str = "companies";
 ///
 /// # Errors
 ///
-/// Fails when [`REMOVED_HOME_ENV`] is set. Ignoring it is what made this class
-/// of mistake cost an hour rather than a minute: several hosts started with
-/// different values all shared one store, and the contaminated roster read as a
-/// product bug rather than a configuration one.
+/// Fails when [`REMOVED_HOME_ENV`] is set — including when `--home` is passed,
+/// because a caller who exported it believes it is placing the data and must be
+/// told otherwise before a stale deploy script silently splits a store.
+/// Ignoring it is what made this class of mistake cost an hour rather than a
+/// minute: several hosts started with different values all shared one store, and
+/// the contaminated roster read as a product bug rather than a configuration
+/// one.
 pub fn resolve_home(flag: Option<PathBuf>) -> Result<PathBuf> {
     resolve_home_from(
         flag,

--- a/src/store/paths.rs
+++ b/src/store/paths.rs
@@ -17,23 +17,128 @@
 //! `secrets/` and `keys/` are excluded from bundle exports (see
 //! [`Bundle::EXPORT_EXCLUDES`]) so a shared bundle never leaks the company's
 //! signing key or per-company secrets.
+//!
+//! [`resolve_home`] resolves the `<home>` root every bundle hangs off, and is
+//! the only place that decision is made.
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use crate::Result;
 use crate::error::OpenCompanyError;
 use crate::ports::types::CompanyId;
 
-/// Resolves the OpenCompany home root.
+/// The one environment knob that places an instance's data root. Also read by
+/// [`data_dir_from_env`](crate::app::config::data_dir_from_env) for the
+/// workspace layout, so a single value moves an entire instance.
+pub const DATA_DIR_ENV: &str = "OPENCOMPANY_DATA_DIR";
+
+/// A knob that never worked. It was documented in this module and read by a
+/// helper no binary path ever called, so exporting it silently did nothing.
+/// [`resolve_home`] now rejects it by name instead of ignoring it.
+const REMOVED_HOME_ENV: &str = "OPENCOMPANY_HOME";
+
+/// The legacy leaf appended to `$HOME/.opencompany` when neither `--home` nor
+/// [`DATA_DIR_ENV`] is set. [`Bundle::new`] appends `companies/` of its own, so
+/// the untouched default resolves bundles to
+/// `~/.opencompany/companies/companies/<slug>`. That extra level is a wart, but
+/// it is where every existing local install's data already sits, so the default
+/// is preserved verbatim rather than silently relocating it.
+const LEGACY_DEFAULT_LEAF: &str = "companies";
+
+/// Resolves the OpenCompany home — the root every [`Bundle`] hangs off — from
+/// the `--home` flag and the process environment.
 ///
-/// Honours `OPENCOMPANY_HOME`, otherwise falls back to `~/.opencompany`
-/// (computed from `$HOME`). No `dirs` dependency.
-pub fn default_home() -> PathBuf {
-    if let Ok(home) = std::env::var("OPENCOMPANY_HOME") {
-        return PathBuf::from(home);
+/// Precedence, highest first:
+///
+/// 1. **`--home`** (`flag`). An explicit flag always wins; no environment
+///    variable may override it.
+/// 2. **`OPENCOMPANY_DATA_DIR`** ([`DATA_DIR_ENV`]), used verbatim. This is the
+///    same value a hosted tenant's entrypoint already forwards as
+///    `--home "$OPENCOMPANY_DATA_DIR"`, so the flag and the variable resolve
+///    identically and the workspace layout and the company bundles share one
+///    root (`<root>/companies/<slug>`, matching
+///    [`DataLayout::companies_dir`](crate::store::DataLayout::companies_dir)).
+/// 3. **`$HOME/.opencompany/companies`**, the legacy local default — see
+///    [`LEGACY_DEFAULT_LEAF`]. Falls back to a relative `.opencompany/companies`
+///    when `$HOME` is unset.
+///
+/// An empty variable counts as unset: an empty `OPENCOMPANY_DATA_DIR` would
+/// otherwise root the instance at the process working directory.
+///
+/// # Errors
+///
+/// Fails when [`REMOVED_HOME_ENV`] is set. Ignoring it is what made this class
+/// of mistake cost an hour rather than a minute: several hosts started with
+/// different values all shared one store, and the contaminated roster read as a
+/// product bug rather than a configuration one.
+pub fn resolve_home(flag: Option<PathBuf>) -> Result<PathBuf> {
+    resolve_home_from(
+        flag,
+        std::env::var_os(DATA_DIR_ENV),
+        std::env::var_os(REMOVED_HOME_ENV),
+        std::env::var_os("HOME"),
+    )
+}
+
+/// Pure core of [`resolve_home`], taking raw environment values so the
+/// precedence chain is tested without mutating the process environment.
+fn resolve_home_from(
+    flag: Option<PathBuf>,
+    data_dir: Option<OsString>,
+    removed_home: Option<OsString>,
+    unix_home: Option<OsString>,
+) -> Result<PathBuf> {
+    let set = |value: Option<OsString>| value.filter(|value| !value.is_empty());
+
+    // Checked before the flag: a caller who exported the removed variable
+    // believes it is doing something, and must hear otherwise either way.
+    if set(removed_home).is_some() {
+        return Err(OpenCompanyError::Config(format!(
+            "{REMOVED_HOME_ENV} is not read by OpenCompany. Unset it and use \
+             {DATA_DIR_ENV} (or the --home flag) to place the instance data root."
+        )));
     }
-    let base = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(base).join(".opencompany")
+    if let Some(flag) = flag {
+        return Ok(flag);
+    }
+    if let Some(dir) = set(data_dir) {
+        return Ok(PathBuf::from(dir));
+    }
+    Ok(match set(unix_home) {
+        Some(home) => PathBuf::from(home)
+            .join(".opencompany")
+            .join(LEGACY_DEFAULT_LEAF),
+        None => PathBuf::from(".opencompany").join(LEGACY_DEFAULT_LEAF),
+    })
+}
+
+/// The operator warning for the one split that survives this resolution: an
+/// explicit `--home` puts company bundles in one place while the instance
+/// workspace (`memory/`, `store/`, `files/`, `logs/`, `tmp/`) stays under the
+/// data root. Isolating two hosts with `--home` alone therefore only half-works
+/// — the bundles separate, the workspace does not.
+///
+/// `data_root` is [`data_dir_from_env`](crate::app::config::data_dir_from_env).
+/// Silent in the two aligned shapes:
+///
+/// - `home == data_root` — a hosted tenant (`--home "$OPENCOMPANY_DATA_DIR"`)
+///   or `OPENCOMPANY_DATA_DIR` alone.
+/// - `home == data_root/companies` — the untouched legacy default, which
+///   diverges by design (see [`LEGACY_DEFAULT_LEAF`]) and must not warn on
+///   every ordinary run.
+pub fn home_divergence_warning(home: &Path, data_root: &Path) -> Option<String> {
+    if home == data_root || home == data_root.join(LEGACY_DEFAULT_LEAF) {
+        return None;
+    }
+    Some(format!(
+        "company bundles resolve under {}, but the instance workspace (memory/, \
+         store/, files/, logs/, tmp/) resolves under {}. Two hosts isolated by \
+         --home alone still share that workspace — set {DATA_DIR_ENV} instead, \
+         or to the same path, to keep an instance in one place.",
+        home.display(),
+        data_root.display(),
+    ))
 }
 
 /// Converts a company id into a filesystem-safe directory name.
@@ -352,15 +457,145 @@ mod test {
         assert!(Bundle::export_excludes().contains(&"secrets"));
     }
 
+    /// `resolve_home_from` with only the values a case cares about.
+    fn resolve(flag: Option<&str>, data_dir: Option<&str>, home: Option<&str>) -> Result<PathBuf> {
+        resolve_home_from(
+            flag.map(PathBuf::from),
+            data_dir.map(OsString::from),
+            None,
+            home.map(OsString::from),
+        )
+    }
+
     #[test]
-    fn default_home_prefers_env_override() {
-        // SAFETY: single-threaded test; restores prior state.
-        let prev = std::env::var("OPENCOMPANY_HOME").ok();
-        unsafe { std::env::set_var("OPENCOMPANY_HOME", "/custom/home") };
-        assert_eq!(default_home(), PathBuf::from("/custom/home"));
-        match prev {
-            Some(v) => unsafe { std::env::set_var("OPENCOMPANY_HOME", v) },
-            None => unsafe { std::env::remove_var("OPENCOMPANY_HOME") },
-        }
+    fn the_flag_outranks_the_data_dir_variable() {
+        // An explicit --home is never overridden by the environment.
+        assert_eq!(
+            resolve(Some("/flag"), Some("/env"), Some("/home/u")).unwrap(),
+            PathBuf::from("/flag")
+        );
+    }
+
+    #[test]
+    fn the_data_dir_variable_outranks_the_default() {
+        // The bug this file exists to fix: OPENCOMPANY_DATA_DIR is read, and
+        // used verbatim so it matches the `--home "$OPENCOMPANY_DATA_DIR"` a
+        // hosted tenant's entrypoint passes.
+        assert_eq!(
+            resolve(None, Some("/data"), Some("/home/u")).unwrap(),
+            PathBuf::from("/data")
+        );
+        // Verbatim means bundles land at <root>/companies/<slug>, i.e. exactly
+        // DataLayout::companies_dir() — one root for the whole instance.
+        let bundle = Bundle::new(
+            resolve(None, Some("/data"), Some("/home/u")).unwrap(),
+            &CompanyId::new("acme"),
+        );
+        assert_eq!(bundle.dir(), Path::new("/data/companies/acme"));
+    }
+
+    #[test]
+    fn the_default_is_unchanged_when_nothing_is_set() {
+        // Existing local installs must not silently relocate: the legacy
+        // default keeps its extra `companies` level (see LEGACY_DEFAULT_LEAF).
+        assert_eq!(
+            resolve(None, None, Some("/home/u")).unwrap(),
+            PathBuf::from("/home/u/.opencompany/companies")
+        );
+        let bundle = Bundle::new(
+            resolve(None, None, Some("/home/u")).unwrap(),
+            &CompanyId::new("acme"),
+        );
+        assert_eq!(
+            bundle.dir(),
+            Path::new("/home/u/.opencompany/companies/companies/acme")
+        );
+        // No $HOME keeps the relative fallback.
+        assert_eq!(
+            resolve(None, None, None).unwrap(),
+            PathBuf::from(".opencompany/companies")
+        );
+    }
+
+    #[test]
+    fn an_empty_data_dir_counts_as_unset() {
+        // Empty would otherwise root the instance at the working directory.
+        assert_eq!(
+            resolve(None, Some(""), Some("/home/u")).unwrap(),
+            PathBuf::from("/home/u/.opencompany/companies")
+        );
+        assert_eq!(
+            resolve(None, Some(""), Some("")).unwrap(),
+            PathBuf::from(".opencompany/companies")
+        );
+    }
+
+    #[test]
+    fn the_removed_home_variable_fails_loudly() {
+        let err = resolve_home_from(
+            None,
+            None,
+            Some(OsString::from("/custom/home")),
+            Some(OsString::from("/home/u")),
+        )
+        .expect_err("OPENCOMPANY_HOME must not be silently ignored");
+        let message = err.to_string();
+        assert!(message.contains(REMOVED_HOME_ENV), "{message}");
+        assert!(
+            message.contains(DATA_DIR_ENV),
+            "names the real knob: {message}"
+        );
+
+        // Loud even alongside an explicit --home, so the mistaken belief that
+        // the variable does something is always corrected.
+        assert!(
+            resolve_home_from(
+                Some(PathBuf::from("/flag")),
+                None,
+                Some(OsString::from("/custom/home")),
+                None,
+            )
+            .is_err()
+        );
+
+        // An empty value is not "set" and stays silent.
+        assert!(resolve_home_from(None, None, Some(OsString::new()), None).is_ok());
+    }
+
+    #[test]
+    fn aligned_roots_never_warn() {
+        // Hosted: the entrypoint passes --home "$OPENCOMPANY_DATA_DIR", and
+        // OPENCOMPANY_DATA_DIR alone lands the same way.
+        assert!(
+            home_divergence_warning(Path::new("/data"), Path::new("/data")).is_none(),
+            "one root for the whole instance is the intended shape"
+        );
+        // The untouched legacy default diverges by design and must stay silent
+        // on every ordinary local run.
+        assert!(
+            home_divergence_warning(
+                Path::new("/home/u/.opencompany/companies"),
+                Path::new("/home/u/.opencompany"),
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn a_split_instance_warns_with_both_roots_named() {
+        // `--home` disagreeing with a set OPENCOMPANY_DATA_DIR.
+        let warning = home_divergence_warning(Path::new("/flag"), Path::new("/data"))
+            .expect("a disagreeing flag and data root must warn");
+        assert!(warning.contains("/flag"), "{warning}");
+        assert!(warning.contains("/data"), "{warning}");
+
+        // `--home` alone, with the data root left at its default: the bundles
+        // separate but the shared workspace does not, which is the half-working
+        // isolation that made this bug expensive.
+        let warning =
+            home_divergence_warning(Path::new("/tmp/oc-a"), Path::new("/home/u/.opencompany"))
+                .expect("--home alone leaves the workspace shared and must warn");
+        assert!(warning.contains("/tmp/oc-a"), "{warning}");
+        assert!(warning.contains("/home/u/.opencompany"), "{warning}");
     }
 }


### PR DESCRIPTION
## Summary

`OPENCOMPANY_DATA_DIR` was not ignored — it was **half-honoured**, which is worse
than being ignored, and that is the actual defect behind #273.

Two resolvers read the instance data root and disagreed:

- `app::config::data_dir_from_env()` **did** read `OPENCOMPANY_DATA_DIR`. It
  places the workspace layout — `memory/`, `store/`, `files/`, `logs/`, `tmp/` —
  plus `config.toml` loading and the disk-quota check.
- the company-bundle home in `src/bin/opencompany.rs` **did not**. It resolved to
  `$HOME/.opencompany/companies` unless `--home` was passed.

So setting the variable did not move an instance; it **split** one across two
roots — workspace in the new place, companies still in the shared old one. Four
hosts on different ports each given their own `OPENCOMPANY_DATA_DIR` were all
still reading and writing the same company store, which produced a roster
carrying 13 teammates and a `legal` desk that appears in no manifest. That read
as a product bug and cost a session's worth of re-checked observations.

This PR makes one variable place the whole instance.

## API Or Behavior Changes

**1. `OPENCOMPANY_DATA_DIR` now places company bundles, not just the workspace.**
Precedence is explicit and single-sourced in `store::resolve_home`:

| Precedence | Source | Resolves to |
| --- | --- | --- |
| 1 | `--home <DIR>` | `<DIR>` verbatim — an explicit flag is never overridden by the environment |
| 2 | `OPENCOMPANY_DATA_DIR` | its value verbatim → bundles at `<root>/companies/<slug>`, matching `DataLayout::companies_dir()` |
| 3 | neither | `$HOME/.opencompany/companies` — **unchanged**, byte for byte |

An empty variable counts as unset (it would otherwise root the instance at the
process working directory).

**2. Hosted tenants were safe only by accident of the entrypoint — that is now
closed.** `docker/entrypoint.sh` passes `--home "${OPENCOMPANY_DATA_DIR:-/data}"`
explicitly, so `/data` reached both consumers and hosted persistence worked.
Nothing in the binary enforced it. A tenant launched without that one line —
a different entrypoint, a direct `opencompany serve`, an image refactor — would
have written every company bundle to `$HOME/.opencompany/companies` **inside the
container**, while `/data`, the only persistent mount, held an empty workspace.
That is silent loss of all company state on restart, one entrypoint edit away.
The binary now honours the variable itself, so the flag is belt-and-braces rather
than the sole mechanism. No behaviour change for tenants today: both paths
resolve to the same `/data`, and precedence keeps the flag winning.

**3. `OPENCOMPANY_HOME` is now a hard error instead of a silent no-op.** It was
dead on arrival — read only by a `pub fn store::paths::default_home()` that no
binary path ever called, and referenced nowhere in the Dockerfile, entrypoint,
deploy manifests, or docs. Setting it did nothing and said nothing. Rather than
carry a second name for one concept, it is removed and `serve`/`export`/`import`
now abort naming `OPENCOMPANY_DATA_DIR`. Fewer knobs, and the removed one fails
loudly. This is the only intentionally breaking change here, and it can only
break a configuration that was already having no effect.

**4. `serve` warns when the home and the data root disagree.** `--home` moves the
bundles but never the shared workspace, so two hosts isolated by the flag alone
still share `memory/`/`store/`/`files/`/`logs/`/`tmp/` — half-working isolation of
exactly the kind this issue is about. The warning names both roots. It is
`eprintln!`, not `tracing::warn!`, because the default `EnvFilter` drops warnings
unless `RUST_LOG` is set, which would make the warning as silent as the bug it
reports. Silent in the two aligned shapes: a hosted tenant (`--home` equals the
variable) and the untouched local default.

**Removed public API:** `store::default_home` (and its `store::paths` re-export).
**Added:** `store::resolve_home`, `store::home_divergence_warning`,
`store::DATA_DIR_ENV`.

## Tests

Unit tests cover the whole precedence chain through a pure core that takes raw
environment values, so no test mutates the process environment: flag over
variable, variable over default, default unchanged (asserted down to the
resolved bundle path), empty-as-unset, the removed variable erroring even
alongside an explicit `--home`, and both silent/warning divergence shapes.

Verified with real hosts, not only unit tests. Two `serve` processes on
different ports, each with its own `OPENCOMPANY_DATA_DIR`, one teammate created
through the first host's API:

```
A roster before: ceo,engineer,writer
B roster before: ceo,engineer,writer
--- creating teammate 'isolation-probe' on host A only ---
A roster after : <new-id>,ceo,engineer,writer
B roster after : ceo,engineer,writer
A bundle: <root-a>/companies/e2e-harness-co/company.toml
B bundle: <root-b>/companies/e2e-harness-co/company.toml
A contains probe: <root-a>/companies/e2e-harness-co/meta.json
B contains probe: (none)
divergence warnings on env-isolated hosts: 0 0
```

Also confirmed on live hosts:

- **flag still wins** — with the variable set to one path and `--home` to
  another, bundles land under the flag, the workspace under the variable, and
  the divergence warning names both.
- **default unchanged** — with neither set (run against a throwaway `$HOME` so
  no real install was touched), the bundle lands at exactly
  `<home>/.opencompany/companies/companies/<slug>/company.toml`, and no warning
  is printed.
- **removed variable fails loudly** — `OPENCOMPANY_HOME` set aborts with
  `OPENCOMPANY_HOME is not read by OpenCompany. Unset it and use
  OPENCOMPANY_DATA_DIR (or the --home flag) to place the instance data root.`,
  exit 1, both with and without `--home`.

Gates, all clean:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 1015 + 6 passed, 0 failed
- [x] `cargo check --all-features`
- [x] `cargo check --features openhuman,mcp,telegram`

The last two are run because the default feature set hides breakage in those
combinations.

## Documentation

- `docs/spec/runtime/storage.md` — a "Choosing the root" section with the
  precedence table, why the untouched default nests one level deeper than the
  canonical layout, why `--home` alone leaves the workspace shared, and a worked
  two-host side-by-side example. This is where the issue asked for it: running
  two companies at once is a normal thing to want, and the failure mode was
  contaminated data rather than an error.
- `AGENTS.md` (and `CLAUDE.md`, its symlink) — the hosted-mode section claimed
  the control plane injects `OPENCOMPANY_DATA_DIR=/data` into every tenant. That
  was true of the entrypoint and false of the binary. A doc describing a contract
  the code did not honour is how this gap survived, so it now states what the
  variable actually places and that the entrypoint's `--home` resolves
  identically.
- `docs/spec/runtime/config.md`, `gitbooks/developers/configuration.md`,
  `gitbooks/developers/cli.md` — reference entries and a "Where state lives"
  section carrying the same precedence.

## Related

Closes #273.

Filed #283 rather than fixing it here: `Bundle::new` appends its own
`companies/`, so the untouched default lands bundles at
`~/.opencompany/companies/companies/<slug>`, one level deeper than the layout
the spec documents. Collapsing that would silently relocate every existing local
install's companies — the same class of silent data movement this issue is
about — so it needs a migration, not a one-line change. Setting
`OPENCOMPANY_DATA_DIR` already yields the canonical single-root layout, so the
wart is confined to the default and is now documented.

Separately noted for triage, not touched here: `cargo check --all-features
--all-targets` fails on `main` with two pre-existing `E0034` ambiguities in
`src/store/sqlite.rs` (a `store.list(..)` call resolving to both `ContextStore`
and `CompanyStore`). CI runs `--all-features` *without* `--all-targets`, so the
lib-test target is never checked under that feature set and the breakage is
invisible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer storage location controls through the `--home` option and `OPENCOMPANY_DATA_DIR` setting.
  - Added support for running multiple local hosts with isolated data directories.
  - Added warnings when company bundle and workspace locations may be misaligned.
  - Empty data-directory settings now fall back safely to the legacy location.

- **Bug Fixes**
  - Unsupported `OPENCOMPANY_HOME` configuration is now rejected with guidance to use the supported setting.

- **Documentation**
  - Expanded CLI, configuration, runtime, and storage documentation covering precedence, defaults, isolation, and migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->