### PR TITLE
feat(harness): enforce the per-agent daily budget (#304)

### DIFF
--- a/companies/e2e_harness/company.toml
+++ b/companies/e2e_harness/company.toml
@@ -61,6 +61,12 @@ description = "Turns rough notes into short, clear written drafts."
 # The one agent that may edit a note, so the "an agent wrote it, the operator
 # sees it" round trip is demonstrable out of the box.
 tools = ["mcp:*", "composio", "workspace"]
+# Issue #304 — one capped teammate so the Team page has a live per-agent budget
+# to render, and `team-budget.spec.ts` can assert the capped/uncapped split for
+# real rather than against a fixture. Deliberately generous: the harness runs on
+# the offline echo brain, which meters no cost, so spend stays $0.00 and this
+# cap never trips during a suite run.
+budget_usd_daily = 5.0
 
 [[group_chat]]
 id = "engineering"

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -33,7 +33,7 @@ description = "Write ads, pages, and campaign copy."
 # NEW optional per-agent keys:
 tier = "reasoning"                 # cognition tier hint (see glossary)
 tools = ["docs.*", "email.send"]   # tool grant globs
-budget_usd_daily = 5.0             # per-agent daily spend cap
+budget_usd_daily = 5.0             # per-agent daily spend cap (UTC day)
 
 # ── new tables (all optional) ──────────────────────────────────────────
 [users]
@@ -101,6 +101,41 @@ prompt = "Weekly review and operator digest"
   use when delegating; it never selects a model (the backend maps tiers to
   SKUs). `tools` and `budget_usd_daily` intersect with the company-wide
   `[tools].allow` and `[budget]` — the most restrictive wins.
+
+  **`budget_usd_daily`** (enforced since issue #304 — before that it was
+  validated, stored and displayed, but nothing read it) caps one teammate's
+  spend over the **UTC calendar day**, resetting at `00:00Z` — the same
+  boundary `[plan]`'s daily token budget uses. Spend is re-read from the usage
+  meter on every check, so a restart mid-day resumes against the real figure
+  rather than a fresh zero.
+
+  It covers **metered, attributed** spend: inference turns and priced tool
+  calls (`web_search`, `media_generate_*`), plus any tool call that declares an
+  `amount_usd`. Two behaviours at the cap:
+
+  - **Dispatch is refused** for that teammate, before any model call, with a
+    notice naming the cap and the reset. The rest of the company keeps running.
+  - **A priced tool call parks for approval** rather than being denied.
+    Approving it runs that one call and nothing more; the cap is not raised.
+    Free reads and sends are unaffected — a spend cap caps spend.
+
+  Known limits, stated rather than papered over:
+
+  - **Executed x402 payments escape the counter.** Ledger entries carry no
+    agent, so there is nothing to attribute them to. What *is* covered is the
+    pre-flight case: a call declaring an `amount_usd` that would breach the
+    remaining budget parks before the money moves. Company-wide payment
+    spending is governed by `[budget].monthly_usd`, which is enforced on the
+    economy path.
+  - **Turn-boundary overshoot.** A turn or call that starts under the cap can
+    finish over it; the overshoot is bounded by one call. There is no
+    reservation ledger in v1 — the same documented window `[plan]` carries.
+  - **Unreadable spend fails differently at each layer, deliberately.** With no
+    meter or a failing meter, dispatch **runs** (bricking a teammate's
+    cognition with no operator recourse is worse than a day of overspend),
+    while a priced tool call **parks** (a human can wave that one through).
+  - **Operator-added (overlay) teammates are uncapped in v1.** Only manifest
+    `[[agent]]` entries carry the field.
 - **`[brain]`** selects the `Brain` implementation. `hosted` requires a
   TinyHumans credential at runtime; `sidecar` requires the `sidecar` feature.
 - **`[inference]`** (issue #56 — BYOK) routes the company's agents through a

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -256,6 +256,19 @@ export interface TeamMemberDto {
    * it. Absent on hosts predating the field; the console reads that as `false`.
    */
   inboxEnabled?: boolean;
+  /**
+   * This teammate's daily spend cap in USD (manifest `budget_usd_daily`).
+   * Absent when the teammate is uncapped — absence IS the uncapped signal, so
+   * never default it to `0`, which would render a permanently exhausted
+   * teammate.
+   */
+  budgetUsdDaily?: number;
+  /**
+   * What this teammate has spent since 00:00 UTC. Sent only alongside
+   * `budgetUsdDaily`; absent for an uncapped teammate and on hosts predating
+   * the field.
+   */
+  spentTodayUsd?: number;
 }
 
 /**

--- a/frontend/src/lib/team.ts
+++ b/frontend/src/lib/team.ts
@@ -18,6 +18,13 @@ export interface TeamMember {
    * page and this toggle agree on the same `InboxStore` state (issue #173).
    */
   inboxEnabled: boolean;
+  /**
+   * The teammate's daily spend cap in USD, when the company sets one. Undefined
+   * means uncapped — the card shows no budget line at all rather than "$0".
+   */
+  budgetUsdDaily?: number;
+  /** What this teammate has spent since 00:00 UTC; only meaningful with a cap. */
+  spentTodayUsd?: number;
 }
 
 const TONE_KEYS = ["sky", "violet", "amber", "emerald", "rose", "cyan", "indigo", "teal"];
@@ -49,6 +56,10 @@ export function fromDto(dto: TeamMemberDto): TeamMember {
     description: dto.description ?? "",
     tone: toneFor(dto.id || name),
     inboxEnabled: dto.inboxEnabled ?? false,
+    // Carried through as-is: `undefined` means uncapped and must stay
+    // `undefined`, never coalesced to `0`.
+    budgetUsdDaily: dto.budgetUsdDaily,
+    spentTodayUsd: dto.spentTodayUsd,
   };
 }
 

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -251,6 +251,7 @@ function MemberCard({
         {member.description && (
           <p className="line-clamp-3 text-sm text-muted-foreground">{member.description}</p>
         )}
+        <DailyBudgetLine member={member} />
         <div className="mt-auto flex items-center justify-between gap-2 border-t pt-3">
           <Badge variant="secondary" className="gap-1">
             <Sparkles className="size-3" /> Agent
@@ -268,6 +269,32 @@ function MemberCard({
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+/**
+ * The teammate's daily spend cap and what it has spent against it today.
+ *
+ * Renders nothing at all for an uncapped teammate: the host omits the fields
+ * entirely rather than sending zeros, so absence means "spends freely" and must
+ * not be drawn as "$0.00/day". Once spend reaches the cap the line turns
+ * destructive — that teammate's dispatch is paused until 00:00 UTC, and the
+ * card is where an operator will look to find out why it went quiet.
+ */
+function DailyBudgetLine({ member }: { member: TeamMember }) {
+  const cap = member.budgetUsdDaily;
+  if (cap === undefined) return null;
+  const spent = member.spentTodayUsd ?? 0;
+  const overBudget = spent >= cap;
+  const usd = (n: number) => `$${n.toFixed(2)}`;
+  return (
+    <p
+      data-testid="team-budget"
+      className={cn("text-xs", overBudget ? "text-destructive" : "text-muted-foreground")}
+    >
+      {usd(cap)}/day · {usd(spent)} spent today
+      {overBudget && " · paused until 00:00 UTC"}
+    </p>
   );
 }
 

--- a/frontend/test/e2e/team-budget.spec.ts
+++ b/frontend/test/e2e/team-budget.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Proof for issue #304: a teammate's `budget_usd_daily` reaches the console.
+ *
+ * The issue described the cap as "validated, persisted and displayed" — the
+ * last of those was never true. Nothing on the wire carried it: `GET …/team`
+ * had no budget field, the GraphQL `TeamMember` had none, and the Team card
+ * rendered nothing. So this spec is not a regression net over a working
+ * surface; it is the first proof the surface exists.
+ *
+ * Two observable consequences, both against the live host (`companies/
+ * e2e_harness`, whose `writer` carries a $5.00/day cap and whose `ceo` /
+ * `engineer` carry none):
+ *
+ *   1. A capped teammate renders its cap and today's spend, from the host —
+ *      not a client-side guess.
+ *   2. An uncapped teammate renders **no** budget line at all. This is the
+ *      assertion that matters: the host omits the fields rather than sending
+ *      zeros, and a console that defaulted them to `0` would paint every
+ *      uncapped teammate as permanently out of budget.
+ *
+ * The harness runs on the offline echo brain, which meters no cost, so spend is
+ * a stable `$0.00` and the cap never trips mid-suite.
+ *
+ * Runs against the same live host as `wiring.spec.ts` (see that file's header).
+ */
+
+test("the Team page shows a capped teammate's daily budget and omits it for uncapped ones", async ({
+  page,
+}) => {
+  await page.goto("/#/team");
+
+  const cards = page.getByTestId("team-card");
+  await expect(cards.first()).toBeVisible({ timeout: 30_000 });
+
+  // The capped teammate: cap and spend both come from the host.
+  const writer = cards.filter({ hasText: "Writer" }).first();
+  const budget = writer.getByTestId("team-budget");
+  await expect(budget).toBeVisible({ timeout: 30_000 });
+  await expect(budget).toHaveText(/\$5\.00\/day/);
+  await expect(budget).toHaveText(/\$0\.00 spent today/);
+  // Under budget, so no paused state.
+  await expect(budget).not.toHaveText(/paused/);
+
+  // The uncapped teammates render no budget line whatsoever — absence is the
+  // uncapped signal, and "$0.00/day" would be a different (and wrong) claim.
+  for (const role of ["Chief Executive", "Engineer"]) {
+    const uncapped = cards.filter({ hasText: role }).first();
+    await expect(uncapped).toBeVisible({ timeout: 30_000 });
+    await expect(uncapped.getByTestId("team-budget")).toHaveCount(0);
+  }
+
+  // Host-backed, not localStorage: the line survives a storage-cleared reload.
+  await page.evaluate(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+  await page.goto("/#/team");
+  await expect(
+    page.getByTestId("team-card").filter({ hasText: "Writer" }).first().getByTestId("team-budget"),
+  ).toHaveText(/\$5\.00\/day/, { timeout: 30_000 });
+});

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -319,6 +319,13 @@ pub struct CompanyAgent {
     pub agent_id: String,
     /// The manifest agent's human-readable role.
     pub role: String,
+    /// This teammate's manifest `budget_usd_daily` cap, carried onto the roster
+    /// so the dispatch gate in [`HarnessPool::run_inner`] can read it without
+    /// re-loading the manifest per turn (issue #304).
+    ///
+    /// `None` for an uncapped teammate — and for every overlay teammate, which
+    /// carries no per-agent cap in v1.
+    pub budget_usd_daily: Option<f64>,
     /// The embedded openhuman session. A [`Mutex`] because a `turn` takes
     /// `&mut self` and one agent must serialise its own turns.
     agent: Mutex<Agent>,
@@ -335,6 +342,23 @@ const GRACEFUL_EMPTY_REPLY: &str = "Sorry — I hit a temporary model hiccup and
 /// [`HarnessPool::run_inner`](HarnessPool::run_inner).
 const TOTAL_BUDGET_EXHAUSTED_NOTICE: &str =
     "Token budget for this period is exhausted — dispatch paused until the period resets.";
+
+/// The operator-facing notice returned when one teammate has spent its manifest
+/// `budget_usd_daily` (issue #304) — a hard dispatch refusal for that teammate
+/// only, made before any model call.
+///
+/// Deliberately a *visible refusal* rather than a silent no-op, and deliberately
+/// per-teammate: the rest of the company keeps running, and the operator is told
+/// which desk stopped, what its cap is, and when it comes back. There is no
+/// per-call unit to park at turn level — an inference turn is not a tool call —
+/// so a notice is the honest answer, mirroring
+/// [`TOTAL_BUDGET_EXHAUSTED_NOTICE`].
+fn agent_budget_exhausted_notice(agent_id: &str, cap_usd: f64) -> String {
+    format!(
+        "{agent_id} has reached its daily spend cap of ${cap_usd:.2} — dispatch to this teammate \
+         is paused until the cap resets at 00:00 UTC. Other teammates are unaffected."
+    )
+}
 
 /// The classification of a single `agent.turn` attempt, for the retry wrapper.
 enum AttemptOutcome {
@@ -1086,6 +1110,70 @@ impl HarnessPool {
             }
         }
 
+        // Per-agent daily spend cap (issue #304): the same HARD, pre-model-call
+        // refusal as the ceiling above, scoped to ONE teammate.
+        //
+        // This is the layer that matters most in practice. The manifest's
+        // `budget_usd_daily` was validated, persisted and passed to
+        // `ApprovalPolicy` — where it sat on a field with no reader. But the
+        // dominant spend stream is not tool calls at all, it is inference, and
+        // inference never reaches a `ToolPolicy`. Gating only priced tool calls
+        // (the policy arm) would leave a capped teammate free to burn its budget
+        // many times over on model turns alone, which is how the cap came to be
+        // decorative in the first place.
+        //
+        // Refused BEFORE retrieve→inject and the memory writeback, exactly like
+        // the total ceiling, so a refused turn costs nothing and leaves no
+        // fabricated outcome in the store. The reply names the teammate, the cap
+        // and the reset — never a bare failure.
+        //
+        // FAIL-OPEN, mirroring #188's documented tradeoff: with no meter, or a
+        // meter whose query errors, we warn and run the turn. Bricking a
+        // company's cognition on a flaky read would be a strictly worse failure
+        // mode than one day of overspend, and there is no operator recourse at
+        // turn level (unlike the policy arm, whose park a human can approve —
+        // which is why THAT layer fails closed and this one does not).
+        if let Some(cap) = agent.budget_usd_daily {
+            match deps.meter.as_deref() {
+                Some(meter) => {
+                    let since = crate::metering::utc_day_start_millis(crate::ports::now_millis());
+                    match meter.query(company, since).await {
+                        Ok(samples) => {
+                            let spent = crate::metering::usd_spent_by_agent(&samples, agent_id);
+                            if spent >= cap {
+                                tracing::info!(
+                                    company = %company,
+                                    agent = agent_id,
+                                    spent,
+                                    cap,
+                                    "[agent-budget] daily spend cap reached; refusing dispatch (no model call) until 00:00 UTC"
+                                );
+                                return Ok(TurnOutcome {
+                                    reply: agent_budget_exhausted_notice(agent_id, cap),
+                                    steps: Vec::new(),
+                                });
+                            }
+                        }
+                        Err(error) => {
+                            tracing::warn!(
+                                company = %company,
+                                agent = agent_id,
+                                %error,
+                                "[agent-budget] daily-spend query failed; running the turn rather than bricking this teammate"
+                            );
+                        }
+                    }
+                }
+                None => {
+                    tracing::warn!(
+                        company = %company,
+                        agent = agent_id,
+                        "[agent-budget] no usage meter; the per-agent daily spend cap cannot be enforced on this host"
+                    );
+                }
+            }
+        }
+
         // Retrieve→inject: pull the top-K prior task outcomes relevant to this
         // message and prepend them as context. On a cold store this yields no
         // hits and the message is passed through unchanged.
@@ -1329,11 +1417,18 @@ pub(crate) fn build_roster(
         Vec::with_capacity(company.manifest.agents.len() + company.overlay_agents.len());
 
     for manifest_agent in &company.manifest.agents {
-        let agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily)
+        let mut agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily)
             .with_requests(deps.approval_requests.clone())
             // Issue #243: stamp who the parked effect belongs to, so approving it
             // can hand the grant back to this agent rather than to nobody.
             .with_agent(manifest_agent.id.clone());
+        // Issue #304: give the policy something to measure `budget_usd_daily`
+        // against. Only wired when the host has a meter — without one the cap
+        // arm stays inert and warns once, rather than parking every priced call
+        // on a host that can never answer the question.
+        if let Some(meter) = deps.meter.as_ref() {
+            agent_policy = agent_policy.with_spend(meter.clone(), company.id.clone());
+        }
         let is_orchestrator = orchestrator.as_deref() == Some(manifest_agent.id.as_str());
         let grants = agent_effective_grants(allow, &manifest_agent.tools);
         let agent = build::build_agent(
@@ -1349,6 +1444,7 @@ pub(crate) fn build_roster(
         roster.push(Arc::new(CompanyAgent {
             agent_id: manifest_agent.id.clone(),
             role: manifest_agent.role.clone(),
+            budget_usd_daily: manifest_agent.budget_usd_daily,
             agent: Mutex::new(agent),
         }));
     }
@@ -1368,12 +1464,17 @@ pub(crate) fn build_roster(
         }
         let manifest_agent = overlay_agent_to_manifest(overlay);
         // No per-teammate budget cap or cognition-tier hint in v1 — see
-        // `overlay_agent_to_manifest`.
-        let agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily)
+        // `overlay_agent_to_manifest`. The spend reader is still wired: the cap
+        // is `None`, so the arm is inert, but an overlay teammate that grows a
+        // cap later needs no second wiring site.
+        let mut agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily)
             .with_requests(deps.approval_requests.clone())
             // An overlay teammate is a real roster agent and re-dispatches the
             // same way a manifest one does (issue #243).
             .with_agent(manifest_agent.id.clone());
+        if let Some(meter) = deps.meter.as_ref() {
+            agent_policy = agent_policy.with_spend(meter.clone(), company.id.clone());
+        }
         let grants = agent_effective_grants(allow, &manifest_agent.tools);
         let agent = build::build_agent(
             &company.id,
@@ -1388,6 +1489,8 @@ pub(crate) fn build_roster(
         roster.push(Arc::new(CompanyAgent {
             agent_id: manifest_agent.id.clone(),
             role: manifest_agent.role.clone(),
+            // Overlay teammates are uncapped in v1 (`overlay_agent_to_manifest`).
+            budget_usd_daily: manifest_agent.budget_usd_daily,
             agent: Mutex::new(agent),
         }));
     }
@@ -1527,12 +1630,37 @@ mod tests {
             self.samples.lock().unwrap().push(sample.clone());
             Ok(())
         }
+        /// Honours `since_millis`, per the port contract ("every sample at or
+        /// after `since_millis`"). The per-agent daily cap (issue #304) is a
+        /// windowed read, so a double that returned everything regardless would
+        /// make the day-rollover test pass against any boundary the code
+        /// computed — including none at all.
+        async fn query(&self, _company: &CompanyId, since: u64) -> crate::Result<Vec<UsageSample>> {
+            Ok(self
+                .samples
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|sample| sample.at_millis >= since)
+                .cloned()
+                .collect())
+        }
+    }
+
+    /// A meter whose reads always fail — for the dispatch gate's fail-open pin.
+    struct FailingMeter;
+
+    #[async_trait]
+    impl UsageMeter for FailingMeter {
+        async fn record(&self, _company: &CompanyId, _sample: &UsageSample) -> crate::Result<()> {
+            Ok(())
+        }
         async fn query(
             &self,
             _company: &CompanyId,
             _since: u64,
         ) -> crate::Result<Vec<UsageSample>> {
-            Ok(self.samples.lock().unwrap().clone())
+            Err(OpenCompanyError::Store("meter unavailable".into()))
         }
     }
 
@@ -2703,7 +2831,7 @@ description = "Sets direction."
     fn deps_with_plan(
         dir: &std::path::Path,
         context: Arc<MockContext>,
-        meter: Option<Arc<RecordingMeter>>,
+        meter: Option<Arc<dyn UsageMeter>>,
         plan: Option<crate::harness::capability_budget::CapabilityPlan>,
     ) -> HarnessDeps {
         HarnessDeps {
@@ -2711,7 +2839,7 @@ description = "Sets direction."
             provider_slug: "mock".to_string(),
             context,
             store: Arc::new(RecordingStore::default()),
-            meter: meter.map(|m| m as Arc<dyn UsageMeter>),
+            meter,
             workspace_root: dir.to_path_buf(),
             model_override: None,
             tasks: None,
@@ -2755,7 +2883,12 @@ description = "Sets direction."
             budgets: std::collections::BTreeMap::new(),
             total_budget: Some(100),
         };
-        let deps = deps_with_plan(dir.path(), context.clone(), Some(meter.clone()), Some(plan));
+        let deps = deps_with_plan(
+            dir.path(),
+            context.clone(),
+            Some(meter.clone() as Arc<dyn UsageMeter>),
+            Some(plan),
+        );
         let pool = HarnessPool::new();
         let rec = record();
         pool.ensure(&rec, &deps).await.expect("ensure");
@@ -2851,6 +2984,234 @@ description = "Sets direction."
         assert_ne!(
             reply, TOTAL_BUDGET_EXHAUSTED_NOTICE,
             "the hard refusal must not fire without a spend read"
+        );
+    }
+
+    // --- The per-agent daily spend cap at dispatch (issue #304) --------------
+
+    /// A company whose `ceo` carries a $5/day cap and whose `engineer` carries
+    /// none — the pair that proves the gate is per-teammate, not per-company.
+    fn capped_record() -> CompanyRecord {
+        let manifest: CompanyManifest = toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+description = "Sets direction."
+budget_usd_daily = 5.0
+
+[[agent]]
+id = "engineer"
+role = "Engineer"
+description = "Builds the product."
+"#,
+        )
+        .expect("valid manifest");
+        CompanyRecord {
+            manifest,
+            ..record()
+        }
+    }
+
+    /// A `$usd` inference sample for `agent`, stamped at `at_millis`.
+    fn spend_sample(agent: &str, usd: f64, at_millis: u64) -> UsageSample {
+        UsageSample {
+            at_millis,
+            agent: agent.into(),
+            provider: "managed".into(),
+            input_tokens: 0,
+            output_tokens: 0,
+            cached_input_tokens: 0,
+            cost_usd: usd,
+            kind: crate::ports::SampleKind::Inference,
+        }
+    }
+
+    /// The heart of #304 at the layer that carries the money: once a teammate
+    /// has spent its manifest `budget_usd_daily`, its next dispatch is refused
+    /// **before any model call** — while its uncapped colleague keeps working.
+    ///
+    /// This is the layer that matters, because the dominant spend stream is
+    /// inference and inference never reaches a `ToolPolicy`. Gating only priced
+    /// tool calls would leave a capped teammate free to burn its budget many
+    /// times over on model turns alone.
+    #[tokio::test]
+    async fn run_refuses_dispatch_for_a_teammate_over_its_daily_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let context = Arc::new(MockContext::default());
+        let meter = Arc::new(RecordingMeter::default());
+        let rec = capped_record();
+
+        // The CEO has spent its whole $5 today. The engineer has spent nothing.
+        meter
+            .record(
+                &rec.id,
+                &spend_sample("ceo", 5.00, crate::ports::now_millis()),
+            )
+            .await
+            .unwrap();
+
+        let deps = deps_with_plan(
+            dir.path(),
+            context.clone(),
+            Some(meter.clone() as Arc<dyn UsageMeter>),
+            None,
+        );
+        let pool = HarnessPool::new();
+        pool.ensure(&rec, &deps).await.expect("ensure");
+
+        let samples_before = meter.samples.lock().unwrap().len();
+        let memory_before = context
+            .list(&rec.id, memory_loop::OUTCOME_LABEL_PREFIX)
+            .await
+            .unwrap()
+            .len();
+
+        let refused = pool
+            .run(&rec.id, "ceo", "should-not-echo", &deps, None)
+            .await
+            .expect("a refusal is a benign outcome, not a hard error")
+            .reply;
+        assert_eq!(
+            refused,
+            agent_budget_exhausted_notice("ceo", 5.0),
+            "the refusal names the teammate, its cap and the reset"
+        );
+        assert!(
+            !refused.contains("should-not-echo"),
+            "the model was never called, so the prompt is not echoed: {refused:?}"
+        );
+        assert_eq!(
+            meter.samples.lock().unwrap().len(),
+            samples_before,
+            "a pre-model-call refusal meters nothing"
+        );
+        assert_eq!(
+            context
+                .list(&rec.id, memory_loop::OUTCOME_LABEL_PREFIX)
+                .await
+                .unwrap()
+                .len(),
+            memory_before,
+            "a refused turn stores no fabricated outcome"
+        );
+
+        // The cap is per-teammate: the uncapped engineer is untouched, and the
+        // CEO's spend does not count against it.
+        let ok = pool
+            .run(&rec.id, "engineer", "hello-marker", &deps, None)
+            .await
+            .expect("an uncapped teammate keeps working")
+            .reply;
+        assert!(
+            ok.contains("hello-marker"),
+            "one teammate's exhausted budget must not stop the company: {ok:?}"
+        );
+    }
+
+    /// Fail-open pin, mirroring #188's documented tradeoff exactly: with a cap
+    /// set but spend unreadable, the turn RUNS.
+    ///
+    /// A `$0` cap would refuse from the first cent if spend were readable, so a
+    /// meter that errors is the only reason this turn can proceed. Bricking a
+    /// teammate's cognition on a flaky read is a strictly worse failure mode
+    /// than one day of overspend — and unlike the policy arm's park, a turn-level
+    /// refusal offers the operator nothing to approve.
+    #[tokio::test]
+    async fn run_does_not_refuse_a_capped_teammate_when_spend_is_unreadable() {
+        let dir = tempfile::tempdir().unwrap();
+        let context = Arc::new(MockContext::default());
+        let manifest: CompanyManifest = toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+description = "Sets direction."
+budget_usd_daily = 0.0
+"#,
+        )
+        .expect("valid manifest");
+        let rec = CompanyRecord {
+            manifest,
+            ..record()
+        };
+
+        let deps = deps_with_plan(
+            dir.path(),
+            context.clone(),
+            Some(Arc::new(FailingMeter) as Arc<dyn UsageMeter>),
+            None,
+        );
+        let pool = HarnessPool::new();
+        pool.ensure(&rec, &deps).await.expect("ensure");
+
+        let reply = pool
+            .run(&rec.id, "ceo", "hello-marker", &deps, None)
+            .await
+            .expect("an unreadable budget must not brick the teammate")
+            .reply;
+        assert!(
+            reply.contains("hello-marker"),
+            "an unreadable cap defers to running the turn: {reply:?}"
+        );
+
+        // ...and with no meter at all, the same deferral.
+        let no_meter = deps_with_plan(dir.path(), context.clone(), None, None);
+        let pool = HarnessPool::new();
+        pool.ensure(&rec, &no_meter).await.expect("ensure");
+        let reply = pool
+            .run(&rec.id, "ceo", "hello-marker", &no_meter, None)
+            .await
+            .expect("no meter must not brick the teammate")
+            .reply;
+        assert!(reply.contains("hello-marker"), "no meter defers: {reply:?}");
+    }
+
+    /// The cap is the UTC calendar day: yesterday's $9 does not refuse today's
+    /// first turn. Depends on `RecordingMeter` honouring `since_millis`.
+    #[tokio::test]
+    async fn a_yesterday_stamped_spend_does_not_refuse_todays_dispatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let context = Arc::new(MockContext::default());
+        let meter = Arc::new(RecordingMeter::default());
+        let rec = capped_record();
+
+        let yesterday =
+            crate::metering::utc_day_start_millis(crate::ports::now_millis()).saturating_sub(1);
+        meter
+            .record(&rec.id, &spend_sample("ceo", 9.00, yesterday))
+            .await
+            .unwrap();
+
+        let deps = deps_with_plan(
+            dir.path(),
+            context.clone(),
+            Some(meter.clone() as Arc<dyn UsageMeter>),
+            None,
+        );
+        let pool = HarnessPool::new();
+        pool.ensure(&rec, &deps).await.expect("ensure");
+
+        let reply = pool
+            .run(&rec.id, "ceo", "hello-marker", &deps, None)
+            .await
+            .expect("a new day admits the turn")
+            .reply;
+        assert!(
+            reply.contains("hello-marker"),
+            "the cap resets at 00:00Z; yesterday's spend is spent: {reply:?}"
         );
     }
 }

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -52,7 +52,24 @@
 //! ([`GRANT_TTL_MILLIS`](crate::runtime::grants::GRANT_TTL_MILLIS)) and the
 //! operator is told the agent did not act, rather than the permission sitting
 //! live indefinitely.
