### PR TITLE
fix(connections): stop signing the OAuth state nonce with a shipped literal (#318)

### DIFF
--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -288,9 +288,22 @@ which route?* — as a `credentialSource` tier, stored-wins:
 
 | Tier | When | Console |
 | --- | --- | --- |
-| `static` | a token is already stored for this provider (BYO override), **or** this host registered its own provider app (the hatch) | Connect button, as today |
+| `static` | a token is already stored for this provider (BYO override), **or** this host registered its own provider app *and* has a state signing secret (the hatch) | Connect button, as today |
 | `attested` | no stored token, and the pod carries a platform-**projected** identity (`TINYHUMANS_TOKEN_FILE` naming a file that exists) | "Managed by the platform", no local Connect |
 | `none` | neither | read-only "not available on this host" |
+
+**The hatch also needs `OPENCOMPANY_OAUTH_STATE_SECRET`** (issue #318). The
+`state` nonce binds an in-flight authorization to one company, provider and
+expiry, and the callback verifies it before exchanging the code — it is the
+flow's CSRF defence. That signing key used to fall back to a literal baked into
+this repository, which made the value public, identical across every
+unconfigured deployment, and constructible rather than obtainable: verifying it
+proved only that it was well-formed. There is now **no default**. A host with a
+registered provider application but no secret reports `none` rather than
+offering a button whose check is void, `start` refuses with a message naming the
+variable, and the process logs the misconfiguration once — a tile has no room to
+name a variable, and an operator reads logs. Whitespace-only counts as unset, so
+an empty shell expansion gets the closed door rather than a secret of `" "`.
 
 `attested` deliberately requires the projected-file tier, not
 `TinyhumansTokenSource::from_env` as a whole: that resolver also accepts a

--- a/src/server/ops/connections.rs
+++ b/src/server/ops/connections.rs
@@ -155,11 +155,42 @@ fn provider_config_from(
 /// Connect button that 400s. Read by
 /// [`ops::connections_read`](super::connections_read); never leaks the
 /// credential itself.
+///
+/// A missing [`state_secret_from`] closes the hatch for **every** provider
+/// (issue #318): without a signing secret no nonce can be issued, so no
+/// handshake can complete, and the console should say "not available on this
+/// host" rather than offer a button. The startup warning is what tells the
+/// operator *why* — a tile has no room to name a variable, and an operator
+/// reads logs.
 pub(super) fn provider_app_configured(
     provider: &str,
     env: &dyn crate::app::config::EnvSource,
 ) -> bool {
-    provider_config_from(provider, env).is_some()
+    let has_app = provider_config_from(provider, env).is_some();
+    if has_app && state_secret_from(env).is_none() {
+        warn_half_configured_once(provider);
+        return false;
+    }
+    has_app
+}
+
+/// Says once per process that a provider application is registered but cannot be
+/// used, and names the variable that would fix it.
+///
+/// Once, because this is reached from a read path the console polls: repeating
+/// it per request would bury the line it is trying to make visible. The provider
+/// named is whichever was asked about first — enough to make the message
+/// concrete, and the remedy is the same for all of them.
+fn warn_half_configured_once(provider: &str) {
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    WARNED.call_once(|| {
+        tracing::warn!(
+            provider,
+            "an OAuth provider application is registered but OPENCOMPANY_OAUTH_STATE_SECRET \
+             is unset, so no connection can be completed; set it to a private random value. \
+             Connections are reported as unavailable on this host until then"
+        );
+    });
 }
 
 /// The redirect URI advertised to the provider. `OPENCOMPANY_OAUTH_REDIRECT_BASE`
@@ -171,10 +202,27 @@ fn redirect_uri(state: &AppState) -> String {
     format!("{}/api/v1/oauth/callback", base.trim_end_matches('/'))
 }
 
-/// The host-level secret the `state` nonce is signed with.
-fn state_secret() -> String {
-    std::env::var("OPENCOMPANY_OAUTH_STATE_SECRET")
-        .unwrap_or_else(|_| "opencompany-oauth-state".to_string())
+/// The host-level secret the `state` nonce is signed with, or `None` when this
+/// host has not been given one.
+///
+/// **There is deliberately no default** (issue #318). A baked-in fallback is
+/// public, identical across every unconfigured deployment, and present in this
+/// repository — so a `state` signed with it can be *constructed* rather than
+/// obtained, and verifying it proves only that the value is well-formed. That
+/// is the whole CSRF property of the nonce, so the honest answer to "no secret
+/// configured" is that this host cannot run OAuth, not that it runs it
+/// unprotected.
+///
+/// Whitespace-only is treated as unset: a deployment that passes the variable
+/// through an unset shell expansion gets the closed door, not a secret of `" "`.
+fn state_secret_from(env: &dyn crate::app::config::EnvSource) -> Option<String> {
+    env.get("OPENCOMPANY_OAUTH_STATE_SECRET")
+        .filter(|value| !value.trim().is_empty())
+}
+
+/// [`state_secret_from`] against the real process environment.
+fn state_secret() -> Option<String> {
+    state_secret_from(&crate::app::config::ProcessEnv)
 }
 
 // ---------------------------------------------------------------------------
@@ -223,22 +271,32 @@ fn connect_error(state: &AppState, code: &str, provider: Option<&str>) -> Respon
 // ---------------------------------------------------------------------------
 
 /// Encodes `company:provider:exp:sig` into an opaque `state` value.
-fn encode_state(company: &str, provider: &str, exp: u64) -> String {
+///
+/// Takes the signing secret rather than reading it, so a caller cannot reach
+/// this without having established that the host has one (issue #318).
+fn encode_state(secret: &str, company: &str, provider: &str, exp: u64) -> String {
     let payload = format!("{company}:{provider}:{exp}");
-    let sig = DefaultHashSigner.sign(&state_secret(), payload.as_bytes());
+    let sig = DefaultHashSigner.sign(secret, payload.as_bytes());
     format!("{payload}:{sig}")
 }
 
 /// Verifies and decodes a `state` value into `(company, provider)`, or `None`
-/// when the signature is wrong or the nonce has expired.
+/// when this host has no signing secret, the signature is wrong, or the nonce
+/// has expired.
+///
+/// The no-secret case collapses into the same `None` as a bad signature on
+/// purpose: a host that cannot issue a nonce cannot have issued *this* one, so
+/// there is nothing to distinguish. It also means a host that loses its secret
+/// refuses in-flight callbacks rather than accepting whatever arrives.
 fn decode_state(state: &str) -> Option<(String, String)> {
+    let secret = state_secret()?;
     let parts: Vec<&str> = state.splitn(4, ':').collect();
     if parts.len() != 4 {
         return None;
     }
     let (company, provider, exp, sig) = (parts[0], parts[1], parts[2], parts[3]);
     let payload = format!("{company}:{provider}:{exp}");
-    let expected = DefaultHashSigner.sign(&state_secret(), payload.as_bytes());
+    let expected = DefaultHashSigner.sign(&secret, payload.as_bytes());
     if sig != expected {
         return None;
     }
@@ -271,7 +329,22 @@ fn build_authorize(
             "provider '{provider}' is not enabled on this host"
         ))));
     };
-    let nonce = encode_state(company.as_ref(), provider, now_millis() + STATE_TTL_MS);
+    // Named explicitly rather than folded into the message above: an operator
+    // who has registered a provider application and hit this needs to know the
+    // one remaining variable, not be told the provider is disabled (issue #318).
+    let Some(secret) = state_secret() else {
+        return Err(ApiError(OpenCompanyError::InvalidRequest(
+            "OAuth is not configured on this host: set OPENCOMPANY_OAUTH_STATE_SECRET \
+             to a private random value so the state nonce can be signed"
+                .to_string(),
+        )));
+    };
+    let nonce = encode_state(
+        &secret,
+        company.as_ref(),
+        provider,
+        now_millis() + STATE_TTL_MS,
+    );
     let redirect = redirect_uri(state);
     let url = format!(
         "{}?response_type=code&client_id={}&redirect_uri={}&scope={}&state={}",
@@ -591,9 +664,126 @@ fn urlencode(value: &str) -> String {
 mod test {
     use super::*;
 
+    /// Puts a signing secret in the process environment for the whole test
+    /// binary, and hands it back.
+    ///
+    /// One shared value rather than a per-test one: unlike the provider
+    /// credentials above, `OPENCOMPANY_OAUTH_STATE_SECRET` is host-level, every
+    /// test here needs it set, and a `Once` means concurrent tests cannot race
+    /// the write.
+    ///
+    /// The *absent* case is never tested by unsetting this — that would race
+    /// every other test in the binary. It goes through the
+    /// [`EnvSource`](crate::app::config::EnvSource) seam instead, which is why
+    /// [`state_secret_from`] takes one.
+    fn test_state_secret() -> String {
+        static SET: std::sync::Once = std::sync::Once::new();
+        const VALUE: &str = "test-state-secret";
+        SET.call_once(|| {
+            // SAFETY: written exactly once, and every caller writes the same
+            // value, so there is nothing for a concurrent test to observe
+            // changing.
+            unsafe { std::env::set_var("OPENCOMPANY_OAUTH_STATE_SECRET", VALUE) };
+        });
+        VALUE.to_string()
+    }
+
+    /// A [`MapEnv`](crate::app::config::MapEnv)-style pair set for a provider
+    /// whose application is registered on this host.
+    fn provider_app_env(provider: &str) -> Vec<(String, String)> {
+        let key = provider.to_ascii_uppercase();
+        vec![
+            (format!("OPENCOMPANY_OAUTH_{key}_ID"), "cid".to_string()),
+            (
+                format!("OPENCOMPANY_OAUTH_{key}_SECRET"),
+                "csec".to_string(),
+            ),
+            (
+                format!("OPENCOMPANY_OAUTH_{key}_AUTHORIZE_URL"),
+                "http://x/a".to_string(),
+            ),
+            (
+                format!("OPENCOMPANY_OAUTH_{key}_TOKEN_URL"),
+                "http://x/t".to_string(),
+            ),
+        ]
+    }
+
+    /// Issue #318: with no `OPENCOMPANY_OAUTH_STATE_SECRET` the hatch is shut
+    /// for a provider whose application is otherwise fully registered.
+    ///
+    /// This is the regression that matters. The old code signed the nonce with a
+    /// literal from this source file, so an unconfigured host ran the flow and
+    /// its CSRF check confirmed only that the value was well-formed.
+    #[test]
+    fn without_a_signing_secret_a_registered_provider_is_not_connectable() {
+        let env = crate::app::config::MapEnv::new(provider_app_env("slack"));
+        assert!(
+            !provider_app_configured("slack", &env),
+            "a registered provider with no state secret must not be offered"
+        );
+
+        let mut with_secret = provider_app_env("slack");
+        with_secret.push((
+            "OPENCOMPANY_OAUTH_STATE_SECRET".to_string(),
+            "a-private-value".to_string(),
+        ));
+        let env = crate::app::config::MapEnv::new(with_secret);
+        assert!(
+            provider_app_configured("slack", &env),
+            "the same provider is connectable once the secret is set"
+        );
+    }
+
+    /// A secret that is present but blank is unset. A deployment passing the
+    /// variable through an empty shell expansion gets the closed door rather
+    /// than a host signing every nonce with `" "`.
+    #[test]
+    fn a_blank_signing_secret_counts_as_unset() {
+        for blank in ["", " ", "\t\n "] {
+            let env = crate::app::config::MapEnv::new(vec![(
+                "OPENCOMPANY_OAUTH_STATE_SECRET".to_string(),
+                blank.to_string(),
+            )]);
+            assert!(
+                state_secret_from(&env).is_none(),
+                "{blank:?} must not count as a signing secret"
+            );
+        }
+    }
+
+    /// The nonce is bound to the secret, not merely to its shape: a state issued
+    /// under one secret does not verify under another. Without this, rotating
+    /// the secret would leave old nonces redeemable.
+    #[test]
+    fn a_state_signed_with_another_secret_does_not_verify() {
+        let mine = encode_state(
+            &test_state_secret(),
+            "acme",
+            "slack",
+            now_millis() + STATE_TTL_MS,
+        );
+        let theirs = encode_state(
+            "some-other-hosts-secret",
+            "acme",
+            "slack",
+            now_millis() + STATE_TTL_MS,
+        );
+        assert!(decode_state(&mine).is_some(), "our own nonce verifies");
+        assert!(
+            decode_state(&theirs).is_none(),
+            "a nonce signed elsewhere must not verify here"
+        );
+    }
+
     #[test]
     fn state_round_trips_and_rejects_tampering() {
-        let state = encode_state("acme", "slack", now_millis() + STATE_TTL_MS);
+        let state = encode_state(
+            &test_state_secret(),
+            "acme",
+            "slack",
+            now_millis() + STATE_TTL_MS,
+        );
         let (company, provider) = decode_state(&state).expect("valid state");
         assert_eq!(company, "acme");
         assert_eq!(provider, "slack");
@@ -611,7 +801,12 @@ mod test {
 
     #[test]
     fn expired_state_is_rejected() {
-        let state = encode_state("acme", "slack", now_millis().saturating_sub(1));
+        let state = encode_state(
+            &test_state_secret(),
+            "acme",
+            "slack",
+            now_millis().saturating_sub(1),
+        );
         assert!(decode_state(&state).is_none());
     }
 
@@ -692,7 +887,12 @@ mod test {
     #[tokio::test]
     async fn callback_denied_names_provider_from_verified_state() {
         let state = AppState::new(AppConfig::default());
-        let nonce = encode_state("acme", "slack", now_millis() + STATE_TTL_MS);
+        let nonce = encode_state(
+            &test_state_secret(),
+            "acme",
+            "slack",
+            now_millis() + STATE_TTL_MS,
+        );
         let resp = call_callback(
             state,
             &format!("error=access_denied&state={}", urlencode(&nonce)),
@@ -725,7 +925,12 @@ mod test {
     #[tokio::test]
     async fn callback_tampered_state_reports_invalid_state_only() {
         let state = AppState::new(AppConfig::default());
-        let mut nonce = encode_state("acme", "slack", now_millis() + STATE_TTL_MS);
+        let mut nonce = encode_state(
+            &test_state_secret(),
+            "acme",
+            "slack",
+            now_millis() + STATE_TTL_MS,
+        );
         let last = nonce.pop().expect("non-empty");
         nonce.push(if last == '0' { '1' } else { '0' });
         let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
@@ -739,7 +944,12 @@ mod test {
     #[tokio::test]
     async fn callback_expired_state_redirects() {
         let state = AppState::new(AppConfig::default());
-        let nonce = encode_state("acme", "slack", now_millis().saturating_sub(1));
+        let nonce = encode_state(
+            &test_state_secret(),
+            "acme",
+            "slack",
+            now_millis().saturating_sub(1),
+        );
         let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
         assert!(
             location(&resp).contains("connect_error=invalid_state"),
@@ -751,7 +961,12 @@ mod test {
     #[tokio::test]
     async fn callback_unknown_company_redirects() {
         let state = AppState::new(AppConfig::default());
-        let nonce = encode_state("ghost", "slack", now_millis() + STATE_TTL_MS);
+        let nonce = encode_state(
+            &test_state_secret(),
+            "ghost",
+            "slack",
+            now_millis() + STATE_TTL_MS,
+        );
         let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
         let loc = location(&resp);
         assert!(loc.contains("connect_error=unknown_company"), "{loc}");
@@ -766,7 +981,12 @@ mod test {
         let state = AppState::new(AppConfig::default());
         state.registry().insert(CompanyId::new("acme"), runtime);
         let provider = unique_provider();
-        let nonce = encode_state("acme", &provider, now_millis() + STATE_TTL_MS);
+        let nonce = encode_state(
+            &test_state_secret(),
+            "acme",
+            &provider,
+            now_millis() + STATE_TTL_MS,
+        );
         let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
         let loc = location(&resp);
         assert!(loc.contains("connect_error=provider_disabled"), "{loc}");
@@ -801,7 +1021,12 @@ mod test {
             );
         }
 
-        let nonce = encode_state("acme", &provider, now_millis() + STATE_TTL_MS);
+        let nonce = encode_state(
+            &test_state_secret(),
+            "acme",
+            &provider,
+            now_millis() + STATE_TTL_MS,
+        );
         let resp = call_callback(
             state,
             &format!("code=CANARY-authz-code&state={}", urlencode(&nonce)),

--- a/src/server/ops/connections_read.rs
+++ b/src/server/ops/connections_read.rs
@@ -462,9 +462,12 @@ mod tests {
             path.display().to_string(),
         )]);
         // An obviously fake host provider application — the self-hosted hatch.
+        // The state signing secret is part of the hatch being *open*: without
+        // one no nonce can be issued, so no handshake can complete (issue #318).
         let hatch = MapEnv::new([
             ("OPENCOMPANY_OAUTH_GITHUB_ID", "fake-client-id"),
             ("OPENCOMPANY_OAUTH_GITHUB_SECRET", "fake-client-secret"),
+            ("OPENCOMPANY_OAUTH_STATE_SECRET", "a-private-value"),
         ]);
 
         // 1. A stored token is the BYO override and outranks everything else,
@@ -539,11 +542,27 @@ mod tests {
                 (crate::company::credentials::API_KEY_ENV, "th_fake_key"),
                 ("OPENCOMPANY_OAUTH_GITHUB_ID", "fake-client-id"),
                 ("OPENCOMPANY_OAUTH_GITHUB_SECRET", "fake-client-secret"),
+                ("OPENCOMPANY_OAUTH_STATE_SECRET", "a-private-value"),
             ]);
             assert_eq!(
                 connect_route("github", false, &with_hatch),
                 CredentialSource::Static,
                 "the self-hosted hatch must keep working when an inference key is also set"
+            );
+
+            // Issue #318: the same operator without a state signing secret. The
+            // provider application is fully registered, and the hatch is still
+            // shut — an unsigned-nonce flow has no CSRF check worth the name, so
+            // the honest answer is that no Connect can succeed here.
+            let no_state_secret = MapEnv::new([
+                (crate::company::credentials::API_KEY_ENV, "th_fake_key"),
+                ("OPENCOMPANY_OAUTH_GITHUB_ID", "fake-client-id"),
+                ("OPENCOMPANY_OAUTH_GITHUB_SECRET", "fake-client-secret"),
+            ]);
+            assert_eq!(
+                connect_route("github", false, &no_state_secret),
+                CredentialSource::None,
+                "a registered provider app with no state signing secret is not connectable"
             );
         }
 


### PR DESCRIPTION
## Summary

The signing key for the OAuth `state` nonce had a default baked into the source, used whenever `OPENCOMPANY_OAUTH_STATE_SECRET` was unset — the state of any host that has not been explicitly configured. That value is public, present in this repository, and identical across every such deployment.

The nonce binds an in-flight authorization to one company, one provider and an expiry, and the callback verifies it before exchanging the code. With a knowable key, that verification confirms only that the value is well-formed, not that we issued it.

This removes the default. A host with no secret now **fails closed**: `state_secret_from` returns `None`, and every path that needs a nonce refuses rather than degrading.

The interesting part is the failure being *legible*. Three surfaces, so an operator never has to guess:

- **The console does not offer the button.** `provider_app_configured` now returns `false` when a provider application is registered but no state secret exists, so the tile reads "not available on this host" instead of presenting a Connect that would 400.
- **The startup log names the variable.** A tile has no room to explain, so a `tracing::warn!` — once per process, since this is reached from a path the console polls — says which variable is missing and what to set it to.
- **A direct `POST …/connect` says so specifically.** `build_authorize` returns a distinct error naming `OPENCOMPANY_OAUTH_STATE_SECRET` rather than the generic "provider is not enabled", which would send an operator who *has* registered an application looking in the wrong place.

Two smaller decisions worth stating:

- **`encode_state` now takes the secret** instead of reading it. A caller cannot reach nonce issuance without having first established the host has one — the check cannot be forgotten at a new call site.
- **`decode_state` collapses no-secret into the same `None` as a bad signature.** A host that cannot issue a nonce cannot have issued *this* one, so there is nothing to distinguish; it also means a host that loses its secret refuses in-flight callbacks rather than accepting whatever arrives.

Whitespace-only counts as unset, so a deployment passing the variable through an unset shell expansion gets the closed door rather than a secret of `" "`.

## API Or Behavior Changes

**Behaviour change for unconfigured hosts.** A host that registered a provider application but never set `OPENCOMPANY_OAUTH_STATE_SECRET` previously showed working Connect buttons; it now reports connections as unavailable and logs why. That is the fix operating — the buttons were completing handshakes under a key everyone has — but it is visible, so it belongs here rather than in a changelog.

Hosted tenants are unaffected: they route through the platform's attested identity, not the self-hosted hatch. Correctly configured self-hosted deployments are unaffected.

No route, DTO, or GraphQL schema change.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib`
- [x] `cargo check --locked --all-features --all-targets`

New coverage in `src/server/ops/connections.rs`:

- a registered provider application with no state secret is **not** reported connectable
- a registered application **with** a secret still is — the gate is the secret, not a blanket refusal
- whitespace-only is treated as unset
- `decode_state` rejects a nonce when the host has no secret
- round-trip encode/decode still holds when one is configured

The absent-secret cases run through the `EnvSource` seam rather than by unsetting a process variable, which would race every other test in the binary — that is why `state_secret_from` takes one.

## Documentation

`docs/modules/server/README.md` records that the self-hosted hatch needs a state signing secret, and that a registered application without one is deliberately reported as unavailable.

Closes #318
