### PR TITLE
feat(auth): sign in to a company console with an ecosystem identity (#315)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
 
-import { verifyCode } from "@/api/auth";
+import { signInWithHubToken, verifyCode } from "@/api/auth";
 import { OpenCompanyClient } from "@/api/client";
 import { ApiError, type CompanyStatus } from "@/api/types";
 import { AppShell } from "@/components/app-shell";
@@ -14,7 +14,7 @@ import { resolveConfig } from "@/config";
 type Phase =
   | { kind: "loading" }
   | { kind: "error"; message: string; hint?: string }
-  | { kind: "login"; company: string | null }
+  | { kind: "login"; company: string | null; notice?: string }
   | { kind: "picker"; companies: CompanyStatus[] }
   | {
       kind: "console";
@@ -41,6 +41,34 @@ function readMagicLink(): { company: string | null; code: string } | null {
 }
 
 /**
+ * Reads `?token=&key=auth` off a hub sign-in landing.
+ *
+ * The hub appends these to the redirect URI it was given, so they arrive on a
+ * plain top-level navigation back to this console. `key=auth` is the hub's own
+ * marker for that redirect and is what distinguishes this token from the
+ * `?token=` the console config uses for a platform bearer — see `config.ts`.
+ *
+ * **Pure**, for the same reason `readMagicLink` is: StrictMode double-invokes
+ * the `useMemo` this runs in, so stripping the URL here would make the second
+ * invocation read a cleaned URL and silently drop the token.
+ *
+ * A failed sign-in comes back as `?error=` instead, which is not read here —
+ * the hub's error text is its own wording about its own flow, and this console
+ * says its piece in `hubNotice`.
+ */
+function readHubToken(): string | null {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get("key") !== "auth") return null;
+  return params.get("token");
+}
+
+/** Whether the hub bounced the sign-in back with a failure rather than a token. */
+function readHubError(): boolean {
+  const params = new URLSearchParams(window.location.search);
+  return params.get("key") === "auth" && params.get("error") !== null;
+}
+
+/**
  * Strips the magic link out of the address bar.
  *
  * The code is a single-use credential, so it must not linger in the URL, the
@@ -55,12 +83,35 @@ function clearMagicLinkFromUrl(): void {
   window.history.replaceState({}, "", window.location.pathname + (query ? `?${query}` : ""));
 }
 
+/**
+ * Strips the hub's sign-in result out of the address bar.
+ *
+ * `replaceState` rather than a push, so the token is gone from the history
+ * entry as well as from the bar — a back button that restored it would hand a
+ * live ecosystem credential to a reload, and a `Referer` carrying it would hand
+ * it to whatever the console links out to next.
+ *
+ * `company` is deliberately kept. It is not a credential, and dropping it would
+ * un-scope the console on a reload of a multi-company host.
+ */
+function clearHubResultFromUrl(): void {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get("key") !== "auth") return;
+  params.delete("token");
+  params.delete("error");
+  params.delete("key");
+  const query = params.toString();
+  window.history.replaceState({}, "", window.location.pathname + (query ? `?${query}` : ""));
+}
+
 export function App() {
   const config = useMemo(() => resolveConfig(), []);
   const client = useMemo(() => new OpenCompanyClient(config), [config]);
   const [phase, setPhase] = useState<Phase>({ kind: "loading" });
   // A pure read, so StrictMode's double render is harmless.
   const magicLink = useMemo(() => readMagicLink(), []);
+  const hubToken = useMemo(() => readHubToken(), []);
+  const hubFailed = useMemo(() => readHubError(), []);
   /**
    * The in-flight redemption, so a link is redeemed exactly once.
    *
@@ -72,10 +123,11 @@ export function App() {
    */
   const redemption = useRef<Promise<unknown> | null>(null);
 
-  // Now that the code is captured in state, take it out of the URL.
+  // Now that the credential is captured in state, take it out of the URL.
   useEffect(() => {
     if (magicLink) clearMagicLinkFromUrl();
-  }, [magicLink]);
+    if (hubToken || hubFailed) clearHubResultFromUrl();
+  }, [magicLink, hubToken, hubFailed]);
 
   // An expired or revoked session anywhere in the console drops to sign-in
   // rather than showing a broken page.