+//!
+//! ## The per-agent daily spend cap (issue #304)
+//!
+//! The manifest's per-agent `budget_usd_daily` was validated, persisted and
+//! passed all the way down to a field on this struct whose getter had no call
+//! sites. It was documentation. The company-wide `[budget].monthly_usd` **is**
+//! enforced on the economy path, so the two knobs presented identically while
+//! only one of them was real.
+//!
+//! Spend arrives through two doors, so enforcement is two layers. Inference —
+//! the dominant stream — is gated at dispatch in
+//! [`HarnessPool::run`](crate::harness::HarnessPool::run), before any model
+//! call. Priced *tool* calls are gated here, by the arm below `always_approve`.
+//! See [`ApprovalPolicy::daily_budget_verdict`] for why the arm sits exactly
+//! where it does, why an at-cap call **parks** rather than being denied, and
+//! what the cap does not see.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -61,7 +78,9 @@ use openhuman_core::openhuman as oh;
 use oh::agent::tool_policy::{ToolPolicy, ToolPolicyDecision, ToolPolicyRequest};
 
 use crate::company::Policy;
-use crate::ports::types::{Effect, EffectGroup};
+use crate::metering::{usd_spent_by_agent, utc_day_start_millis};
+use crate::ports::UsageMeter;
+use crate::ports::types::{CompanyId, Effect, EffectGroup};
 use crate::runtime::grants::{GrantSet, GrantedCall};
 
 /// Most approval requests parked out of a single turn. A model that keeps
