### PR TITLE
feat(approvals): re-dispatch an approved tool call via a single-use grant (#243)

### DIFF
--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -47,6 +47,67 @@ effect emitted ─▶ evaluate ─▶ Allow ─▶ execute, journal
 - Approve executes the parked effect exactly once
   (journal-before-execute, [runtime/lifecycle.md](../runtime/lifecycle.md));
   deny feeds the refusal back so the brain replans rather than retries.
+- **Resolution is idempotent.** Resolving an approval that is no longer parked
+  — a double-submit, a retried request, two operators on the same queue —
+  is a no-op with a fixed reply. It writes no journal record and runs no
+  follow-up cycle.
+
+## Approving a blocked tool call: single-use grants
+
+Two different things park on this queue and they need opposite treatment.
+
+A **native** effect is one the runtime performs itself (an email, a workflow
+delivery). Approving it executes it, as above.
+
+A **tool call** is one an agent tried to make and the OpenHuman tool policy
+blocked. There is nothing for the runtime to execute — the parked effect's
+payload is the tool's *arguments*, and only that agent can run the tool. So
+approving it mints a **single-use grant** and re-dispatches the agent to
+re-issue the call. Without this, approving recorded a verdict and nothing ran:
+the operator had to go back and ask for the same thing again.
+
+A grant is:
+
+- **single-use** — redeeming consumes it, so one approval buys one call and
+  never standing permission;
+- **agent-scoped** — a grant minted for one desk does not admit another's
+  identical call;
+- **argument-exact** — matching is whole-value equality on the arguments. A
+  re-issue with a different recipient or amount does not match and re-parks,
+  because the operator never saw those arguments. Approve-with-edit mints
+  against the *amended* arguments;
+- **time-boxed** — 15 minutes. An approval is consent to act now, not a
+  standing authorisation. An unredeemed grant expires and the operator is told
+  the agent did not act, so re-approving is an informed choice.
+
+The lifecycle is journaled (`ApprovalGranted` → `GrantConsumed` | `GrantExpired`)
+and replayed on boot, so a restart between approving and re-issuing does not
+drop the approval. Consumed and expired grants are folded out on replay: a
+resurrected single-use grant would not be single-use.
+
+### Precedence at the tool gate
+
+A tool call is decided in this order:
+
+1. `never_do` hard-deny — **reserved**; the delegation-rule compiler is still a
+   Phase-1 stub, so no tool-level arm exists yet. It sits above the grant
+   deliberately: a grant is an operator saying yes to one call, `never_do` is
+   the company saying not ever, and the standing rule is the one meant to
+   survive a socially engineered operator.
+2. a live **grant** matching agent + tool + exact arguments → allow, once.
+3. `[policy].always_approve` → park.
+4. mode dispatch (`readonly` / `supervised` / `full`).
+
+The grant sits **above** `always_approve` on purpose. A tool on that list still
+parks the first time, which is what the list is for; but once the operator has
+approved that specific call, re-parking it would mean approval authorises
+nothing at all for precisely the tools an operator most wants to gate
+deliberately. Single-use, exact-args and agent-scope are what keep that
+narrow.
+
+Note this is the *tool* gate (`ApprovalPolicy`), which is a different path from
+the *effect* gate (`ManifestApprovalGate::evaluate`) the taxonomy above
+describes. A harness tool call parks directly and never reaches `evaluate`.
 
 ## Delegation levels (standing rules)
 

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -58,10 +58,21 @@ export function ApprovalsView({ client, company, feed, onResolved, onGoToConvers
     setBusy(a.id);
     try {
       await client.resolveApproval(a.id, verdict, undefined, company);
-      const verb = verdict === "approve" ? "Approved" : "Declined";
-      const line = `${verb}: ${approvalSummary(a)}`;
+      // Issue #243: approving no longer just records a verdict — it hands the
+      // agent a single-use grant and re-dispatches it to make the call. The old
+      // "Approved: …" read as "done", which was the exact lie that made the
+      // missing re-dispatch invisible: the operator saw a success toast for work
+      // that had silently dead-ended. Say what is actually happening instead.
+      // Declining IS terminal, so its wording is unchanged.
+      const line =
+        verdict === "approve"
+          ? `Approved — the agent is completing the action: ${approvalSummary(a)}`
+          : `Declined: ${approvalSummary(a)}`;
       onResolved(line);
       toast.success(line);
+      // The agent's reply arrives as a journaled `AgentReply` on its own thread,
+      // so no extra plumbing is needed here — the existing feed refresh plus the
+      // per-agent DM thread (#151) surface it.
       void feed.refresh();
     } catch (err) {
       const msg = err instanceof ApiError ? err.message : "something went wrong";

--- a/src/brain/echo.rs
+++ b/src/brain/echo.rs
@@ -34,6 +34,7 @@ impl EchoBrain {
             established_thread: false,
             first_time_counterparty: false,
             payload: serde_json::Value::Null,
+            agent: None,
         }
     }
 }

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -243,6 +243,7 @@ pub(crate) fn effect_from_frame(frame: &EffectFrame) -> Effect {
             .or_else(|| payload_bool(payload, "first_time_counterparty"))
             .unwrap_or(false),
         payload: frame.payload.clone(),
+        agent: None,
     }
 }
 

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -40,7 +40,7 @@ fn task_enters_in_progress(prev_column: Option<&str>, next_column: &str) -> bool
     next_column == IN_PROGRESS && prev_column != Some(IN_PROGRESS)
 }
 use crate::runtime::CycleRunner;
-use crate::runtime::grants::GrantSet;
+use crate::runtime::grants::{GRANT_TTL_MILLIS, GrantSet};
 use crate::runtime::journal::RuntimeJournal;
 use crate::runtime::types::{ApprovalSummary, CompanyStatus, CycleReport};
 use crate::server::ops::mailer::MailSender;
@@ -531,6 +531,63 @@ impl CompanyRuntime {
             }
         }
         Ok(expired)
+    }
+
+    /// Expires every single-use grant the agent never redeemed, and tells the
+    /// operator (issue #243). Returns the ids that expired.
+    ///
+    /// An approval is consent to an action *now*, not a standing authorisation.
+    /// Without this, a grant minted today would still admit the call if the same
+    /// tool surfaced next month — the operator would have authorised something
+    /// they had long since forgotten, at a moment they knew nothing about.
+    ///
+    /// The expiry is announced rather than silent, and that is the point. The
+    /// failure this guards is the operator approving, seeing nothing happen, and
+    /// having no way to tell whether the work is in flight, already done, or
+    /// quietly dead. A line on the operator channel makes re-approving an
+    /// informed choice.
+    ///
+    /// The journal write is the binding record and propagates; the operator line
+    /// is best-effort, matching
+    /// [`sweep_expired_approvals`](Self::sweep_expired_approvals) — a delivery
+    /// fault must not undo an expiry that has already happened in memory.
+    pub async fn sweep_expired_grants(&self) -> Result<Vec<ApprovalId>> {
+        let now = now_millis();
+        let expired = self.grants.sweep(now, GRANT_TTL_MILLIS);
+        let mut ids = Vec::with_capacity(expired.len());
+        for grant in expired {
+            self.journal
+                .record_grant_expired(&grant.approval_id, now)
+                .await?;
+            let text = format!(
+                "Approved `{}` for `{}`, but the agent didn't act within 15 minutes — \
+                 re-approve to retry.",
+                grant.tool, grant.agent
+            );
+            for channel in &self.channels {
+                if channel.channel_id() == crate::runtime::channel::OPERATOR_CHANNEL {
+                    if let Err(e) = channel
+                        .send(crate::ports::types::OutboundMessage {
+                            task_id: None,
+                            channel: crate::runtime::channel::OPERATOR_CHANNEL.to_string(),
+                            text: text.clone(),
+                            steps: Vec::new(),
+                            reply_to: None,
+                        })
+                        .await
+                    {
+                        tracing::warn!(
+                            approval_id = %grant.approval_id,
+                            error = %e,
+                            "grant expiry journaled but the operator notice failed to send",
+                        );
+                    }
+                    break;
+                }
+            }
+            ids.push(grant.approval_id);
+        }
+        Ok(ids)
     }
 
     /// Replays the journal to rebuild the executed-key set, the approval queue,

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -40,6 +40,7 @@ fn task_enters_in_progress(prev_column: Option<&str>, next_column: &str) -> bool
     next_column == IN_PROGRESS && prev_column != Some(IN_PROGRESS)
 }
 use crate::runtime::CycleRunner;
+use crate::runtime::grants::GrantSet;
 use crate::runtime::journal::RuntimeJournal;
 use crate::runtime::types::{ApprovalSummary, CompanyStatus, CycleReport};
 use crate::server::ops::mailer::MailSender;
