### PR TITLE
feat(console): render the Task Detail artifacts tab with versions and human-edit diff (#306)

### DIFF
--- a/frontend/src/api/artifacts.ts
+++ b/frontend/src/api/artifacts.ts
@@ -1,0 +1,174 @@
+// The versioned-artifacts API (#187) behind the Task Detail **Artifacts** tab
+// (#306). Mirrors `tasks.ts`: plain functions over `OpenCompanyClient`, the
+// company scope resolved by `client.scopeFor`, and the host's wire shapes
+// re-transcribed here so `tsc` pins the contract.
+//
+// Two of the host's five artifact routes are deliberately **not** wired:
+//
+//   - `POST …/artifacts` — opening an artifact is the producer's job. A
+//     completed dispatch records its output itself; the console inventing a
+//     first version would fabricate agent authorship.
+//   - `DELETE …/artifacts/{id}` — #184 requires that no control on the Task
+//     Detail screen can alter or delete a past event, and an artifact version
+//     is exactly that.
+
+import type { OpenCompanyClient } from "./client";
+
+/** What an artifact holds; picks the renderer. Binary kinds carry a reference, never bytes. */
+export type ArtifactKind = "text" | "markdown" | "image" | "file";
+
+/**
+ * Who wrote a version. The whole point of the port: an operator's pre-approval
+ * edit stays distinguishable from the agent's own re-run.
+ */
+export type ArtifactAuthor = "agent" | "operator";
+
+/** One immutable revision. Versions are append-only and 1-based. */
+export interface ArtifactVersion {
+  /** 1-based revision number, contiguous within the artifact. */
+  version: number;
+  /** The revision's content. */
+  body: string;
+  /** Whether an agent or a human wrote it. */
+  author: ArtifactAuthor;
+  /** The agent id, or the operator's label. Display-only. */
+  authorId: string;
+  /** Epoch-millis the revision was recorded. */
+  createdAtMillis: number;
+  /** The timeline step that produced it (#185), when known. */
+  stepSeq?: number;
+  /** Why this revision exists, e.g. `"operator edit before approval"`. */
+  note?: string;
+}
+
+/** What happened to one diff line. */
+export type DiffOp = "equal" | "insert" | "delete";
+
+/** A single line of a diff. */
+export interface DiffLine {
+  op: DiffOp;
+  /** The line's text, without a trailing newline. */
+  text: string;
+}
+
+/** A line-level diff between two revisions, plus the churn summary. */
+export interface ArtifactDiff {
+  fromVersion: number;
+  toVersion: number;
+  /** Newer-side order with deletions interleaved. */
+  lines: DiffLine[];
+  /** Lines only in the newer side. */
+  added: number;
+  /** Lines only in the older side. */
+  removed: number;
+  /**
+   * Fraction of the older side's lines that changed, 0.0–1.0. The number worth
+   * watching: sustained high churn means the agent's instructions need work.
+   */
+  churn: number;
+}
+
+/**
+ * An artifact as the console renders it.
+ *
+ * The host flattens the record into the response (`#[serde(flatten)]`), so the
+ * record's fields sit at the top level rather than under an `artifact` key —
+ * do not nest this. `humanEditDiff` is derived and omitted entirely when no
+ * human has edited, which is the common, healthy case.
+ */
+export interface ArtifactView {
+  /** Stable id within the company. */
+  id: string;
+  /** The task that produced it. */
+  taskId: string;
+  /** A short display title. */
+  title: string;
+  kind: ArtifactKind;
+  /** Every revision, oldest first. */
+  versions: ArtifactVersion[];
+  /** Epoch-millis the artifact was first created. */
+  createdAtMillis: number;
+  /** Epoch-millis of the newest revision. */
+  updatedAtMillis: number;
+  /**
+   * The last-agent-version → last-operator-version diff, present only once a
+   * human has edited. Inlined by the host so the tab renders the edit story
+   * without a second call.
+   */
+  humanEditDiff?: ArtifactDiff;
+}
+
+/** The append body. `author` is deliberately omitted — see {@link appendArtifactVersion}. */
+export interface AppendVersionInput {
+  body: string;
+  note?: string;
+}
+
+/** One task's artifacts, most-recently-updated first. */
+export function listTaskArtifacts(
+  client: OpenCompanyClient,
+  company: string | null,
+  taskId: string,
+): Promise<ArtifactView[]> {
+  return client.get<ArtifactView[]>(
+    `${client.scopeFor(company)}/tasks/${encodeURIComponent(taskId)}/artifacts`,
+  );
+}
+
+/** One artifact with its full version history. 404s when the id names nothing. */
+export function getArtifact(
+  client: OpenCompanyClient,
+  company: string | null,
+  artifactId: string,
+): Promise<ArtifactView> {
+  return client.get<ArtifactView>(
+    `${client.scopeFor(company)}/artifacts/${encodeURIComponent(artifactId)}`,
+  );
+}
+
+/**
+ * Append a revision — how an operator's pre-approval edit is captured. The
+ * prior version is left untouched, so the diff between them stays computable
+ * forever; there is deliberately no route that rewrites a stored version.
+ *
+ * `author` is **not** sent. The host defaults an unattributed append to
+ * `operator` and stamps the note `"operator edit before approval"`, which is
+ * precisely what an edit from this console is. Sending it explicitly would let
+ * a console bug attribute a human's words to the agent and quietly destroy the
+ * one datum the whole port exists to answer.
+ *
+ * Returns the refreshed artifact, so a caller can render the new version — and
+ * the now-present `humanEditDiff` — without a follow-up read.
+ */
+export function appendArtifactVersion(
+  client: OpenCompanyClient,
+  company: string | null,
+  artifactId: string,
+  body: AppendVersionInput,
+): Promise<ArtifactView> {
+  return client.post<ArtifactView>(
+    `${client.scopeFor(company)}/artifacts/${encodeURIComponent(artifactId)}/versions`,
+    body,
+  );
+}
+
+/**
+ * Diff two specific revisions of an artifact.
+ *
+ * Both bounds are always sent: the host treats "neither" as a request for the
+ * human-edit diff (already inlined on {@link ArtifactView}) and "one" as a 400.
+ * This overload is for comparing a pair the operator picked — two agent drafts
+ * after a re-run, say — which nothing else answers.
+ */
+export function diffArtifact(
+  client: OpenCompanyClient,
+  company: string | null,
+  artifactId: string,
+  from: number,
+  to: number,
+): Promise<ArtifactDiff> {
+  const qs = `?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`;
+  return client.get<ArtifactDiff>(
+    `${client.scopeFor(company)}/artifacts/${encodeURIComponent(artifactId)}/diff${qs}`,
+  );
+}

--- a/frontend/src/views/ArtifactsTab.tsx
+++ b/frontend/src/views/ArtifactsTab.tsx
@@ -1,0 +1,698 @@
+// The Task Detail **Artifacts** tab (#306): the console half of the versioned
+// artifacts + human-edit diff backend (#187).
+//
+// What the tab is for is the diff, not the list. A completed dispatch records
+// its output as an agent-authored version; when an operator fixes it up before
+// approving, that edit lands as a *new version by a different author*, and the
+// gap between the two is the highest-signal quality datum the product produces
+// — heavy churn means the agent's instructions need work. So this tab both
+// shows that story and is where the operator edit is made, because nothing else
+// in the console can author an operator version.
+//
+// Self-fetching by design: the tab panel mounts when the tab is activated, so
+// it owns its own read + poll rather than widening the parent's single
+// `GET …/tasks/{id}` (#185) with a payload three of the four tabs never use.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ArrowLeft,
+  FileText,
+  History,
+  Image as ImageIcon,
+  Loader2,
+  Paperclip,
+  Pencil,
+  UserRound,
+} from "lucide-react";
+
+import {
+  appendArtifactVersion,
+  diffArtifact,
+  listTaskArtifacts,
+  type ArtifactDiff,
+  type ArtifactKind,
+  type ArtifactVersion,
+  type ArtifactView,
+} from "@/api/artifacts";
+import type { OpenCompanyClient } from "@/api/client";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import { Markdown } from "@/components/markdown";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+
+/** Matches the parent screen's poll cadence; visibility-gated the same way. */
+const POLL_MS = 4000;
+
+/** Kinds whose body is text an operator can meaningfully edit in a textarea. */
+const EDITABLE_KINDS: ReadonlySet<ArtifactKind> = new Set<ArtifactKind>(["text", "markdown"]);
+
+const KIND_ICON: Record<ArtifactKind, typeof FileText> = {
+  text: FileText,
+  markdown: FileText,
+  image: ImageIcon,
+  file: Paperclip,
+};
+
+function whenOf(at: number): string {
+  return new Date(at).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+/** `34%` — churn is a 0–1 fraction of the agent draft's lines the human changed. */
+function churnPercent(churn: number): string {
+  return `${Math.round(churn * 100)}%`;
+}
+
+export function ArtifactsTab({
+  client,
+  company,
+  taskId,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+  taskId: string;
+}) {
+  const [artifacts, setArtifacts] = useState<ArtifactView[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  // A poll that lands mid-edit would swap the textarea's seed out from under
+  // the operator, so the editor freezes the refresh while it is open. The ref
+  // (rather than an effect dependency) keeps the timer itself untouched, so
+  // closing the editor resumes on the next tick instead of restarting the poll.
+  const editingRef = useRef(false);
+
+  const load = useCallback(
+    async (isActive: () => boolean = () => true) => {
+      try {
+        const rows = await listTaskArtifacts(client, company, taskId);
+        if (!isActive()) return;
+        setArtifacts(rows);
+        setError(null);
+      } catch (e) {
+        if (!isActive()) return;
+        setError(e instanceof Error ? e.message : "could not load this task's artifacts");
+      } finally {
+        if (isActive()) setLoading(false);
+      }
+    },
+    [client, company, taskId],
+  );
+
+  // Mirrors TaskDetailView's poll: 4s, paused while the tab is hidden, resumed
+  // with an immediate fetch when it comes back. `isActive` is a per-run token
+  // so a superseded run can never apply a previous task's rows.
+  useEffect(() => {
+    let cancelled = false;
+    const isActive = () => !cancelled;
+    setLoading(true);
+    setArtifacts(null);
+    setOpenId(null);
+    void load(isActive);
+    let timer: number | undefined;
+    const stop = () => {
+      if (timer !== undefined) {
+        window.clearInterval(timer);
+        timer = undefined;
+      }
+    };
+    const start = () => {
+      if (timer === undefined) {
+        timer = window.setInterval(() => {
+          if (!editingRef.current) void load(isActive);
+        }, POLL_MS);
+      }
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === "hidden") {
+        stop();
+      } else {
+        if (!editingRef.current) void load(isActive);
+        start();
+      }
+    };
+    if (document.visibilityState !== "hidden") start();
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      cancelled = true;
+      stop();
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [load]);
+
+  const open = useMemo(
+    () => (openId ? (artifacts?.find((a) => a.id === openId) ?? null) : null),
+    [artifacts, openId],
+  );
+
+  // Replace one row in place after an append, so the freshly returned artifact
+  // (with its now-present `humanEditDiff`) renders before the poll comes round.
+  const replace = useCallback((next: ArtifactView) => {
+    setArtifacts((rows) => (rows ?? []).map((a) => (a.id === next.id ? next : a)));
+  }, []);
+
+  // Stable identity: the detail panel reports its editor state through an
+  // effect, and an inline closure here would re-run that effect on every
+  // render — flipping the pause flag off and on again mid-edit.
+  const setEditing = useCallback((editing: boolean) => {
+    editingRef.current = editing;
+  }, []);
+  const refresh = useCallback(() => void load(), [load]);
+
+  if (loading && artifacts === null) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-16 rounded-xl" />
+        <Skeleton className="h-16 rounded-xl" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {open ? (
+        <ArtifactDetail
+          client={client}
+          company={company}
+          artifact={open}
+          onBack={() => setOpenId(null)}
+          onAppended={replace}
+          onRefresh={refresh}
+          onEditingChange={setEditing}
+        />
+      ) : artifacts && artifacts.length > 0 ? (
+        <ul className="space-y-1.5">
+          {artifacts.map((a) => (
+            <ArtifactRow key={a.id} artifact={a} onOpen={() => setOpenId(a.id)} />
+          ))}
+        </ul>
+      ) : (
+        !error && (
+          <div className="rounded-xl border border-dashed py-10 text-center">
+            <p className="text-sm font-medium">No artifacts for this task yet</p>
+            <p className="mx-auto mt-1 max-w-sm text-xs text-muted-foreground">
+              A dispatch that finishes successfully records what the agent produced here, as a
+              version you can browse and edit. Files an agent writes into the workspace are not
+              captured yet — that producer is tracked separately (#244).
+            </p>
+          </div>
+        )
+      )}
+    </div>
+  );
+}
+
+/** One artifact in the list: title, kind, how many versions, and the edit signal. */
+function ArtifactRow({ artifact, onOpen }: { artifact: ArtifactView; onOpen: () => void }) {
+  const Icon = KIND_ICON[artifact.kind];
+  const diff = artifact.humanEditDiff;
+  return (
+    <li>
+      <button
+        className="flex w-full items-center gap-2 rounded-lg border bg-card px-3 py-2 text-left text-xs transition-colors hover:bg-accent"
+        onClick={onOpen}
+      >
+        <Icon className="size-3.5 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate font-medium">{artifact.title}</span>
+        {diff && <EditedBadge diff={diff} />}
+        <Badge variant="outline" className="shrink-0 font-normal capitalize">
+          {artifact.kind}
+        </Badge>
+        <span className="shrink-0 text-[11px] text-muted-foreground">
+          {artifact.versions.length} {artifact.versions.length === 1 ? "version" : "versions"}
+        </span>
+        <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+          {whenOf(artifact.updatedAtMillis)}
+        </span>
+      </button>
+    </li>
+  );
+}
+
+/** The "a human changed this before approving" signal: +added / −removed and churn. */
+function EditedBadge({ diff }: { diff: ArtifactDiff }) {
+  return (
+    <span
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium"
+      title={`An operator edited v${diff.fromVersion} into v${diff.toVersion} — ${churnPercent(diff.churn)} of its lines changed`}
+    >
+      <UserRound className="size-3" />
+      <span className="tabular-nums text-emerald-600 dark:text-emerald-400">+{diff.added}</span>
+      <span className="tabular-nums text-rose-600 dark:text-rose-400">−{diff.removed}</span>
+    </span>
+  );
+}
+
+function ArtifactDetail({
+  client,
+  company,
+  artifact,
+  onBack,
+  onAppended,
+  onRefresh,
+  onEditingChange,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+  artifact: ArtifactView;
+  onBack: () => void;
+  onAppended: (next: ArtifactView) => void;
+  onRefresh: () => void;
+  onEditingChange: (editing: boolean) => void;
+}) {
+  const latest: ArtifactVersion | undefined = artifact.versions[artifact.versions.length - 1];
+  const [selected, setSelected] = useState<number | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  // Follow the newest version unless the operator has pinned an older one, so a
+  // re-run that appends while the panel is open shows its result rather than
+  // silently leaving the reader on a stale draft.
+  const shown = useMemo(() => {
+    if (selected !== null) {
+      const pinned = artifact.versions.find((v) => v.version === selected);
+      if (pinned) return pinned;
+    }
+    return latest;
+  }, [artifact.versions, latest, selected]);
+
+  useEffect(() => {
+    onEditingChange(editing);
+    return () => onEditingChange(false);
+  }, [editing, onEditingChange]);
+
+  const editable = EDITABLE_KINDS.has(artifact.kind) && latest !== undefined;
+
+  function startEditing() {
+    setDraft(latest?.body ?? "");
+    setEditing(true);
+  }
+
+  function stopEditing() {
+    setEditing(false);
+    setDraft("");
+  }
+
+  async function save() {
+    if (!latest) return;
+    setSaving(true);
+    try {
+      const next = await appendArtifactVersion(client, company, artifact.id, { body: draft });
+      onAppended(next);
+      // Pin nothing: the newly appended version is now the latest, so the
+      // follow-the-newest rule lands the reader on exactly what they saved.
+      setSelected(null);
+      stopEditing();
+      onRefresh();
+      toast.success("Saved as a new version — the diff against the agent's draft is below.");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "could not save the edit");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const dirty = editing && draft !== (latest?.body ?? "");
+  const Icon = KIND_ICON[artifact.kind];
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Button variant="ghost" size="sm" className="-ml-2 h-8 px-2" onClick={onBack}>
+          <ArrowLeft className="mr-1.5 size-4" />
+          Artifacts
+        </Button>
+      </div>
+
+      <div className="rounded-xl border bg-card p-4">
+        <div className="flex items-start justify-between gap-3">
+          <h3 className="inline-flex min-w-0 items-center gap-2 text-sm font-semibold">
+            <Icon className="size-4 shrink-0 text-muted-foreground" />
+            <span className="truncate">{artifact.title}</span>
+          </h3>
+          <Badge variant="outline" className="shrink-0 capitalize">
+            {artifact.kind}
+          </Badge>
+        </div>
+        <p className="mt-2 text-[11px] text-muted-foreground">
+          Created {whenOf(artifact.createdAtMillis)} · updated {whenOf(artifact.updatedAtMillis)}
+        </p>
+      </div>
+
+      <VersionRail
+        versions={artifact.versions}
+        shown={shown?.version ?? null}
+        onSelect={(v) => setSelected(v)}
+        disabled={editing}
+      />
+
+      {editing ? (
+        <div className="rounded-xl border bg-card p-3">
+          <p className="mb-2 text-[11px] text-muted-foreground">
+            Saving appends a new version authored by you. The agent's version is never
+            overwritten — that is what keeps the diff answerable later.
+          </p>
+          <Textarea
+            autoFocus
+            value={draft}
+            rows={14}
+            className="font-mono text-xs"
+            disabled={saving}
+            onChange={(e) => setDraft(e.target.value)}
+          />
+          <div className="mt-2 flex items-center gap-2">
+            <Button size="sm" className="h-8" disabled={saving || !dirty} onClick={() => void save()}>
+              {saving && <Loader2 className="mr-1.5 size-3.5 animate-spin" />}
+              Save as new version
+            </Button>
+            {dirty ? (
+              <AlertDialog>
+                <AlertDialogTrigger
+                  render={
+                    <Button variant="ghost" size="sm" className="h-8" disabled={saving}>
+                      Cancel
+                    </Button>
+                  }
+                />
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Discard this edit?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Nothing has been saved yet, so your changes will be lost.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Keep editing</AlertDialogCancel>
+                    <AlertDialogAction
+                      className="bg-destructive text-white hover:bg-destructive/90"
+                      onClick={stopEditing}
+                    >
+                      Discard
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            ) : (
+              <Button variant="ghost" size="sm" className="h-8" disabled={saving} onClick={stopEditing}>
+                Cancel
+              </Button>
+            )}
+          </div>
+        </div>
+      ) : (
+        shown && (
+          <VersionBody
+            artifact={artifact}
+            version={shown}
+            canEdit={editable && shown.version === latest?.version}
+            onEdit={startEditing}
+          />
+        )
+      )}
+
+      {artifact.humanEditDiff && (
+        <DiffPanel
+          title="What the operator changed"
+          note={`v${artifact.humanEditDiff.fromVersion} (agent) → v${artifact.humanEditDiff.toVersion} (operator)`}
+          diff={artifact.humanEditDiff}
+        />
+      )}
+
+      {artifact.versions.length > 1 && (
+        <ComparePanel client={client} company={company} artifact={artifact} />
+      )}
+    </div>
+  );
+}
+
+/** The version browser: who wrote each revision, when, and why. */
+function VersionRail({
+  versions,
+  shown,
+  onSelect,
+  disabled,
+}: {
+  versions: ArtifactVersion[];
+  shown: number | null;
+  onSelect: (version: number) => void;
+  disabled: boolean;
+}) {
+  if (versions.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed py-6 text-center text-xs text-muted-foreground">
+        This artifact has no versions.
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-xl border bg-card/40 p-3">
+      <p className="mb-2 inline-flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        <History className="size-3.5" />
+        Versions
+      </p>
+      <ol className="space-y-1.5">
+        {versions.map((v) => (
+          <li key={v.version}>
+            <button
+              className={cn(
+                "flex w-full items-center gap-2 rounded-lg border bg-card px-2.5 py-1.5 text-left text-xs transition-colors",
+                v.version === shown ? "border-foreground/30 bg-accent" : "hover:bg-accent",
+                disabled && "cursor-not-allowed opacity-60",
+              )}
+              disabled={disabled}
+              onClick={() => onSelect(v.version)}
+            >
+              <span className="shrink-0 font-medium tabular-nums">v{v.version}</span>
+              <Badge
+                variant="outline"
+                className={cn(
+                  "shrink-0 font-normal capitalize",
+                  v.author === "operator" && "border-amber-500/40 text-amber-600 dark:text-amber-400",
+                )}
+              >
+                {v.author}
+              </Badge>
+              <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                {v.note ?? v.authorId}
+              </span>
+              <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+                {whenOf(v.createdAtMillis)}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+/**
+ * One version's content.
+ *
+ * `image` and `file` carry a *reference* — a URL or a workspace path — not
+ * bytes, so they render as the reference plus a caption saying so rather than
+ * pretending to be a preview. Neither is editable: there is no text to edit.
+ */
+function VersionBody({
+  artifact,
+  version,
+  canEdit,
+  onEdit,
+}: {
+  artifact: ArtifactView;
+  version: ArtifactVersion;
+  canEdit: boolean;
+  onEdit: () => void;
+}) {
+  const reference = artifact.kind === "image" || artifact.kind === "file";
+  return (
+    <div className="rounded-xl border bg-card p-3">
+      <div className="mb-2 flex items-center gap-2">
+        <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          v{version.version} · {version.author}
+        </span>
+        {canEdit && (
+          <Button variant="outline" size="sm" className="ml-auto h-7" onClick={onEdit}>
+            <Pencil className="mr-1.5 size-3.5" />
+            Edit as operator
+          </Button>
+        )}
+      </div>
+      {reference ? (
+        <div className="space-y-1">
+          <p className="break-all rounded-lg bg-muted px-2.5 py-2 font-mono text-[11px]">
+            {version.body}
+          </p>
+          <p className="text-[11px] text-muted-foreground">
+            {artifact.kind === "image" ? "An image" : "A file"} reference — the host stores the
+            location, not the bytes.
+          </p>
+        </div>
+      ) : artifact.kind === "markdown" ? (
+        <Markdown className="text-sm">{version.body}</Markdown>
+      ) : (
+        <pre className="whitespace-pre-wrap break-words font-mono text-xs">{version.body}</pre>
+      )}
+    </div>
+  );
+}
+
+/** Compare any two versions — the agent-draft-vs-agent-draft case a re-run creates. */
+function ComparePanel({
+  client,
+  company,
+  artifact,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+  artifact: ArtifactView;
+}) {
+  const numbers = artifact.versions.map((v) => v.version);
+  const [from, setFrom] = useState(() => String(numbers[0]));
+  const [to, setTo] = useState(() => String(numbers[numbers.length - 1]));
+  const [diff, setDiff] = useState<ArtifactDiff | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const same = from === to;
+
+  async function compare() {
+    setBusy(true);
+    try {
+      setDiff(await diffArtifact(client, company, artifact.id, Number(from), Number(to)));
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "could not diff those versions");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const labels = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const v of artifact.versions) out[String(v.version)] = `v${v.version} · ${v.author}`;
+    return out;
+  }, [artifact.versions]);
+
+  return (
+    <div className="rounded-xl border bg-card/40 p-3">
+      <p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        Compare versions
+      </p>
+      <div className="flex flex-wrap items-center gap-2">
+        <Select value={from} onValueChange={(v) => v && setFrom(String(v))} items={labels}>
+          <SelectTrigger className="w-36" size="sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {numbers.map((n) => (
+              <SelectItem key={n} value={String(n)}>
+                {labels[String(n)]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <span className="text-xs text-muted-foreground">→</span>
+        <Select value={to} onValueChange={(v) => v && setTo(String(v))} items={labels}>
+          <SelectTrigger className="w-36" size="sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {numbers.map((n) => (
+              <SelectItem key={n} value={String(n)}>
+                {labels[String(n)]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button size="sm" className="h-7" disabled={busy || same} onClick={() => void compare()}>
+          {busy && <Loader2 className="mr-1.5 size-3.5 animate-spin" />}
+          Compare
+        </Button>
+        {same && <span className="text-[11px] text-muted-foreground">Pick two different versions.</span>}
+      </div>
+      {diff && (
+        <div className="mt-3">
+          <DiffPanel
+            title="Selected comparison"
+            note={`v${diff.fromVersion} → v${diff.toVersion}`}
+            diff={diff}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** A rendered diff: the churn header, then the op-coloured lines. */
+function DiffPanel({ title, note, diff }: { title: string; note: string; diff: ArtifactDiff }) {
+  return (
+    <div className="rounded-xl border bg-card">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b px-3 py-2">
+        <span className="text-xs font-medium">{title}</span>
+        <span className="text-[11px] text-muted-foreground">{note}</span>
+        <span className="ml-auto inline-flex items-center gap-2 text-[11px] tabular-nums">
+          <span className="text-emerald-600 dark:text-emerald-400">+{diff.added}</span>
+          <span className="text-rose-600 dark:text-rose-400">−{diff.removed}</span>
+          <span className="text-muted-foreground">{churnPercent(diff.churn)} churn</span>
+        </span>
+      </div>
+      {diff.lines.length === 0 ? (
+        <p className="px-3 py-3 text-[11px] text-muted-foreground">Both versions are empty.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <pre className="min-w-full py-1 font-mono text-[11px] leading-relaxed">
+            {diff.lines.map((line, i) => (
+              <div
+                key={i}
+                className={cn(
+                  "px-3 whitespace-pre-wrap break-words",
+                  line.op === "insert" && "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+                  line.op === "delete" && "bg-rose-500/10 text-rose-700 dark:text-rose-300",
+                  line.op === "equal" && "text-muted-foreground",
+                )}
+              >
+                <span className="select-none opacity-60">
+                  {line.op === "insert" ? "+" : line.op === "delete" ? "−" : " "}{" "}
+                </span>
+                {line.text}
+              </div>
+            ))}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -1,8 +1,9 @@
 // The Task Detail screen (v1, #184): the epic's capstone read surface. One
 // `GET …/tasks/{id}` (#185/#190) drives a header, the lineage rail, the event
 // timeline, and a controls bar; a 4s visibility-gated poll keeps it live while
-// the card is open. Cost/₹ is intentionally absent everywhere. Several tabs are
-// honest stubs pending their own issues (see the tab bodies).
+// the card is open. Cost/₹ is intentionally absent everywhere. The Artifacts tab is
+// its own self-fetching surface (#306, over #187's routes); Discussion stays an
+// honest stub pending its own backend.
 
 import { useCallback, useEffect, useMemo, useState, type ReactElement } from "react";
 import {
@@ -62,6 +63,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { PRIORITY_STYLES, TASK_COLUMNS } from "@/lib/tasks-sample";
 import { toast } from "sonner";
+import { ArtifactsTab } from "./ArtifactsTab";
 import { AssigneeSelect } from "./AssigneeSelect";
 import { TaskEditDialog } from "./TaskEditDialog";
 
@@ -310,12 +312,7 @@ export function TaskDetailView({
               </TabsContent>
 
               <TabsContent value="artifacts" className="mt-4">
-                {/* TODO(#187): render the task's produced artifacts once the
-                    artifacts read plane exists. No fabricated data until then. */}
-                <EmptyState
-                  title="Artifacts land here"
-                  body="Files and outputs a run produces will show once artifacts ship (#187)."
-                />
+                <ArtifactsTab client={client} company={company} taskId={detail.task.id} />
               </TabsContent>
 
               <TabsContent value="discussion" className="mt-4">


### PR DESCRIPTION
## Summary

Closes #306. Advances #184.

The Task Detail screen's Artifacts tab was a placeholder citing #187 as its blocker. #187 merged — the read plane has been on `main` for weeks: per-task listing, single-artifact read, version append, and a purpose-built diff endpoint. Nothing in the console called any of it, and there was no artifacts API client at all.

So the tab has been claiming to wait on work that already shipped, while real outputs sat unreachable behind it. Every harness-completed task already has an artifact — `record_task_artifact` captures the reply on each success terminal, and the runtime always wires a store.

**This is not a read-only wiring, and that was a deliberate scope call.** The acceptance criterion is "artifact versions show what a human edited" — which needs an *operator* version. Nothing in the system produced one. The append route's server defaults (`author = operator`, note `operator edit before approval`) exist for exactly this purpose and had no caller. So the tab's own edit action is the missing producer, and without it the diff view could only ever be exercised against fixtures.

Worth stating plainly for anyone reading this against #244: folding that in would **not** have satisfied the diff criterion. #244 produces agent artifacts; `human_edit_diff` compares an agent version against an operator one. The two issues are disjoint — different file sets, and #244's added field is additive serde a TypeScript client ignores.

**Not wired, on purpose.** `POST /artifacts` — the producer is the harness, not the console. `DELETE` — #184 states no control on this page may alter or delete a past event.

## API Or Behavior Changes

No wire changes. No backend diff at all — `git diff -- '*.rs' Cargo.toml Cargo.lock` is empty.

Console behaviour:

- The Artifacts tab lists a task's artifacts, with kind, version count and last-updated
- An artifact opens to a version rail carrying author, timestamp and note per version
- The human-edit diff renders by default when present, with churn and per-line ops
- Any two versions can be compared, which covers agent-draft-vs-agent-draft after a re-run
- `text` and `markdown` artifacts can be edited as operator, appending a new version
- `image` and `file` render their reference with a caption — no edit, no diff
- The empty state is truthful and producer-neutral; it cites no merged issue

Version provenance is read from each version's own `author`, never inferred from its index — a harness re-run appends further *agent* versions to the same record, so an index assumption would mislabel them.

## Tests

- [x] `npm ci`
- [x] `npm run typecheck`
- [x] `npm run build`
- N/A: `npm run lint` — no lint script exists in `frontend/package.json`
- N/A: component tests — no frontend unit-test runner exists in this repo

Rust was run as pure regression proof of the zero-line Rust diff: `cargo fmt --all -- --check` clean, `cargo test --features openhuman,tinycortex --lib` 1606 passed / 0 failed / 1 ignored.

**Verified live against real produced output, not fixtures** — the host built with `--features openhuman,mcp,telegram`, serving the built console, isolated with `--home`, against a scripted OpenAI-compatible endpoint. Only the model's choices were scripted; `HarnessBrain`, the dispatch lifecycle, `record_task_artifact` and the fs artifact store all ran for real. Driven end to end in a browser.

- A dispatched card reached `in_review` and its artifact appeared in the tab — `text`, v1 `author: agent`, body the agent's own draft. Nothing seeded.
- Editing v1 in the tab and saving rendered `v1 (agent) → v2 (operator) · +1 −3 · 43% churn`. The assertions read those numbers from the REST response rather than hardcoding them, so the panel is proven to render the host's arithmetic rather than its own.
- `GET /artifacts/{id}` afterwards confirmed v2 persisted with `author: operator` and note `operator edit before approval` — the server default landed precisely because the client omits `author`.
- Dispatching twice produced v1 and v2 both `agent`, **no** `humanEditDiff`, and the pair compare returned `v1 → v2 · +1 −1 · 13% churn`.
- Editor safety: a dirty editor survives two poll cycles intact; cancelling confirms first, and discarding appends no version.
- Lazy mount: zero `/artifacts` requests before the tab is opened, and polling stops on leaving it.

## Documentation

No doc changes. This adds no route, no config and no wire field — it calls endpoints already documented in the artifacts module header.

**One race, real and accepted.** If an agent re-runs while the operator has the editor open, the save lands after the new agent version, so `humanEditDiff` then anchors on a draft the operator never edited. It needs a redispatch during an open editor, versions stay immutable so provenance is intact, and it is not fixable client-side — the append route carries no if-match precondition. Polling pauses during an edit, which narrows the window without closing it. Worth a precondition on the append route if it ever bites.

**One thing the plan got wrong, corrected here.** The plan assumed Radix; this console is Base UI. The conclusion held — `Tabs.Panel` unmounts when inactive, confirmed empirically — so the self-fetching design is right and no controlled-tabs refactor was needed.