@@ -205,9 +224,34 @@ pub struct ApprovalPolicy {
     mode: PolicyMode,
     always_approve: Vec<String>,
     auto_approve_under_usd: Option<f64>,
-    /// Per-agent daily spend cap; retained for the runtime budget gate. `None`
-    /// leaves budget enforcement to the company-wide `[budget]` ceiling.
+    /// Per-agent daily spend cap (issue #304). `None` leaves budget enforcement
+    /// to the company-wide `[budget]` ceiling.
+    ///
+    /// Enforced by [`daily_budget_verdict`](Self::daily_budget_verdict) for
+    /// priced tool calls, and by the dispatch gate in
+    /// [`HarnessPool::run`](crate::harness::HarnessPool::run) for inference. The
+    /// cap is only *readable* when a [`spend`](Self::with_spend) reader is
+    /// chained on, which only `build_roster` does.
     budget_usd_daily: Option<f64>,
+    /// Where "what has this agent spent since UTC midnight" is read from
+    /// (issue #304): the company's [`UsageMeter`] plus the company the cap is
+    /// scoped to.
+    ///
+    /// `None` at every non-harness construction site — and, deliberately, on a
+    /// host with no meter wired — which makes the budget arm **inert**, so every
+    /// existing construction site and test decides exactly as it did before.
+    /// Chained by `build_roster` alongside [`with_requests`](Self::with_requests)
+    /// / [`with_agent`](Self::with_agent) rather than widening
+    /// [`new`](Self::new), for the same reason those are.
+    spend: Option<SpendReader>,
+    /// Whether the "cap set but no meter to read it with" warning has already
+    /// been emitted by this policy instance.
+    ///
+    /// That condition is a permanent deployment fact, not a transient one, so
+    /// warning per priced call would emit a line per tool call for the life of
+    /// the process and bury everything else. Once per policy is the useful
+    /// signal.
+    no_meter_warned: AtomicBool,
     /// Where a `RequireApproval` decision is recorded so the runtime can park it
     /// (issue #172). The default is a private queue nobody drains, which keeps
     /// every non-harness construction site (and every test) behaving exactly as
@@ -223,6 +267,22 @@ pub struct ApprovalPolicy {
     /// projected before: no agent, so no grant, so the runtime executes it
     /// natively. Only `build_roster` sets it.
     agent: Option<String>,
+}
+
+/// Where the per-agent daily spend cap reads today's spend from (issue #304):
+/// the company's durable [`UsageMeter`] and the company id to scope the query
+/// to.
+///
+/// Durable on purpose — spend is re-read from the meter (jsonl / sqlite /
+/// mongo) on every priced call rather than accumulated in memory, so a restart
+/// mid-day resumes against the real figure instead of resetting the cap to
+/// zero. A per-turn snapshot cell was considered and rejected: it is stale
+/// within the turn it is taken for, and it would share the
+/// [`ApprovalRequestQueue::clear`] lifecycle that
+/// `grants_survive_a_queue_clear` exists to warn about.
+struct SpendReader {
+    meter: Arc<dyn UsageMeter>,
+    company: CompanyId,
 }
 
 impl ApprovalPolicy {
@@ -242,6 +302,8 @@ impl ApprovalPolicy {
             budget_usd_daily,
             requests: ApprovalRequestQueue::default(),
             agent: None,
+            spend: None,
+            no_meter_warned: AtomicBool::new(false),
         }
     }
 
@@ -249,6 +311,16 @@ impl ApprovalPolicy {
     /// so the brain can park the request after the turn (issue #172).
     pub fn with_requests(mut self, requests: ApprovalRequestQueue) -> Self {
         self.requests = requests;
+        self
+    }
+
+    /// Installs the meter the per-agent daily spend cap is measured against
+    /// (issue #304).
+    ///
+    /// Without this the cap is inert — which is exactly what every non-harness
+    /// construction site wants, and what a host with no meter gets.
+    pub fn with_spend(mut self, meter: Arc<dyn UsageMeter>, company: CompanyId) -> Self {
+        self.spend = Some(SpendReader { meter, company });
         self
     }
 
@@ -334,6 +406,153 @@ impl ApprovalPolicy {
             top_level_keys(args)
         );
         None
+    }
+
+    /// Does this tool call **spend money**? The predicate the daily budget arm
+    /// gates on (issue #304).
+    ///
+    /// Three signals, any of which is enough:
+    ///
+    /// * the call **declares** an amount (`amount_usd` / `amount`) — the only
+    ///   pre-flight signal there is for an x402 payment;
+    /// * it is a [metered read](is_metered_read) — `web_search` changes nothing
+    ///   but the backend charges per request;
+    /// * it projects onto [`EffectGroup::Spend`] — `media_generate_*`,
+    ///   `pay_*`/`transfer_*`, and anything else the group classifier already
+    ///   calls spend.
+    ///
+    /// Everything else — a read, a send, a publish, a workspace write — is
+    /// **untouched at cap**. A spend cap caps spend; making a teammate unable to
+    /// answer a question because it spent its budget this morning would be a
+    /// different feature, and a worse one.
+    fn is_priced_call(tool: &str, declared_amount: Option<f64>) -> bool {
+        declared_amount.is_some()
+            || is_metered_read(tool)
+            || classify_group(tool) == EffectGroup::Spend
+    }
+
+    /// The per-agent daily spend cap (issue #304): `Some(decision)` when this
+    /// priced call must not proceed on today's budget, `None` to fall through.
+    ///
+    /// ## Where this sits, and why
+    ///
+    /// Below the reserved `never_do` slot, below the `readonly` brake, **below
+    /// grant consumption**, below `always_approve` — and **above**
+    /// `auto_approve_under_usd` and the mode dispatch.
+    ///
+    /// Below the grant is the one placement that is not obvious, and it is the
+    /// same argument #243 made for putting grants above `always_approve`. A
+    /// budget park exists *to ask the operator a question*; the grant is the
+    /// operator's answer. Ranking the budget above the grant would mean
+    /// approving an at-cap call re-parks it, forever — approval would authorise
+    /// nothing for precisely the calls the operator most wants to authorise
+    /// deliberately. `readonly` is different and stays on top: it is the
+    /// emergency brake, not a question, and consent does not survive it.
+    ///
+    /// Above `auto_approve_under_usd` because that threshold is a
+    /// *per-call* convenience ("don't bother me about anything under $5") and
+    /// this is a *per-day* ceiling. Below it, an agent with a $5 cap and a $5
+    /// auto-approve threshold could spend $4.99 at a time without limit — the
+    /// cap would be unreachable by construction. Above `Full` for the same
+    /// reason: full autonomy means "no per-call gate", not "no budget".
+    ///
+    /// ## At cap it PARKS — never denies, never downgrades
+    ///
+    /// A hard deny recreates the pre-#172 silent dead-end: openhuman resolves
+    /// the refusal inline, the model is told no, and the operator never learns
+    /// the company stopped working because one teammate hit its cap. A silent
+    /// downgrade to a cheaper path would be worse still — the suppression-shaped
+    /// "fix" where monitoring goes quiet and the defect keeps running. Parking
+    /// puts the decision in front of the operator, who can approve it (minting a
+    /// #243 single-use grant that re-dispatches the call) or leave it.
+    ///
+    /// ## Failure semantics
+    ///
+    /// * **No meter wired** — inert, with a one-shot warning. This is a
+    ///   permanent deployment fact, not a transient read failure; parking every
+    ///   priced call forever would brick every spend tool on a host that simply
+    ///   has no meter, and no operator approval would ever clear it.
+    /// * **Meter query errored** — **park**, naming the uncertainty. Transient
+    ///   uncertainty about money reads as *ask*, not *allow*. This is the
+    ///   deliberate opposite of the dispatch gate's fail-open, and the asymmetry
+    ///   is the point: there the alternative is bricking the company's cognition
+    ///   with no recourse, here the alternative is one call waiting on a human
+    ///   who can wave it through.
+    ///
+    /// ## What the cap does not see
+    ///
+    /// An **executed** x402 payment. The ledger carries no agent, so there is
+    /// nothing to attribute; the pre-flight `declared_amount` check below covers
+    /// the call *before* the money moves, and that is the whole of the coverage.
+    /// Closing the gap is a store-shape change across three persistence
+    /// backends. Documented in `docs/spec/runtime/manifest.md` rather than
+    /// papered over here.
+    ///
+    /// There is also a turn-boundary TOCTOU window: a call that starts under the
+    /// cap can finish over it, bounded by one call's cost. The same documented
+    /// window `capability_budget` carries; v1 has no reservation ledger.
+    async fn daily_budget_verdict(
+        &self,
+        tool: &str,
+        args: &serde_json::Value,
+        declared_amount: Option<f64>,
+    ) -> Option<ToolPolicyDecision> {
+        let cap = self.budget_usd_daily?;
+        let agent = self.agent.as_deref()?;
+        if !Self::is_priced_call(tool, declared_amount) {
+            return None;
+        }
+        let Some(spend) = self.spend.as_ref() else {
+            if !self.no_meter_warned.swap(true, Ordering::Relaxed) {
+                log::warn!(
+                    "[approval] agent '{agent}' has a daily budget of ${cap:.2} but no usage \
+                     meter is wired; the per-agent spend cap cannot be enforced on this host"
+                );
+            }
+            return None;
+        };
+
+        let since = utc_day_start_millis(crate::ports::now_millis());
+        let samples = match spend.meter.query(&spend.company, since).await {
+            Ok(samples) => samples,
+            Err(error) => {
+                log::warn!(
+                    "[approval] could not read agent '{agent}' spend for the daily budget \
+                     ({error}); parking '{tool}' rather than spending against an unknown balance"
+                );
+                return Some(self.require_approval(
+                    tool,
+                    args,
+                    format!(
+                        "'{tool}' spends money and {agent}'s daily budget could not be verified \
+                         right now"
+                    ),
+                ));
+            }
+        };
+
+        let spent = usd_spent_by_agent(&samples, agent);
+        let amount = declared_amount.unwrap_or(0.0);
+        // Two boundaries: already at/over the cap (`>=`, matching every other
+        // budget gate in the crate), or a declared amount that would carry this
+        // agent past it. A call with no declared amount only trips the first —
+        // its cost is unknowable until it runs.
+        if spent < cap && spent + amount <= cap {
+            return None;
+        }
+
+        let reason = if spent >= cap {
+            format!(
+                "'{tool}' spends money and {agent} has used ${spent:.2} of its ${cap:.2} daily \
+                 budget; approve to let this one call through"
+            )
+        } else {
+            format!(
+                "'{tool}' would spend ${amount:.2}, carrying {agent} past its ${cap:.2} daily \
+                 budget (${spent:.2} used so far); approve to let this one call through"
+            )
+        };
+        Some(self.require_approval(tool, args, reason))
     }
 
     /// The one construction site for a `RequireApproval` decision (issue #172):
@@ -440,11 +659,23 @@ impl ToolPolicy for ApprovalPolicy {
             );
         }
 
