### PR TITLE
feat(runs): read a card's attempts and their traces (#242 PR-3)

### DIFF
--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -675,6 +675,50 @@ Old `RunRecord`s are never synthesised from historical `AgentReply` events:
 fabricating identity for attempts nobody recorded would be worse than a
 pre-existing card honestly showing zero of them.
 
+#### Reading runs back
+
+Three surfaces, all in `src/server/ops/runs.rs`, under both scope forms:
+
+| Route | Answers |
+|---|---|
+| `GET …/runs?task=&status=&limit=` | the company's attempts, newest first |
+| `GET …/runs/{run_id}` | one attempt plus its full persisted step trace |
+| `GET …/tasks/{task_id}` → `runs[]` | the card's attempts, additive on the task detail read |
+
+Each hands its predicates to `RunStore::list_runs` as a `RunFilter`. **No route
+here folds the journal** — that is the whole reason a run is state rather than
+an event, and the sibling `GET …/workflows/runs` (which does fold, and says so)
+is the cost being avoided. `?status=` takes a comma-separated list and refuses
+an unknown word with a `400`, because a typo'd filter answering `[]` is
+indistinguishable from "nothing matched".
+
+Three things the wire shape refuses to imply, each a state the write path really
+produces:
+
+- **`phase`** (`active` · `parked` · `terminal`), projected from
+  `RunStatus::phase`, is how a reader decides liveness. `finishedAtMillis` is
+  absent for a *parked* run exactly as for a running one — a parked run can
+  resume — so inferring liveness from the timestamp renders an attempt waiting
+  on a person as running forever.
+- **`stepCount` / `stepCountCapped`.** The count is the high-water ordinal
+  persisted, capped at `run_trace::MAX_RUN_STEPS`, and written on the settle —
+  so it reads `0` throughout a live run and stops meaning "steps the agent
+  took" once capped. `usage` settles alongside it and is provisional until then.
+- **A step's `status`** (`ok` · `error` · `running`) rides beside its `kind`. A
+  host killed mid-tool-call leaves that call recorded `running` — the point of
+  an incremental trace — meaning in-flight-when-the-trace-stopped, never failed.
+
+Steps project into the console's existing `TimelineEntry` contract (`seq` /
+`atMillis` / `kind` / `label` / `detail`, plus `status` and `elapsedMs`), so
+`kind` widens additively to include `tool_call` · `thinking` · `note` and the
+grouped-timeline renderer is reused rather than reinvented. `usage` is re-cased
+to camelCase by a local DTO — `TokenUsage` carries no `rename_all` because its
+field names are the decode contract for already-journaled events.
+
+Run detail is **refresh-on-read**: steps persist incrementally, so re-reading a
+live attempt shows the progress since. Streaming would widen the harness turn
+stream for something a re-read already answers.
+
 ## Assembly
 
 ```rust

--- a/frontend/src/api/runs.ts
+++ b/frontend/src/api/runs.ts
@@ -1,0 +1,203 @@
+// The run-records API (#242): one *attempt* at a task, and its persisted step
+// trace. Mirrors `tasks.ts` — plain functions over `OpenCompanyClient`, the
+// company scope resolved by `client.scopeFor`, and the host's wire shapes
+// re-transcribed here so `tsc` pins the contract.
+//
+// The host answers these from an indexed store read, not a journal fold, so the
+// attempts list stays cheap however long a company's history gets.
+//
+// **Read-only on purpose.** There is no write here at all: a run is minted,
+// begun and settled by the dispatch path. The console inventing an attempt, or
+// re-statusing one, would fabricate a record of work that never ran — the same
+// reason `artifacts.ts` declines to wire the host's create/delete routes.
+
+import type { OpenCompanyClient } from "./client";
+import type { TimelineEntry } from "./tasks";
+
+/**
+ * Where one attempt stands.
+ *
+ * The two *parked* statuses are separated by *who unblocks the work* (epic
+ * #183): `waiting_approval` means a **person** must act; `paused` means
+ * anything else must — a dependency, a rate limit, a missing credential, a
+ * retry, an operator's pause.
+ *
+ * `paused` is currently unreachable from a delegation, so nothing in the UI may
+ * *depend* on seeing it — but it is handled everywhere a status is, because a
+ * status the console cannot render is worse than one it never meets.
+ */
+export type RunStatus =
+  | "pending"
+  | "running"
+  | "waiting_approval"
+  | "paused"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
+/**
+ * The coarse phase of a {@link RunStatus}, projected by the host.
+ *
+ * **Use this, never a timestamp, to decide whether an attempt is live.**
+ * `finishedAtMillis` is absent for a *parked* attempt exactly as it is for a
+ * running one — a parked run can still resume, so stamping it would make a
+ * resumable attempt read as over. Keying liveness off the missing timestamp is
+ * how an attempt waiting on a human ends up rendered as running forever.
+ *
+ * The host derives it from the state machine that owns the statuses, so a
+ * status added later lands in the right bucket without a console change.
+ */
+export type RunPhase = "active" | "parked" | "terminal";
+
+/** Tokens and cost attributed to an attempt, folded across its turns. */
+export interface RunUsage {
+  input: number;
+  output: number;
+  cachedInput: number;
+  /** Zero when the path reports tokens but bills elsewhere (managed passthrough). */
+  costUsd: number;
+}
+
+/** One recorded attempt at a task. */
+export interface RunSummary {
+  /** Stable id for the attempt within the company. */
+  id: string;
+  /** The card this is an attempt at. */
+  taskId: string;
+  /** The desk/teammate it was dispatched to. */
+  agentId: string;
+  /** Which attempt at the card this is — **1-based**; the first run is `1`. */
+  attempt: number;
+  status: RunStatus;
+  /** `active` | `parked` | `terminal`. See {@link RunPhase} before using it. */
+  phase: RunPhase;
+  /**
+   * The event-log sequence of the dispatch that drove this attempt. Absent
+   * while the run is still `pending` — the row is written *before* the event,
+   * on purpose, so a crash in that gap is visible instead of silent.
+   */
+  triggerEventSeq?: number;
+  /** Epoch-millis the row was minted. */
+  createdAtMillis: number;
+  /** Epoch-millis the cycle began. Absent while `pending`. */
+  startedAtMillis?: number;
+  /** Epoch-millis the attempt reached a **terminal** status. See {@link RunPhase}. */
+  finishedAtMillis?: number;
+  /**
+   * Why the attempt failed, in plain language.
+   *
+   * One value is worth expecting rather than treating as corruption: an attempt
+   * whose start never landed stays `pending`, cannot legally be parked, and is
+   * then closed `failed` by the dispatch cycle's backstop. Rare, but it is the
+   * honest record of a dispatch that died in the gap — render it, don't hide it.
+   */
+  error?: string;
+  /**
+   * Tokens and cost, written on the settle — so a live attempt's figures are
+   * **provisional** until `phase` leaves `active`.
+   *
+   * Deliberately not rendered on the Task Detail screen: epic #184 scopes that
+   * screen with the cost/currency dimension removed (no per-line cost, no
+   * total-cost header). It rides the wire for the usage surfaces that do own it.
+   */
+  usage: RunUsage;
+  /**
+   * The **high-water step ordinal actually persisted**, also written on the
+   * settle. Once {@link stepCountCapped} is set this is no longer "how many
+   * steps the agent took" — say so rather than implying otherwise.
+   */
+  stepCount: number;
+  /** Whether the trace hit the per-attempt ceiling and is a prefix of the run. */
+  stepCountCapped: boolean;
+}
+
+/**
+ * One attempt with its full persisted trace.
+ *
+ * **Refresh-on-read.** Steps persist incrementally *as the turn executes*, so
+ * re-reading a live attempt shows the progress made since the last read. There
+ * is deliberately no live stream: that would mean widening the harness turn
+ * stream for a surface a re-read already serves.
+ */
+export interface RunDetail {
+  run: RunSummary;
+  /**
+   * The step trace, oldest first, in the same {@link TimelineEntry} shape the
+   * Task Detail timeline renders — which is why the grouped-timeline renderer
+   * is reused for it rather than reinvented.
+   */
+  steps: TimelineEntry[];
+}
+
+/** Which attempts to list. All selectors are optional. */
+export interface RunQuery {
+  /** Only attempts at this card. */
+  task?: string;
+  /** Only these statuses. An unknown word is refused with a 400, not silently dropped. */
+  status?: RunStatus[];
+  /** Cap the page; the host clamps it. */
+  limit?: number;
+}
+
+function queryString(query: RunQuery): string {
+  const params = new URLSearchParams();
+  if (query.task) params.set("task", query.task);
+  if (query.status?.length) params.set("status", query.status.join(","));
+  if (query.limit !== undefined) params.set("limit", String(query.limit));
+  const encoded = params.toString();
+  return encoded ? `?${encoded}` : "";
+}
+
+/** The company's recorded attempts, **newest first**. */
+export function listRuns(
+  client: OpenCompanyClient,
+  company: string | null,
+  query: RunQuery = {},
+): Promise<RunSummary[]> {
+  return client.get<RunSummary[]>(`${client.scopeFor(company)}/runs${queryString(query)}`);
+}
+
+/** One attempt and its persisted step trace. 404s when the id names no attempt. */
+export function getRun(
+  client: OpenCompanyClient,
+  company: string | null,
+  id: string,
+): Promise<RunDetail> {
+  return client.get<RunDetail>(`${client.scopeFor(company)}/runs/${encodeURIComponent(id)}`);
+}
+
+// ---------------------------------------------------------------------------
+// Shared presentation helpers
+// ---------------------------------------------------------------------------
+
+/** A short, human word for a status. */
+export const RUN_STATUS_LABEL: Record<RunStatus, string> = {
+  pending: "Queued",
+  running: "Running",
+  waiting_approval: "In review",
+  paused: "Paused",
+  succeeded: "Succeeded",
+  failed: "Failed",
+  cancelled: "Cancelled",
+};
+
+/**
+ * How long an attempt has been going, in millis, or `null` when it has not
+ * started.
+ *
+ * The one place liveness is decided, so it cannot be got wrong twice: a
+ * **terminal** attempt measures to its finish time; anything else — running
+ * *or* parked — measures to `now`, because a parked attempt is still an open
+ * attempt whose clock has not stopped. `now` is the caller's, so the span is
+ * clamped at zero against clock skew.
+ */
+export function runElapsedMillis(run: RunSummary, now: number): number | null {
+  if (run.startedAtMillis === undefined) return null;
+  const end = run.phase === "terminal" ? (run.finishedAtMillis ?? now) : now;
+  return Math.max(0, end - run.startedAtMillis);
+}
+
+/** Whether an attempt's clock is still ticking — i.e. it has not settled. */
+export function isRunOpen(run: RunSummary): boolean {
+  return run.phase !== "terminal";
+}

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -3,6 +3,7 @@
 // the client-side `tasks-sample` illustrative data.
 
 import type { OpenCompanyClient } from "./client";
+import type { RunSummary } from "./runs";
 
 /** A board card as the host returns it. */
 export interface Task {
@@ -63,8 +64,33 @@ export function listTasks(client: OpenCompanyClient, company: string | null): Pr
 /**
  * A stable wire word for what a {@link TimelineEntry} records (#185). The host
  * emits exactly this set today; re-transcribed here so `tsc` pins the contract.
+ *
+ * Widened **additively** by #242 with the three step kinds a run's trace
+ * produces (`tool_call` | `thinking` | `note`). A task timeline never emits
+ * those and a run trace never emits the journal's five, but both arrive in this
+ * one shape on purpose: the grouped-timeline renderer is then reused for the
+ * run-detail drawer rather than reinvented beside it.
  */
-export type TimelineKind = "dispatched" | "reply" | "tool_failed" | "approval" | "completed";
+export type TimelineKind =
+  | "dispatched"
+  | "reply"
+  | "tool_failed"
+  | "approval"
+  | "completed"
+  | "tool_call"
+  | "thinking"
+  | "note";
+
+/**
+ * How a run-trace step ended (#242). Present only on entries that came from a
+ * run's step trace; a journal-derived task-timeline entry has no such notion.
+ *
+ * `running` is a **real and expected** resting state of a persisted row, not a
+ * glitch: the trace is written *as the turn executes*, so a host killed
+ * mid-tool-call leaves that call recorded exactly as it stood. It means
+ * in-flight-when-the-trace-stopped — render it as such, never as a failure.
+ */
+export type StepStatus = "ok" | "error" | "running";
 
 /**
  * One entry on a task's timeline (#185) — the same scrubbed vocabulary the host
@@ -73,16 +99,34 @@ export type TimelineKind = "dispatched" | "reply" | "tool_failed" | "approval" |
  * arguments, output, or call ids.
  */
 export interface TimelineEntry {
-  /** The journal sequence — the stable render key, and the strict order. */
+  /**
+   * The stable render key, and the strict order.
+   *
+   * On a task timeline this is the company-wide journal sequence. On a run's
+   * step trace (#242) it is the **run-scoped** step ordinal, 0-based and dense
+   * — so two different runs both have a step `0`. Never compare a `seq` across
+   * the two surfaces.
+   */
   seq: number;
-  /** Epoch-millis the event was journaled. */
+  /** Epoch-millis the event was journaled, or the step recorded. */
   atMillis: number;
-  /** What happened: `dispatched` | `reply` | `tool_failed` | `approval` | `completed`. */
+  /** What happened. See {@link TimelineKind} for which surface emits which words. */
   kind: TimelineKind;
   /** A short, past-tense human label rendered verbatim. */
   label: string;
   /** Optional scrubbed detail; expands under the row when present. */
   detail?: string;
+  /**
+   * How a run-trace step ended (#242). Absent on task-timeline entries, which
+   * have no such notion — so `undefined` means "not a step", never "unknown
+   * outcome".
+   */
+  status?: StepStatus;
+  /**
+   * How long a run-trace step took (#242), when known. Tool calls report it;
+   * thinking and note steps do not.
+   */
+  elapsedMs?: number;
   /**
    * On an `approval` entry: how long the company sat waiting on the operator
    * before this resolution landed (#305), clamped to the run window.
@@ -117,6 +161,14 @@ export interface TaskDetail {
   timeline: TimelineEntry[];
   /** Parent and children. */
   lineage: TaskLineage;
+  /**
+   * The card's recorded attempts, newest first (#242).
+   *
+   * Empty is a legitimate answer, not an error: run records were not
+   * backfilled, so a card dispatched before they existed genuinely has none —
+   * synthesising attempts from old reply events would fabricate identity.
+   */
+  runs: RunSummary[];
   /**
    * Epoch-millis this task started waiting on an operator *right now* (#305),
    * or absent when nothing is currently parked for its run.

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -10,6 +10,7 @@ import {
   AlertCircle,
   ArrowLeft,
   Ban,
+  Brain,
   CheckCircle2,
   ChevronDown,
   ChevronRight,
@@ -18,6 +19,7 @@ import {
   CornerUpLeft,
   CornerUpRight,
   Hourglass,
+  Layers,
   Loader2,
   MessageSquare,
   MessagesSquare,
@@ -26,7 +28,9 @@ import {
   Send,
   ShieldCheck,
   Square,
+  StickyNote,
   UserCog,
+  Wrench,
 } from "lucide-react";
 
 import {
@@ -35,12 +39,22 @@ import {
   patchTask,
   steerTask,
   type InflightRun,
+  type StepStatus,
   type SteerAction,
   type Task,
   type TaskDetail,
   type TimelineEntry,
   type TimelineKind,
 } from "@/api/tasks";
+import {
+  getRun,
+  isRunOpen,
+  runElapsedMillis,
+  RUN_STATUS_LABEL,
+  type RunDetail,
+  type RunStatus,
+  type RunSummary,
+} from "@/api/runs";
 import { ApiError } from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
 import {
@@ -60,6 +74,13 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { PRIORITY_STYLES, TASK_COLUMNS } from "@/lib/tasks-sample";
@@ -293,8 +314,13 @@ export function TaskDetailView({
   );
 
   // Only tick the 1s clock while something is actually running: a dispatch
-  // window is open, or the task is parked on an operator right now.
-  const ticking = Boolean(worked?.live) || Boolean(waiting?.live);
+  // window is open, the task is parked on an operator right now, or an attempt
+  // has not settled (#242 — a parked attempt's clock is still running, which is
+  // why this asks the run's phase and not its finish time).
+  const ticking =
+    Boolean(worked?.live) ||
+    Boolean(waiting?.live) ||
+    Boolean(detail?.runs.some(isRunOpen));
   useEffect(() => {
     if (!ticking) return;
     const timer = window.setInterval(() => {
@@ -367,6 +393,14 @@ export function TaskDetailView({
             <Tabs defaultValue="timeline">
               <TabsList>
                 <TabsTrigger value="timeline">Timeline</TabsTrigger>
+                <TabsTrigger value="attempts">
+                  Attempts
+                  {detail.runs.length > 0 && (
+                    <span className="ml-1.5 tabular-nums text-muted-foreground">
+                      {detail.runs.length}
+                    </span>
+                  )}
+                </TabsTrigger>
                 <TabsTrigger value="approvals">Approvals</TabsTrigger>
                 <TabsTrigger value="artifacts">Artifacts</TabsTrigger>
                 <TabsTrigger value="discussion">Discussion</TabsTrigger>
@@ -376,6 +410,15 @@ export function TaskDetailView({
                 <TimelineList
                   entries={detail.timeline}
                   waitingSince={detail.waitingSince}
+                  now={now}
+                />
+              </TabsContent>
+
+              <TabsContent value="attempts" className="mt-4">
+                <AttemptsTab
+                  client={client}
+                  company={company}
+                  runs={detail.runs}
                   now={now}
                 />
               </TabsContent>
@@ -826,6 +869,8 @@ function LineageRail({
 interface TimelineGroup {
   key: string;
   kind: TimelineKind;
+  /** A run step's outcome (#242); absent for journal-derived entries. */
+  status?: StepStatus;
   label: string;
   count: number;
   entries: TimelineEntry[];
@@ -860,11 +905,24 @@ function groupTimeline(
   const groups: TimelineGroup[] = [];
   for (const e of entries) {
     const last = groups[groups.length - 1];
-    if (e.kind === "tool_failed" && last && last.kind === "tool_failed" && last.label === e.label) {
+    if (
+      isFailureRow(e) &&
+      last &&
+      last.kind === e.kind &&
+      last.label === e.label &&
+      isFailureRow(last.entries[last.entries.length - 1])
+    ) {
       last.count += 1;
       last.entries.push(e);
     } else {
-      groups.push({ key: String(e.seq), kind: e.kind, label: e.label, count: 1, entries: [e] });
+      groups.push({
+        key: String(e.seq),
+        kind: e.kind,
+        status: e.status,
+        label: e.label,
+        count: 1,
+        entries: [e],
+      });
     }
   }
 
@@ -895,9 +953,31 @@ const KIND_ICON: Record<TimelineKind, ReactElement> = {
   tool_failed: <AlertCircle className="size-3.5" />,
   approval: <ShieldCheck className="size-3.5" />,
   completed: <CheckCircle2 className="size-3.5" />,
+  // The run-trace kinds (#242). Same renderer, three more icon rows.
+  tool_call: <Wrench className="size-3.5" />,
+  thinking: <Brain className="size-3.5" />,
+  note: <StickyNote className="size-3.5" />,
 };
 
-function kindTone(kind: TimelineKind): string {
+/**
+ * The icon for a row. A run step's **outcome** outranks its kind (#242): a
+ * failed tool call reads as a failure, and one still in flight reads as a
+ * spinner — which is the honest render of a step the trace recorded as
+ * `running` because the host died mid-call, not an error.
+ *
+ * Task-timeline entries carry no `status`, so they fall through to the kind
+ * icon exactly as before.
+ */
+function rowIcon(kind: TimelineKind, status?: StepStatus): ReactElement {
+  if (status === "running") return <Loader2 className="size-3.5 animate-spin" />;
+  if (status === "error") return <AlertCircle className="size-3.5" />;
+  return KIND_ICON[kind];
+}
+
+function kindTone(kind: TimelineKind, status?: StepStatus): string {
+  // Outcome first, for the same reason `rowIcon` reads it first.
+  if (status === "running") return "text-sky-600 dark:text-sky-400";
+  if (status === "error") return "text-rose-600 dark:text-rose-400";
   switch (kind) {
     case "completed":
       return "text-emerald-600 dark:text-emerald-400";
@@ -908,6 +988,16 @@ function kindTone(kind: TimelineKind): string {
     default:
       return "text-muted-foreground";
   }
+}
+
+/**
+ * Whether a row is a failure, from either surface: the journal's `tool_failed`
+ * kind, or a run step whose recorded outcome was an error (#242). This is what
+ * the `×N` coalescing keys on, so a tool that failed six times in a row reads
+ * the same in a run's trace as it does on the task timeline.
+ */
+function isFailureRow(entry: TimelineEntry): boolean {
+  return entry.kind === "tool_failed" || entry.status === "error";
 }
 
 function TimelineList({
@@ -991,12 +1081,20 @@ function TimelineRow({ group }: { group: TimelineGroup }) {
         disabled={!expandable}
         onClick={() => expandable && setOpen((o) => !o)}
       >
-        <span className={cn("shrink-0", kindTone(group.kind))}>{KIND_ICON[group.kind]}</span>
+        <span className={cn("shrink-0", kindTone(group.kind, group.status))}>
+          {rowIcon(group.kind, group.status)}
+        </span>
         <span className="min-w-0 flex-1 truncate font-medium">{group.label}</span>
         {group.count > 1 && (
           <Badge variant="outline" className="shrink-0 font-normal">
             ×{group.count}
           </Badge>
+        )}
+        {/* A run step's own duration (#242); journal entries carry none. */}
+        {group.count === 1 && first.elapsedMs !== undefined && (
+          <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+            {first.elapsedMs < 1000 ? `${first.elapsedMs}ms` : formatDuration(first.elapsedMs)}
+          </span>
         )}
         <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
           {timeOf(first.atMillis)}
@@ -1032,6 +1130,288 @@ function TimelineRow({ group }: { group: TimelineGroup }) {
         </div>
       )}
     </li>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Attempts (#242)
+// ---------------------------------------------------------------------------
+
+/**
+ * The tone of a run's status chip. `waiting_approval` and `paused` share the
+ * amber "parked" tone the waiting band already uses — they differ in *who*
+ * unblocks them, not in whether the company is stuck.
+ */
+function runStatusTone(status: RunStatus): string {
+  switch (status) {
+    case "succeeded":
+      return "border-emerald-500/40 text-emerald-700 dark:text-emerald-400";
+    case "failed":
+      return "border-rose-500/40 text-rose-700 dark:text-rose-400";
+    case "cancelled":
+      return "border-muted-foreground/30 text-muted-foreground";
+    case "waiting_approval":
+    case "paused":
+      return "border-amber-500/40 text-amber-700 dark:text-amber-400";
+    default:
+      return "border-sky-500/40 text-sky-700 dark:text-sky-400";
+  }
+}
+
+/**
+ * The card's recorded attempts (#242) — the thing that makes a task which
+ * failed twice and succeeded on the third try look different from one that
+ * succeeded immediately.
+ *
+ * Cost is deliberately absent: epic #184 scopes this screen with the
+ * cost/currency dimension removed (no per-line cost, no total-cost header), and
+ * a per-attempt USD figure is exactly a per-line cost. The usage totals are on
+ * the wire for the surfaces that own them.
+ */
+function AttemptsTab({
+  client,
+  company,
+  runs,
+  now,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+  runs: RunSummary[];
+  now: number;
+}) {
+  const [openId, setOpenId] = useState<string | null>(null);
+  const open = useMemo(() => runs.find((r) => r.id === openId) ?? null, [runs, openId]);
+
+  if (runs.length === 0) {
+    return (
+      <EmptyState
+        title="No recorded attempts"
+        body="Dispatch this card to record one. Cards dispatched before attempts were recorded show none — they were never backfilled, because inventing them would fabricate a record."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-muted-foreground">
+        Every dispatch of this card, newest first. A card can enter review more than once, so
+        several waits on one attempt is the expected record, not a fault.
+      </p>
+      <ol className="space-y-1.5">
+        {runs.map((run) => (
+          <AttemptRow key={run.id} run={run} now={now} onOpen={() => setOpenId(run.id)} />
+        ))}
+      </ol>
+      <RunDrawer
+        client={client}
+        company={company}
+        run={open}
+        now={now}
+        onClose={() => setOpenId(null)}
+      />
+    </div>
+  );
+}
+
+/**
+ * What to say about an attempt's step count, which is **written on the settle**
+ * and so reads `0` for the whole of a live run.
+ *
+ * Three honest cases rather than one misleading number:
+ * - never started (`pending`) — nothing has been traced, and nothing is being
+ *   traced either, so it does not claim to be recording;
+ * - open but unsettled — steps *are* landing incrementally (the drawer shows
+ *   them), the count just has not been written yet;
+ * - settled — the real figure, marked `+` when it is a capped high-water
+ *   ordinal rather than a total.
+ */
+function stepSummary(run: RunSummary): string {
+  if (run.startedAtMillis === undefined) return "not started";
+  if (isRunOpen(run) && run.stepCount === 0) return "recording…";
+  const n = run.stepCount;
+  return `${n}${run.stepCountCapped ? "+" : ""} step${n === 1 ? "" : "s"}`;
+}
+
+function AttemptRow({
+  run,
+  now,
+  onOpen,
+}: {
+  run: RunSummary;
+  now: number;
+  onOpen: () => void;
+}) {
+  const elapsed = runElapsedMillis(run, now);
+  return (
+    <li className="rounded-lg border bg-card">
+      <button
+        className="flex w-full cursor-pointer flex-col gap-1 px-3 py-2 text-left"
+        onClick={onOpen}
+      >
+        <div className="flex w-full items-center gap-2 text-xs">
+          <Layers className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className="shrink-0 font-medium">Attempt {run.attempt}</span>
+          <Badge variant="outline" className={cn("shrink-0 font-normal", runStatusTone(run.status))}>
+            {RUN_STATUS_LABEL[run.status]}
+          </Badge>
+          <span className="min-w-0 flex-1 truncate text-muted-foreground">{run.agentId}</span>
+          {elapsed !== null && (
+            <span
+              className={cn(
+                "shrink-0 tabular-nums text-[11px] text-muted-foreground",
+                isRunOpen(run) && "text-foreground",
+              )}
+            >
+              {formatDuration(elapsed)}
+              {isRunOpen(run) && " …"}
+            </span>
+          )}
+          <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+        </div>
+        <div className="flex w-full items-center gap-2 pl-5 text-[11px] text-muted-foreground">
+          <span className="tabular-nums">{timeOf(run.createdAtMillis)}</span>
+          <span aria-hidden>·</span>
+          <span>{stepSummary(run)}</span>
+          {run.stepCountCapped && <span>(trace capped)</span>}
+        </div>
+        {run.error && (
+          <p className="w-full truncate pl-5 text-[11px] text-rose-600 dark:text-rose-400">
+            {run.error}
+          </p>
+        )}
+      </button>
+    </li>
+  );
+}
+
+/**
+ * One attempt's persisted step trace, in a side drawer (#242).
+ *
+ * **Refresh-on-read.** Steps land in the store *as the turn executes*, so
+ * re-reading an open attempt shows the progress made since — which is why this
+ * re-fetches on the same cadence as the screen while the run has not settled,
+ * and stops once it has. A live stream would mean widening the harness turn
+ * stream for something a re-read already answers.
+ */
+function RunDrawer({
+  client,
+  company,
+  run,
+  now,
+  onClose,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+  run: RunSummary | null;
+  now: number;
+  onClose: () => void;
+}) {
+  const [detail, setDetail] = useState<RunDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const runId = run?.id ?? null;
+  // Re-fetch while the attempt is unsettled. Read from the *summary* the parent
+  // poll refreshes, so the drawer stops polling as soon as the run settles even
+  // if its own last read still showed it open.
+  const live = run !== null && isRunOpen(run);
+
+  useEffect(() => {
+    if (runId === null) {
+      setDetail(null);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    const read = async () => {
+      try {
+        const next = await getRun(client, company, runId);
+        if (!cancelled) {
+          setDetail(next);
+          setError(null);
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "could not load the attempt");
+      }
+    };
+    void read();
+    if (!live) return () => void (cancelled = true);
+    const timer = window.setInterval(() => {
+      if (document.visibilityState !== "hidden") void read();
+    }, POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [client, company, runId, live]);
+
+  const elapsed = run ? runElapsedMillis(run, now) : null;
+
+  return (
+    <Sheet open={run !== null} onOpenChange={(next) => !next && onClose()}>
+      <SheetContent side="right" className="w-full sm:max-w-md">
+        {run && (
+          <>
+            <SheetHeader className="border-b">
+              <SheetTitle>Attempt {run.attempt}</SheetTitle>
+              <SheetDescription className="flex flex-wrap items-center gap-1.5 text-xs">
+                <Badge
+                  variant="outline"
+                  className={cn("font-normal", runStatusTone(run.status))}
+                >
+                  {RUN_STATUS_LABEL[run.status]}
+                </Badge>
+                <span>{run.agentId}</span>
+                {elapsed !== null && (
+                  <>
+                    <span aria-hidden>·</span>
+                    <span className="tabular-nums">{formatDuration(elapsed)}</span>
+                  </>
+                )}
+              </SheetDescription>
+            </SheetHeader>
+            <ScrollArea className="min-h-0 flex-1">
+              <div className="space-y-3 px-4 pb-4">
+                {run.error && (
+                  <Alert variant="destructive">
+                    <AlertDescription className="text-xs">{run.error}</AlertDescription>
+                  </Alert>
+                )}
+                {error && (
+                  <Alert variant="destructive">
+                    <AlertDescription className="text-xs">{error}</AlertDescription>
+                  </Alert>
+                )}
+                {run.stepCountCapped && (
+                  <p className="text-[11px] text-muted-foreground">
+                    This attempt hit the per-run trace ceiling, so what follows is the start of
+                    the run, not all of it.
+                  </p>
+                )}
+                {detail === null && error === null ? (
+                  <div className="space-y-1.5 pt-1">
+                    <Skeleton className="h-9 rounded-lg" />
+                    <Skeleton className="h-9 rounded-lg" />
+                    <Skeleton className="h-9 rounded-lg" />
+                  </div>
+                ) : detail && detail.steps.length === 0 ? (
+                  <EmptyState
+                    title="No steps recorded"
+                    body={
+                      isRunOpen(run)
+                        ? "Steps appear here as the attempt runs."
+                        : "This attempt settled without producing a traceable step."
+                    }
+                  />
+                ) : detail ? (
+                  /* The same grouped-timeline renderer the task timeline uses —
+                     `kind` simply widens to the three step words. */
+                  <TimelineList entries={detail.steps} now={now} />
+                ) : null}
+              </div>
+            </ScrollArea>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
   );
 }
 

--- a/src/ports/runs.rs
+++ b/src/ports/runs.rs
@@ -97,11 +97,58 @@ impl RunStatus {
         }
     }
 
+    /// Parses a wire/column literal back into a status, or `None`.
+    ///
+    /// The inverse of [`Self::as_str`], and deliberately in the same `impl`
+    /// rather than left to each reader: a REST `?status=` filter that grew its
+    /// own literal table would be free to drift from the column the backend
+    /// indexes. [`from_wire_round_trips`](self::test::from_wire_round_trips)
+    /// pins the two together.
+    pub fn from_wire(word: &str) -> Option<Self> {
+        Some(match word {
+            "pending" => Self::Pending,
+            "running" => Self::Running,
+            "waiting_approval" => Self::WaitingApproval,
+            "paused" => Self::Paused,
+            "succeeded" => Self::Succeeded,
+            "failed" => Self::Failed,
+            "cancelled" => Self::Cancelled,
+            _ => return None,
+        })
+    }
+
     /// Whether the attempt is over for good. Nothing moves out of a terminal
     /// status — a re-run is a *new* attempt with its own ordinal, never a
     /// resurrection of this one.
     pub fn is_terminal(self) -> bool {
         matches!(self, Self::Succeeded | Self::Failed | Self::Cancelled)
+    }
+
+    /// Which of the three coarse phases this status sits in: `active`,
+    /// `parked`, or `terminal`.
+    ///
+    /// A projection of [`Self::is_active`] / [`Self::is_parked`] /
+    /// [`Self::is_terminal`], which partition the enum
+    /// ([`phases_partition_every_status`](self::test::phases_partition_every_status)
+    /// pins that).
+    ///
+    /// It exists for readers — chiefly the console — that need to know whether
+    /// an attempt is live, waiting, or over, and must not answer that from a
+    /// timestamp. `finished_at_millis` is `None` for a **parked** run as well as
+    /// a live one, so "no finish time" does not mean "still running"; a reader
+    /// that guessed from the timestamp would render a run waiting on a human as
+    /// though it were burning tokens. Projecting the phase here means the
+    /// terminal set is enumerated once, in the module that owns the state
+    /// machine, instead of being re-derived by every surface and drifting the
+    /// next time a status is added.
+    pub fn phase(self) -> &'static str {
+        if self.is_terminal() {
+            "terminal"
+        } else if self.is_parked() {
+            "parked"
+        } else {
+            "active"
+        }
     }
 
     /// Whether the attempt claims to be live in *this* process — the states a
@@ -616,6 +663,62 @@ mod test {
                 format!("\"{}\"", status.as_str()),
                 "the indexed column literal and the wire form must not drift"
             );
+        }
+    }
+
+    /// The `?status=` filter parses the exact literal the backend indexes —
+    /// pinned in both directions so neither table can drift alone.
+    #[test]
+    fn from_wire_round_trips() {
+        for status in ALL {
+            assert_eq!(
+                RunStatus::from_wire(status.as_str()),
+                Some(status),
+                "{status} does not parse back from its own literal"
+            );
+        }
+        assert_eq!(RunStatus::from_wire("Succeeded"), None, "case is exact");
+        assert_eq!(RunStatus::from_wire("waitingApproval"), None);
+        assert_eq!(RunStatus::from_wire(""), None);
+    }
+
+    /// `phase()` is only sound if the three predicates partition the enum:
+    /// exactly one must hold for every status, or a run would report a phase
+    /// that contradicts one of them.
+    #[test]
+    fn phases_partition_every_status() {
+        for status in ALL {
+            let held = [status.is_active(), status.is_parked(), status.is_terminal()]
+                .into_iter()
+                .filter(|b| *b)
+                .count();
+            assert_eq!(held, 1, "{status} is in {held} phases, not exactly one");
+        }
+        assert_eq!(RunStatus::Pending.phase(), "active");
+        assert_eq!(RunStatus::Running.phase(), "active");
+        assert_eq!(RunStatus::WaitingApproval.phase(), "parked");
+        assert_eq!(RunStatus::Paused.phase(), "parked");
+        assert_eq!(RunStatus::Succeeded.phase(), "terminal");
+        assert_eq!(RunStatus::Failed.phase(), "terminal");
+        assert_eq!(RunStatus::Cancelled.phase(), "terminal");
+    }
+
+    /// The trap this whole projection exists for: a parked run has **no**
+    /// finish time, exactly like a live one, so a reader that inferred
+    /// liveness from the timestamp would call a run waiting on a person "still
+    /// running" forever.
+    #[test]
+    fn a_parked_run_has_no_finish_time_and_is_not_active() {
+        for parked in [RunStatus::WaitingApproval, RunStatus::Paused] {
+            let mut record = run("r1", 10, 1);
+            record.status = RunStatus::Running;
+            record.started_at_millis = Some(11);
+            // What `finish_run` would stamp: only a terminal settle is a finish.
+            record.status = parked;
+            record.finished_at_millis = parked.is_terminal().then_some(12);
+            assert_eq!(record.finished_at_millis, None);
+            assert!(!record.is_active(), "{parked} must not read as live");
+            assert_eq!(record.status.phase(), "parked");
         }
     }
 

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -30,6 +30,7 @@ pub mod mail;
 pub mod mailer;
 pub mod mcp;
 pub mod memory;
+pub mod runs;
 pub mod scope;
 pub mod skills;
 pub mod smtp;
@@ -152,6 +153,7 @@ pub fn router() -> Router<AppState> {
         .merge(smtp::router())
         .merge(inbox::router())
         .merge(tasks::router())
+        .merge(runs::router())
         .merge(artifacts::router())
         .merge(memory::router())
         .merge(workspace::router())

--- a/src/server/ops/runs.rs
+++ b/src/server/ops/runs.rs
@@ -1,0 +1,932 @@
+//! Run reads: `GET …/runs?task=&status=&limit=` and `GET …/runs/{run_id}`,
+//! under both scope forms (issue #242).
+//!
+//! These are the read half of the `Run` object. The write half already exists:
+//! [`CompanyRuntime::dispatch_task`](crate::company::runtime::CompanyRuntime)
+//! mints a row per attempt, [`CycleRunner`](crate::runtime::CycleRunner) begins
+//! and settles it, and
+//! [`RunTraceSink`](crate::harness::run_trace::RunTraceSink) writes the step
+//! trace *during* the turn. Nothing here computes anything the store does not
+//! already hold — these routes project it.
+//!
+//! ## Why this is a store read and not a journal fold
+//!
+//! The sibling run-history route ([`super::workflows::list_runs`]) folds the
+//! company's whole event log on every request, and its own doc says so. That
+//! cost is exactly why [`RunStore`](crate::ports::RunStore) exists: a run is
+//! *queryable state*, indexed on task and status by every backend, so
+//! `GET …/runs` hands its predicates to
+//! [`RunStore::list_runs`](crate::ports::RunStore::list_runs) and reads only the
+//! rows it will return. No route in this module iterates events.
+//!
+//! ## What the wire shape refuses to imply
+//!
+//! Three honesty constraints, all of them states the write path really
+//! produces:
+//!
+//! * **A missing `finishedAtMillis` does not mean "still running."** It is
+//!   absent for a *parked* run too, because a parked run can still resume and
+//!   stamping it would make a resumable attempt read as over. So every summary
+//!   carries [`RunStatus::phase`] — `active` / `parked` / `terminal` — and the
+//!   console keys off that, never off the timestamp.
+//! * **`stepCount` is the high-water ordinal actually persisted**, capped at
+//!   [`MAX_RUN_STEPS`]. On a long attempt it is not "how many steps the agent
+//!   took", so `stepCountCapped` says when the cap was reached instead of
+//!   letting the number quietly lie.
+//! * **A step left `running` is in flight, not broken.** Killing a host
+//!   mid-tool-call leaves that row exactly as the trace sink wrote it — which
+//!   is the entire point of an incremental trace — so the step's
+//!   [`TurnStepStatus`] rides the wire beside its kind and the console renders
+//!   it as in-flight rather than as a failure.
+//!
+//! ## Steps reuse the console's timeline contract
+//!
+//! [`RunStepEntry`]'s wire form is the `TimelineEntry` shape the Task Detail
+//! screen already renders (`super::tasks::TimelineEntry`, and `TimelineEntry`
+//! in `frontend/src/api/tasks.ts`): `seq` / `atMillis` / `kind` / `label` /
+//! `detail`, plus the two fields a step has and a journal entry does not
+//! (`status`, `elapsedMs`). Reusing the contract means the grouped-timeline
+//! renderer is reused rather than reinvented — `kind` simply widens additively
+//! from the journal's five words to include the three [`TurnStepKind`] words.
+
+use axum::extract::{Path, Query};
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+use crate::error::OpenCompanyError;
+use crate::ports::runs::{RunFilter, RunRecord, RunStatus, RunStepRecord};
+use crate::ports::types::{TokenUsage, TurnStepKind, TurnStepStatus};
+use crate::server::error::ApiError;
+use crate::server::ops::{ScopedCompany, scoped};
+
+/// The per-attempt step ceiling the trace sink enforces, re-stated here so the
+/// read side can flag a capped `stepCount` without depending on the harness.
+///
+/// The sink is compiled only under `feature = "openhuman"`; these read routes
+/// are not, and a store written by a harness build is read back by any build.
+/// `the_cap_matches_the_trace_sink` pins the two together on a build that has
+/// both.
+const MAX_RUN_STEPS: u32 = 500;
+
+/// How many attempts `GET …/runs` returns when the caller names no `?limit=`,
+/// and the ceiling a larger one is clamped to.
+const DEFAULT_RUN_LIMIT: usize = 50;
+const MAX_RUN_LIMIT: usize = 200;
+
+/// How many attempts ride along on `GET …/tasks/{id}`.
+///
+/// Bounded because a card can be re-dispatched without limit and the task
+/// detail read must stay one cheap call. The console's attempts section pages
+/// through `GET …/runs?task=` when it wants more.
+pub(crate) const TASK_DETAIL_RUN_LIMIT: usize = 50;
+
+/// Builds the run route fragment.
+pub fn router() -> Router<AppState> {
+    // No static/dynamic ordering hazard here: `/runs` has no static child
+    // segment, so `{run_id}` cannot shadow anything.
+    scoped("/runs", get(list_runs)).merge(scoped("/runs/{run_id}", get(run_detail)))
+}
+
+// ---------------------------------------------------------------------------
+// Wire shapes
+// ---------------------------------------------------------------------------
+
+/// An attempt's token/cost totals, in the console's casing.
+///
+/// A projection of [`TokenUsage`] rather than the type itself, because
+/// `TokenUsage` carries **no** `rename_all`: it is embedded in
+/// [`CycleResult`](crate::ports::types::CycleResult) and therefore in
+/// already-journaled events, where its field names are the durable decode
+/// contract for every row ever written. Renaming it there to suit a REST
+/// response would be a migration, not a rename.
+///
+/// So the wire casing is fixed here instead. Without this the response would
+/// be the worst of both: `input` and `output` looking camelCase by accident of
+/// being single words, beside a snake_case `cached_input` and `cost_usd` — an
+/// object no console type could describe honestly.
+/// `usage_is_camel_case_on_the_wire` pins it.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RunUsage {
+    input: u64,
+    output: u64,
+    cached_input: u64,
+    /// Zero when the path reports tokens but bills elsewhere (the managed
+    /// passthrough echoes no USD), so tokens stay comparable across attempts.
+    cost_usd: f64,
+}
+
+impl From<TokenUsage> for RunUsage {
+    fn from(usage: TokenUsage) -> Self {
+        Self {
+            input: usage.input,
+            output: usage.output,
+            cached_input: usage.cached_input,
+            cost_usd: usage.cost_usd,
+        }
+    }
+}
+
+/// One attempt, as the console's attempts list renders it.
+///
+/// Everything is projected from the stored [`RunRecord`]; the company is
+/// dropped because it is already the scope of the request.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RunSummary {
+    /// Stable id for the attempt.
+    id: String,
+    /// The card this is an attempt at.
+    task_id: String,
+    /// The desk/teammate it was dispatched to.
+    agent_id: String,
+    /// Which attempt at the card this is, 1-based.
+    attempt: u32,
+    /// Where it stands: `pending` · `running` · `waiting_approval` · `paused` ·
+    /// `succeeded` · `failed` · `cancelled`.
+    status: RunStatus,
+    /// The coarse phase of `status`: `active`, `parked`, or `terminal`.
+    ///
+    /// Derived server-side by [`RunStatus::phase`] so the terminal set is
+    /// enumerated once, in the module that owns the state machine. A reader
+    /// must decide liveness from this and never from `finishedAtMillis`, which
+    /// is absent for a parked run as well as a live one.
+    phase: &'static str,
+    /// The event-log seq of the `TaskDispatched` that drove the attempt.
+    /// Absent while the run is still `pending` (the row is written before the
+    /// event, on purpose) and for a dispatch that failed before the append.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trigger_event_seq: Option<u64>,
+    /// Epoch-millis the row was minted.
+    created_at_millis: u64,
+    /// Epoch-millis the cycle began. Absent while `pending`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    started_at_millis: Option<u64>,
+    /// Epoch-millis the attempt reached a **terminal** status. Absent for a
+    /// parked run, which can still resume — see `phase`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    finished_at_millis: Option<u64>,
+    /// Why the attempt failed, in plain language, when the settle carried one.
+    ///
+    /// One value here is worth recognising rather than special-casing away: a
+    /// run whose `begin_run` never landed stays `pending`, a `waiting_approval`
+    /// settle on it is refused by the state machine, and the cycle's
+    /// terminality backstop then closes it `failed` with the reason it could
+    /// not settle. That row is rare but it is the honest record of a dispatch
+    /// that died in the gap.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    /// Tokens and cost folded across the attempt's turns.
+    ///
+    /// Written on the settle, so a live attempt's figures are **provisional**
+    /// until it reaches a terminal or parked status — which `phase` says.
+    usage: RunUsage,
+    /// The high-water step ordinal actually persisted — not "how many steps the
+    /// agent took" once `stepCountCapped` is set. Also written on the settle.
+    step_count: u32,
+    /// Whether `stepCount` hit the per-attempt ceiling, meaning the trace is a
+    /// prefix of the run rather than the whole of it.
+    step_count_capped: bool,
+}
+
+impl From<RunRecord> for RunSummary {
+    fn from(run: RunRecord) -> Self {
+        Self {
+            id: run.id,
+            task_id: run.task_id,
+            agent_id: run.agent_id,
+            attempt: run.attempt,
+            status: run.status,
+            phase: run.status.phase(),
+            trigger_event_seq: run.trigger_event_seq.map(|s| s.value()),
+            created_at_millis: run.created_at_millis,
+            started_at_millis: run.started_at_millis,
+            finished_at_millis: run.finished_at_millis,
+            error: run.error,
+            usage: run.usage.into(),
+            step_count: run.step_count,
+            step_count_capped: run.step_count >= MAX_RUN_STEPS,
+        }
+    }
+}
+
+/// One step of an attempt's trace, in the console's `TimelineEntry` shape.
+///
+/// See the module docs: this is deliberately the same wire contract the Task
+/// Detail timeline already renders, widened additively rather than duplicated.
+/// `kind` and `status` serialize straight from their enums, so the literals
+/// cannot drift from the ones the harness scrubber produces.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RunStepEntry {
+    /// Position within the attempt: 0-based, dense, run-scoped. The render key.
+    ///
+    /// Deliberately **not** an event seq — an event seq is company-wide and
+    /// shared with chat and audit. Two runs both have a step `0`.
+    seq: u32,
+    /// Epoch-millis the step was recorded.
+    at_millis: u64,
+    /// `tool_call` · `thinking` · `note`.
+    kind: TurnStepKind,
+    /// `ok` · `error` · `running`.
+    ///
+    /// `running` is a real, expected terminal state of a *row*: a killed host
+    /// leaves the tool call that was in flight exactly as the sink wrote it.
+    /// It means in-flight-when-the-trace-stopped, never failed.
+    status: TurnStepStatus,
+    /// A short, server-computed human label. Never derived from tool arguments
+    /// or output.
+    label: String,
+    /// Whitelisted, already-scrubbed enrichment. Never raw tool output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+    /// How long the step took, when known (tool calls report it; thinking and
+    /// note steps do not).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    elapsed_ms: Option<u64>,
+}
+
+impl From<RunStepRecord> for RunStepEntry {
+    fn from(record: RunStepRecord) -> Self {
+        Self {
+            seq: record.step_seq,
+            at_millis: record.at_millis,
+            kind: record.step.kind,
+            status: record.step.status,
+            label: record.step.label,
+            detail: record.step.detail,
+            elapsed_ms: record.step.elapsed_ms,
+        }
+    }
+}
+
+/// One attempt with its full persisted trace.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RunDetail {
+    /// The attempt itself — the same shape the list returns per row.
+    run: RunSummary,
+    /// The step trace, oldest first.
+    ///
+    /// **Refresh-on-read.** Steps persist incrementally, so re-reading a live
+    /// attempt shows the progress made since the last read; there is no live
+    /// stream here on purpose, because streaming would mean widening the
+    /// harness turn stream for a surface a poll already serves.
+    steps: Vec<RunStepEntry>,
+}
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+/// The `?task=` / `?status=` / `?limit=` selectors on the run list.
+#[derive(Debug, Deserialize)]
+struct RunsQuery {
+    /// Only attempts at this card. Absent = every card.
+    task: Option<String>,
+    /// A comma-separated status list (`?status=failed,cancelled`). Absent =
+    /// any status. An unknown word is a 400 rather than a silent empty page:
+    /// a typo'd filter that returns `[]` looks exactly like "nothing matched".
+    status: Option<String>,
+    /// Cap the page. Clamped to [`MAX_RUN_LIMIT`]; `0` falls back to the
+    /// default rather than returning an empty page, which is never what a
+    /// caller means.
+    limit: Option<usize>,
+}
+
+impl RunsQuery {
+    /// Turns the query string into the store's own filter — the whole read
+    /// plan, handed to the backend rather than applied to a scan.
+    fn into_filter(self) -> Result<RunFilter, ApiError> {
+        let mut statuses = Vec::new();
+        for word in self
+            .status
+            .iter()
+            .flat_map(|raw| raw.split(','))
+            .map(str::trim)
+            .filter(|word| !word.is_empty())
+        {
+            let status = RunStatus::from_wire(word).ok_or_else(|| {
+                ApiError(OpenCompanyError::InvalidRequest(format!(
+                    "unknown run status '{word}': expected one of pending, running, \
+                     waiting_approval, paused, succeeded, failed, cancelled"
+                )))
+            })?;
+            statuses.push(status);
+        }
+        Ok(RunFilter {
+            task_id: self.task,
+            statuses,
+            limit: Some(match self.limit {
+                Some(0) | None => DEFAULT_RUN_LIMIT,
+                Some(n) => n.min(MAX_RUN_LIMIT),
+            }),
+        })
+    }
+}
+
+/// `GET …/runs?task=&status=&limit=` — the company's attempts, newest first.
+///
+/// An indexed store read: the `task`/`status`/`limit` predicates go to
+/// [`RunStore::list_runs`](crate::ports::RunStore::list_runs), which every
+/// backend answers from its own index, and the ordering is the port's shared
+/// [`sort_newest_first`](crate::ports::runs::sort_newest_first) so all three
+/// backends agree. Nothing here reads the event log.
+async fn list_runs(
+    company: ScopedCompany,
+    Query(query): Query<RunsQuery>,
+) -> Result<Json<Vec<RunSummary>>, ApiError> {
+    let filter = query.into_filter()?;
+    let runs = company
+        .runtime
+        .runs()
+        .list_runs(company.id(), &filter)
+        .await
+        .map_err(ApiError)?;
+    Ok(Json(runs.into_iter().map(RunSummary::from).collect()))
+}
+
+/// The `{run_id}` path segment. Named separately from the scope's `{id}` so
+/// both scope forms extract cleanly (the platform form carries two params).
+#[derive(Debug, Deserialize)]
+struct RunPath {
+    run_id: String,
+}
+
+/// `GET …/runs/{run_id}` — one attempt and its full persisted trace.
+///
+/// 404s when the id names no attempt *in this company*, which is also what
+/// keeps a run id minted for company A from resolving under company B: the
+/// store read is company-scoped, so a cross-company id simply is not found.
+async fn run_detail(
+    company: ScopedCompany,
+    Path(RunPath { run_id }): Path<RunPath>,
+) -> Result<Json<RunDetail>, ApiError> {
+    let runs = company.runtime.runs();
+    let run = runs
+        .get_run(company.id(), &run_id)
+        .await
+        .map_err(ApiError)?
+        .ok_or_else(|| ApiError(OpenCompanyError::NotFound(format!("no run '{run_id}'"))))?;
+    let steps = runs
+        .list_run_steps(company.id(), &run_id)
+        .await
+        .map_err(ApiError)?;
+    Ok(Json(RunDetail {
+        run: run.into(),
+        steps: steps.into_iter().map(RunStepEntry::from).collect(),
+    }))
+}
+
+/// The attempts at one card, newest first — the `runs[]` that rides along on
+/// `GET …/tasks/{task_id}`.
+///
+/// Lives here rather than in [`super::tasks`] so the projection has one home:
+/// the attempts list on the task screen and the standalone run list must not be
+/// able to disagree about what a run looks like.
+pub(crate) async fn runs_for_task(
+    company: &ScopedCompany,
+    task_id: &str,
+) -> Result<Vec<RunSummary>, ApiError> {
+    let filter = RunFilter::for_task(task_id).with_limit(TASK_DETAIL_RUN_LIMIT);
+    let runs = company
+        .runtime
+        .runs()
+        .list_runs(company.id(), &filter)
+        .await
+        .map_err(ApiError)?;
+    Ok(runs.into_iter().map(RunSummary::from).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use crate::company::CompanyManifest;
+    use crate::ports::runs::{NewRun, RunOutcome, RunStore};
+    use crate::ports::types::{CompanyId, CompanyRecord, EventSeq, TurnStep};
+    use crate::ports::{CompanyStore, now_millis};
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+    use crate::store::FsCompanyStore;
+    use crate::{AppConfig, AppState};
+
+    /// The read side must flag a capped trace with the same number the writer
+    /// stops at. The sink is `openhuman`-only; on a build that has it, the two
+    /// constants must agree.
+    #[cfg(feature = "openhuman")]
+    #[test]
+    fn the_cap_matches_the_trace_sink() {
+        assert_eq!(MAX_RUN_STEPS, crate::harness::run_trace::MAX_RUN_STEPS);
+    }
+
+    fn home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("oc-ops-runs-")
+            .tempdir()
+            .expect("tempdir")
+    }
+
+    fn manifest() -> CompanyManifest {
+        toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n").unwrap()
+    }
+
+    /// A running company `acme` with a real (fs-backed) run store.
+    async fn state_with_company(home: &std::path::Path) -> (AppState, CompanyId) {
+        let store = FsCompanyStore::new(home.to_path_buf());
+        let id = CompanyId::new("acme");
+        store
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: manifest(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                template_provenance: None,
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest())
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default()).with_home(home.to_path_buf());
+        state
+            .registry()
+            .insert(id.clone(), std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        (state, id)
+    }
+
+    fn request(uri: &str) -> Request<Body> {
+        Request::builder()
+            .method("GET")
+            .uri(uri)
+            .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    async fn json_body(response: axum::response::Response) -> serde_json::Value {
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    }
+
+    /// The company's run store, straight from the registry — how these tests
+    /// seed attempts. `doctor` on a dev workstation reports no inference
+    /// credential, so a dispatched card boots onto the echo brain and produces
+    /// no rich trace; seeding through the port exercises the same rows the
+    /// dispatch path writes, without a model.
+    fn runs_of(state: &AppState, id: &CompanyId) -> std::sync::Arc<dyn RunStore> {
+        std::sync::Arc::clone(state.registry().get(id).expect("registered").runs())
+    }
+
+    async fn mint(
+        runs: &std::sync::Arc<dyn RunStore>,
+        id: &CompanyId,
+        run_id: &str,
+        task_id: &str,
+    ) -> RunRecord {
+        runs.create_run(
+            id,
+            NewRun {
+                id: run_id.to_string(),
+                task_id: task_id.to_string(),
+                agent_id: "ceo".to_string(),
+            },
+        )
+        .await
+        .expect("mint")
+    }
+
+    fn step(seq: u32, kind: TurnStepKind, status: TurnStepStatus, label: &str) -> TurnStep {
+        let _ = seq;
+        TurnStep {
+            kind,
+            status,
+            label: label.to_string(),
+            detail: None,
+            elapsed_ms: matches!(kind, TurnStepKind::ToolCall).then_some(42),
+        }
+    }
+
+    async fn push_step(
+        runs: &std::sync::Arc<dyn RunStore>,
+        id: &CompanyId,
+        run_id: &str,
+        seq: u32,
+        kind: TurnStepKind,
+        status: TurnStepStatus,
+        label: &str,
+    ) {
+        runs.append_run_step(
+            id,
+            &RunStepRecord {
+                run_id: run_id.to_string(),
+                step_seq: seq,
+                at_millis: now_millis(),
+                step: step(seq, kind, status, label),
+            },
+        )
+        .await
+        .expect("append step");
+    }
+
+    /// The headline read: a card's attempts come back newest first, each with
+    /// its ordinal and status.
+    #[tokio::test]
+    async fn the_run_list_returns_attempts_newest_first() {
+        let dir = home();
+        let (state, id) = state_with_company(dir.path()).await;
+        let runs = runs_of(&state, &id);
+
+        let first = mint(&runs, &id, "run-1", "card-a").await;
+        assert_eq!(first.attempt, 1, "the first attempt at a card is 1");
+        runs.begin_run(&id, "run-1", EventSeq::new(7))
+            .await
+            .expect("begin");
+        runs.finish_run(
+            &id,
+            "run-1",
+            RunOutcome::new(RunStatus::Failed).with_error("the tool refused"),
+        )
+        .await
+        .expect("settle");
+
+        let second = mint(&runs, &id, "run-2", "card-a").await;
+        assert_eq!(second.attempt, 2, "a re-dispatch is a new ordinal");
+
+        let response = router(state)
+            .oneshot(request("/api/v1/company/runs"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = json_body(response).await;
+        let rows = body.as_array().expect("array");
+        assert_eq!(rows.len(), 2, "body: {body}");
+
+        assert_eq!(rows[0]["id"], "run-2");
+        assert_eq!(rows[0]["attempt"], 2);
+        assert_eq!(rows[0]["status"], "pending");
+        assert_eq!(rows[0]["phase"], "active");
+        assert_eq!(rows[1]["id"], "run-1");
+        assert_eq!(rows[1]["status"], "failed");
+        assert_eq!(rows[1]["phase"], "terminal");
+        assert_eq!(rows[1]["error"], "the tool refused");
+        assert_eq!(rows[1]["triggerEventSeq"], 7);
+    }
+
+    /// The trap the `phase` projection exists for. A `waiting_approval` attempt
+    /// is non-terminal, so it has **no** finish time — exactly like a live one.
+    /// A reader keying off the timestamp would show it as running forever.
+    #[tokio::test]
+    async fn a_waiting_attempt_reports_parked_with_no_finish_time() {
+        let dir = home();
+        let (state, id) = state_with_company(dir.path()).await;
+        let runs = runs_of(&state, &id);
+
+        mint(&runs, &id, "run-1", "card-a").await;
+        runs.begin_run(&id, "run-1", EventSeq::new(1))
+            .await
+            .expect("begin");
+        runs.finish_run(&id, "run-1", RunOutcome::new(RunStatus::WaitingApproval))
+            .await
+            .expect("park");
+
+        let response = router(state)
+            .oneshot(request("/api/v1/company/runs"))
+            .await
+            .unwrap();
+        let body = json_body(response).await;
+        let row = &body.as_array().expect("array")[0];
+
+        assert_eq!(row["status"], "waiting_approval");
+        assert_eq!(row["phase"], "parked");
+        assert!(
+            row.get("finishedAtMillis").is_none(),
+            "a parked attempt must carry no finish time: {row}"
+        );
+        assert!(
+            row.get("startedAtMillis").is_some(),
+            "…but it did start: {row}"
+        );
+    }
+
+    /// Epic #183: a card may enter review many times, so several waits on one
+    /// card is the expected record, not a bug. The list must show them all.
+    #[tokio::test]
+    async fn one_card_can_show_several_waits() {
+        let dir = home();
+        let (state, id) = state_with_company(dir.path()).await;
+        let runs = runs_of(&state, &id);
+
+        mint(&runs, &id, "run-1", "card-a").await;
+        let begun = runs
+            .begin_run(&id, "run-1", EventSeq::new(1))
+            .await
+            .expect("begin");
+        for _ in 0..3 {
+            runs.finish_run(&id, "run-1", RunOutcome::new(RunStatus::WaitingApproval))
+                .await
+                .expect("park");
+            runs.begin_run(&id, "run-1", EventSeq::new(2))
+                .await
+                .expect("resume");
+        }
+        let settled = runs
+            .finish_run(&id, "run-1", RunOutcome::new(RunStatus::Succeeded))
+            .await
+            .expect("settle");
+        assert!(settled.finished_at_millis.is_some());
+        // The attempt's start is the moment it *first* began, not its last leg —
+        // so the elapsed figure the console prints spans the whole attempt,
+        // waits included, instead of resetting on every resume.
+        assert_eq!(settled.started_at_millis, begun.started_at_millis);
+
+        let response = router(state)
+            .oneshot(request("/api/v1/company/runs?task=card-a"))
+            .await
+            .unwrap();
+        let body = json_body(response).await;
+        let rows = body.as_array().expect("array");
+        assert_eq!(rows.len(), 1, "three waits are one attempt: {body}");
+        assert_eq!(rows[0]["phase"], "terminal");
+    }
+
+    /// A killed host leaves the in-flight tool call as a `running` step. That is
+    /// the whole point of an incremental trace, so it must reach the console as
+    /// in-flight — with its status intact and distinct from `error`.
+    #[tokio::test]
+    async fn a_killed_run_keeps_its_in_flight_step() {
+        let dir = home();
+        let (state, id) = state_with_company(dir.path()).await;
+        let runs = runs_of(&state, &id);
+
+        mint(&runs, &id, "run-1", "card-a").await;
+        runs.begin_run(&id, "run-1", EventSeq::new(1))
+            .await
+            .expect("begin");
+        push_step(
+            &runs,
+            &id,
+            "run-1",
+            0,
+            TurnStepKind::Thinking,
+            TurnStepStatus::Ok,
+            "Thinking",
+        )
+        .await;
+        push_step(
+            &runs,
+            &id,
+            "run-1",
+            1,
+            TurnStepKind::ToolCall,
+            TurnStepStatus::Error,
+            "Sending mail",
+        )
+        .await;
+        // …and the one that was in flight when the host died.
+        push_step(
+            &runs,
+            &id,
+            "run-1",
+            2,
+            TurnStepKind::ToolCall,
+            TurnStepStatus::Running,
+            "Searching",
+        )
+        .await;
+        // What the boot reaper then does to the row.
+        runs.finish_run(
+            &id,
+            "run-1",
+            RunOutcome::new(RunStatus::Failed).with_error(crate::ports::runs::ORPHAN_ERROR),
+        )
+        .await
+        .expect("reap");
+
+        let response = router(state)
+            .oneshot(request("/api/v1/company/runs/run-1"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = json_body(response).await;
+
+        assert_eq!(body["run"]["status"], "failed");
+        assert_eq!(body["run"]["phase"], "terminal");
+        let steps = body["steps"].as_array().expect("steps");
+        assert_eq!(steps.len(), 3, "body: {body}");
+        // The console's `TimelineEntry` contract, widened additively.
+        assert_eq!(steps[0]["seq"], 0);
+        assert_eq!(steps[0]["kind"], "thinking");
+        assert_eq!(steps[0]["status"], "ok");
+        assert_eq!(steps[0]["label"], "Thinking");
+        assert!(
+            steps[0].get("elapsedMs").is_none(),
+            "thinking steps report no duration: {body}"
+        );
+        assert_eq!(steps[1]["kind"], "tool_call");
+        assert_eq!(steps[1]["status"], "error");
+        assert_eq!(steps[1]["elapsedMs"], 42);
+        // The in-flight one — NOT an error.
+        assert_eq!(steps[2]["kind"], "tool_call");
+        assert_eq!(steps[2]["status"], "running");
+    }
+
+    /// The `?task=` and `?status=` predicates narrow the page, and an unknown
+    /// status word is a 400 rather than a silent empty page.
+    #[tokio::test]
+    async fn the_filters_narrow_and_a_bad_status_is_refused() {
+        let dir = home();
+        let (state, id) = state_with_company(dir.path()).await;
+        let runs = runs_of(&state, &id);
+
+        mint(&runs, &id, "run-1", "card-a").await;
+        runs.begin_run(&id, "run-1", EventSeq::new(1))
+            .await
+            .expect("begin");
+        runs.finish_run(&id, "run-1", RunOutcome::new(RunStatus::Succeeded))
+            .await
+            .expect("settle");
+        mint(&runs, &id, "run-2", "card-b").await;
+
+        let by_task = json_body(
+            router(state.clone())
+                .oneshot(request("/api/v1/company/runs?task=card-b"))
+                .await
+                .unwrap(),
+        )
+        .await;
+        let rows = by_task.as_array().expect("array");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["taskId"], "card-b");
+
+        // Comma-separated, and a status the card does not have is excluded.
+        let by_status = json_body(
+            router(state.clone())
+                .oneshot(request("/api/v1/company/runs?status=succeeded,cancelled"))
+                .await
+                .unwrap(),
+        )
+        .await;
+        let rows = by_status.as_array().expect("array");
+        assert_eq!(rows.len(), 1, "body: {by_status}");
+        assert_eq!(rows[0]["id"], "run-1");
+
+        let bad = router(state)
+            .oneshot(request("/api/v1/company/runs?status=done"))
+            .await
+            .unwrap();
+        assert_eq!(
+            bad.status(),
+            StatusCode::BAD_REQUEST,
+            "a typo'd filter must not look like 'nothing matched'"
+        );
+    }
+
+    /// An unknown id 404s — including one minted in another company, because
+    /// the store read is company-scoped.
+    #[tokio::test]
+    async fn an_unknown_run_is_not_found() {
+        let dir = home();
+        let (state, _id) = state_with_company(dir.path()).await;
+        let response = router(state)
+            .oneshot(request("/api/v1/company/runs/nope"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// `stepCount` is a high-water ordinal, capped — so the wire says when the
+    /// number has stopped meaning "how many steps the agent took".
+    #[tokio::test]
+    async fn a_capped_step_count_is_flagged() {
+        let dir = home();
+        let (state, id) = state_with_company(dir.path()).await;
+        let runs = runs_of(&state, &id);
+
+        mint(&runs, &id, "run-1", "card-a").await;
+        runs.begin_run(&id, "run-1", EventSeq::new(1))
+            .await
+            .expect("begin");
+        let mut outcome = RunOutcome::new(RunStatus::Succeeded);
+        outcome.step_count = MAX_RUN_STEPS;
+        runs.finish_run(&id, "run-1", outcome)
+            .await
+            .expect("settle");
+
+        let body = json_body(
+            router(state)
+                .oneshot(request("/api/v1/company/runs"))
+                .await
+                .unwrap(),
+        )
+        .await;
+        let row = &body.as_array().expect("array")[0];
+        assert_eq!(row["stepCount"], MAX_RUN_STEPS);
+        assert_eq!(row["stepCountCapped"], true);
+    }
+
+    /// Both scope forms answer, like every other route in the ops plane.
+    #[tokio::test]
+    async fn both_scope_forms_answer() {
+        let dir = home();
+        let (state, id) = state_with_company(dir.path()).await;
+        let runs = runs_of(&state, &id);
+        mint(&runs, &id, "run-1", "card-a").await;
+
+        for uri in [
+            "/api/v1/company/runs",
+            "/api/v1/companies/acme/runs",
+            "/api/v1/company/runs/run-1",
+            "/api/v1/companies/acme/runs/run-1",
+        ] {
+            let response = router(state.clone()).oneshot(request(uri)).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK, "{uri}");
+        }
+    }
+
+    /// Every key on the wire is camelCase — including the two inside `usage`.
+    ///
+    /// Regression test for a real defect caught only by curling a live host:
+    /// embedding [`TokenUsage`] directly emitted `cached_input` and `cost_usd`
+    /// beside an otherwise camelCase object, because that type carries no
+    /// `rename_all` (its field names are the decode contract for journaled
+    /// events). Neither `tsc` nor a hand-written console type can catch that —
+    /// only an assertion on the bytes.
+    #[tokio::test]
+    async fn usage_is_camel_case_on_the_wire() {
+        let dir = home();
+        let (state, id) = state_with_company(dir.path()).await;
+        let runs = runs_of(&state, &id);
+
+        mint(&runs, &id, "run-1", "card-a").await;
+        runs.begin_run(&id, "run-1", EventSeq::new(1))
+            .await
+            .expect("begin");
+        let mut outcome = RunOutcome::new(RunStatus::Succeeded);
+        outcome.usage = TokenUsage {
+            input: 100,
+            output: 20,
+            cached_input: 5,
+            cost_usd: 0.25,
+        };
+        runs.finish_run(&id, "run-1", outcome)
+            .await
+            .expect("settle");
+
+        let body = json_body(
+            router(state)
+                .oneshot(request("/api/v1/company/runs"))
+                .await
+                .unwrap(),
+        )
+        .await;
+        let usage = &body.as_array().expect("array")[0]["usage"];
+        assert_eq!(usage["input"], 100);
+        assert_eq!(usage["output"], 20);
+        assert_eq!(usage["cachedInput"], 5, "usage: {usage}");
+        assert_eq!(usage["costUsd"], 0.25, "usage: {usage}");
+        assert!(
+            usage.get("cached_input").is_none() && usage.get("cost_usd").is_none(),
+            "no snake_case may leak through: {usage}"
+        );
+
+        // …and nothing else on the row is snake_case either.
+        for row in body.as_array().expect("array") {
+            for key in row.as_object().expect("object").keys() {
+                assert!(!key.contains('_'), "'{key}' is not camelCase");
+            }
+        }
+    }
+
+    /// `?limit=` clamps, and `0` means "the default" rather than an empty page.
+    #[test]
+    fn the_limit_clamps_and_zero_means_default() {
+        let filter = |limit: Option<usize>| {
+            RunsQuery {
+                task: None,
+                status: None,
+                limit,
+            }
+            .into_filter()
+            .expect("filter")
+        };
+        assert_eq!(filter(None).limit, Some(DEFAULT_RUN_LIMIT));
+        assert_eq!(filter(Some(0)).limit, Some(DEFAULT_RUN_LIMIT));
+        assert_eq!(filter(Some(5)).limit, Some(5));
+        assert_eq!(filter(Some(10_000)).limit, Some(MAX_RUN_LIMIT));
+    }
+}

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -25,6 +25,7 @@ use crate::ports::types::CompanyEvent;
 use crate::ports::{generate_id, now_millis};
 use crate::runtime::assignee;
 use crate::server::error::ApiError;
+use crate::server::ops::runs::{RunSummary, runs_for_task};
 use crate::server::ops::{ScopedCompany, scoped};
 
 /// Builds the task route fragment.
@@ -470,6 +471,15 @@ struct TaskDetail {
     timeline: Vec<TimelineEntry>,
     /// Parent and children.
     lineage: Lineage,
+    /// The card's recorded attempts, newest first (issue #242).
+    ///
+    /// Additive: a card dispatched before run records existed legitimately
+    /// carries an empty list, because synthesising attempts from old
+    /// `AgentReply` events would fabricate identity. Bounded by
+    /// [`TASK_DETAIL_RUN_LIMIT`](crate::server::ops::runs::TASK_DETAIL_RUN_LIMIT)
+    /// — a card can be re-dispatched without limit, and this read stays one
+    /// cheap call.
+    runs: Vec<RunSummary>,
     /// Epoch-millis the company started waiting on an operator *right now*
     /// (issue #305), or `None` when nothing is currently parked for this run.
     ///
@@ -546,10 +556,14 @@ async fn task_detail(
             .min()
     });
 
+    // An indexed store read, not another journal pass (issue #242).
+    let runs = runs_for_task(&company, &task_id).await?;
+
     Ok(Json(TaskDetail {
         task: card.into(),
         timeline,
         lineage: Lineage { parent, children },
+        runs,
         waiting_since,
     }))
 }


### PR DESCRIPTION
## Summary

PR-3 of #242 — **the read surface**. PR-1 built the object, PR-2 populated it; this is where an operator sees it.

- `GET …/runs?task=&status=&limit=` — an indexed store read, newest first
- `GET …/runs/{id}` — the summary plus its step trace
- `TaskDetail` gains an additive `runs[]`
- The task detail page gains an **Attempts** tab and a per-attempt drawer rendering the trace

## Problem

An attempt has been a durable object since PR-2, with a status, a trace and a cost — and nothing could see any of it. The Approvals tab, auto-advance (#337) and artifact attribution (#244) all wait on being able to ask "what did this card actually do".

## Solution

**The list is `list_runs` with a `RunFilter`, not a journal fold.** The existing workflow-run list folds the entire journal on every request and its own doc flags that cost; avoiding a repeat is the reason runs got a store in the first place.

**The awkward states render honestly**, because they are states the write path really produces:

- `WaitingApproval` is non-terminal, so its finish time is null — the UI keys off the status, not the timestamp, and a parked attempt shows its clock still running rather than looking finished.
- A killed run keeps a step in `Running` — an in-flight tool call at the moment of death. Rendered as in-flight, not as an error.
- The rare `Pending`-gap record ("the dispatch cycle ended without settling this attempt") is shown as-is rather than special-cased away.

`RunStatus` gained `from_wire` (the inverse of `as_str`, so a query string round-trips) and `phase()` → `active | parked | terminal`, which lets the console separate parked from active without guessing from timestamps.

## Three corrections to the approved plan

**1. The plan wanted per-attempt cost in the UI. Epic #184 forbids it.** #184 scopes this exact screen "with the cost / currency dimension removed (no per-line cost, no per-child cost, no total-cost header)", and `TaskDetailView.tsx` already carries the comment "Cost/₹ is intentionally absent everywhere". A per-attempt USD figure is a per-line cost. Omitted from the UI; `usage` stays on the wire for the surfaces that own it.

**2. The plan's step mapping dropped the field the honesty requirements depend on.** It mapped `RunStepRecord → TimelineEntry {seq, atMillis, kind, label, detail}` — no `status`. But `TurnStep.status` is `ok | error | running`, and "render a killed run's step as in-flight, not as an error" is unimplementable without it: on `kind` alone, a succeeded, a failed and an in-flight tool call are indistinguishable. Added `status` and `elapsedMs` as additive optional fields — one shape, one renderer.

**3. "Follow the `workflows.rs` pattern" doesn't apply here.** That pattern is static-before-dynamic route ordering (`/workflows/runs` before `/workflows/{id}`). `/runs` has no static child segment, so there is no shadowing hazard. Documented why, rather than copying a comment that would mislead the next reader.

## A defect only a live host caught

`TokenUsage` carries no `rename_all` — its field names are the decode contract for already-journaled `CycleResult` events, so they cannot change. Embedding it directly shipped `cached_input` and `cost_usd` sitting in an otherwise camelCase object.

**Invisible to `tsc` and to every unit test**, because both sides agreed on the wrong thing. Found by curling a real host. Fixed with a local `RunUsage` projection and a test that asserts no key on any row contains an underscore.

## Submission Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **1756 passed, 0 failed**, 1 ignored (+25)
- [x] `cargo check --locked --all-features --all-targets`
- [x] `git diff --stat Cargo.lock` — empty
- [x] `npm ci`, `npm run typecheck`, `npm run build`
- [x] Verified end to end — curl **and** a real Chromium session against the built console

**Which states were actually rendered, and how.** No model turn runs on the verification workstation (`doctor`: `cycles unavailable: needs …`), so runs were seeded through the fs `RunStore` on a throwaway host rather than produced by dispatching a card:

| State | Produced by |
|---|---|
| `succeeded` + 6-step trace incl. a coalesced ×2 failure | seeded |
| `waiting_approval` → parked, no finish time, clock still ticking | seeded |
| `failed` with orphan reason **and a step still `running`** | seeded steps; **the row was reaped by PR-1's real boot reaper** on restart |
| `failed` — "the dispatch cycle ended without settling this attempt" | seeded |
| `running`, live, mid-trace | seeded post-boot |
| `pending`, never started | seeded |
| `cancelled` on another card | seeded — proves `?task=` narrows |
| `paused` | **not rendered — unreachable today**, as PR-2 documented. `?status=paused` returns `[]`. Handled in every mapping. |

Beyond screenshots: a step was appended to a live run **while the drawer was open**, and the in-flight row finalized in place — same `step_seq`, spinner to completed, not duplicated, with a new in-flight row appended. Refresh-on-read proven rather than asserted.

## Impact

Additive throughout. `TaskDetail.runs` is a new field, `TimelineKind` widens with `tool_call | thinking | note`, and `status`/`elapsedMs` are optional. No existing route or payload changed shape.

Run detail is **refresh-on-read** in v1 — steps persist incrementally so a reload shows progress. Live streaming would mean widening `turn_stream` and is deliberately out of scope.

`docs/spec/runtime/ports.md` was **already 771 lines** against the repo's 500-line cap before this PR. The addition here was kept to 44 lines rather than splitting a document that three PRs are currently writing into; the split is worth doing on its own.

## Related

Part of #242 — **PR-3 of 3**. PR-1 (#342) the port and storage, PR-2 (#357) the write path.
Part of #183 — the spine epic.

What this unblocks:
- **#337 (auto-advance)** — `?status=waiting_approval` is the indexed parked set; `phase` separates parked from active without a timestamp guess; `attempt` is the retry ordinal; `triggerEventSeq` joins back to the dispatch event.
- **#333 (approvals on a task)** — `Effect.run_id` from PR-2 is now resolvable to task + attempt + trace, and `runs[]` on `TaskDetail` lets the Approvals tab correlate without a second call.
- **#244 (artifacts)** — `ArtifactVersion.step_seq` existed but was never read. Run detail returns steps keyed by that same seq, so a version can deep-link to the step that wrote it.

Note for #333: it also edits `TaskDetailView.tsx`. The additions here are a new tab plus two components, so the overlap is additive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Attempts view to task details, showing run status, duration, step counts, errors, and detailed step traces.
  * Added run history with filtering by task, status, and result count.
  * Added persisted timelines with step statuses, elapsed times, usage data, lifecycle phases, and incremental updates.
  * Added automatic refresh behavior while runs remain active.

* **Documentation**
  * Documented how to retrieve runs and their persisted step traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->