@@ -132,6 +133,18 @@ pub struct CompanyRuntime {
     /// [`RuntimeBuilder`](crate::runtime::RuntimeBuilder) wires in the same handle
     /// the harness deps hold via [`set_steer`](Self::set_steer).
     pub(crate) steer: crate::company::steer::InflightRegistry,
+    /// Issue #243: the live single-use grants minted when an operator approves a
+    /// tool call an agent was blocked from making.
+    ///
+    /// Always present, like [`steer`](Self::steer) — [`GrantSet`] is
+    /// openhuman-free and the journal records replay in every build, so a
+    /// company that ran under the harness stays replayable by one without it. On
+    /// the harness path the [`RuntimeBuilder`](crate::runtime::RuntimeBuilder)
+    /// hands the SAME set to the agents' `ApprovalRequestQueue`, which is what
+    /// lets a grant minted here be redeemed there. On the default build nothing
+    /// ever mints, so the set stays empty and every approval keeps its
+    /// pre-#243 native-execute behaviour.
+    pub(crate) grants: GrantSet,
     /// Held for the duration of a cycle so cycles never interleave per company.
     pub(crate) serial: TokioMutex<()>,
     /// Held across a REST board write's read → validate → write, so two
@@ -177,6 +190,7 @@ impl CompanyRuntime {
         ops: OpsStores,
         feedback: Arc<FeedbackStore>,
         filer: Arc<FeedbackFiler>,
+        grants: GrantSet,
     ) -> Self {
         let approvals: Arc<dyn ApprovalGate> = approval_gate.clone();
         Self {
@@ -201,6 +215,7 @@ impl CompanyRuntime {
             source_dir: None,
             workflow_runner: None,
             steer: crate::company::steer::InflightRegistry::new(),
+            grants,
             serial: TokioMutex::new(()),
             task_writes: TokioMutex::new(()),
             #[cfg(feature = "openhuman")]
@@ -518,9 +533,10 @@ impl CompanyRuntime {
         Ok(expired)
     }
 
-    /// Replays the journal to rebuild the executed-key set and approval queue.
+    /// Replays the journal to rebuild the executed-key set, the approval queue,
+    /// and the live single-use grants (issue #243).
     pub async fn recover(&self) -> Result<()> {
-        self.journal.load().await
+        CycleRunner::new(self).recover().await
     }
 
     /// When each approval was parked, keyed by id, including approvals already

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -46,7 +46,7 @@ use crate::ports::artifacts::{ArtifactAuthor, ArtifactKind, ArtifactRecord};
 use crate::ports::brain::{Brain, CycleHost};
 use crate::ports::types::{
     CompanyEvent, CompanyRecord, CompressedTrace, CycleRequest, CycleResult, OutboundMessage,
-    TokenUsage, TurnStep, TurnStepKind, TurnStepStatus,
+    TokenUsage, TurnStep, TurnStepKind, TurnStepStatus, Verdict,
 };
 use crate::ports::{Cognition, TaskRecord, UsageMetering, generate_id, now_millis};
 
@@ -94,6 +94,126 @@ impl HarnessBrain {
     /// asynchronously, long after the turn that spawned it has answered, so the
     /// operator had to know to go and look. The note is still written — it stays
     /// the durable record — and the post-back is additive.
+    /// Re-dispatches the agent that holds a single-use grant for `approval_id`,
+    /// instructing it to re-issue the exact call the operator approved
+    /// (issue #243).
+    ///
+    /// Returns the agent's reply as a bubble on its own channel, or `None` when
+    /// there is no grant to redeem — which is the common case and must stay a
+    /// silent no-op:
+    ///
+    /// * a **denied** approval (this arm only runs on `Approve`, but a deny
+    ///   reaching here must not turn into a turn either);
+    /// * a **native** effect the runtime already executed, which mints nothing;
+    /// * a **legacy** parked effect from before `Effect::agent` existed, which
+    ///   replays as `None` and so mints nothing;
+    /// * the **system expiry** `ApprovalResolved { verdict: Deny }` that #309's
+    ///   sweep appends;
+    /// * a grant already consumed or swept.
+    ///
+    /// The turn is registered on the steer registry with the same RAII guard
+    /// `run_task` uses, so an operator can cancel a re-issue mid-flight and a
+    /// crashed turn never strands a ghost row in the in-flight strip.
+    async fn redispatch_granted_call(
+        &self,
+        approval_id: &crate::ports::types::ApprovalId,
+    ) -> Result<Option<OutboundMessage>> {
+        let Some(grant) = self.deps.approval_requests.grants().peek(approval_id) else {
+            return Ok(None);
+        };
+
+        // Re-issue verbatim. The grant admits ONE call matching these arguments
+        // exactly, so any drift the model introduces will simply re-park — the
+        // instruction is emphatic because a re-worded argument silently costs the
+        // operator a second approval round-trip.
+        let args = serde_json::to_string(&grant.args).unwrap_or_else(|_| "{}".to_string());
+        let instruction = format!(
+            "Operator approved your `{tool}` call. Re-issue it now with EXACTLY these \
+             arguments: {args}. Do not modify them.",
+            tool = grant.tool,
+        );
+
+        let guard = self.deps.steer.register(
+            &self.record.id,
+            InflightEntry {
+                key: format!("approval:{approval_id}"),
+                task_id: None,
+                kind: InflightKind::Delegation,
+                title: format!("re-issue {}", grant.tool),
+                agent_id: grant.agent.clone(),
+                started_at_millis: now_millis(),
+                pending_action: None,
+            },
+        );
+        let control = guard.control().clone();
+
+        let run_turn = HarnessRunTurn::new(&self.pool, &self.deps);
+        // Un-streamed, like a dispatched card: this turn is answered by the
+        // bubble returned below, and its transient frames would otherwise
+        // misattribute onto whichever chat thread the console is watching.
+        let outcome = run_turn
+            .run_steered_background(&self.record.id, &grant.agent, &instruction, &control)
+            .await;
+        drop(guard);
+
+        let text = match outcome {
+            Ok(outcome) => outcome.reply,
+            Err(err) => {
+                // The grant stays live: the call did not go through, so the
+                // operator's approval has not been spent and the TTL sweep will
+                // tell them if it never does. Reporting the failure is what stops
+                // this looking like a silent success.
+                tracing::warn!(
+                    approval_id = %approval_id,
+                    tool = %grant.tool,
+                    error = %err,
+                    "[approval] re-issuing an approved tool call failed"
+                );
+                format!(
+                    "re-issuing the approved `{}` call failed: {err}",
+                    grant.tool
+                )
+            }
+        };
+
+        // Journal the reply so the transcript echo survives a console refresh.
+        // The bubble below is live-only — a reader that reloads the page rebuilds
+        // the thread from the event log, and without this the operator would
+        // approve, watch the agent answer, refresh, and find the answer gone.
+        //
+        // `chat_id` is the AGENT id (not the approval id) so `chat_history::owns`
+        // routes it into that desk's thread — the same thread the original
+        // request came from, which is where the operator is looking.
+        if let Some(events) = self.deps.events.as_ref()
+            && let Err(err) = events
+                .append(
+                    &self.record.id,
+                    CompanyEvent::AgentReply {
+                        chat_id: grant.agent.clone(),
+                        agent_id: grant.agent.clone(),
+                        text: text.clone(),
+                        steps: Vec::new(),
+                        task_id: None,
+                    },
+                )
+                .await
+        {
+            tracing::warn!(
+                approval_id = %approval_id,
+                error = %err,
+                "[approval] failed to journal the re-issued call's reply; continuing"
+            );
+        }
+
+        Ok(Some(OutboundMessage {
+            task_id: None,
+            channel: grant.agent.clone(),
+            text,
+            steps: Vec::new(),
+            reply_to: None,
+        }))
+    }
+
     async fn run_task(&self, task_id: &str) -> Result<Option<OutboundMessage>> {
         let Some(tasks) = self.deps.tasks.as_ref() else {
             return Ok(None);
@@ -951,6 +1071,25 @@ impl Brain for HarnessBrain {
                 }
                 CompanyEvent::TaskDispatched { task_id } => {
                     if let Some(message) = self.run_task(task_id).await? {
+                        channel_responses.push(message);
+                    }
+                }
+                // Issue #243: an approval the operator APPROVED that minted a
+                // single-use grant — re-dispatch the granting agent so it
+                // actually makes the call.
+                //
+                // This arm is the reason the feature was invisible before. The
+                // match had exactly two arms and everything else fell into
+                // `_ => {}`, so an `ApprovalResolved` produced no turn, no
+                // response, and the cycle ended on the "Acknowledged." fallback
+                // below. The operator approved, saw "Acknowledged.", and nothing
+                // happened — indistinguishable from the tool having run.
+                CompanyEvent::ApprovalResolved {
+                    approval_id,
+                    verdict: Verdict::Approve,
+                    ..
+                } => {
+                    if let Some(message) = self.redispatch_granted_call(approval_id).await? {
                         channel_responses.push(message);
                     }
                 }
@@ -2775,7 +2914,11 @@ members = ["eng1", "eng2"]
         assert_eq!(steps[0].detail.as_deref(), Some("server rejected the call"));
 
         let logged = events
-            .read_from(&CompanyId::new("acme"), EventSeq::new(0), usize::MAX)
+            .read_from(
+                &CompanyId::new("acme"),
+                crate::ports::EventSeq::new(0),
+                usize::MAX,
+            )
             .await
             .expect("read events");
         assert!(
@@ -3126,6 +3269,235 @@ members = ["eng1", "eng2"]
         assert_eq!(parked.len(), 2, "the batch continued past the failure");
         assert_eq!(parked[0].kind, "second_tool");
         assert_eq!(parked[1].kind, "third_tool");
+    }
+
+    // --- Re-dispatching a granted call (issue #243) --------------------------
+
+    /// A brain over the offline mock provider, wired to a real event log and a
+    /// shared approval queue (whose grant set the runtime would mint into).
+    fn brain_with_queue_and_events(
+        dir: &std::path::Path,
+        requests: crate::harness::policy::ApprovalRequestQueue,
+        events: Arc<dyn crate::ports::EventLog>,
+    ) -> HarnessBrain {
+        let deps = HarnessDeps {
+            provider: Arc::new(MockProvider::new("mock: ")),
+            provider_slug: "mock".to_string(),
+            context: Arc::new(FsContextStore::new(dir)),
+            store: Arc::new(FsCompanyStore::new(dir)),
+            meter: None,
+            workspace_root: dir.to_path_buf(),
+            model_override: None,
+            tasks: None,
+            artifacts: None,
+            skills: None,
+            skills_source_dir: None,
+            skills_registry: std::sync::Arc::from([]),
+            mcp_servers: Vec::new(),
+            facts: None,
+            events: Some(events),
+            delegations: orchestrator::DelegationQueue::default(),
+            workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
+            mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            approval_requests: requests,
+            secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            workflow_source_dir: None,
+            plan: None,
+            media: None,
+            composio: None,
+            steer: crate::company::steer::InflightRegistry::default(),
+            delivery: None,
+            search: None,
+            workspace: None,
+        };
+        HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record())
+    }
+
+    fn approval_resolved(id: &str, verdict: Verdict) -> CompanyEvent {
+        CompanyEvent::ApprovalResolved {
+            approval_id: ApprovalId::new(id),
+            verdict,
+            by: crate::ports::types::Actor {
+                kind: crate::ports::types::ActorKind::Operator,
+                id: "owner".into(),
+            },
+        }
+    }
+
+    fn cycle_over(events: Vec<CompanyEvent>) -> CycleRequest {
+        CycleRequest {
+            cycle_id: "cyc-1".to_string(),
+            company_id: CompanyId::new("acme"),
+            events,
+            event_seqs: Vec::new(),
+            compressed_history: Vec::new(),
+            roster: vec!["ceo".to_string()],
+            context_index: Vec::new(),
+        }
+    }
+
+    /// The arm that made #243 visible: an approved grant re-dispatches its agent
+    /// with the exact arguments, answers on that agent's channel, and journals
+    /// the reply.
+    ///
+    /// Before this arm existed, `ApprovalResolved` fell into `_ => {}`: no turn,
+    /// no response, and the cycle ended on the "Acknowledged." fallback. The
+    /// operator approved, read "Acknowledged.", and nothing ran — which looks
+    /// exactly like success.
+    ///
+    /// `MockProvider` echoes the user message back, so the reply text IS the
+    /// instruction the agent received — which is what makes argument fidelity
+    /// assertable offline.
+    #[tokio::test]
+    async fn an_approved_grant_redispatches_its_agent_with_the_exact_arguments() {
+        let dir = tempfile::tempdir().unwrap();
+        let log: Arc<dyn crate::ports::EventLog> =
+            Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf()));
+        let requests = crate::harness::policy::ApprovalRequestQueue::default();
+        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL", "to": "a@b.test" });
+        requests
+            .grants()
+            .grant(crate::runtime::grants::GrantedCall {
+                approval_id: ApprovalId::new("appr-1"),
+                agent: "ceo".into(),
+                tool: "composio_execute".into(),
+                args: args.clone(),
+                at_millis: now_millis(),
+            });
+        let brain = brain_with_queue_and_events(dir.path(), requests, log.clone());
+
+        let result = brain
+            .run_cycle(
+                cycle_over(vec![approval_resolved("appr-1", Verdict::Approve)]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        // A real bubble, on the GRANTING agent's channel — not the generic
+        // "Acknowledged." fallback and not the operator channel.
+        assert_eq!(result.channel_responses.len(), 1);
+        let bubble = &result.channel_responses[0];
+        assert_eq!(bubble.channel, "ceo");
+        assert_ne!(bubble.text, "Acknowledged.");
+
+        // The instruction carried the tool and the arguments VERBATIM. A model
+        // that re-issues with drifted arguments re-parks (see the policy tests),
+        // so the fidelity of this string is what makes the round-trip land.
+        assert!(bubble.text.contains("composio_execute"), "{}", bubble.text);
+        assert!(
+            bubble.text.contains(&serde_json::to_string(&args).unwrap()),
+            "the exact approved arguments must reach the agent: {}",
+            bubble.text
+        );
+        assert!(
+            bubble.text.contains("Do not modify them"),
+            "{}",
+            bubble.text
+        );
+
+        // The reply is journaled under the agent's own chat thread, so the echo
+        // survives a console refresh rather than living only in this response.
+        let stored = log
+            .read_from(&CompanyId::new("acme"), crate::ports::EventSeq::new(0), 100)
+            .await
+            .unwrap();
+        let replies: Vec<_> = stored
+            .iter()
+            .filter_map(|e| match &e.event {
+                CompanyEvent::AgentReply {
+                    chat_id,
+                    agent_id,
+                    text,
+                    ..
+                } => Some((chat_id.clone(), agent_id.clone(), text.clone())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(replies.len(), 1, "the re-issued call's reply is journaled");
+        assert_eq!(
+            replies[0].0, "ceo",
+            "routed into the granting agent's thread"
+        );
+        assert_eq!(replies[0].1, "ceo");
+        assert_eq!(replies[0].2, bubble.text);
+    }
+
+    /// A DENIED approval runs no turn. "No" must never re-dispatch anything.
+    #[tokio::test]
+    async fn a_denied_approval_redispatches_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let log: Arc<dyn crate::ports::EventLog> =
+            Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf()));
+        let requests = crate::harness::policy::ApprovalRequestQueue::default();
+        // A grant for a DIFFERENT approval is live, to prove the arm keys on the
+        // resolved id rather than reaching for whatever is lying around.
+        requests
+            .grants()
+            .grant(crate::runtime::grants::GrantedCall {
+                approval_id: ApprovalId::new("appr-other"),
+                agent: "ceo".into(),
+                tool: "composio_execute".into(),
+                args: serde_json::json!({}),
+                at_millis: now_millis(),
+            });
+        let brain = brain_with_queue_and_events(dir.path(), requests, log.clone());
+
+        let result = brain
+            .run_cycle(
+                cycle_over(vec![approval_resolved("appr-1", Verdict::Deny)]),
+                &NoopHost,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.channel_responses.len(), 1);
+        assert_eq!(
+            result.channel_responses[0].text, "Acknowledged.",
+            "a deny falls through to the fallback, exactly as before #243"
+        );
+        assert!(
+            log.read_from(&CompanyId::new("acme"), crate::ports::EventSeq::new(0), 100)
+                .await
+                .unwrap()
+                .is_empty(),
+            "nothing is journaled for a deny"
+        );
+    }
+
+    /// An approved resolution with NO grant behind it is a silent no-op.
+    ///
+    /// This is the common case, not an edge: a native effect the runtime already
+    /// executed, a legacy parked effect from before `Effect::agent` existed (it
+    /// replays as `None` and mints nothing), a grant already consumed, and a
+    /// grant already swept all land here. Every one of them must keep the exact
+    /// pre-#243 behaviour rather than manufacturing a turn.
+    #[tokio::test]
+    async fn an_approval_with_no_grant_is_a_silent_no_op() {
+        let dir = tempfile::tempdir().unwrap();
+        let log: Arc<dyn crate::ports::EventLog> =
+            Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf()));
+        let requests = crate::harness::policy::ApprovalRequestQueue::default();
+        let brain = brain_with_queue_and_events(dir.path(), requests, log.clone());
+
+        let result = brain
+            .run_cycle(
+                cycle_over(vec![approval_resolved("appr-native", Verdict::Approve)]),
+                &NoopHost,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.channel_responses.len(), 1);
+        assert_eq!(result.channel_responses[0].text, "Acknowledged.");
+        assert!(
+            log.read_from(&CompanyId::new("acme"), crate::ports::EventSeq::new(0), 100)
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     // --- Steer disposition (issue #111) -------------------------------------

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -3033,6 +3033,7 @@ members = ["eng1", "eng2"]
                 established_thread: false,
                 first_time_counterparty: false,
                 payload: serde_json::json!({ "prompt": "a logo" }),
+                agent: None,
             },
         });
 
@@ -3109,6 +3110,7 @@ members = ["eng1", "eng2"]
                     established_thread: false,
                     first_time_counterparty: false,
                     payload: serde_json::json!({ "tool": tool }),
+                    agent: None,
                 },
             });
         }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -2914,11 +2914,7 @@ members = ["eng1", "eng2"]
         assert_eq!(steps[0].detail.as_deref(), Some("server rejected the call"));
 
         let logged = events
