### PR TITLE
feat(runs): write a run record for every dispatched attempt (#242 PR-2)

### DIFF
--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -620,6 +620,61 @@ The fs backend stores runs in `runs.jsonl` (last-write-wins per id) and steps in
 Deliberately not one file per run: that would make a run id a path component,
 and a store must never let an id it did not mint address the filesystem.
 
+#### Who writes a run, and when
+
+A run wraps a cycle; it never replaces one. Four writers, in order:
+
+1. **`CompanyRuntime::dispatch_task`** — the single choke point every dispatch
+   passes through — mints the `Pending` row *before* the cycle is spawned, and
+   puts its id on the `TaskDispatched` event so the journal is self-describing.
+   If the row cannot be written the dispatch proceeds anyway with
+   `run_id: None`: record-keeping never fails the work it records.
+2. **`CycleRunner::run_locked`** calls `begin_run` right after the event's
+   append yields its seq — the serial lock is held and the seq now exists, so
+   the row can name the exact log line that drove it. After the brain returns
+   (`Ok` *or* `Err`) a **terminality backstop** settles any row still claiming
+   to be live, so a brain that ignores `TaskDispatched` or errors out cannot
+   strand one. Only a panic escapes it, which is the boot reaper's job.
+3. **`HarnessBrain::run_task`** does the rich settle: the `TaskRunEnd` the steer
+   loop yielded maps to a `RunStatus` (`lifecycle::run_status_for`), the folded
+   cost and step count ride along, and a failure carries its reason. It returns
+   before the backstop runs, so the rich settle always wins.
+4. **The trace sink** (`harness::run_trace::RunTraceSink`) writes each step
+   **during** the turn, from the collector task that already drains the harness
+   progress stream. A tool call's start persists as `running` and its completion
+   re-writes the same `step_seq` finalized — which is why killing the host
+   mid-run leaves the prefix behind instead of nothing. The await lives in the
+   collector, never the model loop, so a slow store slows only trace
+   persistence. One sink spans every turn of the attempt (redirect re-runs, and
+   a delegate's turn), so ordinals stay dense and cost folds across all of them.
+
+The explicit price is write amplification: one row per step plus roughly three
+status writes per run, against one event before. Affordable because cycles
+serialise per company.
+
+**Review vs paused at the settle.** A run that otherwise succeeded while parking
+at least one approval finishes `waiting_approval`, not `succeeded` — a person
+must act. A failed, cancelled or paused run keeps the reason it stopped;
+relabelling it "waiting on you" would hide that reason.
+
+#### Correlation fields elsewhere
+
+Four additive `Option<String>` fields point back at a run. All are
+`#[serde(default, skip_serializing_if = "Option::is_none")]`, so **no migration
+and no backfill**: a record written before them loads with `None`, and an
+untagged one serializes byte-identically to how it did before.
+
+| Carrier | Meaning when set |
+|---|---|
+| `CompanyEvent::TaskDispatched.run_id` | the attempt this dispatch opened |
+| `Effect.run_id` | the attempt whose turn parked this approval — stamped at the dispatch boundary, never in `ApprovalPolicy::effect_for` (a policy is per-agent and outlives runs), so a chat-parked effect stays `None` |
+| `ArtifactVersion.run_id` | the attempt that wrote *this revision* — per version, so a card dispatched twice keeps both links |
+| `UsageSample.run_id` | the attempt a turn's tokens were spent under; attribution only, no ledger semantics change |
+
+Old `RunRecord`s are never synthesised from historical `AgentReply` events:
+fabricating identity for attempts nobody recorded would be worse than a
+pre-existing card honestly showing zero of them.
+
 ## Assembly
 
 ```rust

--- a/src/brain/echo.rs
+++ b/src/brain/echo.rs
@@ -35,6 +35,7 @@ impl EchoBrain {
             first_time_counterparty: false,
             payload: serde_json::Value::Null,
             agent: None,
+            run_id: None,
         }
     }
 }

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -104,7 +104,7 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("Deleted memory fact {fact_id}"),
             "memory.fact_deleted",
         ),
-        CompanyEvent::TaskDispatched { task_id } => (
+        CompanyEvent::TaskDispatched { task_id, .. } => (
             Role::System,
             "board".to_string(),
             format!("Dispatched task {task_id}"),

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -244,6 +244,7 @@ pub(crate) fn effect_from_frame(frame: &EffectFrame) -> Effect {
             .unwrap_or(false),
         payload: frame.payload.clone(),
         agent: None,
+        run_id: None,
     }
 }
 

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -367,7 +367,7 @@ impl CompanyRuntime {
         let dispatch = task_enters_in_progress(prev_column.as_deref(), &task.column);
         self.ops.tasks.upsert(&self.id, task).await?;
         if dispatch {
-            self.dispatch_task(task.id.clone());
+            self.dispatch_task(task).await;
         }
         Ok(())
     }
@@ -377,16 +377,23 @@ impl CompanyRuntime {
     /// the cycle writes its outcome back onto the card. In the default build (no
     /// harness) this is a no-op, keeping the board inert.
     ///
+    /// The one **choke point** every dispatch passes through, which is why issue
+    /// #242 mints the attempt's [`RunRecord`](crate::ports::runs::RunRecord)
+    /// here — see [`open_run`](Self::open_run) for why it is minted *before* the
+    /// spawn rather than inside the cycle.
+    ///
     /// [`TaskDispatched`]: crate::ports::types::CompanyEvent::TaskDispatched
-    fn dispatch_task(self: &Arc<Self>, task_id: String) {
+    async fn dispatch_task(self: &Arc<Self>, task: &TaskRecord) {
         #[cfg(feature = "openhuman")]
         if self.harness.is_some() {
+            let task_id = task.id.clone();
+            let run_id = self.open_run(task).await;
             let runtime = Arc::clone(self);
             tokio::spawn(async move {
                 if let Err(err) = runtime
                     .run_cycle(vec![CompanyEvent::TaskDispatched {
                         task_id: task_id.clone(),
-                        run_id: None,
+                        run_id,
                     }])
                     .await
                 {
@@ -401,8 +408,60 @@ impl CompanyRuntime {
             return;
         }
         // Default build / no harness: the board stays inert. The card rests in
-        // `in_progress` until a harness cycle (or a human) advances it.
-        let _ = task_id;
+        // `in_progress` until a harness cycle (or a human) advances it. No run is
+        // minted either — nothing is attempting the card, so an attempt row would
+        // be a fiction.
+        let _ = task;
+    }
+
+    /// Mints this dispatch's [`RunStatus::Pending`] attempt row and returns its
+    /// id, or `None` when the row could not be written (issue #242).
+    ///
+    /// **Before the spawn, deliberately.** The cycle is a detached
+    /// `tokio::spawn`, so a host that dies in the gap between this write and the
+    /// cycle's first turn used to leave *nothing at all* behind: the card sat in
+    /// `in_progress` with no record that anything had ever tried it. Writing the
+    /// row first turns that silent loss into a visible orphan the boot reaper
+    /// ([`reap_orphaned_runs`](crate::ports::runs::reap_orphaned_runs)) fails on
+    /// the next start.
+    ///
+    /// **A failed write never blocks the dispatch.** Record-keeping does not get
+    /// to fail the work it records — the same invariant the workflow-outcome
+    /// journal, the inference meter and the grant-consumption record already
+    /// hold. The dispatch proceeds with `run_id: None`, which every downstream
+    /// reader treats as "this attempt is untracked", and the failure is logged at
+    /// `warn` rather than swallowed.
+    ///
+    /// [`RunStatus::Pending`]: crate::ports::runs::RunStatus::Pending
+    #[cfg(feature = "openhuman")]
+    async fn open_run(&self, task: &TaskRecord) -> Option<String> {
+        let spec = crate::ports::runs::NewRun {
+            id: crate::ports::generate_id(),
+            task_id: task.id.clone(),
+            agent_id: task.assignee.clone(),
+        };
+        match self.ops.runs.create_run(&self.id, spec).await {
+            Ok(run) => {
+                tracing::debug!(
+                    company = %self.id,
+                    task = %task.id,
+                    run = %run.id,
+                    attempt = run.attempt,
+                    "[runs] opened an attempt for a dispatched card"
+                );
+                Some(run.id)
+            }
+            Err(err) => {
+                tracing::warn!(
+                    company = %self.id,
+                    task = %task.id,
+                    error = %err,
+                    "[runs] could not open an attempt row; dispatching anyway — the work runs \
+                     untracked rather than not at all"
+                );
+                None
+            }
+        }
     }
 
     /// This company's workspace file tree.
@@ -808,6 +867,84 @@ mod tests {
         assert!(
             task_enters_in_progress(None, COLUMN_IN_PROGRESS),
             "positive control: the trigger this test relies on is still live"
+        );
+    }
+
+    /// Issue #242: the attempt row exists **before** the cycle is spawned, in
+    /// [`RunStatus::Pending`], carrying the assignee it was dispatched to and a
+    /// 1-based ordinal that climbs per re-dispatch. This is the whole point of
+    /// minting at the choke point rather than inside the cycle — a host that
+    /// dies in the gap leaves a visible orphan instead of nothing.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn a_dispatch_opens_a_pending_attempt_before_the_cycle_spawns() {
+        use crate::ports::TaskRecord;
+        use crate::ports::runs::{RunFilter, RunStatus};
+        use crate::ports::tasks::COLUMN_IN_PROGRESS;
+
+        let home = tempfile::Builder::new()
+            .prefix("opencompany-run-open-")
+            .tempdir()
+            .expect("tempdir");
+        let manifest: crate::company::CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n[[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n[policy]\nmode = \"full\"\n",
+        )
+        .expect("manifest");
+        let id = crate::ports::types::CompanyId::new("acme");
+        let runtime = crate::runtime::RuntimeBuilder::new(home.path().to_path_buf(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .expect("runtime");
+
+        let card = TaskRecord {
+            id: "t-1".to_string(),
+            title: "Ship it".to_string(),
+            note: None,
+            column: COLUMN_IN_PROGRESS.to_string(),
+            priority: "medium".to_string(),
+            assignee: "ceo".to_string(),
+            updated_at_millis: 0,
+            origin_chat_id: None,
+            parent_task_id: None,
+        };
+
+        let first = runtime.open_run(&card).await.expect("an attempt is minted");
+        let runs = runtime
+            .runs()
+            .list_runs(&id, &RunFilter::for_task("t-1"))
+            .await
+            .expect("list");
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].id, first);
+        assert_eq!(
+            runs[0].status,
+            RunStatus::Pending,
+            "the row is written before anything runs, so it starts Pending"
+        );
+        assert_eq!(runs[0].attempt, 1, "the first attempt at a card is 1");
+        assert_eq!(runs[0].agent_id, "ceo");
+        assert!(
+            runs[0].trigger_event_seq.is_none(),
+            "the driving event has not been appended yet"
+        );
+        assert!(runs[0].started_at_millis.is_none());
+
+        // A re-dispatch is a NEW attempt, never a resurrection of the first.
+        let second = runtime.open_run(&card).await.expect("a second attempt");
+        assert_ne!(second, first);
+        let runs = runtime
+            .runs()
+            .list_runs(&id, &RunFilter::for_task("t-1"))
+            .await
+            .expect("list");
+        assert_eq!(runs.len(), 2);
+        assert_eq!(
+            runs.iter()
+                .find(|r| r.id == second)
+                .expect("second")
+                .attempt,
+            2
         );
     }
 }

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -386,6 +386,7 @@ impl CompanyRuntime {
                 if let Err(err) = runtime
                     .run_cycle(vec![CompanyEvent::TaskDispatched {
                         task_id: task_id.clone(),
+                        run_id: None,
                     }])
                     .await
                 {

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -1069,7 +1069,7 @@ impl Brain for HarnessBrain {
                     });
                     channel_responses.extend(turn.bubbles);
                 }
-                CompanyEvent::TaskDispatched { task_id } => {
+                CompanyEvent::TaskDispatched { task_id, .. } => {
                     if let Some(message) = self.run_task(task_id).await? {
                         channel_responses.push(message);
                     }
@@ -1634,6 +1634,7 @@ members = ["engineer"]
             .run_cycle(
                 request(vec![CompanyEvent::TaskDispatched {
                     task_id: "t1".into(),
+                    run_id: None,
                 }]),
                 &NoopHost,
             )
@@ -1716,6 +1717,7 @@ members = ["engineer"]
             .run_cycle(
                 request(vec![CompanyEvent::TaskDispatched {
                     task_id: "t-origin".into(),
+                    run_id: None,
                 }]),
                 &NoopHost,
             )
@@ -1758,6 +1760,7 @@ members = ["engineer"]
             .run_cycle(
                 request(vec![CompanyEvent::TaskDispatched {
                     task_id: "t-cancel".into(),
+                    run_id: None,
                 }]),
                 &NoopHost,
             )
@@ -1815,6 +1818,7 @@ members = ["engineer"]
             .run_cycle(
                 request(vec![CompanyEvent::TaskDispatched {
                     task_id: "t1".into(),
+                    run_id: None,
                 }]),
                 &NoopHost,
             )
@@ -1851,6 +1855,7 @@ members = ["engineer"]
             .run_cycle(
                 request(vec![CompanyEvent::TaskDispatched {
                     task_id: "t1".into(),
+                    run_id: None,
                 }]),
                 &NoopHost,
             )
@@ -1881,6 +1886,7 @@ members = ["engineer"]
             .run_cycle(
                 request(vec![CompanyEvent::TaskDispatched {
                     task_id: "t1".into(),
+                    run_id: None,
                 }]),
                 &NoopHost,
             )
@@ -1927,6 +1933,7 @@ members = ["engineer"]
             .run_cycle(
                 request(vec![CompanyEvent::TaskDispatched {
                     task_id: "t1".into(),
+                    run_id: None,
                 }]),
                 &NoopHost,
             )
@@ -1959,6 +1966,7 @@ members = ["engineer"]
             .run_cycle(
                 request(vec![CompanyEvent::TaskDispatched {
                     task_id: "t1".into(),
+                    run_id: None,
                 }]),
                 &NoopHost,
             )
@@ -1998,6 +2006,7 @@ members = ["engineer"]
             .run_cycle(
                 request(vec![CompanyEvent::TaskDispatched {
                     task_id: "t1".into(),
+                    run_id: None,
                 }]),
                 &NoopHost,
             )
@@ -2051,6 +2060,7 @@ members = ["engineer"]
             .run_cycle(
                 request(vec![CompanyEvent::TaskDispatched {
                     task_id: "nope".into(),
+                    run_id: None,
                 }]),
                 &NoopHost,
             )
@@ -3629,6 +3639,7 @@ members = ["eng1", "eng2"]
             .run_cycle(
                 request(vec![CompanyEvent::TaskDispatched {
                     task_id: "t1".into(),
+                    run_id: None,
                 }]),
                 &NoopHost,
             )
@@ -3662,6 +3673,7 @@ members = ["eng1", "eng2"]
             .run_cycle(
                 request(vec![CompanyEvent::TaskDispatched {
                     task_id: "t1".into(),
+                    run_id: None,
                 }]),
                 &NoopHost,
             )
@@ -3702,6 +3714,7 @@ members = ["eng1", "eng2"]
             .run_cycle(
                 request(vec![CompanyEvent::TaskDispatched {
                     task_id: "t1".into(),
+                    run_id: None,
                 }]),
                 &NoopHost,
             )
@@ -4087,6 +4100,7 @@ members = ["eng1", "eng2"]
             .run_cycle(
                 request(vec![CompanyEvent::TaskDispatched {
                     task_id: id.to_string(),
+                    run_id: None,
                 }]),
                 &NoopHost,
             )

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -603,8 +603,13 @@ impl HarnessBrain {
         // Recorded before the #185 journal writes below because those move
         // `result_text` into the completion event; the artifact only borrows it.
         if card.column == lifecycle::success_terminal_column(&card) {
-            self.record_task_artifact(&card, &responder, &result_text)
-                .await?;
+            self.record_task_artifact(
+                &card,
+                &responder,
+                &result_text,
+                sink.as_ref().map(|s| s.run_id()),
+            )
+            .await?;
         }
 
         // Issue #185: correlate this dispatch's journal trail to its card.
@@ -893,11 +898,15 @@ impl HarnessBrain {
     /// A missing artifact store is a silent no-op, exactly like a missing task
     /// store: the note is still written, so the board behaves as it did before
     /// this issue.
+    /// `run_id` is the attempt that produced `body`, stamped onto the revision
+    /// this call writes (issue #242) so a run row can point at what it actually
+    /// wrote. `None` for an untracked dispatch, which behaves exactly as before.
     async fn record_task_artifact(
         &self,
         card: &TaskRecord,
         responder: &str,
         body: &str,
+        run_id: Option<&str>,
     ) -> Result<()> {
         let Some(artifacts) = self.deps.artifacts.as_ref() else {
             return Ok(());
@@ -908,7 +917,7 @@ impl HarnessBrain {
             .into_iter()
             .max_by_key(|a| a.updated_at_millis);
         let at = now_millis();
-        let record = match existing {
+        let mut record = match existing {
             Some(mut found) => {
                 found.push_version(body, ArtifactAuthor::Agent, responder, at, None);
                 found
@@ -923,6 +932,12 @@ impl HarnessBrain {
                 at,
             ),
         };
+        // Only the revision this run wrote. An earlier attempt's version keeps
+        // the attempt that wrote *it*, which is the point of stamping per
+        // version instead of per record.
+        if let Some(run_id) = run_id {
+            record.stamp_run(run_id);
+        }
         artifacts.upsert(&self.record.id, &record).await?;
         Ok(())
     }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -42,8 +42,18 @@ use crate::runtime::delegation::{self, DelegationRunner, RunTurn};
 /// forever.
 const MAX_REDIRECTS_PER_DISPATCH: u32 = 3;
 
+/// The `error` a dispatched attempt settles with when the company has no task
+/// board wired at all — the card cannot even be read, so nothing was tried.
+const NO_TASK_STORE: &str = "this company has no task board wired, so the card could not be run";
+
+/// The `error` a dispatched attempt settles with when its card is gone by the
+/// time the cycle reaches it (deleted, or never persisted).
+const CARD_VANISHED: &str = "the card was gone by the time its dispatch ran";
+
+use crate::harness::run_trace::RunTraceSink;
 use crate::ports::artifacts::{ArtifactAuthor, ArtifactKind, ArtifactRecord};
 use crate::ports::brain::{Brain, CycleHost};
+use crate::ports::runs::{RunOutcome, RunStatus};
 use crate::ports::types::{
     CompanyEvent, CompanyRecord, CompressedTrace, CycleRequest, CycleResult, OutboundMessage,
     TokenUsage, TurnStep, TurnStepKind, TurnStepStatus, Verdict,
@@ -56,6 +66,18 @@ pub struct HarnessBrain {
     deps: HarnessDeps,
     record: CompanyRecord,
     responder: String,
+    /// The attempt records a dispatched card writes into (issue #242).
+    ///
+    /// Held here rather than on [`HarnessDeps`] on purpose: every one of the
+    /// ~28 `HarnessDeps` literals in this crate would otherwise have to be
+    /// widened for a handle only the dispatch path reads — the same argument
+    /// that put the grant set on `ApprovalRequestQueue` instead.
+    ///
+    /// `None` **fails silent, not closed**: the card still runs, its outcome
+    /// still lands on the board and in the journal, and only the run record is
+    /// missing. That is the right direction for a purely observational store —
+    /// and it is why every test construction can leave it unset.
+    runs: Option<Arc<dyn crate::ports::RunStore>>,
 }
 
 impl HarnessBrain {
@@ -70,12 +92,19 @@ impl HarnessBrain {
             deps,
             record,
             responder,
+            runs: None,
         }
     }
 
     /// Overrides which roster agent answers operator messages.
     pub fn with_responder(mut self, agent_id: impl Into<String>) -> Self {
         self.responder = agent_id.into();
+        self
+    }
+
+    /// Wires the run store a dispatched card records its attempt into (#242).
+    pub fn with_runs(mut self, runs: Arc<dyn crate::ports::RunStore>) -> Self {
+        self.runs = Some(runs);
         self
     }
 
@@ -152,7 +181,7 @@ impl HarnessBrain {
         // bubble returned below, and its transient frames would otherwise
         // misattribute onto whichever chat thread the console is watching.
         let outcome = run_turn
-            .run_steered_background(&self.record.id, &grant.agent, &instruction, &control)
+            .run_steered_background(&self.record.id, &grant.agent, &instruction, &control, None)
             .await;
         drop(guard);
 
@@ -214,8 +243,19 @@ impl HarnessBrain {
         }))
     }
 
-    async fn run_task(&self, task_id: &str) -> Result<Option<OutboundMessage>> {
+    async fn run_task(
+        &self,
+        task_id: &str,
+        run_id: Option<&str>,
+    ) -> Result<Option<OutboundMessage>> {
+        // Issue #242: the attempt this dispatch is recorded under. `None`
+        // whenever the run store is unwired or the choke point could not mint a
+        // row — the card runs either way, untracked.
+        let sink = self.open_trace(run_id);
+
         let Some(tasks) = self.deps.tasks.as_ref() else {
+            self.settle_run(sink.as_deref(), RunStatus::Failed, Some(NO_TASK_STORE))
+                .await;
             return Ok(None);
         };
         let Some(mut card) = tasks
@@ -224,6 +264,8 @@ impl HarnessBrain {
             .into_iter()
             .find(|t| t.id == task_id)
         else {
+            self.settle_run(sink.as_deref(), RunStatus::Failed, Some(CARD_VANISHED))
+                .await;
             return Ok(None);
         };
 
@@ -244,7 +286,9 @@ impl HarnessBrain {
                 assignee = %card.assignee,
                 "[task] refusing dispatch: {reason}"
             );
-            return self.refuse_dispatch(tasks, card, &reason).await;
+            return self
+                .refuse_dispatch(tasks, card, &reason, sink.as_deref())
+                .await;
         }
         // A blank assignee is the one legitimate miss: nobody was named, so the
         // orchestrator picks it up.
@@ -306,11 +350,14 @@ impl HarnessBrain {
         // (issue #176), re-attaching `HarnessDeps` behind `HarnessRunTurn`.
         let run_turn = HarnessRunTurn::new(&self.pool, &self.deps);
 
-        // The loop yields the run's operator-facing result on whichever path
-        // ends it, so the artifact (#187) and the completion event (#185) both
-        // record exactly the text the note does rather than a second, divergent
-        // rendering of the same run.
-        let result_text = loop {
+        // The loop yields how the run ended plus its operator-facing result on
+        // whichever path ends it, so the artifact (#187), the completion event
+        // (#185) and the attempt row (#242) all record exactly what the note
+        // does rather than three divergent renderings of one run. The ending
+        // rides along because the run's status cannot be re-derived from the
+        // card's landing column — `Failed` and `Cancelled` share one column and
+        // are not the same outcome (see [`lifecycle::run_status_for`]).
+        let (run_end, result_text) = loop {
             // Start each turn from an empty queue so nothing a prior turn (this
             // cycle's operator message, or an earlier redirect rerun) left
             // behind can hijack this card — the same guard
@@ -320,7 +367,17 @@ impl HarnessBrain {
                 // A dispatched task card carries no chat bubble (its steps are
                 // discarded into the note), so its live turn frames must not leak
                 // onto the console timeline — run it un-streamed (#125 review).
-                .run_steered_background(&self.record.id, &responder, &instruction, &control)
+                .run_steered_background(
+                    &self.record.id,
+                    &responder,
+                    &instruction,
+                    &control,
+                    // Issue #242: un-streamed does not mean unrecorded. The
+                    // trace this turn produces is written to the attempt row as
+                    // it happens, which is what a redirect re-run appends to
+                    // rather than restarting.
+                    sink.clone(),
+                )
                 .await;
             // One-shot read of what (if anything) the operator asked for. `None`
             // is the ordinary, unsteered path.
@@ -360,6 +417,10 @@ impl HarnessBrain {
                             let handoff = match self
                                 .delegation_runner(&run_turn)
                                 .for_task(&card.id)
+                                // The delegate's turn is part of THIS attempt —
+                                // its steps and its spend belong to the card's
+                                // run, not to nothing (#242).
+                                .for_run(sink.clone())
                                 .handle_task_delegations(&mut card, &responder)
                                 .await
                             {
@@ -367,7 +428,7 @@ impl HarnessBrain {
                                 Err(err) => {
                                     let result = format!("hand-off failed: {err}");
                                     settle(&mut card, TaskRunEnd::Failed, &responder, &result);
-                                    break result;
+                                    break (TaskRunEnd::Failed, result);
                                 }
                             };
                             // `settle` writes the note (attributed to whoever
@@ -375,7 +436,7 @@ impl HarnessBrain {
                             // via the #186 lifecycle seam; the loop still yields
                             // the reply so the #185/#190 completion events
                             // report the same text that landed in the note.
-                            let result = match handoff {
+                            let (end, result) = match handoff {
                                 // The delegate answered: they own the card, and
                                 // every downstream write credits them.
                                 Some(handoff) => {
@@ -388,7 +449,7 @@ impl HarnessBrain {
                                                 &responder,
                                                 &reply,
                                             );
-                                            reply
+                                            (TaskRunEnd::Completed, reply)
                                         }
                                         // The hand-off ran and an operator
                                         // CANCELLED it in flight, so it produced
@@ -417,7 +478,7 @@ impl HarnessBrain {
                                                 &responder,
                                                 &reply,
                                             );
-                                            reply
+                                            (TaskRunEnd::Cancelled, reply)
                                         }
                                     }
                                 }
@@ -426,15 +487,15 @@ impl HarnessBrain {
                                 None => {
                                     let result = outcome.reply;
                                     settle(&mut card, TaskRunEnd::Completed, &responder, &result);
-                                    result
+                                    (TaskRunEnd::Completed, result)
                                 }
                             };
-                            break result;
+                            break (end, result);
                         }
                         Err(err) => {
                             let result = format!("dispatch failed: {err}");
                             settle(&mut card, TaskRunEnd::Failed, &responder, &result);
-                            break result;
+                            break (TaskRunEnd::Failed, result);
                         }
                     }
                 }
@@ -445,7 +506,7 @@ impl HarnessBrain {
                     // that). The loop still yields the text for #185/#190.
                     let result = "cancelled while in flight".to_string();
                     settle(&mut card, TaskRunEnd::Cancelled, &responder, &result);
-                    break result;
+                    break (TaskRunEnd::Cancelled, result);
                 }
                 Some(SteerAction::Pause) => {
                     // Partial work is PRESERVED in the note; the card parks in the
@@ -457,7 +518,7 @@ impl HarnessBrain {
                         Err(err) => format!("[paused] dispatch failed: {err}"),
                     };
                     settle(&mut card, TaskRunEnd::Paused, &responder, &partial);
-                    break partial;
+                    break (TaskRunEnd::Paused, partial);
                 }
                 Some(SteerAction::Redirect { instruction: fresh }) => {
                     redirects += 1;
@@ -475,7 +536,7 @@ impl HarnessBrain {
                             Err(err) => format!("dispatch failed: {err}"),
                         };
                         settle(&mut card, TaskRunEnd::RedirectsExhausted, &responder, &last);
-                        break last;
+                        break (TaskRunEnd::RedirectsExhausted, last);
                     }
                     // Re-run from the original brief plus the (codepoint-capped)
                     // operator instruction.
@@ -492,6 +553,17 @@ impl HarnessBrain {
         tasks.upsert(&self.record.id, &card).await?;
         // `guard` drops here → the run leaves the in-flight strip.
         drop(guard);
+
+        // Issue #242: settle the attempt row from how the run actually ended.
+        //
+        // Here, right after the card is persisted and before any of the
+        // best-effort journal writes below, so the run record and the board
+        // agree the moment either is readable. It also means the cycle's
+        // terminality backstop finds this row already settled and no-ops — the
+        // rich settle always wins the race, because `run_task` returns before
+        // `run_locked` reaches the backstop.
+        self.settle_run_end(sink.as_deref(), run_end, &result_text)
+            .await;
 
         // Issue #187: record the run's output as a versioned artifact so the
         // Task Detail Artifacts tab has something behind it, and so a later
@@ -600,12 +672,17 @@ impl HarnessBrain {
         tasks: &Arc<dyn crate::ports::TaskStore>,
         mut card: TaskRecord,
         reason: &str,
+        sink: Option<&RunTraceSink>,
     ) -> Result<Option<OutboundMessage>> {
         let orchestrator = self.orchestrator();
         let text = format!("dispatch refused: {reason}");
         settle(&mut card, TaskRunEnd::Failed, &orchestrator, &text);
         card.updated_at_millis = now_millis();
         tasks.upsert(&self.record.id, &card).await?;
+        // A refusal is a real, terminal attempt — one that spent nothing. It
+        // settles like any other ending (#242), so the card's run history shows
+        // "this was tried and refused, and why" rather than a gap.
+        self.settle_run_end(sink, TaskRunEnd::Failed, &text).await;
 
         self.journal_task_outcome(&card, &orchestrator, text).await;
 
@@ -618,6 +695,71 @@ impl HarnessBrain {
             &orchestrator,
             origin,
         )))
+    }
+
+    /// Opens the trace sink for this dispatch's attempt row (issue #242), or
+    /// `None` when there is nothing to record into.
+    ///
+    /// Two independent reasons for `None`, and both are ordinary: the run store
+    /// is unwired (every test construction, and any embedder that never called
+    /// [`with_runs`](Self::with_runs)), or the dispatch choke point could not
+    /// mint a row and sent `run_id: None`. In both cases the card runs exactly
+    /// as it did before this issue.
+    fn open_trace(&self, run_id: Option<&str>) -> Option<Arc<RunTraceSink>> {
+        let run_id = run_id?;
+        let runs = self.runs.as_ref()?;
+        Some(Arc::new(RunTraceSink::new(
+            self.record.id.clone(),
+            run_id,
+            Arc::clone(runs),
+        )))
+    }
+
+    /// Settles the attempt row from how its run ended, folding in the trace's
+    /// step count and cost (issue #242).
+    async fn settle_run_end(&self, sink: Option<&RunTraceSink>, end: TaskRunEnd, result: &str) {
+        let status = lifecycle::run_status_for(end);
+        // Only a failure carries a reason: `error` is "why this went wrong", not
+        // "what the agent said". Stamping a success's reply here would put the
+        // deliverable in a field every reader renders as a fault.
+        let error = matches!(status, RunStatus::Failed).then_some(result);
+        self.settle_run(sink, status, error).await;
+    }
+
+    /// Writes one settle through to the run store, best-effort.
+    ///
+    /// Never propagates: the card is already persisted and the operator can
+    /// already see the outcome by the time this runs, so a store fault must not
+    /// fail the cycle — the same journal-after-persist rule
+    /// [`journal_task_outcome`](Self::journal_task_outcome) follows. A run left
+    /// unsettled by a failure here is still caught by the cycle's terminality
+    /// backstop, and failing that by the boot reaper.
+    async fn settle_run(
+        &self,
+        sink: Option<&RunTraceSink>,
+        status: RunStatus,
+        error: Option<&str>,
+    ) {
+        let (Some(sink), Some(runs)) = (sink, self.runs.as_ref()) else {
+            return;
+        };
+        let outcome = RunOutcome {
+            status,
+            error: error.map(str::to_string),
+            usage: sink.usage(),
+            step_count: sink.step_count(),
+        };
+        if let Err(err) = runs
+            .finish_run(&self.record.id, sink.run_id(), outcome)
+            .await
+        {
+            tracing::warn!(
+                company = %self.record.id,
+                run = %sink.run_id(),
+                error = %err,
+                "[runs] could not settle an attempt row; the dispatch itself landed"
+            );
+        }
     }
 
     /// Journals a finished dispatch onto its card's timeline (issue #185): the
@@ -1069,8 +1211,8 @@ impl Brain for HarnessBrain {
                     });
                     channel_responses.extend(turn.bubbles);
                 }
-                CompanyEvent::TaskDispatched { task_id, .. } => {
-                    if let Some(message) = self.run_task(task_id).await? {
+                CompanyEvent::TaskDispatched { task_id, run_id } => {
+                    if let Some(message) = self.run_task(task_id, run_id.as_deref()).await? {
                         channel_responses.push(message);
                     }
                 }
@@ -1550,7 +1692,7 @@ members = ["engineer"]
             .await
             .expect("seed");
 
-        let posted = brain.run_task("t-no-origin").await.expect("run");
+        let posted = brain.run_task("t-no-origin", None).await.expect("run");
         assert!(
             posted.is_none(),
             "a card with no originating thread must not post back"
@@ -1578,7 +1720,7 @@ members = ["engineer"]
             .expect("seed");
 
         let posted = brain
-            .run_task("t-origin")
+            .run_task("t-origin", None)
             .await
             .expect("run")
             .expect("a card with an origin must post back");
@@ -1679,7 +1821,7 @@ members = ["engineer"]
             .expect("roster");
 
         let posted = brain
-            .run_task("t-origin")
+            .run_task("t-origin", None)
             .await
             .expect("run")
             .expect("a card with an origin posts back");
@@ -1866,6 +2008,169 @@ members = ["engineer"]
         assert!(note.contains("[engineer]"), "{note:?}");
     }
 
+    // ── Issue #242: the attempt row records what the dispatch actually did ──
+
+    /// Wires a run store onto a task-capable brain, mints the `Pending` row the
+    /// dispatch choke point would have minted, and returns both.
+    async fn brain_with_a_pending_run(
+        dir: &std::path::Path,
+        assignee: &str,
+    ) -> (HarnessBrain, Arc<FsOps>, Arc<dyn crate::ports::RunStore>) {
+        use crate::ports::runs::NewRun;
+
+        let (brain, tasks) = brain_with_tasks(dir);
+        let runs: Arc<dyn crate::ports::RunStore> = Arc::new(FsOps::new(dir));
+        let company = CompanyId::new("acme");
+        tasks
+            .upsert(&company, &card("t-1", assignee))
+            .await
+            .expect("seed");
+        runs.create_run(
+            &company,
+            NewRun {
+                id: "run-1".to_string(),
+                task_id: "t-1".to_string(),
+                agent_id: assignee.to_string(),
+            },
+        )
+        .await
+        .expect("mint");
+        (brain.with_runs(Arc::clone(&runs)), tasks, runs)
+    }
+
+    /// The settle. This fixture's pool holds no roster, so the turn errors —
+    /// which is exactly the `TaskRunEnd::Failed` path — and the row must end
+    /// **terminal**, carrying the reason the card's note carries, rather than
+    /// sitting `Pending` for the boot reaper to find.
+    #[tokio::test]
+    async fn a_dispatch_settles_its_attempt_row_from_how_the_run_ended() {
+        use crate::ports::runs::RunStatus;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks, runs) = brain_with_a_pending_run(dir.path(), "engineer").await;
+        let company = CompanyId::new("acme");
+
+        brain.run_task("t-1", Some("run-1")).await.expect("run");
+
+        let settled = runs
+            .get_run(&company, "run-1")
+            .await
+            .expect("read")
+            .expect("the row survives");
+        assert_eq!(settled.status, RunStatus::Failed);
+        assert!(
+            settled.finished_at_millis.is_some(),
+            "a terminal settle stamps when the attempt ended"
+        );
+        let reason = settled.error.expect("a failure carries its reason");
+        assert!(reason.contains("dispatch failed"), "{reason}");
+        // …and the row agrees with the card, rather than telling a second story.
+        let note = only_card(&tasks).await.note.expect("note");
+        assert!(note.contains("dispatch failed"), "{note}");
+        // No turn ran on this offline fixture, so there is nothing to charge.
+        assert_eq!(settled.step_count, 0);
+        assert_eq!(settled.usage, TokenUsage::default());
+    }
+
+    /// A refusal is an attempt too. It spends nothing and runs no turn, but it
+    /// is a real, terminal outcome — the card's history must show "this was
+    /// tried and refused, and why" rather than a gap where an attempt was.
+    #[tokio::test]
+    async fn a_refused_dispatch_settles_its_attempt_rather_than_leaving_a_gap() {
+        use crate::ports::runs::RunStatus;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, _tasks, runs) = brain_with_a_pending_run(dir.path(), "Shane").await;
+        let company = CompanyId::new("acme");
+
+        brain.run_task("t-1", Some("run-1")).await.expect("run");
+
+        let settled = runs
+            .get_run(&company, "run-1")
+            .await
+            .expect("read")
+            .expect("row");
+        assert_eq!(settled.status, RunStatus::Failed);
+        let reason = settled.error.expect("reason");
+        assert!(reason.contains("dispatch refused"), "{reason}");
+        assert!(
+            reason.contains("Shane"),
+            "the row must name what was wrong, like the note does: {reason}"
+        );
+    }
+
+    /// The degraded path stays degraded, not broken: a dispatch carrying no run
+    /// id runs the card exactly as before and invents no row for it.
+    #[tokio::test]
+    async fn an_untracked_dispatch_runs_the_card_and_records_no_attempt() {
+        use crate::ports::runs::RunFilter;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, tasks) = brain_with_tasks(dir.path());
+        let runs: Arc<dyn crate::ports::RunStore> = Arc::new(FsOps::new(dir.path()));
+        let brain = brain.with_runs(Arc::clone(&runs));
+        let company = CompanyId::new("acme");
+        tasks
+            .upsert(&company, &card("t-1", "engineer"))
+            .await
+            .expect("seed");
+
+        brain.run_task("t-1", None).await.expect("run");
+
+        assert!(
+            only_card(&tasks).await.note.is_some(),
+            "the card still ran and still recorded its outcome"
+        );
+        assert!(
+            runs.list_runs(&company, &RunFilter::default())
+                .await
+                .expect("list")
+                .is_empty(),
+            "no row was minted for this dispatch, so none may be invented"
+        );
+    }
+
+    /// A card that vanished between the dispatch write and the cycle still
+    /// closes its attempt. Otherwise the row would sit `Pending` until a
+    /// restart reaped it with a misleading "the host restarted" reason.
+    #[tokio::test]
+    async fn a_dispatch_whose_card_is_gone_still_closes_its_attempt() {
+        use crate::ports::runs::{NewRun, RunStatus};
+
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, _tasks) = brain_with_tasks(dir.path());
+        let runs: Arc<dyn crate::ports::RunStore> = Arc::new(FsOps::new(dir.path()));
+        let brain = brain.with_runs(Arc::clone(&runs));
+        let company = CompanyId::new("acme");
+        runs.create_run(
+            &company,
+            NewRun {
+                id: "run-1".to_string(),
+                task_id: "t-gone".to_string(),
+                agent_id: "engineer".to_string(),
+            },
+        )
+        .await
+        .expect("mint");
+
+        assert!(
+            brain
+                .run_task("t-gone", Some("run-1"))
+                .await
+                .expect("run")
+                .is_none(),
+            "a missing card posts nothing back"
+        );
+
+        let settled = runs
+            .get_run(&company, "run-1")
+            .await
+            .expect("read")
+            .expect("row");
+        assert_eq!(settled.status, RunStatus::Failed);
+        assert_eq!(settled.error.as_deref(), Some(CARD_VANISHED));
+    }
+
     // ── Issue #205: the working agent is linked, and a bad assignee is refused ──
 
     /// The reported bug. A card assigned to "Shane" — nobody this company has —
@@ -2034,7 +2339,7 @@ members = ["engineer"]
             .expect("seed");
 
         let posted = brain
-            .run_task("t-origin")
+            .run_task("t-origin", None)
             .await
             .expect("run")
             .expect("a refused card with an origin must still post back");

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -349,6 +349,11 @@ impl HarnessBrain {
         // Route the background turn through the brain-agnostic `RunTurn` seam
         // (issue #176), re-attaching `HarnessDeps` behind `HarnessRunTurn`.
         let run_turn = HarnessRunTurn::new(&self.pool, &self.deps);
+        // Issue #242: where this attempt's own approval requests begin. The
+        // queue is shared with any chat turn earlier in the same cycle and is
+        // append-only until the cycle-end drain, so a position taken here stays
+        // the boundary between "somebody else parked that" and "this run did".
+        let approvals_before = self.deps.approval_requests.queued();
 
         // The loop yields how the run ended plus its operator-facing result on
         // whichever path ends it, so the artifact (#187), the completion event
@@ -562,7 +567,18 @@ impl HarnessBrain {
         // terminality backstop finds this row already settled and no-ops — the
         // rich settle always wins the race, because `run_task` returns before
         // `run_locked` reaches the backstop.
-        self.settle_run_end(sink.as_deref(), run_end, &result_text)
+        // Issue #242 / #333: tag every approval this attempt's turns parked with
+        // the run that produced it, and count them — a run that finished its
+        // work but left a person something to act on has not succeeded, it is in
+        // review.
+        let parked = match sink.as_ref() {
+            Some(sink) => self
+                .deps
+                .approval_requests
+                .stamp_run(approvals_before, sink.run_id()),
+            None => 0,
+        };
+        self.settle_run_end(sink.as_deref(), run_end, &result_text, parked)
             .await;
 
         // Issue #187: record the run's output as a versioned artifact so the
@@ -682,7 +698,8 @@ impl HarnessBrain {
         // A refusal is a real, terminal attempt — one that spent nothing. It
         // settles like any other ending (#242), so the card's run history shows
         // "this was tried and refused, and why" rather than a gap.
-        self.settle_run_end(sink, TaskRunEnd::Failed, &text).await;
+        self.settle_run_end(sink, TaskRunEnd::Failed, &text, 0)
+            .await;
 
         self.journal_task_outcome(&card, &orchestrator, text).await;
 
@@ -717,8 +734,28 @@ impl HarnessBrain {
 
     /// Settles the attempt row from how its run ended, folding in the trace's
     /// step count and cost (issue #242).
-    async fn settle_run_end(&self, sink: Option<&RunTraceSink>, end: TaskRunEnd, result: &str) {
-        let status = lifecycle::run_status_for(end);
+    ///
+    /// `parked_approvals` is how many approval requests **this attempt's own
+    /// turns** left for a person to act on. A run that otherwise succeeded while
+    /// parking at least one finishes [`RunStatus::WaitingApproval`] rather than
+    /// [`RunStatus::Succeeded`] — epic #183 decision 2: a person must act, so
+    /// the attempt is in review, not done. A run that failed, was cancelled or
+    /// was paused keeps its own status; the operator has a bigger problem than a
+    /// pending approval, and overwriting the reason it stopped would hide it.
+    ///
+    /// `WaitingApproval` is terminal-in-v1 (resuming an approved attempt is its
+    /// own issue) and deliberately **re-enterable across attempts**: the
+    /// re-dispatch after an approval is a new run that can wait again, which is
+    /// what keeps #243's single-use, argument-exact grants coherent instead of
+    /// forcing an operator to batch several approvals into one.
+    async fn settle_run_end(
+        &self,
+        sink: Option<&RunTraceSink>,
+        end: TaskRunEnd,
+        result: &str,
+        parked_approvals: usize,
+    ) {
+        let status = lifecycle::settled_run_status(end, parked_approvals);
         // Only a failure carries a reason: `error` is "why this went wrong", not
         // "what the agent said". Stamping a success's reply here would put the
         // deliverable in a field every reader renders as a fault.
@@ -3491,6 +3528,7 @@ members = ["eng1", "eng2"]
                 first_time_counterparty: false,
                 payload: serde_json::json!({ "prompt": "a logo" }),
                 agent: None,
+                run_id: None,
             },
         });
 
@@ -3568,6 +3606,7 @@ members = ["eng1", "eng2"]
                     first_time_counterparty: false,
                     payload: serde_json::json!({ "tool": tool }),
                     agent: None,
+                    run_id: None,
                 },
             });
         }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -567,10 +567,11 @@ impl HarnessBrain {
         // terminality backstop finds this row already settled and no-ops — the
         // rich settle always wins the race, because `run_task` returns before
         // `run_locked` reaches the backstop.
-        // Issue #242 / #333: tag every approval this attempt's turns parked with
-        // the run that produced it, and count them — a run that finished its
-        // work but left a person something to act on has not succeeded, it is in
-        // review.
+        //
+        // First (#333's unblocking move): tag every approval this attempt's own
+        // turns parked with the run that produced it, and count them. A run that
+        // finished its work but left a person something to act on has not
+        // succeeded — it is in review.
         let parked = match sink.as_ref() {
             Some(sink) => self
                 .deps

--- a/src/harness/capability_budget.rs
+++ b/src/harness/capability_budget.rs
@@ -128,6 +128,7 @@ mod tests {
             cached_input_tokens: 0,
             cost_usd: 0.0,
             kind: SampleKind::Inference,
+            run_id: None,
         }
     }
 

--- a/src/harness/cost.rs
+++ b/src/harness/cost.rs
@@ -82,13 +82,28 @@ pub fn ledger_entry_for(turn: &TurnUsage, agent_id: &str) -> Option<LedgerEntry>
 /// Build the [`UsageSample`] for a turn, or `None` for a zero-usage turn — e.g.
 /// one served by the offline [`MockProvider`](super::provider::MockProvider),
 /// whose replies carry no usage.
-pub fn usage_sample_for(turn: &TurnUsage, agent_id: &str, provider: &str) -> Option<UsageSample> {
-    inference::inference_sample(&turn.to_token_usage(), agent_id, provider)
+///
+/// `run_id` attributes the sample to the task attempt the turn ran under, when
+/// it ran under one (issue #242). Stamped here rather than inside
+/// [`inference::inference_sample`] because that function is the *shared* mapping
+/// every cognition path uses and only the harness's per-turn path has a run to
+/// name — widening it would push a `None` onto four call sites that can never
+/// mean anything else.
+pub fn usage_sample_for(
+    turn: &TurnUsage,
+    agent_id: &str,
+    provider: &str,
+    run_id: Option<&str>,
+) -> Option<UsageSample> {
+    let mut sample = inference::inference_sample(&turn.to_token_usage(), agent_id, provider)?;
+    sample.run_id = run_id.map(str::to_string);
+    Some(sample)
 }
 
 /// Record a completed turn's cost: append the ledger entry (always available)
 /// and, when a [`UsageMeter`] is wired, record the usage sample. A zero-usage
 /// turn is a no-op.
+#[allow(clippy::too_many_arguments)]
 pub async fn record_turn_cost(
     turn: &TurnUsage,
     agent_id: &str,
@@ -96,11 +111,13 @@ pub async fn record_turn_cost(
     company: &CompanyId,
     store: &dyn CompanyStore,
     meter: Option<&dyn UsageMeter>,
+    run_id: Option<&str>,
 ) -> crate::Result<()> {
     if let Some(entry) = ledger_entry_for(turn, agent_id) {
         store.append_ledger(company, entry).await?;
     }
-    if let (Some(meter), Some(sample)) = (meter, usage_sample_for(turn, agent_id, provider)) {
+    if let (Some(meter), Some(sample)) = (meter, usage_sample_for(turn, agent_id, provider, run_id))
+    {
         meter.record(company, &sample).await?;
     }
     Ok(())
@@ -171,7 +188,7 @@ mod tests {
     fn zero_usage_turn_produces_no_entry_or_sample() {
         let turn = TurnUsage::default();
         assert!(ledger_entry_for(&turn, "ceo").is_none());
-        assert!(usage_sample_for(&turn, "ceo", "managed").is_none());
+        assert!(usage_sample_for(&turn, "ceo", "managed", None).is_none());
     }
 
     /// The `/openai/v1` passthrough reports tokens but no USD (billing happens
@@ -185,7 +202,7 @@ mod tests {
             cached_input_tokens: 0,
             cost_usd: 0.0,
         };
-        assert!(usage_sample_for(&turn, "ceo", "managed").is_some());
+        assert!(usage_sample_for(&turn, "ceo", "managed", None).is_some());
         // No USD ⇒ no ledger entry, but the token sample still lands.
         assert!(ledger_entry_for(&turn, "ceo").is_none());
     }
@@ -211,6 +228,7 @@ mod tests {
             &CompanyId::new("acme"),
             &store,
             Some(&meter),
+            None,
         )
         .await
         .unwrap();
@@ -224,6 +242,56 @@ mod tests {
         assert_eq!(samples[0].output_tokens, 50);
     }
 
+    /// Issue #242: a turn that ran under a dispatched attempt attributes its
+    /// sample to that attempt, and one that did not stays unattributed. The
+    /// ledger entry is untouched either way — money still moves through the same
+    /// `inference.spend` line, so no accounting semantics change here.
+    #[tokio::test]
+    async fn a_sample_carries_the_attempt_its_turn_ran_under() {
+        let store = RecordingStore::default();
+        let meter = RecordingMeter::default();
+        let turn = turn_with(0.5);
+
+        record_turn_cost(
+            &turn,
+            "ceo",
+            "managed",
+            &CompanyId::new("acme"),
+            &store,
+            Some(&meter),
+            Some("run-7"),
+        )
+        .await
+        .unwrap();
+        // …and a chat turn, which belongs to no attempt.
+        record_turn_cost(
+            &turn,
+            "ceo",
+            "managed",
+            &CompanyId::new("acme"),
+            &store,
+            Some(&meter),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let samples = meter.samples.lock().unwrap();
+        assert_eq!(samples[0].run_id.as_deref(), Some("run-7"));
+        assert_eq!(samples[1].run_id, None);
+        // Attribution only — the spend itself is unchanged.
+        let ledger = store.ledger.lock().unwrap();
+        assert_eq!(ledger.len(), 2);
+        assert!(ledger.iter().all(|e| e.amount_usd == 0.5));
+
+        // The field is additive on the wire: an unattributed sample serializes
+        // exactly as it did before #242.
+        let plain = serde_json::to_string(&samples[1]).expect("serialize");
+        assert!(!plain.contains("runId"), "{plain}");
+        let tagged = serde_json::to_string(&samples[0]).expect("serialize");
+        assert!(tagged.contains(r#""runId":"run-7""#), "{tagged}");
+    }
+
     #[tokio::test]
     async fn record_turn_cost_is_a_noop_for_zero_usage() {
         let store = RecordingStore::default();
@@ -235,6 +303,7 @@ mod tests {
             &CompanyId::new("acme"),
             &store,
             Some(&meter),
+            None,
         )
         .await
         .unwrap();

--- a/src/harness/lifecycle.rs
+++ b/src/harness/lifecycle.rs
@@ -239,6 +239,31 @@ pub fn run_status_for(end: TaskRunEnd) -> RunStatus {
     }
 }
 
+/// The [`RunStatus`] an attempt settles into, given how it ended **and**
+/// whether it left a person something to act on (issue #242).
+///
+/// `parked_approvals` counts the approval requests this attempt's own turns
+/// parked. A run that otherwise succeeded while parking at least one finishes
+/// [`RunStatus::WaitingApproval`] rather than [`RunStatus::Succeeded`] — epic
+/// #183 decision 2 in its purest form: *who* unblocks the work decides where it
+/// parks, and here a person does.
+///
+/// A run that failed, was cancelled or was paused keeps the status its ending
+/// gave it. The operator has a bigger problem than a pending approval, and
+/// relabelling a failure as "waiting on you" would hide the reason it stopped.
+///
+/// [`RunStatus::WaitingApproval`] is terminal-in-v1 (resuming an approved
+/// attempt is its own issue) and deliberately **re-enterable across attempts**:
+/// the re-dispatch that follows an approval is a *new* run which can wait again.
+/// That is what keeps #243's single-use, argument-exact grants coherent instead
+/// of forcing an operator to batch several approvals into one.
+pub fn settled_run_status(end: TaskRunEnd, parked_approvals: usize) -> RunStatus {
+    match run_status_for(end) {
+        RunStatus::Succeeded if parked_approvals > 0 => RunStatus::WaitingApproval,
+        settled => settled,
+    }
+}
+
 /// Who the note block for this ending is attributed to.
 ///
 /// A cancellation is the operator's act, not the assignee's, so it is recorded
@@ -517,24 +542,75 @@ mod test {
 
     /// Epic #183 decision 2 at the settle boundary: only a *person* being
     /// required parks a run in review. An operator pause is resolved by
-    /// resuming, so nothing this module decides may produce `WaitingApproval` —
-    /// that status is minted solely by the parked-approval rule in `run_task`.
+    /// resuming, so no ending alone may produce `WaitingApproval` — that status
+    /// is minted solely by a parked approval.
     #[test]
     fn no_lifecycle_ending_alone_parks_a_run_in_review() {
-        for end in [
-            TaskRunEnd::Completed,
-            TaskRunEnd::RedirectsExhausted,
-            TaskRunEnd::Failed,
-            TaskRunEnd::Cancelled,
-            TaskRunEnd::Paused,
-            TaskRunEnd::Delegated,
-        ] {
+        for end in ALL_ENDINGS {
             assert_ne!(
                 run_status_for(end),
                 RunStatus::WaitingApproval,
                 "{end:?} must not claim a person is needed on the strength of the ending alone"
             );
+            assert_eq!(
+                settled_run_status(end, 0),
+                run_status_for(end),
+                "with nothing parked, the settle is exactly the ending's status"
+            );
         }
+    }
+
+    /// Every `TaskRunEnd`, so a table-driven test cannot silently miss a new
+    /// variant (the exhaustive `match` in `run_status_for` breaks first).
+    const ALL_ENDINGS: [TaskRunEnd; 6] = [
+        TaskRunEnd::Completed,
+        TaskRunEnd::RedirectsExhausted,
+        TaskRunEnd::Failed,
+        TaskRunEnd::Cancelled,
+        TaskRunEnd::Paused,
+        TaskRunEnd::Delegated,
+    ];
+
+    /// Epic #183 decision 2: a run that did its work but left an approval for a
+    /// **person** to act on is in review, not done. Only a success is
+    /// reclassified — a failure, a cancellation and a pause keep the reason they
+    /// stopped, because relabelling them "waiting on you" would hide it.
+    #[test]
+    fn a_parked_approval_turns_a_success_into_review_and_nothing_else() {
+        assert_eq!(
+            settled_run_status(TaskRunEnd::Completed, 1),
+            RunStatus::WaitingApproval
+        );
+        assert_eq!(
+            settled_run_status(TaskRunEnd::RedirectsExhausted, 3),
+            RunStatus::WaitingApproval,
+            "a redirect-capped run that parked something still needs a person"
+        );
+
+        for end in [
+            TaskRunEnd::Failed,
+            TaskRunEnd::Cancelled,
+            TaskRunEnd::Paused,
+            TaskRunEnd::Delegated,
+        ] {
+            assert_eq!(
+                settled_run_status(end, 2),
+                run_status_for(end),
+                "{end:?} must keep the reason it stopped rather than reading as a review"
+            );
+        }
+    }
+
+    /// The review stop is **not** terminal-by-accident: it is non-terminal and
+    /// re-enterable, which is what lets a re-dispatched card wait on a second
+    /// approval instead of forcing #243's single-use grants to be batched.
+    #[test]
+    fn the_review_stop_stays_re_enterable() {
+        let review = settled_run_status(TaskRunEnd::Completed, 1);
+        assert!(review.is_parked());
+        assert!(!review.is_terminal());
+        assert!(RunStatus::Running.can_transition_to(review));
+        assert!(review.can_transition_to(RunStatus::Running));
     }
 
     #[test]

--- a/src/harness/lifecycle.rs
+++ b/src/harness/lifecycle.rs
@@ -41,6 +41,7 @@
 //!   would double-journal the timeline's terminal anchor.
 
 use crate::ports::TaskRecord;
+use crate::ports::runs::RunStatus;
 use crate::ports::types::{OutboundMessage, ReplyTo};
 
 /// The board's column vocabulary, re-exported so every `lifecycle::COLUMN_*`
@@ -193,6 +194,48 @@ pub fn landing_column(end: TaskRunEnd, card: &TaskRecord) -> &'static str {
         // the card keeps the column it was dispatched in and only settles once
         // they come back with something (issue #204).
         TaskRunEnd::Delegated => COLUMN_IN_PROGRESS,
+    }
+}
+
+/// The [`RunStatus`] a run ending this way settles into (issue #242).
+///
+/// The board column and the run status answer two different questions about the
+/// same ending — *where does the card go* and *how did the attempt end* — so
+/// both are decided here, from the one [`TaskRunEnd`], rather than one of them
+/// being re-derived from the other. Deriving the status from the landing column
+/// would be actively wrong: `Failed` and `Cancelled` both land in
+/// [`COLUMN_TODO`] and are emphatically not the same outcome.
+///
+/// The mapping, and why:
+///
+/// * [`Completed`](TaskRunEnd::Completed) and
+///   [`RedirectsExhausted`](TaskRunEnd::RedirectsExhausted) →
+///   [`Succeeded`](RunStatus::Succeeded). Both produced a result and both land
+///   in the card's success terminal; spending the redirect budget is how the
+///   run *ended*, not evidence that it failed.
+/// * [`Failed`](TaskRunEnd::Failed) → [`Failed`](RunStatus::Failed), carrying
+///   the reason.
+/// * [`Cancelled`](TaskRunEnd::Cancelled) →
+///   [`Cancelled`](RunStatus::Cancelled) — an operator stopped it, which is
+///   neither a success nor a defect.
+/// * [`Paused`](TaskRunEnd::Paused) → [`Paused`](RunStatus::Paused). Epic #183
+///   decision 2: an operator pause is resolved by *resuming*, not by a person
+///   approving something, so it is `Paused` and never `WaitingApproval`.
+/// * [`Delegated`](TaskRunEnd::Delegated) → [`Paused`](RunStatus::Paused). A
+///   hand-off is not an ending at all — the card stays in
+///   [`COLUMN_IN_PROGRESS`] — and it is unreachable as a run settle today,
+///   because `run_task` awaits the delegate inside the same attempt. Named
+///   anyway so this mapping is exhaustive: if a future path ever settles a run
+///   on a hand-off, the attempt is waiting on *something other than a person*
+///   (the delegate), which decision 2 makes `Paused` — non-terminal and
+///   resumable — rather than a terminal status that would file unfinished work
+///   as done.
+pub fn run_status_for(end: TaskRunEnd) -> RunStatus {
+    match end {
+        TaskRunEnd::Completed | TaskRunEnd::RedirectsExhausted => RunStatus::Succeeded,
+        TaskRunEnd::Failed => RunStatus::Failed,
+        TaskRunEnd::Cancelled => RunStatus::Cancelled,
+        TaskRunEnd::Paused | TaskRunEnd::Delegated => RunStatus::Paused,
     }
 }
 
@@ -441,6 +484,57 @@ mod test {
             review_note(ReviewDecision::Approve, Some("   ")),
             "reviewed: approved"
         );
+    }
+
+    /// Issue #242: every `TaskRunEnd` maps to exactly one `RunStatus`, and the
+    /// mapping is pinned exhaustively so a new ending cannot be added without a
+    /// deliberate decision about how its attempt reads.
+    #[test]
+    fn run_status_is_decided_per_ending_not_re_derived_from_the_column() {
+        assert_eq!(run_status_for(TaskRunEnd::Completed), RunStatus::Succeeded);
+        assert_eq!(
+            run_status_for(TaskRunEnd::RedirectsExhausted),
+            RunStatus::Succeeded,
+            "spending the redirect budget is how the run ended, not a failure"
+        );
+        assert_eq!(run_status_for(TaskRunEnd::Failed), RunStatus::Failed);
+        assert_eq!(run_status_for(TaskRunEnd::Cancelled), RunStatus::Cancelled);
+        assert_eq!(run_status_for(TaskRunEnd::Paused), RunStatus::Paused);
+        assert_eq!(run_status_for(TaskRunEnd::Delegated), RunStatus::Paused);
+
+        // The reason this cannot be derived from `landing_column`: two endings
+        // share a column and are emphatically not the same outcome.
+        let board = card(COLUMN_IN_REVIEW, None);
+        assert_eq!(
+            landing_column(TaskRunEnd::Failed, &board),
+            landing_column(TaskRunEnd::Cancelled, &board)
+        );
+        assert_ne!(
+            run_status_for(TaskRunEnd::Failed),
+            run_status_for(TaskRunEnd::Cancelled)
+        );
+    }
+
+    /// Epic #183 decision 2 at the settle boundary: only a *person* being
+    /// required parks a run in review. An operator pause is resolved by
+    /// resuming, so nothing this module decides may produce `WaitingApproval` —
+    /// that status is minted solely by the parked-approval rule in `run_task`.
+    #[test]
+    fn no_lifecycle_ending_alone_parks_a_run_in_review() {
+        for end in [
+            TaskRunEnd::Completed,
+            TaskRunEnd::RedirectsExhausted,
+            TaskRunEnd::Failed,
+            TaskRunEnd::Cancelled,
+            TaskRunEnd::Paused,
+            TaskRunEnd::Delegated,
+        ] {
+            assert_ne!(
+                run_status_for(end),
+                RunStatus::WaitingApproval,
+                "{end:?} must not claim a person is needed on the strength of the ending alone"
+            );
+        }
     }
 
     #[test]

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -53,6 +53,7 @@ pub mod memory_loop;
 pub mod orchestrator;
 pub mod policy;
 pub mod provider;
+pub mod run_trace;
 pub mod run_turn;
 pub mod search;
 /// End-to-end proof that the #238 `web_search` tool is reachable from a real
@@ -419,7 +420,7 @@ impl CompanyAgent {
     /// per-turn *local* — deliberately not a [`HarnessDeps`] field — so parallel
     /// turns never collide.
     pub async fn run(&self, message: &str) -> crate::Result<(TurnOutcome, Vec<TurnUsage>)> {
-        self.run_with_steer(message, None, None).await
+        self.run_with_steer(message, None, None, None).await
     }
 
     /// Runs one turn with an optional operator **steer** control installed
@@ -437,11 +438,20 @@ impl CompanyAgent {
     /// empty-response class, the one-shot retry is **skipped** — a cancel (or
     /// pause) issued before any text is produced must not silently restart the
     /// work. With no steer this is byte-identical to the pre-#111 `run`.
+    ///
+    /// When `run_sink` is `Some`, the same collector also writes each step
+    /// through to the [`RunStore`](crate::ports::RunStore) as it arrives, so a
+    /// dispatched card's trace is durable *during* the run rather than only
+    /// after it (issue #242). The await lives in the collector task, never in
+    /// the model loop, so a slow store slows only trace persistence. `None`
+    /// (chat turns, workflow nodes, every test) is byte-identical to the prior
+    /// buffer-only behaviour.
     pub async fn run_with_steer(
         &self,
         message: &str,
         steer: Option<&SteerControl>,
         stream: Option<crate::turn_stream::TurnStreamCtx>,
+        run_sink: Option<Arc<run_trace::RunTraceSink>>,
     ) -> crate::Result<(TurnOutcome, Vec<TurnUsage>)> {
         // Per-turn progress sink + an always-draining collector, so a burst of
         // events never blocks the turn loop on a full channel.
@@ -472,6 +482,11 @@ impl CompanyAgent {
                             .with_chat(ctx.chat_id.clone()),
                     );
                     seq += 1;
+                }
+                // Durable half (#242): persist the step before moving on, so a
+                // process killed mid-run keeps every step written so far.
+                if let Some(sink) = &run_sink {
+                    sink.record(&event).await;
                 }
                 events.push(event);
             }
@@ -956,6 +971,7 @@ impl HarnessPool {
             deps,
             None,
             LiveStream::On { chat_id },
+            None,
         )
         .await
     }
@@ -972,8 +988,16 @@ impl HarnessPool {
         message: &str,
         deps: &HarnessDeps,
     ) -> crate::Result<TurnOutcome> {
-        self.run_inner(company, agent_id, message, deps, None, LiveStream::Off)
-            .await
+        self.run_inner(
+            company,
+            agent_id,
+            message,
+            deps,
+            None,
+            LiveStream::Off,
+            None,
+        )
+        .await
     }
 
     /// Routes a message to one agent with an operator **steer** control installed
@@ -982,6 +1006,12 @@ impl HarnessPool {
     /// [`run`](Self::run) — same retrieve→inject, cost accounting, and
     /// memory-writeback. The steer hook fires only between tool-loop iterations.
     /// `chat_id` routes the live turn-stream frames exactly as in [`run`](Self::run).
+    ///
+    /// `run_sink` is the dispatched attempt this turn belongs to, when it
+    /// belongs to one (issue #242) — a desk turn a *dispatched card* handed its
+    /// work to records into the card's run, while the same delegation reached
+    /// from operator chat passes `None`.
+    #[allow(clippy::too_many_arguments)]
     pub async fn run_steered(
         &self,
         company: &CompanyId,
@@ -990,6 +1020,7 @@ impl HarnessPool {
         deps: &HarnessDeps,
         control: &SteerControl,
         chat_id: Option<&str>,
+        run_sink: Option<Arc<run_trace::RunTraceSink>>,
     ) -> crate::Result<TurnOutcome> {
         self.run_inner(
             company,
@@ -998,6 +1029,7 @@ impl HarnessPool {
             deps,
             Some(control),
             LiveStream::On { chat_id },
+            run_sink,
         )
         .await
     }
@@ -1014,6 +1046,7 @@ impl HarnessPool {
         message: &str,
         deps: &HarnessDeps,
         control: &SteerControl,
+        run_sink: Option<Arc<run_trace::RunTraceSink>>,
     ) -> crate::Result<TurnOutcome> {
         self.run_inner(
             company,
@@ -1022,10 +1055,12 @@ impl HarnessPool {
             deps,
             Some(control),
             LiveStream::Off,
+            run_sink,
         )
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn run_inner(
         &self,
         company: &CompanyId,
@@ -1034,6 +1069,7 @@ impl HarnessPool {
         deps: &HarnessDeps,
         steer: Option<&SteerControl>,
         live: LiveStream<'_>,
+        run_sink: Option<Arc<run_trace::RunTraceSink>>,
     ) -> crate::Result<TurnOutcome> {
         let agent = {
             let guard = self.agents.read().await;
@@ -1213,7 +1249,19 @@ impl HarnessPool {
             }),
             LiveStream::Off => None,
         };
-        let (outcome, turn_costs) = agent.run_with_steer(&augmented, steer, stream_ctx).await?;
+        let (outcome, turn_costs) = agent
+            .run_with_steer(&augmented, steer, stream_ctx, run_sink.clone())
+            .await?;
+        // Issue #242: fold this turn's spend into the attempt it belongs to.
+        // Per turn, not once at the end, so a redirect re-run and a delegate's
+        // turn both count — an attempt's cost is what the attempt spent. This is
+        // a second *reader* of `turn_costs`, not a second writer: the ledger and
+        // the usage meter below stay the only places money is recorded.
+        if let Some(sink) = run_sink.as_ref() {
+            for turn_cost in &turn_costs {
+                sink.add_usage(turn_cost);
+            }
+        }
         // Attribute cost to the provider this turn actually resolved to. With a
         // per-tenant [`TenantProvider`](crate::harness::provider::TenantProvider)
         // a console BYOK switch changes the slug between turns, so read it live
@@ -2130,7 +2178,7 @@ description = "Builds the product."
         let control = SteerControl::new();
         control.request(SteerAction::Cancel);
         let (_outcome, usages) = agent
-            .run_with_steer("hi", Some(&control), None)
+            .run_with_steer("hi", Some(&control), None, None)
             .await
             .expect("runs");
         assert_eq!(

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1275,6 +1275,10 @@ impl HarnessPool {
                 company,
                 deps.store.as_ref(),
                 deps.meter.as_deref(),
+                // Issue #242: attribute the sample to the attempt this turn ran
+                // under, so "what did this run cost?" is answerable from the
+                // meter as well as from the run row.
+                run_sink.as_ref().map(|s| s.run_id()),
             )
             .await?;
         }
@@ -2810,6 +2814,7 @@ description = "Sets direction."
                     cached_input_tokens: 0,
                     cost_usd: 0.0,
                     kind: crate::ports::SampleKind::Inference,
+                    run_id: None,
                 },
             )
             .await
@@ -2965,6 +2970,7 @@ description = "Sets direction."
                     cached_input_tokens: 0,
                     cost_usd: 0.0,
                     kind: crate::ports::SampleKind::Inference,
+                    run_id: None,
                 },
             )
             .await
@@ -3078,6 +3084,7 @@ description = "Builds the product."
             cached_input_tokens: 0,
             cost_usd: usd,
             kind: crate::ports::SampleKind::Inference,
+            run_id: None,
         }
     }
 

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -509,7 +509,7 @@ fn summarize_event(event: &CompanyEvent) -> String {
     match event {
         CompanyEvent::OperatorMessage { .. } => "operator message".to_string(),
         CompanyEvent::AgentReply { agent_id, .. } => format!("reply from {agent_id}"),
-        CompanyEvent::TaskDispatched { task_id } => format!("task dispatched: {task_id}"),
+        CompanyEvent::TaskDispatched { task_id, .. } => format!("task dispatched: {task_id}"),
         CompanyEvent::ScheduleFired { cron, .. } => format!("schedule fired: {cron}"),
         CompanyEvent::WebhookReceived { channel, .. } => format!("webhook on {channel}"),
         CompanyEvent::A2aTaskReceived { from, .. } => format!("A2A task from {from}"),

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -1837,6 +1837,7 @@ mod tests {
             cached_input_tokens: 0,
             cost_usd: usd,
             kind: SampleKind::Inference,
+            run_id: None,
         }
     }
 

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -211,10 +211,34 @@ impl ApprovalRequestQueue {
         self.grants.clone()
     }
 
-    /// The number of queued requests (test/observability).
-    #[cfg(test)]
+    /// The number of queued requests.
+    ///
+    /// Read by a dispatched card **before** its turns run, so it can tell which
+    /// of the queue's entries are its own (issue #242) — the queue is shared
+    /// with the cycle's chat turns, and [`push`](Self::push) only ever appends,
+    /// so a position taken now stays a valid boundary until the cycle-end drain.
     pub fn queued(&self) -> usize {
         self.inner.lock().expect("approval request queue").len()
+    }
+
+    /// Stamps `run_id` onto every request queued at or after `from`, returning
+    /// how many were stamped (issue #242).
+    ///
+    /// This is where an approval learns which task attempt is waiting on it. It
+    /// happens at the **dispatch** boundary rather than in
+    /// [`ApprovalPolicy::effect_for`] because that is the only place the run is
+    /// unambiguous: the policy is per-agent and outlives every run, whereas a
+    /// dispatched card knows exactly which of the queue's entries its own turns
+    /// added. Requests below `from` belong to a chat turn earlier in the same
+    /// cycle and are deliberately left `None`.
+    pub fn stamp_run(&self, from: usize, run_id: &str) -> usize {
+        let mut guard = self.inner.lock().expect("approval request queue");
+        let mut stamped = 0;
+        for request in guard.iter_mut().skip(from) {
+            request.effect.run_id = Some(run_id.to_string());
+            stamped += 1;
+        }
+        stamped
     }
 }
 
@@ -376,6 +400,7 @@ impl ApprovalPolicy {
             first_time_counterparty: false,
             payload: args.clone(),
             agent: self.agent.clone(),
+            run_id: None,
         }
     }
 
@@ -1670,6 +1695,57 @@ mod tests {
                 .is_some(),
             "and the grant is still redeemable through a fresh handle"
         );
+    }
+
+    /// Issue #242: a dispatched card claims only the requests **its own** turns
+    /// added. The queue is shared with any chat turn earlier in the same cycle,
+    /// so stamping from position zero would tag somebody else's approval with
+    /// this run and make the card read as waiting on an approval it never
+    /// triggered.
+    #[test]
+    fn stamping_a_run_claims_only_the_requests_that_came_after_the_boundary() {
+        let queue = ApprovalRequestQueue::default();
+        let queued = |kind: &str| ApprovalRequest {
+            tool: kind.to_string(),
+            reason: "gated".to_string(),
+            effect: Effect {
+                kind: kind.to_string(),
+                group: EffectGroup::Other,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: serde_json::json!({ "kind": kind }),
+                agent: Some("ceo".to_string()),
+                run_id: None,
+            },
+        };
+
+        // A chat turn earlier in this cycle parked one…
+        queue.push(queued("chat.thing"));
+        // …and the dispatch takes its boundary here.
+        let boundary = queue.queued();
+        assert_eq!(boundary, 1);
+        queue.push(queued("dispatch.thing"));
+        queue.push(queued("dispatch.other"));
+
+        assert_eq!(queue.stamp_run(boundary, "run-1"), 2);
+
+        let drained = queue.drain(10);
+        assert_eq!(drained.len(), 3);
+        assert_eq!(
+            drained[0].effect.run_id, None,
+            "the chat turn's approval belongs to no attempt"
+        );
+        assert_eq!(drained[1].effect.run_id.as_deref(), Some("run-1"));
+        assert_eq!(drained[2].effect.run_id.as_deref(), Some("run-1"));
+    }
+
+    /// A dispatch that parked nothing stamps nothing — which is what keeps a
+    /// clean run reading as `Succeeded` rather than as waiting on a person.
+    #[test]
+    fn a_dispatch_that_parked_nothing_claims_nothing() {
+        let queue = ApprovalRequestQueue::default();
+        assert_eq!(queue.stamp_run(queue.queued(), "run-1"), 0);
     }
 
     /// A queue nobody installed stays inert — the default policy behaves exactly

--- a/src/harness/run_trace.rs
+++ b/src/harness/run_trace.rs
@@ -1,0 +1,384 @@
+//! [`RunTraceSink`]: the durable, *incremental* trace of one task attempt.
+//!
+//! A dispatched card's turn already produces everything a trace needs — the
+//! harness progress stream is drained live by the collector task in
+//! [`CompanyAgent::run_with_steer`](crate::harness::CompanyAgent::run_with_steer),
+//! which is where the console's live tool timeline is teed from. What was
+//! missing was somewhere durable to put it: the folded
+//! [`TurnStep`](crate::ports::types::TurnStep) list was handed back at the end
+//! of the turn and then discarded into the card's note, so killing the host
+//! mid-run left no evidence that any of it had happened.
+//!
+//! This sink hangs off that same seam and writes each step to the
+//! [`RunStore`] **as it happens** (issue #242). Kill the process mid-run and
+//! every step written so far survives — which is the property the issue exists
+//! to create, and the opposite of a batch-at-the-end trace that loses the whole
+//! run precisely when it is most interesting.
+//!
+//! ## Where the awaits happen
+//!
+//! Inside the collector task, never the model loop. The collector exists
+//! specifically so a burst of progress events cannot block the turn; adding a
+//! store write there means a slow store slows trace persistence and nothing
+//! else. The write amplification — one row per step, versus one event per turn
+//! before — is the explicit price of the feature, and it is affordable because
+//! cycles serialise per company.
+//!
+//! ## Nothing here may fail the turn
+//!
+//! Every write is best-effort and logged. The tokens are already spent and the
+//! agent's work is already done by the time a step is recorded; a full disk must
+//! not turn a completed turn into a failed one. Same invariant as the inference
+//! meter and the grant-consumption journal.
+//!
+//! Compiled only under `feature = "openhuman"`.
+
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+
+use openhuman_core::openhuman as oh;
+
+use oh::agent::progress::AgentProgress;
+
+use crate::harness::cost::TurnUsage;
+use crate::harness::steps::StepTrace;
+use crate::ports::RunStore;
+use crate::ports::now_millis;
+use crate::ports::runs::RunStepRecord;
+use crate::ports::types::{CompanyId, TokenUsage};
+
+/// The most steps one attempt persists.
+///
+/// A bound, not a design constraint: a runaway tool loop must not write an
+/// unbounded number of rows for a single card. Deliberately far above the
+/// chat-timeline cap (`steps::MAX_STEPS`, 50) — that one exists to keep a
+/// bubble readable, this one only to keep a pathological run from filling a
+/// store — so a normal long-running attempt keeps its trace in full.
+pub const MAX_RUN_STEPS: u32 = 500;
+
+/// Collects one attempt's step trace and cost, writing steps through as they
+/// happen.
+///
+/// **Run-scoped, not turn-scoped.** One sink spans every turn of the attempt —
+/// the redirect re-runs and any delegate's turn — so ordinals stay dense across
+/// the run and a later turn cannot overwrite an earlier one's rows (the store
+/// keys steps on `(run_id, step_seq)`).
+pub struct RunTraceSink {
+    company: CompanyId,
+    run_id: String,
+    runs: Arc<dyn RunStore>,
+    /// The incremental projection. Behind a `std` mutex because it is touched
+    /// from the collector task and never held across an await.
+    trace: StdMutex<StepTrace>,
+    /// Tokens/cost folded across the attempt's turns.
+    usage: StdMutex<TokenUsage>,
+    /// How many step rows were actually written.
+    persisted: StdMutex<u32>,
+}
+
+impl RunTraceSink {
+    /// Opens a sink for `run_id` in `company`.
+    pub fn new(company: CompanyId, run_id: impl Into<String>, runs: Arc<dyn RunStore>) -> Self {
+        Self {
+            company,
+            run_id: run_id.into(),
+            runs,
+            trace: StdMutex::new(StepTrace::default()),
+            usage: StdMutex::new(TokenUsage::default()),
+            persisted: StdMutex::new(0),
+        }
+    }
+
+    /// The attempt this sink is tracing.
+    pub fn run_id(&self) -> &str {
+        &self.run_id
+    }
+
+    /// Records one live progress event, persisting the step it maps to (if any).
+    ///
+    /// A start writes a `Running` row; its completion re-writes the *same*
+    /// ordinal finalized, because `append_run_step` replaces on a matching
+    /// `step_seq`. An event that maps to no step is a no-op.
+    pub async fn record(&self, event: &AgentProgress) {
+        let Some((step_seq, step)) = self
+            .trace
+            .lock()
+            .expect("run trace")
+            // The lock is released before the await below — a store write must
+            // never be held across the mutex the collector re-enters per event.
+            .push(event)
+        else {
+            return;
+        };
+        if step_seq >= MAX_RUN_STEPS {
+            return;
+        }
+        let record = RunStepRecord {
+            run_id: self.run_id.clone(),
+            step_seq,
+            at_millis: now_millis(),
+            step,
+        };
+        match self.runs.append_run_step(&self.company, &record).await {
+            Ok(()) => {
+                let mut persisted = self.persisted.lock().expect("run trace count");
+                // A finalized start rewrites its own row rather than adding one,
+                // so the count is the high-water ordinal, not the write count.
+                *persisted = (*persisted).max(step_seq + 1);
+            }
+            Err(err) => tracing::warn!(
+                company = %self.company,
+                run = %self.run_id,
+                step_seq,
+                error = %err,
+                "[runs] could not persist a step of an attempt's trace; the turn continues"
+            ),
+        }
+    }
+
+    /// Folds one turn's token/cost totals into the attempt's.
+    ///
+    /// Called per turn rather than once at the end so a redirect re-run and a
+    /// delegate's turn both count — an attempt's cost is what the *attempt*
+    /// spent, not what its last turn did.
+    pub fn add_usage(&self, turn: &TurnUsage) {
+        let mut usage = self.usage.lock().expect("run usage");
+        usage.input = usage.input.saturating_add(turn.input_tokens);
+        usage.output = usage.output.saturating_add(turn.output_tokens);
+        usage.cached_input = usage.cached_input.saturating_add(turn.cached_input_tokens);
+        usage.cost_usd += turn.cost_usd;
+    }
+
+    /// The attempt's folded token/cost totals.
+    ///
+    /// Tokens are recorded even when the cost is zero: the managed `/openai/v1`
+    /// passthrough bills backend-side and echoes no USD, so gating on cost would
+    /// make every managed attempt read as having consumed nothing.
+    pub fn usage(&self) -> TokenUsage {
+        *self.usage.lock().expect("run usage")
+    }
+
+    /// How many step rows the attempt has written.
+    pub fn step_count(&self) -> u32 {
+        *self.persisted.lock().expect("run trace count")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::ports::runs::{NewRun, RunFilter};
+    use crate::ports::types::{TurnStepKind, TurnStepStatus};
+    use crate::store::FsOps;
+
+    fn started(call_id: &str, tool: &str, label: Option<&str>) -> AgentProgress {
+        AgentProgress::ToolCallStarted {
+            call_id: call_id.to_string(),
+            tool_name: tool.to_string(),
+            arguments: serde_json::Value::Null,
+            iteration: 1,
+            display_label: label.map(str::to_string),
+            display_detail: None,
+        }
+    }
+
+    fn completed(call_id: &str, tool: &str) -> AgentProgress {
+        AgentProgress::ToolCallCompleted {
+            call_id: call_id.to_string(),
+            tool_name: tool.to_string(),
+            success: true,
+            output_chars: 2,
+            output: "ok".to_string(),
+            arguments: Some(serde_json::json!({ "server": "brave", "tool": "search" })),
+            elapsed_ms: 42,
+            iteration: 1,
+            failure: None,
+        }
+    }
+
+    /// Builds an fs-backed run store with one `Pending` run, and returns the
+    /// sink over it.
+    async fn sink(home: &std::path::Path) -> (Arc<dyn RunStore>, CompanyId, RunTraceSink) {
+        let company = CompanyId::new("acme");
+        let runs: Arc<dyn RunStore> = Arc::new(FsOps::new(home.to_path_buf()));
+        let run = runs
+            .create_run(
+                &company,
+                NewRun {
+                    id: "run-1".to_string(),
+                    task_id: "t-1".to_string(),
+                    agent_id: "ceo".to_string(),
+                },
+            )
+            .await
+            .expect("mint");
+        let sink = RunTraceSink::new(company.clone(), run.id, Arc::clone(&runs));
+        (runs, company, sink)
+    }
+
+    /// The property the whole feature exists for: steps are durable **during**
+    /// the run, so a host killed mid-tool-call still leaves the prefix behind.
+    #[tokio::test]
+    async fn steps_land_while_the_turn_is_still_running() {
+        let home = tempfile::Builder::new()
+            .prefix("opencompany-run-trace-")
+            .tempdir()
+            .expect("tempdir");
+        let (runs, company, sink) = sink(home.path()).await;
+
+        sink.record(&started("c1", "mcp_call_tool", Some("Searching")))
+            .await;
+
+        // Read it back BEFORE the turn ends — nothing has been folded yet.
+        let steps = runs
+            .list_run_steps(&company, "run-1")
+            .await
+            .expect("list steps");
+        assert_eq!(steps.len(), 1, "the step is durable mid-turn");
+        assert_eq!(steps[0].step_seq, 0);
+        assert_eq!(steps[0].step.status, TurnStepStatus::Running);
+        assert_eq!(steps[0].step.label, "Searching");
+        assert_eq!(sink.step_count(), 1);
+
+        // …and the completion finalizes that same row rather than adding one.
+        sink.record(&completed("c1", "mcp_call_tool")).await;
+        let steps = runs
+            .list_run_steps(&company, "run-1")
+            .await
+            .expect("list steps");
+        assert_eq!(steps.len(), 1, "a finalized start must not duplicate");
+        assert_eq!(steps[0].step.status, TurnStepStatus::Ok);
+        assert_eq!(steps[0].step.detail.as_deref(), Some("brave · search"));
+        assert_eq!(steps[0].step.kind, TurnStepKind::ToolCall);
+        assert_eq!(sink.step_count(), 1);
+    }
+
+    /// Cost folds across every turn of the attempt, and tokens are recorded even
+    /// at zero USD (the managed passthrough bills off the wire).
+    #[test]
+    fn usage_folds_across_turns_including_token_only_ones() {
+        // Never written to — this test only exercises the in-memory fold.
+        let runs: Arc<dyn RunStore> = Arc::new(FsOps::new(std::path::PathBuf::from("unused")));
+        let sink = RunTraceSink::new(CompanyId::new("acme"), "run-1", runs);
+        assert_eq!(sink.usage(), TokenUsage::default());
+
+        sink.add_usage(&TurnUsage {
+            input_tokens: 100,
+            output_tokens: 20,
+            cached_input_tokens: 5,
+            cost_usd: 0.25,
+        });
+        sink.add_usage(&TurnUsage {
+            input_tokens: 10,
+            output_tokens: 2,
+            cached_input_tokens: 0,
+            cost_usd: 0.0,
+        });
+
+        let usage = sink.usage();
+        assert_eq!(usage.input, 110);
+        assert_eq!(usage.output, 22);
+        assert_eq!(usage.cached_input, 5);
+        assert_eq!(usage.cost_usd, 0.25);
+    }
+
+    /// A store that cannot take a step must not be able to fail the turn — the
+    /// agent's work is already done by the time a step is recorded.
+    #[tokio::test]
+    async fn a_store_failure_never_reaches_the_turn() {
+        use async_trait::async_trait;
+
+        use crate::error::OpenCompanyError;
+        use crate::ports::runs::{RunRecord, RunStatus};
+
+        struct BrokenRuns;
+
+        #[async_trait]
+        impl RunStore for BrokenRuns {
+            async fn create_run(
+                &self,
+                company: &CompanyId,
+                spec: NewRun,
+            ) -> crate::Result<RunRecord> {
+                Ok(RunRecord {
+                    id: spec.id,
+                    company: company.clone(),
+                    task_id: spec.task_id,
+                    agent_id: spec.agent_id,
+                    attempt: 1,
+                    status: RunStatus::Pending,
+                    trigger_event_seq: None,
+                    created_at_millis: 0,
+                    started_at_millis: None,
+                    finished_at_millis: None,
+                    error: None,
+                    usage: TokenUsage::default(),
+                    step_count: 0,
+                })
+            }
+            async fn get_run(
+                &self,
+                _company: &CompanyId,
+                _id: &str,
+            ) -> crate::Result<Option<RunRecord>> {
+                Ok(None)
+            }
+            async fn put_run(&self, _company: &CompanyId, _run: &RunRecord) -> crate::Result<()> {
+                Ok(())
+            }
+            async fn list_runs(
+                &self,
+                _company: &CompanyId,
+                _filter: &RunFilter,
+            ) -> crate::Result<Vec<RunRecord>> {
+                Ok(Vec::new())
+            }
+            async fn append_run_step(
+                &self,
+                _company: &CompanyId,
+                _step: &RunStepRecord,
+            ) -> crate::Result<()> {
+                Err(OpenCompanyError::Store("disk on fire".to_string()))
+            }
+            async fn list_run_steps(
+                &self,
+                _company: &CompanyId,
+                _run_id: &str,
+            ) -> crate::Result<Vec<RunStepRecord>> {
+                Ok(Vec::new())
+            }
+        }
+
+        let sink = RunTraceSink::new(CompanyId::new("acme"), "run-1", Arc::new(BrokenRuns));
+        // No panic, no propagation — and the count stays honest about what
+        // actually landed.
+        sink.record(&started("c1", "mcp_call_tool", None)).await;
+        assert_eq!(sink.step_count(), 0);
+    }
+
+    /// A runaway tool loop is bounded: past the cap nothing more is written, and
+    /// the reported count stops at the cap rather than claiming rows that do not
+    /// exist.
+    #[tokio::test]
+    async fn a_runaway_turn_stops_writing_at_the_cap() {
+        let home = tempfile::Builder::new()
+            .prefix("opencompany-run-trace-cap-")
+            .tempdir()
+            .expect("tempdir");
+        let (runs, company, sink) = sink(home.path()).await;
+
+        for i in 0..(MAX_RUN_STEPS + 5) {
+            sink.record(&started(&format!("c{i}"), "spawn_task", None))
+                .await;
+        }
+        assert_eq!(sink.step_count(), MAX_RUN_STEPS);
+        assert_eq!(
+            runs.list_run_steps(&company, "run-1")
+                .await
+                .expect("list")
+                .len() as u32,
+            MAX_RUN_STEPS
+        );
+    }
+}

--- a/src/harness/run_turn.rs
+++ b/src/harness/run_turn.rs
@@ -9,10 +9,13 @@
 //!
 //! Compiled only under `feature = "openhuman"`.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::Result;
 use crate::company::steer::SteerControl;
+use crate::harness::run_trace::RunTraceSink;
 use crate::harness::{HarnessDeps, HarnessPool, TurnOutcome};
 use crate::ports::types::CompanyId;
 use crate::runtime::delegation::RunTurn;
@@ -51,9 +54,12 @@ impl RunTurn for HarnessRunTurn<'_> {
         message: &str,
         control: &SteerControl,
         chat_id: Option<&str>,
+        run_sink: Option<Arc<RunTraceSink>>,
     ) -> Result<TurnOutcome> {
         self.pool
-            .run_steered(company, agent_id, message, self.deps, control, chat_id)
+            .run_steered(
+                company, agent_id, message, self.deps, control, chat_id, run_sink,
+            )
             .await
     }
 
@@ -63,9 +69,10 @@ impl RunTurn for HarnessRunTurn<'_> {
         agent_id: &str,
         message: &str,
         control: &SteerControl,
+        run_sink: Option<Arc<RunTraceSink>>,
     ) -> Result<TurnOutcome> {
         self.pool
-            .run_steered_background(company, agent_id, message, self.deps, control)
+            .run_steered_background(company, agent_id, message, self.deps, control, run_sink)
             .await
     }
 }

--- a/src/harness/steps.rs
+++ b/src/harness/steps.rs
@@ -201,12 +201,22 @@ pub fn fold_steps(events: Vec<AgentProgress>) -> Vec<TurnStep> {
 ///
 /// Materialize every yield in ordinal order and the result is byte-identical to
 /// `fold_steps` over the same event stream (pinned by
-/// `incremental_trace_converges_on_the_folded_timeline`), with one deliberate
-/// exception: a start whose completion never arrives — because the process died
-/// mid-tool-call — stays persisted as `Running`. That is not a divergence to
-/// paper over, it is the whole point: the persisted trace records what was
-/// actually observed, and "this tool call was still in flight" is the truth
-/// about a killed run.
+/// `incremental_trace_converges_on_the_folded_timeline`), with **two** deliberate
+/// exceptions:
+///
+/// * **An unfinished call.** A start whose completion never arrives — because
+///   the process died mid-tool-call — stays persisted as `Running`. That is not
+///   a divergence to paper over, it is the whole point: the persisted trace
+///   records what was actually observed, and "this tool call was still in
+///   flight" is the truth about a killed run.
+/// * **Past 50 steps, the two lengths part.** `fold_steps` truncates at
+///   [`MAX_STEPS`] and appends an omission note, because it builds a chat bubble
+///   and a bubble that scrolls forever is unreadable. The trace has no such
+///   limit here; [`run_trace::MAX_RUN_STEPS`](super::run_trace::MAX_RUN_STEPS)
+///   bounds what is persisted, an order of magnitude higher. A record of what an
+///   attempt did should not be truncated at the length a *message* wants to be.
+///   Note that the convergence test runs a handful of events, so it pins the
+///   shared prefix, not this boundary.
 ///
 /// **Run-scoped, not turn-scoped.** One instance spans every turn of an
 /// attempt — the redirect re-runs and a delegate's turn — so ordinals stay

--- a/src/harness/steps.rs
+++ b/src/harness/steps.rs
@@ -180,6 +180,153 @@ pub fn fold_steps(events: Vec<AgentProgress>) -> Vec<TurnStep> {
     steps
 }
 
+/// The incremental counterpart of [`fold_steps`]: the same projection, but
+/// yielding each step **as it happens** with the ordinal it occupies, so a
+/// durable trace can be written during the turn instead of only at its end
+/// (issue #242).
+///
+/// The difference that matters is *when*, not *what*. [`fold_steps`] can only
+/// produce anything once the turn is over, which is why killing the host
+/// mid-run used to leave no trace at all. This yields:
+///
+/// * a `ToolCallStarted` → a new ordinal carrying a
+///   [`Running`](TurnStepStatus::Running) step;
+/// * its matching `ToolCallCompleted` → **the same ordinal again**, finalized.
+///   `RunStore::append_run_step` is keyed on `(run_id, step_seq)` and replaces
+///   on a match, so re-yielding the ordinal finalizes the row in place exactly
+///   as `fold_steps` finalizes the entry in place;
+/// * a completion with no observed start → its own new ordinal, standalone;
+/// * the first `ThinkingDelta` of a run → one coalesced "Thinking" ordinal,
+///   with consecutive deltas yielding nothing.
+///
+/// Materialize every yield in ordinal order and the result is byte-identical to
+/// `fold_steps` over the same event stream (pinned by
+/// `incremental_trace_converges_on_the_folded_timeline`), with one deliberate
+/// exception: a start whose completion never arrives — because the process died
+/// mid-tool-call — stays persisted as `Running`. That is not a divergence to
+/// paper over, it is the whole point: the persisted trace records what was
+/// actually observed, and "this tool call was still in flight" is the truth
+/// about a killed run.
+///
+/// **Run-scoped, not turn-scoped.** One instance spans every turn of an
+/// attempt — the redirect re-runs and a delegate's turn — so ordinals stay
+/// dense and unique across the run rather than restarting per turn and
+/// overwriting earlier rows.
+#[derive(Debug, Default)]
+pub(crate) struct StepTrace {
+    /// The next ordinal to hand out. Also the number of steps yielded so far.
+    next: u32,
+    /// `call_id` → the ordinal and label its start claimed, so the completion
+    /// finalizes that row keeping the richer start-time label.
+    running: std::collections::HashMap<String, (u32, String)>,
+    /// Whether the most recent step is an open "Thinking" run.
+    thinking_open: bool,
+}
+
+impl StepTrace {
+    /// Feeds one progress event, yielding the ordinal + step to persist when the
+    /// event maps to one.
+    pub(crate) fn push(&mut self, event: &AgentProgress) -> Option<(u32, TurnStep)> {
+        match event {
+            AgentProgress::ToolCallStarted {
+                call_id,
+                tool_name,
+                display_label,
+                ..
+            } => {
+                self.thinking_open = false;
+                let label = label_for(display_label.clone(), tool_name);
+                let seq = self.claim();
+                self.running.insert(call_id.clone(), (seq, label.clone()));
+                Some((
+                    seq,
+                    TurnStep {
+                        kind: TurnStepKind::ToolCall,
+                        status: TurnStepStatus::Running,
+                        label,
+                        detail: None,
+                        elapsed_ms: None,
+                    },
+                ))
+            }
+            AgentProgress::ToolCallCompleted {
+                call_id,
+                tool_name,
+                success,
+                output,
+                arguments,
+                elapsed_ms,
+                failure,
+                ..
+            } => {
+                self.thinking_open = false;
+                let status = if *success {
+                    TurnStepStatus::Ok
+                } else {
+                    TurnStepStatus::Error
+                };
+                let detail = if *success {
+                    enrich_detail(tool_name, arguments.as_ref())
+                } else {
+                    error_detail(failure.as_ref(), output, tool_name)
+                };
+                let (seq, label) = match self.running.remove(call_id) {
+                    Some(found) => found,
+                    // No observed start — surface it standalone, exactly as the
+                    // fold does.
+                    None => (self.claim(), humanize(tool_name)),
+                };
+                Some((
+                    seq,
+                    TurnStep {
+                        kind: TurnStepKind::ToolCall,
+                        status,
+                        label,
+                        detail,
+                        elapsed_ms: Some(*elapsed_ms),
+                    },
+                ))
+            }
+            AgentProgress::ThinkingDelta { .. } if !self.thinking_open => {
+                self.thinking_open = true;
+                Some((
+                    self.claim(),
+                    TurnStep {
+                        kind: TurnStepKind::Thinking,
+                        status: TurnStepStatus::Ok,
+                        label: "Thinking".to_string(),
+                        detail: None,
+                        elapsed_ms: None,
+                    },
+                ))
+            }
+            // Visible assistant text closes a thinking run without a step of its
+            // own; everything else contributes nothing and does not break the
+            // coalescing. Both match `fold_steps`.
+            AgentProgress::TextDelta { .. } => {
+                self.thinking_open = false;
+                None
+            }
+            _ => None,
+        }
+    }
+
+    /// How many ordinals have been handed out. Test-only: the sink tracks what
+    /// actually landed in the store, which is not the same number when a write
+    /// fails or the cap bites.
+    #[cfg(test)]
+    pub(crate) fn emitted(&self) -> u32 {
+        self.next
+    }
+
+    /// Takes the next ordinal.
+    fn claim(&mut self) -> u32 {
+        let seq = self.next;
+        self.next = self.next.saturating_add(1);
+        seq
+    }
+}
+
 /// Map one live [`AgentProgress`] event to a scrubbed [`TurnStreamEvent`] for
 /// the transient [`turn_stream`](crate::turn_stream) bus, or `None` for events
 /// with no operator-facing live frame (text/thinking/args deltas, iteration and
@@ -724,6 +871,103 @@ mod tests {
             !detail.contains(SECRET),
             "remote output must never surface as detail: {detail}"
         );
+    }
+
+    /// Materializes a [`StepTrace`] over `events` the way the run store does:
+    /// each yield writes to its ordinal, replacing whatever was there.
+    fn materialize(events: &[AgentProgress]) -> Vec<TurnStep> {
+        let mut trace = StepTrace::default();
+        let mut rows: Vec<Option<TurnStep>> = Vec::new();
+        for event in events {
+            if let Some((seq, step)) = trace.push(event) {
+                let idx = seq as usize;
+                if rows.len() <= idx {
+                    rows.resize(idx + 1, None);
+                }
+                rows[idx] = Some(step);
+            }
+        }
+        assert_eq!(
+            rows.len() as u32,
+            trace.emitted(),
+            "ordinals must be dense — a gap means a row nothing ever writes"
+        );
+        rows.into_iter()
+            .map(|row| row.expect("every claimed ordinal is written"))
+            .collect()
+    }
+
+    /// Issue #242: the incremental trace and the final fold are the SAME
+    /// timeline. If they can drift, the persisted run trace and the chat bubble
+    /// tell an operator two different stories about one turn — which is exactly
+    /// the failure the shared scrubbing helpers exist to prevent.
+    #[test]
+    fn incremental_trace_converges_on_the_folded_timeline() {
+        let events = vec![
+            thinking("hmm"),
+            thinking("still hmm"),
+            started("c1", "mcp_call_tool", Some("Searching the web")),
+            completed(
+                "c1",
+                "mcp_call_tool",
+                true,
+                "ok",
+                Some(serde_json::json!({ "server": "brave", "tool": "search" })),
+                None,
+            ),
+            text("here you go"),
+            thinking("again"),
+            started("c2", "spawn_task", None),
+            completed(
+                "c2",
+                "spawn_task",
+                false,
+                "boom",
+                None,
+                Some(classified(ToolFailureClass::Timeout, "it timed out")),
+            ),
+            // A completion whose start was never observed — the standalone arm.
+            completed("c3", "query_company", true, "ok", None, None),
+        ];
+
+        assert_eq!(materialize(&events), fold_steps(events.clone()));
+    }
+
+    /// The one deliberate divergence, stated as a property rather than left to
+    /// be discovered: a tool call still in flight when the stream ends is
+    /// persisted `Running`. The fold agrees here (it also leaves an unmatched
+    /// start running), and that is what makes a killed run's partial trace
+    /// honest instead of fabricated.
+    #[test]
+    fn an_unfinished_tool_call_is_persisted_as_running() {
+        let events = vec![
+            started("c1", "mcp_call_tool", Some("Searching the web")),
+            // …and the host dies here.
+        ];
+        let rows = materialize(&events);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].status, TurnStepStatus::Running);
+        assert_eq!(rows[0].label, "Searching the web");
+        assert_eq!(rows, fold_steps(events));
+    }
+
+    /// Ordinals are run-scoped, not turn-scoped: a second turn on the same
+    /// trace continues where the first stopped. Restarting per turn would make
+    /// turn 2 overwrite turn 1's rows, since the store keys on
+    /// `(run_id, step_seq)`.
+    #[test]
+    fn ordinals_continue_across_turns_of_one_run() {
+        let mut trace = StepTrace::default();
+        let first = trace
+            .push(&started("c1", "spawn_task", None))
+            .expect("turn 1 step");
+        assert_eq!(first.0, 0);
+        // …turn 1 ends, turn 2 begins on the same run.
+        let second = trace
+            .push(&started("c9", "spawn_task", None))
+            .expect("turn 2 step");
+        assert_eq!(second.0, 1, "turn 2 must not reuse turn 1's ordinals");
+        assert_eq!(trace.emitted(), 2);
     }
 
     /// `stream_event_from` (the live-bus counterpart of `fold_steps`) maps a

--- a/src/metering/capability.rs
+++ b/src/metering/capability.rs
@@ -298,6 +298,7 @@ mod tests {
             cached_input_tokens: 0,
             cost_usd: 0.0,
             kind: SampleKind::Inference,
+            run_id: None,
         }
     }
 
@@ -311,6 +312,7 @@ mod tests {
             cached_input_tokens: 0,
             cost_usd: 0.0,
             kind: SampleKind::OauthCall,
+            run_id: None,
         }
     }
 

--- a/src/metering/daily_budget.rs
+++ b/src/metering/daily_budget.rs
@@ -135,6 +135,7 @@ mod tests {
             cached_input_tokens: 0,
             cost_usd: cost,
             kind,
+            run_id: None,
         }
     }
 

--- a/src/metering/inference.rs
+++ b/src/metering/inference.rs
@@ -92,6 +92,7 @@ pub fn inference_sample(usage: &TokenUsage, agent: &str, provider: &str) -> Opti
         cached_input_tokens: usage.cached_input,
         cost_usd: usage.cost_usd,
         kind: SampleKind::Inference,
+        run_id: None,
     })
 }
 

--- a/src/metering/oauth.rs
+++ b/src/metering/oauth.rs
@@ -61,6 +61,7 @@ pub fn oauth_call_sample(agent: &str, provider: &str, at_millis: u64) -> UsageSa
         cached_input_tokens: 0,
         cost_usd: 0.0,
         kind: SampleKind::OauthCall,
+        run_id: None,
     }
 }
 

--- a/src/metering/search.rs
+++ b/src/metering/search.rs
@@ -91,6 +91,7 @@ pub fn search_call_sample(
         cached_input_tokens: 0,
         cost_usd: attributed_cost_usd(reported_cost_usd),
         kind: SampleKind::SearchCall,
+        run_id: None,
     }
 }
 

--- a/src/metering/usage.rs
+++ b/src/metering/usage.rs
@@ -150,6 +150,7 @@ mod tests {
             cached_input_tokens: 0,
             cost_usd: cost,
             kind: SampleKind::Inference,
+            run_id: None,
         }
     }
 
@@ -163,6 +164,7 @@ mod tests {
             cached_input_tokens: 0,
             cost_usd: 0.0,
             kind: SampleKind::OauthCall,
+            run_id: None,
         }
     }
 

--- a/src/policy/gate.rs
+++ b/src/policy/gate.rs
@@ -337,6 +337,7 @@ mod test {
             first_time_counterparty: false,
             payload: serde_json::Value::Null,
             agent: None,
+            run_id: None,
         }
     }
 

--- a/src/ports/artifacts.rs
+++ b/src/ports/artifacts.rs
@@ -95,6 +95,24 @@ pub struct ArtifactVersion {
     /// Why this revision exists (e.g. `"operator edit before approval"`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
+    /// The task **attempt** ([`RunRecord`](crate::ports::runs::RunRecord)) that
+    /// produced this revision, when an agent turn under one did (issue #242).
+    ///
+    /// Per *version*, not per record, because that is the granularity the
+    /// question has: a card dispatched twice produces v1 under the first attempt
+    /// and v2 under the second, and a record-level field would remember only the
+    /// later one — losing the link the first attempt's row needs to point at
+    /// what it actually wrote. The record-level answer is still available as
+    /// `latest().run_id`.
+    ///
+    /// `None` for an operator edit (no attempt produced it), for a revision
+    /// written by an untracked dispatch, and for every artifact stored before
+    /// this field existed. Artifacts are persisted as a JSON blob on every
+    /// backend (`artifact_json` on sqlite, a document on MongoDB, a file on the
+    /// filesystem), so this needs **no schema migration** and a pre-#242 record
+    /// loads with `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
 }
 
 /// A versioned output of one task.
@@ -144,6 +162,7 @@ impl ArtifactRecord {
                 created_at_millis: at_millis,
                 step_seq: None,
                 note: None,
+                run_id: None,
             }],
             created_at_millis: at_millis,
             updated_at_millis: at_millis,