+        let declared_amount = Self::amount_usd(&request.arguments);
+
+        // 3. The per-agent daily spend cap (issue #304). ABOVE
+        //    `auto_approve_under_usd` and the mode dispatch, so neither a
+        //    sub-threshold trickle nor `full` autonomy can spend past a cap the
+        //    manifest set. See `daily_budget_verdict` for the full ordering
+        //    argument and the park-don't-deny reasoning.
+        if let Some(decision) = self
+            .daily_budget_verdict(tool, &request.arguments, declared_amount)
+            .await
+        {
+            return decision;
+        }
+
         // Auto-approve small spends under the configured threshold.
-        if let (Some(threshold), Some(amount)) = (
-            self.auto_approve_under_usd,
-            Self::amount_usd(&request.arguments),
-        ) && amount < threshold
+        if let (Some(threshold), Some(amount)) = (self.auto_approve_under_usd, declared_amount)
+            && amount < threshold
         {
             return ToolPolicyDecision::Allow;
         }
@@ -1450,5 +1681,454 @@ mod tests {
             p.check(&request("send_email", serde_json::json!({}))).await,
             ToolPolicyDecision::RequireApproval { .. }
         ));
+    }
+
+    // --- The per-agent daily spend cap (issue #304) ---------------------------
+
+    use crate::ports::usage::{SampleKind, UsageMeter, UsageSample};
+    use std::sync::atomic::AtomicUsize;
+
+    /// A meter over a fixed sample set that **respects `since_millis`**.
+    ///
+    /// The respecting is the whole point of the double. A meter that ignored
+    /// `since` — which the crate's other test meters do, harmlessly, because
+    /// nothing they back reads a window — would make the day-boundary tests
+    /// pass no matter what boundary the code computed, including no boundary at
+    /// all. It also counts queries, so "a policy with no cap never asks the
+    /// meter" is an assertion rather than an assumption.
+    #[derive(Default)]
+    struct FixedMeter {
+        samples: Vec<UsageSample>,
+        queries: AtomicUsize,
+    }
+
+    impl FixedMeter {
+        fn with(samples: Vec<UsageSample>) -> Arc<Self> {
+            Arc::new(Self {
+                samples,
+                queries: AtomicUsize::new(0),
+            })
+        }
+
+        fn query_count(&self) -> usize {
+            self.queries.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait]
+    impl UsageMeter for FixedMeter {
+        async fn record(&self, _company: &CompanyId, _sample: &UsageSample) -> crate::Result<()> {
+            Ok(())
+        }
+        async fn query(&self, _company: &CompanyId, since: u64) -> crate::Result<Vec<UsageSample>> {
+            self.queries.fetch_add(1, Ordering::Relaxed);
+            Ok(self
+                .samples
+                .iter()
+                .filter(|sample| sample.at_millis >= since)
+                .cloned()
+                .collect())
+        }
+    }
+
+    /// A meter whose reads fail — the transient-uncertainty case.
+    struct FailingMeter;
+
+    #[async_trait]
+    impl UsageMeter for FailingMeter {
+        async fn record(&self, _company: &CompanyId, _sample: &UsageSample) -> crate::Result<()> {
+            Ok(())
+        }
+        async fn query(
+            &self,
+            _company: &CompanyId,
+            _since: u64,
+        ) -> crate::Result<Vec<UsageSample>> {
+            Err(crate::error::OpenCompanyError::Store(
+                "meter unavailable".into(),
+            ))
+        }
+    }
+
+    /// An inference sample costing `usd`, stamped at `at_millis`.
+    fn spend_sample(agent: &str, usd: f64, at_millis: u64) -> UsageSample {
+        UsageSample {
+            at_millis,
+            agent: agent.into(),
+            provider: "managed".into(),
+            input_tokens: 0,
+            output_tokens: 0,
+            cached_input_tokens: 0,
+            cost_usd: usd,
+            kind: SampleKind::Inference,
+        }
+    }
+
+    /// Some instant today, comfortably after UTC midnight.
+    fn today() -> u64 {
+        crate::ports::now_millis()
+    }
+
+    /// The last millisecond of yesterday, UTC.
+    fn yesterday() -> u64 {
+        crate::metering::utc_day_start_millis(today()).saturating_sub(1)
+    }
+
+    /// A cap-bearing policy bound to `agent`, reading spend from `meter`, plus
+    /// the grant set its queue carries.
+    fn capped_policy(
+        mode: &str,
+        auto_under: Option<f64>,
+        cap: f64,
+        agent: &str,
+        meter: Arc<dyn UsageMeter>,
+    ) -> (ApprovalPolicy, crate::runtime::grants::GrantSet) {
+        let p = Policy {
+            mode: mode.to_string(),
+            always_approve: Vec::new(),
+            auto_approve_under_usd: auto_under,
+        };
+        let queue = ApprovalRequestQueue::default();
+        let grants = queue.grants();
+        (
+            ApprovalPolicy::new(&p, Some(cap))
+                .with_requests(queue)
+                .with_agent(agent)
+                .with_spend(meter, CompanyId::new("acme")),
+            grants,
+        )
+    }
+
+    /// The core of #304: at cap, a **priced** call parks — and it parks through
+    /// the two carve-outs that would otherwise wave it straight through.
+    ///
+    /// * `web_search` under `supervised` is the #238 metered-read carve-out: it
+    ///   never parks, precisely *because* it spends money and the daily call cap
+    ///   was the boundary. A per-agent spend cap is a second, tighter boundary,
+    ///   and it has to outrank the carve-out or the tightest limit in the
+    ///   manifest would be the one that does nothing.
+    /// * Under `full` there is no per-call gate at all. "Full autonomy" means
+    ///   the operator is not asked about each action; it does not mean the
+    ///   budget they wrote down is advisory.
+    #[tokio::test]
+    async fn at_cap_a_priced_call_parks_through_the_metered_read_and_full_carve_outs() {
+        let meter = FixedMeter::with(vec![spend_sample("analyst", 5.00, today())]);
+
+        let (supervised, _) = capped_policy(
+            "supervised",
+            None,
+            5.0,
+            "analyst",
+            meter.clone() as Arc<dyn UsageMeter>,
+        );
+        let decision = supervised
+            .check(&request(
+                "web_search",
+                serde_json::json!({ "query": "acme pricing" }),
+            ))
+            .await;
+        assert!(
+            matches!(decision, ToolPolicyDecision::RequireApproval { .. }),
+            "a metered read must park once the agent is out of budget: {decision:?}"
+        );
+
+        let (full, _) = capped_policy(
+            "full",
+            None,
+            5.0,
+            "analyst",
+            meter.clone() as Arc<dyn UsageMeter>,
+        );
+        assert!(
+            matches!(
+                full.check(&request("media_generate_image", serde_json::json!({})))
+                    .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "full autonomy is not a budget exemption"
+        );
+        assert!(
+            matches!(
+                full.check(&request(
+                    "pay_invoice",
+                    serde_json::json!({ "amount_usd": 1.0 })
+                ))
+                .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "an amount-bearing call must park at cap under full autonomy too"
+        );
+    }
+
+    /// The remaining-budget boundary, and why the arm sits **above**
+    /// `auto_approve_under_usd`: a declared amount that would carry the agent
+    /// past its cap parks even though it is under the auto-approve threshold,
+    /// while an amount that still fits is waved through as before.
+    ///
+    /// Below the threshold instead, an agent with a $5 cap and a $5 auto-approve
+    /// threshold could spend $4.99 at a time forever and the cap would be
+    /// unreachable by construction.
+    #[tokio::test]
+    async fn a_declared_amount_that_breaches_the_remaining_budget_parks() {
+        let meter = FixedMeter::with(vec![spend_sample("analyst", 4.20, today())]);
+        let (p, _) = capped_policy(
+            "supervised",
+            Some(5.0),
+            5.0,
+            "analyst",
+            meter.clone() as Arc<dyn UsageMeter>,
+        );
+
+        // $4.20 spent + $3.00 = $7.20 > $5.00 cap — parks despite being under
+        // the $5 auto-approve threshold.
+        assert!(
+            matches!(
+                p.check(&request(
+                    "pay_invoice",
+                    serde_json::json!({ "amount_usd": 3.0 })
+                ))
+                .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "a sub-threshold spend that breaches the day's remaining budget must park"
+        );
+
+        // $4.20 + $0.50 = $4.70 <= $5.00 — still fits, so auto-approve applies.
+        assert_eq!(
+            p.check(&request(
+                "pay_invoice",
+                serde_json::json!({ "amount_usd": 0.5 })
+            ))
+            .await,
+            ToolPolicyDecision::Allow,
+            "a spend that fits inside the remaining budget is unaffected"
+        );
+    }
+
+    /// A spend cap caps **spend**. At cap a teammate can still read and can
+    /// still park a send for the ordinary supervised reason — it has not been
+    /// muted, it has been defunded.
+    ///
+    /// The send assertion checks the *reason text*, not just the decision:
+    /// `send_email` parks under supervised either way, so only the wording
+    /// distinguishes "parked because it reaches outside" from "parked because
+    /// the budget arm swallowed a free call".
+    #[tokio::test]
+    async fn free_reads_and_sends_are_untouched_at_cap() {
+        let meter = FixedMeter::with(vec![spend_sample("analyst", 9.99, today())]);
+        let (p, _) = capped_policy(
+            "supervised",
+            None,
+            5.0,
+            "analyst",
+            meter.clone() as Arc<dyn UsageMeter>,
+        );
+
+        assert_eq!(
+            p.check(&request("read_file", serde_json::json!({}))).await,
+            ToolPolicyDecision::Allow,
+            "a free read costs nothing and must survive the cap"
+        );
+
+        let decision = p
+            .check(&request(
+                "send_email",
+                serde_json::json!({ "to": "a@b.test" }),
+            ))
+            .await;
+        match decision {
+            ToolPolicyDecision::RequireApproval { reason, .. } => assert!(
+                reason.contains("supervised"),
+                "a free send parks for the ordinary tier reason, not the budget: {reason}"
+            ),
+            other => panic!("send_email must still park under supervised: {other:?}"),
+        }
+    }
+
+    /// The ordering pin, mirroring `a_grant_beats_always_approve`: the operator's
+    /// approval of a budget-parked call actually **runs** it, once.
+    ///
+    /// If the budget arm sat above grant consumption, approving an at-cap call
+    /// would re-park it forever — the park exists to ask the operator a
+    /// question, and the grant is their answer. Ranking the question above the
+    /// answer makes approval mean nothing.
+    #[tokio::test]
+    async fn a_grant_releases_a_budget_parked_call_once_then_it_re_parks() {
+        let meter = FixedMeter::with(vec![spend_sample("analyst", 5.00, today())]);
+        let (p, grants) = capped_policy(
+            "supervised",
+            None,
+            5.0,
+            "analyst",
+            meter.clone() as Arc<dyn UsageMeter>,
+        );
+        let args = serde_json::json!({ "query": "acme pricing" });
+
+        // Out of budget: parks.
+        assert!(matches!(
+            p.check(&request("web_search", args.clone())).await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
+
+        // The operator approves that exact call.
+        grants.grant(granted("analyst", "web_search", args.clone()));
+        assert_eq!(
+            p.check(&request("web_search", args.clone())).await,
+            ToolPolicyDecision::Allow,
+            "an approved at-cap call must run; otherwise approval authorises nothing"
+        );
+
+        // Single-use: the budget is still exhausted, so the next one re-parks.
+        assert!(
+            matches!(
+                p.check(&request("web_search", args)).await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "one approval buys one over-budget call, not a raised cap"
+        );
+    }
+
+    /// `readonly` outranks the budget arm, as it outranks the grant: the brake
+    /// denies outright rather than offering the operator something to approve.
+    #[tokio::test]
+    async fn the_readonly_brake_still_denies_before_the_budget_arm() {
+        let meter = FixedMeter::with(vec![spend_sample("analyst", 9.99, today())]);
+        let (p, _) = capped_policy(
+            "readonly",
+            None,
+            5.0,
+            "analyst",
+            meter.clone() as Arc<dyn UsageMeter>,
+        );
+        assert!(
+            matches!(
+                p.check(&request(
+                    "pay_invoice",
+                    serde_json::json!({ "amount_usd": 1.0 })
+                ))
+                .await,
+                ToolPolicyDecision::Deny { .. }
+            ),
+            "a read-only desk denies a spend; it does not offer it for approval"
+        );
+    }
+
+    /// "Daily" is the UTC calendar day: yesterday's $9 does not hold today's
+    /// budget hostage. This is what the `since`-respecting double buys.
+    #[tokio::test]
+    async fn yesterdays_spend_does_not_count_against_todays_cap() {
+        let meter = FixedMeter::with(vec![spend_sample("analyst", 9.00, yesterday())]);
+        let (p, _) = capped_policy(
+            "supervised",
+            None,
+            5.0,
+            "analyst",
+            meter.clone() as Arc<dyn UsageMeter>,
+        );
+        assert_eq!(
+            p.check(&request(
+                "web_search",
+                serde_json::json!({ "query": "acme" })
+            ))
+            .await,
+            ToolPolicyDecision::Allow,
+            "the cap resets at 00:00Z; yesterday's spend is spent"
+        );
+    }
+
+    /// An uncapped agent never pays for a meter round-trip — the arm
+    /// short-circuits on the cap before anything else.
+    #[tokio::test]
+    async fn an_uncapped_agent_never_queries_the_meter() {
+        let meter = FixedMeter::with(vec![spend_sample("analyst", 99.0, today())]);
+        let p = Policy {
+            mode: "full".to_string(),
+            always_approve: Vec::new(),
+            auto_approve_under_usd: None,
+        };
+        let uncapped = ApprovalPolicy::new(&p, None)
+            .with_requests(ApprovalRequestQueue::default())
+            .with_agent("analyst")
+            .with_spend(meter.clone() as Arc<dyn UsageMeter>, CompanyId::new("acme"));
+
+        assert_eq!(
+            uncapped
+                .check(&request(
+                    "pay_invoice",
+                    serde_json::json!({ "amount_usd": 400.0 })
+                ))
+                .await,
+            ToolPolicyDecision::Allow
+        );
+        assert_eq!(
+            meter.query_count(),
+            0,
+            "no cap means no question to ask the meter"
+        );
+    }
+
+    /// No meter wired — every non-harness construction site, and a host without
+    /// one — leaves the cap inert rather than parking every priced call forever.
+    /// A permanent deployment fact must not brick spend tools with a park no
+    /// approval can clear.
+    #[tokio::test]
+    async fn a_cap_with_no_meter_is_inert() {
+        let p = Policy {
+            mode: "full".to_string(),
+            always_approve: Vec::new(),
+            auto_approve_under_usd: None,
+        };
+        let no_meter = ApprovalPolicy::new(&p, Some(5.0))
+            .with_requests(ApprovalRequestQueue::default())
+            .with_agent("analyst");
+
+        assert_eq!(
+            no_meter
+                .check(&request(
+                    "pay_invoice",
+                    serde_json::json!({ "amount_usd": 400.0 })
+                ))
+                .await,
+            ToolPolicyDecision::Allow,
+            "an unenforceable cap must not park what it can never release"
+        );
+    }
+
+    /// A meter read that **errors** is transient uncertainty about money, and
+    /// reads as *ask*, not *allow*: the priced call parks, naming the
+    /// uncertainty. A free call is untouched — the arm never saw it.
+    ///
+    /// The deliberate opposite of the dispatch gate's fail-open. There the
+    /// alternative is bricking the company's cognition with no recourse; here it
+    /// is one call waiting on a human who can wave it through.
+    #[tokio::test]
+    async fn a_failing_meter_parks_priced_calls_and_leaves_free_ones_alone() {
+        let (p, _) = capped_policy(
+            "full",
+            None,
+            5.0,
+            "analyst",
+            Arc::new(FailingMeter) as Arc<dyn UsageMeter>,
+        );
+
+        let decision = p
+            .check(&request(
+                "pay_invoice",
+                serde_json::json!({ "amount_usd": 1.0 }),
+            ))
+            .await;
+        match decision {
+            ToolPolicyDecision::RequireApproval { reason, .. } => assert!(
+                reason.contains("could not be verified"),
+                "the park must say the budget is unknown, not that it is exceeded: {reason}"
+            ),
+            other => panic!("an unreadable budget must park a spend: {other:?}"),
+        }
+
+        assert_eq!(
+            p.check(&request("read_file", serde_json::json!({}))).await,
+            ToolPolicyDecision::Allow,
+            "a free call never reaches the budget arm, so a meter outage cannot gate it"
+        );
     }
 }

--- a/src/metering/daily_budget.rs
+++ b/src/metering/daily_budget.rs
@@ -1,0 +1,228 @@
+//! Pure per-agent daily-spend math (issue #304): sum one teammate's metered
+//! spend over a window, and find the UTC-midnight boundary that window starts
+//! at.
+//!
+//! This is the I/O-free half of the per-agent `budget_usd_daily` cap — it lives
+//! in `metering` (always compiled, beside [`capability`](super::capability)) so
+//! the console read surface and the feature-gated harness share one definition
+//! of "spent today". The harness halves add the policy arm
+//! ([`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy)) and the dispatch
+//! gate ([`HarnessPool::run`](crate::harness::HarnessPool::run)) on top.
+//!
+//! ## "Daily" means the UTC calendar day
+//!
+//! The window resets at `00:00Z`, delegating to
+//! [`BudgetPeriod::Daily`](super::BudgetPeriod) rather than re-deriving the
+//! boundary — the capability plan's daily budget, the search daily-call cap and
+//! this cap must all roll over at the same instant, and two clocks that agree
+//! today drift the moment one of them grows a special case. A test pins the two
+//! to the same value for exactly that reason.
+//!
+//! A rolling 24-hour window was the alternative and is deliberately not what
+//! this is: an operator reading "$5/day" against a console that renders calendar
+//! days has no way to reason about a cap that resets at a different time for
+//! every agent.
+//!
+//! ## What the sum covers, and what it misses
+//!
+//! [`usd_spent_by_agent`] sums `cost_usd` over **every** [`SampleKind`] — a
+//! model turn ([`Inference`](crate::ports::SampleKind::Inference)), a metered
+//! web search ([`SearchCall`](crate::ports::SampleKind::SearchCall)), a
+//! connected-tool call ([`OauthCall`](crate::ports::SampleKind::OauthCall),
+//! which is zero-cost by definition and so contributes nothing). Filtering to
+//! one kind would make the cap mean "part of what this teammate spent", which
+//! is not a cap anyone can reason about.
+//!
+//! It does **not** see executed x402 payments. Those land on the ledger, and
+//! [`LedgerEntry`](crate::ports::types::LedgerEntry) carries no agent — there is
+//! no attribution to sum. The gate covers the *pre-flight* case instead (a tool
+//! call that declares an `amount_usd` which would breach the remaining budget
+//! parks for approval before the money moves), and the executed-payment gap is
+//! stated plainly in `docs/spec/runtime/manifest.md`. Closing it is a
+//! store-shape change across three backends, not something this module can
+//! paper over.
+
+use crate::ports::UsageSample;
+
+use super::capability::BudgetPeriod;
+
+/// Total USD a single teammate is metered as having spent across `samples`.
+///
+/// Sums `cost_usd` for every sample whose [`agent`](UsageSample::agent) matches,
+/// across all [`SampleKind`](crate::ports::SampleKind)s. Callers scope the
+/// window by what they pass — typically a
+/// [`UsageMeter::query`](crate::ports::UsageMeter::query) anchored at
+/// [`utc_day_start_millis`].
+///
+/// An empty window, or an agent with no samples in it, is **positive** `0.0` —
+/// never an error, and never `-0.0`. "I have spent nothing today" and "I have
+/// no record of spending today" are the same statement to a cap.
+///
+/// The fold seeds at `0.0` rather than using `Iterator::sum`, which is not
+/// stylistic: `<f64 as Sum>` seeds at `-0.0` (the additive identity that
+/// survives `-0.0 + -0.0`), so summing an empty window through it yields
+/// `-0.0`. That value compares equal to zero in Rust and so passes every gate
+/// here unnoticed — but it serialises as `-0.0` onto the wire, and the console
+/// renders `(-0).toFixed(2)` as `"-0.00"`. An operator would read "$-0.00 spent
+/// today" on every capped teammate that had not yet spent anything. Caught by
+/// clicking the Team page, not by the unit tests, which is why one is pinned
+/// below.
+pub fn usd_spent_by_agent(samples: &[UsageSample], agent: &str) -> f64 {
+    samples
+        .iter()
+        .filter(|sample| sample.agent == agent)
+        .map(|sample| sample.cost_usd)
+        .fold(0.0, |total, cost| total + cost)
+}
+
+/// The epoch-millis start (`00:00Z`) of the UTC calendar day `now` falls in —
+/// the `since` a daily-spend query is anchored to.
+///
+/// Delegates to [`BudgetPeriod::Daily`] so this cap and the capability plan's
+/// daily budget can never roll over at different instants.
+pub fn utc_day_start_millis(now: u64) -> u64 {
+    BudgetPeriod::Daily.period_start_millis(now)
+}
+
+/// One teammate's daily-budget status for the console read surface, mirroring
+/// [`TierBudgetStatus`](super::TierBudgetStatus) in shape.
+///
+/// Only produced for a teammate that actually carries a cap: an uncapped
+/// teammate has no row, which is what lets the console tell "spends freely"
+/// apart from "capped and has spent nothing".
+#[derive(Clone, Debug, PartialEq)]
+pub struct AgentBudgetStatus {
+    /// The teammate id the cap belongs to.
+    pub agent: String,
+    /// The manifest `budget_usd_daily` cap.
+    pub budget_usd: f64,
+    /// What this teammate has spent since UTC midnight.
+    pub spent_usd: f64,
+    /// `budget_usd - spent_usd`, floored at zero.
+    pub remaining_usd: f64,
+    /// Whether spend has reached the cap (`spent >= budget`) — the boundary the
+    /// harness gate and the policy arm both trip on.
+    pub exhausted: bool,
+}
+
+impl AgentBudgetStatus {
+    /// Builds a status row from a teammate's cap and its spend since UTC
+    /// midnight.
+    pub fn new(agent: impl Into<String>, budget_usd: f64, spent_usd: f64) -> Self {
+        Self {
+            agent: agent.into(),
+            budget_usd,
+            spent_usd,
+            remaining_usd: (budget_usd - spent_usd).max(0.0),
+            exhausted: spent_usd >= budget_usd,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metering::calendar::{MILLIS_PER_DAY, days_from_civil};
+    use crate::ports::{SampleKind, UsageSample};
+
+    fn sample(agent: &str, cost: f64, kind: SampleKind) -> UsageSample {
+        UsageSample {
+            at_millis: 0,
+            agent: agent.into(),
+            provider: "managed".into(),
+            input_tokens: 0,
+            output_tokens: 0,
+            cached_input_tokens: 0,
+            cost_usd: cost,
+            kind,
+        }
+    }
+
+    /// The sum is per-agent: another teammate's spend never counts against this
+    /// one's cap. Per-agent caps that leaked into each other would make a busy
+    /// desk silently starve a quiet one.
+    #[test]
+    fn spend_is_attributed_to_one_agent() {
+        let samples = vec![
+            sample("analyst", 1.50, SampleKind::Inference),
+            sample("writer", 9.00, SampleKind::Inference),
+            sample("analyst", 0.25, SampleKind::Inference),
+        ];
+        assert!((usd_spent_by_agent(&samples, "analyst") - 1.75).abs() < f64::EPSILON);
+        assert!((usd_spent_by_agent(&samples, "writer") - 9.00).abs() < f64::EPSILON);
+    }
+
+    /// Every metered kind counts. A cap that only saw inference would let a
+    /// teammate spend its whole day on searches and report `$0.00 spent`.
+    #[test]
+    fn spend_sums_across_every_sample_kind() {
+        let samples = vec![
+            sample("analyst", 2.00, SampleKind::Inference),
+            sample("analyst", 0.50, SampleKind::SearchCall),
+            // An OAuth call is zero-cost by definition — included, contributes
+            // nothing, and must not be *excluded* on the assumption it always
+            // will be.
+            sample("analyst", 0.00, SampleKind::OauthCall),
+        ];
+        assert!((usd_spent_by_agent(&samples, "analyst") - 2.50).abs() < f64::EPSILON);
+    }
+
+    /// No samples, or none for this agent, is zero — never an error.
+    ///
+    /// And specifically **positive** zero. `assert_eq!(x, 0.0)` passes for
+    /// `-0.0` too, so the sign is checked through `is_sign_positive`: the whole
+    /// bug this pins is invisible to an equality assertion and only shows up
+    /// once the value is serialised and formatted by the console.
+    #[test]
+    fn an_empty_window_is_positive_zero() {
+        for spent in [
+            usd_spent_by_agent(&[], "analyst"),
+            usd_spent_by_agent(&[sample("writer", 4.0, SampleKind::Inference)], "analyst"),
+        ] {
+            assert_eq!(spent, 0.0);
+            assert!(
+                spent.is_sign_positive(),
+                "an unspent budget must serialise as 0.0, not -0.0 — the console \
+                 renders the latter as \"$-0.00 spent today\""
+            );
+        }
+    }
+
+    /// The load-bearing pin: this cap's day boundary IS
+    /// [`BudgetPeriod::Daily`]'s. If these two ever diverge, a company's
+    /// capability budget and its per-agent spend caps reset at different
+    /// instants and no operator can reason about either.
+    #[test]
+    fn the_day_boundary_is_the_capability_plans_day_boundary() {
+        let noon = (days_from_civil(2026, 8, 4) as u64) * MILLIS_PER_DAY + 12 * 3_600_000;
+        assert_eq!(
+            utc_day_start_millis(noon),
+            BudgetPeriod::Daily.period_start_millis(noon),
+        );
+        // ...and it is midnight UTC of that same day.
+        assert_eq!(
+            utc_day_start_millis(noon),
+            (days_from_civil(2026, 8, 4) as u64) * MILLIS_PER_DAY
+        );
+        // Midnight maps to itself.
+        let midnight = utc_day_start_millis(noon);
+        assert_eq!(utc_day_start_millis(midnight), midnight);
+    }
+
+    /// The console row: remaining floors at zero and `exhausted` trips on `>=`,
+    /// matching the boundary the harness gate and the policy arm use.
+    #[test]
+    fn status_floors_remaining_and_trips_on_reaching_the_cap() {
+        let under = AgentBudgetStatus::new("analyst", 5.0, 1.25);
+        assert!((under.remaining_usd - 3.75).abs() < f64::EPSILON);
+        assert!(!under.exhausted);
+
+        let exactly_at = AgentBudgetStatus::new("analyst", 5.0, 5.0);
+        assert_eq!(exactly_at.remaining_usd, 0.0);
+        assert!(exactly_at.exhausted, "the boundary is `>=`, not `>`");
+
+        let over = AgentBudgetStatus::new("analyst", 5.0, 7.5);
+        assert_eq!(over.remaining_usd, 0.0, "remaining never goes negative");
+        assert!(over.exhausted);
+    }
+}

--- a/src/metering/mod.rs
+++ b/src/metering/mod.rs
@@ -39,6 +39,7 @@ use crate::ports::types::OverlayAgent;
 
 mod calendar;
 pub mod capability;
+pub mod daily_budget;
 mod finances;
 pub mod inference;
 pub mod oauth;
@@ -47,6 +48,7 @@ mod types;
 mod usage;
 
 pub use capability::{BudgetPeriod, CapabilityPlan, TierBudgetStatus, plan_named, tokens_in};
+pub use daily_budget::{AgentBudgetStatus, usd_spent_by_agent, utc_day_start_millis};
 pub use finances::{category_label, finances_from};
 pub use inference::{
     INFERENCE_SPEND_KIND, MEDULLA_PROVIDER, UNATTRIBUTED_AGENT, inference_ledger_entry,

--- a/src/server/graphql/company.rs
+++ b/src/server/graphql/company.rs
@@ -228,6 +228,27 @@ impl CompanyGql {
             .collect();
         let enabled = |id: &str| inbox_enabled.get(id).copied().unwrap_or(false);
 
+        // Issue #304 — mirrored from the REST `list_team` deliberately: the two
+        // reads of the same roster must not drift, so the cap columns are
+        // resolved here by the same rule (one meter read, only when somebody is
+        // capped; spend paired with the cap).
+        let any_capped = record
+            .manifest
+            .agents
+            .iter()
+            .any(|agent| agent.budget_usd_daily.is_some());
+        let spend_today = if any_capped {
+            let since = crate::metering::utc_day_start_millis(crate::ports::now_millis());
+            Some(self.runtime.usage().query(&self.id, since).await?)
+        } else {
+            None
+        };
+        let spent = |id: &str| {
+            spend_today
+                .as_ref()
+                .map(|samples| crate::metering::usd_spent_by_agent(samples, id))
+        };
+
         let mut out: Vec<TeamMemberGql> = record
             .manifest
             .agents
@@ -238,6 +259,8 @@ impl CompanyGql {
                 role: agent.role.clone(),
                 description: agent.description.clone(),
                 inbox_enabled: enabled(&agent.id),
+                budget_usd_daily: agent.budget_usd_daily,
+                spent_today_usd: agent.budget_usd_daily.and_then(|_| spent(&agent.id)),
             })
             .collect();
         out.extend(record.overlay_agents.iter().map(|agent| TeamMemberGql {
@@ -246,6 +269,9 @@ impl CompanyGql {
             role: agent.role.clone(),
             description: agent.description.clone(),
             inbox_enabled: enabled(&agent.id),
+            // Overlay teammates are uncapped in v1.
+            budget_usd_daily: None,
+            spent_today_usd: None,
         }));
         Ok(out)
     }
@@ -310,6 +336,13 @@ pub struct TeamMemberGql {
     pub description: Option<String>,
     /// Whether this teammate has an enabled inbox.
     pub inbox_enabled: bool,
+    /// This teammate's manifest `budget_usd_daily` cap (issue #304), or null
+    /// when it has none. Null-vs-set is the capped/uncapped distinction — `0`
+    /// would mean "capped at nothing".
+    pub budget_usd_daily: Option<f64>,
+    /// What this teammate has spent since 00:00 UTC; non-null only alongside a
+    /// cap.
+    pub spent_today_usd: Option<f64>,
 }
 
 /// Internal desk projection shared between `chats` and `chat`.

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -727,6 +727,17 @@ type TeamMember {
 	Whether this teammate has an enabled inbox.
 	"""
 	inboxEnabled: Boolean!
+	"""
+	This teammate's manifest `budget_usd_daily` cap (issue #304), or null
+	when it has none. Null-vs-set is the capped/uncapped distinction — `0`
+	would mean "capped at nothing".
+	"""
+	budgetUsdDaily: Float
+	"""
+	What this teammate has spent since 00:00 UTC; non-null only alongside a
+	cap.
+	"""
+	spentTodayUsd: Float
 }
 
 """

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -45,6 +45,19 @@ struct TeamMemberDto {
     /// Whether this teammate has an enabled inbox, so the Team page's toggle
     /// renders the host's real state instead of a client-side guess.
     inbox_enabled: bool,
+    /// This teammate's manifest `budget_usd_daily` cap (issue #304), or absent
+    /// when it has none.
+    ///
+    /// Absent-vs-present **is** the capped/uncapped distinction, which is why
+    /// this is skipped rather than zeroed: `0` would read as "capped at nothing"
+    /// and render a permanently exhausted teammate. Overlay teammates carry no
+    /// cap in v1, so they always omit it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    budget_usd_daily: Option<f64>,
+    /// What this teammate has spent since 00:00 UTC, present only alongside a
+    /// cap — an uncapped teammate's spend belongs on the Usage page, not here.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    spent_today_usd: Option<f64>,
 }
 
 /// The add-teammate body.
@@ -98,6 +111,15 @@ async fn list_team(company: ScopedCompany) -> Result<Json<Vec<TeamMemberDto>>, A
         .map(|meta| (meta.key, meta.enabled))
         .collect();
     let enabled = |id: &str| enabled_inboxes.get(id).copied().unwrap_or(false);
+    // Issue #304: today's spend, for capped teammates only. One meter read for
+    // the whole roster, and only when the manifest actually caps somebody —
+    // a company with no caps pays nothing for a column it will not render.
+    let spend_today = daily_spend_samples(&company, record.as_ref()).await?;
+    let spent = |id: &str| {
+        spend_today
+            .as_ref()
+            .map(|samples| crate::metering::usd_spent_by_agent(samples, id))
+    };
     let members = record
         .map(|record| {
             let mut members: Vec<TeamMemberDto> = record
@@ -110,6 +132,9 @@ async fn list_team(company: ScopedCompany) -> Result<Json<Vec<TeamMemberDto>>, A
                     role: agent.role.clone(),
                     description: agent.description.clone(),
                     inbox_enabled: enabled(&agent.id),
+                    budget_usd_daily: agent.budget_usd_daily,
+                    // Paired with the cap: no cap, no spend row.
+                    spent_today_usd: agent.budget_usd_daily.and_then(|_| spent(&agent.id)),
                 })
                 .collect();
             members.extend(record.overlay_agents.iter().map(|agent| TeamMemberDto {
@@ -118,11 +143,44 @@ async fn list_team(company: ScopedCompany) -> Result<Json<Vec<TeamMemberDto>>, A
                 role: agent.role.clone(),
                 description: agent.description.clone(),
                 inbox_enabled: enabled(&agent.id),
+                // Overlay teammates are uncapped in v1.
+                budget_usd_daily: None,
+                spent_today_usd: None,
             }));
             members
         })
         .unwrap_or_default();
     Ok(Json(members))
+}
+
+/// Today's usage samples (since 00:00 UTC), or `None` when no teammate on this
+/// company carries a `budget_usd_daily` cap (issue #304).
+///
+/// Returning `None` rather than an empty vec keeps "nobody is capped" distinct
+/// from "everybody is capped and has spent nothing", and is what lets the
+/// caller skip the meter round-trip entirely for the common uncapped company.
+async fn daily_spend_samples(
+    company: &ScopedCompany,
+    record: Option<&crate::ports::types::CompanyRecord>,
+) -> Result<Option<Vec<crate::ports::usage::UsageSample>>, ApiError> {
+    let any_capped = record.is_some_and(|record| {
+        record
+            .manifest
+            .agents
+            .iter()
+            .any(|agent| agent.budget_usd_daily.is_some())
+    });
+    if !any_capped {
+        return Ok(None);
+    }
+    let since = crate::metering::utc_day_start_millis(crate::ports::now_millis());
+    let samples = company
+        .runtime
+        .usage()
+        .query(company.id(), since)
+        .await
+        .map_err(ApiError)?;
+    Ok(Some(samples))
 }
 
 async fn add_member(
@@ -155,6 +213,9 @@ async fn add_member(
         description: agent.description,
         // A brand-new teammate has no inbox until the toggle writes one.
         inbox_enabled: false,
+        // Overlay teammates carry no per-agent cap in v1 (issue #304).
+        budget_usd_daily: None,
+        spent_today_usd: None,
     }))
 }
 
@@ -245,4 +306,219 @@ async fn load_domain(company: &ScopedCompany) -> Result<Option<String>, ApiError
     };
     let status: DomainStatus = serde_json::from_str(value.expose())?;
     Ok(Some(status.domain))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use serde_json::Value;
+    use tower::ServiceExt;
+
+    use crate::company::CompanyManifest;
+    use crate::ports::CompanyStore;
+    use crate::ports::types::{CompanyId, CompanyRecord};
+    use crate::ports::usage::{SampleKind, UsageSample};
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+    use crate::store::FsCompanyStore;
+    use crate::{AppConfig, AppState};
+
+    fn home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("oc-team-")
+            .tempdir()
+            .expect("tempdir")
+    }
+
+    async fn state_with_manifest(home: &std::path::Path, manifest_toml: &str) -> AppState {
+        let manifest: CompanyManifest = toml::from_str(manifest_toml).unwrap();
+        let store = FsCompanyStore::new(home.to_path_buf());
+        let id = CompanyId::new("acme");
+        store
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                template_provenance: None,
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        state
+    }
+
+    async fn get_team(state: &AppState) -> (StatusCode, Value) {
+        let request = Request::builder()
+            .method("GET")
+            .uri("/api/v1/company/team")
+            .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+            .body(Body::empty())
+            .unwrap();
+        let response = router(state.clone()).oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value = if bytes.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+        };
+        (status, value)
+    }
+
+    /// Two teammates on one manifest: `analyst` is capped, `writer` is not.
+    const ROSTER: &str = "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+         [[agent]]\nid = \"analyst\"\nrole = \"Analyst\"\nbudget_usd_daily = 5.0\n\
+         [[agent]]\nid = \"writer\"\nrole = \"Writer\"\n";
+
+    /// Issue #304 — the cap was never on the wire at all, so the issue's "and
+    /// displayed in the console" was stale against main. A capped teammate now
+    /// carries both its cap and its spend since UTC midnight, summed from the
+    /// meter; an uncapped one carries neither key.
+    ///
+    /// The omission is the contract, not an optimisation: the console tells
+    /// "spends freely" from "capped and has spent nothing" by presence alone.
+    #[tokio::test]
+    async fn a_capped_teammate_carries_its_cap_and_todays_spend() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+        let now = crate::ports::now_millis();
+        for cost in [1.25f64, 0.50] {
+            runtime
+                .usage()
+                .record(
+                    &id,
+                    &UsageSample {
+                        at_millis: now,
+                        agent: "analyst".into(),
+                        provider: "managed".into(),
+                        input_tokens: 10,
+                        output_tokens: 5,
+                        cached_input_tokens: 0,
+                        cost_usd: cost,
+                        kind: SampleKind::Inference,
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        // The uncapped teammate's spend must not leak onto the capped one.
+        runtime
+            .usage()
+            .record(
+                &id,
+                &UsageSample {
+                    at_millis: now,
+                    agent: "writer".into(),
+                    provider: "managed".into(),
+                    input_tokens: 10,
+                    output_tokens: 5,
+                    cached_input_tokens: 0,
+                    cost_usd: 9.00,
+                    kind: SampleKind::Inference,
+                },
+            )
+            .await
+            .unwrap();
+
+        let (status, body) = get_team(&state).await;
+        assert_eq!(status, StatusCode::OK);
+        let rows = body.as_array().unwrap();
+
+        let analyst = rows.iter().find(|m| m["id"] == "analyst").unwrap();
+        assert_eq!(analyst["budgetUsdDaily"], 5.0, "{analyst}");
+        assert!(
+            (analyst["spentTodayUsd"].as_f64().unwrap() - 1.75).abs() < 1e-9,
+            "spend is summed per agent since UTC midnight: {analyst}"
+        );
+
+        let writer = rows.iter().find(|m| m["id"] == "writer").unwrap();
+        assert!(
+            writer.get("budgetUsdDaily").is_none() && writer.get("spentTodayUsd").is_none(),
+            "an uncapped teammate omits both keys: {writer}"
+        );
+    }
+
+    /// Yesterday's spend is not today's: the read is anchored at 00:00 UTC, the
+    /// same boundary the harness gate and the policy arm enforce against.
+    #[tokio::test]
+    async fn spend_today_excludes_yesterday() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+        let yesterday =
+            crate::metering::utc_day_start_millis(crate::ports::now_millis()).saturating_sub(1);
+        runtime
+            .usage()
+            .record(
+                &id,
+                &UsageSample {
+                    at_millis: yesterday,
+                    agent: "analyst".into(),
+                    provider: "managed".into(),
+                    input_tokens: 10,
+                    output_tokens: 5,
+                    cached_input_tokens: 0,
+                    cost_usd: 9.00,
+                    kind: SampleKind::Inference,
+                },
+            )
+            .await
+            .unwrap();
+
+        let (status, body) = get_team(&state).await;
+        assert_eq!(status, StatusCode::OK);
+        let analyst = body
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["id"] == "analyst")
+            .unwrap()
+            .clone();
+        assert_eq!(analyst["budgetUsdDaily"], 5.0, "{analyst}");
+        assert_eq!(
+            analyst["spentTodayUsd"], 0.0,
+            "a capped teammate with no spend today reads $0, not yesterday's $9: {analyst}"
+        );
+    }
+
+    /// A company that caps nobody renders exactly as it did before #304 — and
+    /// the meter is never consulted for it.
+    #[tokio::test]
+    async fn an_uncapped_company_is_unchanged() {
+        let home_dir = home();
+        let state = state_with_manifest(
+            home_dir.path(),
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+             [[agent]]\nid = \"writer\"\nrole = \"Writer\"\n",
+        )
+        .await;
+
+        let (status, body) = get_team(&state).await;
+        assert_eq!(status, StatusCode::OK);
+        let writer = &body.as_array().unwrap()[0];
+        assert_eq!(writer["id"], "writer");
+        assert!(
+            writer.get("budgetUsdDaily").is_none() && writer.get("spentTodayUsd").is_none(),
+            "{writer}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes #304.

`budget_usd_daily` flowed manifest → validator → a struct field whose getter had **zero call sites**. An operator could set a per-agent daily spend cap, see it validated and stored, and it did nothing. Meanwhile the company-wide `[budget].monthly_usd` **is** enforced — so two budget knobs presented identically while only one was real.

Spend leaves by two doors, so this closes both:

- **Dispatch gate** — inference is the dominant stream and never reaches a tool policy at all. A teammate over its cap is refused **before any model call**, with a notice naming the cap and the 00:00 UTC reset. Other teammates keep running: per-agent quarantine, not a company outage.
- **Policy arm** — priced tool calls **park for approval** at cap. Never a hard deny, never a silent downgrade.

## API Or Behavior Changes

**⚠️ `signals_opportunity_studio`'s three caps go live.** That template ships $5/$8/$8 caps that have never done anything. Anyone running it will start seeing refusals. That is the fix working, but it is a behaviour change and it is the first thing to check if that template starts misbehaving.

**Parking, not denial.** A hard deny recreates the silent dead-end the approval bridge exists to close; a silent downgrade is the suppression-shaped fix this repo bans. Parking turns "at the cap" into a question the operator answers — and approving mints a single-use grant (#243) that re-dispatches the call.

**Precedence — below grant consumption, above `auto_approve_under_usd`.** Both placements are load-bearing:

- *Below the grant*: a park whose only purpose is to **ask** must be releasable by the operator's **answer**. Above the grant, approving would re-park forever and authorize nothing for exactly the calls the cap escalates.
- *Above `auto_approve_under_usd`*: below it, a $5 cap with a $5 auto-approve threshold is unreachable by construction — every call slips under the threshold before the cap is consulted.

`readonly` still denies first, and the reserved `never_do` slot is untouched at the top.

**"Daily" is the UTC calendar day**, resetting at 00:00Z — the clock every other "daily" in the product already uses. **Restart is a non-issue**: spend is re-read from the durable usage meter, not an in-memory counter, so a restart at 23:50 with $4.90 spent still refuses a $0.20 call five minutes later.

**Free reads and sends are untouched at cap.** A spend cap caps spend.

**Failure semantics.** No meter wired → inert with a warning (a permanent deployment fact; parking forever would brick every spend tool). Meter query **error** → park with a "could not verify daily budget" reason, because transient uncertainty about money should read as *ask*, not *allow*.

The read surfaces — REST, GraphQL and the Team card — are **net-new**. The issue's claim that the cap is "displayed in the console" was stale against `main`; it was displayed nowhere.

## The bug only the UI could reveal

Rust's `<f64 as Sum>` seeds at `-0.0`, so an empty spend window serialised as `-0.0` and the console rendered **"$-0.00 spent today"** on every capped-but-unspent teammate.

`assert_eq!(x, 0.0)` passes for `-0.0`. No unit test would ever have caught this, and the curl output looked correct. It took rendering the page. Fixed, and pinned with `is_sign_positive()`.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **1671 passed, 0 failed**, 1 ignored
- [x] `cargo check --locked --all-features --all-targets`
- [x] `git diff Cargo.lock` empty
- [x] `npm ci` / `npm run typecheck` / `npm run build`
- [x] Playwright 1/1 against a live host on an isolated home

All gates re-run after rebasing onto current `main`, not only before.

**The dispatch refusal is proven live despite there being no inference credential**, by booting the harness path with a placeholder key against a dead endpoint. Under cap the turn reached the model and failed with a connection error — proof it was calling out. Over cap the identical request returned the notice with **no model error at all**. The refusal is genuinely upstream of the call.

Unit coverage includes the precedence pins: a grant releases a budget-parked call **once** and it then re-parks; readonly still denies first; a yesterday-stamped sample does not count toward today; an uncapped agent never queries the meter; a failing meter parks a priced call while a free one still runs.

**Not proven:** the park → approve → re-dispatch round trip needs a real inference credential, which the workspace has none of. Nine unit tests drive the real `check()` path, but a staging pass before merge is worth it if a key is available.

## Known coverage gap — deliberate and documented

The cap governs **metered, attributed** spend. Executed x402 payments carry no agent on their ledger entry, so they escape the counter; only a declared pre-flight amount is caught. The company-wide monthly cap is the backstop.

This is stated plainly in the code and the spec rather than filed as a follow-up, per an explicit decision. A porous cap that documents its edges is enforcement. One that claims totality is the lying config again.

Turn-boundary overshoot is bounded by a single call — the same documented window the capability budget already has. No reservation ledger in v1.

## Documentation

`docs/spec/runtime/manifest.md` now states what the cap actually enforces: the UTC day, which streams are covered, what happens at cap, and that overlay teammates are uncapped in v1.

## Related

Closes #304. Builds on #243 (grants), #172 (parking) and #188 (the dispatch-gate pattern).

**Merge note:** conflicts with #330 in `companies/e2e_harness/company.toml` — both land in the same `writer` agent block on adjacent lines, different keys. Keep both hunks, then re-run `shipped_companies_grant_the_workspace_tools`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-teammate daily spending limits with UTC midnight resets.
  - Priced actions pause for approval when a teammate reaches their daily cap.
  - Team pages and APIs now show daily limits and spend for capped teammates.
  - Uncapped teammates continue operating without budget indicators.
  - Added handling for spend tracking across tools, approvals, and usage types.

- **Documentation**
  - Documented budget enforcement, covered spending, reset timing, and meter behavior.

- **Tests**
  - Added coverage for cap enforcement, daily resets, teammate isolation, and Team page displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->