### PR TITLE
feat(chat): wire the chat-to-card edge in both directions (#246)

### DIFF
--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -43,7 +43,7 @@ below). Anything a build doesn't serve `404`s — the console treats that as "no
 wired yet".
 
 ```text
-POST   …/tasks                              create a task card
+POST   …/tasks                              create a task card (`originChatId` records the thread it came from, #246)
 PATCH  …/tasks/{taskId}                      edit / move a task
 DELETE …/tasks/{taskId}                      delete a task
 POST   …/memory                             add a memory fact

--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -176,6 +176,18 @@ task-to-task edge that `origin_chat_id` (a *conversation*, shared by every
 sibling spawned in that thread, and absent entirely on a board-native card)
 cannot express. It is the parent half of the Task Detail screen's lineage.
 
+`OutboundMessage` gains `task_id` on the same contract (issue #246): the card a
+chat turn **opened**, so the console can say a card exists instead of leaving an
+operator to notice it on the board. It is journaled onto that turn's
+`AgentReply.task_id`, which widens that field's meaning from "the dispatch that
+produced this reply" to "the card this reply is about" — a card-creating reply
+now also appears on that card's timeline, which is the lineage an operator
+wants and costs no schema change. A turn that opens several cards reports the
+**first**: the journal field is a single optional id, and widening it would
+break the byte-identical round-trip, so the claim is incomplete but never wrong.
+Both `chat/history` surfaces (REST and GraphQL) project it from the shared
+`MessageView`, so the chip survives a transcript reload on either.
+
 ## MemoryStore
 
 The equivalent of Medulla's `CyclePersistence`; TinyCortex is the target
@@ -363,7 +375,10 @@ another pass (a failed dispatch, an orchestrator `revise` verdict) — while
 `todo` is what has been queued up next. `todo` is the board's one manual-entry
 column: the console's `+` button lives there alone and `POST …/tasks` defaults
 to it (issue #206), so an operator cannot create a card straight into
-`in_progress` or a terminal column.
+`in_progress` or a terminal column. The transcript's "Add to board" action
+(issue #246) relies on exactly that default: it omits `column` so the *server*
+decides where a chat-created card lands, which is what keeps the human drag into
+`in_progress` the only thing that spends an agent turn.
 
 `assignee` names a **roster teammate id, a desk, or nobody** (`""`), resolved by
 `crate::runtime::assignee` against the full roster — manifest agents, operator

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -20,6 +20,12 @@ export interface Task {
    * shape is unchanged.
    */
   parentTaskId?: string;
+  /**
+   * The chat thread this card was opened from (issue #246), when it came from
+   * a conversation rather than the board's `+` button. Omitted otherwise, which
+   * is every card created before this shipped.
+   */
+  originChatId?: string;
 }
 
 /** The create body; the host defaults column→`backlog`, priority→`medium`. */
@@ -29,6 +35,16 @@ export interface CreateTask {
   column?: string;
   priority?: string;
   assignee?: string;
+  /**
+   * The chat thread this card is being opened from (issue #246). Set by the
+   * transcript's "Add to board" action; the board's `+` button omits it.
+   *
+   * Note what is deliberately NOT sent alongside it: `column`. Dropping a card
+   * into `in_progress` is what dispatches an agent turn — it spends money — so
+   * the server's intake default decides where a chat-created card lands, and
+   * the human drag stays the only spend gate.
+   */
+  originChatId?: string;
 }
 
 /** A partial update; any omitted field is left as-is. A drag sends `{column}`. */

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -65,6 +65,16 @@ export interface OutboundMessage {
   steps?: TurnStep[];
   /** Channel-specific reply addressing (Telegram). Absent on operator messages. */
   replyTo?: ReplyTo;
+  /**
+   * The board card this turn opened, when it opened one (issue #246). Drives
+   * the reply bubble's "card opened" chip. Absent when the turn opened nothing
+   * — which is every reply the host sent before this field existed.
+   *
+   * Only the *first* card of a turn that opened several: the journal field this
+   * is persisted into is a single id, so the claim is incomplete but never
+   * wrong. The bubble's `steps` timeline still shows every spawn.
+   */
+  taskId?: string;
 }
 
 /** Channel-specific reply addressing. Mirrors `ReplyTo` in `src/ports/types.rs`. */
@@ -141,6 +151,13 @@ export interface ChatHistoryMessageDto {
    * empty (operator messages, tool-less replies).
    */
   steps?: TurnStep[];
+  /**
+   * The board card this reply is about (issue #246) — the card the turn opened,
+   * or the dispatched card it ran for (#185). Projected from the same shared
+   * `MessageView` field the GraphQL `Chat.history` resolver reads, so the chip
+   * renders identically whichever surface hydrated the transcript.
+   */
+  taskId?: string;
 }
 
 /** Response of `/chat` and approval-resolution routes. */

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -358,7 +358,13 @@ export function AppShell({
         if (dup) return t;
         return {
           ...t,
-          messages: [...t.messages, makeMessage("company", event.text, { channel: event.agentId })],
+          messages: [
+            ...t.messages,
+            makeMessage("company", event.text, {
+              channel: event.agentId,
+              taskId: event.taskId,
+            }),
+          ],
         };
       }),
     );
@@ -546,7 +552,19 @@ export function AppShell({
             />
           )}
           {view === "inbox" && <InboxView client={client} company={company} />}
-          {view === "tasks" && <TasksView client={client} company={company} />}
+          {view === "tasks" && (
+            <TasksView
+              client={client}
+              company={company}
+              // Issue #246: the card → chat half of the round trip. A card
+              // opened from a conversation remembers which one, so its detail
+              // screen can put the operator back in that thread.
+              onOpenThread={(threadId) => {
+                setActiveThreadId(threadId);
+                setView("conversation");
+              }}
+            />
+          )}
           {view === "team" && <TeamView client={client} company={company} />}
           {view === "desks" && <DesksView client={client} company={company} />}
           {view === "people" && <PeopleView client={client} company={company} />}

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -11,7 +11,20 @@ import type { DeliveryReport } from "@/api/workflows";
  * raw third-party payload is ever on the wire.
  */
 export type CompanyStreamEvent =
-  | { type: "agent_reply"; seq: number; atMillis: number; chatId: string; agentId: string; text: string }
+  | {
+      type: "agent_reply";
+      seq: number;
+      atMillis: number;
+      chatId: string;
+      agentId: string;
+      text: string;
+      /**
+       * The board card this reply is about (issue #246/#185) — the card the
+       * turn opened, or the dispatched card it ran for. Absent on an ordinary
+       * chat reply.
+       */
+      taskId?: string;
+    }
   | { type: "task_dispatched"; seq: number; atMillis: number; taskId: string }
   | { type: "task_steered"; seq: number; atMillis: number; taskId: string; action: string }
   | {
@@ -79,6 +92,8 @@ export interface AgentReplyEvent {
   chatId: string;
   agentId: string;
   text: string;
+  /** The board card this reply opened (issue #246), when it opened one. */
+  taskId?: string;
 }
 
 interface Options {
@@ -260,7 +275,15 @@ function handleEvent(
       onTaskEvent?.(event);
       break;
     case "agent_reply":
-      onAgentReply?.({ chatId: event.chatId, agentId: event.agentId, text: event.text });
+      onAgentReply?.({
+        chatId: event.chatId,
+        agentId: event.agentId,
+        text: event.text,
+        // Issue #246: a reply injected from the stream — one this console did
+        // not POST for, e.g. an inbound Telegram turn — carries its "card
+        // opened" chip too, rather than only the locally-awaited copy.
+        taskId: event.taskId,
+      });
       break;
     case "approval_resolved":
       toast(event.verdict === "approve" ? "Approval granted" : "Approval denied", {

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -18,6 +18,43 @@ export interface ChatMessage {
    * on your own messages and on tool-less replies.
    */
   steps?: TurnStep[];
+  /**
+   * The board card this line is about (issue #246): one the turn opened, or one
+   * created from this message by "Add to board". Renders as a chip linking to
+   * `#/tasks/<id>`.
+   */
+  taskId?: string;
+}
+
+/**
+ * How long a card title derived from a chat message may be before it is
+ * elided. Long enough to keep a normal one-line ask intact, short enough that a
+ * pasted paragraph does not become a board card nobody can scan.
+ */
+const TITLE_CAP = 80;
+
+/**
+ * A board-card title derived from a chat message (issue #246).
+ *
+ * Takes the first non-blank line — a multi-line ask reads as "headline, then
+ * detail", and the detail belongs in the card's note, which is where the full
+ * text goes. Returns an empty string for a message with nothing in it, so the
+ * caller can refuse rather than opening a blank card.
+ *
+ * Elides on **code points**, not UTF-16 units, so a title cut mid-emoji cannot
+ * produce a lone surrogate; the cap includes the ellipsis rather than
+ * overshooting by one.
+ */
+export function titleFromMessage(text: string): string {
+  const line = text
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  if (!line) return "";
+  const points = Array.from(line);
+  return points.length <= TITLE_CAP
+    ? line
+    : `${points.slice(0, TITLE_CAP - 1).join("")}…`;
 }
 
 let seq = 0;
@@ -27,7 +64,7 @@ const nextId = () => `m${seq++}`;
 export function makeMessage(
   from: ChatMessage["from"],
   text: string,
-  opts: { channel?: string; at?: number; steps?: TurnStep[] } = {},
+  opts: { channel?: string; at?: number; steps?: TurnStep[]; taskId?: string } = {},
 ): ChatMessage {
   return {
     id: nextId(),
@@ -36,6 +73,7 @@ export function makeMessage(
     at: opts.at ?? Date.now(),
     channel: opts.channel,
     steps: opts.steps,
+    taskId: opts.taskId,
   };
 }
 
@@ -60,6 +98,10 @@ export function fromHistory(entries: ChatHistoryMessageDto[]): ChatMessage[] {
       // Rehydrate the persisted tool-call timeline so it survives a thread
       // switch / reload — the render already draws `m.steps` (Conversation.tsx).
       steps: from === "company" ? entry.steps : undefined,
+      // Rehydrate the "card opened" chip (issue #246) for the same reason as
+      // the timeline above: a chip that lives only on the live POST response
+      // vanishes on the first thread switch.
+      taskId: from === "company" ? entry.taskId : undefined,
     };
   });
 }

