### PR TITLE
fix(users): pass the config to eligibility from the hub sign-in path

### DIFF
--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -722,7 +722,7 @@ async fn hub_sign_in(
 
     let email = normalize_email(&identity.email);
     let now = now_millis();
-    let Some(role) = eligibility(&runtime, &email, now)
+    let Some(role) = eligibility(state.config(), &runtime, &email, now)
         .await
         .map_err(|e| ApiError(e).into_response())?
     else {


### PR DESCRIPTION
## Summary

**`main` does not currently compile.** This is the one-line fix.

`eligibility` gained a leading `&AppConfig` parameter in #323, so a provisioned company can treat its injected admin address as a standing invite. #325 added the ecosystem sign-in handler, which calls `eligibility`.

Neither PR was wrong. Each was green, and each was **mergeable**, against a `main` that did not contain the other. `main` stopped compiling the moment the second one landed — the two changes never met until then.

## API Or Behavior Changes

None. One call site gains the argument every other call site already passes.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --features openhuman,tinycortex,oauth --all-targets` — the combination that catches this
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **1671 passed, 0 failed**, 1 ignored

## Note for the next batch

Mergeable is not the same as compiles. When a batch of PRs is merged in sequence, a signature change in one and a new caller in another pass every per-PR check and still break `main` — no individual CI run ever builds the union.

The cheap guard is to build the union locally before merging a batch: cut a scratch branch off fresh `main`, merge each PR branch into it, and compile once.