### PR TITLE
ci: add a Console job so a frontend type error cannot merge (#281)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,3 +180,78 @@ jobs:
       # without running its feature-sensitive tests.
       - name: Check (--all-features)
         run: cargo check --locked --all-features
+
+  # Issue #281. Both jobs above are Rust-only, so before this job existed NOTHING
+  # in CI installed Node: `frontend/` was invisible to the entire build, and a
+  # TypeScript error there passed every required check and merged. The first
+  # thing that noticed a broken console was `deploy-staging.yml`, which runs
+  # AFTER merge, or a person. Same shape as the #202 blind spot the `rust-gated`
+  # job above closed, with more force — that one hid a subset of the build, this
+  # one hid a whole language.
+  #
+  # `tsconfig.app.json` sets `noUnusedLocals` and `noUnusedParameters`, so the
+  # failure modes are easy to hit: dropping an argument from a helper is enough.
+  #
+  # A THIRD TOP-LEVEL JOB, appended after `rust-gated` rather than folded into
+  # either: it shares no setup with them (no submodules, no system packages, no
+  # toolchain), it runs in parallel so it adds nothing to the critical path, and
+  # it gets its own `Console` check name for branch protection to pin.
+  console:
+    name: Console
+    runs-on: ubuntu-latest
+    # A minute of real work. The cap exists only so a wedged registry fetch fails
+    # in ten minutes instead of burning the runner's six-hour default.
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          # No `submodules` — unlike the Rust jobs this one resolves no vendored
+          # manifests, and `vendor/openhuman` is a large checkout to skip.
+
+      # Node 22 tracks `frontend/Dockerfile`, which builds the shipped console
+      # `FROM node:22-slim`. CI must compile on the version that produces the
+      # artifact; bump both together or this job stops being evidence for the
+      # thing that deploys.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      # `npm ci`, NOT `npm install` — do not "simplify" this. It is the npm half
+      # of the same property `--locked` buys the cargo steps above (issue #251):
+      # it installs strictly the tree recorded in `package-lock.json` and exits
+      # non-zero when the lock and `package.json` disagree, so a manifest edit
+      # whose lock was never regenerated is named here rather than absorbed.
+      # `npm install` would silently re-resolve and REWRITE the lock in the
+      # runner, which means CI would be typechecking a dependency tree that is
+      # not the one committed — and a green run could not be attributed to the
+      # diff. It is also the command `frontend/Dockerfile` uses.
+      - run: npm ci
+        working-directory: frontend
+
+      # Three steps, not one, because each catches something the others do not
+      # and a separate step names the failure.
+      #
+      # `typecheck` is `tsc -b`: fails fast on `src/` types.
+      - run: npm run typecheck
+        working-directory: frontend
+
+      # `typecheck:e2e` covers `frontend/test/e2e/` and `playwright.config.ts`,
+      # which `tsc -b` does NOT reach — `tsconfig.app.json` is `include: ["src"]`
+      # — so before this the Playwright specs were compiled by nothing at all.
+      # See the header of `frontend/tsconfig.e2e.json`. This does NOT run the
+      # suite: that needs a live host and is still out of CI, per #281.
+      - run: npm run typecheck:e2e
+        working-directory: frontend
+
+      # `build` runs `tsc -b` again but then invokes Vite, which additionally
+      # catches a module-resolution or plugin failure that type-checking alone
+      # never sees — a bad `@/` import or a missing asset builds a green `tsc`
+      # and a broken bundle.
+      - run: npm run build
+        working-directory: frontend
+
+      # No lint step: the package declares no lint script. Adding one is a
+      # separate decision, not something to smuggle in here.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -101,10 +101,21 @@ Everything is decoupled so you can embed parts elsewhere:
 ## Build
 
 ```sh
-npm run build     # tsc typecheck + vite bundle -> dist/
-npm run preview   # serve the production build
-npm run typecheck # tsc only
+npm run build         # tsc typecheck + vite bundle -> dist/
+npm run preview       # serve the production build
+npm run typecheck     # tsc only, over src/
+npm run typecheck:e2e # tsc only, over test/ + playwright.config.ts
 ```
+
+CI runs `npm ci` and all three of `typecheck`, `typecheck:e2e` and `build` in
+the `Console` job of `.github/workflows/ci.yml`.
+
+`typecheck` covers `src/` and nothing else — `tsconfig.app.json` is
+`include: ["src"]`. The end-to-end suite is a separate TypeScript project
+([`tsconfig.e2e.json`](tsconfig.e2e.json)) with its own script, so a broken spec
+fails on its own rather than blocking `npm run build`. Type-checking the specs
+is not the same as running them — `npm run e2e` drives a live host and stays out
+of CI, so `typecheck:e2e` is all the automated coverage `test/e2e/` gets.
 
 The `dist/` can be served as static files by any web server (or mounted by the
 OpenCompany host); use `window.OPENCOMPANY_CONFIG` to point it at the API.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc -b --noEmit",
+    "typecheck:e2e": "tsc -p tsconfig.e2e.json",
     "e2e": "playwright test",
     "e2e:headed": "playwright test --headed"
   },

