### PR TITLE
ci: build the committed Cargo.lock by passing --locked (#251)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,19 @@ concurrency:
 permissions:
   contents: read
 
+# Issue #251. Every cargo invocation below that resolves a dependency graph
+# passes `--locked` (all of them except `cargo fmt`, which resolves nothing and
+# does not accept the flag): CI must build the graph recorded in the committed
+# `Cargo.lock` and fail loudly rather than re-resolve it in the runner. Without
+# it, a `Cargo.toml` edit whose lock was never regenerated — or a `vendor/`
+# submodule bump that moves a vendored crate's version — is absorbed silently,
+# and a semver-compatible upstream release can change what CI compiles with no
+# change to this repo, so a red run cannot be attributed to the diff.
+#
+# `--locked`, not `--frozen`. `--frozen` is `--locked` plus `--offline`, and
+# these runners have no vendored registry — they must reach crates.io to
+# download the crates the lock names. Pinning *resolution* and forbidding
+# *downloads* are separate properties; only the first is wanted here.
 jobs:
   rust:
     name: Rust
@@ -40,14 +53,17 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      # No `--locked` here, and none is owed: `cargo fmt` is a `rustfmt` wrapper
+      # that never resolves the dependency graph, and `cargo-fmt` does not
+      # accept the flag.
       - name: Format
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings
 
       - name: Test
-        run: cargo test
+        run: cargo test --locked
 
   # Issue #202. The `Rust` job above builds DEFAULT FEATURES ONLY, so every line
   # behind `openhuman` (`src/harness/**`, `src/workflows/**`, `src/runtime/`
@@ -120,7 +136,7 @@ jobs:
       # class of bug that motivated this job) surfaces before the lint pass
       # spends time on a tree that does not build.
       - name: Build (openhuman, tinycortex)
-        run: cargo build --features openhuman,tinycortex --all-targets
+        run: cargo build --locked --features openhuman,tinycortex --all-targets
 
       # `--no-deps` is LOAD-BEARING — do not "simplify" it away. Cargo treats the
       # vendored `[patch]` crates as local packages, so an unscoped `-D warnings`
@@ -129,7 +145,7 @@ jobs:
       # reach first-party code. Scoping to the primary package is what makes it
       # meaningful.
       - name: Clippy (openhuman, tinycortex)
-        run: cargo clippy --no-deps --features openhuman,tinycortex --all-targets -- -D warnings
+        run: cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings
 
       # `--lib` is LOAD-BEARING — do not widen it to a bare `cargo test`. There
       # is no `tests/` directory, and the only other runnable target the feature
@@ -137,7 +153,7 @@ jobs:
       # inference backend and needs a credential. The build step above already
       # proves it compiles; this step must never try to run it.
       - name: Test (openhuman, tinycortex)
-        run: cargo test --features openhuman,tinycortex --lib
+        run: cargo test --locked --features openhuman,tinycortex --lib
 
       # Catches the combination traps no single feature set can: most often a
       # mandatory struct field constructed differently across feature arms.
@@ -146,4 +162,4 @@ jobs:
       # pins for the openhuman-only set. This step must compile the combination
       # without running its feature-sensitive tests.
       - name: Check (--all-features)
-        run: cargo check --all-features
+        run: cargo check --locked --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,23 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      # Issue #251. `--locked` on the compiling steps already fails a stale
+      # `Cargo.lock` — but it fails inside `Clippy` or `Build`, under a step name
+      # that says nothing about the lock, and in both jobs at once. This step is
+      # the legible version of that failure: it resolves the graph and nothing
+      # else, takes seconds, and is the first cargo invocation in the run, so a
+      # lock that does not match `Cargo.toml` — or a vendored submodule bump
+      # landed without the regenerated lock — is named as such before anything
+      # compiles.
+      #
+      # A STEP, not a separate job, on purpose: a dedicated job would pay for a
+      # second runner plus another submodule checkout — minutes of the run's
+      # wall clock — to print a message this step prints for free. `cargo
+      # metadata` reads the whole lock regardless of the feature selection, so
+      # one invocation covers every feature set CI builds.
+      - name: Verify Cargo.lock is in sync
+        run: cargo metadata --locked --format-version 1 > /dev/null
+
       # No `--locked` here, and none is owed: `cargo fmt` is a `rustfmt` wrapper
       # that never resolves the dependency graph, and `cargo-fmt` does not
       # accept the flag.


### PR DESCRIPTION
## Summary

Adds `--locked` to every cargo invocation in `.github/workflows/ci.yml` that resolves a dependency graph, so CI builds the graph recorded in the committed `Cargo.lock` and fails loudly instead of re-resolving it in the runner. Adds one cheap step, `Verify Cargo.lock is in sync`, that names a stale lock before anything compiles.

**The committed lock was verified clean first, and is not stale.** Adopting `--locked` here costs no lockfile refresh, so this PR contains no `Cargo.lock` change. Every feature set CI builds was run locally with `--locked` against the base commit and `Cargo.lock` was byte-identical after each one (`git status` clean throughout) — see Tests.

Two commits, one file:

- `ci: build the committed Cargo.lock by passing --locked (#251)` — the six flags plus a file-header rationale block above `jobs:`.
- `ci: name a stale Cargo.lock in its own step (#251)` — the verification step in the `rust` job.

### `--locked`, not `--frozen`

`--frozen` is `--locked` plus `--offline`. These runners have no vendored registry, so they must still reach crates.io to download the crates the lock names — `--frozen` would fail every build. Pinning *resolution* and forbidding *downloads* are separate properties, and only the first is wanted.

### A step, not a dedicated lock-check job

Considered and rejected. `--locked` on the compiling steps already fails a stale lock, just under a step name (`Clippy`, `Build`) that says nothing about the lock, and in both jobs at once. A dedicated job would buy legibility at the price of a second runner plus another submodule checkout — minutes of the run's wall clock — for a message a single `cargo metadata --locked` prints in seconds. So the legibility fix is a step at the top of the `rust` job instead. `cargo metadata` reads the whole lock regardless of the feature selection, so one invocation covers every feature set CI builds; verified locally that it fails on a dirtied lock exactly like the compiling steps do.

### The vendored submodules can invalidate the lock — this is the one real behaviour change

`Cargo.lock` carries version entries for all eight path packages (`opencompany`, `openhuman`, `tinyagents`, `tinychannels`, `tinycortex`, `tinyflows`, `tinyjuice`, `tinyplace`). Verified: bumping a vendored crate's version in its own manifest — which is what a `vendor/` submodule pointer bump does — makes `cargo metadata --locked` fail with `cannot update the lock file … because --locked was passed to prevent this`.

So after this lands, **a PR that moves a `vendor/` submodule pointer must commit the regenerated `Cargo.lock` alongside it.** Previously the runner absorbed that silently. That is the intended enforcement, but it is a new obligation on submodule-bump PRs and worth knowing before the first one hits it.

### Dependabot is unaffected

Checked the actual history rather than assuming: this repo's Dependabot cargo PRs (#221–#225) change **`Cargo.lock` only** — Dependabot regenerates the lock in the same PR, which is exactly what `--locked` requires. The `github-actions` ecosystem PRs (#216–#220) touch no Rust at all. No Dependabot config change is owed.

### Deliberately out of scope

`.github/workflows/release.yml` (`cargo build --all-targets`, `cargo test`) and the `Dockerfile` release build are left alone. Both would benefit from the same flag, but neither runs on a pull request, so neither can be proven green by this PR — and `release.yml` additionally lacks the nested `tinycortex → tinyagents` submodule init that `ci.yml` carries, a separate pre-existing gap that should be fixed and verified on its own rather than bundled behind a one-word flag change.

## API Or Behavior Changes

No product code changes; the crate, its public API and its runtime behaviour are untouched. Two CI behaviour changes:

- A `Cargo.toml` edit whose regenerated `Cargo.lock` was not committed now fails CI instead of being papered over by the runner. Confirmed by experiment: with a dependency requirement bumped and the lock left stale, `cargo build --locked --features openhuman,tinycortex --all-targets` exits `101`; the same command **without** `--locked` succeeds and silently rewrites `Cargo.lock` in the working tree.
- A `vendor/` submodule pointer bump that moves a vendored crate's version now requires the regenerated lock in the same PR (see Summary).

Note for #281 (frontend CI job): this diff is confined to `.github/workflows/ci.yml` and adds no new job. It inserts a comment block above `jobs:` (base lines 13–14), inserts a step and a comment into the existing `rust` job (base lines 42–47), and edits six single `run:` lines in place (base lines 47, 50, 123, 132, 140, 149). A new top-level `frontend` job appended after `rust-gated` will not overlap any of it.

## Tests

Every cargo command line from the edited workflow, run locally on the base commit with the vendored submodules initialised to their pinned SHAs. `Cargo.lock` was unmodified after each (`git status` reported only `.github/workflows/ci.yml`).

- [x] `cargo metadata --locked --format-version 1` — exit 0
- [x] `cargo fmt --all -- --check` — exit 0
- [x] `cargo clippy --locked --all-targets -- -D warnings` — exit 0
- [x] `cargo test --locked` — exit 0
- [x] `cargo build --locked --features openhuman,tinycortex --all-targets` — exit 0
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — exit 0
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — exit 0
- [x] `cargo check --locked --all-features` — exit 0
- [x] `cargo check --locked --features openhuman,mcp,telegram` — exit 0 (not a CI step; run because that combination has bitten before)

Both jobs were verified, not just the default one — the `openhuman,tinycortex` set exercises `--locked` against the vendored `[patch]` crates, which is where the lock is most likely to drift.

Negative tests, to prove the flag actually gates rather than passing vacuously:

- [x] Dependency requirement bumped in `Cargo.toml` with the lock left stale → `cargo metadata --locked` and `cargo build --locked --features openhuman,tinycortex --all-targets` both exit `101` with `cannot update the lock file … because --locked was passed to prevent this`. Reverted.
- [x] Same dirty state **without** `--locked` → build proceeds and rewrites `Cargo.lock`. This is the papering-over the issue describes, reproduced. Reverted.
- [x] Vendored crate version bumped under `vendor/openhuman` (simulating a submodule pointer bump) → `cargo metadata --locked` exits `101`. Reverted; submodules confirmed back at their pinned SHAs.

Workflow file itself:

- [x] `actionlint .github/workflows/ci.yml` — clean
- [x] YAML parses

CI on this PR is the real proof, since the PR's whole subject is CI.

## Documentation

No docs owed. The rationale lives where it will be read — a header comment above `jobs:` explaining the `--locked` policy and why `--frozen` was rejected, an inline note on the `Format` step recording that `cargo fmt` is exempt on purpose (so a later reader does not "fix" the omission), and a comment on the verification step explaining why it is a step and not a job. `.github/PULL_REQUEST_TEMPLATE.md` still lists the bare local commands, which remain correct for local use — `--locked` is a CI enforcement, not a contributor-workflow change.

Closes #251
