### PR TITLE
ci: compile the test target under --all-features, fixing two E0034s in sqlite.rs (#288)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,11 +174,21 @@ jobs:
 
       # Catches the combination traps no single feature set can: most often a
       # mandatory struct field constructed differently across feature arms.
-      # CHECK-ONLY BY DESIGN — `--all-features` also enables the storage
-      # backends, whose test target does not currently compile (#288), so this
-      # step must not be widened to `--all-targets` or to `cargo test`.
+      #
+      # `--all-targets` is LOAD-BEARING (issue #288). Without it this step
+      # checks the lib and bins only, so test code behind a storage feature is
+      # compiled by NOTHING in CI: the default `rust` job runs `cargo test`
+      # without `sqlite`, and the gated steps above pin `openhuman,tinycortex`.
+      # That gap let two `E0034`s in `src/store/sqlite.rs`'s own tests sit on
+      # `main` unseen — a green check is only evidence for the surface it
+      # actually compiles.
+      #
+      # CHECK-ONLY BY DESIGN — compiling every target is not running any of
+      # them. This step must never become `cargo test`: `--all-features` also
+      # enables `mcp`, which changes what an agent's tool belt *contains*, and
+      # that contract is pinned by the dedicated narrow step below.
       - name: Check (--all-features)
-        run: cargo check --locked --all-features
+        run: cargo check --locked --all-features --all-targets
 
       # The tool belt the SHIPPED tenant image actually builds (issue #297).
       #

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1985,7 +1985,12 @@ mod test {
 
         // The legacy row survives the migration and reports an *unknown* store
         // time — not the epoch, and not a misleading "migrated just now".
-        let metas = store.list(&id, "").await.expect("list after migration");
+        // Fully qualified: `SqliteStore` implements both `ContextStore::list`
+        // and `CompanyStore::list`, and method resolution matches on the name
+        // alone — arity does not disambiguate, so the bare call is `E0034`.
+        let metas = ContextStore::list(&store, &id, "")
+            .await
+            .expect("list after migration");
         assert_eq!(metas.len(), 1, "the legacy row must not be dropped");
         assert_eq!(metas[0].label, "agent/ceo");
         assert_eq!(
@@ -2006,7 +2011,9 @@ mod test {
             .await
             .expect("put into a migrated database");
 
-        let metas = store.list(&id, "").await.expect("list after put");
+        let metas = ContextStore::list(&store, &id, "")
+            .await
+            .expect("list after put");
         assert_eq!(metas.len(), 2);
         let fresh = metas
             .iter()


### PR DESCRIPTION
## Summary

Closes #288.

`cargo check --all-features --all-targets` fails on `main` with two `E0034`s in `src/store/sqlite.rs`'s own tests. Nothing in CI compiles that combination, so the break sat on the default branch unnoticed.

`SqliteStore` implements two traits that each expose a `list`: `ContextStore::list(&self, &CompanyId, &str)` and `CompanyStore::list(&self)`. Rust resolves methods by name before arity, so a bare `store.list(&id, "")` is ambiguous. The file is behind `#[cfg(feature = "sqlite")]`, and the intersection that would catch this — the test target *plus* a storage feature — is compiled by no job: the default `rust` job runs `cargo test` without `sqlite`, and the gated steps pin `openhuman,tinycortex`.

Same shape as #202 and #281. A green check is only evidence for the surface it actually compiles.

**The CI half is the part that matters.** The step's own comment currently forbids widening *and cites #288 as the reason* — so fixing the call sites without rewriting that comment would leave a false prohibition on `main`. Both move together here.

**Commit order is the proof.** `ci:` lands first, alone: the widened job goes red with exactly the two `E0034`s, which is issue #288's "reintroduce the ambiguity and watch CI fail" acceptance criterion satisfied without a deliberately-broken commit ever reaching a mainline. `fix(store):` then turns it green. The failing run is linked in a comment below.

## API Or Behavior Changes

None. Both edits are in `#[cfg(test)]` code, and the disambiguation is not a judgment call — the results are consumed as `ChunkMeta` (`.label`, `.stored_at_millis`), and `CompanyStore::list` takes no arguments and returns `CompanySummary`, so the alternative would not typecheck.

Worth stating precisely: the call never resolved *anywhere* today — every feature set that compiles this file's test target fails — so equivalence rests on typechecking, not on "matches what default features chose".

CI: the `Check (--all-features)` step gains `--all-targets`. That means **compile**, not run. The step must still never become `cargo test`, because `--all-features` also enables `mcp`, which changes what an agent's tool belt contains; that contract stays pinned by the narrow step below it. The rewritten comment keeps that half and drops only the now-false clause.

## Tests

- [x] `cargo check --all-features --all-targets` — clean to completion, which is also the check for further latent errors behind the two that were stopping the target. None surfaced.
- [x] `cargo test --locked --features sqlite --lib store::sqlite` — 21 passed. Proves the disambiguated calls still pass at runtime, not merely compile.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked` — 1111 passed, 0 failed, 1 ignored (+6)
- [x] `git diff Cargo.lock` empty after every run — `--all-targets` changes which targets build, not dependency resolution, so `--locked` survives the widening
- N/A: frontend — no console surface is touched by this change

No sibling widening is owed. The gated `Build`/`Clippy` steps already pass `--all-targets`; the gated `Test` steps' `--lib` is load-bearing by design (the only other runnable target dials a real inference backend); and the default job compiles its test target by running it. The all-features × test-target intersection was the only uncovered surface.

One local trap worth recording for the next person: on a worktree, `git submodule update --init --recursive --force` fails to recurse into `vendor/openhuman` and silently leaves `vendor/tinyagents` empty, so cargo dies at manifest resolution before any of this is reachable. It needs a targeted `--init --force vendor/tinyagents` pass.

## Documentation

No doc changes. The CI comment *is* the documentation being corrected — it is rewritten in the same commit that invalidates it, rather than left to rot naming an issue that is now closed.
