### PR TITLE
fix(platform-auth): authenticate every tenant token before trusting it (#322)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,7 +218,17 @@ rand_core = { version = "0.6", default-features = false, features = ["getrandom"
 # (`github`, `telegram`, `medulla`, …) also depend on, so the default build
 # gains no new heavy native dependency. The read-only status route
 # (`ops::connections_read`) is un-gated and available regardless.
-default = ["oauth"]
+#
+# `platform-jwt` ships in the standard build because it is the *only* way a
+# shipped build can accept a tenant-scoped machine credential: the platform
+# verifier authenticates a bearer either by knowledge of the shared secret or by
+# an HS256 signature, and nothing else. Leaving it optional made the signed path
+# a build-time opt-in, and — because cargo features are additive and no CI lane
+# enabled it — its tests were compiled by the check-only `--all-features` step
+# and *run* by nothing. Moving it into the default set makes both `cargo test`
+# lanes execute them, which is why this needs no new CI lane. It costs one pure
+# dependency (`jsonwebtoken`), already in `Cargo.lock`.
+default = ["oauth", "platform-jwt"]
 tiny = ["tinyagents"]
 # WS4: embed `vendor/openhuman` (`openhuman_core`) directly as the tenant agent
 # harness via `AgentBuilder`. `src/harness/` compiles only under this feature;

--- a/docs/spec/runtime/config.md
+++ b/docs/spec/runtime/config.md
@@ -99,6 +99,8 @@ layer set it, and what is missing for each optional capability.
 | `OPENCOMPANY_MAIL_USERNAME` / `_PASSWORD` | — | SMTP auth. Redacted from `Debug` and never logged |
 | `OPENCOMPANY_MAIL_FROM_NAME` | — | Display name on the `From` header |
 | `OPENCOMPANY_CORS_ORIGINS` | — (CORS off) | Comma-separated exact origins allowed to send the session cookie cross-origin, e.g. `http://localhost:5173`. `*` is refused: a wildcard is illegal with credentials |
+| `OPENCOMPANY_PLATFORM_TOKEN` | — (no machine credential) | The shared platform secret. A bearer equal to it is the `tenant:platform` principal, with the `platform` scope |
+| `OPENCOMPANY_PLATFORM_JWT_SECRET` | — (signed tenant tokens not accepted) | HS256 secret that signs tenant-scoped machine tokens. No shipped literal and no fallback: unset means the path does not exist. Set on a build without `platform-jwt` (in the default feature set) and the host **refuses to boot** |
 
 ### Outbound mail
 
@@ -155,6 +157,33 @@ whole story, and HTTP provisioning is unavailable by construction (load
 companies with `serve --company <dir>`). A company with no admin in its
 manifest's `[users]` cannot be reached until one is listed — that is the
 bootstrap, and it is deliberate.
+
+#### How a platform bearer is authenticated
+
+Exactly two shapes, selected by the two environment variables above:
+
+- **Shared platform secret** (`OPENCOMPANY_PLATFORM_TOKEN`) — an exact match.
+  Authenticated by knowledge of the secret, the same pattern the control plane
+  uses for its own admin token. Grants the single `tenant:platform` principal.
+- **Signed tenant token** (`OPENCOMPANY_PLATFORM_JWT_SECRET`) — HS256 over the
+  `tenant` / `scopes` / `companies` claims, `exp` honored when present. This is
+  how a tenant-scoped machine token is issued.
+
+Both may be set; a bearer accepted by either is accepted. Boot prints the active
+mode (`platform auth: shared-secret | jwt | both`) and never the secret.
+
+No state fails open. No credential means every machine route answers `401`; an
+unauthenticated bearer of any shape is `401`; a wrong secret is `401`; and a
+signing secret on a build compiled without `platform-jwt` aborts boot with a
+message naming the variable and the missing feature rather than degrading to a
+weaker check.
+
+Two limits worth naming. The signing is **symmetric**, so a workload that can
+verify a token could also mint one — acceptable while the trust boundary is a
+single workload; asymmetric keys via the control plane's issuer are the
+follow-up. And a signed token carrying **no `exp` never expires**, because the
+verifier clears its required-claims set; tightening that is a separate policy
+decision.
 
 ### What changed, and why it mattered
 

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -882,19 +882,24 @@ async fn main() -> Result<()> {
                 state = state.with_memory_overlay(overlay);
                 println!("memory backend: {:?}", storage_settings.memory_backend);
             }
-            // Platform (multi-tenant) auth: a shared platform token enables the
-            // provisioning/lifecycle surface. Without it the prosumer operator
-            // path stays in force. Real signed JWT is `platform-jwt`.
-            if let Some(token) = std::env::var("OPENCOMPANY_PLATFORM_TOKEN")
-                .ok()
-                .filter(|v| !v.trim().is_empty())
+            // Platform (multi-tenant) auth: either credential enables the
+            // provisioning/lifecycle surface. Without both the prosumer operator
+            // path stays in force. A signing secret this build cannot verify
+            // aborts boot here rather than silently degrading — same precedent
+            // as a selected-but-unavailable storage backend above.
             {
                 use opencompany::server::platform_auth::{
-                    PlatformAuthConfig, StaticPlatformVerifier,
+                    PLATFORM_JWT_SECRET_ENV, PLATFORM_TOKEN_ENV, configure,
                 };
-                state = state.with_platform_auth(PlatformAuthConfig::new(Arc::new(
-                    StaticPlatformVerifier::new(token),
-                )));
+                if let Some((platform_auth, mode)) = configure(
+                    std::env::var(PLATFORM_TOKEN_ENV).ok(),
+                    std::env::var(PLATFORM_JWT_SECRET_ENV).ok(),
+                )? {
+                    state = state.with_platform_auth(platform_auth);
+                    // The mode only — never the secret, or anything derived
+                    // from it.
+                    println!("platform auth: {mode}");
+                }
             }
             // Outbound webhooks: a URL wires the HTTP sink under `webhooks`;
             // without the feature the request is warned and dropped.

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -887,13 +887,13 @@ async fn memory_operator_fact_is_injected_into_the_agent_turn() {
 #[tokio::test]
 async fn memory_is_isolated_between_companies() {
     use crate::server::platform_auth::{
-        PlatformAuthConfig, PlatformClaims, StaticPlatformVerifier,
+        PlatformAuthConfig, PlatformClaims, UnsignedTenantVerifier,
     };
     use std::collections::HashSet;
 
     let home_dir = home();
     let home = home_dir.path().to_path_buf();
-    let verifier = std::sync::Arc::new(StaticPlatformVerifier::new("plat-secret"));
+    let verifier = std::sync::Arc::new(UnsignedTenantVerifier::new("plat-secret"));
     let state = AppState::new(AppConfig::default())
         .with_home(home.clone())
         .with_platform_auth(PlatformAuthConfig::new(verifier));
@@ -912,7 +912,7 @@ async fn memory_is_isolated_between_companies() {
     }
 
     let token = |tenant: &str| {
-        StaticPlatformVerifier::tenant_token(&PlatformClaims {
+        UnsignedTenantVerifier::tenant_token(&PlatformClaims {
             tenant: tenant.to_string(),
             scopes: HashSet::from(["operator".to_string()]),
             companies: None,
@@ -1198,13 +1198,13 @@ async fn workspace_tree_and_file_reads_reflect_writes() {
 #[tokio::test]
 async fn workspace_reads_are_isolated_between_companies() {
     use crate::server::platform_auth::{
-        PlatformAuthConfig, PlatformClaims, StaticPlatformVerifier,
+        PlatformAuthConfig, PlatformClaims, UnsignedTenantVerifier,
     };
     use std::collections::HashSet;
 
     let home_dir = home();
     let home = home_dir.path().to_path_buf();
-    let verifier = std::sync::Arc::new(StaticPlatformVerifier::new("plat-secret"));
+    let verifier = std::sync::Arc::new(UnsignedTenantVerifier::new("plat-secret"));
     let state = AppState::new(AppConfig::default())
         .with_home(home.clone())
         .with_platform_auth(PlatformAuthConfig::new(verifier));
@@ -1223,7 +1223,7 @@ async fn workspace_reads_are_isolated_between_companies() {
     }
 
     let token = |tenant: &str| {
-        StaticPlatformVerifier::tenant_token(&PlatformClaims {
+        UnsignedTenantVerifier::tenant_token(&PlatformClaims {
             tenant: tenant.to_string(),
             scopes: HashSet::from(["operator".to_string()]),
             companies: None,
@@ -1998,14 +1998,14 @@ async fn chat_accepts_desk_id_and_replies() {
 #[tokio::test]
 async fn credential_route_rejects_foreign_tenant() {
     use crate::server::platform_auth::{
-        PlatformAuthConfig, PlatformClaims, StaticPlatformVerifier,
+        PlatformAuthConfig, PlatformClaims, UnsignedTenantVerifier,
     };
     use std::collections::HashSet;
 
     let home_dir = home();
     let home = home_dir.path().to_path_buf();
     // Platform mode: `acme` is owned by `tenant:acme`.
-    let verifier = std::sync::Arc::new(StaticPlatformVerifier::new("plat-secret"));
+    let verifier = std::sync::Arc::new(UnsignedTenantVerifier::new("plat-secret"));
     let state = AppState::new(AppConfig::default())
         .with_home(home.clone())
         .with_platform_auth(PlatformAuthConfig::new(verifier));
@@ -2021,7 +2021,7 @@ async fn credential_route_rejects_foreign_tenant() {
     state.set_owner(id.clone(), "tenant:acme");
 
     let token = |tenant: &str| {
-        StaticPlatformVerifier::tenant_token(&PlatformClaims {
+        UnsignedTenantVerifier::tenant_token(&PlatformClaims {
             tenant: tenant.to_string(),
             scopes: HashSet::from(["operator".to_string()]),
             companies: None,

--- a/src/server/platform_auth.rs
+++ b/src/server/platform_auth.rs
@@ -454,6 +454,71 @@ mod test {
         assert!(!claims.has_platform_scope());
     }
 
+    /// The shipped default build must not turn a caller-supplied payload into
+    /// platform claims. The bearer is assembled literally, from nothing but the
+    /// wire shape, so this stays a black-box statement about what an
+    /// unauthenticated request can obtain — no helper, no shared constant.
+    #[test]
+    fn hand_constructed_tenant_bearer_is_refused() {
+        let verifier = StaticPlatformVerifier::new("top-secret");
+        let forged = format!(
+            "oc_tenant.{}",
+            b64url_encode(br#"{"tenant":"tenant:victim","scopes":["platform","operator"]}"#)
+        );
+        assert!(
+            verifier.verify(&forged).is_err(),
+            "an unsigned, caller-supplied payload must not resolve to platform claims"
+        );
+    }
+
+    #[cfg(feature = "platform-jwt")]
+    fn sign(secret: &str, claims: &serde_json::Value) -> String {
+        use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+        encode(
+            &Header::new(Algorithm::HS256),
+            claims,
+            &EncodingKey::from_secret(secret.as_bytes()),
+        )
+        .expect("sign")
+    }
+
+    #[cfg(feature = "platform-jwt")]
+    #[test]
+    fn jwt_verifier_refuses_an_expired_token() {
+        let secret = "signing-secret";
+        // 2001-09-09, comfortably in the past whenever this runs.
+        let token = sign(
+            secret,
+            &json!({"tenant": "tenant:acme", "scopes": ["operator"], "exp": 1_000_000_000u64}),
+        );
+        assert!(JwtPlatformVerifier::new(secret).verify(&token).is_err());
+    }
+
+    #[cfg(feature = "platform-jwt")]
+    #[test]
+    fn jwt_verifier_refuses_a_tampered_payload() {
+        let secret = "signing-secret";
+        let token = sign(
+            secret,
+            &json!({"tenant": "tenant:acme", "scopes": ["operator"]}),
+        );
+
+        // Rewrite the claims to grant the platform scope, keeping the original
+        // signature: it no longer covers the body it is attached to.
+        let parts: Vec<&str> = token.split('.').collect();
+        let mut claims: serde_json::Value =
+            serde_json::from_slice(&b64url_decode(parts[1]).expect("payload")).expect("claims");
+        claims["scopes"] = json!(["platform", "operator"]);
+        let tampered = format!(
+            "{}.{}.{}",
+            parts[0],
+            b64url_encode(&serde_json::to_vec(&claims).expect("re-encode")),
+            parts[2]
+        );
+
+        assert!(JwtPlatformVerifier::new(secret).verify(&tampered).is_err());
+    }
+
     #[test]
     fn unrecognized_token_is_rejected() {
         let verifier = StaticPlatformVerifier::new("top-secret");

--- a/src/server/platform_auth.rs
+++ b/src/server/platform_auth.rs
@@ -738,6 +738,36 @@ mod test {
         assert!(JwtPlatformVerifier::new(secret).verify(&tampered).is_err());
     }
 
+    /// `alg: "none"` is the oldest JWT forgery there is: drop the signature,
+    /// keep whatever payload you like, and hope the verifier honors the header's
+    /// choice of algorithm. `Validation::new(Algorithm::HS256)` pins the
+    /// algorithm so it does not, and clearing `required_spec_claims` does not
+    /// loosen that — but only a test says so out loud. The same claims, signed,
+    /// are accepted, which leaves the header as the only thing the rejection can
+    /// be about.
+    #[cfg(feature = "platform-jwt")]
+    #[test]
+    fn jwt_verifier_refuses_an_unsigned_token() {
+        let secret = "signing-secret";
+        let claims = json!({"tenant": "tenant:victim", "scopes": ["platform", "operator"]});
+
+        // Assembled literally, from nothing but the wire shape: header, payload,
+        // and the empty signature an `alg: none` token carries.
+        let unsigned = format!(
+            "{}.{}.",
+            b64url_encode(br#"{"alg":"none","typ":"JWT"}"#),
+            b64url_encode(&serde_json::to_vec(&claims).expect("claims"))
+        );
+
+        assert!(
+            JwtPlatformVerifier::new(secret).verify(&unsigned).is_err(),
+            "an unsigned `alg: none` token must not resolve to platform claims"
+        );
+
+        let signed = sign(secret, &claims);
+        assert!(JwtPlatformVerifier::new(secret).verify(&signed).is_ok());
+    }
+
     #[test]
     fn unrecognized_token_is_rejected() {
         let verifier = StaticPlatformVerifier::new("top-secret");

--- a/src/server/platform_auth.rs
+++ b/src/server/platform_auth.rs
@@ -11,11 +11,34 @@
 //! configured there is no machine credential at all, and a session is the only
 //! way in.
 //!
-//! The verification seam is [`PlatformVerifier`]. The default build ships an
-//! offline [`StaticPlatformVerifier`] (a shared platform secret plus unsigned,
-//! structured tenant tokens) so the scope-gate and cross-tenant logic are fully
-//! covered by `cargo test`. Real signed-JWT verification is added under the
-//! `platform-jwt` feature; the gate logic here is verifier-agnostic.
+//! The verification seam is [`PlatformVerifier`]. A shipped build authenticates
+//! a bearer exactly two ways, and [`configure`] selects between them from the
+//! environment:
+//!
+//! - [`StaticPlatformVerifier`] — an exact match against a shared platform
+//!   secret. Authenticated by *knowledge of the secret*, the same pattern the
+//!   control plane uses for its own admin token.
+//! - [`JwtPlatformVerifier`] — HS256-signed, tenant-scoped claims. This is how a
+//!   tenant token is issued in production.
+//!
+//! A host may set either or both; with both, a bearer is accepted if either
+//! accepts it. Neither set means there is no machine credential at all.
+//!
+//! No shipped build parses caller-supplied claims that carry no authentication.
+//! The offline `oc_tenant.<base64url(json)>` codec survives only as
+//! `UnsignedTenantVerifier`, a `cfg(test)` type, so the scope-gate,
+//! allow-list and ownership suites keep running without signing machinery. It is
+//! a separate type rather than a branch inside `StaticPlatformVerifier::verify`
+//! on purpose: a `cfg(test)` branch there would make the production rejection
+//! unobservable, because the test build would still accept the unsigned shape.
+//!
+//! Known limits, stated rather than fixed here:
+//!
+//! - The signing is **symmetric** — a workload that can verify can also mint.
+//!   Acceptable while the trust boundary is a single workload; asymmetric keys
+//!   via the control plane's issuer are the follow-up.
+//! - A signed token carrying **no `exp` never expires**, because the verifier
+//!   clears its required-claims set. Changing that is a separate policy call.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -75,10 +98,14 @@ pub trait PlatformVerifier: Send + Sync {
     fn verify(&self, bearer: &str) -> crate::Result<PlatformClaims>;
 }
 
-/// An offline/dev verifier. A bearer equal to `platform_secret` is a
-/// platform-scope token; a `oc_tenant.<base64url(json)>` bearer carries
-/// structured (UNSIGNED) tenant claims. Clearly insecure — for local use and
-/// tests. Real signed verification is `platform-jwt`.
+/// The shared-secret verifier: a bearer *equal to* `platform_secret` is a
+/// full platform-scope token, and nothing else is accepted.
+///
+/// Exact match is the whole mechanism, and it is a real one — the credential is
+/// authenticated by knowledge of the secret, so a caller who does not hold it
+/// cannot produce an accepted bearer. Tenant-scoped machine tokens are signed
+/// JWTs ([`JwtPlatformVerifier`]); this verifier issues only the one
+/// `tenant:platform` identity.
 #[derive(Clone)]
 pub struct StaticPlatformVerifier {
     /// The shared secret that grants a full platform-scope token.
@@ -86,20 +113,11 @@ pub struct StaticPlatformVerifier {
 }
 
 impl StaticPlatformVerifier {
-    /// The prefix marking an unsigned structured tenant token.
-    pub const TENANT_PREFIX: &'static str = "oc_tenant.";
-
     /// Builds a verifier around a shared platform secret.
     pub fn new(platform_secret: impl Into<String>) -> Self {
         Self {
             platform_secret: platform_secret.into(),
         }
-    }
-
-    /// Encodes structured claims into a dev tenant token (test helper).
-    pub fn tenant_token(claims: &PlatformClaims) -> String {
-        let json = serde_json::to_vec(claims).expect("claims serialize");
-        format!("{}{}", Self::TENANT_PREFIX, b64url_encode(&json))
     }
 }
 
@@ -112,23 +130,19 @@ impl PlatformVerifier for StaticPlatformVerifier {
                 companies: None,
             });
         }
-        if let Some(encoded) = bearer.strip_prefix(Self::TENANT_PREFIX) {
-            let bytes = b64url_decode(encoded).ok_or_else(|| {
-                OpenCompanyError::InvalidRequest("malformed platform token".to_string())
-            })?;
-            let claims: PlatformClaims = serde_json::from_slice(&bytes)?;
-            return Ok(claims);
-        }
         Err(OpenCompanyError::InvalidRequest(
             "unrecognized token".to_string(),
         ))
     }
 }
 
-/// A real signed-JWT verifier (HS256), gated behind `platform-jwt`. The claim
+/// The signed-JWT verifier (HS256) for tenant-scoped machine tokens. The claim
 /// shape mirrors [`PlatformClaims`] (`tenant`, `scopes`, `companies`); `exp` is
-/// honored when present. The offline [`StaticPlatformVerifier`] covers the
-/// scope-gate logic without this feature.
+/// honored when present.
+///
+/// Gated on `platform-jwt`, which is in the default feature set — a build
+/// without it can verify nothing but the shared secret, and [`configure`]
+/// refuses to boot rather than silently ignoring a signing secret it cannot use.
 #[cfg(feature = "platform-jwt")]
 pub struct JwtPlatformVerifier {
     secret: String,
@@ -184,6 +198,149 @@ impl std::fmt::Debug for PlatformAuthConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PlatformAuthConfig").finish_non_exhaustive()
     }
+}
+
+// ---------------------------------------------------------------------------
+// Boot-time selection
+// ---------------------------------------------------------------------------
+
+/// Environment variable holding the shared platform secret. Unset means the
+/// shared-secret credential does not exist; there is no shipped default.
+pub const PLATFORM_TOKEN_ENV: &str = "OPENCOMPANY_PLATFORM_TOKEN";
+
+/// Environment variable holding the HS256 secret that signs tenant tokens.
+/// Unset means signed tenant tokens are not accepted; there is no shipped
+/// default and no fallback — an absent value is an absent capability, never a
+/// weaker one.
+pub const PLATFORM_JWT_SECRET_ENV: &str = "OPENCOMPANY_PLATFORM_JWT_SECRET";
+
+/// Which credential shapes a running host accepts. Printed at boot so an
+/// operator can read the active mode off the logs; carries no secret material
+/// and is not derived from any.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlatformAuthMode {
+    /// Only the exact-match shared platform secret.
+    SharedSecret,
+    /// Only signed tenant tokens.
+    Jwt,
+    /// Both; a bearer accepted by either is accepted.
+    Both,
+}
+
+impl PlatformAuthMode {
+    /// The mode's log name.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SharedSecret => "shared-secret",
+            Self::Jwt => "jwt",
+            Self::Both => "both",
+        }
+    }
+}
+
+impl std::fmt::Display for PlatformAuthMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Accepts a bearer that any constituent verifier accepts, in order.
+///
+/// Only used when a host configures more than one credential shape. The last
+/// error is surfaced when every verifier refuses — callers turn any error into
+/// a flat `401`, so which one it is never reaches the wire.
+struct AnyPlatformVerifier {
+    verifiers: Vec<Arc<dyn PlatformVerifier>>,
+}
+
+impl PlatformVerifier for AnyPlatformVerifier {
+    fn verify(&self, bearer: &str) -> crate::Result<PlatformClaims> {
+        let mut last = None;
+        for verifier in &self.verifiers {
+            match verifier.verify(bearer) {
+                Ok(claims) => return Ok(claims),
+                Err(err) => last = Some(err),
+            }
+        }
+        Err(last
+            .unwrap_or_else(|| OpenCompanyError::InvalidRequest("unrecognized token".to_string())))
+    }
+}
+
+/// Whether this build can verify a signed tenant token at all.
+const JWT_AVAILABLE: bool = cfg!(feature = "platform-jwt");
+
+/// The boot refusal for a signing secret this build cannot use. Names the
+/// variable and the missing feature; never the value.
+fn jwt_unavailable() -> OpenCompanyError {
+    OpenCompanyError::Config(format!(
+        "{PLATFORM_JWT_SECRET_ENV} is set but this build has no `platform-jwt` feature, \
+         so a signed tenant token cannot be verified. Rebuild with \
+         `--features platform-jwt` (it is in the default set) or unset the variable."
+    ))
+}
+
+#[cfg(feature = "platform-jwt")]
+fn jwt_verifier(secret: String) -> crate::Result<Arc<dyn PlatformVerifier>> {
+    Ok(Arc::new(JwtPlatformVerifier::new(secret)))
+}
+
+#[cfg(not(feature = "platform-jwt"))]
+fn jwt_verifier(_secret: String) -> crate::Result<Arc<dyn PlatformVerifier>> {
+    Err(jwt_unavailable())
+}
+
+/// Builds the platform auth config from the two credential secrets, or `None`
+/// when neither is set (no machine credential — humans and `serve --company`
+/// are the whole story).
+///
+/// Every configuration state either authenticates or refuses; none of them
+/// fails open. No credential is `None` and every machine route 401s; a signing
+/// secret on a build that cannot verify signatures aborts boot with
+/// `jwt_unavailable` rather than degrading to the shared secret. A blank or
+/// whitespace-only value is treated as unset, so an empty injected variable
+/// cannot become an empty accepted bearer.
+pub fn configure(
+    platform_secret: Option<String>,
+    jwt_secret: Option<String>,
+) -> crate::Result<Option<(PlatformAuthConfig, PlatformAuthMode)>> {
+    configure_with(platform_secret, jwt_secret, JWT_AVAILABLE)
+}
+
+/// [`configure`] with the build's JWT support passed in, so the refusal path is
+/// reachable from a test on a build that *does* have the feature.
+fn configure_with(
+    platform_secret: Option<String>,
+    jwt_secret: Option<String>,
+    jwt_available: bool,
+) -> crate::Result<Option<(PlatformAuthConfig, PlatformAuthMode)>> {
+    let platform_secret = platform_secret.filter(|value| !value.trim().is_empty());
+    let jwt_secret = jwt_secret.filter(|value| !value.trim().is_empty());
+
+    let mode = match (platform_secret.is_some(), jwt_secret.is_some()) {
+        (false, false) => return Ok(None),
+        (true, false) => PlatformAuthMode::SharedSecret,
+        (false, true) => PlatformAuthMode::Jwt,
+        (true, true) => PlatformAuthMode::Both,
+    };
+
+    let mut verifiers: Vec<Arc<dyn PlatformVerifier>> = Vec::new();
+    if let Some(secret) = platform_secret {
+        verifiers.push(Arc::new(StaticPlatformVerifier::new(secret)));
+    }
+    if let Some(secret) = jwt_secret {
+        if !jwt_available {
+            return Err(jwt_unavailable());
+        }
+        verifiers.push(jwt_verifier(secret)?);
+    }
+
+    let verifier: Arc<dyn PlatformVerifier> = if verifiers.len() == 1 {
+        verifiers.pop().expect("one verifier")
+    } else {
+        Arc::new(AnyPlatformVerifier { verifiers })
+    };
+    Ok(Some((PlatformAuthConfig::new(verifier), mode)))
 }
 
 /// Extracts the bearer token from the `Authorization` header.
@@ -384,6 +541,11 @@ pub(crate) fn b64url_encode(input: &[u8]) -> String {
 }
 
 /// Decodes unpadded base64url, returning `None` on any invalid input.
+///
+/// `cfg(test)` — the only decoder in this module belonged to the unsigned token
+/// arm, which no longer exists in a shipped build. It stays for
+/// `UnsignedTenantVerifier` and the round-trip test.
+#[cfg(test)]
 fn b64url_decode(input: &str) -> Option<Vec<u8>> {
     fn val(c: u8) -> Option<u32> {
         match c {
@@ -416,6 +578,57 @@ fn b64url_decode(input: &str) -> Option<Vec<u8>> {
     Some(out)
 }
 
+/// A test-only verifier that additionally accepts an **unsigned**
+/// `oc_tenant.<base64url(json)>` bearer as literal claims.
+///
+/// This is how the scope-gate, allow-list and ownership suites mint a
+/// tenant-scoped principal without standing up signing machinery: those suites
+/// exercise what a *verified* tenant token may reach, which is orthogonal to how
+/// it was authenticated. It is `cfg(test)`, so no shipped build contains it, and
+/// it is a distinct type from [`StaticPlatformVerifier`] precisely so that the
+/// production refusal of this shape stays observable to
+/// `hand_constructed_tenant_bearer_is_refused`.
+#[cfg(test)]
+pub struct UnsignedTenantVerifier {
+    inner: StaticPlatformVerifier,
+}
+
+#[cfg(test)]
+impl UnsignedTenantVerifier {
+    /// The prefix marking an unsigned structured tenant token.
+    pub const TENANT_PREFIX: &'static str = "oc_tenant.";
+
+    /// Builds a verifier that also honors the shared platform secret, so a
+    /// suite can hold both principals at once.
+    pub fn new(platform_secret: impl Into<String>) -> Self {
+        Self {
+            inner: StaticPlatformVerifier::new(platform_secret),
+        }
+    }
+
+    /// Encodes claims into an unsigned tenant token.
+    pub fn tenant_token(claims: &PlatformClaims) -> String {
+        let json = serde_json::to_vec(claims).expect("claims serialize");
+        format!("{}{}", Self::TENANT_PREFIX, b64url_encode(&json))
+    }
+}
+
+#[cfg(test)]
+impl PlatformVerifier for UnsignedTenantVerifier {
+    fn verify(&self, bearer: &str) -> crate::Result<PlatformClaims> {
+        match bearer.strip_prefix(Self::TENANT_PREFIX) {
+            Some(encoded) => {
+                let bytes = b64url_decode(encoded).ok_or_else(|| {
+                    OpenCompanyError::InvalidRequest("malformed platform token".to_string())
+                })?;
+                Ok(serde_json::from_slice(&bytes)?)
+            }
+            // Delegate so the suites keep exercising the real secret arm.
+            None => self.inner.verify(bearer),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -444,14 +657,20 @@ mod test {
         assert_eq!(claims.tenant, "tenant:platform");
     }
 
+    /// The offline codec the gate suites mint tenant principals with. It lives
+    /// on the test-only type; the assertion below is about the codec, not about
+    /// anything a shipped build accepts.
     #[test]
-    fn tenant_token_carries_structured_claims_without_platform_scope() {
-        let verifier = StaticPlatformVerifier::new("top-secret");
+    fn unsigned_codec_round_trips_for_the_gate_suites() {
+        let verifier = UnsignedTenantVerifier::new("top-secret");
         let token =
-            StaticPlatformVerifier::tenant_token(&tenant_claims("tenant:acme", &["operator"]));
+            UnsignedTenantVerifier::tenant_token(&tenant_claims("tenant:acme", &["operator"]));
         let claims = verifier.verify(&token).unwrap();
         assert_eq!(claims.tenant, "tenant:acme");
         assert!(!claims.has_platform_scope());
+
+        // It still delegates the shared-secret arm, so a suite can hold both.
+        assert!(verifier.verify("top-secret").unwrap().has_platform_scope());
     }
 
     /// The shipped default build must not turn a caller-supplied payload into
@@ -524,6 +743,117 @@ mod test {
         let verifier = StaticPlatformVerifier::new("top-secret");
         assert!(verifier.verify("nope").is_err());
         assert!(verifier.verify("oc_tenant.@@@not-base64@@@").is_err());
+    }
+
+    #[test]
+    fn no_credential_configures_no_platform_auth() {
+        assert!(configure(None, None).unwrap().is_none());
+        // A blank injected variable is unset, not an empty accepted bearer.
+        assert!(
+            configure(Some("  ".to_string()), Some(String::new()))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn shared_secret_alone_configures_shared_secret_mode() {
+        let (config, mode) = configure(Some("plat-secret".to_string()), None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(mode, PlatformAuthMode::SharedSecret);
+        assert!(
+            config
+                .verifier
+                .verify("plat-secret")
+                .unwrap()
+                .has_platform_scope()
+        );
+        assert!(config.verifier.verify("wrong").is_err());
+    }
+
+    #[cfg(feature = "platform-jwt")]
+    #[test]
+    fn signing_secret_alone_configures_jwt_mode() {
+        let (config, mode) = configure(None, Some("signing-secret".to_string()))
+            .unwrap()
+            .unwrap();
+        assert_eq!(mode, PlatformAuthMode::Jwt);
+
+        let token = sign(
+            "signing-secret",
+            &json!({"tenant": "tenant:acme", "scopes": ["operator"]}),
+        );
+        assert_eq!(
+            config.verifier.verify(&token).unwrap().tenant,
+            "tenant:acme"
+        );
+        // The shared-secret arm is not wired, so nothing else gets in.
+        assert!(config.verifier.verify("signing-secret").is_err());
+    }
+
+    #[cfg(feature = "platform-jwt")]
+    #[test]
+    fn both_secrets_accept_either_credential() {
+        let (config, mode) = configure(
+            Some("plat-secret".to_string()),
+            Some("signing-secret".to_string()),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(mode, PlatformAuthMode::Both);
+
+        assert!(
+            config
+                .verifier
+                .verify("plat-secret")
+                .unwrap()
+                .has_platform_scope()
+        );
+        let token = sign(
+            "signing-secret",
+            &json!({"tenant": "tenant:acme", "scopes": ["operator"]}),
+        );
+        assert_eq!(
+            config.verifier.verify(&token).unwrap().tenant,
+            "tenant:acme"
+        );
+
+        // And a bearer neither arm authenticates is still refused.
+        assert!(config.verifier.verify("oc_tenant.e30").is_err());
+        assert!(config.verifier.verify("nope").is_err());
+    }
+
+    /// A build that cannot verify signatures must abort boot when a signing
+    /// secret is set, not fall back to the shared secret. `configure_with` takes
+    /// the availability flag so this stays observable on a build that *has* the
+    /// feature; a featureless build reaches the same error through
+    /// `jwt_verifier`.
+    #[test]
+    fn signing_secret_without_the_feature_refuses_to_boot() {
+        let err = configure_with(
+            Some("plat-secret".to_string()),
+            Some("signing-secret".to_string()),
+            false,
+        )
+        .expect_err("a signing secret this build cannot use must abort boot");
+
+        let message = err.to_string();
+        assert!(
+            message.contains(PLATFORM_JWT_SECRET_ENV) && message.contains("platform-jwt"),
+            "the refusal must name the variable and the missing feature: {message}"
+        );
+        assert!(
+            !message.contains("signing-secret"),
+            "the refusal must never carry secret material: {message}"
+        );
+    }
+
+    #[test]
+    fn auth_mode_names_are_stable() {
+        assert_eq!(PlatformAuthMode::SharedSecret.to_string(), "shared-secret");
+        assert_eq!(PlatformAuthMode::Jwt.to_string(), "jwt");
+        assert_eq!(PlatformAuthMode::Both.to_string(), "both");
     }
 
     #[test]

--- a/src/server/provision/test.rs
+++ b/src/server/provision/test.rs
@@ -17,7 +17,7 @@ use crate::ports::types::{
 };
 use crate::ports::{CycleHost, EventLog};
 use crate::runtime::RuntimeBuilder;
-use crate::server::platform_auth::{PlatformAuthConfig, PlatformClaims, StaticPlatformVerifier};
+use crate::server::platform_auth::{PlatformAuthConfig, PlatformClaims, UnsignedTenantVerifier};
 use crate::server::router;
 use crate::server::webhook::{WebhookConfig, WebhookKind};
 use crate::store::FsEventLog;
@@ -35,7 +35,7 @@ fn home() -> tempfile::TempDir {
 }
 
 fn platform_state(home: &std::path::Path, max_per_tenant: Option<usize>) -> AppState {
-    let verifier = Arc::new(StaticPlatformVerifier::new(PLATFORM_SECRET));
+    let verifier = Arc::new(UnsignedTenantVerifier::new(PLATFORM_SECRET));
     AppState::new(AppConfig::default())
         .with_home(home.to_path_buf())
         .with_platform_auth(PlatformAuthConfig::new(verifier))
@@ -48,7 +48,7 @@ fn platform_state(home: &std::path::Path, max_per_tenant: Option<usize>) -> AppS
 /// ownership record, so ids and owners stay workload-local and survive boot
 /// hydration, which filters the `owners` rows by this same value.
 fn namespaced_state(home: &std::path::Path, namespace: &str) -> AppState {
-    let verifier = Arc::new(StaticPlatformVerifier::new(PLATFORM_SECRET));
+    let verifier = Arc::new(UnsignedTenantVerifier::new(PLATFORM_SECRET));
     AppState::new(AppConfig {
         tenant_namespace: Some(namespace.to_string()),
         ..AppConfig::default()
@@ -57,8 +57,14 @@ fn namespaced_state(home: &std::path::Path, namespace: &str) -> AppState {
     .with_platform_auth(PlatformAuthConfig::new(verifier))
 }
 
+/// Mints a tenant principal through the `cfg(test)` unsigned codec.
+///
+/// What these tests are about is what a *verified* tenant token may reach —
+/// scopes, the allow-list, cross-tenant ownership — which is independent of how
+/// the bearer was authenticated. The codec keeps them running with no signing
+/// machinery; a shipped build accepts this shape from nobody.
 fn tenant_token(tenant: &str, scopes: &[&str]) -> String {
-    StaticPlatformVerifier::tenant_token(&PlatformClaims {
+    UnsignedTenantVerifier::tenant_token(&PlatformClaims {
         tenant: tenant.to_string(),
         scopes: scopes.iter().map(|s| s.to_string()).collect::<HashSet<_>>(),
         companies: None,


### PR DESCRIPTION
## Summary

Closes #322.

`StaticPlatformVerifier` had two arms. The exact-match shared secret is genuinely authenticated — by knowledge of the secret. The other decoded an `oc_tenant.<base64url(json)>` bearer straight into `PlatformClaims`, so a caller who knew nothing could hand-build a bearer that resolved to whatever tenant, scopes and company allow-list they wrote into it. The downstream gates were sound — the platform scope gates provision/pause/resume/suspend/archive, address authorization and the allow-list are enforced on top, and claim resolution is type-prevented from returning a user principal. The gates were fine; the input they trusted was not.

**What changes**

1. **The shared-secret arm stays in production**, verbatim. It is the same pattern the control plane uses for its own admin token, and it is the only machine-credential flow anything uses today.
2. **The unsigned arm is removed from production entirely.** It survives only as `UnsignedTenantVerifier`, a `cfg(test)` type. A separate **type**, not a `cfg(test)` branch inside `verify` — a branch there would make the production rejection unobservable to unit tests, since the test build would still accept unsigned tokens. The offline encoder is what lets the scope / allow-list / ownership suites run without signing machinery, so those suites keep their coverage with construction-line changes only.
3. **Tenant-scoped machine tokens in production are signed JWTs.** `platform_auth::configure` selects the verifiers from the environment; both credentials may be set, and a bearer accepted by either is accepted.
4. **`platform-jwt` joins the default feature set** — see the CI section below.

**Fail closed, loudly.** No configuration state fails open: no credential → `401`; an unsigned tenant bearer → `401`; a wrong secret → `401`; a signing secret on a build compiled without `platform-jwt` **refuses to boot** with a message naming the variable and the missing feature, rather than degrading to the weaker check — the same precedent the storage backend sets, where selected-but-unavailable aborts instead of silently falling back. Boot prints the active mode (`platform auth: shared-secret | jwt | both`). Mode only, never secret material.

**Key handling.** `OPENCOMPANY_PLATFORM_JWT_SECRET` has no shipped literal and no fallback — unset means the path does not exist. Deliberately not the shape of #318; no default is introduced.

## Deliberate red run — please read this as the proof, not as breakage

The CI half is part of the fix. Because `platform-jwt` was opt-in and no lane enabled it, the signed verifier's tests were compiled by the check-only `cargo check --locked --all-features --all-targets` step and **run by nothing**. Cargo features are additive, so moving `platform-jwt` into the default set makes *both* existing test lanes execute them. No new lane is needed.

The two commits are ordered so the gate proves itself:

- **`be77d63`** — the feature widening plus the new regression tests, **alone**. This run is **red**, on `hand_constructed_tenant_bearer_is_refused`. That single failure demonstrates both that the widened lane really executes these tests and that the bug was real. Nothing was faked to produce it.
- **`0e2a94e`** — the fix. Green.

Run for the red commit: https://github.com/M3gA-Mind/opencompany/actions/runs/30906312125

**Read the `Rust` job, not the run badge.** The run as a whole is labelled *cancelled*, because the follow-up push landed while `Rust (openhuman, tinycortex)` was still building and CI cancels in-progress runs on the same ref. The `Rust` job itself ran to completion and concluded `failure`:

```
6. Format: success
7. Clippy: success
8. Test:   failure

thread 'server::platform_auth::test::hand_constructed_tenant_bearer_is_refused' panicked at
  src/server/platform_auth.rs:468:9
test result: FAILED. 1177 passed; 1 failed; 1 ignored
```

Two things are visible there. `Format` and `Clippy` pass, so the red is the assertion and not a compile or lint error. And in the same run:

```
test server::platform_auth::test::jwt_verifier_round_trips_signed_claims ... ok
test server::platform_auth::test::jwt_verifier_refuses_an_expired_token ... ok
test server::platform_auth::test::jwt_verifier_refuses_a_tampered_payload ... ok
```

`jwt_verifier_round_trips_signed_claims` already existed on `main` and previously ran in **no lane at all**. Seeing it execute is the CI-hole half of the proof; seeing `hand_constructed_tenant_bearer_is_refused` fail is the bug half. The gated lane runs the same tests, so cancelling it costs no evidence.

## API Or Behavior Changes

**A default build no longer accepts an `oc_tenant.<base64url(json)>` bearer.** Any caller sending one now gets `401`. There are zero production consumers of this shape — the control plane injects no platform credential at all, and nothing in this repo, the superproject, the frontend, the e2e harness, the scripts or the docs mints a token of that shape — so this is expected to be a no-op in practice. A loud env opt-in was considered and rejected: an off-switch for authentication preserves a footgun nobody needs.

Public API on `server::platform_auth`:

- Removed: `StaticPlatformVerifier::TENANT_PREFIX`, `StaticPlatformVerifier::tenant_token`.
- Added: `configure`, `PlatformAuthMode`, `PLATFORM_TOKEN_ENV`, `PLATFORM_JWT_SECRET_ENV`.
- `JwtPlatformVerifier` is unchanged but now compiled by the default build.

New environment variable `OPENCOMPANY_PLATFORM_JWT_SECRET` (HS256, tenant-scoped tokens). `OPENCOMPANY_PLATFORM_TOKEN` is unchanged in meaning.

Default features change from `["oauth"]` to `["oauth", "platform-jwt"]`, adding one pure dependency (`jsonwebtoken`) already present in `Cargo.lock`. `Cargo.lock` is untouched.

**Two limits stated rather than fixed**, both documented in the module header and `docs/spec/runtime/config.md`:

- The signing is **symmetric** — a workload that can verify could also mint. Acceptable while the trust boundary is a single workload; asymmetric keys via the control plane's issuer are the follow-up. Deliberately not widened into this PR.
- A token with **no `exp` never expires**, because the verifier clears its required-claims set. Left as-is; changing it is a separate policy decision.

## Tests

- [x] `cargo fmt --all -- --check` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo clippy --all-targets -- -D warnings` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo build --all-targets` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo test` — N/A - full local build matrix is prohibited on this machine; verified in CI

New tests in `src/server/platform_auth.rs`:

| Test | Asserts |
| --- | --- |
| `hand_constructed_tenant_bearer_is_refused` | The regression test. Builds the bearer literally from the wire shape — no helper, no shared constant — and asserts the shipped verifier rejects it |
| `jwt_verifier_refuses_an_expired_token` | A past `exp` is refused |
| `jwt_verifier_refuses_a_tampered_payload` | Claims rewritten to grant `platform`, original signature kept, refused |
| `no_credential_configures_no_platform_auth` | Neither variable set → no machine credential. A blank value is unset, not an empty accepted bearer |
| `shared_secret_alone_configures_shared_secret_mode` | Exact secret works verbatim; anything else `401`s |
| `signing_secret_alone_configures_jwt_mode` | Signed token verifies; the shared-secret arm is not silently wired |
| `both_secrets_accept_either_credential` | Either credential is accepted; an unsigned or unknown bearer still is not |
| `signing_secret_without_the_feature_refuses_to_boot` | Boot aborts, the message names the variable and the missing feature, and does **not** contain the secret |
| `auth_mode_names_are_stable` | The boot line's mode names |
| `unsigned_codec_round_trips_for_the_gate_suites` | The `cfg(test)` codec the gate suites depend on |

`signing_secret_without_the_feature_refuses_to_boot` reaches the refusal through a private `configure_with(.., jwt_available: bool)` seam, so the fail-closed path stays observable on a build that *has* the feature. A build without the feature reaches the identical error through `jwt_verifier`.

The scope / allow-list / ownership suites in `src/server/provision/test.rs` (4 sites) and `src/server/ops/write_test.rs` (9 sites) pass unchanged apart from swapping the verifier they construct. `src/server/users/auth_test.rs` is untouched — it only ever used the exact secret, which still works verbatim.

Nothing was run locally: this machine prohibits the full local build matrix, and `cargo fmt --all` cannot run in this clone at all because `vendor/openhuman` is not initialized. `rustfmt --edition 2024 --check` was run directly on the four changed Rust files and is clean. Everything else is verified in CI.

## Documentation

- `docs/spec/runtime/config.md` — both platform variables added to the environment table, plus a new **"How a platform bearer is authenticated"** section under Authentication: the two credential shapes, the boot line, the full no-fail-open matrix, and the two stated limits. Placeholders only; no secret material.
- `src/server/platform_auth.rs` module header rewritten to describe what a shipped build accepts, why the test-only codec is a separate type, and the two limits.
- `Cargo.toml` — the `default` feature comment records why `platform-jwt` ships and which CI blind spot that closes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JWT authentication is now enabled by default for platform verification.
  * Added flexible platform authentication with shared bearer tokens, JWTs, or both simultaneously.
  * Added configuration options: `OPENCOMPANY_PLATFORM_TOKEN` and `OPENCOMPANY_PLATFORM_JWT_SECRET`.

* **Bug Fixes**
  * Invalid authentication configurations now prevent startup with clear diagnostics.
  * Authentication failures consistently return `401 Unauthorized`.
  * Improved protection against unsigned, tampered, and expired JWTs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->