### PR TITLE
fix(inference): say a restart is required when a saved config cannot reach the running brain (#266)

### DIFF
--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -112,6 +112,13 @@ prompt = "Weekly review and operator digest"
   Precedence is **runtime console override > manifest `[inference]` > managed
   default**, and a per-tenant provider re-resolves it every turn — so a console
   switch takes effect on the agents' next turn with **no restart**.
+  That holds only once the company is already on the harness cognition path.
+  *Which brain a company runs* is decided once, when the runtime is built: a
+  company that resolved no inference source at boot gets the offline echo brain
+  and an unwired workflow runner, and a credential saved afterwards reaches
+  neither. The status route reports that state as `restartRequired` — a resolved
+  config next to a non-harness `cognition` — and the console says "restart"
+  instead of "next turn" for it (issue #266).
 - **`[channels.*]`** enables `ChannelAdapter`s. Unknown channels are a
   validation error; disabled OpenHuman means non-operator channels degrade
   with a boot warning, never a failure.

--- a/frontend/src/api/inference.ts
+++ b/frontend/src/api/inference.ts
@@ -53,6 +53,20 @@ export interface InferenceStatus {
   cognition: CognitionPath;
   /** Where this path's inference usage is metered. */
   usageMetering: UsageMetering;
+  /**
+   * Whether a stored config resolves but the *running* brain predates it, so
+   * only a restart puts it to work (issue #266).
+   *
+   * Which brain a company runs is decided once, when the company is built. A
+   * company that started with no inference source is on the offline echo brain
+   * with an unwired workflow runner, and saving a credential afterwards changes
+   * neither — so "agents use it on their next turn" is false for exactly that
+   * transition, which is also the first one a new operator makes.
+   *
+   * `false` covers both "already live" and "a restart would not help either"
+   * (this host has no harness path at all) — tell those apart with `cognition`.
+   */
+  restartRequired: boolean;
 }
 
 /** The set-provider body. `key` is write-only (never returned). */

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -8,6 +8,7 @@ import {
   revertInference,
   setInference,
   testInference,
+  type InferenceMutation,
   type InferenceProvider,
   type InferenceStatus,
   type UsageMetering,
@@ -81,7 +82,13 @@ type TestState =
  * provider (with a source badge + tier→model rows + a "key set" indicator), a
  * live "Test" probe, and a switch form with per-provider presets. The key input
  * is **write-only** — it is sent on Save, stored server-side, and never read
- * back. A switch takes effect on the agents' next turn with no restart.
+ * back.
+ *
+ * A switch takes effect on the agents' next turn with no restart — *except* the
+ * not-configured → configured transition, where the running brain was already
+ * chosen without one. The host reports that as `restartRequired`, and this
+ * section says so in the toast and keeps saying it in the status card until the
+ * restart happens (issue #266).
  */
 export function InferenceSection({
   client,
@@ -133,22 +140,35 @@ export function InferenceSection({
     try {
       // "Managed" means "use the platform default" — that's a revert, not a
       // runtime override with an empty credential.
+      let result: InferenceMutation;
       if (provider === "managed") {
-        await revertInference(client, company);
+        result = await revertInference(client, company);
       } else {
         const cleanModels = Object.fromEntries(
           Object.entries(models)
             .map(([t, v]) => [t, (v ?? "").trim()])
             .filter(([, v]) => v.length > 0),
         );
-        await setInference(client, company, {
+        result = await setInference(client, company, {
           provider,
           baseUrl: baseUrl.trim() || undefined,
           models: Object.keys(cleanModels).length ? cleanModels : undefined,
           key: key.trim() || undefined,
         });
       }
-      toast.success("Inference updated. Agents use it on their next turn.");
+      // Issue #266: only the host knows whether the *running* brain can act on
+      // what was just saved. Which brain a company runs is fixed when it is
+      // built, so a company that started with no inference source keeps echoing
+      // no matter what lands here — "agents use it on their next turn" was a
+      // promise the runtime could not keep for exactly the transition an
+      // operator makes first. Follow the response instead of asserting.
+      if (result.status.restartRequired) {
+        toast.warning("Inference saved — restart the company for agents to use it.", {
+          description: result.note,
+        });
+      } else {
+        toast.success("Inference updated. Agents use it on their next turn.");
+      }
       setKey("");
       setTest({ kind: "idle" });
       await refresh();
@@ -211,7 +231,9 @@ export function InferenceSection({
       <p className="text-sm text-muted-foreground">
         Choose which model provider your agents think with. Bring your own key for OpenRouter, a
         custom OpenAI-compatible endpoint, or a local Ollama server — the key is stored securely and
-        never shown again. A switch takes effect on the next turn, no restart.
+        never shown again. Switching provider or model takes effect on the agents' next turn. Giving
+        inference to a company that started without any does not: the brain is chosen at startup, so
+        that first setup needs a restart.
       </p>
 
       {load === "loading" ? (
@@ -252,6 +274,26 @@ export function InferenceSection({
                   Cognition: <span className="font-mono">{status.cognition}</span> ·{" "}
                   {METERING_NOTES[status.usageMetering] ?? "usage metering unknown"}
                 </p>
+                {/* Issue #266: a saved config the running brain cannot act on.
+                    The toast that says so is gone in seconds — and an operator
+                    who reloads the page, or comes back tomorrow, sees only a
+                    correct-looking provider next to agents that still echo. This
+                    is the surface that stays until the restart happens. */}
+                {status.restartRequired && (
+                  <div
+                    className="flex items-start gap-1.5 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-400"
+                    data-testid="inference-restart-required"
+                  >
+                    <RotateCcw className="mt-px size-3.5 shrink-0" />
+                    <span>
+                      <span className="font-medium">Restart required.</span> This company started
+                      with no inference source, so it is running the offline echo brain and its
+                      scheduled workflows cannot fire. The brain is chosen at startup — this
+                      configuration is saved, but agents keep echoing until the company is
+                      restarted.
+                    </span>
+                  </div>
+                )}
                 {modelRows.length > 0 && (
                   <ul className="space-y-1 rounded-md bg-muted/40 p-2">
                     {modelRows.map(([tier, model]) => (

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -990,7 +990,7 @@ impl Brain for HarnessBrain {
     /// zero `token_usage` and the runtime's cycle-level metering is a no-op here.
     fn cognition(&self) -> Cognition {
         Cognition {
-            path: "harness",
+            path: crate::ports::brain::HARNESS_PATH,
             provider: "per-turn",
             metering: UsageMetering::PerTurn,
         }

--- a/src/ports/brain.rs
+++ b/src/ports/brain.rs
@@ -33,6 +33,16 @@ pub enum UsageMetering {
     None,
 }
 
+/// The [`Cognition::path`] label of the embedded-harness brain — the only path
+/// a tenant `[inference]` / console BYOK config actually feeds.
+///
+/// A named constant rather than a literal because two places must agree: the
+/// brain that *reports* it (`crate::harness::brain`) and the inference-status
+/// route that *tests* it to decide whether a saved config has reached the
+/// running brain (issue #266). A literal in both would let a wording change on
+/// one side silently turn the test into a permanent `false`.
+pub const HARNESS_PATH: &str = "harness";
+
 /// How a [`Brain`] does cognition, for metering and operator diagnosis.
 ///
 /// The runtime reads [`Self::provider`] when it meters a cycle's usage, and the
@@ -45,8 +55,8 @@ pub enum UsageMetering {
 /// than leaking this shape onto the wire.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Cognition {
-    /// Stable label for the path: `harness`, `hosted`, `echo`, `sidecar`, or
-    /// `custom` for an injected brain.
+    /// Stable label for the path: `harness` ([`HARNESS_PATH`]), `hosted`,
+    /// `echo`, `sidecar`, or `custom` for an injected brain.
     pub path: &'static str,
     /// The provider slug this path's cycle usage is metered under.
     pub provider: &'static str,

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -10,7 +10,13 @@
 //! echoed — the read shape carries only a `keyConfigured` bool.
 //!
 //! A runtime switch takes effect on the agents' **next turn** with no restart:
-//! the per-tenant provider re-resolves this config every turn.
+//! the per-tenant provider re-resolves this config every turn — *once the
+//! company is already on the harness cognition path*. Which brain a company runs
+//! is chosen once, at build time, so a company that resolved **no** inference
+//! source at boot is on the offline echo brain and stays there until the process
+//! restarts, no matter what is saved here. That one transition is reported as
+//! [`InferenceStatusDto::restart_required`] rather than papered over with a
+//! "next turn" promise the runtime cannot keep (issue #266).
 
 use std::collections::BTreeMap;
 
@@ -31,11 +37,21 @@ use crate::ports::UsageMetering;
 use crate::server::error::ApiError;
 use crate::server::ops::{ScopedCompany, scoped};
 
-/// The reminder attached to every mutating response: a per-tenant provider
-/// re-resolves its config each turn, so a switch reaches agents on the next
-/// turn with no restart.
+/// The reminder attached to a mutating response that the running brain can act
+/// on: a per-tenant provider re-resolves its config each turn, so a switch
+/// reaches agents on the next turn with no restart.
 const SWITCH_NOTE: &str =
     "Agents use the new inference provider on their next turn — no restart needed.";
+
+/// The reminder attached instead when [`restart_pending`] holds — the save
+/// landed, but the running brain predates it (issue #266). Says the thing the
+/// operator has to do, and names the two surfaces that stay broken until they do
+/// it, because "agents still echo" and "scheduled workflows never fire" are how
+/// this is actually noticed.
+const RESTART_NOTE: &str = "Saved — but this company started with no inference source, so it is \
+     running the offline echo brain and its workflow runner is unwired. The brain is chosen at \
+     startup: restart the company for agents to think with this provider and for scheduled \
+     workflows to fire.";
 
 /// Builds the inference management route fragment.
 pub fn router() -> Router<AppState> {
@@ -78,6 +94,14 @@ struct InferenceStatusDto {
     /// `none` (nothing to meter — the echo path runs no model, so a zero Usage
     /// reading is the truth rather than a missing hook).
     usage_metering: UsageMetering,
+    /// Whether a stored inference config resolves but the **running** brain
+    /// predates it, so only a restart puts it to work (issue #266).
+    ///
+    /// See [`restart_pending`] for the exact predicate. `false` covers both "the
+    /// config is already live" and "no restart would help either" — the console
+    /// tells the second apart from `cognition` on its own, and this flag never
+    /// promises a restart that would change nothing.
+    restart_required: bool,
 }
 
 /// A mutating response: the resulting status plus the switch reminder.
@@ -118,6 +142,61 @@ fn source_label(source: InferenceSource) -> &'static str {
     }
 }
 
+/// Whether the harness cognition path is reachable on this host at all: the
+/// `openhuman` feature compiled in **and** a harness pool attached at boot.
+///
+/// Without both, no restart can move this company off the echo/hosted brain, so
+/// telling the operator to restart would just be a second false promise. The
+/// pool is attached whenever the serve path ran `attach_harness`, independently
+/// of which brain arm won — which is exactly the "this host could have run the
+/// harness, and didn't" signal we need.
+#[cfg(feature = "openhuman")]
+fn harness_reachable(runtime: &CompanyRuntime) -> bool {
+    runtime.harness().is_some()
+}
+
+#[cfg(not(feature = "openhuman"))]
+fn harness_reachable(_runtime: &CompanyRuntime) -> bool {
+    false
+}
+
+/// Whether a saved inference config is stranded behind a boot-time decision.
+///
+/// Brain selection happens once, in `RuntimeBuilder::build`: a company whose
+/// inference resolved to nothing at boot gets the offline echo brain **and** an
+/// unwired workflow runner, and a later credential write reaches neither. The
+/// per-tenant provider does re-resolve every turn, so swapping a model or
+/// rotating a key on a company already on the harness path is genuinely live —
+/// this is only about the not-configured → configured transition (issue #266).
+///
+/// True requires all three:
+/// 1. a tenant config resolves *now* (the same predicate `build` tests),
+/// 2. the company is **not** on the harness path, and
+/// 3. the harness path is reachable here, so a restart would actually change it.
+fn restart_pending(runtime: &CompanyRuntime, configured: bool) -> bool {
+    configured
+        && runtime.cognition().path != crate::ports::brain::HARNESS_PATH
+        && harness_reachable(runtime)
+}
+
+/// [`restart_pending`] resolved from scratch, for callers outside this module
+/// that hold only a runtime.
+///
+/// The workflow-run route uses it to tell "this build has no workflow execution"
+/// apart from "this *boot* has none, and a restart would fix it" — the two look
+/// identical from `workflow_runner() == None`, and the operator's next step is
+/// completely different. Degrades to `false` on a resolve error: a config we
+/// cannot read is not evidence that a restart would help.
+pub(crate) async fn restart_pending_for(runtime: &CompanyRuntime) -> bool {
+    let Ok(manifest) = manifest_inference(runtime).await else {
+        return false;
+    };
+    let configured = resolve_effective(runtime.id(), &manifest, None, runtime.secrets().as_ref())
+        .await
+        .is_ok_and(|decl| decl.is_some());
+    restart_pending(runtime, configured)
+}
+
 /// Resolves the effective status DTO. The ops layer resolves *tenant* config
 /// only (no env default), so a company with nothing configured reports the
 /// managed default rather than a synthesized env decl.
@@ -128,6 +207,7 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<InferenceStatusDto
         .map_err(ApiError)?;
     // What the company actually booted onto, not what the config implies.
     let cognition = runtime.cognition();
+    let restart_required = restart_pending(runtime, decl.is_some());
     Ok(match decl {
         Some(d) => InferenceStatusDto {
             provider: d.provider.clone(),
@@ -138,6 +218,7 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<InferenceStatusDto
             key_configured: d.key_configured(),
             cognition: cognition.path.to_string(),
             usage_metering: cognition.metering,
+            restart_required,
         },
         None => InferenceStatusDto {
             provider: "managed".to_string(),
@@ -148,6 +229,11 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<InferenceStatusDto
             key_configured: false,
             cognition: cognition.path.to_string(),
             usage_metering: cognition.metering,
+            // `decl` is `None`, so `restart_pending` is `false` here by
+            // construction — nothing tenant-specific is configured to be
+            // stranded. Threaded rather than hardcoded so the two arms cannot
+            // drift apart.
+            restart_required,
         },
     })
 }
@@ -192,9 +278,17 @@ async fn set_config(
             .map_err(ApiError)?;
     }
 
+    let status = effective_status(runtime).await?;
     Ok(Json(MutationResponse {
-        status: effective_status(runtime).await?,
-        note: SWITCH_NOTE.to_string(),
+        // The note follows the *resulting* status, so the response can never
+        // promise "next turn" to a company whose brain cannot honour it.
+        note: if status.restart_required {
+            RESTART_NOTE
+        } else {
+            SWITCH_NOTE
+        }
+        .to_string(),
+        status,
     }))
 }
 
@@ -468,5 +562,143 @@ mod tests {
         for raw in [put_raw, get_raw, test_raw] {
             assert!(!raw.contains(TOKEN), "a response leaked the token: {raw}");
         }
+    }
+
+    // --- Issue #266: a save the running brain cannot honour --------------------
+
+    /// On a host with no harness reachable, a saved config is *never* "restart
+    /// pending" — the echo brain is where this build ends up no matter how many
+    /// times it is restarted, and telling the operator otherwise would send them
+    /// bouncing a process for nothing.
+    ///
+    /// This is the default build, so it is also the guard that keeps the flag
+    /// from firing on every self-hosted instance that simply has no local
+    /// inference compiled in.
+    #[tokio::test]
+    async fn a_save_is_not_restart_pending_when_no_restart_would_help() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_company(&home).await;
+
+        let (status, resp, _) = send(
+            &state,
+            "PUT",
+            "/api/v1/company/inference",
+            Some(json!({ "provider": "openrouter", "key": TOKEN })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        // The config landed...
+        assert_eq!(resp["status"]["source"], "runtime");
+        assert_eq!(resp["status"]["keyConfigured"], true);
+        // ...and the runtime is on the echo brain, but no harness is reachable
+        // here, so there is nothing a restart would change.
+        assert_eq!(resp["status"]["cognition"], "echo");
+        assert_eq!(resp["status"]["restartRequired"], false);
+        assert!(
+            resp["note"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("no restart needed"),
+            "{}",
+            resp["note"]
+        );
+
+        let (_, dto, _) = send(&state, "GET", "/api/v1/company/inference", None).await;
+        assert_eq!(dto["restartRequired"], false);
+    }
+
+    /// A company with nothing configured has nothing stranded, so the flag is
+    /// off even before any save.
+    #[tokio::test]
+    async fn an_unconfigured_company_is_not_restart_pending() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_company(&home).await;
+
+        let (_, dto, _) = send(&state, "GET", "/api/v1/company/inference", None).await;
+        assert_eq!(dto["source"], "managed");
+        assert_eq!(dto["restartRequired"], false);
+    }
+
+    /// Issue #266, reproduced at the route: a company built with a harness pool
+    /// but **no** inference source boots onto the echo brain with an unwired
+    /// workflow runner. Storing a credential afterwards updates the secret store
+    /// and nothing else — the brain is chosen in `RuntimeBuilder::build` and this
+    /// one already ran.
+    ///
+    /// So the save must report `restartRequired`, and the note must say restart
+    /// rather than "next turn".
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn configuring_inference_after_boot_reports_restart_required() {
+        use crate::harness::HarnessPool;
+
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+
+        // Build the company the way the serve path does — with a harness pool
+        // attached — but with no inference source of any kind. That is the boot
+        // this issue is about.
+        let id = CompanyId::new("acme");
+        let runtime = RuntimeBuilder::new(home.clone(), manifest())
+            .with_id(id.clone())
+            .with_harness(std::sync::Arc::new(HarnessPool::new()))
+            .build()
+            .await
+            .unwrap();
+        // The bug's precondition, asserted rather than assumed: the harness was
+        // available and the company still landed on the offline brain.
+        assert_eq!(
+            runtime.cognition().path,
+            "echo",
+            "expected the no-inference boot to select the echo brain"
+        );
+        assert!(
+            runtime.workflow_runner().is_none(),
+            "expected the no-inference boot to leave the workflow runner unwired"
+        );
+
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+
+        // Configure inference, exactly as the console does.
+        let (status, resp, raw) = send(
+            &state,
+            "PUT",
+            "/api/v1/company/inference",
+            Some(json!({
+                "provider": "openai_compatible",
+                "baseUrl": "https://stub.invalid/v1",
+                "key": TOKEN,
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_eq!(resp["status"]["source"], "runtime");
+        assert_eq!(resp["status"]["keyConfigured"], true);
+        // The config resolves now; the running brain still does not know it.
+        assert_eq!(resp["status"]["cognition"], "echo");
+        assert_eq!(resp["status"]["restartRequired"], true, "{raw}");
+
+        let note = resp["note"].as_str().unwrap_or_default();
+        assert!(note.contains("restart"), "note must say restart: {note}");
+        assert!(
+            !note.contains("next turn"),
+            "note must not promise the next turn: {note}"
+        );
+        assert!(!raw.contains(TOKEN), "PUT response leaked the token: {raw}");
+
+        // The flag is a property of the runtime, not of the mutation, so a plain
+        // read reports it too — this is what keeps the warning on screen after
+        // the toast is gone.
+        let (_, dto, _) = send(&state, "GET", "/api/v1/company/inference", None).await;
+        assert_eq!(dto["restartRequired"], true);
+
+        // Reverting to managed un-strands the company: there is no longer a
+        // saved config waiting on a restart, so the flag clears.
+        let (_, resp, _) = send(&state, "DELETE", "/api/v1/company/inference", None).await;
+        assert_eq!(resp["status"]["restartRequired"], false);
     }
 }

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -627,8 +627,10 @@ mod tests {
     /// and nothing else — the brain is chosen in `RuntimeBuilder::build` and this
     /// one already ran.
     ///
-    /// So the save must report `restartRequired`, and the note must say restart
-    /// rather than "next turn".
+    /// So the save must report `restartRequired`, the note must say restart
+    /// rather than "next turn", and `POST …/workflows/{id}/run` must stop
+    /// claiming the deployment lacks workflow execution when what it lacks is a
+    /// restart.
     #[cfg(feature = "openhuman")]
     #[tokio::test]
     async fn configuring_inference_after_boot_reports_restart_required() {
@@ -696,9 +698,39 @@ mod tests {
         let (_, dto, _) = send(&state, "GET", "/api/v1/company/inference", None).await;
         assert_eq!(dto["restartRequired"], true);
 
+        // Second surface: the run route no longer blames the deployment.
+        let (status, err, _) = send(
+            &state,
+            "POST",
+            "/api/v1/company/workflows/daily/run",
+            Some(json!({})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(err["code"], "restart_required");
+        assert!(
+            err["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("Restart"),
+            "{err}"
+        );
+
         // Reverting to managed un-strands the company: there is no longer a
         // saved config waiting on a restart, so the flag clears.
         let (_, resp, _) = send(&state, "DELETE", "/api/v1/company/inference", None).await;
         assert_eq!(resp["status"]["restartRequired"], false);
+
+        // ...and with nothing pending, the run route is back to the honest
+        // "this deployment has no workflow execution" 404.
+        let (status, err, _) = send(
+            &state,
+            "POST",
+            "/api/v1/company/workflows/daily/run",
+            Some(json!({})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(err["code"], "not_wired");
     }
 }

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -196,6 +196,31 @@ pub(crate) fn not_wired(what: &str) -> axum::response::Response {
         .into_response()
 }
 
+/// A `409 restart_required` response for a surface that this build *does* have,
+/// but this company's running runtime does not — because the runtime was wired
+/// at boot, before the inference config that would have wired it existed
+/// (issue #266).
+///
+/// Deliberately not the `not_wired` 404: the console's bare-catch treats that as
+/// a permanent capability gap and degrades to a read-only view, which is the
+/// wrong answer for a state one restart clears. A distinct `code` lets the
+/// console say what to do instead of hiding the button.
+pub(crate) fn restart_required(what: &str) -> axum::response::Response {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    (
+        StatusCode::CONFLICT,
+        axum::Json(serde_json::json!({
+            "error": format!(
+                "{what} is not wired on this company's running runtime: it started with no \
+                 inference source. Restart the company to pick up the saved configuration."
+            ),
+            "code": "restart_required",
+        })),
+    )
+        .into_response()
+}
+
 /// Resolves the sole registered company (single-company alias).
 pub(crate) fn resolve_sole(state: &AppState) -> Result<Arc<CompanyRuntime>, ApiError> {
     state.registry().sole().ok_or_else(|| {

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -515,9 +515,19 @@ async fn run_workflow(
     Path(WorkflowPath { wid }): Path<WorkflowPath>,
     body: Option<Json<RunWorkflowBody>>,
 ) -> Result<Json<RunWorkflowResponse>, Response> {
-    // No runner wired (default build / no harness) → the same "not wired" seam
-    // the networked surfaces use.
+    // No runner wired. Two very different causes look identical from here, and
+    // `not_wired` only describes the first (issue #266):
+    //   1. this build/deployment has no workflow execution at all — nothing the
+    //      operator can do, so "not wired in this deployment" is the truth;
+    //   2. this *boot* has none, because the company started with no inference
+    //      source. The runner is populated from the harness arm at build time, so
+    //      configuring inference afterwards leaves it `None` until a restart —
+    //      and a `not_wired` 404 sends the operator hunting a deployment problem
+    //      that does not exist.
     let Some(runner) = company.runtime.workflow_runner() else {
+        if super::inference::restart_pending_for(company.runtime.as_ref()).await {
+            return Err(super::restart_required("workflow execution"));
+        }
         return Err(super::not_wired("workflow execution"));
     };
 


### PR DESCRIPTION
## Summary

Saving inference toasted "Agents use it on their next turn." That is true when a
company is already thinking with a provider and you swap the model or rotate the key —
the per-tenant provider re-resolves every turn. It is false for the transition a new
operator makes first: **no credential → credential**.

Which brain a company runs is decided once, when the runtime is built. A company that
resolved no inference source at boot gets the offline echo brain, and its workflow
runner is left unwired (it is only populated inside the harness arm). Storing a
credential afterwards writes the secret store and nothing else. So the agents keep
echoing, `POST …/workflows/{id}/run` keeps returning `not_wired`, and the scheduler
keeps warning — until the process is restarted.

This makes the host say so, on every surface where the lie was visible:

- the inference status carries **`restartRequired`**, and the mutating response's note
  follows the *resulting* status instead of asserting "next turn";
- the console shows a **banner that stays** — a toast is gone in seconds, and an
  operator who reloads the page sees only a correct-looking provider next to agents
  that still echo;
- `POST …/workflows/{id}/run` answers **409 `restart_required`** with what to do,
  instead of `not_wired`, which reads as a permanent deployment gap and sends the
  operator hunting a problem that does not exist.

`restartRequired` is deliberately narrow: a tenant config that resolves *now*, next to
a cognition path that is not the harness, **and** a host where the harness path is
reachable (the `openhuman` feature plus an attached pool). On a build with no local
inference compiled in, the echo brain is where the company ends up no matter how often
it is restarted — so the flag stays `false` there rather than sending someone to bounce
a process for nothing. The console distinguishes that weaker case from `cognition`
alone, which the status route already reported.

### Which of the two options, and why

The issue preferred **rebuilding the company runtime** and I went and measured it
before choosing. It is the better answer and it is not a bounded change — so this PR is
the honest-message half done properly, and the rebuild is filed as **#290** with the
findings.

What a rebuild costs today, from reading `RuntimeBuilder::build`, `CompanyRegistry`,
and everything holding a runtime:

1. **The journal forbids a second writer, and the failure is permanent.**
   `src/runtime/journal.rs` documents that exactly one process may write a journal
   file: `append` emits the record and its newline as two separate writes under a
   *per-instance* lock. A rebuild constructs a second journal over the same path, and
   an interleave leaves two records on one line — which fails to parse on replay,
   bricking the *next* boot and `recover()`.
2. **At-most-once effect execution breaks.** `is_executed` reads a per-instance
   in-memory set populated at load. Runtime A commits an effect key, runtime B never
   sees it, the effect runs twice.
3. **Both mutual-exclusion locks are per-instance.** `serial` guards a whole cycle (an
   LLM turn) plus five desk read-modify-write routes; `task_writes` guards a documented
   parent-cycle invariant across the three board-write handlers. Two runtimes, two
   locks, both invariants lapse — against a store whose `save` writes the whole record.
4. **There is no teardown seam.** `CompanyScheduler`, `MailboxPoller` and
   `TelegramPoller` each snapshot an `Arc<CompanyRuntime>` at boot and never re-read
   the registry, so a registry swap leaves all three driving the old echo brain —
   including the cron scheduler, one of the surfaces this issue was reported against.
   (`WorkflowScheduler` already re-reads per tick and is the model to copy.)
5. **In-flight work is genuinely torn out.** `upsert_task` clones the Arc into a spawned
   cycle that lives for a whole agent turn, and the orchestrator's runner handle is a
   `Weak` whose only strong reference is the runtime — dropping the old one makes its
   in-flight `run_workflow` tool silently no-op.
6. **`build()` is not side-effect-free.** A rebuild re-runs going-public (network) and
   re-spawns the MCP boot, which re-dials every installed server into a process-global
   connection map keyed by server id, replacing connections the old runtime's agents
   are mid-call on. The feedback rate limiter is in-memory, so a rebuild loop bypasses
   it.
7. **One builder input is unreachable.** `serve --discoverable` exists only in the
   `serve` stack frame and is retained nowhere; re-reading the manifest would drop it.

So the rebuild needs a quiesce/hand-over lifecycle seam, three pollers converted to
registry-driven, and an idempotent build — a design, not a hunk. #290 carries the
checklist. The hosted motivation the issue gives still stands, which is why it is filed
rather than dropped.

## API Or Behavior Changes

- `GET/PUT/DELETE …/inference` status gains **`restartRequired: boolean`**. Additive.
- `PUT …/inference` `note` is now conditional; the "no restart needed" wording is
  unchanged for the case where it is true.
- `POST …/workflows/{id}/run` returns **409 `{"code":"restart_required"}`** instead of
  404 `not_wired` when the runner is missing *and* a saved config is waiting on a
  restart. A build with no workflow execution at all still gets 404 `not_wired`.
- `crate::ports::brain::HARNESS_PATH` is a new public constant. The status route tests
  the cognition path against it and `HarnessBrain` reports it, so a wording drift
  breaks compilation instead of silently turning the check into a permanent `false`.
- Console: the save toast follows the response; a persistent banner
  (`data-testid="inference-restart-required"`) renders in the status card.

## Tests

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 1011 passed, 0 failed
- [x] `cargo test --features openhuman,mcp,telegram --lib server::ops::inference` — 7 passed
- [x] `cargo test --features openhuman,mcp,telegram --lib server::ops::workflows` — 33 passed
- [x] `cargo check --all-features`
- [x] `cargo check --features openhuman,mcp,telegram`
- [x] `cd frontend && npm ci && npm run typecheck && npm run build`

New tests in `src/server/ops/inference.rs`:

- `configuring_inference_after_boot_reports_restart_required` (feature-gated) — the
  reproduction. Builds a company with a harness pool and **no** inference, asserts the
  precondition (echo brain, unwired runner) rather than assuming it, then configures
  inference and asserts `restartRequired`, the restart note, the flag on a plain `GET`,
  the 409 on the run route, and that reverting to managed clears all of it and returns
  the run route to `not_wired`.
- `a_save_is_not_restart_pending_when_no_restart_would_help` — the guard that keeps the
  flag off on hosts with no harness path.
- `an_unconfigured_company_is_not_restart_pending`.

**Manual verification on a live host** (`--features openhuman,mcp,telegram`,
`--home` isolated, `companies/e2e_harness`, a local stub OpenAI-compatible server, an
obviously-fake key — no real credential was used anywhere):

Reproduced first, before the fix mattered:

| step | result |
|---|---|
| boot with no inference | `cognition: "echo"`, `restartRequired: false` |
| configure `openai_compatible` + key, save | saved (`keyConfigured: true`, `source: "runtime"`) — but `cognition` still `"echo"` |
| send an agent a message | **still echoes** (`"You said: …"`); the stub was never contacted |
| `POST …/workflows/{id}/run` | refused |
| restart | `cognition: "harness"`, `usageMetering: "perTurn"`, `restartRequired: false`; the same message now returns the stub's sentinel and the stub logs the call; the run route gets past the runner check |

Then the console half, driven in a real browser against the built console: the amber
banner renders under the `Cognition: echo` line, the toast says restart rather than
"next turn", and the banner **survives a full page reload** — which is the whole point
of not leaving this to a toast.

## Documentation

- `docs/spec/runtime/manifest.md` — the `[inference]` bullet claimed a console switch
  takes effect on the next turn with no restart, full stop. Scoped to the harness path
  and named the boot-time decision.
- Module docs updated in `src/server/ops/inference.rs` and `InferenceSection.tsx`.

## Related

Closes #266.
Follow-up: #290 — rebuild the runtime so this transition needs no restart at all.

**Collision with #282** (issue #265, also mine): both touch
`frontend/src/views/connections/InferenceSection.tsx`. I kept the hunks apart where I
could — #282's `managed`-discards-a-key guard sits at the top of `save()`, in the
`provider === "managed"` render branch, and on the Save button; mine are the toast
inside `save()`, a banner in the status card, and the section blurb. The one genuine
overlap is `save()` itself, since the toast is what this issue is about, and both PRs
append to the same `[inference]` paragraph in `docs/spec/runtime/manifest.md`. Whichever
merges second rebases; the resolution is additive both ways. I did not touch #282's
`pickProvider` key-retention behaviour or its Save-disabled guard.

## Found, not fixed

- The workflow scheduler's per-company warning ends with a guess —
  `"no workflow runner is wired for this company (inference source unresolved?)"`. It
  is a server log rather than a console surface, so I left it alone rather than widen
  the diff; it is now a guess the status route can answer definitively.
- `cargo check --all-features --all-targets` fails at `src/store/sqlite.rs:2009`
  (trait-method ambiguity) on the base commit. Pre-existing, not touched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Inference status now indicates when a restart is required to activate saved settings.
  - Added clear guidance distinguishing changes applied on the next turn from changes requiring a restart.
  - Workflow actions now explain when they are unavailable pending a restart.

- **Bug Fixes**
  - Improved handling and messaging for inference configurations saved after startup.
  - Console warnings now persist until the required restart is completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->