### PR TITLE
feat(connections): report which credential route a Connect can take on this host (#319)

### DIFF
--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -271,6 +271,45 @@ exchange) are dependency-inverted behind traits carried on `ConnectionsRuntime`
 and default to empty (offline) — a surface whose seam is absent returns
 `404 {"code":"not_wired"}`, which the console degrades gracefully.
 
+### Connections: hosted versus the self-hosted hatch
+
+`ops::connections` (feature `oauth`) runs OAuth with **this host's own provider
+application** — a client id/secret an operator registered themselves and handed
+to the process as `OPENCOMPANY_OAUTH_<PROVIDER>_ID` / `_SECRET`. That is the
+only way a standalone checkout can complete a handshake, and it is supported for
+exactly that reason. It is a hatch, not a deployment mode — the same framing
+`ops::composio` uses for its BYO token. A hosted tenant is injected no
+`OPENCOMPANY_OAUTH_*` variable at all, so on that host `provider_config`
+resolves nothing and a local Connect can only fail.
+
+The read plane says which it is. `ops::connections_read::connect_route` answers
+one question per provider — *can a Connect click possibly succeed here, and by
+which route?* — as a `credentialSource` tier, stored-wins:
+
+| Tier | When | Console |
+| --- | --- | --- |
+| `static` | a token is already stored for this provider (BYO override), **or** this host registered its own provider app (the hatch) | Connect button, as today |
+| `attested` | no stored token, and the pod carries a platform-**projected** identity (`TINYHUMANS_TOKEN_FILE` naming a file that exists) | "Managed by the platform", no local Connect |
+| `none` | neither | read-only "not available on this host" |
+
+`attested` deliberately requires the projected-file tier, not
+`TinyhumansTokenSource::from_env` as a whole: that resolver also accepts a
+long-lived `TINYHUMANS_API_KEY`, which a self-hoster commonly sets to buy
+inference. Accepting it here would tell such an operator their working Connect
+button is platform-managed and take it away. Both the REST route and the GraphQL
+`Company.connections` resolver project the field through the same
+`connect_route_from_env`, so the two read shapes cannot drift.
+
+**Provider mapping to the platform backend.** Its registered OAuth providers are
+`notion`, `google`, `gmail`, `github`, `twitter`, `discord` and `instagram`. Two
+consequences for the console catalog: `gmail` is a registered provider *name* but
+not a separate provider application — it is Google's app requested with the Gmail
+skill scopes, so a Gmail connect and a Google connect share one grant (which is
+why the backend merges scopes incrementally rather than replacing them). And
+there is **no Slack provider** at all (the backend's only Slack credential is an
+internal alerting bot), so Slack has no hosted route except Composio, which runs
+its own OAuth.
+
 ## tiny.place A2A inbound + discovery (`tinyplace` feature)
 
 Behind the `tinyplace` feature the server mounts the agent-to-agent surface

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -296,6 +296,21 @@ export interface InboxMessageDto {
 }
 
 /**
+ * Which route a Connect for one provider can take on this host. Deliberately
+ * the same vocabulary as `ComposioCredentialSource` (`api/composio.ts`) — the
+ * two console surfaces answer the same question and should read the same to an
+ * operator.
+ *
+ * - `attested` — this instance carries a platform-minted identity, so
+ *   connections are the platform's to run. Nothing to register here, and the
+ *   console offers no local Connect.
+ * - `static` — a token this company already stored, or this host's own
+ *   registered provider application (the self-hosted hatch). Connect works.
+ * - `none` — neither, so no Connect can succeed on this host.
+ */
+export type ConnectionCredentialSource = "attested" | "static" | "none";
+
+/**
  * One third-party connection's state, from `GET .../connections`.
  * Forward-looking: hosts that don't expose the connections surface yet simply
  * 404, and the console treats connections as unavailable.
@@ -304,6 +319,12 @@ export interface ConnectionState {
   /** Provider id, matching the console's connection catalog (e.g. "slack"). */
   provider: string;
   connected: boolean;
