### PR TITLE
fix(connections): keep onboarding alive across the OAuth redirect (#300)

### DIFF
--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -98,6 +98,37 @@ POST   …/connections/{provider}/disconnect   drop stored OAuth tokens         
 GET    /api/v1/oauth/callback                OAuth redirect target (unscoped; state carries the company)  [feature: oauth]
 ```
 
+### The OAuth callback always redirects
+
+`/api/v1/oauth/callback` is reached by a **browser navigation**, so anything it
+returns as a body becomes the page the operator is left on. It therefore never
+answers with JSON. Every outcome redirects to the console's Connections view:
+
+- success → `…/connections?connected=<provider>`
+- failure → `…/connections?connect_error=<code>[&provider=<provider>]`
+
+`<code>` is one of a closed set — `denied`, `invalid_request`, `invalid_state`,
+`unknown_company`, `provider_disabled`, `exchange_failed`, `store_failed` — that
+the console maps to operator-facing copy. The provider's own error text is
+logged host-side but never forwarded: it is attacker-influenced and must not
+ride in a URL that lands in browser history and access logs. `provider` is
+appended only when a signature-verified `state` supplies it, so the arms that
+fire before verification omit it.
+
+### Provider catalog vs. configured providers
+
+The console's Connections view offers 11 provider tiles; `well_known()` in
+`server::ops::connections` carries built-in authorize/token URLs for three
+families only (`slack`, `google`/`gmail`, `github`). Every other tile needs
+`OPENCOMPANY_OAUTH_<P>_AUTHORIZE_URL` / `_TOKEN_URL` alongside its `_ID` /
+`_SECRET`, or it is simply not enabled on that host.
+
+This gap is **known and safe**: an unconfigured tile fails at `start` with a
+`400 provider '<p>' is not enabled on this host`, the console shows a toast, and
+the browser never navigates — so there is no broken redirect to come back from.
+Closing the gap (shipping more well-known URLs, or hiding unconfigured tiles) is
+separate work.
+
 ## Read plane — GraphQL (`/graphql`)
 
 Every console **read** is served by a single async-graphql query surface at

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -150,6 +150,38 @@ const TITLES: Record<View, string> = {
 
 const VIEWS = NAV.flatMap((g) => g.items.map((i) => i.view));
 
+/**
+ * Operator-facing copy for a `connect_error` code from the host's OAuth
+ * callback (issue #300). The host sends a stable code rather than the
+ * provider's own error text — that text is attacker-influenced and may carry
+ * credential material, so it never leaves the host's logs.
+ *
+ * Every message says what to do next: the whole point of the bounce-back is
+ * that a failed handshake is recoverable, not a dead end. An unrecognized code
+ * (an older console against a newer host) still gets a usable message.
+ */
+function connectErrorMessage(code: string, provider: string | null): string {
+  const name = provider ?? "the provider";
+  switch (code) {
+    case "denied":
+      return `${provider ?? "That"} connection was cancelled. You can try again whenever you're ready.`;
+    case "invalid_state":
+      return `That ${name} connection link expired. Start the connection again.`;
+    case "invalid_request":
+      return `That ${name} connection came back incomplete. Start the connection again.`;
+    case "unknown_company":
+      return `That connection didn't match this company. Start the connection again.`;
+    case "provider_disabled":
+      return `${provider ?? "That provider"} isn't configured on this host yet.`;
+    case "exchange_failed":
+      return `Couldn't finish connecting ${name}. Try again in a moment.`;
+    case "store_failed":
+      return `Connected to ${name}, but saving the credentials failed. Try again.`;
+    default:
+      return `Couldn't connect ${name}. Try again.`;
+  }
+}
+
 interface Props {
   client: OpenCompanyClient;
   company: string | null;
@@ -206,15 +238,29 @@ export function AppShell({
   const pending = feed.status.pending_approvals;
 
   // OAuth connect bounce-back: the host's callback redirects the browser to
-  // `…/connections?connected={provider}` after storing the token. Land the
-  // operator on the Connections view, confirm with a toast, then strip the
-  // param so a refresh doesn't re-fire it. Runs once; StrictMode's double
-  // invoke is harmless because the first run clears the param the second reads.
+  // `…/connections?connected={provider}` after storing the token, or to
+  // `…/connections?connect_error={code}[&provider={id}]` when the handshake
+  // failed. Land the operator on the Connections view either way, say what
+  // happened, then strip the params so a refresh doesn't re-fire them. Runs
+  // once; StrictMode's double invoke is harmless because the first run clears
+  // the params the second reads.
+  //
+  // The failure half matters as much as the success half: before issue #300 the
+  // host answered a cancelled or expired handshake with a JSON body, which the
+  // browser rendered as the page — a dead end with no way back into the
+  // console. The host now always redirects, so this is where it becomes
+  // recoverable.
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const connected = params.get("connected");
-    if (!connected) return;
+    const failed = params.get("connect_error");
+    if (!connected && !failed) return;
+    // The provider id is advisory — the host omits it on the arms that fire
+    // before the signed state is verified.
+    const providerId = connected ?? params.get("provider");
     params.delete("connected");
+    params.delete("connect_error");
+    params.delete("provider");
     const query = params.toString();
     window.history.replaceState(
       {},
@@ -224,9 +270,11 @@ export function AppShell({
     setView("connections");
     // The callback param carries the raw provider id (e.g. "slack"); show the
     // catalog display name ("Slack") when we know it, falling back to the id.
-    const providerName =
-      CONNECTION_PROVIDERS.find((p) => p.id === connected)?.name ?? connected;
-    toast.success(`Connected ${providerName}.`);
+    const providerName = providerId
+      ? (CONNECTION_PROVIDERS.find((p) => p.id === providerId)?.name ?? providerId)
+      : null;
+    if (failed) toast.error(connectErrorMessage(failed, providerName));
+    else toast.success(`Connected ${providerName}.`);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/frontend/src/tour/TourController.tsx
+++ b/frontend/src/tour/TourController.tsx
@@ -5,7 +5,15 @@ import type { View } from "@/components/app-shell";
 import { TOUR, waitForTarget } from "./steps";
 import { TourTooltip } from "./TourTooltip";
 import { WelcomeDialog } from "./WelcomeDialog";
-import { RESTART_EVENT, tourForced, tourSeen, writeTourState } from "./state";
+import {
+  clearTourResume,
+  readTourResume,
+  RESTART_EVENT,
+  setActiveTourStop,
+  tourForced,
+  tourSeen,
+  writeTourState,
+} from "./state";
 
 // react-joyride (and its floater/popper deps) is a fair chunk; only operators
 // who actually run the tour download it. Types above are `import type`, so they
@@ -53,20 +61,54 @@ export function TourController({
   const [welcomeOpen, setWelcomeOpen] = useState(false);
   const [session, setSession] = useState(false); // mounts Joyride for the run
   const [run, setRun] = useState(false); // joyride active
+  // Which stop this run opens on. `0` for a normal run; the resumed stop when
+  // we came back from a full-page redirect mid-tour.
+  const [startIndex, setStartIndex] = useState(0);
 
   // Offer the tour once per company on first arrival (or every load under the
-  // dev-force flag).
+  // dev-force flag) — unless we're returning mid-tour from a redirect, in which
+  // case pick the tour back up where it left off instead of re-offering it.
   useEffect(() => {
     // A company switch must tear down the prior company's in-flight tour first,
     // otherwise `finish` would record its completion/skip under the NEW
     // company's key (cross-company contamination).
     setRun(false);
     setSession(false);
+    setActiveTourStop(null);
+
+    // Resume takes priority over the welcome dialog: the operator already
+    // started the tour, left to authorize a connection, and came back. Showing
+    // "Welcome to your company" from step 1 here is the bug (issue #300) — the
+    // tour never recorded completed/skipped, so `tourSeen` is still false.
+    const resumeView = readTourResume(company);
+    if (resumeView !== null) {
+      // Consume it either way: a marker that can't be honored must not sit
+      // around waiting to fire on some later, unrelated visit.
+      clearTourResume(company);
+      // Match on view, not index — see `TourResume`. `findIndex` takes the
+      // first stop for a view, which is unambiguous for every view that can
+      // arm a marker today (only Connections navigates the page away).
+      const index = TOUR.findIndex((s) => s.view === resumeView);
+      if (index >= 0) {
+        setStartIndex(index);
+        setWelcomeOpen(false);
+        setSession(true);
+        setRun(true);
+        return;
+      }
+      // -1: the stop was retired since the marker was written (as #302 retired
+      // one). Drop it and fall through to today's behavior.
+    }
+
+    setStartIndex(0);
     if (tourForced() || !tourSeen(company)) setWelcomeOpen(true);
     else setWelcomeOpen(false);
   }, [company]);
 
   const start = useCallback(() => {
+    // A replay from Settings always opens at the top, even if this mount had
+    // resumed mid-tour.
+    setStartIndex(0);
     setWelcomeOpen(false);
     setSession(true);
     setRun(true);
@@ -76,6 +118,9 @@ export function TourController({
     (skipped: boolean) => {
       setRun(false);
       setSession(false);
+      setActiveTourStop(null);
+      // Replaces the whole record, so any resume marker goes with it — the tour
+      // is over, there is nothing left to resume.
       writeTourState(company, skipped ? { skipped: true } : { completed: true });
     },
     [company],
@@ -103,6 +148,9 @@ export function TourController({
     async (data: TourData) => {
       const stop = TOUR[data.index];
       if (!stop) return;
+      // Publish the live position so `armTourResume` can persist it if this
+      // stop hands the browser off to a third party (the OAuth connect flow).
+      setActiveTourStop(stop.view);
       setView(stop.view);
       await waitForTarget(stop.target);
     },
@@ -132,6 +180,11 @@ export function TourController({
           <Joyride
             steps={STEPS}
             run={run}
+            // Resume support without giving up the uncontrolled design: this is
+            // the *initial* index for an uncontrolled tour, so joyride still
+            // owns the stepping from here. (A controlled `stepIndex` would make
+            // us drive every transition by hand.)
+            initialStepIndex={startIndex}
             continuous
             tooltipComponent={TourTooltip}
             options={{

--- a/frontend/src/tour/state.ts
+++ b/frontend/src/tour/state.ts
@@ -91,6 +91,32 @@ export function readTourResume(company: string | null): string | null {
   return pendingResume.view;
 }
 
+/**
+ * The stop a running tour is currently on, or `null` when no tour is running.
+ *
+ * Module-level rather than persisted: it changes on every step, and only the
+ * one moment that hands the browser away needs it to survive. `armTourResume`
+ * is what turns this live position into a stored marker.
+ */
+let activeStopView: string | null = null;
+
+/** Called by the controller as each stop renders; `null` when the tour ends. */
+export function setActiveTourStop(view: string | null): void {
+  activeStopView = view;
+}
+
+/**
+ * Arm a resume marker for wherever the tour currently is, so a full-page
+ * navigation (the OAuth connect flow) can be picked back up.
+ *
+ * A **no-op when no tour is running** — that is what lets a caller arm
+ * unconditionally without first asking whether it is inside onboarding.
+ */
+export function armTourResume(company: string | null): void {
+  if (activeStopView === null) return;
+  markTourResume(company, activeStopView);
+}
+
 /** Drop the resume marker, keeping the completed/skipped flags intact. */
 export function clearTourResume(company: string | null): void {
   const current = readTourState(company);

--- a/frontend/src/tour/state.ts
+++ b/frontend/src/tour/state.ts
@@ -12,7 +12,33 @@ export interface TourState {
   completed?: boolean;
   skipped?: boolean;
   seenAt?: number;
+  /**
+   * Set when a tour stop hands the browser to a third party (the OAuth connect
+   * flow navigates the whole document away), so the controller can pick the
+   * tour back up on the stop the operator left. See `pendingResume` helpers.
+   */
+  pendingResume?: TourResume;
 }
+
+/**
+ * Where to resume the tour after a full-page round trip.
+ *
+ * The stop is identified by its **view**, not its index: issue #302 deleted a
+ * stop, and a stored index would have resumed on the wrong one — or past the
+ * end, where the controller's `if (!stop) return` guard swallows it silently.
+ */
+export interface TourResume {
+  view: string;
+  at: number;
+}
+
+/**
+ * How long a resume marker stays good. Deliberately longer than the OAuth
+ * `state` nonce (10 minutes host-side) so a handshake that only just made it
+ * still resumes, but short enough that a marker abandoned mid-flow cannot
+ * hijack an unrelated visit hours later.
+ */
+const RESUME_TTL_MS = 15 * 60 * 1000;
 
 /** Fired by `restartTour` so a mounted controller can replay from the top. */
 export const RESTART_EVENT = "oc-tour:restart";
@@ -38,6 +64,39 @@ export function writeTourState(company: string | null, next: TourState): void {
 export function tourSeen(company: string | null): boolean {
   const s = readTourState(company);
   return Boolean(s.completed || s.skipped);
+}
+
+/**
+ * Record that the tour was on `view` when the page handed off to a third party,
+ * so the next mount resumes there instead of re-offering the tour from step 1.
+ *
+ * Read-modify-write, and in the **same per-company key** as the seen flags: a
+ * marker written under one company must never resume that company's tour inside
+ * another (the contamination the controller's company-switch teardown guards
+ * against).
+ */
+export function markTourResume(company: string | null, view: string): void {
+  const current = readTourState(company);
+  writeTourState(company, { ...current, pendingResume: { view, at: Date.now() } });
+}
+
+/**
+ * The view to resume on, or `null` when there is no marker or it has aged out.
+ * A stale marker is treated as absent — the caller clears it either way.
+ */
+export function readTourResume(company: string | null): string | null {
+  const { pendingResume } = readTourState(company);
+  if (!pendingResume) return null;
+  if (Date.now() - pendingResume.at > RESUME_TTL_MS) return null;
+  return pendingResume.view;
+}
+
+/** Drop the resume marker, keeping the completed/skipped flags intact. */
+export function clearTourResume(company: string | null): void {
+  const current = readTourState(company);
+  if (!current.pendingResume) return;
+  const { pendingResume: _dropped, ...rest } = current;
+  writeTourState(company, rest);
 }
 
 /** Clear the seen flag and ask any mounted controller to replay from step 1. */

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -45,6 +45,7 @@ import {
   type ConnectionProvider,
 } from "@/lib/connections";
 import { cn } from "@/lib/utils";
+import { armTourResume } from "@/tour/state";
 import { InferenceSection } from "@/views/connections/InferenceSection";
 import { ComposioSection } from "@/views/connections/ComposioSection";
 import { ChannelsSection } from "./connections/ChannelsSection";
@@ -83,6 +84,14 @@ export function ConnectionsView({ client, company }: Props) {
     setBusy(p.id);
     try {
       const { url } = await client.startConnection(p.id, company);
+      // Unlike the MCP sign-in below (which opens a tab and survives), this
+      // navigates the whole document away — taking the product tour's
+      // in-memory step state with it. Arm a resume marker so the operator comes
+      // back to the stop they left instead of the tour restarting from step 1
+      // (issue #300). No-op when no tour is running, and deliberately after the
+      // start call succeeds: a provider that isn't configured 400s here and
+      // never navigates, so it must not leave a marker behind.
+      armTourResume(company);
       window.location.href = url;
     } catch {
       toast.error(`Couldn't start the ${p.name} connection.`);

--- a/frontend/test/e2e/oauth-onboarding-resume.spec.ts
+++ b/frontend/test/e2e/oauth-onboarding-resume.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Issue #300 — an OAuth connection started from inside the onboarding tour.
+ *
+ * The redirect back from the provider is a **full-page navigation**, so neither
+ * half of this can be proven by a unit test: the tour's step state lives in
+ * react-joyride's memory and dies with the document, and the failure arms of the
+ * host callback used to render a JSON body *as the page*.
+ *
+ * These specs drive a running host (see `playwright.config.ts` — the harness
+ * brings it up, there is no `webServer`). CI does not run Playwright.
+ */
+
+/** The tour's per-company localStorage key, discovered from the running app. */
+async function tourKey(page: import("@playwright/test").Page): Promise<string> {
+  const key = await page.evaluate(() =>
+    Object.keys(window.localStorage).find((k) => k.startsWith("oc-tour:")),
+  );
+  expect(key, "the console should have written a per-company tour key").toBeTruthy();
+  return key!;
+}
+
+test("a cancelled handshake lands back in the console, not on a dead page", async ({ page }) => {
+  // Exactly what the host now redirects to when the operator cancels at the
+  // provider's consent screen. Before the fix this route answered with
+  // `{"error":"provider returned: access_denied"}` as the document body.
+  await page.goto("/connections?connect_error=denied&provider=slack");
+
+  // The console renders — the operator is not stranded on raw JSON.
+  await expect(page.getByRole("heading", { name: "Connections" })).toBeVisible();
+
+  // ...and is told what happened, in recoverable terms.
+  await expect(page.getByText(/cancelled/i)).toBeVisible();
+
+  // The param is stripped, so a refresh doesn't re-fire the toast.
+  await expect
+    .poll(() => new URL(page.url()).searchParams.get("connect_error"))
+    .toBeNull();
+
+  // Connecting is still offered: the failure is a retry, not a terminal state.
+  await expect(page.getByRole("button", { name: "Connect" }).first()).toBeEnabled();
+});
+
+test("an unknown failure code still produces a usable message", async ({ page }) => {
+  // An older console against a newer host must not fall silent.
+  await page.goto("/connections?connect_error=something_new_2099");
+  await expect(page.getByRole("heading", { name: "Connections" })).toBeVisible();
+  await expect(page.getByText(/couldn't connect/i)).toBeVisible();
+});
+
+test("the tour resumes on the Connections stop after a redirect", async ({ page }) => {
+  await page.goto("/#/overview");
+
+  // First run offers the tour. Skipping writes the per-company key, which is
+  // how we learn the key name without hard-coding the company id.
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  await expect(skip).toBeVisible();
+  await skip.click();
+  const key = await tourKey(page);
+
+  // Seed exactly what `armTourResume` writes just before ConnectionsView hands
+  // the browser to the provider: mid-tour, on the Connections stop, no
+  // completed/skipped flag (the tour never finished).
+  await page.evaluate(
+    ([k]) =>
+      window.localStorage.setItem(
+        k,
+        JSON.stringify({ pendingResume: { view: "connections", at: Date.now() } }),
+      ),
+    [key],
+  );
+
+  // The return trip from the provider.
+  await page.goto("/connections?connected=slack");
+
+  // Resumed on the stop the operator left...
+  await expect(page.getByText("Connect your tools")).toBeVisible();
+  // ...and NOT restarted from step 1, which is the bug.
+  await expect(page.getByText("Welcome to your company")).toHaveCount(0);
+
+  // The marker is consumed, so it can't fire again on a later visit.
+  const after = await page.evaluate(([k]) => window.localStorage.getItem(k), [key]);
+  expect(JSON.parse(after ?? "{}").pendingResume).toBeUndefined();
+});
+
+test("a stale resume marker does not hijack a later visit", async ({ page }) => {
+  await page.goto("/#/overview");
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  await expect(skip).toBeVisible();
+  await skip.click();
+  const key = await tourKey(page);
+
+  // Older than the 15-minute TTL.
+  await page.evaluate(
+    ([k]) =>
+      window.localStorage.setItem(
+        k,
+        JSON.stringify({
+          skipped: true,
+          pendingResume: { view: "connections", at: Date.now() - 60 * 60 * 1000 },
+        }),
+      ),
+    [key],
+  );
+
+  await page.goto("/#/overview");
+  // No tour: the marker aged out and the tour is already marked skipped.
+  await expect(page.getByText("Connect your tools")).toHaveCount(0);
+  await expect(page.getByText("Welcome to your company")).toHaveCount(0);
+});

--- a/frontend/test/e2e/oauth-onboarding-resume.spec.ts
+++ b/frontend/test/e2e/oauth-onboarding-resume.spec.ts
@@ -12,8 +12,22 @@ import { expect, test } from "@playwright/test";
  * brings it up, there is no `webServer`). CI does not run Playwright.
  */
 
+type Page = import("@playwright/test").Page;
+
+/**
+ * Dismiss the first-run welcome dialog if it is up.
+ *
+ * Not cosmetic: it is a Radix dialog, so while it is open every other element
+ * is `aria-hidden` and therefore invisible to `getByRole`. Any role-based
+ * assertion about the console underneath has to come after this.
+ */
+async function dismissWelcome(page: Page): Promise<void> {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  if (await skip.isVisible().catch(() => false)) await skip.click();
+}
+
 /** The tour's per-company localStorage key, discovered from the running app. */
-async function tourKey(page: import("@playwright/test").Page): Promise<string> {
+async function tourKey(page: Page): Promise<string> {
   const key = await page.evaluate(() =>
     Object.keys(window.localStorage).find((k) => k.startsWith("oc-tour:")),
   );
@@ -27,11 +41,13 @@ test("a cancelled handshake lands back in the console, not on a dead page", asyn
   // `{"error":"provider returned: access_denied"}` as the document body.
   await page.goto("/connections?connect_error=denied&provider=slack");
 
-  // The console renders — the operator is not stranded on raw JSON.
-  await expect(page.getByRole("heading", { name: "Connections" })).toBeVisible();
-
-  // ...and is told what happened, in recoverable terms.
+  // Assert the message first — the toast auto-dismisses, so anything that
+  // blocks for a timeout before this would race it away.
   await expect(page.getByText(/cancelled/i)).toBeVisible();
+
+  // The console renders — the operator is not stranded on raw JSON.
+  await dismissWelcome(page);
+  await expect(page.getByRole("heading", { name: "Connections", level: 2 })).toBeVisible();
 
   // The param is stripped, so a refresh doesn't re-fire the toast.
   await expect
@@ -45,8 +61,9 @@ test("a cancelled handshake lands back in the console, not on a dead page", asyn
 test("an unknown failure code still produces a usable message", async ({ page }) => {
   // An older console against a newer host must not fall silent.
   await page.goto("/connections?connect_error=something_new_2099");
-  await expect(page.getByRole("heading", { name: "Connections" })).toBeVisible();
   await expect(page.getByText(/couldn't connect/i)).toBeVisible();
+  await dismissWelcome(page);
+  await expect(page.getByRole("heading", { name: "Connections", level: 2 })).toBeVisible();
 });
 
 test("the tour resumes on the Connections stop after a redirect", async ({ page }) => {

--- a/src/server/ops/connections.rs
+++ b/src/server/ops/connections.rs
@@ -10,12 +10,18 @@
 //!
 //! The authorize URL carries a signed `state` nonce binding the flow to one
 //! company + provider + expiry, verified on callback so a tampered `state` is
-//! rejected with `401`.
+//! refused before any token exchange.
+//!
+//! The callback is reached by a **browser navigation**, so it never answers with
+//! a body: every outcome — success, cancellation, a bad nonce, a failed exchange
+//! — redirects to the console's Connections view carrying a stable, non-secret
+//! outcome code. Returning JSON there strands the operator on a blank page with
+//! no route back (issue #300).
 
 use std::sync::Arc;
 
 use axum::extract::{Path, State};
-use axum::http::{StatusCode, Uri};
+use axum::http::Uri;
 use axum::response::{IntoResponse, Redirect, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
@@ -120,6 +126,47 @@ fn redirect_uri(state: &AppState) -> String {
 fn state_secret() -> String {
     std::env::var("OPENCOMPANY_OAUTH_STATE_SECRET")
         .unwrap_or_else(|_| "opencompany-oauth-state".to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Console bounce-back
+// ---------------------------------------------------------------------------
+
+/// The console origin the callback bounces the operator's browser back to.
+/// `OPENCOMPANY_CONSOLE_URL` overrides it for deployments that serve the console
+/// from a different origin than the API.
+fn console_base(state: &AppState) -> String {
+    let base =
+        std::env::var("OPENCOMPANY_CONSOLE_URL").unwrap_or_else(|_| state.config().host_base_url());
+    base.trim_end_matches('/').to_string()
+}
+
+/// Sends the operator's browser back to the console's Connections view.
+///
+/// **Every** callback exit goes through here, success and failure alike. A
+/// failure arm that renders a JSON body into the document instead leaves the
+/// operator staring at raw error text on a blank page with no route back — the
+/// dead end reported in issue #300. A redirect keeps them in the console, where
+/// the Connections view can explain what happened and offer a retry.
+fn console_redirect(state: &AppState, params: &str) -> Response {
+    Redirect::to(&format!("{}/connections?{params}", console_base(state))).into_response()
+}
+
+/// Bounces back with a stable, non-secret failure code.
+///
+/// The code is one of a closed set the console maps to operator-facing copy.
+/// The provider's own error text is deliberately **not** propagated: it is
+/// attacker-influenced, unbounded, and may carry credential material — none of
+/// which belongs in a URL that lands in browser history and server access logs.
+///
+/// `provider` is optional because the arms that fire before the signed `state`
+/// is verified cannot always know which provider the flow was for.
+fn connect_error(state: &AppState, code: &str, provider: Option<&str>) -> Response {
+    let mut params = format!("connect_error={}", urlencode(code));
+    if let Some(provider) = provider {
+        params.push_str(&format!("&provider={}", urlencode(provider)));
+    }
+    console_redirect(state, &params)
 }
 
 // ---------------------------------------------------------------------------
@@ -235,39 +282,46 @@ fn percent_decode(value: &str) -> String {
     String::from_utf8_lossy(&out).into_owned()
 }
 
+/// The provider a callback was for, recovered from a **signature-verified**
+/// `state` — used only to enrich a failure bounce-back with the provider name.
+/// An unverified `state` is never trusted for this, so a tampered value simply
+/// yields `None` and the console shows the provider-less message.
+fn provider_from_state(uri: &Uri) -> Option<String> {
+    let raw = query_param(uri, "state")?;
+    decode_state(&raw).map(|(_, provider)| provider)
+}
+
 /// `GET /api/v1/oauth/callback` — verify state, exchange code, store tokens.
+///
+/// Always answers with a redirect into the console (see [`console_redirect`]):
+/// this route is reached by a **browser navigation**, so any body it returns is
+/// rendered as the page the operator is left on.
 async fn callback(State(state): State<AppState>, uri: Uri) -> Response {
     if let Some(err) = query_param(&uri, "error") {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "error": format!("provider returned: {err}"), "code": "oauth_error" })),
-        )
-            .into_response();
+        // Log the provider's text host-side for diagnosis; never forward it to
+        // the browser (see `connect_error`).
+        tracing::warn!(provider_error = %err, "oauth callback: provider returned an error");
+        return connect_error(&state, "denied", provider_from_state(&uri).as_deref());
     }
     let (Some(code), Some(raw_state)) = (query_param(&uri, "code"), query_param(&uri, "state"))
     else {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "error": "missing code or state", "code": "invalid_request" })),
-        )
-            .into_response();
+        return connect_error(
+            &state,
+            "invalid_request",
+            provider_from_state(&uri).as_deref(),
+        );
     };
     // A tampered or expired `state` is rejected before any exchange.
     let Some((company, provider)) = decode_state(&raw_state) else {
-        return (
-            StatusCode::UNAUTHORIZED,
-            Json(json!({ "error": "invalid oauth state", "code": "unauthorized" })),
-        )
-            .into_response();
+        // No provider: the only claim to one came from the `state` we just
+        // refused to trust.
+        return connect_error(&state, "invalid_state", None);
     };
     let Some(runtime) = state.registry().get(&CompanyId::new(&company)) else {
-        return ApiError(OpenCompanyError::CompanyNotFound(company)).into_response();
+        return connect_error(&state, "unknown_company", Some(&provider));
     };
     let Some(config) = provider_config(&provider) else {
-        return ApiError(OpenCompanyError::InvalidRequest(format!(
-            "provider '{provider}' is not enabled on this host"
-        )))
-        .into_response();
+        return connect_error(&state, "provider_disabled", Some(&provider));
     };
 
     match exchange_code(&state, &config, &code).await {
@@ -283,18 +337,16 @@ async fn callback(State(state): State<AppState>, uri: Uri) -> Response {
                 )
                 .await
             {
-                return ApiError(err).into_response();
+                tracing::warn!(provider, "oauth callback: storing the token failed: {err}");
+                return connect_error(&state, "store_failed", Some(&provider));
             }
             // Redirect the browser back to the console connections view.
-            let console = std::env::var("OPENCOMPANY_CONSOLE_URL")
-                .unwrap_or_else(|_| state.config().host_base_url());
-            Redirect::to(&format!(
-                "{}/connections?connected={provider}",
-                console.trim_end_matches('/')
-            ))
-            .into_response()
+            console_redirect(&state, &format!("connected={}", urlencode(&provider)))
         }
-        Err(err) => ApiError(err).into_response(),
+        Err(err) => {
+            tracing::warn!(provider, "oauth callback: token exchange failed: {err}");
+            connect_error(&state, "exchange_failed", Some(&provider))
+        }
     }
 }
 
@@ -531,6 +583,193 @@ mod test {
             Some("Acme".to_string())
         );
         assert_eq!(extract_account(&json!({ "access_token": "x" })), None);
+    }
+
+    // ---- callback bounce-back (issue #300) ---------------------------------
+
+    use crate::AppConfig;
+
+    /// Drives `callback` with a raw query string and returns the response.
+    async fn call_callback(state: AppState, query: &str) -> Response {
+        let uri: Uri = format!("/api/v1/oauth/callback?{query}")
+            .parse()
+            .expect("valid uri");
+        callback(State(state), uri).await
+    }
+
+    /// The `Location` header of a redirect response, asserting it *is* one.
+    fn location(resp: &Response) -> String {
+        assert!(
+            resp.status().is_redirection(),
+            "expected a redirect, got {}",
+            resp.status()
+        );
+        resp.headers()
+            .get("location")
+            .expect("redirect carries a Location")
+            .to_str()
+            .expect("ascii location")
+            .to_string()
+    }
+
+    /// Every failure arm must bounce the browser back to the console's
+    /// Connections view — never render a JSON body into the document, which is
+    /// the dead end issue #300 reports.
+    #[tokio::test]
+    async fn callback_failures_redirect_to_console_connections() {
+        let state = AppState::new(AppConfig::default());
+        for query in [
+            "error=access_denied",
+            "code=abc",  // missing state
+            "state=xyz", // missing code
+            "code=abc&state=not-a-valid-state",
+        ] {
+            let resp = call_callback(state.clone(), query).await;
+            let loc = location(&resp);
+            assert!(
+                loc.contains("/connections?"),
+                "{query} did not bounce to the console: {loc}"
+            );
+            assert!(
+                loc.contains("connect_error="),
+                "{query} carried no failure code: {loc}"
+            );
+        }
+    }
+
+    /// A cancel at the consent screen maps to `denied`, and — because the
+    /// `state` is signature-verified — names the provider so the console can say
+    /// which tile failed.
+    #[tokio::test]
+    async fn callback_denied_names_provider_from_verified_state() {
+        let state = AppState::new(AppConfig::default());
+        let nonce = encode_state("acme", "slack", now_millis() + STATE_TTL_MS);
+        let resp = call_callback(
+            state,
+            &format!("error=access_denied&state={}", urlencode(&nonce)),
+        )
+        .await;
+        let loc = location(&resp);
+        assert!(loc.contains("connect_error=denied"), "{loc}");
+        assert!(loc.contains("provider=slack"), "{loc}");
+        // The provider's own error text is host-side only: it is
+        // attacker-influenced and must never ride in a URL.
+        assert!(
+            !loc.contains("access_denied"),
+            "raw provider error leaked into Location: {loc}"
+        );
+    }
+
+    /// Without a verifiable `state` there is no trustworthy provider claim, so
+    /// the bounce-back carries the code alone.
+    #[tokio::test]
+    async fn callback_denied_without_state_omits_provider() {
+        let state = AppState::new(AppConfig::default());
+        let resp = call_callback(state, "error=access_denied").await;
+        let loc = location(&resp);
+        assert!(loc.contains("connect_error=denied"), "{loc}");
+        assert!(!loc.contains("provider="), "{loc}");
+    }
+
+    /// A tampered `state` must not be mined for a provider name — the only
+    /// claim to one came from the value we just refused to trust.
+    #[tokio::test]
+    async fn callback_tampered_state_reports_invalid_state_only() {
+        let state = AppState::new(AppConfig::default());
+        let mut nonce = encode_state("acme", "slack", now_millis() + STATE_TTL_MS);
+        let last = nonce.pop().expect("non-empty");
+        nonce.push(if last == '0' { '1' } else { '0' });
+        let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
+        let loc = location(&resp);
+        assert!(loc.contains("connect_error=invalid_state"), "{loc}");
+        assert!(!loc.contains("provider="), "{loc}");
+    }
+
+    /// An expired nonce is a recoverable state (the operator simply took too
+    /// long), so it bounces back rather than dead-ending on a 401 body.
+    #[tokio::test]
+    async fn callback_expired_state_redirects() {
+        let state = AppState::new(AppConfig::default());
+        let nonce = encode_state("acme", "slack", now_millis().saturating_sub(1));
+        let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
+        assert!(
+            location(&resp).contains("connect_error=invalid_state"),
+            "expired state must bounce back"
+        );
+    }
+
+    /// A signed state for a company this host doesn't run.
+    #[tokio::test]
+    async fn callback_unknown_company_redirects() {
+        let state = AppState::new(AppConfig::default());
+        let nonce = encode_state("ghost", "slack", now_millis() + STATE_TTL_MS);
+        let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
+        let loc = location(&resp);
+        assert!(loc.contains("connect_error=unknown_company"), "{loc}");
+        assert!(loc.contains("provider=slack"), "{loc}");
+    }
+
+    /// A registered company, but the provider has no app credentials on this
+    /// host — the catalog/backend gap the console shows 11 tiles for.
+    #[tokio::test]
+    async fn callback_unconfigured_provider_redirects() {
+        let (runtime, _home) = test_runtime().await;
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(CompanyId::new("acme"), runtime);
+        let provider = unique_provider();
+        let nonce = encode_state("acme", &provider, now_millis() + STATE_TTL_MS);
+        let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
+        let loc = location(&resp);
+        assert!(loc.contains("connect_error=provider_disabled"), "{loc}");
+        assert!(loc.contains(&format!("provider={provider}")), "{loc}");
+    }
+
+    /// A token endpoint that cannot be reached must bounce back too — and the
+    /// authorization code must not ride along into browser history or logs.
+    #[tokio::test]
+    async fn callback_exchange_failure_redirects_without_leaking_code() {
+        // Bind then drop to obtain a port with nothing listening on it.
+        let dead = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let dead_addr = dead.local_addr().unwrap();
+        drop(dead);
+
+        let (runtime, _home) = test_runtime().await;
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(CompanyId::new("acme"), runtime);
+        let provider = unique_provider();
+        let key = provider.to_ascii_uppercase();
+        // SAFETY: unique per-test provider name → no cross-test env collision.
+        unsafe {
+            std::env::set_var(format!("OPENCOMPANY_OAUTH_{key}_ID"), "cid");
+            std::env::set_var(format!("OPENCOMPANY_OAUTH_{key}_SECRET"), "csec");
+            std::env::set_var(
+                format!("OPENCOMPANY_OAUTH_{key}_AUTHORIZE_URL"),
+                "http://x/a",
+            );
+            std::env::set_var(
+                format!("OPENCOMPANY_OAUTH_{key}_TOKEN_URL"),
+                format!("http://{dead_addr}/token"),
+            );
+        }
+
+        let nonce = encode_state("acme", &provider, now_millis() + STATE_TTL_MS);
+        let resp = call_callback(
+            state,
+            &format!("code=CANARY-authz-code&state={}", urlencode(&nonce)),
+        )
+        .await;
+        let loc = location(&resp);
+        assert!(loc.contains("connect_error=exchange_failed"), "{loc}");
+        assert!(
+            !loc.contains("CANARY-authz-code"),
+            "authorization code leaked into Location: {loc}"
+        );
+
+        unsafe {
+            for suffix in ["ID", "SECRET", "AUTHORIZE_URL", "TOKEN_URL"] {
+                std::env::remove_var(format!("OPENCOMPANY_OAUTH_{key}_{suffix}"));
+            }
+        }
     }
 
     // ---- disconnect / best-effort revoke ----------------------------------


### PR DESCRIPTION
## Summary

Closes #300. Part of MVP spec epic #183 §1.

Connecting an integration from inside onboarding left the operator stranded. The premise checked out — **onboarding is the first-run guided tour**; its controller calls itself the onboarding lifecycle, and the tour has a Connections stop that tells the operator to plug in Gmail/Slack/GitHub. So a connection really does start from inside it.

Three defects compound there, and the issue's own hypothesis — state lost across the redirect, not the callback — was right:

1. Starting a connection navigates the whole document away, unlike the MCP OAuth path in the same view which opens a tab and survives.
2. The tour persists only `completed`/`skipped`; its step index lives in memory. The full-page round trip destroys it, and because neither flag was ever written the app concludes the tour was never seen and **reopens the welcome dialog from step 1** — the operator returns to "Welcome to your company" laid over Connections, with a "Connected Gmail" toast underneath.
3. Independently, and this breaks the plain Connections view too: the callback redirected **only on success**. Every failure arm returned raw JSON into the document, so cancelling at the consent screen left a blank page reading `{"error":"provider returned: access_denied"}` with no route back.

## API Or Behavior Changes

**Host.** The OAuth callback's failure arms now redirect instead of returning JSON:

```
cancel at consent   400 {"error":"provider returned: access_denied"}  →  303 …/connections?connect_error=denied&provider=gmail
bare callback       400 {"error":"missing code or state"}             →  303 …/connections?connect_error=invalid_request
invalid state       401 {"error":"invalid oauth state"}               →  303 …/connections?connect_error=invalid_state
```

Codes are a fixed vocabulary. The provider's raw error text is never echoed into the URL, and no token material appears there. `provider` is optional — the missing-state and invalid-state arms cannot always know it. Confirmed before changing anything: no existing test asserted the old 400/401 bodies.

**Console.** The existing `?connected=` handler also reads `connect_error`, strips it the same way, lands on Connections and shows the failure. A cancelled handshake is now recoverable rather than a dead end.

**Tour.** A short-lived resume marker (~15 min, deliberately longer than the OAuth nonce's 10) is written under the same per-company key before the redirect, and consumed on return to resume at the stop the operator left rather than restarting.

The marker stores a **stable view name, not a step index**. #313 deleted the Desks stop and shifted every index after it; a stored index would resume on the wrong stop, or past the end into `undefined`, which an existing guard swallows silently. This also keeps the change out of the tour steps file entirely.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — exit 0, no warnings from first-party sources
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **1623 passed, 0 failed**
- [x] `cargo check --locked --all-features --all-targets` — exit 0
- [x] `npm run typecheck`, `npm run typecheck:e2e`, `npm run build`
- [x] `git diff Cargo.lock` empty throughout
- N/A: frontend unit tests — no runner exists in `frontend/`

**Verified on a live host, before and after**, isolated with `OPENCOMPANY_DATA_DIR` and driven through a loopback stub identity provider. **Zero real credentials were used at any point.** The same spec run against both trees: **pre-fix 3 failed / 1 passed → post-fix 4 passed.**

The pre-fix symptom was captured from the live page rather than inferred — on return from the provider the accessibility snapshot reads `dialog "Welcome to your company"`, exactly the predicted restart. Post-fix the tour resumes on the Connections stop.

Per the issue's acceptance criteria:

- **Completes and returns to the right step** — full round trip through the stub for two providers, both storing the expected account.
- **Reproduced live before the fix, same path after** — the table above is the before/after, not a description of one.
- **Every provider exercised** — all 11 catalog tiles swept: one resolving through the well-known branch, one through an explicit URL override, one non-well-known via overrides, and the remaining eight returning `400` at `start` **without navigating**, so an unconfigured tile cannot strand the tour.
- **Failure is recoverable** — the three probes above, each landing back in the console and retryable.

Playwright is local evidence only; CI does not run it (the config declares no `webServer`).

**Not done, stated plainly:** no real provider was ever exercised — only the stub. "Every provider" is proven at the `start` / provider-config boundary and through two complete round trips, not eleven live handshakes.

## Documentation

`docs/spec/runtime/api.md` records the callback's redirect contract — the success parameter, the failure codes, and that the provider's own error text is deliberately not propagated.

Two findings recorded for whoever is here next:

- The tour library turned out to support **`initialStepIndex`** for uncontrolled tours, so resuming needed no controlled step index and the deliberately uncontrolled design survives untouched. The plan had assumed a controlled index might be required.
- Two spec locator bugs surfaced only on the live run: the welcome dialog hides the app from role queries while open, and both the topbar heading and the view heading are named "Connections". Neither is a product defect, but both will bite the next person writing specs against this screen.

## Related

Closes #300.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth connection attempts now return to the Connections view with clear success or failure notifications.
  * Connection errors use safe, actionable messages, while sensitive provider details remain protected.
  * Onboarding tours can resume at the appropriate step after navigating away and returning.
  * Tour progress is preserved briefly and reset appropriately after completion, replay, or company changes.

* **Documentation**
  * Added guidance on OAuth callback behavior and provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->