### PR TITLE
ci: read-only tenant diagnostics workflow

### DIFF
--- a/.github/workflows/diag-tenant.yml
+++ b/.github/workflows/diag-tenant.yml
@@ -1,0 +1,51 @@
+# Read-only tenant diagnostics over the same SSH path the deploy uses.
+# Dumps pod state / events / logs for a staging tenant so a failing rollout can
+# be root-caused without direct cluster access. Never mutates anything. Output
+# is redacted for common credential shapes before it reaches the run log.
+name: Diagnose tenant (read-only)
+
+on:
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: Tenant namespace to inspect
+        type: string
+        default: tenant-smoke1
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Add server to known hosts
+        run: ssh-keyscan -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Dump tenant diagnostics (read-only, redacted)
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          NS: ${{ inputs.namespace }}
+        run: |
+          ssh root@${SSH_HOST} "NS='${NS}' bash -s" <<'REMOTE' \
+            | sed -E 's#(mongodb(\+srv)?://[^:]+:)[^@]+@#\1***@#g; s#(Bearer )[A-Za-z0-9._-]{6,}#\1***#g; s#sntryu_[A-Za-z0-9]+#sntryu_***#g; s#(password|passwd|secret|token)([\"'"'"'=: ]+)[A-Za-z0-9._/+-]{8,}#\1\2***#gI'
+          set -uo pipefail
+          export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+          echo "===== get pods ====="
+          kubectl -n "$NS" get pods -o wide 2>&1 || true
+          echo "===== statefulset image ====="
+          kubectl -n "$NS" get sts opencompany -o jsonpath='{.spec.template.spec.containers[0].image}' 2>&1; echo
+          echo "===== describe pod (events tail) ====="
+          kubectl -n "$NS" describe pod -l app=opencompany 2>&1 | tail -45 || true
+          echo "===== current logs (tail 150) ====="
+          kubectl -n "$NS" logs sts/opencompany --tail=150 2>&1 || true
+          echo "===== previous (crashed) logs (tail 150) ====="
+          kubectl -n "$NS" logs sts/opencompany --previous --tail=150 2>&1 || echo "(no previous container)"
+          echo "===== rollout history ====="
+          kubectl -n "$NS" rollout history statefulset/opencompany 2>&1 || true
+          REMOTE


### PR DESCRIPTION
Read-only workflow_dispatch to dump a staging tenant's pod state/events/logs over the existing deploy SSH path — for root-causing the full-feature rollout 500 on smoke1 without direct cluster access. No mutations; output credential-redacted. Not in deploy-staging's trigger paths, so merging does not deploy.