@@ -183,9 +202,23 @@ impl ArtifactRecord {
             created_at_millis: at_millis,
             step_seq: None,
             note,
+            run_id: None,
         });
         self.updated_at_millis = at_millis;
         next
+    }
+
+    /// Stamps the newest revision with the attempt that produced it (#242).
+    ///
+    /// A separate call rather than a sixth parameter on
+    /// [`push_version`](Self::push_version) / [`new`](Self::new): only the
+    /// dispatch path has a run to name, and widening those signatures would make
+    /// every operator-edit and test call site pass a `None` it has no meaning
+    /// for. A no-op on an empty record.
+    pub fn stamp_run(&mut self, run_id: impl Into<String>) {
+        if let Some(latest) = self.versions.last_mut() {
+            latest.run_id = Some(run_id.into());
+        }
     }
 
     /// The diff of what a human changed before approving: the last
@@ -390,7 +423,55 @@ mod test {
             created_at_millis: n as u64,
             step_seq: None,
             note: None,
+            run_id: None,
         }
+    }
+
+    /// Issue #242: the attempt that wrote a revision is recorded **on that
+    /// revision**, so a card dispatched twice keeps both links rather than the
+    /// second attempt erasing the first's. And because artifacts are stored as a
+    /// JSON blob on every backend, a record written before the field existed
+    /// loads with `None` — no schema migration, no backfill.
+    #[test]
+    fn each_revision_remembers_the_attempt_that_wrote_it() {
+        let mut a = ArtifactRecord::new("a1", "t-1", "Draft", ArtifactKind::Text, "one", "ceo", 1);
+        a.stamp_run("run-1");
+        a.push_version("two", ArtifactAuthor::Agent, "ceo", 2, None);
+        a.stamp_run("run-2");
+        // An operator edit names no attempt — nobody's run produced it.
+        a.push_version("three", ArtifactAuthor::Operator, "operator", 3, None);
+
+        assert_eq!(a.version(1).unwrap().run_id.as_deref(), Some("run-1"));
+        assert_eq!(
+            a.version(2).unwrap().run_id.as_deref(),
+            Some("run-2"),
+            "the second attempt must not overwrite the first attempt's link"
+        );
+        assert_eq!(a.version(3).unwrap().run_id, None);
+
+        let json = serde_json::to_string(&a).expect("serialize");
+        assert_eq!(a, serde_json::from_str(&json).expect("round trip"));
+        assert!(json.contains(r#""runId":"run-1""#), "{json}");
+
+        // A pre-#242 blob is exactly what an unstamped record serializes to —
+        // the field is skipped when absent — so it must still load, with `None`.
+        let unstamped =
+            ArtifactRecord::new("a2", "t-1", "Draft", ArtifactKind::Text, "one", "ceo", 1);
+        let legacy = serde_json::to_string(&unstamped).expect("serialize");
+        assert!(!legacy.contains("runId"), "{legacy}");
+        let loaded: ArtifactRecord =
+            serde_json::from_str(&legacy).expect("a pre-#242 artifact blob must still load");
+        assert!(loaded.versions.iter().all(|v| v.run_id.is_none()));
+    }
+
+    /// Stamping an artifact with no revisions is a no-op rather than a panic —
+    /// the accessors already tolerate an empty record, and so must this.
+    #[test]
+    fn stamping_an_empty_record_is_a_no_op() {
+        let mut a = ArtifactRecord::new("a1", "t-1", "Draft", ArtifactKind::Text, "one", "ceo", 1);
+        a.versions.clear();
+        a.stamp_run("run-1");
+        assert!(a.versions.is_empty());
     }
 
     #[test]

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -655,6 +655,26 @@ pub struct Effect {
     /// to parse.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,
+    /// The task **attempt** ([`RunRecord`](crate::ports::runs::RunRecord)) whose
+    /// turn produced this effect, when it was produced inside one at all (issue
+    /// #242).
+    ///
+    /// This is the correlation an approval needs to be answerable *about a
+    /// run*: the approvals queue is company-wide, so without it "which attempt
+    /// is waiting on me?" cannot be asked, and an attempt cannot tell whether it
+    /// parked anything of its own.
+    ///
+    /// Stamped at the **dispatch** boundary, not in
+    /// [`ApprovalPolicy::effect_for`](crate::harness::policy::ApprovalPolicy::effect_for):
+    /// the policy is per-agent and outlives any one run, so it has no run
+    /// context to stamp. An effect a *chat* turn parked therefore stays `None`,
+    /// correctly — no attempt is waiting on it.
+    ///
+    /// Skipped when serializing and defaulted when absent, exactly like
+    /// [`agent`](Self::agent), so journal lines written before this field
+    /// existed replay as `None` rather than failing to parse.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
 }
 
 impl Effect {
@@ -2172,6 +2192,7 @@ mod test {
             first_time_counterparty: false,
             payload: serde_json::json!({"to": "@vendor"}),
             agent: None,
+            run_id: None,
         };
         let back = round_trip(&effect);
         assert_eq!(back, effect);
@@ -2727,6 +2748,47 @@ mod test {
             let again = serde_json::to_string(&event).expect("serialize");
             assert_eq!(again, line, "pre-#228 line must re-serialize unchanged");
         }
+    }
+
+    /// Issue #242: an effect remembers which task attempt produced it, and the
+    /// field is additive in the same way `Effect::agent` was — a journal line
+    /// written before it existed replays as `None` (no run correlation, the
+    /// pre-#242 behaviour) rather than failing to parse and taking the whole
+    /// approval queue down with it on replay.
+    #[test]
+    fn effect_run_id_round_trips_and_a_legacy_line_replays_as_none() {
+        let mut effect = Effect {
+            kind: "composio.execute".to_string(),
+            group: EffectGroup::Other,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::json!({ "tool": "GMAIL_SEND_EMAIL" }),
+            agent: Some("finance".to_string()),
+            run_id: None,
+        };
+        let untagged = serde_json::to_string(&effect).expect("serialize");
+        assert!(
+            !untagged.contains("run_id"),
+            "an untagged effect's wire form must be unchanged: {untagged}"
+        );
+
+        effect.run_id = Some("run-7".to_string());
+        let tagged = serde_json::to_string(&effect).expect("serialize");
+        assert!(tagged.contains(r#""run_id":"run-7""#), "{tagged}");
+        assert_eq!(
+            effect,
+            serde_json::from_str::<Effect>(&tagged).expect("round trip")
+        );
+
+        // The pre-#242 line: same bytes, no field.
+        let legacy: Effect = serde_json::from_str(&untagged).expect("legacy effect must load");
+        assert_eq!(legacy.run_id, None);
+        assert_eq!(
+            legacy.agent.as_deref(),
+            Some("finance"),
+            "the earlier additive field must still be read alongside the new one"
+        );
     }
 
     /// Issue #242: the run id rides the dispatch event, and it is additive in

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -343,6 +343,27 @@ pub enum CompanyEvent {
     TaskDispatched {
         /// The id of the dispatched task card.
         task_id: String,
+        /// The [`RunRecord`](crate::ports::runs::RunRecord) this dispatch is an
+        /// attempt under (issue #242), minted at the dispatch choke point
+        /// *before* the cycle is spawned.
+        ///
+        /// Carrying it on the event is what makes the journal self-describing:
+        /// the run row and the durable log line name each other, so a reader
+        /// holding either one can find the other without re-deriving identity
+        /// from timestamps. It also keeps
+        /// [`Brain::run_cycle`](crate::ports::brain::Brain::run_cycle)'s
+        /// signature stable — the id rides the event the brain already reads
+        /// rather than a new argument every brain would have to thread.
+        ///
+        /// `None` for a dispatch whose run row could not be minted (record-keeping
+        /// never fails the work it records) and for every event journaled before
+        /// this field existed. Additive in exactly the way
+        /// [`AgentReply`](Self::AgentReply)'s `task_id` is: `#[serde(default)]`
+        /// lets an already-persisted log load, and `skip_serializing_if` keeps an
+        /// untagged dispatch serializing byte-for-byte as it did before, so no
+        /// stored record needs migrating.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        run_id: Option<String>,
     },
     /// An agent's MCP tool call failed during a turn, journaled by the harness
     /// so the operator has an audit trail of which server/tool broke and why.
@@ -2706,6 +2727,38 @@ mod test {
             let again = serde_json::to_string(&event).expect("serialize");
             assert_eq!(again, line, "pre-#228 line must re-serialize unchanged");
         }
+    }
+
+    /// Issue #242: the run id rides the dispatch event, and it is additive in
+    /// both directions — a tagged dispatch round-trips it, and an untagged one
+    /// serializes exactly the shape a pre-#242 journal holds (asserted verbatim
+    /// above too, but here against the *writer* rather than the reader).
+    #[test]
+    fn task_dispatched_carries_its_run_id_without_changing_the_untagged_shape() {
+        let untagged = CompanyEvent::TaskDispatched {
+            task_id: "t-1".to_string(),
+            run_id: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&untagged).expect("serialize"),
+            r#"{"kind":"TaskDispatched","task_id":"t-1"}"#
+        );
+
+        let tagged = CompanyEvent::TaskDispatched {
+            task_id: "t-1".to_string(),
+            run_id: Some("run-7".to_string()),
+        };
+        let line = serde_json::to_string(&tagged).expect("serialize");
+        assert!(line.contains(r#""run_id":"run-7""#), "{line}");
+        assert_eq!(
+            tagged,
+            serde_json::from_str::<CompanyEvent>(&line).expect("round trip")
+        );
+
+        // A legacy line loads as an untagged dispatch rather than failing.
+        let legacy: CompanyEvent =
+            serde_json::from_str(r#"{"kind":"TaskDispatched","task_id":"t-1"}"#).expect("legacy");
+        assert_eq!(legacy, untagged);
     }
 
     #[test]

--- a/src/ports/usage.rs
+++ b/src/ports/usage.rs
@@ -71,6 +71,21 @@ pub struct UsageSample {
     pub cost_usd: f64,
     /// What produced the sample.
     pub kind: SampleKind,
+    /// The task **attempt** ([`RunRecord`](crate::ports::runs::RunRecord)) whose
+    /// turn produced this usage, when it ran under one (issue #242).
+    ///
+    /// Purely an attribution key: it lets "what did this attempt cost?" be
+    /// answered from the meter as well as from the run row, and "which attempts
+    /// burned this teammate's budget?" be answered at all. It changes **no**
+    /// ledger semantics — money still moves through the same `inference.spend`
+    /// entry, and [`UNATTRIBUTED_AGENT`](crate::metering::UNATTRIBUTED_AGENT)
+    /// still owns whole-company cycle usage.
+    ///
+    /// `None` for every chat turn, every workflow node, every OAuth/search call,
+    /// and every sample written before this field existed — so a backend's
+    /// stored rows need no migration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
 }
 
 /// Durable per-company usage samples. Company A's usage MUST be invisible to

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1290,7 +1290,13 @@ impl RuntimeBuilder {
                             // `set_workflow_runner`, so this is not a strong cycle.
                             deps.workflow_runner.set(&runner);
                             wf_runner = Some(runner);
-                            Some(Arc::new(HarnessBrain::new(pool, deps, record)) as Arc<dyn Brain>)
+                            Some(Arc::new(
+                                // Issue #242: the same run store the dispatch
+                                // choke point mints into and the boot reaper
+                                // sweeps, so an attempt's trace, cost and
+                                // status all land on the row it opened.
+                                HarnessBrain::new(pool, deps, record).with_runs(ops.runs.clone()),
+                            ) as Arc<dyn Brain>)
                         } else {
                             // Do not degrade silently (issue #174): an openhuman
                             // build with no resolvable inference source disables

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1748,6 +1748,113 @@ mod test {
             .expect("tempdir")
     }
 
+    /// Issue #242, the property this whole PR exists to create, proven across a
+    /// real restart: a host killed mid-run leaves the attempt's **partial trace
+    /// intact**, and the next boot settles the row it stranded.
+    ///
+    /// The kill is simulated by simply not settling — which is exactly what a
+    /// `SIGKILL` looks like from the store's side, and the reason the boot
+    /// reaper's claim is a proof rather than a timeout heuristic: a cycle is a
+    /// process-local spawn, so an active row at boot cannot belong to anything
+    /// still alive.
+    #[tokio::test]
+    async fn a_killed_run_keeps_its_partial_trace_and_is_settled_on_the_next_boot() {
+        use crate::ports::runs::{NewRun, RunStatus, RunStepRecord};
+        use crate::ports::types::{EventSeq, TurnStep, TurnStepKind, TurnStepStatus};
+
+        let home = tmp_home("opencompany-run-restart-");
+        let manifest: CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n[[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n[policy]\nmode = \"full\"\n",
+        )
+        .expect("manifest");
+        let id = CompanyId::new("acme");
+
+        // --- boot 1: a card is dispatched, starts, writes two steps… and dies.
+        {
+            let rt = RuntimeBuilder::new(home.path().to_path_buf(), manifest.clone())
+                .with_id(id.clone())
+                .build()
+                .await
+                .expect("first boot");
+            let runs = rt.runs();
+            runs.create_run(
+                &id,
+                NewRun {
+                    id: "run-1".to_string(),
+                    task_id: "t-1".to_string(),
+                    agent_id: "ceo".to_string(),
+                },
+            )
+            .await
+            .expect("mint");
+            runs.begin_run(&id, "run-1", EventSeq::new(3))
+                .await
+                .expect("begin");
+            for (step_seq, label, status) in [
+                (0u32, "Reading the brief", TurnStepStatus::Ok),
+                (1, "Searching the web", TurnStepStatus::Running),
+            ] {
+                runs.append_run_step(
+                    &id,
+                    &RunStepRecord {
+                        run_id: "run-1".to_string(),
+                        step_seq,
+                        at_millis: 100 + step_seq as u64,
+                        step: TurnStep {
+                            kind: TurnStepKind::ToolCall,
+                            status,
+                            label: label.to_string(),
+                            detail: None,
+                            elapsed_ms: None,
+                        },
+                    },
+                )
+                .await
+                .expect("append step");
+            }
+            // …and the process is gone. Nothing settles the row.
+        }
+
+        // --- boot 2: the builder's reaper runs before anything is dispatched.
+        let rt = RuntimeBuilder::new(home.path().to_path_buf(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .expect("second boot");
+
+        let reaped = rt
+            .runs()
+            .get_run(&id, "run-1")
+            .await
+            .expect("read")
+            .expect("the row survives the restart");
+        assert_eq!(
+            reaped.status,
+            RunStatus::Failed,
+            "an attempt whose process died must not still claim to be running"
+        );
+        assert_eq!(
+            reaped.error.as_deref(),
+            Some(crate::ports::runs::ORPHAN_ERROR)
+        );
+
+        // The whole point: the steps written before the kill are still there,
+        // including the tool call that never got to finish.
+        let steps = rt
+            .runs()
+            .list_run_steps(&id, "run-1")
+            .await
+            .expect("list steps");
+        assert_eq!(steps.len(), 2, "the partial trace must survive the restart");
+        assert_eq!(steps[0].step.label, "Reading the brief");
+        assert_eq!(steps[0].step.status, TurnStepStatus::Ok);
+        assert_eq!(
+            steps[1].step.status,
+            TurnStepStatus::Running,
+            "the call that was in flight when the host died reads as in flight"
+        );
+    }
+
     #[test]
     fn slugifies_display_names() {
         assert_eq!(company_id_from_name("Acme Co!").as_ref(), "acme-co");

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -911,6 +911,7 @@ impl<'a> CycleHostImpl<'a> {
             first_time_counterparty: !established,
             payload: serde_json::json!({ "to": to, "subject": subject, "body": body }),
             agent: None,
+            run_id: None,
         };
         match self.gate_effect(effect).await? {
             EffectDisposition::Executed => Ok(ToolResult {
@@ -1549,6 +1550,7 @@ mod test {
             first_time_counterparty: false,
             payload: serde_json::Value::Null,
             agent: None,
+            run_id: None,
         };
 
         execute_effect_once(&rt, "k1", &effect).await.unwrap();
@@ -1581,6 +1583,7 @@ mod test {
             first_time_counterparty: false,
             payload: serde_json::Value::Null,
             agent: None,
+            run_id: None,
         };
         let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
             .with_brain(Arc::new(EffectBrain {
@@ -1630,6 +1633,7 @@ mod test {
             first_time_counterparty: false,
             payload: args,
             agent: Some(agent.to_string()),
+            run_id: None,
         }
     }
 
@@ -1918,6 +1922,7 @@ mod test {
             first_time_counterparty: false,
             payload: serde_json::Value::Null,
             agent: None,
+            run_id: None,
         };
         let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
             .with_brain(Arc::new(EffectBrain {
@@ -1995,6 +2000,7 @@ mod test {
             first_time_counterparty: false,
             payload: serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
             agent: None,
+            run_id: None,
         };
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .with_brain(Arc::new(ParkingBrain {
@@ -2049,6 +2055,7 @@ mod test {
             first_time_counterparty: false,
             payload: serde_json::Value::Null,
             agent: None,
+            run_id: None,
         };
         let approval_id = {
             let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
@@ -2099,6 +2106,7 @@ mod test {
             first_time_counterparty: false,
             payload: serde_json::json!({ "channel": "operator", "text": "ORIGINAL" }),
             agent: None,
+            run_id: None,
         };
         // A recording operator channel we keep a handle to (Arc-shared buffer).
         let operator_channel = OperatorChannel::new();
@@ -2164,6 +2172,7 @@ mod test {
             first_time_counterparty: false,
             payload: serde_json::Value::Null,
             agent: None,
+            run_id: None,
         };
         // A zero-TTL gate: anything parked is immediately past its deadline.
         let gate = Arc::new(
@@ -2525,6 +2534,7 @@ mod test {
             first_time_counterparty: false,
             payload: serde_json::json!({ "to": "x@ext.com", "subject": "Hi", "body": "yo" }),
             agent: None,
+            run_id: None,
         };
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .with_brain(Arc::new(EffectBrain {
@@ -2594,6 +2604,7 @@ mod test {
                 "body": "Q3 is up 12%.",
             }),
             agent: None,
+            run_id: None,
         };
         let approval_id = rt.approvals.park(rt.id(), effect.clone()).await.unwrap();
         rt.journal
@@ -2658,6 +2669,7 @@ mod test {
                 "body": "Q3 is up 12%.",
             }),
             agent: None,
+            run_id: None,
         };
         let approval_id = rt.approvals.park(rt.id(), effect.clone()).await.unwrap();
         rt.journal
@@ -2702,6 +2714,7 @@ mod test {
                 "body": "Q3 is up 12%.",
             }),
             agent: None,
+            run_id: None,
         };
         let approval_id = {
             let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
@@ -2754,6 +2767,7 @@ mod test {
             first_time_counterparty: false,
             payload: serde_json::json!({ "to": "x@ext.com", "subject": "Hi", "body": "yo" }),
             agent: None,
+            run_id: None,
         };
         let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
             .with_brain(Arc::new(EffectBrain {
@@ -2773,6 +2787,7 @@ mod test {
                 first_time_counterparty: false,
                 payload: serde_json::json!({ "to": "x@ext.com", "subject": "Hi", "body": "yo" }),
                 agent: None,
+                run_id: None,
             },
         )
         .await

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -31,6 +31,7 @@ use crate::error::OpenCompanyError;
 use crate::feedback::tool::SEND_EMAIL_TOOL;
 use crate::policy::gate::ResolveOutcome;
 use crate::ports::brain::{CycleHost, UsageMetering};
+use crate::ports::runs::{RunOutcome, RunStatus};
 use crate::ports::tasks::{COLUMN_TODO, TaskRecord};
 use crate::ports::types::{
     Actor, ApprovalId, CompanyEvent, CompanyId, CompanyRecord, ContextOp, ContextOpResult,
@@ -60,6 +61,16 @@ const HISTORY_LIMIT: usize = 32;
 /// park cards that silently do nothing when approved.
 pub(crate) const EMAIL_SEND_KIND: &str = "email.send";
 
+/// The `error` the terminality backstop stamps on an attempt row whose cycle
+/// ended without settling it (issue #242) — a brain that ignored the dispatch,
+/// not a brain that failed at it.
+pub(crate) const RUN_UNSETTLED_ERROR: &str =
+    "the dispatch cycle ended without settling this attempt";
+
+/// The `error` prefix the backstop stamps when the cycle itself errored, so the
+/// row carries the same reason the caller saw rather than a generic one.
+pub(crate) const RUN_CYCLE_FAILED_ERROR: &str = "the dispatch cycle failed";
+
 /// Drives cycles for one [`CompanyRuntime`].
 pub struct CycleRunner<'a> {
     rt: &'a CompanyRuntime,
@@ -83,10 +94,39 @@ impl<'a> CycleRunner<'a> {
         // 2. Persist input — durable before any thinking.
         let mut persisted_seq = None;
         let mut event_seqs = Vec::with_capacity(events.len());
+        // Issue #242: the attempt rows this cycle is about to run, moved
+        // `Pending` → `Running` below and backstopped after the brain returns.
+        let mut dispatched_runs: Vec<String> = Vec::new();
         for event in &events {
             let seq = self.rt.events.append(&company, event.clone()).await?;
             event_seqs.push(seq);
             persisted_seq = Some(seq);
+            // Start the run here, not inside the brain: the serial lock is held,
+            // the driving event's seq now exists, and every brain — harness,
+            // hosted, echo — passes through this one place. A brain that ignores
+            // `TaskDispatched` entirely still leaves a correctly-started row for
+            // the backstop below to settle.
+            if let CompanyEvent::TaskDispatched {
+                run_id: Some(run_id),
+                ..
+            } = event
+            {
+                match self.rt.runs().begin_run(&company, run_id, seq).await {
+                    Ok(_) => dispatched_runs.push(run_id.clone()),
+                    // Not fatal, and not silent. The row may be missing (its
+                    // `create_run` failed at the choke point and the dispatch
+                    // proceeded anyway) or already past `Pending` (a replayed
+                    // event). Either way the work still runs — record-keeping
+                    // does not fail the work it records — but the run is not
+                    // tracked as this cycle's, so the backstop leaves it alone.
+                    Err(err) => tracing::warn!(
+                        company = %company,
+                        run = %run_id,
+                        error = %err,
+                        "[runs] could not start an attempt row; the cycle runs untracked"
+                    ),
+                }
+            }
         }
 
         // 3. Load — history, context index, roster.
@@ -131,7 +171,16 @@ impl<'a> CycleRunner<'a> {
 
         // 4. Think + 5. Gate — the host services callbacks and gates effects.
         let host = CycleHostImpl::new(company.clone(), cycle_id.clone(), self.rt);
-        let result = self.rt.brain.run_cycle(request, &host).await?;
+        let result = self.rt.brain.run_cycle(request, &host).await;
+        // Issue #242: the terminality backstop. Whatever the brain did — settled
+        // the run richly (the harness path), ignored `TaskDispatched` entirely
+        // (the echo brain), or errored out — no attempt row may be left claiming
+        // to be live once the cycle that owned it is over. Runs deliberately
+        // BEFORE the `?` so a brain error settles its rows too; the only path
+        // that escapes it is a panic, which is the boot reaper's job.
+        self.backstop_dispatched_runs(&company, &dispatched_runs, result.as_ref().err())
+            .await;
+        let result = result?;
 
         // 6. Persist output.
         for trace in &result.new_traces {
@@ -179,6 +228,70 @@ impl<'a> CycleRunner<'a> {
             parked,
             persisted_seq,
         })
+    }
+
+    /// Settles any attempt row this cycle started that is *still* claiming to be
+    /// live (issue #242) — the terminality backstop.
+    ///
+    /// On the ordinary harness path this is a no-op: `run_task` settles the run
+    /// richly (status, cost, step count, failure reason) and returns before
+    /// `run_locked` gets here, so every row is already terminal or parked and
+    /// [`RunStatus::is_active`] is false. The backstop exists for the paths that
+    /// produce no rich settle at all:
+    ///
+    /// * a brain that ignores `TaskDispatched` (the default build's `EchoBrain`,
+    ///   an injected test brain) — the row would otherwise sit `Running` until
+    ///   the next boot reaped it;
+    /// * a brain that **errored**, which is why this runs before the `?`.
+    ///
+    /// Best-effort per row, never propagated: the cycle either produced output
+    /// the operator can already see or failed for a reason worth surfacing, and
+    /// neither should be replaced by a bookkeeping error.
+    ///
+    /// A panic still escapes it — that is deliberately the boot reaper's job
+    /// ([`reap_orphaned_runs`](crate::ports::runs::reap_orphaned_runs)), since a
+    /// panicking cycle cannot run its own cleanup by definition.
+    async fn backstop_dispatched_runs(
+        &self,
+        company: &CompanyId,
+        run_ids: &[String],
+        cycle_error: Option<&OpenCompanyError>,
+    ) {
+        for id in run_ids {
+            let run = match self.rt.runs().get_run(company, id).await {
+                Ok(Some(run)) => run,
+                // Vanished between `begin_run` and here — nothing to settle.
+                Ok(None) => continue,
+                Err(err) => {
+                    tracing::warn!(
+                        company = %company,
+                        run = %id,
+                        error = %err,
+                        "[runs] could not read an attempt row for the terminality backstop"
+                    );
+                    continue;
+                }
+            };
+            if !run.is_active() {
+                // The rich settle already happened (or the run parked). Leaving
+                // a parked run alone is the point: `Paused` / `WaitingApproval`
+                // are waiting on something outside the cycle, not stranded by it.
+                continue;
+            }
+            let reason = match cycle_error {
+                Some(err) => format!("{RUN_CYCLE_FAILED_ERROR}: {err}"),
+                None => RUN_UNSETTLED_ERROR.to_string(),
+            };
+            let outcome = RunOutcome::new(RunStatus::Failed).with_error(reason);
+            if let Err(err) = self.rt.runs().finish_run(company, id, outcome).await {
+                tracing::warn!(
+                    company = %company,
+                    run = %id,
+                    error = %err,
+                    "[runs] the terminality backstop could not settle an attempt row"
+                );
+            }
+        }
     }
 
     /// Meters a finished cycle's inference usage onto the Usage + Finances
@@ -1216,6 +1329,165 @@ mod test {
             delegated.reply_to.as_ref().map(|r| r.chat_id.as_str()),
             Some("strategy")
         );
+    }
+
+    /// A brain that fails every cycle — the shape the terminality backstop has
+    /// to cover, because a `?` on `run_cycle` would otherwise skip every settle
+    /// and strand the attempt row `Running` until the next boot.
+    struct FailingBrain;
+
+    #[async_trait]
+    impl Brain for FailingBrain {
+        async fn run_cycle(
+            &self,
+            _req: CycleRequest,
+            _host: &dyn CycleHost,
+        ) -> Result<CycleResult> {
+            Err(OpenCompanyError::Store("the brain fell over".into()))
+        }
+    }
+
+    /// Mints a `Pending` run for `task`, so a test can drive a dispatch cycle
+    /// the way `CompanyRuntime::dispatch_task` does.
+    async fn pending_run(rt: &crate::company::runtime::CompanyRuntime, task: &str) -> String {
+        rt.runs()
+            .create_run(
+                rt.id(),
+                crate::ports::runs::NewRun {
+                    id: crate::ports::generate_id(),
+                    task_id: task.to_string(),
+                    agent_id: "ceo".to_string(),
+                },
+            )
+            .await
+            .expect("mint a run")
+            .id
+    }
+
+    /// Issue #242, the `begin_run` half: the run moves `Pending` → `Running`
+    /// stamped with the **seq of the very `TaskDispatched` event that drove
+    /// it**, and by the end of the cycle it is terminal rather than stranded —
+    /// even though the default build's brain ignores `TaskDispatched` entirely
+    /// and settles nothing.
+    #[tokio::test]
+    async fn a_dispatch_cycle_starts_its_run_and_never_leaves_it_claiming_to_be_live() {
+        let home_dir = tmp_home();
+        let rt = RuntimeBuilder::fs_defaults(home_dir.path().to_path_buf(), manifest("full"))
+            .await
+            .unwrap();
+        let run_id = pending_run(&rt, "t-1").await;
+
+        let report = rt
+            .run_cycle(vec![CompanyEvent::TaskDispatched {
+                task_id: "t-1".into(),
+                run_id: Some(run_id.clone()),
+            }])
+            .await
+            .expect("the cycle itself succeeds");
+
+        let run = rt
+            .runs()
+            .get_run(rt.id(), &run_id)
+            .await
+            .expect("read")
+            .expect("the run survives its cycle");
+        assert_eq!(
+            run.trigger_event_seq, report.persisted_seq,
+            "the run must name the exact log line that drove it"
+        );
+        assert!(
+            run.started_at_millis.is_some(),
+            "begin_run stamps when the attempt actually began"
+        );
+        assert_eq!(
+            run.status,
+            RunStatus::Failed,
+            "an echo-brain dispatch produces no rich settle, so the backstop closes it"
+        );
+        assert_eq!(run.error.as_deref(), Some(RUN_UNSETTLED_ERROR));
+        assert!(run.finished_at_millis.is_some());
+    }
+
+    /// The other backstop arm: the brain **errored**. The cycle error still
+    /// propagates to the caller (nothing is swallowed), and the row settles
+    /// carrying that same reason instead of sitting `Running` forever.
+    #[tokio::test]
+    async fn a_failed_cycle_settles_its_run_and_still_reports_the_failure() {
+        let home_dir = tmp_home();
+        let rt = RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest("full"))
+            .with_brain(Arc::new(FailingBrain))
+            .build()
+            .await
+            .unwrap();
+        let run_id = pending_run(&rt, "t-1").await;
+
+        let err = rt
+            .run_cycle(vec![CompanyEvent::TaskDispatched {
+                task_id: "t-1".into(),
+                run_id: Some(run_id.clone()),
+            }])
+            .await
+            .expect_err("a failing brain still fails the cycle");
+        assert!(err.to_string().contains("the brain fell over"), "{err}");
+
+        let run = rt
+            .runs()
+            .get_run(rt.id(), &run_id)
+            .await
+            .expect("read")
+            .expect("run");
+        assert_eq!(run.status, RunStatus::Failed);
+        let reason = run.error.unwrap_or_default();
+        assert!(reason.starts_with(RUN_CYCLE_FAILED_ERROR), "{reason}");
+        assert!(
+            reason.contains("the brain fell over"),
+            "the row must carry the reason the caller saw: {reason}"
+        );
+    }
+
+    /// A dispatch whose run row could not be minted (`run_id: None`) — the
+    /// documented degraded path — must still run the cycle normally. The
+    /// dispatch is the work; the row is only the record of it.
+    #[tokio::test]
+    async fn an_untracked_dispatch_still_runs_its_cycle() {
+        let home_dir = tmp_home();
+        let rt = RuntimeBuilder::fs_defaults(home_dir.path().to_path_buf(), manifest("full"))
+            .await
+            .unwrap();
+
+        rt.run_cycle(vec![CompanyEvent::TaskDispatched {
+            task_id: "t-1".into(),
+            run_id: None,
+        }])
+        .await
+        .expect("an untracked dispatch is still a dispatch");
+
+        assert!(
+            rt.runs()
+                .list_runs(rt.id(), &crate::ports::runs::RunFilter::default())
+                .await
+                .expect("list")
+                .is_empty(),
+            "no row was minted, so none may be invented"
+        );
+    }
+
+    /// A `run_id` naming a row that does not exist (a replayed journal line, a
+    /// row lost with its store) must not fail the cycle either — and must not
+    /// be tracked, so the backstop has nothing to settle.
+    #[tokio::test]
+    async fn a_dispatch_naming_an_unknown_run_does_not_fail_the_cycle() {
+        let home_dir = tmp_home();
+        let rt = RuntimeBuilder::fs_defaults(home_dir.path().to_path_buf(), manifest("full"))
+            .await
+            .unwrap();
+
+        rt.run_cycle(vec![CompanyEvent::TaskDispatched {
+            task_id: "t-1".into(),
+            run_id: Some("run-that-never-was".into()),
+        }])
+        .await
+        .expect("an unknown run id is a bookkeeping miss, not a cycle failure");
     }
 
     #[tokio::test]

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1348,6 +1348,100 @@ mod test {
         }
     }
 
+    /// A brain that settles the dispatched run itself, the way `run_task` does
+    /// on the harness path — so the backstop can be shown to leave a rich settle
+    /// alone rather than racing it.
+    struct SettlingBrain {
+        runs: Arc<dyn crate::ports::RunStore>,
+        status: RunStatus,
+    }
+
+    #[async_trait]
+    impl Brain for SettlingBrain {
+        async fn run_cycle(&self, req: CycleRequest, _host: &dyn CycleHost) -> Result<CycleResult> {
+            for event in &req.events {
+                if let CompanyEvent::TaskDispatched {
+                    run_id: Some(run_id),
+                    ..
+                } = event
+                {
+                    let mut outcome = RunOutcome::new(self.status);
+                    if self.status == RunStatus::Failed {
+                        outcome = outcome.with_error("the brain said so");
+                    }
+                    self.runs
+                        .finish_run(&req.company_id, run_id, outcome)
+                        .await?;
+                }
+            }
+            Ok(CycleResult {
+                channel_responses: vec![OutboundMessage {
+                    task_id: None,
+                    channel: "operator".into(),
+                    text: "settled".into(),
+                    steps: Vec::new(),
+                    reply_to: None,
+                }],
+                new_traces: vec![CompressedTrace::now(&req.cycle_id, "settling cycle")],
+                ledger_deltas: Vec::new(),
+                token_usage: TokenUsage::default(),
+            })
+        }
+    }
+
+    /// The rich settle always wins: `run_task` finishes the row *inside*
+    /// `brain.run_cycle`, which is awaited before the backstop, so there is no
+    /// race for the backstop to lose. Pinned rather than argued, because a
+    /// backstop that overwrote a real outcome with a generic failure would be
+    /// worse than no backstop at all.
+    ///
+    /// Both cases matter. A **terminal** settle must survive; so must a
+    /// **parked** one — `Paused` and `WaitingApproval` are waiting on something
+    /// outside the cycle, and reclaiming them would delete real pending work
+    /// every time a cycle ended.
+    #[tokio::test]
+    async fn the_backstop_never_overwrites_a_settle_the_brain_already_made() {
+        for (status, error) in [
+            (RunStatus::Succeeded, None),
+            (RunStatus::Paused, None),
+            (RunStatus::WaitingApproval, None),
+            (RunStatus::Failed, Some("the brain said so")),
+        ] {
+            let home_dir = tmp_home();
+            let runs: Arc<dyn crate::ports::RunStore> =
+                Arc::new(crate::store::FsOps::new(home_dir.path().to_path_buf()));
+            let rt = RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest("full"))
+                .with_runs(Arc::clone(&runs))
+                .with_brain(Arc::new(SettlingBrain {
+                    runs: Arc::clone(&runs),
+                    status,
+                }))
+                .build()
+                .await
+                .unwrap();
+            let run_id = pending_run(&rt, "t-1").await;
+
+            rt.run_cycle(vec![CompanyEvent::TaskDispatched {
+                task_id: "t-1".into(),
+                run_id: Some(run_id.clone()),
+            }])
+            .await
+            .expect("cycle");
+
+            let settled = rt
+                .runs()
+                .get_run(rt.id(), &run_id)
+                .await
+                .expect("read")
+                .expect("row");
+            assert_eq!(
+                settled.status, status,
+                "the backstop must not overwrite a {status} settle"
+            );
+            assert_eq!(settled.error.as_deref(), error);
+        }
+    }
+
     /// Mints a `Pending` run for `task`, so a test can drive a dispatch cycle
     /// the way `CompanyRuntime::dispatch_task` does.
     async fn pending_run(rt: &crate::company::runtime::CompanyRuntime, task: &str) -> String {

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -28,6 +28,7 @@ use crate::company::steer::{
 use crate::harness::TurnOutcome;
 use crate::harness::lifecycle::{self, TaskRunEnd};
 use crate::harness::orchestrator::{self, Delegation, DelegationQueue};
+use crate::harness::run_trace::RunTraceSink;
 use crate::ports::tasks::COLUMN_TODO;
 use crate::ports::types::{CompanyId, CompanyRecord, OutboundMessage, TurnStep};
 use crate::ports::{TaskRecord, TaskStore, generate_id, now_millis};
@@ -55,6 +56,11 @@ pub trait RunTurn: Send + Sync {
     ) -> Result<TurnOutcome>;
 
     /// A streamed, operator-steerable turn (pause / cancel / redirect).
+    ///
+    /// `run_sink` is the dispatched attempt this turn belongs to, when it
+    /// belongs to one (issue #242): a desk turn a *dispatched card* handed its
+    /// work to traces into that card's run, while the same delegation reached
+    /// from operator chat passes `None` and behaves exactly as before.
     async fn run_steered(
         &self,
         company: &CompanyId,
@@ -62,17 +68,24 @@ pub trait RunTurn: Send + Sync {
         message: &str,
         control: &SteerControl,
         chat_id: Option<&str>,
+        run_sink: Option<Arc<RunTraceSink>>,
     ) -> Result<TurnOutcome>;
 
     /// A steerable turn WITHOUT live streaming — for a dispatched card whose
     /// steps are discarded into its note and must not leak onto the console
     /// timeline.
+    ///
+    /// `run_sink` carries the same meaning as on
+    /// [`run_steered`](Self::run_steered). It is *this* method the dispatched
+    /// card's own turns pass a sink to, which is what makes the card's trace
+    /// durable while the turn runs even though nothing is streamed.
     async fn run_steered_background(
         &self,
         company: &CompanyId,
         agent_id: &str,
         message: &str,
         control: &SteerControl,
+        run_sink: Option<Arc<RunTraceSink>>,
     ) -> Result<TurnOutcome>;
 }
 
@@ -215,6 +228,11 @@ pub(crate) struct DelegationRunner<'a> {
     /// #204). Owned rather than borrowed so a caller can hold the card mutably
     /// while the runner runs. `None` for an operator chat turn.
     task: Option<String>,
+    /// The attempt row that card is running under (issue #242), so a delegate's
+    /// turn traces and meters into the *same* run rather than disappearing from
+    /// the record the moment the work changes hands. `None` for an operator chat
+    /// turn, and for a dispatch whose run row could not be minted.
+    run_sink: Option<Arc<RunTraceSink>>,
 }
 
 impl<'a> DelegationRunner<'a> {
@@ -238,6 +256,7 @@ impl<'a> DelegationRunner<'a> {
             queue,
             max_delegations,
             task: None,
+            run_sink: None,
         }
     }
 
@@ -245,6 +264,13 @@ impl<'a> DelegationRunner<'a> {
     /// records that card as its parent (issue #185's `parent_task_id`).
     pub(crate) fn for_task(mut self, task_id: &str) -> Self {
         self.task = Some(task_id.to_string());
+        self
+    }
+
+    /// Scopes this runner to the card's **attempt** (issue #242), so a delegated
+    /// turn's steps and spend land on the same run the dispatch opened.
+    pub(crate) fn for_run(mut self, run_sink: Option<Arc<RunTraceSink>>) -> Self {
+        self.run_sink = run_sink;
         self
     }
 
@@ -614,7 +640,18 @@ impl<'a> DelegationRunner<'a> {
                 let control = guard.control().clone();
                 let outcome = self
                     .run_turn
-                    .run_steered(self.company, &member, &instruction, &control, chat_id)
+                    .run_steered(
+                        self.company,
+                        &member,
+                        &instruction,
+                        &control,
+                        chat_id,
+                        // Issue #242: when this drain is running inside a
+                        // dispatched card, the delegate's turn is part of that
+                        // card's attempt — its steps and its spend belong to the
+                        // same run. `None` for a chat-path delegation.
+                        self.run_sink.clone(),
+                    )
                     .await?;
                 // A cancel issued mid-flight discards the delegated reply —
                 // nothing is relayed. Flagged as a cancellation so a caller that

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -449,6 +449,7 @@ mod test {
             first_time_counterparty: false,
             payload: serde_json::Value::Null,
             agent: None,
+            run_id: None,
         }
     }
 

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -440,6 +440,7 @@ mod test {
                             first_time_counterparty: false,
                             payload: serde_json::Value::Null,
                             agent: None,
+                            run_id: None,
                         })
                         .await?;
                     }

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -584,6 +584,7 @@ async fn usage_reflects_recorded_samples() {
                 cached_input_tokens: 0,
                 cost_usd: 0.5,
                 kind: SampleKind::Inference,
+                run_id: None,
             },
         )
         .await

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -651,7 +651,7 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             }
             o
         }
-        CompanyEvent::TaskDispatched { task_id } => {
+        CompanyEvent::TaskDispatched { task_id, .. } => {
             let mut o = envelope("task_dispatched");
             o["taskId"] = json!(task_id);
             o
@@ -2774,6 +2774,7 @@ mod test {
     fn projects_task_dispatched() {
         let v = super::project_event(&stored(CompanyEvent::TaskDispatched {
             task_id: "t-42".into(),
+            run_id: None,
         }))
         .expect("task_dispatched is an attention signal");
         assert_eq!(v["type"], "task_dispatched");

--- a/src/server/ops/capabilities.rs
+++ b/src/server/ops/capabilities.rs
@@ -529,6 +529,7 @@ mod tests {
                     cached_input_tokens: 0,
                     cost_usd: 0.0,
                     kind: SampleKind::Inference,
+                    run_id: None,
                 },
             )
             .await
@@ -585,6 +586,7 @@ mod tests {
                     cached_input_tokens: 0,
                     cost_usd: 0.0,
                     kind: SampleKind::Inference,
+                    run_id: None,
                 },
             )
             .await

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -641,7 +641,7 @@ fn fold_page(
 
     for ev in page {
         let entry = match &ev.event {
-            CompanyEvent::TaskDispatched { task_id: id } if id == task_id => {
+            CompanyEvent::TaskDispatched { task_id: id, .. } if id == task_id => {
                 *window_opened_at = Some(ev.at_millis);
                 Some(("dispatched", "Dispatched".to_string(), None, None))
             }

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -413,6 +413,7 @@ mod tests {
                         cached_input_tokens: 0,
                         cost_usd: cost,
                         kind: SampleKind::Inference,
+                        run_id: None,
                     },
                 )
                 .await
@@ -432,6 +433,7 @@ mod tests {
                     cached_input_tokens: 0,
                     cost_usd: 9.00,
                     kind: SampleKind::Inference,
+                    run_id: None,
                 },
             )
             .await
@@ -479,6 +481,7 @@ mod tests {
                     cached_input_tokens: 0,
                     cost_usd: 9.00,
                     kind: SampleKind::Inference,
+                    run_id: None,
                 },
             )
             .await

--- a/src/server/ops/usage.rs
+++ b/src/server/ops/usage.rs
@@ -240,6 +240,7 @@ mod tests {
                         cached_input_tokens: 0,
                         cost_usd: 0.25,
                         kind: SampleKind::Inference,
+                        run_id: None,
                     },
                 )
                 .await

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -3082,6 +3082,7 @@ async fn task_detail_assembles_timeline_and_lineage() {
     for event in [
         CompanyEvent::TaskDispatched {
             task_id: "t-1".into(),
+            run_id: None,
         },
         // Tagged to this task — admitted.
         CompanyEvent::AgentReply {
@@ -3285,6 +3286,7 @@ async fn task_timeline_scopes_approvals_to_the_run_window() {
         approval("before"),
         CompanyEvent::TaskDispatched {
             task_id: "t-1".into(),
+            run_id: None,
         },
         // Inside the window — admitted.
         approval("during"),
@@ -3372,6 +3374,7 @@ async fn dispatched_task(
             company,
             CompanyEvent::TaskDispatched {
                 task_id: "t-1".into(),
+                run_id: None,
             },
         )
         .await

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -3402,6 +3402,7 @@ fn parked_effect() -> crate::ports::types::Effect {
         first_time_counterparty: false,
         payload: serde_json::Value::Null,
         agent: None,
+        run_id: None,
     }
 }
 

--- a/src/server/provision/test.rs
+++ b/src/server/provision/test.rs
@@ -714,6 +714,7 @@ async fn webhook_emitted_on_approval_requested() {
         first_time_counterparty: false,
         payload: serde_json::Value::Null,
         agent: None,
+        run_id: None,
     };
     let runtime = RuntimeBuilder::new(home.clone(), manifest)
         .with_id(CompanyId::new("acme"))

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -1318,6 +1318,7 @@ pub async fn assert_usage_meter(usage: Arc<dyn UsageMeter>) {
         cached_input_tokens: 10,
         cost_usd: cost,
         kind: SampleKind::Inference,
+        run_id: None,
     };
 
     usage.record(&alpha, &sample(100, 0.1)).await.unwrap();
@@ -1355,6 +1356,7 @@ pub async fn assert_usage_retention(usage: Arc<dyn UsageMeter>) {
         cached_input_tokens: 10,
         cost_usd: 0.1,
         kind: SampleKind::Inference,
+        run_id: None,
     };
 
     // A fixed base far from epoch 0 so the cutoff math stays positive.

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -564,6 +564,7 @@ async fn park_cold_recipient(
             "body": text,
         }),
         agent: None,
+        run_id: None,
     };
 
     match park_effect(parking, &record.id, effect).await {


### PR DESCRIPTION
## Summary

PR-2 of #242 — **the write path**. PR-1 added the object and its storage; this makes attempts actually get written.

A dispatched task now:

- **mints a `Pending` run before the cycle spawns**, so a crash in the gap leaves a visible orphan instead of a silently lost attempt;
- **records its trace incrementally as the turn runs**, not batched at the end;
- **settles into a real status** with its cost, step count, and — on failure — the reason;
- **stamps four correlation fields** so an approval, an artifact revision and a usage sample can each name the attempt that produced them.

The read surface — REST routes and the console's Attempts section — is PR-3 and is untouched here.

## Problem

An attempt was ephemeral: a cycle ran, folded its steps into one `AgentReply`, and discarded them as a unit. Kill the process mid-run and there was no evidence it ever happened.

**The property this PR exists to create is that a killed run keeps everything written so far.** That is the opposite of the batch-at-the-end approach, where a crash loses the whole trace and leaves the row stranded `running` forever with nothing to reap it.

## Solution

**Incremental trace that converges on the folded one.** `StepTrace` is the streaming counterpart of `fold_steps`: a tool call claims an ordinal as `Running`, and its completion **re-yields the same ordinal** finalized, which `append_run_step`'s `(run_id, step_seq)` replace semantics turn into an in-place finalize. A test pins byte-equality between the persisted trace and what `fold_steps` builds, so the two cannot drift.

The awaits live in the collector task, never the model loop — a slow store delays trace persistence, not the turn.

**Terminality is closed on every non-panic path.** `run_task` does the rich settle (status, usage, error). A backstop in the cycle then closes anything still `Running` — an echo brain, a brain error — so the row always terminates. Panics remain the boot reaper's job. A test pins that the backstop never overwrites a settle that already happened.

**`WaitingApproval` implements #183's decision.** A run that would otherwise have succeeded, but whose own turns parked at least one approval, settles `WaitingApproval` rather than `Succeeded` — a person must act, so the card belongs in In Review. It is re-enterable across attempts, which is what keeps #243's single-use, argument-exact grants coherent instead of forcing approvals to be batched.

## Six places the plan was wrong

The plan was followed except where it was incorrect. Each divergence and why:

**1. The usage vector the plan said to fold doesn't exist in `run_task`.** Usage is collected inside `run_with_steer` and consumed by `record_turn_cost` in `run_inner`; `TurnOutcome` carries only `reply` and `steps`. Threading it back out would have changed `TurnOutcome`'s shape across chat, delegation and workflows. Folded into the sink at `run_inner` instead — same result, no ripple, and it correctly counts redirect re-runs *and* the delegate's turn.

**2. `CycleRequest.run_id` was not added — it would be a second copy that can disagree with the first.** `CycleRequest.events` already carries the `TaskDispatched` event verbatim, including over the wire to hosted cognition, so the brain reads the id off the event.

**3. Reusing the existing stream helper would have double-counted every tool call.** It emits a `tool_call` frame *and* a separate `tool_result` frame, which `fold_steps` merges into one step. Persisting both would produce a trace that never matches the bubble the operator sees. Hence `StepTrace` and the re-yield-the-same-ordinal design above.

As a consequence the plan's predicted "divergence on unmatched starts" isn't a divergence: `fold_steps` also leaves an unmatched start `Running`. The only real difference is that a killed run keeps a `Running` row where a completed one would have finalized it — which is the honest record of what happened.

**4. `TaskRunEnd` has six variants, not five.** `RedirectsExhausted → Succeeded` (it lands in the success terminal). `Delegated → Paused`, documented as unreachable today with the reasoning: a hand-off waits on something other than a person, so #183's decision 2 makes it `Paused` — never a terminal that would file unfinished work as done.

**5. The artifact field belongs on the version, not the record.** A card dispatched twice appends v2 under the second attempt; a record-level field would remember only the later run and silently erase the first attempt's link to what it wrote. Same zero-migration JSON blob either way, and `latest().run_id` recovers the record-level answer.

**6. Two things the plan didn't mention.** `HarnessDeps` has ~28 literals, so the `RunStore` went on `HarnessBrain` behind `with_runs()` — 2 production sites, zero test churn, the same argument the codebase already makes for `GrantSet` on `ApprovalRequestQueue`. And `run_task`'s two early no-op returns (no task store, card vanished) needed explicit settles, or the row would sit `Pending` until a restart reaped it with a misleading "the host restarted" reason.

## Submission Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **1742 passed, 0 failed**, 1 ignored
- [x] `cargo check --locked --all-features --all-targets`
- [x] `git diff --stat Cargo.lock` — empty
- [x] `npm ci`, `npm run typecheck`, `npm run build` — frontend untouched, confirmed unbroken
- [x] Built the binary and booted `serve` on an isolated home; `/healthz` ok, company registered, no warnings

**The restart property is proven across a genuine two-boot cycle on the real fs store** — `a_killed_run_keeps_its_partial_trace_and_is_settled_on_the_next_boot`. A run is interrupted mid-trace, the process ends, and the next boot finds the partial trace intact and the attempt settled.

**One gap, stated plainly:** the live-model version of that walkthrough could not be run here. `doctor` reports `cycles unavailable: needs TINYHUMANS_TOKEN_FILE or TINYHUMANS_API_KEY`, so the company boots onto the echo brain and no model turn executes. The two-boot test above covers the same property against real storage, but a live-model dispatch is still worth doing before this ships.

## Impact

**No migration.** Every new field is `Option` with serde defaults and skip-when-absent, so old journal lines and stored records replay as `None`. Artifacts and usage are JSON blobs, so neither needed a schema change. `AgentReply`'s payload is byte-identical — pinned by test.

**Write amplification is the deliberate price**: one write per step plus roughly three status writes per run, against one event today. Cycles serialise per company and the collector absorbs store latency. Steps are capped at 500 per run.

**Three things a read surface must handle honestly** (carried into PR-3):

- `WaitingApproval` is **non-terminal**, so `finished_at_millis` stays `None`. A null finish time does not mean "still running" — use `status.is_terminal()`.
- A run whose `begin_run` never landed stays `Pending`, and a `WaitingApproval` settle on it is rejected by the state machine and logged. The backstop then closes it `Failed`. Rare, but a run list will occasionally show `Failed` with *"the dispatch cycle ended without settling this attempt"*.
- `Paused` from a delegation is currently unreachable — don't build UI that depends on seeing it.

**Deferred, as the plan permitted:** stamping the ambient task-run id onto `WorkflowRunFinished`. Reaching it means widening the `WorkflowRunner` port trait itself for a pure correlation slot, on a seam PR-3 doesn't need, and the field needs no migration whenever it lands. Not started — nothing half-done.

**Pre-existing, not from this PR:** `docs/spec/runtime/ports.md` is now 775 lines against the repo's 500-line cap. It was ~720 before the 55 lines added here, so it needs splitting on its own.

## Related

Part of #242 — **PR-2 of 3**. PR-1 (`#342`) shipped the port and storage; PR-3 is the REST and console surface.
Part of #183 — the spine epic.
`Effect.run_id` is **#333's join key** — it is now live.
`ArtifactVersion.run_id` is the attach point #244 needs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable run tracking across task dispatch, execution, approvals, usage, and artifact revisions.
  * Execution traces now persist incrementally, including progress steps, token usage, costs, errors, and approval pauses.
  * Delegated work can share the originating run’s trace for a complete activity history.
  * Run-linked records support optional correlation data while remaining compatible with existing data.

* **Bug Fixes**
  * Incomplete runs are recovered and marked failed after a host restart.
  * Run settlement now correctly reflects failures, cancellations, pauses, and approval waiting states.

* **Documentation**
  * Added runtime lifecycle and run-correlation documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->