### PR TITLE
fix(workflows): log a delivery's failure class, not the transport's reply (#248)

### DIFF
--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -73,6 +73,14 @@ diagnosable in the host's stdout, which is not the same as operator-visible.
 Surfacing those outcomes is issue #228; the durable record it needs is the
 first-class `Run` tracked by issue #242.
 
+That distinction decides what the scheduler's log line may say. Every row
+carries two reasons: `detail`, the free text the run response and the console
+render, and `reason`, a closed set (`DeliveryReason`). Only `reason` is logged.
+On the transport-failure arms `detail` interpolates the transport's own reply,
+and a mail transport quotes the mailbox it refused — so `detail` on host stdout
+would put a recipient's address on a platform surface. `reason` says what class
+of thing failed and has no field that could carry the address (issue #248).
+
 Authoring a destination and reading the result back:
 
 Both routes go through `ScopedCompany`, so both need an operator credential —

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -112,8 +112,24 @@ export interface DeliveryReport {
   /** The address or channel actually addressed, when there was one. */
   target?: string;
   status: DeliveryStatus;
-  /** An operator-readable reason — populated even on success. */
+  /**
+   * An operator-readable reason — populated even on success. This is the half
+   * the drawer renders: it may quote the transport verbatim, which is what
+   * makes a refused send fixable, and this console is a tenant surface.
+   */
   detail: string;
+  /**
+   * The same outcome as a stable token out of a closed set (issue #248) —
+   * `"mail-transport-refused"`, `"channel-not-wired"`, and so on.
+   *
+   * It exists because the host's own logs may not carry `detail`: on the
+   * transport-failure arms `detail` interpolates the transport's reply, which
+   * routinely quotes the recipient's address, and host stdout is a platform
+   * surface rather than a tenant one. Nothing renders it today — `detail` is
+   * strictly more informative here — so it is optional on the type (not the
+   * wire), and a response from a host predating #248 still parses.
+   */
+  reason?: string;
 }
 
 /** The result of a run: the engine's final state and any pending approvals. */

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -158,6 +158,11 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
         // recipient's email address and its detail can quote one, and this body
         // is wired out to the inference sidecar; the console reads the full
         // rows from the journal instead, where they belong to the operator.
+        //
+        // Issue #248 pinned this with a test rather than leaving it a comment:
+        // the exclusion is the journal-boundary half of the same rule the
+        // scheduler's log line follows, and an unpinned rule is one refactor
+        // away from not being true.
         CompanyEvent::WorkflowRunFinished {
             workflow_id,
             scheduled,
@@ -334,4 +339,61 @@ pub(crate) fn payload_f64(value: &Value, key: &str) -> Option<f64> {
 
 pub(crate) fn payload_bool(value: &Value, key: &str) -> Option<bool> {
     value.get(key).and_then(Value::as_bool)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ports::workflow_runner::{DeliveryReason, DeliveryReport};
+
+    /// A recipient address for fixtures. `.invalid` is reserved by RFC 2606 and
+    /// can never resolve, so a fixture that escapes names nobody.
+    const RECIPIENT: &str = "recipient@example.invalid";
+
+    /// **Issue #248, one layer below the log line.** A company's journal is a
+    /// single append-only log shared by chat, audit and run history, and this
+    /// function is the seam where it is wired out to the inference sidecar —
+    /// a reader that is not the tenant. A `WorkflowRunFinished` row's `target`
+    /// is a recipient's address and its `detail` quotes one on the
+    /// transport-failure arms, so neither may cross here.
+    ///
+    /// The exclusion was already written this way by #228; this pins it, so a
+    /// later "just include the detail, it is more informative" edit fails CI
+    /// instead of quietly widening the boundary.
+    #[test]
+    fn a_finished_run_wires_out_counts_without_the_recipient_or_the_transport_text() {
+        let event = CompanyEvent::WorkflowRunFinished {
+            workflow_id: "digest".to_string(),
+            scheduled: true,
+            run_id: None,
+            deliveries: vec![DeliveryReport {
+                node: "owner_summary".to_string(),
+                kind: "email".to_string(),
+                target: Some(RECIPIENT.to_string()),
+                status: DeliveryStatus::Failed,
+                detail: format!(
+                    "the mail transport refused the message: 550 5.1.1 <{RECIPIENT}>: Recipient \
+                     address rejected"
+                ),
+                reason: DeliveryReason::MailTransportRefused,
+            }],
+            pending_approvals: Vec::new(),
+            error: None,
+        };
+
+        let wired = wire_event(7, &event);
+
+        assert!(!wired.body.contains(RECIPIENT), "{}", wired.body);
+        assert!(!wired.body.contains("recipient@"), "{}", wired.body);
+        assert!(
+            !wired.body.contains("Recipient address rejected"),
+            "{}",
+            wired.body
+        );
+        assert!(!wired.body.contains("550"), "{}", wired.body);
+        // Still says what happened, in counts.
+        assert!(wired.body.contains("digest"), "{}", wired.body);
+        assert!(wired.body.contains("1 not delivered"), "{}", wired.body);
+        assert_eq!(wired.kind, "workflow.run");
+    }
 }

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -1553,6 +1553,45 @@ mod tests {
         }
     }
 
+    /// **Issue #248, the insight-surface twin of the sidecar guard.** This
+    /// one-liner is folded into the orchestrator's recent-activity context, so
+    /// it is read by a model rather than by the tenant. A delivery row's
+    /// `target` is a recipient's address and its `detail` quotes one when the
+    /// transport refuses, so neither may appear here. The exclusion was written
+    /// this way by #228; this pins it.
+    #[test]
+    fn a_finished_run_summarizes_to_counts_without_the_recipient_or_transport_text() {
+        // `.invalid` is reserved by RFC 2606, so this fixture names nobody.
+        const RECIPIENT: &str = "recipient@example.invalid";
+
+        let summary = summarize_event(&CompanyEvent::WorkflowRunFinished {
+            workflow_id: "digest".to_string(),
+            scheduled: true,
+            run_id: None,
+            deliveries: vec![crate::ports::DeliveryReport {
+                node: "owner_summary".to_string(),
+                kind: "email".to_string(),
+                target: Some(RECIPIENT.to_string()),
+                status: crate::ports::DeliveryStatus::Failed,
+                detail: format!(
+                    "the mail transport refused the message: 550 5.1.1 <{RECIPIENT}>: Recipient \
+                     address rejected"
+                ),
+                reason: crate::ports::DeliveryReason::MailTransportRefused,
+            }],
+            pending_approvals: Vec::new(),
+            error: None,
+        });
+
+        assert!(!summary.contains(RECIPIENT), "{summary}");
+        assert!(!summary.contains("recipient@"), "{summary}");
+        assert!(!summary.contains("Recipient address rejected"), "{summary}");
+        assert!(!summary.contains("550"), "{summary}");
+        // Still useful: which workflow, and that something did not go out.
+        assert!(summary.contains("digest"), "{summary}");
+        assert!(summary.contains("1 not delivered"), "{summary}");
+    }
+
     #[test]
     fn orchestrator_id_prefers_the_tagged_agent() {
         let roster = vec![

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -55,7 +55,9 @@ pub use tools::ToolProvider;
 pub use types::*;
 pub use usage::{SampleKind, UsageMeter, UsageSample};
 pub use users::{InviteRecord, UserRecord, UserRole, UserStatus, UserStore, normalize_email};
-pub use workflow_runner::{DeliveryReport, DeliveryStatus, WorkflowRun, WorkflowRunner};
+pub use workflow_runner::{
+    DeliveryReason, DeliveryReport, DeliveryStatus, WorkflowRun, WorkflowRunner,
+};
 pub use workspace::{NodeKind, WorkspaceNode, WorkspaceStore};
 
 #[cfg(test)]

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -2415,6 +2415,7 @@ mod test {
             target: Some("ada@example.com".to_string()),
             status,
             detail: "emailed the company's admin".to_string(),
+            reason: crate::ports::DeliveryReason::OwnerEmailed,
         }
     }
 

--- a/src/ports/workflow_runner.rs
+++ b/src/ports/workflow_runner.rs
@@ -72,12 +72,138 @@ pub enum DeliveryStatus {
     Failed,
 }
 
+/// Why a delivery attempt came out the way it did, as a closed set (issue
+/// #248).
+///
+/// # Why this is an enum and not another string
+///
+/// [`DeliveryReport::detail`] is free text, and on the transport-failure arms it
+/// interpolates the transport's own words. A mail transport's refusal routinely
+/// quotes the mailbox it refused (an SMTP `550`/`553` reply commonly reads
+/// `<recipient@example.invalid>: Recipient address rejected`), so `detail`
+/// carries a recipient address on exactly the paths an operator most wants to
+/// read about. That is fine on the operator's own surfaces — the run response
+/// and the `WorkflowRunFinished` history a tenant reads back — and not fine on
+/// host stdout, which on a hosted deployment is the platform rather than the
+/// operator.
+///
+/// This enum is the half that may be logged. It is *unable* to carry
+/// transport-supplied text: it has no `String` payload, so there is no
+/// `format!` that produces one. The guarantee is the compiler's rather than a
+/// reviewer's, and a new delivery outcome cannot be added without classifying
+/// it — the construction sites match on this type exhaustively.
+///
+/// Its [`Display`](std::fmt::Display) rendering is the prose that reaches the
+/// log; its serde name is the stable token for querying a run history.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DeliveryReason {
+    /// This build wired no delivery ports at all, so nothing could be sent.
+    NotWired,
+    /// An `owner` report reached the company's admin mailbox.
+    OwnerEmailed,
+    /// An `email` report reached the named recipient on an established thread.
+    RecipientEmailed,
+    /// The mail transport refused the message. **The transport's own reason is
+    /// in `detail`, not here** — that is the string that quotes the address.
+    MailTransportRefused,
+    /// `owner` had no mailbox to send from, so the report went to the operator
+    /// channel instead.
+    OwnerFellBackNoMailbox,
+    /// `owner` had a mailbox but no active admin with an address, so the report
+    /// went to the operator channel instead.
+    OwnerFellBackNoAdminAddress,
+    /// `owner`'s operator-channel fallback itself failed, so nothing was sent.
+    OwnerFallbackFailed,
+    /// The company's `[tools].allow` does not grant `email`, so a workflow may
+    /// not mail a named address.
+    EmailNotGranted,
+    /// No mailbox is configured for the company, so there was nothing to send
+    /// from.
+    NoMailboxConfigured,
+    /// The recipient is not an established thread and this runtime has no
+    /// approvals queue to park the send on.
+    RecipientNotEstablished,
+    /// The recipient is not an established thread; the send is parked in
+    /// Approvals awaiting a human verdict.
+    ParkedForApproval,
+    /// The recipient is not an established thread and the send could not be
+    /// parked for approval either.
+    ParkingUnavailable,
+    /// A `channel` report was posted to the wired adapter.
+    ChannelPosted,
+    /// The destination names a channel this deployment never wired. **Which
+    /// channel, and what is wired instead, is in `detail`** — a channel id is
+    /// the `channel` arm's target, and targets do not go to host logs.
+    ChannelNotWired,
+    /// The channel adapter refused the message. As with mail, the adapter's own
+    /// reason stays in `detail`.
+    ChannelRefused,
+    /// The destination kind is not one this runtime knows how to deliver to
+    /// (unreachable through `parse_workflow`, which rejects unknown kinds).
+    UnknownDestinationKind,
+    /// No reason was recorded. Only reachable by deserializing a
+    /// `WorkflowRunFinished` event written before this field existed.
+    #[default]
+    Unspecified,
+}
+
+impl std::fmt::Display for DeliveryReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Every arm is a literal. Keep it that way: the whole point of the type
+        // is that nothing runtime-supplied can reach a host log through it.
+        f.write_str(match self {
+            Self::NotWired => "report delivery is not wired on this runtime",
+            Self::OwnerEmailed => "emailed the company's admin",
+            Self::RecipientEmailed => "emailed the named recipient on an established thread",
+            Self::MailTransportRefused => "the mail transport refused the message",
+            Self::OwnerFellBackNoMailbox => {
+                "no mailbox is configured for this company, so the report went to the operator \
+                 channel"
+            }
+            Self::OwnerFellBackNoAdminAddress => {
+                "no active admin has an email address, so the report went to the operator channel"
+            }
+            Self::OwnerFallbackFailed => "the operator channel fallback failed",
+            Self::EmailNotGranted => {
+                "this company's [tools].allow does not grant `email`, so a workflow may not send \
+                 mail to a named address"
+            }
+            Self::NoMailboxConfigured => "no mailbox is configured for this company",
+            Self::RecipientNotEstablished => {
+                "the recipient has never written to the company, and this runtime has no approvals \
+                 queue to park the send on"
+            }
+            Self::ParkedForApproval => {
+                "the recipient has never written to the company, so the report is waiting in \
+                 Approvals"
+            }
+            Self::ParkingUnavailable => {
+                "the recipient has never written to the company, and the report could not be \
+                 queued for approval either"
+            }
+            Self::ChannelPosted => "posted to the channel",
+            Self::ChannelNotWired => "the destination channel is not wired on this runtime",
+            Self::ChannelRefused => "the channel refused the message",
+            Self::UnknownDestinationKind => {
+                "the destination kind is not one this runtime can deliver to"
+            }
+            Self::Unspecified => "no reason was recorded for this delivery",
+        })
+    }
+}
+
 /// One attempt to route a reached `output` node's report somewhere.
 ///
 /// On an on-demand run these rows ride the run response into the console's
 /// run-result panel, so an operator can tell a delivered report from an
-/// undelivered one without reading a log. A scheduled run is not persisted, so
-/// its rows reach only the scheduler's log until issue #228 lands.
+/// undelivered one without reading a log. A scheduled run's rows are journaled
+/// as a `WorkflowRunFinished` event (issue #228) that the tenant's own console
+/// reads back, and are summarized on host stdout by the scheduler.
+///
+/// **The two reason fields are not interchangeable.** See [`DeliveryReason`]:
+/// `detail` is for the operator's surfaces and may quote a transport; `reason`
+/// is the only one that may reach a host log.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeliveryReport {
@@ -94,7 +220,27 @@ pub struct DeliveryReport {
     /// An operator-readable reason, always populated — including on success, so
     /// a `sent` row still says *how* it was sent (which matters for `owner`,
     /// whose recipient the graph never named).
+    ///
+    /// **Operator surfaces only — never a host log.** On the transport-failure
+    /// arms this interpolates the transport's own text, which routinely quotes
+    /// the address it refused. Log [`Self::reason`] instead.
+    ///
+    /// "Operator surfaces" is a claim about specific readers, so it is worth
+    /// naming them. This field reaches: the run response, the company-scoped
+    /// SSE projection, and `GET …/workflows/runs` — all three behind the
+    /// `ScopedCompany` guard, and all three reading a **per-company**
+    /// `events.jsonl`. It reaches neither of the journal's two non-tenant
+    /// readers: the inference-sidecar wire-out (`brain::medulla::effects`) and
+    /// the orchestrator's insight summary (`harness::orchestrator`, compiled
+    /// only under `openhuman`) both fold a finished run to counts, and tests
+    /// pin that they do.
     pub detail: String,
+    /// The same outcome as a closed set, safe to log by construction.
+    ///
+    /// `#[serde(default)]` so a `WorkflowRunFinished` event journaled before
+    /// this field existed still loads, as [`DeliveryReason::Unspecified`].
+    #[serde(default)]
+    pub reason: DeliveryReason,
 }
 
 /// Runs a company's workflow graph to completion.

--- a/src/runtime/workflow_outcome.rs
+++ b/src/runtime/workflow_outcome.rs
@@ -115,6 +115,7 @@ mod test {
             target: Some("ada@example.com".to_string()),
             status,
             detail: "this recipient has never written to the company".to_string(),
+            reason: crate::ports::DeliveryReason::RecipientNotEstablished,
         }
     }
 

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -53,6 +53,19 @@
 //! event is the operator's surface. The two answer to different readers, so
 //! neither replaces the other.
 //!
