### PR TITLE
feat(workspace): wire the console Workspace tab to the real backend store (#177)

### DIFF
--- a/companies/e2e_harness/company.toml
+++ b/companies/e2e_harness/company.toml
@@ -37,7 +37,7 @@ admins = ["harness-e2e@tinyhumans.ai"]
 # Both forms are needed: this list is matched with exact/glob semantics, so bare
 # `workspace` covers an agent asking for `workspace` but NOT one asking for
 # `workspace.read`, and `workspace.*` covers the sub-grants but not the bare one.
-allow = ["composio", "workspace", "workspace.*"]
+allow = ["composio", "mcp:*", "workspace", "workspace.*"]
 
 [[agent]]
 id = "ceo"

--- a/companies/e2e_harness/company.toml
+++ b/companies/e2e_harness/company.toml
@@ -28,26 +28,39 @@ admins = ["harness-e2e@tinyhumans.ai"]
 [tools]
 # Composio integration tools (Gmail/Slack/GitHub). Fail-closed until a
 # per-company Composio bearer is set via the console.
-allow = ["composio"]
+#
+# `workspace` opens the company's own note tree — the same tree the console's
+# Workspace tab reads and writes (issue #177). Without it here, no agent gets so
+# much as `workspace_list`, because every agent below lists its tools explicitly
+# and per-agent grants are narrowed by this allow-list.
+#
+# Both forms are needed: this list is matched with exact/glob semantics, so bare
+# `workspace` covers an agent asking for `workspace` but NOT one asking for
+# `workspace.read`, and `workspace.*` covers the sub-grants but not the bare one.
+allow = ["composio", "workspace", "workspace.*"]
 
 [[agent]]
 id = "ceo"
 role = "Chief Executive"
 description = "Sets direction, answers about the company, and delegates the work."
 tier = "orchestrator"
-tools = ["mcp:*", "composio"]
+# `workspace.read` is read-only by design: writes need a bare `workspace` or an
+# explicit `workspace.write`, so this cannot silently overwrite operator notes.
+tools = ["mcp:*", "composio", "workspace.read"]
 
 [[agent]]
 id = "engineer"
 role = "Engineer"
 description = "Explains how things are built and proposes technical plans."
-tools = ["mcp:*", "composio"]
+tools = ["mcp:*", "composio", "workspace.read"]
 
 [[agent]]
 id = "writer"
 role = "Writer"
 description = "Turns rough notes into short, clear written drafts."
-tools = ["mcp:*", "composio"]
+# The one agent that may edit a note, so the "an agent wrote it, the operator
+# sees it" round trip is demonstrable out of the box.
+tools = ["mcp:*", "composio", "workspace"]
 
 [[group_chat]]
 id = "engineering"

--- a/companies/e2e_harness/workspace/README.md
+++ b/companies/e2e_harness/workspace/README.md
@@ -1,0 +1,10 @@
+# Workspace
+
+The company's shared note tree, Obsidian-style. Organize work in **folders**,
+write in **Markdown**, and link notes with `[[wiki links]]`.
+
+This tree is real and durable: it lives on the host in the company's workspace
+store, not in your browser. Whatever you write here, the company's agents can
+read on their next turn — and a note an agent writes shows up here.
+
+See [[Standards]] for the conventions the agents are asked to follow.

--- a/companies/e2e_harness/workspace/Standards.md
+++ b/companies/e2e_harness/workspace/Standards.md
@@ -1,0 +1,9 @@
+# Standards
+
+House conventions for anything this company writes.
+
+- Lead with the answer; put the reasoning under it.
+- Plain words over jargon. Short sentences.
+- Say what is uncertain rather than smoothing over it.
+
+Linked from [[README]], so the backlinks panel has something real to show.

--- a/companies/openhuman_demo/company.toml
+++ b/companies/openhuman_demo/company.toml
@@ -31,7 +31,7 @@ mode = "full"
 # Both forms are needed: this list is matched with exact/glob semantics, so bare
 # `workspace` covers an agent asking for `workspace` but NOT one asking for
 # `workspace.read`, and `workspace.*` covers the sub-grants but not the bare one.
-allow = ["workspace", "workspace.*"]
+allow = ["mcp:*", "workspace", "workspace.*"]
 
 [[agent]]
 id = "ceo"

--- a/companies/openhuman_demo/company.toml
+++ b/companies/openhuman_demo/company.toml
@@ -23,6 +23,16 @@ human_role = "Steering the company and approving anything costly"
 # every agent action, or `readonly` to block mutations entirely.
 mode = "full"
 
+[tools]
+# The company's own note tree — the same one the console's Workspace tab reads
+# and writes (issue #177). An agent-requested grant is narrowed by this list, so
+# without `workspace` here no agent below would receive even `workspace_list`.
+#
+# Both forms are needed: this list is matched with exact/glob semantics, so bare
+# `workspace` covers an agent asking for `workspace` but NOT one asking for
+# `workspace.read`, and `workspace.*` covers the sub-grants but not the bare one.
+allow = ["workspace", "workspace.*"]
+
 [[agent]]
 id = "ceo"
 role = "Chief Executive"
@@ -31,19 +41,23 @@ description = "Sets direction, answers about the company, and delegates the work
 # whole-company context and delegate to the desks below. `mcp:*` grants the
 # remote MCP tool servers declared in `[[mcp_server]]`.
 tier = "orchestrator"
-tools = ["mcp:*"]
+# `workspace.read` is read-only by design: writes need a bare `workspace` or an
+# explicit `workspace.write`, so this cannot silently overwrite operator notes.
+tools = ["mcp:*", "workspace.read"]
 
 [[agent]]
 id = "engineer"
 role = "Engineer"
 description = "Explains how things are built and proposes technical plans."
-tools = ["mcp:*"]
+tools = ["mcp:*", "workspace.read"]
 
 [[agent]]
 id = "writer"
 role = "Writer"
 description = "Turns rough notes into short, clear written drafts."
-tools = ["mcp:*"]
+# The one agent that may edit a note, so the "an agent wrote it, the operator
+# sees it" round trip is demonstrable out of the box.
+tools = ["mcp:*", "workspace"]
 
 # Desks (group chats) the orchestrator can hand a turn to. Each desk's first
 # member is its lead; `delegate_to_desk` runs that member's turn.

--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -38,7 +38,7 @@ address check for `{id}`, operator + `sole()` for the alias).
 |---|---|
 | `tasks` | `POST …/tasks`, `PATCH`/`DELETE …/tasks/{id}` |
 | `memory` | `POST …/memory`, `DELETE …/memory/{id}` (journals `MemoryFactDeleted`) |
