### PR TITLE
feat(tasks): collapse Backlog into To-do, add Planning, single prompt box (#301)

### DIFF
--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -400,8 +400,8 @@ deserialize `column` as a plain string and validate it separately, so a client
 still sending `backlog` gets a `400` naming the valid set.
 
 `planning` sits between intake and dispatch: the card is being turned into a
-plan. It is **accepted but inert** — nothing writes it automatically yet. Epic
-#183 §4's auto-advance owns it and is blocked on #242/#243; the vocabulary lands
+plan. It is **accepted but inert** — nothing writes it automatically yet.
+Epic #183 §4's auto-advance owns it and is blocked on #242/#243; the vocabulary lands
 first so §4's code can write the column through a boundary that already accepts
 it, rather than having #242-dependent code write a column the host rejects. An
 operator may drag a card into it manually and nothing happens, which is correct:

--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -362,17 +362,14 @@ pub trait TaskStore: Send + Sync {
 `TaskRecord` carries `{id, title, note, column, priority, assignee,
 updated_at}`.
 
-`column` ∈ `backlog|todo|in_progress|paused|in_review|done` — the `BOARD_COLUMNS`
-constant in `src/ports/tasks.rs`, which is the one authority the REST write
-boundary, the dispatch edge and the harness lifecycle seam all read, and which
-the console mirrors in the same order. (`paused` arrived with steering, issue
-#111; this line used to omit it.) Entering `in_progress` is what dispatches the
-card; nothing dispatches out of `done`.
+`column` ∈ `todo|planning|in_progress|paused|in_review|done` — the
+`BOARD_COLUMNS` constant in `src/ports/tasks.rs`, which is the one authority the
+REST write boundary, the dispatch edge and the harness lifecycle seam all read,
+and which the console mirrors in the same order. (`paused` arrived with
+steering, issue #111; this line used to omit it.) Entering `in_progress` is what
+dispatches the card; nothing dispatches out of `done`.
 
-`backlog` and `todo` are both "not started", and the split is deliberate:
-`backlog` is the unqueued pool — and where the lifecycle returns work that needs
-another pass (a failed dispatch, an orchestrator `revise` verdict) — while
-`todo` is what has been queued up next. `todo` is the board's one manual-entry
+`todo` is the one **not started** column, and the board's one manual-entry
 column: the console's `+` button lives there alone and `POST …/tasks` defaults
 to it (issue #206), so an operator cannot create a card straight into
 `in_progress` or a terminal column. The transcript's "Add to board" action
@@ -380,12 +377,42 @@ to it (issue #206), so an operator cannot create a card straight into
 decides where a chat-created card lands, which is what keeps the human drag into
 `in_progress` the only thing that spends an agent turn.
 
+**The collapsed `backlog` pool (issue #301, epic #183 §3).** `todo` used to be
+one of two not-started columns: `backlog` was the unqueued pool *and* where the
+lifecycle returned work needing another pass (a failed dispatch, a cancellation,
+an orchestrator `revise` verdict). #206 split them deliberately, to record *why*
+a card had not started — never picked up vs bounced back. #301 reverses that:
+the distinction is **provenance, not position**, and every return path already
+stamps its reason onto the card's note (`review_note`'s "reviewed: needs another
+pass — …", the dispatch error text, `[operator] cancelled while in flight`),
+which the board renders on the card. So a task that cannot proceed goes **back
+to To-do with the reason on the card**, never into a stuck state of its own.
+
+Nothing about that is silent for stored data: `backlog` is no longer a board
+column, so a card persisted under it would fail `is_board_column` and vanish
+from the board — the exact silent disappearance #205 exists to prevent.
+`TaskRecord::column` therefore deserializes through a normalizer that rewrites
+the legacy `backlog` literal to `todo`. Every backend funnels through it (sqlite
+and mongodb store the record as a `task_json` string, the fs bundle as a JSON
+array), so one seam heals every stored board lazily on read and the next upsert
+persists the new literal. Reads heal; **writes do not** — the REST DTOs
+deserialize `column` as a plain string and validate it separately, so a client
+still sending `backlog` gets a `400` naming the valid set.
+
+`planning` sits between intake and dispatch: the card is being turned into a
+plan. It is **accepted but inert** — nothing writes it automatically yet. Epic
+#183 §4's auto-advance owns it and is blocked on #242/#243; the vocabulary lands
+first so §4's code can write the column through a boundary that already accepts
+it, rather than having #242-dependent code write a column the host rejects. An
+operator may drag a card into it manually and nothing happens, which is correct:
+`planning` is not the dispatch edge.
+
 `assignee` names a **roster teammate id, a desk, or nobody** (`""`), resolved by
 `crate::runtime::assignee` against the full roster — manifest agents, operator
 overlay teammates, and desks (by id or case-insensitive name). The write plane
 rejects anything else with a `400` and stores the canonical key rather than what
 was typed; dispatch refuses a card whose assignee no longer resolves, returning
-it to `backlog` with the reason on the note, and writes the agent that actually
+it to `todo` with the reason on the note, and writes the agent that actually
 worked the card back onto `assignee` so the board names the doer (issue #205).
 That write-back covers an unassigned card and a card assigned to a teammate; a
 card assigned to a **desk** keeps the desk id. A desk assignment records who the

--- a/frontend/ARCHITECTURE.md
+++ b/frontend/ARCHITECTURE.md
@@ -129,7 +129,9 @@ it. Responses mirror the TypeScript models in `src/lib/*` and `src/api/types.ts`
   same four invented emails for every teammate).
 
 ### Tasks (Kanban) — `src/views/TasksView.tsx`, `src/lib/tasks-sample.ts`
-- Columns Backlog/In progress/In review/Done; drag to move; priority + assignee.
+- Columns To-do/Planning/In progress/Paused/In review/Done; drag to move. New work
+  enters through one prompt box on To-do (issue #301); priority + assignee are
+  edited on the card afterwards.
 - **Source:** ✅ real — `Company.tasks` (GraphQL, `TaskStore`-backed) reads the
   board; `POST …/tasks`, `PATCH`/`DELETE …/tasks/{id}` (REST) write it.
 

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -28,7 +28,7 @@ export interface Task {
   originChatId?: string;
 }
 
-/** The create body; the host defaults column→`backlog`, priority→`medium`. */
+/** The create body; the host defaults column→`todo`, priority→`medium`. */
 export interface CreateTask {
   title: string;
   note?: string;

--- a/frontend/src/lib/tasks-sample.ts
+++ b/frontend/src/lib/tasks-sample.ts
@@ -25,13 +25,20 @@ export interface TaskColumn {
  * exists only here is one the host will refuse.
  */
 export const TASK_COLUMNS: TaskColumn[] = [
-  // The unqueued pool, and where the lifecycle returns work that needs another
-  // pass (a failed dispatch, an orchestrator `revise` verdict).
-  { id: "backlog", label: "Backlog" },
-  // Queued to be worked next (issue #206). The board's manual-entry column:
-  // `ADD_TASK_COLUMN` below restricts the `+` button to it, and it is what the
-  // host's `POST …/tasks` defaults to.
+  // Everything not started (issue #301): work nobody has picked up yet, and
+  // work the lifecycle returned needing another pass (a failed dispatch, a
+  // cancellation, an orchestrator `revise` verdict) — the reason rides along on
+  // the card's note. This replaces the old Backlog/To-do split (issue #206);
+  // the host rewrites a stored `backlog` card to this column on read.
+  //
+  // It is also the board's manual-entry column: `ADD_TASK_COLUMN` below
+  // restricts the "Add task" box to it, and it is what `POST …/tasks` defaults
+  // to.
   { id: "todo", label: "To-do" },
+  // Between intake and dispatch: the card is being turned into a plan. Inert
+  // today — epic #183 §4's auto-advance is what will move cards through it, and
+  // dragging one here fires nothing (only `in_progress` dispatches).
+  { id: "planning", label: "Planning" },
   { id: "in_progress", label: "In progress" },
   // Where a steered-to-pause run parks (issue #111); a card here offers Resume.
   { id: "paused", label: "Paused" },
@@ -58,9 +65,9 @@ const id = () => `task-${n++}`;
 
 export function sampleTasks(): TaskCard[] {
   return [
-    { id: id(), title: "Q2 campaign brief", note: "Turn the client brief into an angle", column: "backlog", priority: "high", assignee: STRATEGY },
-    { id: id(), title: "Competitor scan", note: "Pull three rival launches", column: "backlog", priority: "low", assignee: STRATEGY },
-    { id: id(), title: "Newsletter refresh", note: "New template + segments", column: "backlog", priority: "medium", assignee: FRONT },
+    { id: id(), title: "Q2 campaign brief", note: "Turn the client brief into an angle", column: "todo", priority: "high", assignee: STRATEGY },
+    { id: id(), title: "Competitor scan", note: "Pull three rival launches", column: "todo", priority: "low", assignee: STRATEGY },
+    { id: id(), title: "Newsletter refresh", note: "New template + segments", column: "planning", priority: "medium", assignee: FRONT },
     { id: id(), title: "Spring launch taglines", note: "Draft three options", column: "in_progress", priority: "high", assignee: CREATIVE },
     { id: id(), title: "Landing hero image", note: "Generate + retouch", column: "in_progress", priority: "medium", assignee: CREATIVE },
     { id: id(), title: "Invoice March retainer", column: "in_review", priority: "medium", assignee: FRONT },

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -713,7 +713,10 @@ function ControlBar({
 
       {reassigning && (
         <div className="mt-2 flex items-center gap-2">
-          {/* Issue #263: the same roster picker the create and edit dialogs use.
+          {/* Issue #263: the same roster picker the edit dialog uses. Since
+              #301 this is the *only* place a card gets an assignee — the create
+              box asks for a prompt and nothing else, so the host's default
+              (unassigned → orchestrator) stands until somebody picks here.
               Unassigned is a row here rather than an empty field, so handing the
               card back to the orchestrator is something you can see and choose. */}
           <AssigneeSelect

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -14,21 +14,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { ADD_TASK_COLUMN, PRIORITY_STYLES, TASK_COLUMNS } from "@/lib/tasks-sample";
 import { toast } from "sonner";
-import { AssigneeSelect } from "./AssigneeSelect";
 import { TaskDetailView } from "./TaskDetailView";
 
 /**
@@ -47,8 +38,6 @@ function readTaskDetailId(): string | null {
     return null;
   }
 }
-
-const PRIORITIES = ["low", "medium", "high"] as const;
 
 /** How often to re-poll the board, so a dispatched card's result appears. */
 const POLL_MS = 4000;
@@ -86,7 +75,7 @@ export function TasksView({
   // The open card's id, mirrored in `#/tasks/<id>` so the detail survives a
   // refresh and honors back/forward.
   const [detailId, setDetailId] = useState<string | null>(readTaskDetailId);
-  const [creatingIn, setCreatingIn] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
   const mounted = useRef(true);
   // A real HTML5 drag fires a trailing click; suppress it so a drag never also
   // opens the detail dialog.
@@ -207,7 +196,7 @@ export function TasksView({
             size="sm"
             variant="outline"
             className="ml-1 h-7"
-            onClick={() => setCreatingIn(ADD_TASK_COLUMN)}
+            onClick={() => setCreating(true)}
           >
             <Plus className="size-4" />
             Add task
@@ -290,11 +279,11 @@ export function TasksView({
       </div>
 
       <CreateTaskDialog
-        column={creatingIn}
-        onClose={() => setCreatingIn(null)}
+        open={creating}
+        onClose={() => setCreating(false)}
         onCreated={(created) => {
           setTasks((ts) => [created, ...ts]);
-          setCreatingIn(null);
+          setCreating(false);
         }}
         client={client}
         company={company}
@@ -379,47 +368,69 @@ function TaskItem({
   );
 }
 
+/** How long a derived title may run before the full prompt moves to the note. */
+const TITLE_CAP = 80;
+
+/**
+ * Splits a prompt into the card's `{title, note}` (issue #301).
+ *
+ * The dialog asks for one thing — what needs doing — so the card's two text
+ * fields are derived rather than collected. The rule mirrors the host's own
+ * chat task-intent derivation (`src/server/operator.rs`) and `delegate_to_desk`'s
+ * `first_line(…, 80)`: the title is the prompt's first line, capped; the note
+ * carries the **full** prompt only when the title was shortened from it, so a
+ * one-liner does not duplicate itself onto its own card.
+ *
+ * The invariant that matters: the operator's full text always survives on the
+ * card, in the title or the note. Epic #183 §4's planner reads it from there.
+ */
+export function derivePromptCard(prompt: string): { title: string; note?: string } {
+  const full = prompt.trim();
+  const firstLine = full.split("\n")[0].trim();
+  const title =
+    firstLine.length > TITLE_CAP ? `${firstLine.slice(0, TITLE_CAP).trimEnd()}…` : firstLine;
+  return { title, note: title === full ? undefined : full };
+}
+
+/**
+ * New work enters the board through one prompt box (issue #301).
+ *
+ * Title/Note/Priority/Assignee used to be collected up front. They are not gone,
+ * only moved: priority and assignee default on the host (`medium`, unassigned →
+ * orchestrator) and are edited on the card afterwards, where #278 put the
+ * picker. `column` is omitted on purpose so the *server's* intake default
+ * decides where the card lands — the same spend gate the transcript's "Add to
+ * board" relies on, keeping the human drag into In progress the only thing that
+ * spends an agent turn.
+ */
 function CreateTaskDialog({
-  column,
+  open,
   onClose,
   onCreated,
   client,
   company,
 }: {
-  column: string | null;
+  open: boolean;
   onClose: () => void;
   onCreated: (t: Task) => void;
   client: OpenCompanyClient;
   company: string | null;
 }) {
-  const [title, setTitle] = useState("");
-  const [note, setNote] = useState("");
-  const [priority, setPriority] = useState("medium");
-  const [assignee, setAssignee] = useState("");
+  const [prompt, setPrompt] = useState("");
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
-    if (column) {
-      setTitle("");
-      setNote("");
-      setPriority("medium");
-      setAssignee("");
-    }
-  }, [column]);
+    if (open) setPrompt("");
+  }, [open]);
 
-  if (!column) return null;
+  if (!open) return null;
 
   async function create() {
-    if (!title.trim()) return;
+    const { title, note } = derivePromptCard(prompt);
+    if (!title) return;
     setBusy(true);
     try {
-      const created = await createTask(client, company, {
-        title: title.trim(),
-        note: note.trim() || undefined,
-        column: column ?? undefined,
-        priority,
-        assignee: assignee.trim() || undefined,
-      });
+      const created = await createTask(client, company, { title, note });
       onCreated(created);
       toast.success("Task created.");
     } catch (e) {
@@ -429,10 +440,11 @@ function CreateTaskDialog({
     }
   }
 
-  const columnLabel = TASK_COLUMNS.find((c) => c.id === column)?.label ?? column;
+  const columnLabel =
+    TASK_COLUMNS.find((c) => c.id === ADD_TASK_COLUMN)?.label ?? ADD_TASK_COLUMN;
 
   return (
-    <Dialog open={!!column} onOpenChange={(open) => !open && onClose()}>
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       {/* `sm:` — DialogContent's own `sm:max-w-sm` beats an unprefixed width. */}
       <DialogContent className="sm:max-w-3xl">
         <DialogHeader>
@@ -440,67 +452,25 @@ function CreateTaskDialog({
           <DialogDescription>Added to “{columnLabel}”.</DialogDescription>
         </DialogHeader>
 
-        <div className="grid gap-3">
-          <div className="grid gap-1.5">
-            <Label htmlFor="new-title">Title</Label>
-            <Input
-              id="new-title"
-              autoFocus
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="What needs doing?"
-            />
-          </div>
-          <div className="grid gap-1.5">
-            <Label htmlFor="new-note">Note</Label>
-            <Textarea
-              id="new-note"
-              // Textarea is `field-sizing-content`, so `rows` is inert — a
-              // min-height is what actually gives the box room.
-              className="min-h-32 resize-y"
-              value={note}
-              onChange={(e) => setNote(e.target.value)}
-              placeholder="Any detail the assignee should act on."
-            />
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            <div className="grid gap-1.5">
-              <Label>Priority</Label>
-              <Select value={priority} onValueChange={(v) => setPriority(v ?? "medium")}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {PRIORITIES.map((p) => (
-                    <SelectItem key={p} value={p} className="capitalize">
-                      {p}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            {/* `min-w-0` so a long teammate id cannot widen this grid track
-                and squeeze the Priority select beside it. */}
-            <div className="grid min-w-0 gap-1.5">
-              <Label htmlFor="new-assignee">Assignee</Label>
-              {/* Issue #263: the roster is a closed set the host enforces, so it
-                  is picked, not typed. Blank is its own labelled row. */}
-              <AssigneeSelect
-                id="new-assignee"
-                client={client}
-                company={company}
-                value={assignee}
-                onChange={setAssignee}
-              />
-            </div>
-          </div>
+        <div className="grid gap-1.5">
+          <Label htmlFor="new-prompt">What needs doing?</Label>
+          <Textarea
+            id="new-prompt"
+            autoFocus
+            // Textarea is `field-sizing-content`, so `rows` is inert — a
+            // min-height is what actually gives the box room.
+            className="min-h-32 resize-y"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder="Describe the work. The first line becomes the card's title."
+          />
         </div>
 
         <DialogFooter>
           <Button variant="outline" onClick={onClose} disabled={busy}>
             Cancel
           </Button>
-          <Button onClick={() => void create()} disabled={busy || !title.trim()}>
+          <Button onClick={() => void create()} disabled={busy || !prompt.trim()}>
             {busy && <Loader2 className="mr-1.5 size-4 animate-spin" />}
             Create
           </Button>

--- a/frontend/test/e2e/alert-dialog-confirm.spec.ts
+++ b/frontend/test/e2e/alert-dialog-confirm.spec.ts
@@ -94,8 +94,8 @@ test("confirming a task delete dismisses the dialog before the request lands", a
 
   // Create a card of our own so the test never deletes somebody else's row.
   const title = `e2e confirm-closes ${Date.now()}`;
-  await page.getByRole("button", { name: "Add task to To-do" }).click();
-  await page.locator("#new-title").fill(title);
+  await page.getByRole("button", { name: "Add task" }).click();
+  await page.locator("#new-prompt").fill(title);
   await page.getByRole("button", { name: "Create", exact: true }).click();
 
   const card = page.locator('[role="button"]').filter({ hasText: title });

--- a/frontend/test/e2e/assignee-picker.spec.ts
+++ b/frontend/test/e2e/assignee-picker.spec.ts
@@ -3,6 +3,12 @@ import { expect, test, type Page, type Request } from "@playwright/test";
 /**
  * Issue #263 — the task assignee is picked from the company roster, not typed.
  *
+ * Issue #301 moved *where*: the create box asks for a prompt and nothing else,
+ * so a new card is always unassigned (the host hands it to the orchestrator)
+ * and the picker lives on the card's own edit surface. These tests therefore
+ * exercise the picker through Edit / Reassign rather than through create — the
+ * invariant under test is unchanged, only the screen it is reached from.
+ *
  * These run against a live host serving the built console, with the
  * `e2e_harness` company: desks `engineering` / `content` and manifest agents
  * `ceo` / `engineer` / `writer`.
@@ -41,11 +47,22 @@ async function dismissTour(page: Page) {
   await expect(skip).toHaveCount(0);
 }
 
-async function openCreateDialog(page: Page) {
+/** Creates a card through the board's one prompt box (issue #301). */
+async function createViaPromptBox(page: Page, prompt: string) {
   await page.goto("/#/tasks");
   await dismissTour(page);
-  await page.getByRole("button", { name: "Add task to To-do" }).click();
+  await page.getByRole("button", { name: "Add task" }).click();
   await expect(page.getByRole("heading", { name: "New task" })).toBeVisible();
+  await page.locator("#new-prompt").fill(prompt);
+  await page.getByRole("button", { name: "Create" }).click();
+}
+
+/** Opens a seeded card's edit dialog — where the assignee is now picked. */
+async function openEditDialog(page: Page, id: string) {
+  await page.goto(`/#/tasks/${id}`);
+  await dismissTour(page);
+  await page.getByRole("button", { name: "Edit" }).click();
+  await expect(page.getByRole("heading", { name: "Edit task" })).toBeVisible();
 }
 
 /** Opens the assignee select and picks the option with this exact-ish name. */
@@ -59,15 +76,29 @@ function card(page: Page, title: string) {
   return page.locator("div[draggable=true]").filter({ hasText: title }).first();
 }
 
-test("the create dialog offers Unassigned, desks and teammates instead of a text field", async ({
+test("the edit dialog offers Unassigned, desks and teammates instead of a text field", async ({
   page,
+  request,
 }) => {
-  await openCreateDialog(page);
+  // The empty-desk row this asserts on needs a desk with nobody on it, and the
+  // `e2e_harness` manifest ships only staffed desks — so seed it rather than
+  // depend on one a previous run happened to leave behind. (This assertion
+  // silently required that leftover state before #301 repaired the spec: on a
+  // fresh host there was no `Legal` desk and it could not pass.) Idempotent, so
+  // a re-run against the same host is fine.
+  await request.post(`${API}/desks`, {
+    data: { id: "legal", name: "Legal", description: "Contracts and review." },
+  });
+
+  const created = await request.post(`${API}/tasks`, {
+    data: { title: `e2e picker ${Date.now()}` },
+  });
+  await openEditDialog(page, (await created.json()).id as string);
 
   // It is a select, not a free-text input: typing a name is no longer possible.
-  await expect(page.locator("input#new-assignee")).toHaveCount(0);
+  await expect(page.locator("input#task-assignee")).toHaveCount(0);
 
-  await page.locator("#new-assignee").click();
+  await page.locator("#task-assignee").click();
 
   // Blank is a labelled choice that says what it does, not an empty field.
   await expect(page.getByRole("option", { name: /Unassigned/ })).toBeVisible();
@@ -94,13 +125,18 @@ test("the create dialog offers Unassigned, desks and teammates instead of a text
   await expect(page.getByRole("option", { name: /Engineering desk — 1 teammate/ })).toBeVisible();
 });
 
-test("a card assigned to a desk keeps the desk, not the desk's lead", async ({ page }) => {
+test("a card assigned to a desk keeps the desk, not the desk's lead", async ({
+  page,
+  request,
+}) => {
   const title = `e2e desk card ${Date.now()}`;
-  await openCreateDialog(page);
-  await page.locator("#new-title").fill(title);
-  await pickAssignee(page, "new-assignee", /Engineering desk/);
-  await page.getByRole("button", { name: "Create" }).click();
+  const seeded = await request.post(`${API}/tasks`, { data: { title } });
+  await openEditDialog(page, (await seeded.json()).id as string);
+  await pickAssignee(page, "task-assignee", /Engineering desk/);
+  await page.getByRole("button", { name: "Save" }).click();
 
+  await page.goto("/#/tasks");
+  await dismissTour(page);
   const created = card(page, title);
   await expect(created).toBeVisible({ timeout: 15_000 });
   // The whole point: `engineering` (the desk), never `engineer` (its lead).
@@ -108,20 +144,24 @@ test("a card assigned to a desk keeps the desk, not the desk's lead", async ({ p
   await expect(created).not.toContainText(/\bengineer\b(?!ing)/);
 });
 
-test("a card can be created for a teammate and for nobody at all", async ({ page }) => {
+test("a card can be assigned to a teammate, and created for nobody at all", async ({
+  page,
+  request,
+}) => {
   const forWriter = `e2e writer card ${Date.now()}`;
-  await openCreateDialog(page);
-  await page.locator("#new-title").fill(forWriter);
-  await pickAssignee(page, "new-assignee", /^writer —/);
-  await page.getByRole("button", { name: "Create" }).click();
+  const seeded = await request.post(`${API}/tasks`, { data: { title: forWriter } });
+  await openEditDialog(page, (await seeded.json()).id as string);
+  await pickAssignee(page, "task-assignee", /^writer —/);
+  await page.getByRole("button", { name: "Save" }).click();
+  await page.goto("/#/tasks");
+  await dismissTour(page);
   await expect(card(page, forWriter)).toContainText("writer", { timeout: 15_000 });
 
+  // Issue #301: the prompt box collects no assignee, so a card created on the
+  // board is unassigned by construction — the host hands it to the
+  // orchestrator. This is the default the create surface now relies on.
   const forNobody = `e2e unassigned card ${Date.now()}`;
-  await openCreateDialog(page);
-  await page.locator("#new-title").fill(forNobody);
-  // Unassigned is the default, but choose it explicitly so the round-trip is real.
-  await pickAssignee(page, "new-assignee", /Unassigned/);
-  await page.getByRole("button", { name: "Create" }).click();
+  await createViaPromptBox(page, forNobody);
 
   const nobody = card(page, forNobody);
   await expect(nobody).toBeVisible({ timeout: 15_000 });
@@ -146,10 +186,7 @@ test("renaming a card does not resubmit its assignee", async ({ page, request })
     }
   });
 
-  await page.goto(`/#/tasks/${id}`);
-  await dismissTour(page);
-  await page.getByRole("button", { name: "Edit" }).click();
-  await expect(page.getByRole("heading", { name: "Edit task" })).toBeVisible();
+  await openEditDialog(page, id);
   await page.locator("#task-title").fill(`${title} renamed`);
   await page.getByRole("button", { name: "Save" }).click();
 

--- a/frontend/test/e2e/board-columns.spec.ts
+++ b/frontend/test/e2e/board-columns.spec.ts
@@ -131,4 +131,14 @@ test("dragging into Planning moves the card without dispatching it", async ({ pa
   // the dispatch toast must NOT appear. This is the assertion that lets the
   // column ship ahead of epic #183 §4's auto-advance.
   await expect(page.getByText("Dispatched — the assignee is working on it.")).toHaveCount(0);
+
+  // The toast is a console-side signal and only fires for `in_progress`, so on
+  // its own it cannot distinguish "never dispatched" from "dispatched and the
+  // run already finished". Assert the host's own record instead: the task's
+  // timeline is folded from the company journal, so a dispatch that happened at
+  // any point leaves a `dispatched` entry behind that no later event removes.
+  const detail = await (await request.get(`${API}/tasks/${id}`)).json();
+  expect(
+    (detail.timeline ?? []).filter((entry: { kind: string }) => entry.kind === "dispatched"),
+  ).toHaveLength(0);
 });

--- a/frontend/test/e2e/board-columns.spec.ts
+++ b/frontend/test/e2e/board-columns.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Issue #301 — the board's shape, asserted against a live host.
+ *
+ * This spec is the drift guard for the console half of a two-language mirror.
+ * `BOARD_COLUMNS` (`src/ports/tasks.rs`) is the source of truth and the REST
+ * write boundary rejects a card against it; `TASK_COLUMNS`
+ * (`src/lib/tasks-sample.ts`) is what actually renders. A Rust test cannot see
+ * the TS list, and there is no frontend unit runner here (the console's scripts
+ * are typecheck / build / e2e only) — so the two lists are only ever joined by
+ * a test that drives the rendered board against a real host. A column present
+ * on one side alone shows up here as either one that never renders or one whose
+ * writes always 400.
+ *
+ * Generating one list from the other is the durable fix and stays deferred: it
+ * needs a build step across a separate npm build that this crate does not have.
+ */
+
+const API = "/api/v1/company";
+
+/** Epic #183 §3's vocabulary, in board order. */
+const EXPECTED_COLUMNS = [
+  "To-do",
+  "Planning",
+  "In progress",
+  "Paused",
+  "In review",
+  "Done",
+];
+
+test.beforeEach(async ({ page }) => {
+  // The first-run tour opens a modal over the board and swallows clicks.
+  await page.addInitScript(() => {
+    const seen = JSON.stringify({ skipped: true, seenAt: Date.now() });
+    for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
+      window.localStorage.setItem(key, seen);
+    }
+  });
+});
+
+async function dismissTour(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    if (!(await skip.isVisible().catch(() => false))) return;
+    await skip.click({ force: true }).catch(() => {});
+    await page.waitForTimeout(300);
+  }
+  await expect(skip).toHaveCount(0);
+}
+
+/** The column headers the board actually renders, left to right. */
+function columnLabels(page: Page) {
+  return page.locator("div.w-72 > div > span.text-sm.font-medium");
+}
+
+test("the board renders the six #183 columns in order, with Backlog gone", async ({ page }) => {
+  await page.goto("/#/tasks");
+  await dismissTour(page);
+
+  await expect(columnLabels(page)).toHaveText(EXPECTED_COLUMNS);
+  // The collapse, stated as its own assertion: Backlog is not a column any more.
+  await expect(page.getByText("Backlog", { exact: true })).toHaveCount(0);
+});
+
+test("new work enters through one prompt box and lands in To-do", async ({ page, request }) => {
+  await page.goto("/#/tasks");
+  await dismissTour(page);
+
+  // Exactly one entry point on the whole board (issue #206's rule, kept).
+  const addTask = page.getByRole("button", { name: "Add task" });
+  await expect(addTask).toHaveCount(1);
+  await addTask.click();
+  await expect(page.getByRole("heading", { name: "New task" })).toBeVisible();
+
+  // One field. Title / Note / Priority / Assignee are gone from create — the
+  // host defaults the last two and the card's edit surface owns them (#278).
+  await expect(page.locator("#new-prompt")).toBeVisible();
+  for (const gone of ["#new-title", "#new-note", "#new-assignee"]) {
+    await expect(page.locator(gone)).toHaveCount(0);
+  }
+
+  // A prompt longer than the title cap: the title is shortened and the full
+  // text survives in the note, so nothing the operator typed is lost.
+  const marker = `e2e board shape ${Date.now()}`;
+  const long = `${marker} — and then a great deal more detail that runs well past the eighty character title cap so the note has to carry it`;
+  await page.locator("#new-prompt").fill(long);
+  await page.getByRole("button", { name: "Create", exact: true }).click();
+
+  type Row = { title: string; note?: string; column: string };
+  const find = async (): Promise<Row | undefined> => {
+    const rows = (await (await request.get(`${API}/tasks`)).json()) as Row[];
+    return rows.find((r) => r.title.startsWith(marker));
+  };
+
+  await expect.poll(async () => (await find()) !== undefined, { timeout: 15_000 }).toBe(true);
+  const created = (await find())!;
+
+  expect(created.column).toBe("todo");
+  expect(created.title.length).toBeLessThanOrEqual(81); // 80 + the ellipsis
+  expect(created.note).toBe(long);
+});
+
+test("dragging into Planning moves the card without dispatching it", async ({ page, request }) => {
+  const title = `e2e planning drag ${Date.now()}`;
+  const seeded = await request.post(`${API}/tasks`, { data: { title } });
+  expect(seeded.ok()).toBeTruthy();
+  const id = (await seeded.json()).id as string;
+
+  await page.goto("/#/tasks");
+  await dismissTour(page);
+
+  const card = page.locator("div[draggable=true]").filter({ hasText: title }).first();
+  await expect(card).toBeVisible({ timeout: 15_000 });
+
+  // Playwright's dragTo does not drive React's HTML5 drag handlers reliably
+  // here, so the drop is dispatched directly at the Planning column.
+  const planning = page.locator("div.w-72").nth(EXPECTED_COLUMNS.indexOf("Planning"));
+  await card.dispatchEvent("dragstart");
+  await planning.dispatchEvent("dragover");
+  await planning.dispatchEvent("drop");
+
+  await expect
+    .poll(
+      async () => (await (await request.get(`${API}/tasks/${id}`)).json()).task.column,
+      { timeout: 15_000 },
+    )
+    .toBe("planning");
+
+  // Planning is deliberately inert: only `in_progress` spends an agent turn, so
+  // the dispatch toast must NOT appear. This is the assertion that lets the
+  // column ship ahead of epic #183 §4's auto-advance.
+  await expect(page.getByText("Dispatched — the assignee is working on it.")).toHaveCount(0);
+});

--- a/src/brain/hosted/test.rs
+++ b/src/brain/hosted/test.rs
@@ -783,7 +783,7 @@ async fn e2e_spawn_task_tool_call_opens_a_board_card() {
     assert_eq!(cards.len(), 1, "one card opened: {cards:?}");
     assert_eq!(cards[0].title, "Ship the invoice flow");
     assert_eq!(cards[0].assignee, "eng");
-    assert_eq!(cards[0].column, "backlog");
+    assert_eq!(cards[0].column, "todo");
 }
 
 /// Medulla emitting a `delegate_to_desk` tool-call resolves the desk and records

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -759,13 +759,17 @@ mod tests {
     fn dispatch_only_on_entering_in_progress() {
         // Fresh card created straight into `in_progress` → dispatch.
         assert!(task_enters_in_progress(None, "in_progress"));
-        // The drag: backlog → in_progress → dispatch.
-        assert!(task_enters_in_progress(Some("backlog"), "in_progress"));
+        // The drag: todo → in_progress → dispatch.
+        assert!(task_enters_in_progress(Some("todo"), "in_progress"));
+        // Issue #301: planning sits before dispatch, so entering it must not
+        // fire one — and leaving it for `in_progress` must.
+        assert!(!task_enters_in_progress(Some("todo"), "planning"));
+        assert!(task_enters_in_progress(Some("planning"), "in_progress"));
         // Already in_progress, re-saved (e.g. an edit) → no re-dispatch.
         assert!(!task_enters_in_progress(Some("in_progress"), "in_progress"));
         // Any non-in_progress target → no dispatch.
         assert!(!task_enters_in_progress(Some("in_progress"), "in_review"));
-        assert!(!task_enters_in_progress(None, "backlog"));
+        assert!(!task_enters_in_progress(None, "todo"));
         assert!(!task_enters_in_progress(Some("in_review"), "done"));
     }
 

--- a/src/company/steer.rs
+++ b/src/company/steer.rs
@@ -46,7 +46,7 @@ pub const MAX_REDIRECT_CHARS: usize = 2000;
 pub enum SteerAction {
     /// Stop the run and park the card in `paused`, preserving its partial work.
     Pause,
-    /// Stop the run and drop its partial work, returning the card to `backlog`.
+    /// Stop the run and drop its partial work, returning the card to `todo`.
     Cancel,
     /// Stop the current attempt and re-run it with an appended operator
     /// instruction. Bounded per dispatch (see the harness disposition).

--- a/src/company/task_intent.rs
+++ b/src/company/task_intent.rs
@@ -7,7 +7,7 @@
 //! leaves no visible work item. This module adds the deterministic half: when an
 //! operator message is an actionable request ("build the landing page",
 //! "can you set up the newsletter"), [`detect_task_intent`] returns a cleaned
-//! task title and the handler opens a `backlog` card. The model's `spawn_task`
+//! task title and the handler opens a `todo` card. The model's `spawn_task`
 //! stays available for sub-tasks it wants to open on top.
 //!
 //! Conservative and cheap by design (no model call): it fires on imperative

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -87,7 +87,7 @@ impl HarnessBrain {
     /// a single turn, and writes the outcome back onto the board — moved to its
     /// success terminal column on success (see
     /// [`lifecycle::success_terminal_column`]),
-    /// back to `backlog` with the error noted on failure. A missing task store
+    /// back to `todo` with the error noted on failure. A missing task store
     /// or a card that has since vanished is a silent no-op.
     ///
     /// Before this the answer only ever reached `card.note`: the card runs
@@ -236,7 +236,7 @@ impl HarnessBrain {
             // invalid name, so the only trace was a timeline that read "reply
             // from ceo" on a card assigned to somebody else. Refuse instead: no
             // turn is run (nothing was asked of the orchestrator), the card
-            // returns to `backlog` carrying the reason, and the operator is
+            // returns to `todo` carrying the reason, and the operator is
             // told — on the board, on the timeline, and in the thread the card
             // came from.
             tracing::warn!(
@@ -355,7 +355,7 @@ impl HarnessBrain {
                             // this fix exists to eliminate.
                             //
                             // The card keeps the delegate as its assignee on the
-                            // way to `backlog` — the hand-off did happen, and a
+                            // way to `todo` — the hand-off did happen, and a
                             // re-dispatch should start from who it was given to.
                             let handoff = match self
                                 .delegation_runner(&run_turn)
@@ -402,7 +402,7 @@ impl HarnessBrain {
                                         // #213 review).
                                         //
                                         // Partial work is discarded and the card
-                                        // returns to the backlog, exactly as a
+                                        // returns to To-do, exactly as a
                                         // cancelled dispatch does — it must not
                                         // read as finished, and it must not
                                         // strand in `in_progress` either.
@@ -440,7 +440,7 @@ impl HarnessBrain {
                 }
                 Some(SteerAction::Cancel) => {
                     // Partial work is DISCARDED — only a cancellation note lands,
-                    // and the card returns to `backlog`. The note is attributed to
+                    // and the card returns to `todo`. The note is attributed to
                     // the operator, not the assignee (the lifecycle seam decides
                     // that). The loop still yields the text for #185/#190.
                     let result = "cancelled while in flight".to_string();
@@ -591,7 +591,7 @@ impl HarnessBrain {
     /// this issue is about. It deliberately skips the three things that belong
     /// to a run that happened: no in-flight registration (nothing is in flight),
     /// no MCP drain (no turn queued anything), and no artifact (`Failed` lands
-    /// in `backlog`, never a success terminal).
+    /// in `todo`, never a success terminal).
     ///
     /// Attributed to the **orchestrator**: it is the company answering for its
     /// own roster, and the named assignee does not exist to speak.
@@ -920,7 +920,7 @@ impl HarnessBrain {
 
     /// Executes one drained delegation from the orchestrator's turn.
     ///
-    /// `spawn_task` opens a backlog card through the same
+    /// `spawn_task` opens a To-do card through the same
     /// [`TaskStore::upsert`](crate::ports::TaskStore) path the console uses and
     /// reports the card's id (issue #246); it surfaces no bubble of its own. A
     /// missing task store is a silent no-op.
@@ -1154,6 +1154,9 @@ mod tests {
     use crate::company::CompanyManifest;
     use crate::harness::provider::{HarnessModel, MockProvider};
     use crate::ports::brain::CycleHost;
+    // Issue #301: every lifecycle return now lands in To-do (the `backlog` pool
+    // is gone), so these assertions read the const rather than a literal.
+    use crate::ports::tasks::COLUMN_TODO;
     use crate::ports::types::{
         ApprovalId, CompanyId, ContextOp, ContextOpResult, Effect, EffectDisposition, OverlayAgent,
         ToolCall, ToolResult,
@@ -1656,7 +1659,7 @@ members = ["engineer"]
         let dir = tempfile::tempdir().unwrap();
         let (brain, tasks) = brain_with_tasks(dir.path());
         // A roster assignee: since #205 an off-roster one never runs a turn, so
-        // it would settle to `backlog` and prove nothing about the terminal.
+        // it would settle to `todo` and prove nothing about the terminal.
         let mut c = card("t-origin", "engineer");
         c.origin_chat_id = Some("strategy".to_string());
         tasks
@@ -1666,7 +1669,7 @@ members = ["engineer"]
         // `run_task` is driven directly here rather than through `run_cycle`,
         // so the roster the turn runs on has to be built explicitly. Without it
         // every dispatch fails with "company not found" and settles to
-        // `backlog` — which still satisfies this test's post-back assertions
+        // `todo` — which still satisfies this test's post-back assertions
         // while proving nothing about the terminal column.
         brain
             .pool
@@ -1761,7 +1764,7 @@ members = ["engineer"]
             .await
             .expect("cycle runs");
 
-        assert_eq!(only_card(&ops).await.column, "backlog");
+        assert_eq!(only_card(&ops).await.column, COLUMN_TODO);
         let artifacts = crate::ports::artifacts::ArtifactStore::list(
             &*ops,
             &CompanyId::new("acme"),
@@ -1863,7 +1866,7 @@ members = ["engineer"]
     /// The reported bug. A card assigned to "Shane" — nobody this company has —
     /// used to dispatch to the orchestrator anyway, keeping `assignee = "Shane"`
     /// while the timeline read "reply from ceo" and nothing said the name was
-    /// invalid. It must now be **refused**: the card goes back to `backlog`
+    /// invalid. It must now be **refused**: the card goes back to `todo`
     /// carrying the reason, and the orchestrator runs no turn on its behalf.
     #[tokio::test]
     async fn task_dispatch_off_roster_assignee_is_refused_not_silently_reassigned() {
@@ -1886,7 +1889,7 @@ members = ["engineer"]
 
         let refused = only_card(&tasks).await;
         assert_eq!(
-            refused.column, "backlog",
+            refused.column, COLUMN_TODO,
             "a card nobody can work must not sit in in_progress"
         );
         assert_eq!(
@@ -2399,9 +2402,9 @@ members = ["eng1", "eng2"]
         );
     }
 
-    /// A `spawn_task` delegation opens a backlog card and surfaces no bubble.
+    /// A `spawn_task` delegation opens a To-do card and surfaces no bubble.
     #[tokio::test]
-    async fn spawn_task_delegation_opens_a_backlog_card() {
+    async fn spawn_task_delegation_opens_a_todo_card() {
         let dir = tempfile::tempdir().unwrap();
         let (brain, tasks) = brain_with_desk(dir.path());
         let out = brain
@@ -2423,7 +2426,7 @@ members = ["eng1", "eng2"]
         let cards = tasks.list(&CompanyId::new("acme")).await.unwrap();
         assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].title, "Draft the plan");
-        assert_eq!(cards[0].column, "backlog");
+        assert_eq!(cards[0].column, COLUMN_TODO);
         assert_eq!(cards[0].assignee, "engineer");
         // Issue #246: it surfaces no *bubble*, but it no longer surfaces
         // *nothing* — the card it opened is reported, which is what lets the
@@ -2581,7 +2584,7 @@ members = ["eng1", "eng2"]
         let dir = tempfile::tempdir().unwrap();
         let (brain, tasks) = brain_with_tasks(dir.path());
         let mut c = card("t-assign", "engineer");
-        c.column = "backlog".to_string();
+        c.column = COLUMN_TODO.to_string();
         tasks.upsert(&CompanyId::new("acme"), &c).await.unwrap();
 
         let out = brain
@@ -2603,7 +2606,7 @@ members = ["eng1", "eng2"]
         let after = only_card(&tasks).await;
         assert_eq!(after.assignee, "ceo");
         assert_eq!(
-            after.column, "backlog",
+            after.column, COLUMN_TODO,
             "assignment records ownership; it must not start the work"
         );
         let note = after.note.expect("note");
@@ -2624,7 +2627,7 @@ members = ["eng1", "eng2"]
         let dir = tempfile::tempdir().unwrap();
         let (brain, tasks) = brain_with_tasks(dir.path());
         let mut c = card("t-assign", "engineer");
-        c.column = "backlog".to_string();
+        c.column = COLUMN_TODO.to_string();
         tasks.upsert(&CompanyId::new("acme"), &c).await.unwrap();
 
         brain
@@ -2657,7 +2660,7 @@ members = ["eng1", "eng2"]
         let dir = tempfile::tempdir().unwrap();
         let (brain, tasks) = brain_with_tasks(dir.path());
         let mut c = card("t-assign", "engineer");
-        c.column = "backlog".to_string();
+        c.column = COLUMN_TODO.to_string();
         tasks.upsert(&CompanyId::new("acme"), &c).await.unwrap();
 
         brain
@@ -2722,9 +2725,9 @@ members = ["eng1", "eng2"]
     }
 
     /// `revise` is a transition #186 does own: the card goes back to the
-    /// backlog so it can be picked up and re-dispatched.
+    /// To-do so it can be picked up and re-dispatched.
     #[tokio::test]
-    async fn review_revise_sends_the_card_back_to_the_backlog() {
+    async fn review_revise_sends_the_card_back_to_todo() {
         let dir = tempfile::tempdir().unwrap();
         let (brain, tasks) = brain_with_tasks(dir.path());
         let mut c = card("t-revise", "engineer");
@@ -2744,7 +2747,7 @@ members = ["eng1", "eng2"]
             .expect("delegation runs");
 
         let after = only_card(&tasks).await;
-        assert_eq!(after.column, "backlog");
+        assert_eq!(after.column, COLUMN_TODO);
         assert!(
             after.note.expect("note").contains("needs another pass"),
             "the verdict must be recorded even without a reviewer comment"
@@ -3610,10 +3613,10 @@ members = ["eng1", "eng2"]
         )
     }
 
-    /// Cancel mid-flight → the card returns to `backlog`, the partial reply is
+    /// Cancel mid-flight → the card returns to `todo`, the partial reply is
     /// DISCARDED, and only the operator cancellation note lands.
     #[tokio::test]
-    async fn steer_cancel_returns_to_backlog_and_discards_partial() {
+    async fn steer_cancel_returns_to_todo_and_discards_partial() {
         let dir = tempfile::tempdir().unwrap();
         let (brain, tasks, _) =
             brain_that_steers_itself(dir.path(), "t1", vec![SteerAction::Cancel]);
@@ -3633,7 +3636,7 @@ members = ["eng1", "eng2"]
             .expect("cycle runs");
 
         let moved = only_card(&tasks).await;
-        assert_eq!(moved.column, "backlog");
+        assert_eq!(moved.column, COLUMN_TODO);
         let note = moved.note.expect("note");
         assert!(note.contains("cancelled while in flight"), "{note:?}");
         // The agent's partial reply must NOT be preserved on a cancel.
@@ -4161,9 +4164,9 @@ members = ["eng1", "eng2"]
     /// to eliminate, reintroduced through the error path.
     ///
     /// So an errored hand-off takes the same arm an errored turn does: settle
-    /// `Failed` → `backlog`, with the reason on the note.
+    /// `Failed` → `todo`, with the reason on the note.
     #[tokio::test]
-    async fn a_hand_off_whose_delegate_errors_lands_in_backlog_not_stranded_in_progress() {
+    async fn a_hand_off_whose_delegate_errors_lands_in_todo_not_stranded_in_progress() {
         let dir = tempfile::tempdir().unwrap();
         // Invoke 1 is the dispatched orchestrator turn (queues the hand-off);
         // invoke 2 is the delegate's own turn, which errors.
@@ -4182,8 +4185,8 @@ members = ["eng1", "eng2"]
 
         let after = only_card(&provider.tasks).await;
         assert_eq!(
-            after.column, "backlog",
-            "an errored hand-off must return the card to the backlog, never leave it stranded in \
+            after.column, COLUMN_TODO,
+            "an errored hand-off must return the card to To-do, never leave it stranded in \
              progress where nothing will re-dispatch it"
         );
         let note = after.note.expect("note");
@@ -4204,14 +4207,14 @@ members = ["eng1", "eng2"]
     }
 
     /// A hand-off an operator cancels mid-flight produced nothing, so the card
-    /// returns to the `backlog` reported as the cancellation it actually was.
+    /// returns to `todo` reported as the cancellation it actually was.
     ///
     /// The claim is only made because `run_delegation` reports the cancellation
     /// as a fact (`DelegationOutcome::cancelled`); a hand-off that ends empty
     /// for any other reason no longer reaches this arm at all (issue #213
     /// review finding 2).
     #[tokio::test]
-    async fn a_cancelled_hand_off_returns_the_card_to_the_backlog_as_a_cancellation() {
+    async fn a_cancelled_hand_off_returns_the_card_to_todo_as_a_cancellation() {
         let dir = tempfile::tempdir().unwrap();
         // Invoke 1 is the dispatched orchestrator turn (queues the hand-off);
         // invoke 2 is the delegate's turn, which cancels itself mid-run.
@@ -4230,7 +4233,7 @@ members = ["eng1", "eng2"]
 
         let after = only_card(&provider.tasks).await;
         assert_eq!(
-            after.column, "backlog",
+            after.column, COLUMN_TODO,
             "a cancelled hand-off must not read as finished, and must not strand in progress"
         );
         let note = after.note.expect("note");
@@ -4253,7 +4256,7 @@ members = ["eng1", "eng2"]
     /// hand-off cancelled mid-flight still produced a `TaskHandoff`, so a second
     /// hand-off in the same drain took the "does not own the card" arm: its
     /// answer was appended to the note, but the card still settled `Cancelled`
-    /// -> `backlog` off the first. Work that ran and produced output ended up
+    /// -> `todo` off the first. Work that ran and produced output ended up
     /// filed under a card marked cancelled.
     #[tokio::test]
     async fn a_later_answering_hand_off_takes_the_card_over_from_an_earlier_empty_one() {
@@ -4473,7 +4476,7 @@ members = ["eng1", "eng2"]
             .iter()
             .find(|c| c.title == "Follow up next week")
             .expect("the spawned card must actually be opened");
-        assert_eq!(spawned.column, "backlog");
+        assert_eq!(spawned.column, COLUMN_TODO);
         assert_eq!(
             spawned.parent_task_id.as_deref(),
             Some("t-parent"),

--- a/src/harness/lifecycle.rs
+++ b/src/harness/lifecycle.rs
@@ -1,7 +1,7 @@
 //! Orchestrator-owned lifecycle for a dispatched board task (issue #186).
 //!
 //! Before this module, `run_task` decided a dispatched card's fate inline: the
-//! landing column was a bare `"in_review"` / `"backlog"` / `"paused"` string
+//! landing column was a bare `"in_review"` / `"todo"` / `"paused"` string
 //! literal written at each of five break points in the steer loop, and the
 //! completion bubble was attributed to whichever agent happened to run the
 //! turn. Two problems with that:
@@ -52,13 +52,15 @@ use crate::ports::types::{OutboundMessage, ReplyTo};
 /// a card awaits the orchestrator, `COLUMN_IN_PROGRESS` where a card is being
 /// worked — where a dispatched card already is, and where one whose turn
 /// **handed the work off** stays while the delegate runs (issue #204) —
-/// `COLUMN_BACKLOG` where a stopped or failed run returns it, `COLUMN_PAUSED`
-/// where a paused run parks it (resume is a plain `column → in_progress` PATCH,
-/// which re-triggers dispatch), and `COLUMN_DONE` the terminal — reached by
-/// [`landing_column`] for a delegated card and by [`review_landing_column`] for
-/// an approved board card (issue #171 / PR #179).
+/// `COLUMN_TODO` where a stopped or failed run returns it (issue #301 — it used
+/// to return to a separate `backlog` pool, which epic #183 §3 collapsed into
+/// To-do), `COLUMN_PAUSED` where a paused run parks it (resume is a plain
+/// `column → in_progress` PATCH, which re-triggers dispatch), `COLUMN_PLANNING`
+/// which nothing here writes yet (§4's auto-advance owns it), and `COLUMN_DONE`
+/// the terminal — reached by [`landing_column`] for a delegated card and by
+/// [`review_landing_column`] for an approved board card (issue #171 / PR #179).
 pub use crate::ports::tasks::{
-    COLUMN_BACKLOG, COLUMN_DONE, COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, COLUMN_PAUSED,
+    COLUMN_DONE, COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, COLUMN_PAUSED, COLUMN_PLANNING, COLUMN_TODO,
 };
 
 /// The note attribution used for an operator-initiated stop, as opposed to a
@@ -105,8 +107,10 @@ pub enum ReviewDecision {
     /// The work is accepted, which finishes the card: this is #171's
     /// done-transition for a board-created card.
     Approve,
-    /// The work needs another pass. The card returns to `backlog` so it can be
-    /// re-dispatched.
+    /// The work needs another pass. The card returns to `todo` so it can be
+    /// re-dispatched, carrying the reviewer's reason in its note (issue #301 /
+    /// epic #183 §3: a card that cannot proceed goes back to To-do with the
+    /// reason on it, never into a stuck state of its own).
     Revise,
 }
 
@@ -135,7 +139,7 @@ impl ReviewDecision {
 pub fn review_landing_column(decision: ReviewDecision) -> &'static str {
     match decision {
         ReviewDecision::Approve => COLUMN_DONE,
-        ReviewDecision::Revise => COLUMN_BACKLOG,
+        ReviewDecision::Revise => COLUMN_TODO,
     }
 }
 
@@ -175,14 +179,15 @@ pub fn success_terminal_column(card: &TaskRecord) -> &'static str {
 /// The board column a run ending this way lands its card in.
 ///
 /// The single authority for that mapping. A failed or cancelled run goes back
-/// to `backlog` (it is not reviewable work); a paused one parks; a hand-off
+/// to `todo` (it is not reviewable work) with its reason on the note — issue
+/// #301 rerouted this from the removed `backlog` pool; a paused one parks; a hand-off
 /// stays in `in_progress` because the work has only changed hands; everything
 /// that produced a result goes to its [`success_terminal_column`] — `done` for
 /// a delegated card, `in_review` for a board-created one.
 pub fn landing_column(end: TaskRunEnd, card: &TaskRecord) -> &'static str {
     match end {
         TaskRunEnd::Completed | TaskRunEnd::RedirectsExhausted => success_terminal_column(card),
-        TaskRunEnd::Failed | TaskRunEnd::Cancelled => COLUMN_BACKLOG,
+        TaskRunEnd::Failed | TaskRunEnd::Cancelled => COLUMN_TODO,
         TaskRunEnd::Paused => COLUMN_PAUSED,
         // A hand-off is explicitly NOT a terminal: the delegate is running, so
         // the card keeps the column it was dispatched in and only settles once
@@ -217,7 +222,10 @@ pub fn relay_text(card: &TaskRecord, responder: &str, orchestrator: &str) -> Str
         COLUMN_IN_REVIEW => "is ready for review",
         COLUMN_IN_PROGRESS => "is still in progress",
         COLUMN_PAUSED => "is paused",
-        COLUMN_BACKLOG => "went back to the backlog",
+        COLUMN_TODO => "is back in To-do",
+        // Nothing lands a card here yet (§4's auto-advance will), but naming it
+        // keeps a future relay off the raw-column-id fallback below.
+        COLUMN_PLANNING => "is being planned",
         COLUMN_DONE => "is done",
         other => other,
     };
@@ -300,11 +308,8 @@ mod test {
             landing_column(TaskRunEnd::RedirectsExhausted, &board),
             COLUMN_IN_REVIEW
         );
-        assert_eq!(landing_column(TaskRunEnd::Failed, &board), COLUMN_BACKLOG);
-        assert_eq!(
-            landing_column(TaskRunEnd::Cancelled, &board),
-            COLUMN_BACKLOG
-        );
+        assert_eq!(landing_column(TaskRunEnd::Failed, &board), COLUMN_TODO);
+        assert_eq!(landing_column(TaskRunEnd::Cancelled, &board), COLUMN_TODO);
         assert_eq!(landing_column(TaskRunEnd::Paused, &board), COLUMN_PAUSED);
         assert_eq!(
             landing_column(TaskRunEnd::Delegated, &board),
@@ -384,10 +389,7 @@ mod test {
     #[test]
     fn an_approving_review_finishes_the_card_and_revise_sends_it_back() {
         assert_eq!(review_landing_column(ReviewDecision::Approve), COLUMN_DONE);
-        assert_eq!(
-            review_landing_column(ReviewDecision::Revise),
-            COLUMN_BACKLOG
-        );
+        assert_eq!(review_landing_column(ReviewDecision::Revise), COLUMN_TODO);
     }
 
     /// The two done-writes are disjoint: review only ever sees a card that
@@ -496,10 +498,28 @@ mod test {
             "paused card must not read as finished"
         );
 
-        let returned = card(COLUMN_BACKLOG, Some("[operator] cancelled while in flight"));
+        let returned = card(COLUMN_TODO, Some("[operator] cancelled while in flight"));
         let text = relay_text(&returned, "maya", "ceo");
-        assert!(text.contains("went back to the backlog"), "{text}");
+        assert!(text.contains("is back in To-do"), "{text}");
+        // Issue #301: collapsing the backlog pool into To-do is only lossless
+        // because the reason rides along on the card. The relay must keep
+        // saying why, or "back in To-do" is indistinguishable from fresh work.
         assert!(text.contains("cancelled while in flight"), "{text}");
+
+        // Every board column has a sentence. Planning is inert today, so
+        // without an arm of its own a relay would fall through to the raw
+        // column id and read `"Ship the thing" planning.`.
+        for column in crate::ports::tasks::BOARD_COLUMNS {
+            let text = relay_text(&card(column, None), "maya", "ceo");
+            assert!(
+                !text.contains(&format!("\" {column}")),
+                "column {column} fell through to the raw-id fallback: {text}"
+            );
+        }
+        assert!(
+            relay_text(&card(COLUMN_PLANNING, None), "maya", "ceo").contains("is being planned"),
+            "planning needs its own sentence"
+        );
     }
 
     /// A card with no note (or a whitespace-only one) still relays a complete

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -34,7 +34,7 @@
 //!   lifecycle. `assign_task` sets or changes who owns an existing card;
 //!   `review_task` records the orchestrator's verdict on one awaiting review
 //!   (`approve` completes it to `done` — #171's transition, PR #179 — and
-//!   `revise` returns it to the backlog). Both enqueue a [`Delegation`] drained
+//!   `revise` returns it to To-do). Both enqueue a [`Delegation`] drained
 //!   by the brain, like the other delegation tools.
 //! * [`AddAgentTool`] (issue #71) — writes a new [`OverlayAgent`] through the
 //!   same store path the console `POST .../team` route uses, so the
@@ -148,7 +148,7 @@ the team starting next turn. \
 You also own the board's lifecycle: `assign_task` to set or change who owns an existing card (this \
 records ownership only — moving the card to In Progress is what starts the work), and \
 `review_task` to record your verdict on a card awaiting review, either `approve` when the work is \
-accepted or `revise` to send it back to the backlog for another pass. \
+accepted or `revise` to send it back to To-do for another pass. \
 Delegate, run or create a workflow, add a teammate, or act on the board only when it genuinely \
 helps — otherwise answer directly and concisely."
         .to_string()
@@ -834,7 +834,8 @@ impl Tool for AssignTaskTool {
 /// one card shape #179's own rule cannot reach: a board-created card, which has
 /// no `origin_chat_id` and so never completes on its own. The verdict is
 /// recorded on the card's note either way; `revise` returns the card to
-/// `backlog` so it can be picked up again. See
+/// `todo` so it can be picked up again, with the verdict readable on it —
+/// issue #301 collapsed the old `backlog` pool into To-do. See
 /// [`crate::harness::lifecycle::review_landing_column`].
 pub struct ReviewTaskTool {
     queue: DelegationQueue,
@@ -854,7 +855,7 @@ impl Tool for ReviewTaskTool {
     }
 
     fn description(&self) -> &str {
-        "Record your review of a task card that is awaiting review. Provide the card's `task_id` and a `decision` of `approve` (the work is accepted) or `revise` (it needs another pass, which returns the card to the backlog), plus an optional `note` with your feedback."
+        "Record your review of a task card that is awaiting review. Provide the card's `task_id` and a `decision` of `approve` (the work is accepted) or `revise` (it needs another pass, which returns the card to To-do), plus an optional `note` with your feedback."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -898,7 +899,7 @@ impl Tool for ReviewTaskTool {
                 "Approved card {task_id}; it is complete and has moved to done."
             )),
             ReviewDecision::Revise => ToolResult::success(format!(
-                "Sent card {task_id} back to the backlog for another pass."
+                "Sent card {task_id} back to To-do for another pass."
             )),
         })
     }

--- a/src/ports/tasks.rs
+++ b/src/ports/tasks.rs
@@ -23,13 +23,29 @@ use crate::ports::types::CompanyId;
 // unchanged, and `CompanyRuntime`'s dispatch edge reads `COLUMN_IN_PROGRESS`
 // from here, so each literal exists in exactly one place.
 
-/// The unqueued pool: cards nobody has committed to yet, plus the ones a failed,
-/// cancelled or revised run returns.
-pub const COLUMN_BACKLOG: &str = "backlog";
-/// Queued to be worked next (issue #206). This is the board's manual-entry
-/// column — the `+` button lives here alone, and it is what `POST …/tasks`
-/// defaults to.
+/// Everything not started (issue #301): work nobody has picked up yet **and**
+/// work a failed, cancelled or revised run returned. This is the board's
+/// manual-entry column — the `+` button lives here alone — and what
+/// `POST …/tasks` defaults to.
+///
+/// Before #301 the returned half lived in a separate `backlog` pool (issue
+/// #206). Epic #183 §3 collapsed the two: the split encoded *why* a card had
+/// not started — never picked vs bounced back — but that is provenance, not
+/// position, and every return path already stamps its reason onto the card's
+/// note (`review_note`, the dispatch error, `[operator] cancelled while in
+/// flight`), which the board renders. See [`LEGACY_COLUMN_BACKLOG`] for how
+/// stored cards migrate.
 pub const COLUMN_TODO: &str = "todo";
+/// Between intake and dispatch: the card is being turned into a plan.
+///
+/// **Inert today, deliberately.** Nothing writes it automatically — epic #183
+/// §4's auto-advance does, and that is blocked on #242/#243. The vocabulary
+/// lands first so §4's code can write `planning` through a write boundary that
+/// already accepts it; shipping the column later instead would leave
+/// #242-dependent code writing a column the host rejects. An operator may drag
+/// a card into it manually (any-column PATCH is today's contract) and nothing
+/// happens, which is correct: planning does not dispatch.
+pub const COLUMN_PLANNING: &str = "planning";
 /// The dispatch column: entering it hands the card to its assignee.
 pub const COLUMN_IN_PROGRESS: &str = "in_progress";
 /// Where a steered-to-pause run parks. Resume is a `column → in_progress` PATCH.
@@ -48,24 +64,63 @@ pub const COLUMN_DONE: &str = "done";
 /// literal `in_progress` edge-fires a dispatch — a typo'd `in-progress` also
 /// silently never ran. This list is what the write boundary checks against.
 ///
-/// `backlog` and `todo` are both "not started", and the split is deliberate
-/// (issue #206): `backlog` is the pool — and where the lifecycle returns work
-/// that needs another pass — while `todo` is what has been picked up for the
-/// next stretch. `todo` therefore has to be in this list, not merely defined:
-/// `POST …/tasks` defaults a new card to it, so a write boundary that did not
-/// know the column would reject every card the board's `+` button creates.
+/// Issue #301 reshaped this list to epic #183 §3: `backlog` was removed and
+/// `planning` added. `todo` absorbed both of `backlog`'s jobs — the unqueued
+/// pool and the lifecycle's return landing — so a card that cannot be planned
+/// goes back to `todo` with the reason on its note rather than into a second
+/// not-started column. `planning` is accepted but nothing writes it yet
+/// (see [`COLUMN_PLANNING`]).
 pub const BOARD_COLUMNS: [&str; 6] = [
-    COLUMN_BACKLOG,
     COLUMN_TODO,
+    COLUMN_PLANNING,
     COLUMN_IN_PROGRESS,
     COLUMN_PAUSED,
     COLUMN_IN_REVIEW,
     COLUMN_DONE,
 ];
 
+/// The column id issue #206 used for the unqueued pool, removed by #301.
+///
+/// Kept only as the migration's left-hand side. Cards persisted before #301
+/// carry this literal, which [`is_board_column`] now rejects — so without a
+/// migration they would fail to render and vanish from the board, the exact
+/// silent disappearance #205 exists to prevent. [`TaskRecord::column`]
+/// normalizes it to [`COLUMN_TODO`] on **read**, so every stored card heals
+/// lazily at its next load and persists the new literal at its next upsert.
+///
+/// Reads heal; writes do not. A client still *sending* `"backlog"` gets a
+/// `400` from the REST write boundary naming the valid set, because the REST
+/// DTOs deserialize `column` as a plain `String` and validate it separately —
+/// legacy data recovers silently, a dead-column write fails loudly.
+pub const LEGACY_COLUMN_BACKLOG: &str = "backlog";
+
 /// Whether `column` names a column the board actually renders.
 pub fn is_board_column(column: &str) -> bool {
     BOARD_COLUMNS.contains(&column)
+}
+
+/// Rewrites a stored column literal that no longer names a board column.
+///
+/// Today that is exactly one mapping: [`LEGACY_COLUMN_BACKLOG`] →
+/// [`COLUMN_TODO`] (issue #301). Applied on deserialization of
+/// [`TaskRecord::column`], which is the single choke point every persistence
+/// backend and the export/import path all funnel through — sqlite and mongodb
+/// both store the record as a `task_json` string and the fs bundle as a JSON
+/// array, so all three parse through this one `impl Deserialize`.
+fn migrate_column(column: String) -> String {
+    if column == LEGACY_COLUMN_BACKLOG {
+        COLUMN_TODO.to_string()
+    } else {
+        column
+    }
+}
+
+/// Serde shim applying [`migrate_column`] to a stored `column`.
+fn deserialize_column<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(migrate_column(String::deserialize(deserializer)?))
 }
 
 /// One card on the company's task board.
@@ -80,6 +135,11 @@ pub struct TaskRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
     /// The board column — one of [`BOARD_COLUMNS`].
+    ///
+    /// Read through [`migrate_column`], so a card persisted before issue #301
+    /// under the removed `backlog` id loads as [`COLUMN_TODO`] instead of as a
+    /// column nothing renders.
+    #[serde(deserialize_with = "deserialize_column")]
     pub column: String,
     /// The priority (`low`, `medium`, `high`).
     pub priority: String,
@@ -105,7 +165,7 @@ pub struct TaskRecord {
     /// parent half of the Task Detail screen's lineage.
     ///
     /// An agent running a dispatched card can itself delegate, opening a new
-    /// backlog card through the same `spawn_task` path. That makes the board a
+    /// To-do card through the same `spawn_task` path. That makes the board a
     /// forest, but nothing recorded the edge: `origin_chat_id` names the
     /// *conversation* a card came from, which is shared by every sibling
     /// spawned in that thread and is `None` entirely for a board-native card.
@@ -154,8 +214,8 @@ mod test {
         assert_eq!(
             BOARD_COLUMNS,
             [
-                "backlog",
                 "todo",
+                "planning",
                 "in_progress",
                 "paused",
                 "in_review",
@@ -177,13 +237,61 @@ mod test {
         for column in BOARD_COLUMNS {
             assert!(is_board_column(column), "{column} is a board column");
         }
-        // Issue #206 added To-do as a column of its own; Backlog stays.
+        // Issue #301: To-do is the one not-started column, Planning is new, and
+        // the old Backlog pool is gone — a client still writing it gets a 400
+        // rather than a card the board cannot render.
         assert!(is_board_column(COLUMN_TODO));
-        assert!(is_board_column(COLUMN_BACKLOG));
+        assert!(is_board_column(COLUMN_PLANNING));
+        assert!(!is_board_column(LEGACY_COLUMN_BACKLOG));
         // Near-misses a typo'd client might send.
         assert!(!is_board_column("to_do"));
         assert!(!is_board_column("To-do"));
         assert!(!is_board_column("inprogress"));
         assert!(!is_board_column(""));
+    }
+
+    /// Issue #301's whole migration, at the seam every persistence backend
+    /// shares. sqlite and mongodb store a card as a `task_json` string and the
+    /// fs bundle as a JSON array, so all three — plus export/import — parse
+    /// through this one `Deserialize`. A stored `backlog` card therefore heals
+    /// on read instead of failing `is_board_column` and vanishing from the
+    /// board.
+    #[test]
+    fn a_stored_backlog_card_reads_back_in_todo() {
+        // A raw blob in exactly the shape a pre-#301 build persisted.
+        let legacy = r#"{
+            "id": "t-1",
+            "title": "Bounced work",
+            "note": "[operator] cancelled while in flight",
+            "column": "backlog",
+            "priority": "medium",
+            "assignee": "maya",
+            "updatedAtMillis": 7
+        }"#;
+        let migrated: TaskRecord = serde_json::from_str(legacy).expect("legacy card parses");
+        assert_eq!(migrated.column, COLUMN_TODO);
+        assert!(
+            is_board_column(&migrated.column),
+            "a migrated card must render on the board"
+        );
+        // The reason the collapse is lossless: the note survives untouched, so
+        // "bounced back" is still readable on the card.
+        assert_eq!(
+            migrated.note.as_deref(),
+            Some("[operator] cancelled while in flight")
+        );
+
+        // The next upsert persists the new literal — nothing re-writes it back.
+        let round_tripped = serde_json::to_string(&migrated).unwrap();
+        assert!(
+            round_tripped.contains("\"column\":\"todo\""),
+            "{round_tripped}"
+        );
+
+        // Migration is exactly one mapping; every live column is passed through
+        // untouched, so a future column cannot be silently rewritten.
+        for column in BOARD_COLUMNS {
+            assert_eq!(migrate_column(column.to_string()), column);
+        }
     }
 }

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -489,7 +489,7 @@ pub enum CompanyEvent {
         /// card's note — never raw tool output, arguments, or call ids.
         output: String,
         /// The board column the card landed in: `in_review` on a normal
-        /// finish, `backlog` on a failure or cancellation, `paused` on a
+        /// finish, `todo` on a failure or cancellation, `paused` on a
         /// pause. Lets a reader tell a successful run from a stopped one
         /// without re-deriving it from `output`.
         column: String,

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -31,7 +31,7 @@ use crate::error::OpenCompanyError;
 use crate::feedback::tool::SEND_EMAIL_TOOL;
 use crate::policy::gate::ResolveOutcome;
 use crate::ports::brain::{CycleHost, UsageMetering};
-use crate::ports::tasks::TaskRecord;
+use crate::ports::tasks::{COLUMN_TODO, TaskRecord};
 use crate::ports::types::{
     Actor, ApprovalId, CompanyEvent, CompanyId, CompanyRecord, ContextOp, ContextOpResult,
     CycleRequest, Effect, EffectDisposition, EffectGroup, LedgerEntry, OutboundMessage,
@@ -831,7 +831,7 @@ impl<'a> CycleHostImpl<'a> {
             id: generate_id(),
             title: parsed.title.clone(),
             note: parsed.note,
-            column: "backlog".to_string(),
+            column: COLUMN_TODO.to_string(),
             priority: "medium".to_string(),
             assignee: parsed.assignee.unwrap_or_default(),
             updated_at_millis: now_millis(),
@@ -919,7 +919,7 @@ impl<'a> CycleHostImpl<'a> {
             id: generate_id(),
             title: first_line(&parsed.instruction, 80),
             note: Some(note),
-            column: "backlog".to_string(),
+            column: COLUMN_TODO.to_string(),
             priority: "medium".to_string(),
             assignee: desk_id.clone(),
             updated_at_millis: now_millis(),
@@ -2887,7 +2887,7 @@ mod test {
                     id: "t1".into(),
                     title: "Ship invoicing".into(),
                     note: Some("build the importer".into()),
-                    column: "backlog".into(),
+                    column: COLUMN_TODO.into(),
                     priority: "medium".into(),
                     assignee: "eng".into(),
                     updated_at_millis: 0,

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -2802,6 +2802,9 @@ mod test {
         assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].title, "Ship it");
         assert_eq!(cards[0].assignee, "eng");
+        // Intake lands in To-do, never on the dispatch edge: a spawned card
+        // must not spend an agent turn before an operator has seen it.
+        assert_eq!(cards[0].column, COLUMN_TODO);
 
         // A blank title is a clean tool error, no card.
         let bad = host
@@ -2844,6 +2847,8 @@ mod test {
         let cards = rt.tasks().list(rt.id()).await.unwrap();
         assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].assignee, "eng");
+        // Same as the spawn path: a handoff opens a card, it does not dispatch.
+        assert_eq!(cards[0].column, COLUMN_TODO);
     }
 
     #[tokio::test]

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -28,6 +28,7 @@ use crate::company::steer::{
 use crate::harness::TurnOutcome;
 use crate::harness::lifecycle::{self, TaskRunEnd};
 use crate::harness::orchestrator::{self, Delegation, DelegationQueue};
+use crate::ports::tasks::COLUMN_TODO;
 use crate::ports::types::{CompanyId, CompanyRecord, OutboundMessage, TurnStep};
 use crate::ports::{TaskRecord, TaskStore, generate_id, now_millis};
 use crate::runtime::assignee;
@@ -434,7 +435,7 @@ impl<'a> DelegationRunner<'a> {
             // The card belongs to the first hand-off that actually PRODUCES
             // something. A hand-off whose run was cancelled produced nothing, so
             // it does not get to keep the card: it would settle `Cancelled` ->
-            // `backlog` while a later hand-off that really ran had its answer
+            // `todo` while a later hand-off that really ran had its answer
             // merely appended to the note — filing work that happened under a
             // card marked cancelled. So an empty hand-off is *provisional* and a
             // later one that answers takes the card over from it (issue #213
@@ -524,7 +525,7 @@ impl<'a> DelegationRunner<'a> {
 
     /// Executes one drained delegation.
     ///
-    /// `spawn_task` opens a backlog card through the
+    /// `spawn_task` opens a To-do card through the
     /// [`TaskStore::upsert`](crate::ports::TaskStore) path the console uses and
     /// **reports the card's id** so the caller can say one was opened (issue
     /// #246) — it surfaces no bubble of its own, which is a different thing
@@ -553,7 +554,7 @@ impl<'a> DelegationRunner<'a> {
                     id: generate_id(),
                     title,
                     note,
-                    column: "backlog".to_string(),
+                    column: COLUMN_TODO.to_string(),
                     priority: "medium".to_string(),
                     assignee: assignee.unwrap_or_default(),
                     updated_at_millis: now_millis(),

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -675,7 +675,7 @@ type Task {
 	"""
 	note: String
 	"""
-	The board column: `backlog` | `todo` | `in_progress` | `paused` |
+	The board column: `todo` | `planning` | `in_progress` | `paused` |
 	`in_review` | `done`.
 	"""
 	column: String!

--- a/src/server/graphql/tasks.rs
+++ b/src/server/graphql/tasks.rs
@@ -18,7 +18,7 @@ pub struct TaskGql {
     pub title: String,
     /// An optional longer note.
     pub note: Option<String>,
-    /// The board column: `backlog` | `todo` | `in_progress` | `paused` |
+    /// The board column: `todo` | `planning` | `in_progress` | `paused` |
     /// `in_review` | `done`.
     pub column: String,
     /// The priority: `low` | `medium` | `high`.

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -445,7 +445,7 @@ async fn tasks_page_reflects_upserts_and_column_filter() {
                 id: "t1".into(),
                 title: "Launch".into(),
                 note: None,
-                column: "backlog".into(),
+                column: "todo".into(),
                 priority: "high".into(),
                 assignee: "maya".into(),
                 updated_at_millis: 1_700_000_000_000,
@@ -458,7 +458,7 @@ async fn tasks_page_reflects_upserts_and_column_filter() {
     let app = router(state);
     let value = query(
         app.clone(),
-        r#"{"query":"{ company(id:\"acme\"){ tasks(column:\"backlog\"){ total items { id title column } } } }"}"#,
+        r#"{"query":"{ company(id:\"acme\"){ tasks(column:\"todo\"){ total items { id title column } } } }"}"#,
     )
     .await;
     assert_eq!(value["data"]["company"]["tasks"]["total"], 1);

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -903,7 +903,7 @@ async fn run_chat(
         None
     };
     // Deterministic task card: an actionable operator request ("build the
-    // landing page", "can you set up the newsletter") opens a `backlog` card so
+    // landing page", "can you set up the newsletter") opens a `todo` card so
     // "do X" always leaves a visible work item on the dashboard — independent of
     // whether the orchestrator model also calls `spawn_task` (it may open
     // sub-tasks on top). Pure questions, greetings, and acknowledgements don't
@@ -918,7 +918,7 @@ async fn run_chat(
             id: crate::ports::generate_id(),
             title,
             note,
-            column: "backlog".to_string(),
+            column: crate::ports::tasks::COLUMN_TODO.to_string(),
             priority: "medium".to_string(),
             assignee: String::new(),
             updated_at_millis: crate::ports::now_millis(),
@@ -1425,12 +1425,12 @@ mod test {
         assert_eq!(value["responses"][0]["channel"], "operator");
     }
 
-    /// An actionable operator chat opens exactly one `backlog` task card on the
+    /// An actionable operator chat opens exactly one `todo` task card on the
     /// dashboard (deterministic, independent of the brain's own `spawn_task`),
     /// and a greeting opens none. Runs on the default echo brain, so it proves
     /// the handler-level wiring, not model behaviour.
     #[tokio::test]
-    async fn actionable_chat_opens_a_backlog_task_card() {
+    async fn actionable_chat_opens_a_todo_task_card() {
         let home_dir = home();
         let home = home_dir.path().to_path_buf();
         let state = state_with_company(&home, "running").await;
@@ -1451,7 +1451,7 @@ mod test {
                 .unwrap()
         };
 
-        // Actionable → one backlog card, titled from the ask.
+        // Actionable → one To-do card, titled from the ask.
         let r = app
             .clone()
             .oneshot(chat("build the landing page"))
@@ -1460,7 +1460,7 @@ mod test {
         assert_eq!(r.status(), StatusCode::OK);
         let tasks = runtime.tasks().list(&id).await.unwrap();
         assert_eq!(tasks.len(), 1, "an actionable ask opens one card");
-        assert_eq!(tasks[0].column, "backlog");
+        assert_eq!(tasks[0].column, crate::ports::tasks::COLUMN_TODO);
         assert_eq!(tasks[0].priority, "medium");
         assert_eq!(tasks[0].title, "Build the landing page");
 

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -216,7 +216,7 @@ fn validate_parent(
 /// `"in-progress"` was persisted verbatim, so the card disappeared from every
 /// rendered column *and* — since only the exact literal `in_progress`
 /// edge-fires a dispatch — silently never ran. Refusing at the write boundary
-/// is the cheap place to keep the board's five columns the only five.
+/// is the cheap place to keep the board's six columns the only six.
 fn validate_column(column: &str) -> Result<(), ApiError> {
     if is_board_column(column) {
         return Ok(());
@@ -278,10 +278,11 @@ async fn create_task(
     // bad assignee is a `400` the operator sees rather than a card that lands
     // somewhere the board cannot render or hands work to a name nobody answers to.
     // Issue #206: a card created here is manual entry — the board's `+` button,
-    // which now lives on To-do alone — so that is the default. It is
-    // deliberately NOT `backlog`: backlog is the unqueued pool and where the
-    // lifecycle returns work that needs another pass, so defaulting new work
-    // there mixed "nobody has picked this up" with "someone just asked for it".
+    // which lives on To-do alone — so that is the default. Issue #301 made it
+    // the *only* not-started column: the separate `backlog` pool was collapsed
+    // into To-do, and every lifecycle return now lands here too, carrying its
+    // reason on the note. So this default is no longer a choice between two
+    // columns; it is simply where not-started work lives.
     let column = body.column.unwrap_or_else(|| COLUMN_TODO.to_string());
     validate_column(&column)?;
     let assignee = resolve_assignee(&company, body.assignee.unwrap_or_default()).await?;

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -148,7 +148,7 @@ async fn tasks_crud_round_trips_under_both_scopes() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(task["title"], "Q2 brief");
-    // Issue #206: manual entry lands in To-do, not the backlog pool.
+    // Issue #206/#301: manual entry lands in To-do, the board's one intake lane.
     assert_eq!(task["column"], "todo");
     let id = task["id"].as_str().unwrap().to_string();
 
@@ -310,6 +310,10 @@ async fn task_writes_reject_a_column_the_board_cannot_render() {
 /// Issue #206: `POST …/tasks` defaults a new card to To-do — the board's one
 /// manual-entry column — while an explicit `column` still wins, so the
 /// lifecycle paths that place a card themselves are untouched.
+///
+/// Issue #301 kept the default and reshaped what "explicit" may say: `planning`
+/// is now a column (inert, but the write boundary must accept it before §4's
+/// auto-advance starts writing it), and the removed `backlog` pool is refused.
 #[tokio::test]
 async fn created_tasks_default_to_the_todo_column() {
     let home_dir = home();
@@ -327,14 +331,44 @@ async fn created_tasks_default_to_the_todo_column() {
 
     // An explicit column is still honored verbatim — `spawn_task`, the
     // orchestrator's `revise`, and a failed run all place their own card.
-    let (_, explicit) = send(
+    let (status, explicit) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks",
+        Some(json!({"title": "being planned", "column": "planning"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(explicit["column"], crate::ports::tasks::COLUMN_PLANNING);
+
+    // Issue #301: `backlog` is gone from the board, so a client still writing
+    // it is refused rather than persisting a card nothing renders. Legacy data
+    // heals silently on read (`ports::tasks`), but a *write* fails loudly — the
+    // error names the set that replaced it.
+    let (status, refused) = send(
         &state,
         "POST",
         "/api/v1/company/tasks",
         Some(json!({"title": "parked", "column": "backlog"})),
     )
     .await;
-    assert_eq!(explicit["column"], crate::ports::tasks::COLUMN_BACKLOG);
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        refused.to_string().contains("todo"),
+        "the refusal must name the columns that replaced it: {refused}"
+    );
+
+    // …and the same on a drag, so a stale console cannot move a card into the
+    // removed column either.
+    let id = defaulted["id"].as_str().unwrap().to_string();
+    let (status, _) = send(
+        &state,
+        "PATCH",
+        &format!("/api/v1/company/tasks/{id}"),
+        Some(json!({"column": "backlog"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
 }
 
 /// Issue #246: `POST …/tasks` carries the thread a card was opened from.
@@ -434,6 +468,21 @@ async fn a_chat_created_card_lands_off_the_dispatch_trigger() {
         "it lands in the board's intake lane, where the human drag is the gate"
     );
 
+    // Issue #301 added a second pre-dispatch column and made To-do the only
+    // intake lane, so the spend gate is re-checked across every creation shape
+    // the board can produce: the bare board `+` (which now sends nothing but a
+    // prompt-derived title) and an explicit `planning`. Neither may dispatch —
+    // `planning` in particular is *not* a dispatch trigger, which is the whole
+    // reason it can ship inert ahead of §4's auto-advance.
+    for body in [
+        json!({"title": "Typed on the board"}),
+        json!({"title": "Being planned", "column": "planning"}),
+    ] {
+        let (status, created) = send(&state, "POST", "/api/v1/company/tasks", Some(body)).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_ne!(created["column"], COLUMN_IN_PROGRESS, "{created}");
+    }
+
     let journal = runtime
         .events()
         .read_from(
@@ -447,7 +496,7 @@ async fn a_chat_created_card_lands_off_the_dispatch_trigger() {
         !journal
             .iter()
             .any(|e| matches!(e.event, CompanyEvent::TaskDispatched { .. })),
-        "creating a card from chat must not dispatch it"
+        "creating a card must not dispatch it, whichever pre-dispatch column it lands in"
     );
 }
 
@@ -477,7 +526,7 @@ async fn steer_task_validates_statuses_and_journals_acceptance() {
                 id: "idle".into(),
                 title: "Idle".into(),
                 note: None,
-                column: "backlog".into(),
+                column: crate::ports::tasks::COLUMN_TODO.into(),
                 priority: "medium".into(),
                 assignee: String::new(),
                 updated_at_millis: 1,

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -640,14 +640,8 @@ pub async fn assert_task_store(tasks: Arc<dyn TaskStore>) {
         parent_task_id: None,
     };
 
-    tasks
-        .upsert(&alpha, &task("t1", "backlog", 1))
-        .await
-        .unwrap();
-    tasks
-        .upsert(&alpha, &task("t2", "backlog", 2))
-        .await
-        .unwrap();
+    tasks.upsert(&alpha, &task("t1", "todo", 1)).await.unwrap();
+    tasks.upsert(&alpha, &task("t2", "todo", 2)).await.unwrap();
     tasks.upsert(&beta, &task("b1", "done", 3)).await.unwrap();
 
     // Isolation + newest-first ordering.


### PR DESCRIPTION
## Summary

The board now reads `To-do · Planning · In Progress · Paused · In Review · Done`, and New Task is a single prompt box.

Two changes, one vocabulary:

**Backlog collapses into To-do.** Every path that used to return a card "to the backlog" — a revised review, a failed run, a cancelled run, an unresolvable assignee — now returns it to To-do. Four spawn sites that wrote a bare `"backlog"` literal now import `COLUMN_TODO`.

**Planning is added, and ships inert.** The host accepts it, the console renders it, nothing auto-advances into it yet. That ordering is deliberate — see below.

**New Task is one autofocused textarea.** Title is the first line, capped at ~80 characters; the full prompt becomes the note when the title was shortened from it, so the whole prompt always survives on the card. Priority, assignee and column take their existing host defaults; the assignee picker stays where #278 put it, on the card's edit surface.

## Problem

The board's vocabulary predated the spine spec, and the create dialog asked for four fields before you could say what you wanted.

**On collapsing Backlog — answering #206 directly, since the issue asks for it.** The split was deliberate: Backlog was the unqueued pool *and* the column the lifecycle returned work to, so the column itself encoded *why* a card had not started — never picked up, versus bounced back.

That distinction is **provenance, not position**. Every return path already stamps the reason onto the card's note — `review_note`'s "reviewed: needs another pass — …", the dispatch error text for a failure, `[operator] cancelled while in flight` for a cancellation — and `TaskItem` renders it. So the collapse loses no information; the column stops carrying that meaning and the note carries it. The lifecycle test now asserts the reason survives the return, so this is pinned rather than asserted.

This is a deliberate reversal of #206, and it is stated as one.

**On Planning shipping inert.** Auto-advance (§4 of the spine) is blocked on #242 and #243. Landing the vocabulary first means that when auto-advance arrives, it writes `planning` through a boundary that already accepts it. The alternative — shipping the column with the automation — would have #242-dependent code writing a column the host rejects. The e2e drag test asserts no dispatch fires on entry to Planning, which is the evidence for the claim. Operators may drag into it manually; a machine-only rule would prejudge §4's design.

## Solution

**Migration is one choke point.** `TaskRecord::column` deserializes through a normalizer mapping the legacy `"backlog"` literal to `todo`. All three backends parse stored cards through `TaskRecord` — sqlite's `task_json` TEXT, mongodb's BSON string, and the fs bundle's `Vec<TaskRecord>` — so one `deserialize_with` heals every stored card lazily on read, and the next upsert persists the new value. Without it a live tenant's `backlog` cards would fail `is_board_column` and vanish from the board, which is exactly the silent-disappearance failure #205 exists to prevent.

**Legacy data heals silently; dead-column writes fail loudly.** The REST DTOs declare their own `column` strings, so a client still *writing* `"backlog"` gets a 400 naming the valid set.

**One model-facing fix the plan did not anticipate.** `src/harness/orchestrator.rs` is not comments — the orchestrator's system prompt and the `review_task` tool description both told the model that `revise` "sends it back to the backlog", and the tool's success string echoed that to the operator. Left alone, the model would have been briefed on a column the write boundary now rejects. A repo-wide grep for the literal is what caught it, along with five other files the initial file list missed.

## Submission Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **1695 passed, 0 failed**, 1 ignored
- [x] `cargo check --locked --all-features --all-targets` — the only gate that compiles the sqlite and mongodb backends this migration depends on
- [x] `git diff --stat Cargo.lock` — empty
- [x] `npm ci`, `npm run typecheck`, `npm run typecheck:e2e`, `npm run build`
- [x] Playwright against a live isolated host — the 3 new board-shape specs and the 8 repaired create-dialog specs all pass (11/11)
- [x] Verified end to end on both the UI and the backend

**The migration is proven against real persisted data, not a fixture.** A `{"column":"backlog"}` card was hand-seeded into a live host's on-disk `tasks.json`; the board served it as `todo` with its "reviewed: needs another pass" note intact, and an unrelated PATCH rewrote the stored literal. Lazy heal and persist-on-next-upsert both confirmed. That is the claim the whole collapse rests on — that the reason rides on the card — so it is worth more than the unit test that also covers it.

Backend, same host: default → `todo`; explicit `planning` → 200; explicit `backlog` → 400 naming the new set; PATCH to `backlog` → 400.

**Two pre-existing problems surfaced while running the full e2e suite, neither caused by this change** (grep-verified: none of the failing specs reference the board columns or the create dialog):

- `workflow-*.spec.ts` fail on `strict mode violation: getByRole('button', {name:'New workflow'}) resolved to 2 elements` — genuine locator drift in the workflows view. **Filed separately.**
- `chat-to-card`, `wiring`, `mcp` and `workflow-run-history` need the mocked LLM backend the harness normally supplies; the verification host ran the offline echo brain.

`assignee-picker.spec.ts` also had a latent state dependency: its `Legal — no members yet` assertion needs an empty desk that the harness manifest never ships and no spec creates, so it was silently relying on leftover state from a hand-poked host and could not pass on a fresh one. The spec now seeds the desk it asserts on; the assertion was not deleted.

## Impact

**Wire break:** `column:"backlog"` on POST or PATCH now returns 400. Stored data heals silently on read; only writes fail. No known client besides the console.

**Behaviour change:** a failed, cancelled or revised run's card now lands in To-do rather than Backlog, carrying its reason. Bounced work is no longer column-separated from fresh intake — that is the trade, taken knowingly.

`src/server/graphql/schema.graphql` was regenerated: the `TaskGql::column` doc comment is embedded in the SDL snapshot, so editing it fails `sdl_snapshot_matches` until regenerated. Worth knowing for anything else touching a GraphQL doc comment.

**#334 (a card cannot be dragged out of In review) is untouched** — no `moveTo()` or PATCH drag mechanics changed, one drop target removed and one added — so this neither fixes nor worsens it, and the new spec deliberately avoids asserting that drag.

## Related

Closes #301
Part of #183 — the spine epic, §3.
Planning goes live in #337 (auto-advance), which is blocked on #242.
Coincides with #334 on `TasksView.tsx` — that one must run after this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the Backlog board column with Planning.
  * New tasks now start in To-do through a simplified single-prompt form.
  * Planning tasks remain inactive until moved to In progress.
  * Long prompts automatically generate a concise title and preserve the full text as a note.
* **Bug Fixes**
  * Blocked, cancelled, retried, or unresolved tasks now return to To-do with the reason recorded.
  * Existing Backlog tasks are automatically normalized to To-do; new Backlog values are rejected.
* **Documentation**
  * Updated task board, lifecycle, API, and GraphQL guidance to reflect the revised workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->