+//! **That split decides what the log lines may say.** Because host stdout is a
+//! platform surface, the undelivered-report warning below carries only fields
+//! that are safe for a reader who is not the tenant: the company, the workflow,
+//! the node, the destination *kind*, whether a target resolved at all, the
+//! status, and a [`DeliveryReason`](crate::ports::DeliveryReason). It does
+//! **not** carry the target, and — since issue #248 — it does not carry
+//! [`DeliveryReport::detail`](crate::ports::DeliveryReport) either: `detail`
+//! interpolates the transport's own text on the failure arms, and a mail
+//! transport quotes the mailbox it refused. `DeliveryReason` is the closed set
+//! that says the same thing about the failure without the ability to carry the
+//! address. The full `detail` still reaches the operator, through the run
+//! response and the journaled event above.
+//!
 //! (A run outcome is deliberately *not* modelled as issue #242's first-class
 //! `RunRecord`. That is a task-attempt record minted at the task dispatch choke
 //! point and keyed to a board task with an attempt ordinal; a workflow run
@@ -338,7 +351,8 @@ impl WorkflowScheduler {
                             let counts = DeliveryCounts::of(&run.deliveries);
                             // One line per undelivered report: a count alone
                             // says something is wrong without saying what to
-                            // fix, and `detail` is the part that names the fix.
+                            // fix, and `reason` is the part that names the
+                            // failure class.
                             for report in &run.deliveries {
                                 if report.status == DeliveryStatus::Sent {
                                     continue;
@@ -373,7 +387,20 @@ impl WorkflowScheduler {
                                     // the part with diagnostic value anyway.
                                     target_configured = report.target.is_some(),
                                     status = ?report.status,
-                                    detail = %report.detail,
+                                    // The classification, NOT `report.detail`.
+                                    // `detail` interpolates the transport's own
+                                    // words on the failure arms, and a mail
+                                    // transport quotes the mailbox it refused —
+                                    // so logging it walks the recipient address
+                                    // onto host stdout through the back door
+                                    // that scrubbing `target` left open (issue
+                                    // #248). `reason` says the same thing about
+                                    // what failed, out of a closed set that
+                                    // cannot carry transport text; the operator
+                                    // still gets the full `detail` on the run
+                                    // response and in the run history their own
+                                    // console reads back.
+                                    reason = %report.reason,
                                     "workflow scheduler: a scheduled run's report was NOT delivered"
                                 );
                             }
@@ -594,7 +621,7 @@ mod test {
     use super::*;
     use crate::company::CompanyManifest;
     use crate::ports::types::{CompanyEvent, CompanyRecord, EventSeq, OverlayWorkflow};
-    use crate::ports::{WorkflowRun, WorkflowRunner};
+    use crate::ports::{DeliveryReason, WorkflowRun, WorkflowRunner};
     use crate::runtime::{FakeClock, RuntimeBuilder};
 
     // --- tracing capture -----------------------------------------------------
@@ -1014,15 +1041,43 @@ to = "done"
 
     // --- report delivery on a scheduled run (issue #170) ---------------------
 
+    /// A row whose classification is the plausible one for its status, so a
+    /// fixture never claims something the two halves would contradict (a `sent`
+    /// row reasoned as a cold recipient, say). Tests that assert on the
+    /// classification itself use [`reported`] and name it.
     fn report(node: &str, status: DeliveryStatus, detail: &str) -> DeliveryReport {
+        let reason = match status {
+            DeliveryStatus::Sent => DeliveryReason::OwnerEmailed,
+            DeliveryStatus::Pending => DeliveryReason::ParkedForApproval,
+            DeliveryStatus::Skipped => DeliveryReason::RecipientNotEstablished,
+            DeliveryStatus::Denied => DeliveryReason::EmailNotGranted,
+            DeliveryStatus::Failed => DeliveryReason::MailTransportRefused,
+        };
+        reported(node, status, reason, detail)
+    }
+
+    /// `report`, with the classification spelled out — for the tests that care
+    /// which half of the row the scheduler logged.
+    fn reported(
+        node: &str,
+        status: DeliveryStatus,
+        reason: DeliveryReason,
+        detail: &str,
+    ) -> DeliveryReport {
         DeliveryReport {
             node: node.to_string(),
             kind: "email".to_string(),
-            target: Some("ada@example.com".to_string()),
+            target: Some(RECIPIENT.to_string()),
             status,
             detail: detail.to_string(),
+            reason,
         }
     }
+
+    /// The recipient address every delivery fixture in this module addresses.
+    /// `.invalid` is reserved by RFC 2606 and can never resolve, so a fixture
+    /// that escapes into a log or a PR body names nobody.
+    const RECIPIENT: &str = "recipient@example.invalid";
 
     /// The fold behind the summary line counts each status separately, because
     /// "policy refused to send" and "something broke" are different problems.
@@ -1059,7 +1114,7 @@ to = "done"
     /// go out must not be silent. There is no HTTP response and no drawer, so
     /// the log line is the whole channel — this reads what the scheduler
     /// actually emitted and asserts the operator-actionable parts are in it:
-    /// which company, which workflow, which node, and the `detail` that says
+    /// which company, which workflow, which node, and the `reason` that says
     /// what to do about it.
     #[tokio::test]
     async fn a_scheduled_run_reports_an_undelivered_report() {
@@ -1117,13 +1172,13 @@ to = "done"
         assert!(line.contains("Skipped"), "names the status: {line}");
         assert!(
             line.contains("never written to the company"),
-            "carries the detail, which is the part that says what to fix: {line}"
+            "carries the reason, which is the part that says what to fix: {line}"
         );
         // …but NOT the recipient's address. This line lands on host stdout,
         // which on a hosted tenant is us rather than the operator, so the
         // address must never ride it — only whether one resolved at all.
         assert!(
-            !line.contains("ada@example.com"),
+            !line.contains(RECIPIENT),
             "must not leak the recipient address to host stdout: {line}"
         );
         assert!(
@@ -1153,6 +1208,129 @@ to = "done"
         assert!(summary.contains("failed=0"), "{summary}");
         assert!(summary.contains("pending_approval=0"), "{summary}");
         assert!(summary.contains("undelivered=1"), "{summary}");
+    }
+
+    /// **Issue #248 — the indirect path.** Scrubbing `report.target` from the
+    /// warning above closed the direct route to host stdout. This is the other
+    /// one: on the transport-failure arms `report.detail` interpolates the
+    /// transport's own words, and a mail transport quotes the mailbox it
+    /// refused — an SMTP `550`/`553` reply is routinely of the form
+    /// `<recipient@…>: Recipient address rejected`. So a row whose `target` is
+    /// scrubbed can still walk the address in through `detail`.
+    ///
+    /// The `detail` here is verbatim what
+    /// [`crate::workflows::delivery`] builds for a refused send, wrapped around
+    /// a realistic SMTP reply, so the fixture fails the way production does
+    /// rather than the way a mock does.
+    ///
+    /// **The assertion is over the emitted event**, not over a string on the way
+    /// to it: it scans the captured `tracing` output for the line the scheduler
+    /// actually wrote. Asserting on `report.reason` alone would prove nothing
+    /// about the log — the whole bug was a field being logged that nobody meant
+    /// to log.
+    #[tokio::test]
+    async fn a_transport_failure_does_not_log_the_address_the_transport_quoted() {
+        let sink = captured_logs();
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let company = "transport-refusal-co";
+        // What `delivery::deliver_one`'s `Err(err)` arm produces, with a reply
+        // shaped like a real one.
+        let detail = format!(
+            "the mail transport refused the message: 550 5.1.1 <{RECIPIENT}>: Recipient address \
+             rejected: User unknown in local recipient table"
+        );
+        let (runner, completed) = RecordingRunner::with_deliveries(vec![reported(
+            "owner_summary",
+            DeliveryStatus::Failed,
+            DeliveryReason::MailTransportRefused,
+            &detail,
+        )]);
+        let registry = company_with_overlays(
+            &home,
+            company,
+            vec![overlay("digest", Some("* * * * *"))],
+            Some(runner),
+            "running",
+        )
+        .await;
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry, clock);
+
+        assert_eq!(scheduler.tick().await, 1);
+        wait_for(|| completed.load(Ordering::SeqCst) == 1).await;
+        wait_for(|| {
+            captured_text(&sink)
+                .lines()
+                .any(|l| l.contains(company) && l.contains("was NOT delivered"))
+        })
+        .await;
+
+        let logs = captured_text(&sink);
+        let line = logs
+            .lines()
+            .find(|l| l.contains(company) && l.contains("was NOT delivered"))
+            .unwrap_or_else(|| panic!("no undelivered-report line for {company}: {logs}"));
+
+        // The point of the issue: not through `target`, and not through the
+        // transport's reply either.
+        assert!(
+            !line.contains(RECIPIENT),
+            "the transport's reply must not walk the recipient address onto host stdout: {line}"
+        );
+        // Belt and braces — the address's local part alone is enough to
+        // identify a person, so an over-eager "strip the domain" fix must fail
+        // this too.
+        assert!(
+            !line.contains("recipient@"),
+            "not even a partial address: {line}"
+        );
+        // The whole reply is absent, not merely masked mid-string: nothing of
+        // the transport's own text reaches the line.
+        assert!(
+            !line.contains("Recipient address rejected"),
+            "no transport-supplied text at all: {line}"
+        );
+
+        // …and the line is still worth reading. An operator paged by this needs
+        // to know where to look and what class of thing broke.
+        assert!(line.contains("digest"), "names the workflow: {line}");
+        assert!(line.contains("owner_summary"), "names the node: {line}");
+        assert!(
+            line.contains("kind=email"),
+            "names the destination kind: {line}"
+        );
+        assert!(line.contains("Failed"), "names the status: {line}");
+        assert!(
+            line.contains("target_configured=true"),
+            "says a target resolved, without saying which: {line}"
+        );
+        assert!(
+            line.contains("the mail transport refused the message"),
+            "names the failure class: {line}"
+        );
+    }
+
+    /// The operator's half is deliberately NOT scrubbed. `detail` is what makes
+    /// a refused send fixable, the run response and the journaled
+    /// `WorkflowRunFinished` event are tenant-scoped surfaces, and an operator
+    /// is entitled to their own recipient's address. Pinned so a later "scrub
+    /// it everywhere" sweep has to argue with a test.
+    #[test]
+    fn the_operator_facing_detail_keeps_the_transport_text() {
+        let detail =
+            format!("the mail transport refused the message: 550 5.1.1 <{RECIPIENT}>: rejected");
+        let row = reported(
+            "owner_summary",
+            DeliveryStatus::Failed,
+            DeliveryReason::MailTransportRefused,
+            &detail,
+        );
+        assert!(row.detail.contains(RECIPIENT), "{row:?}");
+        assert_eq!(row.target.as_deref(), Some(RECIPIENT));
+        // The two halves disagree on purpose — that IS the fix.
+        assert!(!row.reason.to_string().contains(RECIPIENT), "{row:?}");
+        assert!(!row.reason.to_string().contains('@'), "{row:?}");
     }
 
     /// Issue #227: a scheduled run whose report was parked for approval is the
@@ -1206,7 +1384,7 @@ to = "done"
         assert!(line.contains("Approvals view"), "says where to go: {line}");
         // Never the recipient's address on host stdout, same as the warn path.
         assert!(
-            !line.contains("ada@example.com"),
+            !line.contains(RECIPIENT),
             "must not leak the recipient address to host stdout: {line}"
         );
         // Not cried wolf about.
@@ -1361,7 +1539,7 @@ to = "done"
         // The journal is operator-scoped — unlike host stdout — so the resolved
         // target rides it. This is the same field the manual run's HTTP response
         // already ships to the console today.
-        assert_eq!(skipped.target.as_deref(), Some("ada@example.com"));
+        assert_eq!(skipped.target.as_deref(), Some(RECIPIENT));
     }
 
     /// The arm that was quietest of all: a scheduled run that failed outright

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -2790,6 +2790,7 @@ mod test {
             target: Some("ada@example.com".into()),
             status,
             detail: "this recipient has never written to the company".into(),
+            reason: crate::ports::DeliveryReason::RecipientNotEstablished,
         }
     }
 

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1194,6 +1194,7 @@ mod tests {
                 target: Some("ada@example.com".into()),
                 status: DeliveryStatus::Skipped,
                 detail: "never written in".into(),
+                reason: crate::ports::DeliveryReason::RecipientNotEstablished,
             }],
         })
         .unwrap();
