### PR TITLE
ci: enhance tenant diag (events + wake-capture)

### DIFF
--- a/.github/workflows/diag-tenant.yml
+++ b/.github/workflows/diag-tenant.yml
@@ -1,7 +1,8 @@
-# Read-only tenant diagnostics over the same SSH path the deploy uses.
-# Dumps pod state / events / logs for a staging tenant so a failing rollout can
-# be root-caused without direct cluster access. Never mutates anything. Output
-# is redacted for common credential shapes before it reaches the run log.
+# Read-only-ish tenant diagnostics over the same SSH path the deploy uses.
+# Captures why a staging tenant's rollout produces no healthy pod: events,
+# statefulset status, node pressure, and (optionally) a wake that scales the
+# tenant to 1 and captures the booting pod's state + logs before it dies.
+# Output is redacted for common credential shapes before it reaches the run log.
 name: Diagnose tenant (read-only)
 
 on:
@@ -11,6 +12,10 @@ on:
         description: Tenant namespace to inspect
         type: string
         default: tenant-smoke1
+      wake:
+        description: Scale the tenant to 1 and capture the booting pod (else leave as-is)
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -27,25 +32,38 @@ jobs:
       - name: Add server to known hosts
         run: ssh-keyscan -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
 
-      - name: Dump tenant diagnostics (read-only, redacted)
+      - name: Dump tenant diagnostics (redacted)
         env:
           SSH_HOST: ${{ secrets.SSH_HOST }}
           NS: ${{ inputs.namespace }}
+          WAKE: ${{ inputs.wake }}
         run: |
-          ssh root@${SSH_HOST} "NS='${NS}' bash -s" <<'REMOTE' \
-            | sed -E 's#(mongodb(\+srv)?://[^:]+:)[^@]+@#\1***@#g; s#(Bearer )[A-Za-z0-9._-]{6,}#\1***#g; s#sntryu_[A-Za-z0-9]+#sntryu_***#g; s#(password|passwd|secret|token)([\"'"'"'=: ]+)[A-Za-z0-9._/+-]{8,}#\1\2***#gI'
+          ssh root@${SSH_HOST} "NS='${NS}' WAKE='${WAKE}' bash -s" <<'REMOTE' \
+            | sed -E 's#(mongodb(\+srv)?://[^:]+:)[^@]+@#\1***@#g; s#(Bearer )[A-Za-z0-9._-]{6,}#\1***#g; s#sntryu_[A-Za-z0-9]+#sntryu_***#g; s#((password|passwd|secret|token|apikey|api_key)[\"'"'"'=: ]+)[A-Za-z0-9._/+-]{8,}#\1***#gI'
           set -uo pipefail
           export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-          echo "===== get pods ====="
-          kubectl -n "$NS" get pods -o wide 2>&1 || true
-          echo "===== statefulset image ====="
-          kubectl -n "$NS" get sts opencompany -o jsonpath='{.spec.template.spec.containers[0].image}' 2>&1; echo
-          echo "===== describe pod (events tail) ====="
-          kubectl -n "$NS" describe pod -l app=opencompany 2>&1 | tail -45 || true
-          echo "===== current logs (tail 150) ====="
-          kubectl -n "$NS" logs sts/opencompany --tail=150 2>&1 || true
-          echo "===== previous (crashed) logs (tail 150) ====="
-          kubectl -n "$NS" logs sts/opencompany --previous --tail=150 2>&1 || echo "(no previous container)"
-          echo "===== rollout history ====="
-          kubectl -n "$NS" rollout history statefulset/opencompany 2>&1 || true
+          echo "===== statefulset status ====="
+          kubectl -n "$NS" get sts opencompany -o custom-columns=REPLICAS:.spec.replicas,READY:.status.readyReplicas,CURRENT:.status.currentReplicas,IMG:.spec.template.spec.containers[0].image 2>&1 || true
+          echo "===== describe statefulset (events tail) ====="
+          kubectl -n "$NS" describe sts opencompany 2>&1 | tail -30 || true
+          echo "===== namespace events (recent) ====="
+          kubectl -n "$NS" get events --sort-by=.lastTimestamp 2>&1 | tail -40 || true
+          echo "===== node pressure / allocatable ====="
+          kubectl describe nodes 2>&1 | grep -EA6 'Allocated resources|MemoryPressure|DiskPressure' | head -40 || true
+          if [ "$WAKE" = "true" ]; then
+            echo "===== WAKE: scale to 1 + capture ====="
+            kubectl -n "$NS" scale sts/opencompany --replicas=1 2>&1 || true
+            for i in $(seq 1 12); do
+              sleep 8
+              line=$(kubectl -n "$NS" get pods -o wide --no-headers 2>&1 | head -3)
+              echo "[t+$((i*8))s] $line"
+            done
+            echo "----- pod describe (events) -----"
+            kubectl -n "$NS" describe pod -l app=opencompany 2>&1 | sed -n '/Events:/,$p' | head -30 || true
+            echo "----- pod logs (current, tail 200) -----"
+            kubectl -n "$NS" logs -l app=opencompany --tail=200 --all-containers 2>&1 | tail -200 || true
+            echo "----- pod logs (previous, tail 200) -----"
+            kubectl -n "$NS" logs -l app=opencompany --previous --tail=200 --all-containers 2>&1 | tail -200 || echo "(no previous)"
+          fi
+          echo "===== done ====="
           REMOTE


### PR DESCRIPTION
Enhance the diag workflow to root-cause smoke1: no pod exists (scale-to-zero), so capture events + node pressure + a wake that scales to 1 and grabs the booting pod's logs/events before it dies. Read-only except the benign scale (what a request would do anyway).