--- a/frontend/tsconfig.e2e.json
+++ b/frontend/tsconfig.e2e.json
@@ -1,0 +1,44 @@
+// Issue #281. The Playwright suite under `test/e2e/` — and `playwright.config.ts`
+// itself — is type-checked by NOTHING without this file. `tsconfig.app.json`
+// sets `include: ["src"]` and `tsconfig.node.json` sets `include:
+// ["vite.config.ts"]`, so `npm run typecheck` (`tsc -b`, which walks only the
+// two projects `tsconfig.json` references) never compiles a spec. Running the
+// suite is the only thing that has ever checked it, and the suite needs a live
+// host, so in practice a spec that drifts from a signature it calls is caught by
+// a person or not at all.
+//
+// STANDALONE ON PURPOSE — not `composite`, and deliberately NOT added to
+// `tsconfig.json`'s `references`. A reference would pull the specs into
+// `npm run build`, making the shippable console artifact fail on a broken test
+// file; the two should be able to fail independently, and CI reports them as
+// separate steps for the same reason. `npm run typecheck:e2e` runs this project
+// on its own via `tsc -p`.
+//
+// Not an extension of `tsconfig.app.json` either: that config is a browser-app
+// project (`jsx`, `@/*` paths, `allowImportingTsExtensions`) and the specs need
+// none of it. They import `@playwright/test` and read `process.env`, so what
+// they actually require is Node types plus DOM — the latter because
+// `page.evaluate` callbacks are authored inline here but execute in the browser
+// and touch `localStorage`.
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"],
+
+    "strict": true,
+    // Matched to `tsconfig.app.json` rather than left at the TypeScript
+    // defaults. These two are exactly the settings that make the drift this
+    // config exists to catch fail loudly: dropping an argument from a helper, or
+    // leaving behind a locator that a rewritten assertion no longer uses.
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["test", "playwright.config.ts"]
+}


### PR DESCRIPTION
## Summary

Closes #281.

`ci.yml` ran two jobs, both Rust. Nothing in CI installed Node, so `frontend/`
was invisible to the entire build and a TypeScript error there passed every
required check and merged — the first thing to notice was `deploy-staging.yml`,
which runs *after* merge, or a person. Same shape as the #202 blind spot that
motivated the gated Rust job, with more force: that one hid a subset of the
build, this one hid a whole language.

This adds a third top-level job, `Console`, parallel to the two Rust jobs:

```
npm ci → npm run typecheck → npm run typecheck:e2e → npm run build
```

It needs no submodules, no system packages and no toolchain, so it shares no
setup with the Rust jobs and stays a separate job rather than steps bolted onto
one of them. It gets its own check name for branch protection to pin.

**The e2e question from the issue comment: I took option 2.**