@@ -1221,6 +1222,7 @@ mod tests {
                 target: Some("stranger@example.com".into()),
                 status: DeliveryStatus::Pending,
                 detail: "waiting for you in Approvals".into(),
+                reason: crate::ports::DeliveryReason::ParkedForApproval,
             }],
         })
         .unwrap();
@@ -1608,6 +1610,7 @@ mod tests {
                 target: Some("ada@example.com".to_string()),
                 status: crate::ports::DeliveryStatus::Skipped,
                 detail: "this recipient has never written to the company".to_string(),
+                reason: crate::ports::DeliveryReason::RecipientNotEstablished,
             }
         }
 

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -88,6 +88,27 @@
 //! An output node the run never reached (an untaken branch, or a path that
 //! paused for approval) gets no attempt and no row — an absent row means "not
 //! reached", never "silently dropped".
+//!
+//! # Two reasons per row, and why (issue #248)
+//!
+//! Every row carries both a free-text [`DeliveryReport::detail`] and a
+//! [`DeliveryReason`]. They are not redundant — they have different readers:
+//!
+//! * `detail` is for the **operator**: the run response and the
+//!   `WorkflowRunFinished` history their own console reads back. It may quote a
+//!   transport verbatim, which is what makes a failed send diagnosable.
+//! * `reason` is for the **host log**. The scheduler's undelivered-report
+//!   warning goes to host stdout, which on a hosted deployment is the platform
+//!   and not the operator — the same boundary
+//!   [`crate::runtime::workflow_scheduler`]'s module docs draw. A transport
+//!   refusal quotes the mailbox it refused (`550 5.1.1
+//!   <recipient@example.invalid>: Recipient address rejected`), so `detail` is
+//!   not loggable there and `reason` is.
+//!
+//! Both are set at the same construction site, so the classification is made
+//! where the outcome is known rather than recovered later by pattern-matching a
+//! string. `DeliveryReason` has no `String` payload, so the safe half cannot
+//! drift into carrying transport text without changing its type.
 
 use std::sync::Arc;
 
