### PR TITLE
fix(delegation): ground the delegation target and make an undelivered hand-off visible (#272)

### DIFF
--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -3237,6 +3237,10 @@ members = ["eng1", "eng2"]
         /// Invokes that CANCEL their own in-flight delegation mid-run, so the
         /// delegated reply is discarded exactly as an operator cancel does.
         cancel_on: Vec<usize>,
+        /// Desk keys the first turn's `delegate_to_desk` calls named and the
+        /// tool REFUSED (issue #272). A refusal never becomes a `Delegation`,
+        /// so this is how a test reproduces one without standing up the tool.
+        refused_on_first: Vec<String>,
     }
 
     impl DelegatingProvider {
@@ -3283,6 +3287,11 @@ members = ["eng1", "eng2"]
             self.board.lock().unwrap().push(snapshot);
             for delegation in self.pushes.lock().unwrap().pop_front().unwrap_or_default() {
                 self.queue.push(delegation);
+            }
+            if invoke == 1 {
+                for desk in &self.faults.refused_on_first {
+                    self.queue.push_refusal(desk.clone());
+                }
             }
             let message = request
                 .messages
@@ -3795,6 +3804,103 @@ members = ["eng1", "eng2"]
             "the card must not strand in progress waiting on a delegate that cannot run"
         );
         assert_ne!(after.assignee, "ghost");
+    }
+
+    /// Issue #272: settling under the delegator is the right *behaviour* (#213
+    /// chose it so a card is never stranded), but it used to be silent — the
+    /// board showed a card whose note claimed a hand-off and whose owner was the
+    /// delegator, with nothing connecting the two. The undeliverable hand-off is
+    /// now recorded on the card, so an operator reads the fact instead of
+    /// inferring it from an absence.
+    #[tokio::test]
+    async fn a_hand_off_that_cannot_be_delivered_says_so_on_the_card() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, provider) = brain_that_delegates(
+            dir.path(),
+            vec![Some(Delegation::DelegateToDesk {
+                desk: "ghost".to_string(),
+                instruction: "look into it".to_string(),
+            })],
+        );
+        dispatch_card(&brain, &provider.tasks.clone(), "t-loud").await;
+
+        let note = only_card(&provider.tasks).await.note.expect("note");
+        assert!(
+            note.contains("hand-off to the \"ghost\" desk was not delivered"),
+            "the card must name the hand-off that did not happen: {note}"
+        );
+        assert!(
+            note.contains("this card is still with chief"),
+            "the card must say who still owns it: {note}"
+        );
+    }
+
+    /// Issue #272, the grounded half: the tool refused the invented target, so
+    /// no `Delegation` was ever queued. The turn is still free to *say* it
+    /// handed the work off — that is exactly what happened on the live company
+    /// — so the board records the refusal independently of the turn's account
+    /// of it. Without this the card settles under the delegator with a note
+    /// that claims a hand-off and nothing anywhere contradicting it.
+    #[tokio::test]
+    async fn a_refused_hand_off_is_recorded_on_the_card() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, provider) = brain_that_delegates_with(
+            dir.path(),
+            vec![Vec::new()],
+            TurnFaults {
+                refused_on_first: vec!["writer".to_string()],
+                ..TurnFaults::default()
+            },
+        );
+        dispatch_card(&brain, &provider.tasks.clone(), "t-refused").await;
+
+        let after = only_card(&provider.tasks).await;
+        assert_eq!(
+            provider.calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a refused hand-off runs no delegate"
+        );
+        assert_eq!(
+            after.column, "in_review",
+            "the card still settles under the delegator (#213); it is only no longer silent"
+        );
+        let note = after.note.expect("note");
+        assert!(
+            note.contains("hand-off to the \"writer\" desk was not delivered"),
+            "the refused target must be named on the card: {note}"
+        );
+        assert!(
+            note.contains("not a desk this company can hand work to"),
+            "the cause must be on the card: {note}"
+        );
+    }
+
+    /// The other half of #272's note: a delegation that never had a desk target
+    /// (a `spawn_task`) must not pick up an undeliverable-hand-off line.
+    #[tokio::test]
+    async fn a_spawn_task_never_records_an_undeliverable_hand_off() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, provider) = brain_that_delegates(
+            dir.path(),
+            vec![Some(Delegation::SpawnTask {
+                title: "Follow up".to_string(),
+                note: None,
+                assignee: None,
+            })],
+        );
+        dispatch_card(&brain, &provider.tasks.clone(), "t-quiet").await;
+
+        let cards = provider.tasks.list(&CompanyId::new("acme")).await.unwrap();
+        let parent = cards.iter().find(|c| c.id == "t-quiet").expect("parent");
+        assert!(
+            !parent
+                .note
+                .as_deref()
+                .unwrap_or_default()
+                .contains("was not delivered"),
+            "a spawn_task has no desk target to fail: {:?}",
+            parent.note
+        );
     }
 
     /// A `spawn_task` queued by a *dispatched* turn now opens its card with the

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -83,6 +83,7 @@ pub const QUERY_COMPANY_TOOL: &str = "query_company";
 // The `spawn_task` / `delegate_to_desk` names are the brain-agnostic canonical
 // constants (issue #176) — re-exported here so the harness path and the hosted
 // path share one definition and cannot drift.
+use crate::runtime::delegation_tools;
 pub use crate::runtime::delegation_tools::{DELEGATE_TO_DESK_TOOL, SPAWN_TASK_TOOL};
 /// The `run_workflow` tool name (issue #67).
 pub const RUN_WORKFLOW_TOOL: &str = "run_workflow";
