### PR TITLE
feat(runtime): rebuild a company runtime in place when inference resolves (#290)

### DIFF
--- a/docs/spec/runtime/README.md
+++ b/docs/spec/runtime/README.md
@@ -11,6 +11,8 @@ Supporting docs:
 - [ports.md](ports.md) — the port trait contracts (normative)
 - [manifest.md](manifest.md) — `company.toml` schema
 - [lifecycle.md](lifecycle.md) — company state machine and durability
+- [rebuild.md](rebuild.md) — replacing a registered runtime in place (quiesce →
+  hand over → swap), so a first-time inference config needs no restart
 - [api.md](api.md) — HTTP routes and auth
 - [config.md](config.md) — configuration and the one-key story
 - [users.md](users.md) — human collaborators: magic-link/password sign-in,

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -156,6 +156,14 @@ prompt = "Weekly review and operator digest"
   neither. The status route reports that state as `restartRequired` — a resolved
   config next to a non-harness `cognition` — and the console says "restart"
   instead of "next turn" for it (issue #266).
+  Since issue #290 that save **rebuilds the company's runtime in place** rather
+  than asking for a restart the operator may have no way to perform: a hosted
+  tenant's unit of restart is its container, and the control plane has no button
+  for it. `PUT …/inference` quiesces the running runtime, hands its live state to
+  a successor, and swaps the registry — see
+  [runtime rebuild](rebuild.md). `restartRequired` remains on the read shape and
+  stays honest: it is still `true` on a host that wired no rebuilder, which is
+  when a restart genuinely is the only route.
   Saving `managed` from the console is a *revert* (`DELETE …/inference`) and
   carries no credential, so the console refuses that save while a key is still
   typed in the form rather than dropping it and reporting success (issue #265).

--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -657,6 +657,11 @@ at least one approval finishes `waiting_approval`, not `succeeded` — a person
 must act. A failed, cancelled or paused run keeps the reason it stopped;
 relabelling it "waiting on you" would hide that reason.
 
+**A runtime being replaced is a fifth writer.** Writer 1 mints the row before
+writer 2 can start it, so a runtime swapped in between refuses the cycle and
+settles the row itself — and the boot reaper is *not* a safe fallback mid-life.
+See [rebuild.md](rebuild.md#attempt-rows-242).
+
 #### Correlation fields elsewhere
 
 Four additive `Option<String>` fields point back at a run. All are

--- a/docs/spec/runtime/rebuild.md
+++ b/docs/spec/runtime/rebuild.md
@@ -1,0 +1,134 @@
+# Rebuilding a company runtime in place
+
+Issue #290. Which brain a company runs is chosen **once**, in
+`RuntimeBuilder::build`. A company that resolved no inference source at boot is
+on the offline echo brain with an unwired workflow runner, and a credential
+written afterwards reaches neither. #266 shipped the honest half of that: a
+`restartRequired` flag on the inference status, a persistent console banner, and
+a `restart_required` answer from `POST …/workflows/{id}/run`.
+
+The restart is the problem. A hosted tenant's unit of restart is its container,
+and the control plane has no button an operator can press: `POST
+/api/v1/companies` refuses an existing id, archive removes a company with no
+unarchive, and nothing else in the process ever replaced a registered runtime.
+So first-time BYOK setup needed someone with pod access.
+
+This is the seam that removes it.
+
+## The sequence (`src/runtime/rebuild.rs`)
+
+`runtime::rebuild_company(&state, id)`:
+
+1. **Read the manifest** from the company's persisted record — before anything
+   else, so a store failure can never leave a company parked. The record's
+   manifest is the *materialized* one, which matters for two things a fresh
+   `company.toml` read would drop: console-created workflows merged into
+   `[workflows].enabled`, and the `[place]` fields `serve --discoverable`
+   mutated before the original build.
+2. **Quiesce** (`CompanyRuntime::quiesce`). Sets a flag that makes every cycle
+   entry point refuse with `Quiescing` (`503`), then waits on the per-company
+   `serial` lock, which a cycle holds for a whole turn. Both halves are
+   necessary: the flag alone leaves a turn mid-cycle, and the wait alone races a
+   cycle queued behind the one in flight.
+3. **Hand over** (`CompanyRuntime::handover`). Snapshots the per-instance state a
+   second runtime must not duplicate — see below.
+4. **Rebuild** through the host's `RuntimeRebuilder`, which runs the *same*
+   builder assembly boot ran (`company_builder` in `src/bin/opencompany.rs`).
+5. **Swap** the successor into the registry.
+
+## What must be inherited, not rebuilt (`src/runtime/handover.rs`)
+
+Most of a runtime is `Arc<dyn Port>` handles that are safe to share. These are
+not; a second copy of any of them is a correctness bug:
+
+| Piece | Why a second copy breaks |
+|---|---|
+| `RuntimeJournal` | Single-writer. `append` writes a record and its newline separately under a per-instance lock, so two journals interleave onto one line and fail to parse on replay — bricking the *next* boot |
+| At-most-once effect keys | Held in memory, populated at `load()`. A second instance never sees the first's commits, so a send or a spend runs twice |
+| `serial` / `task_writes` | Per-instance mutexes. Two of either and both invariants lapse across the swap |
+| `FsEventLog` | Derives `seq` from a line count under its own lock, and its broadcast sender is what an open console SSE stream is subscribed to |
+| `FeedbackFiler` | In-memory rate limiter; rebuilding it makes a rebuild loop a rate-limit bypass |
+| `HarnessPool` | Holds each agent's conversation history |
+| `McpRuntime` | Dials a *process-global* connection map keyed by server id; re-booting it replaces connections other agents may be mid-call on |
+| `ManifestApprovalGate` + `GrantSet` | Parked approvals and unredeemed single-use grants. Rehydrating a fresh copy from the journal resurrects what the live one has already resolved |
+
+Deliberately **not** carried over: the brain, tools, channels, workflow runner
+and economy (replacing those is the point), and the in-flight steer registry
+(the successor's harness deps mint their own; sound only because the swap
+happens after the drain, so the outgoing registry is empty).
+
+## Boot-only side effects, suppressed on a rebuild
+
+`build()` treats the presence of a handover as "this is a rebuild" and skips:
+
+- **Journal replay** (`load()`) and **approval rehydration** — the inherited
+  journal and gate are already live.
+- **Orphan-run reaping.** At boot it is sound because nothing from this process
+  can be in flight; mid-life that premise is false, and reaping would settle
+  live run records as dead.
+- **Workspace seeding** — the company is already running.
+- **Going public.** A paid, networked handle claim. A company that is already
+  public does not become more public by claiming again.
+- **MCP boot** — see the table above.
+
+## What happens to in-flight work
+
+The cycle in flight at the quiesce **completes** on the outgoing runtime,
+against the same journal, approval queue and stores the successor adopts. It is
+not cancelled, and its effects are not replayed: the executed-key set travels
+with the journal.
+
+Cycles arriving *during* the window are refused with `503 quiescing` rather than
+queued, so a caller retries against the successor instead of silently getting
+the brain the rebuild was replacing. The window is one turn wide.
+
+That is also the bound on the triggering request: `PUT …/inference` blocks until
+the in-flight turn drains, so a save landing mid-turn waits for it. This is a
+deliberate trade. Swapping while a cycle runs is precisely the two-live-runtimes
+hazard the handover exists to avoid, and a bounded wait that gave up and swapped
+anyway would trade a slow response for a corrupted journal. In practice the
+transition this feature exists for — first-time BYOK setup on a company running
+the echo brain — has no expensive turn to wait on.
+
+Parked approvals and unredeemed grants survive untouched, with their ids, parked
+effects and TTLs. Resolving an approval after the swap runs its follow-up cycle
+on the *new* brain — which is the desired outcome, not a compromise.
+
+A rebuild that fails leaves the outgoing runtime registered and **resumes** it. A
+company stuck quiesced would refuse every cycle forever, which is strictly worse
+than the stale brain the rebuild was trying to replace.
+
+## Registry-driven pollers
+
+A registry swap only helps surfaces that read the registry. `WorkflowScheduler`
+already re-read it every tick; `CompanyScheduler`, `MailboxPoller` and
+`TelegramPoller` each snapshotted an `Arc<CompanyRuntime>` at boot and would have
+kept driving the replaced — and now quiesced — runtime forever. Each gained a
+`following(registry)` opt-in that the boot path uses; the snapshot remains the
+fallback, so existing embedders are unaffected.
+
+Cron is the one that matters most here: "scheduled workflows never fire" is one
+of the two surfaces #266 was reported against, so a rebuild that did not reach
+the scheduler would look fixed and not be.
+
+## Wiring
+
+`RuntimeRebuilder` is a trait implemented by the **binary**, because the builder
+inputs (harness pool, OpenHuman RPC transport, managed media/search backends,
+the manager-injected per-tenant mailbox) are assembled there from the process
+environment and feature flags. `AppState::with_rebuilder` installs it, and
+`AppState::set_boot_inputs` stashes what a rebuild cannot recover any other way
+(`--discoverable`, the source directory).
+
+A host that wires **no** rebuilder keeps the pre-#290 behaviour exactly: the
+status still reports `restartRequired`, and the console still says so. That is
+the honest answer when a rebuild genuinely is unavailable, so the flag and the
+banner are retained rather than deleted.
+
+## Related
+
+- #266 — the honest-message half, and where the console reports `restartRequired`
+- [manifest.md](manifest.md#inference) — `[inference]` precedence and the
+  next-turn guarantee
+- [lifecycle.md](lifecycle.md) — company lifecycle states (`paused`, `archived`),
+  which are durable and unrelated to the transient quiesce window

--- a/docs/spec/runtime/rebuild.md
+++ b/docs/spec/runtime/rebuild.md
@@ -51,6 +51,7 @@ not; a second copy of any of them is a correctness bug:
 | `HarnessPool` | Holds each agent's conversation history |
 | `McpRuntime` | Dials a *process-global* connection map keyed by server id; re-booting it replaces connections other agents may be mid-call on |
 | `ManifestApprovalGate` + `GrantSet` | Parked approvals and unredeemed single-use grants. Rehydrating a fresh copy from the journal resurrects what the live one has already resolved |
+| `OpsStores` (incl. the `RunStore`) | Carried whole, so the dispatch choke point, the successor's `HarnessBrain` and the (suppressed) reaper all address one set of attempt rows. A second store would strand every live run and restart attempt ordinals at 1 |
 
 Deliberately **not** carried over: the brain, tools, channels, workflow runner
 and economy (replacing those is the point), and the in-flight steer registry
@@ -63,9 +64,24 @@ happens after the drain, so the outgoing registry is empty).
 
 - **Journal replay** (`load()`) and **approval rehydration** — the inherited
   journal and gate are already live.
-- **Orphan-run reaping.** At boot it is sound because nothing from this process
-  can be in flight; mid-life that premise is false, and reaping would settle
-  live run records as dead.
+- **Orphan-run reaping.** `reap_orphaned_runs` rests its whole argument on
+  "nothing from this process can be in flight yet" — true at boot, false the
+  moment a company has been serving.
+
+  The exposure is narrower than it first looks, and worth stating exactly. The
+  quiesce drains the serial lock, and both `begin_run` and the terminality
+  backstop sit *inside* it, so no `Running` row survives the drain. `Pending`
+  does: the dispatch choke point mints its row **outside** that lock, so a board
+  write landing in the window leaves one behind. Reaping that row stamps the
+  wrong reason on it, and if the rebuild then fails and `resume()` puts the
+  company back to work, the row is already terminal — its cycle's `begin_run` is
+  rejected and a genuinely live attempt runs with no record at all.
+
+  Suppressed, therefore, rather than justified by the drain: relying on the
+  drain would rest correctness on the current call order instead of on the
+  invariant the reaper actually states. The port's doc comment now says the
+  proof is about boot and only boot, so a future second caller has to make the
+  argument again rather than inherit it.
 - **Workspace seeding** — the company is already running.
 - **Going public.** A paid, networked handle claim. A company that is already
   public does not become more public by claiming again.
@@ -93,6 +109,34 @@ the echo brain — has no expensive turn to wait on.
 Parked approvals and unredeemed grants survive untouched, with their ids, parked
 effects and TTLs. Resolving an approval after the swap runs its follow-up cycle
 on the *new* brain — which is the desired outcome, not a compromise.
+
+### Attempt rows (#242)
+
+The same answer, extended to the run write path, because a run is written at
+three points a swap can fall between.
+
+The **attempt in flight** is the cycle in flight, so it completes and settles
+itself on the outgoing runtime, against the store the successor adopts. Its
+trace keeps writing through the drain: the sink holds an `Arc<dyn RunStore>` from
+the inherited `OpsStores`, not a handle to the runtime.
+
+The case that needed a code change is the **attempt that never starts**. Board
+writes are deliberately *not* gated on the quiesce — only cycles are — so a card
+dragged into `in_progress` during the window still passes the dispatch choke
+point and still mints its `Pending` row. Its cycle is then refused, and the
+refusal happens in `CompanyRuntime::run_cycle` *before* `CycleRunner` takes the
+serial lock and therefore before `begin_run` — which puts it out of reach of the
+terminality backstop, since that only settles rows the cycle itself started.
+Left alone the row would claim to be pending for the rest of the process's life,
+and the rebuild has just switched off the one sweep that would have cleaned it
+up.
+
+So the dispatch settles it: `Pending` → `Failed` carrying
+`ports::runs::RUNTIME_REPLACED_ERROR`, a reason string kept distinct from
+`ORPHAN_ERROR` so a run list can tell "we swapped your runtime, try again" apart
+from "the host died". `Pending` → terminal is already the legal move the status
+table names for *a dispatch that failed before the first turn*. The card stays in
+`in_progress`, which is where every other failed dispatch cycle leaves it.
 
 A rebuild that fails leaves the outgoing runtime registered and **resumes** it. A
 company stuck quiesced would refuse every cycle forever, which is strictly worse

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -369,6 +369,22 @@ pub struct AppState {
             HashMap<String, (std::time::Instant, crate::company::mcp_oauth::PendingOAuth)>,
         >,
     >,
+    /// Issue #290: this host's ability to rebuild a registered company's runtime
+    /// in place, so a first-time inference config takes effect without a process
+    /// restart.
+    ///
+    /// Wired by the binary, which is where the builder inputs (harness pool,
+    /// OpenHuman RPC, managed backends, per-tenant mailbox) are assembled.
+    /// `None` — every test host, and any embedder that does not wire one — keeps
+    /// the pre-#290 behaviour: the inference status still reports
+    /// `restartRequired` and the console still says so, which is the honest
+    /// answer when a rebuild is genuinely unavailable.
+    rebuilder: Option<Arc<dyn crate::runtime::RuntimeRebuilder>>,
+    /// The boot-only builder inputs recorded per company at registration, so a
+    /// rebuild configures the successor exactly as boot configured its
+    /// predecessor. See [`BootInputs`](crate::runtime::BootInputs) for why
+    /// `--discoverable` in particular cannot be recovered any other way.
+    boot_inputs: Arc<RwLock<HashMap<CompanyId, crate::runtime::BootInputs>>>,
 }
 
 impl std::fmt::Debug for AppState {
@@ -403,7 +419,43 @@ impl AppState {
             nonce: std::sync::Arc::new(crate::economy::NonceCache::new()),
             #[cfg(feature = "mcp")]
             oauth_pending: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            rebuilder: None,
+            boot_inputs: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    /// Wires this host's in-place runtime rebuilder (issue #290).
+    pub fn with_rebuilder(mut self, rebuilder: Arc<dyn crate::runtime::RuntimeRebuilder>) -> Self {
+        self.rebuilder = Some(rebuilder);
+        self
+    }
+
+    /// This host's in-place runtime rebuilder, when one is wired.
+    pub fn rebuilder(&self) -> Option<Arc<dyn crate::runtime::RuntimeRebuilder>> {
+        self.rebuilder.clone()
+    }
+
+    /// Records the boot-only builder inputs for `id`, at registration.
+    ///
+    /// Cloned state shares this map (it is `Arc`-backed), so a company
+    /// registered after the router was built is still reachable by a rebuild.
+    pub fn set_boot_inputs(&self, id: CompanyId, inputs: crate::runtime::BootInputs) {
+        self.boot_inputs
+            .write()
+            .expect("boot inputs poisoned")
+            .insert(id, inputs);
+    }
+
+    /// The boot-only builder inputs recorded for `id`, or the defaults when the
+    /// company was registered without any (a platform-provisioned tenant has no
+    /// source directory and was never `--discoverable`).
+    pub fn boot_inputs(&self, id: &CompanyId) -> crate::runtime::BootInputs {
+        self.boot_inputs
+            .read()
+            .expect("boot inputs poisoned")
+            .get(id)
+            .cloned()
+            .unwrap_or_default()
     }
 
     /// Sets the OpenCompany home root used to resolve company identities.

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -192,6 +192,70 @@ async fn register_company(
             path: Some(slug.to_string()),
         }
     });
+    // Shared-single-DB mode: namespace the derived id with this tenant so the
+    // same boot template (`OPENCOMPANY_COMPANY`) does not collide across tenants
+    // in one logical database. A no-op when `tenant_namespace` is unset.
+    let derived = opencompany::runtime::company_id_from_name(&name);
+    let company_id = state.config().namespaced_company_id(derived);
+    let mut builder = company_builder(
+        state,
+        home,
+        manifest,
+        &company_id,
+        Some(source_dir.clone()),
+        discoverable,
+    )?;
+    if let Some(provenance) = provenance {
+        builder = builder.with_template_provenance(provenance);
+    }
+    let runtime = builder.build().await?;
+    let company_id = runtime.id().clone();
+    let id = company_id.as_ref().to_string();
+    // Record boot-company ownership so a shared-DB manager can later purge by
+    // tenant. Only meaningful in tenant-namespace mode; otherwise skipped so
+    // db-per-tenant / self-hosted deployments keep their in-memory-only stub.
+    if let Some(tenant) = state.config().tenant_namespace.clone() {
+        // Canonical (bare-slug) form so the persisted `owners` row matches what
+        // tenant-scoped auth compares a `tenant:acme` claim against.
+        let tenant = opencompany::app::canonical_tenant(&tenant).to_string();
+        state.set_owner(company_id.clone(), tenant.clone());
+        if let Some(ownership) = state.stores().and_then(|s| s.ownership.clone())
+            && let Err(err) = ownership.set_owner(&company_id, &tenant).await
+        {
+            eprintln!("failed to persist ownership for `{id}`: {err}");
+        }
+    }
+    // Issue #290: stash what a later in-place rebuild cannot recover any other
+    // way. `--discoverable` is the case that forces this to exist: it lives only
+    // in the `serve` stack frame and mutates the manifest before the build.
+    state.set_boot_inputs(
+        company_id.clone(),
+        opencompany::runtime::BootInputs {
+            source_dir: Some(source_dir),
+            discoverable,
+        },
+    );
+    state.registry().insert(company_id, Arc::new(runtime));
+    Ok((id, name, schedules))
+}
+
+/// Assembles the `RuntimeBuilder` for one company with this host's full boot
+/// wiring: the OpenHuman RPC transport, the harness pool and its managed
+/// backends, feedback routing, the opened storage backend and memory overlay,
+/// the shared skill library, and the manager-injected per-tenant mailbox.
+///
+/// Extracted from [`register_company`] so an in-place rebuild (issue #290) runs
+/// the *same* wiring boot ran. A rebuild that assembled its own would drift from
+/// boot silently, and the first symptom would be a company that came back from a
+/// rebuild missing a capability nobody changed.
+fn company_builder(
+    state: &AppState,
+    home: &std::path::Path,
+    manifest: CompanyManifest,
+    company_id: &CompanyId,
+    source_dir: Option<PathBuf>,
+    discoverable: bool,
+) -> Result<RuntimeBuilder> {
     let mut builder = attach_tinyhumans_feedback(
         attach_harness(attach_openhuman(RuntimeBuilder::new(
             home.to_path_buf(),
@@ -199,19 +263,13 @@ async fn register_company(
         ))),
         state.config(),
     )
-    .with_seed_dir(source_dir.clone())
     .with_tinyplace_api_url(state.config().tinyplace_api_url.clone())
     .with_host_base_url(state.config().host_base_url())
-    .with_skills_registry(state.shared_skill_registry()?);
-    if let Some(provenance) = provenance {
-        builder = builder.with_template_provenance(provenance);
+    .with_skills_registry(state.shared_skill_registry()?)
+    .with_id(company_id.clone());
+    if let Some(source_dir) = source_dir {
+        builder = builder.with_seed_dir(source_dir);
     }
-    // Shared-single-DB mode: namespace the derived id with this tenant so the
-    // same boot template (`OPENCOMPANY_COMPANY`) does not collide across tenants
-    // in one logical database. A no-op when `tenant_namespace` is unset.
-    let derived = opencompany::runtime::company_id_from_name(&name);
-    let company_id = state.config().namespaced_company_id(derived);
-    builder = builder.with_id(company_id.clone());
     if let Some(stores) = state.stores() {
         builder = builder.with_stores(stores);
     }
@@ -235,25 +293,39 @@ async fn register_company(
     if discoverable {
         builder = builder.with_discoverable(true);
     }
-    let runtime = builder.build().await?;
-    let company_id = runtime.id().clone();
-    let id = company_id.as_ref().to_string();
-    // Record boot-company ownership so a shared-DB manager can later purge by
-    // tenant. Only meaningful in tenant-namespace mode; otherwise skipped so
-    // db-per-tenant / self-hosted deployments keep their in-memory-only stub.
-    if let Some(tenant) = state.config().tenant_namespace.clone() {
-        // Canonical (bare-slug) form so the persisted `owners` row matches what
-        // tenant-scoped auth compares a `tenant:acme` claim against.
-        let tenant = opencompany::app::canonical_tenant(&tenant).to_string();
-        state.set_owner(company_id.clone(), tenant.clone());
-        if let Some(ownership) = state.stores().and_then(|s| s.ownership.clone())
-            && let Err(err) = ownership.set_owner(&company_id, &tenant).await
-        {
-            eprintln!("failed to persist ownership for `{id}`: {err}");
-        }
+    Ok(builder)
+}
+
+/// This host's in-place runtime rebuilder (issue #290).
+///
+/// Lives in the binary because [`company_builder`] does: the harness pool, the
+/// OpenHuman transport and the managed media/search backends are assembled here
+/// from the process environment and feature flags, and a rebuild that did not
+/// reuse that assembly would quietly produce a differently-wired company.
+struct BootRebuilder;
+
+#[async_trait::async_trait]
+impl opencompany::runtime::RuntimeRebuilder for BootRebuilder {
+    async fn rebuild(
+        &self,
+        state: &AppState,
+        request: opencompany::runtime::RebuildRequest,
+    ) -> Result<opencompany::CompanyRuntime> {
+        company_builder(
+            state,
+            state.home(),
+            request.manifest,
+            &request.id,
+            request.boot.source_dir,
+            request.boot.discoverable,
+        )?
+        // The whole point: the successor adopts the live journal, approval gate,
+        // grant set, stores, harness pool, MCP runtime and serialising mutexes
+        // rather than constructing a second copy of any of them.
+        .with_handover(request.handover)
+        .build()
+        .await
     }
-    state.registry().insert(company_id, Arc::new(runtime));
-    Ok((id, name, schedules))
 }
 
 /// Starts a company's cron scheduler as a background task, if it has schedules.
@@ -273,7 +345,15 @@ fn spawn_scheduler(
     }
     let runtime = state.registry().get(&CompanyId::new(id))?;
     match CompanyScheduler::new(runtime, schedules, Arc::new(SystemClock)) {
-        Ok(scheduler) => Some(scheduler.spawn(shutdown.clone())),
+        // Follow the registry so an in-place rebuild (issue #290) reaches cron.
+        // Without this the scheduler keeps driving the runtime it snapshotted —
+        // which after a rebuild is the replaced, quiesced one, i.e. exactly the
+        // "scheduled workflows never fire" surface #266 was reported against.
+        Ok(scheduler) => Some(
+            scheduler
+                .following(state.registry().clone())
+                .spawn(shutdown.clone()),
+        ),
         Err(err) => {
             eprintln!("skipping scheduler for `{id}`: {err}");
             None
@@ -345,7 +425,10 @@ fn spawn_mailbox_poller(
             cfg.imap.clone(),
             cfg.address.clone(),
             interval,
-        );
+        )
+        // See `spawn_scheduler`: follow the registry so a rebuild reaches
+        // inbound mail instead of stranding it on the replaced runtime.
+        .following(state.registry().clone());
         handles.push(poller.spawn(shutdown.clone()));
     }
     #[cfg(not(feature = "imap"))]
@@ -387,7 +470,10 @@ fn spawn_telegram_poller(
         api,
         poll_secs,
         webhook_capable,
-    );
+    )
+    // See `spawn_scheduler`: follow the registry so a rebuild reaches inbound
+    // Telegram instead of stranding it on the replaced runtime.
+    .following(state.registry().clone());
     handles.push(poller.spawn(shutdown.clone()));
 }
 
@@ -921,6 +1007,11 @@ async fn main() -> Result<()> {
             }) {
                 state = state.with_skills_root(skills_root);
             }
+            // Issue #290: with every builder input above now resolved, this host
+            // can rebuild a company's runtime in place. Wired BEFORE the
+            // companies register, so the very first `PUT …/inference` on a
+            // freshly booted tenant already has a rebuilder to reach for.
+            state = state.with_rebuilder(Arc::new(BootRebuilder));
             // Schedulers stop cleanly when this is notified (Ctrl-C below).
             let shutdown = Arc::new(Notify::new());
             let mut scheduler_handles = Vec::new();

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -12,6 +12,7 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::Mutex as TokioMutex;
 
@@ -149,7 +150,14 @@ pub struct CompanyRuntime {
     /// pre-#243 native-execute behaviour.
     pub(crate) grants: GrantSet,
     /// Held for the duration of a cycle so cycles never interleave per company.
-    pub(crate) serial: TokioMutex<()>,
+    ///
+    /// `Arc`-shared rather than owned so a rebuilt runtime can inherit the *same*
+    /// lock (issue #290). Two runtimes for one company each holding their own
+    /// mutex would mean two cycles running at once against a store whose `save`
+    /// writes the whole record, which is exactly the invariant this exists to
+    /// hold. Handing the lock over is also what makes
+    /// [`quiesce`](Self::quiesce)'s drain meaningful across the swap.
+    pub(crate) serial: Arc<TokioMutex<()>>,
     /// Held across a REST board write's read → validate → write, so two
     /// concurrent edits cannot each validate against a snapshot that predates
     /// the other's edge (issue #185 review).
@@ -158,7 +166,17 @@ pub struct CompanyRuntime {
     /// whole cycle, which is a live agent turn, so reusing it would park every
     /// board edit behind an LLM call. This one is only ever held across a
     /// couple of store round-trips.
-    pub(crate) task_writes: TokioMutex<()>,
+    ///
+    /// `Arc`-shared for the same reason as [`serial`](Self::serial): a rebuild
+    /// inherits it rather than minting a second one.
+    pub(crate) task_writes: Arc<TokioMutex<()>>,
+    /// Set while this runtime is being replaced (issue #290). Once set, every
+    /// cycle entry point refuses with [`OpenCompanyError::Quiescing`] so the
+    /// in-flight turn can drain and the successor takes over at a point with no
+    /// live cycle. Never cleared by the runtime itself: either the successor
+    /// replaces it in the registry, or the rebuild failed and
+    /// [`resume`](Self::resume) puts this one back to work.
+    pub(crate) quiesced: Arc<AtomicBool>,
     /// WS4: the embedded openhuman harness pool, when wired via
     /// [`RuntimeBuilder::with_harness`](crate::runtime::RuntimeBuilder::with_harness).
     /// Feature-gated so the default build is unaffected.
@@ -219,8 +237,9 @@ impl CompanyRuntime {
             workflow_runner: None,
             steer: crate::company::steer::InflightRegistry::new(),
             grants,
-            serial: TokioMutex::new(()),
-            task_writes: TokioMutex::new(()),
+            serial: Arc::new(TokioMutex::new(())),
+            task_writes: Arc::new(TokioMutex::new(())),
+            quiesced: Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "openhuman")]
             harness: None,
             #[cfg(feature = "mcp")]
@@ -307,6 +326,29 @@ impl CompanyRuntime {
     /// This company's event log (append-only audit trail).
     pub fn events(&self) -> &Arc<dyn EventLog> {
         &self.events
+    }
+
+    /// This company's runtime journal — the at-most-once effect log and the
+    /// durable approval queue.
+    ///
+    /// Exposed so a rebuild can prove it handed the *same* journal to the
+    /// successor: a second `RuntimeJournal` over one path is the corruption
+    /// hazard [`RuntimeHandover`](crate::runtime::RuntimeHandover) exists to
+    /// prevent, and "we passed it along" is only checkable if it is readable.
+    pub fn journal(&self) -> &Arc<RuntimeJournal> {
+        &self.journal
+    }
+
+    /// The per-company cycle lock, so a rebuild can assert the successor
+    /// inherited it rather than minting a second one.
+    pub(crate) fn serial_lock(&self) -> &Arc<TokioMutex<()>> {
+        &self.serial
+    }
+
+    /// The board read-modify-write lock, exposed for the same reason as
+    /// [`serial_lock`](Self::serial_lock).
+    pub(crate) fn task_writes_lock(&self) -> &Arc<TokioMutex<()>> {
+        &self.task_writes
     }
 
     /// This company's durable record store.
@@ -526,8 +568,76 @@ impl CompanyRuntime {
         self.economy.is_some()
     }
 
+    /// Stops this runtime accepting new cycles, then waits for the one in flight
+    /// to finish (issue #290).
+    ///
+    /// The two halves are both necessary and neither is sufficient. Setting the
+    /// flag alone leaves a turn mid-cycle, and a successor that started writing
+    /// the same journal underneath it would interleave two records onto one line
+    /// — a parse failure that bricks the *next* boot, not just this one. Waiting
+    /// on [`serial`](Self::serial) alone would race: a cycle queued behind the
+    /// one in flight would acquire the lock the moment it dropped and the drain
+    /// would return to a runtime that is busy again.
+    ///
+    /// The `serial` guard is deliberately released before returning. It is
+    /// handed to the successor by [`RuntimeHandover`](crate::runtime::RuntimeHandover),
+    /// so holding it here would park the successor's first cycle behind a guard
+    /// this runtime no longer has any reason to own.
+    ///
+    /// What this does **not** drain: work that never takes `serial`. Detached
+    /// task dispatches and scheduled workflow runs each clone an
+    /// `Arc<CompanyRuntime>` and run a cycle, so they *are* covered — they either
+    /// completed before the flag was set or they are the turn being waited on.
+    /// A harness tool call already in flight inside that turn finishes on the old
+    /// pool, which the successor then inherits.
+    pub async fn quiesce(&self) {
+        self.quiesced.store(true, Ordering::SeqCst);
+        // Acquiring proves the in-flight cycle (if any) has finished.
+        let _drained = self.serial.lock().await;
+    }
+
+    /// Puts a quiesced runtime back to work.
+    ///
+    /// Called when a rebuild fails: a company left quiesced would refuse every
+    /// cycle forever, which is a far worse outcome than the stale brain the
+    /// rebuild was trying to replace.
+    pub fn resume(&self) {
+        self.quiesced.store(false, Ordering::SeqCst);
+    }
+
+    /// Whether this runtime has stopped accepting cycles pending a swap.
+    pub fn is_quiesced(&self) -> bool {
+        self.quiesced.load(Ordering::SeqCst)
+    }
+
+    /// Adopts the serialising mutexes of the runtime this one replaces
+    /// (issue #290), so the cycle and board-write invariants span the swap
+    /// instead of lapsing at it.
+    ///
+    /// Called by the [`RuntimeBuilder`](crate::runtime::RuntimeBuilder) on a
+    /// rebuild, before the successor is registered and therefore before anything
+    /// can be holding either lock through *this* runtime.
+    pub fn adopt_locks(&mut self, serial: Arc<TokioMutex<()>>, task_writes: Arc<TokioMutex<()>>) {
+        self.serial = serial;
+        self.task_writes = task_writes;
+    }
+
+    /// Rejects a cycle on a runtime that is being replaced.
+    ///
+    /// Separate from [`ensure_running`](Self::ensure_running): that one reads a
+    /// durable lifecycle an operator chose (paused, archived) and renders `409`;
+    /// this one is a process-local window that clears itself within a turn and
+    /// renders `503`.
+    fn ensure_accepting(&self) -> Result<()> {
+        if self.is_quiesced() {
+            return Err(OpenCompanyError::Quiescing(self.id.as_ref().to_string()));
+        }
+        Ok(())
+    }
+
     /// Runs one cycle over a batch of events, returning what happened.
     pub async fn run_cycle(&self, events: Vec<CompanyEvent>) -> Result<CycleReport> {
+        self.ensure_accepting()?;
         CycleRunner::new(self).run(events).await
     }
 
@@ -539,6 +649,11 @@ impl CompanyRuntime {
         verdict: Verdict,
         by: Actor,
     ) -> Result<CycleReport> {
+        // Checked before the gate is touched, not inside the follow-up cycle: a
+        // resolution that journaled the verdict and then failed to run its
+        // follow-up would leave the brain permanently unaware of an approval the
+        // operator had already granted.
+        self.ensure_accepting()?;
         CycleRunner::new(self)
             .resolve_approval(id, verdict, by)
             .await
@@ -555,6 +670,7 @@ impl CompanyRuntime {
         amended_payload: serde_json::Value,
         by: Actor,
     ) -> Result<CycleReport> {
+        self.ensure_accepting()?;
         CycleRunner::new(self)
             .resolve_approval_amended(id, amended_payload, by)
             .await

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -339,18 +339,6 @@ impl CompanyRuntime {
         &self.journal
     }
 
-    /// The per-company cycle lock, so a rebuild can assert the successor
-    /// inherited it rather than minting a second one.
-    pub(crate) fn serial_lock(&self) -> &Arc<TokioMutex<()>> {
-        &self.serial
-    }
-
-    /// The board read-modify-write lock, exposed for the same reason as
-    /// [`serial_lock`](Self::serial_lock).
-    pub(crate) fn task_writes_lock(&self) -> &Arc<TokioMutex<()>> {
-        &self.task_writes
-    }
-
     /// This company's durable record store.
     pub fn store(&self) -> &Arc<dyn CompanyStore> {
         &self.store

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -419,22 +419,7 @@ impl CompanyRuntime {
             let task_id = task.id.clone();
             let run_id = self.open_run(task).await;
             let runtime = Arc::clone(self);
-            tokio::spawn(async move {
-                if let Err(err) = runtime
-                    .run_cycle(vec![CompanyEvent::TaskDispatched {
-                        task_id: task_id.clone(),
-                        run_id,
-                    }])
-                    .await
-                {
-                    tracing::warn!(
-                        company = %runtime.id,
-                        task = %task_id,
-                        error = %err,
-                        "task dispatch cycle failed"
-                    );
-                }
-            });
+            tokio::spawn(async move { runtime.run_dispatch_cycle(task_id, run_id).await });
             return;
         }
         // Default build / no harness: the board stays inert. The card rests in
@@ -442,6 +427,79 @@ impl CompanyRuntime {
         // minted either — nothing is attempting the card, so an attempt row would
         // be a fiction.
         let _ = task;
+    }
+
+    /// The body of a dispatch's detached cycle (issue #242), split out of the
+    /// `tokio::spawn` so the quiesce path below is reachable from a test.
+    ///
+    /// Owns the settle for the one dispatch failure the cycle's own terminality
+    /// backstop cannot see — see [`abandon_run`](Self::abandon_run).
+    #[cfg(feature = "openhuman")]
+    async fn run_dispatch_cycle(self: Arc<Self>, task_id: String, run_id: Option<String>) {
+        let Err(err) = self
+            .run_cycle(vec![CompanyEvent::TaskDispatched {
+                task_id: task_id.clone(),
+                run_id: run_id.clone(),
+            }])
+            .await
+        else {
+            return;
+        };
+        // Issue #290 meets issue #242. `ensure_accepting` refuses *before*
+        // `CycleRunner` takes the serial lock, so a dispatch that lands in the
+        // window while this runtime is being replaced never reaches `begin_run`
+        // — and the backstop inside the cycle only settles rows that cycle
+        // started. Every other dispatch failure is already covered in there.
+        // Left alone, the row minted a moment ago would sit `Pending` for the
+        // rest of the process's life: a card reading as under way by an attempt
+        // that never began, which nothing re-drives, and which the rebuild
+        // deliberately does *not* run the boot reaper to clean up.
+        if let Some(id) = run_id.as_deref()
+            && matches!(err, OpenCompanyError::Quiescing(_))
+        {
+            self.abandon_run(id).await;
+        }
+        tracing::warn!(
+            company = %self.id,
+            task = %task_id,
+            error = %err,
+            "task dispatch cycle failed"
+        );
+    }
+
+    /// Settles an attempt whose cycle was refused before it could start
+    /// (issue #290).
+    ///
+    /// `Pending` → terminal is exactly the move the transition table names for
+    /// "a dispatch that failed before the first turn"
+    /// ([`RunStatus::can_transition_to`](crate::ports::runs::RunStatus::can_transition_to)),
+    /// so this needs no new state — only a caller willing to use it.
+    ///
+    /// Recorded as [`RunStatus::Failed`](crate::ports::runs::RunStatus::Failed)
+    /// rather than `Cancelled`, for the same reason the boot reaper picks
+    /// `Failed`: the runtime went away underneath a card an operator had just
+    /// dispatched, and that is something they need to see and re-drive, not an
+    /// intentional stop filed quietly away. The reason string is its own
+    /// constant ([`RUNTIME_REPLACED_ERROR`](crate::ports::runs::RUNTIME_REPLACED_ERROR))
+    /// so a run list can tell "we swapped your runtime" apart from "the host
+    /// died". The card itself stays in `in_progress`, which is where every other
+    /// failed dispatch cycle leaves it.
+    ///
+    /// Best-effort and logged, never propagated: the dispatch has already
+    /// failed, and a bookkeeping write cannot make that better or worse.
+    #[cfg(feature = "openhuman")]
+    async fn abandon_run(&self, run_id: &str) {
+        let outcome = crate::ports::runs::RunOutcome::new(crate::ports::runs::RunStatus::Failed)
+            .with_error(crate::ports::runs::RUNTIME_REPLACED_ERROR);
+        if let Err(err) = self.ops.runs.finish_run(&self.id, run_id, outcome).await {
+            tracing::warn!(
+                company = %self.id,
+                run = %run_id,
+                error = %err,
+                "[runs] could not settle an attempt refused by a quiescing runtime; it stays \
+                 Pending until the next boot reaps it"
+            );
+        }
     }
 
     /// Mints this dispatch's [`RunStatus::Pending`] attempt row and returns its
@@ -1050,5 +1108,104 @@ mod tests {
                 .attempt,
             2
         );
+    }
+
+    /// Issue #290 against issue #242's write path: a card dragged into
+    /// `in_progress` while this runtime is being replaced must not leave an
+    /// attempt row claiming to be pending forever.
+    ///
+    /// The board write is deliberately *not* gated on the quiesce — only cycles
+    /// are — so this window is reachable, and the refusal happens before
+    /// `CycleRunner` starts the run, which puts it out of reach of the cycle's
+    /// own terminality backstop. A rebuild also skips the boot reaper by design,
+    /// so nothing else would ever clean the row up.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn a_dispatch_refused_by_a_quiescing_runtime_settles_its_attempt() {
+        use std::sync::Arc;
+
+        use crate::ports::TaskRecord;
+        use crate::ports::runs::{RUNTIME_REPLACED_ERROR, RunStatus};
+        use crate::ports::tasks::COLUMN_IN_PROGRESS;
+
+        let home = tempfile::Builder::new()
+            .prefix("opencompany-run-quiesce-")
+            .tempdir()
+            .expect("tempdir");
+        let manifest: crate::company::CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n[[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n[policy]\nmode = \"full\"\n",
+        )
+        .expect("manifest");
+        let id = crate::ports::types::CompanyId::new("acme");
+        let runtime = Arc::new(
+            crate::runtime::RuntimeBuilder::new(home.path().to_path_buf(), manifest)
+                .with_id(id.clone())
+                .build()
+                .await
+                .expect("runtime"),
+        );
+
+        let card = TaskRecord {
+            id: "t-1".to_string(),
+            title: "Ship it".to_string(),
+            note: None,
+            column: COLUMN_IN_PROGRESS.to_string(),
+            priority: "medium".to_string(),
+            assignee: "ceo".to_string(),
+            updated_at_millis: 0,
+            origin_chat_id: None,
+            parent_task_id: None,
+        };
+
+        // Positive control: on a live runtime the cycle runs, so the row is
+        // settled by the backstop inside it and never reaches the path below.
+        let live = runtime.open_run(&card).await.expect("an attempt");
+        Arc::clone(&runtime)
+            .run_dispatch_cycle(card.id.clone(), Some(live.clone()))
+            .await;
+        let settled = runtime
+            .runs()
+            .get_run(&id, &live)
+            .await
+            .expect("read")
+            .expect("row");
+        assert!(
+            settled.status.is_terminal(),
+            "the ordinary dispatch path still settles its own row"
+        );
+        assert_ne!(
+            settled.error.as_deref(),
+            Some(RUNTIME_REPLACED_ERROR),
+            "the live path must not be settled by the quiesce handler"
+        );
+
+        // The window this test exists for.
+        let stranded = runtime.open_run(&card).await.expect("an attempt");
+        runtime.quiesce().await;
+        Arc::clone(&runtime)
+            .run_dispatch_cycle(card.id.clone(), Some(stranded.clone()))
+            .await;
+
+        let abandoned = runtime
+            .runs()
+            .get_run(&id, &stranded)
+            .await
+            .expect("read")
+            .expect("row");
+        assert_eq!(
+            abandoned.status,
+            RunStatus::Failed,
+            "an attempt whose cycle was refused must not stay Pending"
+        );
+        assert_eq!(
+            abandoned.error.as_deref(),
+            Some(RUNTIME_REPLACED_ERROR),
+            "and it must say the runtime was swapped, not that the host died"
+        );
+        assert!(
+            abandoned.started_at_millis.is_none(),
+            "it never started, so it has no start time"
+        );
+        assert!(abandoned.finished_at_millis.is_some());
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -135,6 +135,15 @@ pub enum OpenCompanyError {
     #[error("conflict: {0}")]
     Conflict(String),
 
+    /// The company's runtime is quiescing for a swap (issue #290): it has
+    /// stopped accepting new cycles while the one in flight drains, and a
+    /// successor is being built. Distinct from
+    /// [`LifecycleConflict`](Self::LifecycleConflict), which is a *durable*
+    /// state an operator chose; this one clears itself within a turn, so it
+    /// renders as `503 Service Unavailable` and the caller should retry.
+    #[error("company {0} is being rebuilt; retry shortly")]
+    Quiescing(String),
+
     /// A request was malformed or internally inconsistent (e.g. an approval
     /// resolution that pairs a `deny` verdict with an amended payload).
     #[error("invalid request: {0}")]
@@ -237,6 +246,7 @@ impl OpenCompanyError {
             Self::BudgetExceeded(_) => "budget_exceeded".to_string(),
             Self::LifecycleConflict(_) => "lifecycle_conflict".to_string(),
             Self::Conflict(_) => "conflict".to_string(),
+            Self::Quiescing(_) => "quiescing".to_string(),
             Self::InvalidRequest(_) => "invalid_request".to_string(),
             Self::Config(_) => "config_error".to_string(),
             Self::Orchestration { code, .. } => code.clone(),

--- a/src/ports/runs.rs
+++ b/src/ports/runs.rs
@@ -51,6 +51,16 @@ use crate::ports::types::{CompanyId, EventSeq, TokenUsage, TurnStep};
 pub const ORPHAN_ERROR: &str =
     "the host restarted while this attempt was running, so its outcome was lost";
 
+/// The `error` stamped on an attempt whose dispatch was refused because the
+/// company's runtime was being replaced (issue #290).
+///
+/// Deliberately distinct from [`ORPHAN_ERROR`]. That one means the host process
+/// died and nothing is left to say what happened; this one means the process is
+/// perfectly healthy and the company's runtime was swapped underneath a card an
+/// operator had just dispatched, which is a retry-me rather than an incident.
+pub const RUNTIME_REPLACED_ERROR: &str =
+    "the company runtime was being replaced when this card was dispatched, so it never started";
+
 // ---------------------------------------------------------------------------
 // RunStatus
 // ---------------------------------------------------------------------------
@@ -536,6 +546,19 @@ fn check_transition(run: &RunRecord, next: RunStatus) -> Result<()> {
 /// Together those mean any active row observed at boot belongs to an attempt
 /// that no longer exists. This is a proof, not a timeout heuristic — nothing
 /// here guesses at staleness from a clock.
+///
+/// ## The proof is about *boot*, and only boot (issue #290)
+///
+/// Invariant 3 is the load-bearing one and it is the one a
+/// [runtime rebuild](crate::runtime::rebuild_company) breaks: a rebuild calls
+/// [`RuntimeBuilder::build`](crate::runtime::RuntimeBuilder::build) a second
+/// time in a live process, where cycles *have* run and may hold rows that are
+/// genuinely in flight. Calling this from there would settle live attempts as
+/// dead, which is the precise corruption the sweep exists to clean up — so
+/// `build()` suppresses it whenever a
+/// [`RuntimeHandover`](crate::runtime::RuntimeHandover) is present. Any future
+/// caller owes the same argument: this function reclaims rows it can *prove* are
+/// abandoned, and outside boot that proof does not exist.
 ///
 /// **Parked runs are never touched.** `WaitingApproval` and `Paused` are
 /// waiting on a person or an external condition, not on a process; reaping them

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -45,6 +45,7 @@ use crate::ports::{
     SkillStateStore, TaskStore, ToolProvider, UsageMeter, UserStore, WorkspaceStore,
 };
 use crate::runtime::channel::{OPERATOR_CHANNEL, OperatorChannel};
+use crate::runtime::handover::RuntimeHandover;
 use crate::runtime::journal::RuntimeJournal;
 use crate::runtime::tools::{StubToolProvider, grant_matches};
 use crate::store::paths::Bundle;
@@ -260,6 +261,14 @@ pub struct RuntimeBuilder {
     /// consumed when a company **explicitly** grants the `search` namespace.
     #[cfg(feature = "openhuman")]
     search_backend: Option<crate::harness::search::SearchBackend>,
+    /// Issue #290: the live state of the runtime this build is *replacing*.
+    ///
+    /// Present only on a rebuild. It supplies the per-instance pieces a second
+    /// runtime must never duplicate (see [`RuntimeHandover`]), and its presence
+    /// is also the "this is a rebuild" signal that suppresses the boot-only side
+    /// effects below: journal replay, orphan-run reaping, workspace seeding,
+    /// going-public, and the MCP re-boot.
+    handover: Option<RuntimeHandover>,
 }
 
 impl RuntimeBuilder {
@@ -318,6 +327,7 @@ impl RuntimeBuilder {
             media_backend: None,
             #[cfg(feature = "openhuman")]
             search_backend: None,
+            handover: None,
         }
     }
 
@@ -558,6 +568,18 @@ impl RuntimeBuilder {
     }
 
     /// Swaps the approval gate (default: manifest `[policy]` gate).
+    /// Issue #290: adopt the live state of the runtime this build replaces,
+    /// instead of constructing a second copy of it.
+    ///
+    /// Setting this makes the build a **rebuild**: see [`RuntimeHandover`] for
+    /// what is inherited and why each piece is a correctness matter, and
+    /// [`rebuild_company`](crate::runtime::rebuild_company) for the quiesce →
+    /// hand over → build → swap sequence a caller must follow around it.
+    pub fn with_handover(mut self, handover: RuntimeHandover) -> Self {
+        self.handover = Some(handover);
+        self
+    }
+
     pub fn with_approvals(mut self, approvals: Arc<ManifestApprovalGate>) -> Self {
         self.approvals = Some(approvals);
         self
@@ -698,18 +720,45 @@ impl RuntimeBuilder {
     pub async fn build(mut self) -> Result<CompanyRuntime> {
         let home = self.home;
         let id = self.id;
+        // Issue #290. Present ⇒ this is a rebuild of a live company, so every
+        // per-instance piece below is inherited rather than constructed, and the
+        // boot-only side effects are skipped. Absent ⇒ an ordinary boot, byte for
+        // byte as before.
+        let handover = self.handover.take();
+        // On a rebuild the *brain* must be built over the inherited harness pool,
+        // not a freshly minted one. The boot path mints a pool per build, so
+        // without this the successor's brain would talk to a new pool while the
+        // runtime reported the old one — two pools for one company, and every
+        // agent's conversation history silently dropped. Done here, before any
+        // field is moved out of `self`, so the brain arm below and the
+        // `set_harness` wiring further down agree by construction.
+        #[cfg(feature = "openhuman")]
+        if let Some(pool) = handover.as_ref().and_then(|h| h.harness.clone()) {
+            self.harness = Some(pool);
+        }
 
-        let store: Arc<dyn CompanyStore> = self
-            .store
+        // Inherit-or-construct. The handover's handles outrank an explicitly
+        // injected one: on a rebuild, a second store over the same data is the
+        // bug, not the configuration.
+        let store: Arc<dyn CompanyStore> = handover
+            .as_ref()
+            .map(|h| h.store.clone())
+            .or(self.store)
             .unwrap_or_else(|| Arc::new(FsCompanyStore::new(home.clone())));
-        let events: Arc<dyn EventLog> = self
-            .events
+        let events: Arc<dyn EventLog> = handover
+            .as_ref()
+            .map(|h| h.events.clone())
+            .or(self.events)
             .unwrap_or_else(|| Arc::new(FsEventLog::new(home.clone())));
-        let memory: Arc<dyn MemoryStore> = self
-            .memory
+        let memory: Arc<dyn MemoryStore> = handover
+            .as_ref()
+            .map(|h| h.memory.clone())
+            .or(self.memory)
             .unwrap_or_else(|| Arc::new(FsMemoryStore::new(home.clone())));
-        let context: Arc<dyn ContextStore> = self
-            .context
+        let context: Arc<dyn ContextStore> = handover
+            .as_ref()
+            .map(|h| h.context.clone())
+            .or(self.context)
             .unwrap_or_else(|| Arc::new(FsContextStore::new(home.clone())));
         // Effective grants narrow the company allow-list by per-agent tools.
         let grants = effective_grants(&self.manifest);
@@ -719,49 +768,68 @@ impl RuntimeBuilder {
         // filing configuration. The consent mode is also the built-in feedback
         // tool's capture mode.
         let bundle = Bundle::new(home.clone(), &id);
-        let feedback = self
-            .feedback
+        let feedback = handover
+            .as_ref()
+            .map(|h| h.feedback.clone())
+            .or(self.feedback)
             .unwrap_or_else(|| Arc::new(FeedbackStore::new(&bundle)));
-        let secrets: Arc<dyn SecretStore> = self
-            .secrets
+        let secrets: Arc<dyn SecretStore> = handover
+            .as_ref()
+            .map(|h| h.secrets.clone())
+            .or(self.secrets)
             .unwrap_or_else(|| Arc::new(FsSecretStore::new(home.clone())));
-        let inbox: Arc<dyn InboxStore> = self
-            .inbox
+        let inbox: Arc<dyn InboxStore> = handover
+            .as_ref()
+            .map(|h| h.inbox.clone())
+            .or(self.inbox)
             .unwrap_or_else(|| Arc::new(FsInboxStore::new(home.clone())));
         // The WS3 console ports default to a single shared fs backend.
         let fs_ops = Arc::new(FsOps::new(home.clone()));
-        let ops = OpsStores {
-            tasks: self.tasks.unwrap_or_else(|| fs_ops.clone()),
-            workspace: self.workspace.unwrap_or_else(|| fs_ops.clone()),
-            facts: self.facts.unwrap_or_else(|| fs_ops.clone()),
-            artifacts: self.artifacts.unwrap_or_else(|| fs_ops.clone()),
-            runs: self.runs.unwrap_or_else(|| fs_ops.clone()),
-            usage: self.usage.unwrap_or_else(|| fs_ops.clone()),
-            skills: self.skills.unwrap_or_else(|| fs_ops.clone()),
-            users: self.users.unwrap_or_else(|| fs_ops.clone()),
-            sessions: self.sessions.unwrap_or_else(|| fs_ops.clone()),
-            login_codes: self.login_codes.unwrap_or_else(|| fs_ops.clone()),
+        let ops = match handover.as_ref() {
+            Some(h) => h.ops.clone(),
+            None => OpsStores {
+                tasks: self.tasks.unwrap_or_else(|| fs_ops.clone()),
+                workspace: self.workspace.unwrap_or_else(|| fs_ops.clone()),
+                facts: self.facts.unwrap_or_else(|| fs_ops.clone()),
+                artifacts: self.artifacts.unwrap_or_else(|| fs_ops.clone()),
+                runs: self.runs.unwrap_or_else(|| fs_ops.clone()),
+                usage: self.usage.unwrap_or_else(|| fs_ops.clone()),
+                skills: self.skills.unwrap_or_else(|| fs_ops.clone()),
+                users: self.users.unwrap_or_else(|| fs_ops.clone()),
+                sessions: self.sessions.unwrap_or_else(|| fs_ops.clone()),
+                login_codes: self.login_codes.unwrap_or_else(|| fs_ops.clone()),
+            },
         };
 
         // Idempotent workspace seeding: only when the workspace is empty (an
         // operator's deletions must stick, so a seeded-then-emptied workspace is
         // never re-seeded). Skills need no seeding — the store holds deltas only
         // and the effective set unions company-dir skills at read time.
-        if let Some(seed_dir) = &self.seed_dir
+        //
+        // Skipped entirely on a rebuild: the workspace belongs to a company that
+        // is already running, so there is nothing to seed and the `is_empty`
+        // probe would only race the live runtime's own writes.
+        if handover.is_none()
+            && let Some(seed_dir) = &self.seed_dir
             && ops.workspace.is_empty(&id).await?
         {
             seed_workspace(ops.workspace.as_ref(), &id, seed_dir).await?;
         }
 
         let consent = self.consent;
-        let filer = Arc::new(FeedbackFiler {
-            client: self.github,
-            tinyhumans: self.tinyhumans_feedback,
-            repo: crate::feedback::DEFAULT_REPO.to_string(),
-            consent,
-            limiter: RateLimiter::default(),
-            quality: crate::feedback::QualityLedger::default(),
-        });
+        // Inherited on a rebuild so the in-memory filing rate limiter survives.
+        // A fresh limiter would make a rebuild loop a rate-limit bypass.
+        let filer = match handover.as_ref() {
+            Some(h) => h.filer.clone(),
+            None => Arc::new(FeedbackFiler {
+                client: self.github,
+                tinyhumans: self.tinyhumans_feedback,
+                repo: crate::feedback::DEFAULT_REPO.to_string(),
+                consent,
+                limiter: RateLimiter::default(),
+                quality: crate::feedback::QualityLedger::default(),
+            }),
+        };
 
         // Probe OpenHuman once; an unreachable daemon degrades, never fails.
         let openhuman_healthy = match &openhuman {
@@ -854,10 +922,25 @@ impl RuntimeBuilder {
         // produces or mutates, so hoisting it is a pure move. The same two
         // `Arc`s go to the delivery deps and to the runtime — one gate, one
         // journal, one approvals queue.
-        let journal = Arc::new(RuntimeJournal::new(
-            Bundle::new(home.clone(), &id).journal_jsonl(),
-        ));
-        journal.load().await?;
+        //
+        // On a rebuild the journal is **inherited, never reopened**. It is the
+        // one piece where a second instance is not merely wasteful: `append`
+        // writes a record and its newline as two writes under a per-instance
+        // lock, so two journals on one path interleave onto a single line and
+        // fail to parse on replay — bricking the next boot, not just this
+        // process. `load()` is skipped for the same reason it is not repeated at
+        // boot: the inherited journal is already replayed, and re-reading it
+        // would re-apply records the live instance has since resolved.
+        let journal = match handover.as_ref() {
+            Some(h) => h.journal.clone(),
+            None => {
+                let journal = Arc::new(RuntimeJournal::new(
+                    Bundle::new(home.clone(), &id).journal_jsonl(),
+                ));
+                journal.load().await?;
+                journal
+            }
+        };
 
         // Issue #242, the other half of boot replay: reclaim run records left
         // active by a previous host process.
@@ -877,7 +960,15 @@ impl RuntimeBuilder {
         // and scheduler spawns further down, so no fresh run can be reaped by
         // mistake. A store failure is logged, never fatal: record-keeping must
         // not stop a company from booting.
-        if let Err(err) = crate::ports::runs::reap_orphaned_runs(ops.runs.as_ref(), &id).await {
+        //
+        // Issue #290: suppressed on a rebuild. The whole argument above rests on
+        // "nothing from this process can be in flight yet", which is true at
+        // boot and false mid-life. A rebuild that reaped would settle live run
+        // records as dead — the exact bookkeeping corruption this sweep exists
+        // to clean up.
+        if handover.is_none()
+            && let Err(err) = crate::ports::runs::reap_orphaned_runs(ops.runs.as_ref(), &id).await
+        {
             tracing::warn!(
                 company = %id,
                 error = %err,
@@ -885,12 +976,25 @@ impl RuntimeBuilder {
             );
         }
 
-        let gate = self
-            .approvals
-            .unwrap_or_else(|| Arc::new(ManifestApprovalGate::new(self.manifest.policy.clone())));
-        for pending in journal.pending() {
-            gate.rehydrate(pending.id, pending.effect, pending.at_millis);
-        }
+        // The policy gate, rehydrated from the journal replay above so approvals
+        // survive a restart with their original ids.
+        //
+        // Inherited on a rebuild, along with its parked approvals: an approval
+        // waiting on a person keeps its id, its parked effect and its TTL across
+        // the swap, and rehydrating a fresh gate from the journal would resurrect
+        // approvals the live gate has already resolved.
+        let gate = match handover.as_ref() {
+            Some(h) => h.approval_gate.clone(),
+            None => {
+                let gate = self.approvals.unwrap_or_else(|| {
+                    Arc::new(ManifestApprovalGate::new(self.manifest.policy.clone()))
+                });
+                for pending in journal.pending() {
+                    gate.rehydrate(pending.id, pending.effect, pending.at_millis);
+                }
+                gate
+            }
+        };
 
         // Issue #243: the single-use grant set, seeded from the same replay.
         //
@@ -908,8 +1012,19 @@ impl RuntimeBuilder {
         // asking for a permission it had just been given. Consumed and expired
         // grants are folded out during replay, so this can only re-arm one that
         // never fired.
-        let grants = crate::runtime::grants::GrantSet::default();
-        grants.rehydrate(journal.replayed_grants());
+        //
+        // Inherited on a rebuild for the same reason as the gate: the operator
+        // who approved a blocked tool call moments before the swap must not be
+        // asked to approve it again, and a set rebuilt from the journal replay
+        // would re-arm grants the live set has already consumed.
+        let grants = match handover.as_ref() {
+            Some(h) => h.grants.clone(),
+            None => {
+                let grants = crate::runtime::grants::GrantSet::default();
+                grants.rehydrate(journal.replayed_grants());
+                grants
+            }
+        };
 
         // Brain selection, in precedence order:
         //   1. an explicit brain (test injection) always wins;
@@ -1438,20 +1553,47 @@ impl RuntimeBuilder {
         // skills/workflows content on the serve path.
         runtime.set_source_dir(self.seed_dir.clone());
 
+        // Issue #290: adopt the outgoing runtime's serialising mutexes. Two
+        // runtimes for one company each holding their own `serial` would let two
+        // cycles run at once against a store whose `save` writes the whole
+        // record; two `task_writes` would let two board edits each validate
+        // against a snapshot predating the other. Adopting them is also what
+        // makes the quiesce drain mean something after the swap.
+        if let Some(h) = handover.as_ref() {
+            runtime.adopt_locks(h.serial.clone(), h.task_writes.clone());
+        }
+
         // MCP uses OpenHuman's process-global live connection registry. Keep a
         // runtime-owned config for this OpenCompany home so REST and agents see
         // the same installed servers, and reconnect persisted installs without
         // delaying company boot.
+        //
+        // A rebuild adopts the live one and does **not** re-boot it: the connect
+        // map is keyed by server id and shared process-wide, so re-dialling would
+        // replace connections the outgoing runtime's agents may still be
+        // mid-call on.
         #[cfg(feature = "mcp")]
         {
-            let mcp = Arc::new(crate::harness::mcp::McpRuntime::new(home.join("mcp")));
-            runtime.set_mcp(mcp.clone());
-            tokio::spawn(async move { mcp.boot().await });
+            match handover.as_ref().and_then(|h| h.mcp.clone()) {
+                Some(mcp) => runtime.set_mcp(mcp),
+                None => {
+                    let mcp = Arc::new(crate::harness::mcp::McpRuntime::new(home.join("mcp")));
+                    runtime.set_mcp(mcp.clone());
+                    tokio::spawn(async move { mcp.boot().await });
+                }
+            }
         }
 
-        // WS4: attach the embedded harness pool when one was provided.
+        // WS4: attach the embedded harness pool when one was provided. On a
+        // rebuild the outgoing pool wins over any freshly minted one, so each
+        // agent's conversation history survives the swap instead of being
+        // silently dropped.
         #[cfg(feature = "openhuman")]
-        if let Some(harness) = self.harness.clone() {
+        if let Some(harness) = handover
+            .as_ref()
+            .and_then(|h| h.harness.clone())
+            .or_else(|| self.harness.clone())
+        {
             runtime.set_harness(harness);
         }
 
@@ -1473,14 +1615,21 @@ impl RuntimeBuilder {
 
         // Boot lifecycle step 3: going-public. Best-effort and non-blocking —
         // any failure degrades to "private" with a warning and never fails boot.
-        maybe_go_public(
-            &economy,
-            &self.manifest,
-            &id,
-            going_public,
-            self.host_base_url.as_deref(),
-        )
-        .await;
+        //
+        // Skipped on a rebuild (issue #290): the handle claim is a paid,
+        // networked, once-per-boot action, and a company that is already public
+        // does not become more public by claiming again. Firing it on every
+        // inference save would spend money for nothing.
+        if handover.is_none() {
+            maybe_go_public(
+                &economy,
+                &self.manifest,
+                &id,
+                going_public,
+                self.host_base_url.as_deref(),
+            )
+            .await;
+        }
 
         Ok(runtime)
     }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -962,10 +962,27 @@ impl RuntimeBuilder {
         // not stop a company from booting.
         //
         // Issue #290: suppressed on a rebuild. The whole argument above rests on
-        // "nothing from this process can be in flight yet", which is true at
-        // boot and false mid-life. A rebuild that reaped would settle live run
-        // records as dead — the exact bookkeeping corruption this sweep exists
-        // to clean up.
+        // "nothing from this process can be in flight yet" — true at boot, false
+        // the moment a company has been serving. Mid-life this sweep would be
+        // reclaiming rows it cannot prove are abandoned, which is the one thing
+        // it promises never to do.
+        //
+        // Precisely which rows are at risk, since the answer is narrower than it
+        // looks: `rebuild_company` quiesces and drains before reaching here, and
+        // both `begin_run` and the terminality backstop sit inside the serial
+        // lock, so no `Running` row survives the drain. `Pending` does — the
+        // dispatch choke point mints a row *outside* that lock, so a board write
+        // landing in the window leaves one behind. Reaping it would stamp the
+        // wrong reason on it ("the host restarted"), and if the rebuild then
+        // fails and `resume()` puts the company back to work, the row is already
+        // terminal: its cycle's `begin_run` is rejected and a genuinely live
+        // attempt runs with no record at all.
+        //
+        // Suppressing rather than leaning on the drain also keeps this resting
+        // on the invariant the reaper states instead of on the current call
+        // order. It costs nothing: a refused dispatch settles its own row
+        // (`CompanyRuntime::abandon_run`), and the next real boot sweeps
+        // anything that escapes.
         if handover.is_none()
             && let Err(err) = crate::ports::runs::reap_orphaned_runs(ops.runs.as_ref(), &id).await
         {

--- a/src/runtime/handover.rs
+++ b/src/runtime/handover.rs
@@ -1,0 +1,125 @@
+//! [`RuntimeHandover`]: the per-instance state a rebuilt company runtime must
+//! **inherit** rather than reconstruct (issue #290).
+//!
+//! Rebuilding a company — so that first-time BYOK setup moves it off the offline
+//! echo brain without a process restart — is not "call
+//! [`RuntimeBuilder::build`](crate::runtime::RuntimeBuilder::build) twice". Most
+//! of a runtime is `Arc<dyn Port>` handles that are safe to share, but several
+//! pieces carry state that exists *only* in the live instance, and constructing
+//! a second copy of any of them is a correctness bug rather than a waste:
+//!
+//! - **The journal is single-writer.** [`RuntimeJournal::append`] emits a record
+//!   and its newline as two writes under a *per-instance* lock. A second journal
+//!   over the same path interleaves two records onto one line, which fails to
+//!   parse on replay — bricking the next boot and
+//!   [`CompanyRuntime::recover`](crate::company::runtime::CompanyRuntime), not
+//!   merely this process.
+//! - **At-most-once effects are per-instance.** The executed-key set is built in
+//!   memory at `load()`. A second instance never sees the first's commits, so a
+//!   send or a spend runs twice.
+//! - **The two serialising mutexes are per-instance.** `serial` guards a whole
+//!   cycle; `task_writes` guards the board's read-modify-write. Two mutexes mean
+//!   both invariants lapse across the swap.
+//! - **The filesystem event log's `seq` is per-instance**, derived from a line
+//!   count under its own lock, and its broadcast sender is what an open console
+//!   SSE connection is subscribed to. A fresh one mints duplicate sequence
+//!   numbers and leaves every open stream permanently deaf.
+//! - **The feedback filer's rate limiter is in memory**, so rebuilding it turns a
+//!   rebuild loop into a rate-limit bypass.
+//! - **The harness pool holds each agent's conversation history**, which a fresh
+//!   pool would silently drop; and the MCP runtime dials into a *process-global*
+//!   connection map keyed by server id, so a re-boot replaces connections the
+//!   outgoing runtime's agents may still be mid-call on.
+//!
+//! What is deliberately **not** carried over:
+//!
+//! - **The brain, tools, channels, workflow runner and economy.** Replacing
+//!   those is the entire point of a rebuild.
+//! - **The in-flight steer registry.** The successor's harness deps mint their
+//!   own, and the operator steer routes read whichever runtime is registered.
+//!   That is sound only because a swap happens after
+//!   [`quiesce`](crate::company::runtime::CompanyRuntime::quiesce) has drained
+//!   the cycle that would have registered a run, so the outgoing registry is
+//!   empty at the swap point.
+//! - **`source_dir`, mail, and the boot-only inputs.** Those are re-supplied by
+//!   the rebuild caller from the same values boot used, so the successor is
+//!   configured by one code path rather than two.
+
+use std::sync::Arc;
+
+use tokio::sync::Mutex as TokioMutex;
+
+use crate::company::runtime::{CompanyRuntime, OpsStores};
+use crate::feedback::service::FeedbackFiler;
+use crate::feedback::store::FeedbackStore;
+use crate::policy::ManifestApprovalGate;
+use crate::ports::{CompanyStore, ContextStore, EventLog, InboxStore, MemoryStore, SecretStore};
+use crate::runtime::grants::GrantSet;
+use crate::runtime::journal::RuntimeJournal;
+
+/// The live state a successor runtime adopts from the runtime it replaces.
+///
+/// Produced by [`CompanyRuntime::handover`] and consumed by
+/// [`RuntimeBuilder::with_handover`](crate::runtime::RuntimeBuilder::with_handover).
+/// Cheap to make: every field is an `Arc` clone or an `Arc`-backed handle.
+///
+/// Its presence is also what tells `build()` it is rebuilding rather than
+/// booting, which suppresses the boot-only side effects (journal replay, orphan
+/// run reaping, going-public, MCP re-boot) that must not fire a second time.
+#[derive(Clone)]
+pub struct RuntimeHandover {
+    pub(crate) store: Arc<dyn CompanyStore>,
+    pub(crate) events: Arc<dyn EventLog>,
+    pub(crate) memory: Arc<dyn MemoryStore>,
+    pub(crate) context: Arc<dyn ContextStore>,
+    pub(crate) secrets: Arc<dyn SecretStore>,
+    pub(crate) inbox: Arc<dyn InboxStore>,
+    pub(crate) ops: OpsStores,
+    pub(crate) feedback: Arc<FeedbackStore>,
+    pub(crate) filer: Arc<FeedbackFiler>,
+    pub(crate) journal: Arc<RuntimeJournal>,
+    pub(crate) approval_gate: Arc<ManifestApprovalGate>,
+    pub(crate) grants: GrantSet,
+    pub(crate) serial: Arc<TokioMutex<()>>,
+    pub(crate) task_writes: Arc<TokioMutex<()>>,
+    #[cfg(feature = "openhuman")]
+    pub(crate) harness: Option<Arc<crate::harness::HarnessPool>>,
+    #[cfg(feature = "mcp")]
+    pub(crate) mcp: Option<Arc<crate::harness::mcp::McpRuntime>>,
+}
+
+impl std::fmt::Debug for RuntimeHandover {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RuntimeHandover").finish_non_exhaustive()
+    }
+}
+
+impl CompanyRuntime {
+    /// Snapshots the live state a successor must inherit (issue #290).
+    ///
+    /// Take this *after* [`quiesce`](Self::quiesce): the handover is only sound
+    /// at a point with no cycle in flight, because a cycle holds `serial` and
+    /// writes the journal, and the successor is about to own both.
+    pub fn handover(&self) -> RuntimeHandover {
+        RuntimeHandover {
+            store: self.store.clone(),
+            events: self.events.clone(),
+            memory: self.memory.clone(),
+            context: self.context.clone(),
+            secrets: self.secrets.clone(),
+            inbox: self.inbox.clone(),
+            ops: self.ops.clone(),
+            feedback: self.feedback.clone(),
+            filer: self.filer.clone(),
+            journal: self.journal.clone(),
+            approval_gate: self.approval_gate.clone(),
+            grants: self.grants.clone(),
+            serial: self.serial.clone(),
+            task_writes: self.task_writes.clone(),
+            #[cfg(feature = "openhuman")]
+            harness: self.harness.clone(),
+            #[cfg(feature = "mcp")]
+            mcp: self.mcp.clone(),
+        }
+    }
+}

--- a/src/runtime/mailbox_poller.rs
+++ b/src/runtime/mailbox_poller.rs
@@ -22,6 +22,10 @@ use crate::server::ops::smtp::local_part;
 /// it into the addressed inbox via [`file_and_notify`].
 pub struct MailboxPoller {
     runtime: Arc<CompanyRuntime>,
+    /// When set, the runtime to file into is looked up here every tick so a
+    /// runtime swap (issue #290) reaches inbound mail. `None` keeps the boot
+    /// snapshot.
+    registry: Option<crate::runtime::CompanyRegistry>,
     receiver: Arc<dyn MailReceiver>,
     creds: ImapCredentials,
     address: String,
@@ -40,11 +44,32 @@ impl MailboxPoller {
     ) -> Self {
         Self {
             runtime,
+            registry: None,
             receiver,
             creds,
             address,
             interval: Duration::from_secs(interval_secs.max(1)),
         }
+    }
+
+    /// Issue #290: re-read `registry` for this company on every tick, instead of
+    /// driving the `Arc<CompanyRuntime>` snapshotted at boot.
+    ///
+    /// Without this, a runtime swap never reaches this loop: it keeps driving a
+    /// runtime that has been replaced and quiesced, so every tick fails. Opted
+    /// into by the boot path, so existing callers keep the snapshot behaviour.
+    pub fn following(mut self, registry: crate::runtime::CompanyRegistry) -> Self {
+        self.registry = Some(registry);
+        self
+    }
+
+    /// The runtime to drive this tick: whatever is registered now, else the
+    /// snapshot taken at construction.
+    fn runtime(&self) -> Arc<CompanyRuntime> {
+        self.registry
+            .as_ref()
+            .and_then(|registry| registry.get(self.runtime.id()))
+            .unwrap_or_else(|| self.runtime.clone())
     }
 
     /// Fetches new mail and files each message. Returns the count filed. Skips
@@ -59,7 +84,8 @@ impl MailboxPoller {
     /// choices mean one bad message can never mark itself (or any message
     /// after it) seen without having been filed, so nothing is silently lost.
     pub async fn tick(&self) -> crate::Result<usize> {
-        if self.runtime.ensure_running().await.is_err() {
+        let runtime = self.runtime();
+        if runtime.ensure_running().await.is_err() {
             return Ok(0);
         }
         let messages = self.receiver.fetch_new(&self.creds).await?;
@@ -76,7 +102,7 @@ impl MailboxPoller {
                 read: false,
                 outbound: false,
             };
-            match file_and_notify(&self.runtime, &self.address, record).await {
+            match file_and_notify(&runtime, &self.address, record).await {
                 Ok(()) => filed_uids.push(m.uid),
                 Err(err) => {
                     tracing::warn!(

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -41,8 +41,17 @@ pub mod delegation_tools;
 /// are feature-independent, so a company that ran under the harness stays
 /// replayable by a build without it.
 pub mod grants;
+/// Issue #290: [`RuntimeHandover`] — the live, per-instance state a rebuilt
+/// company runtime must inherit rather than construct a second copy of (the
+/// journal, the approval gate, the grant set, the event log, the stores, the
+/// harness pool, the MCP runtime, and the two serialising mutexes). See
+/// [`handover`].
+pub mod handover;
 pub mod journal;
 pub mod mailbox_poller;
+/// Issue #290: replacing a registered company's runtime in place, so first-time
+/// BYOK setup takes effect without a process restart. See [`rebuild`].
+pub mod rebuild;
 pub mod registry;
 pub mod scheduler;
 /// Issue #203: the Telegram `getUpdates` long-polling listener — the inbound
@@ -60,6 +69,8 @@ pub use builder::{RuntimeBuilder, company_id_from_name};
 pub use channel::{OPERATOR_CHANNEL, OperatorChannel};
 pub use cron::{CivilTime, CronExpr};
 pub use cycle::CycleRunner;
+pub use handover::RuntimeHandover;
+pub use rebuild::{BootInputs, RebuildRequest, RuntimeRebuilder, rebuild_company};
 pub use registry::CompanyRegistry;
 pub use scheduler::{Clock, CompanyScheduler, FakeClock, SystemClock};
 pub use tools::StubToolProvider;

--- a/src/runtime/rebuild.rs
+++ b/src/runtime/rebuild.rs
@@ -1,0 +1,400 @@
+//! Replacing a registered company's runtime in place (issue #290).
+//!
+//! Which brain a company runs is chosen once, in
+//! [`RuntimeBuilder::build`](crate::runtime::RuntimeBuilder::build). A company
+//! that resolved no inference at boot is on the offline echo brain with an
+//! unwired workflow runner, and a credential written afterwards reaches neither.
+//! #266 shipped the honest half of that (`restartRequired`, and a console banner
+//! saying so); this module is the half that removes the restart, which is the
+//! only form a hosted tenant can actually act on — the control plane has no
+//! "restart this tenant" button, and the container is the unit of restart.
+//!
+//! # The sequence
+//!
+//! 1. **Quiesce.** [`CompanyRuntime::quiesce`] stops the outgoing runtime
+//!    accepting cycles and waits for the one in flight to drain, so the swap
+//!    happens at a point with no live turn.
+//! 2. **Hand over.** [`CompanyRuntime::handover`] snapshots the per-instance
+//!    state a second runtime must not duplicate — the journal, the approval gate,
+//!    the grant set, the event log, the stores, the harness pool, the MCP
+//!    runtime, and the two serialising mutexes. See [`RuntimeHandover`] for why
+//!    each one is a correctness matter rather than an optimisation.
+//! 3. **Rebuild.** A host-supplied [`RuntimeRebuilder`] runs the *same* wiring
+//!    boot used, with the handover attached. It lives behind a trait because that
+//!    wiring (harness pool, OpenHuman RPC, managed backends, per-tenant mailbox)
+//!    is assembled in the binary, above this crate's public surface.
+//! 4. **Swap.** The successor replaces the outgoing runtime in the registry.
+//!
+//! # What happens to in-flight work
+//!
+//! The cycle in flight at step 1 **completes** on the outgoing runtime, against
+//! the same journal, approval queue and stores the successor then adopts. It is
+//! not cancelled and its effects are not replayed: the executed-key set moves
+//! across with the journal, so an effect committed by the outgoing runtime stays
+//! committed for the successor.
+//!
+//! Cycles that arrive *during* the window are refused with
+//! [`OpenCompanyError::Quiescing`] (`503`) rather than queued, so a caller
+//! retries against the successor instead of silently getting the brain the
+//! rebuild was replacing. The window is one turn wide, and that is also the
+//! bound on the *triggering* request: a rebuild started mid-turn blocks until
+//! the turn drains. Giving up and swapping anyway would trade a slow response
+//! for a corrupted journal, so the wait is unbounded on purpose.
+//!
+//! Parked approvals survive untouched: the gate itself is handed over, so an
+//! approval waiting on a person keeps its id, its parked effect and its TTL, and
+//! resolving it after the swap runs the follow-up on the *new* brain. The same
+//! goes for single-use grants — an operator who approved a tool call a moment
+//! before the rebuild does not have to approve it again.
+//!
+//! Orphan-run reaping is suppressed on a rebuild. At boot it is sound because
+//! nothing from this process can be in flight; during a rebuild that premise is
+//! false, and reaping would settle live run records as dead.
+//!
+//! # On failure
+//!
+//! A rebuild that fails leaves the outgoing runtime registered and
+//! [`resume`](CompanyRuntime::resume)s it. A company stuck quiesced would refuse
+//! every cycle forever, which is strictly worse than the stale brain the rebuild
+//! was trying to replace.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::Result;
+use crate::app::AppState;
+use crate::company::CompanyManifest;
+use crate::company::runtime::CompanyRuntime;
+use crate::error::OpenCompanyError;
+use crate::ports::types::CompanyId;
+use crate::runtime::handover::RuntimeHandover;
+
+/// The boot-only builder inputs a rebuild cannot recover from the runtime or the
+/// environment, stashed at registration so a later rebuild configures the
+/// successor exactly as boot configured its predecessor.
+///
+/// `discoverable` is the motivating case: `serve --discoverable` exists only in
+/// the `serve` stack frame and mutates the manifest *before* the build, so a
+/// rebuild that re-read `company.toml` from `source_dir` would silently drop it
+/// and un-publish a public company.
+#[derive(Clone, Debug, Default)]
+pub struct BootInputs {
+    /// The company's on-disk source directory (`companies/<name>`), used to seed
+    /// the workspace and resolve committed skills/workflows.
+    pub source_dir: Option<PathBuf>,
+    /// Whether `serve --discoverable` forced this company public regardless of
+    /// its manifest `[place].discoverable`.
+    pub discoverable: bool,
+}
+
+/// Everything a [`RuntimeRebuilder`] needs to produce a successor runtime.
+pub struct RebuildRequest {
+    /// The company being rebuilt. Already registered; the successor keeps this id.
+    pub id: CompanyId,
+    /// The company's **materialized** manifest, read from its persisted record
+    /// rather than re-parsed from disk.
+    ///
+    /// This is the manifest the running company actually has, which matters for
+    /// two things a fresh `company.toml` read would drop: the console-created
+    /// workflows merged into `[workflows].enabled`, and the `[place]` fields
+    /// `serve --discoverable` mutated before the original build. A
+    /// platform-provisioned tenant has no `company.toml` at all, so the record is
+    /// the only source.
+    pub manifest: CompanyManifest,
+    /// The boot-only inputs recorded when this company was registered.
+    pub boot: BootInputs,
+    /// The live state the successor must adopt rather than reconstruct.
+    pub handover: RuntimeHandover,
+}
+
+/// A host's ability to rebuild one of its companies with the wiring it booted
+/// with.
+///
+/// Implemented by the binary, because the inputs (`HarnessPool`, the OpenHuman
+/// RPC transport, managed media/search backends, the injected per-tenant
+/// mailbox) are assembled there from the process environment and feature flags.
+/// A host that wires no rebuilder keeps the pre-#290 behaviour exactly: the
+/// inference status still reports `restartRequired` and the console still says
+/// so, which is the honest answer when a rebuild genuinely is not available.
+#[async_trait]
+pub trait RuntimeRebuilder: Send + Sync + 'static {
+    /// Builds the successor runtime. Must attach `request.handover` to the
+    /// builder; returning a runtime built without it is a correctness bug, not a
+    /// missed optimisation (see [`RuntimeHandover`]).
+    ///
+    /// `state` is passed in rather than captured so an implementation can read
+    /// the host's opened stores, memory overlay and skill registry without
+    /// holding an [`AppState`] that holds it back — that cycle would keep both
+    /// alive for the life of the process.
+    async fn rebuild(&self, state: &AppState, request: RebuildRequest) -> Result<CompanyRuntime>;
+}
+
+/// Rebuilds `id`'s runtime in place and swaps it into the registry.
+///
+/// Returns the successor. See the [module docs](self) for the sequence, what
+/// happens to in-flight work, and the failure behaviour.
+///
+/// # Errors
+///
+/// - [`OpenCompanyError::CompanyNotFound`] when `id` is not registered.
+/// - [`OpenCompanyError::Config`] when this host wired no [`RuntimeRebuilder`].
+/// - Whatever the rebuilder returns, after the outgoing runtime has been resumed.
+pub async fn rebuild_company(state: &AppState, id: &CompanyId) -> Result<Arc<CompanyRuntime>> {
+    let outgoing = state
+        .registry()
+        .get(id)
+        .ok_or_else(|| OpenCompanyError::CompanyNotFound(id.as_ref().to_string()))?;
+    let rebuilder = state.rebuilder().ok_or_else(|| {
+        OpenCompanyError::Config(
+            "this host cannot rebuild a company runtime in place; restart the process to pick up \
+             the new configuration"
+                .to_string(),
+        )
+    })?;
+
+    // The materialized manifest, read before the quiesce so a store failure
+    // never leaves a company parked.
+    let manifest = outgoing
+        .store()
+        .load(id)
+        .await?
+        .map(|record| record.manifest)
+        .ok_or_else(|| {
+            OpenCompanyError::CompanyNotFound(format!(
+                "{id} is registered but has no persisted record to rebuild from"
+            ))
+        })?;
+
+    // Stop accepting cycles and let the one in flight finish. Everything after
+    // this point must either swap or resume — never leave the company quiesced.
+    outgoing.quiesce().await;
+
+    let request = RebuildRequest {
+        id: id.clone(),
+        manifest,
+        boot: state.boot_inputs(id),
+        handover: outgoing.handover(),
+    };
+    let built = match rebuilder.rebuild(state, request).await {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            // The stale brain is a worse company; a permanently quiesced one is
+            // not a company at all.
+            outgoing.resume();
+            return Err(err);
+        }
+    };
+
+    let successor = Arc::new(built);
+    state.registry().insert(id.clone(), successor.clone());
+    tracing::info!(
+        company = %id,
+        cognition = %successor.cognition().path,
+        "rebuilt company runtime in place",
+    );
+    Ok(successor)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::app::AppConfig;
+    use crate::company::CompanyManifest;
+    use crate::ports::types::CompanyEvent;
+    use crate::runtime::RuntimeBuilder;
+
+    /// A minimal event to drive one cycle with.
+    fn tick() -> CompanyEvent {
+        CompanyEvent::ScheduleFired {
+            cron: "* * * * *".to_string(),
+            prompt: "status".to_string(),
+        }
+    }
+
+    fn manifest() -> CompanyManifest {
+        toml::from_str("[company]\nname = \"Acme\"\n").expect("valid manifest")
+    }
+
+    fn tmp_home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("opencompany-rebuild-")
+            .tempdir()
+            .expect("tempdir")
+    }
+
+    async fn runtime(home: &std::path::Path, id: &CompanyId) -> CompanyRuntime {
+        RuntimeBuilder::new(home.to_path_buf(), manifest())
+            .with_id(id.clone())
+            .build()
+            .await
+            .expect("build")
+    }
+
+    /// A rebuilder that always builds a fresh runtime over the handover.
+    struct Working {
+        home: PathBuf,
+    }
+
+    #[async_trait]
+    impl RuntimeRebuilder for Working {
+        async fn rebuild(
+            &self,
+            _state: &AppState,
+            request: RebuildRequest,
+        ) -> Result<CompanyRuntime> {
+            RuntimeBuilder::new(self.home.clone(), request.manifest)
+                .with_id(request.id)
+                .with_handover(request.handover)
+                .build()
+                .await
+        }
+    }
+
+    /// A rebuilder that always fails, so the failure path is exercised.
+    struct Broken;
+
+    #[async_trait]
+    impl RuntimeRebuilder for Broken {
+        async fn rebuild(
+            &self,
+            _state: &AppState,
+            _request: RebuildRequest,
+        ) -> Result<CompanyRuntime> {
+            Err(OpenCompanyError::Config("no inference backend".to_string()))
+        }
+    }
+
+    async fn state_with(home: &std::path::Path, id: &CompanyId) -> AppState {
+        let state = AppState::new(AppConfig::default());
+        state
+            .registry()
+            .insert(id.clone(), Arc::new(runtime(home, id).await));
+        state.set_boot_inputs(id.clone(), BootInputs::default());
+        state
+    }
+
+    #[tokio::test]
+    async fn a_rebuild_swaps_the_registered_runtime_and_hands_state_over() {
+        let home_dir = tmp_home();
+        let home = home_dir.path();
+        let id = CompanyId::new("acme");
+        let state = state_with(home, &id)
+            .await
+            .with_rebuilder(Arc::new(Working {
+                home: home.to_path_buf(),
+            }));
+        let before = state.registry().get(&id).expect("registered");
+
+        let after = rebuild_company(&state, &id).await.expect("rebuilds");
+
+        // A different runtime is registered...
+        assert!(!Arc::ptr_eq(&before, &after));
+        assert!(Arc::ptr_eq(
+            &state.registry().get(&id).expect("registered"),
+            &after
+        ));
+        // ...and it is accepting work, not stuck in the quiesced window.
+        assert!(!after.is_quiesced());
+        // The pieces a second instance must never duplicate came across intact.
+        assert!(Arc::ptr_eq(before.journal(), after.journal()));
+        // The gate itself, not a re-rehydrated copy: an approval waiting on a
+        // person keeps its id, its parked effect and its TTL across the swap.
+        assert!(Arc::ptr_eq(&before.approval_gate, &after.approval_gate));
+        assert!(Arc::ptr_eq(before.events(), after.events()));
+        assert!(Arc::ptr_eq(before.store(), after.store()));
+        // Same serial lock, so the cycle invariant spans the swap rather than
+        // lapsing at it.
+        assert!(Arc::ptr_eq(before.serial_lock(), after.serial_lock()));
+        assert!(Arc::ptr_eq(
+            before.task_writes_lock(),
+            after.task_writes_lock()
+        ));
+    }
+
+    #[tokio::test]
+    async fn the_successor_runs_cycles_the_outgoing_runtime_now_refuses() {
+        let home_dir = tmp_home();
+        let home = home_dir.path();
+        let id = CompanyId::new("acme");
+        let state = state_with(home, &id)
+            .await
+            .with_rebuilder(Arc::new(Working {
+                home: home.to_path_buf(),
+            }));
+        let outgoing = state.registry().get(&id).expect("registered");
+
+        let successor = rebuild_company(&state, &id).await.expect("rebuilds");
+
+        // The outgoing runtime stays quiesced forever: anything still holding an
+        // Arc to it must not keep driving a company that has been replaced.
+        let refused = outgoing
+            .run_cycle(vec![tick()])
+            .await
+            .expect_err("a replaced runtime accepts no cycles");
+        assert!(
+            matches!(refused, OpenCompanyError::Quiescing(_)),
+            "{refused}"
+        );
+        assert_eq!(refused.code(), "quiescing");
+
+        successor
+            .run_cycle(vec![tick()])
+            .await
+            .expect("the successor is live");
+    }
+
+    #[tokio::test]
+    async fn a_failed_rebuild_resumes_the_company_it_quiesced() {
+        // The worst outcome is not a stale brain: it is a company that refuses
+        // every cycle because a rebuild died between quiesce and swap.
+        let home_dir = tmp_home();
+        let home = home_dir.path();
+        let id = CompanyId::new("acme");
+        let state = state_with(home, &id).await.with_rebuilder(Arc::new(Broken));
+        let outgoing = state.registry().get(&id).expect("registered");
+
+        let err = rebuild_company(&state, &id)
+            .await
+            .expect_err("the rebuilder fails");
+        assert!(matches!(err, OpenCompanyError::Config(_)), "{err}");
+
+        assert!(Arc::ptr_eq(
+            &state.registry().get(&id).expect("still registered"),
+            &outgoing
+        ));
+        assert!(
+            !outgoing.is_quiesced(),
+            "a failed rebuild must not park the company"
+        );
+        outgoing
+            .run_cycle(vec![tick()])
+            .await
+            .expect("the surviving runtime still runs cycles");
+    }
+
+    #[tokio::test]
+    async fn a_host_with_no_rebuilder_says_so_instead_of_quiescing() {
+        let home_dir = tmp_home();
+        let home = home_dir.path();
+        let id = CompanyId::new("acme");
+        let state = state_with(home, &id).await;
+
+        let err = rebuild_company(&state, &id)
+            .await
+            .expect_err("no rebuilder is wired");
+        assert!(matches!(err, OpenCompanyError::Config(_)), "{err}");
+        // Crucially, the check happens before the quiesce.
+        assert!(!state.registry().get(&id).expect("registered").is_quiesced());
+    }
+
+    #[tokio::test]
+    async fn rebuilding_an_unregistered_company_is_a_not_found() {
+        let state = AppState::new(AppConfig::default());
+        let err = rebuild_company(&state, &CompanyId::new("nobody"))
+            .await
+            .expect_err("nothing to rebuild");
+        assert!(matches!(err, OpenCompanyError::CompanyNotFound(_)), "{err}");
+    }
+}

--- a/src/runtime/rebuild.rs
+++ b/src/runtime/rebuild.rs
@@ -305,12 +305,12 @@ mod test {
         assert!(Arc::ptr_eq(before.events(), after.events()));
         assert!(Arc::ptr_eq(before.store(), after.store()));
         // Same serial lock, so the cycle invariant spans the swap rather than
-        // lapsing at it.
-        assert!(Arc::ptr_eq(before.serial_lock(), after.serial_lock()));
-        assert!(Arc::ptr_eq(
-            before.task_writes_lock(),
-            after.task_writes_lock()
-        ));
+        // lapsing at it. Read off the fields, like the gate above: every
+        // production holder (`CycleRunner::run`, the desk routes, `quiesce`'s
+        // drain) takes them the same way, so an accessor here would be a public
+        // surface that exists only for this assertion.
+        assert!(Arc::ptr_eq(&before.serial, &after.serial));
+        assert!(Arc::ptr_eq(&before.task_writes, &after.task_writes));
     }
 
     #[tokio::test]

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -87,6 +87,10 @@ struct ParsedSchedule {
 /// Drives the cron schedules of a single [`CompanyRuntime`].
 pub struct CompanyScheduler {
     runtime: Arc<CompanyRuntime>,
+    /// When set, the runtime to drive is looked up here every tick so a runtime
+    /// swap (issue #290) reaches cron instead of leaving it on the replaced
+    /// instance. `None` keeps the boot snapshot.
+    registry: Option<crate::runtime::CompanyRegistry>,
     schedules: Vec<ParsedSchedule>,
     clock: Arc<dyn Clock>,
     /// Per-schedule last-fired epoch minute, so a schedule fires at most once per
@@ -115,10 +119,39 @@ impl CompanyScheduler {
         }
         Ok(Self {
             runtime,
+            registry: None,
             schedules: parsed,
             clock,
             last_fired: HashMap::new(),
         })
+    }
+
+    /// Issue #290: re-read `registry` for this company on every tick, instead of
+    /// driving the `Arc<CompanyRuntime>` snapshotted at boot.
+    ///
+    /// Without this, a runtime swap never reaches this loop: it keeps driving the
+    /// replaced runtime — which, after a rebuild, is the offline echo brain the
+    /// rebuild existed to get rid of, and is quiesced besides, so every tick
+    /// fails. [`WorkflowScheduler`](crate::runtime::WorkflowScheduler) already
+    /// reads the registry per tick; this is that pattern, opted into by the boot
+    /// path so existing callers and tests keep the snapshot behaviour.
+    ///
+    /// The boot snapshot stays as the fallback: a company removed from the
+    /// registry (archive) is not a reason to start driving nothing at all
+    /// silently — `ensure_running` already rejects an archived company, and that
+    /// is the check with the right error.
+    pub fn following(mut self, registry: crate::runtime::CompanyRegistry) -> Self {
+        self.registry = Some(registry);
+        self
+    }
+
+    /// The runtime to drive this tick: whatever is registered now, else the
+    /// snapshot taken at construction.
+    fn runtime(&self) -> Arc<CompanyRuntime> {
+        self.registry
+            .as_ref()
+            .and_then(|registry| registry.get(self.runtime.id()))
+            .unwrap_or_else(|| self.runtime.clone())
     }
 
     /// Whether this scheduler has any schedules to drive.
@@ -136,8 +169,9 @@ impl CompanyScheduler {
         if self.schedules.is_empty() {
             return Ok(0);
         }
+        let runtime = self.runtime();
         // Skip firing for a company that is not accepting work.
-        if self.runtime.ensure_running().await.is_err() {
+        if runtime.ensure_running().await.is_err() {
             return Ok(0);
         }
 
@@ -154,7 +188,7 @@ impl CompanyScheduler {
                 continue; // already fired this minute
             }
             self.last_fired.insert(idx, minute);
-            self.runtime
+            runtime
                 .run_cycle(vec![CompanyEvent::ScheduleFired {
                     cron: schedule.cron.clone(),
                     prompt: schedule.prompt.clone(),
@@ -175,8 +209,9 @@ impl CompanyScheduler {
     /// agent simply never acted). It announces itself on the operator channel
     /// instead.
     pub async fn tick_maintenance(&self) -> Result<Vec<crate::ports::types::ApprovalId>> {
-        let expired = self.runtime.sweep_expired_approvals().await?;
-        self.runtime.sweep_expired_grants().await?;
+        let runtime = self.runtime();
+        let expired = runtime.sweep_expired_approvals().await?;
+        runtime.sweep_expired_grants().await?;
         Ok(expired)
     }
 
@@ -381,6 +416,98 @@ mod test {
             .await
             .unwrap();
         assert_eq!(events.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn following_the_registry_reaches_a_rebuilt_runtime() {
+        // Issue #290. The cron scheduler snapshots an `Arc<CompanyRuntime>` at
+        // boot, so before this it kept driving a runtime that had been replaced
+        // — and a replaced runtime is quiesced, so every fire failed. "Scheduled
+        // workflows never fire" is one of the two surfaces #266 was reported
+        // against, which makes this the half of a rebuild that is easiest to
+        // ship broken.
+        use crate::runtime::CompanyRegistry;
+
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let manifest = scheduled_manifest();
+        let schedules = manifest.schedules.clone();
+        let outgoing = Arc::new(
+            RuntimeBuilder::new(home.clone(), manifest)
+                .with_brain(Arc::new(ScheduleBrain))
+                .build()
+                .await
+                .unwrap(),
+        );
+        let id = outgoing.id().clone();
+        let registry = CompanyRegistry::new();
+        registry.insert(id.clone(), outgoing.clone());
+
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = CompanyScheduler::new(outgoing.clone(), &schedules, clock.clone())
+            .unwrap()
+            .following(registry.clone());
+
+        // Stand in for a rebuild: quiesce the snapshotted runtime and register a
+        // successor over the same home.
+        outgoing.quiesce().await;
+        let successor = Arc::new(
+            RuntimeBuilder::new(home.clone(), scheduled_manifest())
+                .with_id(id.clone())
+                .with_brain(Arc::new(ScheduleBrain))
+                .with_handover(outgoing.handover())
+                .build()
+                .await
+                .unwrap(),
+        );
+        registry.insert(id.clone(), successor.clone());
+
+        // The fire lands, which it could not have done against the quiesced
+        // runtime the scheduler was built with.
+        assert_eq!(scheduler.tick().await.unwrap(), 1);
+        let events = successor
+            .events()
+            .read_from(&id, EventSeq::new(0), 10)
+            .await
+            .unwrap();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e.event, CompanyEvent::ScheduleFired { .. })),
+            "the successor ran the scheduled cycle",
+        );
+    }
+
+    #[tokio::test]
+    async fn without_following_a_scheduler_drives_its_snapshot() {
+        // The opt-in is real: an un-followed scheduler still drives the runtime
+        // it was handed, which is what every existing caller and test relies on.
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let manifest = scheduled_manifest();
+        let schedules = manifest.schedules.clone();
+        let rt = Arc::new(
+            RuntimeBuilder::new(home.clone(), manifest)
+                .with_brain(Arc::new(ScheduleBrain))
+                .build()
+                .await
+                .unwrap(),
+        );
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
+
+        rt.quiesce().await;
+
+        // No registry to consult, so the quiesced snapshot is what it tries, and
+        // the refusal surfaces rather than being silently swallowed.
+        let err = scheduler
+            .tick()
+            .await
+            .expect_err("a quiesced snapshot refuses the cycle");
+        assert!(
+            matches!(err, crate::error::OpenCompanyError::Quiescing(_)),
+            "{err}"
+        );
     }
 
     #[tokio::test]

--- a/src/runtime/telegram_poller.rs
+++ b/src/runtime/telegram_poller.rs
@@ -72,6 +72,10 @@ pub enum PollOutcome {
 /// Drives one company's Telegram inbound over `getUpdates` long-polling.
 pub struct TelegramPoller {
     runtime: Arc<CompanyRuntime>,
+    /// When set, the runtime to drive is looked up here every tick so a runtime
+    /// swap (issue #290) reaches inbound Telegram. `None` keeps the boot
+    /// snapshot.
+    registry: Option<crate::runtime::CompanyRegistry>,
     api: Arc<dyn TelegramApi>,
     /// Long-poll hold handed to `getUpdates`, and the idle back-off.
     poll: Duration,
@@ -105,6 +109,7 @@ impl TelegramPoller {
     ) -> Self {
         Self {
             runtime,
+            registry: None,
             api,
             poll: Duration::from_secs(poll_secs.max(1)),
             webhook_capable,
@@ -112,6 +117,27 @@ impl TelegramPoller {
             offset: None,
             handshaked: false,
         }
+    }
+
+    /// Issue #290: re-read `registry` for this company on every tick, instead of
+    /// driving the `Arc<CompanyRuntime>` snapshotted at boot.
+    ///
+    /// Without this, a runtime swap never reaches this loop: it keeps driving a
+    /// runtime that has been replaced and quiesced, so every inbound message
+    /// fails. Opted into by the boot path, so existing callers keep the snapshot
+    /// behaviour.
+    pub fn following(mut self, registry: crate::runtime::CompanyRegistry) -> Self {
+        self.registry = Some(registry);
+        self
+    }
+
+    /// The runtime to drive this tick: whatever is registered now, else the
+    /// snapshot taken at construction.
+    fn runtime(&self) -> Arc<CompanyRuntime> {
+        self.registry
+            .as_ref()
+            .and_then(|registry| registry.get(self.runtime.id()))
+            .unwrap_or_else(|| self.runtime.clone())
     }
 
     /// The bot token for this company, or `None` when unset/blank. An empty
@@ -187,7 +213,8 @@ impl TelegramPoller {
             self.offset = None;
             self.handshaked = false;
         }
-        if self.runtime.ensure_running().await.is_err() {
+        let runtime = self.runtime();
+        if runtime.ensure_running().await.is_err() {
             return Ok(PollOutcome::Idle);
         }
         if !self.handshaked && !self.handshake(&token).await? {
@@ -228,20 +255,15 @@ impl TelegramPoller {
                 channel: TELEGRAM_CHANNEL.to_string(),
                 body: update,
             };
-            match self.runtime.run_cycle(vec![event]).await {
+            match runtime.run_cycle(vec![event]).await {
                 Ok(report) => {
                     turns += 1;
-                    deliver_replies(
-                        self.api.as_ref(),
-                        self.runtime.id(),
-                        &token,
-                        &report.responses,
-                    )
-                    .await;
+                    deliver_replies(self.api.as_ref(), runtime.id(), &token, &report.responses)
+                        .await;
                 }
                 Err(err) => {
                     tracing::warn!(
-                        company = %self.runtime.id(),
+                        company = %runtime.id(),
                         "telegram polled cycle failed: {}",
                         scrub_token(&err.to_string(), &token)
                     );

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -45,6 +45,9 @@ impl ApiError {
             OpenCompanyError::LifecycleConflict(_) | OpenCompanyError::Conflict(_) => {
                 StatusCode::CONFLICT
             }
+            // A runtime swap is in progress and clears itself within a turn, so
+            // this is a retry-me, not a refusal (issue #290).
+            OpenCompanyError::Quiescing(_) => StatusCode::SERVICE_UNAVAILABLE,
             OpenCompanyError::ToolNotGranted(_) => StatusCode::FORBIDDEN,
             OpenCompanyError::BudgetExceeded(_) => StatusCode::PAYMENT_REQUIRED,
             // tiny.place transport: an unreachable backend degrades to 503 so

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -21,6 +21,7 @@
 use std::collections::BTreeMap;
 
 use axum::Router;
+use axum::extract::State;
 use axum::routing::{get, post};
 use axum::{Json, response::Response};
 use serde::{Deserialize, Serialize};
@@ -52,6 +53,13 @@ const RESTART_NOTE: &str = "Saved — but this company started with no inference
      running the offline echo brain and its workflow runner is unwired. The brain is chosen at \
      startup: restart the company for agents to think with this provider and for scheduled \
      workflows to fire.";
+
+/// The reminder attached when [`restart_pending`] held and the runtime was
+/// rebuilt in place to clear it (issue #290). The restart the operator was
+/// previously told to perform has already happened, for this company only.
+const REBUILT_NOTE: &str = "Saved, and this company's runtime was rebuilt so the new provider is \
+     live now. Agents think with it from their next turn and scheduled workflows fire again — no \
+     restart needed.";
 
 /// Builds the inference management route fragment.
 pub fn router() -> Router<AppState> {
@@ -246,6 +254,7 @@ async fn get_status(company: ScopedCompany) -> Result<Json<InferenceStatusDto>, 
 /// `PUT …/inference` — set (or replace) the runtime provider override, and
 /// optionally rotate the write-only outbound credential.
 async fn set_config(
+    State(state): State<AppState>,
     company: ScopedCompany,
     Json(body): Json<SetInference>,
 ) -> Result<Json<MutationResponse>, ApiError> {
@@ -279,6 +288,40 @@ async fn set_config(
     }
 
     let status = effective_status(runtime).await?;
+    // Issue #290: the not-configured → configured transition is the one a save
+    // alone cannot deliver, because the brain was chosen at build time. Rather
+    // than telling the operator to restart a container they may have no access
+    // to, rebuild this company's runtime in place and re-read the status from
+    // the successor.
+    if status.restart_required {
+        match crate::runtime::rebuild_company(&state, runtime.id()).await {
+            Ok(successor) => {
+                let status = effective_status(successor.as_ref()).await?;
+                return Ok(Json(MutationResponse {
+                    // Read off the *successor*, so a rebuild that somehow landed
+                    // on the same brain still reports honestly rather than
+                    // claiming a success the runtime cannot back up.
+                    note: if status.restart_required {
+                        RESTART_NOTE
+                    } else {
+                        REBUILT_NOTE
+                    }
+                    .to_string(),
+                    status,
+                }));
+            }
+            Err(err) => {
+                // The save landed and the company is still running its old
+                // brain, which is exactly what RESTART_NOTE describes. Falling
+                // through is therefore the honest answer, not a swallowed error.
+                tracing::warn!(
+                    company = %runtime.id(),
+                    error = %err,
+                    "inference saved but the runtime could not be rebuilt; a restart is still required",
+                );
+            }
+        }
+    }
     Ok(Json(MutationResponse {
         // The note follows the *resulting* status, so the response can never
         // promise "next turn" to a company whose brain cannot honour it.
@@ -732,5 +775,131 @@ mod tests {
         .await;
         assert_eq!(status, StatusCode::NOT_FOUND);
         assert_eq!(err["code"], "not_wired");
+    }
+
+    /// A brain standing in for the one a rebuild puts a configured company on,
+    /// so the route's behaviour is pinned without constructing a real harness
+    /// brain (which would resolve MCP servers, Composio and an agent roster
+    /// inside a unit test).
+    ///
+    /// Only its [`Cognition`](crate::ports::Cognition) matters here: reporting
+    /// the harness path is exactly what makes `restart_pending` false, which is
+    /// the observable the console reads.
+    #[cfg(feature = "openhuman")]
+    struct RebuiltBrain;
+
+    #[cfg(feature = "openhuman")]
+    #[async_trait::async_trait]
+    impl crate::ports::brain::Brain for RebuiltBrain {
+        async fn run_cycle(
+            &self,
+            _req: crate::ports::types::CycleRequest,
+            _host: &dyn crate::ports::brain::CycleHost,
+        ) -> crate::Result<crate::ports::types::CycleResult> {
+            Ok(crate::ports::types::CycleResult {
+                channel_responses: Vec::new(),
+                new_traces: Vec::new(),
+                ledger_deltas: Vec::new(),
+                token_usage: crate::ports::types::TokenUsage::default(),
+            })
+        }
+
+        fn cognition(&self) -> crate::ports::Cognition {
+            crate::ports::Cognition {
+                path: crate::ports::brain::HARNESS_PATH,
+                // A stub brain meters per turn and reports zero usage, so
+                // nothing is double-counted (see `Brain::cognition`).
+                provider: "stub",
+                metering: crate::ports::UsageMetering::PerTurn,
+            }
+        }
+    }
+
+    /// A rebuilder that runs the real builder over the real handover, and puts
+    /// the successor on a brain that reports the harness path — the shape a live
+    /// rebuild produces once inference resolves.
+    #[cfg(feature = "openhuman")]
+    struct StubRebuilder {
+        home: std::path::PathBuf,
+    }
+
+    #[cfg(feature = "openhuman")]
+    #[async_trait::async_trait]
+    impl crate::runtime::RuntimeRebuilder for StubRebuilder {
+        async fn rebuild(
+            &self,
+            _state: &AppState,
+            request: crate::runtime::RebuildRequest,
+        ) -> crate::Result<crate::company::runtime::CompanyRuntime> {
+            RuntimeBuilder::new(self.home.clone(), request.manifest)
+                .with_id(request.id)
+                .with_harness(std::sync::Arc::new(crate::harness::HarnessPool::new()))
+                .with_brain(std::sync::Arc::new(RebuiltBrain))
+                .with_handover(request.handover)
+                .build()
+                .await
+        }
+    }
+
+    /// Issue #290, the half #266 did not ship: with a rebuilder wired, the save
+    /// that *would* have set `restartRequired` rebuilds the company instead, and
+    /// the response reports the successor rather than the runtime that is being
+    /// replaced.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn configuring_inference_after_boot_rebuilds_instead_of_asking_for_a_restart() {
+        use crate::harness::HarnessPool;
+
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let id = CompanyId::new("acme");
+        let runtime = RuntimeBuilder::new(home.clone(), manifest())
+            .with_id(id.clone())
+            .with_harness(std::sync::Arc::new(HarnessPool::new()))
+            .build()
+            .await
+            .unwrap();
+        assert_eq!(runtime.cognition().path, "echo");
+
+        let outgoing = std::sync::Arc::new(runtime);
+        let state = AppState::new(AppConfig::default())
+            .with_rebuilder(std::sync::Arc::new(StubRebuilder { home: home.clone() }));
+        state.registry().insert(id.clone(), outgoing.clone());
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+
+        let (status, resp, raw) = send(
+            &state,
+            "PUT",
+            "/api/v1/company/inference",
+            Some(json!({
+                "provider": "openai_compatible",
+                "baseUrl": "https://stub.invalid/v1",
+                "key": TOKEN,
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        // The save landed, and the company is no longer stranded behind a boot
+        // decision: it reports the live cognition path, not "restart me".
+        assert_eq!(resp["status"]["source"], "runtime");
+        assert_eq!(resp["status"]["keyConfigured"], true);
+        assert_eq!(resp["status"]["cognition"], "harness", "{raw}");
+        assert_eq!(resp["status"]["restartRequired"], false, "{raw}");
+        let note = resp["note"].as_str().unwrap_or_default();
+        assert!(!note.contains("restart the company"), "{note}");
+        assert!(!raw.contains(TOKEN), "PUT response leaked the token: {raw}");
+
+        // The registry really was swapped, and the replaced runtime is left
+        // quiesced so nothing still holding it keeps driving a dead company.
+        let registered = state.registry().get(&id).expect("still registered");
+        assert!(!std::sync::Arc::ptr_eq(&registered, &outgoing));
+        assert!(outgoing.is_quiesced());
+        assert!(!registered.is_quiesced());
+
+        // A plain read agrees: the banner clears itself rather than needing the
+        // console to remember what the mutation said.
+        let (_, dto, _) = send(&state, "GET", "/api/v1/company/inference", None).await;
+        assert_eq!(dto["restartRequired"], false);
+        assert_eq!(dto["cognition"], "harness");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #290. Builds the half #266 did not ship: rebuild the company runtime when inference goes unresolved → resolved, so first-time BYOK setup needs no restart.

The restart is the actual product gap. A hosted tenant's unit of restart is its container, and the control plane has no button an operator can press: `POST /api/v1/companies` refuses an existing id, archive removes a company with no unarchive, and nothing in the process ever replaced a registered runtime. So this is not "call `build()` twice" — it is the runtime-lifecycle seam the issue asked for.

### 1. Quiesce (`CompanyRuntime::quiesce`)

Sets a flag that makes every cycle entry point (`run_cycle`, `resolve_approval`, `resolve_approval_amended`) refuse with a new `OpenCompanyError::Quiescing` → **`503`**, then waits on the per-company `serial` lock, which a cycle holds for a whole turn. Both halves are load-bearing: the flag alone leaves a turn mid-cycle; the wait alone races a cycle already queued behind the one in flight.

The check on `resolve_approval*` is deliberately at the `CompanyRuntime` entry point rather than inside the follow-up cycle: a resolution that journaled the verdict and then failed to run its follow-up would leave the brain permanently unaware of an approval the operator had granted.

`Quiescing` is distinct from `LifecycleConflict` (`409`) on purpose. That one is a durable state an operator chose; this one clears itself within a turn, so it is a retry-me.

### 2. Hand over, don't reconstruct (`src/runtime/handover.rs`)

`RuntimeHandover` moves the per-instance state a second runtime must not duplicate. Each of these is a correctness matter, not an optimisation:

| Piece | Why a second copy breaks |
|---|---|
| `RuntimeJournal` | Single-writer. `append` writes a record and its newline separately under a per-instance lock, so two journals on one path interleave onto a single line and fail to parse on replay, bricking the **next** boot |
| At-most-once effect keys | In memory, populated at `load()`. A second instance never sees the first's commits, so a send or a spend runs twice |
| `serial` / `task_writes` | Per-instance mutexes. Both changed to `Arc<Mutex<_>>` so the successor adopts them; two of either and both invariants lapse at the swap |
| `FsEventLog` | Derives `seq` from a line count under its own lock, and its broadcast sender is what an open console SSE stream is subscribed to |
| `FeedbackFiler` | In-memory rate limiter; a fresh one makes a rebuild loop a rate-limit bypass |
| `HarnessPool` | Each agent's conversation history. Also injected back into `self.harness` **before** brain selection, so the successor's brain and its runtime share one pool rather than the brain getting a freshly minted one |
| `McpRuntime` | Dials a process-global connect map keyed by server id; re-booting replaces connections other agents may be mid-call on |
| `OpsStores` (incl. the `RunStore`) | Carried whole (#242), so the dispatch choke point, the successor's `HarnessBrain` (via `with_runs`) and the suppressed reaper all address one set of attempt rows. A second store strands every live run and restarts attempt ordinals at 1 |
| `ManifestApprovalGate` + `GrantSet` | Parked approvals and unredeemed grants. Rehydrating a fresh copy from the journal resurrects what the live one has already resolved |

Deliberately **not** carried over: the brain, tools, channels, workflow runner and economy (replacing those is the point), and the in-flight steer registry — the successor's harness deps mint their own, which is sound *only* because the swap happens after the drain, so the outgoing registry is empty at that point.

### 3. `build()` is idempotent on rebuild

A handover's presence is the "this is a rebuild" signal, suppressing every boot-only side effect: journal `load()`, approval rehydration, grant rehydration, **orphan-run reaping**, workspace seeding, going-public, and the MCP re-boot.

Orphan-run reaping is the subtle one, and the rebase onto #242 PR-2 is what made it worth stating exactly. Its own doc comment rests the argument on "nothing from this process can be in flight yet" — true at boot, false the moment a company has been serving.

The exposure is narrower than "a rebuild would kill live runs", and stating it loosely hides where the real edge is:

* **No `Running` row survives the drain.** `quiesce` waits on `serial`, and *both* `begin_run` and the terminality backstop sit inside that lock.
* **`Pending` rows do survive.** The dispatch choke point mints its row **outside** `serial` (in `upsert_task`, before the spawn), and board writes are not gated on the quiesce.
* **Reaping one of those is the actual hazard.** It stamps the wrong reason on it, and if the rebuild then *fails* and `resume()` puts the company back to work, that row is already terminal — its cycle's `begin_run` is rejected by the transition check and a genuinely live attempt runs with no record at all.

So it stays suppressed, and deliberately **not** on the strength of the drain: leaning on the drain would rest correctness on the current call order in `rebuild_company` rather than on the invariant `reap_orphaned_runs` states. That function's doc comment now says the proof is about boot and only boot, so a future second caller has to make the argument again rather than inherit it.

### 4. The three pollers are registry-driven

`CompanyScheduler`, `MailboxPoller` and `TelegramPoller` each snapshotted an `Arc<CompanyRuntime>` at boot and would have driven the replaced (and now quiesced) runtime forever. Each gained a `following(registry)` opt-in that the boot path uses, copying `WorkflowScheduler`. The snapshot stays as the fallback, so every existing caller and test is unaffected — this is an opt-in, not a signature change.

Cron matters most: "scheduled workflows never fire" is one of the two surfaces #266 was reported against, so a rebuild that did not reach the scheduler would look fixed and not be. Covered by a test.

### 5. Boot-only inputs are stashed

`AppState::set_boot_inputs` records `BootInputs { source_dir, discoverable }` at registration. `--discoverable` is the case that forces this to exist: it lives only in the `serve` stack frame and mutates the manifest before the build, so a rebuild re-reading `company.toml` would silently un-publish a public company.

The manifest itself comes from the **persisted record**, not a fresh `company.toml` read, so console-created workflows merged into `[workflows].enabled` (#208) and the `[place]` fields survive — and a platform-provisioned tenant with no `company.toml` is rebuildable at all.

### 6. Triggered from `PUT …/inference`

When `restartRequired` would otherwise become true, the route rebuilds and re-reads the status **from the successor**, so it can never claim a success the runtime cannot back up. A host that wired no rebuilder, or a rebuild that fails, falls through to the existing `RESTART_NOTE` — the save landed and the company is still on its old brain, which is exactly what that note describes.

`RuntimeRebuilder` is a trait implemented by the binary, because the builder inputs (harness pool, OpenHuman RPC, managed media/search backends, the injected per-tenant mailbox) are assembled there. `register_company`'s assembly is extracted into `company_builder` and shared, so a rebuild cannot drift from boot. `AppState` is passed *into* `rebuild`, not captured, so there is no `AppState` ↔ rebuilder `Arc` cycle.

## What happens to in-flight work

**The cycle in flight completes.** It is not cancelled and its effects are not replayed: the executed-key set travels with the journal, so an effect the outgoing runtime committed stays committed for the successor. Anything the outgoing runtime spawned detached (a task dispatch, a scheduled workflow run) goes through `run_cycle` and therefore through `serial`, so it is either already finished or it *is* the turn being drained.

**Cycles arriving during the window are refused (`503`), not queued.** A queued cycle would acquire the shared lock after the swap and run on the brain the rebuild was replacing. A caller retries against the successor instead.

**The journal and approval queue are continuous across the swap.** Parked approvals keep their ids, parked effects and TTLs; resolving one after the swap runs its follow-up cycle on the *new* brain. Unredeemed single-use grants survive too, so an operator who approved a blocked tool call moments before the rebuild is not asked again.

**Attempt rows (#242) get the same answer, extended.** The attempt *in flight* is the cycle in flight, so it completes and settles itself on the outgoing runtime, against the store the successor adopts; its trace keeps writing through the drain, because the sink holds an `Arc<dyn RunStore>` from the inherited `OpsStores` rather than a handle to the runtime.

The case that needed a code change is **the attempt that never starts**, and it is a real defect this rebase surfaced. Board writes are deliberately not gated on the quiesce — only cycles are — so a card dragged into `in_progress` during the window still mints its `Pending` row at the choke point. Its cycle is then refused by `ensure_accepting`, which runs *before* `CycleRunner` takes the serial lock and therefore before `begin_run` — putting it out of reach of the terminality backstop, which only settles rows that cycle started. Every other dispatch failure is already covered in there; this is the one that escapes. And the rebuild has just switched off the one sweep that would have caught it. Net: a row claiming to be pending for the rest of the process's life, on a card that reads as under way by an attempt that never began, which nothing re-drives. Pre-#357 that window merely dropped the dispatch with a `warn`; #357 makes it leave a durable lie.

The refused dispatch now settles its own row: `Pending` → `Failed` carrying a new `ports::runs::RUNTIME_REPLACED_ERROR`, kept distinct from `ORPHAN_ERROR` so a run list can tell *"we swapped your runtime, retry"* apart from *"the host died"*. `Pending` → terminal is already the legal move the status table names for **"a dispatch that failed before the first turn"**, so this needs no new state — only a caller willing to use it. `Failed` rather than `Cancelled` for the same reason the reaper picks `Failed`: the runtime went away underneath a card an operator had just dispatched, and that wants to be visible, not filed away as an intentional stop. The card stays in `in_progress`, which is where every other failed dispatch cycle leaves it.

**The window bounds the triggering request.** `PUT …/inference` blocks until the in-flight turn drains. That is a deliberate trade, stated in `docs/spec/runtime/rebuild.md`: swapping mid-cycle is precisely the two-live-runtimes hazard the handover exists to avoid, and a bounded wait that gave up and swapped anyway would trade a slow response for a corrupted journal. The transition this exists for (first-time setup on an echo-brain company) has no expensive turn to wait on.

**A failed rebuild resumes the company it quiesced.** A company left quiesced would refuse every cycle forever, which is strictly worse than the stale brain the rebuild was replacing. Covered by a test.

## API Or Behavior Changes

- **Behavior:** `PUT …/inference` on a company whose config was stranded behind a boot decision now rebuilds that company's runtime in place instead of asking for a restart, and returns a note saying so. A host with no rebuilder wired, or a failed rebuild, keeps the previous response verbatim.
- **Behavior:** a cycle attempted against a quiescing/replaced runtime returns `503` with code `quiescing`. Previously no runtime was ever replaced, so this state did not exist.
- **Behavior:** `serve` now runs its cron scheduler, mailbox poller and Telegram poller off the registry rather than a boot snapshot. Identical unless a swap happens.
- **API (new):** `ports::runs::RUNTIME_REPLACED_ERROR`; `OpenCompanyError::Quiescing`; `CompanyRuntime::{quiesce, resume, is_quiesced, handover, adopt_locks, journal}`; `runtime::{RuntimeHandover, BootInputs, RebuildRequest, RuntimeRebuilder, rebuild_company}`; `RuntimeBuilder::with_handover`; `AppState::{with_rebuilder, rebuilder, set_boot_inputs, boot_inputs}`; `CompanyScheduler/MailboxPoller/TelegramPoller::following`.
- **API (changed):** `CompanyRuntime`'s `serial` and `task_writes` are `Arc<Mutex<()>>` rather than owned. Both are `pub(crate)` and every call site is `.lock().await`, which is unchanged by the `Arc`.
- **No frontend change.** The `restartRequired` banner in `InferenceSection.tsx` is retained on purpose: after this it is only reachable when a rebuild is genuinely unavailable, which is the situation it was written for, and it self-clears because the PUT response and the GET both read the successor. Deleting it would re-introduce a silent failure on exactly the hosts that still need a restart.

## Tests

- [x] `cargo fmt --all -- --check` — N/A - full local build matrix is prohibited on this machine; verified in CI (ran `rustfmt --edition 2024` on every touched Rust file; clean)
- [x] `cargo clippy --all-targets -- -D warnings` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo build --all-targets` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo test` — N/A - full local build matrix is prohibited on this machine; verified in CI

Tests added with the behavior change (CI runs them):

`src/runtime/rebuild.rs` — `a_rebuild_swaps_the_registered_runtime_and_hands_state_over` (asserts pointer identity of the journal, approval gate, store, event log and **both** mutexes across the swap), `the_successor_runs_cycles_the_outgoing_runtime_now_refuses` (the replaced runtime stays quiesced and answers `quiescing`; the successor is live), `a_failed_rebuild_resumes_the_company_it_quiesced`, `a_host_with_no_rebuilder_says_so_instead_of_quiescing` (and proves the check runs *before* the quiesce), `rebuilding_an_unregistered_company_is_a_not_found`.

`src/company/runtime.rs` — `a_dispatch_refused_by_a_quiescing_runtime_settles_its_attempt`, with a positive control: the same call on a **live** runtime goes down the ordinary path (the cycle runs, the backstop settles the row), so the assertion below it is specifically about the quiesce refusal. Then quiesce, re-dispatch, and assert the row is `Failed` / `RUNTIME_REPLACED_ERROR` with no start time and a finish time.

`src/runtime/scheduler.rs` — `following_the_registry_reaches_a_rebuilt_runtime` (drives a real quiesce → handover → swap and asserts the scheduled cycle lands on the successor), `without_following_a_scheduler_drives_its_snapshot` (the opt-in is real, and the refusal surfaces rather than being swallowed).

`src/server/ops/inference.rs` — `configuring_inference_after_boot_rebuilds_instead_of_asking_for_a_restart`: with a rebuilder wired, the save clears `restartRequired`, reports the successor's cognition, swaps the registry, leaves the outgoing runtime quiesced and the successor accepting, and a plain `GET` agrees. The pre-existing `configuring_inference_after_boot_reports_restart_required` is untouched and now also pins the no-rebuilder fallback.

The inference test's rebuilder runs the **real** builder over the **real** handover and injects a brain that reports the harness cognition path, rather than constructing a live `HarnessBrain` (which would resolve MCP servers, Composio and an agent roster inside a unit test). Only the cognition path is stubbed; the swap, the handover and the route logic are the real thing.

## Documentation

- `docs/spec/runtime/rebuild.md` (new) — the full sequence, the inherit-vs-reconstruct table with the reason each piece cannot be duplicated, the suppressed boot-only side effects, what happens to in-flight work, the registry-driven pollers, and the wiring.
- `docs/spec/runtime/README.md` — indexed.
- `docs/spec/runtime/manifest.md` — the `[inference]` section's restart paragraph now points at the rebuild and explains why `restartRequired` stays on the read shape.
- Module docs on `src/runtime/handover.rs` and `src/runtime/rebuild.rs` carry the rationale; `build()`'s existing boot-replay and orphan-reaping comments are extended in place rather than duplicated.

## Checklist against the issue

- [x] **Quiesce**: stop accepting new cycles and drain the one in flight
- [x] **Hand over, don't reconstruct**: journal, approval gate, event log, harness pool and the two serialising mutexes are moved
- [x] **Make the three pollers registry-driven**, the way `WorkflowScheduler` is
- [x] **Make `build()` idempotent on rebuild**: going-public and MCP re-boot skipped (plus journal replay, rehydration, orphan-run reaping, workspace seeding)
- [x] **Stash the boot-only inputs** (`--discoverable`, source dir) where a rebuild can reach them
- [x] **Trigger it from `PUT …/inference`** when `restartRequired` would otherwise become true. The banner is retained rather than dropped, for the reason given under *API Or Behavior Changes*.