-| `workspace` | `POST …/workspace`, `PUT …/workspace/file/{id}`, `PATCH`/`DELETE …/workspace/{id}` |
+| `workspace` | `GET …/workspace`, `GET …/workspace/file/{id}`, `POST …/workspace`, `PUT …/workspace/file/{id}`, `PATCH`/`DELETE …/workspace/{id}` (the two `GET`s are REST twins of the GraphQL reads — the console has no GraphQL client, #177) |
 | `skills` | `POST …/skills`, `GET …/skills/registry`, `POST …/skills/{slug}/install\|uninstall`, `PUT …/skills/{slug}` |
 | `team` | `POST …/team`, `DELETE …/team/{id}`, `PUT …/team/{id}/inbox` (overlay; roster-only in v1) |
 | `mail` | `POST …/inboxes/{key}/read` |

--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -37,10 +37,10 @@ with no `{id}`.
 The console's writes are a REST router family under `src/server/ops/`, each
 route registered under **both** scope forms (`…/companies/{id}/…` and the
 `…/company/…` prosumer alias) by the `scoped` helper. These are the mutations,
-plus **one deliberate read exception**: the two inbox `GET`s at the end of the
-block below. Every other console read goes through GraphQL (see the read plane
-below). Anything a build doesn't serve `404`s — the console treats that as "not
-wired yet".
+plus **two deliberate read exceptions**: the two inbox `GET`s at the end of the
+block below, and the two workspace `GET`s (#177). Every other console read goes
+through GraphQL (see the read plane below). Anything a build doesn't serve
+`404`s — the console treats that as "not wired yet".
 
 ```text
 POST   …/tasks                              create a task card (`originChatId` records the thread it came from, #246)
@@ -48,6 +48,8 @@ PATCH  …/tasks/{taskId}                      edit / move a task
 DELETE …/tasks/{taskId}                      delete a task
 POST   …/memory                             add a memory fact
 DELETE …/memory/{factId}                     delete a memory fact
+GET    …/workspace                          the whole tree (metadata; no bodies)
+GET    …/workspace/file/{nodeId}             one file: content + inbound backlinks
 POST   …/workspace                          create a folder/file (or upload)
 PUT    …/workspace/file/{nodeId}             write file content
 PATCH  …/workspace/{nodeId}                  rename / move
@@ -75,6 +77,19 @@ into, and `GET …/team` tags each teammate with `inboxEnabled` so the Team togg
 reflects that store too. Messages come back in append order; the console sorts
 them newest-first. The GraphQL resolver stays the canonical read for any client
 that does speak GraphQL — these routes duplicate it, they do not replace it.
+
+The two workspace `GET`s are the same story one issue later (#177): the console
+had no reachable workspace read either, so the Workspace tab persisted to
+`localStorage` and the operator and the agents looked at two different trees —
+a note written by an agent through its `workspace_*` tools (#237) was invisible
+to the operator, and vice versa. They are REST twins of `Company.workspaceTree`
+/ `workspaceFile`, differing only in timestamp shape (epoch millis, matching
+every other console read, rather than ISO-8601 strings). The backlink scan is
+literally shared code (`company::workspace_links`), so the two surfaces cannot
+report different backlinks for the same note. The tree read carries metadata
+only — bodies are fetched per file, so a navigation read does not grow with the
+size of the workspace. Reading a folder id as a file is a `404`, never an empty
+note.
 
 Team writes are an **operator overlay** persisted through the store, merged
 into the manifest roster at read time — the version-controlled `company.toml`
@@ -133,8 +148,9 @@ separate work.
 
 Every console **read** is served by a single async-graphql query surface at
 `POST /graphql` (with a `GET /graphql` GraphiQL explorer in development) — the
-sole exception being the two inbox `GET`s above, which exist because the console
-ships no GraphQL client and the Inbox view needs a per-agent read. The schema is
+sole exceptions being the two inbox `GET`s and the two workspace `GET`s above,
+which exist because the console ships no GraphQL client and those two views need
+a reachable read (issues #173 and #177 respectively). The schema is
 query-only — REST otherwise owns writes — and is **built once at startup** and
 stored on `AppState`; each request injects its resolved `GqlAuth` principal.
 

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -1,0 +1,142 @@
+// The live workspace API: the console reads and writes the company's real
+// durable note tree through the host's `…/workspace` routes (REST, camelCase
+// over the wire). Replaces the client-side `lib/workspace` localStorage stub —
+// the same move `api/memory.ts` made for the Brain — so the operator and the
+// agents finally look at one tree instead of two.
+//
+// Agents reach the same store through the `workspace_list` / `workspace_read` /
+// `workspace_write` tools (issue #237), which means a note written by an agent
+// shows up here and a note the operator writes here is readable by an agent on
+// its next turn.
+
+import type { OpenCompanyClient } from "./client";
+
+/** Whether a node is a folder or a file. */
+export type NodeKind = "folder" | "file";
+
+/**
+ * One node in the workspace tree, as the host returns it.
+ *
+ * The tree read carries metadata only — `content` is always absent there, and a
+ * body is fetched per file by {@link fetchFile}. `parentId` is normalized to
+ * `null` at the workspace root (the host omits the field entirely).
+ */
+export interface FsNode {
+  id: string;
+  name: string;
+  kind: NodeKind;
+  /** null = workspace root. */
+  parentId: string | null;
+  /** Markdown body. Only ever set on a node built from a file read. */
+  content?: string;
+  /** Epoch-millis of the last update. */
+  updatedAt: number;
+}
+
+/** One file's body plus the notes that link to it, from `GET …/workspace/file/{id}`. */
+export interface WorkspaceFile {
+  id: string;
+  name: string;
+  content: string;
+  updatedAt: number;
+  /** Other files whose content links to this one via `[[name]]` — computed by the host. */
+  backlinks: FsNode[];
+}
+
+/** The wire shape: `parentId` is omitted at the root rather than sent as null. */
+interface FsNodeWire extends Omit<FsNode, "parentId"> {
+  parentId?: string | null;
+}
+
+/**
+ * Normalizes a node off the wire. The host omits `parentId` at the workspace
+ * root (`skip_serializing_if = "Option::is_none"`), and every tree query in the
+ * view keys off `parentId === null`, so an absent field becomes an explicit
+ * null exactly once — here — rather than at each call site.
+ */
+function normalize(node: FsNodeWire): FsNode {
+  return { ...node, parentId: node.parentId ?? null };
+}
+
+/** Every node in the company's workspace (metadata only; no bodies). */
+export async function fetchTree(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<FsNode[]> {
+  const nodes = await client.get<FsNodeWire[]>(`${client.scopeFor(company)}/workspace`);
+  return nodes.map(normalize);
+}
+
+/** One file's content and its server-computed backlinks. 404s on a folder id. */
+export async function fetchFile(
+  client: OpenCompanyClient,
+  company: string | null,
+  id: string,
+): Promise<WorkspaceFile> {
+  const file = await client.get<Omit<WorkspaceFile, "backlinks"> & { backlinks: FsNodeWire[] }>(
+    `${client.scopeFor(company)}/workspace/file/${encodeURIComponent(id)}`,
+  );
+  return { ...file, backlinks: file.backlinks.map(normalize) };
+}
+
+/** Create a folder or file. The host mints the id and the timestamp. */
+export async function createNode(
+  client: OpenCompanyClient,
+  company: string | null,
+  input: { name: string; kind: NodeKind; parentId?: string | null; content?: string },
+): Promise<FsNode> {
+  const node = await client.post<FsNodeWire>(`${client.scopeFor(company)}/workspace`, input);
+  return normalize(node);
+}
+
+/** Overwrite a file's content; returns the new last-updated stamp. */
+export function writeFile(
+  client: OpenCompanyClient,
+  company: string | null,
+  id: string,
+  content: string,
+): Promise<{ updatedAt: number }> {
+  return client.put<{ updatedAt: number }>(
+    `${client.scopeFor(company)}/workspace/file/${encodeURIComponent(id)}`,
+    { content },
+  );
+}
+
+/**
+ * Rename and/or move a node, returning the authoritative node.
+ *
+ * The `parentId` contract is a double option and the distinction is load-bearing:
+ * **omit** the key to leave the parent alone (a pure rename), and pass an
+ * explicit `null` to move the node back to the workspace root. `JSON.stringify`
+ * drops `undefined` properties but keeps `null`, so building the body
+ * conditionally — as below — maps straight onto the server's
+ * `Option<Option<String>>`. Spreading `{ parentId }` unconditionally would turn
+ * every rename into a move-to-root.
+ *
+ * The move-cycle guard (a folder into its own descendant) is the store's, not
+ * the console's: it answers 400 `invalid_request`.
+ */
+export async function renameMoveNode(
+  client: OpenCompanyClient,
+  company: string | null,
+  id: string,
+  changes: { name?: string; parentId?: string | null },
+): Promise<FsNode> {
+  const body: { name?: string; parentId?: string | null } = {};
+  if (changes.name !== undefined) body.name = changes.name;
+  if ("parentId" in changes) body.parentId = changes.parentId ?? null;
+  const node = await client.patch<FsNodeWire>(
+    `${client.scopeFor(company)}/workspace/${encodeURIComponent(id)}`,
+    body,
+  );
+  return normalize(node);
+}
+
+/** Delete a node; folders go recursively. */
+export function deleteNode(
+  client: OpenCompanyClient,
+  company: string | null,
+  id: string,
+): Promise<void> {
+  return client.del<void>(`${client.scopeFor(company)}/workspace/${encodeURIComponent(id)}`);
+}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -604,7 +604,7 @@ export function AppShell({
                 </div>
               }
             >
-              <WorkspaceView company={company} />
+              <WorkspaceView client={client} company={company} />
             </Suspense>
           )}
           {view === "approvals" && (

--- a/frontend/src/lib/workspace.ts
+++ b/frontend/src/lib/workspace.ts
@@ -1,23 +1,19 @@
-// The team's workspace: a client-side file tree (folders + markdown files) the
-// operator can organize, edit, upload to, and delete. Persisted to
-// localStorage per company — the console has no file API yet, so this is a
-// local working surface (a Drive/Notion-style scratch space).
+// Pure tree helpers for the team's workspace — a real, durable file tree of
+// folders and markdown notes that lives on the **host**, in the company's
+// `WorkspaceStore`. The console reads and writes it over the `…/workspace`
+// routes in `@/api/workspace`; the company's agents read and write the same
+// tree through their workspace tools, so operator and agents share one surface.
+//
+// Nothing here persists anything. These are the derivations the view needs on
+// top of a tree it has already fetched (ordering, ancestry, wiki-link title
+// resolution). The one localStorage touch left is the *migration* pair at the
+// bottom, which exists solely to rescue notes typed into the retired
+// client-side scratchpad and is expected to become a no-op once every browser
+// has been through it once.
 
-export interface FsNode {
-  id: string;
-  name: string;
-  kind: "folder" | "file";
-  /** null = workspace root. */
-  parentId: string | null;
-  /** Markdown body for files. */
-  content?: string;
-  updatedAt: number;
-}
+export type { FsNode } from "@/api/workspace";
 
-let n = 0;
-const genId = () => `fs-${Date.now().toString(36)}-${n++}`;
-
-const now = () => Date.now();
+import type { FsNode } from "@/api/workspace";
 
 /* ---- queries ---- */
 
@@ -34,7 +30,15 @@ export function nodeById(nodes: FsNode[], id: string | null): FsNode | undefined
   return id ? nodes.find((x) => x.id === id) : undefined;
 }
 
-/** A file's display title — its name without the markdown extension. */
+/**
+ * A file's display title — its name without the markdown extension.
+ *
+ * Known divergence: this strips `.md`, `.markdown` and `.txt`, while the host's
+ * `link_target` (which computes backlinks) strips only `.md`. So a `[[link]]`
+ * to a `.txt` note styles as resolved here but is not counted as a backlink
+ * server-side. Cosmetic, and deliberately left alone — the seeder only ever
+ * creates `.md` notes, and narrowing this would silently restyle existing links.
+ */
 export function titleOf(node: FsNode): string {
   return node.name.replace(/\.(md|markdown|txt)$/i, "");
 }
@@ -43,19 +47,6 @@ export function titleOf(node: FsNode): string {
 export function fileByTitle(nodes: FsNode[], target: string): FsNode | undefined {
   const want = target.trim().toLowerCase();
   return nodes.find((x) => x.kind === "file" && titleOf(x).toLowerCase() === want);
-}
-
-/** Files whose body links to `target`'s title via `[[…]]` (backlinks). */
-export function backlinksTo(nodes: FsNode[], target: FsNode): FsNode[] {
-  const title = titleOf(target).toLowerCase();
-  const re = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g;
-  return nodes.filter((x) => {
-    if (x.kind !== "file" || x.id === target.id || !x.content) return false;
-    for (const m of x.content.matchAll(re)) {
-      if (m[1].trim().toLowerCase() === title) return true;
-    }
-    return false;
-  });
 }
 
 /** Ancestor folders (root → current), for breadcrumbs. */
@@ -85,114 +76,71 @@ export function subtreeIds(nodes: FsNode[], id: string): Set<string> {
   return ids;
 }
 
-/* ---- mutations (pure; return a new array) ---- */
-
-export function addFolder(nodes: FsNode[], parentId: string | null, name: string): FsNode[] {
-  return [...nodes, { id: genId(), name: name.trim() || "New folder", kind: "folder", parentId, updatedAt: now() }];
-}
-
-export function addFile(
-  nodes: FsNode[],
-  parentId: string | null,
-  name: string,
-  content = "",
-): { nodes: FsNode[]; id: string } {
-  const id = genId();
-  const fileName = ensureMdExt(name.trim() || "Untitled");
-  return {
-    nodes: [...nodes, { id, name: fileName, kind: "file", parentId, content, updatedAt: now() }],
-    id,
-  };
-}
-
-export function renameNode(nodes: FsNode[], id: string, name: string): FsNode[] {
-  const target = nodeById(nodes, id);
-  const next = target?.kind === "file" ? ensureMdExt(name.trim()) : name.trim();
-  return nodes.map((x) => (x.id === id ? { ...x, name: next || x.name, updatedAt: now() } : x));
-}
-
-export function removeNode(nodes: FsNode[], id: string): FsNode[] {
-  const ids = subtreeIds(nodes, id);
-  return nodes.filter((x) => !ids.has(x.id));
-}
-
-export function moveNode(nodes: FsNode[], id: string, newParentId: string | null): FsNode[] {
-  // Never move a folder into itself or a descendant.
-  const blocked = subtreeIds(nodes, id);
-  if (newParentId && blocked.has(newParentId)) return nodes;
-  return nodes.map((x) => (x.id === id ? { ...x, parentId: newParentId, updatedAt: now() } : x));
-}
-
-export function setContent(nodes: FsNode[], id: string, content: string): FsNode[] {
-  return nodes.map((x) => (x.id === id ? { ...x, content, updatedAt: now() } : x));
-}
-
-function ensureMdExt(name: string): string {
+/** Notes get a markdown extension unless they already carry a known one. */
+export function ensureMdExt(name: string): string {
   return /\.(md|markdown|txt)$/i.test(name) ? name : `${name}.md`;
 }
 
-/* ---- persistence ---- */
+/* ---- migration off the retired localStorage scratchpad ---- */
 
 const KEY = (company: string | null) => `oc-workspace:${company ?? "single"}`;
 
-export function loadWorkspace(company: string | null): FsNode[] {
+/**
+ * Ids the *bundled seed* used. These four nodes were app source shipped to
+ * every browser — marketing copy about a "Spring launch" campaign that belonged
+ * to no real company. They carry zero user information, so they are dropped
+ * rather than imported: pushing them into the host would inject invented
+ * content into every company's genuine workspace.
+ */
+const SEED_ID_PREFIX = "seed-";
+
+/**
+ * Notes a user actually typed into the old client-side workspace, if any.
+ *
+ * Returns only nodes the *user* authored (the retired `addFile`/`addFolder`
+ * minted `fs-…` ids); bundled seed nodes are filtered out. An empty array means
+ * there is nothing worth rescuing — either the key is absent, unparseable, or
+ * holds nothing but the seed.
+ */
+export function readLegacyLocalNodes(company: string | null): FsNode[] {
+  let raw: string | null = null;
   try {
-    const raw = localStorage.getItem(KEY(company));
-    if (raw) return JSON.parse(raw) as FsNode[];
+    raw = localStorage.getItem(KEY(company));
   } catch {
-    /* fall through to seed */
+    return [];
   }
-  return seedWorkspace();
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter(
+    (node): node is FsNode =>
+      Boolean(node) &&
+      typeof (node as FsNode).id === "string" &&
+      typeof (node as FsNode).name === "string" &&
+      ((node as FsNode).kind === "file" || (node as FsNode).kind === "folder") &&
+      !(node as FsNode).id.startsWith(SEED_ID_PREFIX),
+  );
 }
 
-export function saveWorkspace(company: string | null, nodes: FsNode[]): void {
+/** Whether the legacy key exists at all (so a seed-only key can be swept). */
+export function hasLegacyLocal(company: string | null): boolean {
   try {
-    localStorage.setItem(KEY(company), JSON.stringify(nodes));
+    return localStorage.getItem(KEY(company)) !== null;
   } catch {
-    /* storage unavailable — keep the in-memory tree */
+    return false;
   }
 }
 
-/* ---- seed ---- */
-
-function seedWorkspace(): FsNode[] {
-  const campaigns: FsNode = { id: "seed-campaigns", name: "Campaigns", kind: "folder", parentId: null, updatedAt: now() };
-  const brand: FsNode = { id: "seed-brand", name: "Brand", kind: "folder", parentId: null, updatedAt: now() };
-  return [
-    campaigns,
-    brand,
-    {
-      id: "seed-readme",
-      name: "README.md",
-      kind: "file",
-      parentId: null,
-      updatedAt: now(),
-      content:
-        "# Workspace\n\nThe team's shared space, Obsidian-style. Organize work in **folders**, " +
-        "write in **Markdown**, and link notes with `[[wiki links]]`.\n\n" +
-        "Start here:\n\n- [[Spring launch]] — the campaign in flight\n- [[Brand voice]] — how we sound\n\n" +
-        "Use the explorer on the left to browse, and the backlinks panel to see what links here.\n",
-    },
-    {
-      id: "seed-spring",
-      name: "Spring launch.md",
-      kind: "file",
-      parentId: "seed-campaigns",
-      updatedAt: now(),
-      content:
-        "# Spring launch\n\nFollows our [[Brand voice]].\n\n## Goals\n- Drive signups from the spring push\n" +
-        "- 3 hero taglines in review\n\n## Checklist\n" +
-        "- [x] Brief approved\n- [ ] Taglines drafted\n- [ ] Hero image\n- [ ] Landing page\n\n> Owner: Creative studio\n",
-    },
-    {
-      id: "seed-voice",
-      name: "Brand voice.md",
-      kind: "file",
-      parentId: "seed-brand",
-      updatedAt: now(),
-      content:
-        "# Brand voice\n\nWarm, confident, concise.\n\n| Do | Don't |\n| --- | --- |\n| Speak plainly | Use jargon |\n" +
-        "| Lead with value | Bury the point |\n",
-    },
-  ];
+/** Drop the retired scratchpad for this company. */
+export function clearLegacyLocal(company: string | null): void {
+  try {
+    localStorage.removeItem(KEY(company));
+  } catch {
+    /* storage unavailable — nothing to clear */
+  }
 }

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ChevronDown,
   ChevronRight,
@@ -8,13 +8,28 @@ import {
   FolderOpen,
   FolderPlus,
   Link2,
+  Loader2,
   MoreHorizontal,
   PanelLeft,
+  RefreshCw,
   Upload,
 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { toast } from "sonner";
 
+import { ApiError } from "@/api/types";
+import type { OpenCompanyClient } from "@/api/client";
+import {
+  createNode,
+  deleteNode as deleteNodeApi,
+  fetchFile,
+  fetchTree,
+  renameMoveNode,
+  writeFile,
+  type WorkspaceFile,
+} from "@/api/workspace";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -35,62 +50,338 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import {
-  addFile,
-  addFolder,
-  backlinksTo,
   childrenOf,
+  clearLegacyLocal,
+  ensureMdExt,
   fileByTitle,
   type FsNode,
-  loadWorkspace,
-  moveNode,
+  hasLegacyLocal,
   nodeById,
   pathOf,
-  removeNode,
-  renameNode,
-  saveWorkspace,
-  setContent,
+  readLegacyLocalNodes,
   subtreeIds,
   titleOf,
 } from "@/lib/workspace";
 
 interface Props {
+  client: OpenCompanyClient;
   company: string | null;
 }
 
-/** An Obsidian-style workspace: a file-tree explorer, a markdown note pane with
- *  `[[wiki links]]`, and a backlinks panel. */
-export function WorkspaceView({ company }: Props) {
-  const [nodes, setNodes] = useState<FsNode[]>(() => loadWorkspace(company));
+/** How long typing settles before the editor pushes a save to the host. */
+const AUTOSAVE_DELAY_MS = 800;
+
+/** The folder created to hold notes rescued from the retired local scratchpad. */
+const IMPORT_FOLDER_NAME = "Imported from this browser";
+
+/** What the editor's status line is currently reporting. */
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+/** Formats an epoch-millis instant for the open note's header. */
+function formatUpdated(ms: number): string {
+  if (!ms) return "—";
+  return new Date(ms).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+/** Whether a failed request was a 404 (the note is gone on the host). */
+function isNotFound(e: unknown): boolean {
+  return e instanceof ApiError && e.status === 404;
+}
+
+function message(e: unknown, fallback: string): string {
+  return e instanceof Error ? e.message : fallback;
+}
+
+/**
+ * An Obsidian-style workspace: a file-tree explorer, a markdown note pane with
+ * `[[wiki links]]`, and a backlinks panel — all of it the company's **real**
+ * workspace, read and written on the host over `…/workspace` (issue #177).
+ *
+ * This used to be a localStorage scratchpad seeded with invented marketing
+ * notes, so the operator's workspace and the one the agents read and write
+ * (their `workspace_*` tools, issue #237) were two unrelated trees. Now there is
+ * one: a note an agent writes shows up here on the next refresh, and a note
+ * typed here is readable by an agent on its next turn.
+ *
+ * Writes are **apply-on-ack**, never optimistic — every mutation returns the
+ * authoritative node, so local state is patched from the response and a failure
+ * simply leaves the tree as it was. The editor is the one exception: it keeps a
+ * local dirty buffer so typing is never blocked on (or lost to) the network.
+ *
+ * Two gaps are deliberate and tracked rather than worked around: notes carry no
+ * authorship, so an agent's note is indistinguishable from the operator's
+ * (#326), and there is no live push, so a write that lands while the tab is open
+ * appears on refresh/refocus rather than instantly (#327).
+ */
+export function WorkspaceView({ client, company }: Props) {
+  const [nodes, setNodes] = useState<FsNode[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
   const [openId, setOpenId] = useState<string | null>(null);
+  const [openFile, setOpenFile] = useState<WorkspaceFile | null>(null);
+  const [fileError, setFileError] = useState<string | null>(null);
+
   const [mode, setMode] = useState<"read" | "edit">("read");
-  const [expanded, setExpanded] = useState<Set<string>>(
-    () => new Set(childrenOf(loadWorkspace(company), null).filter((n) => n.kind === "folder").map((n) => n.id)),
-  );
+  const [draft, setDraft] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   const [prompt, setPrompt] = useState<PromptState | null>(null);
   const [moving, setMoving] = useState<FsNode | null>(null);
   const [showExplorer, setShowExplorer] = useState(true);
+  const [legacy, setLegacy] = useState<FsNode[]>([]);
+  const [importing, setImporting] = useState(false);
   const uploadRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    saveWorkspace(company, nodes);
-  }, [company, nodes]);
+  // Generation tokens so a response from a previous company scope (or from a
+  // file that has since been closed) can never overwrite the current one.
+  const treeGen = useRef(0);
+  const fileGen = useRef(0);
+  // Whether the explorer's initial folder expansion has happened yet, so a later
+  // refresh never re-opens folders the operator collapsed.
+  const expandedSeeded = useRef(false);
 
-  const openFile = nodeById(nodes, openId);
-  const backlinks = useMemo(
-    () => (openFile ? backlinksTo(nodes, openFile) : []),
-    [nodes, openFile],
+  /* ---- tree ---- */
+
+  const loadTree = useCallback(
+    async (opts?: { silent?: boolean }) => {
+      const mine = ++treeGen.current;
+      if (opts?.silent) setRefreshing(true);
+      else setLoading(true);
+      try {
+        const tree = await fetchTree(client, company);
+        if (mine !== treeGen.current) return;
+        setNodes(tree);
+        setError(null);
+        if (!expandedSeeded.current) {
+          expandedSeeded.current = true;
+          setExpanded(
+            new Set(
+              childrenOf(tree, null)
+                .filter((n) => n.kind === "folder")
+                .map((n) => n.id),
+            ),
+          );
+        }
+      } catch (e) {
+        if (mine !== treeGen.current) return;
+        setError(message(e, "could not load the workspace"));
+      } finally {
+        if (mine === treeGen.current) {
+          setLoading(false);
+          setRefreshing(false);
+        }
+      }
+    },
+    [client, company],
   );
 
-  function open(id: string) {
+  // Mount / company change: reset every scoped piece of state, then load.
+  useEffect(() => {
+    expandedSeeded.current = false;
+    setNodes([]);
+    setOpenId(null);
+    setOpenFile(null);
+    setDraft(null);
+    setSaveState("idle");
+    setExpanded(new Set());
+    void loadTree();
+    return () => {
+      treeGen.current++;
+      fileGen.current++;
+    };
+  }, [loadTree]);
+
+  /* ---- the open note ---- */
+
+  const loadFile = useCallback(
+    async (id: string) => {
+      const mine = ++fileGen.current;
+      try {
+        const file = await fetchFile(client, company, id);
+        if (mine !== fileGen.current) return file;
+        setOpenFile(file);
+        setFileError(null);
+        return file;
+      } catch (e) {
+        if (mine !== fileGen.current) return null;
+        setOpenFile(null);
+        setFileError(message(e, "could not open this note"));
+        return null;
+      }
+    },
+    [client, company],
+  );
+
+  /* ---- the editor's dirty buffer ---- */
+
+  // The pending save, held in a ref so the debounce timer and the unmount
+  // cleanup both see the latest value without re-subscribing on every keystroke.
+  const pending = useRef<{ id: string; content: string } | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const flush = useCallback(async () => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+    const job = pending.current;
+    if (!job) return;
+    pending.current = null;
+    setSaveState("saving");
+    try {
+      const ack = await writeFile(client, company, job.id, job.content);
+      setSaveState("saved");
+      // Patch the authoritative stamp onto both the open file and the tree row,
+      // so "last updated" is the host's answer and not a guess.
+      setOpenFile((f) =>
+        f && f.id === job.id ? { ...f, content: job.content, updatedAt: ack.updatedAt } : f,
+      );
+      setNodes((all) =>
+        all.map((n) => (n.id === job.id ? { ...n, updatedAt: ack.updatedAt } : n)),
+      );
+    } catch (e) {
+      // Keep the buffer: the operator's text is never dropped because a save
+      // failed. A 404 means the note is gone on the host, which needs a decision
+      // rather than a retry, so say so explicitly.
+      pending.current = job;
+      setSaveState("error");
+      if (isNotFound(e)) {
+        toast.error("This note no longer exists on the host.", {
+          description: "Someone deleted it. Your text is still here — save it as a new note.",
+        });
+      } else {
+        toast.error(message(e, "could not save this note"));
+      }
+    }
+  }, [client, company]);
+
+  // Always flush through the newest closure, including from cleanup callbacks
+  // that captured an older one.
+  const flushRef = useRef(flush);
+  useEffect(() => {
+    flushRef.current = flush;
+  }, [flush]);
+
+  // Unmounting (tab switch, sign-out) must not silently drop buffered typing.
+  useEffect(() => {
+    return () => {
+      void flushRef.current();
+    };
+  }, []);
+
+  function onEdit(id: string, content: string) {
+    setDraft(content);
+    setSaveState("idle");
+    pending.current = { id, content };
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => void flushRef.current(), AUTOSAVE_DELAY_MS);
+  }
+
+  /* ---- refresh on refocus ---- */
+
+  // No live push (#327): a note written by an agent or another browser is
+  // invisible until we ask again. Coming back to the tab is the moment an
+  // operator most expects to see current state, so refetch quietly there.
+  useEffect(() => {
+    const refresh = () => {
+      if (document.visibilityState === "visible") void loadTree({ silent: true });
+    };
+    window.addEventListener("focus", refresh);
+    document.addEventListener("visibilitychange", refresh);
+    return () => {
+      window.removeEventListener("focus", refresh);
+      document.removeEventListener("visibilitychange", refresh);
+    };
+  }, [loadTree]);
+
+  /* ---- migration off the retired localStorage scratchpad ---- */
+
+  useEffect(() => {
+    const mine = readLegacyLocalNodes(company);
+    if (mine.length > 0) {
+      setLegacy(mine);
+      return;
+    }
+    // A key holding nothing but the bundled seed is app-shipped bytes with zero
+    // user information — sweep it silently rather than offering to import
+    // invented marketing copy into a real company's workspace.
+    if (hasLegacyLocal(company)) clearLegacyLocal(company);
+    setLegacy([]);
+  }, [company]);
+
+  async function importLegacy() {
+    setImporting(true);
+    try {
+      const root = await createNode(client, company, {
+        name: IMPORT_FOLDER_NAME,
+        kind: "folder",
+      });
+      // Folders first, so a child's remapped parent id always exists by the time
+      // it is created. Old ids are local-only and meaningless to the host.
+      const remap = new Map<string, string>();
+      const parentFor = (node: FsNode) =>
+        node.parentId ? (remap.get(node.parentId) ?? root.id) : root.id;
+      for (const folder of legacy.filter((n) => n.kind === "folder")) {
+        const created = await createNode(client, company, {
+          name: folder.name,
+          kind: "folder",
+          parentId: parentFor(folder),
+        });
+        remap.set(folder.id, created.id);
+      }
+      for (const file of legacy.filter((n) => n.kind === "file")) {
+        await createNode(client, company, {
+          name: ensureMdExt(file.name),
+          kind: "file",
+          parentId: parentFor(file),
+          content: file.content ?? "",
+        });
+      }
+      clearLegacyLocal(company);
+      setLegacy([]);
+      toast.success(`Imported ${legacy.length} note${legacy.length === 1 ? "" : "s"}.`);
+      await loadTree({ silent: true });
+    } catch (e) {
+      // The key is left intact on failure, so the banner comes back and nothing
+      // the operator wrote is lost to a half-finished import.
+      toast.error(message(e, "could not import your local notes"));
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  function discardLegacy() {
+    clearLegacyLocal(company);
+    setLegacy([]);
+  }
+
+  /* ---- navigation ---- */
+
+  async function open(id: string) {
+    await flush();
     setOpenId(id);
     setMode("read");
+    setDraft(null);
+    setSaveState("idle");
+    setOpenFile(null);
+    setFileError(null);
     setExpanded((prev) => {
       const next = new Set(prev);
       for (const a of pathOf(nodes, id)) if (a.kind === "folder") next.add(a.id);
       return next;
     });
+    await loadFile(id);
   }
 
   function toggle(id: string) {
@@ -102,16 +393,108 @@ export function WorkspaceView({ company }: Props) {
     });
   }
 
-  function onWiki(target: string) {
+  // Switching to Edit refetches first, so the operator edits what the host
+  // currently holds rather than a copy that may be minutes stale — the cheapest
+  // mitigation available for the no-CAS overwrite window.
+  async function changeMode(next: "read" | "edit") {
+    await flush();
+    if (next === "edit" && openId) {
+      const fresh = await loadFile(openId);
+      setDraft(fresh?.content ?? null);
+    } else {
+      setDraft(null);
+    }
+    setSaveState("idle");
+    setMode(next);
+  }
+
+  /* ---- mutations (apply-on-ack) ---- */
+
+  async function createAndOpen(name: string, content?: string) {
+    try {
+      const created = await createNode(client, company, {
+        name: ensureMdExt(name.trim() || "Untitled"),
+        kind: "file",
+        parentId: null,
+        content: content ?? "",
+      });
+      setNodes((all) => [...all, created]);
+      setOpenId(created.id);
+      setOpenFile({
+        id: created.id,
+        name: created.name,
+        content: content ?? "",
+        updatedAt: created.updatedAt,
+        backlinks: [],
+      });
+      setFileError(null);
+      setDraft(content ?? "");
+      setSaveState("idle");
+      setMode("edit");
+    } catch (e) {
+      toast.error(message(e, "could not create the note"));
+    }
+  }
+
+  async function createFolder(name: string) {
+    try {
+      const created = await createNode(client, company, {
+        name: name.trim() || "New folder",
+        kind: "folder",
+        parentId: null,
+      });
+      setNodes((all) => [...all, created]);
+    } catch (e) {
+      toast.error(message(e, "could not create the folder"));
+    }
+  }
+
+  async function rename(node: FsNode, name: string) {
+    const next = (node.kind === "file" ? ensureMdExt(name.trim()) : name.trim()) || node.name;
+    try {
+      const updated = await renameMoveNode(client, company, node.id, { name: next });
+      setNodes((all) => all.map((n) => (n.id === updated.id ? updated : n)));
+      setOpenFile((f) => (f && f.id === updated.id ? { ...f, name: updated.name } : f));
+    } catch (e) {
+      toast.error(message(e, "could not rename this item"));
+    }
+  }
+
+  async function move(node: FsNode, destId: string | null) {
+    try {
+      // The move-cycle guard is the host's: it answers 400 for a folder moved
+      // under its own descendant, which surfaces here as a toast.
+      const updated = await renameMoveNode(client, company, node.id, { parentId: destId });
+      setNodes((all) => all.map((n) => (n.id === updated.id ? updated : n)));
+    } catch (e) {
+      toast.error(message(e, "could not move this item"));
+    }
+  }
+
+  async function remove(node: FsNode) {
+    const removed = subtreeIds(nodes, node.id);
+    try {
+      await deleteNodeApi(client, company, node.id);
+      setNodes((all) => all.filter((n) => !removed.has(n.id)));
+      if (openId && removed.has(openId)) {
+        pending.current = null;
+        setOpenId(null);
+        setOpenFile(null);
+        setDraft(null);
+      }
+    } catch (e) {
+      toast.error(message(e, "could not delete this item"));
+    }
+  }
+
+  async function onWiki(target: string) {
     const existing = fileByTitle(nodes, target);
     if (existing) {
-      open(existing.id);
+      await open(existing.id);
       return;
     }
-    const res = addFile(nodes, null, target, `# ${target}\n`);
-    setNodes(res.nodes);
-    setOpenId(res.id);
-    setMode("edit");
+    await flush();
+    await createAndOpen(target, `# ${target}\n`);
   }
 
   async function onUpload(files: FileList | null) {
@@ -119,21 +502,23 @@ export function WorkspaceView({ company }: Props) {
     const reads = await Promise.all(
       Array.from(files).map(async (f) => ({ name: f.name, text: await f.text().catch(() => "") })),
     );
-    setNodes((n) => {
-      let next = n;
-      for (const r of reads) next = addFile(next, null, r.name, r.text).nodes;
-      return next;
-    });
+    for (const r of reads) {
+      try {
+        const created = await createNode(client, company, {
+          name: ensureMdExt(r.name),
+          kind: "file",
+          parentId: null,
+          content: r.text,
+        });
+        setNodes((all) => [...all, created]);
+      } catch (e) {
+        toast.error(`${r.name}: ${message(e, "upload failed")}`);
+      }
+    }
   }
 
-  function createFile(name: string) {
-    setNodes((n) => {
-      const res = addFile(n, null, name);
-      setOpenId(res.id);
-      setMode("edit");
-      return res.nodes;
-    });
-  }
+  const body = draft ?? openFile?.content ?? "";
+  const openNode = nodeById(nodes, openId);
 
   return (
     <div className="flex flex-1 overflow-hidden">
@@ -148,6 +533,13 @@ export function WorkspaceView({ company }: Props) {
           <span className="flex-1 px-1 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
             Explorer
           </span>
+          <IconBtn
+            label="Refresh"
+            onClick={() => void loadTree({ silent: true })}
+            data-testid="workspace-refresh"
+          >
+            <RefreshCw className={cn("size-4", refreshing && "animate-spin")} />
+          </IconBtn>
           <IconBtn label="New file" onClick={() => setPrompt({ mode: "file" })}>
             <FilePlus2 className="size-4" />
           </IconBtn>
@@ -169,35 +561,89 @@ export function WorkspaceView({ company }: Props) {
             }}
           />
         </div>
-        <div className="flex-1 overflow-y-auto py-1">
-          <Tree
-            nodes={nodes}
-            parentId={null}
-            depth={0}
-            expanded={expanded}
-            openId={openId}
-            onToggle={toggle}
-            onOpen={open}
-            onRename={(node) => setPrompt({ mode: "rename", node })}
-            onMove={(node) => setMoving(node)}
-            onDelete={(node) => {
-              setNodes((n) => removeNode(n, node.id));
-              if (openId && subtreeIds(nodes, node.id).has(openId)) setOpenId(null);
-            }}
-          />
+        <div className="flex-1 overflow-y-auto py-1" data-testid="workspace-tree">
+          {loading ? (
+            <div className="space-y-2 px-2 py-2">
+              <Skeleton className="h-5 w-4/5" />
+              <Skeleton className="h-5 w-3/5" />
+              <Skeleton className="h-5 w-2/3" />
+            </div>
+          ) : error ? (
+            <div className="px-2 py-2">
+              <Alert variant="destructive">
+                <AlertDescription data-testid="workspace-error">{error}</AlertDescription>
+              </Alert>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-2 w-full"
+                onClick={() => void loadTree()}
+              >
+                Try again
+              </Button>
+            </div>
+          ) : nodes.length === 0 ? (
+            <p className="px-3 py-2 text-xs text-muted-foreground">
+              This workspace is empty. Create a note to start.
+            </p>
+          ) : (
+            <Tree
+              nodes={nodes}
+              parentId={null}
+              depth={0}
+              expanded={expanded}
+              openId={openId}
+              onToggle={toggle}
+              onOpen={(id) => void open(id)}
+              onRename={(node) => setPrompt({ mode: "rename", node })}
+              onMove={(node) => setMoving(node)}
+              onDelete={(node) => void remove(node)}
+            />
+          )}
         </div>
       </aside>
 
       {/* Note pane */}
       <section className={cn("flex-1 flex-col overflow-hidden", showExplorer ? "hidden md:flex" : "flex")}>
-        {openFile && openFile.kind === "file" ? (
+        {legacy.length > 0 && (
+          <Alert className="m-3 mb-0 w-auto" data-testid="workspace-migration-banner">
+            <AlertDescription className="flex flex-wrap items-center gap-3">
+              <span className="flex-1">
+                {legacy.length} note{legacy.length === 1 ? "" : "s"} from this browser's old
+                scratchpad {legacy.length === 1 ? "is" : "are"} not in the company workspace yet.
+              </span>
+              <Button
+                size="sm"
+                disabled={importing}
+                onClick={() => void importLegacy()}
+                data-testid="workspace-migration-import"
+              >
+                {importing && <Loader2 className="size-3.5 animate-spin" />} Import
+              </Button>
+              <Button size="sm" variant="ghost" disabled={importing} onClick={discardLegacy}>
+                Discard
+              </Button>
+            </AlertDescription>
+          </Alert>
+        )}
+        {openNode && openNode.kind === "file" ? (
           <>
             <div className="flex items-center gap-2 border-b px-3 py-2">
               <IconBtn label="Toggle explorer" onClick={() => setShowExplorer((s) => !s)}>
                 <PanelLeft className="size-4" />
               </IconBtn>
-              <span className="truncate text-sm font-medium">{titleOf(openFile)}</span>
-              <Tabs value={mode} onValueChange={(v) => setMode(v as "read" | "edit")} className="ml-auto">
+              <span className="truncate text-sm font-medium">{titleOf(openNode)}</span>
+              {/* No authorship on a node (#326), so "when" is the only signal an
+                  agent has been in here — worth showing plainly. */}
+              <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
+                {formatUpdated(openFile?.updatedAt ?? openNode.updatedAt)}
+              </span>
+              <SaveStatus state={saveState} />
+              <Tabs
+                value={mode}
+                onValueChange={(v) => void changeMode(v as "read" | "edit")}
+                className="ml-auto"
+              >
                 <TabsList>
                   <TabsTrigger value="read">Reading</TabsTrigger>
                   <TabsTrigger value="edit">Edit</TabsTrigger>
@@ -206,32 +652,47 @@ export function WorkspaceView({ company }: Props) {
             </div>
             <div className="flex flex-1 overflow-hidden">
               <div className="flex-1 overflow-y-auto">
-                {mode === "edit" ? (
+                {fileError ? (
+                  <div className="p-6">
+                    <Alert variant="destructive">
+                      <AlertDescription>{fileError}</AlertDescription>
+                    </Alert>
+                  </div>
+                ) : !openFile ? (
+                  <div className="mx-auto max-w-3xl space-y-3 px-6 py-6">
+                    <Skeleton className="h-6 w-1/3" />
+                    <Skeleton className="h-4 w-full" />
+                    <Skeleton className="h-4 w-5/6" />
+                  </div>
+                ) : mode === "edit" ? (
                   <Textarea
-                    value={openFile.content ?? ""}
-                    onChange={(e) => setNodes((n) => setContent(n, openFile.id, e.target.value))}
+                    value={body}
+                    onChange={(e) => onEdit(openFile.id, e.target.value)}
+                    onBlur={() => void flush()}
                     placeholder="Write in Markdown… link with [[Note name]]"
+                    data-testid="workspace-editor"
                     className="h-full min-h-0 resize-none rounded-none border-0 p-6 font-mono text-sm shadow-none focus-visible:ring-0"
                   />
                 ) : (
-                  <div className="mx-auto max-w-3xl px-6 py-6">
-                    <NoteMarkdown source={openFile.content ?? ""} nodes={nodes} onWiki={onWiki} />
+                  <div className="mx-auto max-w-3xl px-6 py-6" data-testid="workspace-note">
+                    <NoteMarkdown source={body} nodes={nodes} onWiki={(t) => void onWiki(t)} />
                   </div>
                 )}
               </div>
-              {/* Backlinks */}
+              {/* Backlinks — computed by the host, not derived here: the tree
+                  read carries no bodies, so the client has nothing to scan. */}
               <aside className="hidden w-56 shrink-0 flex-col border-l bg-card/30 xl:flex">
                 <div className="border-b px-3 py-2 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
                   Backlinks
                 </div>
                 <div className="flex-1 overflow-y-auto p-2">
-                  {backlinks.length === 0 ? (
+                  {!openFile || openFile.backlinks.length === 0 ? (
                     <p className="px-1 py-2 text-xs text-muted-foreground">No backlinks yet.</p>
                   ) : (
-                    backlinks.map((b) => (
+                    openFile.backlinks.map((b) => (
                       <button
                         key={b.id}
-                        onClick={() => open(b.id)}
+                        onClick={() => void open(b.id)}
                         className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent"
                       >
                         <Link2 className="size-3.5 shrink-0 text-muted-foreground" />
@@ -252,10 +713,9 @@ export function WorkspaceView({ company }: Props) {
         state={prompt}
         onClose={() => setPrompt(null)}
         onSubmit={(name) => {
-          if (prompt?.mode === "folder") setNodes((n) => addFolder(n, null, name));
-          else if (prompt?.mode === "file") createFile(name);
-          else if (prompt?.mode === "rename" && prompt.node)
-            setNodes((n) => renameNode(n, prompt.node!.id, name));
+          if (prompt?.mode === "folder") void createFolder(name);
+          else if (prompt?.mode === "file") void createAndOpen(name);
+          else if (prompt?.mode === "rename" && prompt.node) void rename(prompt.node, name);
           setPrompt(null);
         }}
       />
@@ -264,11 +724,30 @@ export function WorkspaceView({ company }: Props) {
         moving={moving}
         onClose={() => setMoving(null)}
         onMove={(destId) => {
-          if (moving) setNodes((n) => moveNode(n, moving.id, destId));
+          if (moving) void move(moving, destId);
           setMoving(null);
         }}
       />
     </div>
+  );
+}
+
+/** The editor's save indicator: quiet when idle, explicit when it matters. */
+function SaveStatus({ state }: { state: SaveState }) {
+  if (state === "idle") return null;
+  const label =
+    state === "saving" ? "Saving…" : state === "saved" ? "Saved" : "Not saved — retrying on edit";
+  return (
+    <span
+      data-testid="workspace-save-state"
+      data-state={state}
+      className={cn(
+        "shrink-0 text-xs",
+        state === "error" ? "text-destructive" : "text-muted-foreground",
+      )}
+    >
+      {label}
+    </span>
   );
 }
 
@@ -435,13 +914,21 @@ function IconBtn({
   label,
   onClick,
   children,
+  ...rest
 }: {
   label: string;
   onClick: () => void;
   children: React.ReactNode;
-}) {
+} & Omit<React.ComponentProps<typeof Button>, "onClick" | "children">) {
   return (
-    <Button variant="ghost" size="icon" className="size-7 text-muted-foreground" aria-label={label} onClick={onClick}>
+    <Button
+      variant="ghost"
+      size="icon"
+      className="size-7 text-muted-foreground"
+      aria-label={label}
+      onClick={onClick}
+      {...rest}
+    >
       {children}
     </Button>
   );

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -254,7 +254,13 @@ export function WorkspaceView({ client, company }: Props) {
       // Keep the buffer: the operator's text is never dropped because a save
       // failed. A 404 means the note is gone on the host, which needs a decision
       // rather than a retry, so say so explicitly.
-      pending.current = job;
+      //
+      // Only restore when nothing newer arrived. The operator can keep typing
+      // during the await above, and that typing writes a fresher job into
+      // `pending.current` — overwriting it with the job we just failed to save
+      // would silently discard every keystroke made while the request was in
+      // flight, which is the exact loss this buffer exists to prevent.
+      if (!pending.current) pending.current = job;
       setSaveState("error");
       if (isNotFound(e)) {
         toast.error("This note no longer exists on the host.", {

--- a/frontend/test/e2e/workspace.spec.ts
+++ b/frontend/test/e2e/workspace.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
 
 /**
  * Regression proof for issue #177: the Workspace tab must read and write the
@@ -43,10 +43,32 @@ async function dismissOnboarding(page: Page) {
   }
 }
 
+/**
+ * Open the Workspace tab on a genuinely fresh app instance.
+ *
+ * The explicit `reload()` is load-bearing: the console is a hash router, so a
+ * second `goto("/#/workspace")` at the same URL does not remount anything and
+ * the view keeps whatever it already had in React state. Without the reload,
+ * "survives a storage-cleared reload" would assert nothing, and the migration
+ * effect (which runs on mount) would never re-run.
+ */
 async function openWorkspace(page: Page) {
   await page.goto("/#/workspace");
+  await page.reload();
   await dismissOnboarding(page);
   await expect(page.getByTestId("workspace-tree")).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * The localStorage key the retired scratchpad used for this host, derived the
+ * same way the app derives the company it operates: the console resolves a lone
+ * registered company to its **id** (`App.tsx`), falling back to `single` when
+ * there is none. Hardcoding `oc-workspace:single` silently plants a key nothing
+ * reads, and the migration assertions below would then pass vacuously.
+ */
+async function legacyKeyFor(request: APIRequestContext): Promise<string> {
+  const companies = (await (await request.get("/api/v1/companies")).json()) as { id: string }[];
+  return `oc-workspace:${companies.length === 1 ? companies[0].id : "single"}`;
 }
 
 test("the Workspace tab reads and writes the host's store, not localStorage", async ({
@@ -152,6 +174,7 @@ test("the retired local scratchpad is offered for import, its seed discarded", a
 }) => {
   const stamp = Date.now().toString(36);
   const rescued = `local-note-${stamp}`;
+  const legacyKey = await legacyKeyFor(request);
 
   // Plant a legacy key holding one user-authored note (`fs-…`) alongside a
   // bundled seed node (`seed-…`), exactly as the retired store would have.
@@ -181,7 +204,7 @@ test("the retired local scratchpad is offered for import, its seed discarded", a
         ]),
       );
     },
-    ["oc-workspace:single", rescued] as const,
+    [legacyKey, rescued] as const,
   );
 
   await openWorkspace(page);
@@ -211,7 +234,7 @@ test("the retired local scratchpad is offered for import, its seed discarded", a
   expect(nodes.some((n) => n.name.includes("Spring launch"))).toBe(false);
 
   // The legacy key is gone, so the banner does not come back.
-  const leftover = await page.evaluate(() => localStorage.getItem("oc-workspace:single"));
+  const leftover = await page.evaluate((key) => localStorage.getItem(key), legacyKey);
   expect(leftover).toBeNull();
 
   // ---- cleanup ----

--- a/frontend/test/e2e/workspace.spec.ts
+++ b/frontend/test/e2e/workspace.spec.ts
@@ -1,0 +1,219 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Regression proof for issue #177: the Workspace tab must read and write the
+ * **host's** `WorkspaceStore`, never a client-side localStorage tree.
+ *
+ * The retired stub (`lib/workspace.ts`) persisted to `oc-workspace:<company>`
+ * and seeded four invented marketing notes — "Spring launch", "Brand voice" —
+ * into every browser. So the operator's workspace and the tree the company's
+ * agents read and write through their `workspace_*` tools (#237) were two
+ * unrelated things: a note an agent wrote was invisible in the console, and a
+ * note the operator typed was invisible to every agent.
+ *
+ * This spec pins the four observable consequences of the fix:
+ *
+ *   1. The tree the tab renders is the one the host serves — including the
+ *      company's seeded notes, which no client-side fixture ever had.
+ *   2. Notes created in the tab survive a *storage-cleared* reload. Only host
+ *      state can survive that; a localStorage tree could not.
+ *   3. A write made **out of band** over REST (standing in for an agent, or a
+ *      second browser) shows up after a refresh.
+ *   4. Editing in the tab persists — the debounced autosave reaches the host.
+ *
+ * Plus: none of the retired fixture's invented notes ever render.
+ *
+ * Runs against the same live host as `wiring.spec.ts` (see that file's header
+ * for the auth / storage-state arrangement).
+ */
+
+/** Notes the deleted client-side seed fabricated for every browser. */
+const FIXTURE_NOTES = ["Spring launch", "Brand voice", "Campaigns"];
+
+/**
+ * A fresh host greets the first visit with a welcome tour rendered over the
+ * console, which swallows clicks on the view beneath it. Dismiss it if present.
+ */
+async function dismissOnboarding(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  await skip.waitFor({ state: "visible", timeout: 15_000 }).catch(() => {});
+  if (await skip.isVisible()) {
+    await skip.click();
+    await expect(skip).toBeHidden();
+  }
+}
+
+async function openWorkspace(page: Page) {
+  await page.goto("/#/workspace");
+  await dismissOnboarding(page);
+  await expect(page.getByTestId("workspace-tree")).toBeVisible({ timeout: 30_000 });
+}
+
+test("the Workspace tab reads and writes the host's store, not localStorage", async ({
+  page,
+  request,
+}) => {
+  // A unique name per run, so re-running the suite against a persistent host
+  // never collides with a previous run's note.
+  const stamp = Date.now().toString(36);
+  const viaApi = `api-note-${stamp}`;
+  const viaUi = `ui-note-${stamp}`;
+
+  // ---- 1. The tab renders the host's tree -------------------------------
+  const tree = (await (await request.get("/api/v1/company/workspace")).json()) as {
+    id: string;
+    name: string;
+    kind: string;
+  }[];
+  await openWorkspace(page);
+
+  // The harness company seeds `README.md` + `Standards.md`, so a real seeded
+  // note must be on screen. It came from the company bundle, not the console.
+  const seeded = tree.find((n) => n.name === "README.md");
+  expect(seeded, "the harness company must seed a workspace").toBeTruthy();
+  await expect(page.getByTestId("workspace-tree")).toContainText("README", {
+    timeout: 30_000,
+  });
+
+  // None of the retired fixture's invented notes survive anywhere.
+  for (const invented of FIXTURE_NOTES) {
+    await expect(page.getByText(invented, { exact: false })).toHaveCount(0);
+  }
+
+  // ---- 2. A note written out of band appears on refresh -----------------
+  // This is the half that was structurally impossible before: an agent writing
+  // through `workspace_write` lands in exactly this store.
+  const created = await request.post("/api/v1/company/workspace", {
+    data: { name: `${viaApi}.md`, kind: "file", content: `# ${viaApi}\n\nWritten over REST.` },
+  });
+  expect(created.ok()).toBeTruthy();
+
+  await page.getByTestId("workspace-refresh").click();
+  await expect(page.getByTestId("workspace-tree")).toContainText(viaApi, { timeout: 30_000 });
+
+  // Opening it shows the body the host holds — the tree carries no content, so
+  // this proves the per-file read is wired too.
+  await page.getByTestId("workspace-tree").getByText(viaApi, { exact: false }).click();
+  await expect(page.getByTestId("workspace-note")).toContainText("Written over REST", {
+    timeout: 30_000,
+  });
+
+  // ---- 3. A note created in the tab reaches the host --------------------
+  await page.getByRole("button", { name: "New file" }).click();
+  await page.getByLabel("Name").fill(viaUi);
+  await page.getByRole("button", { name: "Create", exact: true }).click();
+
+  // Creating opens the new note straight in Edit; type and let autosave settle.
+  const editor = page.getByTestId("workspace-editor");
+  await expect(editor).toBeVisible({ timeout: 30_000 });
+  await editor.fill(`# ${viaUi}\n\nTyped in the console.`);
+  await expect(page.getByTestId("workspace-save-state")).toHaveAttribute("data-state", "saved", {
+    timeout: 30_000,
+  });
+
+  // The host has it — asserted over the API, not by reading the UI back.
+  const after = (await (await request.get("/api/v1/company/workspace")).json()) as {
+    id: string;
+    name: string;
+  }[];
+  const persisted = after.find((n) => n.name === `${viaUi}.md`);
+  expect(persisted, "a note created in the console must reach the host").toBeTruthy();
+  const file = (await (
+    await request.get(`/api/v1/company/workspace/file/${persisted!.id}`)
+  ).json()) as { content: string };
+  expect(file.content).toContain("Typed in the console");
+
+  // ---- 4. It survives a storage-cleared reload --------------------------
+  // Drop every client-side store, then reload: only host state can survive.
+  await page.evaluate(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+  await openWorkspace(page);
+  await expect(page.getByTestId("workspace-tree")).toContainText(viaUi, { timeout: 30_000 });
+  await expect(page.getByTestId("workspace-tree")).toContainText(viaApi, { timeout: 30_000 });
+
+  // ---- cleanup: leave the host as we found it ---------------------------
+  for (const name of [`${viaApi}.md`, `${viaUi}.md`]) {
+    const node = after.find((n) => n.name === name) ?? tree.find((n) => n.name === name);
+    if (node) await request.delete(`/api/v1/company/workspace/${node.id}`);
+  }
+});
+
+/**
+ * The localStorage migration: notes a user typed into the retired scratchpad are
+ * offered for import rather than silently dropped — but the *bundled seed* is
+ * swept without asking, because importing it would inject invented marketing
+ * copy into a real company's workspace.
+ */
+test("the retired local scratchpad is offered for import, its seed discarded", async ({
+  page,
+  request,
+}) => {
+  const stamp = Date.now().toString(36);
+  const rescued = `local-note-${stamp}`;
+
+  // Plant a legacy key holding one user-authored note (`fs-…`) alongside a
+  // bundled seed node (`seed-…`), exactly as the retired store would have.
+  await page.goto("/#/workspace");
+  await dismissOnboarding(page);
+  await page.evaluate(
+    ([key, name]) => {
+      localStorage.setItem(
+        key,
+        JSON.stringify([
+          {
+            id: "seed-readme",
+            name: "README.md",
+            kind: "file",
+            parentId: null,
+            updatedAt: Date.now(),
+            content: "# Workspace\n\n[[Spring launch]]",
+          },
+          {
+            id: "fs-user-1",
+            name: `${name}.md`,
+            kind: "file",
+            parentId: null,
+            updatedAt: Date.now(),
+            content: "Something the operator actually typed.",
+          },
+        ]),
+      );
+    },
+    ["oc-workspace:single", rescued] as const,
+  );
+
+  await openWorkspace(page);
+
+  // The banner offers only the user's note — the seed is not counted.
+  const banner = page.getByTestId("workspace-migration-banner");
+  await expect(banner).toBeVisible({ timeout: 30_000 });
+  await expect(banner).toContainText("1 note");
+
+  await page.getByTestId("workspace-migration-import").click();
+  await expect(banner).toBeHidden({ timeout: 30_000 });
+
+  // The rescued note is on the host, under the import folder.
+  const nodes = (await (await request.get("/api/v1/company/workspace")).json()) as {
+    id: string;
+    name: string;
+    kind: string;
+    parentId?: string | null;
+  }[];
+  const folder = nodes.find((n) => n.kind === "folder" && n.name === "Imported from this browser");
+  expect(folder, "the import must land in its own folder").toBeTruthy();
+  const note = nodes.find((n) => n.name === `${rescued}.md`);
+  expect(note, "the user's note must be imported").toBeTruthy();
+  expect(note!.parentId).toBe(folder!.id);
+
+  // The seed's invented note was never imported.
+  expect(nodes.some((n) => n.name.includes("Spring launch"))).toBe(false);
+
+  // The legacy key is gone, so the banner does not come back.
+  const leftover = await page.evaluate(() => localStorage.getItem("oc-workspace:single"));
+  expect(leftover).toBeNull();
+
+  // ---- cleanup ----
+  if (folder) await request.delete(`/api/v1/company/workspace/${folder.id}`);
+});

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -32,6 +32,12 @@ pub mod telegram;
 mod types;
 mod workflow_create;
 mod workflow_file;
+// The shared workspace-file read (node + content + `[[wikilink]]` backlinks)
+// behind both the GraphQL `workspaceFile` resolver and the REST
+// `GET …/workspace/file/{id}` route the console calls. Always compiled: the
+// REST route is in the default build, and one shared scan is what keeps the two
+// read surfaces from drifting.
+pub(crate) mod workspace_links;
 pub mod workspace_seed;
 
 use std::path::Path;

--- a/src/company/workspace_links.rs
+++ b/src/company/workspace_links.rs
@@ -42,7 +42,12 @@ pub(crate) async fn file_with_backlinks(
     let Some((node, content)) = store.read(company, id).await? else {
         return Ok(None);
     };
-    let target = link_target(&node.name).to_string();
+    // Lowercased to match the console, which resolves a wiki link through
+    // `fileByTitle` with both sides lowercased (`frontend/src/lib/workspace.ts`).
+    // Comparing case-sensitively here would let `[[Voice]]` render as a resolved
+    // link to `voice.md` while `voice.md` reported no backlink — the two halves
+    // of one feature disagreeing about the same link.
+    let target = link_target(&node.name).to_ascii_lowercase();
 
     // Backlinks: scan every other file node's content for a `[[target]]` link.
     let mut backlinks = Vec::new();
@@ -53,7 +58,7 @@ pub(crate) async fn file_with_backlinks(
         if let Some((other_node, other_content)) = store.read(company, &other.id).await?
             && extract_wikilinks(&other_content)
                 .iter()
-                .any(|link| link == &target)
+                .any(|link| link.to_ascii_lowercase() == target)
         {
             backlinks.push(other_node);
         }

--- a/src/company/workspace_links.rs
+++ b/src/company/workspace_links.rs
@@ -1,0 +1,63 @@
+//! One workspace file plus the `[[wikilink]]` backlinks pointing at it.
+//!
+//! The company workspace is read through two surfaces — the GraphQL
+//! `Company.workspaceFile(id)` resolver and the REST `GET …/workspace/file/{id}`
+//! route the operator console calls. Both need the same answer: the node, its
+//! body, and every *other* file whose content links to it. That scan lives here,
+//! once, so the two surfaces cannot drift apart (a backlink the console shows
+//! but GraphQL doesn't, or vice versa, would be a silent correctness bug in
+//! whichever one the reader wasn't looking at).
+//!
+//! Always compiled and feature-free: `ops::workspace` is in the default build,
+//! so gating this would only re-create the divergence it exists to prevent.
+
+use crate::Result;
+use crate::company::extract_wikilinks;
+use crate::ports::types::CompanyId;
+use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceStore};
+
+/// The link target a file's name presents: its base name minus a `.md` suffix.
+///
+/// Deliberately narrower than the console's `titleOf`, which also strips
+/// `.markdown` / `.txt`. A `[[link]]` resolves against note *names*, and the
+/// seeder only ever creates `.md` notes, so `.md` is the only extension a link
+/// can be written without. See the "Known limits" note in the workspace module
+/// docs.
+pub(crate) fn link_target(name: &str) -> &str {
+    name.strip_suffix(".md").unwrap_or(name)
+}
+
+/// Reads one workspace node with its content and inbound `[[wikilink]]`
+/// backlinks, or `None` when the id names nothing in this company's tree.
+///
+/// Kind-agnostic on purpose: the store answers a folder id with an empty body,
+/// and each caller decides what that means (GraphQL returns it; the REST route
+/// 404s, because the console only ever opens files). Backlinks only ever name
+/// *file* nodes, and a node never links to itself.
+pub(crate) async fn file_with_backlinks(
+    store: &dyn WorkspaceStore,
+    company: &CompanyId,
+    id: &str,
+) -> Result<Option<(WorkspaceNode, String, Vec<WorkspaceNode>)>> {
+    let Some((node, content)) = store.read(company, id).await? else {
+        return Ok(None);
+    };
+    let target = link_target(&node.name).to_string();
+
+    // Backlinks: scan every other file node's content for a `[[target]]` link.
+    let mut backlinks = Vec::new();
+    for other in store.tree(company).await? {
+        if other.id == node.id || !matches!(other.kind, NodeKind::File) {
+            continue;
+        }
+        if let Some((other_node, other_content)) = store.read(company, &other.id).await?
+            && extract_wikilinks(&other_content)
+                .iter()
+                .any(|link| link == &target)
+        {
+            backlinks.push(other_node);
+        }
+    }
+
+    Ok(Some((node, content, backlinks)))
+}

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1753,6 +1753,30 @@ mod test {
                     "{company}/{} write access is wrong; effective grants: {grants:?}",
                     agent.id
                 );
+                // Every shipped agent asks for `mcp:*`, and `agent_effective_grants`
+                // intersects that request with the company allow-list — so an
+                // allow-list that omits it silently hands the agent no MCP at all.
+                // Both manifests were in exactly that state before this test
+                // existed (`openhuman_demo` had no allow-list, which covers
+                // nothing, so its agents resolved to an empty toolbelt). Asserted
+                // here because the symptom is a missing capability, not an error:
+                // nothing logs, nothing fails, the tools are simply absent.
+                //
+                // Probed with `grant_matches` against a concrete `mcp:<server>`
+                // name rather than `grants_cover`: MCP grants are colon-namespaced
+                // (`mcp:*`, `mcp:notion`) while `grants_cover` only understands the
+                // dot form, so it answers `false` for a grant list that plainly
+                // contains `mcp:*`.
+                if agent.tools.iter().any(|tool| tool == "mcp:*") {
+                    assert!(
+                        grants
+                            .iter()
+                            .any(|grant| grant_matches(grant, "mcp:any-server")),
+                        "{company}/{} asks for mcp:* but the allow-list does not \
+                         cover it; effective grants: {grants:?}",
+                        agent.id
+                    );
+                }
             }
         }
     }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1713,6 +1713,50 @@ mod test {
         assert_eq!(company_id_from_name("***").as_ref(), "company");
     }
 
+    /// The shipped companies actually hand their agents the workspace tools
+    /// (issue #177, gap 2).
+    ///
+    /// Before this, `[tools].allow` listed no `workspace` grant while every
+    /// agent enumerated its tools explicitly — and per-agent grants are narrowed
+    /// by the company allow-list, so *no* agent received even `workspace_list`.
+    /// The tools existed (#237) and no shipped company could reach them, which
+    /// made the "an agent writes a note, the operator sees it" round trip
+    /// impossible out of the box.
+    ///
+    /// Reads are namespace-covered and writes need an explicit grant, so this
+    /// also pins the asymmetry: readers must NOT come out write-capable.
+    #[cfg(feature = "openhuman")]
+    #[test]
+    fn shipped_companies_grant_the_workspace_tools() {
+        use crate::company::grants_workspace_write_explicit;
+        use crate::harness::build::grants_cover;
+
+        for company in ["e2e_harness", "openhuman_demo"] {
+            let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("companies")
+                .join(company);
+            let manifest = CompanyManifest::from_path(&path)
+                .unwrap_or_else(|e| panic!("{company} manifest must parse: {e}"));
+
+            for agent in &manifest.agents {
+                let grants = agent_effective_grants(&manifest.tools.allow, &agent.tools);
+                assert!(
+                    grants_cover(&grants, "workspace"),
+                    "{company}/{} must reach the workspace tools; effective grants: {grants:?}",
+                    agent.id
+                );
+                // Only the writer edits notes; everyone else is read-only, so a
+                // reader can never overwrite operator-owned guidance.
+                assert_eq!(
+                    grants_workspace_write_explicit(&grants),
+                    agent.id == "writer",
+                    "{company}/{} write access is wrong; effective grants: {grants:?}",
+                    agent.id
+                );
+            }
+        }
+    }
+
     #[tokio::test]
     async fn user_auth_stores_default_to_fs_and_are_reachable() {
         use crate::ports::{

--- a/src/server/graphql/workspace.rs
+++ b/src/server/graphql/workspace.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use async_graphql::{ID, SimpleObject};
 
 use super::iso8601;
-use crate::company::extract_wikilinks;
 use crate::company::runtime::CompanyRuntime;
+use crate::company::workspace_links::file_with_backlinks;
 use crate::ports::workspace::{NodeKind, WorkspaceNode};
 
 /// One node (folder or file) in the workspace tree. Mirrors [`WorkspaceNode`].
@@ -58,11 +58,6 @@ pub struct WorkspaceFileGql {
     pub backlinks: Vec<FsNodeGql>,
 }
 
-/// The link target a file's name presents: its base name minus a `.md` suffix.
-fn link_target(name: &str) -> &str {
-    name.strip_suffix(".md").unwrap_or(name)
-}
-
 /// Resolves `Company.workspaceTree`.
 pub(crate) async fn resolve_tree(
     runtime: &Arc<CompanyRuntime>,
@@ -72,36 +67,26 @@ pub(crate) async fn resolve_tree(
 }
 
 /// Resolves `Company.workspaceFile(id)`, returning null when absent.
+///
+/// The node + content + backlink scan is
+/// [`file_with_backlinks`](crate::company::workspace_links::file_with_backlinks),
+/// shared with the REST `GET …/workspace/file/{id}` route the console reads, so
+/// the two surfaces can never report different backlinks for the same note.
 pub(crate) async fn resolve_file(
     runtime: &Arc<CompanyRuntime>,
     id: &str,
 ) -> async_graphql::Result<Option<WorkspaceFileGql>> {
-    let Some((node, content)) = runtime.workspace().read(runtime.id(), id).await? else {
+    let Some((node, content, backlinks)) =
+        file_with_backlinks(runtime.workspace().as_ref(), runtime.id(), id).await?
+    else {
         return Ok(None);
     };
-    let target = link_target(&node.name).to_string();
-
-    // Backlinks: scan every other file node's content for a `[[target]]` link.
-    let mut backlinks = Vec::new();
-    for other in runtime.workspace().tree(runtime.id()).await? {
-        if other.id == node.id || !matches!(other.kind, NodeKind::File) {
-            continue;
-        }
-        if let Some((other_node, other_content)) =
-            runtime.workspace().read(runtime.id(), &other.id).await?
-            && extract_wikilinks(&other_content)
-                .iter()
-                .any(|link| link == &target)
-        {
-            backlinks.push(FsNodeGql::from(other_node));
-        }
-    }
 
     Ok(Some(WorkspaceFileGql {
         id: ID(node.id),
         name: node.name,
         content,
         updated_at: iso8601(node.updated_at_millis),
-        backlinks,
+        backlinks: backlinks.into_iter().map(FsNodeGql::from).collect(),
     }))
 }

--- a/src/server/ops/workspace.rs
+++ b/src/server/ops/workspace.rs
@@ -1,9 +1,44 @@
-//! Workspace writes: create a node, overwrite a file, rename/move a node, and
-//! delete (folders recursive) — under both scope forms.
+//! Workspace reads + writes: list the tree, read one file with its backlinks,
+//! create a node, overwrite a file, rename/move a node, and delete (folders
+//! recursive) — under both scope forms.
 //!
-//! Bodies mirror the console's `FsNode` (`frontend/src/lib/workspace.ts`).
+//! Bodies mirror the console's `FsNode` (`frontend/src/api/workspace.ts`).
 //! Writes land in the [`WorkspaceStore`](crate::ports::WorkspaceStore); node
 //! ids are stable ULIDs so a rename/move never breaks a reference.
+//!
+//! ```text
+//! GET    …/workspace                  the whole tree (metadata; no bodies)
+//! GET    …/workspace/file/{nodeId}    one file: content + inbound backlinks
+//! POST   …/workspace                  create a folder/file (or upload)
+//! PUT    …/workspace/file/{nodeId}    overwrite file content
+//! PATCH  …/workspace/{nodeId}         rename / move
+//! DELETE …/workspace/{nodeId}         delete a node (folders recursive)
+//! ```
+//!
+//! ## Why the two `GET`s are REST and not GraphQL
+//!
+//! Every other console read goes through GraphQL, and `Company.workspaceTree` /
+//! `workspaceFile` have existed since the read plane landed — but the operator
+//! console ships **no GraphQL client**. Reaching them from the Workspace tab
+//! would mean a second wire protocol, a second auth path, a second error
+//! envelope and ISO-8601 string timestamps in a view whose siblings all use
+//! epoch millis. These twins keep the console on one client; the backlink scan
+//! itself is shared with the resolver
+//! ([`file_with_backlinks`](crate::company::workspace_links::file_with_backlinks))
+//! so the two surfaces cannot answer differently.
+//!
+//! ## Known limits (issue #177 — documented, not worked around)
+//!
+//! * **No authorship.** [`WorkspaceNode`] carries no author/origin field, so a
+//!   note an agent wrote is indistinguishable from one the operator typed.
+//!   Tracked by issue #326.
+//! * **No live push.** A write that lands while the tab is open is only visible
+//!   on a refetch (refresh button / window focus). Tracked by issue #327.
+//! * **No CAS on the console write path.** Agent writes require an
+//!   `expected_updated_at` compare-and-swap token; the console `PUT` does not,
+//!   so a concurrent agent write can be overwritten by the operator's save. That
+//!   is the store's stated design — the operator is the dominant editor, and the
+//!   agent's *next* CAS write fails and re-reads, so the agent side self-heals.
 
 use axum::extract::Path;
 use axum::http::StatusCode;
@@ -12,6 +47,7 @@ use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
+use crate::company::workspace_links::file_with_backlinks;
 use crate::error::OpenCompanyError;
 use crate::ports::generate_id;
 use crate::ports::workspace::{NodeKind, WorkspaceNode};
@@ -20,8 +56,11 @@ use crate::server::ops::{ScopedCompany, scoped};
 
 /// Builds the workspace route fragment.
 pub fn router() -> Router<AppState> {
-    scoped("/workspace", post(create_node))
-        .merge(scoped("/workspace/file/{node_id}", put(write_file)))
+    scoped("/workspace", post(create_node).get(list_tree))
+        .merge(scoped(
+            "/workspace/file/{node_id}",
+            put(write_file).get(read_file),
+        ))
         .merge(scoped(
             "/workspace/{node_id}",
             patch(rename_move).delete(delete_node),
@@ -53,6 +92,22 @@ impl FsNode {
             updated_at: node.updated_at_millis,
         }
     }
+}
+
+/// One workspace file with its body and the notes that link to it.
+///
+/// The REST twin of the GraphQL `WorkspaceFile`, differing only in timestamp
+/// shape (epoch millis, like every other console read) — the backlinks come
+/// from the same shared scan.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceFileBody {
+    id: String,
+    name: String,
+    content: String,
+    updated_at: u64,
+    /// Other files whose content links to this one via `[[name]]`.
+    backlinks: Vec<FsNode>,
 }
 
 /// The create-node body.
@@ -109,6 +164,54 @@ struct WriteAck {
 #[derive(Debug, Deserialize)]
 struct NodePath {
     node_id: String,
+}
+
+/// `GET …/workspace` — every node in the tree, metadata only.
+///
+/// Bodies are deliberately omitted: a tree read is the console's *navigation*
+/// call and happens on every mount, focus and refresh, so shipping every note's
+/// content would make it grow without bound with the workspace. The console
+/// fetches a body when a note is opened ([`read_file`]) — the same
+/// index-then-fetch split the agent-facing `workspace_list` / `workspace_read`
+/// tools make.
+async fn list_tree(company: ScopedCompany) -> Result<Json<Vec<FsNode>>, ApiError> {
+    let nodes = company.runtime.workspace().tree(company.id()).await?;
+    Ok(Json(
+        nodes
+            .into_iter()
+            .map(|node| FsNode::from_node(node, None))
+            .collect(),
+    ))
+}
+
+/// `GET …/workspace/file/{node_id}` — one file's content plus the notes that
+/// link to it.
+///
+/// A folder id 404s rather than answering with an empty body: the console only
+/// ever opens files, so a folder id here is a caller bug, and reporting it as an
+/// empty note would hide it.
+async fn read_file(
+    company: ScopedCompany,
+    Path(NodePath { node_id }): Path<NodePath>,
+) -> Result<Json<WorkspaceFileBody>, ApiError> {
+    let found =
+        file_with_backlinks(company.runtime.workspace().as_ref(), company.id(), &node_id).await?;
+    let Some((node, content, backlinks)) = found.filter(|(node, _, _)| node.kind == NodeKind::File)
+    else {
+        return Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
+            "workspace file {node_id}"
+        ))));
+    };
+    Ok(Json(WorkspaceFileBody {
+        id: node.id,
+        name: node.name,
+        content,
+        updated_at: node.updated_at_millis,
+        backlinks: backlinks
+            .into_iter()
+            .map(|node| FsNode::from_node(node, None))
+            .collect(),
+    }))
 }
 
 async fn create_node(

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -997,6 +997,236 @@ async fn workspace_create_write_move_and_cycle_rejection() {
     assert_eq!(status, StatusCode::NO_CONTENT);
 }
 
+/// The read plane the console's Workspace tab runs on (issue #177): the tree
+/// `GET` reflects writes, and the file `GET` carries content plus
+/// server-computed backlinks.
+///
+/// Before this the only workspace read was GraphQL, which the console has no
+/// client for — so the tab rendered a localStorage fixture and never saw a note
+/// an agent (or another browser) wrote.
+#[tokio::test]
+async fn workspace_tree_and_file_reads_reflect_writes() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+
+    // A workspace with nothing seeded into it reads as an empty tree, not a 404
+    // and not a fixture.
+    let (status, tree) = send(&state, "GET", "/api/v1/company/workspace", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(tree.as_array().unwrap().len(), 0);
+
+    let (_, folder) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workspace",
+        Some(json!({"name": "Standards", "kind": "folder"})),
+    )
+    .await;
+    let folder_id = folder["id"].as_str().unwrap().to_string();
+
+    let (_, voice) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workspace",
+        Some(json!({
+            "name": "voice.md",
+            "kind": "file",
+            "parentId": folder_id,
+            "content": "# Voice\n\nWarm and concise.",
+        })),
+    )
+    .await;
+    let voice_id = voice["id"].as_str().unwrap().to_string();
+
+    // A second note links to the first, so it must show up as its backlink.
+    let (_, brief) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workspace",
+        Some(json!({
+            "name": "brief.md",
+            "kind": "file",
+            "content": "Follows our [[voice]].",
+        })),
+    )
+    .await;
+    let brief_id = brief["id"].as_str().unwrap().to_string();
+
+    // The tree carries every node's metadata — and deliberately no bodies, so a
+    // navigation read never grows with the size of the workspace.
+    let (status, tree) = send(&state, "GET", "/api/v1/company/workspace", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let tree = tree.as_array().unwrap();
+    assert_eq!(tree.len(), 3);
+    for node in tree {
+        assert!(
+            node.get("content").is_none(),
+            "the tree read must not ship note bodies"
+        );
+        assert!(node["updatedAt"].is_number());
+    }
+    let listed = tree
+        .iter()
+        .find(|node| node["id"] == json!(voice_id))
+        .expect("the created note is in the tree");
+    assert_eq!(listed["name"], "voice.md");
+    assert_eq!(listed["kind"], "file");
+    assert_eq!(listed["parentId"], json!(folder_id));
+
+    // The file read carries the body and the inbound backlink, computed server
+    // side — the console derives neither.
+    let (status, file) = send(
+        &state,
+        "GET",
+        &format!("/api/v1/company/workspace/file/{voice_id}"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(file["name"], "voice.md");
+    assert!(
+        file["content"]
+            .as_str()
+            .unwrap()
+            .contains("Warm and concise")
+    );
+    assert!(file["updatedAt"].is_number());
+    let backlinks = file["backlinks"].as_array().unwrap();
+    assert_eq!(backlinks.len(), 1);
+    assert_eq!(backlinks[0]["id"], json!(brief_id));
+    assert_eq!(backlinks[0]["name"], "brief.md");
+
+    // An out-of-band write (an agent, or another browser) is visible on the very
+    // next read — the whole point of the tab reading the store.
+    let (status, _) = send(
+        &state,
+        "PUT",
+        &format!("/api/v1/company/workspace/file/{voice_id}"),
+        Some(json!({"content": "# Voice\n\nRewritten elsewhere."})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (_, file) = send(
+        &state,
+        "GET",
+        &format!("/api/v1/company/workspace/file/{voice_id}"),
+        None,
+    )
+    .await;
+    assert!(
+        file["content"]
+            .as_str()
+            .unwrap()
+            .contains("Rewritten elsewhere")
+    );
+
+    // A folder id and an unknown id are both 404 — never an empty note.
+    let (status, body) = send(
+        &state,
+        "GET",
+        &format!("/api/v1/company/workspace/file/{folder_id}"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(body["code"], "company_not_found");
+
+    let (status, _) = send(
+        &state,
+        "GET",
+        "/api/v1/company/workspace/file/does-not-exist",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+/// Two-company isolation over the workspace read plane: company A's notes are
+/// invisible to B, and a tenant token may not address a company it does not own.
+/// The store is per-company by construction — this pins that the new `GET`s do
+/// not widen it.
+#[tokio::test]
+async fn workspace_reads_are_isolated_between_companies() {
+    use crate::server::platform_auth::{
+        PlatformAuthConfig, PlatformClaims, StaticPlatformVerifier,
+    };
+    use std::collections::HashSet;
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let verifier = std::sync::Arc::new(StaticPlatformVerifier::new("plat-secret"));
+    let state = AppState::new(AppConfig::default())
+        .with_home(home.clone())
+        .with_platform_auth(PlatformAuthConfig::new(verifier));
+
+    for name in ["a", "b"] {
+        let id = CompanyId::new(name);
+        let runtime = RuntimeBuilder::new(home.clone(), manifest())
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        state
+            .registry()
+            .insert(id.clone(), std::sync::Arc::new(runtime));
+        state.set_owner(id.clone(), format!("tenant:{name}"));
+    }
+
+    let token = |tenant: &str| {
+        StaticPlatformVerifier::tenant_token(&PlatformClaims {
+            tenant: tenant.to_string(),
+            scopes: HashSet::from(["operator".to_string()]),
+            companies: None,
+        })
+    };
+
+    let (status, note) = send_auth(
+        &state,
+        "POST",
+        "/api/v1/companies/a/workspace",
+        Some(json!({"name": "secret.md", "kind": "file", "content": "A body"})),
+        Some(&token("tenant:a")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let note_id = note["id"].as_str().unwrap().to_string();
+
+    // B's own workspace is empty — A's note is not in it.
+    let (status, tree_b) = send_auth(
+        &state,
+        "GET",
+        "/api/v1/companies/b/workspace",
+        None,
+        Some(&token("tenant:b")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(tree_b.as_array().unwrap().len(), 0);
+
+    // Even naming A's node id explicitly, B's scope does not resolve it.
+    let (status, _) = send_auth(
+        &state,
+        "GET",
+        &format!("/api/v1/companies/b/workspace/file/{note_id}"),
+        None,
+        Some(&token("tenant:b")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    // And A's token may not address B's workspace at all — 403 (scoped auth).
+    let (status, _) = send_auth(
+        &state,
+        "GET",
+        "/api/v1/companies/b/workspace",
+        None,
+        Some(&token("tenant:a")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
 #[tokio::test]
 async fn skills_install_persists_the_registry_document_not_the_client_metadata() {
     let home_dir = home();


### PR DESCRIPTION
## Summary

Closes #177.

Agents write to the company workspace. The console's Workspace tab reads `localStorage`. They were two different trees, and neither could see the other — an agent produced a document and the operator's tab showed nothing, while the operator's notes reached no agent and did not survive a browser profile change.

This wires the tab to the real store. It is the missing half of #237, which shipped the agent-facing tools but left the console where it was.

**A second gap turned up while building it, and it mattered more than the first.** No shipped company grants the workspace tools at all — `e2e_harness` allows only `composio` and every agent lists explicit tools. So even after #237, no agent could reach the workspace on any company we ship. "Agent writes, operator sees" was unreachable from both ends, not one.

## API Or Behavior Changes

Additive: `GET …/workspace` (tree metadata, bodies omitted) and `GET …/workspace/file/{id}` (content plus server-computed backlinks). The write routes already existed. `schema.graphql` is unchanged.

**REST rather than GraphQL-in-the-console** — reads existed only in GraphQL, and the console has no GraphQL client, one auth path, one error path, and number-millis timestamps end to end. Adding a second wire protocol and ISO-string timestamps for one view was the worse trade. GraphQL's `resolve_file` now delegates to the same shared helper, so the two read surfaces cannot drift.

**Mutations apply on acknowledgement, not optimistically.** Every write returns the authoritative node, so success patches state from the response and failure leaves state untouched and toasts. No rollback machinery to get wrong.

**The editor keeps a dirty buffer** with a debounced save rather than persisting per keystroke. On failure the buffer is kept, so typing is never lost.

**Existing local notes are not silently discarded.** Anything the operator typed triggers an Import/Discard banner. A key holding only the app's bundled marketing seed is cleared silently — those are shipped bytes with zero user information, and importing them would inject fake content into every real workspace.

## The plan was wrong about grants, and the fix is pinned

The approved plan called for `workspace.read` on the read-only agents, expecting a bare `workspace` in `[tools].allow` to cover it "via namespace-cover". **It does not.** `[tools].allow` is matched by `allow_covers` → `grant_matches`, which is exact-or-trailing-glob. An agent asking for `workspace.read` under a bare `workspace` allow-entry gets **zero** workspace tools.

The confusable part: `grants_cover`, applied later at the harness gate, *is* namespace-aware. Two similarly-named predicates with different matching rules, one of which silently yields an empty toolbelt.

Both manifests now list `["workspace", "workspace.*"]`, and a new test loads the **real shipped manifests** and pins both the coverage and the read/write asymmetry. That test is what caught this, and it fails loudly if anyone re-narrows the list.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **1654 passed, 0 failed**, 1 ignored
- [x] `cargo check --locked --all-features --all-targets`
- [x] `git diff Cargo.lock` empty
- [x] `npm ci` / `npm run typecheck` / `npm run typecheck:e2e` / `npm run build`

**Verified against a live host on an isolated home, both halves.** Playwright 2/2 pass; independent curl confirms the seed lands, backlinks are computed server-side, folder and unknown ids 404, unauthenticated requests 401, and the PATCH double-option contract behaves — an omitted `parentId` preserves the parent while an explicit `null` moves the node to root.

**Running the browser spec caught two bugs unit tests could not.** The console is a hash router, so a repeat `goto()` at the same URL does not remount and the assertions would have passed vacuously — an explicit reload is required. And the legacy storage key is `oc-workspace:<company-id>`, not `oc-workspace:single`, because a lone registered company resolves to its id; the migration would have found nothing to import.

**One thing not proven, stated plainly.** With no inference credential the harness runs the echo brain, so a genuine agent tool call could not be driven. An out-of-band REST write stands in — same store, same code path — but *"an agent writes it and the operator sees it"* has not been observed with a live agent.

## Documentation

`docs/spec/runtime/api.md` and the server module doc gain the read routes.

Two known limits are documented at their call sites rather than papered over: the console PUT has no compare-and-set while agent writes require one, so an agent write landing mid-edit is overwritten by the operator's save — the store's stated design, where the operator is the dominant editor and the agent's next write fails and re-reads. And there is no push channel, so an agent-written file appears on refresh rather than live.

## Related

Closes #177. Completes the console half of #237.

Follow-ups filed rather than folded in: **#326** (a workspace note carries no authorship, so agent-written and operator-written files are indistinguishable — this ships `updatedAt` as a weak interim signal) and **#327** (no push channel; refetch on focus and visibility covers tab-out/tab-back but not a tab left open).

**Merge note:** conflicts with #304 in `companies/e2e_harness/company.toml` — its `budget_usd_daily` and this branch's `tools` line land on adjacent lines inside the same `writer` agent block. Keep both hunks, then re-run `shipped_companies_grant_the_workspace_tools`, which fails if the `tools` line is lost in the merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace content is now shared and synchronized through the host service across sessions and devices.
  * Added workspace browsing, file viewing, editing, folder and file management, uploads, renaming, moving, and deletion.
  * File views now display backlinks from related wiki-links.
  * Added automatic saving with status indicators, retry support, refresh controls, and clearer loading/error states.
  * Legacy browser-stored notes can be migrated into the shared workspace.

* **Documentation**
  * Added workspace usage, writing standards, and REST API documentation.

* **Bug Fixes**
  * Improved company isolation and workspace access permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->