@@ -129,11 +130,14 @@ pub fn orchestrator_brief() -> String {
     " You are also this company's orchestrator: the single point of contact for the operator. \
 Answer from whole-company context, and when a request belongs to a specialist desk or should be \
 tracked as work, delegate instead of guessing. Use `query_company` to ground answers in the \
-company's durable facts, recent activity, saved workflows, and team roster — it is the source of \
-truth for what workflows exist and who is on the team, so consult it before answering \"what \
-workflows/teammates do we have?\" rather than guessing or naming a skill \
+company's durable facts, recent activity, saved workflows, team roster, and desks — it is the \
+source of truth for what workflows exist, who is on the team, and which desks can take work, so \
+consult it before answering \"what workflows/teammates do we have?\" or before delegating, rather \
+than guessing or naming a skill \
 — `delegate_to_desk` to hand a turn to a desk's lead \
-member, `spawn_task` to open a tracked task card, `run_workflow` to execute one of the \
+member, naming the desk by an id `query_company` lists under Desks (a desk is not a person: \
+handing work to a teammate's name is not a delegation), \
+`spawn_task` to open a tracked task card, `run_workflow` to execute one of the \
 company's saved workflows by id (for example to advance or finish a task that is waiting on a \
 workflow run) — you can run workflows yourself; never claim the run_workflow tool is unavailable — \
 `create_workflow` to author and save a brand-new workflow graph (a trigger plus agent / tool / \
@@ -203,6 +207,17 @@ pub enum Delegation {
 #[derive(Clone, Default)]
 pub struct DelegationQueue {
     inner: Arc<Mutex<Vec<Delegation>>>,
+    /// Desk keys a `delegate_to_desk` call named that the company does not have
+    /// (issue #272).
+    ///
+    /// A refused hand-off never becomes a [`Delegation`], so without this the
+    /// drain has no way to know one was attempted — and a dispatched card would
+    /// settle under the delegator with only whatever the turn chose to say about
+    /// it. Carried on the queue because it shares the queue's exact lifetime:
+    /// filled by the tool during a turn, read by the drain right after, and
+    /// wiped by the same [`clear`](Self::clear) that keeps a prior turn from
+    /// leaking into this one.
+    refused: Arc<Mutex<Vec<String>>>,
 }
 
 impl DelegationQueue {
@@ -214,10 +229,27 @@ impl DelegationQueue {
             .push(delegation);
     }
 
+    /// Records that a hand-off named `desk`, which the company cannot hand work
+    /// to, so the drain can report the attempt (issue #272).
+    pub fn push_refusal(&self, desk: String) {
+        self.refused.lock().expect("delegation queue").push(desk);
+    }
+
+    /// Drains up to `cap` refused desk keys (FIFO) and discards the rest, so a
+    /// turn that calls the tool repeatedly cannot grow an unbounded note.
+    pub fn drain_refusals(&self, cap: usize) -> Vec<String> {
+        let mut guard = self.refused.lock().expect("delegation queue");
+        let take = guard.len().min(cap);
+        let drained: Vec<String> = guard.drain(..take).collect();
+        guard.clear();
+        drained
+    }
+
     /// Empties the queue (called before an orchestrator turn so stale
     /// delegations from a prior turn never leak into this one).
     pub fn clear(&self) {
         self.inner.lock().expect("delegation queue").clear();
+        self.refused.lock().expect("delegation queue").clear();
     }
 
     /// Drains up to `cap` queued delegations (FIFO) and discards the rest, so a
@@ -284,7 +316,7 @@ impl Tool for QueryCompanyTool {
     }
 
     fn description(&self) -> &str {
-        "Read the company's durable facts, recent activity, saved workflows, and team roster to ground an answer in whole-company context — use this to answer \"what workflows do we have?\" or \"who is on the team?\" instead of guessing. Optionally pass a `query` to filter facts by a case-insensitive substring."
+        "Read the company's durable facts, recent activity, saved workflows, team roster, and desks to ground an answer in whole-company context — use this to answer \"what workflows do we have?\", \"who is on the team?\", or \"which desks can take work?\" instead of guessing, and to get the exact desk id `delegate_to_desk` needs. Optionally pass a `query` to filter facts by a case-insensitive substring."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -426,12 +458,46 @@ impl Tool for QueryCompanyTool {
             }
         }
 
+        // Desks (issue #272). The roster was already here, but the *desks* were
+        // not — so an orchestrator asked to hand work to a desk had nothing
+        // authoritative to read and reached for a teammate's id instead. These
+        // are exactly the ids `delegate_to_desk` accepts, with each desk's lead
+        // named so the two are never confused for one another again.
+        let desks: Vec<(String, Option<String>)> = record
+            .as_ref()
+            .map(|record| {
+                delegation_tools::desk_ids(record)
+                    .into_iter()
+                    .map(|id| {
+                        let lead = delegation_tools::desk_lead(record, &id);
+                        (id, lead)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        md.push_str("\n## Desks\n");
+        if desks.is_empty() {
+            md.push_str("_No desks. Answer directly rather than delegating._\n");
+        } else {
+            for (id, lead) in &desks {
+                match lead {
+                    Some(lead) => md.push_str(&format!(
+                        "- **{id}** — lead: {lead} (delegate with `delegate_to_desk` desk=`{id}`)\n"
+                    )),
+                    None => md.push_str(&format!(
+                        "- **{id}** — no member on the roster, so it cannot be handed work\n"
+                    )),
+                }
+            }
+        }
+
         Ok(ToolResult::success_with_markdown(
             json!({
                 "facts": facts.len(),
                 "recent_events": recent.len(),
                 "workflows": workflows.len(),
                 "team": roster.len(),
+                "desks": desks.len(),
             }),
             md,
         ))
@@ -558,14 +624,58 @@ impl Tool for SpawnTaskTool {
 /// A delegation tool that hands a turn to a desk's lead member. Enqueues a
 /// [`Delegation::DelegateToDesk`]; the harness brain runs the desk turn on
 /// drain and surfaces its reply as its own chat bubble.
+///
+/// The target is **grounded against the company's real desks** before anything
+/// is queued (issue #272): a `desk` that matches no desk — or a desk nobody on
+/// the roster leads, which no turn could ever run for — is refused here, with
+/// the valid desk ids in the refusal, instead of being queued and quietly
+/// dropped at drain time. `delegate_to_desk` is an
+/// [intrinsic tool](crate::harness::steps), so the refusal reaches both the
+/// model (as a failed tool result it can retry from in the same turn) and the
+/// operator's run trail verbatim.
 pub struct DelegateToDeskTool {
     queue: DelegationQueue,
+    company: CompanyId,
+    /// The company store, read at call time so the desk set is the **current**
+    /// one. Deliberately not a snapshot captured when the agent was built: an
+    /// operator can create a desk mid-session (the desk-creation overlay), and a
+    /// stale snapshot would refuse a desk that exists — a worse failure than the
+    /// one this grounding fixes.
+    store: Arc<dyn CompanyStore>,
 }
 
 impl DelegateToDeskTool {
-    /// Builds the tool over the shared delegation queue.
-    pub fn new(queue: DelegationQueue) -> Self {
-        Self { queue }
+    /// Builds the tool over the shared delegation queue and the company store it
+    /// grounds the target against.
+    pub fn new(queue: DelegationQueue, company: CompanyId, store: Arc<dyn CompanyStore>) -> Self {
+        Self {
+            queue,
+            company,
+            store,
+        }
+    }
+
+    /// The refusal for `desk`, or `None` when it names a desk that can take
+    /// work.
+    ///
+    /// **Fails open**: if the record cannot be read the delegation is queued
+    /// exactly as it was before this grounding existed. A store hiccup must not
+    /// take delegation offline; the drain-time fall-through still records what
+    /// happened.
+    async fn refusal(&self, desk: &str) -> Option<String> {
+        match self.store.load(&self.company).await {
+            Ok(Some(record)) => delegation_tools::reject_desk_target(&record, desk),
+            Ok(None) => None,
+            Err(err) => {
+                tracing::warn!(
+                    company = %self.company,
+                    error = %err,
+                    "[delegate_to_desk] could not read the company record to ground the desk target; \
+                     queuing the hand-off ungrounded"
+                );
+                None
+            }
+        }
     }
 }
 
@@ -602,6 +712,21 @@ impl Tool for DelegateToDeskTool {
             .filter(|i| !i.is_empty())
             .ok_or_else(|| anyhow::anyhow!("`instruction` is required"))?
             .to_string();
+
+        // Ground the target before queuing anything: an invented desk is
+        // refused here, in the model's own turn, rather than surviving as a
+        // queued hand-off that the drain silently cannot deliver (issue #272).
+        if let Some(refusal) = self.refusal(&desk).await {
+            tracing::info!(
+                company = %self.company,
+                "[delegate_to_desk] refused an ungrounded delegation target"
+            );
+            // Recorded as well as returned: the model can still describe this
+            // turn however it likes, so the *board* must carry the fact
+            // independently of what the turn says about it.
+            self.queue.push_refusal(desk);
+            return Ok(ToolResult::error(refusal));
+        }
 
         self.queue.push(Delegation::DelegateToDesk {
             desk: desk.clone(),
@@ -787,10 +912,18 @@ fn optional_str(args: &Value, key: &str) -> Option<String> {
 /// `spawn_task`, `delegate_to_desk`, and — since #186 part b — `assign_task`
 /// and `review_task`. `query_company` is built separately because it needs the
 /// read ports, not the queue.
-pub fn delegation_tools(queue: &DelegationQueue) -> Vec<Box<dyn Tool>> {
+///
+/// `delegate_to_desk` additionally takes the company id + store, which it reads
+/// at call time to ground the delegation target against the company's real
+/// desks (issue #272).
+pub fn delegation_tools(
+    queue: &DelegationQueue,
+    company: CompanyId,
+    store: Arc<dyn CompanyStore>,
+) -> Vec<Box<dyn Tool>> {
     vec![
         Box::new(SpawnTaskTool::new(queue.clone())),
-        Box::new(DelegateToDeskTool::new(queue.clone())),
+        Box::new(DelegateToDeskTool::new(queue.clone(), company, store)),
         Box::new(AssignTaskTool::new(queue.clone())),
         Box::new(ReviewTaskTool::new(queue.clone())),
     ]
@@ -961,7 +1094,7 @@ pub fn orchestrator_tools(
         workflow_source_dir.clone(),
         Some(store.clone()),
     ))];
-    tools.extend(delegation_tools(queue));
+    tools.extend(delegation_tools(queue, company.clone(), store.clone()));
     tools.push(Box::new(RunWorkflowTool::new(
         company.clone(),
         workflow_source_dir.clone(),
@@ -1734,7 +1867,9 @@ mod tests {
     /// The orchestrator is actually handed the new tools.
     #[test]
     fn delegation_tools_include_the_lifecycle_tools() {
-        let names: Vec<String> = delegation_tools(&DelegationQueue::default())
+        let company = CompanyId::new("acme");
+        let store = Arc::new(MemStore::seeded(seeded_record(&company)));
+        let names: Vec<String> = delegation_tools(&DelegationQueue::default(), company, store)
             .iter()
             .map(|t| t.name().to_string())
             .collect();
@@ -1748,13 +1883,60 @@ mod tests {
         );
     }
 
+    /// A company with a `strategy` desk led by a roster teammate, an
+    /// `archive` desk nobody on the roster sits on, and a `writer` teammate who
+    /// is *not* a desk — the exact shape issue #272 was observed on.
+    fn desks_record(id: &CompanyId) -> CompanyRecord {
+        let manifest = toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+tier = "orchestrator"
+
+[[agent]]
+id = "writer"
+role = "Writer"
+
+[[group_chat]]
+id = "strategy"
+name = "Strategy desk"
+members = ["writer"]
+
+[[group_chat]]
+id = "archive"
+name = "Archive desk"
+members = ["nobody"]
+"#,
+        )
+        .expect("valid manifest");
+        CompanyRecord {
+            manifest,
+            ..seeded_record(id)
+        }
+    }
+
+    fn desk_tool(record: CompanyRecord, queue: &DelegationQueue) -> DelegateToDeskTool {
+        let company = record.id.clone();
+        DelegateToDeskTool::new(
+            queue.clone(),
+            company,
+            Arc::new(MemStore::seeded(record)) as Arc<dyn CompanyStore>,
+        )
+    }
+
     #[tokio::test]
     async fn delegate_to_desk_tool_enqueues_a_hand_off() {
         let queue = DelegationQueue::default();
-        let tool = DelegateToDeskTool::new(queue.clone());
-        tool.execute(json!({ "desk": "strategy", "instruction": "draft a plan" }))
+        let tool = desk_tool(desks_record(&CompanyId::new("acme")), &queue);
+        let result = tool
+            .execute(json!({ "desk": "strategy", "instruction": "draft a plan" }))
             .await
             .expect("execute");
+        assert!(!result.is_error, "a real desk with a lead is delegatable");
         let drained = queue.drain(MAX_DELEGATIONS_PER_TURN);
         assert_eq!(
             drained,
@@ -1763,6 +1945,79 @@ mod tests {
                 instruction: "draft a plan".to_string(),
             }]
         );
+    }
+
+    /// Issue #272: the observed failure — the orchestrator handed work to
+    /// `writer`, which is a teammate rather than a desk. Nothing may be queued,
+    /// and the refusal must carry the real desk ids so the model can correct
+    /// itself in the same turn.
+    #[tokio::test]
+    async fn delegate_to_desk_tool_refuses_a_desk_that_does_not_exist() {
+        let queue = DelegationQueue::default();
+        let tool = desk_tool(desks_record(&CompanyId::new("acme")), &queue);
+        let result = tool
+            .execute(json!({ "desk": "writer", "instruction": "draft the release note" }))
+            .await
+            .expect("execute");
+        assert!(result.is_error, "an invented desk must be refused");
+        let text = result.output_for_llm(true);
+        assert!(text.contains("strategy"), "valid ids must be named: {text}");
+        assert!(
+            text.contains("teammate"),
+            "a teammate-as-desk target must be named as such: {text}"
+        );
+        assert_eq!(
+            queue.queued(),
+            0,
+            "a refused target must not survive as a queued hand-off"
+        );
+        assert_eq!(
+            queue.drain_refusals(MAX_DELEGATIONS_PER_TURN),
+            vec!["writer".to_string()],
+            "the drain must be able to report the attempt on the card"
+        );
+    }
+
+    /// A desk that exists but has nobody on the roster can never run a turn, so
+    /// the hand-off is refused rather than queued into a drain that cannot
+    /// deliver it.
+    #[tokio::test]
+    async fn delegate_to_desk_tool_refuses_a_desk_with_no_roster_lead() {
+        let queue = DelegationQueue::default();
+        let tool = desk_tool(desks_record(&CompanyId::new("acme")), &queue);
+        let result = tool
+            .execute(json!({ "desk": "archive", "instruction": "file it" }))
+            .await
+            .expect("execute");
+        assert!(result.is_error, "a leadless desk must be refused");
+        let text = result.output_for_llm(true);
+        assert!(
+            text.contains("no member on the roster"),
+            "the refusal must name the cause: {text}"
+        );
+        assert!(
+            text.contains("strategy"),
+            "a desk that CAN take work must be offered: {text}"
+        );
+        assert_eq!(queue.queued(), 0);
+    }
+
+    /// Fail-open: with no record to read, delegation behaves exactly as it did
+    /// before grounding existed. A store gap must not take delegation offline.
+    #[tokio::test]
+    async fn delegate_to_desk_tool_queues_ungrounded_when_no_record_is_readable() {
+        let queue = DelegationQueue::default();
+        let tool = DelegateToDeskTool::new(
+            queue.clone(),
+            CompanyId::new("acme"),
+            Arc::new(MemStore::default()) as Arc<dyn CompanyStore>,
+        );
+        let result = tool
+            .execute(json!({ "desk": "whatever", "instruction": "do it" }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error);
+        assert_eq!(queue.queued(), 1);
     }
 
     #[tokio::test]
@@ -1827,6 +2082,33 @@ name = "Morning"
         assert!(
             out.contains("Fact Fetcher"),
             "overlay teammate name missing: {out}"
+        );
+    }
+
+    /// Issue #272: `query_company` is the grounding surface the orchestrator is
+    /// told to consult, but it listed the roster and not the **desks** — so an
+    /// orchestrator about to delegate had no authoritative id to read and
+    /// reached for a teammate's name instead. Every desk is listed by the id
+    /// `delegate_to_desk` takes, with its lead, and a desk nobody leads says so.
+    #[tokio::test]
+    async fn query_company_tool_lists_the_desks_delegation_accepts() {
+        let company = CompanyId::new("acme");
+        let store: Arc<dyn CompanyStore> = Arc::new(MemStore::seeded(desks_record(&company)));
+        let tool = QueryCompanyTool::new(company, None, None, None, Some(store));
+        let out = tool
+            .execute(json!({}))
+            .await
+            .expect("execute")
+            .output_for_llm(true);
+
+        assert!(out.contains("## Desks"), "{out}");
+        assert!(
+            out.contains("**strategy** — lead: writer"),
+            "a delegatable desk must name its id and lead: {out}"
+        );
+        assert!(
+            out.contains("**archive** — no member on the roster"),
+            "a leadless desk must say it cannot be handed work: {out}"
         );
     }
 

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -40,6 +40,7 @@ use crate::ports::{generate_id, now_millis};
 use crate::runtime::channel::OPERATOR_CHANNEL;
 use crate::runtime::delegation_tools::{
     DELEGATE_TO_DESK_TOOL, DelegateArgs, SPAWN_TASK_TOOL, SpawnTaskArgs, desk_lead,
+    unknown_desk_message,
 };
 use crate::runtime::types::CycleReport;
 use crate::server::ops::mailer::{MailCredentials, OutboundEmail};
@@ -743,11 +744,27 @@ impl<'a> CycleHostImpl<'a> {
             .as_ref()
             .and_then(|r| r.resolve_desk_id(&parsed.desk))
         else {
+            // Issue #272: the refusal now carries the company's real desk ids
+            // (and, when the invented target names a teammate, the desk that
+            // teammate is on), so the remote cognition can correct itself in the
+            // same turn rather than only learning that its pick was wrong. The
+            // message is the one the harness tool's boundary check uses, so the
+            // two paths cannot drift.
+            //
+            // Only the *unknown* desk is refused here. A real desk with no
+            // roster lead is left alone on this path: the hosted hand-off is a
+            // durable card assigned to the desk, which is visible on the board
+            // whether or not anyone leads it yet — there is nothing silent
+            // about it.
+            let error = match record.as_ref() {
+                Some(record) => unknown_desk_message(record, &parsed.desk),
+                None => format!("no desk matches \"{}\"", parsed.desk),
+            };
             return Ok(ToolResult {
                 ok: false,
                 output: serde_json::json!({
                     "status": "unknown_desk",
-                    "error": format!("no desk matches \"{}\"", parsed.desk),
+                    "error": error,
                 }),
             });
         };

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -327,6 +327,28 @@ impl<'a> DelegationRunner<'a> {
         card: &mut TaskRecord,
         delegator: &str,
     ) -> Result<Option<TaskHandoff>> {
+        // A hand-off the tool refused (issue #272) never becomes a
+        // `Delegation`, so it is read separately — and recorded on the card
+        // before anything else, because the turn's own account of it is exactly
+        // what cannot be trusted: a refused hand-off is precisely the case where
+        // the reply claimed work had changed hands and the board showed
+        // otherwise.
+        for desk in self.queue.drain_refusals(self.max_delegations) {
+            tracing::warn!(
+                task_id = %card.id,
+                delegator = %delegator,
+                "[task] a hand-off was refused before it could be queued"
+            );
+            card.note = Some(append_note(
+                card.note.as_deref(),
+                delegator,
+                &undeliverable_handoff(
+                    &desk,
+                    delegator,
+                    "it is not a desk this company can hand work to",
+                ),
+            ));
+        }
         let queued = self.queue.drain(self.max_delegations);
         if queued.is_empty() {
             return Ok(None);
@@ -347,7 +369,28 @@ impl<'a> DelegationRunner<'a> {
                 _ => None,
             };
             let Some(member) = lead else {
+                // A hand-off whose desk resolves to no lead cannot be
+                // delivered. #213 settles the card under the delegator rather
+                // than stranding it, which is right — but until #272 it did so
+                // silently, leaving a card whose note claimed a hand-off that
+                // never happened and whose assignee was the delegator, with
+                // nothing on the board connecting the two. Record the
+                // undeliverable hand-off on the card so the operator reads the
+                // fact instead of inferring it from an absence. Every other
+                // delegation kind carries no desk and is unaffected.
+                let desk = desk_of(&delegation).map(str::to_string);
                 self.run_delegation(delegation, None).await?;
+                if let Some(desk) = desk {
+                    card.note = Some(append_note(
+                        card.note.as_deref(),
+                        delegator,
+                        &undeliverable_handoff(
+                            &desk,
+                            delegator,
+                            "no desk with that id has a lead on the roster",
+                        ),
+                    ));
+                }
                 continue;
             };
             // The card belongs to the first hand-off that actually PRODUCES
@@ -491,6 +534,18 @@ impl<'a> DelegationRunner<'a> {
             }
             Delegation::DelegateToDesk { desk, instruction } => {
                 let Some(member) = desk_lead(self.record, &desk) else {
+                    // Since #272 the harness tool refuses an ungrounded target
+                    // before it is ever queued, so reaching here means the desk
+                    // lost its lead between the tool call and this drain (or the
+                    // delegation came from a path with no tool boundary). Either
+                    // way it is a hand-off that will not happen: say so in the
+                    // log, and — on the task path — on the card itself.
+                    tracing::warn!(
+                        company = %self.company,
+                        desk = %desk,
+                        "[delegation] hand-off could not be delivered: no desk with that id has a \
+                         lead on the roster"
+                    );
                     return Ok(DelegationOutcome::default());
                 };
                 // Register the delegated turn so an operator can CANCEL it
@@ -665,6 +720,31 @@ fn instruction_of(delegation: &Delegation) -> &str {
         Delegation::DelegateToDesk { instruction, .. } => instruction,
         _ => "",
     }
+}
+
+/// The desk a hand-off targets, or `None` for every other delegation kind —
+/// which is what distinguishes "this delegation had a target that did not
+/// resolve" from "this delegation never had a target" (issue #272).
+fn desk_of(delegation: &Delegation) -> Option<&str> {
+    match delegation {
+        Delegation::DelegateToDesk { desk, .. } => Some(desk),
+        _ => None,
+    }
+}
+
+/// The note recorded on a card when a hand-off could not be delivered (issue
+/// #272).
+///
+/// Written in the delegator's voice, like every other note this seam appends,
+/// and deliberately explicit about the two facts an operator otherwise has to
+/// infer: nothing was handed off, and the card is still theirs. Names only the
+/// desk key, the cause, and the delegator — no instruction text, no delegate
+/// output.
+fn undeliverable_handoff(desk: &str, delegator: &str, cause: &str) -> String {
+    format!(
+        "hand-off to the \"{desk}\" desk was not delivered — {cause}. Nothing was delegated; this \
+card is still with {delegator}."
+    )
 }
 
 /// Appends a responder-attributed result block to a card's note, preserving any

--- a/src/runtime/delegation_tools.rs
+++ b/src/runtime/delegation_tools.rs
@@ -121,6 +121,135 @@ pub fn desk_lead(record: &CompanyRecord, desk: &str) -> Option<String> {
         .find(|m| record.is_roster_agent(m))
 }
 
+/// How many desk ids a rejection message names before eliding the rest, so the
+/// message stays short enough to be useful on a company with many desks.
+const LISTED_DESKS: usize = 12;
+
+/// Every desk id the company actually has: the manifest `[[group_chat]]` desks
+/// in declaration order, then any operator-created overlay desks, deduplicated.
+///
+/// The **id** is what [`delegate_to_desk`](DELEGATE_TO_DESK_TOOL) takes, so this
+/// is the set a delegation target is grounded against. Reads the same two
+/// sources [`CompanyRecord::resolve_desk_id`] searches, so "what ids exist" and
+/// "does this id resolve" cannot disagree.
+pub fn desk_ids(record: &CompanyRecord) -> Vec<String> {
+    let mut ids: Vec<String> = Vec::new();
+    for chat in &record.manifest.group_chats {
+        if !ids.contains(&chat.id) {
+            ids.push(chat.id.clone());
+        }
+    }
+    for desk in &record.overlay_desks {
+        if !ids.contains(&desk.id) {
+            ids.push(desk.id.clone());
+        }
+    }
+    ids
+}
+
+/// Why a `delegate_to_desk` target cannot be delivered, phrased for the model
+/// that called the tool — or `None` when `key` names a desk that can actually
+/// take the work (issue #272).
+///
+/// Two refusals, deliberately distinct so the caller can act on them:
+///
+/// * **Unknown desk** — `key` resolves to no desk at all. This is the invented
+///   target: the observed failure was a hand-off to `writer`, which is a
+///   *teammate*, not a desk. The message names the company's real desk ids so
+///   the model can retry in the same turn, and when the key does name a
+///   teammate it says so and points at the desk that teammate leads.
+/// * **Leadless desk** — the desk is real but no member of it is on the roster,
+///   so no turn can ever run for it. Delegating there is always a no-op.
+///
+/// Returning the reason as a string (rather than rejecting inside the tool)
+/// keeps this brain-agnostic: the harness tool turns it into a
+/// `ToolResult::error` and the hosted device-side handler turns it into a failed
+/// tool frame, from one definition.
+pub fn reject_desk_target(record: &CompanyRecord, key: &str) -> Option<String> {
+    let Some(desk_id) = record.resolve_desk_id(key) else {
+        return Some(unknown_desk_message(record, key));
+    };
+    if desk_lead(record, &desk_id).is_some() {
+        return None;
+    }
+    let with_leads = desk_list(
+        desk_ids(record)
+            .into_iter()
+            .filter(|id| desk_lead(record, id).is_some())
+            .collect(),
+    );
+    Some(match with_leads {
+        Some(list) => format!(
+            "The \"{desk_id}\" desk has no member on the roster, so nothing can be handed to it. \
+Desks that can take work: {list}."
+        ),
+        None => format!(
+            "The \"{desk_id}\" desk has no member on the roster, so nothing can be handed to it, \
+and no other desk has a lead either. Answer directly instead of delegating."
+        ),
+    })
+}
+
+/// The refusal for a delegation target that matches no desk (issue #272).
+///
+/// Public because the hosted path refuses **only** this case: there, a hand-off
+/// is a durable board card assigned to the desk, so a real desk with no lead yet
+/// is still visible work rather than a silent drop. The harness path — where a
+/// hand-off is a live turn that a leadless desk can never run — goes through
+/// [`reject_desk_target`], which covers both.
+pub fn unknown_desk_message(record: &CompanyRecord, key: &str) -> String {
+    let Some(list) = desk_list(desk_ids(record)) else {
+        return format!(
+            "There is no \"{key}\" desk — this company has no desks at all, so `delegate_to_desk` \
+cannot be used. Answer directly instead."
+        );
+    };
+    // A teammate's id is the most common invented target (the orchestrator
+    // reaches for the person it has in mind rather than the desk they sit on),
+    // so name the mistake instead of only listing the alternatives.
+    let Some(agent) = record.resolve_roster_agent_id(key) else {
+        return format!(
+            "There is no \"{key}\" desk. Valid desk ids: {list}. Call `delegate_to_desk` again \
+with one of those ids."
+        );
+    };
+    match desk_of_member(record, &agent) {
+        Some(desk) => format!(
+            "There is no \"{key}\" desk — \"{key}\" is a teammate, not a desk. The desk they are \
+on is \"{desk}\". Valid desk ids: {list}."
+        ),
+        None => format!(
+            "There is no \"{key}\" desk — \"{key}\" is a teammate, not a desk, and is on no desk. \
+Valid desk ids: {list}."
+        ),
+    }
+}
+
+/// The first desk `member` is on, so an invented teammate-as-desk target can be
+/// redirected at the desk that teammate actually sits on.
+fn desk_of_member(record: &CompanyRecord, member: &str) -> Option<String> {
+    desk_ids(record).into_iter().find(|id| {
+        record
+            .effective_desk_members(id)
+            .iter()
+            .any(|m| m == member)
+    })
+}
+
+/// Renders a desk-id list for a message, capped at [`LISTED_DESKS`] with the
+/// remainder counted. `None` when there are no ids to list.
+fn desk_list(ids: Vec<String>) -> Option<String> {
+    if ids.is_empty() {
+        return None;
+    }
+    let shown = ids.len().min(LISTED_DESKS);
+    let mut list = ids[..shown].join(", ");
+    if ids.len() > shown {
+        list.push_str(&format!(" (+{} more)", ids.len() - shown));
+    }
+    Some(list)
+}
+
 /// Parsed `spawn_task` arguments: a required title, an optional brief note, and
 /// an optional assignee. Blank strings are treated as absent.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -211,6 +340,114 @@ mod test {
             .expect("valid");
         assert_eq!(bare.note, None);
         assert_eq!(bare.assignee, None);
+    }
+
+    /// The company shape issue #272 was observed on: real desks, plus a
+    /// teammate (`writer`) the orchestrator mistook for one.
+    fn record() -> CompanyRecord {
+        let manifest = toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+
+[[agent]]
+id = "writer"
+role = "Writer"
+
+[[group_chat]]
+id = "engineering"
+name = "Engineering desk"
+members = ["ceo"]
+
+[[group_chat]]
+id = "content"
+name = "Content desk"
+members = ["writer"]
+
+[[group_chat]]
+id = "legal"
+name = "Legal desk"
+members = ["counsel"]
+"#,
+        )
+        .expect("valid manifest");
+        CompanyRecord {
+            id: crate::ports::types::CompanyId::new("acme"),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            template_provenance: None,
+        }
+    }
+
+    #[test]
+    fn desk_ids_lists_manifest_desks_in_declaration_order() {
+        assert_eq!(desk_ids(&record()), ["engineering", "content", "legal"]);
+    }
+
+    #[test]
+    fn a_real_desk_with_a_lead_is_not_rejected() {
+        assert_eq!(reject_desk_target(&record(), "content"), None);
+        // The id-or-name key `resolve_desk_id` already accepts still works.
+        assert_eq!(reject_desk_target(&record(), "Content desk"), None);
+    }
+
+    /// The observed bug: `writer` is a teammate, not a desk. The refusal must
+    /// name the real desk ids so the model can retry in the same turn, and say
+    /// which desk that teammate is actually on.
+    #[test]
+    fn an_invented_desk_is_rejected_with_the_valid_set() {
+        let message = reject_desk_target(&record(), "writer").expect("rejected");
+        assert!(message.contains("engineering"), "{message}");
+        assert!(message.contains("content"), "{message}");
+        assert!(message.contains("legal"), "{message}");
+        assert!(
+            message.contains("teammate"),
+            "a teammate-as-desk target must be named as such: {message}"
+        );
+        // A key that is neither a desk nor a teammate still gets the valid set.
+        let message = reject_desk_target(&record(), "growth").expect("rejected");
+        assert!(message.contains("engineering"), "{message}");
+        assert!(!message.contains("teammate"), "{message}");
+    }
+
+    /// A desk that exists but has nobody on the roster can never run a turn, so
+    /// it is refused too — with the desks that CAN take work.
+    #[test]
+    fn a_desk_with_no_roster_lead_is_rejected() {
+        let message = reject_desk_target(&record(), "legal").expect("rejected");
+        assert!(message.contains("no member on the roster"), "{message}");
+        assert!(
+            message.contains("Desks that can take work: engineering, content."),
+            "only desks with a lead may be offered as alternatives: {message}"
+        );
+    }
+
+    /// A company with no desks at all cannot delegate; say so rather than
+    /// offering an empty list.
+    #[test]
+    fn a_company_with_no_desks_says_so() {
+        let mut record = record();
+        record.manifest.group_chats.clear();
+        let message = reject_desk_target(&record, "content").expect("rejected");
+        assert!(message.contains("no desks at all"), "{message}");
+    }
+
+    #[test]
+    fn the_desk_list_is_capped_and_counts_the_remainder() {
+        let ids: Vec<String> = (0..LISTED_DESKS + 3).map(|i| format!("d{i}")).collect();
+        let list = desk_list(ids).expect("non-empty");
+        assert!(list.ends_with("(+3 more)"), "{list}");
+        assert_eq!(desk_list(Vec::new()), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #272.

When the orchestrator hands work to a desk it never had to name a desk that
exists. It invented one, the invented one was accepted, and the hand-off then
failed with nothing anywhere saying so.

**Reproduced first, on a live host.** A harness company with desks
`engineering`, `content` and `legal`; `writer` is a *teammate* who leads
`content`. A dispatched board card whose turn calls
`delegate_to_desk(desk: "writer")` produced, before this change:

- tool result: `Delegated to the writer desk. Its lead will answer this turn.`
- the delegation queued and drained (`queued=1`), and no delegate turn ever ran
- the card settled in `in_review`, `assignee: ceo`, note:
  `[ceo] Handed off to the **writer** desk — their lead will draft the release note and respond this turn.`

which is the report verbatim. On the board a delegation to a desk that does not
exist is indistinguishable from a delegation that produced nothing.

**Two changes, matching the two halves of the issue.**

*Ground the target.* `delegate_to_desk` now resolves `desk` against the
company's real desks before anything is queued, and refuses what it cannot
deliver — an id that matches no desk, and a desk with no member on the roster,
which no turn could ever run for. The refusal names the valid desk ids, and when
the invented target is a teammate it says so and points at the desk that
teammate is on:

```
There is no "writer" desk — "writer" is a teammate, not a desk.
The desk they are on is "content". Valid desk ids: engineering, content, legal.
```

`query_company` — the surface the orchestrator's own brief tells it to consult —
listed the roster but not the desks, so there was no authoritative place to read
a desk id in the first place. It now has a `## Desks` section listing each desk
by the id `delegate_to_desk` takes, with its lead, and marking a desk nobody
leads as unable to take work. That is the preventive half; the refusal is the
corrective half.

*Make the fall-through loud.* Settling under the delegator stays exactly as
#213 chose it — a card is never stranded waiting on a delegate that cannot run.
It is only no longer silent. A dispatched card now records the attempt:

```
[ceo] hand-off to the "writer" desk was not delivered — it is not a desk this
company can hand work to. Nothing was delegated; this card is still with ceo.
```

This is written from a refusal recorded on the delegation queue, **not** from
the turn's own account of itself — the turn is free to keep claiming a hand-off
happened, and on the live company it did exactly that. The same note covers the
other route to an undelivered hand-off: a desk that had a lead when the tool
accepted it and lost it before the drain.

## API Or Behavior Changes

- **`delegate_to_desk` can now fail.** An unknown desk, or a desk with no
  roster-backed lead, returns a `ToolResult::error` and queues nothing. It
  previously always succeeded. `delegate_to_desk` is already in
  `harness::steps::INTRINSIC_TOOLS`, so the OC-authored refusal reaches the
  operator's run trail verbatim (bounded to 200 chars) as well as the model.
- **Fails open.** If the company record cannot be read, the hand-off is queued
  ungrounded exactly as before. A store hiccup does not take delegation offline.
- **`DelegateToDeskTool::new` and `orchestrator::delegation_tools` take the
  company id + store.** The store is read at call time, never snapshotted at
  agent-build time — see the trade-off below.
- **`DelegationQueue` carries refused desk keys** alongside queued delegations,
  drained by `handle_task_delegations` and wiped by the same `clear()`.
- **`query_company` gains a `## Desks` section** and a `desks` count in its JSON
  payload. Additive; no existing section changed.
- **Hosted path**: the unknown-desk tool error now carries the valid desk ids
  instead of only `no desk matches "x"`. A real desk with no lead is deliberately
  *not* refused there — a hosted hand-off is a durable card assigned to the desk,
  visible on the board whether or not anyone leads it yet, so nothing is silent.
- No REST/GraphQL schema changes, and no frontend changes.

## Choices that differ from the issue, and why

**Schema enum vs. tool-boundary rejection.** The issue proposes rejection; I
checked first whether the schema could carry the desk ids as an enum so the
model is constrained rather than corrected. It cannot, for two reasons worth
recording: `Tool::parameters_schema` is synchronous, so it cannot read the
company store, and desks are dynamic per company — an operator can create one
mid-session through the desk overlay. Any enum baked at agent-build time would
go stale and refuse a desk that genuinely exists, which is a worse failure than
the one being fixed. Rejection at the boundary, reading the store fresh on each
call, is the version that stays correct.

**No new `CompanyEvent` variant.** The trail loudness the issue asks about is
already there: `delegate_to_desk` is an intrinsic tool, so its own refusal text
is surfaced on the run trail verbatim rather than collapsed to a generic class.
Against that, `CompanyEvent` is documented in `runtime/journal.rs` as "a closed,
binding enum with no marker variants", it is projected in several places, and
the brain-agnostic `DelegationRunner` holds no event-log handle — so a variant
would mean threading one across that seam for something the trail and the card
note already carry. If a reviewer wants the event anyway it is a small follow-up,
not a rewrite.

**Refusing a leadless desk is mine, not the issue's.** The issue asks only that
unknown ids be refused. A desk with no roster member can never run a turn, and
the tool's success message ("its lead will answer this turn") is exactly the lie
this issue is about, so it is refused too — with a distinct message, and only on
the harness path, where a hand-off is a live turn rather than a durable card.

## Does the in-turn self-correction actually work?

**The mechanism does, verified live** rather than assumed. Driving a real host
with a scripted OpenAI-compatible endpoint, so the model's choices are
deterministic and the rest of the path is real: the orchestrator calls
`delegate_to_desk(desk: "writer")`, gets the refusal back as a failed tool result
inside the same turn, calls `delegate_to_desk(desk: "content")`, and the hand-off
completes — card reassigned to `writer` (the content desk's lead) and settled on
the delegate's own output. The loop does feed the error back, and does act on a
corrected retry.

**What that does not prove** is that a real model chooses to correct itself. The
scripted endpoint decides to retry; a live model might instead answer in prose
without retrying — which the second scripted run exercises, and which also lands
correctly: the refusal recorded on the card, no phantom hand-off. Both outcomes
are honest on the board now, so the fix does not depend on the model cooperating.
That is precisely why the loud note is written from the recorded refusal rather
than from what the turn says about itself.

## Tests

New coverage:

- `reject_desk_target` / `unknown_desk_message`: the valid set in the refusal,
  the teammate-is-not-a-desk case, the leadless-desk case offering only desks
  that can take work, a company with no desks, and the desk-list cap.
- `delegate_to_desk_tool_refuses_a_desk_that_does_not_exist` — nothing queued,
  valid ids and the teammate hint in the error, refusal recorded for the drain.
- `delegate_to_desk_tool_refuses_a_desk_with_no_roster_lead`.
- `delegate_to_desk_tool_queues_ungrounded_when_no_record_is_readable` — the
  fail-open contract.
- `query_company_tool_lists_the_desks_delegation_accepts` — each desk by id with
  its lead; a leadless desk says it cannot be handed work.
- `a_refused_hand_off_is_recorded_on_the_card` — the card carries the refusal
  even though the turn claimed a hand-off; still settles under the delegator.
- `a_hand_off_that_cannot_be_delivered_says_so_on_the_card` — the drain-time
  route (a lead lost between the tool call and the drain).
- `a_spawn_task_never_records_an_undeliverable_hand_off` — a delegation with no
  desk target must not pick up the line.

The existing #213 pins (`a_hand_off_to_an_unknown_desk_settles_under_the_delegator`
and the cancellation / card-ownership set) are untouched and still pass — the
settle behaviour is unchanged.

Commands run locally:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets` — via `cargo check --all-targets` on both
      feature sets below, plus a full `cargo build --features openhuman,mcp,telegram`
      for the live host
- [x] `cargo test` — 1015 + 6 pass
- [x] `cargo test --features openhuman` — 1397 + 6 pass (the harness suite is
      where this code lives; the default build does not compile `src/harness/`)
- [x] `cargo check --features openhuman,mcp,telegram --all-targets`
- [x] `cargo check --all-features --all-targets`
- [x] Live verification on a running host (isolated `--home`, harness company with
      `engineering` / `content` / `legal`): bug reproduced before the change, then
      all three post-change paths — invented desk refused, leadless desk refused,
      corrected retry delivering to the right lead.

N/A: no `frontend/` files are touched by this diff, so the console gates
(`npm run typecheck` / `npm run build`) were not run.

## Documentation

No doc file names `delegate_to_desk` or the delegation contract — those decisions
live in rustdoc, which is where this codebase keeps them (as with #204 and #213).
The rustdoc on `reject_desk_target`, `DelegateToDeskTool`,
`DelegationQueue::refused` and `undeliverable_handoff` records the grounding
rules, the fail-open contract, the read-the-store-at-call-time reasoning, and why
the hosted path refuses only the unknown-desk half. The orchestrator persona
brief and the `query_company` tool description are updated to point at the desk
list.