+  /**
+   * Which credential route a Connect for this provider would take — a tier
+   * name, never a credential. Optional so a host predating issue #319 (which
+   * omits the field) still parses; the view falls back to today's behaviour.
+   */
+  credentialSource?: ConnectionCredentialSource;
   /** The connected account label, when known (e.g. an email or workspace). */
   account?: string;
 }

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -9,6 +9,7 @@ import {
   Plug,
   Plus,
   Server,
+  ShieldCheck,
   Trash2,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -114,6 +115,12 @@ export function ConnectionsView({ client, company }: Props) {
   }
 
   const connectedCount = Object.values(states).filter((s) => s.connected).length;
+  // `attested` is a property of the *instance*, not of one provider: it means
+  // this pod carries a platform-minted identity, so every connection is the
+  // platform's to run. One row reporting it is therefore enough to say so once
+  // at the top, rather than only in per-tile copy (issue #319).
+  const platformManaged =
+    load === "ready" && Object.values(states).some((s) => s.credentialSource === "attested");
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -137,6 +144,18 @@ export function ConnectionsView({ client, company }: Props) {
             <AlertDescription>
               The catalog below shows what your company can connect once the host exposes its OAuth
               endpoints. Connecting is disabled until then.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {platformManaged && (
+          <Alert data-testid="connections-platform-managed">
+            <ShieldCheck className="size-4" />
+            <AlertTitle>Connections are managed by the platform</AlertTitle>
+            <AlertDescription>
+              This instance signs in with its own platform identity, so there is no provider key to
+              register here and nothing stored on this instance. Connect a provider from the
+              platform and it shows up here.
             </AlertDescription>
           </Alert>
         )}
@@ -186,6 +205,27 @@ export function ConnectionsView({ client, company }: Props) {
   );
 }
 
+/**
+ * One provider tile.
+ *
+ * The unconnected foot of the card is a tri-state driven by the host's
+ * `credentialSource` (issue #319) — the same three tiers the Composio section
+ * above already reports, worded the same way on purpose:
+ *
+ * - `static` — a Connect can succeed here, either through a token this company
+ *   already holds or through this host's own registered provider application
+ *   (the self-hosted hatch). Unchanged: the Connect button, exactly as today.
+ * - `attested` — this instance carries a platform identity, so connections are
+ *   the platform's to run and no provider credential is (or should be) present
+ *   locally. A local Connect on such a host could only ever 400, so the button
+ *   is replaced by "Managed by the platform" and that failure becomes
+ *   unreachable from the console by construction.
+ * - `none` — nothing can complete a handshake here; the tile says so instead of
+ *   offering a button that fails.
+ *
+ * A host that predates the field sends no `credentialSource`; that falls back
+ * to the Connect button so an older host is never silently disabled.
+ */
 function ConnectionCard({
   provider,
   state,
@@ -202,6 +242,9 @@ function ConnectionCard({
   onDisconnect: () => void;
 }) {
   const connected = Boolean(state?.connected);
+  const source = state?.credentialSource;
+  const managedByPlatform = source === "attested";
+  const noRoute = source === "none";
   return (
     <Card className={cn(connected && "border-primary/30")}>
       <CardContent className="flex h-full flex-col gap-3 py-4">
@@ -227,6 +270,20 @@ function ConnectionCard({
               {busy ? <Loader2 className="size-4 animate-spin" /> : null}
               Disconnect
             </Button>
+          ) : managedByPlatform ? (
+            <p
+              className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400"
+              data-testid={`connection-managed-${provider.id}`}
+            >
+              <ShieldCheck className="size-3" /> Managed by the platform — nothing to set up here
+            </p>
+          ) : noRoute ? (
+            <p
+              className="text-xs text-muted-foreground"
+              data-testid={`connection-unavailable-${provider.id}`}
+            >
+              Not available on this host.
+            </p>
           ) : (
             <Button
               variant={disabled ? "outline" : "default"}

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -189,6 +189,7 @@ export function ConnectionsView({ client, company }: Props) {
                       key={p.id}
                       provider={p}
                       state={states[p.id]}
+                      platformManaged={platformManaged}
                       disabled={load === "unavailable"}
                       busy={busy === p.id}
                       onConnect={() => void connect(p)}
@@ -225,10 +226,20 @@ export function ConnectionsView({ client, company }: Props) {
  *
  * A host that predates the field sends no `credentialSource`; that falls back
  * to the Connect button so an older host is never silently disabled.
+ *
+ * `platformManaged` covers the tiles the host said nothing about. `/connections`
+ * only answers for providers the company's manifest declares, but this grid
+ * renders the whole catalog — so on a hosted instance the undeclared tiles would
+ * otherwise keep a Connect button sitting under a banner that says connections
+ * are the platform's, and clicking it would 400. `attested` is a property of the
+ * *instance*, not of one provider, so it is safe to apply to every tile. `none`
+ * is NOT: it is provider-specific, and a host can hold a provider app for a
+ * provider the manifest never declared, where Connect genuinely works.
  */
 function ConnectionCard({
   provider,
   state,
+  platformManaged,
   disabled,
   busy,
   onConnect,
@@ -236,6 +247,7 @@ function ConnectionCard({
 }: {
   provider: ConnectionProvider;
   state?: ConnectionState;
+  platformManaged: boolean;
   disabled: boolean;
   busy: boolean;
   onConnect: () => void;
@@ -243,7 +255,7 @@ function ConnectionCard({
 }) {
   const connected = Boolean(state?.connected);
   const source = state?.credentialSource;
-  const managedByPlatform = source === "attested";
+  const managedByPlatform = source === "attested" || (platformManaged && source === undefined);
   const noRoute = source === "none";
   return (
     <Card className={cn(connected && "border-primary/30")}>

--- a/src/server/graphql/connections.rs
+++ b/src/server/graphql/connections.rs
@@ -8,6 +8,7 @@ use async_graphql::SimpleObject;
 
 use crate::company::dns::DomainStatus;
 use crate::company::runtime::CompanyRuntime;
+use crate::server::ops::connections_read::connect_route_from_env;
 use crate::server::ops::smtp::{SmtpCredentials, SmtpStatus};
 
 /// The reserved SecretStore key holding the JSON domain status.
@@ -23,6 +24,12 @@ pub struct ConnectionStateGql {
     pub provider: String,
     /// Whether an OAuth token is stored for this provider.
     pub connected: bool,
+    /// Which route a Connect for this provider would take on this host:
+    /// `attested` (the platform runs it — nothing to register here), `static`
+    /// (a token already stored for this company, or this host's own registered
+    /// provider application: the self-hosted hatch), or `none` (no Connect can
+    /// succeed here). A tier name, never a credential and never a path.
+    pub credential_source: String,
     /// The connected account label, when known.
     pub account: Option<String>,
     /// The manifest's stated reason for wanting this connection.
@@ -125,6 +132,9 @@ pub(crate) async fn resolve_connections(
             _ => (false, None),
         };
         out.push(ConnectionStateGql {
+            credential_source: connect_route_from_env(&connection.provider, connected)
+                .as_str()
+                .to_string(),
             provider: connection.provider.clone(),
             connected,
             account,

--- a/src/server/graphql/connections.rs
+++ b/src/server/graphql/connections.rs
@@ -8,7 +8,7 @@ use async_graphql::SimpleObject;
 
 use crate::company::dns::DomainStatus;
 use crate::company::runtime::CompanyRuntime;
-use crate::server::ops::connections_read::connect_route_from_env;
+use crate::server::ops::connections_read::HostConnectRoutes;
 use crate::server::ops::smtp::{SmtpCredentials, SmtpStatus};
 
 /// The reserved SecretStore key holding the JSON domain status.
@@ -116,6 +116,8 @@ pub(crate) async fn resolve_connections(
         return Ok(Vec::new());
     };
     let mut out = Vec::with_capacity(record.manifest.connections.len());
+    // Host-level, so resolved once rather than per connection below.
+    let host = HostConnectRoutes::from_env();
     for connection in &record.manifest.connections {
         let key = format!("oauth/{}", connection.provider);
         let (connected, account) = match runtime.secrets().get(runtime.id(), &key).await? {
@@ -132,7 +134,8 @@ pub(crate) async fn resolve_connections(
             _ => (false, None),
         };
         out.push(ConnectionStateGql {
-            credential_source: connect_route_from_env(&connection.provider, connected)
+            credential_source: host
+                .route_from_env(&connection.provider, connected)
                 .as_str()
                 .to_string(),
             provider: connection.provider.clone(),

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -187,6 +187,14 @@ type ConnectionState {
 	"""
 	connected: Boolean!
 	"""
+	Which route a Connect for this provider would take on this host:
+	`attested` (the platform runs it — nothing to register here), `static`
+	(a token already stored for this company, or this host's own registered
+	provider application: the self-hosted hatch), or `none` (no Connect can
+	succeed here). A tier name, never a credential and never a path.
+	"""
+	credentialSource: String!
+	"""
 	The connected account label, when known.
 	"""
 	account: String

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -363,6 +363,73 @@ async fn connections_reflect_manifest_intent_disconnected() {
     assert_eq!(conns[0]["reason"], "Post updates.");
 }
 
+/// The two connection projections are one shape: whatever credential tier the
+/// REST route reports for a provider, the GraphQL resolver must report the same
+/// (issue #319). They share `connect_route_from_env`, and this pins that they
+/// keep sharing it — a second copy of the resolution order is a second chance to
+/// tell the console a hosted instance can run a local Connect.
+#[tokio::test]
+async fn rest_and_graphql_agree_on_the_connection_credential_source() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_rich_company(&home).await;
+
+    let value = query(
+        router(state.clone()),
+        r#"{"query":"{ company(id:\"acme\"){ connections { provider credentialSource } } }"}"#,
+    )
+    .await;
+    let gql: Vec<(String, String)> = value["data"]["company"]["connections"]
+        .as_array()
+        .expect("connections")
+        .iter()
+        .map(|row| {
+            (
+                row["provider"].as_str().unwrap().to_string(),
+                row["credentialSource"]
+                    .as_str()
+                    .expect("every GraphQL row carries a credentialSource")
+                    .to_string(),
+            )
+        })
+        .collect();
+    assert!(!gql.is_empty(), "expected at least one connection: {value}");
+
+    let response = router(state)
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/company/connections")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let rest: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let rest_rows: Vec<(String, String)> = rest
+        .as_array()
+        .expect("array")
+        .iter()
+        .map(|row| {
+            (
+                row["provider"].as_str().unwrap().to_string(),
+                row["credentialSource"]
+                    .as_str()
+                    .expect("every REST row carries a credentialSource")
+                    .to_string(),
+            )
+        })
+        .collect();
+
+    assert_eq!(
+        rest_rows, gql,
+        "REST and GraphQL disagree on the connection credential source"
+    );
+}
+
 #[tokio::test]
 async fn tasks_page_reflects_upserts_and_column_filter() {
     use crate::ports::tasks::TaskRecord;

--- a/src/server/ops/connections.rs
+++ b/src/server/ops/connections.rs
@@ -1,4 +1,26 @@
-//! OAuth connection lifecycle: start, callback, disconnect.
+//! OAuth connection lifecycle: start, callback, disconnect — **the self-hosted
+//! hatch**.
+//!
+//! ## What this module is for
+//!
+//! Every provider reached from here is reached with **this host's own provider
+//! application**: an operator registers a client id/secret with Slack / Google /
+//! GitHub themselves and hands them to the process as
+//! `OPENCOMPANY_OAUTH_<PROVIDER>_ID` / `_SECRET`. That is the only way a
+//! standalone checkout of this public repository can complete an OAuth handshake
+//! at all, and it is supported for exactly that reason.
+//!
+//! It is **not** the hosted path, and it is not parity with it. Framed the way
+//! [`ops::composio`](super::composio) frames its BYO token: a hatch, not a
+//! deployment mode. On the platform a company registers nothing and pastes
+//! nothing — the instance already carries a platform-minted, audience-bound
+//! identity, and the connection is attributed through that. A hosted tenant is
+//! injected no `OPENCOMPANY_OAUTH_*` variable at all, so on that host
+//! [`provider_config`] resolves nothing and a Connect can only ever fail here;
+//! the read plane reports that host as `credentialSource: "attested"` and the
+//! console offers no local Connect (issue #319). See
+//! [`ops::connections_read`](super::connections_read) for the resolution order
+//! and the hosted-vs-hatch split.
 //!
 //! Gated behind the `oauth` feature because token exchange needs `reqwest`;
 //! without it these routes are absent (404) and the console shows the read-only
@@ -91,11 +113,22 @@ fn well_known(provider: &str) -> Option<(&'static str, &'static str)> {
     }
 }
 
-/// Resolves a provider's config from the environment, or `None` when the app
-/// credentials are not configured (the provider is not enabled on this host).
+/// Resolves a provider's config from the process environment, or `None` when the
+/// app credentials are not configured (the provider is not enabled on this
+/// host).
 fn provider_config(provider: &str) -> Option<ProviderConfig> {
+    provider_config_from(provider, &crate::app::config::ProcessEnv)
+}
+
+/// [`provider_config`] over an [`EnvSource`](crate::app::config::EnvSource)
+/// seam, so the "is this provider enabled here?" question is answerable from a
+/// test map without mutating the process environment.
+fn provider_config_from(
+    provider: &str,
+    env: &dyn crate::app::config::EnvSource,
+) -> Option<ProviderConfig> {
     let key = provider.to_ascii_uppercase();
-    let env = |suffix: &str| std::env::var(format!("OPENCOMPANY_OAUTH_{key}_{suffix}")).ok();
+    let env = |suffix: &str| env.get(&format!("OPENCOMPANY_OAUTH_{key}_{suffix}"));
     let client_id = env("ID")?;
     let client_secret = env("SECRET")?;
     let (default_authorize, default_token) = well_known(provider).unwrap_or(("", ""));
@@ -111,6 +144,22 @@ fn provider_config(provider: &str) -> Option<ProviderConfig> {
         token_url,
         default_scopes: env("SCOPES").unwrap_or_default(),
     })
+}
+
+/// Whether a Connect for `provider` could reach a provider application on this
+/// host — i.e. whether the hatch is open for it.
+///
+/// This is [`provider_config`]'s own answer rather than a second copy of the
+/// rule: a bare "is `_ID` set?" probe would report a provider enabled even when
+/// no authorize/token URL can be resolved for it, and the console would render a
+/// Connect button that 400s. Read by
+/// [`ops::connections_read`](super::connections_read); never leaks the
+/// credential itself.
+pub(super) fn provider_app_configured(
+    provider: &str,
+    env: &dyn crate::app::config::EnvSource,
+) -> bool {
+    provider_config_from(provider, env).is_some()
 }
 
 /// The redirect URI advertised to the provider. `OPENCOMPANY_OAUTH_REDIRECT_BASE`

--- a/src/server/ops/connections_read.rs
+++ b/src/server/ops/connections_read.rs
@@ -8,10 +8,45 @@
 //! per-provider state and lights up the Connect buttons.
 //!
 //! Every field here is a **non-secret projection** — the provider id, a
-//! `connected` boolean, and an optional account label — mirroring the GraphQL
-//! `Company.connections` resolver
+//! `connected` boolean, an optional account label, and the credential tier the
+//! Connect would route through — mirroring the GraphQL `Company.connections`
+//! resolver
 //! ([`resolve_connections`](crate::server::graphql::connections::resolve_connections)).
 //! The stored OAuth token material never appears in the response or any log.
+//!
+//! ## Hosted versus the self-hosted hatch (issue #319)
+//!
+//! [`connect_route`] answers one question per provider: *can a Connect click
+//! possibly succeed on this host, and by which route?* It reports a
+//! [`CredentialSource`] tier — the same vocabulary
+//! [`ops::composio`](super::composio) already uses, so the two console surfaces
+//! read the same to an operator:
+//!
+//! * `attested` — the pod carries a platform-projected identity, so connections
+//!   are the platform's to run. Nothing to register here, and the console offers
+//!   no local Connect. A hosted tenant is injected no `OPENCOMPANY_OAUTH_*`
+//!   variable, so a local Connect on such a host could only ever fail; reporting
+//!   the tier makes that failure unreachable from the console rather than a
+//!   400 the operator has to interpret.
+//! * `static` — either a token this company already stored (a BYO override), or
+//!   this host's own registered provider application: the **self-hosted hatch**
+//!   documented on [`ops::connections`](super::connections). Connect works
+//!   exactly as it does today.
+//! * `none` — neither, so no Connect can succeed and the console says so.
+//!
+//! ### Provider mapping, for when the hosted route lands
+//!
+//! The platform backend's registered OAuth providers are `notion`, `google`,
+//! `gmail`, `github`, `twitter`, `discord` and `instagram`. Two consequences for
+//! this console's catalog:
+//!
+//! * `gmail` is a registered provider **name**, but not a separate provider
+//!   application: it is Google's app requested with the Gmail skill scopes. A
+//!   Gmail connect and a Google connect therefore share one grant, which is why
+//!   the backend merges scopes incrementally rather than replacing them.
+//! * There is **no Slack provider** at all (the backend's only Slack credential
+//!   is an internal alerting bot). Slack has no hosted route except Composio,
+//!   which runs its own OAuth — see [`ops::composio`](super::composio).
 
 use axum::Json;
 use axum::Router;
@@ -19,22 +54,92 @@ use axum::routing::get;
 use serde::Serialize;
 
 use crate::AppState;
+use crate::app::config::EnvSource;
+use crate::company::credentials::{CredentialSource, TinyhumansTokenSource, TokenTier};
 use crate::company::runtime::CompanyRuntime;
 use crate::server::error::ApiError;
 use crate::server::ops::{ScopedCompany, scoped};
 
 /// One connection's non-secret status, matching the console `ConnectionState`
-/// wire type (`frontend/src/api/types.ts`): `{ provider, connected, account? }`.
+/// wire type (`frontend/src/api/types.ts`):
+/// `{ provider, connected, credentialSource, account? }`.
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct ConnectionStateDto {
     /// The provider id (e.g. `github`, `slack`, `gmail`).
     provider: String,
     /// Whether a non-empty OAuth token is stored for this provider.
     connected: bool,
+    /// Which route a Connect for this provider would take on this host — see
+    /// [`connect_route`]. A tier name, never a credential and never a path.
+    credential_source: CredentialSource,
     /// The connected account label, when known — never token material. Omitted
     /// when not connected or when the stored blob carries no account.
     #[serde(skip_serializing_if = "Option::is_none")]
     account: Option<String>,
+}
+
+/// Can a Connect click for `provider` possibly succeed on this host, and by
+/// which route?
+///
+/// Stored-wins, mirroring [`ops::composio`](super::composio)'s precedence:
+///
+/// 1. a token already stored for this provider → [`CredentialSource::Static`]
+///    (the BYO override — whatever else the host offers, this company is
+///    already connected through its own grant);
+/// 2. else a platform-projected instance identity →
+///    [`CredentialSource::Attested`];
+/// 3. else this host's own registered provider application →
+///    [`CredentialSource::Static`] (the self-hosted hatch);
+/// 4. else [`CredentialSource::None`].
+///
+/// Step 2 is deliberately restricted to the **projected-file** tier.
+/// [`TinyhumansTokenSource::from_env`] also resolves a long-lived
+/// [`API_KEY_ENV`](crate::company::credentials::API_KEY_ENV) as its static tier,
+/// and a self-hoster commonly sets exactly that to buy inference. Accepting it
+/// here would tell such an operator their working Connect button is "managed by
+/// the platform" and take it away — the platform runs no connection on their
+/// behalf. Only a pod the platform actually projected an identity into is
+/// hosted.
+///
+/// Takes the environment as a seam so the matrix is testable without mutating
+/// the process environment.
+fn connect_route(provider: &str, stored: bool, env: &dyn EnvSource) -> CredentialSource {
+    if stored {
+        return CredentialSource::Static;
+    }
+    if TinyhumansTokenSource::from_env(env).map(|source| source.tier())
+        == Some(TokenTier::ProjectedFile)
+    {
+        return CredentialSource::Attested;
+    }
+    if host_provider_app_configured(provider, env) {
+        return CredentialSource::Static;
+    }
+    CredentialSource::None
+}
+
+/// Whether this host has a provider application registered for `provider`,
+/// delegated to the hatch module so the rule lives in exactly one place.
+#[cfg(feature = "oauth")]
+fn host_provider_app_configured(provider: &str, env: &dyn EnvSource) -> bool {
+    super::connections::provider_app_configured(provider, env)
+}
+
+/// Without the `oauth` feature the token-exchanging write routes are not
+/// compiled at all (they 404), so no local Connect can succeed on this host no
+/// matter what the environment holds.
+#[cfg(not(feature = "oauth"))]
+fn host_provider_app_configured(_provider: &str, _env: &dyn EnvSource) -> bool {
+    false
+}
+
+/// [`connect_route`] against the real process environment. The one entry point
+/// the two read projections — this module and the GraphQL
+/// [`resolve_connections`](crate::server::graphql::connections::resolve_connections)
+/// — share, so they cannot drift apart.
+pub(crate) fn connect_route_from_env(provider: &str, stored: bool) -> CredentialSource {
+    connect_route(provider, stored, &crate::app::config::ProcessEnv)
 }
 
 /// Builds the connection-status route fragment (both scope forms).
@@ -45,8 +150,10 @@ pub fn router() -> Router<AppState> {
 /// Projects each manifest connection into its non-secret status by reading the
 /// `oauth/{provider}` secret. Mirrors
 /// [`resolve_connections`](crate::server::graphql::connections::resolve_connections):
-/// only `provider` / `connected` / `account` ever leave this function — the
-/// token blob stays in the [`SecretStore`](crate::ports::SecretStore).
+/// only `provider` / `connected` / `credentialSource` / `account` ever leave
+/// this function — the token blob stays in the
+/// [`SecretStore`](crate::ports::SecretStore), and `credentialSource` is a tier
+/// name, never a credential and never a path.
 async fn project(runtime: &CompanyRuntime) -> Result<Vec<ConnectionStateDto>, ApiError> {
     let Some(record) = runtime.store().load(runtime.id()).await.map_err(ApiError)? else {
         return Ok(Vec::new());
@@ -75,6 +182,7 @@ async fn project(runtime: &CompanyRuntime) -> Result<Vec<ConnectionStateDto>, Ap
             _ => (false, None),
         };
         out.push(ConnectionStateDto {
+            credential_source: connect_route_from_env(&connection.provider, connected),
             provider: connection.provider.clone(),
             connected,
             account,
@@ -90,6 +198,8 @@ async fn list(company: ScopedCompany) -> Result<Json<Vec<ConnectionStateDto>>, A
 
 #[cfg(test)]
 mod tests {
+    use super::{ConnectionStateDto, CredentialSource, connect_route};
+
     use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode};
     use serde_json::Value;
@@ -220,6 +330,9 @@ mod tests {
             .expect("github row");
         assert_eq!(github["connected"], true);
         assert_eq!(github["account"], "octocat");
+        // A stored token is the BYO override and outranks every host tier, so
+        // this is `static` whatever the ambient environment happens to hold.
+        assert_eq!(github["credentialSource"], "static", "{github}");
 
         let slack = list
             .iter()
@@ -229,6 +342,18 @@ mod tests {
         assert!(
             slack.get("account").is_none(),
             "no account when not connected: {slack}"
+        );
+        // Nothing stored, so this row reports whichever host tier the ambient
+        // environment resolves to. Assert only that the field is present and a
+        // known tier name — the exhaustive precedence matrix is pinned against a
+        // `MapEnv` in `connect_route_*` below, where it does not depend on the
+        // test runner's environment.
+        let tier = slack["credentialSource"]
+            .as_str()
+            .expect("every row carries a credentialSource");
+        assert!(
+            matches!(tier, "attested" | "static" | "none"),
+            "unknown credential tier {tier:?}"
         );
 
         // A connected provider whose stored blob carries no `account` label is
@@ -256,6 +381,161 @@ mod tests {
         assert!(
             !body.to_string().contains("access_token"),
             "token field leaked into the connections response: {body}"
+        );
+        // The new field is a tier name, so it must not have opened a path for a
+        // token file, an api key, or a client secret to ride along.
+        for forbidden in [
+            crate::company::credentials::TOKEN_FILE_ENV,
+            crate::company::credentials::API_KEY_ENV,
+            "OPENCOMPANY_OAUTH_",
+            "clientSecret",
+            "client_secret",
+        ] {
+            assert!(
+                !body.to_string().contains(forbidden),
+                "{forbidden} leaked into the connections response: {body}"
+            );
+        }
+    }
+
+    /// The precedence matrix from [`connect_route`], driven through the env seam
+    /// so nothing mutates the process environment: stored wins, else a projected
+    /// platform identity, else this host's own provider app, else nothing.
+    #[test]
+    fn connect_route_follows_stored_then_attested_then_hatch() {
+        use crate::app::config::MapEnv;
+
+        let dir = tempfile::Builder::new()
+            .prefix("oc-connect-route-")
+            .tempdir()
+            .expect("tempdir");
+        let path = dir.path().join("token");
+        std::fs::write(&path, "projected-instance-token").unwrap();
+        let projected = MapEnv::new([(
+            crate::company::credentials::TOKEN_FILE_ENV,
+            path.display().to_string(),
+        )]);
+        // An obviously fake host provider application — the self-hosted hatch.
+        let hatch = MapEnv::new([
+            ("OPENCOMPANY_OAUTH_GITHUB_ID", "fake-client-id"),
+            ("OPENCOMPANY_OAUTH_GITHUB_SECRET", "fake-client-secret"),
+        ]);
+
+        // 1. A stored token is the BYO override and outranks everything else,
+        //    including a projected platform identity.
+        assert_eq!(
+            connect_route("github", true, &projected),
+            CredentialSource::Static
+        );
+        assert_eq!(
+            connect_route("github", true, &MapEnv::default()),
+            CredentialSource::Static
+        );
+
+        // 2. Nothing stored + a projected platform identity → the platform owns
+        //    the connection, for every provider (the identity is host-level).
+        assert_eq!(
+            connect_route("github", false, &projected),
+            CredentialSource::Attested
+        );
+        assert_eq!(
+            connect_route("slack", false, &projected),
+            CredentialSource::Attested
+        );
+
+        // 3. No platform identity, but this host registered its own provider
+        //    application → the hatch is open and Connect works as it does today.
+        //    Only for the provider it was registered for.
+        if cfg!(feature = "oauth") {
+            assert_eq!(
+                connect_route("github", false, &hatch),
+                CredentialSource::Static
+            );
+        }
+        assert_eq!(
+            connect_route("slack", false, &hatch),
+            CredentialSource::None
+        );
+
+        // 4. Neither → no Connect can succeed on this host.
+        assert_eq!(
+            connect_route("github", false, &MapEnv::default()),
+            CredentialSource::None
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The regression this restriction exists for: a self-hoster who set
+    /// `TINYHUMANS_API_KEY` to buy inference has **no** platform-run connection
+    /// route, so their Connect must not be reported as platform-managed and
+    /// taken away from them.
+    ///
+    /// `TinyhumansTokenSource::from_env` happily resolves that key as its static
+    /// tier; [`connect_route`] deliberately accepts only the projected-file tier.
+    #[test]
+    fn a_static_api_key_is_not_a_hosted_connection_route() {
+        use crate::app::config::MapEnv;
+
+        // Inference credential only, nothing else: NOT attested.
+        let inference_only =
+            MapEnv::new([(crate::company::credentials::API_KEY_ENV, "th_fake_key")]);
+        assert_eq!(
+            connect_route("github", false, &inference_only),
+            CredentialSource::None,
+            "a static inference key must not be read as a platform connection route"
+        );
+
+        // Same operator, with their own GitHub app registered: the hatch stays
+        // open and still reads `static`, not `attested`.
+        if cfg!(feature = "oauth") {
+            let with_hatch = MapEnv::new([
+                (crate::company::credentials::API_KEY_ENV, "th_fake_key"),
+                ("OPENCOMPANY_OAUTH_GITHUB_ID", "fake-client-id"),
+                ("OPENCOMPANY_OAUTH_GITHUB_SECRET", "fake-client-secret"),
+            ]);
+            assert_eq!(
+                connect_route("github", false, &with_hatch),
+                CredentialSource::Static,
+                "the self-hosted hatch must keep working when an inference key is also set"
+            );
+        }
+
+        // And a `TINYHUMANS_TOKEN_FILE` naming a path that does not exist
+        // degrades to the static tier inside the resolver — which is likewise
+        // not a hosted connection route.
+        let dangling = MapEnv::new([
+            (
+                crate::company::credentials::TOKEN_FILE_ENV,
+                "/nonexistent/oc/projected/token",
+            ),
+            (crate::company::credentials::API_KEY_ENV, "th_fake_key"),
+        ]);
+        assert_eq!(
+            connect_route("github", false, &dangling),
+            CredentialSource::None,
+            "a token file that was never projected is not a hosted connection route"
+        );
+    }
+
+    /// The DTO's whole serialized surface: three non-secret facts plus an
+    /// optional label. Pins the field set so a future addition has to be a
+    /// deliberate edit here, and pins the camelCase spelling the console reads.
+    #[test]
+    fn the_dto_carries_a_tier_name_and_nothing_secret() {
+        let dto = ConnectionStateDto {
+            provider: "github".to_string(),
+            connected: true,
+            credential_source: CredentialSource::Attested,
+            account: Some("octocat".to_string()),
+        };
+        let json = serde_json::to_value(&dto).unwrap();
+        assert_eq!(json["credentialSource"], "attested");
+        let keys: Vec<&String> = json.as_object().unwrap().keys().collect();
+        assert_eq!(
+            keys,
+            vec!["provider", "connected", "credentialSource", "account"],
+            "the read shape must stay exactly this: {keys:?}"
         );
     }
 

--- a/src/server/ops/connections_read.rs
+++ b/src/server/ops/connections_read.rs
@@ -104,19 +104,71 @@ struct ConnectionStateDto {
 ///
 /// Takes the environment as a seam so the matrix is testable without mutating
 /// the process environment.
+///
+/// Test-only because production resolves the host-level half once per request
+/// and then loops — see [`HostConnectRoutes`]. It is defined *in terms of* that
+/// type rather than restating the precedence, so what the tests exercise is the
+/// same code the request path runs.
+#[cfg(test)]
 fn connect_route(provider: &str, stored: bool, env: &dyn EnvSource) -> CredentialSource {
-    if stored {
-        return CredentialSource::Static;
+    HostConnectRoutes::resolve(env).route(provider, stored, env)
+}
+
+/// The host-level half of [`connect_route`], resolved once.
+///
+/// Step 2 of the precedence — "is this pod carrying a platform-projected
+/// identity?" — reads the environment and then *stats a file*. Its answer is a
+/// property of the pod, not of a provider, so resolving it inside a loop over a
+/// company's connections repeats a syscall for an answer that cannot differ
+/// between iterations. Both read planes build this once per request and then ask
+/// it per provider.
+///
+/// Deliberately still one rule: [`route`](Self::route) holds the whole
+/// precedence, and [`connect_route`] is defined in terms of it, so a single-shot
+/// caller and a looping caller cannot diverge.
+pub(crate) struct HostConnectRoutes {
+    /// Whether the pod carries a platform-**projected** identity — the only
+    /// tier that means the platform runs connections here.
+    attested: bool,
+}
+
+impl HostConnectRoutes {
+    /// Resolves the host-level facts once, against an environment seam.
+    fn resolve(env: &dyn EnvSource) -> Self {
+        Self {
+            attested: TinyhumansTokenSource::from_env(env).map(|source| source.tier())
+                == Some(TokenTier::ProjectedFile),
+        }
     }
-    if TinyhumansTokenSource::from_env(env).map(|source| source.tier())
-        == Some(TokenTier::ProjectedFile)
-    {
-        return CredentialSource::Attested;
+
+    /// Resolves against the real process environment. Call once per request,
+    /// then [`route_from_env`](Self::route_from_env) per provider.
+    pub(crate) fn from_env() -> Self {
+        Self::resolve(&crate::app::config::ProcessEnv)
     }
-    if host_provider_app_configured(provider, env) {
-        return CredentialSource::Static;
+
+    /// The full precedence for one provider, given the already-resolved
+    /// host-level facts.
+    fn route(&self, provider: &str, stored: bool, env: &dyn EnvSource) -> CredentialSource {
+        if stored {
+            return CredentialSource::Static;
+        }
+        if self.attested {
+            return CredentialSource::Attested;
+        }
+        if host_provider_app_configured(provider, env) {
+            return CredentialSource::Static;
+        }
+        CredentialSource::None
     }
-    CredentialSource::None
+
+    /// [`route`](Self::route) against the real process environment. The one
+    /// entry point the two read projections — this module and the GraphQL
+    /// [`resolve_connections`](crate::server::graphql::connections::resolve_connections)
+    /// — share, so they cannot drift apart.
+    pub(crate) fn route_from_env(&self, provider: &str, stored: bool) -> CredentialSource {
+        self.route(provider, stored, &crate::app::config::ProcessEnv)
+    }
 }
 
 /// Whether this host has a provider application registered for `provider`,
@@ -132,14 +184,6 @@ fn host_provider_app_configured(provider: &str, env: &dyn EnvSource) -> bool {
 #[cfg(not(feature = "oauth"))]
 fn host_provider_app_configured(_provider: &str, _env: &dyn EnvSource) -> bool {
     false
-}
-
-/// [`connect_route`] against the real process environment. The one entry point
-/// the two read projections — this module and the GraphQL
-/// [`resolve_connections`](crate::server::graphql::connections::resolve_connections)
-/// — share, so they cannot drift apart.
-pub(crate) fn connect_route_from_env(provider: &str, stored: bool) -> CredentialSource {
-    connect_route(provider, stored, &crate::app::config::ProcessEnv)
 }
 
 /// Builds the connection-status route fragment (both scope forms).
@@ -159,6 +203,8 @@ async fn project(runtime: &CompanyRuntime) -> Result<Vec<ConnectionStateDto>, Ap
         return Ok(Vec::new());
     };
     let mut out = Vec::with_capacity(record.manifest.connections.len());
+    // Host-level, so resolved once rather than per connection below.
+    let host = HostConnectRoutes::from_env();
     for connection in &record.manifest.connections {
         let key = format!("oauth/{}", connection.provider);
         let (connected, account) = match runtime
@@ -182,7 +228,7 @@ async fn project(runtime: &CompanyRuntime) -> Result<Vec<ConnectionStateDto>, Ap
             _ => (false, None),
         };
         out.push(ConnectionStateDto {
-            credential_source: connect_route_from_env(&connection.provider, connected),
+            credential_source: host.route_from_env(&connection.provider, connected),
             provider: connection.provider.clone(),
             connected,
             account,


### PR DESCRIPTION
## Summary

First slice of #319. It does not move OAuth onto the platform backend — it makes the console tell the truth about whether a Connect can succeed here at all, which is the precondition for that move and is independently a bug fix.

On a hosted tenant today the Connections screen renders a full grid of live Connect buttons, and **every one of them fails**. The manager injects fifteen environment variables into a tenant and none is an OAuth provider credential, so `provider_config` resolves nothing and `start` refuses before the handshake begins. The operator gets a 400 to interpret; nothing in the console said the button could not work.

This adds one non-secret field, `credentialSource`, to both connection read planes, and drives the tile off it:

- **`attested`** — the pod carries a platform-projected identity, so connections are the platform's to run. No local Connect is offered, and a banner says so once at the top.
- **`static`** — a token this company already stored, or this host's own registered provider application (the **self-hosted hatch**). Connect works exactly as today.
- **`none`** — neither, so the tile says the provider is unavailable here instead of offering a button that 400s.

The vocabulary is deliberately the same three tiers `ops::composio` already reports, worded the same way, so the two surfaces read alike to an operator.

## API Or Behavior Changes

Additive. `credentialSource` joins `GET .../connections` and GraphQL `Company.connections`. It is a **tier name — never a credential, never a path**. Both planes resolve it through one shared entry point (`connect_route_from_env`) so they cannot drift.

Resolution is stored-wins, mirroring Composio's precedence: a token this company already holds → `static`; else a platform-projected identity → `attested`; else this host's own provider app → `static`; else `none`.

**The `attested` probe is restricted to the projected-file tier on purpose.** `TinyhumansTokenSource::from_env` also resolves a long-lived API key as its static tier, and a self-hoster commonly sets exactly that to buy inference. Accepting it here would tell such an operator their working Connect button is "managed by the platform" and take it away — the platform runs no connection on their behalf. Only a pod the platform actually projected an identity into is hosted.

**`attested` is applied to catalog tiles the host said nothing about; `none` is not.** `/connections` only answers for providers the manifest declares, but the grid renders the whole catalog — so without this the undeclared tiles keep a Connect button sitting directly under a banner saying connections are the platform's, and clicking it 400s. That is what the first pass actually shipped, and it was only visible in a browser. `attested` is a property of the *instance*, so applying it everywhere is sound; `none` is provider-specific and a host can genuinely hold an app for an undeclared provider, so it is not.

The hatch's "is this provider enabled?" question is answered by `provider_config` itself rather than a second copy of the rule — a bare "is `_ID` set?" probe would report a provider enabled with no resolvable authorize URL, and the console would render a button that 400s.

A host predating this field sends nothing, and the console falls back to today's Connect button, so an older host is never silently disabled.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib`
- [x] `cargo check --locked --all-features --all-targets`
- [x] `npm ci` / `npm run typecheck` / `npm run build`
- [x] `git diff Cargo.lock` empty
- N/A: frontend unit tests — no runner exists in `frontend/`

Both `provider_config` and the token source are read through an `EnvSource` seam, so the whole matrix is exercised from a test map without mutating the process environment.

New tests cover the full precedence order, the static-API-key case that must **not** read as hosted, the DTO carrying a tier name and nothing secret, and a REST-versus-GraphQL agreement test that fails if the two planes ever answer differently.

**Verified in a browser, not only in tests** — the undeclared-tile bug above is not inferable from the unit tests and was found by looking at the running console.

## Documentation

`ops::connections` is retitled as the self-hosted hatch, with its module doc stating plainly that it is a hatch and not the hosted path, and not parity with it. `ops::connections_read` documents the resolution order and why step 2 is projected-file only. `docs/modules/server/README.md` records the split.

The provider mapping is recorded there for when the hosted route lands, because two details are easy to get wrong from the outside: `gmail` is a registered provider **name** but not a separate provider application (it is Google's app with Gmail scopes, so a Gmail and a Google connect share one grant — which is why scopes must merge rather than replace), and there is **no Slack provider** at all on the backend, so Slack has no hosted route except Composio.

## Related

Part of #319. The remaining work — actually routing the handshake through the platform backend — is unblocked by this but not attempted here.

Adjacent: #316 (one operator, one account, live connection state) builds on this field; #318 (OAuth state signing key falls back to a shipped literal) is untouched by this change and remains open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Connection status now identifies whether credentials are platform-managed, configured locally, or unavailable.
  - Connection cards display appropriate platform-managed and unavailable states, avoiding invalid Connect actions.
  - REST and GraphQL connection responses now provide consistent credential-source information without exposing secrets.

- **Documentation**
  - Added guidance for credential-source detection and connection behavior across hosted and self-hosted deployments.

- **Bug Fixes**
  - Improved connection routing and status handling for OAuth and API-key connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->