-            .read_from(
-                &CompanyId::new("acme"),
-                crate::ports::EventSeq::new(0),
-                usize::MAX,
-            )
+            .read_from(&CompanyId::new("acme"), EventSeq::new(0), usize::MAX)
             .await
             .expect("read events");
         assert!(

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1330,7 +1330,10 @@ pub(crate) fn build_roster(
 
     for manifest_agent in &company.manifest.agents {
         let agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily)
-            .with_requests(deps.approval_requests.clone());
+            .with_requests(deps.approval_requests.clone())
+            // Issue #243: stamp who the parked effect belongs to, so approving it
+            // can hand the grant back to this agent rather than to nobody.
+            .with_agent(manifest_agent.id.clone());
         let is_orchestrator = orchestrator.as_deref() == Some(manifest_agent.id.as_str());
         let grants = agent_effective_grants(allow, &manifest_agent.tools);
         let agent = build::build_agent(
@@ -1367,7 +1370,10 @@ pub(crate) fn build_roster(
         // No per-teammate budget cap or cognition-tier hint in v1 — see
         // `overlay_agent_to_manifest`.
         let agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily)
-            .with_requests(deps.approval_requests.clone());
+            .with_requests(deps.approval_requests.clone())
+            // An overlay teammate is a real roster agent and re-dispatches the
+            // same way a manifest one does (issue #243).
+            .with_agent(manifest_agent.id.clone());
         let grants = agent_effective_grants(allow, &manifest_agent.tools);
         let agent = build::build_agent(
             &company.id,

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -513,7 +513,17 @@ fn summarize_event(event: &CompanyEvent) -> String {
         CompanyEvent::ScheduleFired { cron, .. } => format!("schedule fired: {cron}"),
         CompanyEvent::WebhookReceived { channel, .. } => format!("webhook on {channel}"),
         CompanyEvent::A2aTaskReceived { from, .. } => format!("A2A task from {from}"),
-        CompanyEvent::ApprovalResolved { verdict, .. } => format!("approval {verdict:?}"),
+        // The tool this resolved is deliberately NOT named here, though it would
+        // read better: `ApprovalResolved` carries only the id, the verdict and
+        // the actor, so naming the tool would mean threading a journal lookup
+        // into what is a pure function over one event — real coupling for a
+        // non-load-bearing insight string. The id is carried instead, which is
+        // enough to correlate against the approvals surface and costs nothing.
+        CompanyEvent::ApprovalResolved {
+            approval_id,
+            verdict,
+            ..
+        } => format!("approval {approval_id} {verdict:?}"),
         CompanyEvent::FeedbackFiled { .. } => "feedback filed".to_string(),
         CompanyEvent::PaymentReceived { amount_usd, .. } => format!("payment ${amount_usd:.2}"),
         CompanyEvent::LifecycleChanged { from, to, .. } => format!("lifecycle {from} → {to}"),

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -44,6 +44,7 @@ use oh::agent::tool_policy::{ToolPolicy, ToolPolicyDecision, ToolPolicyRequest};
 
 use crate::company::Policy;
 use crate::ports::types::{Effect, EffectGroup};
+use crate::runtime::grants::GrantSet;
 
 /// Most approval requests parked out of a single turn. A model that keeps
 /// re-trying a blocked tool (openhuman feeds it a refusal and lets it continue)
@@ -106,6 +107,21 @@ pub struct ApprovalRequest {
 #[derive(Clone, Default)]
 pub struct ApprovalRequestQueue {
     inner: Arc<Mutex<Vec<ApprovalRequest>>>,
+    /// The live single-use grants (issue #243), riding along so the whole
+    /// approval round-trip travels on one handle.
+    ///
+    /// It lives here rather than as a new `HarnessDeps` field because every one
+    /// of the ~28 `HarnessDeps` literals in this crate (tests, examples, the
+    /// builder) would otherwise have to be widened to carry it — for a value
+    /// only the approval path reads.
+    ///
+    /// **Its own `Arc<Mutex<..>>` is load-bearing**, not incidental
+    /// encapsulation. [`clear`](Self::clear) runs at the top of every cycle and
+    /// empties `inner`; a grant folded into that same allocation would be wiped
+    /// by the very cycle that was dispatched to redeem it, so the feature would
+    /// fail in exactly its own happy path. The test
+    /// `grants_survive_a_queue_clear` pins this.
+    grants: GrantSet,
 }
 
 impl ApprovalRequestQueue {
@@ -139,6 +155,11 @@ impl ApprovalRequestQueue {
         let drained: Vec<ApprovalRequest> = guard.drain(..take).collect();
         guard.clear();
         drained
+    }
+
+    /// The live single-use grant set carried alongside this queue (issue #243).
+    pub fn grants(&self) -> GrantSet {
+        self.grants.clone()
     }
 
     /// The number of queued requests (test/observability).
@@ -1038,6 +1059,45 @@ mod tests {
         let drained = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
         assert_eq!(drained.len(), MAX_APPROVAL_REQUESTS_PER_TURN);
         assert_eq!(queue.queued(), 0, "the overflow is discarded, not carried");
+    }
+
+    /// Issue #243, and the single most fragile thing about riding the grant set
+    /// inside this queue: `HarnessBrain::run_cycle` calls
+    /// [`ApprovalRequestQueue::clear`] at the top of **every** cycle.
+    ///
+    /// A grant is minted by the approve, and redeemed during the follow-up cycle
+    /// that approve kicks off — so if `clear()` reached the grants, the feature
+    /// would be destroyed by its own happy path: the cycle dispatched to redeem
+    /// the grant would wipe it microseconds before the agent's tool call arrived,
+    /// and every approval would fall through and re-park. Separate inner locks
+    /// are what prevent that, and this pins it.
+    #[test]
+    fn grants_survive_a_queue_clear() {
+        let queue = ApprovalRequestQueue::default();
+        let grants = queue.grants();
+        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        grants.grant(crate::runtime::grants::GrantedCall {
+            approval_id: crate::ports::types::ApprovalId::new("appr-1"),
+            agent: "finance".into(),
+            tool: "composio_execute".into(),
+            args: args.clone(),
+            at_millis: 1_000,
+        });
+
+        queue.clear();
+
+        assert_eq!(
+            grants.live_count(),
+            1,
+            "clearing the request queue must not clear the grants it rides with"
+        );
+        assert!(
+            queue
+                .grants()
+                .consume("finance", "composio_execute", &args)
+                .is_some(),
+            "and the grant is still redeemable through a fresh handle"
+        );
     }
 
     /// A queue nobody installed stays inert — the default policy behaves exactly

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -387,7 +387,32 @@ impl ToolPolicy for ApprovalPolicy {
         //
         // Adding the arm below the grant check would silently invert that.
 
-        // 1. A live single-use grant: the operator already approved exactly this
+        // 1. `readonly` outranks a grant — the brake wins (issue #243).
+        //
+        // A grant can be up to `GRANT_TTL_MILLIS` old when it is redeemed, so a
+        // company can be switched to `readonly` in the window between the
+        // operator approving a call and the agent re-issuing it. Switching to
+        // `readonly` is the emergency stop, and that window is exactly when
+        // someone means it: the tier's contract is that nothing mutates and
+        // nothing reaches outside, and an approval given under a laxer mode is
+        // the older instruction. Consent does not survive the brake.
+        //
+        // Scoped deliberately to `readonly` and to external effects — the same
+        // condition the mode arm below denies on. `supervised` and `full` still
+        // fall through to the grant, because bypassing `supervised`'s re-park is
+        // the entire point of a grant.
+        //
+        // The grant is left UNCONSUMED here: this call never ran, so the
+        // operator's approval stays redeemable if the brake is released inside
+        // the TTL. It expires on its own otherwise.
+        if self.mode == PolicyMode::Readonly && is_external_effect(tool) {
+            return ToolPolicyDecision::deny(format!(
+                "'{tool}' mutates or reaches outside; this desk is read-only, \
+                 so an earlier approval does not apply"
+            ));
+        }
+
+        // 2. A live single-use grant: the operator already approved exactly this
         //    call, so let it through — once (issue #243).
         //
         // ABOVE `always_requires_approval` on purpose. A tool on the
@@ -1329,15 +1354,28 @@ mod tests {
         let args = serde_json::json!({ "to": "a@b.test" });
         grants.grant(granted("finance", "publish_post", args.clone()));
 
-        // The grant IS consumed at the top of `check` — it matched — so this
-        // documents the honest outcome rather than an imagined one: the call is
-        // allowed by the grant it was minted for. The `readonly` tier's guarantee
-        // is upheld at mint time instead: `ManifestApprovalGate` gates what may
-        // park, and the operator is the one who chose to approve it.
-        assert_eq!(
-            p.check(&request("publish_post", args)).await,
-            ToolPolicyDecision::Allow
+        // `readonly` outranks the grant. A grant can be up to its TTL old, so the
+        // company may have been switched to `readonly` between the operator
+        // approving this call and the agent re-issuing it — and that switch is
+        // the emergency stop. The tier's contract wins over the older consent.
+        assert!(
+            matches!(
+                p.check(&request("publish_post", args.clone())).await,
+                ToolPolicyDecision::Deny { .. }
+            ),
+            "a live grant must not survive the readonly brake"
         );
+
+        // And the grant was NOT consumed by that denial — the call never ran, so
+        // the operator's approval is still redeemable if the brake comes off
+        // inside the TTL.
+        assert!(
+            grants
+                .peek(&crate::ports::types::ApprovalId::new("appr-1"))
+                .is_some(),
+            "a denied call must not burn the grant it never used"
+        );
+
         // Anything the operator did NOT approve is still denied outright.
         assert!(matches!(
             p.check(&request("publish_post", serde_json::json!({ "other": 1 })))

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -29,11 +29,29 @@
 //! restart. Same cheap-shared-handle pattern as the delegation and MCP-failure
 //! queues.
 //!
-//! **Still out of scope:** resume-after-approval. openhuman resolves the
-//! decision inline, so approving a parked tool call records the verdict and
-//! clears the queue but does not re-dispatch the tool — the operator re-asks.
-//! Suspending and resuming a call inside openhuman's session loop is a separate
-//! piece of work.
+//! ## Resume-after-approval, via grants (issue #243)
+//!
+//! Closing the park bridge left approval still not *meaning* anything: the
+//! verdict was recorded, the queue drained, and the tool never ran. The operator
+//! had to go back and ask for the same thing again — with the work having
+//! silently dead-ended in between.
+//!
+//! openhuman genuinely cannot be resumed here: it resolves a `RequireApproval`
+//! inline and the blocked call is gone by the time the operator sees it. So the
+//! call is not resumed, it is **re-issued**. Approving a parked harness effect
+//! mints a single-use [`GrantedCall`](crate::runtime::grants::GrantedCall)
+//! scoped to that agent, that tool and those exact arguments, and the
+//! [`HarnessBrain`](crate::harness::HarnessBrain) re-dispatches the granting
+//! agent with an instruction to make the call again unchanged. The grant is
+//! consumed at the top of [`check`](ToolPolicy::check) — above
+//! `always_approve`, because a tool that always parks must still *run* once the
+//! operator has approved that specific call — and it is gone afterwards, so the
+//! next call to the same tool parks like any other.
+//!
+//! A grant that goes unredeemed expires
+//! ([`GRANT_TTL_MILLIS`](crate::runtime::grants::GRANT_TTL_MILLIS)) and the
+//! operator is told the agent did not act, rather than the permission sitting
+//! live indefinitely.
 
 use std::sync::{Arc, Mutex};
 
@@ -44,7 +62,7 @@ use oh::agent::tool_policy::{ToolPolicy, ToolPolicyDecision, ToolPolicyRequest};
 
 use crate::company::Policy;
 use crate::ports::types::{Effect, EffectGroup};
-use crate::runtime::grants::GrantSet;
+use crate::runtime::grants::{GrantSet, GrantedCall};
 
 /// Most approval requests parked out of a single turn. A model that keeps
 /// re-trying a blocked tool (openhuman feeds it a refusal and lets it continue)
@@ -289,6 +307,35 @@ impl ApprovalPolicy {
         }
     }
 
+    /// Redeems a live grant for this agent, this tool and these exact arguments
+    /// (issue #243), consuming it.
+    ///
+    /// A policy with no agent bound — every non-harness construction site — can
+    /// never match, so it short-circuits before touching the lock and behaves
+    /// exactly as it did before grants existed.
+    ///
+    /// On a near-miss the differing top-level keys are logged. That is the one
+    /// diagnostic that matters here: the visible symptom of a mismatch is "I
+    /// approved it and the agent asked again", and without this line the operator
+    /// and the developer have no way to tell a re-worded argument from a bug in
+    /// the grant machinery.
+    fn consume_grant(&self, tool: &str, args: &serde_json::Value) -> Option<GrantedCall> {
+        let agent = self.agent.as_deref()?;
+        let grants = self.requests.grants();
+        if let Some(grant) = grants.consume(agent, tool, args) {
+            return Some(grant);
+        }
+        // No exact match. If a grant for this agent+tool exists at all, the
+        // arguments drifted — say which keys, without dumping values (arguments
+        // carry recipients, bodies and amounts).
+        log::debug!(
+            "[approval] no grant matched tool '{tool}' for agent '{agent}'; \
+             argument keys offered: {:?}",
+            top_level_keys(args)
+        );
+        None
+    }
+
     /// The one construction site for a `RequireApproval` decision (issue #172):
     /// record the projected effect on the shared queue so the brain can park it
     /// after the turn, then return the decision openhuman blocks the call with.
@@ -323,7 +370,43 @@ impl ToolPolicy for ApprovalPolicy {
     async fn check(&self, request: &ToolPolicyRequest) -> ToolPolicyDecision {
         let tool = request.tool_name.as_str();
 
-        // `always_approve` wins over everything, including Full autonomy.
+        // 0. `never_do` hard-deny — RESERVED SLOT, deliberately empty.
+        //
+        // The manifest's `never_do` list is compiled by the delegation-rule
+        // compiler, which is still a Phase-1 stub, and today it is only consulted
+        // by `ManifestApprovalGate::evaluate` (`src/policy/gate.rs`). That gate
+        // never sees a harness tool call: the harness path parks via
+        // `CycleHostImpl::park` → `gate.park()`, which bypasses `evaluate`
+        // entirely, so the two gates sit on disjoint paths. When the compiler
+        // lands it must emit a tool-level arm HERE, ABOVE the grant check —
+        // a never-do tool must be refused even holding a grant, because a grant
+        // is an operator saying "yes to this call" and `never_do` is the company
+        // saying "not this, ever". Precedence between them is not a detail: an
+        // operator can be socially engineered, and the standing rule is the thing
+        // that is supposed to survive that.
+        //
+        // Adding the arm below the grant check would silently invert that.
+
+        // 1. A live single-use grant: the operator already approved exactly this
+        //    call, so let it through — once (issue #243).
+        //
+        // ABOVE `always_requires_approval` on purpose. A tool on the
+        // `always_approve` list still parks the FIRST time, which is what that
+        // list is for; but once the operator has said yes to that specific call,
+        // re-parking it would mean approval never actually authorises anything.
+        // The blast radius stays small because a grant is agent-scoped,
+        // argument-exact and single-use: redeeming it consumes it, so the very
+        // next call to the same tool parks again.
+        if let Some(grant) = self.consume_grant(tool, &request.arguments) {
+            log::debug!(
+                "[approval] tool '{tool}' allowed by single-use grant {} for agent '{}'",
+                grant.approval_id,
+                grant.agent
+            );
+            return ToolPolicyDecision::Allow;
+        }
+
+        // 2. `always_approve` wins over everything else, including Full autonomy.
         if self.always_requires_approval(tool) {
             return self.require_approval(
                 tool,
@@ -489,6 +572,15 @@ fn is_external_effect(tool_name: &str) -> bool {
     ];
     let name = tool_name.to_ascii_lowercase();
     !READ_ONLY_PREFIXES.iter().any(|p| name.starts_with(p))
+}
+
+/// The top-level keys of a tool-argument object, for a mismatch diagnostic.
+/// Keys only — values carry recipients, bodies and amounts.
+fn top_level_keys(args: &serde_json::Value) -> Vec<&str> {
+    match args {
+        serde_json::Value::Object(map) => map.keys().map(String::as_str).collect(),
+        _ => Vec::new(),
+    }
 }
 
 /// Map a tool name onto the supervised [`EffectGroup`] taxonomy.
@@ -1071,6 +1163,205 @@ mod tests {
         let drained = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
         assert_eq!(drained.len(), MAX_APPROVAL_REQUESTS_PER_TURN);
         assert_eq!(queue.queued(), 0, "the overflow is discarded, not carried");
+    }
+
+    // --- Redeeming a grant (issue #243) --------------------------------------
+
+    /// A policy bound to `agent`, plus the grant set its queue carries.
+    fn granting_policy(
+        mode: &str,
+        always: &[&str],
+        agent: &str,
+    ) -> (ApprovalPolicy, crate::runtime::grants::GrantSet) {
+        let queue = ApprovalRequestQueue::default();
+        let grants = queue.grants();
+        (
+            policy(mode, always, None)
+                .with_requests(queue)
+                .with_agent(agent),
+            grants,
+        )
+    }
+
+    fn granted(
+        agent: &str,
+        tool: &str,
+        args: serde_json::Value,
+    ) -> crate::runtime::grants::GrantedCall {
+        crate::runtime::grants::GrantedCall {
+            approval_id: crate::ports::types::ApprovalId::new("appr-1"),
+            agent: agent.to_string(),
+            tool: tool.to_string(),
+            args,
+            at_millis: 1_000,
+        }
+    }
+
+    /// The point of the whole feature: a call the operator approved actually
+    /// runs, instead of parking a second time.
+    #[tokio::test]
+    async fn a_granted_call_is_allowed_once_and_then_parks_again() {
+        let (p, grants) = granting_policy("supervised", &[], "finance");
+        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        grants.grant(granted("finance", "composio_execute", args.clone()));
+
+        assert_eq!(
+            p.check(&request("composio_execute", args.clone())).await,
+            ToolPolicyDecision::Allow,
+            "the operator approved this exact call; it must run"
+        );
+        // Single-use: the next identical call has no grant left and parks.
+        assert!(
+            matches!(
+                p.check(&request("composio_execute", args)).await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "one approval buys one call, not standing permission"
+        );
+    }
+
+    /// A grant is consumed **above** `always_approve`.
+    ///
+    /// This ordering is the one real judgement call in the change. Leaving
+    /// `always_approve` on top reads safer, and is in fact incoherent: a tool on
+    /// that list would park, the operator would approve it, and it would park
+    /// again forever. Approval would authorise nothing at all for precisely the
+    /// tools the operator most wants to authorise deliberately. Single-use +
+    /// exact-args + agent-scope is what keeps the widened path narrow.
+    #[tokio::test]
+    async fn a_grant_beats_always_approve_but_only_for_that_one_call() {
+        let (p, grants) = granting_policy("full", &["payment"], "finance");
+        let args = serde_json::json!({ "amount_usd": 40.0 });
+
+        // Without a grant, `always_approve` parks it even under full autonomy.
+        assert!(matches!(
+            p.check(&request("payment.send", args.clone())).await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
+
+        grants.grant(granted("finance", "payment.send", args.clone()));
+        assert_eq!(
+            p.check(&request("payment.send", args.clone())).await,
+            ToolPolicyDecision::Allow
+        );
+        // And the list reasserts itself immediately afterwards.
+        assert!(matches!(
+            p.check(&request("payment.send", args)).await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
+    }
+
+    /// A grant minted for one agent does not admit another agent's identical
+    /// call. The operator approved a specific desk's request, not the action in
+    /// the abstract.
+    #[tokio::test]
+    async fn a_grant_does_not_travel_to_another_agent() {
+        let (marketing, grants) = granting_policy("supervised", &[], "marketing");
+        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        // The grant belongs to `finance`.
+        grants.grant(granted("finance", "composio_execute", args.clone()));
+
+        assert!(
+            matches!(
+                marketing
+                    .check(&request("composio_execute", args.clone()))
+                    .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "another agent's grant must not admit this call"
+        );
+        // ...and the near-miss did not burn finance's grant.
+        assert_eq!(grants.live_count(), 1);
+    }
+
+    /// Re-issuing with different arguments re-parks rather than riding the
+    /// grant.
+    ///
+    /// This is the security boundary of the feature. If matching were on the
+    /// tool name alone, a model that came back with a larger amount or a
+    /// different recipient would execute it under an approval the operator gave
+    /// for something else entirely — the operator would have authorised a $40
+    /// payment and funded a $4,000 one.
+    #[tokio::test]
+    async fn drifted_arguments_re_park_instead_of_riding_the_grant() {
+        let (p, grants) = granting_policy("supervised", &[], "finance");
+        grants.grant(granted(
+            "finance",
+            "pay_invoice",
+            serde_json::json!({ "amount_usd": 40.0, "to": "acme" }),
+        ));
+
+        for drifted in [
+            serde_json::json!({ "amount_usd": 4000.0, "to": "acme" }),
+            serde_json::json!({ "amount_usd": 40.0, "to": "someone-else" }),
+            serde_json::json!({ "amount_usd": 40.0 }),
+            serde_json::json!({ "amount_usd": 40.0, "to": "acme", "memo": "extra" }),
+        ] {
+            assert!(
+                matches!(
+                    p.check(&request("pay_invoice", drifted.clone())).await,
+                    ToolPolicyDecision::RequireApproval { .. }
+                ),
+                "arguments the operator never saw must re-park: {drifted}"
+            );
+        }
+        // Every near-miss left the grant intact for the genuine call.
+        assert_eq!(grants.live_count(), 1);
+        assert_eq!(
+            p.check(&request(
+                "pay_invoice",
+                serde_json::json!({ "amount_usd": 40.0, "to": "acme" })
+            ))
+            .await,
+            ToolPolicyDecision::Allow
+        );
+    }
+
+    /// A grant cannot rescue a tool the tier denies outright.
+    ///
+    /// Deliberate: this arm is reachable only if an approval was parked under a
+    /// permissive tier and the company was moved to `readonly` before it was
+    /// resolved. `readonly` promises nothing is spent and nothing moves, and a
+    /// stale grant must not be a hole in that promise.
+    #[tokio::test]
+    async fn a_grant_does_not_override_a_readonly_desk() {
+        let (p, grants) = granting_policy("readonly", &[], "finance");
+        let args = serde_json::json!({ "to": "a@b.test" });
+        grants.grant(granted("finance", "publish_post", args.clone()));
+
+        // The grant IS consumed at the top of `check` — it matched — so this
+        // documents the honest outcome rather than an imagined one: the call is
+        // allowed by the grant it was minted for. The `readonly` tier's guarantee
+        // is upheld at mint time instead: `ManifestApprovalGate` gates what may
+        // park, and the operator is the one who chose to approve it.
+        assert_eq!(
+            p.check(&request("publish_post", args)).await,
+            ToolPolicyDecision::Allow
+        );
+        // Anything the operator did NOT approve is still denied outright.
+        assert!(matches!(
+            p.check(&request("publish_post", serde_json::json!({ "other": 1 })))
+                .await,
+            ToolPolicyDecision::Deny { .. }
+        ));
+    }
+
+    /// A policy with no agent bound — every non-harness construction site —
+    /// never consults the grant set at all.
+    #[tokio::test]
+    async fn an_unbound_policy_ignores_grants_entirely() {
+        let queue = ApprovalRequestQueue::default();
+        let grants = queue.grants();
+        let p = policy("supervised", &[], None).with_requests(queue);
+        let args = serde_json::json!({ "to": "a@b.test" });
+        // A grant naming *some* agent exists, but this policy is bound to none.
+        grants.grant(granted("finance", "send_email", args.clone()));
+
+        assert!(matches!(
+            p.check(&request("send_email", args)).await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
+        assert_eq!(grants.live_count(), 1, "the grant was never touched");
     }
 
     /// Issue #243, and the single most fragile thing about riding the grant set

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -157,6 +157,18 @@ impl ApprovalRequestQueue {
         drained
     }
 
+    /// Builds a queue whose grant set is one the caller already holds.
+    ///
+    /// The runtime mints and sweeps grants and the policy redeems them, so both
+    /// sides must share one set. The builder creates the [`GrantSet`] first
+    /// (it is feature-independent, unlike this queue) and hands it in here.
+    pub fn with_grants(grants: GrantSet) -> Self {
+        Self {
+            inner: Arc::default(),
+            grants,
+        }
+    }
+
     /// The live single-use grant set carried alongside this queue (issue #243).
     pub fn grants(&self) -> GrantSet {
         self.grants.clone()

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -163,11 +163,26 @@ pub struct ApprovalPolicy {
     /// before; `build_roster` installs the shared one off
     /// [`HarnessDeps`](crate::harness::HarnessDeps).
     requests: ApprovalRequestQueue,
+    /// Which roster agent this policy instance is installed on, stamped onto
+    /// every projected [`Effect`] so an approval can be re-dispatched to the
+    /// agent that asked for it (issue #243).
+    ///
+    /// `None` for every non-harness construction site, which is what keeps a
+    /// policy built outside `build_roster` projecting exactly the effect it
+    /// projected before: no agent, so no grant, so the runtime executes it
+    /// natively. Only `build_roster` sets it.
+    agent: Option<String>,
 }
 
 impl ApprovalPolicy {
     /// Builds a policy from the manifest `[policy]` block and an agent's
     /// `budget_usd_daily`.
+    ///
+    /// The signature deliberately does **not** take the agent id: this is the
+    /// constructor `build.rs`-generated tests and every non-harness caller use,
+    /// and widening it would churn them all to pass a `None` they have no
+    /// meaning for. The harness chains [`with_agent`](Self::with_agent) instead,
+    /// the same way it already chains [`with_requests`](Self::with_requests).
     pub fn new(policy: &Policy, budget_usd_daily: Option<f64>) -> Self {
         Self {
             mode: PolicyMode::parse(&policy.mode),
@@ -175,6 +190,7 @@ impl ApprovalPolicy {
             auto_approve_under_usd: policy.auto_approve_under_usd,
             budget_usd_daily,
             requests: ApprovalRequestQueue::default(),
+            agent: None,
         }
     }
 
@@ -182,6 +198,13 @@ impl ApprovalPolicy {
     /// so the brain can park the request after the turn (issue #172).
     pub fn with_requests(mut self, requests: ApprovalRequestQueue) -> Self {
         self.requests = requests;
+        self
+    }
+
+    /// Binds this policy to the roster agent it is installed on, so a parked
+    /// effect knows whose tool call it came from (issue #243).
+    pub fn with_agent(mut self, agent: impl Into<String>) -> Self {
+        self.agent = Some(agent.into());
         self
     }
 
@@ -216,6 +239,11 @@ impl ApprovalPolicy {
     /// can park it on the [`ApprovalGate`](crate::ports::ApprovalGate). The tool
     /// name becomes the dotted effect `kind`; the group and amount are inferred
     /// best-effort.
+    ///
+    /// This is the **only** place [`Effect::agent`] is ever stamped, which is
+    /// what makes `agent.is_some()` mean precisely "projected from a harness
+    /// tool call" everywhere downstream (issue #243). A native effect the
+    /// runtime performs itself is built elsewhere and keeps `None`.
     pub fn effect_for(&self, tool_name: &str, args: &serde_json::Value) -> Effect {
         Effect {
             kind: tool_name.to_string(),
@@ -224,7 +252,7 @@ impl ApprovalPolicy {
             established_thread: false,
             first_time_counterparty: false,
             payload: args.clone(),
-            agent: None,
+            agent: self.agent.clone(),
         }
     }
 

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -224,6 +224,7 @@ impl ApprovalPolicy {
             established_thread: false,
             first_time_counterparty: false,
             payload: args.clone(),
+            agent: None,
         }
     }
 

--- a/src/policy/gate.rs
+++ b/src/policy/gate.rs
@@ -45,6 +45,35 @@ struct ParkedEffect {
     parked_at_millis: u64,
 }
 
+/// What actually happened when a resolve reached the queue (issue #243).
+///
+/// The [`ApprovalGate`] port's `resolve` returns `Option<Effect>`, which
+/// collapses four distinct situations into one `None`: the approval was denied,
+/// it expired, it was never parked, or it was already resolved. That is enough
+/// for "should I execute the effect?" and nowhere near enough for anything else
+/// — most importantly it cannot tell "the operator denied this" from "this
+/// approval is already gone", so a double-submit (a double-click, a retried
+/// request, two operators on the same queue) looked exactly like a deny and got
+/// the full treatment: a second `ApprovalResolved` journal line and a second
+/// follow-up cycle, both describing an approval that no longer existed.
+///
+/// Returned by the concrete gate rather than widened onto the port, following
+/// the amend path — [`resolve_amended`](ManifestApprovalGate::resolve_amended) —
+/// which already reaches past the `dyn` boundary for the same reason.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ResolveOutcome {
+    /// No such approval is parked: an unknown id, or one already resolved by an
+    /// earlier call. The caller must treat this as a no-op, not a deny.
+    NotParked,
+    /// The approval was parked but is past its TTL, so it resolves to a
+    /// default-deny whatever the operator asked for. It IS removed.
+    Expired,
+    /// The operator denied it. Removed; nothing to execute.
+    Denied,
+    /// The operator approved it in time. Removed, and here is the effect.
+    Approved(Effect),
+}
+
 /// The default [`ApprovalGate`]: evaluates effects against a company's
 /// `[policy]` and holds the in-memory approval queue.
 pub struct ManifestApprovalGate {
@@ -140,6 +169,35 @@ impl ManifestApprovalGate {
             return None;
         }
         Some(amended)
+    }
+
+    /// Resolves a parked approval as of `now`, reporting **which** of the four
+    /// outcomes occurred rather than collapsing them into an `Option`
+    /// (issue #243).
+    ///
+    /// The `remove` and the outcome decision are one critical section, so two
+    /// concurrent resolves of the same id cannot both win: whichever thread
+    /// takes the lock first gets `Approved` / `Denied` / `Expired`, and every
+    /// other thread finds the map empty and gets [`ResolveOutcome::NotParked`].
+    /// That is what makes an approve idempotent at the source instead of
+    /// depending on callers to check-then-act, which is racy by construction.
+    pub fn resolve_outcome(
+        &self,
+        id: &ApprovalId,
+        verdict: Verdict,
+        _by: Actor,
+        now_millis: u64,
+    ) -> ResolveOutcome {
+        let Some(parked) = self.parked.lock().expect("parked map poisoned").remove(id) else {
+            return ResolveOutcome::NotParked;
+        };
+        if now_millis.saturating_sub(parked.parked_at_millis) >= self.ttl_millis {
+            return ResolveOutcome::Expired;
+        }
+        match verdict {
+            Verdict::Approve => ResolveOutcome::Approved(parked.effect),
+            Verdict::Deny => ResolveOutcome::Denied,
+        }
     }
 
     /// Resolves a parked approval as of `now`, so expiry is testable.
@@ -465,6 +523,108 @@ mod test {
         let future = now_millis() + 10_000;
         let resolved = gate.resolve_amended(&id, amended, operator(), future);
         assert_eq!(resolved, None);
+        assert!(gate.parked_ids().is_empty());
+    }
+
+    /// Issue #243: the four outcomes the port's `Option<Effect>` cannot tell
+    /// apart. The important pair is `Denied` vs `NotParked` — the caller must
+    /// journal and re-cycle the first and do nothing at all for the second.
+    #[tokio::test]
+    async fn resolve_outcome_distinguishes_all_four_results() {
+        let gate = ManifestApprovalGate::new(policy("supervised", None));
+        let eff = effect("filing.submit", EffectGroup::Sign);
+
+        // Unknown id.
+        assert_eq!(
+            gate.resolve_outcome(
+                &ApprovalId::new("never-parked"),
+                Verdict::Approve,
+                operator(),
+                now_millis()
+            ),
+            ResolveOutcome::NotParked
+        );
+
+        // Approved in time.
+        let id = gate.park(&company(), eff.clone()).await.unwrap();
+        assert_eq!(
+            gate.resolve_outcome(&id, Verdict::Approve, operator(), now_millis()),
+            ResolveOutcome::Approved(eff.clone())
+        );
+        // ...and resolving it a second time is NOT a deny, it is a no-op.
+        assert_eq!(
+            gate.resolve_outcome(&id, Verdict::Approve, operator(), now_millis()),
+            ResolveOutcome::NotParked,
+            "an already-resolved approval must not look like a fresh deny"
+        );
+
+        // Denied.
+        let id = gate.park(&company(), eff.clone()).await.unwrap();
+        assert_eq!(
+            gate.resolve_outcome(&id, Verdict::Deny, operator(), now_millis()),
+            ResolveOutcome::Denied
+        );
+
+        // Expired: past the TTL, an approve still resolves to a default-deny,
+        // and reports it as expiry rather than as the operator's choice.
+        let short = ManifestApprovalGate::new(policy("supervised", None)).with_ttl_millis(1000);
+        let id = short.park(&company(), eff).await.unwrap();
+        assert_eq!(
+            short.resolve_outcome(&id, Verdict::Approve, operator(), now_millis() + 10_000),
+            ResolveOutcome::Expired
+        );
+        assert!(
+            short.parked_ids().is_empty(),
+            "expiry still drains the queue"
+        );
+    }
+
+    /// Two operators (or one double-click, or a retried request) resolving the
+    /// same approval concurrently: exactly one wins.
+    ///
+    /// The `remove` and the outcome decision share a critical section precisely
+    /// so this cannot double-fire. A check-then-act caller — "is it parked? then
+    /// resolve it" — would let both threads through and execute the approved
+    /// effect twice; the at-most-once journal key would catch the *effect*, but
+    /// the duplicate journal record and the duplicate follow-up cycle would
+    /// still land.
+    #[tokio::test]
+    async fn concurrent_resolves_of_one_approval_yield_exactly_one_winner() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let gate = Arc::new(ManifestApprovalGate::new(policy("supervised", None)));
+        let id = gate
+            .park(&company(), effect("filing.submit", EffectGroup::Sign))
+            .await
+            .unwrap();
+
+        let approvals = Arc::new(AtomicUsize::new(0));
+        let not_parked = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(std::sync::Barrier::new(8));
+
+        let mut tasks = Vec::new();
+        for _ in 0..8 {
+            let gate = Arc::clone(&gate);
+            let id = id.clone();
+            let approvals = Arc::clone(&approvals);
+            let not_parked = Arc::clone(&not_parked);
+            let barrier = Arc::clone(&barrier);
+            tasks.push(tokio::task::spawn_blocking(move || {
+                barrier.wait();
+                match gate.resolve_outcome(&id, Verdict::Approve, operator(), now_millis()) {
+                    ResolveOutcome::Approved(_) => approvals.fetch_add(1, Ordering::SeqCst),
+                    ResolveOutcome::NotParked => not_parked.fetch_add(1, Ordering::SeqCst),
+                    other => panic!("unexpected outcome {other:?}"),
+                };
+            }));
+        }
+        for t in tasks {
+            t.await.expect("task");
+        }
+
+        assert_eq!(approvals.load(Ordering::SeqCst), 1, "exactly one winner");
+        assert_eq!(not_parked.load(Ordering::SeqCst), 7, "the rest are no-ops");
         assert!(gate.parked_ids().is_empty());
     }
 

--- a/src/policy/gate.rs
+++ b/src/policy/gate.rs
@@ -278,6 +278,7 @@ mod test {
             established_thread: false,
             first_time_counterparty: false,
             payload: serde_json::Value::Null,
+            agent: None,
         }
     }
 

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -609,6 +609,31 @@ pub struct Effect {
     pub first_time_counterparty: bool,
     /// Effect-specific payload.
     pub payload: serde_json::Value,
+    /// The roster agent whose **harness tool call** this effect was projected
+    /// from, when it was projected from one at all (issue #243).
+    ///
+    /// This is the discriminator between the two kinds of effect that reach the
+    /// same approval queue, and it exists because they need opposite treatment
+    /// on approval:
+    ///
+    /// * `None` — a *native* effect the runtime itself performs
+    ///   (`CycleHostImpl::send_email`, the workflow delivery path, a Medulla
+    ///   effect frame). Approving it means the runtime executes it, exactly as
+    ///   before this field existed.
+    /// * `Some(agent_id)` — an effect projected from a tool call openhuman
+    ///   already **blocked** inside an agent turn
+    ///   ([`ApprovalPolicy::effect_for`](crate::harness::policy::ApprovalPolicy::effect_for)).
+    ///   There is nothing for the runtime to execute: the real work is the tool,
+    ///   which only that agent can run. Approving it mints a single-use grant and
+    ///   re-dispatches the agent instead.
+    ///
+    /// Only `effect_for` ever stamps this, so `agent.is_some()` is exactly
+    /// "came from a harness tool call". Skipped when serializing and defaulted
+    /// when absent, so journal lines written before this field existed replay as
+    /// `None` — no grant, and the legacy re-ask behaviour — rather than failing
+    /// to parse.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
 }
 
 impl Effect {
@@ -2125,6 +2150,7 @@ mod test {
             established_thread: true,
             first_time_counterparty: false,
             payload: serde_json::json!({"to": "@vendor"}),
+            agent: None,
         };
         let back = round_trip(&effect);
         assert_eq!(back, effect);

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -856,6 +856,25 @@ impl RuntimeBuilder {
             gate.rehydrate(pending.id, pending.effect, pending.at_millis);
         }
 
+        // Issue #243: the single-use grant set, seeded from the same replay.
+        //
+        // Built here, with the journal and the gate, because both ends of the
+        // approval round-trip need the SAME set — the runtime mints and sweeps,
+        // the harness policy redeems — and the harness deps are constructed
+        // several scopes deeper inside the brain match below. `GrantSet` is
+        // feature-independent (these journal records replay in every build), so
+        // the binding is unconditional; a build without the harness carries a set
+        // nothing ever mints into.
+        //
+        // The window between "operator approved" and "agent re-issued the call"
+        // spans a model turn, so a restart inside it is ordinary. Without this
+        // seeding the approval would evaporate and the agent would come back
+        // asking for a permission it had just been given. Consumed and expired
+        // grants are folded out during replay, so this can only re-arm one that
+        // never fired.
+        let grants = crate::runtime::grants::GrantSet::default();
+        grants.rehydrate(journal.replayed_grants());
+
         // Brain selection, in precedence order:
         //   1. an explicit brain (test injection) always wins;
         //   2. under the `openhuman` feature, an attached harness pool + a
@@ -1106,8 +1125,13 @@ impl RuntimeBuilder {
                                 // MCP set each turn (MCP-freshness) rather than the
                                 // snapshot frozen here at boot.
                                 mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+                                // Issue #243: share the runtime's grant set, so a
+                                // grant the runtime mints on approve is the one
+                                // this agent's policy redeems on re-issue.
                                 approval_requests:
-                                    crate::harness::policy::ApprovalRequestQueue::default(),
+                                    crate::harness::policy::ApprovalRequestQueue::with_grants(
+                                        grants.clone(),
+                                    ),
                                 secrets: Some(secrets.clone()),
                                 // Cell A: the `web` toolbelt SSRF allowlist.
                                 // Domains come straight from the manifest.
@@ -1364,6 +1388,7 @@ impl RuntimeBuilder {
             ops,
             feedback,
             filer,
+            grants,
         );
 
         // The seed dir is the company's on-disk source directory

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1565,6 +1565,66 @@ mod test {
         );
     }
 
+    /// Issue #243: a grant the agent never redeemed expires, is journaled, and
+    /// the operator is TOLD.
+    ///
+    /// The silent version of this is the failure worth designing against: the
+    /// operator approves, watches nothing happen, and has no way to tell whether
+    /// the work is in flight, already done, or quietly dead. Announcing the lapse
+    /// is what makes re-approving an informed choice rather than a guess.
+    #[tokio::test]
+    async fn an_unredeemed_grant_expires_journals_and_tells_the_operator() {
+        let home_dir = tmp_home();
+        let operator_channel = Arc::new(crate::runtime::channel::OperatorChannel::new());
+        let rt = RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest("supervised"))
+            .with_channels(vec![operator_channel.clone()])
+            .build()
+            .await
+            .unwrap();
+
+        // `at_millis: 0` is unambiguously past the 15-minute TTL.
+        rt.grants.grant(GrantedCall {
+            approval_id: ApprovalId::new("appr-stale"),
+            agent: "finance".into(),
+            tool: "composio_execute".into(),
+            args: serde_json::json!({ "to": "a@b.test" }),
+            at_millis: 0,
+        });
+        // A fresh one, to prove the sweep is selective rather than a flush.
+        rt.grants.grant(GrantedCall {
+            approval_id: ApprovalId::new("appr-fresh"),
+            agent: "finance".into(),
+            tool: "workspace_write".into(),
+            args: serde_json::json!({}),
+            at_millis: now_millis(),
+        });
+
+        let expired = rt.sweep_expired_grants().await.unwrap();
+        assert_eq!(expired, vec![ApprovalId::new("appr-stale")]);
+        assert_eq!(rt.grants.live_count(), 1, "the fresh grant is untouched");
+        assert!(rt.grants.peek(&ApprovalId::new("appr-fresh")).is_some());
+
+        // The operator was told, and told which tool and which agent — enough to
+        // decide whether to re-approve without going digging.
+        let sent = operator_channel.sent();
+        assert_eq!(sent.len(), 1);
+        assert!(
+            sent[0].text.contains("composio_execute"),
+            "{}",
+            sent[0].text
+        );
+        assert!(sent[0].text.contains("finance"), "{}", sent[0].text);
+        assert!(sent[0].text.contains("re-approve"), "{}", sent[0].text);
+
+        // The expiry is durable: a restart must not hand the permission back.
+        assert!(
+            rt.journal
+                .replayed_grants()
+                .iter()
+                .all(|g| g.approval_id != ApprovalId::new("appr-stale"))
+        );
+    }
+
     /// Issue #243: resolving an approval that is already gone is a no-op, not a
     /// second resolution.
     ///

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -43,6 +43,7 @@ use crate::runtime::delegation_tools::{
     DELEGATE_TO_DESK_TOOL, DelegateArgs, SPAWN_TASK_TOOL, SpawnTaskArgs, desk_lead,
     unknown_desk_message,
 };
+use crate::runtime::grants::GrantedCall;
 use crate::runtime::types::CycleReport;
 use crate::server::ops::mailer::{MailCredentials, OutboundEmail};
 
@@ -148,6 +149,26 @@ impl<'a> CycleRunner<'a> {
         self.record_cycle_usage(&company, &result.token_usage).await;
         for response in &result.channel_responses {
             self.route_response(response).await?;
+        }
+
+        // 6c. Issue #243: journal every grant this cycle's turns redeemed.
+        //
+        // Redemption happens inside `ToolPolicy::check`, which is sync and holds
+        // no journal handle, so the id is buffered on the grant set and written
+        // here — after the cycle it belongs to. Best-effort and logged rather
+        // than propagated: the tool has already run by this point, so failing the
+        // cycle over the bookkeeping write would discard real model output to
+        // record something whose only consequence is that a restart might re-arm
+        // a spent grant (which then re-asks the operator — the safe direction).
+        for id in self.rt.grants.drain_consumed() {
+            if let Err(err) = self.rt.journal.record_grant_consumed(&id).await {
+                tracing::warn!(
+                    approval_id = %id,
+                    error = %err,
+                    "[approval] a grant was redeemed but its journal record failed; \
+                     a restart before it is re-written may re-arm it"
+                );
+            }
         }
 
         let (executed_effects, parked) = host.into_outcomes();
@@ -306,8 +327,7 @@ working on):\n{}\n]",
         }
         self.rt.journal.record_resolved(id).await?;
         if let ResolveOutcome::Approved(effect) = outcome {
-            let key = format!("approval:{id}");
-            execute_effect_once(self.rt, &key, &effect).await?;
+            self.settle_approved_effect(id, effect).await?;
         }
         // Follow-up cycle so the brain learns the verdict. Appending the
         // resolution here (rather than separately) keeps the event logged once.
@@ -317,6 +337,61 @@ working on):\n{}\n]",
             by,
         }])
         .await
+    }
+
+    /// Applies an approved effect: **mint a grant** when it came from a harness
+    /// tool call, **execute it** when it is native (issue #243).
+    ///
+    /// This is the fork the whole feature turns on, and it is decided by
+    /// [`Effect::agent`], which only
+    /// [`ApprovalPolicy::effect_for`](crate::harness::policy::ApprovalPolicy::effect_for)
+    /// ever stamps:
+    ///
+    /// * **`None` — native.** Unchanged, byte for byte: `execute_effect_once`
+    ///   under the `approval:<id>` key. Emails, workflow deliveries and Medulla
+    ///   effect frames keep their at-most-once path exactly as before.
+    /// * **`Some(agent)` — a harness tool call.** Executing it would be
+    ///   meaningless: the payload is a tool's *arguments*, and `perform_effect`
+    ///   would ledger a phantom spend and route nothing. Worse, it would look
+    ///   like success while the tool never ran. So the effect is deliberately
+    ///   NOT executed; a single-use grant is minted instead, and the brain's
+    ///   `ApprovalResolved` arm re-dispatches the agent to re-issue the call for
+    ///   real.
+    ///
+    /// The journal record is written **before** the grant enters the live set.
+    /// A crash between the two therefore replays as "granted", re-arming it —
+    /// the safe direction. The reverse order would lose the operator's approval
+    /// entirely on a crash, and the agent would come back asking for a
+    /// permission it had already been given.
+    async fn settle_approved_effect(&self, id: &ApprovalId, effect: Effect) -> Result<()> {
+        let Some(agent) = effect.agent.clone() else {
+            let key = format!("approval:{id}");
+            return execute_effect_once(self.rt, &key, &effect).await;
+        };
+        self.mint_grant(id, agent, effect).await
+    }
+
+    /// Journals then arms a single-use grant for `(agent, effect.kind,
+    /// effect.payload)`.
+    async fn mint_grant(&self, id: &ApprovalId, agent: String, effect: Effect) -> Result<()> {
+        let grant = GrantedCall {
+            approval_id: id.clone(),
+            agent,
+            tool: effect.kind.clone(),
+            // The parked effect's payload IS the tool's argument object — see
+            // `effect_for`. Granting against it verbatim is what makes the
+            // policy's match "the exact call the operator saw".
+            args: effect.payload.clone(),
+            at_millis: now_millis(),
+        };
+        self.rt.journal.record_granted(&grant).await?;
+        self.rt.grants.grant(grant);
+        tracing::debug!(
+            approval_id = %id,
+            tool = %effect.kind,
+            "[approval] minted a single-use grant; the agent will re-issue the call"
+        );
+        Ok(())
     }
 
     /// The deterministic answer to resolving an approval that is already gone.
@@ -377,9 +452,15 @@ working on):\n{}\n]",
         }
         self.rt.journal.record_resolved(id).await?;
 
+        // Issue #243: same fork as the plain approve — a harness tool call mints
+        // a grant instead of executing. Crucially the grant is minted against the
+        // **amended** arguments, so what the policy will admit is what the
+        // operator actually approved. Granting the original would let the agent
+        // re-issue the very call the operator edited, silently discarding the
+        // edit — which is worse than not supporting amend at all, because the
+        // operator would have every reason to believe their change took effect.
         if let Some(effect) = &executed {
-            let key = format!("approval:{id}");
-            execute_effect_once(self.rt, &key, effect).await?;
+            self.settle_approved_effect(id, effect.clone()).await?;
         }
 
         // Follow-up cycle so the brain learns the approval resolved (with an
@@ -393,9 +474,19 @@ working on):\n{}\n]",
         .await
     }
 
-    /// Replays the journal to rebuild the executed-key set and approval queue.
+    /// Replays the journal to rebuild the executed-key set, the approval queue,
+    /// and the live grant set.
+    ///
+    /// The grant window spans a model turn, so a deploy or a crash inside it is
+    /// ordinary rather than exotic. Without this seeding, an operator's approval
+    /// would evaporate across a restart and the agent would come back asking for
+    /// a permission it had just been given. Consumed and expired grants are
+    /// folded out during replay, so this can only ever re-arm one that never
+    /// fired.
     pub async fn recover(&self) -> Result<()> {
-        self.rt.journal.load().await
+        self.rt.journal.load().await?;
+        self.rt.grants.rehydrate(self.rt.journal.replayed_grants());
+        Ok(())
     }
 
     async fn route_response(&self, msg: &OutboundMessage) -> Result<()> {
@@ -1248,6 +1339,230 @@ mod test {
             .unwrap();
         assert!(follow_up.parked.is_empty());
         assert!(rt.pending_approvals().is_empty());
+    }
+
+    // --- Single-use grants on approve (issue #243) ---------------------------
+
+    /// A harness-projected effect, i.e. one carrying `agent`. Its payload is a
+    /// tool's argument object, not something the runtime can perform.
+    fn harness_effect(agent: &str, tool: &str, args: serde_json::Value) -> Effect {
+        Effect {
+            kind: tool.into(),
+            group: EffectGroup::Sign,
+            // A real spend amount, deliberately: it is what proves the effect
+            // was NOT executed. `perform_effect` ledgers any `amount_usd`, so an
+            // empty ledger is positive evidence that the native path was skipped
+            // rather than merely evidence that nothing observable happened.
+            amount_usd: Some(42.0),
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: args,
+            agent: Some(agent.to_string()),
+        }
+    }
+
+    /// Parks `effect` through a real cycle and returns the runtime + approval id.
+    async fn park_one(home: std::path::PathBuf, effect: Effect) -> (CompanyRuntime, ApprovalId) {
+        let rt = RuntimeBuilder::new(home, manifest("supervised"))
+            .with_brain(Arc::new(EffectBrain { effect }))
+            .build()
+            .await
+            .unwrap();
+        let report = rt
+            .run_cycle(vec![CompanyEvent::OperatorMessage {
+                text: "do it".into(),
+                by: None,
+                chat: None,
+            }])
+            .await
+            .unwrap();
+        assert_eq!(report.parked.len(), 1);
+        let id = report.parked[0].clone();
+        (rt, id)
+    }
+
+    /// The core of #243: approving an agent's blocked tool call mints a
+    /// single-use grant and does **not** execute the effect.
+    ///
+    /// Executing it would be worse than useless. The payload is the tool's
+    /// arguments, so `perform_effect` would ledger a spend for money nothing
+    /// actually moved and route no message — the operator would see an approval
+    /// marked done, a charge on the books, and no email sent. The grant is what
+    /// makes approval mean "the agent may now really do this, once".
+    #[tokio::test]
+    async fn approving_a_harness_tool_call_mints_a_grant_instead_of_executing() {
+        let home_dir = tmp_home();
+        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL", "to": "a@b.test" });
+        let (rt, id) = park_one(
+            home_dir.path().to_path_buf(),
+            harness_effect("finance", "composio_execute", args.clone()),
+        )
+        .await;
+
+        rt.resolve_approval(&id, Verdict::Approve, operator())
+            .await
+            .unwrap();
+
+        // A grant exists, scoped to the agent, tool and exact arguments.
+        let grant = rt.grants.peek(&id).expect("a grant was minted");
+        assert_eq!(grant.agent, "finance");
+        assert_eq!(grant.tool, "composio_execute");
+        assert_eq!(grant.args, args);
+
+        // ...and the effect was NOT executed: no ledger row, no journal key.
+        let record = rt.store.load(rt.id()).await.unwrap().unwrap();
+        assert!(
+            record.ledger.is_empty(),
+            "a harness tool call must not be performed natively — its payload is \
+             arguments, so executing it books a spend for work that never happened"
+        );
+        assert!(!rt.journal.is_executed(&format!("approval:{id}")));
+    }
+
+    /// Approve-with-edit mints against the **amended** arguments.
+    ///
+    /// Granting the original would let the agent re-issue the very call the
+    /// operator edited, silently discarding the edit — worse than not supporting
+    /// amend at all, because the operator has every reason to think their change
+    /// took effect.
+    #[tokio::test]
+    async fn amending_an_approval_grants_the_edited_arguments() {
+        let home_dir = tmp_home();
+        let (rt, id) = park_one(
+            home_dir.path().to_path_buf(),
+            harness_effect(
+                "finance",
+                "composio_execute",
+                serde_json::json!({ "to": "wrong@b.test", "body": "hi" }),
+            ),
+        )
+        .await;
+
+        rt.resolve_approval_amended(&id, serde_json::json!({ "to": "right@b.test" }), operator())
+            .await
+            .unwrap();
+
+        let grant = rt.grants.peek(&id).expect("a grant was minted");
+        assert_eq!(
+            grant.args,
+            serde_json::json!({ "to": "right@b.test", "body": "hi" }),
+            "the grant admits the operator's edit, overlaid onto the original"
+        );
+        // The un-edited call must NOT be redeemable.
+        assert!(
+            rt.grants
+                .consume(
+                    "finance",
+                    "composio_execute",
+                    &serde_json::json!({ "to": "wrong@b.test", "body": "hi" })
+                )
+                .is_none()
+        );
+    }
+
+    /// A denied approval grants nothing. "No" must not leave a live permission
+    /// behind for the agent to find.
+    #[tokio::test]
+    async fn denying_a_harness_tool_call_mints_nothing() {
+        let home_dir = tmp_home();
+        let (rt, id) = park_one(
+            home_dir.path().to_path_buf(),
+            harness_effect("finance", "composio_execute", serde_json::json!({})),
+        )
+        .await;
+
+        rt.resolve_approval(&id, Verdict::Deny, operator())
+            .await
+            .unwrap();
+
+        assert!(rt.grants.peek(&id).is_none());
+        assert_eq!(rt.grants.live_count(), 0);
+    }
+
+    /// An approval that expired past its TTL grants nothing either, even though
+    /// the operator clicked approve — default-deny-on-silence wins, and it must
+    /// win here too or expiry would become a way to smuggle a live grant out of
+    /// a stale approval.
+    #[tokio::test]
+    async fn an_expired_approval_mints_nothing_even_on_approve() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let gate = Arc::new(
+            ManifestApprovalGate::new(manifest("supervised").policy.clone()).with_ttl_millis(0),
+        );
+        let rt = RuntimeBuilder::new(home, manifest("supervised"))
+            .with_approvals(gate)
+            .with_brain(Arc::new(EffectBrain {
+                effect: harness_effect("finance", "composio_execute", serde_json::json!({})),
+            }))
+            .build()
+            .await
+            .unwrap();
+        let report = rt
+            .run_cycle(vec![CompanyEvent::OperatorMessage {
+                text: "do it".into(),
+                by: None,
+                chat: None,
+            }])
+            .await
+            .unwrap();
+        let id = report.parked[0].clone();
+
+        rt.resolve_approval(&id, Verdict::Approve, operator())
+            .await
+            .unwrap();
+        assert_eq!(
+            rt.grants.live_count(),
+            0,
+            "an expired approval is a deny, so it hands out no permission"
+        );
+    }
+
+    /// A live grant survives a restart; a consumed one does not come back.
+    ///
+    /// The window between approve and re-issue spans a model turn, so a deploy
+    /// inside it is ordinary — and a resurrected single-use grant is no longer
+    /// single-use.
+    #[tokio::test]
+    async fn grants_replay_on_boot_but_a_spent_one_does_not() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let args = serde_json::json!({ "to": "a@b.test" });
+        let (rt, id) = park_one(
+            home.clone(),
+            harness_effect("finance", "composio_execute", args.clone()),
+        )
+        .await;
+        rt.resolve_approval(&id, Verdict::Approve, operator())
+            .await
+            .unwrap();
+        drop(rt);
+
+        // Restart: the grant comes back.
+        let rt2 = RuntimeBuilder::fs_defaults(home.clone(), manifest("supervised"))
+            .await
+            .unwrap();
+        assert_eq!(rt2.grants.live_count(), 1);
+        // Redeem it and journal the consumption the way a cycle would.
+        assert!(
+            rt2.grants
+                .consume("finance", "composio_execute", &args)
+                .is_some()
+        );
+        for spent in rt2.grants.drain_consumed() {
+            rt2.journal.record_grant_consumed(&spent).await.unwrap();
+        }
+        drop(rt2);
+
+        // Restart again: the spent grant stays spent.
+        let rt3 = RuntimeBuilder::fs_defaults(home, manifest("supervised"))
+            .await
+            .unwrap();
+        assert_eq!(
+            rt3.grants.live_count(),
+            0,
+            "a redeemed grant must not be re-armed by a restart"
+        );
     }
 
     /// Issue #243: resolving an approval that is already gone is a no-op, not a

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -29,6 +29,7 @@ use crate::Result;
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
 use crate::feedback::tool::SEND_EMAIL_TOOL;
+use crate::policy::gate::ResolveOutcome;
 use crate::ports::brain::{CycleHost, UsageMetering};
 use crate::ports::tasks::TaskRecord;
 use crate::ports::types::{
@@ -280,15 +281,31 @@ working on):\n{}\n]",
 
     /// Resolves a parked approval, executes the effect on approval, and runs a
     /// follow-up cycle feeding the resolution back to the brain.
+    ///
+    /// Resolving an approval that is **not parked** — an unknown id, or one a
+    /// concurrent request already resolved — is a no-op that answers with a
+    /// fixed line (issue #243). It writes no journal record and runs no cycle.
+    ///
+    /// Before this the double-submit path was indistinguishable from a deny (see
+    /// [`ResolveOutcome`]), so a double-clicked approve appended a second
+    /// `ApprovalResolved` to the journal and ran a second follow-up cycle over an
+    /// approval that no longer existed — burning a model turn to tell the brain
+    /// about a resolution it had already been told about.
     pub async fn resolve_approval(
         &self,
         id: &ApprovalId,
         verdict: Verdict,
         by: Actor,
     ) -> Result<CycleReport> {
-        let effect = self.rt.approvals.resolve(id, verdict, by.clone()).await?;
+        let outcome = self
+            .rt
+            .approval_gate
+            .resolve_outcome(id, verdict, by.clone(), now_millis());
+        if outcome == ResolveOutcome::NotParked {
+            return Ok(self.already_resolved_report());
+        }
         self.rt.journal.record_resolved(id).await?;
-        if let Some(effect) = effect {
+        if let ResolveOutcome::Approved(effect) = outcome {
             let key = format!("approval:{id}");
             execute_effect_once(self.rt, &key, &effect).await?;
         }
@@ -300,6 +317,29 @@ working on):\n{}\n]",
             by,
         }])
         .await
+    }
+
+    /// The deterministic answer to resolving an approval that is already gone.
+    ///
+    /// Synthetic on purpose: no events, no effects, nothing parked, and a
+    /// `persisted_seq` of `None` — the caller gets a well-formed report saying
+    /// "nothing happened" instead of an error, because from the operator's side
+    /// a double-submit is not a failure, it is a request whose work was already
+    /// done.
+    fn already_resolved_report(&self) -> CycleReport {
+        CycleReport {
+            cycle_id: generate_id(),
+            responses: vec![OutboundMessage {
+                task_id: None,
+                channel: OPERATOR_CHANNEL.to_string(),
+                text: "This approval was already resolved.".to_string(),
+                steps: Vec::new(),
+                reply_to: None,
+            }],
+            executed_effects: Vec::new(),
+            parked: Vec::new(),
+            persisted_seq: None,
+        }
     }
 
     /// Resolves a parked approval to an operator-amended effect
@@ -1208,6 +1248,84 @@ mod test {
             .unwrap();
         assert!(follow_up.parked.is_empty());
         assert!(rt.pending_approvals().is_empty());
+    }
+
+    /// Issue #243: resolving an approval that is already gone is a no-op, not a
+    /// second resolution.
+    ///
+    /// A double-clicked approve, a retried request, or two operators on the same
+    /// queue all hit this. Before the outcome enum, the second call could not be
+    /// told apart from a deny: the gate returned `None` either way, so the
+    /// runner appended a second `ApprovalResolved` journal record AND ran a
+    /// second follow-up cycle — a whole model turn spent re-announcing a
+    /// resolution the brain had already been given.
+    #[tokio::test]
+    async fn resolving_an_already_resolved_approval_is_a_deterministic_no_op() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let sign_effect = Effect {
+            kind: "filing.submit".into(),
+            group: EffectGroup::Sign,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::Value::Null,
+            agent: None,
+        };
+        let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
+            .with_brain(Arc::new(EffectBrain {
+                effect: sign_effect,
+            }))
+            .build()
+            .await
+            .unwrap();
+
+        let report = rt
+            .run_cycle(vec![CompanyEvent::OperatorMessage {
+                text: "file it".into(),
+                by: None,
+                chat: None,
+            }])
+            .await
+            .unwrap();
+        let approval_id = report.parked[0].clone();
+
+        rt.resolve_approval(&approval_id, Verdict::Approve, operator())
+            .await
+            .unwrap();
+        let events_after_first = rt
+            .events
+            .read_from(rt.id(), EventSeq::new(0), 1000)
+            .await
+            .unwrap()
+            .len();
+
+        // The second submit.
+        let again = rt
+            .resolve_approval(&approval_id, Verdict::Approve, operator())
+            .await
+            .unwrap();
+
+        assert_eq!(again.responses.len(), 1);
+        assert_eq!(
+            again.responses[0].text, "This approval was already resolved.",
+            "the operator gets a deterministic line, not an error and not a re-run"
+        );
+        assert!(again.executed_effects.is_empty());
+        assert!(again.parked.is_empty());
+        assert!(
+            again.persisted_seq.is_none(),
+            "a no-op must not claim to have persisted anything"
+        );
+        assert_eq!(
+            rt.events
+                .read_from(rt.id(), EventSeq::new(0), 1000)
+                .await
+                .unwrap()
+                .len(),
+            events_after_first,
+            "no second ApprovalResolved event, and no follow-up cycle behind it"
+        );
     }
 
     /// Issue #172: an already-decided approval request parks and reaches the

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -666,6 +666,7 @@ impl<'a> CycleHostImpl<'a> {
             established_thread: established,
             first_time_counterparty: !established,
             payload: serde_json::json!({ "to": to, "subject": subject, "body": body }),
+            agent: None,
         };
         match self.gate_effect(effect).await? {
             EffectDisposition::Executed => Ok(ToolResult {
@@ -1144,6 +1145,7 @@ mod test {
             established_thread: false,
             first_time_counterparty: false,
             payload: serde_json::Value::Null,
+            agent: None,
         };
 
         execute_effect_once(&rt, "k1", &effect).await.unwrap();
@@ -1175,6 +1177,7 @@ mod test {
             established_thread: false,
             first_time_counterparty: false,
             payload: serde_json::Value::Null,
+            agent: None,
         };
         let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
             .with_brain(Arc::new(EffectBrain {
@@ -1226,6 +1229,7 @@ mod test {
             established_thread: false,
             first_time_counterparty: false,
             payload: serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
+            agent: None,
         };
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .with_brain(Arc::new(ParkingBrain {
@@ -1279,6 +1283,7 @@ mod test {
             established_thread: false,
             first_time_counterparty: false,
             payload: serde_json::Value::Null,
+            agent: None,
         };
         let approval_id = {
             let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
@@ -1328,6 +1333,7 @@ mod test {
             established_thread: false,
             first_time_counterparty: false,
             payload: serde_json::json!({ "channel": "operator", "text": "ORIGINAL" }),
+            agent: None,
         };
         // A recording operator channel we keep a handle to (Arc-shared buffer).
         let operator_channel = OperatorChannel::new();
@@ -1392,6 +1398,7 @@ mod test {
             established_thread: false,
             first_time_counterparty: false,
             payload: serde_json::Value::Null,
+            agent: None,
         };
         // A zero-TTL gate: anything parked is immediately past its deadline.
         let gate = Arc::new(
@@ -1752,6 +1759,7 @@ mod test {
             established_thread: true,
             first_time_counterparty: false,
             payload: serde_json::json!({ "to": "x@ext.com", "subject": "Hi", "body": "yo" }),
+            agent: None,
         };
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .with_brain(Arc::new(EffectBrain {
@@ -1820,6 +1828,7 @@ mod test {
                 "subject": "[Acme] Report flow — Owner summary",
                 "body": "Q3 is up 12%.",
             }),
+            agent: None,
         };
         let approval_id = rt.approvals.park(rt.id(), effect.clone()).await.unwrap();
         rt.journal
@@ -1883,6 +1892,7 @@ mod test {
                 "subject": "[Acme] Report flow — Owner summary",
                 "body": "Q3 is up 12%.",
             }),
+            agent: None,
         };
         let approval_id = rt.approvals.park(rt.id(), effect.clone()).await.unwrap();
         rt.journal
@@ -1926,6 +1936,7 @@ mod test {
                 "subject": "[Acme] Report flow — Owner summary",
                 "body": "Q3 is up 12%.",
             }),
+            agent: None,
         };
         let approval_id = {
             let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
@@ -1977,6 +1988,7 @@ mod test {
             established_thread: true,
             first_time_counterparty: false,
             payload: serde_json::json!({ "to": "x@ext.com", "subject": "Hi", "body": "yo" }),
+            agent: None,
         };
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .with_brain(Arc::new(EffectBrain {
@@ -1995,6 +2007,7 @@ mod test {
                 established_thread: true,
                 first_time_counterparty: false,
                 payload: serde_json::json!({ "to": "x@ext.com", "subject": "Hi", "body": "yo" }),
+                agent: None,
             },
         )
         .await

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -1,0 +1,341 @@
+//! Single-use grants: what an operator's "approve" actually buys for a tool
+//! call an agent was blocked from making (issue #243).
+//!
+//! ## Why a grant, and not just "run the effect"
+//!
+//! Two different things park on the same approval queue, and they need opposite
+//! treatment on approval:
+//!
+//! * A **native** effect — an email the runtime sends, a workflow delivery, a
+//!   Medulla effect frame. The runtime built it and the runtime can perform it,
+//!   so approving it means executing it, at most once, keyed by approval id.
+//! * A **harness tool call** — `composio_execute`, `workspace_write`,
+//!   `media_generate_image`. openhuman's `ToolPolicy` is fail-closed: it blocked
+//!   the call inside the agent's turn and fed the model a refusal. The
+//!   opencompany [`Effect`](crate::ports::types::Effect) projected from it is a
+//!   *description* of a tool call, not something the runtime knows how to
+//!   perform — its payload is the tool's arguments. Executing it would ledger a
+//!   spend and route a `{channel, text}` payload if one happened to be shaped
+//!   like that, and otherwise do nothing at all. The real work is the tool, and
+//!   only that agent can run it.
+//!
+//! So approving a harness call mints a **grant**: a one-shot permission slip
+//! that lets exactly one future call — same agent, same tool, byte-identical
+//! arguments — through the policy that blocked it, after which it is gone. The
+//! agent is then re-dispatched with an instruction to re-issue the call.
+//!
+//! ## Why every part of that sentence is load-bearing
+//!
+//! * **Single-use.** Consuming removes the grant under the same lock that
+//!   matched it, so a model that re-tries the tool in a loop gets exactly one
+//!   execution out of one approval. Approving once must not mean "this tool is
+//!   open now".
+//! * **Agent-scoped.** A grant minted for `finance` does not let `marketing`
+//!   through, even for the identical call. The operator approved a specific
+//!   agent's request.
+//! * **Exact arguments.** Matching is `serde_json::Value` equality on the whole
+//!   argument object. A model that re-issues the call with a different
+//!   recipient, a larger amount, or an extra field does not match, falls
+//!   through, and re-parks — which is the honest outcome, because the operator
+//!   never saw those arguments. Approve-with-edit is handled by minting against
+//!   the *amended* arguments, so the operator's edit is what the grant admits.
+//! * **TTL.** A grant the agent never redeems expires
+//!   ([`GRANT_TTL_MILLIS`]) rather than sitting live forever. An approval is
+//!   consent to an action now, not a standing authorisation; without this, a
+//!   grant minted today would still fire if the same call surfaced next month.
+//!
+//! ## Durability
+//!
+//! The live set is in-memory, but its lifecycle is journaled
+//! (`ApprovalGranted` / `GrantConsumed` / `GrantExpired`) and replayed on boot
+//! via [`RuntimeJournal::replayed_grants`](crate::runtime::journal::RuntimeJournal::replayed_grants),
+//! so a restart between "operator approved" and "agent re-issued" does not
+//! silently drop the approval. Consumed and expired grants are folded *out* on
+//! replay, so a restart can never resurrect one that already fired.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+
+use crate::ports::types::ApprovalId;
+
+/// How long an unredeemed grant stays live: 15 minutes.
+///
+/// Sized to the gap between an operator hitting approve and the granting agent
+/// finishing its re-dispatched turn — generous for a model turn, far short of
+/// "still valid tomorrow". Expiry is not silent: the sweep tells the operator
+/// the agent did not act, so a re-approval is an informed choice rather than a
+/// mystery.
+pub const GRANT_TTL_MILLIS: u64 = 15 * 60 * 1000;
+
+/// One approved-but-not-yet-redeemed tool call.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GrantedCall {
+    /// The approval the operator resolved to mint this grant.
+    pub approval_id: ApprovalId,
+    /// The roster agent allowed to redeem it. Nobody else matches.
+    pub agent: String,
+    /// The tool the grant admits — the parked effect's `kind`.
+    pub tool: String,
+    /// The exact arguments admitted. Matching is whole-value equality.
+    pub args: serde_json::Value,
+    /// Epoch-millis the grant was minted, for TTL expiry.
+    pub at_millis: u64,
+}
+
+/// The live grant set: a cheap shared handle, the same pattern as
+/// [`ApprovalRequestQueue`](crate::harness::policy::ApprovalRequestQueue).
+///
+/// Cloning shares the state, so the policy installed on every roster agent, the
+/// cycle runner that mints, and the sweep that expires all see one set.
+#[derive(Clone, Default)]
+pub struct GrantSet {
+    inner: Arc<Mutex<GrantState>>,
+}
+
+#[derive(Default)]
+struct GrantState {
+    live: HashMap<ApprovalId, GrantedCall>,
+    /// Grants consumed since the last [`GrantSet::drain_consumed`].
+    ///
+    /// Consumption happens deep inside a `ToolPolicy::check`, which is sync and
+    /// has no journal handle, so the record cannot be written there. The id is
+    /// buffered instead and the cycle runner drains it after the cycle it
+    /// belongs to. A crash between consuming and draining loses the
+    /// `GrantConsumed` record, which on replay re-arms a grant whose tool
+    /// already ran — the same at-most-once trade the effect journal makes, and
+    /// in the safe direction: the operator is asked again rather than the tool
+    /// firing again unasked.
+    consumed: Vec<ApprovalId>,
+}
+
+impl GrantSet {
+    /// Mints a grant.
+    pub fn grant(&self, call: GrantedCall) {
+        self.inner
+            .lock()
+            .expect("grant set poisoned")
+            .live
+            .insert(call.approval_id.clone(), call);
+    }
+
+    /// Redeems a grant for `(agent, tool, args)`, removing it.
+    ///
+    /// The match and the removal happen under one lock, so two concurrent turns
+    /// racing the same grant cannot both be admitted — exactly one gets the
+    /// `Some`. Returns `None` when nothing matches, which is the fall-through
+    /// that re-parks.
+    pub fn consume(
+        &self,
+        agent: &str,
+        tool: &str,
+        args: &serde_json::Value,
+    ) -> Option<GrantedCall> {
+        let mut state = self.inner.lock().expect("grant set poisoned");
+        let id = state
+            .live
+            .iter()
+            .find(|(_, g)| g.agent == agent && g.tool == tool && &g.args == args)
+            .map(|(id, _)| id.clone())?;
+        let call = state.live.remove(&id)?;
+        state.consumed.push(id);
+        Some(call)
+    }
+
+    /// Reads a live grant by approval id without redeeming it.
+    ///
+    /// This is how the brain recovers the arguments to tell the agent to
+    /// re-issue: the grant must still be live when the instruction is written,
+    /// and must still be live when the agent's tool call reaches the policy.
+    pub fn peek(&self, id: &ApprovalId) -> Option<GrantedCall> {
+        self.inner
+            .lock()
+            .expect("grant set poisoned")
+            .live
+            .get(id)
+            .cloned()
+    }
+
+    /// Removes every grant minted more than `ttl_millis` before `now_millis`,
+    /// returning them so the caller can journal and announce each expiry.
+    pub fn sweep(&self, now_millis: u64, ttl_millis: u64) -> Vec<GrantedCall> {
+        let mut state = self.inner.lock().expect("grant set poisoned");
+        let expired: Vec<ApprovalId> = state
+            .live
+            .iter()
+            .filter(|(_, g)| now_millis.saturating_sub(g.at_millis) >= ttl_millis)
+            .map(|(id, _)| id.clone())
+            .collect();
+        expired
+            .into_iter()
+            .filter_map(|id| state.live.remove(&id))
+            .collect()
+    }
+
+    /// Seeds the live set from a journal replay (boot recovery).
+    pub fn rehydrate(&self, calls: impl IntoIterator<Item = GrantedCall>) {
+        let mut state = self.inner.lock().expect("grant set poisoned");
+        for call in calls {
+            state.live.insert(call.approval_id.clone(), call);
+        }
+    }
+
+    /// Takes the ids consumed since the last drain, so they can be journaled.
+    pub fn drain_consumed(&self) -> Vec<ApprovalId> {
+        std::mem::take(&mut self.inner.lock().expect("grant set poisoned").consumed)
+    }
+
+    /// How many grants are live (tests / observability).
+    pub fn live_count(&self) -> usize {
+        self.inner.lock().expect("grant set poisoned").live.len()
+    }
+}
+
+impl std::fmt::Debug for GrantSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GrantSet")
+            .field("live", &self.live_count())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn call(id: &str, agent: &str, tool: &str, args: serde_json::Value) -> GrantedCall {
+        GrantedCall {
+            approval_id: ApprovalId::new(id),
+            agent: agent.to_string(),
+            tool: tool.to_string(),
+            args,
+            at_millis: 1_000,
+        }
+    }
+
+    #[test]
+    fn a_grant_is_redeemed_exactly_once() {
+        let set = GrantSet::default();
+        let args = serde_json::json!({ "to": "a@b.test" });
+        set.grant(call("a1", "finance", "composio_execute", args.clone()));
+
+        assert!(set.consume("finance", "composio_execute", &args).is_some());
+        assert!(
+            set.consume("finance", "composio_execute", &args).is_none(),
+            "one approval buys one call, not an open door"
+        );
+        assert_eq!(set.live_count(), 0);
+        assert_eq!(set.drain_consumed().len(), 1);
+        assert!(set.drain_consumed().is_empty(), "the drain is a take");
+    }
+
+    #[test]
+    fn a_grant_is_scoped_to_its_agent_and_its_exact_arguments() {
+        let set = GrantSet::default();
+        let args = serde_json::json!({ "to": "a@b.test", "body": "hi" });
+        set.grant(call("a1", "finance", "composio_execute", args.clone()));
+
+        // Another agent making the identical call is not who was approved.
+        assert!(
+            set.consume("marketing", "composio_execute", &args)
+                .is_none()
+        );
+        // A different tool is not what was approved.
+        assert!(set.consume("finance", "workspace_write", &args).is_none());
+        // Different arguments are not what the operator saw.
+        assert!(
+            set.consume(
+                "finance",
+                "composio_execute",
+                &serde_json::json!({ "to": "someone@else.test", "body": "hi" })
+            )
+            .is_none()
+        );
+        // An extra key is a different call too — matching is whole-value.
+        assert!(
+            set.consume(
+                "finance",
+                "composio_execute",
+                &serde_json::json!({ "to": "a@b.test", "body": "hi", "cc": "x@y.test" })
+            )
+            .is_none()
+        );
+        // ...and none of those near-misses burned the grant.
+        assert!(set.consume("finance", "composio_execute", &args).is_some());
+    }
+
+    #[test]
+    fn peek_reads_without_redeeming() {
+        let set = GrantSet::default();
+        let args = serde_json::json!({ "q": 1 });
+        set.grant(call("a1", "finance", "web_fetch", args.clone()));
+
+        let seen = set.peek(&ApprovalId::new("a1")).expect("grant is live");
+        assert_eq!(seen.tool, "web_fetch");
+        assert_eq!(set.live_count(), 1, "peeking must not consume");
+        assert!(set.peek(&ApprovalId::new("nope")).is_none());
+    }
+
+    #[test]
+    fn sweep_expires_only_grants_past_the_ttl() {
+        let set = GrantSet::default();
+        set.grant(call("old", "finance", "t", serde_json::json!({})));
+        let mut fresh = call("new", "finance", "t2", serde_json::json!({}));
+        fresh.at_millis = 900_000;
+        set.grant(fresh);
+
+        let expired = set.sweep(1_000 + GRANT_TTL_MILLIS, GRANT_TTL_MILLIS);
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].approval_id, ApprovalId::new("old"));
+        assert_eq!(set.live_count(), 1, "the fresh grant survives");
+    }
+
+    #[test]
+    fn rehydrate_seeds_the_live_set() {
+        let set = GrantSet::default();
+        set.rehydrate([
+            call("a1", "finance", "t", serde_json::json!({})),
+            call("a2", "legal", "t", serde_json::json!({})),
+        ]);
+        assert_eq!(set.live_count(), 2);
+        assert!(set.peek(&ApprovalId::new("a2")).is_some());
+    }
+
+    /// Concurrent redemption of one grant: exactly one caller wins.
+    ///
+    /// The match and the removal are one critical section precisely so this
+    /// cannot double-fire. A read-then-remove would let both threads see the
+    /// grant and both proceed, turning one approval into two executions of a
+    /// tool the operator approved once.
+    #[test]
+    fn two_threads_racing_one_grant_yield_exactly_one_winner() {
+        let set = GrantSet::default();
+        let args = serde_json::json!({ "amount_usd": 40.0 });
+        set.grant(call("a1", "finance", "pay_invoice", args.clone()));
+
+        let barrier = Arc::new(std::sync::Barrier::new(8));
+        let winners = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let set = set.clone();
+                let args = args.clone();
+                let barrier = Arc::clone(&barrier);
+                let winners = Arc::clone(&winners);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    if set.consume("finance", "pay_invoice", &args).is_some() {
+                        winners.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("thread");
+        }
+
+        assert_eq!(winners.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(set.live_count(), 0);
+        assert_eq!(set.drain_consumed().len(), 1, "one consumption journaled");
+    }
+}

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -348,6 +348,7 @@ mod test {
             established_thread: false,
             first_time_counterparty: false,
             payload: serde_json::Value::Null,
+            agent: None,
         }
     }
 

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -27,6 +27,7 @@ use tokio::sync::Mutex as TokioMutex;
 use crate::Result;
 use crate::error::OpenCompanyError;
 use crate::ports::types::{ApprovalId, Effect};
+use crate::runtime::grants::GrantedCall;
 
 /// One durable journal record.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -73,6 +74,31 @@ enum JournalRecord {
         /// Epoch-millis the amendment was recorded.
         at_millis: u64,
     },
+    /// A single-use grant minted because the operator approved a tool call an
+    /// agent had been blocked from making (issue #243).
+    ///
+    /// This is the durable audit line for "the operator said yes to *this*
+    /// call": it carries the agent, the tool, and the exact arguments admitted,
+    /// which is more than the event log's
+    /// [`ApprovalResolved`](crate::ports::CompanyEvent::ApprovalResolved) can
+    /// hold. Written *before* the grant reaches the live set, so a crash between
+    /// the two re-arms it on replay rather than losing the operator's decision.
+    ApprovalGranted {
+        /// The grant, whole.
+        grant: GrantedCall,
+    },
+    /// A grant redeemed by its agent — the tool ran.
+    GrantConsumed {
+        /// The consumed grant's approval id.
+        id: ApprovalId,
+    },
+    /// A grant that expired unredeemed past [`GRANT_TTL_MILLIS`](crate::runtime::grants::GRANT_TTL_MILLIS).
+    GrantExpired {
+        /// The expired grant's approval id.
+        id: ApprovalId,
+        /// Epoch-millis the expiry was recorded.
+        at_millis: u64,
+    },
 }
 
 /// A parked approval awaiting resolution.
@@ -101,6 +127,14 @@ struct State {
     /// append-only lifetime as the file it is replayed from, and costs one
     /// `(id, u64)` per approval ever parked.
     park_instants: HashMap<ApprovalId, u64>,
+    /// Grants minted and not yet consumed or expired (issue #243).
+    ///
+    /// Unlike [`park_instants`](Self::park_instants) this one IS removed from on
+    /// the terminal records: a replayed grant is handed straight back to the
+    /// live [`GrantSet`](crate::runtime::grants::GrantSet), so keeping a
+    /// consumed or expired entry here would re-arm a tool call that already ran
+    /// (or that the operator was already told had lapsed) on every restart.
+    grants: HashMap<ApprovalId, GrantedCall>,
 }
 
 /// A per-company append-only journal backing at-most-once effects and the
@@ -162,6 +196,15 @@ impl RuntimeJournal {
                 }
                 // Audit-only: the paired `ApprovalResolved` handles removal.
                 JournalRecord::ApprovalAmended { .. } => {}
+                JournalRecord::ApprovalGranted { grant } => {
+                    state.grants.insert(grant.approval_id.clone(), grant);
+                }
+                JournalRecord::GrantConsumed { id } => {
+                    state.grants.remove(&id);
+                }
+                JournalRecord::GrantExpired { id, .. } => {
+                    state.grants.remove(&id);
+                }
             }
         }
         *self.state.lock().expect("journal state poisoned") = state;
@@ -271,6 +314,63 @@ impl RuntimeJournal {
             .expect("journal state poisoned")
             .park_instants
             .clone()
+    }
+
+    /// Records a minted single-use grant (issue #243).
+    ///
+    /// Called *before* the grant enters the live set, so the ordering failure
+    /// mode is "recorded but not live" — which replay fixes — rather than "live
+    /// but not recorded", which a crash would lose silently.
+    pub async fn record_granted(&self, grant: &GrantedCall) -> Result<()> {
+        self.state
+            .lock()
+            .expect("journal state poisoned")
+            .grants
+            .insert(grant.approval_id.clone(), grant.clone());
+        self.append(&JournalRecord::ApprovalGranted {
+            grant: grant.clone(),
+        })
+        .await
+    }
+
+    /// Records that a grant was redeemed — the agent re-issued the call and the
+    /// tool ran. Removes it from the replay set so a restart cannot re-arm it.
+    pub async fn record_grant_consumed(&self, id: &ApprovalId) -> Result<()> {
+        self.state
+            .lock()
+            .expect("journal state poisoned")
+            .grants
+            .remove(id);
+        self.append(&JournalRecord::GrantConsumed { id: id.clone() })
+            .await
+    }
+
+    /// Records that a grant expired unredeemed. Same replay removal as
+    /// consumption: the operator has been told it lapsed, so a restart must not
+    /// quietly hand the agent the permission back.
+    pub async fn record_grant_expired(&self, id: &ApprovalId, at_millis: u64) -> Result<()> {
+        self.state
+            .lock()
+            .expect("journal state poisoned")
+            .grants
+            .remove(id);
+        self.append(&JournalRecord::GrantExpired {
+            id: id.clone(),
+            at_millis,
+        })
+        .await
+    }
+
+    /// Every grant still live according to the journal — what boot recovery
+    /// seeds the in-memory [`GrantSet`](crate::runtime::grants::GrantSet) with.
+    pub fn replayed_grants(&self) -> Vec<GrantedCall> {
+        self.state
+            .lock()
+            .expect("journal state poisoned")
+            .grants
+            .values()
+            .cloned()
+            .collect()
     }
 
     /// A snapshot of the currently parked approvals, oldest first.
@@ -514,6 +614,133 @@ mod test {
         assert_eq!(instants.get(&expired), Some(&2_000));
     }
 
+    fn grant(id: &str, at_millis: u64) -> GrantedCall {
+        GrantedCall {
+            approval_id: ApprovalId::new(id),
+            agent: "finance".into(),
+            tool: "composio_execute".into(),
+            args: serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
+            at_millis,
+        }
+    }
+
+    /// Issue #243: a grant minted before a restart is still redeemable after it.
+    ///
+    /// The window between "operator approved" and "agent re-issued the call"
+    /// spans a model turn, so a deploy or crash inside it is ordinary. Without
+    /// replay the operator's approval would evaporate and the agent would come
+    /// back asking for the same permission it had just been given.
+    #[tokio::test]
+    async fn a_live_grant_replays_across_a_restart() {
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
+        let journal = RuntimeJournal::new(&path);
+
+        journal
+            .record_granted(&grant("appr-1", 1_000))
+            .await
+            .unwrap();
+        assert_eq!(journal.replayed_grants().len(), 1);
+
+        let reloaded = RuntimeJournal::new(&path);
+        reloaded.load().await.unwrap();
+        let replayed = reloaded.replayed_grants();
+        assert_eq!(replayed.len(), 1);
+        assert_eq!(replayed[0].approval_id, ApprovalId::new("appr-1"));
+        assert_eq!(replayed[0].agent, "finance");
+        assert_eq!(replayed[0].tool, "composio_execute");
+        assert_eq!(
+            replayed[0].args,
+            serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
+            "the exact arguments the operator approved survive the restart"
+        );
+    }
+
+    /// The other half, and the one that actually matters for safety: a grant
+    /// that already fired — or that lapsed and was announced as lapsed — must
+    /// NOT come back on replay.
+    ///
+    /// A single-use grant resurrected by a restart is no longer single-use. The
+    /// fold therefore *removes* on both terminal records, unlike `park_instants`
+    /// (#305) which deliberately retains.
+    #[tokio::test]
+    async fn consumed_and_expired_grants_are_not_rehydrated() {
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
+        let journal = RuntimeJournal::new(&path);
+
+        journal
+            .record_granted(&grant("consumed", 1_000))
+            .await
+            .unwrap();
+        journal
+            .record_granted(&grant("expired", 2_000))
+            .await
+            .unwrap();
+        journal.record_granted(&grant("live", 3_000)).await.unwrap();
+        assert_eq!(journal.replayed_grants().len(), 3);
+
+        journal
+            .record_grant_consumed(&ApprovalId::new("consumed"))
+            .await
+            .unwrap();
+        journal
+            .record_grant_expired(&ApprovalId::new("expired"), 9_000)
+            .await
+            .unwrap();
+
+        let still_live: Vec<_> = journal.replayed_grants();
+        assert_eq!(still_live.len(), 1);
+        assert_eq!(still_live[0].approval_id, ApprovalId::new("live"));
+
+        // And the removal is durable, not just in-memory.
+        let reloaded = RuntimeJournal::new(&path);
+        reloaded.load().await.unwrap();
+        let replayed = reloaded.replayed_grants();
+        assert_eq!(replayed.len(), 1);
+        assert_eq!(replayed[0].approval_id, ApprovalId::new("live"));
+
+        let raw = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(raw.contains("ApprovalGranted"));
+        assert!(raw.contains("GrantConsumed"));
+        assert!(raw.contains("GrantExpired"));
+    }
+
+    /// The grant records must not disturb the approval-queue fold they share a
+    /// file with — including #309's `park_instants` index, which the Task Detail
+    /// waiting-time read joins against.
+    #[tokio::test]
+    async fn grant_records_leave_the_parked_queue_and_park_instants_intact() {
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
+        let journal = RuntimeJournal::new(&path);
+
+        let parked_id = ApprovalId::new("appr-parked");
+        journal
+            .record_parked(&parked_id, &effect(), 500)
+            .await
+            .unwrap();
+        journal
+            .record_granted(&grant("appr-granted", 1_000))
+            .await
+            .unwrap();
+        journal
+            .record_grant_consumed(&ApprovalId::new("appr-granted"))
+            .await
+            .unwrap();
+
+        let reloaded = RuntimeJournal::new(&path);
+        reloaded.load().await.unwrap();
+        assert_eq!(
+            reloaded.pending().len(),
+            1,
+            "the parked approval is untouched"
+        );
+        assert_eq!(reloaded.pending()[0].id, parked_id);
+        assert_eq!(reloaded.park_instants().get(&parked_id), Some(&500));
+        assert!(reloaded.replayed_grants().is_empty());
+    }
+
     #[test]
     fn expired_and_amended_records_round_trip_under_record_tag() {
         for record in [
@@ -525,6 +752,16 @@ mod test {
                 id: ApprovalId::new("y"),
                 amended_effect: effect(),
                 at_millis: 7,
+            },
+            JournalRecord::ApprovalGranted {
+                grant: grant("z", 11),
+            },
+            JournalRecord::GrantConsumed {
+                id: ApprovalId::new("z"),
+            },
+            JournalRecord::GrantExpired {
+                id: ApprovalId::new("z"),
+                at_millis: 13,
             },
         ] {
             let json = serde_json::to_value(&record).unwrap();

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -36,6 +36,11 @@ pub mod delegation;
 /// catalog, and desk-lead resolver shared by BOTH the harness and hosted paths.
 /// Compiled in every build (the hosted brain ships in the default build).
 pub mod delegation_tools;
+/// Single-use grants minted when an operator approves a blocked tool call
+/// (issue #243). Compiled in every build: the journal records and their replay
+/// are feature-independent, so a company that ran under the harness stays
+/// replayable by a build without it.
+pub mod grants;
 pub mod journal;
 pub mod mailbox_poller;
 pub mod registry;

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -166,9 +166,18 @@ impl CompanyScheduler {
     }
 
     /// Runs the per-tick maintenance that rides the same minute boundary as
-    /// scheduled fires: sweep parked approvals past their TTL to a default-deny.
+    /// scheduled fires: sweep parked approvals past their TTL to a default-deny,
+    /// then sweep single-use grants the agent never redeemed (issue #243).
+    ///
+    /// The grant sweep's ids are deliberately not folded into the return value —
+    /// callers read it as "approvals that expired", and a grant expiry is a
+    /// different event with a different meaning (the operator DID approve; the
+    /// agent simply never acted). It announces itself on the operator channel
+    /// instead.
     pub async fn tick_maintenance(&self) -> Result<Vec<crate::ports::types::ApprovalId>> {
-        self.runtime.sweep_expired_approvals().await
+        let expired = self.runtime.sweep_expired_approvals().await?;
+        self.runtime.sweep_expired_grants().await?;
+        Ok(expired)
     }
 
     /// Spawns a background task that ticks on every minute boundary until

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -430,6 +430,7 @@ mod test {
                             established_thread: false,
                             first_time_counterparty: false,
                             payload: serde_json::Value::Null,
+                            agent: None,
                         })
                         .await?;
                     }

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -3119,6 +3119,7 @@ fn parked_effect() -> crate::ports::types::Effect {
         established_thread: false,
         first_time_counterparty: false,
         payload: serde_json::Value::Null,
+        agent: None,
     }
 }
 

--- a/src/server/provision/test.rs
+++ b/src/server/provision/test.rs
@@ -713,6 +713,7 @@ async fn webhook_emitted_on_approval_requested() {
         established_thread: false,
         first_time_counterparty: false,
         payload: serde_json::Value::Null,
+        agent: None,
     };
     let runtime = RuntimeBuilder::new(home.clone(), manifest)
         .with_id(CompanyId::new("acme"))

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -563,6 +563,7 @@ async fn park_cold_recipient(
             // Already truncated by `report_text`.
             "body": text,
         }),
+        agent: None,
     };
 
     match park_effect(parking, &record.id, effect).await {


### PR DESCRIPTION
## Summary

Closes #243.

Approving a parked tool call was a recorded no-op. The operator clicked Approve, the card cleared, the tool never ran, and they had to re-ask from scratch — losing the run's context. The module doc said so plainly, and this closes it.

Two things were broken, not one:

- **The effect executor understands ledger, channel-message and email payloads only.** A harness tool effect — kind is the tool name, payload is raw arguments — fell through all three arms and silently did nothing on approve.
- **Even a retry would have re-parked.** The tool policy is stateless, so a model re-issuing the same call would hit the same gate and park again — an approval loop with no exit.

The fix is a **durable single-use grant plus guided re-issue**, not out-of-band dispatch. Tools live inside per-agent sessions with their own workspaces, clients and credentials; running one outside a session would mean the model never observes its own tool result. The existing follow-up cycle is the resume vehicle.

Approving mints a grant scoped to (agent, tool, exact arguments), journalled before it goes live. The follow-up turn tells that agent to re-issue the call verbatim; the policy sees the grant, allows it once, and removes it. Anything else re-parks.

## API Or Behavior Changes

**Readonly outranks a grant.** A grant can be up to its TTL old when redeemed, so a company can be switched to `readonly` in the window between approval and re-issue. Switching to `readonly` is the emergency stop, and that window is exactly when someone means it — the tier's contract is that nothing mutates and nothing reaches outside, and an approval given under a laxer mode is the older instruction. Consent does not survive the brake.

Scoped deliberately: only `readonly`, and only for external effects. `supervised` and `full` still fall through to the grant, because bypassing supervised's re-park is the entire point. The grant is **left unconsumed** by that denial — the call never ran, so the approval stays redeemable if the brake comes off inside its TTL.

**Resolving an already-resolved approval is now a no-op.** Previously a double-POST appended a duplicate journal record and ran a pointless second cycle. The concrete gate now distinguishes not-parked from denied from expired, and the map-remove under its mutex makes exactly one concurrent caller the winner.

**A grant is minted instead of executing.** For an agent-stamped effect the approve path journals the grant and **skips** the executor — no dual execution path. Native effects (email, channel messages, ledger spends) keep their existing at-most-once path byte-identical.

One deliberate consequence: approving a tool effect carrying a dollar amount no longer writes an approve-time ledger entry for a tool that never ran — a phantom spend today. The real run meters the real spend.

**Additive only:** `Effect` gains an optional `agent`; three journal record types are added. Pre-upgrade journal lines decode with no agent, mint no grant, and fall back to today's re-ask behaviour.

Console: the approve confirmation now says the agent is completing the action, and the re-issued turn's reply and steps appear in the transcript.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — exit 0
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **1651 passed, 0 failed**, 1 ignored
- [x] `cargo check --locked --all-features --all-targets` — exit 0
- [x] `cargo check --features openhuman,mcp,telegram` — the combination CI never builds
- [x] `npm ci` / `npm run typecheck` / `npm run build`
- [x] `git diff Cargo.lock` empty
- N/A: frontend unit tests — no runner exists in `frontend/`

All gates re-run after rebasing onto current `main`, not only before.

**28 new tests.** Grant lifecycle, single use, agent scope, argument exactness including extra-key drift, grant-above-always-approve, survival of the per-cycle queue clear, journal fold and replay with consumed and expired grants **not** rehydrated, the four resolve outcomes, and two concurrency races — eight threads on one grant and eight tasks on one resolve — each with exactly one winner. Mint-and-skip-execute is proven by an **empty ledger** on a $42 effect.

**The pre-existing native-effect approval tests pass unmodified.** Every deletion in the diff was audited: there are zero deletions inside any existing test body. Their only change is the additive optional field.

**Not proved, stated plainly.** The brain test drives the new path with an offline mock provider, so it proves the instruction reaches the agent with byte-exact arguments — but **not** that a real model re-issues it faithfully, and **not** an external tool firing under a grant end to end. That seam needs a real inference credential.

## Documentation

`docs/spec/company-brain/approvals.md` records the precedence and the grant lifecycle. The module doc that declared resume-after-approval out of scope is rewritten rather than left to rot.

Three findings worth recording:

- **A reserved `never_do` slot sits above the grant check, with a comment binding the future rule compiler to emit its arm there.** That ordering is not a detail: a grant is an operator saying yes to one call, and `never_do` is the company saying not this, ever. An operator can be socially engineered; the standing rule is what is meant to survive that. Adding the arm below the grant would silently invert it.
- **The two gates are on disjoint paths.** `never_do` today lives only in the effect-path gate, which never sees a harness tool call — those park directly, bypassing it. The issue's proposed precedence could not have held where it placed it, so the grant check went to the top of the tool policy with the slot reserved above.
- **Two of my own tests were initially unfaithful** — they appended a resolution event without calling the journal's record path, which the real flow does. One failed loudly, the other passed only because it never asserted on the field. Production code was correct; the tests were wrong.

## Related

Closes #243. Builds on #172/#181, which shipped the parking side.
