### PR TITLE
fix(tasks): move a card from In review to Done by dragging it (#334)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -536,7 +536,15 @@ export function AppShell({
         <SidebarRail />
       </Sidebar>
 
-      <SidebarInset className="min-h-0">
+      {/* `min-w-0`: the inset is a flex item beside the sidebar, and a flex
+          item's default `min-width: auto` floors it at its content's
+          min-content width. That floor won — the inset measured a full window
+          wide while sitting a sidebar's width to the right of the origin, so
+          its last ~256px hung past the right edge of the window inside a
+          wrapper that clips and cannot scroll. On the task board that clipped
+          strip held the "Done" column, which is why a card could not be dragged
+          into it (issue #334); every view was losing the same strip. */}
+      <SidebarInset className="min-h-0 min-w-0">
         <header className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
           <SidebarTrigger className="-ml-1" />
           <h1 className="text-sm font-semibold">{TITLES[view]}</h1>

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { type DragEvent, useCallback, useEffect, useRef, useState } from "react";
 import { Loader2, Play, Plus } from "lucide-react";
 
 import { createTask, listTasks, patchTask, type Task } from "@/api/tasks";
@@ -42,8 +42,44 @@ function readTaskDetailId(): string | null {
 /** How often to re-poll the board, so a dispatched card's result appears. */
 const POLL_MS = 4000;
 
+/**
+ * The MIME type a dragged card stamps its id onto (issue #334).
+ *
+ * The drop used to read the dragged id out of React state alone. That is a
+ * silent single point of failure: a drag that began on anything other than a
+ * card leaves the state null, and the drop handler then returned without a
+ * word. Putting the id on the drag itself makes a drop self-describing.
+ *
+ * Filling the data store at all matters for a second reason: a drag whose store
+ * is empty is aborted outright by Firefox and Safari, so the board's one
+ * documented gesture never even started there.
+ *
+ * Every read and write of it is optional-chained. A real drag always carries a
+ * `dataTransfer`; a synthesized `DragEvent` — which is how the e2e suite drives
+ * these handlers — does not, and the `dragId` fallback covers that case.
+ */
+const CARD_MIME = "application/x-opencompany-task";
+
+/**
+ * How near the board's left or right edge a drag has to come before the board
+ * starts scrolling itself, and how fast it goes once hard against that edge.
+ *
+ * The board is a horizontal scroller and, at six columns, wider than an
+ * ordinary window: the last column sits off the right edge. HTML5
+ * drag-and-drop does not scroll a nested scroll container on its own — a drag
+ * parked on the edge moves it zero pixels — so without this the far column
+ * cannot be reached by the very gesture the board's own hint recommends.
+ */
+const EDGE_BAND_PX = 72;
+const EDGE_SPEED_PX = 16;
+
 function priorityStyle(priority: string): string {
   return PRIORITY_STYLES[priority as keyof typeof PRIORITY_STYLES] ?? PRIORITY_STYLES.low;
+}
+
+/** A column's board label, for messages the operator reads. */
+function columnLabel(id: string): string {
+  return TASK_COLUMNS.find((c) => c.id === id)?.label ?? id;
 }
 
 /**
@@ -80,6 +116,14 @@ export function TasksView({
   // A real HTML5 drag fires a trailing click; suppress it so a drag never also
   // opens the detail dialog.
   const dragged = useRef(false);
+  // The horizontal scroller holding the columns, so a drag near its edge can
+  // scroll it (issue #334).
+  const boardRef = useRef<HTMLDivElement | null>(null);
+  // Pixels per frame the board is currently scrolling itself by, and the frame
+  // that is doing it. Both refs rather than state: this is driven by dragover
+  // at pointer rate and must not re-render the board on every move.
+  const edgeSpeed = useRef(0);
+  const edgeFrame = useRef<number | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -112,6 +156,52 @@ export function TasksView({
     return () => window.removeEventListener("hashchange", onHash);
   }, []);
 
+  const stopEdgeScroll = useCallback(() => {
+    edgeSpeed.current = 0;
+    if (edgeFrame.current !== null) {
+      cancelAnimationFrame(edgeFrame.current);
+      edgeFrame.current = null;
+    }
+  }, []);
+
+  /**
+   * Aims the board's self-scroll at wherever the drag currently is: full speed
+   * hard against an edge, easing to nothing at the band's inner lip, and off
+   * entirely across the middle of the board.
+   */
+  const edgeScrollTo = useCallback(
+    (clientX: number) => {
+      const board = boardRef.current;
+      if (!board) return;
+      const { left, right } = board.getBoundingClientRect();
+      const ramp = (depth: number) => Math.min(1, Math.max(0, 1 - depth / EDGE_BAND_PX));
+      let speed = 0;
+      if (clientX < left + EDGE_BAND_PX) speed = -EDGE_SPEED_PX * ramp(clientX - left);
+      else if (clientX > right - EDGE_BAND_PX) speed = EDGE_SPEED_PX * ramp(right - clientX);
+      if (speed === 0) {
+        stopEdgeScroll();
+        return;
+      }
+      edgeSpeed.current = speed;
+      if (edgeFrame.current !== null) return;
+      const step = () => {
+        const el = boardRef.current;
+        if (!el || edgeSpeed.current === 0) {
+          edgeFrame.current = null;
+          return;
+        }
+        el.scrollLeft += edgeSpeed.current;
+        edgeFrame.current = requestAnimationFrame(step);
+      };
+      edgeFrame.current = requestAnimationFrame(step);
+    },
+    [stopEdgeScroll],
+  );
+
+  // A drag interrupted by a view change (the detail screen replaces the board
+  // in place) must not leave a frame running against a detached node.
+  useEffect(() => stopEdgeScroll, [stopEdgeScroll]);
+
   const openDetail = useCallback((id: string) => {
     window.location.hash = `/tasks/${encodeURIComponent(id)}`;
     setDetailId(id);
@@ -121,13 +211,32 @@ export function TasksView({
     setDetailId(null);
   }, []);
 
-  async function moveTo(column: string) {
-    const id = dragId;
+  /**
+   * Lands a dropped card in `column`. `dropped` is the id the drag carried on
+   * its dataTransfer, which is authoritative; `dragId` is the fallback for a
+   * drop that arrives without one.
+   *
+   * Every exit from here now says something (issue #334). A drop that goes
+   * nowhere and reports nothing is indistinguishable from a frozen app, and
+   * that is what made one failed gesture read as "there is no way to do this".
+   * The one deliberate silence is a card landing back in its own column: that
+   * is a no-op, not a refusal.
+   */
+  async function moveTo(column: string, dropped: string | null) {
+    const id = dropped || dragId;
     setDragId(null);
     setOverCol(null);
-    if (!id) return;
+    if (!id) {
+      toast.error("That drop did not carry a card, so nothing moved.");
+      return;
+    }
     const current = tasks.find((t) => t.id === id);
-    if (!current || current.column === column) return;
+    if (!current) {
+      toast.error("That card is no longer on the board. Reloading it now.");
+      void refresh();
+      return;
+    }
+    if (current.column === column) return;
     // Optimistic move; reconcile with the server's echo (and revert on error).
     setTasks((ts) => ts.map((t) => (t.id === id ? { ...t, column } : t)));
     try {
@@ -140,7 +249,14 @@ export function TasksView({
       }
     } catch (e) {
       setTasks((ts) => ts.map((t) => (t.id === id ? { ...t, column: current.column } : t)));
-      toast.error(e instanceof Error ? e.message : "could not move the card");
+      // The card has already snapped back by the time this is read, so the
+      // message carries the whole story: which card, where it was going, and
+      // the host's own words for why it would not go. The board validates
+      // nothing itself — `BOARD_COLUMNS` is the host's list — so the reason for
+      // a refusal only ever exists in the response.
+      toast.error(`Could not move "${current.title}" to ${columnLabel(column)}.`, {
+        description: e instanceof Error ? e.message : "the host refused the move",
+      });
     }
   }
 
@@ -215,7 +331,34 @@ export function TasksView({
         </div>
       )}
 
-      <div className="flex min-h-0 flex-1 gap-4 overflow-x-auto py-4 pl-4">
+      <div
+        ref={boardRef}
+        onDragOver={(e) => {
+          // The columns preventDefault as well; this handler also covers the
+          // pixels between and around them, so the board keeps scrolling while
+          // a drag crosses a gap on its way to a far column.
+          e.preventDefault();
+          edgeScrollTo(e.clientX);
+        }}
+        onDragLeave={(e) => {
+          // Only when the pointer has genuinely left the board, not while it
+          // moves between two of the board's own children.
+          if (!e.currentTarget.contains(e.relatedTarget as Node | null)) stopEdgeScroll();
+        }}
+        onDrop={(e) => {
+          // Columns claim their own drops and stop them here, so anything that
+          // reaches this handler landed on dead board pixels: the gap between
+          // two columns, the leading padding, the trailing gutter. Those used
+          // to swallow the whole gesture without a word (issue #334).
+          e.preventDefault();
+          stopEdgeScroll();
+          const id = e.dataTransfer?.getData(CARD_MIME) || dragId;
+          setDragId(null);
+          setOverCol(null);
+          if (id) toast.error("Drop the card on a column to move it.");
+        }}
+        className="flex min-h-0 flex-1 gap-4 overflow-x-auto py-4 pl-4"
+      >
         {TASK_COLUMNS.map((col) => {
           const items = tasks.filter((t) => t.column === col.id);
           return (
@@ -223,10 +366,21 @@ export function TasksView({
               key={col.id}
               onDragOver={(e) => {
                 e.preventDefault();
+                // Runs before the board's own dragover (this is the inner
+                // handler), and the board leaves it alone — so the cursor says
+                // "move" over a column and nothing over the dead pixels.
+                if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
                 setOverCol(col.id);
               }}
               onDragLeave={() => setOverCol((c) => (c === col.id ? null : c))}
-              onDrop={() => void moveTo(col.id)}
+              onDrop={(e) => {
+                e.preventDefault();
+                // Claim the drop, so anything still reaching the board's own
+                // handler is known to have missed every column.
+                e.stopPropagation();
+                stopEdgeScroll();
+                void moveTo(col.id, e.dataTransfer?.getData(CARD_MIME) ?? null);
+              }}
               className={cn(
                 "flex min-h-0 w-72 shrink-0 flex-col rounded-xl border bg-card/40 transition-colors",
                 overCol === col.id && "border-primary/40 bg-accent/40",
@@ -250,13 +404,23 @@ export function TasksView({
                       dragging={dragId === t.id}
                       onOpen={() => openCard(t)}
                       onResume={() => void resume(t)}
-                      onDragStart={() => {
+                      onDragStart={(e) => {
                         dragged.current = true;
                         setDragId(t.id);
+                        if (e.dataTransfer) {
+                          e.dataTransfer.effectAllowed = "move";
+                          // The id is what the drop reads back. The
+                          // `text/plain` copy is what makes the drag
+                          // well-formed for the browsers that abort one
+                          // carrying no data at all.
+                          e.dataTransfer.setData(CARD_MIME, t.id);
+                          e.dataTransfer.setData("text/plain", t.title);
+                        }
                       }}
                       onDragEnd={() => {
                         setDragId(null);
                         setOverCol(null);
+                        stopEdgeScroll();
                         // Clear the drag-suppression shortly after, so a genuine
                         // click that follows is honored.
                         setTimeout(() => (dragged.current = false), 0);
@@ -304,7 +468,8 @@ function TaskItem({
   dragging: boolean;
   onOpen: () => void;
   onResume: () => void;
-  onDragStart: () => void;
+  /** Takes the event so the card can stamp its id onto the drag (issue #334). */
+  onDragStart: (e: DragEvent<HTMLDivElement>) => void;
   onDragEnd: () => void;
 }) {
   return (

--- a/frontend/test/e2e/board-drag.spec.ts
+++ b/frontend/test/e2e/board-drag.spec.ts
@@ -1,0 +1,238 @@
+import { expect, test, type APIRequestContext, type Locator, type Page } from "@playwright/test";
+
+/**
+ * Issue #334 — moving a card out of In review by dragging it onto Done.
+ *
+ * QA reported this as "a card cannot be moved out of In review": the drop
+ * appeared to work, the counts did not change, and nothing said why. Two
+ * separate things produced that:
+ *
+ * 1. **The last column was mostly off-window.** `SidebarInset` is a flex item
+ *    beside the sidebar, and a flex item's default `min-width: auto` floors it
+ *    at its content's min-content width — so the inset measured a full window
+ *    wide while starting a sidebar's width in from the left, and its trailing
+ *    strip hung outside the window inside a wrapper that clips and does not
+ *    scroll. Scrolled hard right, "Done" showed a ~64px sliver hugging the
+ *    window edge. At five columns the strip held only slack; the sixth (#301)
+ *    pushed a real column into it.
+ * 2. **Every miss was silent.** The drop read the dragged id out of React state
+ *    alone and returned wordlessly when it was absent, and the pixels between
+ *    and around the columns had no drop handler at all — so a near miss, which
+ *    a 64px target makes the common case, did nothing and said nothing.
+ *
+ * These tests are the guard for both, and for the third leg of the fix: the
+ * board now scrolls itself while a drag sits on its edge, because HTML5
+ * drag-and-drop does not scroll a nested scroll container, so a column parked
+ * off-screen could not be reached by the gesture at all.
+ *
+ * They drive a real browser against a live host, which the issue calls out as
+ * the only way this is observable. CI does not run this suite.
+ */
+
+const API = "/api/v1/company";
+
+/** Board order (issue #301), so a column can be addressed by position. */
+const COLUMNS = ["To-do", "Planning", "In progress", "Paused", "In review", "Done"];
+const IN_REVIEW = COLUMNS.indexOf("In review");
+const DONE = COLUMNS.indexOf("Done");
+
+test.beforeEach(async ({ page }) => {
+  // The first-run tour opens a modal over the board and swallows clicks.
+  await page.addInitScript(() => {
+    const seen = JSON.stringify({ skipped: true, seenAt: Date.now() });
+    for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
+      window.localStorage.setItem(key, seen);
+    }
+  });
+});
+
+async function dismissTour(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    if (!(await skip.isVisible().catch(() => false))) return;
+    await skip.click({ force: true }).catch(() => {});
+    await page.waitForTimeout(300);
+  }
+  await expect(skip).toHaveCount(0);
+}
+
+const column = (page: Page, index: number) => page.locator("div.w-72").nth(index);
+const board = (page: Page) => page.locator("div.overflow-x-auto").first();
+
+/** Seeds a card straight into In review and opens the board on it. */
+async function seedInReview(page: Page, request: APIRequestContext, title: string) {
+  const created = await request.post(`${API}/tasks`, { data: { title } });
+  expect(created.ok()).toBeTruthy();
+  const id = (await created.json()).id as string;
+  const moved = await request.patch(`${API}/tasks/${id}`, { data: { column: "in_review" } });
+  expect(moved.ok()).toBeTruthy();
+
+  await page.goto("/#/tasks");
+  await dismissTour(page);
+  const card = page.locator("div[draggable=true]").filter({ hasText: title }).first();
+  await expect(card).toBeVisible({ timeout: 15_000 });
+  return { id, card };
+}
+
+/**
+ * A real pointer drag: press the card, walk to `(toX, toY)` in small steps so
+ * Chromium promotes it to a drag session, and release.
+ *
+ * `dragTo` is not usable for these cases — it scrolls the target into view
+ * before pressing, which is precisely the step the operator cannot take
+ * mid-gesture and which this fix exists to supply.
+ */
+async function handDrag(page: Page, card: Locator, toX: number, toY: number) {
+  const box = await card.boundingBox();
+  if (!box) throw new Error("the card has no box to grab");
+  const fromX = box.x + box.width / 2;
+  const fromY = box.y + box.height / 2;
+  await page.mouse.move(fromX, fromY);
+  await page.mouse.down();
+  for (let step = 1; step <= 12; step += 1) {
+    await page.mouse.move(fromX + ((toX - fromX) * step) / 12, fromY + ((toY - fromY) * step) / 12);
+    await page.waitForTimeout(40);
+  }
+  await page.waitForTimeout(150);
+  await page.mouse.up();
+}
+
+test("the whole board fits the window, so the last column is a full drop target", async ({
+  page,
+}) => {
+  await page.goto("/#/tasks");
+  await dismissTour(page);
+  await expect(column(page, DONE)).toHaveCount(1);
+
+  // The regression this guards: the shell used to be a sidebar's width wider
+  // than the window, and the overshoot was clipped by an ancestor that cannot
+  // be scrolled — so those pixels were unreachable by any means.
+  const overshoot = await page.evaluate(() => {
+    const inset = document.querySelector('[data-slot="sidebar-inset"]');
+    if (!inset) throw new Error("no sidebar inset");
+    return Math.round(inset.getBoundingClientRect().right - window.innerWidth);
+  });
+  expect(overshoot).toBeLessThanOrEqual(0);
+
+  // Scrolled to the end, Done is a whole column inside the window rather than
+  // a sliver of one pinned against the edge.
+  await board(page).evaluate((el) => {
+    el.scrollLeft = el.scrollWidth;
+  });
+  await page.waitForTimeout(300);
+  const done = await column(page, DONE).boundingBox();
+  const width = page.viewportSize()!.width;
+  expect(done).not.toBeNull();
+  expect(Math.min(done!.x + done!.width, width) - done!.x).toBeGreaterThan(200);
+});
+
+test("a card drags from In review to Done, and the board scrolls to get there", async ({
+  page,
+  request,
+}) => {
+  const title = `e2e in-review to done ${Date.now()}`;
+  const { id, card } = await seedInReview(page, request, title);
+
+  // Park the board so In review is on screen and Done is not. This is the
+  // operator's actual starting position, and the case the gesture could not
+  // finish before: nothing scrolls a nested container during an HTML5 drag.
+  const scrolled = await board(page).evaluate((el) => {
+    el.scrollLeft = Math.max(0, el.scrollWidth - el.clientWidth - 260);
+    return el.scrollLeft;
+  });
+  await page.waitForTimeout(300);
+
+  const box = await card.boundingBox();
+  if (!box) throw new Error("the seeded card has no box");
+  const viewport = page.viewportSize()!;
+
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  // Ride the right edge and let the board bring Done to the pointer.
+  for (let tick = 0; tick < 25; tick += 1) {
+    await page.mouse.move(viewport.width - 8 - (tick % 2), box.y + 160);
+    await page.waitForTimeout(60);
+  }
+  const rode = await board(page).evaluate((el) => el.scrollLeft);
+  expect(rode, "the board follows a drag held against its edge").toBeGreaterThan(scrolled);
+
+  const done = await column(page, DONE).boundingBox();
+  if (!done) throw new Error("Done has no box");
+  await page.mouse.move(done.x + done.width / 2, done.y + done.height / 2);
+  await page.waitForTimeout(150);
+  await page.mouse.up();
+
+  // The host's own record, which is the only thing that settles whether the
+  // move happened rather than merely appeared to.
+  await expect
+    .poll(async () => (await (await request.get(`${API}/tasks/${id}`)).json()).task.column, {
+      timeout: 15_000,
+    })
+    .toBe("done");
+
+  // And the counts the operator was watching.
+  await expect(column(page, DONE)).toContainText(title);
+  await expect(column(page, IN_REVIEW)).not.toContainText(title);
+});
+
+test("a drop that misses every column says so instead of doing nothing", async ({
+  page,
+  request,
+}) => {
+  const title = `e2e drag near miss ${Date.now()}`;
+  const { id, card } = await seedInReview(page, request, title);
+
+  await board(page).evaluate((el) => {
+    el.scrollLeft = el.scrollWidth;
+  });
+  await page.waitForTimeout(300);
+
+  // The trailing gutter past the last column: board pixels that belong to no
+  // column. This is where a near miss lands, and it used to swallow the whole
+  // gesture without a word.
+  const gutter = await page.locator("div[aria-hidden].w-4").first().boundingBox();
+  if (!gutter) throw new Error("no trailing gutter");
+  await handDrag(page, card, gutter.x + gutter.width / 2, gutter.y + 200);
+
+  await expect(page.getByText("Drop the card on a column to move it.")).toBeVisible({
+    timeout: 5_000,
+  });
+  // Saying so is not the same as moving it: the card must stay where it was.
+  expect((await (await request.get(`${API}/tasks/${id}`)).json()).task.column).toBe("in_review");
+  await expect(column(page, IN_REVIEW)).toContainText(title);
+});
+
+test("a move the host refuses names the card, the column, and the reason", async ({
+  page,
+  request,
+}) => {
+  const title = `e2e refused move ${Date.now()}`;
+  const { card } = await seedInReview(page, request, title);
+
+  // The host accepts in_review → done, so the refusal has to be induced. This
+  // asserts the console's half of the contract: whatever the host says, the
+  // operator reads it rather than watching the card snap back in silence.
+  await page.route("**/tasks/*", async (route) => {
+    if (route.request().method() !== "PATCH") return route.fallback();
+    await route.fulfill({
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ code: "invalid_request", error: "the board is read-only right now" }),
+    });
+  });
+
+  await board(page).evaluate((el) => {
+    el.scrollLeft = el.scrollWidth;
+  });
+  await page.waitForTimeout(300);
+  const done = await column(page, DONE).boundingBox();
+  if (!done) throw new Error("Done has no box");
+  await handDrag(page, card, done.x + done.width / 2, done.y + done.height / 2);
+
+  await expect(page.getByText(`Could not move "${title}" to Done.`)).toBeVisible({
+    timeout: 5_000,
+  });
+  await expect(page.getByText("the board is read-only right now")).toBeVisible();
+  // Refused means refused: the optimistic move is rolled back.
+  await expect(column(page, IN_REVIEW)).toContainText(title);
+});

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -307,6 +307,59 @@ async fn task_writes_reject_a_column_the_board_cannot_render() {
     assert_eq!(board.as_array().expect("board")[0]["column"], "paused");
 }
 
+/// #334: `in_review → done` is a move the write boundary accepts, and the one
+/// the board's drag actually sends.
+///
+/// QA reported that a card "cannot be moved out of In review" — the drop did
+/// nothing and said nothing, which cannot distinguish a host refusing the write
+/// from a console that never sent it. It was the console (the drop was missing
+/// the mostly off-window last column, and every miss was silent), but nothing
+/// pinned the host's half of that answer. This does: both columns are in
+/// `BOARD_COLUMNS`, the transition is special-cased nowhere, and `done` is
+/// terminal — the card lands there and no dispatch fires behind it.
+#[tokio::test]
+async fn a_card_moves_from_in_review_to_done() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+
+    let (status, seeded) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks",
+        Some(json!({"title": "Invoice March retainer", "column": "in_review"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let id = seeded["id"].as_str().unwrap().to_string();
+
+    // Exactly the body a drag onto Done sends.
+    let (status, moved) = send(
+        &state,
+        "PATCH",
+        &format!("/api/v1/company/tasks/{id}"),
+        Some(json!({"column": "done"})),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "the board's drag PATCH must be accepted: {moved}"
+    );
+    assert_eq!(moved["column"], crate::ports::tasks::COLUMN_DONE);
+
+    // What the board reads back on its next poll, not just what the echo said —
+    // a card that snaps back is the shape of the original report.
+    let (_, board) = send(&state, "GET", "/api/v1/company/tasks", None).await;
+    let card = board
+        .as_array()
+        .expect("board")
+        .iter()
+        .find(|c| c["id"] == json!(id))
+        .expect("the card is still on the board");
+    assert_eq!(card["column"], crate::ports::tasks::COLUMN_DONE);
+}
+
 /// Issue #206: `POST …/tasks` defaults a new card to To-do — the board's one
 /// manual-entry column — while an explicit `column` still wins, so the
 /// lifecycle paths that place a card themselves are untouched.


### PR DESCRIPTION
Fixes #334

## Summary

A card in **In review** could not be dragged to **Done**: the drop appeared to work, the counts did not change, and nothing said why.

The issue asked which side refuses the drop — the host, or the console before any request goes out. I reproduced it in a headless Chromium with every drag event instrumented: **the console, before any request**. `PATCH …/tasks/{id}` is never sent. A host refusal, when one does happen, already surfaced correctly. Three separate causes, all console-side:

**1. The last column was mostly off-window.** `SidebarInset` is a flex item beside the sidebar, and a flex item's default `min-width: auto` floors it at its content's min-content width. That floor won: the inset measured a full window wide while starting a sidebar's width in from the left, so its trailing strip hung outside the window inside a wrapper that clips and cannot scroll. Those pixels were unreachable by any means. At 1280x800 the strip is 256px, and on the board it held the Done column. **Scrolled hard right, Done showed a 64px sliver** hugging the window edge. Every view was losing the same strip; the board is where #301's sixth column pushed real content into it.

**2. Nothing scrolled the board during a drag.** HTML5 drag-and-drop does not scroll a nested scroll container. Measured against a live drag session: the pointer parked on the board's right edge for 1.8s moved `scrollLeft` **0 → 0** of a possible 832. A column parked off-screen could not be reached by the very gesture the board's own hint recommends.

**3. Every miss was silent.** `moveTo` read the dragged card's id out of React state alone and returned wordlessly when it was absent — which it is for any drag that did not begin on a card. And the pixels between and around the columns had no drop handler at all, so a near miss did nothing and said nothing. With a 64px target, a near miss is the common case, not the rare one. That is what made one failed gesture read as *"there is no way to do this"* rather than *"this one gesture failed"*.

### What changed

* **`frontend/src/components/app-shell.tsx`** — `min-w-0` on `SidebarInset` removes the min-content floor, so the inset measures the space it actually has and the board's own `overflow-x-auto` handles the columns.
* **`frontend/src/views/TasksView.tsx`**
  * The board scrolls itself while a drag sits in an edge band, ramping from nothing at the band's inner lip to full speed hard against the edge (rAF-driven, torn down on dragend / dragleave / unmount).
  * A card stamps its id onto the drag's `dataTransfer` and the drop reads it back, with the old React state as the fallback. Filling the data store matters on its own too: a drag carrying nothing is aborted outright by Firefox and Safari, so the board's one documented gesture never even started there.
  * Columns claim their own drops; the board handles what is left over — the gap between two columns, the leading padding, the trailing gutter — and says the card has to land on a column.
  * Every exit from the move now speaks: a drop carrying no card, a card that has left the board, and a host refusal, which now names the card and the target column and carries the host's own words as the reason. The one deliberate silence is a card dropped back into its own column, which is a no-op rather than a refusal.

Every `dataTransfer` access is optional-chained: a real drag always carries one, a synthesized `DragEvent` does not, and the existing suite drives these handlers with synthesized events. Verified that path still moves the card.

### Measurements, before and after

| | before | after |
|---|---|---|
| Done column visible width, max scroll @ 1280px | 64px | 288px |
| `SidebarInset` right edge vs. window (1280px) | 1536 | 1280 |
| `scrollLeft` riding the right edge mid-drag | 560 → 560 | 560 → 832 |
| Drag In review → Done | no PATCH, no toast, counts unchanged | `PATCH {"column":"done"}`, In review 1→0, Done 1→2 |
| Released beside a column | silence | "Drop the card on a column to move it." |
| Host refuses with a 400 | bare message | names card + target column + host's reason, card rolls back |

### Scope

Only the drag interaction and the silence around it, as the issue directs. `TaskEditDialog`'s Column control is untouched and still works as the alternative path (#269). Independent of #301: this fixes the container the columns live in, not the column vocabulary.

## API Or Behavior Changes

No API change. The wire contract is untouched — the board still writes a column with `PATCH …/tasks/{id}` and the host still validates against `BOARD_COLUMNS`.

Console behavior changes:

* The app shell no longer extends past the right edge of the window. This affects every view, but only by removing overflow — no view loses width. Spot-checked Tasks, Team and Workflows: all sit exactly inside the window.
* The board scrolls itself when a drag is held near its left or right edge.
* A drop that cannot be applied now raises a message instead of reverting in silence. A card dropped back into its own column stays silent, as before.

## Tests

- [x] `cargo fmt --all -- --check` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo clippy --all-targets -- -D warnings` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo build --all-targets` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo test` — N/A - full local build matrix is prohibited on this machine; verified in CI

Run locally:

* `pnpm typecheck` — clean
* `pnpm typecheck:e2e` — clean
* `rustfmt --edition 2024 --check src/server/ops/write_test.rs` — clean

Added with the change:

* **`frontend/test/e2e/board-drag.spec.ts`** (new, 4 tests). The issue calls out that a drag is not observable any other way, and `frontend/test/e2e/` is where UI behaviour gets checked here. Drives a real browser against a live host: the shell no longer overshoots the window and Done is a full-width drop target; a card rides the board's edge from In review into Done, with the counts following and the host's own record confirming the move; a drop that misses every column surfaces a message and moves nothing; a refused move names the card, the column and the reason, and rolls back. CI does not run this suite.
* **`src/server/ops/write_test.rs::a_card_moves_from_in_review_to_done`** — pins the half of the report's question that *is* a host question: `in_review → done` is exactly the PATCH the drag sends, the write boundary accepts it, and the card lands in the terminal column and reads back from it. This one does run in CI.

## Documentation

No docs needed. The REST contract is unchanged, and no doc describes the console's drag mechanics — `docs/spec/runtime/ports.md` covers the column vocabulary and the write boundary, both untouched here. The reasoning for each fix is in the code comments and in the e2e spec's header, next to what it guards.
