### PR TITLE
refactor(console): drop Inbox, Desks, Brain and Finances from the sidebar (#302)

### DIFF
--- a/frontend/ARCHITECTURE.md
+++ b/frontend/ARCHITECTURE.md
@@ -103,9 +103,17 @@ it. Responses mirror the TypeScript models in `src/lib/*` and `src/api/types.ts`
   desks from `[[group_chat]]` and page their history; send uses the `chat`
   endpoint. Desk-scoped routing of replies is single-responder in v1 (the full
   desk-member handler is WS3).
+- **Console:** the Desks management screen (`src/views/DesksView.tsx`) is no
+  longer listed in the sidebar as of issue #302 — hidden, not retired. The
+  `/desks` routes and store are unchanged and this thread list still builds from
+  real desks; desk management is manifest-only until a hierarchy/org-tree
+  successor lands.
 
 ### Inbox — `src/views/InboxView.tsx`, `src/api/inbox.ts`
 - Per-agent email inbox; enabled via a Team toggle.
+- **Console:** not listed in the sidebar as of issue #302 — hidden, not retired.
+  Every endpoint below is unchanged and still serving; only the operator entry
+  point is gone. The Team toggle that enables an inbox stays where it was.
 - **Source:** ✅ real — `client.listInboxes()` (`GET …/inboxes`) lists every inbox
   with its unread count and `client.inboxMessages()`
   (`GET …/inboxes/{key}/messages`) reads one teammate's mail, both
@@ -141,8 +149,11 @@ it. Responses mirror the TypeScript models in `src/lib/*` and `src/api/types.ts`
   `PATCH`/`DELETE …/workspace/{id}`. New companies seed from
   `companies/<name>/workspace/**` on first use.
 
-### Memory — `src/views/MemoryView.tsx`, `src/lib/memory.ts`
+### Memory (Brain) — `src/views/MemoryView.tsx`, `src/lib/memory.ts`
 - Durable facts (fact/preference/person/project/reference); search + add/delete.
+- **Console:** not listed in the sidebar as of issue #302 — hidden, not retired.
+  The endpoints below are unchanged and agents keep reading and writing memory;
+  only the operator-facing Brain tab is gone.
 - **Source:** ✅ real — `Company.memory` (GraphQL, `FactStore`-backed, with
   query/kind filters); `POST …/memory` adds and `DELETE …/memory/{id}` deletes
   (deletion journals `MemoryFactDeleted` to the EventLog).
@@ -162,6 +173,9 @@ it. Responses mirror the TypeScript models in `src/lib/*` and `src/api/types.ts`
 
 ### Finances — `src/views/FinancesView.tsx`, `src/lib/finance-sample.ts`
 - Wallet balance, revenue, spend vs budget, spend-by-category, transactions.
+- **Console:** not listed in the sidebar as of issue #302 — hidden, not retired.
+  The `Company.finances` projection below is unchanged; only the operator entry
+  point is gone.
 - **Source:** ✅ real — `Company.finances` (GraphQL) projects the ledger +
   `[budget]` + optional economy wallet balance (balance, budget vs spend,
   revenue, byCategory, transactions). **Caveat:** the inference-cost component

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -1,15 +1,12 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import {
-  Brain,
   ChartColumnBig,
   FolderClosed,
   Flag,
-  Inbox,
   LayoutDashboard,
   type LucideIcon,
   MessageSquareWarning,
   MessagesSquare,
-  PanelsTopLeft,
   Plug,
   Settings2,
   ShieldCheck,
@@ -17,7 +14,6 @@ import {
   SquareKanban,
   UserCog,
   Users,
-  Wallet,
   Workflow,
 } from "lucide-react";
 
@@ -60,11 +56,8 @@ import { Conversation } from "@/views/Conversation";
 import { ApprovalsView } from "@/views/ApprovalsView";
 import { TasksView } from "@/views/TasksView";
 import { TeamView } from "@/views/TeamView";
-import { DesksView } from "@/views/DesksView";
 import { PeopleView } from "@/views/PeopleView";
 import { SkillsView } from "@/views/SkillsView";
-import { InboxView } from "@/views/InboxView";
-import { MemoryView } from "@/views/MemoryView";
 import { ConnectionsView } from "@/views/ConnectionsView";
 import { SettingsView } from "@/views/SettingsView";
 import { FeedbackView } from "@/views/FeedbackView";
@@ -79,26 +72,22 @@ const WorkspaceView = lazy(() =>
 );
 // Recharts is heavy — load the usage dashboard on demand.
 const UsageView = lazy(() => import("@/views/UsageView").then((m) => ({ default: m.UsageView })));
-// Also Recharts-backed — load on demand.
-const FinancesView = lazy(() =>
-  import("@/views/FinancesView").then((m) => ({ default: m.FinancesView })),
-);
 
+// Issue #302: Inbox, Desks, Brain and Finances are hidden from the console, not
+// retired. Their host routes, stores and tests are untouched — only the
+// operator-facing entry points are gone, so re-listing a view here is all it
+// takes to bring one back. The view components stay in `src/views/`.
 export type View =
   | "overview"
   | "people"
   | "conversation"
-  | "inbox"
   | "tasks"
   | "team"
-  | "desks"
   | "skills"
   | "workspace"
-  | "memory"
   | "approvals"
   | "workflows"
   | "usage"
-  | "finances"
   | "connections"
   | "settings"
   | "feedback";
@@ -120,13 +109,10 @@ const NAV: NavGroup[] = [
     items: [
       { view: "overview", label: "Overview", icon: LayoutDashboard },
       { view: "conversation", label: "Conversation", icon: MessagesSquare },
-      { view: "inbox", label: "Inbox", icon: Inbox },
       { view: "tasks", label: "Tasks", icon: SquareKanban },
       { view: "team", label: "Team", icon: Users },
-      { view: "desks", label: "Desks", icon: PanelsTopLeft },
       { view: "skills", label: "Skills", icon: Sparkles },
       { view: "workspace", label: "Workspace", icon: FolderClosed },
-      { view: "memory", label: "Brain", icon: Brain },
       { view: "approvals", label: "Approvals", icon: ShieldCheck },
       { view: "workflows", label: "Workflows", icon: Workflow },
     ],
@@ -135,7 +121,6 @@ const NAV: NavGroup[] = [
     label: "Configure",
     items: [
       { view: "usage", label: "Usage", icon: ChartColumnBig },
-      { view: "finances", label: "Finances", icon: Wallet },
       { view: "connections", label: "Connections", icon: Plug },
       { view: "people", label: "People", icon: UserCog },
       { view: "settings", label: "Settings", icon: Settings2 },
@@ -150,17 +135,13 @@ const NAV: NavGroup[] = [
 const TITLES: Record<View, string> = {
   overview: "Overview",
   conversation: "Conversation",
-  inbox: "Inbox",
   tasks: "Tasks",
   team: "Team",
-  desks: "Desks",
   skills: "Skills",
   workspace: "Workspace",
-  memory: "Brain",
   approvals: "Approvals",
   workflows: "Workflows",
   usage: "Usage",
-  finances: "Finances",
   connections: "Connections",
   people: "People",
   settings: "Settings",
@@ -551,7 +532,6 @@ export function AppShell({
               onSendEnd={onSendEnd}
             />
           )}
-          {view === "inbox" && <InboxView client={client} company={company} />}
           {view === "tasks" && (
             <TasksView
               client={client}
@@ -566,10 +546,8 @@ export function AppShell({
             />
           )}
           {view === "team" && <TeamView client={client} company={company} />}
-          {view === "desks" && <DesksView client={client} company={company} />}
           {view === "people" && <PeopleView client={client} company={company} />}
           {view === "skills" && <SkillsView client={client} company={company} />}
-          {view === "memory" && <MemoryView client={client} company={company} />}
           {view === "workspace" && (
             <Suspense
               fallback={
@@ -614,17 +592,6 @@ export function AppShell({
               }
             >
               <UsageView client={client} company={company} />
-            </Suspense>
-          )}
-          {view === "finances" && (
-            <Suspense
-              fallback={
-                <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
-                  Loading finances…
-                </div>
-              }
-            >
-              <FinancesView client={client} company={company} />
             </Suspense>
           )}
           {view === "connections" && <ConnectionsView client={client} company={company} />}

--- a/frontend/src/hooks/use-hash-view.ts
+++ b/frontend/src/hooks/use-hash-view.ts
@@ -22,18 +22,38 @@ export function useHashView<T extends string>(
 
   const [view, setView] = useState<T>(resolve);
 
-  // Reflect the initial view into the URL if it arrived without a hash.
+  /**
+   * Rewrite the URL so it names the view actually on screen. An empty hash and
+   * an unknown one (`#/finances` after a surface is retired, a typo, a stale
+   * bookmark) both resolve to `fallback`, and without this the address bar
+   * keeps claiming a view that isn't rendered.
+   *
+   * Replace semantics, never push: pushing leaves the unknown hash in the
+   * history stack, so Back returns to it, this rewrite bounces forward again,
+   * and the operator is stuck in a ping-pong they cannot Back out of.
+   */
+  const canonicalize = useCallback((next: T) => {
+    if (readHash() === next) return;
+    window.history.replaceState(null, "", `#/${next}`);
+  }, []);
+
+  // Reflect the resolved view into the URL when the page arrived with no hash
+  // or an unrecognized one.
   useEffect(() => {
-    if (!readHash()) window.location.replace(`#/${view}`);
+    canonicalize(view);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Follow browser back/forward and manual hash edits.
   useEffect(() => {
-    const onHash = () => setView(resolve());
+    const onHash = () => {
+      const next = resolve();
+      setView(next);
+      canonicalize(next);
+    };
     window.addEventListener("hashchange", onHash);
     return () => window.removeEventListener("hashchange", onHash);
-  }, [resolve]);
+  }, [resolve, canonicalize]);
 
   const navigate = useCallback((next: T) => {
     if (readHash() !== next) window.location.hash = `/${next}`;

--- a/frontend/src/tour/steps.ts
+++ b/frontend/src/tour/steps.ts
@@ -51,13 +51,6 @@ export const TOUR: TourStop[] = [
     body: "The agents that actually do the work. Each has a role and the tools to match.",
   },
   {
-    view: "desks",
-    target: '[data-tour="nav-desks"]',
-    placement: "right",
-    title: "Desks",
-    body: "Teammates group into desks by function — Engineering, Support, and so on. Work routed to a desk goes to its lead. Spin up your own with New desk anytime.",
-  },
-  {
     view: "workflows",
     target: '[data-tour="nav-workflows"]',
     placement: "right",

--- a/frontend/src/views/DesksView.tsx
+++ b/frontend/src/views/DesksView.tsx
@@ -1,3 +1,9 @@
+// Issue #302: unmounted from the console — hidden, not retired. Desk
+// management is manifest-driven for now, pending a hierarchy/org-tree
+// successor; the host's `/desks` routes, store and tests are unchanged, and
+// Conversation still builds its threads from real desks. Re-listing "desks" in
+// `app-shell.tsx`'s `View`/`NAV` brings this surface back. Do not delete it as
+// dead code.
 import { useCallback, useEffect, useState } from "react";
 import { ChevronDown, ChevronUp, Crown, Plus, Trash2, Users, X } from "lucide-react";
 

--- a/frontend/src/views/FinancesView.tsx
+++ b/frontend/src/views/FinancesView.tsx
@@ -1,3 +1,7 @@
+// Issue #302: unmounted from the console — hidden, not retired. The host's
+// finances routes, economy state and tests are unchanged; re-listing "finances"
+// in `app-shell.tsx`'s `View`/`NAV` (behind a `lazy()` import, as it was)
+// brings this surface back. Do not delete it as dead code.
 import { useEffect, useState } from "react";
 import { Bar, BarChart, LabelList, XAxis, YAxis } from "recharts";
 import { ArrowDownLeft, ArrowUpRight, Coins, PiggyBank, TrendingUp, Wallet } from "lucide-react";

--- a/frontend/src/views/InboxView.tsx
+++ b/frontend/src/views/InboxView.tsx
@@ -1,3 +1,7 @@
+// Issue #302: unmounted from the console — hidden, not retired. The host's
+// inbox routes, per-agent store and tests are unchanged; re-listing "inbox" in
+// `app-shell.tsx`'s `View`/`NAV` brings this surface straight back. Do not
+// delete it as dead code.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowLeft, Inbox as InboxIcon, Mail, Send } from "lucide-react";
 

--- a/frontend/src/views/MemoryView.tsx
+++ b/frontend/src/views/MemoryView.tsx
@@ -1,3 +1,8 @@
+// Issue #302: unmounted from the console — hidden, not retired. The host's
+// `/memory` routes, FactStore and tests are unchanged, and agents keep reading
+// and writing memory; only the operator-facing Brain tab is gone. Re-listing
+// "memory" in `app-shell.tsx`'s `View`/`NAV` brings it back. Do not delete it
+// as dead code.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Brain, Loader2, Plus, Search, Trash2 } from "lucide-react";
 import { toast } from "sonner";

--- a/frontend/test/e2e/inbox.spec.ts
+++ b/frontend/test/e2e/inbox.spec.ts
@@ -16,6 +16,12 @@ import { expect, test } from "@playwright/test";
  *      the real empty state instead of invented correspondence.
  *
  * Runs against the same live host as `wiring.spec.ts` (see that file's header).
+ *
+ * Parked by issue #302: the console no longer lists Inbox, so `/#/inbox` now
+ * canonicalizes to Overview and the assertions below cannot run. The host's
+ * inbox routes and per-agent store are unchanged, so the #173 guarantee still
+ * holds — this stays here verbatim to be un-skipped the day the surface is
+ * relisted, rather than deleted and rewritten from memory.
  */
 
 /** All four senders the deleted fixture invented for every teammate. */
@@ -28,7 +34,7 @@ const FIXTURE_SENDERS = ["Priya Sharma", "Stripe", "Weekly Digest", "Figma"];
  */
 const FIXTURE_SUBJECTS = ["Re: Spring campaign timeline"];
 
-test("Inbox reads the host's per-agent store, not a seeded fixture", async ({ page }) => {
+test.skip("Inbox reads the host's per-agent store, not a seeded fixture", async ({ page }) => {
   // Switch on the first teammate's inbox from the Team page. The toggle writes
   // to the host keyed by agent id — the same key the ingest webhook files under.
   await page.goto("/#/team");

--- a/frontend/test/e2e/wiring.spec.ts
+++ b/frontend/test/e2e/wiring.spec.ts
@@ -39,7 +39,14 @@ test("operator console renders a mocked backend reply end to end", async ({
   await expect(page.getByText(/^Couldn't send/)).toHaveCount(0);
 });
 
-test("operator adds a Brain memory that persists across reload and can be deleted", async ({
+/**
+ * Parked by issue #302: the console no longer lists Brain, so `/#/memory` now
+ * canonicalizes to Overview and the assertions below cannot run. The host's
+ * `/memory` routes and FactStore are unchanged — this stays here verbatim to be
+ * un-skipped the day the surface is relisted, rather than deleted and rewritten
+ * from memory.
+ */
+test.skip("operator adds a Brain memory that persists across reload and can be deleted", async ({
   page,
 }) => {
   // The Brain tab reads the real FactStore over `…/memory`; adding a note must


### PR DESCRIPTION
## Summary

Closes #302. Part of the MVP spec epic #183 §2.

Removes four surfaces from the console sidebar — **Inbox, Desks, Brain and Finances** — and makes an unknown URL hash canonicalise to the fallback view instead of silently rendering Overview under a lying address bar.

**All four are hidden, not retired.** Every backend route, store and test stays exactly where it was. `git diff --name-only main..HEAD | grep '^src/'` returns nothing, and that empty result is the acceptance receipt, not a claim.

Two things about the issue as written, both settled with the maintainer before any code:

- **"Routes must 404 or redirect" rests on a false premise.** Views live in `location.hash`, and a URL fragment is never transmitted, so the host physically cannot see `#/finances` — let alone 404 it. Redirect is the only mechanism available short of converting the console to a path router. That is what ships, and it is the honest option here: for all four the capability is hidden rather than gone, so "the door is closed" is the correct message.
- **The literal "sidebar shows only Workspace and Team Desks" is shorthand.** Taken at face value it would also strand Conversation, Tasks, Team, Skills, Approvals, Workflows, Usage, Connections, People and Feedback — and epic #183 §5's own criterion requires Workflows to stay reachable, so the spec contradicts itself in the same document. Confirmed reading: remove exactly the four named.

The desk consequence is real and deliberate: **desk creation and membership editing become unreachable**, because those dialogs are console-only. Desks are manifest-editable from here. #311 tracks the successor — an org hierarchy tree, per the roadmap's Desks→nodes-on-the-org-chart mapping — rather than a restored flat Desks page.

## API Or Behavior Changes

No API change. No route added, changed or removed on the host.

Console:

- The sidebar renders Overview · Conversation · Tasks · Team · Skills · Workspace · Approvals · Workflows (Operate) · Usage · Connections · People · Settings (Configure) · Feedback (Support). No group is left empty.
- `#/inbox`, `#/desks`, `#/memory` and `#/finances` now resolve to `#/overview` **and rewrite the address bar to match**. Previously the pane fell back while the URL kept claiming the old view.
- The rewrite uses **replace** semantics, not push. Push would produce a back-button ping-pong — bounce to Overview, press Back, land on the dead hash, bounce again, forever. Verified by sampling the hash at 50/200/500/1000/1500 ms after Back on all four: `#/overview` every time, no motion.
- The fix is generic rather than four hard-coded rules, so it also repairs `#/mcp` — already orphaned on `main` — and every future removal.

A user sitting on a removed route when this ships keeps working: they hold the old bundle, and there is no service worker or version handshake. On their next reload they land on Overview with the URL corrected. One pre-existing sharp edge, unchanged by this PR: `FinancesView` was lazily loaded, so an old-bundle session that triggers that chunk after a redeploy gets a Suspense rejection on a hashed file that no longer exists. That is true of every deploy of this console today (Workflows, Workspace, Usage all behave the same); noted, not introduced.

**Removed vs hidden, per surface** — backend routes, tests and stores are untouched in all four cases:

| Surface | Console component | Consequence |
|---|---|---|
| Inbox | kept, unwired | The Team view's inbox toggle survives, so an operator can still provision a mail-ingesting address with no reader for it. Named here, not fixed. |
| Desks | kept, unwired | Desk creation and membership editing become unreachable — manifest-only. Successor tracked in #311. Desk *threads* in Conversation are untouched. |
| Brain | kept, unwired | Cleanest case: agents read and write memory every turn; only the operator's window closes. |
| Finances | kept, unwired | Usage is **not** in the removal list, so spend observability does not drop to zero. |

## Tests

- [x] `npm run typecheck` — clean. Load-bearing beyond the usual here: `noUnusedLocals` / `noUnusedParameters` mechanically prove every dead import and icon is gone, and the exhaustive `Record<View, string>` title map catches a leftover key. Also re-run as `tsc -b --force --noEmit`, since `tsc -b` is incremental and a cached run would not have re-proved any of that.
- [x] `npm run typecheck:e2e` — clean.
- [x] `npm run build` — 3177 modules, clean. **No `FinancesView` chunk is emitted**, and grepping the built assets for markers from the three former eager views returns zero hits each, so they are tree-shaken out rather than merely unrouted.
- N/A: `cargo` gates — no Rust file is touched by this branch.
- N/A: frontend lint — no lint script exists in `frontend/package.json`.

Playwright specs are not run by CI (the config declares no `webServer` by design), so nothing below is CI evidence.

**Verified manually against a live host**, driving real Chromium at the built console:

- Sidebar: none of the four present, every kept item present, no empty groups.
- Each hidden hash lands on Overview with the URL corrected; Back does not ping-pong on any of the four.
- Conversation still lists the desk-derived threads, proving the desk data path is untouched.
- The Team inbox toggle round-trips through the host and back.
- **Approvals renders with its nav item active, and the pending badge path still works** — exercised by injecting a non-zero pending count at the status read (no code change): the badge renders, the nav item reads the count, and the rising-edge toast fires. This matters because #243 is in flight against that view.
- The guided tour runs 8/8 stops with no stall and no gap where the Desks stop used to be.

**The hidden-not-retired receipt** — in the same authenticated session where the Brain nav entry does not exist, the memory endpoints answer normally: write `200`, read `200`, stats `200` returning real counts with the newest item verbatim, on both the single-company and multi-company scopes. Hidden door, live room.

Two e2e specs are parked rather than deleted (`test.skip`, annotated with this issue) so their assertions — the fixture-ban proof and the Brain add/persist/delete proof — stay in git verbatim and keep type-checking. Deleting them would have thrown away the evidence that the capability still works, which is the opposite of what this change claims. Only the Brain test in the wiring spec is skipped; its sibling still runs.

## Documentation

`frontend/ARCHITECTURE.md` only. Its "surfaces and the endpoints they need" chapter maps each console surface to its endpoints, so its Inbox / Memory / Finances sections read as though those screens are reachable; each now carries a line saying the console door is closed while the endpoints stay live. The Desks note rides on the Conversation-threads section, which is where desks are actually documented, and records that desk management is manifest-only pending #311.

Deliberately **not** edited: `docs/spec/runtime/api.md`, `docs/modules/runtime/README.md` and `docs/spec/roadmap.md` mention these surfaces only as rationale for host routes and projections that do not change. Editing them would misrepresent this as a backend removal — precisely the misreading the issue warns against.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Removed Inbox, Desks, Memory, and Finances from the console sidebar.
  * Updated the guided tour to omit the unavailable Desks section.

* **Navigation**
  * Unknown or unavailable direct links now redirect to the appropriate available view and keep the URL synchronized.

* **Documentation**
  * Clarified that hidden sections and their underlying functionality remain available for potential future restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->