@@ -100,8 +121,8 @@ use crate::ports::types::{
     Actor, ActorKind, CompanyId, CompanyRecord, Effect, EffectGroup, OutboundMessage, Verdict,
 };
 use crate::ports::{
-    ApprovalGate, ChannelAdapter, DeliveryReport, DeliveryStatus, EmailRecord, InboxStore,
-    UserRole, UserStatus, UserStore, generate_id, now_millis,
+    ApprovalGate, ChannelAdapter, DeliveryReason, DeliveryReport, DeliveryStatus, EmailRecord,
+    InboxStore, UserRole, UserStatus, UserStore, generate_id, now_millis,
 };
 use crate::runtime::cycle::EMAIL_SEND_KIND;
 use crate::runtime::journal::RuntimeJournal;
@@ -247,6 +268,7 @@ pub async fn deliver_outputs(
                 detail: "report delivery is not wired on this runtime — the workflow ran and its \
                          result is in this run, but nothing was sent"
                     .to_string(),
+                reason: DeliveryReason::NotWired,
             });
             continue;
         };
@@ -278,12 +300,19 @@ async fn deliver_one(
     text: &str,
     reports: &mut Vec<DeliveryReport>,
 ) {
-    let row = |target: Option<String>, status: DeliveryStatus, detail: String| DeliveryReport {
+    // `reason` sits between `status` and `detail` on purpose: the classification
+    // is not optional trailing garnish, and a caller has to walk past it to
+    // reach the free-text half.
+    let row = |target: Option<String>,
+               status: DeliveryStatus,
+               reason: DeliveryReason,
+               detail: String| DeliveryReport {
         node: node_id.to_string(),
         kind: destination.kind.clone(),
         target,
         status,
         detail,
+        reason,
     };
     let target = destination.target.as_deref().map(str::trim).unwrap_or("");
 
@@ -300,11 +329,16 @@ async fn deliver_one(
                             Ok(()) => row(
                                 Some(address),
                                 DeliveryStatus::Sent,
+                                DeliveryReason::OwnerEmailed,
                                 "emailed the company's admin".to_string(),
                             ),
+                            // `err` is the transport's own words and can quote
+                            // the mailbox it refused, so it stays on the
+                            // operator's half only (issue #248).
                             Err(err) => row(
                                 Some(address),
                                 DeliveryStatus::Failed,
+                                DeliveryReason::MailTransportRefused,
                                 format!("the mail transport refused the message: {err}"),
                             ),
                         });
@@ -314,10 +348,16 @@ async fn deliver_one(
                 // always-present operator channel so the owner still hears about
                 // it. Never a silent no-op.
                 _ => {
-                    let why = if delivery.mail.is_none() {
-                        "no mailbox is configured for this company"
+                    let (why, why_reason) = if delivery.mail.is_none() {
+                        (
+                            "no mailbox is configured for this company",
+                            DeliveryReason::OwnerFellBackNoMailbox,
+                        )
                     } else {
-                        "no active admin has an email address"
+                        (
+                            "no active admin has an email address",
+                            DeliveryReason::OwnerFellBackNoAdminAddress,
+                        )
                     };
                     reports.push(
                         post_to_channel(
@@ -331,13 +371,20 @@ async fn deliver_one(
                             row(
                                 Some(crate::runtime::channel::OPERATOR_CHANNEL.to_string()),
                                 DeliveryStatus::Sent,
+                                why_reason,
                                 format!("{why}, so the report went to the operator channel"),
                             )
                         })
-                        .unwrap_or_else(|detail| {
+                        // The channel's own failure class (`_class`) is dropped
+                        // in favour of naming the fallback, which is the part an
+                        // operator reading a host log needs: the interesting
+                        // fact is that `owner` had nowhere left to go. The full
+                        // text, class included, is on `detail`.
+                        .unwrap_or_else(|(_class, detail)| {
                             row(
                                 Some(crate::runtime::channel::OPERATOR_CHANNEL.to_string()),
                                 DeliveryStatus::Failed,
+                                DeliveryReason::OwnerFallbackFailed,
                                 format!(
                                     "{why}, and the operator channel fallback failed: {detail}"
                                 ),
@@ -363,6 +410,7 @@ async fn deliver_one(
                 reports.push(row(
                     Some(target.to_string()),
                     DeliveryStatus::Denied,
+                    DeliveryReason::EmailNotGranted,
                     "this company's [tools].allow does not grant `email`, so a workflow may not \
                      send mail to a named address"
                         .to_string(),
@@ -373,6 +421,7 @@ async fn deliver_one(
                 reports.push(row(
                     Some(target.to_string()),
                     DeliveryStatus::Skipped,
+                    DeliveryReason::NoMailboxConfigured,
                     "no mailbox is configured for this company, so there is nothing to send from"
                         .to_string(),
                 ));
@@ -399,11 +448,17 @@ async fn deliver_one(
                     Ok(()) => row(
                         Some(target.to_string()),
                         DeliveryStatus::Sent,
+                        DeliveryReason::RecipientEmailed,
                         "emailed the named recipient on an established thread".to_string(),
                     ),
+                    // The `email` arm is where the leak mattered most: `target`
+                    // IS the recipient's address, and an SMTP refusal echoes it
+                    // back inside `err`. Classified here, so the log line can
+                    // say what failed without saying to whom (issue #248).
                     Err(err) => row(
                         Some(target.to_string()),
                         DeliveryStatus::Failed,
+                        DeliveryReason::MailTransportRefused,
                         format!("the mail transport refused the message: {err}"),
                     ),
                 },
@@ -417,9 +472,15 @@ async fn deliver_one(
                     Ok(()) => row(
                         Some(target.to_string()),
                         DeliveryStatus::Sent,
+                        DeliveryReason::ChannelPosted,
                         "posted to the channel".to_string(),
                     ),
-                    Err(detail) => row(Some(target.to_string()), DeliveryStatus::Failed, detail),
+                    Err((reason, detail)) => row(
+                        Some(target.to_string()),
+                        DeliveryStatus::Failed,
+                        reason,
+                        detail,
+                    ),
                 },
             );
         }
@@ -430,6 +491,7 @@ async fn deliver_one(
         other => reports.push(row(
             destination.target.clone(),
             DeliveryStatus::Failed,
+            DeliveryReason::UnknownDestinationKind,
             format!("`{other}` is not a destination kind this runtime knows how to deliver to"),
         )),
     }
@@ -463,7 +525,7 @@ async fn park_cold_recipient(
     target: &str,
     subject: &str,
     text: &str,
-    row: impl Fn(Option<String>, DeliveryStatus, String) -> DeliveryReport,
+    row: impl Fn(Option<String>, DeliveryStatus, DeliveryReason, String) -> DeliveryReport,
 ) -> DeliveryReport {
     let Some(parking) = &delivery.parking else {
         // Fail closed to the pre-#227 behaviour. A `pending` row on a runtime
@@ -478,6 +540,7 @@ async fn park_cold_recipient(
         return row(
             Some(target.to_string()),
             DeliveryStatus::Skipped,
+            DeliveryReason::RecipientNotEstablished,
             "this recipient has never written to the company, so a workflow may not open the \
              conversation — send once from the inbox first"
                 .to_string(),
@@ -513,6 +576,7 @@ async fn park_cold_recipient(
             row(
                 Some(target.to_string()),
                 DeliveryStatus::Pending,
+                DeliveryReason::ParkedForApproval,
                 "this recipient has never written to the company, so a workflow may not open the \
                  conversation on its own — the report is waiting for you in Approvals, and \
                  approving it sends the mail"
@@ -538,6 +602,7 @@ async fn park_cold_recipient(
             row(
                 Some(target.to_string()),
                 DeliveryStatus::Skipped,
+                DeliveryReason::ParkingUnavailable,
                 "this recipient has never written to the company, and this report could not be \
                  queued for your approval either — send once from the inbox first"
                     .to_string(),
@@ -730,14 +795,18 @@ async fn recipient_is_established(
 
 /// Posts a report to the wired channel adapter with id `channel_id`.
 ///
-/// `Err(detail)` carries an operator-readable reason: an unwired id names what
-/// *is* wired, so the fix is obvious from the run result alone.
+/// `Err((reason, detail))` carries both halves the caller needs: `detail` is the
+/// operator-readable text — an unwired id names what *is* wired, so the fix is
+/// obvious from the run result alone — and `reason` is the classification that
+/// may be logged. They are returned together because only this function knows
+/// which of the two failure shapes happened; recovering it later from the string
+/// is exactly the pattern-match-on-prose coupling issue #248 exists to avoid.
 async fn post_to_channel(
     delivery: &WorkflowDeliveryDeps,
     channel_id: &str,
     subject: &str,
     text: &str,
-) -> Result<(), String> {
+) -> Result<(), (DeliveryReason, String)> {
     let Some(adapter) = delivery
         .channels
         .iter()
@@ -748,14 +817,17 @@ async fn post_to_channel(
             .iter()
             .map(|c| c.channel_id())
             .collect::<Vec<_>>();
-        return Err(if wired.is_empty() {
-            format!("`{channel_id}` is not wired on this runtime, which has no channels at all")
-        } else {
-            format!(
-                "`{channel_id}` is not a wired channel — this runtime has: {}",
-                wired.join(", ")
-            )
-        });
+        return Err((
+            DeliveryReason::ChannelNotWired,
+            if wired.is_empty() {
+                format!("`{channel_id}` is not wired on this runtime, which has no channels at all")
+            } else {
+                format!(
+                    "`{channel_id}` is not a wired channel — this runtime has: {}",
+                    wired.join(", ")
+                )
+            },
+        ));
     };
     adapter
         .send(OutboundMessage {
@@ -765,7 +837,14 @@ async fn post_to_channel(
             reply_to: None,
         })
         .await
-        .map_err(|err| format!("the channel refused the message: {err}"))
+        // `err` is the adapter's own words. Same rule as mail: it rides
+        // `detail`, never the classification (issue #248).
+        .map_err(|err| {
+            (
+                DeliveryReason::ChannelRefused,
+                format!("the channel refused the message: {err}"),
+            )
+        })
 }
 
 /// Whether the run's output carries an entry for `node_id` — i.e. the engine
@@ -1771,8 +1850,76 @@ mode = "full"
         assert_eq!(reports.len(), 1, "{reports:?}");
         assert_eq!(reports[0].status, DeliveryStatus::Failed);
         assert!(reports[0].detail.contains("smtp said no"), "{reports:?}");
+        assert_eq!(reports[0].reason, DeliveryReason::MailTransportRefused);
         // A refused send leaves no outbound audit record — the mail never went.
         assert!(h.inbox_messages().await.iter().all(|m| !m.outbound));
+    }
+
+    /// **Issue #248 at the source.** A real SMTP refusal quotes the mailbox it
+    /// refused, so the transport's own words are an address-bearing string. This
+    /// asserts the split holds where the row is built: `detail` keeps the reply
+    /// (the operator needs it), `reason` cannot carry it.
+    ///
+    /// `.invalid` is reserved by RFC 2606 and can never resolve, so the fixture
+    /// names nobody even if it escapes.
+    #[tokio::test]
+    async fn a_refusal_that_quotes_the_address_keeps_it_out_of_the_loggable_half() {
+        const ADDRESS: &str = "recipient@example.invalid";
+
+        /// Refuses the way a real MTA does: `550` with the rejected mailbox
+        /// echoed back inside the reply.
+        struct AddressQuotingMailSender;
+
+        #[async_trait]
+        impl MailSender for AddressQuotingMailSender {
+            async fn send(
+                &self,
+                _creds: &MailCredentials,
+                email: &OutboundEmail,
+            ) -> Result<(), OpenCompanyError> {
+                Err(OpenCompanyError::Config(format!(
+                    "550 5.1.1 <{}>: Recipient address rejected: User unknown in local recipient \
+                     table",
+                    email.to
+                )))
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut h = Harness::new(dir.path(), true, true);
+        h.deps.mail = Some(CompanyMail {
+            sender: Arc::new(AddressQuotingMailSender),
+            smtp: smtp_creds(),
+        });
+        h.receive_from(ADDRESS).await;
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["*"]),
+            &graph("email", Some(ADDRESS)),
+            &reached_output(),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        let row = &reports[0];
+        assert_eq!(row.status, DeliveryStatus::Failed);
+
+        // The operator's half is untouched: the reply is what makes this
+        // fixable, and the run response goes to the tenant, not the platform.
+        assert!(row.detail.contains(ADDRESS), "{row:?}");
+        assert!(row.detail.contains("550 5.1.1"), "{row:?}");
+
+        // The loggable half classifies the same failure and cannot carry the
+        // address — not by scrubbing it, but by having nowhere to put it.
+        assert_eq!(row.reason, DeliveryReason::MailTransportRefused);
+        let reason = row.reason.to_string();
+        assert!(!reason.contains(ADDRESS), "{reason}");
+        assert!(!reason.contains('@'), "{reason}");
+        assert!(
+            reason.contains("the mail transport refused the message"),
+            "{reason}"
+        );
     }
 
     // --- channel -------------------------------------------------------------
@@ -1820,6 +1967,16 @@ mode = "full"
             "{reports:?}"
         );
         assert!(reports[0].detail.contains(OPERATOR_CHANNEL), "{reports:?}");
+        // The two channel failures are classified apart: "you named a channel
+        // that does not exist" and "the channel said no" want different fixes,
+        // and the log line only ever sees this half.
+        assert_eq!(reports[0].reason, DeliveryReason::ChannelNotWired);
+        // The channel id — which for this arm IS the target — stays off the
+        // loggable half, same rule as a recipient address (issue #248).
+        assert!(
+            !reports[0].reason.to_string().contains("telegram"),
+            "{reports:?}"
+        );
         assert!(h.channel.sent().is_empty());
     }
 


### PR DESCRIPTION
## Summary

The workflow scheduler's undelivered-report warning logged `report.detail`. On
most paths that is static prose this codebase wrote, but on the transport-failure
arms it interpolates the transport's own words — and a mail transport quotes the
mailbox it refused (`550 5.1.1 <someone@example.invalid>: Recipient address
rejected`). That line goes to host stdout, which on a self-hosted deployment is
the operator but on a hosted tenant is the platform. PR #226 already removed
`report.target` from this line and replaced it with a `target_configured`
boolean; `detail` was the remaining path by which a recipient address could
reach the same place.

Rather than filter the string on its way to `tracing`, this splits the row's
reason in two so the loggable half is loggable by construction:

- `DeliveryReport::detail` — unchanged. Free text for the operator's own
  surfaces. It still quotes the transport verbatim, which is what makes a
  refused send fixable.
- `DeliveryReport::reason` — new. A `DeliveryReason` enum: a closed set of
  outcomes with **no `String` payload**, so no `format!` can produce one and no
  transport-supplied text can reach it without changing its type. This is the
  only half the scheduler logs.

Both are set at the same construction site, so the classification is made where
the outcome is known instead of being recovered later by pattern-matching prose.
A regex over the transport reply was the alternative and was rejected: the input
is unbounded (every MTA words a refusal differently), a matcher tuned to today's
replies rots quietly, and a near-miss leaks the whole line rather than failing
loudly.

### Sites covered

This is the family, not the one line.

- `runtime/workflow_scheduler.rs` — the undelivered-report warning now carries
  `reason` instead of `detail`. The only behaviour change in the PR.
- `workflows/delivery.rs` — all three arms that interpolate a transport error
  (`owner` mail, `email` mail, `channel` post) plus the `owner`
  operator-channel fallback now classify where the row is built.
  `post_to_channel` returns `Result<(), (DeliveryReason, String)>` so the two
  channel failure shapes — "you named a channel that does not exist" and "the
  channel said no" — stay distinguishable without the caller parsing a message.
- `brain/medulla/effects.rs` and `harness/orchestrator.rs` — the journal's two
  non-tenant readers. Both already fold a finished run to counts and exclude
  `target`/`detail`; #228 wrote them that way. Neither exclusion was pinned by a
  test, so both now are. An unpinned rule is one refactor from not being true.

### Why `detail` keeps the address, and the check behind that

`detail` is only safe to leave alone if its readers are genuinely tenant-scoped,
so this was traced rather than assumed. `WorkflowRunFinished` is appended
through `EventLog` to a **per-company** `companies/<slug>/events.jsonl` — the
journal is shared across event kinds (chat, audit, run history) within one
company, not across companies. Reading the full rows back:

| Reader | Guard |
|---|---|
| `GET …/workflows/runs` | `ScopedCompany` |
| operator SSE `GET {scope}/events` | `ScopedCompany` |
| manual run HTTP response | `ScopedCompany` |

`ScopedCompany` resolves the company, then runs `authorize_address`: a user
principal must belong to that company; a platform principal must either hold
platform scope or own the company and be permitted to address it. A
platform-scope token can therefore read these rows — deliberately, and the same
token already reads that company's chat history, memory and manifest. That is a
credentialed administrative boundary, and a different thing from a log line on
host stdout, which needs no credential at all. The two readers that are *not*
tenant-scoped — the inference-sidecar wire-out and the orchestrator's insight
summary — never saw `detail`, and now have tests saying so.

So the split stands, and the companion test pinning that `detail` keeps the
address is pinning the intended behaviour rather than a defect.

Sibling sites reviewed and deliberately left alone: the remaining
`error = %err` interpolations in the delivery path (a park failure, the
approval-gate rollback, an unreadable user directory, a failed outbound-mail
record) carry store, queue or serialization errors rather than transport
replies, so none can quote a recipient. The scheduler's `scheduled run failed`
warning carries a runner error, and a delivery failure never fails a run, so a
transport reply cannot reach it either.

Closes #248

## API Or Behavior Changes

**Behavior.** One log line changes. For a scheduled run whose delivery the mail
transport refuses, the warning was:

```
... report was NOT delivered company=acme workflow=digest node=owner_summary
kind=email target_configured=true status=Failed detail=the mail transport
refused the message: 550 5.1.1 <someone@example.invalid>: Recipient address
rejected: User unknown in local recipient table
```

and is now — copied from the event the new test captures:

```
2026-08-02T20:11:38.553244Z  WARN opencompany::runtime::workflow_scheduler:
workflow scheduler: a scheduled run's report was NOT delivered
company=transport-refusal-co workflow=digest node=owner_summary kind=email
target_configured=true status=Failed reason=the mail transport refused the
message
```

Everything needed to route the problem is still there — which company, which
workflow, which node, which destination kind, that a target resolved at all, the
status, and the failure class. What is gone is the transport's own sentence,
which is the only part that could name a person. That sentence still reaches the
operator in full, through the run response and through the
`WorkflowRunFinished` event their own console reads back (#228).

**API.** Additive and backward compatible. `DeliveryReport` gains `reason` on
the wire (`"reason": "mail-transport-refused"`). It is `#[serde(default)]`, so a
`WorkflowRunFinished` event journaled before this change still deserializes, as
`"unspecified"`. The console's `DeliveryReport` type declares it optional;
nothing renders it, because `detail` remains strictly more informative on a
tenant surface. No route, status value, or existing field changed.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 1012 passed, 0 failed

Also run, because the default feature set compiles neither
`workflows/delivery.rs` nor `harness/orchestrator.rs` and would have hidden
every change in them:

- [x] `cargo check --all-features --all-targets`
- [x] `cargo check --features openhuman,mcp,telegram --all-targets`
- [x] `cargo test --features openhuman,mcp,telegram` over the touched modules
- [x] `cd frontend && npx tsc -b --noEmit`

New tests:

- `a_transport_failure_does_not_log_the_address_the_transport_quoted`
  (`runtime::workflow_scheduler`) — the regression guard the issue asked for,
  mirroring the existing `target` guard. It drives a scheduled run whose
  delivery row carries a realistic SMTP refusal with the address embedded, then
  **asserts over the emitted `tracing` event** — the captured subscriber output,
  not an intermediate string — that the line contains neither the address, nor
  its local part alone, nor any of the transport's text, while still naming the
  workflow, node, kind, status and failure class.
- `the_operator_facing_detail_keeps_the_transport_text`
  (`runtime::workflow_scheduler`) — the other half, pinned so a later "scrub it
  everywhere" sweep has to argue with a test.
- `a_refusal_that_quotes_the_address_keeps_it_out_of_the_loggable_half`
  (`workflows::delivery`) — the same property at the source, through the real
  `deliver_outputs` path with a sender that refuses the way an MTA does.
- `a_finished_run_wires_out_counts_without_the_recipient_or_the_transport_text`
  (`brain::medulla::effects`) — the journal boundary to the inference sidecar.
- `a_finished_run_summarizes_to_counts_without_the_recipient_or_transport_text`
  (`harness::orchestrator`) — the same for the insight summary a model reads.
- `channel_that_is_not_wired_fails_with_the_wired_list` and
  `a_send_failure_is_reported_and_does_not_abort_delivery` extended to assert
  the classification, including that a channel id stays off the loggable half.

Fixtures use `example.invalid` (RFC 2606 reserved), so a fixture that ever
escapes into a log names nobody.

## Documentation

- `docs/modules/server/README.md` — the delivery section now states which of the
  two reasons is logged and why.
- Module docs updated where the rule has to be found: `workflows::delivery`
  gains a "Two reasons per row" section, and `runtime::workflow_scheduler`'s
  existing note about host stdout being a platform surface now spells out what
  that permits the warning to carry.
- `DeliveryReason` and both `DeliveryReport` reason fields carry doc comments
  naming which reader each half is for, including the enumerated read paths
  behind `detail`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured delivery outcome reasons for workflow runs.
  * Delivery reports now retain operator-facing details while providing stable, log-safe reason labels.
  * Older saved workflow data remains compatible.

* **Bug Fixes**
  * Prevented recipient addresses and transport error text from appearing in scheduler and host logs.
  * Preserved detailed delivery information in operator-facing workflow views.

* **Documentation**
  * Clarified the separation between operator-facing delivery details and safe scheduler log reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->