### PR TITLE
companies: grant `search` to the research templates so web_search is reachable (#312)

### DIFF
--- a/companies/agentic_consultation_firm/company.toml
+++ b/companies/agentic_consultation_firm/company.toml
@@ -7,6 +7,23 @@ name = "Agentic Consulting Firm"
 output = "Strategy decks and implementation plans"
 human_role = "Executive workshops"
 
+[tools]
+# Full tool belt plus the metered `web_search` (#238, granted here in #312): this
+# company's skills instruct agents to search broadly and cite their sources, and
+# nothing in the `web` namespace can *find* a URL — `web_fetch` / `http_request`
+# only read one the agent already has.
+#
+# Every entry below is load-bearing. `allow` REPLACES the default
+# (`["*", "media", "composio"]`); it never extends it. `*` covers
+# files/docs/shell/code/web/subagent but deliberately excludes the opt-in
+# namespaces, so `media`, `composio` and `search` are each listed literally.
+# Reducing this line to `["search"]` would silently strip the whole belt from
+# every agent in the company.
+#
+# Search spend is bounded by `[tools].search_daily_calls` (200/day by default);
+# setting it to `0` pauses search without editing this list.
+allow = ["*", "media", "composio", "search"]
+
 [[agent]]
 id = "researcher"
 role = "Researcher"

--- a/companies/agentic_design_studio/company.toml
+++ b/companies/agentic_design_studio/company.toml
@@ -7,6 +7,23 @@ name = "Agentic Design Studio"
 output = "Brand and product design systems"
 human_role = "Creative direction sign-off"
 
+[tools]
+# Full tool belt plus the metered `web_search` (#238, granted here in #312): this
+# company's skills instruct agents to search broadly and cite their sources, and
+# nothing in the `web` namespace can *find* a URL — `web_fetch` / `http_request`
+# only read one the agent already has.
+#
+# Every entry below is load-bearing. `allow` REPLACES the default
+# (`["*", "media", "composio"]`); it never extends it. `*` covers
+# files/docs/shell/code/web/subagent but deliberately excludes the opt-in
+# namespaces, so `media`, `composio` and `search` are each listed literally.
+# Reducing this line to `["search"]` would silently strip the whole belt from
+# every agent in the company.
+#
+# Search spend is bounded by `[tools].search_daily_calls` (200/day by default);
+# setting it to `0` pauses search without editing this list.
+allow = ["*", "media", "composio", "search"]
+
 [[agent]]
 id = "brand_designer"
 role = "Brand Designer"

--- a/companies/agentic_law_firm/company.toml
+++ b/companies/agentic_law_firm/company.toml
@@ -7,6 +7,23 @@ name = "Agentic Law Firm"
 output = "Research, drafts, and discovery"
 human_role = "Approving filings"
 
+[tools]
+# Full tool belt plus the metered `web_search` (#238, granted here in #312): this
+# company's skills instruct agents to search broadly and cite their sources, and
+# nothing in the `web` namespace can *find* a URL — `web_fetch` / `http_request`
+# only read one the agent already has.
+#
+# Every entry below is load-bearing. `allow` REPLACES the default
+# (`["*", "media", "composio"]`); it never extends it. `*` covers
+# files/docs/shell/code/web/subagent but deliberately excludes the opt-in
+# namespaces, so `media`, `composio` and `search` are each listed literally.
+# Reducing this line to `["search"]` would silently strip the whole belt from
+# every agent in the company.
+#
+# Search spend is bounded by `[tools].search_daily_calls` (200/day by default);
+# setting it to `0` pauses search without editing this list.
+allow = ["*", "media", "composio", "search"]
+
 [[agent]]
 id = "legal_researcher"
 role = "Legal Researcher"

--- a/companies/agentic_marketing_agency/company.toml
+++ b/companies/agentic_marketing_agency/company.toml
@@ -7,6 +7,23 @@ name = "Agentic Marketing Agency"
 output = "Campaigns across every channel"
 human_role = "Campaign review and sign-off"
 
+[tools]
+# Full tool belt plus the metered `web_search` (#238, granted here in #312): this
+# company's skills instruct agents to search broadly and cite their sources, and
+# nothing in the `web` namespace can *find* a URL — `web_fetch` / `http_request`
+# only read one the agent already has.
+#
+# Every entry below is load-bearing. `allow` REPLACES the default
+# (`["*", "media", "composio"]`); it never extends it. `*` covers
+# files/docs/shell/code/web/subagent but deliberately excludes the opt-in
+# namespaces, so `media`, `composio` and `search` are each listed literally.
+# Reducing this line to `["search"]` would silently strip the whole belt from
+# every agent in the company.
+#
+# Search spend is bounded by `[tools].search_daily_calls` (200/day by default);
+# setting it to `0` pauses search without editing this list.
+allow = ["*", "media", "composio", "search"]
+
 [[agent]]
 id = "creative_director"
 role = "Creative Director"

--- a/companies/agentic_media_company/company.toml
+++ b/companies/agentic_media_company/company.toml
@@ -7,6 +7,23 @@ name = "Agentic Media Company"
 output = "Published, distributed stories"
 human_role = "Editorial standards"
 
+[tools]
+# Full tool belt plus the metered `web_search` (#238, granted here in #312): this
+# company's skills instruct agents to search broadly and cite their sources, and
+# nothing in the `web` namespace can *find* a URL — `web_fetch` / `http_request`
+# only read one the agent already has.
+#
+# Every entry below is load-bearing. `allow` REPLACES the default
+# (`["*", "media", "composio"]`); it never extends it. `*` covers
+# files/docs/shell/code/web/subagent but deliberately excludes the opt-in
+# namespaces, so `media`, `composio` and `search` are each listed literally.
+# Reducing this line to `["search"]` would silently strip the whole belt from
+# every agent in the company.
+#
+# Search spend is bounded by `[tools].search_daily_calls` (200/day by default);
+# setting it to `0` pauses search without editing this list.
+allow = ["*", "media", "composio", "search"]
+
 [[agent]]
 id = "story_scout"
 role = "Story Scout"

--- a/companies/signals_opportunity_studio/company.toml
+++ b/companies/signals_opportunity_studio/company.toml
@@ -24,7 +24,11 @@ id = "signal_scout"
 role = "Signal Scout"
 description = "Continuously gather raw market signals from web, forums, and inbound channels."
 tier = "subconscious"
-tools = ["web.*"]
+# `search` is listed alongside `web.*` because the two are not interchangeable:
+# `web.*` reads a URL the agent already has, `search` is the only way to find
+# one. It must appear here AND in `[tools].allow` below — the per-agent list
+# narrows the company-wide one, so either edit alone is a silent no-op (#312).
+tools = ["web.*", "search"]
 budget_usd_daily = 5.0
 
 [[agent]]
@@ -32,7 +36,7 @@ id = "opportunity_analyst"
 role = "Opportunity Analyst"
 description = "Cluster signals into pains and rank the resulting opportunities by evidence and size."
 tier = "reasoning"
-tools = ["web.*", "docs.*"]
+tools = ["web.*", "docs.*", "search"]
 budget_usd_daily = 8.0
 
 [[agent]]
@@ -40,7 +44,7 @@ id = "research_agent"
 role = "Research Agent"
 description = "Deep-dive the top opportunities and compile the operator's weekly brief."
 tier = "reasoning"
-tools = ["web.*", "docs.*"]
+tools = ["web.*", "docs.*", "search"]
 budget_usd_daily = 8.0
 
 [brain]
@@ -48,7 +52,15 @@ mode = "hosted"
 max_passes = 12
 
 [tools]
-allow = ["web.*", "docs.*"]
+# This company deliberately overrides the default belt (`["*", "media",
+# "composio"]`) down to reading and writing docs off the web — it is a research
+# studio, not a general-purpose one. `search` is added because the whole roster
+# is described as gathering signals "from web", and the grant check matches only
+# `search` / `search.` — `web.*` confers nothing towards it (#312).
+#
+# This list gates the company; each agent's own `tools` narrows it further, so
+# `search` also has to appear on the scout / analyst / research agents above.
+allow = ["web.*", "docs.*", "search"]
 
 [channels.operator]
 enabled = true

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -6,7 +6,11 @@
 
 use std::path::{Path, PathBuf};
 
-use super::{CompanyManifest, load_dir_skills, parse_workflow, walk_workspace};
+use super::{
+    CompanyManifest, Tools, grants_composio_explicit, grants_media_explicit,
+    grants_search_explicit, load_dir_skills, parse_workflow, walk_workspace,
+};
+use crate::runtime::builder::effective_grants;
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -83,6 +87,149 @@ fn every_company_skill_and_workspace_parses() {
         // Workspace tree.
         walk_workspace(&company.join("workspace"))
             .unwrap_or_else(|err| panic!("{}/workspace: {err}", company.display()));
+    }
+}
+
+/// Templates whose shipped skills (`web-research`, `seo-audit`,
+/// `competitor-scan`) instruct agents to search the web and cite sources, so
+/// each must carry an explicit `search` grant (issue #312).
+const SEARCH_GRANTED_COMPANIES: [&str; 6] = [
+    "agentic_consultation_firm",
+    "agentic_design_studio",
+    "agentic_law_firm",
+    "agentic_marketing_agency",
+    "agentic_media_company",
+    "signals_opportunity_studio",
+];
+
+/// Templates that must NEVER reach the metered search backend: `e2e_harness` is
+/// a deterministic fixture (a priced network call would make it non-hermetic and
+/// flaky), and `openhuman_demo` is a walkthrough nobody opted into spend for.
+const SEARCH_DENIED_COMPANIES: [&str; 2] = ["e2e_harness", "openhuman_demo"];
+
+/// The subset of [`SEARCH_GRANTED_COMPANIES`] that restates the default belt
+/// verbatim and appends `search`. `signals_opportunity_studio` is deliberately
+/// excluded: it overrides the default down to a research-only belt on purpose.
+const FULL_BELT_PLUS_SEARCH: [&str; 5] = [
+    "agentic_consultation_firm",
+    "agentic_design_studio",
+    "agentic_law_firm",
+    "agentic_marketing_agency",
+    "agentic_media_company",
+];
+
+fn load_company(name: &str) -> CompanyManifest {
+    let dir = repo_root().join("companies").join(name);
+    CompanyManifest::from_path(&dir).unwrap_or_else(|err| panic!("{}: {err}", dir.display()))
+}
+
+/// One agent's effective grants: the company `[tools].allow` narrowed by that
+/// agent's own `tools`. Runs the *real* narrowing (`effective_grants` over a
+/// one-agent roster) rather than reimplementing it, so the test cannot drift
+/// from the rule the harness applies.
+fn grants_for_one_agent(manifest: &CompanyManifest, index: usize) -> Vec<String> {
+    let mut solo = manifest.clone();
+    solo.agents = vec![manifest.agents[index].clone()];
+    effective_grants(&solo)
+}
+
+/// The metered `web_search` tool (issue #238) is wired only behind an explicit
+/// `search` grant — the catch-all `*` deliberately does not confer it. That
+/// grant is narrowed twice: by the company-wide `[tools].allow`, and again by
+/// each agent's own `tools` list. An agent that declares `tools` and omits
+/// `search` is silently searchless even when the company grants it, which is
+/// exactly how `signals_opportunity_studio`'s scout shipped unable to search.
+#[test]
+fn research_templates_grant_search_at_both_layers() {
+    for name in SEARCH_GRANTED_COMPANIES {
+        let manifest = load_company(name);
+        assert!(
+            grants_search_explicit(&manifest.tools.allow),
+            "{name}: company-wide `[tools].allow` must grant `search` \
+             (found {:?}); note `web.*` confers nothing here — the check \
+             matches only `search` / `search.`",
+            manifest.tools.allow
+        );
+        assert!(
+            !manifest.agents.is_empty(),
+            "{name}: expected a roster to check per-agent grants against"
+        );
+        for (index, agent) in manifest.agents.iter().enumerate() {
+            let grants = grants_for_one_agent(&manifest, index);
+            assert!(
+                grants_search_explicit(&grants),
+                "{name}: agent `{}` ends up without `search`. Its own \
+                 `tools` list ({:?}) narrows the company allow-list ({:?}), so \
+                 `search` has to appear in BOTH — either edit alone is a \
+                 silent no-op.",
+                agent.id,
+                agent.tools,
+                manifest.tools.allow
+            );
+        }
+    }
+}
+
+/// The deterministic fixture and the demo must stay off the priced path.
+#[test]
+fn fixture_templates_never_grant_search() {
+    for name in SEARCH_DENIED_COMPANIES {
+        let manifest = load_company(name);
+        let grants = effective_grants(&manifest);
+        assert!(
+            !grants_search_explicit(&grants),
+            "{name}: must not grant `search` — a priced network call here \
+             makes the fixture non-hermetic (found {grants:?})"
+        );
+    }
+}
+
+/// The footgun this suite exists to catch: `[tools].allow` **replaces** the
+/// default (`["*", "media", "composio"]`), it never extends it. A reviewer
+/// "simplifying" a grant to `allow = ["search"]` would silently strip
+/// files/docs/shell/code/web/subagent, `media` and `composio` from every agent
+/// in the company — no parse error, no warning, just a company that quietly
+/// lost its tool belt. This asserts both halves: the shipped form keeps the
+/// inherited entries, and the reduced form provably loses them.
+#[test]
+fn granting_search_never_strips_the_inherited_default_belt() {
+    let default_allow = Tools::default().allow;
+    assert!(
+        !grants_search_explicit(&default_allow),
+        "the default belt is expected to stay search-free (opt-in per #238); \
+         if that changed, these templates no longer need to restate it"
+    );
+
+    for name in FULL_BELT_PLUS_SEARCH {
+        let manifest = load_company(name);
+        for inherited in &default_allow {
+            assert!(
+                manifest.tools.allow.contains(inherited),
+                "{name}: `[tools].allow` is {:?} and dropped the inherited \
+                 default entry `{inherited}`. `allow` REPLACES the default \
+                 ({default_allow:?}) — it must be restated verbatim, then \
+                 extended.",
+                manifest.tools.allow
+            );
+        }
+
+        // Prove the loss is real rather than asserted: reduce the same
+        // manifest to the "simplified" form and watch the belt vanish.
+        let mut reduced = manifest.clone();
+        reduced.tools.allow = vec!["search".to_string()];
+        let grants = effective_grants(&reduced);
+        assert!(
+            !grants.iter().any(|grant| grant == "*"),
+            "{name}: expected `allow = [\"search\"]` to strip the `*` belt"
+        );
+        assert!(
+            !grants_media_explicit(&grants),
+            "{name}: expected `allow = [\"search\"]` to strip `media`"
+        );
+        assert!(
+            !grants_composio_explicit(&grants),
+            "{name}: expected `allow = [\"search\"]` to strip `composio`"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #312. Makes #238's metered `web_search` actually reachable.

`web_search` shipped this morning fully built, fully metered and wired to nothing. It has three gates, and only one of them was ever shut:

- **Managed credential** — already open. Search and managed inference resolve the platform identity through the *same* call, so any tenant where inference works already has search credentialed. Confirmed by reading the resolver, not assumed.
- **Daily cap** — open by default at 200 calls.
- **Explicit `search` grant** — **shut in every template we ship.**

So three skills that instruct an agent to "search broadly and cite your sources" have been sitting permanently in their degraded branch, and the belt's only way to satisfy the instruction was to invent plausible URLs — the exact failure #238 was written to end.

The grant is shut at **two** layers, and both have to open for an agent that declares its own tool list: the company-wide `[tools].allow`, and each agent's own `tools`, which narrows it. The sharpest case is `signals_opportunity_studio`, whose scout agent is described as "continuously gather raw market signals from web" while holding `allow = ["web.*"]` — and the grant check matches only `search`, so `web.*` confers nothing. That agent has never been able to search.

## API Or Behavior Changes

No API change, no route, no schema, no migration. Six manifests and one test file.

Behaviourally: agents in the six research templates can now call `web_search`, priced and capped as #238 defines. Spend becomes real for those templates, bounded by the daily cap at roughly $2/day/company. Setting `search_daily_calls = 0` pauses a company without touching `allow`.

Existing tenants pick this up on their next rebuild, since `[tools]` is seed-authoritative.

**The footgun this PR is shaped around:** `allow` **replaces** the default; it does not extend it. The default is exactly `["*", "media", "composio"]`, so every new section restates those three verbatim before adding `search`. Reducing any of them to `allow = ["search"]` would silently strip files, shell, web, media and composio from every agent in that company. That is not a hypothetical — it is a one-word edit away and produces no error.

Deliberately excluded: `e2e_harness` (a deterministic fixture must never make priced network calls) and `openhuman_demo`.

No console change was needed, and I checked rather than assuming: the capabilities endpoint already derives `search_granted` from the same explicit-grant predicate, and the Usage view already renders all five states — not in build / not granted / awaiting credential / paused at cap 0 / active.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — exit 0
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **1615 passed, 0 failed**, 1 ignored
- [x] `cargo test --locked` (default features) — **1114 passed, 0 failed**
- [x] `cargo check --locked --all-features --all-targets` — exit 0
- [x] `git diff Cargo.lock` empty
- N/A: frontend — no console file is touched, and the badge this feature needs already exists

**The test is ungated on purpose, and that detail is load-bearing.** CI has two Rust test lanes: default features, and `openhuman,tinycortex --lib`. The obvious helper for reading an agent's effective grants is behind `#[cfg(feature = "openhuman")]`, so a test written against it would have compiled out of the default lane and quietly covered half of what it appeared to. The tests use the ungated builder-side narrowing function instead — the same code the runtime uses, not a reimplementation — and the default lane was run explicitly to confirm.

**The guards are mutation-proven, not merely green.** Each was made to fail on purpose before being kept:

- reducing a template to `allow = ["search"]` fails with "dropped the inherited default entry `*`"
- removing `search` from a company's `allow` fails with "company-wide `[tools].allow` must grant `search`"
- the subtle one: leaving the company-wide grant intact but removing `search` from the scout agent's own list fails with "agent `signal_scout` ends up without `search` … either edit alone is a silent no-op"

That third case is the whole reason this issue needed two edits rather than one.

**Live boot:** the six manifests register cleanly and validate. The search backend resolves from the platform key — the same variable managed inference uses, which independently confirms that the credential gate was already open.

**Not proved, stated plainly:** no live search ran, because no credential is present in this environment. Worth recording *why* the usual "granted but uncredentialed" check is unreachable here: inference and search key off the **same** variable, so with it unset the harness disables itself before agent build and the search gate is never evaluated at all. With a dummy key the harness comes up, but agents build lazily on first turn, so there is still no boot-time roster line to grep. Proving `web_search` in a live roster requires a real turn against a real credential.

## Documentation

None. The grant lives in the manifests themselves, and #238's module doc already describes the gate this opens.

One editorial note for the record: the three search-naming skills live in the repo-root registry, which any company can install — they are not auto-assigned per company. `agentic_marketing_agency` additionally ships its own `seo-audit` that shadows the registry copy by slug and does not mention `web_search`. So the choice of these six templates is an editorial judgement about which companies do research work, not something derivable from skill assignment. Flagging it so the next person doesn't go looking for a rule that isn't there.
