### PR TITLE
fix(store): resolve the default home to the workspace root, not one level deeper (#283)

### DIFF
--- a/docs/spec/runtime/config.md
+++ b/docs/spec/runtime/config.md
@@ -83,7 +83,7 @@ layer set it, and what is missing for each optional capability.
 | `TINYHUMANS_API_KEY` | — (required for cycles when no token file) | Static TinyHumans credential (JWT or API key) |
 | `TINYHUMANS_API_URL` | `https://api.tinyhumans.ai` | Backend base URL |
 | `OPENCOMPANY_BIND` | `127.0.0.1:8080` | HTTP bind address |
-| `OPENCOMPANY_DATA_DIR` | `~/.opencompany` (workspace) / `~/.opencompany/companies` (bundle home) | The instance data root: both the workspace layout and the company-bundle home. `--home` outranks it for the bundle home **only** — the workspace (`memory/`, `store/`, `files/`, `logs/`, `tmp/`) still resolves under this variable, so `--home` alone does not move a whole instance. The only knob that isolates two hosts from each other — see [storage](storage.md#choosing-the-root-srcstorepathsrs) |
+| `OPENCOMPANY_DATA_DIR` | `~/.opencompany` (workspace and bundle home alike; bundles at `companies/<slug>`) | The instance data root: both the workspace layout and the company-bundle home. `--home` outranks it for the bundle home **only** — the workspace (`memory/`, `store/`, `files/`, `logs/`, `tmp/`) still resolves under this variable, so `--home` alone does not move a whole instance. The only knob that isolates two hosts from each other — see [storage](storage.md#choosing-the-root-srcstorepathsrs) |
 | `OPENCOMPANY_BRAIN_MODE` | `hosted` | `hosted` \| `sidecar` (overrides `[brain].mode`) |
 | `OPENCOMPANY_OPENHUMAN_URL` | — | Attach to a running `openhuman-core serve` instead of launching |
 | `OPENCOMPANY_INFERENCE_KEY` | `TINYHUMANS_API_KEY` | Harness-brain credential (`openhuman` feature). Per-tenant override of the platform key |

--- a/docs/spec/runtime/storage.md
+++ b/docs/spec/runtime/storage.md
@@ -117,11 +117,25 @@ company invisible, so `serve`, `export`, and `import` all run
   bundle slugged `companies` and is left exactly as it is.
 - Every other entry is renamed up one level, and any `opencompany.db` (with its
   `-wal`/`-shm` siblings, as a set) moves from `<home>/companies/` to `<home>/`.
+  Only **regular files** count as the database: a company slugged
+  `opencompany.db` owns the directory at that exact path, and relocating it would
+  delete the company.
 - An occupied destination is **skipped**, never merged: two copies of one company
   hold two event logs and two signing keys, which cannot be interleaved. Both
   copies stay put and a warning names both paths.
 - The nest directory is removed only once emptied, so a crash mid-migration
   resumes on the next boot. Re-running a migrated install is silent.
+- The database set resumes the same way. It is detected from **any** surviving
+  member, not from `opencompany.db` alone, so a run that moved the database and
+  then died is finished by the next boot rather than being read as complete —
+  which would have paired a relocated database with a stranded write-ahead log
+  and lost whatever that log still held.
+- A source another process moved first is a success, not a failure. Running
+  `opencompany export` against a home a `serve` process is booting is ordinary
+  and both migrate; the loser of that race must not abort on a `NotFound` that
+  means "already done". Note that this is race *tolerance*, not a concurrency
+  guarantee: two processes sharing one home is unsupported for the same reason
+  the runtime journal is single-writer, and this migration does not change that.
 
 Moves are printed on stderr rather than logged through `warn!`, which the default
 `EnvFilter` drops unless `RUST_LOG` is set.

--- a/docs/spec/runtime/storage.md
+++ b/docs/spec/runtime/storage.md
@@ -105,24 +105,51 @@ install's bundles were nested one level too deep at
 `~/.opencompany/{memory,store,files,logs,tmp}` beside the *first* `companies/`. A
 local sqlite database was orphaned the same way, at
 `~/.opencompany/companies/opencompany.db`, because `serve` hands the resolved
-home to `open_storage`.
+home to `open_storage`. So were the two runtime trees that hang off the home
+rather than off a bundle: the harness agent workspaces (`<home>/harness`) and the
+MCP runtime registry (`<home>/mcp`, whose persisted installs and stored
+environment values are reconnected on boot).
 
 Dropping the leaf without moving that data would leave every existing local
 company invisible, so `serve`, `export`, and `import` all run
-`store::migrate_legacy_nest` against the resolved home before reading anything:
+`store::migrate::migrate_legacy_nest` against the resolved home before reading
+anything:
 
 - No `<home>/companies/companies` directory is a no-op. A hosted tenant takes
   this branch on every boot: two `stat`s that find nothing.
-- A nest holding a `company.toml` or `meta.json` at its top level is a real
-  bundle slugged `companies` and is left exactly as it is.
-- Every other entry is renamed up one level, and any `opencompany.db` (with its
-  `-wal`/`-shm` siblings, as a set) moves from `<home>/companies/` to `<home>/`.
-  Only **regular files** count as the database: a company slugged
-  `opencompany.db` owns the directory at that exact path, and relocating it would
-  delete the company.
+- A nest that is **bundle-shaped** — holding any of the top-level files
+  (`company.toml`, `meta.json`, `events.jsonl`, `ledger.jsonl`, `tasks.json`, …)
+  or subdirectories (`keys/`, `secrets/`, `memory/`, `context/`, …) that only a
+  company owns — is a real bundle slugged `companies` and is left exactly as it
+  is. A manifest is deliberately *not* the test: `Bundle::ensure_dirs` creates a
+  bundle with neither marker at ~20 call sites, and under
+  `OPENCOMPANY_STORAGE=sqlite|mongodb` the manifest never reaches the filesystem
+  at all while the keys, secrets and task board still do — so a marker test would
+  have dissolved exactly the installs that have no manifest to find.
+- Only entries that are **themselves bundle-shaped directories** are relocated,
+  the same test one level down. Anything else stays where it is, silently: the
+  legacy nest holds nothing but bundles, so an entry that does not look like one
+  is not something the migration knows where to put.
+- Any `opencompany.db` (with its `-wal`/`-shm` siblings, as a set) moves from
+  `<home>/companies/` to `<home>/`. Only **regular files** count as the database:
+  a company slugged `opencompany.db` owns the directory at that exact path, and
+  relocating it would delete the company.
+- `<home>/companies/{harness,mcp}` move up to `<home>/{harness,mcp}` under the
+  same shape guard — a company really can be slugged `harness`, and its canonical
+  bundle sits at exactly the path the legacy tree occupied.
 - An occupied destination is **skipped**, never merged: two copies of one company
   hold two event logs and two signing keys, which cannot be interleaved. Both
   copies stay put and a warning names both paths.
+- Files move by `link`+`unlink`, never by `rename`. A rename replaces a regular
+  file silently, and a "is the destination free?" check taken beforehand is stale
+  the instant it is read — a `serve` that has already migrated is writing a live
+  `-wal` at that path, and a rename over it drops every committed transaction the
+  log still holds. A hard link fails when the destination exists, so the check and
+  the move are one indivisible step. A crash between the link and the unlink
+  leaves one file reachable under both names, which the next run recognises by
+  device and inode and finishes rather than reporting as two databases.
+  Directories keep `rename`, which cannot replace a populated directory
+  (`ENOTEMPTY`) or a regular file (`ENOTDIR`) at all.
 - The nest directory is removed only once emptied, so a crash mid-migration
   resumes on the next boot. Re-running a migrated install is silent.
 - The database set resumes the same way. It is detected from **any** surviving
@@ -136,6 +163,15 @@ company invisible, so `serve`, `export`, and `import` all run
   means "already done". Note that this is race *tolerance*, not a concurrency
   guarantee: two processes sharing one home is unsupported for the same reason
   the runtime journal is single-writer, and this migration does not change that.
+  What the no-replace moves above do guarantee is that losing such a race can
+  never cost data, whatever the interleaving.
+
+An install whose migration genuinely cannot complete — `EXDEV` because
+`companies/` is a mount point, a root-owned or read-only nest — still boots:
+`--home ~/.opencompany/companies` resolves every bundle exactly where it already
+sits and finds no nest beneath it to migrate. That shape warns about the split
+workspace, correctly, and is the supported way to run an install this migration
+cannot move.
 
 Moves are printed on stderr rather than logged through `warn!`, which the default
 `EnvFilter` drops unless `RUST_LOG` is set.

--- a/docs/spec/runtime/storage.md
+++ b/docs/spec/runtime/storage.md
@@ -75,21 +75,17 @@ bundle hangs off through `store::resolve_home`, in this order:
 | --- | --- | --- |
 | 1 | `--home <DIR>` | `<DIR>` verbatim — an explicit flag is never overridden by the environment |
 | 2 | `OPENCOMPANY_DATA_DIR` | its value verbatim, so bundles land at `<root>/companies/<slug>` — exactly the layout above |
-| 3 | neither | `$HOME/.opencompany/companies` (the legacy default; see below) |
+| 3 | neither | `$HOME/.opencompany` (a relative `.opencompany` when `$HOME` is unset) |
 
 An empty `OPENCOMPANY_DATA_DIR` counts as unset — it would otherwise root the
 instance at the process working directory.
 
-Two consequences worth knowing:
+All three branches resolve the home to the **workspace root**, so `Bundle`'s own
+`companies/` segment puts bundles at `<root>/companies/<slug>` in every case —
+exactly the layout above, and exactly `DataLayout::companies_dir()`.
 
-- **The legacy default is one level deeper than the layout above.** With neither
-  the flag nor the variable set, the home is `$HOME/.opencompany/companies` and
-  `Bundle` appends a `companies/` of its own, so bundles sit at
-  `~/.opencompany/companies/companies/<slug>` while `DataLayout` materializes
-  `~/.opencompany/{memory,store,files,logs,tmp}`. That extra level is a wart kept
-  for compatibility with existing local installs rather than silently relocating
-  their data. Setting `OPENCOMPANY_DATA_DIR` gives the canonical single-root
-  layout.
+One consequence worth knowing:
+
 - **`--home` moves the bundles but not the workspace.** It places company
   bundles only; `memory/`, `store/`, `files/`, `logs/` and `tmp/` always follow
   `OPENCOMPANY_DATA_DIR`. So two hosts isolated by `--home` alone still share one
@@ -97,7 +93,38 @@ Two consequences worth knowing:
   whenever they are not aligned. Prefer `OPENCOMPANY_DATA_DIR`, which moves the
   whole instance. A hosted tenant sets both to the same value
   (`docker/entrypoint.sh` passes `--home "$OPENCOMPANY_DATA_DIR"`), so it never
-  warns — nor does the untouched local default.
+  warns — nor does the local default, whose home and data root are now the same
+  path. Passing `--home ~/.opencompany/companies` by hand recreates the legacy
+  doubled shape below and does warn, correctly.
+
+#### Migrating a legacy doubled install (`src/store/migrate.rs`)
+
+The default home used to append a `companies` leaf of its own, so a default local
+install's bundles were nested one level too deep at
+`~/.opencompany/companies/companies/<slug>` while `DataLayout` materialized
+`~/.opencompany/{memory,store,files,logs,tmp}` beside the *first* `companies/`. A
+local sqlite database was orphaned the same way, at
+`~/.opencompany/companies/opencompany.db`, because `serve` hands the resolved
+home to `open_storage`.
+
+Dropping the leaf without moving that data would leave every existing local
+company invisible, so `serve`, `export`, and `import` all run
+`store::migrate_legacy_nest` against the resolved home before reading anything:
+
+- No `<home>/companies/companies` directory is a no-op. A hosted tenant takes
+  this branch on every boot: two `stat`s that find nothing.
+- A nest holding a `company.toml` or `meta.json` at its top level is a real
+  bundle slugged `companies` and is left exactly as it is.
+- Every other entry is renamed up one level, and any `opencompany.db` (with its
+  `-wal`/`-shm` siblings, as a set) moves from `<home>/companies/` to `<home>/`.
+- An occupied destination is **skipped**, never merged: two copies of one company
+  hold two event logs and two signing keys, which cannot be interleaved. Both
+  copies stay put and a warning names both paths.
+- The nest directory is removed only once emptied, so a crash mid-migration
+  resumes on the next boot. Re-running a migrated install is silent.
+
+Moves are printed on stderr rather than logged through `warn!`, which the default
+`EnvFilter` drops unless `RUST_LOG` is set.
 
 `OPENCOMPANY_HOME` is **not** a synonym and is **not supported**. It was never
 wired to anything, so setting it used to be ignored silently. The resolver now

--- a/gitbooks/developers/cli.md
+++ b/gitbooks/developers/cli.md
@@ -24,7 +24,7 @@ opencompany serve --company companies/agentic_marketing_agency
 | --- | --- |
 | `--bind <ADDR>` | Address to bind. Default `127.0.0.1:8080`. |
 | `--company <DIR>` | A company to load at boot — a manifest file or a directory containing one. **Repeatable** for multi-company hosting. |
-| `--home <DIR>` | OpenCompany home holding company bundles. Falls back to `OPENCOMPANY_DATA_DIR`, then to `$HOME/.opencompany/companies`. |
+| `--home <DIR>` | OpenCompany home holding company bundles (`<home>/companies/<slug>`). Falls back to `OPENCOMPANY_DATA_DIR`, then to `$HOME/.opencompany`. |
 | `--discoverable` | Opt every loaded company into going public on [tiny.place](../overview/tiny-place.md), regardless of each manifest's `[place].discoverable`. Needs the `tinyplace` feature to reach the network. |
 | `--openhuman_root <PATH>` | Optional OpenHuman checkout path to report in `/spec`. |
 
@@ -77,7 +77,13 @@ precedence first:
 2. `OPENCOMPANY_DATA_DIR` — the instance data root. Set it to run two hosts side
    by side; without isolation they share one company store and each one's
    teammates and desks show up in the other.
-3. `$HOME/.opencompany/companies` — the default when neither is set.
+3. `$HOME/.opencompany` — the default when neither is set.
+
+Bundles hang off `<home>/companies/<slug>` in all three cases. Installs created
+before the default dropped a redundant `companies` leaf are nested one level
+deeper; `serve`, `export`, and `import` move them up on first launch and print
+what moved. A same-named company already at the destination is skipped with both
+paths named, never merged.
 
 `OPENCOMPANY_HOME` is not supported. It never was, so setting it used to do
 nothing silently; `serve`, `export`, and `import` now abort and point at

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -36,7 +36,7 @@ enum Command {
         #[arg(long = "company", value_name = "DIR")]
         companies: Vec<PathBuf>,
         /// OpenCompany home holding company bundles. Defaults to
-        /// `$HOME/.opencompany/companies`.
+        /// `$HOME/.opencompany`, with bundles under `companies/<slug>`.
         #[arg(long)]
         home: Option<PathBuf>,
         /// Opt every loaded company into going public on tiny.place, regardless
@@ -84,7 +84,7 @@ enum Command {
         #[arg(long)]
         include_secrets: bool,
         /// OpenCompany home holding company bundles. Defaults to
-        /// `$HOME/.opencompany/companies`.
+        /// `$HOME/.opencompany`, with bundles under `companies/<slug>`.
         #[arg(long)]
         home: Option<PathBuf>,
     },
@@ -94,7 +94,7 @@ enum Command {
         /// Bundle `.tar` or unpacked bundle directory to import.
         path: PathBuf,
         /// OpenCompany home to import into. Defaults to
-        /// `$HOME/.opencompany/companies`.
+        /// `$HOME/.opencompany`, with bundles under `companies/<slug>`.
         #[arg(long)]
         home: Option<PathBuf>,
     },
@@ -586,6 +586,20 @@ fn connections_runtime() -> Result<opencompany::server::ops::ConnectionsRuntime>
     Ok(connections)
 }
 
+/// Resolves the OpenCompany home and moves any legacy doubled install up before
+/// anything reads it.
+///
+/// Every command that touches bundles resolves through this rather than calling
+/// `store::resolve_home` directly. `serve` needs it or the operator's companies
+/// vanish from the console; `export` and `import` need it because otherwise an
+/// un-migrated install's first post-upgrade command is the one that fails to
+/// find its bundles. See `store::migrate` for the rules and the hosted no-op.
+fn resolve_home_migrated(flag: Option<PathBuf>) -> Result<PathBuf> {
+    let home = opencompany::store::resolve_home(flag)?;
+    opencompany::store::migrate_legacy_nest_announced(&home)?;
+    Ok(home)
+}
+
 /// Builds the four fs storage ports over `home` as trait objects.
 fn fs_ports(home: &std::path::Path) -> opencompany::store::export::Ports {
     use opencompany::store::{FsCompanyStore, FsContextStore, FsEventLog, FsMemoryStore};
@@ -635,7 +649,7 @@ async fn run_export(
     include_secrets: bool,
     home: Option<PathBuf>,
 ) -> Result<()> {
-    let home = opencompany::store::resolve_home(home)?;
+    let home = resolve_home_migrated(home)?;
     let id = CompanyId::new(company);
     let dest = out.unwrap_or_else(|| PathBuf::from(format!("{}-bundle", id.as_ref())));
     export_to_dir(&home, &id, include_secrets, &dest).await?;
@@ -656,7 +670,7 @@ async fn run_export(
 ) -> Result<()> {
     use opencompany::store::export::pack_tar;
 
-    let home = opencompany::store::resolve_home(home)?;
+    let home = resolve_home_migrated(home)?;
     let id = CompanyId::new(company);
     let out = out.unwrap_or_else(|| PathBuf::from(format!("{}.tar", id.as_ref())));
 
@@ -713,7 +727,7 @@ async fn import_from_dir(dir: &std::path::Path, home: Option<PathBuf>) -> Result
     use opencompany::store::export::{find_bundle_root, import_bundle, restore_fs_artifacts};
     use opencompany::store::paths::Bundle;
 
-    let home = opencompany::store::resolve_home(home)?;
+    let home = resolve_home_migrated(home)?;
     let root = find_bundle_root(dir)?;
     let (store, events, memory, context) = fs_ports(&home);
     let id = import_bundle(&root, store, events, memory, context).await?;
@@ -736,8 +750,9 @@ async fn main() -> Result<()> {
             home,
             discoverable,
         }) => {
-            // `--home` > OPENCOMPANY_DATA_DIR > $HOME/.opencompany/companies.
-            let home = opencompany::store::resolve_home(home)?;
+            // `--home` > OPENCOMPANY_DATA_DIR > $HOME/.opencompany, then any
+            // legacy doubled install is moved up before a single bundle is read.
+            let home = resolve_home_migrated(home)?;
             // Materialize the canonical data-dir workspace layout and empty the
             // ephemeral `tmp/` scratch so nothing stale survives a restart. The
             // `[workspace]` section of `config.toml` (in the data dir) toggles
@@ -1047,12 +1062,43 @@ mod test {
     fn the_home_flag_is_taken_verbatim() {
         // The binary owns no home policy of its own: it delegates to
         // `store::resolve_home`, whose precedence chain (flag >
-        // OPENCOMPANY_DATA_DIR > $HOME/.opencompany/companies) is covered in
+        // OPENCOMPANY_DATA_DIR > $HOME/.opencompany) is covered in
         // `src/store/paths.rs`. This only pins the wiring.
         assert_eq!(
             opencompany::store::resolve_home(Some(PathBuf::from("/flag"))).unwrap(),
             PathBuf::from("/flag")
         );
+    }
+
+    #[test]
+    fn every_home_resolving_command_migrates_the_legacy_nest() {
+        // `serve`, `export`, and `import` all resolve through
+        // `resolve_home_migrated`, so an un-migrated install's first
+        // post-upgrade command is not the one that finds no bundles.
+        let home = std::env::temp_dir().join(format!(
+            "oc-bin-migrate-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&home);
+        let nested = home.join("companies/companies/acme");
+        std::fs::create_dir_all(&nested).expect("legacy bundle");
+        std::fs::write(nested.join("company.toml"), "[company]\n").expect("manifest");
+
+        let resolved = resolve_home_migrated(Some(home.clone())).expect("resolves and migrates");
+
+        assert_eq!(resolved, home);
+        assert!(home.join("companies/acme/company.toml").exists());
+        assert!(!home.join("companies/companies").exists());
+        // The wiring is what is under test, but the bundle path it produces is
+        // the point of the whole change.
+        assert_eq!(
+            opencompany::store::Bundle::new(resolved, &CompanyId::new("acme"))
+                .dir()
+                .to_path_buf(),
+            home.join("companies/acme")
+        );
+        let _ = std::fs::remove_dir_all(&home);
     }
 
     #[tokio::test]

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -1101,6 +1101,73 @@ mod test {
         let _ = std::fs::remove_dir_all(&home);
     }
 
+    #[test]
+    fn no_command_resolves_a_home_without_migrating_it() {
+        // The test above pins the helper; this pins that the helper is the only
+        // door. A command that called `store::resolve_home` directly would read
+        // an un-migrated install and find no companies — and no runtime test
+        // would catch it, because the defect is a call that never happens. The
+        // needle is split so this assertion does not match its own source line.
+        let needle = concat!("store::", "resolve_home(");
+        let source = include_str!("opencompany.rs");
+        let production = source.split("\nmod test {").next().unwrap_or(source);
+
+        let direct: Vec<&str> = production
+            .lines()
+            .filter(|line| line.contains(needle))
+            .collect();
+
+        assert_eq!(
+            direct.len(),
+            1,
+            "`resolve_home` belongs to `resolve_home_migrated` alone; found {direct:?}"
+        );
+        let (before_helper, _) = production
+            .split_once("fn resolve_home_migrated")
+            .expect("the helper is declared");
+        assert!(
+            !before_helper.contains(needle),
+            "the one call must be the one inside `resolve_home_migrated`"
+        );
+    }
+
+    #[tokio::test]
+    async fn export_and_import_migrate_before_they_read() {
+        // Both commands run against an install whose first post-upgrade command
+        // may well be one of them, so neither may be the one that finds no
+        // bundles. Their results are irrelevant here — the migration happens
+        // before either touches a path, which is the whole point.
+        for command in ["export", "import"] {
+            let home = std::env::temp_dir().join(format!(
+                "oc-bin-{command}-migrate-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            let _ = std::fs::remove_dir_all(&home);
+            let nested = home.join("companies/companies/acme");
+            std::fs::create_dir_all(&nested).expect("legacy bundle");
+            std::fs::write(nested.join("company.toml"), "[company]\n").expect("manifest");
+
+            match command {
+                "export" => {
+                    let out = home.join("out");
+                    let _ =
+                        run_export("acme".to_string(), Some(out), false, Some(home.clone())).await;
+                }
+                _ => {
+                    let _ = import_from_dir(&home.join("nothing-here"), Some(home.clone())).await;
+                }
+            }
+
+            assert!(
+                home.join("companies/acme/company.toml").exists(),
+                "`{command}` resolved a home without migrating it"
+            );
+            assert!(!home.join("companies/companies").exists());
+            let _ = std::fs::remove_dir_all(&home);
+        }
+    }
+
     #[tokio::test]
     async fn register_company_loads_manifest_and_registers() {
         let home = std::env::temp_dir().join(format!("oc-bin-{}", std::process::id()));

--- a/src/store/migrate.rs
+++ b/src/store/migrate.rs
@@ -37,6 +37,16 @@
 //!   unrecoverable. Picking a winner is the same bet with the loser deleted.
 //! - The nest directory is removed only once emptied, so a crash mid-loop simply
 //!   resumes on the next boot. Idempotent by construction.
+//! - The database and its `-wal`/`-shm` siblings resume the same way: the set is
+//!   detected from *any* surviving member, not from the database alone, so a run
+//!   that moved the database and then died is finished by the next boot rather
+//!   than being mistaken for a completed one.
+//! - Only **regular files** are ever treated as the database. A company slugged
+//!   `opencompany.db` owns the directory at that exact path, and moving it would
+//!   delete the company.
+//! - A source another process moved first is a success, not a failure: `serve`
+//!   and a hand-run `export` against one home both migrate, and neither should
+//!   abort because the other won the race.
 //!
 //! Moves are announced on stderr rather than through `warn!`: the default
 //! `EnvFilter` drops warnings unless `RUST_LOG` is set, which would make the
@@ -190,8 +200,9 @@ fn migrate_bundles(companies: &Path, migration: &mut NestMigration) -> Result<()
             });
             continue;
         }
-        rename(&legacy, &destination)?;
-        migration.moved.push((Relocated::Company, destination));
+        if rename_or_already_moved(&legacy, &destination)? {
+            migration.moved.push((Relocated::Company, destination));
+        }
     }
 
     // Only once emptied. A skipped collision keeps the nest, and the next boot
@@ -211,18 +222,36 @@ fn migrate_bundles(companies: &Path, migration: &mut NestMigration) -> Result<()
 /// A hosted tenant never has one: it resolves its home to the data root, so its
 /// database is written at `<root>/opencompany.db` to begin with.
 fn migrate_sqlite(home: &Path, companies: &Path, migration: &mut NestMigration) -> Result<()> {
-    // The second and last `stat` a settled install pays. The siblings are only
-    // looked for once the database itself is here.
-    if !exists(&companies.join(SQLITE_DB)) {
+    // **Regular files only.** A company whose slug happens to be
+    // `opencompany.db` has its canonical bundle at exactly
+    // `<home>/companies/opencompany.db`, and a bare existence check accepts that
+    // directory. Moving it up would delete the company from every bundle lookup
+    // and hand sqlite a directory to open. `slug` permits `.`, so this is a name
+    // an operator can really have.
+    let mut moves: Vec<(PathBuf, PathBuf)> = Vec::new();
+    for name in LEGACY_SQLITE_FILES {
+        let legacy = companies.join(name);
+        if is_regular_file(&legacy)? {
+            moves.push((legacy, home.join(name)));
+        }
+    }
+    // Detection deliberately does **not** hinge on the database file alone. A
+    // previous run that moved `opencompany.db` and then died would leave the
+    // `-wal` behind, and keying off the database would read that as "already
+    // migrated" — pairing a relocated database with a stranded write-ahead log,
+    // which loses committed transactions. Any surviving member of the set is a
+    // migration to resume, so the next boot finishes what the last one started.
+    if moves.is_empty() {
         return Ok(());
     }
-    let moves: Vec<(PathBuf, PathBuf)> = LEGACY_SQLITE_FILES
-        .iter()
-        .map(|name| (companies.join(name), home.join(name)))
-        .filter(|(legacy, _)| exists(legacy))
-        .collect();
-    // Move the set or none of it. A half-move pairs a relocated database with a
-    // stranded write-ahead log, which is worse than not moving at all.
+    // An occupied destination among the files still to move means two databases,
+    // i.e. two histories. Skip the whole set and say so.
+    //
+    // A resumed half-move is not this case: there the database is already at its
+    // destination and is no longer among `moves`, so only the stranded siblings
+    // are checked and they find their destinations free. The one shape that
+    // cannot be told apart — a legacy `-wal` with no legacy `.db`, beside an
+    // unrelated canonical database — is not one sqlite produces.
     if let Some((legacy, destination)) = moves.iter().find(|(_, dest)| exists(dest)) {
         migration.collisions.push(Collision {
             what: Relocated::Database,
@@ -232,8 +261,9 @@ fn migrate_sqlite(home: &Path, companies: &Path, migration: &mut NestMigration) 
         return Ok(());
     }
     for (legacy, destination) in moves {
-        rename(&legacy, &destination)?;
-        migration.moved.push((Relocated::Database, destination));
+        if rename_or_already_moved(&legacy, &destination)? {
+            migration.moved.push((Relocated::Database, destination));
+        }
     }
     Ok(())
 }
@@ -269,16 +299,42 @@ fn read_dir_names(dir: &Path) -> Result<Vec<std::ffi::OsString>> {
         .collect()
 }
 
-/// Renames within one directory tree, reporting the source path on failure.
+/// Whether `path` is a regular file, following no symlink. Absent is `false`;
+/// an unreadable path is an error rather than a silent `false`.
+fn is_regular_file(path: &Path) -> Result<bool> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(metadata.file_type().is_file()),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(source) => Err(OpenCompanyError::StoreIo {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+/// Renames within one directory tree, returning whether *this* call performed
+/// the move.
 ///
-/// A failure aborts the boot rather than continuing with half an install: a
+/// A source that vanished between enumeration and rename, whose destination now
+/// exists, is another process having migrated it first — `Ok(false)`, not a
+/// failure. Running `opencompany export` against a home a `serve` process is
+/// booting is ordinary, and both commands migrate; aborting one of them on a
+/// `NotFound` that means "already done" would be a boot failure with nothing
+/// wrong behind it.
+///
+/// Every other failure aborts rather than continuing with half an install: a
 /// runtime that silently comes up missing companies is the exact symptom this
-/// migration exists to prevent.
-fn rename(from: &Path, to: &Path) -> Result<()> {
-    std::fs::rename(from, to).map_err(|source| OpenCompanyError::StoreIo {
-        path: from.to_path_buf(),
-        source,
-    })
+/// migration exists to prevent. A `NotFound` with the destination *also* absent
+/// is such a failure (a missing destination parent, say) and propagates.
+fn rename_or_already_moved(from: &Path, to: &Path) -> Result<bool> {
+    match std::fs::rename(from, to) {
+        Ok(()) => Ok(true),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound && exists(to) => Ok(false),
+        Err(source) => Err(OpenCompanyError::StoreIo {
+            path: from.to_path_buf(),
+            source,
+        }),
+    }
 }
 
 #[cfg(test)]
@@ -543,6 +599,78 @@ mod test {
         assert_eq!(migration.collisions.len(), 1);
         assert!(!home.path().join("opencompany.db").exists());
         assert!(home.path().join("companies/opencompany.db").exists());
+    }
+
+    #[test]
+    fn a_company_slugged_like_the_database_is_never_moved_as_one() {
+        // `slug` permits `.`, so a company really can be called
+        // `opencompany.db` — and its canonical bundle is at exactly the path the
+        // legacy database would occupy. Moving that directory up would delete the
+        // company from every bundle lookup and hand sqlite a directory to open.
+        let home = TempHome::new("db-named-company");
+        home.bundle("companies/opencompany.db");
+        home.write("companies/opencompany.db/events.jsonl", "a real company\n");
+
+        let migration = migrate_legacy_nest(home.path()).expect("leaves the bundle alone");
+
+        assert!(migration.is_empty(), "{migration:?}");
+        assert!(
+            home.path()
+                .join("companies/opencompany.db/company.toml")
+                .exists()
+        );
+        assert!(
+            !home.path().join("opencompany.db").exists(),
+            "the bundle must not be relocated as a database"
+        );
+    }
+
+    #[test]
+    fn a_half_moved_database_set_is_finished_on_the_next_run() {
+        // A run that moved `opencompany.db` and then died leaves the sidecars
+        // behind. Keying detection off the database alone would call that
+        // finished, pairing a relocated database with a stranded write-ahead log
+        // — losing whatever the log still held.
+        let home = TempHome::new("half-moved-db");
+        home.write("opencompany.db", "already moved");
+        home.write("companies/opencompany.db-wal", "stranded wal");
+        home.write("companies/opencompany.db-shm", "stranded shm");
+
+        let migration = migrate_legacy_nest(home.path()).expect("resumes");
+
+        assert_eq!(migration.moved.len(), 2, "{migration:?}");
+        assert!(migration.collisions.is_empty(), "{migration:?}");
+        assert_eq!(
+            std::fs::read_to_string(home.path().join("opencompany.db-wal")).unwrap(),
+            "stranded wal"
+        );
+        assert!(home.path().join("opencompany.db-shm").exists());
+        assert!(!home.path().join("companies/opencompany.db-wal").exists());
+        // The already-moved database is untouched.
+        assert_eq!(
+            std::fs::read_to_string(home.path().join("opencompany.db")).unwrap(),
+            "already moved"
+        );
+    }
+
+    #[test]
+    fn a_source_another_process_already_moved_is_not_a_failure() {
+        // `serve` booting and a hand-run `export` against one home both migrate.
+        // Losing that race must not abort the loser with a NotFound that means
+        // "already done".
+        let home = TempHome::new("raced");
+        let destination = home.write("companies/acme/company.toml", "[company]\n");
+        let vanished = home.path().join("companies/companies/acme/company.toml");
+
+        assert!(
+            !rename_or_already_moved(&vanished, &destination).expect("tolerated"),
+            "a vanished source whose destination now exists did not move here",
+        );
+
+        // A NotFound with the destination *also* absent is a real failure and
+        // still propagates, so this tolerance cannot mask a broken migration.
+        let nowhere = home.path().join("companies/companies/globex/company.toml");
+        assert!(rename_or_already_moved(&vanished, &nowhere).is_err());
     }
 
     #[test]

--- a/src/store/migrate.rs
+++ b/src/store/migrate.rs
@@ -57,13 +57,15 @@ use std::path::{Path, PathBuf};
 use crate::Result;
 use crate::error::OpenCompanyError;
 
-/// The local sqlite database file, as named by
-/// [`open_storage`](crate::store::open_storage).
-const SQLITE_DB: &str = "opencompany.db";
-
-/// The database and its write-ahead-log siblings. These travel as a set: leaving
-/// a `-wal` behind either strands committed transactions or pairs a moved
-/// database with a stale log.
+/// The local sqlite database — named by
+/// [`open_storage`](crate::store::open_storage) — and its write-ahead-log
+/// siblings.
+///
+/// These travel as a set: leaving a `-wal` behind either strands committed
+/// transactions or pairs a moved database with a stale log. The whole slice is
+/// also the *detector*, not just the payload — a run that moved the database and
+/// then died is recognised by whichever member it left behind, which is what
+/// makes the move resumable without a migration journal.
 const LEGACY_SQLITE_FILES: &[&str] =
     &["opencompany.db", "opencompany.db-wal", "opencompany.db-shm"];
 

--- a/src/store/migrate.rs
+++ b/src/store/migrate.rs
@@ -23,20 +23,44 @@
 //! its own sake: otherwise an un-migrated install's first post-upgrade command
 //! fails to find its bundles.
 //!
+//! The harness workspace and the MCP registry are orphaned by the same shift:
+//! both hang off the resolved home rather than off a bundle
+//! (`runtime/builder.rs`), so an operator's installed MCP servers — and the
+//! environment values stored with them — would be left behind at
+//! `~/.opencompany/companies/mcp` exactly as the database was.
+//!
 //! The migration is a detect-and-move:
 //!
 //! - No `<home>/companies/companies` directory is a no-op. A hosted tenant, whose
 //!   home resolves to `/data`, takes this branch on every boot: two `stat`s that
 //!   find nothing.
-//! - A nest holding a `company.toml` or `meta.json` at its top level *is* a real
-//!   bundle whose slug happens to be `companies`, and is left alone.
-//! - Each entry is renamed up one level when the destination is free.
+//! - A nest that is itself **bundle-shaped** — holding any of the files or
+//!   subdirectories only a company owns — *is* a real bundle whose slug happens
+//!   to be `companies`, and is left alone. A manifest is deliberately not the
+//!   test: ~20 sites create a bundle through
+//!   [`Bundle::ensure_dirs`](crate::store::Bundle::ensure_dirs) with neither
+//!   `company.toml` nor `meta.json`, and under a sqlite or mongodb store the
+//!   manifest never reaches the filesystem at all while the keys, secrets and
+//!   task board still do. Keying off the manifest would have dissolved exactly
+//!   those installs — hosted ones included.
+//! - Only entries that are **themselves bundle-shaped directories** are
+//!   relocated. That is the same test one level down, and it is the second
+//!   guard: even if the check above ever misread a bundle as a nest, that
+//!   bundle's own `keys/`, `secrets/` and `tasks.json` are not bundle-shaped and
+//!   would stay where they are. Anything unrecognised is left exactly where it
+//!   is, silently — the legacy nest holds nothing but bundles, so an entry that
+//!   does not look like one is not something this migration knows how to place.
+//! - Each recognised entry is renamed up one level when the destination is free.
 //! - A destination that already exists is **skipped with a warning naming both
 //!   paths**, never merged: a user who ran the app both ways has two copies of
 //!   one company, and interleaving two event logs and two signing keys is
 //!   unrecoverable. Picking a winner is the same bet with the loser deleted.
 //! - The nest directory is removed only once emptied, so a crash mid-loop simply
 //!   resumes on the next boot. Idempotent by construction.
+//! - The harness workspace (`<home>/harness`) and the MCP runtime registry
+//!   (`<home>/mcp`) move up beside the workspace like the database, under the
+//!   same shape guard: a company really can be slugged `harness`, and its
+//!   canonical bundle is at exactly the path the legacy tree occupied.
 //! - The database and its `-wal`/`-shm` siblings resume the same way: the set is
 //!   detected from *any* surviving member, not from the database alone, so a run
 //!   that moved the database and then died is finished by the next boot rather
@@ -44,9 +68,21 @@
 //! - Only **regular files** are ever treated as the database. A company slugged
 //!   `opencompany.db` owns the directory at that exact path, and moving it would
 //!   delete the company.
+//! - Files move by `link`+`unlink`, never by `rename`: a rename replaces a
+//!   regular file silently, and a "is the destination free?" check taken
+//!   beforehand is stale the instant it is read. Directories keep `rename`,
+//!   which cannot replace a populated directory (`ENOTEMPTY`) or a regular file
+//!   (`ENOTDIR`) at all.
 //! - A source another process moved first is a success, not a failure: `serve`
 //!   and a hand-run `export` against one home both migrate, and neither should
 //!   abort because the other won the race.
+//!
+//! An install whose migration genuinely cannot complete — `EXDEV` because the
+//! nest is a mount point, a root-owned or read-only `companies/` — still boots:
+//! `--home ~/.opencompany/companies` resolves every bundle exactly where it
+//! already sits and finds no nest beneath it to migrate. That shape warns about
+//! the split workspace, correctly, and is the documented way to run an install
+//! this migration cannot move.
 //!
 //! Moves are announced on stderr rather than through `warn!`: the default
 //! `EnvFilter` drops warnings unless `RUST_LOG` is set, which would make the
@@ -69,10 +105,59 @@ use crate::error::OpenCompanyError;
 const LEGACY_SQLITE_FILES: &[&str] =
     &["opencompany.db", "opencompany.db-wal", "opencompany.db-shm"];
 
-/// Marker files that prove a directory is a company bundle rather than a nest of
-/// them. Their presence at `<home>/companies/companies` means the operator has a
-/// real company slugged `companies`, which must not be dissolved.
-const BUNDLE_MARKERS: &[&str] = &["company.toml", "meta.json"];
+/// Top-level files only a company bundle has, from the layout
+/// [`Bundle`](crate::store::Bundle) defines. These are the strong half of the
+/// shape test: a company slug is always a *directory*, so no nest of bundles can
+/// hold a `company.toml` or an `events.jsonl` of its own.
+///
+/// A manifest alone is not enough to identify a bundle — most of these files
+/// exist in installs that never materialize one — which is why the whole list is
+/// the marker rather than `company.toml`.
+const BUNDLE_FILES: &[&str] = &[
+    "company.toml",
+    "meta.json",
+    "events.jsonl",
+    "ledger.jsonl",
+    "journal.jsonl",
+    "inbox.jsonl",
+    "inbox-meta.json",
+    "tasks.json",
+    "facts.jsonl",
+    "artifacts.jsonl",
+    "users.json",
+    "user-invites.json",
+    "user-sessions.json",
+    "login-codes.json",
+    "usage.jsonl",
+    "skills.json",
+];
+
+/// Top-level subdirectories a company bundle owns — the four
+/// [`Bundle::ensure_dirs`](crate::store::Bundle::ensure_dirs) creates, plus the
+/// two written on first use. This is the weaker half of the test: a company
+/// *could* be slugged `keys` or `memory`, so a nest holding one of these reads
+/// as a bundle. That bias is deliberate and one-directional — it can only ever
+/// leave data where it is.
+const BUNDLE_DIRS: &[&str] = &[
+    "keys",
+    "secrets",
+    "memory",
+    "context",
+    "workspace",
+    "feedback",
+];
+
+/// Runtime trees written under the *home* rather than under a bundle, so the
+/// dropped `companies` leaf orphans them exactly as it orphaned the database.
+///
+/// `<home>/harness` holds every agent's working files
+/// (`runtime/builder.rs`, `workspace_root`); `<home>/mcp` holds the MCP runtime
+/// registry, whose persisted installs and stored environment values are
+/// reconnected on boot.
+const LEGACY_HOME_DIRS: &[(&str, Relocated)] = &[
+    ("harness", Relocated::HarnessWorkspace),
+    ("mcp", Relocated::McpRegistry),
+];
 
 /// What a migrated path holds, so the operator message names it accurately.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -81,6 +166,11 @@ pub enum Relocated {
     Company,
     /// The local sqlite database or one of its `-wal`/`-shm` siblings.
     Database,
+    /// The harness workspace tree holding every agent's working files.
+    HarnessWorkspace,
+    /// The MCP runtime registry: installed servers and their stored environment
+    /// values.
+    McpRegistry,
 }
 
 /// A same-named entry that already existed at its destination. Both copies are
@@ -119,6 +209,8 @@ impl NestMigration {
             let noun = match what {
                 Relocated::Company => "company bundle",
                 Relocated::Database => "local database file",
+                Relocated::HarnessWorkspace => "harness agent workspace",
+                Relocated::McpRegistry => "MCP server registry",
             };
             lines.push(format!(
                 "moved {noun} up out of the legacy nested layout: {}",
@@ -136,6 +228,15 @@ impl NestMigration {
                     "Two databases hold two separate histories. Keep one by hand \
                      and move or delete the other, including its -wal and -shm \
                      siblings."
+                }
+                Relocated::HarnessWorkspace => {
+                    "Two harness workspaces hold two sets of agent working \
+                     files. Keep one by hand and move or delete the other."
+                }
+                Relocated::McpRegistry => {
+                    "Two MCP registries hold two sets of installed servers and \
+                     the environment values stored with them. Keep one by hand \
+                     and move or delete the other."
                 }
             };
             lines.push(format!(
@@ -170,7 +271,22 @@ pub fn migrate_legacy_nest(home: &Path) -> Result<NestMigration> {
     let mut migration = NestMigration::default();
     migrate_bundles(&companies, &mut migration)?;
     migrate_sqlite(home, &companies, &mut migration)?;
+    migrate_home_dirs(home, &companies, &mut migration)?;
     Ok(migration)
+}
+
+/// Whether `dir` holds anything only a company bundle holds.
+///
+/// The manifest is not the test — see the [module docs](self) for why. Used
+/// twice, and in opposite directions: a bundle-shaped *nest* is a company that
+/// must not be dissolved, and a bundle-shaped *entry* is a company that must be
+/// moved up. Both readings fail safe on a miss, because the only thing an
+/// unrecognised path can do here is stay exactly where it already is.
+fn is_bundle_shaped(dir: &Path) -> bool {
+    BUNDLE_FILES
+        .iter()
+        .chain(BUNDLE_DIRS)
+        .any(|name| exists(&dir.join(name)))
 }
 
 /// Renames every `<companies>/companies/<slug>` up into `<companies>/<slug>`.
@@ -181,11 +297,10 @@ fn migrate_bundles(companies: &Path, migration: &mut NestMigration) -> Result<()
         return Ok(());
     }
     // A real bundle that happens to be slugged `companies`. Dissolving it would
-    // scatter its event log and keys across the companies directory.
-    if BUNDLE_MARKERS
-        .iter()
-        .any(|marker| exists(&nest.join(marker)))
-    {
+    // scatter its event log, task board and signing key across the companies
+    // directory — and a bundle needs no manifest at all to be one, which is what
+    // makes the shape rather than a marker file the test.
+    if is_bundle_shaped(&nest) {
         return Ok(());
     }
 
@@ -193,6 +308,13 @@ fn migrate_bundles(companies: &Path, migration: &mut NestMigration) -> Result<()
     names.sort();
     for name in names {
         let legacy = nest.join(&name);
+        // The second guard. The legacy nest holds nothing but bundles, so an
+        // entry that does not look like one is either a stray or evidence that
+        // this nest is a bundle after all. Either way it is not something this
+        // migration knows where to put, and leaving it costs nothing.
+        if !legacy.is_dir() || !is_bundle_shaped(&legacy) {
+            continue;
+        }
         let destination = companies.join(&name);
         if exists(&destination) {
             migration.collisions.push(Collision {
@@ -254,17 +376,65 @@ fn migrate_sqlite(home: &Path, companies: &Path, migration: &mut NestMigration) 
     // are checked and they find their destinations free. The one shape that
     // cannot be told apart — a legacy `-wal` with no legacy `.db`, beside an
     // unrelated canonical database — is not one sqlite produces.
-    if let Some((legacy, destination)) = moves.iter().find(|(_, dest)| exists(dest)) {
-        migration.collisions.push(Collision {
-            what: Relocated::Database,
-            legacy: legacy.clone(),
-            destination: destination.clone(),
-        });
-        return Ok(());
+    //
+    // A destination that is the *same file* as its source is not this case
+    // either: it is the link half of a move that died before unlinking the
+    // source, and reporting that as two databases would send the operator to
+    // resolve a collision between a file and itself.
+    for (legacy, destination) in &moves {
+        if exists(destination) && !same_file(legacy, destination)? {
+            migration.collisions.push(Collision {
+                what: Relocated::Database,
+                legacy: legacy.clone(),
+                destination: destination.clone(),
+            });
+            return Ok(());
+        }
     }
     for (legacy, destination) in moves {
+        let outcome = move_file_no_replace(&legacy, &destination)?;
+        match outcome {
+            Moved::Here => migration.moved.push((Relocated::Database, destination)),
+            Moved::Already => {}
+            // The scan above found this destination free and something claimed
+            // it in between. Stop the set rather than move the rest around it:
+            // whatever is there now is live, and the next boot resumes.
+            Moved::Occupied => {
+                migration.collisions.push(Collision {
+                    what: Relocated::Database,
+                    legacy,
+                    destination,
+                });
+                return Ok(());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Moves the runtime trees that hang off the *home* rather than off a bundle —
+/// the harness workspace and the MCP registry — up beside the workspace.
+///
+/// Guarded by the same shape test as the nest: `<home>/companies/harness` is
+/// both where the legacy harness tree sat and where a company slugged `harness`
+/// has its canonical bundle, and only one of the two is bundle-shaped.
+fn migrate_home_dirs(home: &Path, companies: &Path, migration: &mut NestMigration) -> Result<()> {
+    for (name, what) in LEGACY_HOME_DIRS {
+        let legacy = companies.join(name);
+        if !legacy.is_dir() || is_bundle_shaped(&legacy) {
+            continue;
+        }
+        let destination = home.join(name);
+        if exists(&destination) {
+            migration.collisions.push(Collision {
+                what: *what,
+                legacy,
+                destination,
+            });
+            continue;
+        }
         if rename_or_already_moved(&legacy, &destination)? {
-            migration.moved.push((Relocated::Database, destination));
+            migration.moved.push((*what, destination));
         }
     }
     Ok(())
@@ -339,6 +509,98 @@ fn rename_or_already_moved(from: &Path, to: &Path) -> Result<bool> {
     }
 }
 
+/// What one file move did.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Moved {
+    /// This call performed the move.
+    Here,
+    /// The file was already at its destination — a previous run, or another
+    /// process, got there first. Nothing left to do and nothing to report.
+    Already,
+    /// Something else occupies the destination. Nothing was touched.
+    Occupied,
+}
+
+/// Moves a regular file, never replacing whatever is at the destination.
+///
+/// [`std::fs::rename`] replaces a regular file silently, and a separate "is the
+/// destination free?" check cannot close that: the answer is stale the moment it
+/// is read. The window is narrow and the loss is total — a `serve` that has
+/// already migrated and opened the database is writing a live
+/// `opencompany.db-wal` at the destination, and a rename over it drops every
+/// committed transaction that log still holds.
+///
+/// [`std::fs::hard_link`] fails when the destination exists, so the check and
+/// the move are one indivisible step and no interleaving can produce a
+/// replacement. The source is unlinked once the link is in place; a crash
+/// between the two leaves one file reachable under both names, which the next
+/// run recognises by device and inode and finishes rather than reporting as two
+/// databases.
+///
+/// Directories keep [`rename_or_already_moved`]: `rename` cannot replace a
+/// populated directory (`ENOTEMPTY`) or a regular file (`ENOTDIR`), so the only
+/// thing it can overwrite there is an empty directory, which holds nothing.
+fn move_file_no_replace(from: &Path, to: &Path) -> Result<Moved> {
+    match std::fs::hard_link(from, to) {
+        Ok(()) => {
+            remove_file(from)?;
+            Ok(Moved::Here)
+        }
+        // Another process moved this file between the scan and here.
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound && exists(to) => {
+            Ok(Moved::Already)
+        }
+        Err(source) if source.kind() == std::io::ErrorKind::AlreadyExists => {
+            if same_file(from, to)? {
+                // Our own link, from a run that died before the unlink.
+                remove_file(from)?;
+                return Ok(Moved::Already);
+            }
+            Ok(Moved::Occupied)
+        }
+        Err(source) => Err(OpenCompanyError::StoreIo {
+            path: from.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+/// Whether two paths name one file — two links to a single inode rather than two
+/// copies.
+///
+/// Always `false` off unix, where a crash between `link` and `unlink` degrades
+/// to a reported collision the operator resolves by hand instead of resolving
+/// itself. Both paths must exist; every caller has just established that.
+fn same_file(a: &Path, b: &Path) -> Result<bool> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        let left = std::fs::symlink_metadata(a).map_err(|source| OpenCompanyError::StoreIo {
+            path: a.to_path_buf(),
+            source,
+        })?;
+        let right = std::fs::symlink_metadata(b).map_err(|source| OpenCompanyError::StoreIo {
+            path: b.to_path_buf(),
+            source,
+        })?;
+        Ok(left.dev() == right.dev() && left.ino() == right.ino())
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (a, b);
+        Ok(false)
+    }
+}
+
+/// Removes a file, naming it in the error.
+fn remove_file(path: &Path) -> Result<()> {
+    std::fs::remove_file(path).map_err(|source| OpenCompanyError::StoreIo {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -368,6 +630,26 @@ mod test {
             let dir = self.0.join(relative);
             std::fs::create_dir_all(&dir).expect("bundle dir");
             std::fs::write(dir.join("company.toml"), "[company]\n").expect("manifest");
+            dir
+        }
+
+        /// A bundle the way `Bundle::ensure_dirs` creates one: subdirectories
+        /// only, no `company.toml` and no `meta.json`. ~20 call sites produce
+        /// exactly this, and a sqlite or mongodb install never materializes a
+        /// manifest on the filesystem at all.
+        fn marker_less_bundle(&self, relative: &str) -> PathBuf {
+            let dir = self.0.join(relative);
+            for sub in ["memory", "context/blobs", "secrets", "keys"] {
+                std::fs::create_dir_all(dir.join(sub)).expect("bundle subdir");
+            }
+            std::fs::write(dir.join("keys/agent.ed25519"), "seed").expect("identity seed");
+            dir
+        }
+
+        /// A bare directory with nothing in it.
+        fn dir(&self, relative: &str) -> PathBuf {
+            let dir = self.0.join(relative);
+            std::fs::create_dir_all(&dir).expect("dir");
             dir
         }
 
@@ -521,6 +803,193 @@ mod test {
 
         assert!(migration.is_empty());
         assert!(home.path().join("companies/companies/meta.json").exists());
+    }
+
+    #[test]
+    fn a_marker_less_bundle_slugged_companies_is_not_dissolved() {
+        // The shape every `Bundle::ensure_dirs` call site produces, and the only
+        // shape a sqlite or mongodb install ever has on the filesystem: no
+        // manifest, no `meta.json`, and a signing key that cannot be re-derived.
+        // Reading it as a nest would rename `keys/`, `secrets/` and
+        // `tasks.json` up into `<home>/companies/` and orphan the identity —
+        // which is precisely the hosted case, since hosted is the non-fs store.
+        let home = TempHome::new("marker-less-slug");
+        home.marker_less_bundle("companies/companies");
+        home.write("companies/companies/tasks.json", "[]");
+
+        let migration = migrate_legacy_nest(home.path()).expect("leaves the bundle alone");
+
+        assert!(migration.is_empty(), "{migration:?}");
+        assert!(
+            home.path()
+                .join("companies/companies/keys/agent.ed25519")
+                .exists()
+        );
+        assert!(home.path().join("companies/companies/tasks.json").exists());
+        // Nothing was scattered up into the companies directory.
+        assert!(!home.path().join("companies/keys").exists());
+        assert!(!home.path().join("companies/secrets").exists());
+        assert!(!home.path().join("companies/tasks.json").exists());
+    }
+
+    #[test]
+    fn a_marker_less_nested_bundle_still_moves() {
+        // The widened guard must not cost the migration its purpose: a bundle
+        // with no manifest is exactly what a sqlite install has, and it is
+        // still nested one level too deep.
+        let home = TempHome::new("marker-less-nest");
+        home.marker_less_bundle("companies/companies/acme");
+
+        let migration = migrate_legacy_nest(home.path()).expect("migrates");
+
+        assert_eq!(migration.moved.len(), 1, "{migration:?}");
+        assert!(
+            home.path()
+                .join("companies/acme/keys/agent.ed25519")
+                .exists()
+        );
+        assert!(!home.path().join("companies/companies").exists());
+    }
+
+    #[test]
+    fn an_unrecognised_nest_entry_is_left_where_it_is() {
+        // Only bundle-shaped directories move. Anything else is either a stray
+        // or evidence the nest is a bundle after all, and either way this
+        // migration has nowhere to put it.
+        let home = TempHome::new("stray");
+        home.bundle("companies/companies/acme");
+        home.write("companies/companies/notes.txt", "stray\n");
+        home.dir("companies/companies/empty");
+
+        let migration = migrate_legacy_nest(home.path()).expect("migrates");
+
+        assert_eq!(migration.moved.len(), 1, "{migration:?}");
+        assert!(home.path().join("companies/acme/company.toml").exists());
+        assert!(home.path().join("companies/companies/notes.txt").exists());
+        assert!(!home.path().join("companies/notes.txt").exists());
+        // The nest survives because it is not empty — and the next boot, having
+        // nothing left it recognises, says nothing at all.
+        assert!(home.path().join("companies/companies").is_dir());
+        assert!(migrate_legacy_nest(home.path()).expect("rerun").is_empty());
+    }
+
+    #[test]
+    fn the_harness_and_mcp_trees_move_up_with_the_bundles() {
+        // Both hang off the resolved home rather than off a bundle, so the same
+        // one-level shift that orphaned the database orphans every agent's
+        // working files and the operator's installed MCP servers — including
+        // the environment values stored with them.
+        let home = TempHome::new("home-dirs");
+        home.bundle("companies/companies/acme");
+        home.write("companies/harness/acme/ceo/workspace/notes.md", "draft\n");
+        home.write("companies/mcp/registry.db", "installs");
+
+        let migration = migrate_legacy_nest(home.path()).expect("migrates");
+
+        assert_eq!(
+            std::fs::read_to_string(home.path().join("harness/acme/ceo/workspace/notes.md"))
+                .unwrap(),
+            "draft\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(home.path().join("mcp/registry.db")).unwrap(),
+            "installs"
+        );
+        assert!(!home.path().join("companies/harness").exists());
+        assert!(!home.path().join("companies/mcp").exists());
+        let moved: Vec<Relocated> = migration.moved.iter().map(|(what, _)| *what).collect();
+        assert!(
+            moved.contains(&Relocated::HarnessWorkspace),
+            "{migration:?}"
+        );
+        assert!(moved.contains(&Relocated::McpRegistry), "{migration:?}");
+        // The report names them for what they are, not as company bundles.
+        let report = migration.report().join("\n");
+        assert!(report.contains("harness agent workspace"), "{report}");
+        assert!(report.contains("MCP server registry"), "{report}");
+    }
+
+    #[test]
+    fn a_company_slugged_like_the_harness_tree_is_never_moved_as_one() {
+        // `<home>/companies/harness` is both where the legacy harness tree sat
+        // and where a company slugged `harness` has its canonical bundle. Only
+        // one of the two is bundle-shaped.
+        let home = TempHome::new("harness-company");
+        home.marker_less_bundle("companies/harness");
+
+        let migration = migrate_legacy_nest(home.path()).expect("leaves the bundle alone");
+
+        assert!(migration.is_empty(), "{migration:?}");
+        assert!(
+            home.path()
+                .join("companies/harness/keys/agent.ed25519")
+                .exists()
+        );
+        assert!(
+            !home.path().join("harness").exists(),
+            "the bundle must not be relocated as a runtime tree"
+        );
+    }
+
+    #[test]
+    fn an_mcp_registry_at_the_destination_is_left_for_the_operator() {
+        // Two registries hold two sets of installed servers. Merging them is
+        // not a decision this migration can make.
+        let home = TempHome::new("mcp-collision");
+        home.write("companies/mcp/registry.db", "legacy");
+        home.write("mcp/registry.db", "canonical");
+
+        let migration = migrate_legacy_nest(home.path()).expect("migrates");
+
+        assert!(migration.moved.is_empty(), "{migration:?}");
+        assert_eq!(migration.collisions.len(), 1);
+        assert_eq!(migration.collisions[0].what, Relocated::McpRegistry);
+        assert_eq!(
+            std::fs::read_to_string(home.path().join("mcp/registry.db")).unwrap(),
+            "canonical"
+        );
+        assert_eq!(
+            std::fs::read_to_string(home.path().join("companies/mcp/registry.db")).unwrap(),
+            "legacy"
+        );
+    }
+
+    #[test]
+    fn a_file_move_never_replaces_the_destination() {
+        // The property the whole database set rests on. `rename` would have
+        // replaced the destination silently, and no check taken beforehand can
+        // close that window — only a move that cannot replace anything can.
+        let home = TempHome::new("no-replace");
+        let from = home.write("companies/opencompany.db", "legacy");
+        let to = home.write("opencompany.db", "live");
+
+        assert_eq!(
+            move_file_no_replace(&from, &to).expect("reports rather than replaces"),
+            Moved::Occupied
+        );
+
+        assert_eq!(std::fs::read_to_string(&to).unwrap(), "live");
+        assert_eq!(std::fs::read_to_string(&from).unwrap(), "legacy");
+    }
+
+    #[test]
+    fn a_half_linked_database_is_finished_rather_than_reported() {
+        // The crash window inside a no-replace move: the link is in place and
+        // the source is not yet unlinked, so one file is reachable under both
+        // names. Reading that as two databases would send the operator to
+        // resolve a collision between a file and itself.
+        let home = TempHome::new("half-linked");
+        let legacy = home.write("companies/opencompany.db", "one database");
+        std::fs::hard_link(&legacy, home.path().join("opencompany.db")).expect("half a move");
+
+        let migration = migrate_legacy_nest(home.path()).expect("finishes the move");
+
+        assert!(migration.collisions.is_empty(), "{migration:?}");
+        assert!(!legacy.exists(), "the source link is unlinked");
+        assert_eq!(
+            std::fs::read_to_string(home.path().join("opencompany.db")).unwrap(),
+            "one database"
+        );
     }
 
     #[test]

--- a/src/store/migrate.rs
+++ b/src/store/migrate.rs
@@ -1,0 +1,556 @@
+//! One-shot boot migration off the legacy doubled home layout.
+//!
+//! Until the default home lost its `companies` leaf,
+//! [`resolve_home`](crate::store::resolve_home) returned
+//! `$HOME/.opencompany/companies` and [`Bundle`](crate::store::Bundle) appended a
+//! `companies/` of its own, so a default local install's bundles sit one level
+//! too deep:
+//!
+//! ```text
+//! ~/.opencompany/companies/companies/<slug>/   ← legacy (doubled)
+//! ~/.opencompany/companies/<slug>/             ← canonical
+//! ```
+//!
+//! A local sqlite install is orphaned the same way: `serve` hands the resolved
+//! home to [`open_storage`](crate::store::open_storage), so its database sits at
+//! `~/.opencompany/companies/opencompany.db` rather than beside the workspace.
+//!
+//! Correcting the resolver without moving that data would silently orphan every
+//! local company: the operator opens the console and their companies are gone,
+//! which is worse than the wart itself. So `serve`, `export`, and `import` all
+//! call [`migrate_legacy_nest_announced`] against the resolved home before
+//! touching it. Running it for `export` and `import` too is not thoroughness for
+//! its own sake: otherwise an un-migrated install's first post-upgrade command
+//! fails to find its bundles.
+//!
+//! The migration is a detect-and-move:
+//!
+//! - No `<home>/companies/companies` directory is a no-op. A hosted tenant, whose
+//!   home resolves to `/data`, takes this branch on every boot: two `stat`s that
+//!   find nothing.
+//! - A nest holding a `company.toml` or `meta.json` at its top level *is* a real
+//!   bundle whose slug happens to be `companies`, and is left alone.
+//! - Each entry is renamed up one level when the destination is free.
+//! - A destination that already exists is **skipped with a warning naming both
+//!   paths**, never merged: a user who ran the app both ways has two copies of
+//!   one company, and interleaving two event logs and two signing keys is
+//!   unrecoverable. Picking a winner is the same bet with the loser deleted.
+//! - The nest directory is removed only once emptied, so a crash mid-loop simply
+//!   resumes on the next boot. Idempotent by construction.
+//!
+//! Moves are announced on stderr rather than through `warn!`: the default
+//! `EnvFilter` drops warnings unless `RUST_LOG` is set, which would make the
+//! announcement exactly as invisible as the bug it reports.
+
+use std::path::{Path, PathBuf};
+
+use crate::Result;
+use crate::error::OpenCompanyError;
+
+/// The local sqlite database file, as named by
+/// [`open_storage`](crate::store::open_storage).
+const SQLITE_DB: &str = "opencompany.db";
+
+/// The database and its write-ahead-log siblings. These travel as a set: leaving
+/// a `-wal` behind either strands committed transactions or pairs a moved
+/// database with a stale log.
+const LEGACY_SQLITE_FILES: &[&str] =
+    &["opencompany.db", "opencompany.db-wal", "opencompany.db-shm"];
+
+/// Marker files that prove a directory is a company bundle rather than a nest of
+/// them. Their presence at `<home>/companies/companies` means the operator has a
+/// real company slugged `companies`, which must not be dissolved.
+const BUNDLE_MARKERS: &[&str] = &["company.toml", "meta.json"];
+
+/// What a migrated path holds, so the operator message names it accurately.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Relocated {
+    /// A company bundle directory.
+    Company,
+    /// The local sqlite database or one of its `-wal`/`-shm` siblings.
+    Database,
+}
+
+/// A same-named entry that already existed at its destination. Both copies are
+/// left exactly where they are.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Collision {
+    /// What the two copies hold.
+    pub what: Relocated,
+    /// The copy still sitting in the legacy nested layout.
+    pub legacy: PathBuf,
+    /// The copy already at the canonical location.
+    pub destination: PathBuf,
+}
+
+/// What [`migrate_legacy_nest`] did, so the caller can report it.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct NestMigration {
+    /// Paths moved up one level, in their new canonical locations.
+    pub moved: Vec<(Relocated, PathBuf)>,
+    /// Entries skipped because the destination was occupied.
+    pub collisions: Vec<Collision>,
+}
+
+impl NestMigration {
+    /// True when nothing moved and nothing collided: the ordinary case on every
+    /// boot after the first, and on every hosted boot.
+    pub fn is_empty(&self) -> bool {
+        self.moved.is_empty() && self.collisions.is_empty()
+    }
+
+    /// Operator-facing lines describing the migration, in report order. Empty
+    /// when [`is_empty`](Self::is_empty), so a settled install stays silent.
+    pub fn report(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        for (what, destination) in &self.moved {
+            let noun = match what {
+                Relocated::Company => "company bundle",
+                Relocated::Database => "local database file",
+            };
+            lines.push(format!(
+                "moved {noun} up out of the legacy nested layout: {}",
+                destination.display()
+            ));
+        }
+        for collision in &self.collisions {
+            let advice = match collision.what {
+                Relocated::Company => {
+                    "Two copies of one company cannot be merged: interleaving two \
+                     event logs and two signing keys is not recoverable. Keep one \
+                     by hand and move or delete the other."
+                }
+                Relocated::Database => {
+                    "Two databases hold two separate histories. Keep one by hand \
+                     and move or delete the other, including its -wal and -shm \
+                     siblings."
+                }
+            };
+            lines.push(format!(
+                "left both copies in place: {} already exists, so the legacy copy \
+                 stays at {}. {advice}",
+                collision.destination.display(),
+                collision.legacy.display(),
+            ));
+        }
+        lines
+    }
+}
+
+/// Moves a legacy `<home>/companies/companies/<slug>` install up one level, plus
+/// any local sqlite database orphaned beside it, and announces what moved on
+/// stderr.
+///
+/// This is the boot entry point; [`migrate_legacy_nest`] is the silent core the
+/// tests drive.
+pub fn migrate_legacy_nest_announced(home: &Path) -> Result<NestMigration> {
+    let migration = migrate_legacy_nest(home)?;
+    for line in migration.report() {
+        eprintln!("opencompany: {line}");
+    }
+    Ok(migration)
+}
+
+/// Migrates the legacy doubled layout under `home`. See the [module docs](self)
+/// for the rules; idempotent, and a no-op when there is no nest.
+pub fn migrate_legacy_nest(home: &Path) -> Result<NestMigration> {
+    let companies = home.join("companies");
+    let mut migration = NestMigration::default();
+    migrate_bundles(&companies, &mut migration)?;
+    migrate_sqlite(home, &companies, &mut migration)?;
+    Ok(migration)
+}
+
+/// Renames every `<companies>/companies/<slug>` up into `<companies>/<slug>`.
+fn migrate_bundles(companies: &Path, migration: &mut NestMigration) -> Result<()> {
+    let nest = companies.join("companies");
+    // The hosted no-op: one `stat` that finds nothing.
+    if !nest.is_dir() {
+        return Ok(());
+    }
+    // A real bundle that happens to be slugged `companies`. Dissolving it would
+    // scatter its event log and keys across the companies directory.
+    if BUNDLE_MARKERS
+        .iter()
+        .any(|marker| exists(&nest.join(marker)))
+    {
+        return Ok(());
+    }
+
+    let mut names = read_dir_names(&nest)?;
+    names.sort();
+    for name in names {
+        let legacy = nest.join(&name);
+        let destination = companies.join(&name);
+        if exists(&destination) {
+            migration.collisions.push(Collision {
+                what: Relocated::Company,
+                legacy,
+                destination,
+            });
+            continue;
+        }
+        rename(&legacy, &destination)?;
+        migration.moved.push((Relocated::Company, destination));
+    }
+
+    // Only once emptied. A skipped collision keeps the nest, and the next boot
+    // picks up where this one stopped.
+    if read_dir_names(&nest)?.is_empty() {
+        // A failure here leaves an empty directory, not lost data, and the next
+        // boot retries. Never worth aborting a boot for.
+        let _ = std::fs::remove_dir(&nest);
+    }
+    Ok(())
+}
+
+/// Moves a local sqlite database orphaned at `<home>/companies/opencompany.db`
+/// beside the workspace at `<home>/opencompany.db`, with its `-wal`/`-shm`
+/// siblings.
+///
+/// A hosted tenant never has one: it resolves its home to the data root, so its
+/// database is written at `<root>/opencompany.db` to begin with.
+fn migrate_sqlite(home: &Path, companies: &Path, migration: &mut NestMigration) -> Result<()> {
+    // The second and last `stat` a settled install pays. The siblings are only
+    // looked for once the database itself is here.
+    if !exists(&companies.join(SQLITE_DB)) {
+        return Ok(());
+    }
+    let moves: Vec<(PathBuf, PathBuf)> = LEGACY_SQLITE_FILES
+        .iter()
+        .map(|name| (companies.join(name), home.join(name)))
+        .filter(|(legacy, _)| exists(legacy))
+        .collect();
+    // Move the set or none of it. A half-move pairs a relocated database with a
+    // stranded write-ahead log, which is worse than not moving at all.
+    if let Some((legacy, destination)) = moves.iter().find(|(_, dest)| exists(dest)) {
+        migration.collisions.push(Collision {
+            what: Relocated::Database,
+            legacy: legacy.clone(),
+            destination: destination.clone(),
+        });
+        return Ok(());
+    }
+    for (legacy, destination) in moves {
+        rename(&legacy, &destination)?;
+        migration.moved.push((Relocated::Database, destination));
+    }
+    Ok(())
+}
+
+/// Existence that a dangling symlink still counts as occupying: plain
+/// [`Path::exists`] follows the link and reports `false`, and a rename onto a
+/// dangling symlink would silently replace it.
+fn exists(path: &Path) -> bool {
+    std::fs::symlink_metadata(path).is_ok()
+}
+
+/// Directory entry names, or an empty vec when the directory is gone.
+fn read_dir_names(dir: &Path) -> Result<Vec<std::ffi::OsString>> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) => {
+            return Err(OpenCompanyError::StoreIo {
+                path: dir.to_path_buf(),
+                source,
+            });
+        }
+    };
+    entries
+        .map(|entry| {
+            entry
+                .map(|entry| entry.file_name())
+                .map_err(|source| OpenCompanyError::StoreIo {
+                    path: dir.to_path_buf(),
+                    source,
+                })
+        })
+        .collect()
+}
+
+/// Renames within one directory tree, reporting the source path on failure.
+///
+/// A failure aborts the boot rather than continuing with half an install: a
+/// runtime that silently comes up missing companies is the exact symptom this
+/// migration exists to prevent.
+fn rename(from: &Path, to: &Path) -> Result<()> {
+    std::fs::rename(from, to).map_err(|source| OpenCompanyError::StoreIo {
+        path: from.to_path_buf(),
+        source,
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// A scratch home that cleans itself up, named per test so parallel runs
+    /// never share a tree.
+    struct TempHome(PathBuf);
+
+    impl TempHome {
+        fn new(tag: &str) -> Self {
+            let dir = std::env::temp_dir().join(format!(
+                "oc-migrate-{tag}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).expect("scratch home");
+            Self(dir)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+
+        /// Creates a bundle directory holding one marker file.
+        fn bundle(&self, relative: &str) -> PathBuf {
+            let dir = self.0.join(relative);
+            std::fs::create_dir_all(&dir).expect("bundle dir");
+            std::fs::write(dir.join("company.toml"), "[company]\n").expect("manifest");
+            dir
+        }
+
+        fn write(&self, relative: &str, body: &str) -> PathBuf {
+            let path = self.0.join(relative);
+            std::fs::create_dir_all(path.parent().expect("parent")).expect("parent dir");
+            std::fs::write(&path, body).expect("file");
+            path
+        }
+    }
+
+    impl Drop for TempHome {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn a_missing_nest_is_a_no_op() {
+        // The hosted boot, and every local boot after the first.
+        let home = TempHome::new("absent");
+        home.bundle("companies/acme");
+
+        let migration = migrate_legacy_nest(home.path()).expect("no nest to migrate");
+
+        assert!(migration.is_empty());
+        assert!(migration.report().is_empty(), "a no-op says nothing");
+        assert!(home.path().join("companies/acme/company.toml").exists());
+    }
+
+    #[test]
+    fn nested_bundles_move_up_one_level() {
+        let home = TempHome::new("move");
+        home.bundle("companies/companies/acme");
+        home.bundle("companies/companies/globex");
+
+        let migration = migrate_legacy_nest(home.path()).expect("migrates");
+
+        assert!(home.path().join("companies/acme/company.toml").exists());
+        assert!(home.path().join("companies/globex/company.toml").exists());
+        // The emptied nest is removed, so the layout is genuinely canonical.
+        assert!(!home.path().join("companies/companies").exists());
+        assert_eq!(migration.moved.len(), 2);
+        assert!(migration.collisions.is_empty());
+        assert_eq!(migration.report().len(), 2);
+    }
+
+    #[test]
+    fn re_running_is_silent() {
+        let home = TempHome::new("idempotent");
+        home.bundle("companies/companies/acme");
+
+        migrate_legacy_nest(home.path()).expect("first run migrates");
+        let second = migrate_legacy_nest(home.path()).expect("second run is a no-op");
+
+        assert!(second.is_empty(), "{second:?}");
+        assert!(home.path().join("companies/acme/company.toml").exists());
+    }
+
+    #[test]
+    fn a_collision_keeps_both_copies_and_names_both_paths() {
+        // The user who ran the app both ways. Two event logs and two signing
+        // keys cannot be merged, so neither copy may be touched.
+        let home = TempHome::new("collision");
+        home.bundle("companies/acme");
+        home.write("companies/acme/events.jsonl", "canonical\n");
+        home.bundle("companies/companies/acme");
+        home.write("companies/companies/acme/events.jsonl", "legacy\n");
+
+        let migration = migrate_legacy_nest(home.path()).expect("migrates");
+
+        assert!(migration.moved.is_empty());
+        assert_eq!(migration.collisions.len(), 1);
+        assert_eq!(migration.collisions[0].what, Relocated::Company);
+        // Both copies survive with their own event logs.
+        assert_eq!(
+            std::fs::read_to_string(home.path().join("companies/acme/events.jsonl")).unwrap(),
+            "canonical\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(home.path().join("companies/companies/acme/events.jsonl"))
+                .unwrap(),
+            "legacy\n"
+        );
+        // The nest survives too, since it is not empty.
+        assert!(home.path().join("companies/companies").is_dir());
+        // Both paths are named, so the operator can act without guessing.
+        let report = migration.report().join("\n");
+        assert!(
+            report.contains(&home.path().join("companies/acme").display().to_string()),
+            "{report}"
+        );
+        assert!(
+            report.contains(
+                &home
+                    .path()
+                    .join("companies/companies/acme")
+                    .display()
+                    .to_string()
+            ),
+            "{report}"
+        );
+    }
+
+    #[test]
+    fn a_collision_does_not_block_the_other_bundles() {
+        let home = TempHome::new("partial");
+        home.bundle("companies/acme");
+        home.bundle("companies/companies/acme");
+        home.bundle("companies/companies/globex");
+
+        let migration = migrate_legacy_nest(home.path()).expect("migrates");
+
+        assert_eq!(migration.moved.len(), 1);
+        assert_eq!(migration.collisions.len(), 1);
+        assert!(home.path().join("companies/globex/company.toml").exists());
+        assert!(home.path().join("companies/companies/acme").is_dir());
+    }
+
+    #[test]
+    fn a_company_genuinely_slugged_companies_is_untouched() {
+        // `<home>/companies/companies` holding a manifest is a bundle, not a
+        // nest. This guard is also what proves a hosted tenant is never
+        // dissolved.
+        let home = TempHome::new("real-slug");
+        home.bundle("companies/companies");
+        home.write("companies/companies/events.jsonl", "real bundle\n");
+
+        let migration = migrate_legacy_nest(home.path()).expect("leaves the bundle alone");
+
+        assert!(migration.is_empty());
+        assert!(
+            home.path()
+                .join("companies/companies/company.toml")
+                .exists()
+        );
+        assert_eq!(
+            std::fs::read_to_string(home.path().join("companies/companies/events.jsonl")).unwrap(),
+            "real bundle\n"
+        );
+    }
+
+    #[test]
+    fn a_meta_json_alone_also_marks_a_real_bundle() {
+        // A bundle whose manifest is not materialized yet still has `meta.json`;
+        // that is not a nest either.
+        let home = TempHome::new("meta-marker");
+        home.write("companies/companies/meta.json", "{}\n");
+
+        let migration = migrate_legacy_nest(home.path()).expect("leaves the bundle alone");
+
+        assert!(migration.is_empty());
+        assert!(home.path().join("companies/companies/meta.json").exists());
+    }
+
+    #[test]
+    fn an_orphaned_sqlite_database_moves_with_its_siblings() {
+        // `serve` passed the resolved home to `open_storage`, so the legacy
+        // default's database landed inside the bundle home.
+        let home = TempHome::new("sqlite");
+        home.bundle("companies/companies/acme");
+        home.write("companies/opencompany.db", "db");
+        home.write("companies/opencompany.db-wal", "wal");
+        home.write("companies/opencompany.db-shm", "shm");
+
+        let migration = migrate_legacy_nest(home.path()).expect("migrates");
+
+        for name in LEGACY_SQLITE_FILES {
+            assert!(home.path().join(name).exists(), "{name} moved up");
+            assert!(
+                !home.path().join("companies").join(name).exists(),
+                "{name} left behind"
+            );
+        }
+        assert_eq!(
+            migration
+                .moved
+                .iter()
+                .filter(|(what, _)| *what == Relocated::Database)
+                .count(),
+            3
+        );
+    }
+
+    #[test]
+    fn a_database_without_a_write_ahead_log_still_moves() {
+        let home = TempHome::new("sqlite-clean");
+        home.write("companies/opencompany.db", "db");
+
+        migrate_legacy_nest(home.path()).expect("migrates");
+
+        assert!(home.path().join("opencompany.db").exists());
+        assert!(!home.path().join("companies/opencompany.db").exists());
+    }
+
+    #[test]
+    fn a_database_at_the_destination_is_never_overwritten() {
+        // Two databases means two histories. Overwriting one destroys an
+        // install, so both are kept and the operator is told.
+        let home = TempHome::new("sqlite-collision");
+        home.write("companies/opencompany.db", "legacy");
+        home.write("opencompany.db", "canonical");
+
+        let migration = migrate_legacy_nest(home.path()).expect("migrates");
+
+        assert!(migration.moved.is_empty());
+        assert_eq!(migration.collisions.len(), 1);
+        assert_eq!(migration.collisions[0].what, Relocated::Database);
+        assert_eq!(
+            std::fs::read_to_string(home.path().join("opencompany.db")).unwrap(),
+            "canonical"
+        );
+        assert_eq!(
+            std::fs::read_to_string(home.path().join("companies/opencompany.db")).unwrap(),
+            "legacy"
+        );
+    }
+
+    #[test]
+    fn a_wal_at_the_destination_blocks_the_whole_database_move() {
+        // Half a move pairs a moved database with a stranded log, so a single
+        // occupied sibling stops the set.
+        let home = TempHome::new("wal-collision");
+        home.write("companies/opencompany.db", "legacy");
+        home.write("companies/opencompany.db-wal", "legacy wal");
+        home.write("opencompany.db-wal", "canonical wal");
+
+        let migration = migrate_legacy_nest(home.path()).expect("migrates");
+
+        assert!(migration.moved.is_empty());
+        assert_eq!(migration.collisions.len(), 1);
+        assert!(!home.path().join("opencompany.db").exists());
+        assert!(home.path().join("companies/opencompany.db").exists());
+    }
+
+    #[test]
+    fn an_empty_home_migrates_nothing() {
+        let home = TempHome::new("empty");
+
+        let migration = migrate_legacy_nest(home.path()).expect("nothing to do");
+
+        assert!(migration.is_empty());
+    }
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -21,6 +21,10 @@ pub mod fs_ops;
 /// (`companies/`, `memory/`, `store/`, `files/`, `logs/`, `tmp/`) and the
 /// startup lifecycle that creates them and, by default, clears `tmp/`.
 pub mod layout;
+/// The one-shot boot migration off the legacy doubled home layout
+/// (`companies/companies/<slug>`), run by `serve`, `export`, and `import`
+/// against the resolved home before anything reads it.
+pub mod migrate;
 pub mod paths;
 
 /// Config-driven backend selection: maps `OPENCOMPANY_STORAGE` (fs | sqlite |
@@ -75,6 +79,9 @@ pub use fs::{
 };
 pub use fs_ops::FsOps;
 pub use layout::DataLayout;
+pub use migrate::{
+    Collision, NestMigration, Relocated, migrate_legacy_nest, migrate_legacy_nest_announced,
+};
 pub use paths::{Bundle, DATA_DIR_ENV, home_divergence_warning, resolve_home};
 pub use select::{
     MemoryBackend, MemoryOverlay, StorageHandles, StorageKind, StorageSettings,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -79,9 +79,11 @@ pub use fs::{
 };
 pub use fs_ops::FsOps;
 pub use layout::DataLayout;
-pub use migrate::{
-    Collision, NestMigration, Relocated, migrate_legacy_nest, migrate_legacy_nest_announced,
-};
+// Only the boot entry point is re-exported here. The migration is a one-shot
+// step the binary runs before it reads anything, and its silent core and result
+// types are its own business — reachable at `store::migrate::*` for anyone
+// reading the rules, not part of the store's own surface.
+pub use migrate::migrate_legacy_nest_announced;
 pub use paths::{Bundle, DATA_DIR_ENV, home_divergence_warning, resolve_home};
 pub use select::{
     MemoryBackend, MemoryOverlay, StorageHandles, StorageKind, StorageSettings,

--- a/src/store/paths.rs
+++ b/src/store/paths.rs
@@ -19,7 +19,10 @@
 //! signing key or per-company secrets.
 //!
 //! [`resolve_home`] resolves the `<home>` root every bundle hangs off, and is
-//! the only place that decision is made.
+//! the only place that decision is made. It resolves to the instance workspace
+//! root in every branch, so the single `companies/` segment above is the only
+//! one; installs predating that carry an extra level and are moved up on boot by
+//! [`migrate_legacy_nest`](crate::store::migrate_legacy_nest).
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -38,14 +41,6 @@ pub const DATA_DIR_ENV: &str = "OPENCOMPANY_DATA_DIR";
 /// [`resolve_home`] now rejects it by name instead of ignoring it.
 const REMOVED_HOME_ENV: &str = "OPENCOMPANY_HOME";
 
-/// The legacy leaf appended to `$HOME/.opencompany` when neither `--home` nor
-/// [`DATA_DIR_ENV`] is set. [`Bundle::new`] appends `companies/` of its own, so
-/// the untouched default resolves bundles to
-/// `~/.opencompany/companies/companies/<slug>`. That extra level is a wart, but
-/// it is where every existing local install's data already sits, so the default
-/// is preserved verbatim rather than silently relocating it.
-const LEGACY_DEFAULT_LEAF: &str = "companies";
-
 /// Resolves the OpenCompany home — the root every [`Bundle`] hangs off — from
 /// the `--home` flag and the process environment.
 ///
@@ -61,9 +56,18 @@ const LEGACY_DEFAULT_LEAF: &str = "companies";
 ///    identically and the workspace layout and the company bundles share one
 ///    root (`<root>/companies/<slug>`, matching
 ///    [`DataLayout::companies_dir`](crate::store::DataLayout::companies_dir)).
-/// 3. **`$HOME/.opencompany/companies`**, the legacy local default — see
-///    [`LEGACY_DEFAULT_LEAF`]. Falls back to a relative `.opencompany/companies`
-///    when `$HOME` is unset.
+/// 3. **`$HOME/.opencompany`**, the local default. Falls back to a relative
+///    `.opencompany` when `$HOME` is unset.
+///
+/// All three branches resolve the home to the *workspace root*, so bundles land
+/// at `<root>/companies/<slug>` in every case — the layout
+/// [`DataLayout::companies_dir`](crate::store::DataLayout::companies_dir) and
+/// `docs/spec/runtime/storage.md` document. The default used to append a
+/// `companies` leaf of its own on top of the one [`Bundle::new`] adds, nesting a
+/// default local install's bundles at `~/.opencompany/companies/companies/<slug>`.
+/// That leaf is gone; existing installs are moved up on first launch by
+/// [`migrate_legacy_nest`](crate::store::migrate_legacy_nest), which `serve`,
+/// `export`, and `import` all run before touching the home.
 ///
 /// An empty variable counts as unset: an empty `OPENCOMPANY_DATA_DIR` would
 /// otherwise root the instance at the process working directory.
@@ -111,10 +115,8 @@ fn resolve_home_from(
         return Ok(PathBuf::from(dir));
     }
     Ok(match set(unix_home) {
-        Some(home) => PathBuf::from(home)
-            .join(".opencompany")
-            .join(LEGACY_DEFAULT_LEAF),
-        None => PathBuf::from(".opencompany").join(LEGACY_DEFAULT_LEAF),
+        Some(home) => PathBuf::from(home).join(".opencompany"),
+        None => PathBuf::from(".opencompany"),
     })
 }
 
@@ -125,15 +127,17 @@ fn resolve_home_from(
 /// — the bundles separate, the workspace does not.
 ///
 /// `data_root` is [`data_dir_from_env`](crate::app::config::data_dir_from_env).
-/// Silent in the two aligned shapes:
+/// Silent in the one aligned shape, `home == data_root`, which now covers every
+/// branch of [`resolve_home`]: a hosted tenant
+/// (`--home "$OPENCOMPANY_DATA_DIR"`), `OPENCOMPANY_DATA_DIR` alone, and the
+/// untouched local default.
 ///
-/// - `home == data_root` — a hosted tenant (`--home "$OPENCOMPANY_DATA_DIR"`)
-///   or `OPENCOMPANY_DATA_DIR` alone.
-/// - `home == data_root/companies` — the untouched legacy default, which
-///   diverges by design (see [`LEGACY_DEFAULT_LEAF`]) and must not warn on
-///   every ordinary run.
+/// One deliberate consequence: an explicit `--home ~/.opencompany/companies`
+/// recreates the old doubled shape and now warns where the legacy default was
+/// silent. That is correct — the bundles really are one level away from the
+/// workspace there.
 pub fn home_divergence_warning(home: &Path, data_root: &Path) -> Option<String> {
-    if home == data_root || home == data_root.join(LEGACY_DEFAULT_LEAF) {
+    if home == data_root {
         return None;
     }
     Some(format!(
@@ -500,12 +504,14 @@ mod test {
     }
 
     #[test]
-    fn the_default_is_unchanged_when_nothing_is_set() {
-        // Existing local installs must not silently relocate: the legacy
-        // default keeps its extra `companies` level (see LEGACY_DEFAULT_LEAF).
+    fn the_default_resolves_to_the_workspace_root() {
+        // The default no longer appends a `companies` leaf on top of the one
+        // `Bundle::new` adds, so a default local install has the same
+        // single-root shape as a hosted tenant. Existing doubled installs are
+        // moved up by `store::migrate_legacy_nest` rather than orphaned.
         assert_eq!(
             resolve(None, None, Some("/home/u")).unwrap(),
-            PathBuf::from("/home/u/.opencompany/companies")
+            PathBuf::from("/home/u/.opencompany")
         );
         let bundle = Bundle::new(
             resolve(None, None, Some("/home/u")).unwrap(),
@@ -513,13 +519,30 @@ mod test {
         );
         assert_eq!(
             bundle.dir(),
-            Path::new("/home/u/.opencompany/companies/companies/acme")
+            Path::new("/home/u/.opencompany/companies/acme")
         );
         // No $HOME keeps the relative fallback.
         assert_eq!(
             resolve(None, None, None).unwrap(),
-            PathBuf::from(".opencompany/companies")
+            PathBuf::from(".opencompany")
         );
+    }
+
+    #[test]
+    fn every_branch_resolves_to_the_same_shape() {
+        // Flag, variable, and default now agree: the home is the workspace root
+        // and bundles hang off `<root>/companies/<slug>` in all three.
+        let roots = [
+            resolve(Some("/root"), None, None).unwrap(),
+            resolve(None, Some("/root"), None).unwrap(),
+            resolve(None, None, Some("/root")).unwrap(),
+        ];
+        assert_eq!(roots[0], roots[1]);
+        assert_eq!(roots[2], PathBuf::from("/root/.opencompany"));
+        for root in roots {
+            let bundle = Bundle::new(root.clone(), &CompanyId::new("acme"));
+            assert_eq!(bundle.dir(), root.join("companies").join("acme"));
+        }
     }
 
     #[test]
@@ -527,11 +550,11 @@ mod test {
         // Empty would otherwise root the instance at the working directory.
         assert_eq!(
             resolve(None, Some(""), Some("/home/u")).unwrap(),
-            PathBuf::from("/home/u/.opencompany/companies")
+            PathBuf::from("/home/u/.opencompany")
         );
         assert_eq!(
             resolve(None, Some(""), Some("")).unwrap(),
-            PathBuf::from(".opencompany/companies")
+            PathBuf::from(".opencompany")
         );
     }
 
@@ -575,14 +598,32 @@ mod test {
             home_divergence_warning(Path::new("/data"), Path::new("/data")).is_none(),
             "one root for the whole instance is the intended shape"
         );
-        // The untouched legacy default diverges by design and must stay silent
-        // on every ordinary local run.
+        // The default local run: both the home and the data root resolve to
+        // $HOME/.opencompany now, so an ordinary run is silent without needing a
+        // special case for a doubled shape.
         assert!(
             home_divergence_warning(
-                Path::new("/home/u/.opencompany/companies"),
+                Path::new("/home/u/.opencompany"),
                 Path::new("/home/u/.opencompany"),
             )
             .is_none()
+        );
+    }
+
+    #[test]
+    fn recreating_the_old_doubled_shape_by_hand_now_warns() {
+        // A deliberate consequence of dropping the default's `companies` leaf:
+        // an explicit --home at the old path really does put the bundles one
+        // level away from the workspace, which is exactly what this warning is
+        // for. It used to be special-cased silent.
+        let warning = home_divergence_warning(
+            Path::new("/home/u/.opencompany/companies"),
+            Path::new("/home/u/.opencompany"),
+        )
+        .expect("an explicit --home at the legacy path is a real divergence");
+        assert!(
+            warning.contains("/home/u/.opencompany/companies"),
+            "{warning}"
         );
     }
 

--- a/src/store/paths.rs
+++ b/src/store/paths.rs
@@ -22,7 +22,7 @@
 //! the only place that decision is made. It resolves to the instance workspace
 //! root in every branch, so the single `companies/` segment above is the only
 //! one; installs predating that carry an extra level and are moved up on boot by
-//! [`migrate_legacy_nest`](crate::store::migrate_legacy_nest).
+//! [`migrate_legacy_nest`](crate::store::migrate::migrate_legacy_nest).
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -66,7 +66,7 @@ const REMOVED_HOME_ENV: &str = "OPENCOMPANY_HOME";
 /// `companies` leaf of its own on top of the one [`Bundle::new`] adds, nesting a
 /// default local install's bundles at `~/.opencompany/companies/companies/<slug>`.
 /// That leaf is gone; existing installs are moved up on first launch by
-/// [`migrate_legacy_nest`](crate::store::migrate_legacy_nest), which `serve`,
+/// [`migrate_legacy_nest`](crate::store::migrate::migrate_legacy_nest), which `serve`,
 /// `export`, and `import` all run before touching the home.
 ///
 /// An empty variable counts as unset: an empty `OPENCOMPANY_DATA_DIR` would
@@ -508,7 +508,7 @@ mod test {
         // The default no longer appends a `companies` leaf on top of the one
         // `Bundle::new` adds, so a default local install has the same
         // single-root shape as a hosted tenant. Existing doubled installs are
-        // moved up by `store::migrate_legacy_nest` rather than orphaned.
+        // moved up by `store::migrate::migrate_legacy_nest` rather than orphaned.
         assert_eq!(
             resolve(None, None, Some("/home/u")).unwrap(),
             PathBuf::from("/home/u/.opencompany")


### PR DESCRIPTION
## Summary

Fixes #283.

`resolve_home` appended a `companies` leaf to `$HOME/.opencompany` when neither `--home` nor `OPENCOMPANY_DATA_DIR` was set, and `Bundle::new` appends a `companies/` segment of its own. A default local install therefore stored bundles at `~/.opencompany/companies/companies/<slug>` while `DataLayout` materialized `~/.opencompany/{memory,store,files,logs,tmp}` beside the **first** `companies/`.

**The resolver's leaf is what goes, not `Bundle::new`'s segment.** `Bundle::new`'s segment is what puts a hosted tenant's bundles at `/data/companies/<slug>`; removing that would relocate every hosted tenant and every `OPENCOMPANY_DATA_DIR` user to `<root>/<slug>`, mixed in with the sibling workspace directories. Dropping the resolver's leaf makes all three precedence branches resolve the home to the workspace root, restoring the documented single-root layout everywhere.

### The sqlite database is orphaned too

`serve` passes the resolved home to `open_storage`, so a default local sqlite install's database sits at `~/.opencompany/companies/opencompany.db`. Fixing the path without moving that file leaves the database behind as well as the bundles, so the migration moves it (with its `-wal`/`-shm` siblings) alongside.

### Migration: detect-and-move on boot (`src/store/migrate.rs`)

`serve`, `export`, and `import` all resolve through a new `resolve_home_migrated`, which calls `store::migrate_legacy_nest_announced` before anything reads the home. `export`/`import` are included deliberately: otherwise an un-migrated install's first post-upgrade command is the one that fails to find its bundles.

- Nest is `<home>/companies/companies`. Not a directory: no-op.
- **Guard:** a nest holding `company.toml` or `meta.json` at its top level is a real bundle whose slug happens to be `companies`, and is left exactly as it is.
- Each entry is renamed up one level when the destination is free.
- **On collision, skip and warn, never merge and never pick a winner.** A user who ran the app both ways can have two copies of one company; interleaving two event logs and two signing keys is unrecoverable, and picking a winner is the same bet with the loser deleted. Both copies stay put and the warning names both directories.
- The sqlite database moves as a **set** with its `-wal`/`-shm` siblings; a single occupied destination stops the whole set, because a half-move pairs a relocated database with a stranded write-ahead log.
- The nest directory is removed only once emptied, so a crash mid-loop resumes on the next boot. Idempotent by construction: re-running a migrated install is silent.
- Moves print on **stderr**, not `warn!`, which the default `EnvFilter` drops unless `RUST_LOG` is set.

Alternatives rejected per the issue: warn-only (the operator still sees an empty console, which is the symptom itself), symlink (self-referential loop under `companies/`, breaks the export tree-walk, non-portable), dual-path reads (lazy bundle creation forks one company into two half-bundles, making the merge hazard permanent).

### Hosted blast radius, shown rather than asserted

A tenant never reaches the changed branch:

- `Dockerfile:61` and `Dockerfile:96` set `OPENCOMPANY_DATA_DIR=/data`.
- `docker/entrypoint.sh` always passes the flag:
  ```sh
  exec opencompany serve \
    --company "${DIR}" \
    --bind "${OPENCOMPANY_BIND:-0.0.0.0:8080}" \
    --home "${OPENCOMPANY_DATA_DIR:-/data}" \
    ${DISCOVER}
  ```
  `resolve_home` returns the flag before it consults `OPENCOMPANY_DATA_DIR` or the default, so a tenant takes precedence branch 1 and branch 3 is unreachable there.

The only new hosted behaviour is the migration's two `stat`s per boot that find nothing: `/data/companies/companies` is not a directory (and if a tenant ever did have a company slugged `companies`, the marker-file guard leaves it alone), and `/data/companies/opencompany.db` never exists because sqlite opens at `<home>/opencompany.db` = `/data/opencompany.db`.

### `--home` versus `OPENCOMPANY_DATA_DIR`

Unchanged: both still resolve verbatim and identically. The known coverage split (`--home` moves bundles and sqlite while the workspace follows `OPENCOMPANY_DATA_DIR`, which `home_divergence_warning` already reports) is left as-is; this only makes the default branch agree in shape with the other two.

One deliberate consequence: `home_divergence_warning` loses its `home == data_root/companies` special case, so an explicit `--home ~/.opencompany/companies` recreates the old shape and now prints the divergence warning where it was previously silent. That is correct — the bundles really are one level away from the workspace there. Covered by a test.

## API Or Behavior Changes

- **Behavior:** the default OpenCompany home is now `$HOME/.opencompany` (relative `.opencompany` without `$HOME`) instead of `$HOME/.opencompany/companies`. Bundles land at `~/.opencompany/companies/<slug>`; a default sqlite database at `~/.opencompany/opencompany.db`.
- **Behavior:** `serve`, `export`, and `import` migrate a legacy doubled install on first launch and print a summary on stderr. Same-slug collisions are skipped with both paths named.
- **Behavior:** an explicit `--home` at the old default path now emits the existing divergence warning.
- **API:** new public `store::migrate` module — `migrate_legacy_nest`, `migrate_legacy_nest_announced`, `NestMigration`, `Collision`, `Relocated`. Nothing removed from the public surface (`LEGACY_DEFAULT_LEAF` was private).
- `--home` and `OPENCOMPANY_DATA_DIR` behaviour is unchanged.

## Tests

- [x] `cargo fmt --all -- --check` — N/A - full local build matrix is prohibited on this machine; verified in CI (ran `rustfmt --edition 2024` on every touched Rust file; clean)
- [x] `cargo clippy --all-targets -- -D warnings` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo build --all-targets` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo test` — N/A - full local build matrix is prohibited on this machine; verified in CI

Tests added with the behavior change (CI runs them):

`src/store/migrate.rs` — `a_missing_nest_is_a_no_op` (the hosted and settled-install path), `nested_bundles_move_up_one_level`, `re_running_is_silent` (idempotence), `a_collision_keeps_both_copies_and_names_both_paths`, `a_collision_does_not_block_the_other_bundles`, `a_company_genuinely_slugged_companies_is_untouched`, `a_meta_json_alone_also_marks_a_real_bundle`, `an_orphaned_sqlite_database_moves_with_its_siblings`, `a_database_without_a_write_ahead_log_still_moves`, `a_database_at_the_destination_is_never_overwritten`, `a_wal_at_the_destination_blocks_the_whole_database_move`, `an_empty_home_migrates_nothing`.

`src/store/paths.rs` — `the_default_resolves_to_the_workspace_root`, `every_branch_resolves_to_the_same_shape`, `an_empty_data_dir_counts_as_unset` (updated), `aligned_roots_never_warn` (updated), `recreating_the_old_doubled_shape_by_hand_now_warns`.

`src/bin/opencompany.rs` — `every_home_resolving_command_migrates_the_legacy_nest` pins the CLI wiring end to end (legacy tree in, canonical `Bundle` path out).

## Documentation

- `docs/spec/runtime/storage.md` — precedence table row 3 corrected, the "legacy default is one level deeper" consequence removed, and a new **Migrating a legacy doubled install** section documenting the rules and the hosted no-op.
- `docs/spec/runtime/config.md` — `OPENCOMPANY_DATA_DIR` default column no longer advertises a split workspace/bundle-home default.
- `gitbooks/developers/cli.md` — `--home` flag row and the "Where state lives" precedence list updated, with a note on the first-launch migration.
- `src/store/paths.rs` and `src/bin/opencompany.rs` doc comments updated; `src/store/migrate.rs` carries the full rationale.
- `docs/spec/runtime/lifecycle.md` and `docs/spec/runtime/README.md` already documented `~/.opencompany/companies/<slug>/`, which is now what the code actually does.

## Acceptance (from #283)

- [x] A default local install stores bundles at `~/.opencompany/companies/<slug>`
- [x] An existing doubled install has its bundles **and** any sqlite DB moved up on first launch, with a printed summary
- [x] A same-slug collision is skipped, both copies preserved, both paths named in a warning
- [x] Re-running is silent (idempotent)
- [x] A bundle genuinely slugged `companies` is untouched
- [x] `OPENCOMPANY_DATA_DIR` and `--home` behaviour unchanged
- [x] `docs/spec/runtime/storage.md` matches the restored layout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized the workspace location to `$HOME/.opencompany`, with company bundles stored under `companies/<slug>`.
  * Added automatic migration from legacy doubled `companies` layouts.
  * Added handling and reporting for moved files, conflicts, database files, and resumable migrations.
  * Added warnings for conflicting home-directory configuration settings.

* **Documentation**
  * Updated configuration, storage, and CLI documentation with the new layout and migration behavior.
  * Updated CLI help text to reflect canonical bundle locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->