### PR TITLE
feat(runs): add the RunStore port, three backends, and a boot reaper (#242 PR-1)

### DIFF
--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -340,10 +340,10 @@ pub trait SecretStore: Send + Sync {
 
 ## Console-surface stores (WS3)
 
-Six additional ports back the operator console's durable surfaces. They follow
+Seven additional ports back the operator console's durable surfaces. They follow
 the same one-trait-per-file convention (`src/ports/{tasks,workspace,facts,
-usage,skills_state,inbox}.rs`), key everything on `CompanyId`, return the crate
-`Result<T>`, and are covered by the conformance suite
+usage,skills_state,inbox,runs}.rs`), key everything on `CompanyId`, return the
+crate `Result<T>`, and are covered by the conformance suite
 ([storage.md](storage.md)). Their fs/sqlite/mongodb backends live alongside the
 five core ports.
 
@@ -562,6 +562,63 @@ pub trait InboxStore: Send + Sync {
 
 Real send/receive depends on the domain/SMTP transport and the HMAC-signed
 inbound ingest webhook ([api.md](api.md)); the store itself is transport-blind.
+
+### RunStore
+
+One attempt at a task, and its trace (`src/ports/runs.rs`). A `RunRecord`
+carries the task and agent it belongs to, its 1-based `attempt` ordinal, a
+status, the cost it accrued, and — on failure — why. A `RunStepRecord` is one
+entry of its trace, keyed `(run_id, step_seq)` on a run-scoped dense counter
+rather than an `EventSeq`.
+
+```rust
+pub trait RunStore: Send + Sync {
+    // storage verbs
+    async fn create_run(&self, company: &CompanyId, spec: NewRun) -> Result<RunRecord>;
+    async fn get_run(&self, company: &CompanyId, id: &str) -> Result<Option<RunRecord>>;
+    async fn put_run(&self, company: &CompanyId, run: &RunRecord) -> Result<()>;
+    async fn list_runs(&self, company: &CompanyId, filter: &RunFilter)
+        -> Result<Vec<RunRecord>>;
+    async fn append_run_step(&self, company: &CompanyId, step: &RunStepRecord) -> Result<()>;
+    async fn list_run_steps(&self, company: &CompanyId, run_id: &str)
+        -> Result<Vec<RunStepRecord>>;
+
+    // transitions — provided methods; legality is enforced here, not per backend
+    async fn begin_run(&self, /* company, id, trigger_event_seq */) -> Result<RunRecord>;
+    async fn finish_run(&self, /* company, id, outcome */) -> Result<RunRecord>;
+}
+```
+
+**The transitions are the API; the storage verbs are the seam.** `create_run`
+mints `Pending` and allocates the attempt ordinal, `begin_run` moves
+`Pending → Running`, and `finish_run` settles a run into a parked or terminal
+status. Legality lives in the provided methods, so no backend can re-derive the
+state machine and drift from the others. `put_run` writes a row verbatim with no
+check at all — it exists because Rust cannot hide a trait method from a `dyn`
+caller, and it is documented as the backend seam rather than something to call.
+
+`RunStatus` is `pending · running · waiting_approval · paused · succeeded ·
+failed · cancelled`. The two parked statuses are separated by **who unblocks
+them**: `waiting_approval` means a *person* must act; `paused` means anything
+else must — a dependency, a rate limit, a missing credential, a retry, an
+operator steer. Defining the split by who resolves it, rather than by cause,
+keeps it correct as new blocking reasons appear. `waiting_approval` is
+re-enterable: approval grants are single-use and argument-exact, so a run that
+could only stop once would force approvals to be batched into one prompt.
+
+**Boot reaping.** `reap_orphaned_runs` runs at startup, before dispatch and the
+scheduler spawn, and settles every `pending`/`running` row as `failed` with an
+orphan reason. This is a proof rather than a timeout heuristic, resting on three
+invariants held elsewhere in the runtime: cycles are process-local
+`tokio::spawn`s, exactly one process may write a given company's journal, and
+cycles serialise on a per-company mutex. Any active row present at boot is
+therefore necessarily dead. The two parked statuses are never reaped — parked is
+not orphaned.
+
+The fs backend stores runs in `runs.jsonl` (last-write-wins per id) and steps in
+`run-steps.jsonl` (a true append, folded per `(run_id, step_seq)` on read).
+Deliberately not one file per run: that would make a run id a path component,
+and a store must never let an id it did not mint address the filesystem.
 
 ## Assembly
 

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -25,8 +25,9 @@ use crate::ports::now_millis;
 use crate::ports::types::{Actor, ActorKind, ApprovalId, CompanyEvent, CompanyId, Verdict};
 use crate::ports::{
     AgentEconomy, ApprovalGate, ArtifactStore, Brain, ChannelAdapter, CompanyStore, ContextStore,
-    EventLog, FactStore, InboxStore, LoginCodeStore, MemoryStore, SecretStore, SessionStore,
-    SkillStateStore, TaskRecord, TaskStore, ToolProvider, UsageMeter, UserStore, WorkspaceStore,
+    EventLog, FactStore, InboxStore, LoginCodeStore, MemoryStore, RunStore, SecretStore,
+    SessionStore, SkillStateStore, TaskRecord, TaskStore, ToolProvider, UsageMeter, UserStore,
+    WorkspaceStore,
 };
 
 /// The board column a task must enter to be dispatched to its assignee. Read
@@ -59,6 +60,8 @@ pub struct OpsStores {
     pub facts: Arc<dyn FactStore>,
     /// Versioned task artifacts and their human-edit history (#187).
     pub artifacts: Arc<dyn ArtifactStore>,
+    /// First-class records of each task attempt: status, trace, cost (#242).
+    pub runs: Arc<dyn RunStore>,
     /// The usage meter (written by the WS4 cost hook, read by WS5).
     pub usage: Arc<dyn UsageMeter>,
     /// Operator deltas over the company's skills.
@@ -414,6 +417,12 @@ impl CompanyRuntime {
     /// This company's versioned task artifacts (#187).
     pub fn artifacts(&self) -> &Arc<dyn ArtifactStore> {
         &self.ops.artifacts
+    }
+
+    /// This company's task-run records (#242): one row per attempt at a card,
+    /// with its status, step trace and cost.
+    pub fn runs(&self) -> &Arc<dyn RunStore> {
+        &self.ops.runs
     }
 
     /// This company's usage meter (written by the cost hook, read by WS5).

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -19,6 +19,7 @@ pub mod facts;
 pub mod inbox;
 pub mod login_codes;
 pub mod memory;
+pub mod runs;
 pub mod secrets;
 pub mod sessions;
 pub mod skills_state;
@@ -46,6 +47,10 @@ pub use ids::{generate_id, now_millis};
 pub use inbox::{EmailRecord, InboxMeta, InboxStore};
 pub use login_codes::{LoginCodeRecord, LoginCodeStore};
 pub use memory::MemoryStore;
+pub use runs::{
+    NewRun, RunFilter, RunOutcome, RunRecord, RunStatus, RunStepRecord, RunStore,
+    reap_orphaned_runs,
+};
 pub use secrets::SecretStore;
 pub use sessions::{SessionRecord, SessionStore};
 pub use skills_state::{SkillSource, SkillState, SkillStateStore};
@@ -91,6 +96,7 @@ mod test {
         _users: &dyn crate::ports::users::UserStore,
         _sessions: &dyn crate::ports::sessions::SessionStore,
         _login_codes: &dyn crate::ports::login_codes::LoginCodeStore,
+        _runs: &dyn crate::ports::runs::RunStore,
         _workflow_runner: &dyn crate::ports::workflow_runner::WorkflowRunner,
     ) {
     }

--- a/src/ports/runs.rs
+++ b/src/ports/runs.rs
@@ -1,0 +1,790 @@
+//! The [`RunStore`] port: a task attempt as a first-class, queryable record.
+//!
+//! A dispatched task used to be an *ephemeral* cycle — a
+//! [`CycleRequest`](crate::ports::types::CycleRequest) whose scrubbed
+//! [`TurnStep`] list was folded once into the `AgentReply` event and then
+//! discarded as a unit. There was no id for the attempt, no status while it
+//! ran, and no per-attempt cost, so a crash between the dispatch edge and the
+//! spawned cycle left nothing at all behind.
+//!
+//! This port records that attempt. A [`RunRecord`] is *mutable, queryable
+//! state*; the event log stays the immutable trail. The two are deliberately
+//! distinct: folding the whole journal per read is what makes the existing
+//! workflow-run list expensive, and one event per [`TurnStep`] would flood
+//! every chat-history reload.
+//!
+//! ## The transition API
+//!
+//! The port does **not** expose a free-form "upsert a run" verb as its API.
+//! A task board that accepted any string as a column silently lost cards until
+//! #205 put the vocabulary behind a check ([`crate::ports::tasks`]); the same
+//! argument applies here with more force, because a run's status is a state
+//! *machine*, not a label. So writers move a run with
+//! [`RunStore::create_run`], [`RunStore::begin_run`] and
+//! [`RunStore::finish_run`], and the legality of each move is enforced here, in
+//! the port layer, once — backends only ever see dumb storage verbs.
+//!
+//! ## Paused is not WaitingApproval
+//!
+//! Epic #183 settled that **who unblocks the work** decides where it parks: if
+//! a person has to act, the attempt is [`RunStatus::WaitingApproval`];
+//! everything else — a dependency, a rate limit, a missing credential, a retry
+//! — is [`RunStatus::Paused`]. Both are non-terminal, and
+//! [`RunStatus::WaitingApproval`] is deliberately **re-enterable**: #243 grants
+//! are single-use and argument-exact, so an attempt that needed three separate
+//! approvals must be able to park three separate times. A state machine that
+//! allowed only one approval stop would force those into one batched grant,
+//! which is exactly what #243 rules out.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::Result;
+use crate::error::OpenCompanyError;
+use crate::ports::now_millis;
+use crate::ports::types::{CompanyId, EventSeq, TokenUsage, TurnStep};
+
+/// The `error` a boot reaper stamps on a run it found still active.
+///
+/// See [`reap_orphaned_runs`] for why an active row at boot is provably dead
+/// rather than merely suspicious.
+pub const ORPHAN_ERROR: &str =
+    "the host restarted while this attempt was running, so its outcome was lost";
+
+// ---------------------------------------------------------------------------
+// RunStatus
+// ---------------------------------------------------------------------------
+
+/// Where one task attempt currently stands.
+///
+/// Serialized in `snake_case` (`waiting_approval`), matching the board's own
+/// column vocabulary, and [`Self::as_str`] returns the identical literal so a
+/// backend's indexed `status` column and the JSON blob can never disagree.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunStatus {
+    /// Minted, not yet started. The row exists *before* the cycle spawns, which
+    /// is the whole point: a crash in the gap is visible instead of silent.
+    Pending,
+    /// The cycle is executing.
+    Running,
+    /// Parked because **a person** must act — an approval, a review, a
+    /// decision. Re-enterable: see the module docs.
+    WaitingApproval,
+    /// Parked because something *other than a person* must resolve — a
+    /// dependency, a rate limit, a missing credential, a retry, an operator
+    /// steer-to-pause. Neither cancelled nor failed.
+    Paused,
+    /// Terminal: the attempt completed.
+    Succeeded,
+    /// Terminal: the attempt failed. [`RunRecord::error`] carries why.
+    Failed,
+    /// Terminal: the attempt was cancelled before it could settle.
+    Cancelled,
+}
+
+impl RunStatus {
+    /// The wire/column literal for this status.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::WaitingApproval => "waiting_approval",
+            Self::Paused => "paused",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    /// Whether the attempt is over for good. Nothing moves out of a terminal
+    /// status — a re-run is a *new* attempt with its own ordinal, never a
+    /// resurrection of this one.
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Succeeded | Self::Failed | Self::Cancelled)
+    }
+
+    /// Whether the attempt claims to be live in *this* process — the states a
+    /// boot reaper reclaims. Deliberately excludes both parked states: parked
+    /// is not orphaned.
+    pub fn is_active(self) -> bool {
+        matches!(self, Self::Pending | Self::Running)
+    }
+
+    /// Whether the attempt is parked awaiting something outside the cycle.
+    pub fn is_parked(self) -> bool {
+        matches!(self, Self::WaitingApproval | Self::Paused)
+    }
+
+    /// Whether a run may move from `self` to `next`.
+    ///
+    /// The table, in one place:
+    ///
+    /// - `Pending` → `Running` (the cycle started), or straight to a terminal
+    ///   (it never got to start — a reaper, or a dispatch that failed before
+    ///   the first turn).
+    /// - `Running` → any parked or terminal status.
+    /// - parked → `Running` (resumed), the *other* parked status, or a
+    ///   terminal. Re-entering `WaitingApproval` is a `Running` →
+    ///   `WaitingApproval` move, so the resume edge is what makes it repeatable.
+    /// - terminal → nothing.
+    ///
+    /// A no-op move (`s` → `s`) is rejected for the active states, because
+    /// `Running` → `Running` would mean a second `begin_run` on a live run and
+    /// that is a caller bug worth hearing about. Parked → same-parked *is*
+    /// allowed: settling a paused run as paused again (a second steer) is
+    /// ordinary.
+    pub fn can_transition_to(self, next: Self) -> bool {
+        match self {
+            Self::Pending => next == Self::Running || next.is_terminal(),
+            Self::Running => next.is_parked() || next.is_terminal(),
+            Self::WaitingApproval | Self::Paused => {
+                next == Self::Running || next.is_parked() || next.is_terminal()
+            }
+            Self::Succeeded | Self::Failed | Self::Cancelled => false,
+        }
+    }
+}
+
+impl std::fmt::Display for RunStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+/// One recorded attempt at a task.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunRecord {
+    /// Stable id for the attempt within the company. Minted by the caller
+    /// *before* the cycle spawns.
+    pub id: String,
+    /// The company that owns the attempt. Carried on the record as well as in
+    /// the store key so an exported/streamed row is self-describing.
+    pub company: CompanyId,
+    /// The board card this attempt is an attempt *at*.
+    pub task_id: String,
+    /// The desk/teammate the card was dispatched to.
+    pub agent_id: String,
+    /// Which attempt at `task_id` this is, **1-based** — the first run of a card
+    /// is `Attempt 1`. Assigned by the backend at create time; see
+    /// [`RunStore::create_run`] for the concurrency contract.
+    pub attempt: u32,
+    /// Where the attempt stands.
+    pub status: RunStatus,
+    /// The [`EventLog`](crate::ports::EventLog) seq of the `TaskDispatched`
+    /// event that drove this attempt, once it has been appended.
+    ///
+    /// `None` while the run is still `Pending` (the row is written before the
+    /// event, on purpose) and for any run whose dispatch failed before the
+    /// append.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_event_seq: Option<EventSeq>,
+    /// Epoch-millis the row was minted.
+    pub created_at_millis: u64,
+    /// Epoch-millis the cycle actually began. `None` while `Pending`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at_millis: Option<u64>,
+    /// Epoch-millis the attempt reached a **terminal** status.
+    ///
+    /// Stays `None` for a parked run: `Paused` and `WaitingApproval` can still
+    /// resume, so stamping a finish time there would make a resumable attempt
+    /// read as over.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finished_at_millis: Option<u64>,
+    /// Why the attempt failed, in plain language. `None` unless the settle
+    /// carried one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Tokens and cost attributed to this attempt, folded across its turns.
+    #[serde(default)]
+    pub usage: TokenUsage,
+    /// How many [`RunStepRecord`]s the attempt produced.
+    #[serde(default)]
+    pub step_count: u32,
+}
+
+impl RunRecord {
+    /// Whether this attempt claims to be live in the current process.
+    pub fn is_active(&self) -> bool {
+        self.status.is_active()
+    }
+}
+
+/// One step of an attempt's trace, in the order it happened.
+///
+/// The payload is a [`TurnStep`] rather than a bespoke shape so this stream
+/// inherits the harness's scrubbing guarantees for free: labels are
+/// server-computed, details are whitelisted, and raw tool arguments/output can
+/// never reach here.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunStepRecord {
+    /// The attempt this step belongs to.
+    pub run_id: String,
+    /// Position within the attempt: 0-based and dense.
+    ///
+    /// Deliberately **not** an [`EventSeq`]. An event seq is company-wide and
+    /// shared with chat and audit; a step ordinal is run-scoped, so keeping
+    /// them the same type would invite reading one as the other. It is also
+    /// what makes an append idempotent — a backend keys on
+    /// `(run_id, step_seq)`, so replaying a step overwrites rather than
+    /// duplicates.
+    pub step_seq: u32,
+    /// Epoch-millis the step was recorded.
+    pub at_millis: u64,
+    /// The scrubbed step itself.
+    pub step: TurnStep,
+}
+
+/// What [`RunStore::create_run`] needs to mint a row. Everything else on a
+/// [`RunRecord`] is either derived (`attempt`, `created_at_millis`) or arrives
+/// through a later transition.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NewRun {
+    /// The caller-minted run id.
+    pub id: String,
+    /// The card being attempted.
+    pub task_id: String,
+    /// The desk it was dispatched to.
+    pub agent_id: String,
+}
+
+/// The settle of an attempt, as handed to [`RunStore::finish_run`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct RunOutcome {
+    /// The status to settle into. Must not be [`RunStatus::Pending`] or
+    /// [`RunStatus::Running`] — `finish_run` is how a run *stops* advancing,
+    /// and the legality check rejects both.
+    pub status: RunStatus,
+    /// Why, when the settle carried a reason.
+    pub error: Option<String>,
+    /// Tokens/cost folded across the attempt's turns.
+    pub usage: TokenUsage,
+    /// How many steps the attempt produced.
+    pub step_count: u32,
+}
+
+impl RunOutcome {
+    /// A settle carrying nothing but a status — the shape a reaper and the
+    /// terminality backstop use.
+    pub fn new(status: RunStatus) -> Self {
+        Self {
+            status,
+            error: None,
+            usage: TokenUsage::default(),
+            step_count: 0,
+        }
+    }
+
+    /// Attaches a failure reason.
+    pub fn with_error(mut self, error: impl Into<String>) -> Self {
+        self.error = Some(error.into());
+        self
+    }
+}
+
+/// Which runs [`RunStore::list_runs`] should return.
+///
+/// [`Default`] is "every run in the company, newest first".
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RunFilter {
+    /// Only attempts at this card.
+    pub task_id: Option<String>,
+    /// Only these statuses. Empty means "any status".
+    pub statuses: Vec<RunStatus>,
+    /// At most this many rows, applied *after* ordering. `None` is unbounded.
+    pub limit: Option<usize>,
+}
+
+impl RunFilter {
+    /// Narrows to one card's attempts.
+    pub fn for_task(task_id: impl Into<String>) -> Self {
+        Self {
+            task_id: Some(task_id.into()),
+            ..Self::default()
+        }
+    }
+
+    /// Narrows to the statuses a boot reaper reclaims
+    /// ([`RunStatus::is_active`]).
+    pub fn active() -> Self {
+        Self {
+            statuses: vec![RunStatus::Pending, RunStatus::Running],
+            ..Self::default()
+        }
+    }
+
+    /// Adds a status to the filter.
+    pub fn with_status(mut self, status: RunStatus) -> Self {
+        self.statuses.push(status);
+        self
+    }
+
+    /// Caps the result count.
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Whether `run` passes the `task_id`/`statuses` predicates. The `limit` is
+    /// **not** applied here — it is an ordering-dependent cap, so backends that
+    /// filter in memory apply it after [`sort_newest_first`].
+    pub fn matches(&self, run: &RunRecord) -> bool {
+        if let Some(task_id) = &self.task_id
+            && &run.task_id != task_id
+        {
+            return false;
+        }
+        if !self.statuses.is_empty() && !self.statuses.contains(&run.status) {
+            return false;
+        }
+        true
+    }
+}
+
+/// The canonical [`RunStore::list_runs`] ordering: newest first, by
+/// `created_at_millis` descending, ties broken by `attempt` then `id`, both
+/// descending.
+///
+/// Shared by every backend rather than left to each one's natural order,
+/// because the conformance suite asserts an exact sequence and two runs minted
+/// in the same millisecond are the common case, not the exotic one — a
+/// timestamp-only sort would make the suite pass or fail on scheduler luck.
+pub fn sort_newest_first(runs: &mut [RunRecord]) {
+    runs.sort_by(|a, b| {
+        b.created_at_millis
+            .cmp(&a.created_at_millis)
+            .then_with(|| b.attempt.cmp(&a.attempt))
+            .then_with(|| b.id.cmp(&a.id))
+    });
+}
+
+// ---------------------------------------------------------------------------
+// The port
+// ---------------------------------------------------------------------------
+
+/// Durable per-company run records and their step traces. Company A's runs MUST
+/// be invisible to company B.
+///
+/// ## What a backend implements, and what it does not
+///
+/// The required methods are storage verbs only. The three transition
+/// methods — [`create_run`](Self::create_run) is the exception and is required,
+/// see below — are **provided**: they read, check legality, and write through
+/// [`put_run`](Self::put_run). A backend that overrode them would be re-deriving
+/// the state machine, which is the one thing this port exists to prevent, so
+/// don't.
+///
+/// [`put_run`](Self::put_run) is the unchecked write the transitions are built
+/// from. It is public only because Rust has no way to hide a supertrait method
+/// from a `dyn` caller; treat it as the backend seam, not as API. Callers move
+/// runs with the transition methods.
+#[async_trait]
+pub trait RunStore: Send + Sync {
+    // -- storage verbs ------------------------------------------------------
+
+    /// Mints a [`RunStatus::Pending`] row and assigns its `attempt` ordinal:
+    /// one more than the highest ordinal already recorded for `spec.task_id`,
+    /// so the first attempt at a card is `1`.
+    ///
+    /// **Concurrency contract.** The ordinal is allocated atomically where the
+    /// backend can do so cheaply (sqlite in a transaction, MongoDB from its
+    /// counters collection) and best-effort where it cannot (the filesystem
+    /// backend allocates under its per-path lock, which is process-local). This
+    /// is benign in practice because dispatch serialises through an awaited
+    /// board write before it ever reaches here, so two attempts at one card do
+    /// not race. It is documented rather than papered over: a caller that
+    /// invents its own concurrency must not assume ordinals are gap-free or
+    /// globally unique under contention.
+    ///
+    /// Creating a run whose id already exists is an
+    /// [`OpenCompanyError::Conflict`] — ids are minted, and a repeat means the
+    /// caller lost track of one, not that it wanted to overwrite an attempt.
+    async fn create_run(&self, company: &CompanyId, spec: NewRun) -> Result<RunRecord>;
+
+    /// Reads one run by id, or `None`.
+    async fn get_run(&self, company: &CompanyId, id: &str) -> Result<Option<RunRecord>>;
+
+    /// Writes a run row verbatim, creating or replacing it.
+    ///
+    /// The backend seam behind the transition methods — **not** the API. It
+    /// performs no legality check at all, so calling it directly is how a run
+    /// ends up in a state the rest of the system does not believe in.
+    async fn put_run(&self, company: &CompanyId, run: &RunRecord) -> Result<()>;
+
+    /// Lists runs matching `filter`, newest first (see [`sort_newest_first`]).
+    async fn list_runs(&self, company: &CompanyId, filter: &RunFilter) -> Result<Vec<RunRecord>>;
+
+    /// Appends (or replaces, on a matching `step_seq`) one step of a run's
+    /// trace.
+    async fn append_run_step(&self, company: &CompanyId, step: &RunStepRecord) -> Result<()>;
+
+    /// Reads a run's steps in `step_seq` order, oldest first.
+    async fn list_run_steps(&self, company: &CompanyId, run_id: &str)
+    -> Result<Vec<RunStepRecord>>;
+
+    // -- transitions (provided; legality enforced here) ----------------------
+
+    /// `Pending` → `Running`, stamping the driving event's seq and the start
+    /// time.
+    async fn begin_run(
+        &self,
+        company: &CompanyId,
+        id: &str,
+        trigger_event_seq: EventSeq,
+    ) -> Result<RunRecord> {
+        let mut run = require_run(self, company, id).await?;
+        check_transition(&run, RunStatus::Running)?;
+        run.status = RunStatus::Running;
+        run.trigger_event_seq = Some(trigger_event_seq);
+        // A resumed run keeps the moment it first started: `started_at_millis`
+        // is when the attempt began, not when its latest leg did.
+        run.started_at_millis.get_or_insert_with(now_millis);
+        self.put_run(company, &run).await?;
+        Ok(run)
+    }
+
+    /// Settles a run into a parked or terminal status, recording its cost,
+    /// step count and (on failure) reason.
+    ///
+    /// Rejects [`RunStatus::Pending`] and [`RunStatus::Running`] outright: this
+    /// is the verb that *stops* a run advancing, and `begin_run` is the only
+    /// way into `Running`.
+    async fn finish_run(
+        &self,
+        company: &CompanyId,
+        id: &str,
+        outcome: RunOutcome,
+    ) -> Result<RunRecord> {
+        if outcome.status.is_active() {
+            return Err(OpenCompanyError::InvalidRequest(format!(
+                "finish_run cannot settle a run as '{}': use begin_run to start one",
+                outcome.status
+            )));
+        }
+        let mut run = require_run(self, company, id).await?;
+        check_transition(&run, outcome.status)?;
+        run.status = outcome.status;
+        run.error = outcome.error;
+        run.usage = outcome.usage;
+        run.step_count = outcome.step_count;
+        // Only a terminal settle is a finish. A parked run can still resume, so
+        // stamping it would make a resumable attempt read as over.
+        run.finished_at_millis = outcome.status.is_terminal().then(now_millis);
+        self.put_run(company, &run).await?;
+        Ok(run)
+    }
+
+    /// Every run still claiming to be `Pending` or `Running`.
+    ///
+    /// At process start these are, by construction, dead — see
+    /// [`reap_orphaned_runs`].
+    async fn list_stale_active(&self, company: &CompanyId) -> Result<Vec<RunRecord>> {
+        self.list_runs(company, &RunFilter::active()).await
+    }
+}
+
+/// Loads a run or reports it missing — the shared prelude of every transition.
+async fn require_run<S: RunStore + ?Sized>(
+    store: &S,
+    company: &CompanyId,
+    id: &str,
+) -> Result<RunRecord> {
+    store
+        .get_run(company, id)
+        .await?
+        .ok_or_else(|| OpenCompanyError::NotFound(format!("no run '{id}'")))
+}
+
+/// Rejects an illegal move with a message that names both ends, so a caller
+/// reading the log can see which half surprised it.
+fn check_transition(run: &RunRecord, next: RunStatus) -> Result<()> {
+    if run.status.can_transition_to(next) {
+        return Ok(());
+    }
+    Err(OpenCompanyError::Conflict(format!(
+        "run '{}' cannot move from '{}' to '{}'",
+        run.id, run.status, next
+    )))
+}
+
+// ---------------------------------------------------------------------------
+// Boot reaper
+// ---------------------------------------------------------------------------
+
+/// Fails every run still recorded as `Pending` or `Running` for `company`,
+/// returning how many were reclaimed.
+///
+/// ## Why an active row at boot is *provably* dead, not merely suspicious
+///
+/// Three invariants, all verified against this tree:
+///
+/// 1. A cycle is a process-local `tokio::spawn` (`CompanyRuntime::dispatch_task`
+///    and the scheduler), so it cannot outlive the process that spawned it.
+/// 2. Exactly one process owns a company at a time — the append-only
+///    [`RuntimeJournal`](crate::runtime::journal::RuntimeJournal) is documented
+///    single-writer, and a second writer corrupts it.
+/// 3. Cycles serialise on the per-company mutex held by
+///    [`CycleRunner::run`](crate::runtime::CycleRunner), so no cycle from this
+///    process is in flight before boot completes.
+///
+/// Together those mean any active row observed at boot belongs to an attempt
+/// that no longer exists. This is a proof, not a timeout heuristic — nothing
+/// here guesses at staleness from a clock.
+///
+/// **Parked runs are never touched.** `WaitingApproval` and `Paused` are
+/// waiting on a person or an external condition, not on a process; reaping them
+/// would delete real pending work every time the host restarted.
+pub async fn reap_orphaned_runs(runs: &dyn RunStore, company: &CompanyId) -> Result<u32> {
+    let stale = runs.list_stale_active(company).await?;
+    let mut reaped = 0u32;
+    for run in stale {
+        let outcome = RunOutcome::new(RunStatus::Failed).with_error(ORPHAN_ERROR);
+        match runs.finish_run(company, &run.id, outcome).await {
+            Ok(_) => reaped += 1,
+            // One unreclaimable row must not stop the rest, and must not fail
+            // boot — but it is logged at warn, not swallowed, because a store
+            // that cannot write at startup is a real problem.
+            Err(err) => tracing::warn!(
+                company = %company,
+                run = %run.id,
+                error = %err,
+                "could not reap an orphaned run record"
+            ),
+        }
+    }
+    if reaped > 0 {
+        tracing::info!(
+            company = %company,
+            reaped,
+            "failed run records stranded by a previous host process"
+        );
+    }
+    Ok(reaped)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ports::types::{TurnStepKind, TurnStepStatus};
+
+    /// Every status, so a table-driven test cannot silently miss a new variant
+    /// (adding one without extending this list fails the exhaustiveness check
+    /// in [`all_statuses_are_listed`]).
+    const ALL: [RunStatus; 7] = [
+        RunStatus::Pending,
+        RunStatus::Running,
+        RunStatus::WaitingApproval,
+        RunStatus::Paused,
+        RunStatus::Succeeded,
+        RunStatus::Failed,
+        RunStatus::Cancelled,
+    ];
+
+    #[test]
+    fn all_statuses_are_listed() {
+        // A `match` with no wildcard: adding a variant breaks compilation here
+        // first, which is the reminder to extend `ALL`.
+        for status in ALL {
+            match status {
+                RunStatus::Pending
+                | RunStatus::Running
+                | RunStatus::WaitingApproval
+                | RunStatus::Paused
+                | RunStatus::Succeeded
+                | RunStatus::Failed
+                | RunStatus::Cancelled => (),
+            };
+        }
+        let mut seen: Vec<&str> = ALL.iter().map(|s| s.as_str()).collect();
+        seen.sort_unstable();
+        seen.dedup();
+        assert_eq!(seen.len(), ALL.len(), "status literals must be unique");
+    }
+
+    #[test]
+    fn status_literals_match_their_serde_form() {
+        for status in ALL {
+            let json = serde_json::to_string(&status).unwrap();
+            assert_eq!(
+                json,
+                format!("\"{}\"", status.as_str()),
+                "the indexed column literal and the wire form must not drift"
+            );
+        }
+    }
+
+    #[test]
+    fn terminal_statuses_are_final() {
+        for from in ALL.into_iter().filter(|s| s.is_terminal()) {
+            for to in ALL {
+                assert!(
+                    !from.can_transition_to(to),
+                    "{from} is terminal but claims it can move to {to}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn pending_only_starts_or_dies() {
+        assert!(RunStatus::Pending.can_transition_to(RunStatus::Running));
+        assert!(RunStatus::Pending.can_transition_to(RunStatus::Failed));
+        assert!(RunStatus::Pending.can_transition_to(RunStatus::Cancelled));
+        // A run that never began cannot have succeeded... but it also cannot
+        // park: nothing has run to hit an approval or a rate limit.
+        assert!(!RunStatus::Pending.can_transition_to(RunStatus::WaitingApproval));
+        assert!(!RunStatus::Pending.can_transition_to(RunStatus::Paused));
+        assert!(!RunStatus::Pending.can_transition_to(RunStatus::Pending));
+    }
+
+    #[test]
+    fn running_cannot_restart() {
+        assert!(!RunStatus::Running.can_transition_to(RunStatus::Running));
+        assert!(!RunStatus::Running.can_transition_to(RunStatus::Pending));
+    }
+
+    /// Epic #183 decision 3: an attempt may enter review many times, because
+    /// #243 grants are single-use and argument-exact.
+    #[test]
+    fn waiting_approval_is_re_enterable() {
+        assert!(RunStatus::Running.can_transition_to(RunStatus::WaitingApproval));
+        assert!(RunStatus::WaitingApproval.can_transition_to(RunStatus::Running));
+        // …and round again.
+        assert!(RunStatus::Running.can_transition_to(RunStatus::WaitingApproval));
+    }
+
+    /// Epic #183 decision 2: who unblocks it decides where it parks, so the two
+    /// parked states are distinct and both are non-terminal and resumable.
+    #[test]
+    fn both_parked_states_resume() {
+        for parked in [RunStatus::WaitingApproval, RunStatus::Paused] {
+            assert!(parked.is_parked());
+            assert!(!parked.is_terminal());
+            assert!(!parked.is_active());
+            assert!(parked.can_transition_to(RunStatus::Running));
+            assert!(parked.can_transition_to(RunStatus::Succeeded));
+        }
+        // A run waiting on a person can turn into one waiting on a dependency
+        // (and back) without a terminal hop in between.
+        assert!(RunStatus::WaitingApproval.can_transition_to(RunStatus::Paused));
+        assert!(RunStatus::Paused.can_transition_to(RunStatus::WaitingApproval));
+    }
+
+    #[test]
+    fn only_pending_and_running_are_reapable() {
+        for status in ALL {
+            assert_eq!(
+                status.is_active(),
+                matches!(status, RunStatus::Pending | RunStatus::Running),
+                "{status} is misclassified for the boot reaper"
+            );
+        }
+    }
+
+    fn run(id: &str, created: u64, attempt: u32) -> RunRecord {
+        RunRecord {
+            id: id.to_string(),
+            company: CompanyId::new("alpha"),
+            task_id: "card".to_string(),
+            agent_id: "ceo".to_string(),
+            attempt,
+            status: RunStatus::Pending,
+            trigger_event_seq: None,
+            created_at_millis: created,
+            started_at_millis: None,
+            finished_at_millis: None,
+            error: None,
+            usage: TokenUsage::default(),
+            step_count: 0,
+        }
+    }
+
+    #[test]
+    fn ordering_breaks_ties_deterministically() {
+        // Same millisecond — the common case, not the exotic one.
+        let mut runs = vec![run("a", 10, 1), run("c", 10, 3), run("b", 10, 2)];
+        sort_newest_first(&mut runs);
+        let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, ["c", "b", "a"], "newest attempt first within a tick");
+
+        // A later timestamp outranks a higher ordinal.
+        let mut runs = vec![run("old", 10, 9), run("new", 20, 1)];
+        sort_newest_first(&mut runs);
+        assert_eq!(runs[0].id, "new");
+    }
+
+    #[test]
+    fn filter_matches_task_and_status() {
+        let mut pending = run("a", 10, 1);
+        let mut done = run("b", 10, 2);
+        done.status = RunStatus::Succeeded;
+        done.task_id = "other".to_string();
+
+        assert!(RunFilter::default().matches(&pending));
+        assert!(RunFilter::default().matches(&done));
+
+        assert!(RunFilter::for_task("card").matches(&pending));
+        assert!(!RunFilter::for_task("card").matches(&done));
+
+        assert!(RunFilter::active().matches(&pending));
+        assert!(!RunFilter::active().matches(&done));
+
+        pending.status = RunStatus::Running;
+        assert!(RunFilter::active().matches(&pending));
+
+        let only_succeeded = RunFilter::default().with_status(RunStatus::Succeeded);
+        assert!(only_succeeded.matches(&done));
+        assert!(!only_succeeded.matches(&pending));
+    }
+
+    #[test]
+    fn step_records_round_trip() {
+        let record = RunStepRecord {
+            run_id: "r1".to_string(),
+            step_seq: 0,
+            at_millis: 42,
+            step: TurnStep {
+                kind: TurnStepKind::ToolCall,
+                status: TurnStepStatus::Ok,
+                label: "Reading messages".to_string(),
+                detail: None,
+                elapsed_ms: Some(12),
+            },
+        };
+        let json = serde_json::to_string(&record).unwrap();
+        assert_eq!(record, serde_json::from_str(&json).unwrap());
+        // The wire form is camelCase, like every other console-facing shape.
+        assert!(json.contains("\"runId\""), "{json}");
+        assert!(json.contains("\"stepSeq\""), "{json}");
+    }
+
+    #[test]
+    fn run_records_round_trip_and_omit_empty_optionals() {
+        let mut record = run("r1", 100, 1);
+        let json = serde_json::to_string(&record).unwrap();
+        assert_eq!(record, serde_json::from_str(&json).unwrap());
+        assert!(!json.contains("triggerEventSeq"), "{json}");
+        assert!(!json.contains("finishedAtMillis"), "{json}");
+
+        record.status = RunStatus::Failed;
+        record.trigger_event_seq = Some(EventSeq::new(7));
+        record.finished_at_millis = Some(200);
+        record.error = Some(ORPHAN_ERROR.to_string());
+        record.usage = TokenUsage {
+            input: 10,
+            output: 5,
+            cached_input: 1,
+            cost_usd: 0.25,
+        };
+        record.step_count = 3;
+        let json = serde_json::to_string(&record).unwrap();
+        assert_eq!(record, serde_json::from_str(&json).unwrap());
+        assert!(json.contains("\"status\":\"failed\""), "{json}");
+    }
+}

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -41,8 +41,8 @@ use crate::ports::types::{
 };
 use crate::ports::{
     AgentEconomy, ArtifactStore, Brain, ChannelAdapter, CompanyStore, ContextStore, EventLog,
-    FactStore, InboxStore, LoginCodeStore, MemoryStore, SecretStore, SessionStore, SkillStateStore,
-    TaskStore, ToolProvider, UsageMeter, UserStore, WorkspaceStore,
+    FactStore, InboxStore, LoginCodeStore, MemoryStore, RunStore, SecretStore, SessionStore,
+    SkillStateStore, TaskStore, ToolProvider, UsageMeter, UserStore, WorkspaceStore,
 };
 use crate::runtime::channel::{OPERATOR_CHANNEL, OperatorChannel};
 use crate::runtime::journal::RuntimeJournal;
@@ -215,6 +215,7 @@ pub struct RuntimeBuilder {
     workspace: Option<Arc<dyn WorkspaceStore>>,
     facts: Option<Arc<dyn FactStore>>,
     artifacts: Option<Arc<dyn ArtifactStore>>,
+    runs: Option<Arc<dyn RunStore>>,
     usage: Option<Arc<dyn UsageMeter>>,
     skills: Option<Arc<dyn SkillStateStore>>,
     users: Option<Arc<dyn UserStore>>,
@@ -296,6 +297,7 @@ impl RuntimeBuilder {
             workspace: None,
             facts: None,
             artifacts: None,
+            runs: None,
             usage: None,
             skills: None,
             users: None,
@@ -401,6 +403,7 @@ impl RuntimeBuilder {
         self.workspace = Some(handles.workspace.clone());
         self.facts = Some(handles.facts.clone());
         self.artifacts = Some(handles.artifacts.clone());
+        self.runs = Some(handles.runs.clone());
         self.usage = Some(handles.usage.clone());
         self.skills = Some(handles.skills.clone());
         self.users = Some(handles.users.clone());
@@ -464,6 +467,12 @@ impl RuntimeBuilder {
     /// Swaps the artifact store (default: fs-backed).
     pub fn with_artifacts(mut self, artifacts: Arc<dyn ArtifactStore>) -> Self {
         self.artifacts = Some(artifacts);
+        self
+    }
+
+    /// Swaps the task-run store (default: fs-backed).
+    pub fn with_runs(mut self, runs: Arc<dyn RunStore>) -> Self {
+        self.runs = Some(runs);
         self
     }
 
@@ -726,6 +735,7 @@ impl RuntimeBuilder {
             workspace: self.workspace.unwrap_or_else(|| fs_ops.clone()),
             facts: self.facts.unwrap_or_else(|| fs_ops.clone()),
             artifacts: self.artifacts.unwrap_or_else(|| fs_ops.clone()),
+            runs: self.runs.unwrap_or_else(|| fs_ops.clone()),
             usage: self.usage.unwrap_or_else(|| fs_ops.clone()),
             skills: self.skills.unwrap_or_else(|| fs_ops.clone()),
             users: self.users.unwrap_or_else(|| fs_ops.clone()),
@@ -848,6 +858,32 @@ impl RuntimeBuilder {
             Bundle::new(home.clone(), &id).journal_jsonl(),
         ));
         journal.load().await?;
+
+        // Issue #242, the other half of boot replay: reclaim run records left
+        // active by a previous host process.
+        //
+        // A run row is written *before* its cycle spawns, so a crash in that
+        // gap — or anywhere inside the cycle — leaves a row claiming to be
+        // Pending or Running that nothing will ever settle. Three invariants
+        // make every such row provably dead rather than merely suspicious:
+        // cycles are process-local `tokio::spawn`s, exactly one process owns a
+        // company (the journal above is single-writer), and cycles serialise on
+        // the per-company mutex — so nothing from this process can be in flight
+        // yet. `reap_orphaned_runs` therefore needs no timeout heuristic, and it
+        // never touches a parked run: WaitingApproval and Paused are waiting on
+        // a person or an external condition, not on a process.
+        //
+        // It runs here, beside `journal.load()`, and well before the dispatch
+        // and scheduler spawns further down, so no fresh run can be reaped by
+        // mistake. A store failure is logged, never fatal: record-keeping must
+        // not stop a company from booting.
+        if let Err(err) = crate::ports::runs::reap_orphaned_runs(ops.runs.as_ref(), &id).await {
+            tracing::warn!(
+                company = %id,
+                error = %err,
+                "could not sweep orphaned run records at boot"
+            );
+        }
 
         let gate = self
             .approvals
@@ -1894,6 +1930,84 @@ mod test {
                 .unwrap()
                 .is_some()
         );
+    }
+
+    /// Issue #242: a run row left active by a dead host is reclaimed at the next
+    /// boot, and a parked one is not.
+    ///
+    /// The store is the default fs backend over the same home, so the second
+    /// `build()` is a genuine restart of the same company — this asserts the
+    /// reaper is *wired into boot*, not merely that the port function works
+    /// (which the conformance suite covers for all three backends).
+    #[tokio::test]
+    async fn boot_reaps_runs_stranded_by_a_previous_host() {
+        use crate::ports::runs::{NewRun, ORPHAN_ERROR, RunOutcome, RunStatus};
+
+        let home_dir = tmp_home("oc-run-reap-");
+        let home = home_dir.path().to_path_buf();
+        let manifest = parse("[company]\nname=\"Acme\"\n[policy]\nmode=\"full\"\n");
+        let id = CompanyId::new("acme");
+        let spec = |run: &str, task: &str| NewRun {
+            id: run.to_string(),
+            task_id: task.to_string(),
+            agent_id: "ceo".to_string(),
+        };
+
+        let first_boot = RuntimeBuilder::new(home.clone(), manifest.clone())
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let runs = first_boot.runs().clone();
+
+        // Two attempts the host is "running", and one parked for a person.
+        runs.create_run(&id, spec("pending", "card-a"))
+            .await
+            .unwrap();
+        runs.create_run(&id, spec("running", "card-b"))
+            .await
+            .unwrap();
+        runs.begin_run(&id, "running", crate::ports::types::EventSeq::new(1))
+            .await
+            .unwrap();
+        runs.create_run(&id, spec("review", "card-c"))
+            .await
+            .unwrap();
+        runs.begin_run(&id, "review", crate::ports::types::EventSeq::new(2))
+            .await
+            .unwrap();
+        runs.finish_run(&id, "review", RunOutcome::new(RunStatus::WaitingApproval))
+            .await
+            .unwrap();
+
+        // The host dies here — no settle, no journal entry, nothing.
+        drop(first_boot);
+
+        let second_boot = RuntimeBuilder::new(home.clone(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let runs = second_boot.runs();
+
+        for stranded in ["pending", "running"] {
+            let run = runs.get_run(&id, stranded).await.unwrap().unwrap();
+            assert_eq!(
+                run.status,
+                RunStatus::Failed,
+                "{stranded} outlived its process and must be reclaimed"
+            );
+            assert_eq!(run.error.as_deref(), Some(ORPHAN_ERROR));
+            assert!(run.finished_at_millis.is_some());
+        }
+
+        // Parked is not orphaned: this one is waiting on a person, and a restart
+        // must not throw that work away.
+        let review = runs.get_run(&id, "review").await.unwrap().unwrap();
+        assert_eq!(review.status, RunStatus::WaitingApproval);
+        assert_eq!(review.error, None);
+
+        assert!(runs.list_stale_active(&id).await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -1546,3 +1546,503 @@ pub async fn assert_workspace_store(ws: Arc<dyn WorkspaceStore>) {
     assert!(tree.iter().all(|n| n.id != "root" && n.id != "child"));
     assert!(!ws.delete(&alpha, "root").await.unwrap());
 }
+
+// ---------------------------------------------------------------------------
+// RunStore (issue #242)
+// ---------------------------------------------------------------------------
+//
+// Imports for this suite are function-local rather than added to the module
+// header: the header is being edited concurrently on another branch, and a
+// `use` inside the function keeps this suite a pure append.
+
+/// Asserts the [`RunStore`](crate::ports::runs::RunStore) contract: per-company
+/// isolation, per-task attempt ordinals, transition legality, the step trace,
+/// and the list filters.
+pub async fn assert_run_store(runs: Arc<dyn crate::ports::runs::RunStore>) {
+    use crate::ports::runs::{NewRun, RunFilter, RunOutcome, RunStatus, RunStepRecord};
+    use crate::ports::types::{TokenUsage, TurnStep, TurnStepKind, TurnStepStatus};
+
+    let alpha = CompanyId::new("alpha");
+    let beta = CompanyId::new("beta");
+    let spec = |id: &str, task: &str| NewRun {
+        id: id.to_string(),
+        task_id: task.to_string(),
+        agent_id: "ceo".to_string(),
+    };
+
+    // -- create: a fresh run is Pending and nothing else ---------------------
+
+    let first = runs.create_run(&alpha, spec("r1", "card")).await.unwrap();
+    assert_eq!(first.status, RunStatus::Pending);
+    assert_eq!(first.attempt, 1, "the first attempt at a card is 1-based");
+    assert_eq!(first.company, alpha);
+    assert_eq!(first.task_id, "card");
+    assert_eq!(first.agent_id, "ceo");
+    assert_eq!(first.trigger_event_seq, None);
+    assert_eq!(first.started_at_millis, None);
+    assert_eq!(first.finished_at_millis, None);
+    assert_eq!(first.error, None);
+    assert_eq!(first.step_count, 0);
+    assert!(first.created_at_millis > 0);
+
+    // Read-back is byte-identical (the export-totality precondition).
+    assert_eq!(runs.get_run(&alpha, "r1").await.unwrap(), Some(first));
+
+    // -- attempt ordinals are per card, not per company ----------------------
+
+    let second = runs.create_run(&alpha, spec("r2", "card")).await.unwrap();
+    assert_eq!(second.attempt, 2);
+    let third = runs.create_run(&alpha, spec("r3", "card")).await.unwrap();
+    assert_eq!(third.attempt, 3);
+    let other_card = runs.create_run(&alpha, spec("r4", "other")).await.unwrap();
+    assert_eq!(
+        other_card.attempt, 1,
+        "a different card starts its own attempt count"
+    );
+
+    // A repeated id is a conflict, never a silent overwrite of a live attempt.
+    assert!(
+        runs.create_run(&alpha, spec("r1", "card")).await.is_err(),
+        "creating a run with an existing id must fail"
+    );
+
+    // -- company isolation ---------------------------------------------------
+
+    let beta_run = runs.create_run(&beta, spec("b1", "card")).await.unwrap();
+    assert_eq!(
+        beta_run.attempt, 1,
+        "attempt ordinals do not leak across companies"
+    );
+    assert!(runs.get_run(&beta, "r1").await.unwrap().is_none());
+    assert!(runs.get_run(&alpha, "b1").await.unwrap().is_none());
+    let beta_all = runs.list_runs(&beta, &RunFilter::default()).await.unwrap();
+    assert_eq!(beta_all.len(), 1);
+    assert_eq!(beta_all[0].id, "b1");
+
+    // -- begin_run: Pending → Running ---------------------------------------
+
+    let begun = runs
+        .begin_run(&alpha, "r1", EventSeq::new(7))
+        .await
+        .unwrap();
+    assert_eq!(begun.status, RunStatus::Running);
+    assert_eq!(begun.trigger_event_seq, Some(EventSeq::new(7)));
+    assert!(begun.started_at_millis.is_some());
+    assert_eq!(begun.finished_at_millis, None);
+    assert_eq!(runs.get_run(&alpha, "r1").await.unwrap(), Some(begun));
+
+    // A second begin on a live run is a caller bug, not an idempotent no-op.
+    assert!(
+        runs.begin_run(&alpha, "r1", EventSeq::new(8))
+            .await
+            .is_err(),
+        "Running → Running must be rejected"
+    );
+
+    // A transition against a run that does not exist is an error, not a
+    // silently created row.
+    assert!(
+        runs.begin_run(&alpha, "nope", EventSeq::new(1))
+            .await
+            .is_err()
+    );
+    assert!(runs.get_run(&alpha, "nope").await.unwrap().is_none());
+
+    // -- finish_run: cost, step count and terminality ------------------------
+
+    let usage = TokenUsage {
+        input: 120,
+        output: 60,
+        cached_input: 10,
+        cost_usd: 0.5,
+    };
+    let settled = runs
+        .finish_run(
+            &alpha,
+            "r1",
+            RunOutcome {
+                status: RunStatus::Succeeded,
+                error: None,
+                usage,
+                step_count: 3,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(settled.status, RunStatus::Succeeded);
+    assert_eq!(settled.usage, usage);
+    assert_eq!(settled.step_count, 3);
+    assert!(
+        settled.finished_at_millis.is_some(),
+        "a terminal settle stamps the finish time"
+    );
+    assert_eq!(runs.get_run(&alpha, "r1").await.unwrap(), Some(settled));
+
+    // Terminal is final: nothing moves out of it. A re-run is a NEW attempt.
+    assert!(
+        runs.finish_run(&alpha, "r1", RunOutcome::new(RunStatus::Failed))
+            .await
+            .is_err()
+    );
+    assert!(
+        runs.begin_run(&alpha, "r1", EventSeq::new(9))
+            .await
+            .is_err()
+    );
+    assert_eq!(
+        runs.get_run(&alpha, "r1").await.unwrap().unwrap().status,
+        RunStatus::Succeeded,
+        "a rejected transition leaves the row untouched"
+    );
+
+    // `finish_run` is how a run stops advancing — it can never start one.
+    assert!(
+        runs.finish_run(&alpha, "r2", RunOutcome::new(RunStatus::Running))
+            .await
+            .is_err()
+    );
+    assert!(
+        runs.finish_run(&alpha, "r2", RunOutcome::new(RunStatus::Pending))
+            .await
+            .is_err()
+    );
+
+    // -- parked runs are not finished runs (epic #183 decisions 2 and 3) -----
+
+    runs.begin_run(&alpha, "r2", EventSeq::new(10))
+        .await
+        .unwrap();
+    let parked = runs
+        .finish_run(&alpha, "r2", RunOutcome::new(RunStatus::WaitingApproval))
+        .await
+        .unwrap();
+    assert_eq!(parked.status, RunStatus::WaitingApproval);
+    assert_eq!(
+        parked.finished_at_millis, None,
+        "a parked run can still resume, so it carries no finish time"
+    );
+
+    // Re-enterable: #243 grants are single-use, so one attempt may stop for
+    // review many times.
+    let resumed = runs
+        .begin_run(&alpha, "r2", EventSeq::new(11))
+        .await
+        .unwrap();
+    assert_eq!(resumed.status, RunStatus::Running);
+    assert_eq!(
+        resumed.started_at_millis, parked.started_at_millis,
+        "a resume keeps the moment the attempt first started"
+    );
+    runs.finish_run(&alpha, "r2", RunOutcome::new(RunStatus::WaitingApproval))
+        .await
+        .unwrap();
+    runs.begin_run(&alpha, "r2", EventSeq::new(12))
+        .await
+        .unwrap();
+
+    // Waiting-on-a-person can become waiting-on-something-else without a
+    // terminal hop in between.
+    runs.finish_run(&alpha, "r2", RunOutcome::new(RunStatus::Paused))
+        .await
+        .unwrap();
+    let repark = runs
+        .finish_run(&alpha, "r2", RunOutcome::new(RunStatus::WaitingApproval))
+        .await
+        .unwrap();
+    assert_eq!(repark.status, RunStatus::WaitingApproval);
+
+    // …and finally settles for good, carrying its reason.
+    let failed = runs
+        .finish_run(
+            &alpha,
+            "r2",
+            RunOutcome::new(RunStatus::Failed).with_error("the tool never came back"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(failed.status, RunStatus::Failed);
+    assert_eq!(failed.error.as_deref(), Some("the tool never came back"));
+    assert!(failed.finished_at_millis.is_some());
+
+    // A run that never started can still settle — the shape a boot reaper and a
+    // dispatch that died before its first turn both need.
+    let never_ran = runs
+        .finish_run(
+            &alpha,
+            "r3",
+            RunOutcome::new(RunStatus::Cancelled).with_error("the operator withdrew the card"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(never_ran.status, RunStatus::Cancelled);
+    assert_eq!(never_ran.started_at_millis, None);
+
+    // -- the step trace ------------------------------------------------------
+
+    let step = |run_id: &str, seq: u32, label: &str| RunStepRecord {
+        run_id: run_id.to_string(),
+        step_seq: seq,
+        at_millis: 1_000 + u64::from(seq),
+        step: TurnStep {
+            kind: TurnStepKind::ToolCall,
+            status: TurnStepStatus::Ok,
+            label: label.to_string(),
+            detail: None,
+            elapsed_ms: Some(5),
+        },
+    };
+
+    assert!(
+        runs.list_run_steps(&alpha, "r1").await.unwrap().is_empty(),
+        "a run with no trace reads back empty, not missing"
+    );
+
+    runs.append_run_step(&alpha, &step("r1", 0, "Reading messages"))
+        .await
+        .unwrap();
+    runs.append_run_step(&alpha, &step("r1", 1, "Thinking"))
+        .await
+        .unwrap();
+    runs.append_run_step(&alpha, &step("r1", 2, "Writing the reply"))
+        .await
+        .unwrap();
+    // A different run's trace must not bleed into this one.
+    runs.append_run_step(&alpha, &step("r4", 0, "Somebody else's step"))
+        .await
+        .unwrap();
+    // …nor another company's.
+    runs.append_run_step(&beta, &step("r1", 0, "Beta's step"))
+        .await
+        .unwrap();
+
+    let trace = runs.list_run_steps(&alpha, "r1").await.unwrap();
+    assert_eq!(trace.len(), 3);
+    assert_eq!(
+        trace.iter().map(|s| s.step_seq).collect::<Vec<_>>(),
+        [0, 1, 2],
+        "steps read back in run order, oldest first"
+    );
+    assert_eq!(trace[1].step.label, "Thinking");
+    assert_eq!(trace[0], step("r1", 0, "Reading messages"));
+
+    assert_eq!(runs.list_run_steps(&alpha, "r4").await.unwrap().len(), 1);
+    let beta_trace = runs.list_run_steps(&beta, "r1").await.unwrap();
+    assert_eq!(beta_trace.len(), 1);
+    assert_eq!(beta_trace[0].step.label, "Beta's step");
+
+    // Re-appending the same `(run_id, step_seq)` overwrites: a retried write
+    // must not duplicate a step.
+    runs.append_run_step(&alpha, &step("r1", 1, "Thinking harder"))
+        .await
+        .unwrap();
+    let trace = runs.list_run_steps(&alpha, "r1").await.unwrap();
+    assert_eq!(
+        trace.len(),
+        3,
+        "an idempotent append does not grow the trace"
+    );
+    assert_eq!(trace[1].step.label, "Thinking harder");
+
+    // -- filters and ordering ------------------------------------------------
+
+    let all = runs.list_runs(&alpha, &RunFilter::default()).await.unwrap();
+    assert_eq!(all.len(), 4, "r1..r4");
+
+    let for_card = runs
+        .list_runs(&alpha, &RunFilter::for_task("card"))
+        .await
+        .unwrap();
+    assert_eq!(
+        for_card.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
+        ["r3", "r2", "r1"],
+        "one card's attempts come back newest first"
+    );
+
+    let succeeded = runs
+        .list_runs(
+            &alpha,
+            &RunFilter::default().with_status(RunStatus::Succeeded),
+        )
+        .await
+        .unwrap();
+    assert_eq!(succeeded.len(), 1);
+    assert_eq!(succeeded[0].id, "r1");
+
+    let settled_two = runs
+        .list_runs(
+            &alpha,
+            &RunFilter::default()
+                .with_status(RunStatus::Failed)
+                .with_status(RunStatus::Cancelled),
+        )
+        .await
+        .unwrap();
+    let mut ids: Vec<&str> = settled_two.iter().map(|r| r.id.as_str()).collect();
+    ids.sort_unstable();
+    assert_eq!(ids, ["r2", "r3"], "a multi-status filter is a union");
+
+    // Task and status compose.
+    let none = runs
+        .list_runs(
+            &alpha,
+            &RunFilter::for_task("other").with_status(RunStatus::Succeeded),
+        )
+        .await
+        .unwrap();
+    assert!(none.is_empty());
+
+    // The limit truncates the newest end, after ordering.
+    let capped = runs
+        .list_runs(&alpha, &RunFilter::for_task("card").with_limit(2))
+        .await
+        .unwrap();
+    assert_eq!(
+        capped.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
+        ["r3", "r2"]
+    );
+    assert!(
+        runs.list_runs(&alpha, &RunFilter::default().with_limit(0))
+            .await
+            .unwrap()
+            .is_empty()
+    );
+
+    // A filter that matches nothing is empty, not an error.
+    assert!(
+        runs.list_runs(&alpha, &RunFilter::for_task("no-such-card"))
+            .await
+            .unwrap()
+            .is_empty()
+    );
+
+    // -- list_stale_active ---------------------------------------------------
+
+    // r1 Succeeded, r2 Failed, r3 Cancelled, r4 still Pending.
+    let stale = runs.list_stale_active(&alpha).await.unwrap();
+    assert_eq!(stale.len(), 1);
+    assert_eq!(stale[0].id, "r4");
+    assert_eq!(stale[0].status, RunStatus::Pending);
+
+    runs.begin_run(&alpha, "r4", EventSeq::new(20))
+        .await
+        .unwrap();
+    let stale = runs.list_stale_active(&alpha).await.unwrap();
+    assert_eq!(stale.len(), 1, "Running is active too");
+
+    runs.finish_run(&alpha, "r4", RunOutcome::new(RunStatus::WaitingApproval))
+        .await
+        .unwrap();
+    assert!(
+        runs.list_stale_active(&alpha).await.unwrap().is_empty(),
+        "parked is not active: a run waiting on a person is not stale"
+    );
+}
+
+/// Asserts the boot-reaper contract
+/// ([`reap_orphaned_runs`](crate::ports::runs::reap_orphaned_runs)): every run
+/// left `Pending` or `Running` by a dead process is failed with the orphan
+/// reason, and every parked run is left exactly as it was.
+pub async fn assert_run_reaper(runs: Arc<dyn crate::ports::runs::RunStore>) {
+    use crate::ports::runs::{NewRun, ORPHAN_ERROR, RunFilter, RunOutcome, RunStatus};
+
+    let alpha = CompanyId::new("alpha");
+    let beta = CompanyId::new("beta");
+    let spec = |id: &str, task: &str| NewRun {
+        id: id.to_string(),
+        task_id: task.to_string(),
+        agent_id: "ceo".to_string(),
+    };
+
+    // One of each state the reaper has an opinion about.
+    runs.create_run(&alpha, spec("pending", "a")).await.unwrap();
+
+    runs.create_run(&alpha, spec("running", "b")).await.unwrap();
+    runs.begin_run(&alpha, "running", EventSeq::new(1))
+        .await
+        .unwrap();
+
+    runs.create_run(&alpha, spec("review", "c")).await.unwrap();
+    runs.begin_run(&alpha, "review", EventSeq::new(2))
+        .await
+        .unwrap();
+    runs.finish_run(
+        &alpha,
+        "review",
+        RunOutcome::new(RunStatus::WaitingApproval),
+    )
+    .await
+    .unwrap();
+
+    runs.create_run(&alpha, spec("paused", "d")).await.unwrap();
+    runs.begin_run(&alpha, "paused", EventSeq::new(3))
+        .await
+        .unwrap();
+    runs.finish_run(&alpha, "paused", RunOutcome::new(RunStatus::Paused))
+        .await
+        .unwrap();
+
+    runs.create_run(&alpha, spec("done", "e")).await.unwrap();
+    runs.begin_run(&alpha, "done", EventSeq::new(4))
+        .await
+        .unwrap();
+    runs.finish_run(&alpha, "done", RunOutcome::new(RunStatus::Succeeded))
+        .await
+        .unwrap();
+
+    // Another company's stranded run must survive alpha's sweep.
+    runs.create_run(&beta, spec("beta-pending", "a"))
+        .await
+        .unwrap();
+
+    let reaped = crate::ports::runs::reap_orphaned_runs(runs.as_ref(), &alpha)
+        .await
+        .unwrap();
+    assert_eq!(reaped, 2, "exactly the Pending and Running rows");
+
+    let status = |id: &'static str| {
+        let runs = runs.clone();
+        let alpha = alpha.clone();
+        async move { runs.get_run(&alpha, id).await.unwrap().unwrap() }
+    };
+
+    let pending = status("pending").await;
+    assert_eq!(pending.status, RunStatus::Failed);
+    assert_eq!(pending.error.as_deref(), Some(ORPHAN_ERROR));
+    assert!(pending.finished_at_millis.is_some());
+
+    assert_eq!(status("running").await.status, RunStatus::Failed);
+
+    // Parked is not orphaned — reaping these would delete real pending work on
+    // every restart.
+    assert_eq!(status("review").await.status, RunStatus::WaitingApproval);
+    assert_eq!(status("review").await.error, None);
+    assert_eq!(status("paused").await.status, RunStatus::Paused);
+
+    // A terminal run is untouched, and keeps its own outcome.
+    assert_eq!(status("done").await.status, RunStatus::Succeeded);
+    assert_eq!(status("done").await.error, None);
+
+    // Isolation: beta's stranded run is still stranded.
+    assert_eq!(
+        runs.get_run(&beta, "beta-pending")
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        RunStatus::Pending
+    );
+
+    // The sweep is idempotent: a second boot finds nothing left to reclaim.
+    assert_eq!(
+        crate::ports::runs::reap_orphaned_runs(runs.as_ref(), &alpha)
+            .await
+            .unwrap(),
+        0
+    );
+    assert!(
+        runs.list_runs(&alpha, &RunFilter::active())
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -8,6 +8,8 @@
 //! - sessions → `user-sessions.json`, login codes → `login-codes.json`
 //!   (credential material: token/code *hashes* only, never plaintext)
 //! - facts → `facts.jsonl` (last-write-wins per id, rewritten on mutate)
+//! - runs → `runs.jsonl` (last-write-wins per id) + `run-steps.jsonl`
+//!   (append-only trace, last-write-wins per `(run_id, step_seq)`)
 //! - usage → `usage.jsonl` (append-only samples)
 //! - skills → `skills.json` (operator deltas)
 //! - workspace → real folders + Markdown files under `workspace/`, indexed by
@@ -25,6 +27,9 @@ use crate::ports::artifacts::{ArtifactRecord, ArtifactStore};
 use crate::ports::facts::{FactKind, FactRecord, FactStore};
 use crate::ports::login_codes::{LoginCodeRecord, LoginCodeStore};
 use crate::ports::now_millis;
+use crate::ports::runs::{
+    NewRun, RunFilter, RunRecord, RunStatus, RunStepRecord, RunStore, sort_newest_first,
+};
 use crate::ports::sessions::{SessionRecord, SessionStore};
 use crate::ports::skills_state::{SkillState, SkillStateStore};
 use crate::ports::tasks::{TaskRecord, TaskStore};
@@ -509,6 +514,109 @@ impl ArtifactStore for FsOps {
 }
 
 // ---------------------------------------------------------------------------
+// RunStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl RunStore for FsOps {
+    async fn create_run(&self, company: &CompanyId, spec: NewRun) -> Result<RunRecord> {
+        let bundle = self.bundle(company);
+        bundle.ensure_dirs().await?;
+        let path = bundle.runs_jsonl();
+        // The per-path lock is what makes read-max-then-write atomic. It is
+        // process-local — the documented fs-backend assumption everywhere in
+        // this file — which is why the port's `create_run` contract calls the
+        // filesystem ordinal best-effort rather than transactional.
+        let lock = self.locks.get(&path);
+        let _guard = lock.lock().await;
+        let mut runs = dedup_latest(read_jsonl::<RunRecord>(&path).await?);
+        if runs.iter().any(|r| r.id == spec.id) {
+            return Err(OpenCompanyError::Conflict(format!(
+                "run '{}' already exists",
+                spec.id
+            )));
+        }
+        let attempt = runs
+            .iter()
+            .filter(|r| r.task_id == spec.task_id)
+            .map(|r| r.attempt)
+            .max()
+            .unwrap_or(0)
+            .saturating_add(1);
+        let run = RunRecord {
+            id: spec.id,
+            company: company.clone(),
+            task_id: spec.task_id,
+            agent_id: spec.agent_id,
+            attempt,
+            status: RunStatus::Pending,
+            trigger_event_seq: None,
+            created_at_millis: now_millis(),
+            started_at_millis: None,
+            finished_at_millis: None,
+            error: None,
+            usage: Default::default(),
+            step_count: 0,
+        };
+        runs.push(run.clone());
+        rewrite_jsonl(&path, &runs).await?;
+        Ok(run)
+    }
+
+    async fn get_run(&self, company: &CompanyId, id: &str) -> Result<Option<RunRecord>> {
+        let runs = dedup_latest(read_jsonl::<RunRecord>(&self.bundle(company).runs_jsonl()).await?);
+        Ok(runs.into_iter().find(|r| r.id == id))
+    }
+
+    async fn put_run(&self, company: &CompanyId, run: &RunRecord) -> Result<()> {
+        let bundle = self.bundle(company);
+        bundle.ensure_dirs().await?;
+        let path = bundle.runs_jsonl();
+        let lock = self.locks.get(&path);
+        let _guard = lock.lock().await;
+        let mut runs = dedup_latest(read_jsonl::<RunRecord>(&path).await?);
+        match runs.iter_mut().find(|r| r.id == run.id) {
+            Some(existing) => *existing = run.clone(),
+            None => runs.push(run.clone()),
+        }
+        rewrite_jsonl(&path, &runs).await
+    }
+
+    async fn list_runs(&self, company: &CompanyId, filter: &RunFilter) -> Result<Vec<RunRecord>> {
+        let mut runs =
+            dedup_latest(read_jsonl::<RunRecord>(&self.bundle(company).runs_jsonl()).await?);
+        runs.retain(|r| filter.matches(r));
+        sort_newest_first(&mut runs);
+        if let Some(limit) = filter.limit {
+            runs.truncate(limit);
+        }
+        Ok(runs)
+    }
+
+    async fn append_run_step(&self, company: &CompanyId, step: &RunStepRecord) -> Result<()> {
+        let bundle = self.bundle(company);
+        bundle.ensure_dirs().await?;
+        let path = bundle.run_steps_jsonl();
+        let line = serde_json::to_string(step)?;
+        let lock = self.locks.get(&path);
+        let _guard = lock.lock().await;
+        // A genuine append: the trace only ever grows, and a replayed
+        // `(run_id, step_seq)` is folded out at read time rather than by
+        // rewriting the whole file per step.
+        append_line(&path, &line).await
+    }
+
+    async fn list_run_steps(
+        &self,
+        company: &CompanyId,
+        run_id: &str,
+    ) -> Result<Vec<RunStepRecord>> {
+        let steps = read_jsonl::<RunStepRecord>(&self.bundle(company).run_steps_jsonl()).await?;
+        Ok(dedup_steps(steps, run_id))
+    }
+}
+
+// ---------------------------------------------------------------------------
 // UsageMeter
 // ---------------------------------------------------------------------------
 
@@ -912,6 +1020,32 @@ impl HasId for ArtifactRecord {
     }
 }
 
+impl HasId for RunRecord {
+    fn record_id(&self) -> &str {
+        &self.id
+    }
+}
+
+/// Folds a raw `run-steps.jsonl` read down to one run's trace: the last record
+/// per `step_seq`, oldest first.
+///
+/// Steps are appended, never rewritten, so a replayed append leaves two lines
+/// with the same `(run_id, step_seq)`. Keeping the later one makes an append
+/// idempotent — the same guarantee the sqlite and MongoDB backends get from
+/// their composite primary key.
+fn dedup_steps(steps: Vec<RunStepRecord>, run_id: &str) -> Vec<RunStepRecord> {
+    let mut by_seq: HashMap<u32, RunStepRecord> = HashMap::new();
+    for step in steps {
+        if step.run_id != run_id {
+            continue;
+        }
+        by_seq.insert(step.step_seq, step);
+    }
+    let mut out: Vec<RunStepRecord> = by_seq.into_values().collect();
+    out.sort_by_key(|s| s.step_seq);
+    out
+}
+
 /// Keeps the last record per id (last-write-wins), preserving first-seen order.
 fn dedup_latest<T: HasId>(records: Vec<T>) -> Vec<T> {
     let mut order: Vec<String> = Vec::new();
@@ -992,6 +1126,20 @@ mod test {
         let root = root_dir.path().to_path_buf();
         conformance::assert_fact_store(Arc::new(FsOps::new(&root))).await;
         conformance::assert_artifact_store(Arc::new(FsOps::new(&root))).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_run_store() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        conformance::assert_run_store(Arc::new(FsOps::new(&root))).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_run_reaper() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        conformance::assert_run_reaper(Arc::new(FsOps::new(&root))).await;
     }
 
     #[tokio::test]

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -121,7 +121,7 @@ impl MongoStore {
         // Not every index can be unique: a user holds many sessions, and an
         // address may have several login codes over time.
         let nonunique = |keys: Document| IndexModel::builder().keys(keys).build();
-        let plans: [(&str, IndexModel); 24] = [
+        let plans: [(&str, IndexModel); 28] = [
             ("companies", unique(doc! {"company_id": 1})),
             ("ledger", unique(doc! {"company_id": 1, "idx": 1})),
             ("events", unique(doc! {"company_id": 1, "seq": 1})),
@@ -167,6 +167,14 @@ impl MongoStore {
                 unique(doc! {"company_id": 1, "code_hash": 1}),
             ),
             ("login_codes", nonunique(doc! {"company_id": 1, "email": 1})),
+            ("runs", unique(doc! {"company_id": 1, "run_id": 1})),
+            // A card has many attempts, and many attempts share a status.
+            ("runs", nonunique(doc! {"company_id": 1, "task_id": 1})),
+            ("runs", nonunique(doc! {"company_id": 1, "status": 1})),
+            (
+                "run_steps",
+                unique(doc! {"company_id": 1, "run_id": 1, "step_seq": 1}),
+            ),
         ];
         for (name, index) in plans {
             self.collection(name)
@@ -1374,6 +1382,185 @@ impl crate::ports::artifacts::ArtifactStore for MongoStore {
 }
 
 // ---------------------------------------------------------------------------
+// RunStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl crate::ports::runs::RunStore for MongoStore {
+    async fn create_run(
+        &self,
+        company: &CompanyId,
+        spec: crate::ports::runs::NewRun,
+    ) -> Result<crate::ports::runs::RunRecord> {
+        use crate::ports::runs::{RunRecord, RunStatus};
+
+        // The ordinal comes from the same atomic `$inc` counter the event and
+        // usage sequences use, keyed per card — so concurrent creates cannot
+        // collide even across processes. `next_seq` is 0-based; attempts are
+        // 1-based (`Attempt 1` is the first).
+        let attempt = self
+            .next_seq(company, &format!("run:{}", spec.task_id))
+            .await?
+            .saturating_add(1);
+        let run = RunRecord {
+            id: spec.id,
+            company: company.clone(),
+            task_id: spec.task_id,
+            agent_id: spec.agent_id,
+            attempt: attempt as u32,
+            status: RunStatus::Pending,
+            trigger_event_seq: None,
+            created_at_millis: now_millis(),
+            started_at_millis: None,
+            finished_at_millis: None,
+            error: None,
+            usage: Default::default(),
+            step_count: 0,
+        };
+        // A plain insert, not an upsert: the unique `(company_id, run_id)`
+        // index is what turns a repeated id into the port's documented
+        // conflict instead of a silently overwritten attempt.
+        let existing = self
+            .collection("runs")
+            .find_one(doc! {"company_id": company.as_ref(), "run_id": &run.id})
+            .await
+            .map_err(mongo_err)?;
+        if existing.is_some() {
+            return Err(OpenCompanyError::Conflict(format!(
+                "run '{}' already exists",
+                run.id
+            )));
+        }
+        self.collection("runs")
+            .insert_one(doc! {
+                "company_id": company.as_ref(),
+                "run_id": &run.id,
+                "task_id": &run.task_id,
+                "status": run.status.as_str(),
+                "attempt": run.attempt as i64,
+                "created_ms": run.created_at_millis as i64,
+                "run_json": serde_json::to_string(&run)?,
+            })
+            .await
+            .map_err(mongo_err)?;
+        Ok(run)
+    }
+
+    async fn get_run(
+        &self,
+        company: &CompanyId,
+        id: &str,
+    ) -> Result<Option<crate::ports::runs::RunRecord>> {
+        let found = self
+            .collection("runs")
+            .find_one(doc! {"company_id": company.as_ref(), "run_id": id})
+            .await
+            .map_err(mongo_err)?;
+        match found {
+            Some(doc) => Ok(Some(serde_json::from_str(&get_str(&doc, "run_json")?)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn put_run(
+        &self,
+        company: &CompanyId,
+        run: &crate::ports::runs::RunRecord,
+    ) -> Result<()> {
+        self.collection("runs")
+            .update_one(
+                doc! {"company_id": company.as_ref(), "run_id": &run.id},
+                doc! {"$set": {
+                    "task_id": &run.task_id,
+                    "status": run.status.as_str(),
+                    "attempt": run.attempt as i64,
+                    "created_ms": run.created_at_millis as i64,
+                    "run_json": serde_json::to_string(run)?,
+                }},
+            )
+            .with_options(UpdateOptions::builder().upsert(true).build())
+            .await
+            .map_err(mongo_err)?;
+        Ok(())
+    }
+
+    async fn list_runs(
+        &self,
+        company: &CompanyId,
+        filter: &crate::ports::runs::RunFilter,
+    ) -> Result<Vec<crate::ports::runs::RunRecord>> {
+        let mut query = doc! {"company_id": company.as_ref()};
+        if let Some(task_id) = &filter.task_id {
+            query.insert("task_id", task_id.as_str());
+        }
+        if !filter.statuses.is_empty() {
+            let statuses: Vec<&str> = filter.statuses.iter().map(|s| s.as_str()).collect();
+            query.insert("status", doc! {"$in": statuses});
+        }
+        // The canonical port ordering (see `runs::sort_newest_first`), pushed
+        // into the query so the limit truncates the right end.
+        let runs = self.collection("runs");
+        let mut find = runs
+            .find(query)
+            .sort(doc! {"created_ms": -1, "attempt": -1, "run_id": -1});
+        if let Some(limit) = filter.limit
+            && let Some(limit) = find_limit(limit)
+        {
+            find = find.limit(limit);
+        }
+        let mut cursor = find.await.map_err(mongo_err)?;
+        let mut out = Vec::new();
+        while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
+            out.push(serde_json::from_str(&get_str(&doc, "run_json")?)?);
+        }
+        Ok(out)
+    }
+
+    async fn append_run_step(
+        &self,
+        company: &CompanyId,
+        step: &crate::ports::runs::RunStepRecord,
+    ) -> Result<()> {
+        // Upsert on `(run_id, step_seq)`: a replayed append overwrites rather
+        // than duplicating, matching the other two backends.
+        self.collection("run_steps")
+            .update_one(
+                doc! {
+                    "company_id": company.as_ref(),
+                    "run_id": &step.run_id,
+                    "step_seq": step.step_seq as i64,
+                },
+                doc! {"$set": {
+                    "at_ms": step.at_millis as i64,
+                    "step_json": serde_json::to_string(step)?,
+                }},
+            )
+            .with_options(UpdateOptions::builder().upsert(true).build())
+            .await
+            .map_err(mongo_err)?;
+        Ok(())
+    }
+
+    async fn list_run_steps(
+        &self,
+        company: &CompanyId,
+        run_id: &str,
+    ) -> Result<Vec<crate::ports::runs::RunStepRecord>> {
+        let mut cursor = self
+            .collection("run_steps")
+            .find(doc! {"company_id": company.as_ref(), "run_id": run_id})
+            .sort(doc! {"step_seq": 1})
+            .await
+            .map_err(mongo_err)?;
+        let mut out = Vec::new();
+        while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
+            out.push(serde_json::from_str(&get_str(&doc, "step_json")?)?);
+        }
+        Ok(out)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // UsageMeter
 // ---------------------------------------------------------------------------
 
@@ -1876,6 +2063,20 @@ mod test {
     async fn conformance_context_chunk_stamps() {
         let Some(s) = store().await else { return };
         conformance::assert_context_chunk_stamps(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_run_store() {
+        let Some(s) = store().await else { return };
+        conformance::assert_run_store(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_run_reaper() {
+        let Some(s) = store().await else { return };
+        conformance::assert_run_reaper(s.clone()).await;
         drop_db(&s).await;
     }
 

--- a/src/store/paths.rs
+++ b/src/store/paths.rs
@@ -283,6 +283,31 @@ impl Bundle {
         self.dir.join("artifacts.jsonl")
     }
 
+    /// Path to the task-run log (`runs.jsonl`, one [`RunRecord`] per line;
+    /// last-write-wins per id).
+    ///
+    /// One shared log rather than a file per run: a run id would otherwise
+    /// become a path component, and a store must never let an id it did not
+    /// mint address the filesystem.
+    ///
+    /// [`RunRecord`]: crate::ports::runs::RunRecord
+    pub fn runs_jsonl(&self) -> PathBuf {
+        self.dir.join("runs.jsonl")
+    }
+
+    /// Path to the run step traces (`run-steps.jsonl`, one
+    /// [`RunStepRecord`] per line; last-write-wins per `(run_id, step_seq)`).
+    ///
+    /// Separate from `runs.jsonl` so a step is a **true append** — the run row
+    /// mutates on every transition and is rewritten, but a trace only ever
+    /// grows, and rewriting the whole trace per step would make a long attempt
+    /// quadratic.
+    ///
+    /// [`RunStepRecord`]: crate::ports::runs::RunStepRecord
+    pub fn run_steps_jsonl(&self) -> PathBuf {
+        self.dir.join("run-steps.jsonl")
+    }
+
     /// Path to the human user directory (`users.json`, the full set as a JSON
     /// array).
     pub fn users_json(&self) -> PathBuf {

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -24,6 +24,7 @@ use crate::ports::facts::FactStore;
 use crate::ports::inbox::InboxStore;
 use crate::ports::login_codes::LoginCodeStore;
 use crate::ports::memory::MemoryStore;
+use crate::ports::runs::RunStore;
 use crate::ports::secrets::SecretStore;
 use crate::ports::sessions::SessionStore;
 use crate::ports::skills_state::SkillStateStore;
@@ -133,6 +134,8 @@ pub struct StorageHandles {
     pub workspace: Arc<dyn WorkspaceStore>,
     pub facts: Arc<dyn FactStore>,
     pub artifacts: Arc<dyn ArtifactStore>,
+    /// First-class task-run records and their step traces (#242).
+    pub runs: Arc<dyn RunStore>,
     pub usage: Arc<dyn UsageMeter>,
     pub skills: Arc<dyn SkillStateStore>,
     pub users: Arc<dyn UserStore>,
@@ -386,6 +389,7 @@ fn open_sqlite(data_dir: &Path) -> Result<Option<StorageHandles>> {
         workspace: store.clone(),
         facts: store.clone(),
         artifacts: store.clone(),
+        runs: store.clone(),
         usage: store.clone(),
         skills: store.clone(),
         users: store.clone(),
@@ -422,6 +426,7 @@ async fn open_mongodb(settings: &StorageSettings) -> Result<Option<StorageHandle
         workspace: store.clone(),
         facts: store.clone(),
         artifacts: store.clone(),
+        runs: store.clone(),
         usage: store.clone(),
         skills: store.clone(),
         users: store.clone(),

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -139,6 +139,26 @@ CREATE TABLE IF NOT EXISTS artifacts (
     PRIMARY KEY (company_id, id)
 );
 CREATE INDEX IF NOT EXISTS artifacts_by_task ON artifacts (company_id, task_id);
+CREATE TABLE IF NOT EXISTS runs (
+    company_id TEXT NOT NULL,
+    id         TEXT NOT NULL,
+    task_id    TEXT NOT NULL,
+    status     TEXT NOT NULL,
+    attempt    INTEGER NOT NULL,
+    created_ms INTEGER NOT NULL,
+    run_json   TEXT NOT NULL,
+    PRIMARY KEY (company_id, id)
+);
+CREATE INDEX IF NOT EXISTS runs_by_task ON runs (company_id, task_id);
+CREATE INDEX IF NOT EXISTS runs_by_status ON runs (company_id, status);
+CREATE TABLE IF NOT EXISTS run_steps (
+    company_id TEXT NOT NULL,
+    run_id     TEXT NOT NULL,
+    step_seq   INTEGER NOT NULL,
+    at_ms      INTEGER NOT NULL,
+    step_json  TEXT NOT NULL,
+    PRIMARY KEY (company_id, run_id, step_seq)
+);
 CREATE TABLE IF NOT EXISTS usage_samples (
     company_id TEXT NOT NULL,
     seq        INTEGER NOT NULL,
@@ -1526,6 +1546,224 @@ impl crate::ports::artifacts::ArtifactStore for SqliteStore {
 }
 
 // ---------------------------------------------------------------------------
+// RunStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl crate::ports::runs::RunStore for SqliteStore {
+    async fn create_run(
+        &self,
+        company: &CompanyId,
+        spec: crate::ports::runs::NewRun,
+    ) -> Result<crate::ports::runs::RunRecord> {
+        use crate::ports::runs::{RunRecord, RunStatus};
+
+        let mut guard = self.conn();
+        // Read-max-then-insert inside one transaction, so two concurrent
+        // creates on one card cannot mint the same ordinal. This is the
+        // "transactional where the backend can do so cheaply" half of the
+        // port's `create_run` concurrency contract.
+        let tx = guard.transaction().map_err(sql_err)?;
+        let exists: bool = tx
+            .query_row(
+                "SELECT 1 FROM runs WHERE company_id = ?1 AND id = ?2",
+                params![company.as_ref(), spec.id],
+                |_| Ok(true),
+            )
+            .optional()
+            .map_err(sql_err)?
+            .unwrap_or(false);
+        if exists {
+            return Err(OpenCompanyError::Conflict(format!(
+                "run '{}' already exists",
+                spec.id
+            )));
+        }
+        let attempt: i64 = tx
+            .query_row(
+                "SELECT COALESCE(MAX(attempt), 0) + 1 FROM runs \
+                 WHERE company_id = ?1 AND task_id = ?2",
+                params![company.as_ref(), spec.task_id],
+                |r| r.get(0),
+            )
+            .map_err(sql_err)?;
+        let run = RunRecord {
+            id: spec.id,
+            company: company.clone(),
+            task_id: spec.task_id,
+            agent_id: spec.agent_id,
+            attempt: attempt as u32,
+            status: RunStatus::Pending,
+            trigger_event_seq: None,
+            created_at_millis: now_millis(),
+            started_at_millis: None,
+            finished_at_millis: None,
+            error: None,
+            usage: Default::default(),
+            step_count: 0,
+        };
+        tx.execute(
+            "INSERT INTO runs (company_id, id, task_id, status, attempt, created_ms, run_json) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                company.as_ref(),
+                run.id,
+                run.task_id,
+                run.status.as_str(),
+                run.attempt as i64,
+                run.created_at_millis as i64,
+                serde_json::to_string(&run)?,
+            ],
+        )
+        .map_err(sql_err)?;
+        tx.commit().map_err(sql_err)?;
+        Ok(run)
+    }
+
+    async fn get_run(
+        &self,
+        company: &CompanyId,
+        id: &str,
+    ) -> Result<Option<crate::ports::runs::RunRecord>> {
+        let conn = self.conn();
+        let json: Option<String> = conn
+            .query_row(
+                "SELECT run_json FROM runs WHERE company_id = ?1 AND id = ?2",
+                params![company.as_ref(), id],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(sql_err)?;
+        match json {
+            Some(json) => Ok(Some(serde_json::from_str(&json)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn put_run(
+        &self,
+        company: &CompanyId,
+        run: &crate::ports::runs::RunRecord,
+    ) -> Result<()> {
+        let json = serde_json::to_string(run)?;
+        let conn = self.conn();
+        // `status` and `task_id` are mirrored out of the blob so the indexes
+        // can answer a filtered list without deserializing every row.
+        conn.execute(
+            "INSERT INTO runs (company_id, id, task_id, status, attempt, created_ms, run_json) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) \
+             ON CONFLICT(company_id, id) DO UPDATE SET task_id = excluded.task_id, \
+             status = excluded.status, attempt = excluded.attempt, \
+             created_ms = excluded.created_ms, run_json = excluded.run_json",
+            params![
+                company.as_ref(),
+                run.id,
+                run.task_id,
+                run.status.as_str(),
+                run.attempt as i64,
+                run.created_at_millis as i64,
+                json,
+            ],
+        )
+        .map_err(sql_err)?;
+        Ok(())
+    }
+
+    async fn list_runs(
+        &self,
+        company: &CompanyId,
+        filter: &crate::ports::runs::RunFilter,
+    ) -> Result<Vec<crate::ports::runs::RunRecord>> {
+        // Every predicate is pushed into SQL (both columns are indexed) so a
+        // long-lived company does not deserialize its whole run history to
+        // answer one card's Attempts list.
+        let mut sql = String::from("SELECT run_json FROM runs WHERE company_id = ?1");
+        let mut args: Vec<String> = vec![company.as_ref().to_string()];
+        if let Some(task_id) = &filter.task_id {
+            args.push(task_id.clone());
+            sql.push_str(&format!(" AND task_id = ?{}", args.len()));
+        }
+        if !filter.statuses.is_empty() {
+            let placeholders: Vec<String> = filter
+                .statuses
+                .iter()
+                .map(|status| {
+                    args.push(status.as_str().to_string());
+                    format!("?{}", args.len())
+                })
+                .collect();
+            sql.push_str(&format!(" AND status IN ({})", placeholders.join(", ")));
+        }
+        // The canonical port ordering, in SQL: see `runs::sort_newest_first`.
+        sql.push_str(" ORDER BY created_ms DESC, attempt DESC, id DESC");
+        if let Some(limit) = filter.limit {
+            sql.push_str(&format!(" LIMIT {}", sql_limit(limit)));
+        }
+        let conn = self.conn();
+        let mut stmt = conn.prepare(&sql).map_err(sql_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(args.iter()), |r| {
+                r.get::<_, String>(0)
+            })
+            .map_err(sql_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(serde_json::from_str(&row.map_err(sql_err)?)?);
+        }
+        Ok(out)
+    }
+
+    async fn append_run_step(
+        &self,
+        company: &CompanyId,
+        step: &crate::ports::runs::RunStepRecord,
+    ) -> Result<()> {
+        let json = serde_json::to_string(step)?;
+        let conn = self.conn();
+        // `(run_id, step_seq)` is the primary key, so a replayed append
+        // overwrites rather than duplicating — the same idempotence the fs
+        // backend gets by folding its JSONL.
+        conn.execute(
+            "INSERT INTO run_steps (company_id, run_id, step_seq, at_ms, step_json) \
+             VALUES (?1, ?2, ?3, ?4, ?5) \
+             ON CONFLICT(company_id, run_id, step_seq) DO UPDATE SET \
+             at_ms = excluded.at_ms, step_json = excluded.step_json",
+            params![
+                company.as_ref(),
+                step.run_id,
+                step.step_seq as i64,
+                step.at_millis as i64,
+                json,
+            ],
+        )
+        .map_err(sql_err)?;
+        Ok(())
+    }
+
+    async fn list_run_steps(
+        &self,
+        company: &CompanyId,
+        run_id: &str,
+    ) -> Result<Vec<crate::ports::runs::RunStepRecord>> {
+        let conn = self.conn();
+        let mut stmt = conn
+            .prepare(
+                "SELECT step_json FROM run_steps WHERE company_id = ?1 AND run_id = ?2 \
+                 ORDER BY step_seq",
+            )
+            .map_err(sql_err)?;
+        let rows = stmt
+            .query_map(params![company.as_ref(), run_id], |r| r.get::<_, String>(0))
+            .map_err(sql_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(serde_json::from_str(&row.map_err(sql_err)?)?);
+        }
+        Ok(out)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // UsageMeter
 // ---------------------------------------------------------------------------
 
@@ -2034,6 +2272,16 @@ mod test {
             "INTEGER NOT NULL DEFAULT 0",
         )
         .expect("adding an existing column is a no-op, not an error");
+    }
+
+    #[tokio::test]
+    async fn conformance_run_store() {
+        conformance::assert_run_store(store()).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_run_reaper() {
+        conformance::assert_run_reaper(store()).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

First slice of #242. This adds the **object** — a `RunStore` port, three conforming backends, and a boot reaper — and nothing else.

**Zero behaviour change: nothing writes a run record yet.** That is deliberate. The write path (run wraps the cycle, incremental trace, approval correlation) is PR-2; the REST and console surfaces are PR-3. Slicing this way keeps each PR independently green and reviewable, and lets the port's shape be argued before anything depends on it.

Two things ship value today:

- **The boot reaper.** An attempt that died with its process stops being invisible — on startup every `Pending`/`Running` row becomes `Failed` with an orphan reason and a finish stamp.
- **The seam three blocked issues need.** #333 (approvals carry no attempt id), #244 (artifacts have nowhere to attach), and #337 (auto-advance has no status to read) are all waiting on exactly this.

## Problem

A task attempt is currently ephemeral. `CycleRequest`/`CycleResult` produce a scrubbed `Vec<TurnStep>` that gets folded once at turn end into an `AgentReply` event and discarded as a unit. No id, no status, no per-attempt cost, and no trace that survives the process.

The closest existing thing — `WorkflowRunFinished` — shows both the model to generalise and its limits: written best-effort *after* the run (so a crashed run records nothing), read back by folding the **entire journal** on every GET, and carrying a `run_id: None` field that was reserved for this issue.

**Why a store and not more journal events** — this was argued, not assumed. Runs are mutable, queryable state; the journal is an append-only trail shared with chat and audit. Reading runs by journal-fold is a cost the existing workflow-run list already demonstrates, and one event per `TurnStep` would flood every `chat_history` reload. Events stay the immutable trail; run rows are the record of state.

## Solution

**A transition API, not free-form upserts.** `create_run` mints `Pending` and computes the attempt ordinal; `begin_run` moves `Pending → Running`; `finish_run` writes a terminal status with its error, usage and step count. Legality lives in provided trait methods, so a backend only ever sees storage verbs and no backend can re-derive the state machine. The pre-#205 vanishing-card bug is the argument against letting callers write whatever they like.

**`RunStatus` encodes two decisions from the spine epic (#183):**

- `Paused` and `WaitingApproval` are distinct because **who unblocks it** is the distinction that matters — a person must act → `WaitingApproval`; a dependency, rate limit, missing credential or retry → `Paused`. The reaper never touches either: parked is not orphaned.
- `WaitingApproval` is re-enterable across attempts, because #243's grants are single-use and argument-exact. A run that could only stop once would force batched approvals, which is the property #243 exists to avoid.

The transition table permits both **without hard-coding any producer policy** — PR-2 decides when to write them.

**The reaper is a proof, not a timeout heuristic.** Three invariants were re-verified against this base and all three hold: cycles are process-local `tokio::spawn`s (`company/runtime.rs`, `runtime/scheduler.rs`); exactly one process may write a given company's journal (`runtime/journal.rs` states this as an invariant); and cycles serialise on a per-company mutex (`runtime/cycle.rs`). Therefore any `Pending`/`Running` row present at boot is necessarily dead. Nothing here waits out a timer.

## Submission Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **1713 passed, 0 failed**, 1 ignored, of which **15 are new**
- [x] `cargo check --locked --all-features --all-targets` — the only gate that compiles the sqlite and mongodb backends this PR adds
- [x] `git diff --stat Cargo.lock` — empty
- [x] `npm ci`, `npm run typecheck`, `npm run build` — frontend untouched, confirmed unbroken
- [x] Verified on a real host, on two backends

**The reaper was proven on a running host, not just in a unit test.** On the **fs** backend: booted the harness company with an isolated home, hand-seeded a `running`, a `pending` and a `waiting_approval` row, restarted — both active rows became `failed` with the orphan reason and a finish stamp, and the parked row was left alone. Repeated on **sqlite**: the `runs` and `run_steps` tables and their indexes were created on first boot, the same reap result held, and the reaper logged its count.

Conformance (`assert_run_store` + `assert_run_reaper`) runs against fs and sqlite in CI; the mongodb pair compiles and self-skips without a live server.

## Impact

No behaviour change. Nothing calls the new port yet, no existing route or event moved, and no migration is needed — sqlite gains two additive `CREATE TABLE IF NOT EXISTS` statements, mongodb two collections, fs two JSONL files.

**Three decisions worth a reviewer's attention:**

**The fs layout deviates from the plan, on purpose.** The plan said "per-run JSON file plus a JSONL steps file". A per-run file would make the **run id a path component**, and a store must never let an id it did not mint address the filesystem. Shipped instead: `runs.jsonl` (last-write-wins per id) and `run-steps.jsonl` (true append, folded per `(run_id, step_seq)` at read). The property the plan cared about — steps are a genuine append rather than a per-step rewrite — is preserved exactly, and it reuses the existing helpers.

**`attempt` is 1-based** — `Attempt 1` is a card's first run, unlike the codebase's 0-based event seqs. Chosen for how PR-3 will render it; pinned by conformance so it cannot drift.

**`put_run` is a public unchecked write.** Rust cannot hide a trait method from a `dyn` caller, so the escape hatch exists. It is documented as the backend seam, no caller uses it, and the three transitions are provided methods so the state machine cannot be bypassed by a backend. Sealing it properly means a separate `RunStorage` supertrait plus a blanket impl — deliberately not done here, to keep this port shaped like every other port in the tree.

**Two known gaps, neither a blocker:**

- **Runs are not in the bundle export.** `export.rs` reads every port and writes the canonical fs layout; `RunStore` is not wired into it, so an exported bundle carries no run history. Out of scope here; worth a follow-up decision.
- The attempt ordinal is transactional on sqlite and best-effort on fs. Benign in practice because dispatch serialises through the awaited board write; conformance documents the contract rather than pretending atomicity.

## Related

Part of #242 — this is **PR-1 of 3**. PR-2 is the write path, PR-3 the REST and console surfaces.
Part of #183 — the spine epic.
Unblocks #333, #244 and #337 once PR-2 lands.
