### PR TITLE
feat(console): edit a saved workflow (#259)

### DIFF
--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -165,6 +165,26 @@ curl -X DELETE "$HOST/api/v1/company/workflows/weekly_digest?expectedVersion=a60
      -H "Authorization: Bearer $TOKEN"
 ```
 
+**In the console.** The Workflows view offers Edit and Delete side by side, both
+greyed out with the host's own explanation when `editable` is `false` — an
+explicit `false` only, since a host predating this sends no such field and
+`undefined` must not read as a refusal. Edit reopens the create dialog hydrated
+from the saved graph, with the **id read-only** (a rename is a `400`, so
+offering the field would be a trap) and `version` sent as `expectedVersion`. A
+`409` leaves the dialog open with the host's message and raises the same
+persistent conflict banner Delete uses, whose Reload re-reads the graph and its
+token; nothing is retried without one.
+
+**An edit does not disarm a schedule.** OpenHuman's `flows_update` forces
+`enabled = false` when an edit turns a manual trigger into an automatic one, so
+a new schedule cannot go live unreviewed. This host has no equivalent and
+deliberately gains none here: `WorkflowScheduler::tick` does not gate on
+`[workflows].enabled` at all, so writing `false` would stop nothing, and
+`adding_a_schedule_by_edit_arms_the_workflow_on_the_next_tick` pins that. An
+edit is therefore exactly as live as a create, which already persists a running
+schedule the same way. Reversing this means first making the scheduler honour
+`enabled`, which is the enable/disable follow-up below.
+
 **Deliberately not in #259**, each its own follow-up: revision history and
 rollback (OpenHuman keeps a bounded snapshot ring in a dedicated table; our
 overlay bodies live inside `CompanyRecord`, which is saved whole on every write,

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -3,6 +3,12 @@
 // are restricted to the ones the engine actually executes today
 // (`CREATABLE_NODE_KINDS`); `tool_call`/`http_request` stay off the palette
 // until they're wired (see `src/workflows/caps.rs`).
+//
+// It is also the EDITOR (issue #259): pass a `workflow` and the same form
+// hydrates from that saved graph and saves through `updateWorkflow`, carrying
+// the graph's `version` as the optimistic-concurrency token. One component
+// rather than two because an edit is the same form with the same rules — a
+// second one would drift the moment either side grew a field.
 
 import { useEffect, useId, useState } from "react";
 import { Plus, Trash2 } from "lucide-react";
@@ -11,12 +17,14 @@ import {
   CREATABLE_NODE_KINDS,
   DESTINATION_KINDS,
   createWorkflow,
+  updateWorkflow,
   type WorkflowDestination,
   type WorkflowEdge,
   type WorkflowGraph,
   type WorkflowNode,
 } from "@/api/workflows";
 import type { OpenCompanyClient } from "@/api/client";
+import { ApiError } from "@/api/types";
 import { CronPreviewLine } from "@/views/CronPreviewLine";
 import type { TeamMemberDto } from "@/api/types";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -57,6 +65,24 @@ interface DraftNode {
   destinationKind: "" | WorkflowDestination["kind"];
   /** The address (`email`) or channel id (`channel`). Unused for `owner`. */
   destinationTarget: string;
+  /**
+   * Fields the form has no control for, carried through an edit **verbatim**
+   * (issue #259).
+   *
+   * An overlay graph can carry them — `POST`/`PUT` accept them and the
+   * orchestrator's own `create_workflow` tool writes them — so a graph authored
+   * outside this dialog can reach it. Rebuilding the node from the visible
+   * controls alone would then quietly delete a retry policy or an approval gate
+   * on the first save, which is a worse bug than the write-once one this fixes.
+   *
+   * They ride on the ROW, not on the node id, so they follow the row when its
+   * id is edited. `config` is the exception: it is kind-specific, so
+   * {@link changeKind} drops it along with every other kind-conditional field.
+   */
+  config?: unknown;
+  onError?: string;
+  retry?: WorkflowNode["retry"];
+  requiresApproval?: boolean;
 }
 
 /** "No schedule" — the workflow runs only when something starts it. A sentinel
@@ -194,7 +220,18 @@ function nextKey(): string {
  * this reset.
  */
 function changeKind(kind: string): Partial<DraftNode> {
-  return { kind, agent: "", schedule: "", destinationKind: "", destinationTarget: "" };
+  return {
+    kind,
+    agent: "",
+    schedule: "",
+    destinationKind: "",
+    destinationTarget: "",
+    // Kind-specific by definition (a `switch`'s cases, a `sub_workflow`'s
+    // target), so it means nothing on the new kind — and unlike the fields
+    // above there is no control that could ever show what was dropped. The
+    // kind-agnostic policies (`onError`, `retry`, `requiresApproval`) are kept.
+    config: undefined,
+  };
 }
 
 /** A blank node row, so every construction site stays in step as the shape grows. */
@@ -217,6 +254,43 @@ function starterNodes(): DraftNode[] {
   return [blankNode({ id: "start", kind: "trigger", name: "Start" })];
 }
 
+/** The saved graph's nodes as draft rows (issue #259).
+ *
+ * Every row goes through {@link blankNode}, so each gets a **fresh** `key` from
+ * `nextKey()`. Reusing the saved node ids as keys would be the obvious shortcut
+ * and a real bug: `fieldErrors` is keyed on `key`, so two graphs that share a
+ * node id (`start` is the starter row's id, so most of them do) would share an
+ * error map, and a complaint raised on one graph would render on the next.
+ */
+function draftNodes(graph: WorkflowGraph): DraftNode[] {
+  return graph.nodes.map((n) =>
+    blankNode({
+      id: n.id,
+      kind: n.kind,
+      name: n.name,
+      summary: n.summary ?? "",
+      agent: n.agent ?? "",
+      schedule: n.schedule ?? "",
+      destinationKind: n.destination?.kind ?? "",
+      destinationTarget: n.destination?.target ?? "",
+      config: n.config,
+      onError: n.onError,
+      retry: n.retry,
+      requiresApproval: n.requiresApproval,
+    }),
+  );
+}
+
+/** The saved graph's edges as draft rows, on the same fresh-key rule. */
+function draftEdges(graph: WorkflowGraph): DraftEdge[] {
+  return graph.edges.map((e) => ({
+    key: nextKey(),
+    from: e.from,
+    to: e.to,
+    label: e.label ?? "",
+  }));
+}
+
 /** A safe on-disk id: only letters, digits, `_`, and `-` — a subset of what the
  * host's `safe_wid` accepts (any single path component), chosen to keep ids
  * simple and unambiguous without a round-trip to the server first. */
@@ -230,13 +304,33 @@ export function WorkflowCreateDialog({
   open,
   onOpenChange,
   onCreated,
+  workflow = null,
+  onSaved,
+  onConflict,
 }: {
   client: OpenCompanyClient;
   company: string | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onCreated: (graph: WorkflowGraph) => void;
+  /** Called with the stored graph after a create. Create mode only. */
+  onCreated?: (graph: WorkflowGraph) => void;
+  /**
+   * The saved graph to edit (issue #259). `null` is create mode. Pass the graph
+   * straight from `getWorkflow` — its `version` is what makes the save
+   * conditional, so a copy without one silently loses the guard.
+   */
+  workflow?: WorkflowGraph | null;
+  /** Called with the stored graph, and its FRESH version, after an edit. */
+  onSaved?: (graph: WorkflowGraph) => void;
+  /**
+   * The host's message when it refused the save with a `409` — the graph moved
+   * under this edit, or the new display name is taken. The dialog stays open
+   * with the same message inline (so the author keeps what they typed); this
+   * hands it to the view, whose persistent banner carries the way out (Reload).
+   */
+  onConflict?: (message: string) => void;
 }) {
+  const editing = workflow !== null;
   const [id, setId] = useState("");
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -254,13 +348,23 @@ export function WorkflowCreateDialog({
 
   // Reload the roster (for the agent-node picker) and reset the draft each
   // time the dialog opens, so a prior attempt never leaks into the next one.
+  //
+  // Edit mode hydrates HERE rather than anywhere else on purpose (issue #259):
+  // this is the one place `fieldErrors` is cleared, so a draft populated by any
+  // other path would carry the previous graph's errors — attached to rows that
+  // no longer exist and pointing at fields nobody can see.
+  //
+  // `workflow` is a dependency, so the conflict banner's Reload re-hydrates an
+  // open dialog with the fresh graph and its fresh token. That discards what
+  // was typed, which is the honest outcome: Reload means "show me the latest",
+  // and keeping the edit would keep the stale token with it.
   useEffect(() => {
     if (!open) return;
-    setId("");
-    setName("");
-    setDescription("");
-    setNodes(starterNodes());
-    setEdges([]);
+    setId(workflow?.id ?? "");
+    setName(workflow?.name ?? "");
+    setDescription(workflow?.description ?? "");
+    setNodes(workflow ? draftNodes(workflow) : starterNodes());
+    setEdges(workflow ? draftEdges(workflow) : []);
     setError(null);
     setFieldErrors({});
     let live = true;
@@ -277,7 +381,7 @@ export function WorkflowCreateDialog({
     return () => {
       live = false;
     };
-  }, [open, client, company]);
+  }, [open, client, company, workflow]);
 
   function addNode() {
     setNodes((rows) => [...rows, blankNode()]);
@@ -445,6 +549,13 @@ export function WorkflowCreateDialog({
                       : n.destinationTarget.trim() || undefined,
                 }
               : undefined,
+          // Whatever the form has no control for, straight back out again — an
+          // edit must not delete what it cannot show. Always `undefined` on a
+          // create, and `undefined` is omitted from the JSON body.
+          config: n.config,
+          onError: n.onError,
+          retry: n.retry,
+          requiresApproval: n.requiresApproval,
         }),
       ),
       edges: edges.map(
@@ -456,11 +567,42 @@ export function WorkflowCreateDialog({
       ),
     };
     try {
-      const created = await createWorkflow(client, company, graph);
-      onCreated(created);
+      if (workflow) {
+        // The id keys the saved graph, the schedule and the run history, so it
+        // is the graph's own id that is sent, not the (read-only) field —
+        // there is no path here that renames anything, and the host answers
+        // 400 if one ever appeared. `version` makes the write conditional: it
+        // means "save over the graph I was looking at", not "over whatever is
+        // there now". The response carries a fresh token, so a second save
+        // needs no intervening read.
+        const saved = await updateWorkflow(
+          client,
+          company,
+          workflow.id,
+          graph,
+          workflow.version,
+        );
+        onSaved?.(saved);
+      } else {
+        const created = await createWorkflow(client, company, graph);
+        onCreated?.(created);
+      }
       onOpenChange(false);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "could not create the workflow");
+      setError(
+        e instanceof Error
+          ? e.message
+          : workflow
+            ? "could not save the workflow"
+            : "could not create the workflow",
+      );
+      // A refused write is the one failure the operator can act on, and the
+      // action (reload, or pick another name) happens out in the view — so it
+      // is raised there too, where the banner persists past this dialog. The
+      // dialog stays open with the same message so the edit is not thrown away.
+      if (workflow && e instanceof ApiError && e.status === 409) {
+        onConflict?.(e.message);
+      }
     } finally {
       setSubmitting(false);
     }
@@ -470,21 +612,36 @@ export function WorkflowCreateDialog({
     <Dialog open={open} onOpenChange={(o) => !submitting && onOpenChange(o)}>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
-          <DialogTitle>New workflow</DialogTitle>
+          <DialogTitle>{editing ? "Edit workflow" : "New workflow"}</DialogTitle>
           <DialogDescription>
-            Define the graph by hand — nodes, then how they connect.
+            {editing
+              ? "Change the nodes, how they connect, or when it runs. Saving replaces the whole graph."
+              : "Define the graph by hand — nodes, then how they connect."}
           </DialogDescription>
         </DialogHeader>
 
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="grid gap-2">
             <Label htmlFor={`${formId}-id`}>Id</Label>
+            {/* Read-only in edit mode, not merely rejected on save: the id keys
+                the saved graph, the scheduler and every past run, so the host
+                answers 400 to a rename. Letting an author type a new one and
+                then refusing it would be a trap. */}
             <Input
               id={`${formId}-id`}
               value={id}
               onChange={(e) => setId(e.target.value)}
+              readOnly={editing}
+              aria-readonly={editing || undefined}
+              className={editing ? "text-muted-foreground" : undefined}
               placeholder="e.g. campaign_pipeline"
             />
+            {editing && (
+              <p className="text-[11px] leading-snug text-muted-foreground">
+                A workflow&apos;s id can&apos;t change. It keys the saved graph, its
+                schedule and its run history.
+              </p>
+            )}
           </div>
           <div className="grid gap-2">
             <Label htmlFor={`${formId}-name`}>Name</Label>
@@ -580,8 +737,18 @@ export function WorkflowCreateDialog({
           <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={submitting}>
             Cancel
           </Button>
-          <Button onClick={() => void submit()} disabled={submitting}>
-            {submitting ? "Creating…" : "Create workflow"}
+          <Button
+            onClick={() => void submit()}
+            disabled={submitting}
+            data-testid="workflow-dialog-submit"
+          >
+            {editing
+              ? submitting
+                ? "Saving…"
+                : "Save changes"
+              : submitting
+                ? "Creating…"
+                : "Create workflow"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -10,7 +10,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useTheme } from "next-themes";
-import { History, Loader2, Play, Plus, RotateCw, Trash2 } from "lucide-react";
+import { History, Loader2, Pencil, Play, Plus, RotateCw, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -101,6 +101,10 @@ export function WorkflowsView({
   const [ranWith, setRanWith] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
+  // Issue #259: the same dialog, hydrated from the selected graph. Separate
+  // state from `createOpen` rather than a mode flag, so the create path keeps
+  // working exactly as it did and neither can be half-open.
+  const [editOpen, setEditOpen] = useState(false);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   // Issue #228: what past runs did, read back from the host's journal. This is
   // the half that survives a reload — before it, a manual run's delivery rows
@@ -300,6 +304,30 @@ export function WorkflowsView({
     }
   }, [client, company, selectedId, graph, workflows]);
 
+  // Issue #259: the edit dialog saved. The host answers with the stored graph
+  // AND a fresh version token, so holding onto it is what lets the operator
+  // save again without a re-read — dropping it and re-fetching would be a round
+  // trip that can only return the same thing.
+  const handleSaved = useCallback((saved: WorkflowGraph) => {
+    setGraph(saved);
+    // The name and description are editable, so the picker entry has to move
+    // with them. The id cannot change, which is what makes this a rewrite of
+    // one row rather than a re-list.
+    setWorkflows((prev) =>
+      prev
+        .map((w) =>
+          w.id === saved.id
+            ? { ...w, name: saved.name, description: saved.description }
+            : w,
+        )
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    );
+    // The write landed, so whatever we hold is current — the same reasoning as
+    // the graph-load effect's clear.
+    setConflict(null);
+    toast.success("Workflow saved.");
+  }, []);
+
   // The creator posts the full graph back, so the new entry can be spliced
   // straight into the list and selected — no extra round trip to re-list.
   const handleCreated = useCallback((created: WorkflowGraph) => {
@@ -340,8 +368,11 @@ export function WorkflowsView({
   // read as a refusal, so only an explicit `false` disables the affordance.
   const notEditable = graph?.editable === false;
   const canDelete = !!graph && !notEditable && !deleting;
+  // Same predicate as Delete, and deliberately the same explanation: the host
+  // refuses both writes for the same reason, with one message.
+  const canEdit = !!graph && !notEditable && !loadingGraph && !deleting;
   const notEditableReason = graph
-    ? `“${graph.name}” is defined by a file in the company source tree, so it can't be removed from the console. Edit workflows/${graph.id}.toml in the company repository instead.`
+    ? `“${graph.name}” is defined by a file in the company source tree, so it can't be changed or removed from the console. Edit workflows/${graph.id}.toml in the company repository instead.`
     : undefined;
 
   return (
@@ -427,6 +458,19 @@ export function WorkflowsView({
           {/* Issue #259. The wrapping span carries the explanation: a disabled
               button swallows pointer events in most browsers, so a `title` on
               the button itself would never show. */}
+          <span title={notEditable ? notEditableReason : undefined}>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setEditOpen(true)}
+              disabled={!canEdit}
+              aria-label="Edit workflow"
+              data-testid="workflow-edit"
+            >
+              <Pencil className="mr-1.5 size-4" />
+              Edit
+            </Button>
+          </span>
           <span title={notEditable ? notEditableReason : undefined}>
             <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
               <AlertDialogTrigger
@@ -577,6 +621,25 @@ export function WorkflowsView({
         open={createOpen}
         onOpenChange={setCreateOpen}
         onCreated={handleCreated}
+      />
+
+      {/* Issue #259: the same dialog in edit mode. `graph` carries the version
+          token the save is conditional on, so it is passed as loaded rather
+          than copied — and a 409 lands in the banner above, which outlives the
+          dialog and holds the way out.
+
+          `open` is gated on `graph` too: without it, a selection that goes away
+          under an open dialog (a company switch, a failed re-read) would leave
+          `workflow` null, which IS create mode — the operator would be looking
+          at a blank New workflow form wearing the Edit title. */}
+      <WorkflowCreateDialog
+        client={client}
+        company={company}
+        open={editOpen && graph !== null}
+        onOpenChange={setEditOpen}
+        workflow={graph}
+        onSaved={handleSaved}
+        onConflict={setConflict}
       />
     </div>
   );

--- a/frontend/test/e2e/workflow-edit-delete.spec.ts
+++ b/frontend/test/e2e/workflow-edit-delete.spec.ts
@@ -55,15 +55,29 @@ async function dismissTour(page: Page) {
   await expect(skip).toBeHidden();
 }
 
+/**
+ * Node fields the dialog has no control for. `outputExtras` puts them on the
+ * report node so a spec can check they survive an edit — the dialog cannot show
+ * them, and a save that rebuilds nodes from the visible controls alone would
+ * delete them.
+ */
+type NodeExtras = Record<string, unknown>;
+
 /** A minimal valid graph body: one trigger, one output, one edge. */
-function graphBody(id: string, name: string, schedule: string, description: string) {
+function graphBody(
+  id: string,
+  name: string,
+  schedule: string,
+  description: string,
+  outputExtras: NodeExtras = {},
+) {
   return {
     id,
     name,
     description,
     nodes: [
       { id: "start", kind: "trigger", name: "Start", schedule },
-      { id: "done", kind: "output", name: "Report" },
+      { id: "done", kind: "output", name: "Report", ...outputExtras },
     ],
     edges: [{ from: "start", to: "done" }],
   };
@@ -74,9 +88,10 @@ async function createWorkflow(
   request: APIRequestContext,
   id: string,
   name: string,
+  outputExtras: NodeExtras = {},
 ): Promise<string> {
   const res = await request.post(`${COMPANY_SCOPE}/workflows`, {
-    data: graphBody(id, name, "0 9 * * *", "Created by the #259 e2e spec."),
+    data: graphBody(id, name, "0 9 * * *", "Created by the #259 e2e spec.", outputExtras),
   });
   expect(res.ok(), `create ${id}: ${res.status()} ${await res.text()}`).toBeTruthy();
   const body = await res.json();
@@ -307,7 +322,16 @@ test("an author can change a saved workflow's schedule, and the id is read-only"
 }) => {
   const id = `e2e-edit-${Date.now()}`;
   const name = `Edit probe ${Date.now()}`;
-  await createWorkflow(request, id, name);
+  // Policies the dialog cannot show. A graph carrying them is not exotic: the
+  // API accepts them and the orchestrator's own `create_workflow` tool writes
+  // them, so an author can easily be editing one.
+  const hidden = {
+    config: { note: "kept across an edit" },
+    onError: "continue",
+    retry: { maxAttempts: 2, backoff: "fixed" },
+    requiresApproval: true,
+  };
+  await createWorkflow(request, id, name, hidden);
 
   try {
     await page.goto("/#/workflows");
@@ -341,6 +365,15 @@ test("an author can change a saved workflow's schedule, and the id is read-only"
         timeout: 15_000,
       })
       .toBe("0 9 * * MON");
+
+    // …and the save did not quietly delete the policies it had no control for.
+    // A node rebuilt from the visible fields alone would have dropped every one
+    // of these, silently, on the first edit of any field at all.
+    const report = (await readWorkflow(request, id)).nodes[1];
+    expect(report.config, "an edit must not drop node config").toEqual(hidden.config);
+    expect(report.onError, "an edit must not drop the error policy").toBe("continue");
+    expect(report.retry, "an edit must not drop the retry policy").toEqual(hidden.retry);
+    expect(report.requiresApproval, "an edit must not drop an approval gate").toBe(true);
   } finally {
     await removeWorkflow(request, id);
   }

--- a/frontend/test/e2e/workflow-edit-delete.spec.ts
+++ b/frontend/test/e2e/workflow-edit-delete.spec.ts
@@ -19,6 +19,20 @@ import { expect, test, type Page, type APIRequestContext } from "@playwright/tes
  *   out-of-band over HTTP while the console holds a stale copy — rather than
  *   trusting that the token is wired through.
  *
+ * Edit mode landed after the rest of #259 (the backend, the client and Delete
+ * shipped in #279), and its specs are here rather than in their own file
+ * because they are the same feature and share this file's fixtures — a graph
+ * created over HTTP, the tour dismissal, the picker helper. They cover:
+ *
+ * * an edit round trip that the host actually stored;
+ * * the id being **read-only**, not merely rejected on save (the host answers
+ *   400 to a rename, so offering the field would be a trap);
+ * * a stale save landing in the same conflict banner Delete uses, having
+ *   written nothing;
+ * * field errors **not** carrying from one graph to the next, which is what
+ *   the fresh-row-key hydration exists to prevent and is invisible anywhere
+ *   but a browser.
+ *
  * Runs against the live host the harness brings up (see `playwright.config.ts`).
  * Not run by CI, which has no host.
  */
@@ -92,6 +106,25 @@ async function selectWorkflow(page: Page, name: string) {
 }
 
 const DELETE = "workflow-delete";
+const EDIT = "workflow-edit";
+const SUBMIT = "workflow-dialog-submit";
+
+/** Opens the edit dialog for the currently selected workflow. */
+async function openEditDialog(page: Page) {
+  const button = page.getByTestId(EDIT);
+  await expect(button, "an overlay-backed workflow must be editable").toBeEnabled();
+  await button.click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByText("Edit workflow", { exact: true })).toBeVisible();
+  return dialog;
+}
+
+/** Reads a workflow's stored graph back from the host. */
+async function readWorkflow(request: APIRequestContext, id: string) {
+  const res = await request.get(`${COMPANY_SCOPE}/workflows/${id}`);
+  expect(res.ok(), `read ${id}: ${res.status()}`).toBeTruthy();
+  return res.json();
+}
 
 test("a source-defined workflow cannot be deleted, and the console says why", async ({
   page,
@@ -241,5 +274,175 @@ test("a version conflict surfaces distinctly with a way out, and deletes nothing
       .toBe(404);
   } finally {
     await removeWorkflow(request, id);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Edit mode (issue #259, the remainder after #279)
+// ---------------------------------------------------------------------------
+
+test("a source-defined workflow offers no Edit, with the same explanation Delete gives", async ({
+  page,
+}) => {
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+
+  await selectWorkflow(page, "Committed flow");
+
+  const button = page.getByTestId(EDIT);
+  await expect(button).toBeVisible();
+  await expect(button, "a seed-backed workflow must not be editable").toBeDisabled();
+
+  // One refusal, one explanation: the host answers 409 to a PUT and a DELETE
+  // for the same reason, so the console must not tell two stories about it.
+  const explanation = page.locator(`span:has([data-testid="${EDIT}"])`);
+  await expect(explanation).toHaveAttribute("title", /company source tree/);
+  await expect(explanation).toHaveAttribute("title", /can't be changed or removed/);
+  await expect(explanation).toHaveAttribute("title", /workflows\/committed\.toml/);
+});
+
+test("an author can change a saved workflow's schedule, and the id is read-only", async ({
+  page,
+  request,
+}) => {
+  const id = `e2e-edit-${Date.now()}`;
+  const name = `Edit probe ${Date.now()}`;
+  await createWorkflow(request, id, name);
+
+  try {
+    await page.goto("/#/workflows");
+    await dismissTour(page);
+    await selectWorkflow(page, name);
+
+    const dialog = await openEditDialog(page);
+
+    // Hydrated from the saved graph, not blank — the whole point of edit mode.
+    await expect(dialog.getByLabel("Id", { exact: true })).toHaveValue(id);
+    await expect(dialog.getByLabel("Name", { exact: true })).toHaveValue(name);
+    await expect(dialog.getByRole("textbox", { name: "Node id" }).first()).toHaveValue("start");
+
+    // The id may not change through a PUT — the host answers 400 — so the field
+    // states that by being unwritable rather than by refusing after the click.
+    await expect(
+      dialog.getByLabel("Id", { exact: true }),
+      "an id field that accepts a rename can only ever 400",
+    ).toHaveJSProperty("readOnly", true);
+
+    // Correct the trigger's schedule: the very mistake #259 is about.
+    await dialog.getByRole("combobox", { name: "Schedule" }).click();
+    await page.getByRole("option", { name: /Weekly/ }).click();
+
+    await dialog.getByTestId(SUBMIT).click();
+    await expect(dialog).toBeHidden({ timeout: 15_000 });
+
+    // The host stored it — the console did not merely redraw its own copy.
+    await expect
+      .poll(async () => (await readWorkflow(request, id)).nodes[0].schedule, {
+        timeout: 15_000,
+      })
+      .toBe("0 9 * * MON");
+  } finally {
+    await removeWorkflow(request, id);
+  }
+});
+
+test("a stale save surfaces the conflict banner and writes nothing", async ({
+  page,
+  request,
+}) => {
+  const id = `e2e-edit-conflict-${Date.now()}`;
+  const name = `Edit conflict probe ${Date.now()}`;
+  await createWorkflow(request, id, name);
+
+  try {
+    await page.goto("/#/workflows");
+    await dismissTour(page);
+    await selectWorkflow(page, name);
+
+    const dialog = await openEditDialog(page);
+
+    // Someone else saves while this dialog holds the token it loaded a moment
+    // ago. Forced for real, as with the delete conflict above.
+    const edited = await request.put(`${COMPANY_SCOPE}/workflows/${id}`, {
+      data: graphBody(id, name, "0 11 * * *", "Edited out-of-band, mid-edit."),
+    });
+    expect(edited.ok(), `out-of-band edit: ${edited.status()}`).toBeTruthy();
+
+    await dialog.getByRole("combobox", { name: "Schedule" }).click();
+    await page.getByRole("option", { name: /Weekly/ }).click();
+    await dialog.getByTestId(SUBMIT).click();
+
+    // Refused, and said so where the author is looking. The dialog stays open:
+    // throwing away what they typed would be a second loss on top of the race.
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText(/changed since you loaded it/, { timeout: 15_000 });
+
+    // Nothing was written — the out-of-band value still stands.
+    expect((await readWorkflow(request, id)).nodes[0].schedule).toBe("0 11 * * *");
+
+    // And the way out is the banner Delete already had, waiting behind the
+    // dialog rather than vanishing with it.
+    await dialog.getByRole("button", { name: "Cancel" }).click();
+    const banner = page.getByTestId("workflow-conflict");
+    await expect(banner).toBeVisible();
+    await banner.getByTestId("workflow-conflict-reload").click();
+    await expect(banner).toBeHidden({ timeout: 15_000 });
+
+    // Reloaded, the same edit goes through — so the loop terminates.
+    const reopened = await openEditDialog(page);
+    await reopened.getByRole("combobox", { name: "Schedule" }).click();
+    await page.getByRole("option", { name: /Weekly/ }).click();
+    await reopened.getByTestId(SUBMIT).click();
+    await expect(reopened).toBeHidden({ timeout: 15_000 });
+    await expect
+      .poll(async () => (await readWorkflow(request, id)).nodes[0].schedule, {
+        timeout: 15_000,
+      })
+      .toBe("0 9 * * MON");
+  } finally {
+    await removeWorkflow(request, id);
+  }
+});
+
+test("a field error raised on one graph never appears on another", async ({
+  page,
+  request,
+}) => {
+  const stamp = Date.now();
+  const first = { id: `e2e-errors-a-${stamp}`, name: `Errors probe A ${stamp}` };
+  const second = { id: `e2e-errors-b-${stamp}`, name: `Errors probe B ${stamp}` };
+  await createWorkflow(request, first.id, first.name);
+  await createWorkflow(request, second.id, second.name);
+
+  try {
+    await page.goto("/#/workflows");
+    await dismissTour(page);
+    await selectWorkflow(page, first.name);
+
+    // Raise a real blur-time error on the first graph's trigger row.
+    const dialog = await openEditDialog(page);
+    await dialog.getByRole("combobox", { name: "Schedule" }).click();
+    await page.getByRole("option", { name: /Custom cron/ }).click();
+    const cron = dialog.getByRole("textbox", { name: "Custom cron schedule" });
+    await cron.fill("hourly");
+    await cron.blur();
+    // The rule, not the standing hint under the field (which also says
+    // "5-field cron") — those are different strings for a reason.
+    await expect(dialog).toContainText(/A schedule is a 5-field cron/);
+    await dialog.getByRole("button", { name: "Cancel" }).click();
+
+    // Both graphs have a trigger node whose id is `start`, so an error map keyed
+    // on the node id (rather than on the freshly minted row key) would carry
+    // this complaint straight over to the second graph, attached to a field the
+    // author never touched.
+    await selectWorkflow(page, second.name);
+    const other = await openEditDialog(page);
+    await expect(
+      other,
+      "a stale field error must not follow the author to another graph",
+    ).not.toContainText("5-field cron, e.g.");
+  } finally {
+    await removeWorkflow(request, first.id);
+    await removeWorkflow(request, second.id);
   }
 });


### PR DESCRIPTION
## Summary

Closes the last piece of #259: **edit mode in the workflow dialog**, wired to the
`updateWorkflow` and the `version` token that #279 already shipped. Nothing on the
backend, the API client or Delete was rebuilt.

`WorkflowCreateDialog` now takes an optional `workflow`. When it is set the same form
hydrates from that saved graph and saves through `updateWorkflow(client, company,
graph.id, graph, graph.version)`; `null` is the create path, unchanged. `WorkflowsView`
gains an Edit button beside Delete, behind the same `editable === false` predicate and
the same explanation, and a save swaps the graph in place with its fresh token.

Four things worth reading closely, three of them called out by the issue:

* **Hydration goes through the dialog-open effect** — the one place `fieldErrors` is
  cleared. A draft populated anywhere else carries the previous graph's errors onto rows
  that no longer exist.
* **Fresh row keys.** Every hydrated row is minted by `blankNode()`/`nextKey()`. Reusing
  saved node ids as keys would collide the error map across graphs, and most graphs have
  a trigger node called `start`.
* **The id is read-only in edit mode**, not merely rejected on save. The host answers 400
  to a rename, so offering the field would be a trap; a line under it says why.
* **An edit no longer silently deletes what the form cannot show.** An overlay graph can
  carry `config`, `onError`, `retry` and `requiresApproval` (`POST`/`PUT` accept them and
  the orchestrator's own `create_workflow` tool writes them). Rebuilding a node from the
  visible controls alone would drop a retry policy or an approval gate on the first save,
  so those fields ride on the draft row and go back out verbatim. `config` is
  kind-specific and is dropped by `changeKind()` along with every other kind-conditional
  field — the matched pair the issue names.

**On the 409.** The dialog stays open with the host's message inline, so the author keeps
what they typed, *and* calls `setConflict(e.message)` so the existing persistent banner
and its Reload sit behind it with the way out. The banner, its Reload and the `graphTick`
refetch are untouched. Reload re-hydrates an open dialog with the fresh graph and token,
which discards the edit — the honest outcome, since keeping it would keep the stale token
with it. `PUT` also answers 409 for a display name already taken; that lands in the same
banner rather than being sniffed out of the message text, which would couple the console
to host copy.

## The open design question

**Decided: an edit does not disarm a schedule.** OpenHuman's `flows_update` forces
`enabled = false` when an edit turns a manual trigger automatic. This host gains no
equivalent here, because `WorkflowScheduler::tick` deliberately does not gate on
`[workflows].enabled` at all — writing `false` would stop nothing, and
`adding_a_schedule_by_edit_arms_the_workflow_on_the_next_tick` pins that. An edit is
therefore exactly as live as a create, which already persists a running schedule the same
way. Reversing it means first making the scheduler honour `enabled`, which is the
enable/disable follow-up already listed on #259. Written down in
`docs/modules/server/README.md` rather than left implicit.

## API Or Behavior Changes

Console only; no route, payload or Rust behavior changed.

* Workflows view: an **Edit** button beside Delete, disabled with the same explanation for
  a source-defined workflow (`editable === false`; an absent field still reads as
  editable).
* The workflow dialog reads "Edit workflow" / "Save changes" when editing, with a
  read-only id.
* `WorkflowCreateDialog` props: `onCreated` is now optional, and `workflow` / `onSaved` /
  `onConflict` are new. Both existing call sites are in this repo.
* The Delete tooltip now reads "can't be changed or removed" rather than "can't be
  removed" — one refusal, one sentence, matching the host's own message.

## Tests

Extended `frontend/test/e2e/workflow-edit-delete.spec.ts` (the harness the issue points
at) with four specs: an edit round trip the host actually stored, the read-only id, a
stale save that surfaces the conflict banner and writes nothing before succeeding after a
Reload, and a field error raised on one graph that must not appear on another. The whole
remaining scope is UI, and three of those four are observable nowhere else.

Run locally, from `frontend/`:

- `npm ci`
- `npm run typecheck` — clean
- `npm run typecheck:e2e` — clean (this is what compiles the new specs)

**Not run locally, stated plainly:** the Playwright suite and the browser walk-through the
issue's acceptance list asks for. Both need a live host, which means a full local build
matrix that is prohibited on this machine. The specs are written for the harness and are
compiled by CI's `typecheck:e2e`; the `Console` job also runs `npm run build`.

- [x] `cargo fmt --all -- --check` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo clippy --all-targets -- -D warnings` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo build --all-targets` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo test` — N/A - full local build matrix is prohibited on this machine; verified in CI

No Rust file is touched by this branch.

## Documentation

`docs/modules/server/README.md`, in the existing "Editing and removing a workflow (issue
#259)" section: what the console now offers, and the schedule decision above.

Closes #259.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow editing from the workflow list.
  * Edit dialogs load existing workflow details and keep workflow IDs read-only.
  * Workflow changes preserve advanced node settings and update schedules on the next scheduler cycle.
  * Added conflict handling for stale edits without automatic retries.

* **Bug Fixes**
  * Prevented editing and deletion for workflows marked as non-editable.
  * Improved error handling so validation errors remain isolated to the affected workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->