### PR TITLE
feat(tasks): split worked from waiting time and render waiting to scale (#305)

### DIFF
--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -83,6 +83,15 @@ export interface TimelineEntry {
   label: string;
   /** Optional scrubbed detail; expands under the row when present. */
   detail?: string;
+  /**
+   * On an `approval` entry: how long the company sat waiting on the operator
+   * before this resolution landed (#305), clamped to the run window.
+   *
+   * Absent — never `0` — when the host cannot recover the park instant, so the
+   * console degrades to rendering the row with no waiting band rather than
+   * claiming an instant sign-off that never happened.
+   */
+  waitedMillis?: number;
 }
 
 /** A neighbouring card in the lineage, trimmed to what a link needs (#185). */
@@ -108,6 +117,15 @@ export interface TaskDetail {
   timeline: TimelineEntry[];
   /** Parent and children. */
   lineage: TaskLineage;
+  /**
+   * Epoch-millis this task started waiting on an operator *right now* (#305),
+   * or absent when nothing is currently parked for its run.
+   *
+   * A still-parked approval has no resolution event yet, so it cannot reach the
+   * timeline — this is the only signal that the task is idle on a human at this
+   * moment, which is the state the screen exists to expose.
+   */
+  waitingSince?: number;
 }
 
 /**

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -17,6 +17,7 @@ import {
   CornerDownRight,
   CornerUpLeft,
   CornerUpRight,
+  Hourglass,
   Loader2,
   MessageSquare,
   MessagesSquare,
@@ -101,6 +102,68 @@ function workedMillis(timeline: TimelineEntry[], now: number): { millis: number;
   const live = openAt !== null;
   if (openAt !== null) total += Math.max(0, now - openAt);
   return { millis: total, live };
+}
+
+/**
+ * The task's waiting-on-a-human spans, merged and summed (#305).
+ *
+ * Each resolved approval carries `waitedMillis` — the host's exact park→resolve
+ * span, already clamped to the run window — so a span is reconstructed as
+ * `[atMillis - waitedMillis, atMillis]` rather than inferred from gaps between
+ * rows. A still-parked approval has no resolution event yet, so the live wait
+ * arrives separately as `waitingSince` and runs to `now`.
+ *
+ * Spans are interval-merged before summing. Two approvals can be parked at once
+ * — the company is waiting *once* over that overlap, not twice — and without
+ * the merge the waiting figure could exceed the elapsed time it is subtracted
+ * from, which would read as a bug to anyone doing the arithmetic.
+ */
+function waitingMillis(
+  timeline: TimelineEntry[],
+  waitingSince: number | undefined,
+  now: number,
+): { millis: number; live: boolean } {
+  const spans: Array<[number, number]> = [];
+  for (const e of timeline) {
+    if (e.kind !== "approval") continue;
+    const waited = e.waitedMillis;
+    // `undefined` means the host could not recover the park instant; `0` is a
+    // real (instant) sign-off. Neither contributes a span.
+    if (waited === undefined || waited <= 0) continue;
+    spans.push([e.atMillis - waited, e.atMillis]);
+  }
+  const live = waitingSince !== undefined;
+  if (waitingSince !== undefined) spans.push([waitingSince, Math.max(waitingSince, now)]);
+
+  spans.sort((a, b) => a[0] - b[0]);
+  let total = 0;
+  let cursor: [number, number] | null = null;
+  for (const span of spans) {
+    if (cursor && span[0] <= cursor[1]) {
+      cursor[1] = Math.max(cursor[1], span[1]);
+    } else {
+      if (cursor) total += cursor[1] - cursor[0];
+      cursor = [span[0], span[1]];
+    }
+  }
+  if (cursor) total += cursor[1] - cursor[0];
+  return { millis: Math.max(0, total), live };
+}
+
+/**
+ * The pixel height of a waiting band for a span of `millis` (#305).
+ *
+ * Sub-linear on purpose. The point of the band is that a four-hour wait and a
+ * four-second wait must not look alike, but a linear scale makes the short one
+ * invisible and the long one taller than the screen. A log curve with a floor
+ * and a cap keeps both on the page: ~14px at four seconds, ~112px at four
+ * hours. Past the cap the printed duration inside the band carries the
+ * precision the height no longer can.
+ */
+export function waitingBandHeight(millis: number): number {
+  const minutes = Math.max(0, millis) / 60_000;
+  const raw = 12 + 26 * Math.log2(1 + minutes);
+  return Math.round(Math.min(112, Math.max(12, raw)));
 }
 
 /** `1h 04m 09s` / `4m 09s` / `9s`. */
@@ -224,15 +287,21 @@ export function TaskDetailView({
     () => (detail ? workedMillis(detail.timeline, now) : null),
     [detail, now],
   );
+  const waiting = useMemo(
+    () => (detail ? waitingMillis(detail.timeline, detail.waitingSince, now) : null),
+    [detail, now],
+  );
 
-  // Only tick the 1s clock while a dispatch window is open (worked is live).
+  // Only tick the 1s clock while something is actually running: a dispatch
+  // window is open, or the task is parked on an operator right now.
+  const ticking = Boolean(worked?.live) || Boolean(waiting?.live);
   useEffect(() => {
-    if (!worked?.live) return;
+    if (!ticking) return;
     const timer = window.setInterval(() => {
       if (document.visibilityState !== "hidden") setNow(Date.now());
     }, 1000);
     return () => window.clearInterval(timer);
-  }, [worked?.live]);
+  }, [ticking]);
 
   if (notFound) {
     return (
@@ -276,7 +345,7 @@ export function TaskDetailView({
       ) : detail ? (
         <ScrollArea className="min-h-0 flex-1">
           <div className="mx-auto w-full max-w-3xl space-y-5 p-4">
-            <DetailHeader task={detail.task} worked={worked} />
+            <DetailHeader task={detail.task} worked={worked} waiting={waiting} />
 
             <ControlBar
               task={detail.task}
@@ -304,7 +373,11 @@ export function TaskDetailView({
               </TabsList>
 
               <TabsContent value="timeline" className="mt-4">
-                <TimelineList entries={detail.timeline} />
+                <TimelineList
+                  entries={detail.timeline}
+                  waitingSince={detail.waitingSince}
+                  now={now}
+                />
               </TabsContent>
 
               <TabsContent value="approvals" className="mt-4">
@@ -350,11 +423,22 @@ export function TaskDetailView({
 function DetailHeader({
   task,
   worked,
+  waiting,
 }: {
   task: Task;
   worked: { millis: number; live: boolean } | null;
+  waiting: { millis: number; live: boolean } | null;
 }) {
   const hasDispatch = worked !== null && (worked.millis > 0 || worked.live);
+  // `worked` is the whole elapsed run window; waiting sits *inside* it, so
+  // working time is the remainder. Clamped at zero because the two figures come
+  // from different sources (event log vs journal join) and a clock skew between
+  // them must never render a negative duration.
+  const waitedMs = waiting?.millis ?? 0;
+  const workingMs = Math.max(0, (worked?.millis ?? 0) - waitedMs);
+  // The acceptance line: a task that never waited shows no waiting figure at
+  // all, not a "Waiting 0s".
+  const showWaiting = waitedMs > 0 || Boolean(waiting?.live);
   return (
     <div className="rounded-xl border bg-card p-4">
       <div className="flex items-start justify-between gap-3">
@@ -390,7 +474,7 @@ function DetailHeader({
           {hasDispatch ? (
             <>
               <span className="font-medium text-foreground">
-                Worked {formatDuration(worked!.millis)}
+                Worked {formatDuration(workingMs)}
               </span>
               {worked!.live && (
                 <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
@@ -403,6 +487,20 @@ function DetailHeader({
             <span>Not yet dispatched</span>
           )}
         </span>
+        {showWaiting && (
+          <span className="inline-flex items-center gap-1.5">
+            <Hourglass className="size-3.5 text-amber-600 dark:text-amber-400" />
+            <span className="font-medium text-amber-700 dark:text-amber-400">
+              Waiting {formatDuration(waitedMs)}
+            </span>
+            {waiting!.live && (
+              <span className="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400">
+                <span className="size-1.5 animate-pulse rounded-full bg-current" aria-hidden />
+                on you
+              </span>
+            )}
+          </span>
+        )}
       </div>
 
       {task.note && (
@@ -411,12 +509,16 @@ function DetailHeader({
         </p>
       )}
 
-      {/* Deferred (#172): the working-vs-waiting split needs the park instant a
-          real park effect records. Until then we show only worked time — never
-          a waiting figure fabricated from timeline gaps. */}
-      <p className="mt-2 text-[11px] text-muted-foreground/70">
-        Waiting time appears when parking lands (#172).
-      </p>
+      {/* Each waiting span itself is exact — a real park instant to a real
+          resolution. What stays approximate is which task an approval belonged
+          to: parked effects carry no task id, so they are correlated to the run
+          window. Said plainly rather than left for a reader to discover. */}
+      {showWaiting && (
+        <p className="mt-2 text-[11px] text-muted-foreground/70">
+          Waiting is correlated to this task&rsquo;s run window — approvals are not linked
+          per-task.
+        </p>
+      )}
     </div>
   );
 }
@@ -727,10 +829,31 @@ interface TimelineGroup {
 }
 
 /**
+ * One item in the rendered timeline: an event row, or a waiting band (#305).
+ *
+ * The band is not an event — nothing is journaled while the company waits — so
+ * it cannot be a `TimelineGroup`. Making the list a union keeps the band's
+ * variable height out of the row renderer entirely.
+ */
+type TimelineItem =
+  | { row: "group"; key: string; group: TimelineGroup }
+  | { row: "wait"; key: string; millis: number; live: boolean };
+
+/**
  * Folds a timeline into rows, coalescing consecutive same-label `tool_failed`
  * entries into one `×N` row. Every other kind is its own row.
+ *
+ * Waiting bands (#305) are spliced in *before* the approval row that ended the
+ * wait — the band is the pause that led to the decision, so it reads in that
+ * order — and a live band is appended at the foot when the task is parked on an
+ * operator right now. Approvals are never coalesced, so no band can land inside
+ * a `×N` group.
  */
-function groupTimeline(entries: TimelineEntry[]): TimelineGroup[] {
+function groupTimeline(
+  entries: TimelineEntry[],
+  waitingSince?: number,
+  now: number = Date.now(),
+): TimelineItem[] {
   const groups: TimelineGroup[] = [];
   for (const e of entries) {
     const last = groups[groups.length - 1];
@@ -741,7 +864,26 @@ function groupTimeline(entries: TimelineEntry[]): TimelineGroup[] {
       groups.push({ key: String(e.seq), kind: e.kind, label: e.label, count: 1, entries: [e] });
     }
   }
-  return groups;
+
+  const items: TimelineItem[] = [];
+  for (const g of groups) {
+    const waited = g.kind === "approval" ? g.entries[0].waitedMillis : undefined;
+    if (waited !== undefined && waited > 0) {
+      // `wait-` prefixed so a band can never collide with a row key, which is
+      // the bare sequence number.
+      items.push({ row: "wait", key: `wait-${g.entries[0].seq}`, millis: waited, live: false });
+    }
+    items.push({ row: "group", key: g.key, group: g });
+  }
+  if (waitingSince !== undefined) {
+    items.push({
+      row: "wait",
+      key: "wait-live",
+      millis: Math.max(0, now - waitingSince),
+      live: true,
+    });
+  }
+  return items;
 }
 
 const KIND_ICON: Record<TimelineKind, ReactElement> = {
@@ -765,9 +907,20 @@ function kindTone(kind: TimelineKind): string {
   }
 }
 
-function TimelineList({ entries }: { entries: TimelineEntry[] }) {
-  const groups = useMemo(() => groupTimeline(entries), [entries]);
-  if (groups.length === 0) {
+function TimelineList({
+  entries,
+  waitingSince,
+  now,
+}: {
+  entries: TimelineEntry[];
+  waitingSince?: number;
+  now: number;
+}) {
+  const items = useMemo(
+    () => groupTimeline(entries, waitingSince, now),
+    [entries, waitingSince, now],
+  );
+  if (items.length === 0) {
     return (
       <EmptyState
         title="Nothing has happened yet"
@@ -777,10 +930,45 @@ function TimelineList({ entries }: { entries: TimelineEntry[] }) {
   }
   return (
     <ol className="space-y-1.5">
-      {groups.map((g) => (
-        <TimelineRow key={g.key} group={g} />
-      ))}
+      {items.map((item) =>
+        item.row === "wait" ? (
+          <WaitingBand key={item.key} millis={item.millis} live={item.live} />
+        ) : (
+          <TimelineRow key={item.key} group={item.group} />
+        ),
+      )}
     </ol>
+  );
+}
+
+/**
+ * A waiting period, rendered as space rather than as another uniform row (#305).
+ *
+ * This is the acceptance criterion the timeline exists for: a four-hour wait and
+ * a four-second wait must not look alike. The height carries the comparison at a
+ * glance; the printed duration carries the exact figure, including past the
+ * point the height saturates.
+ */
+function WaitingBand({ millis, live }: { millis: number; live: boolean }) {
+  // Height is quantised to the 4s poll while the band is live, so a 1s text tick
+  // does not relayout the list underneath the reader's cursor every second.
+  const height = waitingBandHeight(live ? Math.round(millis / 4000) * 4000 : millis);
+  return (
+    <li
+      className={cn(
+        "flex items-center justify-center gap-1.5 rounded-lg border border-dashed",
+        "border-amber-400/60 bg-amber-50/60 text-[11px] text-amber-700",
+        "dark:border-amber-500/40 dark:bg-amber-950/20 dark:text-amber-400",
+        live && "animate-pulse",
+      )}
+      style={{ minHeight: height }}
+      aria-label={`Waiting on a human for ${formatDuration(millis)}`}
+    >
+      <Hourglass className="size-3.5 shrink-0" aria-hidden />
+      <span className="font-medium tabular-nums">
+        {live ? `Waiting on you · ${formatDuration(millis)}` : `Waited ${formatDuration(millis)}`}
+      </span>
+    </li>
   );
 }
 
@@ -850,8 +1038,8 @@ function ApprovalsTab({ entries }: { entries: TimelineEntry[] }) {
     <div className="space-y-3">
       <p className="text-xs text-muted-foreground">
         Approvals resolved <span className="font-medium text-foreground">during this run</span> —
-        correlated to the dispatch window, not linked per-task. The full approvals ledger arrives
-        with #172.
+        correlated to the dispatch window, not linked per-task. Each wait is measured from the
+        moment the effect actually parked.
       </p>
       {approvals.length === 0 ? (
         <EmptyState
@@ -867,6 +1055,11 @@ function ApprovalsTab({ entries }: { entries: TimelineEntry[] }) {
             >
               <ShieldCheck className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
               <span className="min-w-0 flex-1 truncate font-medium">{e.label}</span>
+              {e.waitedMillis !== undefined && (
+                <span className="shrink-0 text-[11px] tabular-nums text-amber-700 dark:text-amber-400">
+                  waited {formatDuration(e.waitedMillis)}
+                </span>
+              )}
               <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
                 {timeOf(e.atMillis)}
               </span>

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -22,7 +22,7 @@ use crate::feedback::store::FeedbackStore;
 use crate::feedback::types::{FeedbackInput, FeedbackItem, FeedbackSummary};
 use crate::policy::ManifestApprovalGate;
 use crate::ports::now_millis;
-use crate::ports::types::{Actor, ApprovalId, CompanyEvent, CompanyId, Verdict};
+use crate::ports::types::{Actor, ActorKind, ApprovalId, CompanyEvent, CompanyId, Verdict};
 use crate::ports::{
     AgentEconomy, ApprovalGate, ArtifactStore, Brain, ChannelAdapter, CompanyStore, ContextStore,
     EventLog, FactStore, InboxStore, LoginCodeStore, MemoryStore, SecretStore, SessionStore,
@@ -479,11 +479,41 @@ impl CompanyRuntime {
     /// Sweeps every parked approval past its TTL, resolving each to a
     /// default-deny and writing an `ApprovalExpired` audit entry to the journal.
     /// Returns the ids that expired. Driven by the runtime's maintenance timer.
+    ///
+    /// Each expiry also appends a `ApprovalResolved { verdict: Deny }` event
+    /// attributed to the system. Expiry *is* a resolution — a default-deny on
+    /// silence — but before this it wrote only the journal record, so a wait
+    /// that ended in a timeout produced no event at all and was invisible to
+    /// every event-log reader, including the task timeline (issue #305). The
+    /// append is best-effort for the same reason steer's audit is: a sweep that
+    /// already denied the effect must not be undone by a log write, and the
+    /// journal remains the binding audit trail either way.
     pub async fn sweep_expired_approvals(&self) -> Result<Vec<ApprovalId>> {
         let now = now_millis();
         let expired = self.approval_gate.sweep_expired(now);
         for id in &expired {
             self.journal.record_expired(id, now).await?;
+            if let Err(e) = self
+                .events
+                .append(
+                    &self.id,
+                    CompanyEvent::ApprovalResolved {
+                        approval_id: id.clone(),
+                        verdict: Verdict::Deny,
+                        by: Actor {
+                            kind: ActorKind::System,
+                            id: "expiry".into(),
+                        },
+                    },
+                )
+                .await
+            {
+                tracing::warn!(
+                    approval_id = %id,
+                    error = %e,
+                    "approval expiry journaled but its event-log entry failed",
+                );
+            }
         }
         Ok(expired)
     }
@@ -491,6 +521,18 @@ impl CompanyRuntime {
     /// Replays the journal to rebuild the executed-key set and approval queue.
     pub async fn recover(&self) -> Result<()> {
         self.journal.load().await
+    }
+
+    /// When each approval was parked, keyed by id, including approvals already
+    /// resolved or expired.
+    ///
+    /// The Task Detail read joins this against the event log's
+    /// `ApprovalResolved` to recover how long the company was waiting on an
+    /// operator (issue #305). Delegates to the journal so the `pub(crate)`
+    /// field stays encapsulated, mirroring
+    /// [`pending_approvals`](Self::pending_approvals).
+    pub fn approval_park_instants(&self) -> std::collections::HashMap<ApprovalId, u64> {
+        self.journal.park_instants()
     }
 
     /// The approvals currently awaiting the operator.

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -91,6 +91,16 @@ pub struct PendingApproval {
 struct State {
     executed: HashSet<String>,
     parked: HashMap<ApprovalId, (Effect, u64)>,
+    /// When each approval was *parked*, retained after it leaves `parked`.
+    ///
+    /// This is what makes waiting time readable (issue #305). The park instant
+    /// is journal-only — [`CompanyEvent::ApprovalResolved`](crate::ports::CompanyEvent::ApprovalResolved)
+    /// carries the resolution but no park time — so a resolved approval's wait
+    /// is only recoverable by joining the two on [`ApprovalId`]. Entries are
+    /// therefore **never removed** on resolve or expiry: the index has the same
+    /// append-only lifetime as the file it is replayed from, and costs one
+    /// `(id, u64)` per approval ever parked.
+    park_instants: HashMap<ApprovalId, u64>,
 }
 
 /// A per-company append-only journal backing at-most-once effects and the
@@ -141,6 +151,7 @@ impl RuntimeJournal {
                     effect,
                     at_millis,
                 } => {
+                    state.park_instants.insert(id.clone(), at_millis);
                     state.parked.insert(id, (effect, at_millis));
                 }
                 JournalRecord::ApprovalResolved { id } => {
@@ -189,11 +200,11 @@ impl RuntimeJournal {
         effect: &Effect,
         at_millis: u64,
     ) -> Result<()> {
-        self.state
-            .lock()
-            .expect("journal state poisoned")
-            .parked
-            .insert(id.clone(), (effect.clone(), at_millis));
+        {
+            let mut state = self.state.lock().expect("journal state poisoned");
+            state.park_instants.insert(id.clone(), at_millis);
+            state.parked.insert(id.clone(), (effect.clone(), at_millis));
+        }
         self.append(&JournalRecord::ApprovalParked {
             id: id.clone(),
             effect: effect.clone(),
@@ -244,6 +255,22 @@ impl RuntimeJournal {
             at_millis,
         })
         .await
+    }
+
+    /// A snapshot of when each approval was parked, keyed by [`ApprovalId`],
+    /// including approvals that have since been resolved or expired.
+    ///
+    /// The read side joins this against the event log's
+    /// [`ApprovalResolved`](crate::ports::CompanyEvent::ApprovalResolved) to
+    /// recover how long an approval was actually waiting (issue #305). Taken as
+    /// one snapshot per request rather than per lookup, so a fold never holds
+    /// the state lock while it works.
+    pub fn park_instants(&self) -> HashMap<ApprovalId, u64> {
+        self.state
+            .lock()
+            .expect("journal state poisoned")
+            .park_instants
+            .clone()
     }
 
     /// A snapshot of the currently parked approvals, oldest first.
@@ -440,6 +467,50 @@ mod test {
         let raw = tokio::fs::read_to_string(&path).await.unwrap();
         assert!(raw.contains("ApprovalAmended"));
         assert!(raw.contains("\"edited\":true"));
+    }
+
+    /// Issue #305: the park instant outlives the parked entry.
+    ///
+    /// Waiting time is only recoverable by joining a resolved approval back to
+    /// when it parked, and the event log carries no park time. If the index were
+    /// cleared alongside `parked` on resolve — the obvious symmetry — every
+    /// *finished* wait would be unreadable, which is exactly the case the header
+    /// needs. Expiry (the default-deny path) must retain it for the same reason.
+    #[tokio::test]
+    async fn park_instants_outlive_resolution_and_expiry_and_survive_reload() {
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
+        let journal = RuntimeJournal::new(&path);
+
+        let resolved = ApprovalId::new("appr-resolved");
+        let expired = ApprovalId::new("appr-expired");
+        journal
+            .record_parked(&resolved, &effect(), 1_000)
+            .await
+            .unwrap();
+        journal
+            .record_parked(&expired, &effect(), 2_000)
+            .await
+            .unwrap();
+
+        journal.record_resolved(&resolved).await.unwrap();
+        journal.record_expired(&expired, 9_000).await.unwrap();
+
+        // Both left the queue...
+        assert!(journal.pending().is_empty());
+        // ...but their park instants are still joinable.
+        let instants = journal.park_instants();
+        assert_eq!(instants.get(&resolved), Some(&1_000));
+        assert_eq!(instants.get(&expired), Some(&2_000));
+
+        // And a restart replays them out of the file, so history predating this
+        // process is readable too.
+        let reloaded = RuntimeJournal::new(&path);
+        reloaded.load().await.unwrap();
+        let instants = reloaded.park_instants();
+        assert!(reloaded.pending().is_empty());
+        assert_eq!(instants.get(&resolved), Some(&1_000));
+        assert_eq!(instants.get(&expired), Some(&2_000));
     }
 
     #[test]

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -412,6 +412,21 @@ struct TimelineEntry {
     /// Optional scrubbed detail (see the type docs for what may appear here).
     #[serde(skip_serializing_if = "Option::is_none")]
     detail: Option<String>,
+    /// For an `approval` entry: how long the company sat waiting on the
+    /// operator before this resolution landed (issue #305).
+    ///
+    /// Recovered by joining the resolution's `approval_id` against the runtime
+    /// journal's park instants — the park time is journal-only, so the event log
+    /// alone cannot answer it. Omitted, rather than zeroed, when the park
+    /// instant is unknown (an approval parked by a build older than the index):
+    /// the console then renders the row exactly as it did before, and a wait is
+    /// never fabricated from a gap between timeline rows.
+    ///
+    /// Clamped to the run window's opening, so an approval that was already
+    /// parked when this task was dispatched charges only the part of its wait
+    /// that overlapped this run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    waited_millis: Option<u64>,
 }
 
 /// A neighbouring card in the lineage, trimmed to what a link needs.
@@ -454,6 +469,16 @@ struct TaskDetail {
     timeline: Vec<TimelineEntry>,
     /// Parent and children.
     lineage: Lineage,
+    /// Epoch-millis the company started waiting on an operator *right now*
+    /// (issue #305), or `None` when nothing is currently parked for this run.
+    ///
+    /// This is the live half of the working-vs-waiting split: a still-open
+    /// approval has no `ApprovalResolved` event yet, so it cannot appear as a
+    /// timeline entry, yet it is precisely the state an operator opening this
+    /// screen most needs to see. Set only while the run window is open, and
+    /// only from approvals parked at or after the window opened.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    waiting_since: Option<u64>,
 }
 
 /// `GET …/tasks/{task_id}` — the Task Detail screen's single read (issue #185).
@@ -503,12 +528,28 @@ async fn task_detail(
     children.sort_by_key(|t| t.updated_at_millis);
     let children = children.into_iter().map(LineageRef::from).collect();
 
-    let timeline = task_timeline(&company, &task_id).await?;
+    let (timeline, open_window_at) = task_timeline(&company, &task_id).await?;
+
+    // The live wait (issue #305). Only meaningful while a run window is open —
+    // a parked approval on a finished task belongs to whatever runs next, not to
+    // this one — and only for approvals parked at or after the window opened, so
+    // a pre-existing park is not re-attributed to this dispatch. Earliest wins:
+    // waiting started when the first of them parked.
+    let waiting_since = open_window_at.and_then(|opened_at| {
+        company
+            .runtime
+            .pending_approvals()
+            .into_iter()
+            .map(|a| a.at_millis)
+            .filter(|at| *at >= opened_at)
+            .min()
+    });
 
     Ok(Json(TaskDetail {
         task: card.into(),
         timeline,
         lineage: Lineage { parent, children },
+        waiting_since,
     }))
 }
 
@@ -533,14 +574,22 @@ const TIMELINE_PAGE: usize = 512;
 /// which is worse than the cost it saves. Bounding the page size gives the
 /// memory win without that correctness loss; a stored per-task dispatch offset
 /// is the durable fix for the traversal cost and is left to the epic.
+///
+/// Returns the timeline alongside the instant the *still-open* window opened,
+/// or `None` when the task is not mid-run — the caller needs that anchor to
+/// scope the live wait (issue #305).
 async fn task_timeline(
     company: &ScopedCompany,
     task_id: &str,
-) -> Result<Vec<TimelineEntry>, ApiError> {
+) -> Result<(Vec<TimelineEntry>, Option<u64>), ApiError> {
     use crate::ports::types::EventSeq;
 
+    // One snapshot for the whole fold, not a lookup per event: the fold is a
+    // pure function over it, and the journal lock is never held while paging.
+    let park_instants = company.runtime.approval_park_instants();
+
     let mut timeline = Vec::new();
-    let mut window_open = false;
+    let mut window_opened_at: Option<u64> = None;
     let mut next_seq = 0u64;
     loop {
         let page = company
@@ -559,27 +608,41 @@ async fn task_timeline(
             .map(|ev| ev.seq.value() + 1)
             .unwrap_or(next_seq + 1);
         let exhausted = page.len() < TIMELINE_PAGE;
-        fold_page(&page, task_id, &mut window_open, &mut timeline);
+        fold_page(
+            &page,
+            task_id,
+            &park_instants,
+            &mut window_opened_at,
+            &mut timeline,
+        );
         if exhausted {
             break;
         }
     }
-    Ok(timeline)
+    Ok((timeline, window_opened_at))
 }
 
 /// Folds one page of journal events onto `timeline`, carrying the window state
 /// across pages.
+///
+/// `window_opened_at` is both the window flag and its anchor: `Some(at)` while
+/// a dispatch is open, `None` once it closes. `park_instants` is the journal
+/// snapshot the approval arm joins against to recover waiting time (#305);
+/// keeping it a parameter leaves this a pure function of its inputs.
 fn fold_page(
     page: &[crate::ports::types::StoredEvent],
     task_id: &str,
-    window_open: &mut bool,
+    park_instants: &std::collections::HashMap<crate::ports::types::ApprovalId, u64>,
+    window_opened_at: &mut Option<u64>,
     timeline: &mut Vec<TimelineEntry>,
 ) {
+    use crate::ports::types::ActorKind;
+
     for ev in page {
         let entry = match &ev.event {
             CompanyEvent::TaskDispatched { task_id: id } if id == task_id => {
-                *window_open = true;
-                Some(("dispatched", "Dispatched".to_string(), None))
+                *window_opened_at = Some(ev.at_millis);
+                Some(("dispatched", "Dispatched".to_string(), None, None))
             }
             CompanyEvent::AgentReply {
                 agent_id,
@@ -590,6 +653,7 @@ fn fold_page(
                 "reply",
                 format!("Reply from {agent_id}"),
                 Some(text.clone()),
+                None,
             )),
             CompanyEvent::McpCallFailed {
                 server,
@@ -601,6 +665,7 @@ fn fold_page(
                 "tool_failed",
                 format!("{server} · {tool} failed"),
                 Some(message.clone()),
+                None,
             )),
             CompanyEvent::DeskTaskCompleted {
                 task_id: id,
@@ -608,33 +673,55 @@ fn fold_page(
                 output,
                 column,
             } if id == task_id => {
-                *window_open = false;
+                *window_opened_at = None;
                 Some((
                     "completed",
                     format!("Finished on {desk} → {column}"),
                     Some(output.clone()),
+                    None,
                 ))
             }
             // Window-correlated, not id-correlated — see `task_detail`'s docs.
             // The operator's identity is deliberately dropped: it can carry a
             // user id, matching the SSE projection's deny-by-default stance.
-            CompanyEvent::ApprovalResolved { verdict, .. } if *window_open => Some((
-                "approval",
-                format!(
-                    "Approval {}",
-                    crate::brain::medulla::effects::verdict_word(*verdict)
-                ),
-                None,
-            )),
+            // Only `by.kind` is read, which names a category and never a person.
+            CompanyEvent::ApprovalResolved {
+                approval_id,
+                verdict,
+                by,
+            } if window_opened_at.is_some() => {
+                // The approval id joins the resolution back to the journal's
+                // park instant. Clamping to the window's opening keeps a wait
+                // that began before this task was dispatched from charging its
+                // pre-dispatch portion to this run.
+                let waited = park_instants.get(approval_id).map(|parked_at| {
+                    let from =
+                        window_opened_at.map_or(*parked_at, |opened| (*parked_at).max(opened));
+                    ev.at_millis.saturating_sub(from)
+                });
+                // A system actor here is the TTL sweep, not a person: expiry
+                // resolves to a default-deny, and saying "Approval denied" for
+                // it would read as though somebody looked at it and said no.
+                let label = if by.kind == ActorKind::System {
+                    "Approval expired (auto-denied)".to_string()
+                } else {
+                    format!(
+                        "Approval {}",
+                        crate::brain::medulla::effects::verdict_word(*verdict)
+                    )
+                };
+                Some(("approval", label, None, waited))
+            }
             _ => None,
         };
-        if let Some((kind, label, detail)) = entry {
+        if let Some((kind, label, detail, waited_millis)) = entry {
             timeline.push(TimelineEntry {
                 seq: ev.seq.value(),
                 at_millis: ev.at_millis,
                 kind: kind.to_string(),
                 label,
                 detail,
+                waited_millis,
             });
         }
     }

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -3050,6 +3050,362 @@ async fn task_timeline_scopes_approvals_to_the_run_window() {
     assert!(!raw.contains("u-1"), "operator identity leaked: {raw}");
 }
 
+// ── Issue #305: working time vs waiting-on-a-human time ──────────────────────
+//
+// The split is a *read-time join*: the park instant lives only in the runtime
+// journal (`ApprovalParked`), the resolution only in the event log
+// (`ApprovalResolved`), and `approval_id` is the single key shared by both.
+// These tests pin that join, its window clamp, and the two ways a wait can end
+// (an operator decided, or the TTL swept it) — plus the negative case, which is
+// an acceptance criterion in its own right: a task that never waited must
+// report no waiting figure at all rather than a zero.
+
+/// Parks an approval in the journal and seeds a card + its dispatch anchor.
+/// Returns `(runtime, dispatched_at_millis)`.
+async fn dispatched_task(
+    state: &AppState,
+    company: &CompanyId,
+) -> (std::sync::Arc<crate::CompanyRuntime>, u64) {
+    use crate::ports::types::CompanyEvent;
+
+    let runtime = state.registry().get(company).unwrap();
+    runtime
+        .tasks()
+        .upsert(
+            company,
+            &TaskRecord {
+                id: "t-1".into(),
+                title: "Ship it".into(),
+                note: None,
+                column: "in_progress".into(),
+                priority: "medium".into(),
+                assignee: "ceo".into(),
+                updated_at_millis: 1,
+                origin_chat_id: None,
+                parent_task_id: None,
+            },
+        )
+        .await
+        .unwrap();
+    runtime
+        .events()
+        .append(
+            company,
+            CompanyEvent::TaskDispatched {
+                task_id: "t-1".into(),
+            },
+        )
+        .await
+        .unwrap();
+    let dispatched_at = runtime
+        .events()
+        .read_from(company, crate::ports::types::EventSeq::new(0), 64)
+        .await
+        .unwrap()
+        .last()
+        .unwrap()
+        .at_millis;
+    (runtime, dispatched_at)
+}
+
+/// A parked effect to journal. Its content is irrelevant to the join — only the
+/// id and the instant matter.
+fn parked_effect() -> crate::ports::types::Effect {
+    use crate::ports::types::{Effect, EffectGroup};
+    Effect {
+        kind: "filing.submit".into(),
+        group: EffectGroup::Sign,
+        amount_usd: None,
+        established_thread: false,
+        first_time_counterparty: false,
+        payload: serde_json::Value::Null,
+    }
+}
+
+/// Pulls the single `approval` row out of a task-detail body.
+fn only_approval(body: &Value) -> Value {
+    let rows: Vec<Value> = body["timeline"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|e| e["kind"] == "approval")
+        .cloned()
+        .collect();
+    assert_eq!(rows.len(), 1, "expected exactly one approval row: {rows:?}");
+    rows[0].clone()
+}
+
+/// **The acceptance test** (#305): an approval that parked and later resolved
+/// reports the wait it actually caused.
+///
+/// Before this, `ApprovalResolved` carried a verdict and an actor but no park
+/// time, so the console could only show one undifferentiated elapsed figure — a
+/// task idle all day on a human looked exactly like one busy all day. The
+/// assertion is exact arithmetic against the observed event timestamps, not a
+/// tolerance: the whole value of the number is that it is not an estimate.
+#[tokio::test]
+async fn task_timeline_reports_the_wait_an_approval_actually_caused() {
+    use crate::ports::types::{Actor, ActorKind, ApprovalId, CompanyEvent, Verdict};
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let company = CompanyId::new("acme");
+    let (runtime, dispatched_at) = dispatched_task(&state, &company).await;
+
+    // Parked 40ms into the run. The sleep only guarantees the resolution lands
+    // strictly after the park; the assertion below derives the expected span
+    // from the real timestamps rather than from the sleep's duration.
+    let id = ApprovalId::new("appr-1");
+    let parked_at = dispatched_at + 40;
+    runtime
+        .journal
+        .record_parked(&id, &parked_effect(), parked_at)
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    // Both halves of a real resolution: the journal drops it from the parked
+    // queue *and* the event log gains the resolution. Doing only the latter
+    // would leave the task reading as still waiting — the assertion at the end
+    // of this test is what pins the pair together.
+    runtime.journal.record_resolved(&id).await.unwrap();
+    runtime
+        .events()
+        .append(
+            &company,
+            CompanyEvent::ApprovalResolved {
+                approval_id: id.clone(),
+                verdict: Verdict::Approve,
+                by: Actor {
+                    kind: ActorKind::User,
+                    id: "u-1".into(),
+                },
+            },
+        )
+        .await
+        .unwrap();
+
+    let (status, body) = send(&state, "GET", "/api/v1/company/tasks/t-1", None).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let approval = only_approval(&body);
+    let resolved_at = approval["atMillis"].as_u64().unwrap();
+    assert!(
+        resolved_at > parked_at,
+        "the sleep did not outlast the park"
+    );
+    assert_eq!(
+        approval["waitedMillis"].as_u64().unwrap(),
+        resolved_at - parked_at,
+        "the wait must be the real park→resolve span, not an inference",
+    );
+    assert_eq!(approval["label"], "Approval approved");
+
+    // The join must not become a new identity leak: it reads `approval_id` and
+    // `by.kind`, never `by.id`.
+    let raw = serde_json::to_string(&body["timeline"]).unwrap();
+    assert!(!raw.contains("u-1"), "operator identity leaked: {raw}");
+
+    // The wait is over, so nothing is pending: no live figure.
+    assert!(
+        body.get("waitingSince").is_none(),
+        "a resolved approval must not leave the task reading as still waiting",
+    );
+}
+
+/// A wait that ended in a TTL sweep is still a wait, and must not read as a
+/// human decision.
+///
+/// Expiry used to write *only* a journal record, so a default-deny-on-silence
+/// produced no event at all — the single case where waiting is most costly was
+/// the one case the timeline could not see. The sweep now also appends a
+/// system-attributed `ApprovalResolved`, and the read side labels it as an
+/// expiry: rendering "Approval denied" would claim somebody looked at it.
+#[tokio::test]
+async fn expired_approval_is_labelled_as_an_expiry_and_carries_its_wait() {
+    use crate::ports::types::ApprovalId;
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let company = CompanyId::new("acme");
+    let (runtime, dispatched_at) = dispatched_task(&state, &company).await;
+
+    let id = ApprovalId::new("appr-stale");
+    let parked_at = dispatched_at + 40;
+    runtime
+        .journal
+        .record_parked(&id, &parked_effect(), parked_at)
+        .await
+        .unwrap();
+    // Re-park into the gate at epoch 0 so it is unambiguously past any TTL.
+    runtime
+        .approval_gate
+        .rehydrate(id.clone(), parked_effect(), 0);
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    let expired = runtime.sweep_expired_approvals().await.unwrap();
+    assert_eq!(expired, vec![id]);
+
+    let (status, body) = send(&state, "GET", "/api/v1/company/tasks/t-1", None).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let approval = only_approval(&body);
+    assert_eq!(
+        approval["label"], "Approval expired (auto-denied)",
+        "an expiry must not read as though a human decided",
+    );
+    let resolved_at = approval["atMillis"].as_u64().unwrap();
+    assert_eq!(
+        approval["waitedMillis"].as_u64().unwrap(),
+        resolved_at - parked_at,
+        "an expired approval's wait is the span nobody answered in",
+    );
+}
+
+/// An approval already parked when the task was dispatched charges this run only
+/// for the part of its wait that overlapped the run.
+///
+/// Approvals carry no task id, so they are correlated to the dispatch window.
+/// Without the clamp, an effect parked hours before this card was dispatched
+/// would dump its whole backlog wait onto this task's header — a figure larger
+/// than the task's own elapsed time, which is visibly wrong.
+#[tokio::test]
+async fn a_wait_that_began_before_dispatch_is_clamped_to_the_run_window() {
+    use crate::ports::types::{Actor, ActorKind, ApprovalId, CompanyEvent, Verdict};
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let company = CompanyId::new("acme");
+    let (runtime, dispatched_at) = dispatched_task(&state, &company).await;
+
+    // Parked a full hour before this task was ever dispatched.
+    let id = ApprovalId::new("appr-old");
+    runtime
+        .journal
+        .record_parked(&id, &parked_effect(), dispatched_at - 3_600_000)
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    runtime.journal.record_resolved(&id).await.unwrap();
+    runtime
+        .events()
+        .append(
+            &company,
+            CompanyEvent::ApprovalResolved {
+                approval_id: id,
+                verdict: Verdict::Deny,
+                by: Actor {
+                    kind: ActorKind::Operator,
+                    id: "owner".into(),
+                },
+            },
+        )
+        .await
+        .unwrap();
+
+    let (_, body) = send(&state, "GET", "/api/v1/company/tasks/t-1", None).await;
+    let approval = only_approval(&body);
+    let resolved_at = approval["atMillis"].as_u64().unwrap();
+    let waited = approval["waitedMillis"].as_u64().unwrap();
+    assert_eq!(
+        waited,
+        resolved_at - dispatched_at,
+        "the pre-dispatch hour must not be charged to this run",
+    );
+    assert!(waited < 3_600_000, "the clamp did not apply: {waited}");
+    assert_eq!(approval["label"], "Approval denied");
+}
+
+/// A task parked on an operator *right now* reports it, even though no
+/// resolution event exists yet.
+///
+/// This is the state the screen most needs to surface — "your agent is stopped,
+/// waiting on you" — and it is invisible in the event log by construction: the
+/// approval has not been resolved, so nothing has been appended. It comes from
+/// the still-pending queue instead, scoped to the open run window.
+#[tokio::test]
+async fn a_currently_parked_approval_surfaces_as_a_live_wait() {
+    use crate::ports::types::ApprovalId;
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let company = CompanyId::new("acme");
+    let (runtime, dispatched_at) = dispatched_task(&state, &company).await;
+
+    let parked_at = dispatched_at + 10;
+    runtime
+        .journal
+        .record_parked(&ApprovalId::new("appr-live"), &parked_effect(), parked_at)
+        .await
+        .unwrap();
+
+    let (status, body) = send(&state, "GET", "/api/v1/company/tasks/t-1", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["waitingSince"].as_u64().unwrap(),
+        parked_at,
+        "the live wait must start at the park instant",
+    );
+    // Nothing resolved, so nothing reached the timeline.
+    assert!(
+        body["timeline"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|e| e["kind"] != "approval"),
+        "an unresolved approval must not fake a timeline row",
+    );
+}
+
+/// A task that never waited reports no waiting at all — not a zero.
+///
+/// Both fields are `skip_serializing_if = "Option::is_none"`, so their absence
+/// is what lets the console omit the figure entirely. If either were serialized
+/// as `0`, every task on the board would grow a permanent "Waiting 0s", which
+/// the issue calls out by name.
+#[tokio::test]
+async fn a_task_that_never_waited_reports_no_waiting_fields() {
+    use crate::ports::types::CompanyEvent;
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let company = CompanyId::new("acme");
+    let (runtime, _) = dispatched_task(&state, &company).await;
+
+    runtime
+        .events()
+        .append(
+            &company,
+            CompanyEvent::DeskTaskCompleted {
+                task_id: "t-1".into(),
+                desk: "ceo".into(),
+                output: "shipped".into(),
+                column: "in_review".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let (status, body) = send(&state, "GET", "/api/v1/company/tasks/t-1", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body.get("waitingSince").is_none(),
+        "a task with nothing parked must not report a live wait",
+    );
+    for entry in body["timeline"].as_array().unwrap() {
+        assert!(
+            entry.get("waitedMillis").is_none(),
+            "a non-approval row must never carry a wait: {entry:?}",
+        );
+    }
+}
+
 /// #185 review follow-up: the lineage forest is enforced at the write boundary.
 ///
 /// Without this a card could be its own parent (appearing as both parent and


### PR DESCRIPTION
## Summary

Closes #305. Advances #184.

The Task Detail header showed one elapsed figure and a placeholder deferring to #172. #172 merged on 30 July, so that text had stopped describing a blocker and started hiding unfinished work — while the screen still could not answer the question it exists to answer: was this task slow because the agent was busy, or because it sat waiting on us?

Two things stood between the header and that answer.

**The park instant was unreachable.** It lives only as a private `JournalRecord::ApprovalParked` in the approvals journal, while the task timeline folds the event log — whose `ApprovalResolved` carries neither a park timestamp nor a task id.

**Expired approvals were invisible everywhere.** When an approval timed out to a default-deny, the sweep wrote a journal record and no event at all. A task could park for hours, expire, and every downstream read would show it as though nothing happened. That is fixed here as a prerequisite, not a side effect.

The join is done at read time on the approval id, rather than promoting parking onto the event log. Promotion would contradict the journal module's documented design — parking markers deliberately do not ride the event log — change the wire and SSE surface, and cover no historical data. Threading a task id onto the approval record instead needs task context through brain → gate → journal record shape, which the epic already deferred. The read-time join covers all history for free, because journal replay rebuilds the park index at boot.

## API Or Behavior Changes

Additive only. No new route, no removed field, no enum variant.

- `TimelineEntry` gains `waitedMillis?: number` — how long an approval sat parked before it resolved
- `TaskDetail` gains `waitingSince?: number` — the live "waiting right now" instant, set only while a run window is open
- An expired approval now appends `ApprovalResolved { verdict: Deny, by: System }` to the event log, best-effort: a failure logs and never fails the sweep
- The timeline labels those "Approval expired (auto-denied)"

Console:

- The header reports worked and waiting as separate figures. Waiting is **omitted entirely when zero** — never rendered as `0s`
- Waiting ticks live while an approval is parked
- The timeline inserts amber waiting bands before their approval rows, with height scaled sublinearly so a 4-second wait stays visible and a 4-hour one stays readable, the exact duration printed inside

**Known limit, stated plainly.** Approvals are correlated to a task by time window, not by task id — pre-existing, and documented in the code and the Approvals tab copy. The measured span is always exact (real park to real resolve); only the attribution is heuristic, so two tasks overlapping in time could misattribute one. Guarded three ways: the span is clamped to the window so a pre-dispatch park cannot charge time to this task, overlapping spans are interval-merged so waiting can never exceed wall clock, and the header carries a visible caveat. Exact per-task linkage stays an epic-level follow-up.

Historical behaviour is honest in both directions: past *resolved* approvals do get spans, because replay rebuilds the index; past *expired* ones stay invisible, since no event row exists to backfill. A lost or rotated journal degrades to today's display — never to a wrong number.

## Tests

- [x] `cargo fmt --all --check`
- [x] `cargo test --features openhuman,tinycortex --lib` — **1612 passed, 0 failed, 1 ignored**
- [x] `cargo clippy --features openhuman,tinycortex --no-deps -- -D warnings` — 0 errors
- [x] `cargo check --all-features` — 0 errors
- [x] `npm ci` / `npm run typecheck` / `npm run build`
- N/A: frontend unit tests — no test runner exists in `frontend/`

Six new backend tests: park-instant retention across resolution and reload, the parked→resolved split, the expiry label and span, the pre-window-park clamp, live `waitingSince`, and no-waiting → fields absent.

Note on clippy: `--all-targets -- -D warnings` lints vendored crates and fails on two pre-existing `large_enum_variant` errors in `vendor/tinyagents`. CI uses `--no-deps` for the featured run; that is the form run here.

**Verified live** against the real host with an isolated `--home` bundle, real magic-link auth and real routes:

- A never-waiting task returned **no `waitingSince` key and no `waitedMillis`** — the acceptance criterion checked at the wire, not as a rendered zero
- A parked approval survived a restart: boot replay rehydrated it into both the journal and the gate, and `waitingSince` came back as the exact park instant. Observed ticking 83s → 87s → 90s
- Resolving through the real `POST /approvals/{id}` produced `waitedMillis: 93145` — exactly resolve minus park — and `waitingSince` disappeared
- Proportionality was checked by running the shipped view module against the live payload: header `Worked 8m 56s` + `Waiting 42m 18s` summing to the `51m 14s` elapsed window, with bands at `4s → 14px`, `40m → 112px`, live `2m 14s → 56px`, each inserted before its approval row

**What the live run does not cover:** a brain-produced park. `dispatch_task` is a compile-time no-op without the `openhuman` harness, which needs an inference credential — the epic's documented prerequisite. The park was seeded into the bundle instead, which still exercises real boot replay, the real resolve route and the real read join; what it does not exercise is the brain emitting the supervised effect, which is #172's unchanged code.

## Documentation

No doc changes — every `#172` deferral reference is deleted rather than rewritten, including the Approvals tab copy.

Two things found while implementing, recorded for whoever hits them next:

- Two of my own tests were unfaithful: they appended `ApprovalResolved` to the event log without calling `journal.record_resolved`, which the real resolve path does. One failed loudly, the other passed only because it did not assert on the field. Both now write both halves — the production code was correct, the tests were wrong.
- `git submodule update --init --recursive --force` does **not** land on the pins; it left five nested submodules on branch heads. A second `--recursive --force --checkout` pass fixed them. One pass builds green and lies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task details now show total worked time alongside approval waiting periods.
  * Live waiting status is displayed for tasks paused for approval.
  * Timelines include visual waiting periods and measured approval wait durations.
  * Historical and currently pending approval waits are reported, including waits ending through expiry.
* **Bug Fixes**
  * Waiting times are accurately bounded to the task’s active run period and preserved after approval resolution or expiry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->