`tsconfig.app.json` is `include: ["src"]` and `tsconfig.node.json` is
`include: ["vite.config.ts"]`, so `npm run typecheck` never compiled
`test/e2e/` — and `playwright.config.ts` was compiled by nothing at all. The
job as proposed in the issue would not have covered either. So this adds a
standalone `frontend/tsconfig.e2e.json` over `test` + `playwright.config.ts`,
a `typecheck:e2e` script, and a step in the same job.

Three things made option 2 the easy call rather than a close one:

1. **The specs typecheck as written.** All six existing files pass with
   `strict`, `noUnusedLocals` and `noUnusedParameters` on. Nothing had to be
   fixed to turn this on, so the cost is one config file.
2. **A separate tsconfig is clean here, not fiddly.** The specs import
   `@playwright/test` and read `process.env` — no `@/` aliases, no `src`
   imports, no JSX. They need Node types plus DOM (a `page.evaluate` callback
   in `inbox.spec.ts` touches `localStorage`), and that is the whole config.
   There is no shared surface with `tsconfig.app.json` worth extending from.
3. **Seven open PRs each add a new spec** (#294, #285, #284, #282, #279, #278,
   #277). This is the fastest-growing type-unchecked surface in the repo. I
   fetched all seven from their PR heads and ran them through the new config —
   all clean, so this does not retroactively redden anyone's branch.

The new project is **not** in `tsconfig.json`'s `references`, deliberately: a
reference would pull the specs into `npm run build`, so a broken test file
would fail the shippable console artifact. They should fail independently, and
CI reports them as separate steps for the same reason.

**Coverage this job does and does not give**, stated plainly so nobody assumes
wider: it type-checks `src/`, `test/e2e/` and `playwright.config.ts`, and it
builds the bundle. It does **not run** the Playwright suite — that needs a live
host, `playwright.config.ts` declares no `webServer`, and it stays out of CI per
the issue's Out-of-scope section. There is also no lint step, because the
package declares no lint script; adding one is a separate decision.

**`npm ci`, not `npm install`.** This is the npm half of the same property
`--locked` buys the cargo steps in #292: it installs strictly the tree recorded
in `package-lock.json` and exits non-zero when the lock and `package.json`
disagree, so a manifest edit whose lock was never regenerated is named here
rather than absorbed. `npm install` would silently re-resolve and *rewrite* the
lock inside the runner, which means CI would be type-checking a dependency tree
that is not the committed one and a green run could not be attributed to the
diff. It is also what `frontend/Dockerfile` uses. The reasoning is in a comment
on the step so it does not get "simplified" later.

Node 22 is pinned to match `frontend/Dockerfile` (`FROM node:22-slim`), which
builds the artifact that actually deploys — verified against the repo rather
than taken from the issue, which proposed `setup-node@v4`; this uses `@v7` to
match the `checkout@v7` already pinned here.

### Collision with #292

**#292** (issue #251, `--locked` on the cargo invocations) also edits
`.github/workflows/ci.yml`. I structured this as a new job appended after
`rust-gated` so the two do not overlap semantically, and they do not — but they
are not textually clean either, and it is worth being precise about that rather
than claiming otherwise:

`git merge-tree` reports **one conflict**, at the very end of the file. #292's
last hunk rewrites `run: cargo check --all-features` → `cargo check --locked
--all-features`, and this branch appends its new job on the line immediately
after it, with no unchanged line between them. Resolution is mechanical: keep
#292's `--locked` line, then keep this branch's `console:` block below it. No
other hunk in either diff touches the other's lines.

Whichever merges second should do that; happy to rebase this one if #292 lands
first.

## API Or Behavior Changes

No runtime or API change — the console bundle is byte-for-byte what it was.

Two things maintainers should know:

- **New required check.** The last acceptance criterion on #281 — adding
  `Console` to branch protection's required checks — needs repo-admin rights
  and cannot be done from a PR. It needs doing after merge, or the job is
  advisory and a red `Console` will not actually block anything.
- **New npm script**, `typecheck:e2e`. `npm run typecheck` is unchanged and
  still `src/`-only.

## Tests

Locally, in `frontend/`:

```
npm ci
npm run typecheck      # pass
npm run typecheck:e2e  # pass (6 files: 5 specs + playwright.config.ts)
npm run build          # pass
```

`actionlint .github/workflows/ci.yml` — clean.

**The job is proven to fail, twice, on real errors** — not asserted. Both proof
commits were pushed to the branch, observed red, and then dropped; `git log`
below is the three commits that remain.

1. **`src/` error** — a `const: number = "string"` appended to
   `src/config.ts`, pushed as `90a32a0`.
   [Run 30769851269](https://github.com/oxoxDev/opencompany/actions/runs/30769851269):
   `Console` **failure** at step `Run npm run typecheck`:

   ```
   ##[error]src/config.ts(72,14): error TS2322: Type 'string' is not assignable to type 'number'.
   ##[error]Process completed with exit code 2.
   ```

2. **spec error** — the same break moved into `test/e2e/wiring.spec.ts`, pushed
   as `3c10692`.
   [Run 30769927151](https://github.com/oxoxDev/opencompany/actions/runs/30769927151):
   `npm run typecheck` **passed**, `Console` **failure** at step
   `Run npm run typecheck:e2e`:

   ```
   ##[error]test/e2e/wiring.spec.ts(76,7): error TS2322: Type 'string' is not assignable to type 'number'.
   ##[error]test/e2e/wiring.spec.ts(76,7): error TS6133: '__ci_proof_281' is declared but its value is never read.
   ##[error]Process completed with exit code 2.
   ```

   This is the one that matters for the option-2 decision: it shows the src
   typecheck passing straight over a broken spec, which is exactly the gap the
   issue comment describes, and the new step catching it. The `TS6133` line also
   confirms `noUnusedLocals`/`noUnusedParameters` are live on the specs.

3. **Green on the head of this branch** —
   [run 30770078549](https://github.com/oxoxDev/opencompany/actions/runs/30770078549),
   `Console` **success**, all four steps green
   (`npm ci` → `typecheck` → `typecheck:e2e` → `build`).

**Timing** — `Console` finished in 26s, 24s and 38s across the three runs, while
both Rust jobs were still running. It does not extend the critical path.

No Rust source, `Cargo.toml` or `Cargo.lock` is touched by this PR, so the four
cargo gates below were deliberately not run — the diff is four files, three of
them under `frontend/` and one a workflow. Saying so explicitly rather than
leaving the boxes ambiguous:

- [x] N/A: `cargo fmt --all -- --check` — no Rust changed.
- [x] N/A: `cargo clippy --all-targets -- -D warnings` — no Rust changed.
- [x] N/A: `cargo build --all-targets` — no Rust changed.
- [x] N/A: `cargo test` — no Rust changed.

## Documentation

`frontend/README.md` — the Build section listed the scripts but not what each
covers, which is the confusion behind this issue. It now says `typecheck` is
`src/`-only, names `typecheck:e2e` and what it spans, points at the `Console`
job, and states that type-checking the specs is not the same as running them.

`frontend/tsconfig.e2e.json` carries a header comment explaining why it is
standalone, why it is not referenced from `tsconfig.json`, and why it does not
extend `tsconfig.app.json`.

### Noticed, not fixed

`frontend/` carries both `package-lock.json` and a `pnpm-lock.yaml`. The npm
lock is the live one — it is what `frontend/Dockerfile` installs from and what
this job caches on — while `pnpm-lock.yaml` was last touched in a docs commit
and appears to be an abandoned leftover. Deleting it is a judgement call that
belongs to whoever knows why it is there, not to a CI PR, but it is a live trap:
someone reaching for `pnpm install` today gets a stale tree with no warning.
Worth its own issue if a maintainer confirms it is dead.
