### PR TITLE
feat(users): let a provisioned company bootstrap its creator as admin (#321)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,11 @@ injects its environment. When developing hosted behavior, know the seams:
   additionally forwards it as `--home "$OPENCOMPANY_DATA_DIR"`, which resolves
   identically (the flag outranks the variable). Locally it is the only knob that
   isolates two `serve` processes from each other — see
-  `docs/spec/runtime/storage.md`. Plus — when database-per-tenant storage is enabled —
+  `docs/spec/runtime/storage.md`. It also injects `OPENCOMPANY_ADMIN_EMAIL`, the
+  address that provisioned the instance: a standing admin invite equivalent to a
+  manifest `[users].admins` entry, without which a provisioned company (whose
+  manifest names nobody) has nobody eligible to sign in — see
+  `docs/spec/runtime/users.md`. Plus — when database-per-tenant storage is enabled —
   `OPENCOMPANY_STORAGE=mongodb`, `OPENCOMPANY_MONGODB_URI` (credentials
   scoped to that tenant's database only), and `OPENCOMPANY_MONGODB_DB`.
 - In the alternative **shared-single-DB** mode (all tenants on one logical

--- a/docs/spec/runtime/users.md
+++ b/docs/spec/runtime/users.md
@@ -95,6 +95,47 @@ Manifest admins appear in the invite list as synthetic `manifest:` entries.
 Revoking one is refused: the manifest would re-grant it on the next login, so
 succeeding would be a lie.
 
+## Bootstrap: `OPENCOMPANY_ADMIN_EMAIL`
+
+A company the *platform* provisions has an empty `[users] admins`. The person
+who asked for it is recorded on the control plane's tenant row, which the
+manifest never sees — so nobody is eligible, and there is no operator token to
+send the first invite with. The company is unreachable by the human who created
+it (issue #321).
+
+The deployment therefore may name **one** more standing admin through the
+environment:
+
+```sh
+OPENCOMPANY_ADMIN_EMAIL=ada@example.com
+```
+
+It is the same grant as a manifest entry, not a second kind of one:
+
+- listing the address makes it *eligible*; only redeeming a link mints the user,
+  as an `admin`
+- unsetting it stops future bootstrapping and does not delete an account it
+  already created
+- it is normalized with the same `normalize_email`, so case and surrounding
+  whitespace do not matter
+- unset, empty, and whitespace-only are one behaviour — no grant at all. The
+  platform renders the variable for every tenant, so a tenant with no recorded
+  creator must be indistinguishable from a deployment predating the variable.
+
+It admits exactly that address. It is **not** "trust whoever the platform says
+owns this instance": the root of trust stays with what the company is
+configured with, never with an assertion made at sign-in time.
+
+The address appears in the invite list as a synthetic `platform:` entry, and
+revoking it is refused the same way — the error points at the variable rather
+than at `[users].admins`. An address named in both places renders once, as
+`manifest:`: that is the grant that outlives the deployment's variable.
+
+**Recovery for a company already provisioned with an empty admin list**: set the
+variable on the instance and restart it. The workload reads it at boot, and
+eligibility is evaluated per login rather than cached, so the next link request
+from that address succeeds.
+
 ## Routes
 
 Login routes are **unauthenticated by construction** (`PublicCompany`), because

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 
 use crate::app::config::{BrainMode, EnvSource, redacted};
 use crate::company::{CredentialSource, SkillDoc, TinyhumansTokenSource, load_dir_skills};
+use crate::ports::normalize_email;
 use crate::ports::types::{CompanyId, SecretValue};
 use crate::runtime::CompanyRegistry;
 use crate::server::platform_auth::PlatformAuthConfig;
@@ -58,6 +59,24 @@ pub struct AppConfig {
     /// unique index. `None` (the default) is a no-op: db-per-tenant and
     /// single-tenant deployments are unaffected.
     pub tenant_namespace: Option<String>,
+    /// One address the deployment bootstraps as an admin of every company it
+    /// serves (`OPENCOMPANY_ADMIN_EMAIL`), on top of each manifest's
+    /// `[users] admins`.
+    ///
+    /// A company the *platform* provisions has no one in its manifest: the
+    /// person who asked for it is recorded on the control plane's tenant row,
+    /// which the manifest never sees. With an empty `[users] admins` and no
+    /// invite outstanding nobody is eligible, and there is no operator token to
+    /// send the first invite with — the company is unreachable by the human who
+    /// created it (issue #321). This is the seam the platform injects that
+    /// address through.
+    ///
+    /// It is a *standing invite*, not an account: exactly like a manifest
+    /// admin, listing the address makes it eligible to log in, and only
+    /// redeeming a link mints the user. Unsetting it stops future bootstrapping
+    /// and does not delete an account it already created. `None` — and an empty
+    /// or whitespace-only value — is a clean no-op.
+    pub admin_email: Option<String>,
 }
 
 impl Default for AppConfig {
@@ -75,6 +94,7 @@ impl Default for AppConfig {
             max_companies_per_tenant: None,
             webhook: None,
             tenant_namespace: None,
+            admin_email: None,
         }
     }
 }
@@ -154,6 +174,23 @@ impl AppConfig {
             None if self.tinyhumans_credential.is_some() => CredentialSource::Static,
             None => CredentialSource::None,
         }
+    }
+
+    /// The deployment-wide bootstrap admin address, normalized, or `None`.
+    ///
+    /// Normalization goes through the same [`normalize_email`] the manifest and
+    /// login paths use, so `Ada@Example.com ` and `ada@example.com` name one
+    /// address here exactly as they do there — an injected value that only
+    /// matched with the right capitalization would be a lockout that looks like
+    /// a typo. A value that is empty or trims to nothing is `None`: the
+    /// platform renders this variable for every tenant, and a tenant with no
+    /// recorded creator must be indistinguishable from one deployed before the
+    /// variable existed.
+    pub fn bootstrap_admin(&self) -> Option<String> {
+        self.admin_email
+            .as_deref()
+            .map(normalize_email)
+            .filter(|email| !email.is_empty())
     }
 
     /// Namespaces a company id for shared-single-DB mode.

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -775,6 +775,15 @@ async fn main() -> Result<()> {
             let tenant_namespace = std::env::var("OPENCOMPANY_TENANT_ID")
                 .ok()
                 .filter(|value| !value.trim().is_empty());
+            // The address the platform records as this instance's creator. A
+            // provisioned company's manifest names no admin, so without this
+            // nobody is eligible to log in and there is no operator token to
+            // send the first invite with (issue #321). Treated exactly like a
+            // manifest `[users].admins` entry — a standing invite, not an
+            // account. Unset (self-hosted, local `serve`) is a full no-op.
+            let admin_email = std::env::var("OPENCOMPANY_ADMIN_EMAIL")
+                .ok()
+                .filter(|value| !value.trim().is_empty());
             // Hosted-brain credential, resolved with the same precedence the
             // harness uses (`harness_inference_from_env`) so `/spec`'s
             // `cycles_available` reflects whether cognition can actually run.
@@ -797,6 +806,7 @@ async fn main() -> Result<()> {
                 tinyplace_api_url,
                 public_url,
                 tenant_namespace,
+                admin_email,
                 tinyhumans_credential,
                 ..AppConfig::default()
             })

--- a/src/server/users/admin.rs
+++ b/src/server/users/admin.rs
@@ -165,7 +165,7 @@ async fn list_invites(
         .list_users(runtime.id())
         .await
         .map_err(|e| ApiError(e).into_response())?;
-    let synthetic = manifest_admin_invites(&runtime, now)
+    let synthetic = manifest_admin_invites(state.config(), &runtime, now)
         .await
         .map_err(|e| ApiError(e).into_response())?;
     for invite in synthetic {
@@ -241,12 +241,21 @@ async fn revoke_invite(
     let runtime = company.runtime.clone();
     require_admin(&headers, &state, &runtime).await?;
     let invite_id = params.get("invite_id").cloned().unwrap_or_default();
-    // A manifest admin has no stored invite; revoking it would be a lie, since
-    // the manifest would re-grant on the next login.
+    // A bootstrapped admin has no stored invite; revoking it would be a lie,
+    // since its source would re-grant on the next login. The two sources are
+    // withdrawn in different places, so say which one this row came from.
     if invite_id.starts_with("manifest:") {
         return Err(ApiError(OpenCompanyError::InvalidRequest(
             "this admin comes from the company manifest; remove them from \
              [users].admins there instead"
+                .to_string(),
+        ))
+        .into_response());
+    }
+    if invite_id.starts_with("platform:") {
+        return Err(ApiError(OpenCompanyError::InvalidRequest(
+            "this admin comes from the deployment's OPENCOMPANY_ADMIN_EMAIL; \
+             unset it there instead"
                 .to_string(),
         ))
         .into_response());

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -18,6 +18,12 @@
 //! Access is invite-only, so someone must send the first invite. There is no
 //! operator token to do it with, so the company manifest's `[users] admins`
 //! list is the root of trust: those addresses are standing admin invites.
+//!
+//! A platform-provisioned company has an empty list — its creator is recorded
+//! on the control plane, not in the manifest — so the deployment may name one
+//! more standing admin through [`AppConfig::bootstrap_admin`]. It is the same
+//! kind of grant, not a second one: eligibility only, minted on redemption,
+//! revoked by unsetting the source.
 
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode, header};
@@ -26,7 +32,6 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
-use crate::AppState;
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
 use crate::ports::types::CompanyId;
@@ -39,6 +44,7 @@ use crate::server::graphql::auth::{GqlAuth, UserPrincipal, resolve_principal};
 use crate::server::ops::mailer::OutboundEmail;
 use crate::server::users::scope::{PublicCompany, public_scoped};
 use crate::server::users::{cookie, password, token};
+use crate::{AppConfig, AppState};
 
 /// How long a manifest-bootstrapped admin invite stays redeemable once
 /// materialized. Long, because it is regenerated from the manifest on demand.
@@ -180,15 +186,43 @@ pub(crate) async fn manifest_admins(
         .unwrap_or_default())
 }
 
+/// The addresses this company bootstraps as admins without an invite record:
+/// the manifest's `[users] admins`, plus the deployment's
+/// [`AppConfig::bootstrap_admin`] when one is injected.
+///
+/// Both are the same grant, so they are one list — deduplicated, because an
+/// address named in both places is still one standing invite and must render as
+/// one row on the invite page.
+pub(crate) async fn bootstrap_admins(
+    config: &AppConfig,
+    runtime: &CompanyRuntime,
+) -> Result<Vec<String>, OpenCompanyError> {
+    Ok(with_platform_admin(config, manifest_admins(runtime).await?))
+}
+
+/// Appends the deployment's bootstrap admin to a manifest admin list.
+///
+/// Split out so the invite listing can tell the two sources apart without
+/// reading the manifest twice.
+fn with_platform_admin(config: &AppConfig, mut admins: Vec<String>) -> Vec<String> {
+    if let Some(email) = config.bootstrap_admin()
+        && !admins.contains(&email)
+    {
+        admins.push(email);
+    }
+    admins
+}
+
 /// Whether `email` may hold an account in this company, and as what role.
 ///
 /// Three ways in, checked in order:
 /// 1. They already are a user (their role stands).
-/// 2. The manifest's `[users] admins` names them — the bootstrap path.
+/// 2. A [`bootstrap_admins`] entry names them — the bootstrap path.
 /// 3. An admin invited them, and the invite is still redeemable.
 ///
 /// `None` means the address gets no code and no session, indistinguishably.
 async fn eligibility(
+    config: &AppConfig,
     runtime: &CompanyRuntime,
     email: &str,
     now: u64,
@@ -199,7 +233,11 @@ async fn eligibility(
         // as an unknown address.
         return Ok((user.status == UserStatus::Active).then_some(user.role));
     }
-    if manifest_admins(runtime).await?.iter().any(|a| a == email) {
+    if bootstrap_admins(config, runtime)
+        .await?
+        .iter()
+        .any(|a| a == email)
+    {
         return Ok(Some(UserRole::Admin));
     }
     let invite = runtime.users().find_invite_by_email(id, email).await?;
@@ -338,7 +376,7 @@ async fn request_code(
     let runtime = company.runtime.clone();
     let now = now_millis();
 
-    let eligible = eligibility(&runtime, &email, now)
+    let eligible = eligibility(state.config(), &runtime, &email, now)
         .await
         .map_err(|e| ApiError(e).into_response())?;
     let Some(_role) = eligible else {
@@ -514,7 +552,7 @@ async fn verify_code(
 
     // The address comes from the *code*, never from the request: otherwise
     // anyone holding any valid link could name whoever they liked.
-    let Some(role) = eligibility(&runtime, &code.email, now)
+    let Some(role) = eligibility(state.config(), &runtime, &code.email, now)
         .await
         .map_err(|e| ApiError(e).into_response())?
     else {
@@ -686,27 +724,40 @@ pub(crate) async fn current_user(
     }
 }
 
-/// Materializes the manifest's `[users] admins` as invite records.
+/// Materializes [`bootstrap_admins`] as invite records.
 ///
 /// Exposed for the admin routes, so listing invites shows the bootstrapped
 /// admins rather than an empty page that contradicts who can actually log in.
 /// These are synthetic — no such row exists — which is why their ids are
-/// prefixed `manifest:` and revoking one is refused.
+/// prefixed `manifest:` / `platform:` and revoking one is refused.
+///
+/// The prefix names the source because the two are withdrawn in different
+/// places: a `manifest:` row goes away by editing `[users].admins`, a
+/// `platform:` row by unsetting the deployment's variable. An address in both
+/// renders as `manifest:` — that is the grant that outlives the variable.
 pub(crate) async fn manifest_admin_invites(
+    config: &AppConfig,
     runtime: &CompanyRuntime,
     now: u64,
 ) -> Result<Vec<InviteRecord>, OpenCompanyError> {
-    Ok(manifest_admins(runtime)
-        .await?
+    let from_manifest = manifest_admins(runtime).await?;
+    Ok(with_platform_admin(config, from_manifest.clone())
         .into_iter()
-        .map(|email| InviteRecord {
-            id: format!("manifest:{email}"),
-            email,
-            role: UserRole::Admin,
-            invited_by: "manifest".to_string(),
-            created_at_millis: now,
-            expires_at_millis: now + MANIFEST_INVITE_TTL_MILLIS,
-            accepted_at_millis: None,
+        .map(|email| {
+            let source = if from_manifest.contains(&email) {
+                "manifest"
+            } else {
+                "platform"
+            };
+            InviteRecord {
+                id: format!("{source}:{email}"),
+                email,
+                role: UserRole::Admin,
+                invited_by: source.to_string(),
+                created_at_millis: now,
+                expires_at_millis: now + MANIFEST_INVITE_TTL_MILLIS,
+                accepted_at_millis: None,
+            }
         })
         .collect())
 }

--- a/src/server/users/routes_test.rs
+++ b/src/server/users/routes_test.rs
@@ -33,6 +33,13 @@ fn manifest() -> CompanyManifest {
     .unwrap()
 }
 
+/// A manifest with **no** `[users] admins` — the shape a company the platform
+/// provisions boots with, and the reason issue #321 exists: nobody is eligible
+/// and there is no operator token to send the first invite with.
+fn manifest_without_admins() -> CompanyManifest {
+    toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n").unwrap()
+}
+
 async fn state_with(home: &std::path::Path, connections: ConnectionsRuntime) -> AppState {
     state_bound_to(home, &AppConfig::default().bind, connections).await
 }
@@ -44,12 +51,32 @@ async fn state_bound_to(
     bind: &str,
     connections: ConnectionsRuntime,
 ) -> AppState {
+    state_from(
+        home,
+        manifest(),
+        AppConfig {
+            bind: bind.to_string(),
+            ..AppConfig::default()
+        },
+        connections,
+    )
+    .await
+}
+
+/// State over an explicit manifest and config — the seam the bootstrap-admin
+/// tests need, since they turn on both.
+async fn state_from(
+    home: &std::path::Path,
+    manifest: CompanyManifest,
+    config: AppConfig,
+    connections: ConnectionsRuntime,
+) -> AppState {
     let store = crate::store::FsCompanyStore::new(home.to_path_buf());
     let id = CompanyId::new("acme");
     store
         .save(&CompanyRecord {
             id: id.clone(),
-            manifest: manifest(),
+            manifest: manifest.clone(),
             ledger: Vec::new(),
             lifecycle: "running".to_string(),
             overlay_agents: Vec::new(),
@@ -61,23 +88,20 @@ async fn state_bound_to(
         })
         .await
         .unwrap();
-    let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest())
+    let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
         .with_id(id.clone())
         .build()
         .await
         .unwrap();
-    let state = AppState::new(AppConfig {
-        bind: bind.to_string(),
-        ..AppConfig::default()
-    })
-    .with_home(home.to_path_buf())
-    .with_connections(connections);
+    let state = AppState::new(config)
+        .with_home(home.to_path_buf())
+        .with_connections(connections);
     state.registry().insert(id, Arc::new(runtime));
     state
 }
 
-/// State with a recording mail sender wired, so links are "delivered".
-async fn state_with_mail(home: &std::path::Path) -> (AppState, RecordingMailSender) {
+/// A recording mail sender wired as a transport, so links are "delivered".
+fn mail_connections() -> (ConnectionsRuntime, RecordingMailSender) {
     let sender = RecordingMailSender::new();
     let connections = ConnectionsRuntime::new()
         .with_mail(Arc::new(sender.clone()))
@@ -90,7 +114,31 @@ async fn state_with_mail(home: &std::path::Path) -> (AppState, RecordingMailSend
             from_name: "Acme".into(),
             from_email: "noreply@acme.test".into(),
         }));
+    (connections, sender)
+}
+
+/// State with a recording mail sender wired, so links are "delivered".
+async fn state_with_mail(home: &std::path::Path) -> (AppState, RecordingMailSender) {
+    let (connections, sender) = mail_connections();
     (state_with(home, connections).await, sender)
+}
+
+/// State with mail wired over an explicit manifest and `OPENCOMPANY_ADMIN_EMAIL`
+/// value — `None` being the pre-#321 deployment.
+async fn state_with_admin_email(
+    home: &std::path::Path,
+    manifest: CompanyManifest,
+    admin_email: Option<&str>,
+) -> (AppState, RecordingMailSender) {
+    let (connections, sender) = mail_connections();
+    let config = AppConfig {
+        admin_email: admin_email.map(str::to_string),
+        ..AppConfig::default()
+    };
+    (
+        state_from(home, manifest, config, connections).await,
+        sender,
+    )
 }
 
 async fn body_json(response: axum::response::Response) -> serde_json::Value {
@@ -1167,4 +1215,185 @@ async fn with_mail_wired_the_code_is_never_echoed() {
     let sent = sender.sent();
     assert_eq!(sent.len(), 1);
     assert!(sent[0].1.body.contains("/login?company=acme&code="));
+}
+
+// ---------------------------------------------------------------------------
+// The deployment bootstrap admin (`OPENCOMPANY_ADMIN_EMAIL`, issue #321)
+// ---------------------------------------------------------------------------
+
+/// The bug this fixes: a platform-provisioned company's manifest names nobody,
+/// so before the variable existed *no address at all* could get in. The
+/// injected address is the only one that can, and it comes out an admin — the
+/// same grant a manifest entry gives, minted only on redemption.
+#[tokio::test]
+async fn the_env_admin_can_sign_in_to_a_company_whose_manifest_names_nobody() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let (state, sender) =
+        state_with_admin_email(&home, manifest_without_admins(), Some("zoe@example.com")).await;
+
+    let cookie = login_via_link(&state, &sender, "zoe@example.com").await;
+
+    let app = router(state.clone());
+    let response = app
+        .oneshot(get_with_cookie("/api/v1/companies/acme/auth/me", &cookie))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let me = body_json(response).await;
+    assert_eq!(me["email"], "zoe@example.com");
+    assert_eq!(
+        me["role"], "admin",
+        "the injected address bootstraps as an admin, exactly like a manifest entry"
+    );
+}
+
+/// Unset, empty, and whitespace-only are one behaviour: the company as it was
+/// before #321. Empty matters on its own — the platform renders the variable
+/// for every tenant, so a tenant with no recorded creator gets an empty value
+/// rather than no variable, and that must not grant anyone anything.
+#[tokio::test]
+async fn no_env_admin_leaves_a_provisioned_company_refusing_everyone() {
+    for admin_email in [None, Some(""), Some("   ")] {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let (state, sender) =
+            state_with_admin_email(&home, manifest_without_admins(), admin_email).await;
+
+        assert_eq!(request_dev_code(&state, "zoe@example.com").await, None);
+        assert!(
+            sender.sent().is_empty(),
+            "{admin_email:?} must grant no eligibility, so no link is ever sent"
+        );
+    }
+}
+
+/// The injected address admits exactly one address, not "anyone the platform
+/// vouches for". Everyone else meets the same silence as before.
+#[tokio::test]
+async fn a_different_address_is_still_refused() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let (state, sender) =
+        state_with_admin_email(&home, manifest_without_admins(), Some("zoe@example.com")).await;
+
+    assert_eq!(request_dev_code(&state, "eve@example.com").await, None);
+    assert!(
+        sender.sent().is_empty(),
+        "an address the platform did not name must get no link"
+    );
+}
+
+/// Case and surrounding whitespace are normalized the way the manifest path
+/// normalizes them. A value that only matched with the right capitalization
+/// would be a lockout that reads as a typo.
+#[tokio::test]
+async fn the_env_admin_is_normalized_like_a_manifest_admin() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let (state, sender) = state_with_admin_email(
+        &home,
+        manifest_without_admins(),
+        Some("  ZOE@Example.COM  "),
+    )
+    .await;
+
+    let cookie = login_via_link(&state, &sender, "zoe@example.com").await;
+    let app = router(state.clone());
+    let response = app
+        .oneshot(get_with_cookie("/api/v1/companies/acme/auth/me", &cookie))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_json(response).await["email"], "zoe@example.com");
+}
+
+/// An address named in both places is one standing invite, not two. It stays a
+/// `manifest:` row: that grant outlives the deployment's variable, so it is the
+/// one the operator has to withdraw.
+#[tokio::test]
+async fn an_env_admin_already_in_the_manifest_is_not_invited_twice() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let manifest = toml::from_str(
+        "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+         [users]\nadmins = [\"Ada@Example.com\", \"Bob@Example.com\"]\n",
+    )
+    .unwrap();
+    let (state, sender) = state_with_admin_email(&home, manifest, Some("Bob@Example.com")).await;
+
+    // Ada signs in so there is an admin to read the invite page with; she
+    // becomes a user, which is why only bob's synthetic row is left.
+    let admin = login_via_link(&state, &sender, "ada@example.com").await;
+    let app = router(state.clone());
+    let response = app
+        .oneshot(get_with_cookie(
+            "/api/v1/companies/acme/users/invites",
+            &admin,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let invites = body_json(response).await;
+    let rows = invites.as_array().expect("invite list");
+    assert_eq!(
+        rows.len(),
+        1,
+        "bob is named twice but is one invite: {invites}"
+    );
+    assert_eq!(rows[0]["email"], "bob@example.com");
+    assert_eq!(rows[0]["id"], "manifest:bob@example.com");
+    assert_eq!(rows[0]["role"], "admin", "the role must not change");
+    assert_eq!(rows[0]["invitedBy"], "manifest");
+}
+
+/// An injected address the manifest does not name renders as its own
+/// `platform:` row, so the invite page does not contradict who can log in — and
+/// revoking it is refused, pointing at the variable rather than the manifest.
+#[tokio::test]
+async fn the_env_admin_shows_on_the_invite_page_and_cannot_be_revoked() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let (state, sender) = state_with_admin_email(&home, manifest(), Some("zoe@example.com")).await;
+    let admin = login_via_link(&state, &sender, "ada@example.com").await;
+
+    let app = router(state.clone());
+    let response = app
+        .oneshot(get_with_cookie(
+            "/api/v1/companies/acme/users/invites",
+            &admin,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let invites = body_json(response).await;
+    let rows = invites.as_array().expect("invite list");
+    assert_eq!(rows.len(), 1, "expected one synthetic row: {invites}");
+    assert_eq!(rows[0]["id"], "platform:zoe@example.com");
+    assert_eq!(rows[0]["invitedBy"], "platform");
+    assert_eq!(rows[0]["role"], "admin");
+
+    let app = router(state.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/api/v1/companies/acme/users/invites/platform:zoe@example.com")
+                .header("cookie", &admin)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "revoking would be a lie: the variable re-grants on the next login"
+    );
+    assert!(
+        body_json(response).await["error"]
+            .as_str()
+            .unwrap()
+            .contains("OPENCOMPANY_ADMIN_EMAIL")
+    );
 }


### PR DESCRIPTION
## Summary

Closes #321.

A company's `[users].admins` is the bootstrap root of trust: listing an address makes it *eligible* to sign in, and redeeming a link then mints it as an admin. A **provisioned** company has that list empty. Nobody is eligible, there is no operator token to send the first invite with, and the company is unreachable by the person who asked for it.

This adds one environment variable, `OPENCOMPANY_ADMIN_EMAIL`, treated as a standing admin invite exactly equivalent to a manifest entry. The control plane injects it from the creator address it already stores. (The manager-side change lives in the platform superproject and is a separate PR — this half is inert without it, and harmless.)

**Why not the alternatives.** Trusting the platform's assertion of instance ownership at sign-in time would move the root of trust off the manifest — a deliberate design property, not something to change as a side effect of fixing provisioning. Posting a manifest at provision time would need a call the manager does not have: it passes a company *name* into the image and nothing else, so there is no manifest for a seed to attach to.

**Why it went unnoticed.** Every path exercised so far sidesteps it — local development uses bundled companies that already list an admin, the e2e harness ships one for exactly this reason, and hosted tenants have been reached with the machine credential, which never consults the admin list. It surfaces the moment a human tries to sign in to a company the platform created for them.

## API Or Behavior Changes

Additive. No route, no schema, no wire change.

`OPENCOMPANY_ADMIN_EMAIL` grants **eligibility only** — no account exists until a link is redeemed, at which point the identical `upsert_from_eligibility` path a manifest admin goes through mints it as `Admin`. Unsetting stops future bootstrapping and does **not** delete an account already created. The address is normalised the same way manifest entries are, and empty or whitespace-only is a clean no-op rather than an error.

An address present in both the manifest and the variable is one standing invite, not two, and renders as `manifest:` — because that grant outlives the deployment variable. An env-only address renders as `platform:`, and revoking it is refused with a message pointing at the variable rather than at `[users].admins`.

The variable is named for what it does: it maps one-to-one onto `[users].admins`. `OPENCOMPANY_OPERATOR_*` was avoided deliberately — `operator` is already overloaded in this repo (a known channel, and the operator console and token), so that name would have read as the channel.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **1657 passed, 0 failed**, 1 ignored
- [x] `cargo check --locked --all-features --all-targets`
- [x] `git diff Cargo.lock` empty
- N/A: frontend — no console surface is touched

Six new tests: sign-in on an empty-admin manifest yielding the admin role; unset, `""` and whitespace-only each granting nothing and sending no mail; a different address still refused; `"  ZOE@Example.COM  "` normalising; an address in both manifest and variable rendering as a single `manifest:` row with unchanged role; and an env-only address rendering as `platform:` with revoke refused.

**Verified end to end on a live host**, isolated with `OPENCOMPANY_DATA_DIR`, against a company fixture with a genuinely empty admin list — because unit tests passing is not the acceptance criterion here.

With the variable set, the request returns a dev code, verify returns `200` with a session cookie and `role: admin`, and an admin-only route accepts that session. With the variable unset and a fresh data directory, the **same company** returns no dev code and verify returns `401`.

Worth noting for whoever reads those two transcripts: both requests answer `{"sent": true}`. That is the deliberate anti-membership-oracle behaviour — the response must not reveal whether an address is eligible. On a loopback host with no mail configured, the presence or absence of the echoed dev code is what distinguishes them.

## Documentation

`docs/spec/runtime/users.md` gains a bootstrap section covering the variable, its manifest-equivalent semantics, and the recovery path for a company that was already provisioned with an empty admin list. `AGENTS.md` records it in the injected-variable list.

One inconsistency found while writing that and deliberately not changed: the synthetic `platform:` invite row is not observable by the bootstrap admin themselves, because `list_invites` filters entries for addresses that are already users — and redeeming is what makes you one. The behaviour is consistent and unit-tested; the prose reads as though you would see your own entry. Flagged rather than fixed, since changing the filter is a behaviour change unrelated to this issue.

## Related

Closes #321. Unblocks the hosted half of #315 — an ecosystem sign-in reaches the tenant, and the tenant then has to decide whether that identity may enter. Before this, on a provisioned company, the answer was always no.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployments can designate a bootstrap administrator using `OPENCOMPANY_ADMIN_EMAIL`.
  * The configured administrator can sign in and receive access even when no administrators are listed in the company manifest.
  * Bootstrap administrator invitations appear alongside manifest invitations, with duplicate addresses handled automatically.
* **Documentation**
  * Added guidance covering configuration, email normalization, blank values, recovery, and invitation behavior.
* **Bug Fixes**
  * Prevented platform-provided bootstrap invitations from being revoked through the standard invitation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->