@@ -91,6 +143,33 @@ export function App() {
     const set = (p: Phase) => !cancelled && setPhase(p);
 
     async function boot() {
+      // The hub bounced them back without a token (they cancelled at the
+      // provider, or the hub refused the redirect). Nothing to exchange.
+      if (hubFailed) {
+        set({
+          kind: "login",
+          company: config.company,
+          notice: "That sign-in didn't complete. Try again, or use a link below.",
+        });
+        return;
+      }
+
+      // A hub landing: exchange the platform token for a session here before
+      // anything else, for the same reason a magic link does — the session has
+      // to exist before the console asks for data.
+      if (hubToken) {
+        try {
+          redemption.current ??= signInWithHubToken(client, config.company, hubToken);
+          await redemption.current;
+        } catch (err) {
+          // A refused sign-in falls back to this company's own form rather than
+          // stranding them: the magic link still works, and it is the only
+          // thing that works on a self-hosted host anyway.
+          set({ kind: "login", company: config.company, notice: hubNotice(err) });
+          return;
+        }
+      }
+
       // A magic-link landing: redeem it before anything else, so the session
       // exists by the time the console asks for data.
       if (magicLink) {
@@ -147,7 +226,7 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [client, config.company, magicLink]);
+  }, [client, config.company, magicLink, hubToken, hubFailed]);
 
   const switchCompany = useCallback(
     async (id: string, companies: CompanyStatus[]) => {
@@ -180,6 +259,7 @@ export function App() {
         <Login
           client={client}
           company={phase.company}
+          notice={phase.notice}
           onSignedIn={() => window.location.reload()}
         />
       );
@@ -229,6 +309,28 @@ function FullScreen({ children }: { children: React.ReactNode }) {
   return (
     <div className="grid min-h-svh place-items-center bg-background p-6 text-center">{children}</div>
   );
+}
+
+/**
+ * What to tell someone whose ecosystem sign-in did not work.
+ *
+ * Each line is about the *credential* or the *host*, never about the person:
+ * "expired", "no access yet", "not connected". None of them confirms or denies
+ * that any address has an account here, which is the rule the whole sign-in
+ * surface is built around.
+ */
+function hubNotice(err: unknown): string {
+  const code = err instanceof ApiError ? err.code : "";
+  switch (code) {
+    case "hub_rejected":
+      return "That sign-in expired. Try again, or use a link below.";
+    case "not_a_member":
+      return "You're signed in to TinyHumans, but this company hasn't given you access yet. Ask an admin to invite you.";
+    case "hub_unavailable":
+      return "This host isn't connected to a TinyHumans account. Sign in with a link instead.";
+    default:
+      return "We couldn't complete that sign-in. Try a link below.";
+  }
 }
 
 function connectionError(client: OpenCompanyClient, err: unknown, company: string | null): Phase {

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -57,6 +57,60 @@ export async function verifyCode(
   return client.post<Me>(`${client.scopeFor(company)}/auth/verify`, { code });
 }
 
+/** One ecosystem sign-in button, as the host describes it. */
+export interface HubProvider {
+  /** The hub's provider slug (`google`, `github`, `twitter`). */
+  id: string;
+  /** What to put on the button. */
+  label: string;
+  /**
+   * Where to send the browser. Built by the host, never assembled here: only
+   * the host knows the hub's base URL and the origin the hub must return to,
+   * and a console guessing at either would aim a live sign-in at its guess.
+   */
+  startUrl: string;
+}
+
+/**
+ * Asks the host which ecosystem providers it can sign someone in with.
+ *
+ * An empty list is the normal answer on a self-hosted host and is not an
+ * error — it means "no ecosystem here, show the magic-link form alone". So this
+ * never throws for that case; callers only need to handle the network failing.
+ */
+export async function fetchHubProviders(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<HubProvider[]> {
+  const result = await client.get<{ providers: HubProvider[] }>(
+    `${client.scopeFor(company)}/auth/hub`,
+  );
+  return result.providers ?? [];
+}
+
+/**
+ * Turns a platform token from the hub into a session on this company.
+ *
+ * The token arrives in the URL as `?token=…&key=auth` after the hub completes
+ * OAuth and redirects back here. It is not an identity this console can read or
+ * check — it is handed straight to the host, which asks the hub whose it is and
+ * then applies this company's own roster. So this returns the same `Me` a magic
+ * link would, and the browser keeps nothing either way: the session comes back
+ * as an HttpOnly cookie and the token is stripped from the URL.
+ *
+ * The distinguishable failures are `hub_rejected` (expired or forged — sign in
+ * again), `not_a_member` (a real ecosystem account with no access here), and
+ * `hub_unavailable` (this host has no ecosystem at all). Read them off
+ * {@link ApiError.code}.
+ */
+export async function signInWithHubToken(
+  client: OpenCompanyClient,
+  company: string | null,
+  token: string,
+): Promise<Me> {
+  return client.post<Me>(`${client.scopeFor(company)}/auth/hub`, { token });
+}
+
 /** Exchanges an email and password for a session. */
 export async function loginWithPassword(
   client: OpenCompanyClient,

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -39,7 +39,13 @@ function fromQuery(): Partial<ConsoleConfig> {
   const token = q.get("token");
   if (api !== null) out.baseUrl = api;
   if (company !== null) out.company = company;
-  if (token !== null) out.operatorToken = token;
+  // `?token=` is ours ONLY when the hub did not put it there. The hub's OAuth
+  // callback returns `?token=<platform jwt>&key=auth`, and that token is a
+  // credential for the *hub*, not a platform token for this host. Reading it
+  // here would attach someone's ecosystem bearer to every API call the console
+  // makes — see `signInWithHubToken`, which hands it to the host once and lets
+  // it go. `key=auth` is the hub's own marker for that redirect.
+  if (token !== null && q.get("key") !== "auth") out.operatorToken = token;
   return out;
 }
 

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -1,21 +1,43 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ArrowRight, Building2, Loader2, MailCheck } from "lucide-react";
 
-import { loginWithPassword, requestCode, verifyCode, type Me } from "@/api/auth";
+import {
+  fetchHubProviders,
+  loginWithPassword,
+  requestCode,
+  verifyCode,
+  type HubProvider,
+  type Me,
+} from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
 import { ApiError } from "@/api/types";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { cn } from "@/lib/utils";
+
+/** Where the ecosystem's terms live. Same documents OpenHuman links from its welcome screen. */
+const TERMS_OF_USE_URL = "https://tinyhumans.gitbook.io/openhuman/legal/terms-of-use";
+const PRIVACY_POLICY_URL = "https://tinyhumans.gitbook.io/openhuman/legal/privacy-policy";
 
 interface Props {
   client: OpenCompanyClient;
   company: string | null;
   /** The company's display name, when the host would tell us before sign-in. */
   companyName?: string;
+  /**
+   * Why they landed here, when it was not simply "not signed in yet".
+   *
+   * Set after a refused ecosystem sign-in. Without it a rejected or ineligible
+   * sign-in renders an ordinary form and looks like the click did nothing — the
+   * one failure mode most likely to be reported as "the button is broken". It
+   * never names an address, so it cannot become the membership oracle the rest
+   * of this view refuses to be.
+   */
+  notice?: string;
   /** A code lifted out of a magic-link URL, redeemed on mount by the caller. */
   onSignedIn: (me: Me) => void;
 }
@@ -35,8 +57,18 @@ type Mode = "link" | "password";
  *    keeps; there is nothing to put in localStorage and nothing for an XSS to
  *    steal.
  */
-export function Login({ client, company, companyName, onSignedIn }: Props) {
+export function Login({ client, company, companyName, notice, onSignedIn }: Props) {
   const [mode, setMode] = useState<Mode>("link");
+  /**
+   * The ecosystem sign-in buttons this host offers, or `[]` if it offers none.
+   *
+   * Asked of the host rather than assumed, because only the host knows the
+   * hub's base URL and the origin the hub must return to. A self-hosted host
+   * answers with an empty list and this view renders the magic-link form alone,
+   * which is why a failure to fetch is swallowed: no buttons is a valid state,
+   * not an error worth showing anyone.
+   */
+  const [hubProviders, setHubProviders] = useState<HubProvider[]>([]);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [busy, setBusy] = useState(false);
@@ -44,6 +76,21 @@ export function Login({ client, company, companyName, onSignedIn }: Props) {
   const [sent, setSent] = useState(false);
   // Only ever set on a host with no mail transport (local dev).
   const [devCode, setDevCode] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchHubProviders(client, company)
+      .then((providers) => {
+        if (!cancelled) setHubProviders(providers);
+      })
+      .catch(() => {
+        // No buttons. The form below still works, and a host that cannot answer
+        // this question could not have completed the flow anyway.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client, company]);
 
   async function sendLink(e: React.FormEvent) {
     e.preventDefault();
@@ -100,6 +147,12 @@ export function Login({ client, company, companyName, onSignedIn }: Props) {
       </header>
 
       <main className="mx-auto flex w-full max-w-md flex-col justify-center px-6 py-16">
+        {notice && (
+          <Alert className="mb-6">
+            <AlertDescription>{notice}</AlertDescription>
+          </Alert>
+        )}
+
         <div className="mb-6 space-y-1">
           <h1 className="text-2xl font-semibold tracking-tight">
             Sign in{companyName ? ` to ${companyName}` : ""}
@@ -110,6 +163,59 @@ export function Login({ client, company, companyName, onSignedIn }: Props) {
               : "Use the password you set for this company."}
           </p>
         </div>
+
+        {/*
+          Ecosystem sign-in, above the form because it is the path most people
+          take: one click, no mailbox round trip. Rendered only when the host
+          says it has a hub — a self-hosted console shows the form alone.
+
+          Each button is a plain link to a host-supplied URL, not a fetch: the
+          hub's OAuth start is a top-level navigation, and the browser must own
+          it so the provider's own domain appears in the address bar.
+        */}
+        {hubProviders.length > 0 && (
+          <div className="mb-6 space-y-3">
+            <div className="grid gap-2">
+              {hubProviders.map((provider) => (
+                <a
+                  key={provider.id}
+                  href={provider.startUrl}
+                  className={cn(buttonVariants({ variant: "outline", size: "lg" }), "w-full")}
+                >
+                  Continue with {provider.label}
+                </a>
+              ))}
+            </div>
+
+            <p className="text-center text-[11px] leading-5 text-muted-foreground">
+              By continuing, you agree to the{" "}
+              <a
+                href={TERMS_OF_USE_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="font-medium underline underline-offset-2 hover:text-foreground"
+              >
+                Terms
+              </a>{" "}
+              and{" "}
+              <a
+                href={PRIVACY_POLICY_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="font-medium underline underline-offset-2 hover:text-foreground"
+              >
+                Privacy Policy
+              </a>
+              .
+            </p>
+
+            <div className="flex items-center gap-3">
+              <div className="h-px flex-1 bg-border" />
+              <span className="text-xs text-muted-foreground">or</span>
+              <div className="h-px flex-1 bg-border" />
+            </div>
+          </div>
+        )}
 
         <Card className="p-6">
           {sent && mode === "link" ? (

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -306,6 +306,10 @@ pub struct AppState {
     /// Injected network seams for the credential surfaces (DNS resolver, mail
     /// sender). Empty by default so the build stays offline.
     connections: crate::server::ops::ConnectionsRuntime,
+    /// The hub exchange backing `…/auth/hub`. `None` (the default, and every
+    /// self-hosted host) means the console offers no ecosystem sign-in at all,
+    /// rather than offering a button that leads nowhere.
+    hub_identity: Option<Arc<dyn crate::server::hub_identity::HubIdentityExchange>>,
     /// Cross-origin allowlist. Empty (the default) means CORS is off, which is
     /// correct for every same-origin deployment.
     cors: crate::server::cors::CorsConfig,
@@ -356,6 +360,7 @@ impl AppState {
             skill_registry: Arc::new(OnceLock::new()),
             schema: crate::server::graphql::build_schema(),
             connections: crate::server::ops::ConnectionsRuntime::new(),
+            hub_identity: None,
             cors: crate::server::cors::CorsConfig::default(),
             #[cfg(feature = "tinyplace")]
             nonce: std::sync::Arc::new(crate::economy::NonceCache::new()),
@@ -461,6 +466,33 @@ impl AppState {
     /// The injected connection seams for the credential surfaces.
     pub fn connections(&self) -> &crate::server::ops::ConnectionsRuntime {
         &self.connections
+    }
+
+    /// Installs the hub identity exchange backing `…/auth/hub`.
+    ///
+    /// An injected seam rather than a client built per request, so the route's
+    /// refusals — rejected token, unreachable hub, address not on this
+    /// company's roster — are testable offline against
+    /// [`MockHubIdentityExchange`](crate::server::hub_identity::MockHubIdentityExchange)
+    /// in a build that links no HTTP crate at all.
+    pub fn with_hub_identity(
+        mut self,
+        exchange: Arc<dyn crate::server::hub_identity::HubIdentityExchange>,
+    ) -> Self {
+        self.hub_identity = Some(exchange);
+        self
+    }
+
+    /// The hub identity exchange, when one is wired.
+    ///
+    /// `None` means this host has no ecosystem to sign in against, which is the
+    /// correct default: a host that cannot ask the hub whose token it is
+    /// holding has no way to check one, and accepting it on trust would make an
+    /// unverifiable JWT a bearer credential for this company.
+    pub fn hub_identity(
+        &self,
+    ) -> Option<&Arc<dyn crate::server::hub_identity::HubIdentityExchange>> {
+        self.hub_identity.as_ref()
     }
 
     /// Installs platform (multi-tenant) auth. Mirrors [`Self::with_home`].

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -477,6 +477,29 @@ fn attach_tinyhumans_feedback(builder: RuntimeBuilder, _config: &AppConfig) -> R
     builder
 }
 
+/// Wires the hub identity exchange, when this build can reach the hub.
+///
+/// Rides the existing `tinyhumans` feature rather than earning one of its own:
+/// that flag already means "this instance talks to the hub about its
+/// credential's owner", and asking the hub whose sign-in token this is is the
+/// same conversation about the same owner.
+///
+/// Unwired, `…/auth/hub` reports no providers and the console shows only the
+/// magic-link form — which is the right answer for a self-hosted host that has
+/// no ecosystem to sign in against.
+#[cfg(not(feature = "tinyhumans"))]
+fn attach_hub_identity(state: AppState) -> AppState {
+    state
+}
+
+#[cfg(feature = "tinyhumans")]
+fn attach_hub_identity(state: AppState) -> AppState {
+    use opencompany::server::hub_identity::HttpHubIdentityExchange;
+
+    let exchange = HttpHubIdentityExchange::new(state.config().api_url.clone());
+    state.with_hub_identity(std::sync::Arc::new(exchange))
+}
+
 #[cfg(feature = "tinyhumans")]
 fn attach_tinyhumans_feedback(builder: RuntimeBuilder, config: &AppConfig) -> RuntimeBuilder {
     use opencompany::feedback::HttpTinyHumansClient;
@@ -790,7 +813,7 @@ async fn main() -> Result<()> {
                 .ok()
                 .filter(|value| !value.trim().is_empty())
                 .unwrap_or_else(|| AppConfig::default().api_url);
-            let mut state = AppState::new(AppConfig {
+            let state = AppState::new(AppConfig {
                 bind,
                 openhuman_root,
                 api_url,
@@ -806,6 +829,7 @@ async fn main() -> Result<()> {
                 env_usize("OPENCOMPANY_MAX_COMPANIES"),
                 env_usize("OPENCOMPANY_MAX_COMPANIES_PER_TENANT"),
             );
+            let mut state = attach_hub_identity(state);
             // Storage backend selection: fs (default) needs nothing; sqlite and
             // mongodb are opened once here and injected into every company's
             // builder. A selected-but-unavailable backend aborts boot rather

--- a/src/server/hub_identity.rs
+++ b/src/server/hub_identity.rs
@@ -1,0 +1,322 @@
+//! Learning which ecosystem address is behind a platform token.
+//!
+//! Sign-in happens **here**, on the company's own console. The browser is sent
+//! to the hub's OAuth start pointed back at this origin, the hub completes the
+//! provider dance and redirects back carrying a platform JWT, and this module
+//! turns that JWT into one address.
+//!
+//! ## Why this tenant does not verify the token
+//!
+//! It cannot. The signing secret belongs to the hub, and handing it to every
+//! tenant so each could check a signature would also let every tenant *mint* a
+//! token for any user in the ecosystem — the plainest possible way to lose the
+//! isolation the hosting layer exists to provide.
+//!
+//! So the tenant does not verify the token; it *uses* it. It presents the token
+//! to the hub's own `GET /auth/me`, exactly as the dashboard would. If the hub
+//! answers with an identity, that **is** the proof: only the hub can say who a
+//! token it signed belongs to, and a forged or expired one gets a 401 there.
+//! No shared secret, no minted code, no second round trip to invent.
+//!
+//! ## What this costs, stated plainly
+//!
+//! The tenant briefly holds a hub credential belonging to the person signing
+//! in — one that carries their ecosystem privileges, not merely their identity.
+//! That is a real delegation of trust to the tenant, and it is strictly more
+//! than a single-use, slug-bound code would have handed over. It is accepted
+//! here because the console *is* the company: a person signing in to their own
+//! company's host is already trusting that host with everything the company
+//! holds. What this module owes in return is discipline — the token is used
+//! once, for one request, and is never persisted, never logged, and never
+//! echoed back in an error.
+//!
+//! Authorization is emphatically **not** delegated. The hub says who they are;
+//! this company's own roster says whether they may in — the same
+//! `eligibility` → `upsert_from_eligibility` → `mint_session` path a magic link
+//! answers to.
+//!
+//! ## Shape
+//!
+//! The [`HubIdentityExchange`] trait and its offline [`MockHubIdentityExchange`]
+//! compile in the default build, so the whole route — eligibility, session
+//! minting, every refusal — is exercised without linking a network crate. Only
+//! [`HttpHubIdentityExchange`] is gated behind the existing `tinyhumans`
+//! feature, which is already what "this instance talks to the hub about its
+//! credential's owner" means. It does not earn a feature flag of its own.
+
+use std::collections::HashMap;
+use std::sync::Mutex as StdMutex;
+
+use async_trait::async_trait;
+
+use crate::Result;
+
+/// An identity provider the hub can complete a sign-in with.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HubProvider {
+    /// The hub's provider slug, as it appears in `GET /auth/{id}/login`.
+    pub id: &'static str,
+    /// What the console calls it on the button.
+    pub label: &'static str,
+}
+
+/// The providers offered on the console's sign-in screen, in OpenHuman's order.
+///
+/// Deliberately the same three, in the same sequence, as OpenHuman's welcome
+/// screen. Someone who signs in to the desktop app with GitHub should not have
+/// to hunt for it here, and an ecosystem that offers a different identity set
+/// per surface teaches people that the account is per-surface too.
+///
+/// Discord is registered at the hub and supports login, but OpenHuman hides it
+/// on welcome (`showOnWelcome: false`), so it stays hidden here too.
+pub const HUB_PROVIDERS: &[HubProvider] = &[
+    HubProvider {
+        id: "google",
+        label: "Google",
+    },
+    HubProvider {
+        id: "github",
+        label: "GitHub",
+    },
+    HubProvider {
+        id: "twitter",
+        label: "X",
+    },
+];
+
+/// Builds the hub URL that starts a sign-in and comes back to `redirect_uri`.
+///
+/// `redirect_uri` is round-tripped by the hub verbatim, with `token=…&key=auth`
+/// appended, so it must arrive percent-encoded as a single query value —
+/// unescaped it would end at the console origin's own `?` and the hub would
+/// read the console's `company=` as one of its own parameters.
+///
+/// ## The hosted blocker
+///
+/// The hub accepts `redirectUri` only when it passes an RFC 8252 **loopback**
+/// check (`http://` on `127.0.0.1`, `localhost`, or `[::1]`). A console on
+/// `127.0.0.1:<port>` satisfies that today, which is why the whole flow can be
+/// built and demonstrated locally against the route exactly as it ships.
+///
+/// A hosted console on an `https://<slug>.<domain>` origin satisfies neither
+/// that check nor the named `redirect ∈ {app,dashboard,admin}` targets, so the
+/// hub will answer `400` until it learns to allowlist tenant console origins.
+/// Nothing here needs to change when it does: the origin this builds on comes
+/// from [`AppConfig::host_base_url`](crate::AppConfig::host_base_url), so
+/// hosted is `OPENCOMPANY_PUBLIC_URL=https://…` and no code edit.
+pub fn login_start_url(api_url: &str, provider: &str, redirect_uri: &str) -> String {
+    format!(
+        "{}/auth/{}/login?redirectUri={}",
+        api_url.trim_end_matches('/'),
+        provider,
+        percent_encode(redirect_uri),
+    )
+}
+
+/// Percent-encodes `value` for use as a single query-string value.
+///
+/// Hand-rolled rather than pulled in: the crate has no direct URL dependency in
+/// the default build, and adding one to escape a handful of characters would
+/// move `Cargo.lock` for no benefit. Keeps only the RFC 3986 unreserved set,
+/// which is stricter than necessary and therefore cannot under-escape.
+fn percent_encode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(*byte as char)
+            }
+            other => out.push_str(&format!("%{other:02X}")),
+        }
+    }
+    out
+}
+
+/// Who a platform token stands for.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HubIdentity {
+    /// The ecosystem address the hub resolved the token to. Not normalized
+    /// here — the route does that before it goes anywhere near a user lookup.
+    pub email: String,
+}
+
+/// The hub, scoped to the one question this tenant may ask it: whose token is
+/// this?
+#[async_trait]
+pub trait HubIdentityExchange: Send + Sync {
+    /// Resolves `token` to the address that holds it.
+    ///
+    /// Implementations must treat `token` as a live credential: never log it,
+    /// never store it, and never include it in an error. It is the caller's
+    /// only proof of identity and would be replayable by anyone who read it.
+    async fn identify(&self, token: &str) -> Result<HubIdentity>;
+}
+
+/// An in-memory [`HubIdentityExchange`] for offline tests and local demos.
+///
+/// Non-destructive, unlike a single-use code: a platform token is a bearer
+/// credential with a lifetime, so presenting it twice legitimately succeeds
+/// twice. A mock that expired it on first use would make the route look
+/// stricter than it is.
+#[derive(Debug, Default)]
+pub struct MockHubIdentityExchange {
+    tokens: StdMutex<HashMap<String, String>>,
+    /// A forced transport failure, standing in for "the hub is not answering".
+    unreachable: bool,
+}
+
+impl MockHubIdentityExchange {
+    /// An exchange that knows no tokens; every lookup is rejected.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Seeds one live token and the address it resolves to.
+    pub fn with_token(self, token: &str, email: &str) -> Self {
+        self.tokens
+            .lock()
+            .expect("mock poisoned")
+            .insert(token.to_string(), email.to_string());
+        self
+    }
+
+    /// An exchange whose hub cannot be reached at all.
+    ///
+    /// Distinct from an unknown token on purpose: one is a dead credential the
+    /// caller should re-earn by signing in again, the other is an outage the
+    /// caller can do nothing about, and the route must not tell someone to
+    /// click again when clicking again cannot work.
+    pub fn unreachable() -> Self {
+        Self {
+            unreachable: true,
+            ..Self::default()
+        }
+    }
+}
+
+/// The error the hub returns for a token that is forged, expired, or revoked.
+///
+/// One shape for all three, mirroring the hub: `GET /auth/me` answers 401 for
+/// every one of them, and inventing a finer distinction here would be this
+/// tenant guessing at a fact only the hub holds.
+fn rejected() -> crate::error::OpenCompanyError {
+    crate::error::OpenCompanyError::TinyHumans {
+        code: "http_401".to_string(),
+        message: "The hub did not recognize that sign-in".to_string(),
+    }
+}
+
+#[async_trait]
+impl HubIdentityExchange for MockHubIdentityExchange {
+    async fn identify(&self, token: &str) -> Result<HubIdentity> {
+        if self.unreachable {
+            return Err(crate::error::OpenCompanyError::TinyHumans {
+                code: "unreachable".to_string(),
+                message: "connection refused".to_string(),
+            });
+        }
+        self.tokens
+            .lock()
+            .expect("mock poisoned")
+            .get(token)
+            .map(|email| HubIdentity {
+                email: email.clone(),
+            })
+            .ok_or_else(rejected)
+    }
+}
+
+/// The real HTTP exchange, compiled only under the `tinyhumans` feature.
+#[cfg(feature = "tinyhumans")]
+pub use http::HttpHubIdentityExchange;
+
+#[cfg(feature = "tinyhumans")]
+mod http {
+    use super::{HubIdentity, HubIdentityExchange};
+    use crate::Result;
+    use crate::error::OpenCompanyError;
+    use async_trait::async_trait;
+    use serde::Deserialize;
+
+    /// The hub's envelope for `GET /auth/me`.
+    #[derive(Debug, Deserialize)]
+    struct MeResponse {
+        data: MeData,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct MeData {
+        email: String,
+    }
+
+    /// A [`HubIdentityExchange`] backed by `GET {api_url}/auth/me`.
+    ///
+    /// Deliberately the hub's *existing* session route rather than anything
+    /// built for tenants. There is no new endpoint to secure, no new token type
+    /// to expire, and no way for this call to learn more than the person who
+    /// presented the token already knows about themselves.
+    pub struct HttpHubIdentityExchange {
+        api_url: String,
+        http: reqwest::Client,
+    }
+
+    impl HttpHubIdentityExchange {
+        /// Builds an exchange against `api_url`.
+        pub fn new(api_url: impl Into<String>) -> Self {
+            Self {
+                // Trailing slashes would produce `//auth/me`.
+                api_url: api_url.into().trim_end_matches('/').to_string(),
+                http: reqwest::Client::new(),
+            }
+        }
+
+        fn err(context: &str, e: impl std::fmt::Display) -> OpenCompanyError {
+            OpenCompanyError::TinyHumans {
+                code: context.to_string(),
+                message: e.to_string(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl HubIdentityExchange for HttpHubIdentityExchange {
+        async fn identify(&self, token: &str) -> Result<HubIdentity> {
+            let url = format!("{}/auth/me", self.api_url);
+            let resp = self
+                .http
+                .get(&url)
+                .bearer_auth(token)
+                .send()
+                .await
+                .map_err(|e| Self::err("unreachable", e))?;
+
+            let status = resp.status();
+            if !status.is_success() {
+                // The hub's own message is safe to surface — it describes the
+                // token's standing, never the person's. The token itself is
+                // never echoed, and `reqwest`'s error Display would not carry
+                // it either (the bearer lives in a header, not the URL).
+                let detail = resp.text().await.unwrap_or_default();
+                return Err(Self::err(
+                    &format!("http_{}", status.as_u16()),
+                    truncate(&detail, 200),
+                ));
+            }
+
+            let parsed: MeResponse = resp.json().await.map_err(|e| Self::err("decode", e))?;
+            Ok(HubIdentity {
+                email: parsed.data.email,
+            })
+        }
+    }
+
+    /// Caps an error detail at `max` **characters**, never bytes: slicing a
+    /// UTF-8 string by byte offset panics mid-codepoint, and an error path is
+    /// the worst possible place to learn that.
+    fn truncate(value: &str, max: usize) -> String {
+        if value.chars().count() <= max {
+            return value.to_string();
+        }
+        value.chars().take(max).collect()
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6,6 +6,7 @@ mod error;
 pub mod feedback;
 pub mod graphql;
 pub mod hooks;
+pub mod hub_identity;
 // Console MCP OAuth callback (issue #90): the unauthenticated browser-redirect
 // landing route. Gated on `mcp` (it needs the OAuth token-exchange path).
 #[cfg(feature = "mcp")]

--- a/src/server/users/hub_test.rs
+++ b/src/server/users/hub_test.rs
@@ -1,0 +1,354 @@
+//! End-to-end tests for `GET`/`POST …/auth/hub`.
+//!
+//! Every case runs against [`MockHubIdentityExchange`], so the route's whole
+//! decision tree — ask the hub, check eligibility, mint a session, and every
+//! refusal — is exercised in a build that links no HTTP crate.
+//!
+//! The distinction these tests exist to protect is between the three ways a
+//! sign-in can fail: the *token* is dead (say so, tell them to sign in again),
+//! the *person* is not on this company's roster (say so, tell them to ask for
+//! an invite), and the *hub* is down (say nothing about either, and do not tell
+//! them to click again when clicking again cannot work). Collapsing any two of
+//! those into one status is the regression worth catching.
+
+use std::sync::Arc;
+
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use crate::company::CompanyManifest;
+use crate::ports::types::{CompanyId, CompanyRecord};
+use crate::ports::{CompanyStore, UserRecord, UserRole, UserStatus, generate_id, now_millis};
+use crate::runtime::RuntimeBuilder;
+use crate::server::hub_identity::MockHubIdentityExchange;
+use crate::server::router;
+use crate::{AppConfig, AppState};
+
+fn home() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix("oc-hub-auth-")
+        .tempdir()
+        .expect("tempdir")
+}
+
+/// `Ada` is a manifest-bootstrapped admin, spelled with capitals so the route's
+/// email normalization is exercised against a hub that returns a different case.
+fn manifest() -> CompanyManifest {
+    toml::from_str(
+        "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+         [users]\nadmins = [\"Ada@Example.com\"]\n",
+    )
+    .unwrap()
+}
+
+/// A host with `exchange` wired, bound to loopback as a local console is.
+async fn state_with(
+    home: &std::path::Path,
+    exchange: Option<Arc<MockHubIdentityExchange>>,
+) -> AppState {
+    let store = crate::store::FsCompanyStore::new(home.to_path_buf());
+    let id = CompanyId::new("acme");
+    store
+        .save(&CompanyRecord {
+            id: id.clone(),
+            manifest: manifest(),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            template_provenance: None,
+        })
+        .await
+        .unwrap();
+    let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest())
+        .with_id(id.clone())
+        .build()
+        .await
+        .unwrap();
+    let mut state = AppState::new(AppConfig {
+        bind: "127.0.0.1:8080".to_string(),
+        api_url: "https://hub.example.com".to_string(),
+        ..AppConfig::default()
+    })
+    .with_home(home.to_path_buf());
+    if let Some(exchange) = exchange {
+        state = state.with_hub_identity(exchange);
+    }
+    state.registry().insert(id, Arc::new(runtime));
+    state
+}
+
+fn post(uri: &str, body: serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+fn get_with_cookie(uri: &str, cookie: &str) -> Request<Body> {
+    Request::builder()
+        .uri(uri)
+        .header("cookie", cookie)
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn body_json(response: axum::response::Response) -> serde_json::Value {
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+fn session_cookie(response: &axum::response::Response) -> String {
+    let set = response
+        .headers()
+        .get("set-cookie")
+        .expect("a session response must set a cookie")
+        .to_str()
+        .unwrap();
+    set.split(';').next().unwrap().to_string()
+}
+
+async fn sign_in(state: &AppState, token: &str) -> axum::response::Response {
+    router(state.clone())
+        .oneshot(post(
+            "/api/v1/companies/acme/auth/hub",
+            serde_json::json!({ "token": token }),
+        ))
+        .await
+        .unwrap()
+}
+
+async fn providers(state: &AppState) -> serde_json::Value {
+    let response = router(state.clone())
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/companies/acme/auth/hub")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    body_json(response).await
+}
+
+// ---------------------------------------------------------------------------
+// The buttons
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_host_with_a_hub_offers_the_three_openhuman_providers() {
+    let home = home();
+    let state = state_with(home.path(), Some(Arc::new(MockHubIdentityExchange::new()))).await;
+
+    let body = providers(&state).await;
+    let listed = body["providers"].as_array().unwrap();
+
+    // Same three, same order, as OpenHuman's welcome screen. Discord is a
+    // registered login provider at the hub but hidden there, so it stays hidden.
+    let ids: Vec<&str> = listed
+        .iter()
+        .map(|p| p["id"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec!["google", "github", "twitter"]);
+    assert_eq!(listed[2]["label"], "X");
+}
+
+#[tokio::test]
+async fn the_start_url_points_at_the_hub_and_returns_to_this_console() {
+    let home = home();
+    let state = state_with(home.path(), Some(Arc::new(MockHubIdentityExchange::new()))).await;
+
+    let body = providers(&state).await;
+    let start = body["providers"][0]["startUrl"].as_str().unwrap();
+
+    // The hub's own OAuth start, not something this crate invented.
+    assert!(
+        start.starts_with("https://hub.example.com/auth/google/login?redirectUri="),
+        "unexpected start URL: {start}"
+    );
+    // The return origin is derived from the bind, so a local console is an RFC
+    // 8252 loopback URI — the one shape the hub's redirectUri check accepts
+    // today. A hosted origin arrives here by configuring OPENCOMPANY_PUBLIC_URL,
+    // with no change to this code.
+    assert!(
+        start.ends_with("redirectUri=http%3A%2F%2F127.0.0.1%3A8080%2F%3Fcompany%3Dacme"),
+        "the redirect must be a percent-encoded loopback URI: {start}"
+    );
+    // Encoded as one value: unescaped, the console's own `?company=` would be
+    // read by the hub as one of its own query parameters.
+    assert!(!start.contains("redirectUri=http://"));
+}
+
+#[tokio::test]
+async fn a_self_hosted_host_offers_no_providers_at_all() {
+    let home = home();
+    let state = state_with(home.path(), None).await;
+
+    let body = providers(&state).await;
+
+    // Empty rather than a 404, so the console has one code path — and empty
+    // rather than three dead buttons, because a host with no exchange could not
+    // check a token that came back.
+    assert_eq!(body["providers"].as_array().unwrap().len(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Signing in
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_valid_token_for_an_eligible_address_mints_a_session() {
+    let home = home();
+    let exchange =
+        Arc::new(MockHubIdentityExchange::new().with_token("platform-jwt", "Ada@Example.com"));
+    let state = state_with(home.path(), Some(exchange)).await;
+
+    let response = sign_in(&state, "platform-jwt").await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let cookie = session_cookie(&response);
+    assert!(
+        cookie.starts_with("oc_session_acme="),
+        "the cookie must be named for this company: {cookie}"
+    );
+    let body = body_json(response).await;
+    // The hub's casing is normalized on the way in, so this address cannot end
+    // up holding a second account alongside a magic-link sign-in.
+    assert_eq!(body["email"], "ada@example.com");
+    assert_eq!(body["role"], "admin");
+    assert_eq!(body["company"], "acme");
+
+    // And the session actually works.
+    let me = router(state.clone())
+        .oneshot(get_with_cookie("/api/v1/companies/acme/auth/me", &cookie))
+        .await
+        .unwrap();
+    assert_eq!(me.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn the_same_token_may_be_presented_twice() {
+    let home = home();
+    let exchange =
+        Arc::new(MockHubIdentityExchange::new().with_token("platform-jwt", "Ada@Example.com"));
+    let state = state_with(home.path(), Some(exchange)).await;
+
+    assert_eq!(
+        sign_in(&state, "platform-jwt").await.status(),
+        StatusCode::OK
+    );
+
+    // Unlike a single-use handoff code, a platform token is a bearer credential
+    // with a lifetime. A reload that re-posts it must not look like an attack.
+    assert_eq!(
+        sign_in(&state, "platform-jwt").await.status(),
+        StatusCode::OK
+    );
+}
+
+#[tokio::test]
+async fn an_address_this_company_does_not_know_is_refused() {
+    let home = home();
+    let exchange =
+        Arc::new(MockHubIdentityExchange::new().with_token("platform-jwt", "stranger@example.com"));
+    let state = state_with(home.path(), Some(exchange)).await;
+
+    let response = sign_in(&state, "platform-jwt").await;
+
+    // Signed in to the ecosystem, and still refused here: the hub says who they
+    // are, this company's roster says whether they may in.
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert!(response.headers().get("set-cookie").is_none());
+    assert_eq!(body_json(response).await["code"], "not_a_member");
+}
+
+#[tokio::test]
+async fn an_address_removed_from_the_roster_is_refused() {
+    let home = home();
+    let exchange =
+        Arc::new(MockHubIdentityExchange::new().with_token("platform-jwt", "bob@example.com"));
+    let state = state_with(home.path(), Some(exchange)).await;
+
+    // Bob was a member and is suspended. He is still a perfectly good ecosystem
+    // identity, which is exactly why the hub cannot be the one to decide this.
+    let id = CompanyId::new("acme");
+    let runtime = state.registry().get(&id).unwrap();
+    let now = now_millis();
+    runtime
+        .users()
+        .upsert_user(
+            &id,
+            &UserRecord {
+                id: generate_id(),
+                email: "bob@example.com".to_string(),
+                display_name: None,
+                role: UserRole::Member,
+                status: UserStatus::Suspended,
+                password_hash: None,
+                must_change_password: false,
+                created_at_millis: now,
+                last_seen_at_millis: None,
+                updated_at_millis: now,
+            },
+        )
+        .await
+        .unwrap();
+
+    let response = sign_in(&state, "platform-jwt").await;
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert!(response.headers().get("set-cookie").is_none());
+    assert_eq!(body_json(response).await["code"], "not_a_member");
+}
+
+#[tokio::test]
+async fn a_token_the_hub_rejects_is_a_client_error_not_a_bad_gateway() {
+    let home = home();
+    let exchange = Arc::new(MockHubIdentityExchange::new());
+    let state = state_with(home.path(), Some(exchange)).await;
+
+    let response = sign_in(&state, "forged-or-expired").await;
+
+    // The hub's 401 must not surface as the 502 the error type otherwise maps
+    // to: a dead token is the caller's problem to fix by signing in again, and
+    // telling them the ecosystem is down is the wrong instruction.
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert!(response.headers().get("set-cookie").is_none());
+    assert_eq!(body_json(response).await["code"], "hub_rejected");
+}
+
+#[tokio::test]
+async fn an_unreachable_hub_is_not_reported_as_a_dead_token() {
+    let home = home();
+    let exchange = Arc::new(MockHubIdentityExchange::unreachable());
+    let state = state_with(home.path(), Some(exchange)).await;
+
+    let response = sign_in(&state, "platform-jwt").await;
+
+    // An outage keeps its 5xx. Reporting it as `hub_rejected` would send
+    // someone round the OAuth loop forever against a hub that cannot answer.
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert!(response.headers().get("set-cookie").is_none());
+    assert_ne!(body_json(response).await["code"], "hub_rejected");
+}
+
+#[tokio::test]
+async fn a_host_with_no_hub_refuses_every_token() {
+    let home = home();
+    let state = state_with(home.path(), None).await;
+
+    let response = sign_in(&state, "platform-jwt").await;
+
+    // Without an exchange there is no way to check the token, and accepting it
+    // on trust would make an unverifiable JWT a bearer credential here.
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert!(response.headers().get("set-cookie").is_none());
+    assert_eq!(body_json(response).await["code"], "hub_unavailable");
+}

--- a/src/server/users/mod.rs
+++ b/src/server/users/mod.rs
@@ -44,4 +44,6 @@ pub use routes::router;
 #[cfg(test)]
 mod auth_test;
 #[cfg(test)]
+mod hub_test;
+#[cfg(test)]
 mod routes_test;

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -66,6 +66,10 @@ pub fn router() -> Router<AppState> {
         .merge(public_scoped("/auth/login", post(login_password)))
         .merge(public_scoped("/auth/logout", post(logout)))
         .merge(public_scoped("/auth/me", get(me)))
+        .merge(public_scoped(
+            "/auth/hub",
+            get(hub_providers).post(hub_sign_in),
+        ))
         .merge(public_scoped("/auth/password", post(set_password)))
 }
 
@@ -94,6 +98,33 @@ struct RequestCodeResult {
 #[derive(Debug, Deserialize)]
 struct VerifyCode {
     code: String,
+}
+
+/// A platform token, handed back by the hub on the sign-in redirect.
+#[derive(Debug, Deserialize)]
+struct HubToken {
+    token: String,
+}
+
+/// One sign-in button, ready to render.
+///
+/// The console never assembles a hub URL itself. Only the host knows the hub's
+/// base URL and the origin the hub must return to, and a frontend guessing at
+/// either would aim a live sign-in at whatever it guessed.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HubProviderOption {
+    id: &'static str,
+    label: &'static str,
+    start_url: String,
+}
+
+/// What the console needs to draw its sign-in screen.
+#[derive(Debug, Serialize)]
+struct HubProvidersResult {
+    /// Empty on every host with no hub wired, which is how the console knows to
+    /// render the magic-link form alone rather than buttons that lead nowhere.
+    providers: Vec<HubProviderOption>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -522,6 +553,150 @@ async fn verify_code(
         return Err(invalid_login());
     };
     let user = upsert_from_eligibility(&runtime, &code.email, role, now)
+        .await
+        .map_err(|e| ApiError(e).into_response())?;
+    mint_session(&state, &runtime, &user, &headers).await
+}
+
+/// `403` for an ecosystem sign-in this host cannot or will not honor.
+///
+/// Unlike [`invalid_login`], these say what went wrong. The generic-failure
+/// rule exists so the login routes cannot be used as a membership oracle, and
+/// nothing here leaks membership: "this host has no hub" is a fact about the
+/// *deployment* the caller already knew, and "the hub rejected that" is about
+/// the token. `not_a_member` is the one that touches a person, and it is only
+/// ever reached by someone who has just proved to the hub that they hold that
+/// address — they are not learning anything they did not already know.
+fn hub_refused(code: &'static str, message: &'static str) -> Response {
+    (
+        StatusCode::FORBIDDEN,
+        Json(serde_json::json!({ "error": message, "code": code })),
+    )
+        .into_response()
+}
+
+/// Where the hub sends the browser back to after a sign-in.
+///
+/// Built from [`AppConfig::host_base_url`](crate::AppConfig::host_base_url) —
+/// the configured `OPENCOMPANY_PUBLIC_URL` when there is one, otherwise
+/// `http://{bind}`. That single seam is what makes hosted a configuration
+/// change rather than a code change: locally the bind fallback yields
+/// `http://127.0.0.1:<port>/`, which is the RFC 8252 loopback URI the hub
+/// already accepts; hosted, `OPENCOMPANY_PUBLIC_URL` yields the real origin and
+/// this function is untouched.
+///
+/// Carries `?company=` so the console lands scoped to the company it left from.
+/// The hub appends its own `token=…&key=auth` with `&`, so the two coexist.
+fn console_redirect_uri(state: &AppState, company: &CompanyId) -> String {
+    let origin = state.config().host_base_url();
+    format!("{}/?company={}", origin.trim_end_matches('/'), company)
+}
+
+/// `GET …/auth/hub` — the ecosystem sign-in buttons, ready to render.
+///
+/// Answers `{"providers": []}` rather than a 404 on a host with no hub, so the
+/// console has one code path: ask, render what comes back, and fall through to
+/// the magic-link form when nothing does.
+async fn hub_providers(
+    company: PublicCompany,
+    State(state): State<AppState>,
+) -> Json<HubProvidersResult> {
+    // No exchange means no way to check a token that came back, so there is no
+    // honest button to offer. Refusing here — rather than at redemption — is
+    // the difference between a console that says "sign in with a link" and one
+    // that sends someone through Google to be turned away on return.
+    if state.hub_identity().is_none() {
+        return Json(HubProvidersResult {
+            providers: Vec::new(),
+        });
+    }
+    let redirect_uri = console_redirect_uri(&state, company.runtime.id());
+    let api_url = &state.config().api_url;
+    Json(HubProvidersResult {
+        providers: crate::server::hub_identity::HUB_PROVIDERS
+            .iter()
+            .map(|provider| HubProviderOption {
+                id: provider.id,
+                label: provider.label,
+                start_url: crate::server::hub_identity::login_start_url(
+                    api_url,
+                    provider.id,
+                    &redirect_uri,
+                ),
+            })
+            .collect(),
+    })
+}
+
+/// `POST …/auth/hub` — turn an ecosystem sign-in into a session here.
+///
+/// The console sends the browser to the hub's OAuth start pointed back at this
+/// origin; the hub completes the provider dance and returns a platform JWT in
+/// the URL. This route takes that token, asks the hub whose it is, and — if
+/// that address is eligible in *this* company by the same rules a magic link
+/// answers to — mints an ordinary human session.
+///
+/// It is deliberately the same three calls the magic-link path makes:
+/// [`eligibility`], [`upsert_from_eligibility`], [`mint_session`]. First login
+/// and Nth login stay one code path, and an ecosystem sign-in gets no privilege
+/// a mailed link would not have given the same person. In particular this does
+/// not touch `platform_auth`: that surface is the hosting layer's machine
+/// credential, and a human signing in must not acquire one.
+///
+/// The token is used for exactly one outbound request and then dropped. It is
+/// never persisted, never logged, and never echoed into an error.
+async fn hub_sign_in(
+    company: PublicCompany,
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(body): Json<HubToken>,
+) -> Result<Response, Response> {
+    let runtime = company.runtime.clone();
+
+    // Refuse before going anywhere when this host has no hub to ask. Accepting
+    // the token on trust would make an unverifiable JWT a bearer credential.
+    let Some(exchange) = state.hub_identity().cloned() else {
+        return Err(hub_refused(
+            "hub_unavailable",
+            "this host is not part of a TinyHumans ecosystem",
+        ));
+    };
+
+    // The hub answering is what proves the token was real — this tenant cannot
+    // check the signature and does not try. Everything below reasons about the
+    // identity the hub returned, never about the request body.
+    let identity = match exchange.identify(&body.token).await {
+        Ok(identity) => identity,
+        // A 4xx from the hub means the token is expired, revoked, or was never
+        // real — a dead credential, not a broken hub. Surfacing the 502 the
+        // error type otherwise maps to would tell the user the ecosystem is
+        // down when all they need to do is sign in again.
+        Err(OpenCompanyError::TinyHumans { code, .. }) if code.starts_with("http_4") => {
+            return Err(hub_refused(
+                "hub_rejected",
+                "that sign-in has expired — sign in again",
+            ));
+        }
+        // Anything else really is the hub being unreachable or wrong, and keeps
+        // its 502/503 so an operator can tell the two apart.
+        Err(err) => return Err(ApiError(err).into_response()),
+    };
+
+    let email = normalize_email(&identity.email);
+    let now = now_millis();
+    let Some(role) = eligibility(&runtime, &email, now)
+        .await
+        .map_err(|e| ApiError(e).into_response())?
+    else {
+        // Signed in to the ecosystem, but not a person this company knows. A
+        // distinct code so the console can say "ask an admin to invite you"
+        // instead of "that sign-in is dead".
+        return Err(hub_refused(
+            "not_a_member",
+            "that account has no access to this company",
+        ));
+    };
+    let user = upsert_from_eligibility(&runtime, &email, role, now)
         .await
         .map_err(|e| ApiError(e).into_response())?;
     mint_session(&state, &runtime, &user, &headers).await


### PR DESCRIPTION
## Summary

Part of #315: sign in to a company's console with a **TinyHumans ecosystem identity** — Google, GitHub or X, the same three OpenHuman offers on its welcome screen — instead of only a mailed link.

The company **picker** half of #315 is not here. This is the half that had to come first: an ecosystem identity has to be able to enter *one* company before "which of your companies?" is a question worth asking.

**The design turns on one observation.** A tenant cannot verify a platform JWT — it holds no key, and giving every tenant one would make each of them a place the ecosystem's signing material lives. So it does not try. It hands the token to the hub's `GET /auth/me` and uses the answer. **The hub answering *is* the verification**, which is what removes the shared secret this issue was blocked on.

The flow:

1. The console asks the host which providers it can offer, and renders those buttons. A host with no hub answers `[]` and the console shows the magic-link form alone.
2. The button sends the browser to the hub's OAuth start, pointed back at this console's origin.
3. The hub completes the provider dance and returns to `/?company=…&token=<jwt>&key=auth`.
4. The console posts that token to the host once. The host asks the hub whose it is, applies **this company's own roster**, and mints an ordinary session cookie.

## API Or Behavior Changes

Additive: `GET`/`POST …/auth/hub`. No existing route or wire shape changes. On a host with no hub wired, `GET` returns `{"providers": []}` and `POST` refuses — so a self-hosted deployment behaves exactly as today.

**An ecosystem sign-in earns no privilege a mailed link would not have given the same person.** It makes literally the same three calls the magic-link path makes — `eligibility`, `upsert_from_eligibility`, `mint_session` — so first login and Nth login stay one code path. It deliberately does **not** touch `platform_auth`: that surface is the hosting layer's machine credential, and a human signing in must not acquire one.

**Three distinguishable refusals**, so the console can say something useful: `hub_rejected` (expired or forged — sign in again), `not_a_member` (a real ecosystem account with no access to *this* company), `hub_unavailable` (no ecosystem here at all). A 4xx from the hub is mapped to a client error rather than the 502 the error type would otherwise produce — telling someone the ecosystem is down when they just need to sign in again is a worse failure than the original.

Nothing here becomes a membership oracle. `not_a_member` is only ever reached by someone who has *just proved to the hub* that they hold that address; they learn nothing they did not already know. The login form's generic-failure rule is untouched.

**One security fix that is not obvious from the feature.** `config.ts` already parsed `?token=` as the platform operator token. The hub returns `?token=<jwt>&key=auth` on the same navigation — so without a guard, every ecosystem sign-in would have latched that user's hub bearer onto the console's API client for the rest of the session. It is now gated on `key !== "auth"`. The token is used for exactly one outbound request, is stripped from the URL with `replaceState` (so a back button cannot restore it and a `Referer` cannot carry it), and is never persisted or logged.

The redirect URI is built from `host_base_url()`, which is what makes hosted a configuration change rather than a code change: locally the bind fallback yields the RFC 8252 loopback URI the hub already accepts; hosted, `OPENCOMPANY_PUBLIC_URL` yields the real origin and the function is untouched.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib`
- [x] `cargo check --locked --all-features --all-targets`
- [x] `npm ci` / `npm run typecheck` / `npm run build`
- [x] `git diff Cargo.lock` empty
- N/A: frontend unit tests — no runner exists in `frontend/`

Ten route tests against a stub hub cover the whole server-side chain: the three providers offered, the start URL pointing at the hub and returning here, a self-hosted host offering none, a valid token minting a session, replay of the same token, an address the company does not know, an address **removed** from the roster, a hub 4xx staying a client error, an unreachable hub *not* being reported as a dead token, and a no-hub host refusing everything.

**What is not proven, stated plainly: the browser walkthrough.** The server chain is proven against a stub hub, and the console compiles and type-checks — but **clicking the button, the URL stripping, the history behaviour and reload persistence have not been exercised in a real browser.** They are reasoned about in the code comments, not demonstrated. Treat that as the open risk in this PR.

Hosted end-to-end additionally needs the hub to allowlist a tenant console origin as an OAuth redirect target, which is not ours to configure.

## Documentation

Every non-obvious decision is documented at its call site rather than in a separate note: why the console never assembles a hub URL itself, why `readHubToken` must stay pure under StrictMode, why the URL is cleared with `replaceState` rather than a push, why `company` is deliberately kept while `token` is dropped, and why a failed provider fetch is swallowed rather than surfaced.

## Related

Part of #315; the company picker is not in this PR.

Depends in practice on #321 (`tinyhumansai/opencompany#323`): on a *provisioned* company the admin list is empty, so an ecosystem identity would reach the tenant and always be told `not_a_member`. This PR is what makes that question reachable; #321 is what lets the answer be yes. #323 touches `eligibility()`'s signature in this same file, so whichever lands second needs a small mechanical rebase.