--- a/frontend/src/views/Conversation.tsx
+++ b/frontend/src/views/Conversation.tsx
@@ -12,6 +12,7 @@ import {
   Pause,
   PenSquare,
   Send,
+  SquareKanban,
   Wrench,
   X,
 } from "lucide-react";
@@ -19,13 +20,19 @@ import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
 import { ApiError, type TurnStep, type TurnStepKind } from "@/api/types";
-import { listInflight, steerTask, type InflightRun, type SteerAction } from "@/api/tasks";
+import {
+  createTask,
+  listInflight,
+  steerTask,
+  type InflightRun,
+  type SteerAction,
+} from "@/api/tasks";
 import { Markdown } from "@/components/markdown";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { type ChatMessage, makeMessage } from "@/lib/chat";
+import { type ChatMessage, makeMessage, titleFromMessage } from "@/lib/chat";
 import type { Thread, ThreadContact } from "@/lib/threads";
 
 interface Props {
@@ -172,6 +179,8 @@ function ChatPane({
 }) {
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
+  /** The message whose "Add to board" create is in flight (issue #246). */
+  const [addingId, setAddingId] = useState<string | null>(null);
   const scroller = useRef<HTMLDivElement>(null);
 
   const messages = thread.messages;
@@ -194,7 +203,14 @@ function ChatPane({
       const reply = await client.chat(text, company, thread.id);
       const replies = reply.responses.length
         ? reply.responses.map((r) =>
-            makeMessage("company", r.text, { channel: r.channel, steps: r.steps }),
+            // `taskId` (issue #246): when the turn opened a board card, the
+            // bubble says so immediately. The same id is journaled onto the
+            // reply, so the chip is still there after a transcript reload.
+            makeMessage("company", r.text, {
+              channel: r.channel,
+              steps: r.steps,
+              taskId: r.taskId,
+            }),
           )
         : [makeMessage("system", "(no reply)")];
       setMessages(thread.id, (m) => [...m, ...replies]);
@@ -207,6 +223,49 @@ function ChatPane({
       onSendEnd?.(thread.id);
     }
   }
+
+  /**
+   * Turns one transcript message into a board card (issue #246).
+   *
+   * Deliberately goes through the REST create rather than asking the responder
+   * to call `spawn_task`: only the orchestrator carries the delegation tools,
+   * so a toolbelt route would work on the main thread and silently do nothing
+   * on a desk or DM thread. Going through REST is what makes the action true on
+   * *every* thread — which is the whole point — without widening the v1
+   * depth-1 delegation design.
+   *
+   * `column` is omitted on purpose. Dropping a card into `in_progress` is what
+   * dispatches an agent turn, so letting the server's intake default decide
+   * keeps the human drag as the only thing that spends money. `assignee` is
+   * omitted for the same reason: an unassigned card asks nothing of anyone.
+   *
+   * The composer draft is untouched on both paths — a failure surfaces as a
+   * toast and nothing the operator typed is cleared.
+   */
+  const addToBoard = useCallback(
+    async (message: ChatMessage) => {
+      const title = titleFromMessage(message.text);
+      if (!title || addingId) return;
+      setAddingId(message.id);
+      try {
+        const created = await createTask(client, company, {
+          title,
+          // The full text as the note, so nothing is lost to the title's cap.
+          note: message.text,
+          originChatId: thread.id,
+        });
+        setMessages(thread.id, (all) =>
+          all.map((m) => (m.id === message.id ? { ...m, taskId: created.id } : m)),
+        );
+        toast.success(`Added to the board — ${created.title}`);
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "could not add this to the board");
+      } finally {
+        setAddingId(null);
+      }
+    },
+    [addingId, client, company, setMessages, thread.id],
+  );
 
   function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key === "Enter" && !e.shiftKey) {
@@ -248,7 +307,13 @@ function ChatPane({
         <div className="mx-auto flex w-full max-w-3xl flex-col gap-1.5 px-4 py-6">
           {messages.length === 0 && <EmptyConversation contact={thread.contact} />}
           {groups.map((g, i) => (
-            <MessageGroup key={g.key} group={g} prev={groups[i - 1]} />
+            <MessageGroup
+              key={g.key}
+              group={g}
+              prev={groups[i - 1]}
+              onAddToBoard={addToBoard}
+              addingId={addingId}
+            />
           ))}
           {sending && (
             <>
@@ -520,7 +585,19 @@ interface Group {
   messages: ChatMessage[];
 }
 
-function MessageGroup({ group, prev }: { group: Group; prev?: Group }) {
+function MessageGroup({
+  group,
+  prev,
+  onAddToBoard,
+  addingId,
+}: {
+  group: Group;
+  prev?: Group;
+  /** Turns one message into a board card (issue #246). */
+  onAddToBoard: (message: ChatMessage) => void;
+  /** The message whose create is in flight, if any. */
+  addingId: string | null;
+}) {
   const showDay = !prev || !sameDay(prev.at, group.at);
 
   if (group.sender.kind === "system") {
@@ -556,7 +633,23 @@ function MessageGroup({ group, prev }: { group: Group; prev?: Group }) {
           {group.messages.map((m, i) => (
             <Fragment key={m.id}>
               {!mine && m.steps && m.steps.length > 0 && <StepTimeline steps={m.steps} />}
-              <Bubble message={m} mine={mine} last={i === group.messages.length - 1} />
+              {/* The bubble and its hover action share a row so the action can
+                  sit outside the bubble without overlapping the text. `group`
+                  scopes the reveal to this one message. */}
+              <div
+                className={cn(
+                  "group/msg flex max-w-full items-center gap-1",
+                  mine ? "flex-row-reverse" : "flex-row",
+                )}
+              >
+                <Bubble message={m} mine={mine} last={i === group.messages.length - 1} />
+                <AddToBoardAction
+                  message={m}
+                  busy={addingId === m.id}
+                  disabled={addingId !== null && addingId !== m.id}
+                  onAdd={onAddToBoard}
+                />
+              </div>
             </Fragment>
           ))}
         </div>
@@ -592,7 +685,81 @@ function Bubble({ message, mine, last }: { message: ChatMessage; mine: boolean; 
         // block margins so a reply stays flush inside the tight bubble padding.
         <Markdown className="[&>:first-child]:mt-0 [&>:last-child]:mb-0">{message.text}</Markdown>
       )}
+      {message.taskId && <CardChip taskId={message.taskId} mine={mine} />}
     </div>
+  );
+}
+
+/**
+ * The "this message has a card" chip (issue #246), linking to the card's detail
+ * screen.
+ *
+ * Two provenances, one render. On a company reply it means the turn opened a
+ * card by itself — that id is journaled onto the reply, so this chip survives a
+ * transcript reload. On your own message it means you pressed "Add to board";
+ * that link lives in the session only, because the durable record of it is
+ * `originChatId` on the card rather than anything on the operator message.
+ *
+ * `clear-both` because the bubble floats its timestamp right; without it the
+ * chip tucks under the time instead of starting a fresh line.
+ */
+function CardChip({ taskId, mine }: { taskId: string; mine: boolean }) {
+  return (
+    <a
+      href={`#/tasks/${encodeURIComponent(taskId)}`}
+      className={cn(
+        "mt-1.5 flex w-fit clear-both items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium transition-opacity hover:opacity-80",
+        mine
+          ? "bg-primary-foreground/15 text-primary-foreground"
+          : "bg-accent text-accent-foreground",
+      )}
+    >
+      <SquareKanban className="size-3 shrink-0" />
+      {mine ? "Added to the board" : "Card opened"}
+    </a>
+  );
+}
+
+/**
+ * The per-message "Add to board" affordance (issue #246).
+ *
+ * On every message in every thread — desk, DM and orchestrator — because it
+ * creates through REST rather than through the responder's toolbelt, which only
+ * the orchestrator carries.
+ *
+ * Renders nothing once the message already has a card, so a second press cannot
+ * open a duplicate; and nothing for a message with no text to title a card
+ * from. Revealed on hover on pointer devices, but always present in the DOM and
+ * focusable, so it is reachable by keyboard and on touch.
+ */
+function AddToBoardAction({
+  message,
+  busy,
+  disabled,
+  onAdd,
+}: {
+  message: ChatMessage;
+  busy: boolean;
+  disabled: boolean;
+  onAdd: (message: ChatMessage) => void;
+}) {
+  if (message.taskId || !titleFromMessage(message.text)) return null;
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="size-7 shrink-0 text-muted-foreground opacity-0 transition-opacity focus-visible:opacity-100 group-hover/msg:opacity-100"
+      onClick={() => onAdd(message)}
+      disabled={busy || disabled}
+      title="Add to board"
+      aria-label="Add to board"
+    >
+      {busy ? (
+        <Loader2 className="size-3.5 animate-spin" />
+      ) : (
+        <SquareKanban className="size-3.5" />
+      )}
+    </Button>
   );
 }
 

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -18,6 +18,7 @@ import {
   CornerUpRight,
   Loader2,
   MessageSquare,
+  MessagesSquare,
   Pencil,
   Play,
   Send,
@@ -124,6 +125,7 @@ export function TaskDetailView({
   taskId,
   onBack,
   onNavigate,
+  onOpenThread,
   onSaved,
   onDeleted,
 }: {
@@ -134,6 +136,8 @@ export function TaskDetailView({
   onBack: () => void;
   /** Navigate the detail to a neighbouring (lineage) task. */
   onNavigate: (id: string) => void;
+  /** Open the chat thread this card was created from (issue #246). */
+  onOpenThread?: (threadId: string) => void;
   /** Hand a saved card back to the board for reconciliation. */
   onSaved: (t: Task) => void;
   /** Tell the board a card was deleted. */
@@ -279,6 +283,11 @@ export function TaskDetailView({
               onChanged={load}
               onSaved={onSaved}
               onEdit={() => setEditing(true)}
+            />
+
+            <OriginThreadRow
+              originChatId={detail.task.originChatId}
+              onOpenThread={onOpenThread}
             />
 
             <LineageRail lineage={detail.lineage} onNavigate={onNavigate} />
@@ -617,6 +626,47 @@ function ControlBar({
         </div>
       )}
     </div>
+  );
+}
+
+/**
+ * "Opened from a conversation" — the card → chat half of issue #246.
+ *
+ * `originChatId` has been on the record since #151, but nothing ever read it
+ * back, so a card created out of a conversation looked exactly like one typed
+ * onto the board. Renders nothing for a card with no conversation behind it,
+ * which is every card the `+` button creates.
+ *
+ * Falls back to plain text when no navigation callback is supplied: stating the
+ * origin is the part that must always work; the jump is a convenience the host
+ * screen may or may not be able to offer.
+ */
+function OriginThreadRow({
+  originChatId,
+  onOpenThread,
+}: {
+  originChatId?: string;
+  onOpenThread?: (threadId: string) => void;
+}) {
+  if (!originChatId) return null;
+  const label = "Opened from chat";
+  if (!onOpenThread) {
+    return (
+      <div className="flex items-center gap-2 rounded-xl border bg-card/40 px-3 py-2 text-xs text-muted-foreground">
+        <MessagesSquare className="size-3.5 shrink-0" />
+        <span className="truncate">{label}</span>
+      </div>
+    );
+  }
+  return (
+    <button
+      className="flex w-full items-center gap-2 rounded-xl border bg-card/40 px-3 py-2 text-left text-xs transition-colors hover:bg-accent"
+      onClick={() => onOpenThread(originChatId)}
+    >
+      <MessagesSquare className="size-3.5 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      <span className="shrink-0 text-muted-foreground">Open the conversation</span>
+    </button>
   );
 }
 

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -66,9 +66,16 @@ function priorityStyle(priority: string): string {
 export function TasksView({
   client,
   company,
+  onOpenThread,
 }: {
   client: OpenCompanyClient;
   company: string | null;
+  /**
+   * Opens the chat thread a card came from (issue #246). Absent when the board
+   * is rendered somewhere with no conversation pane to jump to, in which case
+   * the detail screen states the origin without offering the jump.
+   */
+  onOpenThread?: (threadId: string) => void;
 }) {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
@@ -182,6 +189,7 @@ export function TasksView({
         taskId={detailId}
         onBack={closeDetail}
         onNavigate={openDetail}
+        onOpenThread={onOpenThread}
         onSaved={(saved) => setTasks((ts) => ts.map((t) => (t.id === saved.id ? saved : t)))}
         onDeleted={(id) => setTasks((ts) => ts.filter((t) => t.id !== id))}
       />

--- a/frontend/test/e2e/chat-to-card.spec.ts
+++ b/frontend/test/e2e/chat-to-card.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * End-to-end proof for the chat↔card edge (issue #246).
+ *
+ * Runs against a live host the harness brings up separately, with an inference
+ * backend whose *choices* are scripted: a prompt carrying `SPAWNONE` makes the
+ * orchestrator call `spawn_task` once. Everything else — the harness, the tool
+ * plumbing, the cycle, the journal, the HTTP surface — is real.
+ *
+ * Three things are asserted that a curl cannot reach:
+ *
+ * 1. the "Add to board" action exists on a **desk** thread, where no responder
+ *    carries the delegation tools and a card was previously unreachable;
+ * 2. the chip a spawned card produces survives a **reload**, not merely the
+ *    live POST response;
+ * 3. the card links back to the conversation it came from.
+ */
+
+/**
+ * A console opened against a fresh company home shows the welcome tour, which
+ * renders as a modal over the whole console and swallows the first click.
+ * Dismiss it when it is up. Whether it appears depends on console-local state,
+ * so its absence is not a failure.
+ */
+async function dismissWelcome(page: Page) {
+  const skip = page.getByRole("button", { name: /Skip for now/ });
+  try {
+    await skip.waitFor({ state: "visible", timeout: 5_000 });
+  } catch {
+    return;
+  }
+  await skip.click();
+  await skip.waitFor({ state: "hidden", timeout: 10_000 });
+}
+
+/**
+ * Opens the conversation view and selects a thread by its contact name.
+ *
+ * Scoped to the chat list: the sidebar's company switcher is also a button and
+ * also carries the company name, and it precedes the list in the DOM — so an
+ * unscoped `.first()` resolves to the switcher and never opens a thread.
+ */
+async function openThread(page: Page, name: RegExp) {
+  await page.goto("/#/conversation");
+  await dismissWelcome(page);
+  await page.getByRole("complementary").getByRole("button", { name }).first().click();
+}
+
+test("any message on a desk thread can be added to the board", async ({ page }) => {
+  await openThread(page, /Engineering desk/);
+
+  const prompt = `ship the launch checklist ${Date.now()}`;
+  await page.getByPlaceholder(/^Message /).fill(prompt);
+  await page.getByRole("button", { name: "Send" }).click();
+
+  // The operator's own bubble is the one being turned into a card.
+  const bubble = page.getByText(prompt, { exact: true }).first();
+  await expect(bubble).toBeVisible({ timeout: 60_000 });
+
+  // The action is hover-revealed but always focusable; hover for realism.
+  await bubble.hover();
+  const row = page.locator("div.group\\/msg", { hasText: prompt }).first();
+  await row.getByRole("button", { name: "Add to board" }).click();
+
+  // The confirmation chip appears on that message and links to the card.
+  const chip = row.getByRole("link", { name: /Added to the board/ });
+  await expect(chip).toBeVisible({ timeout: 30_000 });
+  const href = await chip.getAttribute("href");
+  expect(href).toMatch(/^#\/tasks\/.+/);
+
+  // The card is real, titled from the message, and — the spend gate — did NOT
+  // land in `in_progress`.
+  await page.goto(href!);
+  await dismissWelcome(page);
+  await expect(page.getByText(prompt).first()).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByText("In progress", { exact: true })).toHaveCount(0);
+
+  // …and it knows which conversation opened it.
+  await expect(page.getByRole("button", { name: /Opened from chat/ })).toBeVisible();
+});
+
+test("a card the orchestrator opens is chipped in chat, and survives a reload", async ({
+  page,
+}) => {
+  await openThread(page, /Your company/);
+
+  // `SPAWNONE` is the scripted backend's cue to call `spawn_task` once.
+  const prompt = `please track this SPAWNONE ${Date.now()}`;
+  await page.getByPlaceholder(/^Message /).fill(prompt);
+  await page.getByRole("button", { name: "Send" }).click();
+
+  // Live: the reply bubble says a card was opened.
+  const chip = page.getByRole("link", { name: /Card opened/ }).last();
+  await expect(chip).toBeVisible({ timeout: 60_000 });
+  const href = await chip.getAttribute("href");
+  expect(href).toMatch(/^#\/tasks\/.+/);
+
+  // After a reload the transcript is rehydrated from `chat/history`, so a chip
+  // that only existed on the live POST response would vanish here.
+  await page.reload();
+  await openThread(page, /Your company/);
+  const rehydrated = page.getByRole("link", { name: /Card opened/ }).last();
+  await expect(rehydrated).toBeVisible({ timeout: 30_000 });
+  expect(await rehydrated.getAttribute("href")).toBe(href);
+});

--- a/src/brain/echo.rs
+++ b/src/brain/echo.rs
@@ -45,6 +45,7 @@ impl Brain for EchoBrain {
         for event in &req.events {
             if let CompanyEvent::OperatorMessage { text, .. } = event {
                 channel_responses.push(OutboundMessage {
+                    task_id: None,
                     channel: "operator".to_string(),
                     text: format!("You said: {text}"),
                     steps: Vec::new(),
@@ -73,6 +74,7 @@ impl Brain for EchoBrain {
                     (format!("webhook on {channel}"), None)
                 };
                 channel_responses.push(OutboundMessage {
+                    task_id: None,
                     channel: channel.clone(),
                     text,
                     steps: Vec::new(),
@@ -82,6 +84,7 @@ impl Brain for EchoBrain {
         }
         if channel_responses.is_empty() {
             channel_responses.push(OutboundMessage {
+                task_id: None,
                 channel: "operator".to_string(),
                 text: "Acknowledged.".to_string(),
                 steps: Vec::new(),

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -267,6 +267,7 @@ pub(crate) fn channel_message_from_effect(effect: &Effect) -> Option<OutboundMes
         .or_else(|| payload_str(payload, "message"))?
         .to_string();
     Some(OutboundMessage {
+        task_id: None,
         channel,
         text,
         steps: Vec::new(),

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -653,4 +653,32 @@ mod tests {
         assert!(!task_enters_in_progress(None, "backlog"));
         assert!(!task_enters_in_progress(Some("in_review"), "done"));
     }
+
+    /// Issue #246 spend gate. A card opened from chat goes through
+    /// `POST …/tasks` with **no** `column`, so what stops it from spending
+    /// money the operator never approved is that the server's default column is
+    /// not the dispatch trigger. That is two independent facts — what the
+    /// default is, and what the trigger is — living in two different modules,
+    /// so a change to either alone silently opens the gate. This pins them
+    /// together.
+    ///
+    /// The second assertion is the positive control: without it the first
+    /// would still pass if `task_enters_in_progress` were broken to always
+    /// return `false`, and the test would be guarding nothing.
+    #[test]
+    fn the_column_a_chat_created_card_defaults_to_does_not_dispatch() {
+        use crate::ports::tasks::{COLUMN_IN_PROGRESS, COLUMN_TODO};
+
+        // `create_task` (src/server/ops/tasks.rs) defaults an omitted `column`
+        // to this one.
+        assert!(
+            !task_enters_in_progress(None, COLUMN_TODO),
+            "a chat-created card must not spend an agent turn on arrival — the \
+             human drag into in_progress is the approval gate"
+        );
+        assert!(
+            task_enters_in_progress(None, COLUMN_IN_PROGRESS),
+            "positive control: the trigger this test relies on is still live"
+        );
+    }
 }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -935,6 +935,12 @@ impl Brain for HarnessBrain {
                     // steps on the operator bubble — one surface, one renderer.
                     self.surface_mcp_failures(&mut operator_steps, None).await?;
                     channel_responses.push(OutboundMessage {
+                        // Issue #246: when the turn opened a board card, say so
+                        // on the bubble it opened it from. Before this a
+                        // `spawn_task` was invisible in chat — the card landed
+                        // on the board and the reply carried nothing tying the
+                        // two together.
+                        task_id: turn.spawned_task,
                         channel: "operator".to_string(),
                         text: operator_reply,
                         reply_to: None,
@@ -959,6 +965,7 @@ impl Brain for HarnessBrain {
         // The runtime requires at least one channel response per cycle.
         if channel_responses.is_empty() {
             channel_responses.push(OutboundMessage {
+                task_id: None,
                 channel: "operator".to_string(),
                 text: "Acknowledged.".to_string(),
                 steps: Vec::new(),
@@ -2266,6 +2273,135 @@ members = ["eng1", "eng2"]
         assert_eq!(cards[0].title, "Draft the plan");
         assert_eq!(cards[0].column, "backlog");
         assert_eq!(cards[0].assignee, "engineer");
+        // Issue #246: it surfaces no *bubble*, but it no longer surfaces
+        // *nothing* — the card it opened is reported, which is what lets the
+        // caller tell the operator a card exists instead of leaving them to
+        // notice it on the board.
+        assert_eq!(
+            out.spawned_task.as_deref(),
+            Some(cards[0].id.as_str()),
+            "the opened card must be reported, and be the one actually written"
+        );
+    }
+
+    /// Issue #246: a chat turn that opened a card says so on the bubble it
+    /// answered from. Before this the card appeared on the board and the reply
+    /// carried nothing tying the two together, so an operator had no way to
+    /// tell a turn that opened work from one that only talked about it.
+    #[tokio::test]
+    async fn a_turn_that_opens_a_card_reports_it_on_the_operator_bubble() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, _provider) = brain_that_delegates(
+            dir.path(),
+            vec![Some(Delegation::SpawnTask {
+                title: "Draft the announcement".to_string(),
+                note: None,
+                assignee: None,
+            })],
+        );
+
+        let result = brain
+            .run_cycle(
+                request(vec![CompanyEvent::OperatorMessage {
+                    text: "we should announce this".into(),
+                    by: None,
+                    chat: None,
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        assert_eq!(result.channel_responses.len(), 1);
+        let bubble = &result.channel_responses[0];
+        let reported = bubble.task_id.as_deref().expect("the bubble names a card");
+        let cards = brain.deps.tasks.as_ref().unwrap().list(&brain.record.id).await.unwrap();
+        assert_eq!(cards.len(), 1);
+        assert_eq!(
+            reported, cards[0].id,
+            "the reported card must be the one on the board"
+        );
+    }
+
+    /// Issue #246, the documented limitation stated as a test rather than only
+    /// as prose: a turn that opens several cards reports the **first**. The
+    /// journal field this feeds is a single optional id, so widening it would
+    /// break the byte-identical round-trip every already-stored reply relies
+    /// on. Pinned to *first* — not "whichever won" — because a later spawn
+    /// silently overwriting an earlier one would make the reported card depend
+    /// on queue order, which is the model's choice, not a contract.
+    #[tokio::test]
+    async fn a_turn_that_opens_several_cards_reports_the_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, _provider) = brain_that_delegates_with(
+            dir.path(),
+            vec![vec![
+                Delegation::SpawnTask {
+                    title: "First".to_string(),
+                    note: None,
+                    assignee: None,
+                },
+                Delegation::SpawnTask {
+                    title: "Second".to_string(),
+                    note: None,
+                    assignee: None,
+                },
+            ]],
+            TurnFaults::default(),
+        );
+
+        let result = brain
+            .run_cycle(
+                request(vec![CompanyEvent::OperatorMessage {
+                    text: "two things".into(),
+                    by: None,
+                    chat: None,
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        let reported = result.channel_responses[0]
+            .task_id
+            .as_deref()
+            .expect("the bubble names a card");
+        let cards = brain.deps.tasks.as_ref().unwrap().list(&brain.record.id).await.unwrap();
+        assert_eq!(cards.len(), 2, "both cards are opened either way");
+        let first = cards
+            .iter()
+            .find(|c| c.title == "First")
+            .expect("the first card exists");
+        assert_eq!(
+            reported, first.id,
+            "the bubble reports the first card opened, not the last"
+        );
+    }
+
+    /// The other side of the same contract: a turn that opened no card must
+    /// leave the field empty, so no bubble grows a "card opened" chip it has
+    /// not earned.
+    #[tokio::test]
+    async fn a_turn_that_opens_no_card_reports_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, _provider) = brain_that_delegates(dir.path(), Vec::new());
+
+        let result = brain
+            .run_cycle(
+                request(vec![CompanyEvent::OperatorMessage {
+                    text: "status?".into(),
+                    by: None,
+                    chat: None,
+                }]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        assert!(
+            result.channel_responses[0].task_id.is_none(),
+            "an ordinary chat turn must not claim a card"
+        );
     }
 
     // ── Issue #186 part b: orchestrator lifecycle authority ────────────────

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -2315,7 +2315,14 @@ members = ["eng1", "eng2"]
         assert_eq!(result.channel_responses.len(), 1);
         let bubble = &result.channel_responses[0];
         let reported = bubble.task_id.as_deref().expect("the bubble names a card");
-        let cards = brain.deps.tasks.as_ref().unwrap().list(&brain.record.id).await.unwrap();
+        let cards = brain
+            .deps
+            .tasks
+            .as_ref()
+            .unwrap()
+            .list(&brain.record.id)
+            .await
+            .unwrap();
         assert_eq!(cards.len(), 1);
         assert_eq!(
             reported, cards[0].id,
@@ -2366,7 +2373,14 @@ members = ["eng1", "eng2"]
             .task_id
             .as_deref()
             .expect("the bubble names a card");
-        let cards = brain.deps.tasks.as_ref().unwrap().list(&brain.record.id).await.unwrap();
+        let cards = brain
+            .deps
+            .tasks
+            .as_ref()
+            .unwrap()
+            .list(&brain.record.id)
+            .await
+            .unwrap();
         assert_eq!(cards.len(), 2, "both cards are opened either way");
         let first = cards
             .iter()

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -802,7 +802,8 @@ impl HarnessBrain {
     ///
     /// `spawn_task` opens a backlog card through the same
     /// [`TaskStore::upsert`](crate::ports::TaskStore) path the console uses and
-    /// surfaces nothing extra (a missing task store is a silent no-op).
+    /// reports the card's id (issue #246); it surfaces no bubble of its own. A
+    /// missing task store is a silent no-op.
     /// `delegate_to_desk` runs a single turn on the desk's lead member and
     /// **returns its reply for the orchestrator to relay** (a [`DeskReply`]) —
     /// the CEO-relay hand-back: instead of a disconnected sibling bubble the

--- a/src/harness/lifecycle.rs
+++ b/src/harness/lifecycle.rs
@@ -251,6 +251,7 @@ pub fn relay_reply(
     origin_chat_id: String,
 ) -> OutboundMessage {
     OutboundMessage {
+        task_id: None,
         channel: orchestrator.to_string(),
         text: relay_text(card, responder, orchestrator),
         reply_to: Some(ReplyTo {

--- a/src/openhuman/channel.rs
+++ b/src/openhuman/channel.rs
@@ -67,6 +67,7 @@ mod test {
         assert_eq!(adapter.channel_id(), "email");
         adapter
             .send(OutboundMessage {
+                task_id: None,
                 channel: "email".into(),
                 text: "hello".into(),
                 steps: Vec::new(),
@@ -95,6 +96,7 @@ mod test {
         let adapter = OpenHumanChannelAdapter::new("email", rpc);
         let err = adapter
             .send(OutboundMessage {
+                task_id: None,
                 channel: "email".into(),
                 text: "hi".into(),
                 steps: Vec::new(),

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -945,6 +945,36 @@ pub struct OutboundMessage {
     /// (same `by`/`chat`/`McpCallFailed` additive precedent above).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reply_to: Option<ReplyTo>,
+    /// The board card this bubble's turn **opened**, when it opened one (issue
+    /// #246).
+    ///
+    /// A `spawn_task` used to surface nothing at all: the card appeared on the
+    /// board and the operator's reply said nothing about it, so there was no
+    /// way to tell a turn that opened work from one that only talked about it.
+    /// This is the correlation key that lets the console render a "card opened"
+    /// chip, and it is the value journaled onto
+    /// [`AgentReply::task_id`](CompanyEvent::AgentReply) so the chip survives a
+    /// transcript reload rather than existing only on the live response.
+    ///
+    /// **Only the first card of a multi-spawn turn.** The journal field it
+    /// feeds is a single optional id, and widening it to a list would break the
+    /// byte-identical round-trip every stored reply depends on. The claim it
+    /// makes — "this reply opened that card" — is therefore true but
+    /// incomplete, never false; the bubble's [`steps`](Self::steps) timeline
+    /// still shows every `spawn_task` call the turn made.
+    ///
+    /// Additive and non-secret: a card id, omitted on the wire when absent, so
+    /// every prior producer round-trips byte-identically (same `steps` /
+    /// `reply_to` precedent above).
+    ///
+    /// The wire name is pinned to `taskId` rather than inherited, because this
+    /// struct — unlike almost everything else the console reads — carries no
+    /// `rename_all`. The console sees the same card on three surfaces (this
+    /// POST response, the SSE `agent_reply` frame, and the `chat/history` DTO),
+    /// and the other two are camelCase; letting this one alone be `task_id`
+    /// would be a trap for whoever wires the next reader.
+    #[serde(default, rename = "taskId", skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
 }
 
 /// One visible step in an agent turn's processing timeline, surfaced in the
@@ -1690,6 +1720,7 @@ mod test {
     #[test]
     fn outbound_message_steps_are_additive_and_omitted_when_empty() {
         let no_steps = OutboundMessage {
+            task_id: None,
             channel: "operator".to_string(),
             text: "hi".to_string(),
             steps: Vec::new(),
@@ -1703,6 +1734,7 @@ mod test {
         assert!(legacy.steps.is_empty());
 
         let with_steps = OutboundMessage {
+            task_id: None,
             channel: "operator".to_string(),
             text: "done".to_string(),
             steps: vec![TurnStep {
@@ -1715,6 +1747,46 @@ mod test {
             reply_to: None,
         };
         assert_eq!(round_trip(&with_steps), with_steps);
+    }
+
+    /// Issue #246: `OutboundMessage.task_id` is additive on exactly the same
+    /// terms as `steps` above — a bubble that opened no card must serialize
+    /// byte-for-byte as it did before the field existed, and a payload written
+    /// before it existed must still load. Without both halves every already-
+    /// stored response would change shape the moment this field shipped.
+    #[test]
+    fn outbound_message_task_id_is_additive_and_omitted_when_absent() {
+        let no_card = OutboundMessage {
+            task_id: None,
+            channel: "operator".to_string(),
+            text: "hi".to_string(),
+            steps: Vec::new(),
+            reply_to: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&no_card).unwrap(),
+            r#"{"channel":"operator","text":"hi"}"#,
+            "a bubble that opened no card keeps the pre-#246 wire form"
+        );
+
+        let legacy: OutboundMessage =
+            serde_json::from_str(r#"{"channel":"operator","text":"hi"}"#).unwrap();
+        assert!(legacy.task_id.is_none());
+
+        let with_card = OutboundMessage {
+            task_id: Some("t-42".to_string()),
+            channel: "operator".to_string(),
+            text: "opened one".to_string(),
+            steps: Vec::new(),
+            reply_to: None,
+        };
+        assert_eq!(round_trip(&with_card), with_card);
+        assert!(
+            serde_json::to_string(&with_card)
+                .unwrap()
+                .contains(r#""taskId":"t-42""#),
+            "the console reads the card off a camelCase key"
+        );
     }
 
     /// `AgentReply.steps` is additive the same way: a reply journaled before

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -73,6 +73,7 @@ mod test {
         assert_eq!(channel.channel_id(), "operator");
         channel
             .send(OutboundMessage {
+                task_id: None,
                 channel: "operator".into(),
                 text: "hello".into(),
                 steps: Vec::new(),

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -456,6 +456,7 @@ async fn perform_effect(rt: &CompanyRuntime, effect: &Effect) -> Result<()> {
             if adapter.channel_id() == channel {
                 adapter
                     .send(OutboundMessage {
+                        task_id: None,
                         channel: channel.to_string(),
                         text: text.to_string(),
                         steps: Vec::new(),
@@ -944,6 +945,7 @@ mod test {
                 if let CompanyEvent::OperatorMessage { text, .. } = event {
                     host.emit_effect(self.effect.clone()).await?;
                     responses.push(OutboundMessage {
+                        task_id: None,
                         channel: "operator".into(),
                         text: format!("handled: {text}"),
                         steps: Vec::new(),
@@ -975,6 +977,7 @@ mod test {
                 if let CompanyEvent::OperatorMessage { text, .. } = event {
                     host.park_effect(self.effect.clone()).await?;
                     responses.push(OutboundMessage {
+                        task_id: None,
                         channel: "operator".into(),
                         text: format!("that needs your approval: {text}"),
                         steps: Vec::new(),
@@ -1002,12 +1005,14 @@ mod test {
             Ok(CycleResult {
                 channel_responses: vec![
                     OutboundMessage {
+                        task_id: None,
                         channel: "operator".into(),
                         text: "orchestrator".into(),
                         steps: Vec::new(),
                         reply_to: None,
                     },
                     OutboundMessage {
+                        task_id: None,
                         // Addressed by *agent id*: no adapter answers to this.
                         channel: "maya".into(),
                         text: "delegated reply".into(),
@@ -1429,6 +1434,7 @@ mod test {
         async fn run_cycle(&self, req: CycleRequest, _host: &dyn CycleHost) -> Result<CycleResult> {
             Ok(CycleResult {
                 channel_responses: vec![OutboundMessage {
+                    task_id: None,
                     channel: "operator".into(),
                     text: "thought about it".into(),
                     steps: Vec::new(),

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -119,6 +119,19 @@ pub(crate) struct DelegationOutcome {
     /// flag carries the cancellation as a **fact** so a caller can report the
     /// cause rather than inferring one from an absence (issue #213 review).
     pub(crate) cancelled: bool,
+    /// The id of the board card a `spawn_task` opened (issue #246).
+    ///
+    /// A `spawn_task` used to be entirely silent: it returned
+    /// `DelegationOutcome::default()`, documented as surfacing nothing, so the
+    /// operator got a reply with no sign that work had been opened. Reporting
+    /// the id here is what lets the caller stamp it onto the bubble — and, from
+    /// there, onto the journaled reply — so "a card was opened" is a fact the
+    /// console can render rather than something the operator has to spot on the
+    /// board.
+    ///
+    /// `None` for every other delegation kind, and for a `spawn_task` that
+    /// found no task store to write to.
+    pub(crate) spawned_task: Option<String>,
 }
 
 /// A synchronous desk-lead answer captured for the orchestrator to relay: which
@@ -140,6 +153,19 @@ pub(crate) struct OperatorTurn {
     pub(crate) reply: String,
     pub(crate) steps: Vec<TurnStep>,
     pub(crate) bubbles: Vec<OutboundMessage>,
+    /// The board card this turn opened, when it opened one (issue #246) — the
+    /// **first**, if it opened several.
+    ///
+    /// Carried to the caller so the operator bubble can say a card was opened,
+    /// which a `spawn_task` never did before: the card appeared on the board
+    /// and the reply gave no sign of it.
+    ///
+    /// First-only because the field this ultimately lands in — the journaled
+    /// `AgentReply.task_id` — is a single optional id, and widening it would
+    /// break the byte-identical round-trip every already-stored reply relies
+    /// on. The resulting claim is incomplete but never wrong, and the bubble's
+    /// step timeline still shows every `spawn_task` the turn made.
+    pub(crate) spawned_task: Option<String>,
 }
 
 /// What a **dispatched card's** turn handed off (issue #204).
@@ -254,8 +280,17 @@ impl<'a> DelegationRunner<'a> {
         // bubble lands in `bubbles`.
         let mut bubbles = Vec::new();
         let mut desk_replies: Vec<(String, String)> = Vec::new();
+        // Issue #246: the first card this turn opened, which is what the
+        // operator bubble reports. `get_or_insert` rather than assignment keeps
+        // it the FIRST — a later spawn must not overwrite the id an earlier one
+        // already claimed, or the reported card would be whichever the model
+        // happened to queue last.
+        let mut spawned_task: Option<String> = None;
         for delegation in self.queue.drain(self.max_delegations) {
             let out = self.run_delegation(delegation, chat_id).await?;
+            if let Some(id) = out.spawned_task {
+                spawned_task.get_or_insert(id);
+            }
             if let Some(bubble) = out.bubble {
                 bubbles.push(bubble);
             }
@@ -288,6 +323,7 @@ impl<'a> DelegationRunner<'a> {
             reply: operator_reply,
             steps: operator_steps,
             bubbles,
+            spawned_task,
         })
     }
 
@@ -487,7 +523,13 @@ impl<'a> DelegationRunner<'a> {
                     parent_task_id: self.task.clone(),
                 };
                 tasks.upsert(self.company, &card).await?;
-                Ok(DelegationOutcome::default())
+                // Issue #246: report the card so the caller can surface it. The
+                // id is reported only after the write succeeded, so a bubble can
+                // never claim a card that is not on the board.
+                Ok(DelegationOutcome {
+                    spawned_task: Some(card.id),
+                    ..DelegationOutcome::default()
+                })
             }
             Delegation::DelegateToDesk { desk, instruction } => {
                 let Some(member) = desk_lead(self.record, &desk) else {
@@ -534,6 +576,7 @@ impl<'a> DelegationRunner<'a> {
                         steps: outcome.steps,
                     }),
                     cancelled: false,
+                    spawned_task: None,
                 })
             }
             // ── Issue #186 part b: orchestrator lifecycle authority ─────────

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -98,8 +98,10 @@ summarize it or pass it along. Do not delegate again; just relay what came back.
 
 /// The outcome of draining one queued delegation.
 ///
-/// A `spawn_task` yields nothing operator-visible (it only opens a board card).
-/// A synchronous `delegate_to_desk` yields a [`DeskReply`] — the teammate's
+/// A `spawn_task` yields no bubble of its own — it opens a board card and
+/// reports that card's id (issue #246), which is what the caller stamps onto the
+/// bubble it was already sending. A synchronous `delegate_to_desk` yields a
+/// [`DeskReply`] — the teammate's
 /// answer captured so the orchestrator can **relay** it in a follow-up turn (the
 /// CEO-relay hand-back) instead of leaving it as a disconnected sibling bubble.
 /// `bubble` stays for any future delegation that surfaces its own standalone
@@ -481,7 +483,10 @@ impl<'a> DelegationRunner<'a> {
     ///
     /// `spawn_task` opens a backlog card through the
     /// [`TaskStore::upsert`](crate::ports::TaskStore) path the console uses and
-    /// surfaces nothing extra (a missing task store is a silent no-op).
+    /// **reports the card's id** so the caller can say one was opened (issue
+    /// #246) — it surfaces no bubble of its own, which is a different thing
+    /// from the nothing it used to surface. A missing task store is a silent
+    /// no-op.
     /// `delegate_to_desk` runs a single turn on the desk's lead member and
     /// **returns its reply for the orchestrator to relay** (a [`DeskReply`]). An
     /// unknown desk (no roster-backed lead) or a cancelled run yields nothing to

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -286,6 +286,7 @@ mod test {
             for event in &req.events {
                 if let CompanyEvent::ScheduleFired { prompt, .. } = event {
                     responses.push(OutboundMessage {
+                        task_id: None,
                         channel: "operator".into(),
                         text: format!("scheduled: {prompt}"),
                         steps: Vec::new(),

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -90,6 +90,15 @@ pub struct MessageView {
     /// transcript renders the same tool-call timeline the live turn showed.
     /// Empty for operator messages and tool-less replies.
     pub steps: Vec<TurnStep>,
+    /// The board card this reply is about (issue #246) — the card the turn
+    /// opened, or the dispatched card the turn ran for (#185).
+    ///
+    /// Projected here so a rehydrated transcript renders the same "card opened"
+    /// chip the live turn showed. Both surfaces read it from this one field, so
+    /// REST and GraphQL cannot disagree about which messages carry a card
+    /// (issue #65's whole point). `None` on operator messages and on every
+    /// reply journaled before the field existed.
+    pub task_id: Option<String>,
 }
 
 impl MessageView {
@@ -109,6 +118,7 @@ impl MessageView {
                 agent_id,
                 text,
                 steps,
+                task_id,
                 ..
             } => MessageView {
                 id,
@@ -118,6 +128,7 @@ impl MessageView {
                 at_millis,
                 mine: false,
                 steps,
+                task_id,
             },
             CompanyEvent::OperatorMessage { text, by, .. } => {
                 let (author, mine) = match &by {
@@ -142,6 +153,7 @@ impl MessageView {
                     at_millis,
                     mine,
                     steps: Vec::new(),
+                    task_id: None,
                 }
             }
             // `owns` never admits other variants into a history.
@@ -153,6 +165,7 @@ impl MessageView {
                 at_millis,
                 mine: false,
                 steps: Vec::new(),
+                task_id: None,
             },
         }
     }

--- a/src/server/graphql/company.rs
+++ b/src/server/graphql/company.rs
@@ -410,6 +410,12 @@ pub struct MessageGql {
     /// transcript renders the same timeline the REST route returns (issue #65
     /// parity). Empty for operator messages and tool-less replies.
     pub steps: Vec<MessageStepGql>,
+    /// The board card this reply is about (issue #246): the card the turn
+    /// opened, or the dispatched card it ran for (#185). Projected from the
+    /// same [`MessageView`] field the REST route reads, so the two surfaces
+    /// agree on which messages carry a card. Null on operator messages and on
+    /// every reply journaled before the field existed.
+    pub task_id: Option<ID>,
 }
 
 /// One scrubbed step in a reply's processing timeline. GraphQL mirror of the
@@ -456,6 +462,7 @@ impl From<MessageView> for MessageGql {
             at_millis: view.at_millis,
             mine: view.mine,
             steps: view.steps.into_iter().map(MessageStepGql::from).collect(),
+            task_id: view.task_id.map(ID),
         }
     }
 }

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -478,6 +478,14 @@ type Message {
 	parity). Empty for operator messages and tool-less replies.
 	"""
 	steps: [MessageStep!]!
+	"""
+	The board card this reply is about (issue #246): the card the turn
+	opened, or the dispatched card it ran for (#185). Projected from the
+	same [`MessageView`] field the REST route reads, so the two surfaces
+	agree on which messages carry a card. Null on operator messages and on
+	every reply journaled before the field existed.
+	"""
+	taskId: ID
 }
 
 """

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -291,6 +291,61 @@ async fn chat_history_finds_agent_replies_under_general_and_main() {
     );
 }
 
+/// Issue #246 + #65: the card a reply opened is projected on **both** history
+/// surfaces, from the one shared `MessageView` field. The console reads REST,
+/// but GraphQL is the paginated surface, and #65 exists precisely because the
+/// two drifting apart is how a transcript ends up meaning different things
+/// depending on which door you came in.
+#[tokio::test]
+async fn chat_history_projects_the_card_a_reply_opened() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_rich_company(&home).await;
+    let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+    for (text, task_id) in [
+        ("opened a card", Some("t-77".to_string())),
+        ("opened nothing", None),
+    ] {
+        runtime
+            .events()
+            .append(
+                runtime.id(),
+                crate::ports::types::CompanyEvent::AgentReply {
+                    task_id,
+                    chat_id: "General".to_string(),
+                    agent_id: "maya".to_string(),
+                    text: text.to_string(),
+                    steps: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    let app = router(state);
+    let value = query(
+        app,
+        r#"{"query":"{ company(id:\"acme\"){ chat(id:\"general\"){ history(first: 10) { items { text taskId } } } } }"}"#,
+    )
+    .await;
+    let items = value["data"]["company"]["chat"]["history"]["items"]
+        .as_array()
+        .unwrap();
+    let opened = items
+        .iter()
+        .find(|m| m["text"] == "opened a card")
+        .expect("the card-opening reply is in history");
+    assert_eq!(opened["taskId"], "t-77");
+    let plain = items
+        .iter()
+        .find(|m| m["text"] == "opened nothing")
+        .expect("the ordinary reply is in history");
+    assert!(
+        plain["taskId"].is_null(),
+        "an ordinary reply carries no card: {plain}"
+    );
+}
+
 #[tokio::test]
 async fn connections_reflect_manifest_intent_disconnected() {
     let home_dir = home();

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -946,7 +946,16 @@ async fn chat_and_emit(
             .append(
                 id,
                 CompanyEvent::AgentReply {
-                    task_id: None,
+                    // Issue #246: carry the card this turn opened onto the
+                    // durable record, so the console's "card opened" chip
+                    // survives a transcript reload instead of living only on
+                    // the live POST response. This widens the field's meaning
+                    // from "the dispatch that produced this reply" to "the card
+                    // this reply is about" — a card-creating reply now shows up
+                    // in that card's timeline alongside its dispatch replies,
+                    // which is the lineage an operator wants and costs no
+                    // schema change.
+                    task_id: response.task_id.clone(),
                     chat_id: desk.clone(),
                     agent_id: response.channel.clone(),
                     text: response.text.clone(),
@@ -1061,6 +1070,12 @@ struct ChatHistoryMessageDto {
     /// empty (operator messages, tool-less replies) — keeps the legacy shape.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     steps: Vec<TurnStep>,
+    /// The board card this reply is about (issue #246), so a rehydrated
+    /// transcript renders the same "card opened" chip the live turn showed.
+    /// Omitted when absent — which is every message journaled before the field
+    /// existed — so the legacy shape is unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    task_id: Option<String>,
 }
 
 impl From<MessageView> for ChatHistoryMessageDto {
@@ -1073,6 +1088,7 @@ impl From<MessageView> for ChatHistoryMessageDto {
             at_millis: view.at_millis,
             mine: view.mine,
             steps: view.steps,
+            task_id: view.task_id,
         }
     }
 }
@@ -2277,6 +2293,76 @@ mod test {
         );
         assert_eq!(reply["steps"][0]["status"], "ok");
         assert_eq!(reply["steps"][0]["elapsedMs"], 9);
+    }
+
+    /// Issue #246: a reply that opened a board card must still say so after a
+    /// transcript reload. The "card opened" chip is rendered from `taskId`, and
+    /// a chip that exists only on the live POST response vanishes the moment
+    /// the operator switches threads and comes back — which is exactly when
+    /// they would go looking for it.
+    #[tokio::test]
+    async fn chat_history_route_rehydrates_the_card_a_reply_opened() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_company(&home, "running").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+
+        for (text, task_id) in [
+            ("opened one", Some("t-77".to_string())),
+            ("just talking", None),
+        ] {
+            runtime
+                .events()
+                .append(
+                    runtime.id(),
+                    CompanyEvent::AgentReply {
+                        task_id,
+                        chat_id: "main".to_string(),
+                        agent_id: "ceo".to_string(),
+                        text: text.to_string(),
+                        steps: Vec::new(),
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        let app = router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/company/chat/history")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let messages = value.as_array().unwrap();
+
+        let opened = messages
+            .iter()
+            .find(|m| m["text"] == "opened one")
+            .expect("the card-opening reply is in history");
+        assert_eq!(
+            opened["taskId"], "t-77",
+            "the chip's correlation key must ride back on the history DTO"
+        );
+
+        // A reply that opened nothing omits the key rather than sending null,
+        // so no bubble grows a chip it should not have — and every message
+        // journaled before this field existed reads back unchanged.
+        let chatter = messages
+            .iter()
+            .find(|m| m["text"] == "just talking")
+            .expect("the ordinary reply is in history");
+        assert!(
+            chatter.get("taskId").is_none(),
+            "an ordinary chat reply must not carry a card: {chatter}"
+        );
     }
 
     /// A desk id with no `?desk=` selector defaults to the operator/General

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -66,6 +66,16 @@ struct TaskCard {
     /// the board's existing wire shape is unchanged.
     #[serde(skip_serializing_if = "Option::is_none")]
     parent_task_id: Option<String>,
+    /// The chat thread this card was opened from (issue #246).
+    ///
+    /// `TaskRecord::origin_chat_id` has existed since #151 (it is what lets a
+    /// completed run answer in the conversation that asked), and the tool-spawn
+    /// path stamps it — but it was never *readable*: no DTO projected it, so
+    /// task detail could not show where a card came from. Omitted when absent,
+    /// which is every card the board created before this, so the existing wire
+    /// shape is unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    origin_chat_id: Option<String>,
 }
 
 impl From<TaskRecord> for TaskCard {
@@ -79,6 +89,7 @@ impl From<TaskRecord> for TaskCard {
             assignee: t.assignee,
             updated_at: t.updated_at_millis,
             parent_task_id: t.parent_task_id,
+            origin_chat_id: t.origin_chat_id,
         }
     }
 }
@@ -100,6 +111,14 @@ struct CreateTask {
     /// lineage root, which is every card the board creates today.
     #[serde(default)]
     parent_task_id: Option<String>,
+    /// The chat thread this card is being opened from (issue #246).
+    ///
+    /// Set by the transcript's "Add to board" action, which is the one creation
+    /// entry point that *has* an originating conversation; the board's `+`
+    /// button omits it. Absent is the previous behaviour and stays the default,
+    /// so no existing caller changes.
+    #[serde(default)]
+    origin_chat_id: Option<String>,
 }
 
 /// The partial patch body (any subset; a drag sends `{column}`).
@@ -274,7 +293,17 @@ async fn create_task(
         priority: body.priority.unwrap_or_else(|| "medium".to_string()),
         assignee,
         updated_at_millis: now_millis(),
-        origin_chat_id: None,
+        // Issue #246: provenance is now carried, not dropped. This was
+        // hardcoded `None` while the tool-spawn path stamped the same field
+        // correctly, so a card opened from a conversation had no way back to it
+        // — and #151's "answer where you were asked" post-back could never fire
+        // for anything the REST surface created. A blank string is normalised
+        // away so an empty form field cannot persist as a thread id that
+        // matches nothing.
+        origin_chat_id: body
+            .origin_chat_id
+            .map(|id| id.trim().to_string())
+            .filter(|id| !id.is_empty()),
         parent_task_id: body.parent_task_id,
     };
     company.runtime.upsert_task(&record).await?;

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -311,6 +311,126 @@ async fn created_tasks_default_to_the_todo_column() {
     assert_eq!(explicit["column"], crate::ports::tasks::COLUMN_BACKLOG);
 }
 
+/// Issue #246: `POST …/tasks` carries the thread a card was opened from.
+///
+/// `TaskRecord.origin_chat_id` has existed since #151 and the tool-spawn path
+/// stamped it, but this handler hardcoded `None` and no DTO projected it — so a
+/// card opened from a conversation had no way back to it, and #151's
+/// "answer where you were asked" post-back could never fire for anything the
+/// REST surface created. Both halves are checked here: the write keeps it, and
+/// **both** reads (the board list and task detail) hand it back.
+#[tokio::test]
+async fn a_task_created_from_a_thread_remembers_and_reads_back_that_thread() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+
+    let (status, created) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks",
+        Some(json!({"title": "Ship the brief", "originChatId": "strategy"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(created["originChatId"], "strategy");
+    let id = created["id"].as_str().unwrap().to_string();
+
+    // The board read (what the console lists) carries it…
+    let (_, board) = send(&state, "GET", "/api/v1/company/tasks", None).await;
+    assert_eq!(board.as_array().unwrap()[0]["originChatId"], "strategy");
+
+    // …and so does task detail, which is where an operator asks "where did
+    // this come from?".
+    let (status, detail) = send(
+        &state,
+        "GET",
+        &format!("/api/v1/company/tasks/{id}"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(detail["task"]["originChatId"], "strategy");
+
+    // A card created without a thread — the board's `+` button — omits the key
+    // entirely rather than sending null, so the pre-#246 wire shape is
+    // unchanged for every card that has no conversation behind it.
+    let (_, plain) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks",
+        Some(json!({"title": "Typed on the board"})),
+    )
+    .await;
+    assert!(
+        plain.get("originChatId").is_none(),
+        "a card with no originating thread must not grow the key: {plain}"
+    );
+
+    // A blank thread id is normalised away rather than persisted as a thread
+    // that matches nothing.
+    let (_, blank) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks",
+        Some(json!({"title": "Blank origin", "originChatId": "   "})),
+    )
+    .await;
+    assert!(blank.get("originChatId").is_none(), "{blank}");
+}
+
+/// Issue #246 spend gate, at the HTTP boundary. The transcript's "Add to
+/// board" action omits `column` on purpose so the *server* decides where a
+/// chat-created card lands — and the one thing that must never happen is that
+/// it lands on the dispatch trigger, which spends an agent turn nobody
+/// approved. `dispatch_task` is a no-op in this build (no harness attached),
+/// so the load-bearing assertion is the landing column itself; the journal
+/// check is the belt to that braces, and would catch a create that started
+/// journaling a dispatch of its own.
+#[tokio::test]
+async fn a_chat_created_card_lands_off_the_dispatch_trigger() {
+    use crate::ports::tasks::{COLUMN_IN_PROGRESS, COLUMN_TODO};
+    use crate::ports::types::CompanyEvent;
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+
+    let (status, created) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks",
+        Some(json!({"title": "Draft the announcement", "originChatId": "main"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_ne!(
+        created["column"], COLUMN_IN_PROGRESS,
+        "a chat-created card must never arrive already dispatched"
+    );
+    assert_eq!(
+        created["column"], COLUMN_TODO,
+        "it lands in the board's intake lane, where the human drag is the gate"
+    );
+
+    let journal = runtime
+        .events()
+        .read_from(
+            runtime.id(),
+            crate::ports::types::EventSeq::new(0),
+            usize::MAX,
+        )
+        .await
+        .unwrap();
+    assert!(
+        !journal
+            .iter()
+            .any(|e| matches!(e.event, CompanyEvent::TaskDispatched { .. })),
+        "creating a card from chat must not dispatch it"
+    );
+}
+
 #[tokio::test]
 async fn steer_task_validates_statuses_and_journals_acceptance() {
     let home_dir = home();

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -342,13 +342,7 @@ async fn a_task_created_from_a_thread_remembers_and_reads_back_that_thread() {
 
     // …and so does task detail, which is where an operator asks "where did
     // this come from?".
-    let (status, detail) = send(
-        &state,
-        "GET",
-        &format!("/api/v1/company/tasks/{id}"),
-        None,
-    )
-    .await;
+    let (status, detail) = send(&state, "GET", &format!("/api/v1/company/tasks/{id}"), None).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(detail["task"]["originChatId"], "strategy");
 

--- a/src/server/provision/test.rs
+++ b/src/server/provision/test.rs
@@ -676,6 +676,7 @@ impl Brain for EffectBrain {
             if let CompanyEvent::OperatorMessage { text, .. } = event {
                 host.emit_effect(self.effect.clone()).await?;
                 responses.push(OutboundMessage {
+                    task_id: None,
                     channel: "operator".into(),
                     text: format!("handled: {text}"),
                     steps: Vec::new(),

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -759,6 +759,7 @@ async fn post_to_channel(
     };
     adapter
         .send(OutboundMessage {
+            task_id: None,
             channel: channel_id.to_string(),
             text: format!("{subject}\n\n{text}"),
             steps: Vec::new(),


### PR DESCRIPTION
## Summary

Closes #246.

#126 opened task cards from chat but left the chat↔card edge unwired in both
directions. This closes it:

1. **`POST …/tasks` carries the thread a card came from.** It hardcoded
   `origin_chat_id: None` while the tool-spawn path stamped the same field
   correctly, and no DTO projected it — so a card opened from a conversation had
   no way back to it, and the #151 "answer where you were asked" post-back could
   never fire for anything the REST surface created. The create now accepts an
   optional `originChatId`, and both reads (board list, task detail) hand it
   back.

2. **A chat turn that opens a card says so.** `run_delegation`'s `SpawnTask` arm
   returned `DelegationOutcome::default()` — the card landed on the board and
   the reply carried nothing tying the two together. It now reports the card's
   id, the harness brain stamps it onto the operator bubble
   (`OutboundMessage.task_id`), and the chat cycle journals it onto that turn's
   `AgentReply.task_id`, so the console's chip survives a transcript reload.

3. **Any message, in any thread, can become a card.** Only the orchestrator
   carries the delegation tools, so a request typed into a desk or DM thread
   could not become a card by *any* path. A per-message "Add to board" action
   creates through REST rather than through the responder's toolbelt — which is
   what makes it true on every thread without widening the v1 depth-1 delegation
   design.

### What I verified against the issue, and what had gone stale

The issue is unusually precise; three of its claims held exactly, three had
aged:

| Claim | Status |
|---|---|
| REST create hardcodes `origin_chat_id: None` | **Held** (line ref drifted; the code was as described) |
| `SpawnTask` arm returns `DelegationOutcome::default()`, wire carries no task id | **Held** |
| Desk leads / DM-routed agents carry no delegation tools | **Held** |
| "there is no enum [for `column`]" | **Stale.** #205 landed `BOARD_COLUMNS` + a write-boundary `validate_column`; an unrenderable column is now a `400`, not a silently-persisted string. The issue's "Free-form `column`" worry — that a chat-created card could land in a lane the board does not render — is obsolete, and the mitigation it proposes (a single-default constant plus a heads-up on #206) is unnecessary. |
| "When #206 introduces its To-do intake lane…" | **Stale.** #206 has landed. `COLUMN_TODO` is already the create default, so "omit `column` and let the server decide" resolves to the intake lane **today**. The spend gate is therefore provable now rather than pending on a future issue — which is why the regression test below is a real assertion and not a placeholder. |
| `frontend/src/lib/tasks-sample.ts` lanes are client-hardcoded | Still hardcoded, but the file now documents the backend as the source of truth and the write boundary rejects any mismatch, so the "card lands in a column the board can't render" risk is closed from the other end. |

### The spend-gate proof

The create call omits `column` on purpose, so this rests on the server default
not being the dispatch trigger. That is two facts in two modules, so a change to
either alone would silently open the gate. Both are now pinned:

- `create_task` defaults an omitted `column` to `COLUMN_TODO`.
- `CompanyRuntime::upsert_task` edge-fires a dispatch only through
  `task_enters_in_progress`, and only on entry into the literal `in_progress`.
- `the_column_a_chat_created_card_defaults_to_does_not_dispatch` asserts
  `!task_enters_in_progress(None, COLUMN_TODO)` **plus** a positive control
  (`task_enters_in_progress(None, COLUMN_IN_PROGRESS)`) so the test cannot pass
  by the trigger simply never firing.
- `a_chat_created_card_lands_off_the_dispatch_trigger` asserts the same at the
  HTTP boundary, and that no `TaskDispatched` reaches the journal.

Honest caveat on that last one: in the default (harness-less) build
`dispatch_task` is already a no-op, so the journal assertion is belt rather than
braces — it would catch a create that started journaling a dispatch of its own.
The load-bearing assertion is the landing column, tied to the same predicate the
runtime dispatches on.

### Where I chose differently from the issue

**Multi-spawn turns — first, not "whichever won."** The issue accepts stamping
only the first task id. I kept that (the journal field is a single optional id;
widening it would break the byte-identical round-trip every stored reply relies
on) but made *first* an explicit contract rather than an accident of iteration
order, with a test pinning it. The claim "this reply opened that card" is then
incomplete but never false, and the bubble's step timeline still shows every
spawn. Stamping the last would have made the reported card depend on the model's
queue order, which is not a contract anyone can rely on.

**The wire carries the id only, not `{id, title}` — the issue's own design
would have failed the issue's own acceptance criterion.** #246 proposes
`spawned_task: Option<{id, title}>` and, separately, requires the chip to render
"live **and** after a transcript reload". Those two cannot both hold: the
journal field the chip is rehydrated from (`AgentReply.task_id`) can persist only
an id, so a title available live and absent after reload would make the two chips
render differently — which is precisely the failure the criterion exists to
prevent. The wire therefore carries the id alone, and the chip's wording is
derived from whose message it is ("Card opened" on a company reply, "Added to the
board" on your own). Both paths then render identically, live and rehydrated.

**`AgentReply.task_id` semantic widening.** No serde change was needed: the
field already existed from #185 and this only populates it on a new occasion.
Pre-existing journals therefore round-trip byte-identically by construction, and
the existing #185 test `task_id_correlation_is_additive_and_omitted_when_absent`
— which asserts an untagged reply serializes to the exact legacy string — still
passes unchanged. The widening is real but only in meaning: "the dispatch that
produced this reply" becomes "the card this reply is about", so a card-creating
reply now also appears on that card's timeline, which is lineage an operator
wants at no schema cost.

**`OutboundMessage`'s wire name is pinned to `taskId`.** That struct carries no
`rename_all`, unlike the two sibling surfaces the console reads the same card on
(the SSE `agent_reply` frame and the `chat/history` DTO). Letting this one alone
be `task_id` would be a trap for the next reader.

**One asymmetry, stated rather than hidden.** The chip on a *company reply* is
rehydrated from the journal and survives reload. The chip on *your own* message
(the "Add to board" path) is session-only, because the operator message carries
no card id in the journal — the durable record of that link is `originChatId` on
the card, which task detail now reads back and offers a jump from. Making the
operator-message chip durable would mean a new journal field, which is more
schema than this edge is worth.

### Collision with #293 (issue #272)

#293 is open on `src/runtime/delegation.rs`, `src/harness/brain.rs`,
`src/harness/orchestrator.rs`, `src/runtime/cycle.rs` and
`src/runtime/delegation_tools.rs`. I read its diff before starting.

Both PRs edit the same `match` in `run_delegation`, in adjacent arms: #293 adds
a refusal path (a `refused` list on `DelegationQueue`, drained in
`handle_task_delegations`, plus a `tracing::warn!` in the `DelegateToDesk` arm's
no-lead branch); this adds a `spawned_task` field to `DelegationOutcome`, set in
the `SpawnTask` arm. Only this PR changes the struct, so #293's bare
`DelegationOutcome::default()` returns keep compiling.

The two hunks are close enough to share context lines — my last changed line is
the `SpawnTask` arm's return, #293's first is three lines later inside
`DelegateToDesk` — so a clean auto-merge is likely but not guaranteed, and a
clean merge is not the thing to check anyway. Whoever lands second should re-run
`cargo test --features openhuman,tinycortex --lib` rather than trust the merge,
since both PRs change what that `match` reports and only the harness tests
exercise it.

We also both touch `src/runtime/cycle.rs` and `src/harness/brain.rs`, without
overlap: in `cycle.rs` my edits are struct-literal `task_id: None` fills at the
construction and test sites while #293's are at the imports and `CycleHostImpl`;
in `brain.rs` we both append tests at the tail, which is the likelier textual
conflict of the two and a trivial one. I touch neither `orchestrator.rs` nor
`delegation_tools.rs`.

Also checked: **#278** (assignee picker) touches `TaskDetailView.tsx` and
`TasksView.tsx`, which I also edit — but its hunks are inside `ControlBar` and
`CreateTaskDialog`, while mine are the props block, the render slot and a new
component. Adjacent, not overlapping. **#289** (`DeliveryReason`) does not
intersect.

### Found but not fixed

Deliberately out of scope; each is a separate decision:

- **`run_chat`'s deterministic intent card** (`src/server/operator.rs`) — #126's
  own auto-created card — still writes `origin_chat_id: None` and
  `column: "backlog"` even though `message.chat` is in scope one line away.
  Stamping it is a one-liner, but it would change behaviour: #151's post-back
  would start firing into that thread on completion. That is arguably the right
  behaviour, but it is a behaviour change no acceptance criterion asks for, and
  it does not belong in a visibility PR.
- **The hosted-brain spawn path** (`CycleHostImpl::spawn_task`,
  `src/runtime/cycle.rs`) also writes `origin_chat_id: None` and reports nothing
  to a bubble. It has no chat id in scope and no `DelegationOutcome` equivalent,
  so it needs its own plumbing.
- **`frontend/src/api/types.ts` mis-declares `OutboundMessage.replyTo` /
  `ReplyTo.chatId`.** The Rust structs carry no `rename_all`, so the wire is
  `reply_to` / `chat_id`. Harmless today because nothing reads them — which is
  exactly why it will bite whoever does first. Pre-existing.
- The GraphQL `Task` type carries neither `parentTaskId` (#185) nor
  `originChatId`. Left alone: that type is a deliberately lean read and the
  console reads the board over REST.

## API Or Behavior Changes

All additive; no existing wire shape changes.

- `POST …/tasks` accepts an optional `originChatId`. A blank value is normalised
  away rather than persisted as a thread id matching nothing.
- `TaskCard` (both `GET …/tasks` and `GET …/tasks/{id}`) gains `originChatId`,
  omitted when absent.
- `OutboundMessage` gains `taskId` (wire name pinned), omitted when absent. A
  bubble that opened no card serializes byte-for-byte as before.
- `GET …/chat/history` DTO and the GraphQL `Message` type both gain `taskId`,
  projected from the one shared `MessageView` field (#65's rule), so the two
  surfaces cannot disagree. GraphQL SDL snapshot regenerated.
- `AgentReply.task_id` is now also written for a chat turn that opened a card.
  No serde change; stored journals are untouched.
- Console: a per-message "Add to board" action on every thread; a chip on any
  message tied to a card, linking to `#/tasks/<id>`; a jump from task detail
  back to the originating conversation.

No changes to board lanes, the `+` button, assignee validation, or the
dispatch/review lifecycle.

## Tests

Backend gates, run on this branch:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 1015 passed, 0 failed
- [x] `cargo clippy --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --features openhuman,tinycortex --lib` — 1431 passed, 0 failed
- [x] `cargo check --all-features`
- [x] `cd frontend && npm ci && npm run typecheck && npm run build`
- [x] `npx playwright test test/e2e/chat-to-card.spec.ts` — 2 passed, against a live host

The harness-feature runs are listed because the delegation and journal paths
this touches do not compile under default features, so `cargo test` alone never
executes the three `harness::brain` tests below. `--no-deps` scopes clippy to
this crate: the vendored `openhuman` checkout emits its own warnings, and
`-D warnings` applies to the primary crate, not to a path dependency.

New tests:

| Test | What it pins |
|---|---|
| `a_task_created_from_a_thread_remembers_and_reads_back_that_thread` | the write keeps `originChatId`, both reads return it, a blank one is normalised away, and a card with no thread does not grow the key |
| `a_chat_created_card_lands_off_the_dispatch_trigger` | the HTTP-level spend gate |
| `the_column_a_chat_created_card_defaults_to_does_not_dispatch` | the default column and the dispatch trigger, together, with a positive control |
| `outbound_message_task_id_is_additive_and_omitted_when_absent` | a bubble with no card keeps the pre-#246 wire form; a legacy payload still loads |
| `a_turn_that_opens_a_card_reports_it_on_the_operator_bubble` | the reported id is the card actually on the board |
| `a_turn_that_opens_several_cards_reports_the_first` | the documented limitation, as a contract rather than prose |
| `a_turn_that_opens_no_card_reports_none` | no bubble claims a chip it has not earned |
| `chat_history_route_rehydrates_the_card_a_reply_opened` | the chip survives a reload over REST |
| `chat_history_projects_the_card_a_reply_opened` | …and over GraphQL, from the same shared field |

End-to-end, `frontend/test/e2e/chat-to-card.spec.ts` — **2 passed**. A real host
built `--features openhuman,tinycortex` on an isolated `--home`, serving the
built console, with only the model's *choices* stubbed behind a scripted
OpenAI-compatible endpoint; the harness, tool plumbing, cycle, journal and HTTP
surface all real.

The stub's call log is the part worth reading, because it evidences the two
claims that motivated the feature:

- on the **desk** thread the responder was offered only
  `['memory_recall', 'memory_store']` — no `spawn_task` — which is precisely the
  case where a card was previously unreachable by any path. "Add to board" works
  there anyway because it creates over REST rather than through the responder's
  toolbelt.
- on the **orchestrator** thread the toolbelt included `spawn_task`, and the
  following call arrives with `tool_result=True` — a real tool round-trip, not a
  canned reply. The chip that turn produced is then still present, pointing at
  the same card id, after a full reload.

## Documentation

- `docs/spec/runtime/ports.md` — `OutboundMessage.task_id`, the
  `AgentReply.task_id` widening and its multi-spawn limitation, and why the
  "Add to board" action leans on the `todo` create default as the spend gate.
- `docs/spec/runtime/api.md` — `originChatId` on the create route.
