### PR TITLE
feat(team): set a teammate's daily budget from the Console, without a redeploy (#343)

### DIFF
--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -62,6 +62,8 @@ PUT    …/skills/{slug}                       enable / disable a skill
 POST   …/team                               add an operator-overlay teammate
 DELETE …/team/{agentId}                      remove an overlay teammate
 PUT    …/team/{agentId}/inbox                toggle a teammate's inbox
+PUT    …/team/{agentId}/budget               set / change / remove a daily cap
+DELETE …/team/{agentId}/budget               reset the cap to the manifest default
 POST   …/inboxes/{key}/read                  mark inbox messages read
 POST   …/inboxes/ingest                     HMAC-signed inbound email → inbox
 GET    …/inboxes                            list inboxes + unread counts
@@ -95,6 +97,31 @@ Team writes are an **operator overlay** persisted through the store, merged
 into the manifest roster at read time — the version-controlled `company.toml`
 is never rewritten. In v1 overlay teammates are **roster-only**: they appear in
 the roster and get an inbox, but no harness `Agent` is built for them yet.
+
+The two **budget** routes (issue #343) are how a teammate's `budget_usd_daily`
+becomes changeable without a redeploy. Both are **admin-only** — a member gets
+`403` and an unauthenticated caller `401` — and both stamp who set the cap and
+when, surfaced as `budgetSetBy` / `budgetSetAtMillis` on the roster row. A
+stored cap wins over the manifest, and the change is enforced on the teammate's
+**next dispatch**: the harness fingerprints the override set alongside its other
+freshness axes, so the roster is rebuilt before the next turn rather than at the
+next process start.
+
+`PUT` takes `{"budgetUsdDaily": <number|null>}` and the three cases stay apart
+on the wire, which is the point of the route:
+
+| body | effect |
+|---|---|
+| `{"budgetUsdDaily": 5}` | cap at $5/day |
+| `{"budgetUsdDaily": 0}` | cap at nothing — a real cap, not "uncapped" |
+| `{"budgetUsdDaily": null}` | remove the cap, beating a manifest cap |
+| `{}` | **`422`** — an omitted key is never read as "remove the cap" |
+
+A negative or non-finite amount is `400`; an unknown teammate is `404`.
+`DELETE` drops the override so the manifest default applies again — distinct
+from `PUT null`, and not expressible by it. `POST …/team` also accepts an
+optional `budgetUsdDaily`, so a console-created teammate can be given a cap at
+creation; only that form of the add requires an admin.
 
 ### Credential-bearing surfaces (feature-gated)
 

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -134,8 +134,25 @@ prompt = "Weekly review and operator digest"
     meter or a failing meter, dispatch **runs** (bricking a teammate's
     cognition with no operator recourse is worse than a day of overspend),
     while a priced tool call **parks** (a human can wave that one through).
-  - **Operator-added (overlay) teammates are uncapped in v1.** Only manifest
-    `[[agent]]` entries carry the field.
+  Since issue #343 the manifest value is a **default, not the last word**. An
+  admin can set, change or clear a teammate's cap from the console
+  (`PUT`/`DELETE …/team/{agentId}/budget`); the override is stored on the
+  company record, wins over `budget_usd_daily` everywhere the cap is read
+  ([`CompanyRecord::effective_budget`] is the single reconciliation point), and
+  takes effect on the teammate's **next dispatch** — no restart, no redeploy.
+  That matters most on a hosted tenant, where `company.toml` is baked into the
+  container image and an operator has no way to edit it. Three stored states,
+  kept deliberately distinct: no override (the manifest applies), a cap of `x`
+  (`0` included, meaning "may not spend"), and an explicit "uncapped" that beats
+  a manifest cap. `DELETE` drops the override so the manifest applies again,
+  which no `PUT` body can express. Writes are admin-only and record who set the
+  cap and when.
+
+  - **Operator-added (overlay) teammates carry no manifest cap**, because they
+    have no `[[agent]]` entry — but since #343 they can be capped through a
+    console override like anyone else, including at creation.
+
+  [`CompanyRecord::effective_budget`]: ../../../src/ports/types.rs
 - **`[brain]`** selects the `Brain` implementation. `hosted` requires a
   TinyHumans credential at runtime; `sidecar` requires the `sidecar` feature.
 - **`[inference]`** (issue #56 — BYOK) routes the company's agents through a

--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -99,8 +99,11 @@ per-teammate daily spend caps an admin sets from the console, which win over the
 manifest's `budget_usd_daily` and are read through
 `CompanyRecord::effective_budget` — the single reconciliation point the harness
 gate, the approval policy, and both roster reads share, so a cap raised in the
-console cannot be honoured by one surface and ignored by another. And (issue
-#168) `overlay_workflows`: the
+console cannot be honoured by one surface and ignored by another. At most one
+`overlay_budgets` entry may exist per teammate — the console write path upserts
+through `CompanyRecord::upsert_budget_override`, and a bundle import carrying two
+entries for the same teammate is rejected rather than resolved by guesswork.
+And (issue #168) `overlay_workflows`: the
 workflow graph bodies authored at runtime through the console's create dialog or
 the orchestrator's `create_workflow` tool. These are persisted here rather than
 written into `companies/<name>/workflows/<id>.toml` because the company source

--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -94,7 +94,13 @@ construction, ≥1 response per cycle) are inherited, not re-verified.
 Durable company records: charter, roster, ledger, approval queue.
 
 The record also carries the **operator overlays** — teammates, desk members,
-desk order, operator-created desks, and (issue #168) `overlay_workflows`: the
+desk order, operator-created desks, (issue #343) `overlay_budgets`: the
+per-teammate daily spend caps an admin sets from the console, which win over the
+manifest's `budget_usd_daily` and are read through
+`CompanyRecord::effective_budget` — the single reconciliation point the harness
+gate, the approval policy, and both roster reads share, so a cap raised in the
+console cannot be honoured by one surface and ignored by another. And (issue
+#168) `overlay_workflows`: the
 workflow graph bodies authored at runtime through the console's create dialog or
 the orchestrator's `create_workflow` tool. These are persisted here rather than
 written into `companies/<name>/workflows/<id>.toml` because the company source
@@ -119,8 +125,12 @@ Every other manifest field is **seed-authoritative**; for `[tools]` and
 `[policy]` that is a security property, not a convention — a record-wins merge
 would let a runtime grant or a relaxed approval mode outlive the operator
 revoking it in version control. Runtime additions that must persist get their own
-overlay field instead (`overlay_agents`, `overlay_desks`, the `SecretStore` for
-console MCP credentials).
+overlay field instead (`overlay_agents`, `overlay_desks`, `overlay_budgets`, the
+`SecretStore` for console MCP credentials). `overlay_budgets` is the clearest
+case for why: a manifest baked into a hosted tenant's image cannot be edited at
+all, so without a record-side override the shipped cap would be the only cap
+forever — while keeping it *seed-authoritative* for everything else is what stops
+a console write from silently outliving a revocation in version control.
 
 ```rust
 // src/ports/store.rs

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -91,6 +91,7 @@ async fn main() -> anyhow::Result<()> {
         overlay_desk_order: Vec::new(),
         overlay_desks: Vec::new(),
         overlay_workflows: Vec::new(),
+        overlay_budgets: Vec::new(),
         template_provenance: None,
     };
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -32,6 +32,7 @@ import {
   type FinancesDto,
   type InboxDto,
   type InboxMessageDto,
+  type SetBudgetInput,
   type TeamMemberDto,
   type UsageDto,
   type Verdict,
@@ -335,10 +336,51 @@ export class OpenCompanyClient {
    * callers fall back to a local-only add.
    */
   addTeamMember(
-    input: { name: string; role: string; description?: string },
+    input: { name: string; role: string; description?: string; budgetUsdDaily?: number },
     company?: string | null,
   ): Promise<TeamMemberDto> {
     return this.request<TeamMemberDto>("POST", `${this.scope(company)}/team`, input);
+  }
+
+  /**
+   * Set, change, or remove a teammate's daily spend cap (issue #343). Admin-only
+   * on the host — a member gets 403 — and the change is enforced on the
+   * company's next dispatch, with no restart.
+   *
+   * Pass `null` to remove the cap and a number to set one; `0` is a real cap of
+   * nothing, not the same thing as `null`. The argument is required precisely so
+   * an accidental `undefined` cannot be serialised away into `{}`, which the host
+   * rejects with a 422 rather than reading as "remove the cap".
+   *
+   * Returns the teammate's updated roster row, so the caller can refresh one
+   * card instead of refetching the team.
+   */
+  setTeamBudget(
+    agentId: string,
+    budgetUsdDaily: number | null,
+    company?: string | null,
+  ): Promise<TeamMemberDto> {
+    const body: SetBudgetInput = { budgetUsdDaily };
+    return this.request<TeamMemberDto>(
+      "PUT",
+      `${this.scope(company)}/team/${encodeURIComponent(agentId)}/budget`,
+      body,
+    );
+  }
+
+  /**
+   * Drop a teammate's cap override so the company's manifest default applies
+   * again (issue #343). Admin-only.
+   *
+   * Not the same as `setTeamBudget(id, null)`: that stores "uncapped, decided by
+   * an admin", while this restores whatever the company defines — which for a
+   * manifest-capped teammate brings the cap back.
+   */
+  clearTeamBudgetOverride(agentId: string, company?: string | null): Promise<TeamMemberDto> {
+    return this.request<TeamMemberDto>(
+      "DELETE",
+      `${this.scope(company)}/team/${encodeURIComponent(agentId)}/budget`,
+    );
   }
 
   /** Remove an operator-added teammate. 409s for a manifest teammate (can't be removed here). */

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -257,7 +257,10 @@ export interface TeamMemberDto {
    */
   inboxEnabled?: boolean;
   /**
-   * This teammate's daily spend cap in USD (manifest `budget_usd_daily`).
+   * This teammate's daily spend cap in USD, as the host will actually enforce
+   * it: an operator override set from this console when one exists, otherwise
+   * the manifest's `budget_usd_daily`.
+   *
    * Absent when the teammate is uncapped — absence IS the uncapped signal, so
    * never default it to `0`, which would render a permanently exhausted
    * teammate.
@@ -269,6 +272,30 @@ export interface TeamMemberDto {
    * the field.
    */
   spentTodayUsd?: number;
+  /**
+   * The user id of the admin who last set this teammate's cap from the console.
+   * Absent when no override is stored — i.e. when the cap (if any) is just the
+   * company's manifest default.
+   *
+   * Deliberately NOT paired with `budgetUsdDaily`: it is present even for an
+   * override that *removed* a cap, which is the only way to tell "nobody has
+   * touched this" from "an admin deliberately uncapped this".
+   */
+  budgetSetBy?: string;
+  /** When that cap was set (epoch millis). Paired with `budgetSetBy`. */
+  budgetSetAtMillis?: number;
+}
+
+/**
+ * The body of `PUT .../team/{id}/budget`.
+ *
+ * `budgetUsdDaily` must always be present — `null` to remove the cap, a number
+ * to set one (including `0`, which caps at nothing). The host rejects a body
+ * that omits the key with a 422 rather than reading it as "remove the cap", so
+ * never build this object conditionally.
+ */
+export interface SetBudgetInput {
+  budgetUsdDaily: number | null;
 }
 
 /**

--- a/frontend/src/lib/team.ts
+++ b/frontend/src/lib/team.ts
@@ -19,12 +19,26 @@ export interface TeamMember {
    */
   inboxEnabled: boolean;
   /**
-   * The teammate's daily spend cap in USD, when the company sets one. Undefined
-   * means uncapped — the card shows no budget line at all rather than "$0".
+   * The teammate's daily spend cap in USD, as the host will enforce it — an
+   * admin's console override when one is set, otherwise the company's own
+   * default. Undefined means uncapped: the card shows no budget line at all
+   * rather than "$0".
    */
   budgetUsdDaily?: number;
   /** What this teammate has spent since 00:00 UTC; only meaningful with a cap. */
   spentTodayUsd?: number;
+  /**
+   * The admin who last set this teammate's cap from the console, when one did.
+   * Undefined means the cap (if any) is just the company default.
+   *
+   * Its presence is what makes "set" and "reset to default" different actions
+   * in the UI, and it is set even for an override that removed a cap — so an
+   * operator can see that a person uncapped this teammate rather than that it
+   * was never capped.
+   */
+  budgetSetBy?: string;
+  /** When that cap was set (epoch millis). Paired with `budgetSetBy`. */
+  budgetSetAtMillis?: number;
 }
 
 const TONE_KEYS = ["sky", "violet", "amber", "emerald", "rose", "cyan", "indigo", "teal"];
@@ -60,6 +74,10 @@ export function fromDto(dto: TeamMemberDto): TeamMember {
     // `undefined`, never coalesced to `0`.
     budgetUsdDaily: dto.budgetUsdDaily,
     spentTodayUsd: dto.spentTodayUsd,
+    // Same rule for the attribution — `undefined` means "no override stored",
+    // which the card renders differently from "an admin set this".
+    budgetSetBy: dto.budgetSetBy,
+    budgetSetAtMillis: dto.budgetSetAtMillis,
   };
 }
 

--- a/frontend/src/views/TeamView.tsx
+++ b/frontend/src/views/TeamView.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
-import { Mail, MoreHorizontal, Plus, Sparkles, UserPlus } from "lucide-react";
+import { Mail, MoreHorizontal, Plus, Sparkles, UserPlus, Wallet } from "lucide-react";
 import { toast } from "sonner";
 
+import { listPeople, me as fetchMe, type Person } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
 import { setInboxEnabled } from "@/api/inbox";
 import { ApiError, type TeamMemberDto } from "@/api/types";
@@ -20,6 +21,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
@@ -50,6 +52,38 @@ export function TeamView({ client, company }: Props) {
   const [fromHost, setFromHost] = useState(false);
   const [members, setMembers] = useState<TeamMember[]>([]);
   const [addOpen, setAddOpen] = useState(false);
+  const [isAdmin, setIsAdmin] = useState(false);
+  // Who set which cap. Only an admin may read the user directory, so this stays
+  // empty for a member — and the attribution line degrades to "an admin"
+  // rather than disappearing.
+  const [people, setPeople] = useState<Person[]>([]);
+  // The member whose budget dialog is open, if any.
+  const [budgetFor, setBudgetFor] = useState<TeamMember | null>(null);
+
+  /**
+   * Hiding the budget controls from a non-admin is **courtesy, not enforcement**.
+   * The host refuses the write with a 403 whatever this says; showing an
+   * operator a control they cannot use is the only thing this prevents.
+   */
+  const loadViewer = useCallback(async () => {
+    let admin = false;
+    try {
+      admin = (await fetchMe(client, company)).role === "admin";
+    } catch {
+      // No user plane on this host, or not signed in — treat as non-admin.
+    }
+    setIsAdmin(admin);
+    if (!admin) {
+      setPeople([]);
+      return;
+    }
+    try {
+      setPeople(await listPeople(client, company));
+    } catch {
+      // Attribution falls back to "an admin"; not worth a toast.
+      setPeople([]);
+    }
+  }, [client, company]);
 
   /**
    * Give a teammate an inbox, or take it away, on the host — keyed by the
@@ -106,13 +140,58 @@ export function TeamView({ client, company }: Props) {
   useEffect(() => {
     setLoad("loading");
     void boot();
-  }, [boot]);
+    void loadViewer();
+  }, [boot, loadViewer]);
 
-  async function addMember(fields: { name: string; role: string; description: string; inbox?: boolean }) {
+  /** A human label for whoever set a cap — never a raw user id. */
+  function whoSet(userId: string): string {
+    const person = people.find((p) => p.id === userId);
+    return person?.displayName?.trim() || person?.email || "an admin";
+  }
+
+  /**
+   * Set, change, or remove a teammate's daily cap.
+   *
+   * `cap` is `null` to remove the cap and a number to set one — `0` included,
+   * which caps the teammate at nothing. The two are different states on the host
+   * and must stay different here, which is why this takes `number | null` and
+   * never an optional.
+   */
+  async function applyBudget(member: TeamMember, cap: number | null) {
+    try {
+      const row = await client.setTeamBudget(member.id, cap, company);
+      // Update the one card from the host's answer rather than refetching the
+      // roster: the response IS the new state, so a refetch could only disagree.
+      setMembers((ms) => ms.map((m) => (m.id === member.id ? { ...m, ...fromDto(row) } : m)));
+      toast.success(cap === null ? "Daily cap removed." : `Daily cap set to $${cap.toFixed(2)}.`);
+    } catch (error) {
+      toast.error(budgetError(error, "Couldn't change the daily cap."));
+    }
+  }
+
+  /** Drop the override so the company's own default applies again. */
+  async function resetBudget(member: TeamMember) {
+    try {
+      const row = await client.clearTeamBudgetOverride(member.id, company);
+      setMembers((ms) => ms.map((m) => (m.id === member.id ? { ...m, ...fromDto(row) } : m)));
+      toast.success("Reset to the company default.");
+    } catch (error) {
+      toast.error(budgetError(error, "Couldn't reset the daily cap."));
+    }
+  }
+
+  async function addMember(fields: AddMemberFields) {
     let created: TeamMemberDto | null = null;
     try {
       created = await client.addTeamMember(
-        { name: fields.name, role: fields.role, description: fields.description || undefined },
+        {
+          name: fields.name,
+          role: fields.role,
+          description: fields.description || undefined,
+          // Omitted unless the operator typed one: an add that carries a cap is
+          // admin-only on the host, while a plain add is open to any member.
+          budgetUsdDaily: fields.budgetUsdDaily,
+        },
         company,
       );
     } catch (error) {
@@ -189,6 +268,13 @@ export function TeamView({ client, company }: Props) {
                 inboxOn={m.inboxEnabled}
                 onToggleInbox={() => void toggleMemberInbox(m)}
                 onRemove={() => void removeMember(m)}
+                // Budget edits need a teammate the host actually knows about;
+                // starter-team cards are local placeholders with no record.
+                canEditBudget={isAdmin && fromHost}
+                onEditBudget={() => setBudgetFor(m)}
+                onRemoveCap={() => void applyBudget(m, null)}
+                onResetBudget={() => void resetBudget(m)}
+                setByLabel={m.budgetSetBy ? whoSet(m.budgetSetBy) : undefined}
               />
             ))}
             <button
@@ -202,9 +288,50 @@ export function TeamView({ client, company }: Props) {
         )}
       </div>
 
-      <AddMemberDialog open={addOpen} onOpenChange={setAddOpen} onAdd={addMember} />
+      <AddMemberDialog
+        open={addOpen}
+        onOpenChange={setAddOpen}
+        onAdd={addMember}
+        canSetBudget={isAdmin && fromHost}
+      />
+      <BudgetDialog
+        member={budgetFor}
+        onOpenChange={(open) => {
+          if (!open) setBudgetFor(null);
+        }}
+        onSave={(cap) => {
+          const target = budgetFor;
+          setBudgetFor(null);
+          if (target) void applyBudget(target, cap);
+        }}
+      />
     </div>
   );
+}
+
+/** The fields the add dialog collects. */
+interface AddMemberFields {
+  name: string;
+  role: string;
+  description: string;
+  inbox?: boolean;
+  /** An optional daily cap. Undefined means "don't set one", never "$0". */
+  budgetUsdDaily?: number;
+}
+
+/**
+ * Turns a failed budget write into something worth reading.
+ *
+ * The 403 is the one an operator will actually hit, and it needs to say *why* —
+ * "only an admin can change a spend limit" is the answer, not "request failed".
+ */
+function budgetError(error: unknown, fallback: string): string {
+  if (error instanceof ApiError) {
+    if (error.status === 403) return "Only an admin can change a teammate's daily cap.";
+    if (error.status === 404) return "This host doesn't support console budgets yet.";
+    return error.message;
+  }
+  return error instanceof Error ? error.message : fallback;
 }
 
 function MemberCard({
@@ -212,12 +339,28 @@ function MemberCard({
   inboxOn,
   onToggleInbox,
   onRemove,
+  canEditBudget,
+  onEditBudget,
+  onRemoveCap,
+  onResetBudget,
+  setByLabel,
 }: {
   member: TeamMember;
   inboxOn: boolean;
   onToggleInbox: () => void;
   onRemove: () => void;
+  /** Whether to offer the budget controls at all (admins, host-backed cards). */
+  canEditBudget: boolean;
+  onEditBudget: () => void;
+  onRemoveCap: () => void;
+  onResetBudget: () => void;
+  /** Who set the current override, already resolved to something readable. */
+  setByLabel?: string;
 }) {
+  const capped = member.budgetUsdDaily !== undefined;
+  // An override exists (someone set this deliberately), as opposed to the cap
+  // simply coming from the company's own definition.
+  const overridden = member.budgetSetBy !== undefined;
   return (
     <Card data-testid="team-card">
       <CardContent className="flex h-full flex-col gap-3 py-4">
@@ -242,6 +385,25 @@ function MemberCard({
               <MoreHorizontal className="size-4" />
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
+              {canEditBudget && (
+                <>
+                  <DropdownMenuItem onClick={onEditBudget} data-testid="team-budget-edit">
+                    <Wallet className="size-4" />
+                    {capped ? "Change daily budget…" : "Set daily budget…"}
+                  </DropdownMenuItem>
+                  {capped && (
+                    <DropdownMenuItem onClick={onRemoveCap} data-testid="team-budget-remove">
+                      Remove cap
+                    </DropdownMenuItem>
+                  )}
+                  {overridden && (
+                    <DropdownMenuItem onClick={onResetBudget} data-testid="team-budget-reset">
+                      Reset to company default
+                    </DropdownMenuItem>
+                  )}
+                  <DropdownMenuSeparator />
+                </>
+              )}
               <DropdownMenuItem variant="destructive" onClick={onRemove}>
                 Remove
               </DropdownMenuItem>
@@ -251,7 +413,7 @@ function MemberCard({
         {member.description && (
           <p className="line-clamp-3 text-sm text-muted-foreground">{member.description}</p>
         )}
-        <DailyBudgetLine member={member} />
+        <DailyBudgetLine member={member} setByLabel={setByLabel} />
         <div className="mt-auto flex items-center justify-between gap-2 border-t pt-3">
           <Badge variant="secondary" className="gap-1">
             <Sparkles className="size-3" /> Agent
@@ -281,20 +443,111 @@ function MemberCard({
  * destructive — that teammate's dispatch is paused until 00:00 UTC, and the
  * card is where an operator will look to find out why it went quiet.
  */
-function DailyBudgetLine({ member }: { member: TeamMember }) {
+function DailyBudgetLine({
+  member,
+  setByLabel,
+}: {
+  member: TeamMember;
+  setByLabel?: string;
+}) {
   const cap = member.budgetUsdDaily;
-  if (cap === undefined) return null;
+  const attribution =
+    setByLabel && member.budgetSetAtMillis !== undefined ? (
+      <p data-testid="team-budget-attribution" className="text-xs text-muted-foreground">
+        {cap === undefined ? "Uncapped by" : "Set by"} {setByLabel} ·{" "}
+        {new Date(member.budgetSetAtMillis).toLocaleDateString()}
+      </p>
+    ) : null;
+
+  // No cap: render nothing but the attribution, if a human deliberately removed
+  // one. "Uncapped by Ana" and "nobody ever capped this" are different facts,
+  // and only the first has a line.
+  if (cap === undefined) return attribution;
+
   const spent = member.spentTodayUsd ?? 0;
   const overBudget = spent >= cap;
   const usd = (n: number) => `$${n.toFixed(2)}`;
   return (
-    <p
-      data-testid="team-budget"
-      className={cn("text-xs", overBudget ? "text-destructive" : "text-muted-foreground")}
-    >
-      {usd(cap)}/day · {usd(spent)} spent today
-      {overBudget && " · paused until 00:00 UTC"}
-    </p>
+    <div className="space-y-0.5">
+      <p
+        data-testid="team-budget"
+        className={cn("text-xs", overBudget ? "text-destructive" : "text-muted-foreground")}
+      >
+        {usd(cap)}/day · {usd(spent)} spent today
+        {overBudget && " · paused until 00:00 UTC"}
+      </p>
+      {attribution}
+    </div>
+  );
+}
+
+/**
+ * Enter a daily cap for one teammate.
+ *
+ * Empty input is **not** submittable: "no cap" is the explicit "Remove cap"
+ * action on the card, not a blank field, so an operator clearing the box and
+ * saving can never silently uncap a teammate. `0` is allowed and means exactly
+ * what it says — this teammate may not spend.
+ */
+function BudgetDialog({
+  member,
+  onOpenChange,
+  onSave,
+}: {
+  member: TeamMember | null;
+  onOpenChange: (open: boolean) => void;
+  onSave: (cap: number) => void;
+}) {
+  const [value, setValue] = useState("");
+
+  useEffect(() => {
+    setValue(member?.budgetUsdDaily !== undefined ? String(member.budgetUsdDaily) : "");
+  }, [member]);
+
+  const parsed = Number(value);
+  const valid = value.trim() !== "" && Number.isFinite(parsed) && parsed >= 0;
+
+  return (
+    <Dialog open={member !== null} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Daily budget</DialogTitle>
+          <DialogDescription>
+            The most {member?.name ?? "this teammate"} may spend per day. It takes effect on their
+            next task — no restart needed.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-2">
+          <Label htmlFor="member-budget">US dollars per day</Label>
+          <Input
+            id="member-budget"
+            type="number"
+            min={0}
+            step="0.01"
+            inputMode="decimal"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="e.g. 5.00"
+            data-testid="team-budget-input"
+          />
+          <p className="text-xs text-muted-foreground">
+            $0 stops them spending entirely. To let them spend freely, use “Remove cap”.
+          </p>
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => valid && onSave(parsed)}
+            disabled={!valid}
+            data-testid="team-budget-save"
+          >
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -302,26 +555,40 @@ function AddMemberDialog({
   open,
   onOpenChange,
   onAdd,
+  canSetBudget,
 }: {
   open: boolean;
   onOpenChange: (o: boolean) => void;
-  onAdd: (fields: { name: string; role: string; description: string; inbox?: boolean }) => void;
+  onAdd: (fields: AddMemberFields) => void;
+  /** Whether to offer the cap field — setting one is admin-only on the host. */
+  canSetBudget: boolean;
 }) {
   const [name, setName] = useState("");
   const [role, setRole] = useState("");
   const [description, setDescription] = useState("");
   const [inbox, setInbox] = useState(false);
+  const [budget, setBudget] = useState("");
 
   function reset() {
     setName("");
     setRole("");
     setDescription("");
     setInbox(false);
+    setBudget("");
   }
 
+  const parsedBudget = Number(budget);
+  // A blank field means "no cap", which is the default for a new teammate —
+  // so it is left out of the request entirely rather than sent as 0.
+  const budgetUsdDaily =
+    budget.trim() !== "" && Number.isFinite(parsedBudget) && parsedBudget >= 0
+      ? parsedBudget
+      : undefined;
+  const budgetInvalid = budget.trim() !== "" && budgetUsdDaily === undefined;
+
   function submit() {
-    if (!name.trim() || !role.trim()) return;
-    onAdd({ name, role, description, inbox });
+    if (!name.trim() || !role.trim() || budgetInvalid) return;
+    onAdd({ name, role, description, inbox, budgetUsdDaily });
     reset();
   }
 
@@ -366,6 +633,22 @@ function AddMemberDialog({
             placeholder="e.g. Runs paid acquisition and reports on ROAS."
           />
         </div>
+        {canSetBudget && (
+          <div className="grid gap-2">
+            <Label htmlFor="member-budget-new">Daily budget (optional)</Label>
+            <Input
+              id="member-budget-new"
+              type="number"
+              min={0}
+              step="0.01"
+              inputMode="decimal"
+              value={budget}
+              onChange={(e) => setBudget(e.target.value)}
+              placeholder="e.g. 5.00 — leave blank for no cap"
+              data-testid="team-add-budget"
+            />
+          </div>
+        )}
         <label className="flex items-center justify-between rounded-lg border p-3">
           <span className="flex items-center gap-2 text-sm">
             <Mail className="size-4 text-muted-foreground" /> Give this agent an inbox
@@ -376,7 +659,7 @@ function AddMemberDialog({
           <Button variant="ghost" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button onClick={submit} disabled={!name.trim() || !role.trim()}>
+          <Button onClick={submit} disabled={!name.trim() || !role.trim() || budgetInvalid}>
             Add member
           </Button>
         </DialogFooter>

--- a/frontend/test/e2e/team-budget-edit.spec.ts
+++ b/frontend/test/e2e/team-budget-edit.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Proof for issue #343: an admin can set, change and clear a teammate's daily
+ * cap **from the Console**, against the live host, with no redeploy.
+ *
+ * `team-budget.spec.ts` (issue #304) proves the cap is *displayed*. This proves
+ * it is *editable* — which is the whole of #343, because before it the only way
+ * to change a cap was for us to edit `company.toml` and ship a new image.
+ *
+ * Runs against the same live host as `wiring.spec.ts` (`companies/e2e_harness`),
+ * whose `writer` carries a $5.00/day cap and whose `engineer` carries none. The
+ * suite signs in through `global-setup.ts` as `harness-e2e@tinyhumans.ai`, which
+ * the harness manifest lists under `[users] admins` — so the session driving
+ * these specs really is an admin, and the controls below are visible.
+ *
+ * The spec restores every teammate it touches, so it can run repeatedly against
+ * a host whose data directory persists between runs.
+ */
+
+/** The card for the teammate whose role matches `role`. */
+function card(page: Page, role: string) {
+  return page.getByTestId("team-card").filter({ hasText: role }).first();
+}
+
+/**
+ * Opens a card's action menu.
+ *
+ * Located by label rather than by role: the trigger carries `aria-haspopup`,
+ * and `getByRole("button", …)` does not resolve it.
+ */
+async function openMenu(page: Page, role: string) {
+  await card(page, role).getByLabel("Member actions").click();
+}
+
+/**
+ * A fresh host greets the first visit with a welcome tour rendered over the
+ * console, which swallows clicks on the view beneath it. Dismiss it if present.
+ */
+async function dismissOnboarding(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  await skip.waitFor({ state: "visible", timeout: 15_000 }).catch(() => {});
+  if (await skip.isVisible()) {
+    await skip.click();
+    await expect(skip).toBeHidden();
+  }
+}
+
+/** Sets a cap through the dialog. */
+async function setCap(page: Page, role: string, amount: string) {
+  await openMenu(page, role);
+  await page.getByTestId("team-budget-edit").click();
+  const input = page.getByTestId("team-budget-input");
+  await expect(input).toBeVisible();
+  await input.fill(amount);
+  await page.getByTestId("team-budget-save").click();
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/#/team");
+  await dismissOnboarding(page);
+  await expect(page.getByTestId("team-card").first()).toBeVisible({ timeout: 30_000 });
+});
+
+test("an admin can cap a teammate the company left uncapped, and reset it back", async ({
+  page,
+}) => {
+  // The engineer starts uncapped: no budget line at all.
+  await expect(card(page, "Engineer").getByTestId("team-budget")).toHaveCount(0);
+
+  await setCap(page, "Engineer", "9");
+
+  // The cap is on the card, from the host — and attributed to a person.
+  const budget = card(page, "Engineer").getByTestId("team-budget");
+  await expect(budget).toHaveText(/\$9\.00\/day/, { timeout: 30_000 });
+  await expect(card(page, "Engineer").getByTestId("team-budget-attribution")).toContainText(
+    /Set by/,
+  );
+
+  // Host-backed, not local state: it survives a storage-cleared reload. This is
+  // the assertion that separates "the console remembers" from "the company was
+  // actually changed".
+  await page.evaluate(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+  await page.goto("/#/team");
+  await dismissOnboarding(page);
+  await expect(card(page, "Engineer").getByTestId("team-budget")).toHaveText(/\$9\.00\/day/, {
+    timeout: 30_000,
+  });
+
+  // Reset hands the teammate back to the company's own definition — which for
+  // the engineer means uncapped, so both the cap and the attribution go away.
+  await openMenu(page, "Engineer");
+  await page.getByTestId("team-budget-reset").click();
+  await expect(card(page, "Engineer").getByTestId("team-budget")).toHaveCount(0, {
+    timeout: 30_000,
+  });
+  await expect(card(page, "Engineer").getByTestId("team-budget-attribution")).toHaveCount(0);
+});
+
+test("an admin can change a company-set cap, remove it, and reset it back", async ({ page }) => {
+  // The writer's $5.00 comes from the company definition, so no attribution.
+  await expect(card(page, "Writer").getByTestId("team-budget")).toHaveText(/\$5\.00\/day/, {
+    timeout: 30_000,
+  });
+  await expect(card(page, "Writer").getByTestId("team-budget-attribution")).toHaveCount(0);
+
+  // Raising it beats the company's number — the remedy this issue exists for.
+  await setCap(page, "Writer", "42");
+  await expect(card(page, "Writer").getByTestId("team-budget")).toHaveText(/\$42\.00\/day/, {
+    timeout: 30_000,
+  });
+
+  // Removing the cap is not the same as zeroing it: the line disappears
+  // entirely rather than reading "$0.00/day", and the attribution stays so an
+  // operator can see a human did this.
+  await openMenu(page, "Writer");
+  await page.getByTestId("team-budget-remove").click();
+  await expect(card(page, "Writer").getByTestId("team-budget")).toHaveCount(0, { timeout: 30_000 });
+  await expect(card(page, "Writer").getByTestId("team-budget-attribution")).toContainText(
+    /Uncapped by/,
+  );
+
+  // Reset restores the company's $5.00 — which no "set" could express, because
+  // the value lives in the manifest rather than in the console.
+  await openMenu(page, "Writer");
+  await page.getByTestId("team-budget-reset").click();
+  await expect(card(page, "Writer").getByTestId("team-budget")).toHaveText(/\$5\.00\/day/, {
+    timeout: 30_000,
+  });
+  await expect(card(page, "Writer").getByTestId("team-budget-attribution")).toHaveCount(0);
+});

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -850,6 +850,7 @@ to = "done"
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         }
     }

--- a/src/economy/adapter.rs
+++ b/src/economy/adapter.rs
@@ -349,6 +349,7 @@ mod test {
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -1444,6 +1444,7 @@ description = "Runs Acme."
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         }
     }
@@ -1591,6 +1592,7 @@ description = "Builds it."
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         }
     }
@@ -2478,6 +2480,7 @@ members = ["engineer"]
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         }
     }
@@ -2623,6 +2626,7 @@ name = "Design"
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         };
         let (brain, _tasks) = brain_over(dir.path(), record);
@@ -2681,6 +2685,7 @@ members = ["eng1", "eng2"]
             }],
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         };
         let (brain, _tasks) = brain_over(dir.path(), record);
@@ -2735,6 +2740,7 @@ members = ["eng1", "eng2"]
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -96,7 +96,7 @@ use crate::harness::mcp_probe::McpFailureQueue;
 use crate::harness::orchestrator::DelegationQueue;
 use crate::harness::policy::{ApprovalPolicy, ApprovalRequestQueue};
 use crate::ports::skills_state::{SkillState, SkillStateStore};
-use crate::ports::types::{CompanyId, CompanyRecord, OverlayAgent, TurnStep};
+use crate::ports::types::{BudgetOverride, CompanyId, CompanyRecord, OverlayAgent, TurnStep};
 use crate::ports::{
     ArtifactStore, CompanyStore, ContextStore, EventLog, FactStore, SecretStore, TaskStore,
     UsageMeter,
@@ -637,6 +637,20 @@ pub struct HarnessPool {
     /// process restart (the regression this fixes). With no skill store wired
     /// the delta set is always empty — stable fingerprint, no rebuild.
     skill_fingerprints: RwLock<HashMap<CompanyId, u64>>,
+    /// Fingerprint of the operator budget-override set the cached roster was
+    /// built from, keyed by company (issue #343). Drives budget freshness:
+    /// [`ensure`](Self::ensure) re-resolves the overrides from
+    /// [`HarnessDeps::store`] on every call and rebuilds the roster whenever a
+    /// cap is set, changed, cleared or reset — so a budget edited on the console
+    /// Team page reaches the dispatch gate and the per-agent
+    /// [`ApprovalPolicy`](policy::ApprovalPolicy) on the company's **next** turn,
+    /// with no restart and no redeploy. That is the entire point of #343: the
+    /// cap is enforced from the roster, and without this axis every other
+    /// fingerprint is stable on a budget-only change, so the fast path would
+    /// reuse a roster still carrying the old cap until the process restarted.
+    /// A company that never sets an override keeps an empty set and a stable
+    /// fingerprint — no rebuild, byte-identical to the pre-#343 behaviour.
+    budget_fingerprints: RwLock<HashMap<CompanyId, u64>>,
 }
 
 impl Default for HarnessPool {
@@ -668,6 +682,7 @@ impl HarnessPool {
             capability_fingerprints: RwLock::new(HashMap::new()),
             composio_fingerprints: RwLock::new(HashMap::new()),
             skill_fingerprints: RwLock::new(HashMap::new()),
+            budget_fingerprints: RwLock::new(HashMap::new()),
         }
     }
 
@@ -698,14 +713,27 @@ impl HarnessPool {
     /// when every other axis (MCP, overlay, capability, composio) is unchanged.
     /// With no skill store wired the delta set is empty and the fingerprint is
     /// stable — no rebuild, exactly as before.
+    ///
+    /// **Budget freshness (issue #343)**: the operator's per-teammate daily
+    /// spend caps ride the same live [`HarnessDeps::store`] read as the overlay
+    /// agents and are fingerprinted alongside them, so a cap set, raised,
+    /// cleared or reset from the console Team page rebuilds the roster and is
+    /// enforced on the company's **next** dispatch. Nothing downstream had to
+    /// change for this: the L1 gate in [`Self::run`] reads
+    /// [`CompanyAgent::budget_usd_daily`] and the policy arm reads the
+    /// [`ApprovalPolicy`](policy::ApprovalPolicy) both roster-built here, so
+    /// rebuilding the roster *is* the enforcement update. That is what makes
+    /// "no restart, no redeploy" a property of the design rather than a claim.
     pub async fn ensure(&self, company: &CompanyRecord, deps: &HarnessDeps) -> crate::Result<()> {
         // Re-resolve + fingerprint the effective MCP set (cheap; no rebuild yet).
         let effective_mcp = self.resolve_effective_mcp(company, deps).await;
         let mcp_fp = mcp_fingerprint(&effective_mcp);
 
-        // Re-resolve + fingerprint the live overlay-agent set the same way.
-        let overlay_agents = self.resolve_effective_overlay(company, deps).await;
+        // Re-resolve + fingerprint the live overlay-agent set the same way, and
+        // the operator budget overrides riding the same store read (issue #343).
+        let (overlay_agents, overlay_budgets) = self.resolve_effective_overlay(company, deps).await;
         let overlay_fp = overlay_fingerprint(&overlay_agents);
+        let budget_fp = budget_fingerprint(&overlay_budgets);
 
         // Re-resolve + fingerprint the tenant's capability filter (issue #108):
         // a per-tenant, per-period, fail-closed budget read from the meter. With
@@ -742,12 +770,14 @@ impl HarnessPool {
             let capability_fingerprints = self.capability_fingerprints.read().await;
             let composio_fingerprints = self.composio_fingerprints.read().await;
             let skill_fingerprints = self.skill_fingerprints.read().await;
+            let budget_fingerprints = self.budget_fingerprints.read().await;
             if agents.contains_key(&company.id)
                 && mcp_fingerprints.get(&company.id) == Some(&mcp_fp)
                 && overlay_fingerprints.get(&company.id) == Some(&overlay_fp)
                 && capability_fingerprints.get(&company.id) == Some(&capability_fp)
                 && composio_fingerprints.get(&company.id) == Some(&composio_fp)
                 && skill_fingerprints.get(&company.id) == Some(&skill_fp)
+                && budget_fingerprints.get(&company.id) == Some(&budget_fp)
             {
                 return Ok(());
             }
@@ -771,6 +801,11 @@ impl HarnessPool {
         // built from the live-resolved overlay set, not `company.overlay_agents`.
         let mut fresh_company = company.clone();
         fresh_company.overlay_agents = overlay_agents;
+        // Same treatment for the budget overrides (issue #343): `build_roster`
+        // resolves every agent's cap through `fresh_company.effective_budget`,
+        // so installing the live set here is what carries a console budget edit
+        // into the roster the very next turn runs on.
+        fresh_company.overlay_budgets = overlay_budgets;
         let roster = build_roster(&fresh_company, &fresh_deps, &skill_deltas)?;
 
         let mut agents = self.agents.write().await;
@@ -795,6 +830,10 @@ impl HarnessPool {
             .write()
             .await
             .insert(company.id.clone(), skill_fp);
+        self.budget_fingerprints
+            .write()
+            .await
+            .insert(company.id.clone(), budget_fp);
         Ok(())
     }
 
@@ -896,21 +935,30 @@ impl HarnessPool {
         }
     }
 
-    /// Re-resolves the company's live overlay-agent set (issue #71): reloads the
-    /// [`CompanyRecord`] from [`HarnessDeps::store`] so a teammate added through
-    /// the console `POST .../team` route or the orchestrator's `add_agent` tool
-    /// reaches the roster on the company's next `ensure` call — the same
-    /// live-re-resolution pattern as [`Self::resolve_effective_mcp`]. A missing
-    /// record or a store error degrades to the `company` snapshot passed in
-    /// (never worse than the pre-#71 always-static behaviour).
+    /// Re-resolves the company's live overlay-agent set (issue #71) **and** its
+    /// operator budget overrides (issue #343): reloads the [`CompanyRecord`]
+    /// from [`HarnessDeps::store`] so a teammate added through the console
+    /// `POST .../team` route or the orchestrator's `add_agent` tool, and a cap
+    /// written through `PUT .../team/{id}/budget`, both reach the roster on the
+    /// company's next `ensure` call — the same live-re-resolution pattern as
+    /// [`Self::resolve_effective_mcp`]. A missing record or a store error
+    /// degrades to the `company` snapshot passed in (never worse than the
+    /// pre-#71 always-static behaviour).
+    ///
+    /// The two collections share **one** store round-trip deliberately: they
+    /// come off the same record, and splitting them would double the per-turn
+    /// read for no gain.
     async fn resolve_effective_overlay(
         &self,
         company: &CompanyRecord,
         deps: &HarnessDeps,
-    ) -> Vec<OverlayAgent> {
+    ) -> (Vec<OverlayAgent>, Vec<BudgetOverride>) {
         match deps.store.load(&company.id).await {
-            Ok(Some(record)) => record.overlay_agents,
-            _ => company.overlay_agents.clone(),
+            Ok(Some(record)) => (record.overlay_agents, record.overlay_budgets),
+            _ => (
+                company.overlay_agents.clone(),
+                company.overlay_budgets.clone(),
+            ),
         }
     }
 
@@ -944,6 +992,15 @@ impl HarnessPool {
     #[cfg(test)]
     pub async fn skill_fingerprint_of(&self, company: &CompanyId) -> Option<u64> {
         self.skill_fingerprints.read().await.get(company).copied()
+    }
+
+    /// The current budget-override fingerprint for a company (test-only), so a
+    /// budget-freshness test can assert the roster was actually rebuilt after a
+    /// console cap change rather than inferring it from the refusal (issue
+    /// #343). This is the observable that makes "no restart" testable.
+    #[cfg(test)]
+    pub async fn budget_fingerprint_of(&self, company: &CompanyId) -> Option<u64> {
+        self.budget_fingerprints.read().await.get(company).copied()
     }
 
     /// Routes a message to one agent and returns its reply, recording the turn's
@@ -1409,6 +1466,47 @@ fn overlay_fingerprint(agents: &[OverlayAgent]) -> u64 {
     hasher.finish()
 }
 
+/// A stable fingerprint of a company's operator budget-override set (issue
+/// #343), used to detect a cap set / changed / cleared / reset between
+/// [`HarnessPool::ensure`] calls. Mirrors [`overlay_fingerprint`]'s shape; a
+/// [`BudgetOverride`] holds no secret.
+///
+/// Two details carry weight:
+///
+/// - The set is **sorted by `agent_id`** first, because the write routes push
+///   and retain rather than maintain an order, and an order-sensitive hash would
+///   rebuild the roster (dropping live agent sessions) on a save that changed
+///   nothing an agent can observe.
+/// - The cap is hashed as an `Option` **discriminant plus `f64::to_bits`**, not
+///   through `PartialEq`. `f64` is not `Hash`, and going through bits is also
+///   what keeps `Some(0.0)` distinct from `None` in the hash — the very
+///   distinction the issue insists must not collapse. `to_bits` additionally
+///   makes the hash total over values `PartialEq` would call incomparable.
+fn budget_fingerprint(overrides: &[BudgetOverride]) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut ordered: Vec<&BudgetOverride> = overrides.iter().collect();
+    ordered.sort_by(|a, b| a.agent_id.cmp(&b.agent_id));
+
+    let mut hasher = DefaultHasher::new();
+    ordered.len().hash(&mut hasher);
+    for entry in ordered {
+        entry.agent_id.hash(&mut hasher);
+        match entry.budget_usd_daily {
+            Some(cap) => {
+                1u8.hash(&mut hasher);
+                cap.to_bits().hash(&mut hasher);
+            }
+            None => 0u8.hash(&mut hasher),
+        }
+    }
+    // Attribution is deliberately NOT hashed: who set the cap and when changes
+    // nothing an agent can act on, and folding it in would rebuild the roster
+    // (discarding live sessions) every time the same value was re-saved.
+    hasher.finish()
+}
+
 /// A stable fingerprint of a company's operator skill-delta set (issue #41),
 /// used to detect a skill authored / edited / enabled / disabled between
 /// [`HarnessPool::ensure`] calls. Mirrors [`mcp_fingerprint`]'s shape.
@@ -1469,7 +1567,13 @@ pub(crate) fn build_roster(
         Vec::with_capacity(company.manifest.agents.len() + company.overlay_agents.len());
 
     for manifest_agent in &company.manifest.agents {
-        let mut agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily)
+        // Issue #343: the cap in force, not the one the manifest shipped with.
+        // `effective_budget` is an operator override when one is stored and the
+        // manifest value otherwise, so a console cap change reaches BOTH readers
+        // built below — the `ApprovalPolicy` arm and `CompanyAgent`'s copy that
+        // the L1 dispatch gate reads — from this one call.
+        let effective_budget = company.effective_budget(&manifest_agent.id);
+        let mut agent_policy = ApprovalPolicy::new(policy, effective_budget)
             .with_requests(deps.approval_requests.clone())
             // Issue #243: stamp who the parked effect belongs to, so approving it
             // can hand the grant back to this agent rather than to nobody.
@@ -1496,7 +1600,7 @@ pub(crate) fn build_roster(
         roster.push(Arc::new(CompanyAgent {
             agent_id: manifest_agent.id.clone(),
             role: manifest_agent.role.clone(),
-            budget_usd_daily: manifest_agent.budget_usd_daily,
+            budget_usd_daily: effective_budget,
             agent: Mutex::new(agent),
         }));
     }
@@ -1515,11 +1619,12 @@ pub(crate) fn build_roster(
             continue;
         }
         let manifest_agent = overlay_agent_to_manifest(overlay);
-        // No per-teammate budget cap or cognition-tier hint in v1 — see
-        // `overlay_agent_to_manifest`. The spend reader is still wired: the cap
-        // is `None`, so the arm is inert, but an overlay teammate that grows a
-        // cap later needs no second wiring site.
-        let mut agent_policy = ApprovalPolicy::new(policy, manifest_agent.budget_usd_daily)
+        // Issue #343: an overlay teammate has no manifest row to carry a cap, so
+        // before the override existed it was unconditionally uncapped — the "v1
+        // limitation" this lifts. `effective_budget` gives it a stored cap when
+        // an operator set one, and `None` (as before) when nobody has.
+        let effective_budget = company.effective_budget(&manifest_agent.id);
+        let mut agent_policy = ApprovalPolicy::new(policy, effective_budget)
             .with_requests(deps.approval_requests.clone())
             // An overlay teammate is a real roster agent and re-dispatches the
             // same way a manifest one does (issue #243).
@@ -1541,8 +1646,7 @@ pub(crate) fn build_roster(
         roster.push(Arc::new(CompanyAgent {
             agent_id: manifest_agent.id.clone(),
             role: manifest_agent.role.clone(),
-            // Overlay teammates are uncapped in v1 (`overlay_agent_to_manifest`).
-            budget_usd_daily: manifest_agent.budget_usd_daily,
+            budget_usd_daily: effective_budget,
             agent: Mutex::new(agent),
         }));
     }
@@ -1554,7 +1658,10 @@ pub(crate) fn build_roster(
 /// [`build::build_agent`] consumes: an empty `tools` list (so
 /// [`agent_effective_grants`] falls back to the full company `[tools].allow`
 /// — the "standard tool grant"), no cognition tier (→ the default `chat-v1`
-/// model), and no per-agent budget cap. The overlay's `name` is a display
+/// model), and no manifest budget cap — an overlay teammate has no manifest row
+/// at all, so its cap (if any) comes from the record's budget overrides via
+/// [`CompanyRecord::effective_budget`], resolved by the caller. The overlay's
+/// `name` is a display
 /// label only — already surfaced through
 /// [`crate::metering::roster_display_names`] — so the persona is framed from
 /// `role`/`description` alone, exactly like a manifest teammate
@@ -3169,6 +3276,269 @@ description = "Builds the product."
         assert!(
             ok.contains("hello-marker"),
             "one teammate's exhausted budget must not stop the company: {ok:?}"
+        );
+    }
+
+    // --- Console budget overrides, live (issue #343) -------------------------
+
+    /// **The no-restart proof.** A daily cap written through the company store —
+    /// the exact path `PUT …/team/{id}/budget` writes through — is enforced on
+    /// the company's **next dispatch**, in one process, with no restart and no
+    /// redeploy.
+    ///
+    /// This is the whole of #343 at the layer that decides whether a teammate
+    /// works. Before it, `budget_usd_daily` was readable only from the manifest,
+    /// which is a boot snapshot baked into the tenant image — so an operator
+    /// whose teammate had stopped had no remedy short of us shipping a new
+    /// image. The four phases walk exactly that operator's day:
+    ///
+    ///   A. the CEO has spent its manifest $5 and is refused (issue #304, and
+    ///      the state that motivates the issue);
+    ///   B. an admin **raises** the cap to $50 — the stopped teammate works
+    ///      again on its very next turn. This is the acceptance criterion;
+    ///   C. the admin sets the cap to **$0** — a real cap of nothing, refused
+    ///      from the first cent;
+    ///   D. the admin **clears** the cap — an explicitly-uncapped override that
+    ///      beats the manifest's $5 even with $5 already spent, so the teammate
+    ///      works again.
+    ///
+    /// C and D are the same route with different bodies and they must not
+    /// resolve alike: C refuses, D runs. That is "clearing is distinct from
+    /// zeroing" asserted on live behaviour rather than on a type.
+    ///
+    /// Throughout, the pool holds **one** resident company and is never
+    /// reconstructed — `resident_companies()` stays 1 and the same `pool` binding
+    /// serves every phase — so the only mechanism that can be carrying these
+    /// changes is the budget fingerprint flipping and `ensure` rebuilding the
+    /// roster in place. Each phase asserts that fingerprint actually moved.
+    #[tokio::test]
+    async fn a_budget_written_through_the_store_is_enforced_on_the_next_dispatch() {
+        use crate::ports::types::{Actor, ActorKind, BudgetOverride};
+
+        let dir = tempfile::tempdir().unwrap();
+        let context = Arc::new(MockContext::default());
+        let meter = Arc::new(RecordingMeter::default());
+        let rec = capped_record();
+
+        // A live store, so `ensure` re-resolves the overrides the way it does in
+        // production. `deps_with_plan`'s default store is inert.
+        let live_store = Arc::new(LiveStore::default());
+        live_store.save(&rec).await.unwrap();
+
+        // The CEO has already spent its manifest $5 today.
+        meter
+            .record(
+                &rec.id,
+                &spend_sample("ceo", 5.00, crate::ports::now_millis()),
+            )
+            .await
+            .unwrap();
+
+        let mut deps = deps_with_plan(
+            dir.path(),
+            context.clone(),
+            Some(meter.clone() as Arc<dyn UsageMeter>),
+            None,
+        );
+        deps.store = live_store.clone();
+
+        // ONE pool for the whole test. Nothing below reconstructs it, so nothing
+        // below can be smuggling in a restart.
+        let pool = HarnessPool::new();
+
+        /// Writes an override through the store exactly as the console route
+        /// does, and returns the record for the next `ensure`.
+        fn with_override(base: &CompanyRecord, cap: Option<f64>) -> CompanyRecord {
+            let mut next = base.clone();
+            next.overlay_budgets = vec![BudgetOverride {
+                agent_id: "ceo".to_string(),
+                budget_usd_daily: cap,
+                set_by: Actor {
+                    kind: ActorKind::User,
+                    id: "user-admin".to_string(),
+                },
+                at_millis: crate::ports::now_millis(),
+            }];
+            next
+        }
+
+        // --- A. The manifest cap is spent: the teammate is stopped. ----------
+        pool.ensure(&rec, &deps).await.expect("ensure A");
+        let fp_manifest = pool
+            .budget_fingerprint_of(&rec.id)
+            .await
+            .expect("fingerprinted");
+        let refused = pool
+            .run(&rec.id, "ceo", "should-not-echo", &deps, None)
+            .await
+            .expect("a refusal is a benign outcome")
+            .reply;
+        assert_eq!(
+            refused,
+            agent_budget_exhausted_notice("ceo", 5.0),
+            "phase A: the manifest's $5 cap is spent, so dispatch is refused"
+        );
+
+        // --- B. An admin raises the cap. The teammate works again. -----------
+        live_store
+            .save(&with_override(&rec, Some(50.0)))
+            .await
+            .unwrap();
+        pool.ensure(&rec, &deps).await.expect("ensure B");
+        let fp_raised = pool
+            .budget_fingerprint_of(&rec.id)
+            .await
+            .expect("fingerprinted");
+        assert_ne!(
+            fp_manifest, fp_raised,
+            "phase B: setting a cap must move the budget fingerprint, or the \
+             cached roster is reused and the change never reaches the gate"
+        );
+        assert_eq!(
+            pool.resident_companies().await,
+            1,
+            "phase B: the same company, rebuilt in place — not a new process"
+        );
+        let unblocked = pool
+            .run(&rec.id, "ceo", "hello-marker", &deps, None)
+            .await
+            .expect("the raised cap unblocks the teammate")
+            .reply;
+        assert!(
+            unblocked.contains("hello-marker"),
+            "phase B: raising the cap from the console must unblock the stopped \
+             teammate on its very next dispatch, with no restart: {unblocked:?}"
+        );
+
+        // --- C. The admin sets the cap to zero. Zero is a real cap. ----------
+        live_store
+            .save(&with_override(&rec, Some(0.0)))
+            .await
+            .unwrap();
+        pool.ensure(&rec, &deps).await.expect("ensure C");
+        let fp_zero = pool
+            .budget_fingerprint_of(&rec.id)
+            .await
+            .expect("fingerprinted");
+        assert_ne!(fp_raised, fp_zero, "phase C: lowering a cap is a change");
+        let zeroed = pool
+            .run(&rec.id, "ceo", "should-not-echo", &deps, None)
+            .await
+            .expect("a refusal is a benign outcome")
+            .reply;
+        assert_eq!(
+            zeroed,
+            agent_budget_exhausted_notice("ceo", 0.0),
+            "phase C: a $0 cap refuses from the first cent"
+        );
+
+        // --- D. The admin clears the cap. Cleared is not zero. ---------------
+        live_store.save(&with_override(&rec, None)).await.unwrap();
+        pool.ensure(&rec, &deps).await.expect("ensure D");
+        let fp_cleared = pool
+            .budget_fingerprint_of(&rec.id)
+            .await
+            .expect("fingerprinted");
+        assert_ne!(
+            fp_zero, fp_cleared,
+            "phase D: 'no cap' and 'a cap of $0' must not hash alike — if they \
+             did, clearing a cap would silently leave the teammate at zero"
+        );
+        let cleared = pool
+            .run(&rec.id, "ceo", "hello-marker", &deps, None)
+            .await
+            .expect("an explicitly-uncapped teammate runs")
+            .reply;
+        assert!(
+            cleared.contains("hello-marker"),
+            "phase D: an explicitly-uncapped override beats the manifest's $5 \
+             even with $5 already spent today: {cleared:?}"
+        );
+
+        // Nothing above restarted anything.
+        assert_eq!(
+            pool.resident_companies().await,
+            1,
+            "one company, rebuilt in place across all four phases"
+        );
+
+        // A further `ensure` with no change is a no-op: the axis is not thrashing
+        // the roster (and dropping live agent sessions) on every turn.
+        pool.ensure(&rec, &deps).await.expect("ensure idempotent");
+        assert_eq!(pool.budget_fingerprint_of(&rec.id).await, Some(fp_cleared));
+    }
+
+    /// An **overlay** teammate — one added from the console, with no manifest
+    /// row — can be capped through the same override, and is refused when it has
+    /// spent it. Before #343 an overlay teammate was unconditionally uncapped
+    /// ("overlay teammates are uncapped in v1"), so this is a capability that did
+    /// not exist rather than a behaviour that changed.
+    #[tokio::test]
+    async fn an_overlay_teammate_can_be_capped_from_the_console() {
+        use crate::ports::types::{Actor, ActorKind, BudgetOverride};
+
+        let dir = tempfile::tempdir().unwrap();
+        let context = Arc::new(MockContext::default());
+        let meter = Arc::new(RecordingMeter::default());
+
+        let mut rec = record();
+        rec.overlay_agents.push(OverlayAgent {
+            id: "growth".into(),
+            name: "Jamie".into(),
+            role: "Growth Lead".into(),
+            description: None,
+        });
+        let live_store = Arc::new(LiveStore::default());
+        live_store.save(&rec).await.unwrap();
+
+        let mut deps = deps_with_plan(
+            dir.path(),
+            context.clone(),
+            Some(meter.clone() as Arc<dyn UsageMeter>),
+            None,
+        );
+        deps.store = live_store.clone();
+        let pool = HarnessPool::new();
+
+        // Uncapped to begin with: it answers.
+        pool.ensure(&rec, &deps).await.expect("ensure");
+        let reply = pool
+            .run(&rec.id, "growth", "hello-marker", &deps, None)
+            .await
+            .expect("an uncapped overlay teammate answers")
+            .reply;
+        assert!(reply.contains("hello-marker"), "got {reply:?}");
+
+        // The operator caps it at $1 and it has already spent $2.
+        meter
+            .record(
+                &rec.id,
+                &spend_sample("growth", 2.00, crate::ports::now_millis()),
+            )
+            .await
+            .unwrap();
+        let mut capped = rec.clone();
+        capped.overlay_budgets = vec![BudgetOverride {
+            agent_id: "growth".to_string(),
+            budget_usd_daily: Some(1.0),
+            set_by: Actor {
+                kind: ActorKind::User,
+                id: "user-admin".to_string(),
+            },
+            at_millis: crate::ports::now_millis(),
+        }];
+        live_store.save(&capped).await.unwrap();
+
+        pool.ensure(&rec, &deps).await.expect("ensure again");
+        let refused = pool
+            .run(&rec.id, "growth", "should-not-echo", &deps, None)
+            .await
+            .expect("a refusal is a benign outcome")
+            .reply;
+        assert_eq!(
+            refused,
+            agent_budget_exhausted_notice("growth", 1.0),
+            "a console-added teammate is capped by the same gate as a manifest one"
         );
     }
 

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1750,6 +1750,7 @@ description = "Builds the product."
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         }
     }
@@ -2714,6 +2715,7 @@ description = "Sets direction."
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         }
     }

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -2218,6 +2218,7 @@ name = "Morning"
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         }
     }
@@ -2575,6 +2576,7 @@ name = "Morning"
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         }
     }

--- a/src/harness/search_turn_test.rs
+++ b/src/harness/search_turn_test.rs
@@ -317,6 +317,7 @@ async fn harness(
         overlay_desk_order: Vec::new(),
         overlay_desks: Vec::new(),
         overlay_workflows: Vec::new(),
+        overlay_budgets: Vec::new(),
         template_provenance: None,
     };
 

--- a/src/harness/workspace_turn_test.rs
+++ b/src/harness/workspace_turn_test.rs
@@ -300,6 +300,7 @@ async fn harness(
         overlay_desk_order: Vec::new(),
         overlay_desks: Vec::new(),
         overlay_workflows: Vec::new(),
+        overlay_budgets: Vec::new(),
         template_provenance: None,
     };
 

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -1275,6 +1275,40 @@ pub struct OverlayWorkflow {
     pub toml: String,
 }
 
+/// An operator-set daily spend cap for one teammate, persisted on the
+/// [`CompanyRecord`] so it wins over the manifest's `budget_usd_daily` without
+/// rewriting `company.toml` and without a redeploy (issue #343).
+///
+/// The manifest is a **boot snapshot** baked into the tenant image, so before
+/// this the shipped number was the only number. An entry here is the durable
+/// override the console writes; [`CompanyRecord::effective_budget`] is the one
+/// place the two are reconciled.
+///
+/// Three states, and keeping them apart is the point:
+///
+/// - **no entry** — the manifest value applies (the pre-#343 behaviour exactly);
+/// - **entry with `Some(x)`** — capped at `x`, including a legitimate `0.0`
+///   ("this teammate may not spend");
+/// - **entry with `None`** — explicitly **uncapped**, which beats a manifest cap.
+///   Without this state, clearing a cap on a manifest-capped teammate would be
+///   impossible: dropping the row would fall back to the very cap being cleared.
+///
+/// "Cleared" and "zero" are therefore different rows, never the same one.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct BudgetOverride {
+    /// The teammate this caps — a manifest `[[agent]]` id or an
+    /// [`OverlayAgent`] id.
+    pub agent_id: String,
+    /// The cap in USD per UTC day, or `None` for "explicitly uncapped".
+    #[serde(default)]
+    pub budget_usd_daily: Option<f64>,
+    /// Who set it. Attribution is part of the acceptance: a cap that can be
+    /// raised anonymously is not much of a cap.
+    pub set_by: Actor,
+    /// When it was set (epoch millis).
+    pub at_millis: u64,
+}
+
 /// The operator overlays persisted as a single JSON blob by the string-column
 /// stores (sqlite + mongodb `overlay_json`). The filesystem store keeps the two
 /// collections as typed fields on its own `Meta` instead.
@@ -1302,6 +1336,11 @@ pub struct OverlayBlob {
     /// `#[serde(default)]` loads them as empty.
     #[serde(default)]
     pub workflows: Vec<OverlayWorkflow>,
+    /// The operator-set per-teammate daily spend caps (issue #343). Absent on
+    /// rows written before console budget writes existed, so `#[serde(default)]`
+    /// loads them as empty — which is exactly "the manifest still decides".
+    #[serde(default)]
+    pub budgets: Vec<BudgetOverride>,
     /// The source-template provenance recorded at launch. `None` for companies
     /// provisioned from a raw manifest and for legacy rows written before
     /// provenance existed (the `#[serde(default)]` keeps those rows loading).
@@ -1318,6 +1357,7 @@ impl OverlayBlob {
             desk_order: record.overlay_desk_order.clone(),
             desks: record.overlay_desks.clone(),
             workflows: record.overlay_workflows.clone(),
+            budgets: record.overlay_budgets.clone(),
             provenance: record.template_provenance.clone(),
         }
     }
@@ -1340,6 +1380,7 @@ impl OverlayBlob {
                     desk_order: Vec::new(),
                     desks: Vec::new(),
                     workflows: Vec::new(),
+                    budgets: Vec::new(),
                     provenance: None,
                 })
                 .map_err(|_| original),
@@ -1383,6 +1424,15 @@ pub struct CompanyRecord {
     /// authoring persisted through the store loading without a migration.
     #[serde(default)]
     pub overlay_workflows: Vec<OverlayWorkflow>,
+    /// Operator-set per-teammate daily spend caps that win over the manifest's
+    /// `budget_usd_daily` (issue #343). Read through
+    /// [`Self::effective_budget`] — never directly — so the console write path,
+    /// the roster build and both read surfaces cannot drift. Empty means the
+    /// manifest decides, which is byte-for-byte the pre-#343 behaviour; the
+    /// `#[serde(default)]` keeps records written before console budget writes
+    /// existed loading without a migration.
+    #[serde(default)]
+    pub overlay_budgets: Vec<BudgetOverride>,
     /// Where this company's manifest was seeded from — the source template's
     /// stable identity, stamped once at launch and carried across rebuilds.
     /// `None` for companies provisioned from a raw manifest body. The
@@ -1538,6 +1588,46 @@ impl CompanyRecord {
             .filter(|a| a.name.eq_ignore_ascii_case(name_key))
             .map(|a| a.id.clone())
             .collect()
+    }
+
+    /// This teammate's operator-set budget override, if one exists.
+    ///
+    /// The presence of a row is itself information — it is what the console
+    /// renders the "set by … " attribution line from, and what tells "reset to
+    /// the manifest default" (drop the row) apart from "remove the cap" (a row
+    /// whose `budget_usd_daily` is `None`). Callers that only want the number
+    /// should use [`Self::effective_budget`].
+    pub fn budget_override(&self, agent_id: &str) -> Option<&BudgetOverride> {
+        self.overlay_budgets
+            .iter()
+            .find(|entry| entry.agent_id == agent_id)
+    }
+
+    /// The daily USD cap actually in force for `agent_id`: the operator's
+    /// override when one is stored, else the manifest's `budget_usd_daily`,
+    /// else `None` (uncapped).
+    ///
+    /// **The single source of truth for "what may this teammate spend today"**,
+    /// in the shape of [`Self::effective_desk_members`]. The harness gate, the
+    /// per-agent [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy) arm,
+    /// the REST roster and the GraphQL roster all read through here, so a cap
+    /// raised in the console cannot be honoured by one and ignored by another.
+    ///
+    /// An **overlay** teammate has no manifest row at all, so before #343 it was
+    /// unconditionally uncapped; now a stored override caps it like any other.
+    /// A stored `Some(0.0)` really does mean zero, and a stored `None` really
+    /// does mean uncapped even when the manifest names a cap — that asymmetry is
+    /// the whole reason the override is `Option<f64>` rather than `f64`.
+    pub fn effective_budget(&self, agent_id: &str) -> Option<f64> {
+        match self.budget_override(agent_id) {
+            Some(entry) => entry.budget_usd_daily,
+            None => self
+                .manifest
+                .agents
+                .iter()
+                .find(|a| a.id == agent_id)
+                .and_then(|a| a.budget_usd_daily),
+        }
     }
 }
 
@@ -2266,6 +2356,7 @@ mod test {
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         }
     }
@@ -2539,6 +2630,126 @@ mod test {
             OverlayBlob::parse("[]")
                 .expect("legacy array")
                 .workflows
+                .is_empty()
+        );
+    }
+
+    /// A manifest with two teammates, one capped at $5/day and one uncapped —
+    /// the two starting positions every budget-override case builds on.
+    const BUDGET_ROSTER: &str = "[company]\nname = \"Acme\"\n\
+         [[agent]]\nid = \"analyst\"\nrole = \"Analyst\"\nbudget_usd_daily = 5.0\n\
+         [[agent]]\nid = \"writer\"\nrole = \"Writer\"\n";
+
+    fn budget_entry(agent_id: &str, cap: Option<f64>) -> BudgetOverride {
+        BudgetOverride {
+            agent_id: agent_id.to_string(),
+            budget_usd_daily: cap,
+            set_by: Actor {
+                kind: ActorKind::User,
+                id: "user-1".to_string(),
+            },
+            at_millis: 1_700_000_000_000,
+        }
+    }
+
+    /// Issue #343: with no override stored, `effective_budget` is the manifest
+    /// value verbatim — the pre-#343 behaviour, and the regression net that says
+    /// adding this field changed nothing for a company that never uses it.
+    #[test]
+    fn effective_budget_falls_back_to_the_manifest() {
+        let record = desk_record(BUDGET_ROSTER, Vec::new());
+        assert_eq!(record.effective_budget("analyst"), Some(5.0));
+        assert_eq!(record.effective_budget("writer"), None);
+        // An id on no roster at all is uncapped rather than an error: the gate
+        // reads this per dispatched agent and must not invent a cap.
+        assert_eq!(record.effective_budget("nobody"), None);
+    }
+
+    /// A stored override wins over the manifest in both directions — raising a
+    /// cap and lowering one. This is the "no redeploy" property at its source:
+    /// nothing here consults `company.toml` once a row exists.
+    #[test]
+    fn a_stored_override_beats_the_manifest() {
+        let mut record = desk_record(BUDGET_ROSTER, Vec::new());
+        record
+            .overlay_budgets
+            .push(budget_entry("analyst", Some(50.0)));
+        assert_eq!(record.effective_budget("analyst"), Some(50.0));
+
+        record.overlay_budgets = vec![budget_entry("analyst", Some(1.0))];
+        assert_eq!(record.effective_budget("analyst"), Some(1.0));
+    }
+
+    /// The distinction the issue calls out by name: clearing a cap and setting
+    /// it to zero are different states and must not collapse into each other.
+    ///
+    /// `Some(0.0)` caps the teammate at nothing (it will refuse to dispatch);
+    /// `None` means explicitly uncapped and beats the manifest's $5. If these
+    /// two ever resolved the same way, an operator lifting a cap would instead
+    /// have silenced the teammate completely — the opposite of what they asked
+    /// for, and unrecoverable from the console.
+    #[test]
+    fn clearing_a_cap_is_not_the_same_as_zeroing_it() {
+        let mut record = desk_record(BUDGET_ROSTER, Vec::new());
+
+        record.overlay_budgets = vec![budget_entry("analyst", Some(0.0))];
+        assert_eq!(record.effective_budget("analyst"), Some(0.0));
+
+        record.overlay_budgets = vec![budget_entry("analyst", None)];
+        assert_eq!(
+            record.effective_budget("analyst"),
+            None,
+            "an explicitly-uncapped override must beat the manifest's cap"
+        );
+    }
+
+    /// An **overlay** teammate has no manifest row, so before #343 it could not
+    /// be capped at all. A stored override caps it like anyone else — and
+    /// dropping that override returns it to uncapped, since there is no manifest
+    /// value underneath to fall back to.
+    #[test]
+    fn an_overlay_teammate_can_be_capped() {
+        let mut record = desk_record(BUDGET_ROSTER, Vec::new());
+        record.overlay_agents.push(OverlayAgent {
+            id: "shane".to_string(),
+            name: "Shane".to_string(),
+            role: "Growth".to_string(),
+            description: None,
+        });
+        assert_eq!(record.effective_budget("shane"), None);
+
+        record.overlay_budgets = vec![budget_entry("shane", Some(2.5))];
+        assert_eq!(record.effective_budget("shane"), Some(2.5));
+
+        record.overlay_budgets.clear();
+        assert_eq!(record.effective_budget("shane"), None);
+    }
+
+    /// Issue #343: the budget overrides round-trip through the `OverlayBlob` the
+    /// sqlite/mongodb stores persist, and pre-#343 rows load as "no overrides"
+    /// (the manifest still decides) rather than failing to parse.
+    #[test]
+    fn overlay_blob_round_trips_budgets() {
+        let mut record = desk_record(BUDGET_ROSTER, Vec::new());
+        record.overlay_budgets = vec![
+            budget_entry("analyst", Some(9.0)),
+            budget_entry("writer", None),
+        ];
+        let json = serde_json::to_string(&OverlayBlob::from_record(&record)).expect("serialize");
+        let blob = OverlayBlob::parse(&json).expect("reparse");
+        assert_eq!(blob.budgets, record.overlay_budgets);
+
+        let legacy = r#"{"agents":[],"desk_members":[]}"#;
+        assert!(
+            OverlayBlob::parse(legacy)
+                .expect("pre-budget object")
+                .budgets
+                .is_empty()
+        );
+        assert!(
+            OverlayBlob::parse("[]")
+                .expect("legacy array")
+                .budgets
                 .is_empty()
         );
     }

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -1309,6 +1309,32 @@ pub struct BudgetOverride {
     pub at_millis: u64,
 }
 
+impl BudgetOverride {
+    /// The first `agent_id` appearing more than once in `entries`, if any.
+    ///
+    /// For validating a set of overrides this process did not write — an
+    /// imported bundle, principally. [`CompanyRecord::budget_override`] reads the
+    /// *first* match, so a second row for one teammate is not a harmless
+    /// duplicate: it makes the applied cap a function of serialization order.
+    /// The two rows can differ in cap *and* in attribution, so there is no
+    /// answer to pick — one choice over-restricts a teammate, the other hands
+    /// back an allowance an admin revoked, and both name someone in the console
+    /// who may not have set it. Callers reject rather than guess.
+    ///
+    /// Linear scan: an override set is one row per capped teammate, so it is
+    /// bounded by roster size.
+    pub fn duplicate_agent_id(entries: &[BudgetOverride]) -> Option<&str> {
+        let mut seen: Vec<&str> = Vec::with_capacity(entries.len());
+        for entry in entries {
+            if seen.contains(&entry.agent_id.as_str()) {
+                return Some(&entry.agent_id);
+            }
+            seen.push(&entry.agent_id);
+        }
+        None
+    }
+}
+
 /// The operator overlays persisted as a single JSON blob by the string-column
 /// stores (sqlite + mongodb `overlay_json`). The filesystem store keeps the two
 /// collections as typed fields on its own `Meta` instead.
@@ -1431,6 +1457,13 @@ pub struct CompanyRecord {
     /// manifest decides, which is byte-for-byte the pre-#343 behaviour; the
     /// `#[serde(default)]` keeps records written before console budget writes
     /// existed loading without a migration.
+    ///
+    /// **At most one entry per `agent_id`.** [`Self::effective_budget`] reads the
+    /// first match, so a second entry for the same teammate is not a harmless
+    /// duplicate — it is a silently unreachable cap, and which of the two wins
+    /// depends on insertion order rather than on what an admin last decided.
+    /// Mutate through [`Self::upsert_budget_override`] rather than pushing, and
+    /// check untrusted input with [`Self::duplicate_budget_agent_id`].
     #[serde(default)]
     pub overlay_budgets: Vec<BudgetOverride>,
     /// Where this company's manifest was seeded from — the source template's
@@ -1628,6 +1661,27 @@ impl CompanyRecord {
                 .find(|a| a.id == agent_id)
                 .and_then(|a| a.budget_usd_daily),
         }
+    }
+
+    /// Stores `entry` as **the** override for its teammate, replacing any entry
+    /// already held for that `agent_id`.
+    ///
+    /// The one way a write path should add to [`Self::overlay_budgets`]. Pushing
+    /// directly is what lets a record accumulate two rows for one teammate, and
+    /// [`Self::budget_override`] reads the *first* — so the stale row would keep
+    /// winning and every surface would agree on a cap no admin last set. Making
+    /// the replacement part of the type rather than a convention each caller
+    /// remembers is the point: there is no correct way to append.
+    pub fn upsert_budget_override(&mut self, entry: BudgetOverride) {
+        self.overlay_budgets
+            .retain(|held| held.agent_id != entry.agent_id);
+        self.overlay_budgets.push(entry);
+    }
+
+    /// The first `agent_id` on this record carrying more than one override, if
+    /// any. See [`BudgetOverride::duplicate_agent_id`].
+    pub fn duplicate_budget_agent_id(&self) -> Option<&str> {
+        BudgetOverride::duplicate_agent_id(&self.overlay_budgets)
     }
 }
 
@@ -2723,6 +2777,62 @@ mod test {
 
         record.overlay_budgets.clear();
         assert_eq!(record.effective_budget("shane"), None);
+    }
+
+    /// Issue #343: one override per teammate. `upsert_budget_override` replaces
+    /// the held row instead of appending a second, so the cap an admin last set
+    /// is the cap every surface reads.
+    ///
+    /// Appending would leave the *first* row winning `budget_override`'s
+    /// find-first read — meaning a raise or a revocation would persist happily
+    /// and change nothing, the failure mode hardest to notice from the console.
+    #[test]
+    fn upserting_an_override_replaces_rather_than_appends() {
+        let mut record = desk_record(BUDGET_ROSTER, Vec::new());
+        record.upsert_budget_override(budget_entry("analyst", Some(50.0)));
+        record.upsert_budget_override(budget_entry("writer", Some(3.0)));
+        record.upsert_budget_override(budget_entry("analyst", None));
+
+        assert_eq!(
+            record.overlay_budgets.len(),
+            2,
+            "a second write for one teammate must replace, not accumulate: {:?}",
+            record.overlay_budgets
+        );
+        assert_eq!(
+            record.effective_budget("analyst"),
+            None,
+            "the latest write must win over the manifest's $5"
+        );
+        assert_eq!(record.effective_budget("writer"), Some(3.0));
+    }
+
+    /// Issue #343: duplicates are detectable, so a caller holding overrides it
+    /// did not write (a bundle import) can refuse them instead of silently
+    /// applying whichever row happens to sort first.
+    #[test]
+    fn duplicate_overrides_are_detected() {
+        let mut record = desk_record(BUDGET_ROSTER, Vec::new());
+        assert_eq!(record.duplicate_budget_agent_id(), None);
+
+        record.overlay_budgets = vec![
+            budget_entry("analyst", Some(9.0)),
+            budget_entry("writer", None),
+        ];
+        assert_eq!(
+            record.duplicate_budget_agent_id(),
+            None,
+            "distinct teammates are not a duplicate"
+        );
+
+        // Two rows for one teammate that disagree about the cap — the case where
+        // guessing would either over-restrict or hand back a revoked allowance.
+        record.overlay_budgets = vec![
+            budget_entry("analyst", Some(9.0)),
+            budget_entry("writer", None),
+            budget_entry("analyst", Some(0.0)),
+        ];
+        assert_eq!(record.duplicate_budget_agent_id(), Some("analyst"));
     }
 
     /// Issue #343: the budget overrides round-trip through the `OverlayBlob` the

--- a/src/runtime/assignee.rs
+++ b/src/runtime/assignee.rs
@@ -199,6 +199,7 @@ mod tests {
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         }
     }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -969,6 +969,16 @@ impl RuntimeBuilder {
             .as_ref()
             .map(|r| r.overlay_workflows.clone())
             .unwrap_or_default();
+        // Issue #343: the operator-set daily spend caps. Carried across the
+        // rebuild for the same reason as the workflow bodies — the manifest is a
+        // read-only boot snapshot on a hosted tenant, so dropping these would
+        // silently revert every console-set cap to the number baked into the
+        // image on the next restart, which is the exact failure #343 exists to
+        // end.
+        let overlay_budgets = existing
+            .as_ref()
+            .map(|r| r.overlay_budgets.clone())
+            .unwrap_or_default();
         // Issue #208: `[workflows].enabled` is the one manifest field a runtime
         // write mutates (`create_company_workflow` pushes the new id alongside
         // the overlay body, in the same save). Rebuilding the record from the
@@ -1272,6 +1282,7 @@ impl RuntimeBuilder {
                                 overlay_desk_order: overlay_desk_order.clone(),
                                 overlay_desks: overlay_desks.clone(),
                                 overlay_workflows: overlay_workflows.clone(),
+                                overlay_budgets: overlay_budgets.clone(),
                                 template_provenance: template_provenance.clone(),
                             };
                             // Workflow agent nodes execute on the same pool as the
@@ -1387,6 +1398,7 @@ impl RuntimeBuilder {
                 overlay_desk_order,
                 overlay_desks,
                 overlay_workflows,
+                overlay_budgets,
                 template_provenance,
             })
             .await?;
@@ -2766,6 +2778,7 @@ mod test {
                 }],
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/runtime/delegation_tools.rs
+++ b/src/runtime/delegation_tools.rs
@@ -385,6 +385,7 @@ members = ["counsel"]
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         }
     }

--- a/src/server/graphql/company.rs
+++ b/src/server/graphql/company.rs
@@ -232,11 +232,17 @@ impl CompanyGql {
         // reads of the same roster must not drift, so the cap columns are
         // resolved here by the same rule (one meter read, only when somebody is
         // capped; spend paired with the cap).
+        // Issue #343: the scan is over EFFECTIVE caps across the whole roster
+        // (manifest agents plus overlay teammates), because a console override
+        // can cap somebody the manifest never did — including a teammate the
+        // manifest does not contain at all.
         let any_capped = record
             .manifest
             .agents
             .iter()
-            .any(|agent| agent.budget_usd_daily.is_some());
+            .map(|agent| &agent.id)
+            .chain(record.overlay_agents.iter().map(|agent| &agent.id))
+            .any(|id| record.effective_budget(id).is_some());
         let spend_today = if any_capped {
             let since = crate::metering::utc_day_start_millis(crate::ports::now_millis());
             Some(self.runtime.usage().query(&self.id, since).await?)
@@ -249,29 +255,44 @@ impl CompanyGql {
                 .map(|samples| crate::metering::usd_spent_by_agent(samples, id))
         };
 
+        // Issue #343: caps and their attribution resolve through the record for
+        // BOTH arms, exactly as the REST handler does — an overlay teammate is
+        // no longer hardcoded uncapped.
+        let row = |id: &str, name: Option<String>, role: String, description: Option<String>| {
+            let cap = record.effective_budget(id);
+            let attribution = record.budget_override(id);
+            TeamMemberGql {
+                id: ID(id.to_string()),
+                name,
+                role,
+                description,
+                inbox_enabled: enabled(id),
+                budget_usd_daily: cap,
+                spent_today_usd: cap.and_then(|_| spent(id)),
+                budget_set_by: attribution.map(|entry| entry.set_by.id.clone()),
+                budget_set_at_millis: attribution.map(|entry| entry.at_millis as f64),
+            }
+        };
         let mut out: Vec<TeamMemberGql> = record
             .manifest
             .agents
             .iter()
-            .map(|agent| TeamMemberGql {
-                id: ID(agent.id.clone()),
-                name: None,
-                role: agent.role.clone(),
-                description: agent.description.clone(),
-                inbox_enabled: enabled(&agent.id),
-                budget_usd_daily: agent.budget_usd_daily,
-                spent_today_usd: agent.budget_usd_daily.and_then(|_| spent(&agent.id)),
+            .map(|agent| {
+                row(
+                    &agent.id,
+                    None,
+                    agent.role.clone(),
+                    agent.description.clone(),
+                )
             })
             .collect();
-        out.extend(record.overlay_agents.iter().map(|agent| TeamMemberGql {
-            id: ID(agent.id.clone()),
-            name: Some(agent.name.clone()),
-            role: agent.role.clone(),
-            description: agent.description.clone(),
-            inbox_enabled: enabled(&agent.id),
-            // Overlay teammates are uncapped in v1.
-            budget_usd_daily: None,
-            spent_today_usd: None,
+        out.extend(record.overlay_agents.iter().map(|agent| {
+            row(
+                &agent.id,
+                Some(agent.name.clone()),
+                agent.role.clone(),
+                agent.description.clone(),
+            )
         }));
         Ok(out)
     }
@@ -336,13 +357,24 @@ pub struct TeamMemberGql {
     pub description: Option<String>,
     /// Whether this teammate has an enabled inbox.
     pub inbox_enabled: bool,
-    /// This teammate's manifest `budget_usd_daily` cap (issue #304), or null
-    /// when it has none. Null-vs-set is the capped/uncapped distinction — `0`
-    /// would mean "capped at nothing".
+    /// This teammate's daily spend cap in force (issue #304), or null when it
+    /// has none. Null-vs-set is the capped/uncapped distinction — `0` would
+    /// mean "capped at nothing".
+    ///
+    /// Since #343 this is the **effective** cap: an operator override set from
+    /// the console when one is stored, the manifest value otherwise.
     pub budget_usd_daily: Option<f64>,
     /// What this teammate has spent since 00:00 UTC; non-null only alongside a
     /// cap.
     pub spent_today_usd: Option<f64>,
+    /// The user id of the admin who last set this teammate's cap from the
+    /// console (issue #343); null when no override is stored. Non-null even
+    /// when the override *removed* the cap, which is how "nobody capped this"
+    /// is told from "an admin uncapped this".
+    pub budget_set_by: Option<String>,
+    /// When that cap was set (epoch millis). `Float` round-trips the full u64
+    /// range that would overflow GraphQL's `Int`, matching `Approval.atMillis`.
+    pub budget_set_at_millis: Option<f64>,
 }
 
 /// Internal desk projection shared between `chats` and `chat`.

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -728,9 +728,12 @@ type TeamMember {
 	"""
 	inboxEnabled: Boolean!
 	"""
-	This teammate's manifest `budget_usd_daily` cap (issue #304), or null
-	when it has none. Null-vs-set is the capped/uncapped distinction — `0`
-	would mean "capped at nothing".
+	This teammate's daily spend cap in force (issue #304), or null when it
+	has none. Null-vs-set is the capped/uncapped distinction — `0` would
+	mean "capped at nothing".
+	
+	Since #343 this is the **effective** cap: an operator override set from
+	the console when one is stored, the manifest value otherwise.
 	"""
 	budgetUsdDaily: Float
 	"""
@@ -738,6 +741,18 @@ type TeamMember {
 	cap.
 	"""
 	spentTodayUsd: Float
+	"""
+	The user id of the admin who last set this teammate's cap from the
+	console (issue #343); null when no override is stored. Non-null even
+	when the override *removed* the cap, which is how "nobody capped this"
+	is told from "an admin uncapped this".
+	"""
+	budgetSetBy: String
+	"""
+	When that cap was set (epoch millis). `Float` round-trips the full u64
+	range that would overflow GraphQL's `Int`, matching `Approval.atMillis`.
+	"""
+	budgetSetAtMillis: Float
 }
 
 """

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -282,6 +282,135 @@ async fn team_reports_the_effective_cap_and_its_attribution() {
     );
 }
 
+/// Issue #343: the three budget states stay distinct **on the wire**, where the
+/// console reads them.
+///
+/// `effective_budget` keeping them apart in Rust is necessary but not
+/// sufficient — GraphQL flattens `Option<f64>` to a JSON value, and that is
+/// where the states can collapse without any Rust type changing:
+///
+/// - a stored `Some(0.0)` must serialize as numeric **`0`**, not `null`. If it
+///   arrives as `null` the console renders "no cap" for a teammate an admin
+///   deliberately muted, and the operator has no way to see the mute they set.
+/// - an explicit `None` must serialize as **`null` with the attribution still
+///   present**. The attribution is the only thing distinguishing "an admin
+///   uncapped this teammate" from "nobody ever set anything" — the two states
+///   whose difference the whole `Option<Option<f64>>` wire shape exists to carry.
+/// - a manifest cap with **no** override must serialize as the manifest number
+///   with **no** attribution, so the console never invents a "set by" line for a
+///   value that came out of `company.toml`.
+///
+/// All three are asserted against `Value::Null` / a numeric literal rather than
+/// with `is_some()`, because `assert!(v.is_null())` and an absent key are the
+/// same thing in `serde_json` — and "absent" is a fourth state the console would
+/// read as uncapped.
+#[tokio::test]
+async fn team_keeps_zero_explicit_null_and_manifest_only_caps_distinct() {
+    use crate::ports::types::{Actor, ActorKind, BudgetOverride, OverlayAgent};
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_rich_company(&home).await;
+
+    let id = CompanyId::new("acme");
+    let store = FsCompanyStore::new(home.clone());
+    let mut record = store.load(&id).await.unwrap().unwrap();
+
+    // `maya` (manifest) gets a manifest cap and NO override — the fallback arm.
+    record.manifest.agents[0].budget_usd_daily = Some(4.25);
+
+    // Two overlay teammates carry the two override states.
+    record.overlay_agents.push(OverlayAgent {
+        id: "zeroed".to_string(),
+        name: "Zeroed".to_string(),
+        role: "Growth".to_string(),
+        description: None,
+    });
+    record.overlay_agents.push(OverlayAgent {
+        id: "uncapped".to_string(),
+        name: "Uncapped".to_string(),
+        role: "Ops".to_string(),
+        description: None,
+    });
+    let admin = Actor {
+        kind: ActorKind::User,
+        id: "user-admin".to_string(),
+    };
+    record.overlay_budgets = vec![
+        BudgetOverride {
+            agent_id: "zeroed".to_string(),
+            budget_usd_daily: Some(0.0),
+            set_by: admin.clone(),
+            at_millis: 1_700_000_000_000,
+        },
+        BudgetOverride {
+            agent_id: "uncapped".to_string(),
+            budget_usd_daily: None,
+            set_by: admin,
+            at_millis: 1_700_000_000_001,
+        },
+    ];
+    store.save(&record).await.unwrap();
+
+    let value = query(
+        router(state),
+        r#"{"query":"{ company(id:\"acme\"){ team { id budgetUsdDaily budgetSetBy budgetSetAtMillis } } }"}"#,
+    )
+    .await;
+    let team = value["data"]["company"]["team"].as_array().unwrap();
+
+    // 1. `Some(0.0)` — numeric zero, attributed. Not null, not absent.
+    // `as_f64` is `None` for both null and an absent key, so this one assertion
+    // rules out all three ways a zero cap could stop being a number.
+    let zeroed = team.iter().find(|m| m["id"] == "zeroed").unwrap();
+    assert_eq!(
+        zeroed["budgetUsdDaily"].as_f64(),
+        Some(0.0),
+        "a zero cap must arrive as numeric 0 — null or absent would render a \
+         muted teammate as uncapped: {zeroed}"
+    );
+    assert_eq!(zeroed["budgetSetBy"], "user-admin", "{zeroed}");
+    assert_eq!(
+        zeroed["budgetSetAtMillis"], 1_700_000_000_000f64,
+        "{zeroed}"
+    );
+
+    // 2. Explicit `None` — null cap, attribution still present.
+    let uncapped = team.iter().find(|m| m["id"] == "uncapped").unwrap();
+    assert_eq!(
+        uncapped["budgetUsdDaily"],
+        serde_json::Value::Null,
+        "an explicitly-uncapped override must arrive as a null cap: {uncapped}"
+    );
+    assert_eq!(
+        uncapped["budgetSetBy"], "user-admin",
+        "attribution is what tells an admin-set uncap apart from no override at \
+         all — it must survive the cap being null: {uncapped}"
+    );
+    assert_eq!(
+        uncapped["budgetSetAtMillis"], 1_700_000_000_001f64,
+        "{uncapped}"
+    );
+
+    // 3. Manifest cap, no override — the manifest number, no attribution.
+    let maya = team.iter().find(|m| m["id"] == "maya").unwrap();
+    assert_eq!(
+        maya["budgetUsdDaily"].as_f64(),
+        Some(4.25),
+        "with no override stored the manifest value must come through: {maya}"
+    );
+    assert_eq!(
+        maya["budgetSetBy"],
+        serde_json::Value::Null,
+        "a manifest cap has no operator to attribute it to: {maya}"
+    );
+    assert_eq!(
+        maya["budgetSetAtMillis"],
+        serde_json::Value::Null,
+        "a manifest cap has no set-at timestamp: {maya}"
+    );
+}
+
 #[tokio::test]
 async fn chats_list_the_manifest_desks() {
     let home_dir = home();

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -40,6 +40,7 @@ pub(crate) async fn state_with_company(home: &std::path::Path) -> AppState {
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -182,6 +183,7 @@ async fn state_with_rich_company(home: &std::path::Path) -> AppState {
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -707,6 +709,7 @@ async fn skills_and_workflows_resolve_from_source_dir() {
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -778,6 +781,7 @@ async fn company_skills_project_the_pinned_snapshot_of_a_registry_install() {
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -890,6 +894,7 @@ async fn workflows_resolve_from_the_record_overlay_with_no_source_dir() {
                        [[edge]]\nfrom = \"n1\"\nto = \"n2\"\n"
                     .to_string(),
             }],
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -981,6 +986,7 @@ async fn workflows_summary_lists_an_overlay_workflow_with_no_enabled_entry() {
                        [[node]]\nid = \"n1\"\nkind = \"trigger\"\nname = \"Start\"\n"
                     .to_string(),
             }],
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         })
         .await

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -218,6 +218,70 @@ async fn team_lists_manifest_teammates() {
     assert!(team[0]["name"].is_null());
 }
 
+/// Issue #343: the GraphQL roster resolves the **effective** cap and its
+/// attribution, so the two reads of the same roster cannot drift.
+///
+/// The REST handler is the console's consumer, but this resolver reads the same
+/// record and has its own copy of the merge — which is exactly how a surface
+/// ends up reporting a manifest cap the dispatch gate stopped enforcing. Both
+/// halves are asserted here: a manifest teammate whose cap was overridden, and
+/// an overlay teammate that the pre-#343 arm hardcoded to `null`.
+#[tokio::test]
+async fn team_reports_the_effective_cap_and_its_attribution() {
+    use crate::ports::types::{Actor, ActorKind, BudgetOverride, OverlayAgent};
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_rich_company(&home).await;
+
+    let id = CompanyId::new("acme");
+    let store = FsCompanyStore::new(home.clone());
+    let mut record = store.load(&id).await.unwrap().unwrap();
+    record.overlay_agents.push(OverlayAgent {
+        id: "jamie".to_string(),
+        name: "Jamie".to_string(),
+        role: "Growth".to_string(),
+        description: None,
+    });
+    let admin = Actor {
+        kind: ActorKind::User,
+        id: "user-admin".to_string(),
+    };
+    record.overlay_budgets = vec![
+        BudgetOverride {
+            agent_id: "maya".to_string(),
+            budget_usd_daily: Some(7.5),
+            set_by: admin.clone(),
+            at_millis: 1_700_000_000_000,
+        },
+        BudgetOverride {
+            agent_id: "jamie".to_string(),
+            budget_usd_daily: Some(2.0),
+            set_by: admin,
+            at_millis: 1_700_000_000_001,
+        },
+    ];
+    store.save(&record).await.unwrap();
+
+    let value = query(
+        router(state),
+        r#"{"query":"{ company(id:\"acme\"){ team { id budgetUsdDaily budgetSetBy budgetSetAtMillis } } }"}"#,
+    )
+    .await;
+    let team = value["data"]["company"]["team"].as_array().unwrap();
+
+    let maya = team.iter().find(|m| m["id"] == "maya").unwrap();
+    assert_eq!(maya["budgetUsdDaily"], 7.5, "{maya}");
+    assert_eq!(maya["budgetSetBy"], "user-admin", "{maya}");
+    assert_eq!(maya["budgetSetAtMillis"], 1_700_000_000_000f64, "{maya}");
+
+    let jamie = team.iter().find(|m| m["id"] == "jamie").unwrap();
+    assert_eq!(
+        jamie["budgetUsdDaily"], 2.0,
+        "an overlay teammate is no longer hardcoded uncapped: {jamie}"
+    );
+}
+
 #[tokio::test]
 async fn chats_list_the_manifest_desks() {
     let home_dir = home();

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1382,6 +1382,7 @@ mod test {
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
                 template_provenance: None,
             })
             .await
@@ -1503,6 +1504,7 @@ mod test {
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         };
         FsCompanyStore::new(home.to_path_buf())
@@ -1613,6 +1615,7 @@ mod test {
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/ops/capabilities.rs
+++ b/src/server/ops/capabilities.rs
@@ -340,6 +340,7 @@ mod tests {
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -368,6 +368,7 @@ mod tests {
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/ops/connections_read.rs
+++ b/src/server/ops/connections_read.rs
@@ -281,6 +281,7 @@ mod tests {
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/ops/finances.rs
+++ b/src/server/ops/finances.rs
@@ -103,6 +103,7 @@ mod tests {
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -407,6 +407,7 @@ mod tests {
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/ops/runs.rs
+++ b/src/server/ops/runs.rs
@@ -451,6 +451,7 @@ mod tests {
                 overlay_desk_members: Vec::new(),
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
+                overlay_budgets: Vec::new(),
                 overlay_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -1,15 +1,40 @@
-//! Team writes: add an overlay teammate, remove one, and toggle a teammate's
-//! inbox — under both scope forms.
+//! Team writes: add an overlay teammate, remove one, set a teammate's daily
+//! spend cap, and toggle its inbox — under both scope forms.
 //!
 //! Adds use the **operator-overlay** model: a new teammate is persisted as an
 //! [`OverlayAgent`](crate::ports::types::OverlayAgent) on the `CompanyRecord`
 //! through [`CompanyStore`](crate::ports::CompanyStore) and merged into the
 //! roster at read time; the version-controlled `company.toml` is never
-//! rewritten. Overlay teammates are roster-only in v1. A teammate defined in the
-//! manifest cannot be removed here (409).
+//! rewritten. A teammate defined in the manifest cannot be removed here (409).
+//!
+//! ## Daily budgets (issue #343)
+//!
+//! `budget_usd_daily` is enforced (issue #304) but was readable only from the
+//! manifest, which on a hosted tenant is baked into the container image — so an
+//! operator whose teammate hit its cap had no remedy short of a redeploy.
+//! `PUT`/`DELETE …/team/{agent_id}/budget` write a
+//! [`BudgetOverride`](crate::ports::types::BudgetOverride) onto the record, and
+//! [`CompanyRecord::effective_budget`](crate::ports::types::CompanyRecord::effective_budget)
+//! resolves it ahead of the manifest everywhere the cap is read. The harness
+//! fingerprints the override set, so the new value is enforced on the company's
+//! next dispatch with no restart.
+//!
+//! Three rules the surface exists to keep:
+//!
+//! - **Admin-only, and attributed.** Raising your own spend limit is a privilege
+//!   boundary, so both writes go through
+//!   [`require_admin`](crate::server::users::admin::require_admin) and stamp who
+//!   did it and when.
+//! - **Clearing is not zeroing.** `{"budgetUsdDaily": null}` removes the cap;
+//!   `{"budgetUsdDaily": 0}` caps at nothing. They are different stored states
+//!   and different behaviours. An **omitted** key is neither, so it is a 422
+//!   rather than a silent uncap — see [`SetBudget`].
+//! - **Reset is its own verb.** `DELETE` drops the override so the manifest
+//!   default applies again, which no `PUT` body can express.
 
-use axum::extract::Path;
-use axum::http::StatusCode;
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, put};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
@@ -17,19 +42,24 @@ use serde::{Deserialize, Serialize};
 use crate::AppState;
 use crate::company::dns::DomainStatus;
 use crate::error::OpenCompanyError;
-use crate::ports::generate_id;
 use crate::ports::inbox::InboxMeta;
 use crate::ports::store::company_write_lock;
-use crate::ports::types::OverlayAgent;
+use crate::ports::types::{Actor, ActorKind, BudgetOverride, CompanyRecord, OverlayAgent};
+use crate::ports::{generate_id, now_millis};
 use crate::server::error::ApiError;
 use crate::server::ops::language;
 use crate::server::ops::{DOMAIN_KEY, ScopedCompany, scoped};
+use crate::server::users::admin::require_admin;
 
 /// Builds the team route fragment.
 pub fn router() -> Router<AppState> {
     scoped("/team", get(list_team).post(add_member))
         .merge(scoped("/team/{agent_id}", delete(remove_member)))
         .merge(scoped("/team/{agent_id}/inbox", put(toggle_inbox)))
+        .merge(scoped(
+            "/team/{agent_id}/budget",
+            put(set_budget).delete(clear_budget),
+        ))
 }
 
 /// One teammate as the console renders it (mirrors `TeamMemberDto`).
@@ -45,28 +75,87 @@ struct TeamMemberDto {
     /// Whether this teammate has an enabled inbox, so the Team page's toggle
     /// renders the host's real state instead of a client-side guess.
     inbox_enabled: bool,
-    /// This teammate's manifest `budget_usd_daily` cap (issue #304), or absent
-    /// when it has none.
+    /// This teammate's daily spend cap in force (issue #304), or absent when it
+    /// has none.
     ///
     /// Absent-vs-present **is** the capped/uncapped distinction, which is why
     /// this is skipped rather than zeroed: `0` would read as "capped at nothing"
-    /// and render a permanently exhausted teammate. Overlay teammates carry no
-    /// cap in v1, so they always omit it.
+    /// and render a permanently exhausted teammate.
+    ///
+    /// Since #343 this is the **effective** cap — an operator override when one
+    /// is stored, the manifest value otherwise — so the card shows what the
+    /// dispatch gate will actually enforce. An overlay teammate can carry one
+    /// too; it is no longer unconditionally uncapped.
     #[serde(skip_serializing_if = "Option::is_none")]
     budget_usd_daily: Option<f64>,
     /// What this teammate has spent since 00:00 UTC, present only alongside a
     /// cap — an uncapped teammate's spend belongs on the Usage page, not here.
     #[serde(skip_serializing_if = "Option::is_none")]
     spent_today_usd: Option<f64>,
+    /// The user id of the admin who last set this teammate's cap from the
+    /// console (issue #343), absent when no override is stored.
+    ///
+    /// Present **whenever an override exists**, including one that removed the
+    /// cap — which is why it is not paired with `budgetUsdDaily`. "Nobody has
+    /// touched this" and "an admin deliberately uncapped this" look identical
+    /// on the cap alone, and the second is exactly what an operator asking
+    /// "why is this teammate spending freely?" needs to see.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    budget_set_by: Option<String>,
+    /// When that cap was set (epoch millis). Paired with `budgetSetBy`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    budget_set_at_millis: Option<u64>,
 }
 
 /// The add-teammate body.
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct AddMember {
     name: String,
     role: String,
     #[serde(default)]
     description: Option<String>,
+    /// An optional daily spend cap for the new teammate (issue #343): "a
+    /// teammate created through the Console can be given a cap at creation".
+    ///
+    /// Only `Some` requires an admin — a budget-less add keeps working for any
+    /// member exactly as before, so adding the field takes no permission away.
+    #[serde(default)]
+    budget_usd_daily: Option<f64>,
+}
+
+/// The set-budget body.
+///
+/// `budget_usd_daily` is a **double option** so the three cases stay apart on
+/// the wire, which is the whole point of the route:
+///
+/// | body | parses as | means |
+/// |---|---|---|
+/// | `{"budgetUsdDaily": 5}` | `Some(Some(5.0))` | cap at $5/day |
+/// | `{"budgetUsdDaily": 0}` | `Some(Some(0.0))` | cap at nothing |
+/// | `{"budgetUsdDaily": null}` | `Some(None)` | remove the cap |
+/// | `{}` | *rejected* | — |
+///
+/// The last row is deliberate. There is **no `#[serde(default)]`**, so an
+/// omitted key is a deserialization failure and axum answers `422` — an empty
+/// body can never be read as "uncap this teammate". A client that means to
+/// remove a cap has to say `null` and mean it.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetBudget {
+    #[serde(deserialize_with = "double_option")]
+    budget_usd_daily: Option<Option<f64>>,
+}
+
+/// Deserializes into `Some(inner)` when the field is present (so an explicit
+/// `null` becomes `Some(None)`). Without a companion `#[serde(default)]` an
+/// omitted field stays an error — which is what [`SetBudget`] wants.
+fn double_option<'de, D, T>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Option::deserialize(deserializer).map(Some)
 }
 
 /// The inbox-toggle body.
@@ -126,26 +215,28 @@ async fn list_team(company: ScopedCompany) -> Result<Json<Vec<TeamMemberDto>>, A
                 .manifest
                 .agents
                 .iter()
-                .map(|agent| TeamMemberDto {
-                    id: agent.id.clone(),
-                    name: None,
-                    role: agent.role.clone(),
-                    description: agent.description.clone(),
-                    inbox_enabled: enabled(&agent.id),
-                    budget_usd_daily: agent.budget_usd_daily,
-                    // Paired with the cap: no cap, no spend row.
-                    spent_today_usd: agent.budget_usd_daily.and_then(|_| spent(&agent.id)),
+                .map(|agent| {
+                    member_row(
+                        &record,
+                        &agent.id,
+                        None,
+                        agent.role.clone(),
+                        agent.description.clone(),
+                        enabled(&agent.id),
+                        &spent,
+                    )
                 })
                 .collect();
-            members.extend(record.overlay_agents.iter().map(|agent| TeamMemberDto {
-                id: agent.id.clone(),
-                name: Some(agent.name.clone()),
-                role: agent.role.clone(),
-                description: agent.description.clone(),
-                inbox_enabled: enabled(&agent.id),
-                // Overlay teammates are uncapped in v1.
-                budget_usd_daily: None,
-                spent_today_usd: None,
+            members.extend(record.overlay_agents.iter().map(|agent| {
+                member_row(
+                    &record,
+                    &agent.id,
+                    Some(agent.name.clone()),
+                    agent.role.clone(),
+                    agent.description.clone(),
+                    enabled(&agent.id),
+                    &spent,
+                )
             }));
             members
         })
@@ -153,23 +244,55 @@ async fn list_team(company: ScopedCompany) -> Result<Json<Vec<TeamMemberDto>>, A
     Ok(Json(members))
 }
 
+/// Builds one roster row, resolving the cap and its attribution through the
+/// record so the manifest arm and the overlay arm cannot drift (issue #343).
+///
+/// `spent` is the shared per-agent spend lookup — `None` for a company where
+/// nobody is capped, in which case the meter was never read.
+fn member_row(
+    record: &CompanyRecord,
+    agent_id: &str,
+    name: Option<String>,
+    role: String,
+    description: Option<String>,
+    inbox_enabled: bool,
+    spent: &dyn Fn(&str) -> Option<f64>,
+) -> TeamMemberDto {
+    let cap = record.effective_budget(agent_id);
+    let attribution = record.budget_override(agent_id);
+    TeamMemberDto {
+        id: agent_id.to_string(),
+        name,
+        role,
+        description,
+        inbox_enabled,
+        budget_usd_daily: cap,
+        // Paired with the cap: no cap, no spend row.
+        spent_today_usd: cap.and_then(|_| spent(agent_id)),
+        budget_set_by: attribution.map(|entry| entry.set_by.id.clone()),
+        budget_set_at_millis: attribution.map(|entry| entry.at_millis),
+    }
+}
+
 /// Today's usage samples (since 00:00 UTC), or `None` when no teammate on this
-/// company carries a `budget_usd_daily` cap (issue #304).
+/// company carries a daily cap (issue #304).
 ///
 /// Returning `None` rather than an empty vec keeps "nobody is capped" distinct
 /// from "everybody is capped and has spent nothing", and is what lets the
 /// caller skip the meter round-trip entirely for the common uncapped company.
+///
+/// The scan runs over **effective** caps across the **whole** roster (issue
+/// #343). Both halves matter: an override that caps a previously-uncapped
+/// teammate has to start the meter read, or its card would render a cap with no
+/// spend beside it; and overlay teammates are now cappable, so restricting the
+/// scan to manifest agents would miss the only capped teammate on a company
+/// whose roster was built entirely from the console.
 async fn daily_spend_samples(
     company: &ScopedCompany,
-    record: Option<&crate::ports::types::CompanyRecord>,
+    record: Option<&CompanyRecord>,
 ) -> Result<Option<Vec<crate::ports::usage::UsageSample>>, ApiError> {
-    let any_capped = record.is_some_and(|record| {
-        record
-            .manifest
-            .agents
-            .iter()
-            .any(|agent| agent.budget_usd_daily.is_some())
-    });
+    let any_capped = record
+        .is_some_and(|record| roster_ids(record).any(|id| record.effective_budget(id).is_some()));
     if !any_capped {
         return Ok(None);
     }
@@ -183,21 +306,48 @@ async fn daily_spend_samples(
     Ok(Some(samples))
 }
 
+/// Every roster teammate's id — manifest agents first, then overlay teammates.
+/// The same union `CompanyRecord::is_roster_agent` accepts.
+fn roster_ids(record: &CompanyRecord) -> impl Iterator<Item = &String> {
+    record
+        .manifest
+        .agents
+        .iter()
+        .map(|agent| &agent.id)
+        .chain(record.overlay_agents.iter().map(|agent| &agent.id))
+}
+
+/// `POST {scope}/team` — add an operator-defined teammate, optionally with a
+/// daily spend cap (issue #343).
+///
+/// The cap and the teammate land in **one** record save, so a company can never
+/// end up with a teammate whose intended cap silently failed to apply.
 async fn add_member(
     company: ScopedCompany,
+    State(state): State<AppState>,
+    headers: HeaderMap,
     Json(body): Json<AddMember>,
-) -> Result<Json<TeamMemberDto>, ApiError> {
+) -> Result<Json<TeamMemberDto>, Response> {
+    // Setting a cap is admin-only, so an add that carries one is too — but an
+    // add that does not keeps working for any member, exactly as before. The
+    // check is deliberately conditional: adding this field must not quietly
+    // take the existing capability away from members.
+    let author = match body.budget_usd_daily {
+        Some(cap) => {
+            if let Some(refusal) = validate_cap(cap) {
+                return Err(refusal);
+            }
+            Some(require_admin(&headers, &state, &company.runtime).await?)
+        }
+        None => None,
+    };
+
     // Serialize per-company writes so concurrent console POST /team and
     // orchestrator add_agent calls can't clobber each other's overlay_agents.
     let write_lock = company_write_lock(company.id());
     let _lock = write_lock.lock().await;
 
-    let mut record = company
-        .runtime
-        .store()
-        .load(company.id())
-        .await?
-        .ok_or_else(|| OpenCompanyError::CompanyNotFound(company.id().to_string()))?;
+    let mut record = load_record(&company).await?;
     let agent = OverlayAgent {
         id: generate_id(),
         name: body.name,
@@ -205,7 +355,24 @@ async fn add_member(
         description: body.description,
     };
     record.overlay_agents.push(agent.clone());
-    company.runtime.store().save(&record).await?;
+    let attribution = author.map(|admin| BudgetOverride {
+        agent_id: agent.id.clone(),
+        budget_usd_daily: body.budget_usd_daily,
+        set_by: Actor {
+            kind: ActorKind::User,
+            id: admin.user_id,
+        },
+        at_millis: now_millis(),
+    });
+    if let Some(entry) = attribution.clone() {
+        record.overlay_budgets.push(entry);
+    }
+    company
+        .runtime
+        .store()
+        .save(&record)
+        .await
+        .map_err(|e| ApiError(e).into_response())?;
     Ok(Json(TeamMemberDto {
         id: agent.id,
         name: Some(agent.name),
@@ -213,9 +380,14 @@ async fn add_member(
         description: agent.description,
         // A brand-new teammate has no inbox until the toggle writes one.
         inbox_enabled: false,
-        // Overlay teammates carry no per-agent cap in v1 (issue #304).
-        budget_usd_daily: None,
-        spent_today_usd: None,
+        budget_usd_daily: body.budget_usd_daily,
+        // Brand new, so nothing has been spent against the cap yet. Sent as
+        // `0.0` rather than omitted so the card renders "$0.00 spent today"
+        // beside a cap it was just given, instead of a cap with nothing next
+        // to it.
+        spent_today_usd: body.budget_usd_daily.map(|_| 0.0),
+        budget_set_by: attribution.as_ref().map(|entry| entry.set_by.id.clone()),
+        budget_set_at_millis: attribution.as_ref().map(|entry| entry.at_millis),
     }))
 }
 
@@ -246,8 +418,210 @@ async fn remove_member(
             "teammate {agent_id}"
         ))));
     }
+    // Drop the teammate's budget override with it (issue #343). Overlay ids are
+    // generated, so a future teammate will not collide with this one — but a
+    // record that accumulated dead override rows would grow without bound and
+    // make the roster read scan entries for teammates that no longer exist.
+    record.overlay_budgets.retain(|b| b.agent_id != agent_id);
     company.runtime.store().save(&record).await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// `PUT {scope}/team/{agent_id}/budget` — set, change, or remove a teammate's
+/// daily spend cap. Admin-only, attributed, and in force on the next dispatch.
+///
+/// See [`SetBudget`] for why `{}` is a `422` rather than an uncap.
+async fn set_budget(
+    company: ScopedCompany,
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(AgentPath { agent_id }): Path<AgentPath>,
+    Json(body): Json<SetBudget>,
+) -> Result<Json<TeamMemberDto>, Response> {
+    let admin = require_admin(&headers, &state, &company.runtime).await?;
+    // `Some(_)` is guaranteed by `SetBudget`'s missing-key rejection; the inner
+    // option is the cap-or-uncap the operator asked for.
+    let cap = body.budget_usd_daily.flatten();
+    if let Some(refusal) = cap.and_then(validate_cap) {
+        return Err(refusal);
+    }
+
+    let write_lock = company_write_lock(company.id());
+    let _lock = write_lock.lock().await;
+
+    let mut record = load_record(&company).await?;
+    if let Some(refusal) = require_roster_teammate(&record, &agent_id) {
+        return Err(refusal);
+    }
+
+    let entry = BudgetOverride {
+        agent_id: agent_id.clone(),
+        budget_usd_daily: cap,
+        set_by: Actor {
+            kind: ActorKind::User,
+            id: admin.user_id,
+        },
+        at_millis: now_millis(),
+    };
+    // One override per teammate: replace in place rather than accumulating, so
+    // `effective_budget`'s first-match read can never see a stale row.
+    record.overlay_budgets.retain(|b| b.agent_id != agent_id);
+    record.overlay_budgets.push(entry);
+    company
+        .runtime
+        .store()
+        .save(&record)
+        .await
+        .map_err(|e| ApiError(e).into_response())?;
+
+    updated_row(&company, &record, &agent_id).await
+}
+
+/// `DELETE {scope}/team/{agent_id}/budget` — drop the override so the manifest
+/// default applies again.
+///
+/// Distinct from `PUT null`, and not expressible by it: `PUT null` stores "no
+/// cap, decided by an admin", while this restores whatever `company.toml`
+/// declares — which for a manifest-capped teammate means the cap comes **back**.
+/// Deleting when nothing is stored is a no-op rather than a 404: the caller's
+/// intent ("this teammate should follow the manifest") is already satisfied.
+async fn clear_budget(
+    company: ScopedCompany,
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(AgentPath { agent_id }): Path<AgentPath>,
+) -> Result<Json<TeamMemberDto>, Response> {
+    require_admin(&headers, &state, &company.runtime).await?;
+
+    let write_lock = company_write_lock(company.id());
+    let _lock = write_lock.lock().await;
+
+    let mut record = load_record(&company).await?;
+    if let Some(refusal) = require_roster_teammate(&record, &agent_id) {
+        return Err(refusal);
+    }
+
+    record.overlay_budgets.retain(|b| b.agent_id != agent_id);
+    company
+        .runtime
+        .store()
+        .save(&record)
+        .await
+        .map_err(|e| ApiError(e).into_response())?;
+
+    updated_row(&company, &record, &agent_id).await
+}
+
+/// Rejects a cap that is not a spendable amount of money, mirroring the
+/// manifest validation in `crate::company::manifest` so a value the console
+/// accepts is one `company.toml` would have accepted too.
+///
+/// NaN and the infinities are refused as well as negatives. They parse as JSON
+/// numbers in some encoders and would poison every comparison downstream: the
+/// dispatch gate's `spent >= cap` is false for NaN, so a NaN cap would read as
+/// "capped" everywhere in the console while enforcing nothing at all.
+fn validate_cap(cap: f64) -> Option<Response> {
+    if !cap.is_finite() {
+        return Some(
+            ApiError(OpenCompanyError::InvalidRequest(
+                "a daily budget has to be a real number of dollars.".to_string(),
+            ))
+            .into_response(),
+        );
+    }
+    if cap < 0.0 {
+        return Some(
+            ApiError(OpenCompanyError::InvalidRequest(format!(
+                "a daily budget cannot be negative — you sent `{cap}`."
+            )))
+            .into_response(),
+        );
+    }
+    None
+}
+
+/// Loads the addressed company's record, or 404s.
+async fn load_record(company: &ScopedCompany) -> Result<CompanyRecord, Response> {
+    company
+        .runtime
+        .store()
+        .load(company.id())
+        .await
+        .map_err(|e| ApiError(e).into_response())?
+        .ok_or_else(|| {
+            ApiError(OpenCompanyError::CompanyNotFound(company.id().to_string())).into_response()
+        })
+}
+
+/// 404s unless `agent_id` names a real roster teammate.
+///
+/// Without this an unknown id would store an override nothing ever reads —
+/// a write that reports success and changes nothing, which is worse than a
+/// refusal because the operator believes the cap is in place.
+fn require_roster_teammate(record: &CompanyRecord, agent_id: &str) -> Option<Response> {
+    if record.is_roster_agent(agent_id) {
+        return None;
+    }
+    Some(
+        ApiError(OpenCompanyError::CompanyNotFound(format!(
+            "teammate {agent_id}"
+        )))
+        .into_response(),
+    )
+}
+
+/// The teammate's roster row after a budget write, so the console can update the
+/// card from the response instead of refetching the whole team.
+async fn updated_row(
+    company: &ScopedCompany,
+    record: &CompanyRecord,
+    agent_id: &str,
+) -> Result<Json<TeamMemberDto>, Response> {
+    let spend_today = daily_spend_samples(company, Some(record))
+        .await
+        .map_err(|e| e.into_response())?;
+    let spent = |id: &str| {
+        spend_today
+            .as_ref()
+            .map(|samples| crate::metering::usd_spent_by_agent(samples, id))
+    };
+    let inbox_enabled = company
+        .runtime
+        .inbox()
+        .inboxes(company.id())
+        .await
+        .map_err(|e| ApiError(e).into_response())?
+        .into_iter()
+        .any(|meta| meta.key == agent_id && meta.enabled);
+
+    // A manifest teammate is named by its role and carries no display name; an
+    // overlay teammate always has one. Same rule as `list_team`.
+    let overlay = record.overlay_agents.iter().find(|a| a.id == agent_id);
+    let (name, role, description) = match overlay {
+        Some(agent) => (
+            Some(agent.name.clone()),
+            agent.role.clone(),
+            agent.description.clone(),
+        ),
+        None => {
+            let agent = record
+                .manifest
+                .agents
+                .iter()
+                .find(|a| a.id == agent_id)
+                .expect("roster membership was checked before the write");
+            (None, agent.role.clone(), agent.description.clone())
+        }
+    };
+    Ok(Json(member_row(
+        record,
+        agent_id,
+        name,
+        role,
+        description,
+        inbox_enabled,
+        &spent,
+    )))
 }
 
 async fn toggle_inbox(
@@ -312,7 +686,7 @@ async fn load_domain(company: &ScopedCompany) -> Result<Option<String>, ApiError
 mod tests {
     use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode};
-    use serde_json::Value;
+    use serde_json::{Value, json};
     use tower::ServiceExt;
 
     use crate::company::CompanyManifest;
@@ -384,6 +758,479 @@ mod tests {
     const ROSTER: &str = "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
          [[agent]]\nid = \"analyst\"\nrole = \"Analyst\"\nbudget_usd_daily = 5.0\n\
          [[agent]]\nid = \"writer\"\nrole = \"Writer\"\n";
+
+    /// Drives any team route with an explicit cookie, so the auth boundary can
+    /// be exercised with an admin session, a member session, or none at all.
+    async fn send(
+        state: &AppState,
+        method: &str,
+        uri: &str,
+        body: Option<Value>,
+        cookie: Option<&str>,
+    ) -> (StatusCode, Value) {
+        let mut builder = Request::builder().method(method).uri(uri);
+        if let Some(cookie) = cookie {
+            builder = builder.header("cookie", cookie);
+        }
+        let request = match &body {
+            Some(value) => builder
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(value).unwrap()))
+                .unwrap(),
+            None => builder.body(Body::empty()).unwrap(),
+        };
+        let response = router(state.clone()).oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value = if bytes.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+        };
+        (status, value)
+    }
+
+    fn admin_cookie() -> String {
+        crate::server::test_support::fixed_cookie("acme")
+    }
+
+    /// `PUT …/team/{id}/budget` as the seeded admin.
+    async fn put_budget(state: &AppState, agent: &str, body: Value) -> (StatusCode, Value) {
+        send(
+            state,
+            "PUT",
+            &format!("/api/v1/company/team/{agent}/budget"),
+            Some(body),
+            Some(&admin_cookie()),
+        )
+        .await
+    }
+
+    /// One roster row from `GET …/team`.
+    async fn team_row(state: &AppState, agent: &str) -> Value {
+        let (status, body) = get_team(state).await;
+        assert_eq!(status, StatusCode::OK);
+        body.as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["id"] == agent)
+            .unwrap_or_else(|| panic!("no {agent} row in {body}"))
+            .clone()
+    }
+
+    // --- Console budget writes (issue #343) ---------------------------------
+
+    /// The acceptance criterion, on the wire: an admin sets, changes and clears
+    /// a cap, and every state is visible on the next read.
+    ///
+    /// The `writer` starts **uncapped in the manifest**, which is the case the
+    /// pre-#343 code could not express at all — there was no field to write.
+    #[tokio::test]
+    async fn an_admin_can_set_change_and_clear_a_cap() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        // Uncapped to begin with — no cap key, no attribution.
+        let before = team_row(&state, "writer").await;
+        assert!(before.get("budgetUsdDaily").is_none(), "{before}");
+        assert!(before.get("budgetSetBy").is_none(), "{before}");
+
+        // Set.
+        let (status, row) = put_budget(&state, "writer", json!({"budgetUsdDaily": 12.5})).await;
+        assert_eq!(status, StatusCode::OK, "{row}");
+        assert_eq!(row["budgetUsdDaily"], 12.5, "{row}");
+        let after_set = team_row(&state, "writer").await;
+        assert_eq!(after_set["budgetUsdDaily"], 12.5, "{after_set}");
+        assert!(
+            after_set["budgetSetBy"].is_string(),
+            "a set cap is attributable to the admin who set it: {after_set}"
+        );
+        assert!(
+            after_set["budgetSetAtMillis"].as_u64().unwrap() > 0,
+            "{after_set}"
+        );
+
+        // Change.
+        let (status, _) = put_budget(&state, "writer", json!({"budgetUsdDaily": 3.0})).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(team_row(&state, "writer").await["budgetUsdDaily"], 3.0);
+
+        // Remove the cap (explicit null).
+        let (status, row) = put_budget(&state, "writer", json!({"budgetUsdDaily": null})).await;
+        assert_eq!(status, StatusCode::OK, "{row}");
+        let uncapped = team_row(&state, "writer").await;
+        assert!(
+            uncapped.get("budgetUsdDaily").is_none(),
+            "an uncapped teammate omits the cap key entirely: {uncapped}"
+        );
+        assert!(
+            uncapped["budgetSetBy"].is_string(),
+            "…but the attribution stays, so an operator can see that a human \
+             uncapped this teammate rather than that nobody ever capped it: {uncapped}"
+        );
+    }
+
+    /// A cap set from the console **wins over the manifest**, and `DELETE`
+    /// puts the manifest back. This is the pair that makes the override a
+    /// remedy rather than a second opinion.
+    #[tokio::test]
+    async fn an_override_beats_the_manifest_and_delete_restores_it() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        assert_eq!(team_row(&state, "analyst").await["budgetUsdDaily"], 5.0);
+
+        let (status, _) = put_budget(&state, "analyst", json!({"budgetUsdDaily": 50.0})).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            team_row(&state, "analyst").await["budgetUsdDaily"],
+            50.0,
+            "the stored cap wins over the manifest's $5"
+        );
+
+        let (status, row) = send(
+            &state,
+            "DELETE",
+            "/api/v1/company/team/analyst/budget",
+            None,
+            Some(&admin_cookie()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{row}");
+        let reset = team_row(&state, "analyst").await;
+        assert_eq!(
+            reset["budgetUsdDaily"], 5.0,
+            "DELETE drops the override, so the manifest default applies again: {reset}"
+        );
+        assert!(
+            reset.get("budgetSetBy").is_none(),
+            "with no override there is nothing to attribute: {reset}"
+        );
+    }
+
+    /// The issue's third rule, pinned **on the wire** rather than in Rust: `0`
+    /// and `null` are different bodies with different stored outcomes.
+    ///
+    /// `0` caps the teammate at nothing (the cap key comes back as `0.0`);
+    /// `null` removes the cap (the key is absent). If these ever collapsed, an
+    /// operator lifting a cap would instead have silenced the teammate.
+    #[tokio::test]
+    async fn zero_and_null_are_different_states() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        let (status, _) = put_budget(&state, "analyst", json!({"budgetUsdDaily": 0})).await;
+        assert_eq!(status, StatusCode::OK);
+        let zeroed = team_row(&state, "analyst").await;
+        assert_eq!(
+            zeroed["budgetUsdDaily"], 0.0,
+            "a zero cap is sent as 0, not omitted: {zeroed}"
+        );
+
+        let (status, _) = put_budget(&state, "analyst", json!({"budgetUsdDaily": null})).await;
+        assert_eq!(status, StatusCode::OK);
+        let cleared = team_row(&state, "analyst").await;
+        assert!(
+            cleared.get("budgetUsdDaily").is_none(),
+            "a cleared cap omits the key — and beats the manifest's $5: {cleared}"
+        );
+    }
+
+    /// An omitted key is **not** an uncap. `{}` cannot be mistaken for
+    /// `{"budgetUsdDaily": null}`, so a client bug or a truncated body can never
+    /// silently lift a cap; axum rejects the body before the handler runs.
+    #[tokio::test]
+    async fn an_absent_key_is_rejected_rather_than_read_as_uncapped() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        let (status, _) = put_budget(&state, "analyst", json!({})).await;
+        assert_eq!(
+            status,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "an empty body must never be read as 'remove the cap'"
+        );
+        assert_eq!(
+            team_row(&state, "analyst").await["budgetUsdDaily"],
+            5.0,
+            "and nothing was written"
+        );
+    }
+
+    /// A cap has to be a real, non-negative number of dollars — the same rule
+    /// the manifest validator applies, so the console cannot store a value
+    /// `company.toml` would have rejected.
+    #[tokio::test]
+    async fn a_nonsensical_cap_is_refused() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        let (status, body) = put_budget(&state, "analyst", json!({"budgetUsdDaily": -1.0})).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+
+        // NaN and ∞ have no JSON literal, so they arrive as raw tokens. Either
+        // outcome is a refusal; what must never happen is one being stored,
+        // because `spent >= NaN` is false and the cap would enforce nothing
+        // while the console rendered it as set.
+        for raw in ["{\"budgetUsdDaily\": NaN}", "{\"budgetUsdDaily\": 1e400}"] {
+            let request = Request::builder()
+                .method("PUT")
+                .uri("/api/v1/company/team/analyst/budget")
+                .header("cookie", admin_cookie())
+                .header("content-type", "application/json")
+                .body(Body::from(raw))
+                .unwrap();
+            let status = router(state.clone())
+                .oneshot(request)
+                .await
+                .unwrap()
+                .status();
+            assert!(status.is_client_error(), "{raw} → {status}");
+        }
+
+        assert_eq!(
+            team_row(&state, "analyst").await["budgetUsdDaily"],
+            5.0,
+            "no refused write left anything behind"
+        );
+    }
+
+    /// An unknown teammate 404s rather than storing an override nothing reads.
+    #[tokio::test]
+    async fn an_unknown_teammate_is_not_found() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        let (status, _) = put_budget(&state, "nobody", json!({"budgetUsdDaily": 1.0})).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+
+        let (status, _) = send(
+            &state,
+            "DELETE",
+            "/api/v1/company/team/nobody/budget",
+            None,
+            Some(&admin_cookie()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    /// The privilege boundary: a signed-in **member** cannot change a cap, and
+    /// an unauthenticated caller cannot reach the route at all.
+    ///
+    /// "A cap that can be raised silently is not much of a cap" — so this is the
+    /// assertion that makes the enforcement worth having. It is checked on the
+    /// backend, never on the console's hidden buttons.
+    #[tokio::test]
+    async fn a_non_admin_cannot_change_a_cap() {
+        use crate::ports::UserRole;
+
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+        let member =
+            crate::server::test_support::seed_session(&state, "acme", UserRole::Member).await;
+
+        for (method, body) in [
+            ("PUT", Some(json!({"budgetUsdDaily": 999.0}))),
+            ("DELETE", None),
+        ] {
+            let (status, _) = send(
+                &state,
+                method,
+                "/api/v1/company/team/analyst/budget",
+                body.clone(),
+                Some(&member),
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "{method} as a member must be refused"
+            );
+
+            let (status, _) = send(
+                &state,
+                method,
+                "/api/v1/company/team/analyst/budget",
+                body,
+                None,
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::UNAUTHORIZED,
+                "{method} with no session must be refused"
+            );
+        }
+
+        assert_eq!(
+            team_row(&state, "analyst").await["budgetUsdDaily"],
+            5.0,
+            "the manifest cap is untouched"
+        );
+    }
+
+    /// A teammate created through the console can be given a cap at creation —
+    /// and that is admin-only, while a budget-less add stays open to any member
+    /// exactly as it was before #343.
+    #[tokio::test]
+    async fn a_new_teammate_can_be_created_with_a_cap() {
+        use crate::ports::UserRole;
+
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+        let member =
+            crate::server::test_support::seed_session(&state, "acme", UserRole::Member).await;
+
+        // A member may still add a teammate — no permission was taken away.
+        let (status, plain) = send(
+            &state,
+            "POST",
+            "/api/v1/company/team",
+            Some(json!({"name": "Jamie", "role": "Growth"})),
+            Some(&member),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{plain}");
+        assert!(plain.get("budgetUsdDaily").is_none(), "{plain}");
+
+        // …but not with a budget attached.
+        let (status, _) = send(
+            &state,
+            "POST",
+            "/api/v1/company/team",
+            Some(json!({"name": "Sam", "role": "Ops", "budgetUsdDaily": 4.0})),
+            Some(&member),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "setting a cap is admin-only wherever it happens"
+        );
+
+        // An admin can.
+        let (status, created) = send(
+            &state,
+            "POST",
+            "/api/v1/company/team",
+            Some(json!({"name": "Sam", "role": "Ops", "budgetUsdDaily": 4.0})),
+            Some(&admin_cookie()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{created}");
+        assert_eq!(created["budgetUsdDaily"], 4.0, "{created}");
+        let sam = created["id"].as_str().unwrap().to_string();
+        let row = team_row(&state, &sam).await;
+        assert_eq!(
+            row["budgetUsdDaily"], 4.0,
+            "the cap and the teammate landed in one save: {row}"
+        );
+        assert!(row["budgetSetBy"].is_string(), "{row}");
+    }
+
+    /// An **overlay** teammate can be capped after the fact too — the case the
+    /// pre-#343 read path hardcoded to `None` ("uncapped in v1").
+    ///
+    /// Capping it also has to start the spend read for the whole roster, which
+    /// the old `any_capped` scan (manifest agents only) would have missed on a
+    /// company whose only capped teammate came from the console.
+    #[tokio::test]
+    async fn an_overlay_teammate_can_be_capped_and_reports_its_spend() {
+        let home_dir = home();
+        let state = state_with_manifest(
+            home_dir.path(),
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+             [[agent]]\nid = \"writer\"\nrole = \"Writer\"\n",
+        )
+        .await;
+
+        let (status, created) = send(
+            &state,
+            "POST",
+            "/api/v1/company/team",
+            Some(json!({"name": "Jamie", "role": "Growth"})),
+            Some(&admin_cookie()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{created}");
+        let jamie = created["id"].as_str().unwrap().to_string();
+
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+        runtime
+            .usage()
+            .record(
+                &id,
+                &UsageSample {
+                    at_millis: crate::ports::now_millis(),
+                    agent: jamie.clone(),
+                    provider: "managed".into(),
+                    input_tokens: 10,
+                    output_tokens: 5,
+                    cached_input_tokens: 0,
+                    cost_usd: 0.75,
+                    kind: SampleKind::Inference,
+                    run_id: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let (status, _) = put_budget(&state, &jamie, json!({"budgetUsdDaily": 2.0})).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let row = team_row(&state, &jamie).await;
+        assert_eq!(row["budgetUsdDaily"], 2.0, "{row}");
+        assert!(
+            (row["spentTodayUsd"].as_f64().unwrap() - 0.75).abs() < 1e-9,
+            "capping the only console-added teammate must start the meter read \
+             for the roster: {row}"
+        );
+    }
+
+    /// Removing a teammate takes its override with it, so the record does not
+    /// accumulate rows for teammates that no longer exist.
+    #[tokio::test]
+    async fn removing_a_teammate_drops_its_budget_override() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        let (_, created) = send(
+            &state,
+            "POST",
+            "/api/v1/company/team",
+            Some(json!({"name": "Jamie", "role": "Growth", "budgetUsdDaily": 2.0})),
+            Some(&admin_cookie()),
+        )
+        .await;
+        let jamie = created["id"].as_str().unwrap().to_string();
+
+        let (status, _) = send(
+            &state,
+            "DELETE",
+            &format!("/api/v1/company/team/{jamie}"),
+            None,
+            Some(&admin_cookie()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+
+        let record = state
+            .registry()
+            .get(&CompanyId::new("acme"))
+            .unwrap()
+            .store()
+            .load(&CompanyId::new("acme"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            record.overlay_budgets.is_empty(),
+            "the removed teammate's override went with it: {:?}",
+            record.overlay_budgets
+        );
+    }
 
     /// Issue #304 — the cap was never on the wire at all, so the issue's "and
     /// displayed in the console" was stale against main. A capped teammate now

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -365,7 +365,11 @@ async fn add_member(
         at_millis: now_millis(),
     });
     if let Some(entry) = attribution.clone() {
-        record.overlay_budgets.push(entry);
+        // Through the upsert even though `agent.id` is freshly generated and so
+        // cannot already hold a row: the "one override per teammate" invariant
+        // belongs to the record, not to each call site's reasoning about id
+        // uniqueness.
+        record.upsert_budget_override(entry);
     }
     company
         .runtime
@@ -465,8 +469,7 @@ async fn set_budget(
     };
     // One override per teammate: replace in place rather than accumulating, so
     // `effective_budget`'s first-match read can never see a stale row.
-    record.overlay_budgets.retain(|b| b.agent_id != agent_id);
-    record.overlay_budgets.push(entry);
+    record.upsert_budget_override(entry);
     company
         .runtime
         .store()

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -346,6 +346,7 @@ mod tests {
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/ops/test.rs
+++ b/src/server/ops/test.rs
@@ -50,6 +50,7 @@ async fn state_with(home: &std::path::Path, connections: ConnectionsRuntime) -> 
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         })
         .await

--- a/src/server/ops/usage.rs
+++ b/src/server/ops/usage.rs
@@ -157,6 +157,7 @@ mod tests {
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1699,6 +1699,7 @@ mod tests {
                     overlay_desk_order: Vec::new(),
                     overlay_desks: Vec::new(),
                     overlay_workflows: Vec::new(),
+                    overlay_budgets: Vec::new(),
                     template_provenance: None,
                 })
                 .await
@@ -1773,6 +1774,7 @@ mod tests {
                     overlay_desk_order: Vec::new(),
                     overlay_desks: Vec::new(),
                     overlay_workflows: Vec::new(),
+                    overlay_budgets: Vec::new(),
                     template_provenance: None,
                 })
                 .await
@@ -2747,6 +2749,7 @@ mod tests {
                     overlay_desk_order: Vec::new(),
                     overlay_desks: Vec::new(),
                     overlay_workflows: Vec::new(),
+                    overlay_budgets: Vec::new(),
                     template_provenance: None,
                 })
                 .await

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -46,6 +46,7 @@ async fn state_with_company(home: &std::path::Path) -> AppState {
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -2096,6 +2097,7 @@ async fn state_with_manifest(home: &std::path::Path, manifest: CompanyManifest) 
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -2343,6 +2345,7 @@ async fn state_with_source_dir(
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -2661,6 +2664,7 @@ async fn state_with_telegram_at(
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         })
         .await

--- a/src/server/users/admin.rs
+++ b/src/server/users/admin.rs
@@ -79,7 +79,15 @@ fn unauthorized() -> Response {
 }
 
 /// Requires a live session whose user is an admin of this company.
-async fn require_admin(
+///
+/// Shared beyond this module (issue #343: the team budget writes) so "who may
+/// administer this company" is decided in exactly one place. Note what it
+/// resolves through: [`current_user`] yields a principal only for a **human**
+/// session, so a platform/tenant bearer — a machine credential — is not an
+/// admin here and is refused as unauthenticated. That is the same "no operator
+/// break-glass" doctrine this module's header states, and it is what makes the
+/// attribution recorded by callers a real person rather than a token.
+pub(crate) async fn require_admin(
     headers: &HeaderMap,
     state: &AppState,
     runtime: &CompanyRuntime,

--- a/src/server/users/auth_test.rs
+++ b/src/server/users/auth_test.rs
@@ -49,6 +49,7 @@ async fn state_with(home: &std::path::Path, companies: &[&str]) -> AppState {
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/server/users/hub_test.rs
+++ b/src/server/users/hub_test.rs
@@ -60,6 +60,7 @@ async fn state_with(
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         })
         .await

--- a/src/server/users/routes_test.rs
+++ b/src/server/users/routes_test.rs
@@ -84,6 +84,7 @@ async fn state_from(
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -648,6 +649,7 @@ async fn a_https_deployment_marks_the_cookie_secure() {
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         })
         .await

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -77,11 +77,49 @@ fn sample_overlay_workflow() -> crate::ports::types::OverlayWorkflow {
     }
 }
 
+/// The operator-set daily spend caps the fixture seeds every record with, so
+/// each backend (fs, sqlite, mongodb) proves a console-set budget survives
+/// persistence (issue #343).
+///
+/// Deliberately **three** rows, because the field's whole point is that the
+/// three states stay apart across a round-trip: an ordinary cap, a legitimate
+/// `0.0` cap, and an entry whose `budget_usd_daily` is `None` — "explicitly
+/// uncapped", which beats a manifest cap. A backend that collapsed the last one
+/// into "no row" (or into `0.0`) would silently re-impose the very cap the
+/// operator cleared, and only this fixture would catch it.
+fn sample_budget_overrides() -> Vec<crate::ports::types::BudgetOverride> {
+    use crate::ports::types::{Actor, ActorKind, BudgetOverride};
+    let admin = Actor {
+        kind: ActorKind::User,
+        id: "user-conformance".to_string(),
+    };
+    vec![
+        BudgetOverride {
+            agent_id: "ceo".to_string(),
+            budget_usd_daily: Some(12.5),
+            set_by: admin.clone(),
+            at_millis: 1_700_000_000_000,
+        },
+        BudgetOverride {
+            agent_id: "eng".to_string(),
+            budget_usd_daily: Some(0.0),
+            set_by: admin.clone(),
+            at_millis: 1_700_000_000_001,
+        },
+        BudgetOverride {
+            agent_id: "writer".to_string(),
+            budget_usd_daily: None,
+            set_by: admin,
+            at_millis: 1_700_000_000_002,
+        },
+    ]
+}
+
 /// Builds a running record for `id` carrying a non-empty desk-order overlay (so
 /// the store round-trip covers the operator desk-hierarchy field, issue #131), a
-/// runtime-authored workflow body (issue #168), and stamped with the sample
-/// template provenance (so round-trips assert it survives persistence, issue
-/// #85).
+/// runtime-authored workflow body (issue #168), a populated budget-override set
+/// (issue #343), and stamped with the sample template provenance (so round-trips
+/// assert it survives persistence, issue #85).
 fn record(id: &CompanyId) -> CompanyRecord {
     CompanyRecord {
         id: id.clone(),
@@ -96,6 +134,7 @@ fn record(id: &CompanyId) -> CompanyRecord {
         }],
         overlay_desks: Vec::new(),
         overlay_workflows: vec![sample_overlay_workflow()],
+        overlay_budgets: sample_budget_overrides(),
         template_provenance: Some(sample_provenance()),
     }
 }
@@ -194,6 +233,22 @@ pub async fn assert_isolation_by_company(
         loaded.overlay_workflows,
         vec![sample_overlay_workflow()],
         "overlay_workflows did not survive save/load"
+    );
+    // The operator-set daily spend caps survive the store round-trip (issue
+    // #343), all three states intact — a cap, a real `0.0`, and the explicitly-
+    // uncapped `None`. Collapsing the last one would silently restore the
+    // manifest cap the operator had cleared.
+    assert_eq!(
+        loaded.overlay_budgets,
+        sample_budget_overrides(),
+        "overlay_budgets did not survive save/load"
+    );
+    assert!(
+        loaded
+            .overlay_budgets
+            .iter()
+            .any(|entry| entry.agent_id == "writer" && entry.budget_usd_daily.is_none()),
+        "the explicitly-uncapped override decayed into an absent or zeroed entry"
     );
     assert_eq!(
         events
@@ -416,6 +471,14 @@ pub async fn assert_export_totality(
         loaded.overlay_workflows,
         vec![sample_overlay_workflow()],
         "overlay_workflows did not round-trip through the store"
+    );
+    // Issue #343: the console-set daily caps round-trip on every backend. This
+    // is what makes "no redeploy" durable rather than in-memory — a cap raised
+    // from the Team page has to still be raised after the process restarts.
+    assert_eq!(
+        loaded.overlay_budgets,
+        sample_budget_overrides(),
+        "overlay_budgets did not round-trip through the store"
     );
 
     // Full event log round-trips with seqs and payloads intact.

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -31,8 +31,8 @@ use crate::ports::events::EventLog;
 use crate::ports::memory::MemoryStore;
 use crate::ports::store::CompanyStore;
 use crate::ports::types::{
-    CompanyId, CompanyRecord, CompressedTrace, ContextChunk, EventSeq, LedgerEntry, OverlayAgent,
-    OverlayDesk, OverlayDeskMember, OverlayDeskOrder, OverlayWorkflow, StoredEvent,
+    BudgetOverride, CompanyId, CompanyRecord, CompressedTrace, ContextChunk, EventSeq, LedgerEntry,
+    OverlayAgent, OverlayDesk, OverlayDeskMember, OverlayDeskOrder, OverlayWorkflow, StoredEvent,
     TemplateProvenance,
 };
 
@@ -118,6 +118,12 @@ struct BundleMeta {
     /// back-compat with older bundles.
     #[serde(default)]
     overlay_workflows: Vec<OverlayWorkflow>,
+    /// The operator-set per-teammate daily spend caps (issue #343). Preserved so
+    /// an export→import keeps the caps an operator set from the console, rather
+    /// than silently reverting every teammate to its manifest default.
+    /// `#[serde(default)]` for back-compat with older bundles.
+    #[serde(default)]
+    overlay_budgets: Vec<BudgetOverride>,
     /// The source-template provenance, when the exported company carried one.
     /// `#[serde(default)]` keeps older bundles written before provenance existed
     /// importing cleanly (they decode to `None` — no migration).
@@ -166,6 +172,9 @@ struct BundleContents {
     /// The operator workflow-authoring overlay, carried through the bundle so
     /// export→import preserves console-created workflow graphs.
     overlay_workflows: Vec<OverlayWorkflow>,
+    /// The operator-set per-teammate daily spend caps, carried through the
+    /// bundle so export→import preserves console-set budgets (issue #343).
+    overlay_budgets: Vec<BudgetOverride>,
 }
 
 impl BundleContents {
@@ -210,6 +219,7 @@ impl BundleContents {
             overlay_desk_order: record.overlay_desk_order,
             overlay_desks: record.overlay_desks,
             overlay_workflows: record.overlay_workflows,
+            overlay_budgets: record.overlay_budgets,
         })
     }
 
@@ -237,6 +247,7 @@ impl BundleContents {
                 overlay_desk_order: self.overlay_desk_order.clone(),
                 overlay_desks: self.overlay_desks.clone(),
                 overlay_workflows: self.overlay_workflows.clone(),
+                overlay_budgets: self.overlay_budgets.clone(),
                 template_provenance: self.template_provenance.clone(),
             })
             .await?;
@@ -279,6 +290,7 @@ impl BundleContents {
             overlay_desk_order: self.overlay_desk_order.clone(),
             overlay_desks: self.overlay_desks.clone(),
             overlay_workflows: self.overlay_workflows.clone(),
+            overlay_budgets: self.overlay_budgets.clone(),
             template_provenance: self.template_provenance.clone(),
         };
         write_file(
@@ -362,6 +374,7 @@ impl BundleContents {
             overlay_desk_order: meta.overlay_desk_order,
             overlay_desks: meta.overlay_desks,
             overlay_workflows: meta.overlay_workflows,
+            overlay_budgets: meta.overlay_budgets,
         })
     }
 }
@@ -809,6 +822,7 @@ mod test {
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         })
         .await
@@ -880,6 +894,7 @@ mod test {
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: Some(provenance.clone()),
         })
         .await
@@ -989,6 +1004,7 @@ mod test {
             overlay_desk_order: order.clone(),
             overlay_desks: desks.clone(),
             overlay_workflows: workflows.clone(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         })
         .await

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -342,6 +342,23 @@ impl BundleContents {
 
         let meta: BundleMeta = serde_json::from_str(&read_to_string(&src.join(META_JSON)).await?)?;
 
+        // A bundle is the one place `overlay_budgets` arrives from outside this
+        // process, so it is the one place the "at most one override per teammate"
+        // invariant can be violated by data we did not write. Refuse rather than
+        // resolve: `CompanyRecord::effective_budget` reads the first match, so
+        // importing two rows for one teammate would apply whichever the bundle
+        // happened to serialize first — possibly the obsolete one, possibly the
+        // looser one, and with somebody else's name on the attribution. A bundle
+        // that disagrees with itself about a spend cap has no right answer to
+        // pick, and picking silently is how a revoked allowance comes back.
+        if let Some(agent_id) = BudgetOverride::duplicate_agent_id(&meta.overlay_budgets) {
+            return Err(OpenCompanyError::Store(format!(
+                "invalid {META_JSON}: {} carries more than one budget override for teammate \
+                 '{agent_id}'; at most one is allowed",
+                meta.id
+            )));
+        }
+
         let ledger = read_jsonl::<LedgerEntry>(&src.join(LEDGER_JSONL)).await?;
         let events = read_jsonl::<StoredEvent>(&src.join(EVENTS_JSONL)).await?;
         let traces =
@@ -1068,6 +1085,217 @@ mod test {
             dst_record.effective_desk_members("eng")[0],
             "cto",
             "routing lead reverted to blueprint after import"
+        );
+
+        for dir in [home1, home2, dest] {
+            tokio::fs::remove_dir_all(&dir).await.ok();
+        }
+    }
+
+    /// A manifest naming two capped teammates, so a round-trip that dropped the
+    /// overrides would fall back to real caps rather than to "uncapped" — the
+    /// regression would still show as the *wrong* numbers, not as absent ones.
+    fn budget_manifest() -> CompanyManifest {
+        toml::from_str(
+            r#"
+            [company]
+            name = "Budget Co"
+            output = "widgets"
+
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+            budget_usd_daily = 5.0
+
+            [[agent]]
+            id = "cto"
+            role = "Tech"
+            budget_usd_daily = 9.0
+        "#,
+        )
+        .expect("parse manifest")
+    }
+
+    fn admin_actor() -> Actor {
+        Actor {
+            kind: ActorKind::User,
+            id: "user-admin".into(),
+        }
+    }
+
+    /// Issue #343: **all three** budget states survive an export→import — not
+    /// just the empty overlay every other fixture carries.
+    ///
+    /// The three are only distinct if serialization keeps them distinct, and two
+    /// of the three collapse into each other under the obvious mistakes:
+    /// `Some(0.0)` becomes `None` if the field is ever serialized with
+    /// `skip_serializing_if = "is_zero"`-style cleverness, and an explicit `None`
+    /// becomes "no entry at all" if the row is dropped when it carries no cap.
+    /// Either collapse is a silent unrecoverable change to a spend cap: a
+    /// teammate an admin muted starts spending again, or a teammate an admin
+    /// deliberately uncapped inherits the manifest's cap back. Attribution is
+    /// asserted alongside the cap because a restored cap nobody appears to have
+    /// set is its own defect.
+    #[tokio::test]
+    async fn budget_overrides_survive_roundtrip_including_zero_and_explicit_none() {
+        let home1 = tmp_root("budget-src");
+        let home2 = tmp_root("budget-dst");
+        let dest = tmp_root("budget-bundle");
+        let id = CompanyId::new("budget-co");
+
+        let budgets = vec![
+            // Cap of exactly zero: "this teammate may not spend", NOT "no cap".
+            BudgetOverride {
+                agent_id: "ceo".into(),
+                budget_usd_daily: Some(0.0),
+                set_by: admin_actor(),
+                at_millis: 1_700_000_000_000,
+            },
+            // Explicitly uncapped, beating the manifest's $9.
+            BudgetOverride {
+                agent_id: "cto".into(),
+                budget_usd_daily: None,
+                set_by: admin_actor(),
+                at_millis: 1_700_000_000_001,
+            },
+        ];
+
+        let (s1, e1, m1, c1) = fs_ports(&home1);
+        s1.save(&CompanyRecord {
+            id: id.clone(),
+            manifest: budget_manifest(),
+            ledger: Vec::new(),
+            lifecycle: "running".into(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: budgets.clone(),
+            template_provenance: None,
+        })
+        .await
+        .unwrap();
+
+        // Sanity: both overrides already beat the manifest in the source.
+        let src_record = s1.load(&id).await.unwrap().unwrap();
+        assert_eq!(src_record.effective_budget("ceo"), Some(0.0));
+        assert_eq!(src_record.effective_budget("cto"), None);
+
+        export_bundle(&id, &dest, s1, e1, m1, c1, ExportOpts::default())
+            .await
+            .unwrap();
+        let (s2, e2, m2, c2) = fs_ports(&home2);
+        import_bundle(&dest, s2.clone(), e2, m2, c2).await.unwrap();
+
+        let dst_record = s2.load(&id).await.unwrap().unwrap();
+        assert_eq!(
+            dst_record.overlay_budgets, budgets,
+            "budget overrides altered by the bundle round-trip"
+        );
+
+        // Cap, attribution and timestamp, read the way every surface reads them.
+        assert_eq!(
+            dst_record.effective_budget("ceo"),
+            Some(0.0),
+            "a zero cap must survive as zero, not decay into uncapped"
+        );
+        assert_eq!(
+            dst_record.effective_budget("cto"),
+            None,
+            "an explicitly-uncapped override must survive and still beat the manifest's $9"
+        );
+        let ceo = dst_record.budget_override("ceo").expect("ceo attribution");
+        assert_eq!(ceo.set_by, admin_actor());
+        assert_eq!(ceo.at_millis, 1_700_000_000_000);
+        let cto = dst_record.budget_override("cto").expect(
+            "an explicitly-uncapped override must keep its attribution row — it is exactly the \
+             case an operator needs to see attributed",
+        );
+        assert_eq!(cto.set_by, admin_actor());
+        assert_eq!(cto.at_millis, 1_700_000_000_001);
+
+        for dir in [home1, home2, dest] {
+            tokio::fs::remove_dir_all(&dir).await.ok();
+        }
+    }
+
+    /// Issue #343: a bundle carrying two overrides for one teammate is **refused**
+    /// at import, not silently reduced to whichever row deserialized first.
+    ///
+    /// Import is the only boundary where `overlay_budgets` arrives from outside
+    /// this process, so it is the only place the write path's one-per-teammate
+    /// invariant can be broken. The two rows here disagree ($0 versus $50, set by
+    /// different people), which is the point: there is no correct row to pick,
+    /// and picking silently would either mute a teammate or restore an allowance
+    /// an admin revoked, with the wrong name on the attribution either way.
+    #[tokio::test]
+    async fn a_bundle_with_duplicate_budget_overrides_is_rejected() {
+        let home1 = tmp_root("dup-src");
+        let home2 = tmp_root("dup-dst");
+        let dest = tmp_root("dup-bundle");
+        let id = CompanyId::new("dup-co");
+
+        let (s1, e1, m1, c1) = fs_ports(&home1);
+        s1.save(&CompanyRecord {
+            id: id.clone(),
+            manifest: budget_manifest(),
+            ledger: Vec::new(),
+            lifecycle: "running".into(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            template_provenance: None,
+        })
+        .await
+        .unwrap();
+        export_bundle(&id, &dest, s1, e1, m1, c1, ExportOpts::default())
+            .await
+            .unwrap();
+
+        // Forge the tampered/foreign bundle by rewriting its meta.json — the shape
+        // an import can be handed but the write path can never produce.
+        let meta_path = dest.join(META_JSON);
+        let mut meta: BundleMeta =
+            serde_json::from_str(&tokio::fs::read_to_string(&meta_path).await.unwrap()).unwrap();
+        meta.overlay_budgets = vec![
+            BudgetOverride {
+                agent_id: "ceo".into(),
+                budget_usd_daily: Some(0.0),
+                set_by: admin_actor(),
+                at_millis: 1_700_000_000_000,
+            },
+            BudgetOverride {
+                agent_id: "ceo".into(),
+                budget_usd_daily: Some(50.0),
+                set_by: Actor {
+                    kind: ActorKind::User,
+                    id: "user-other".into(),
+                },
+                at_millis: 1_700_000_000_002,
+            },
+        ];
+        tokio::fs::write(&meta_path, serde_json::to_string(&meta).unwrap())
+            .await
+            .unwrap();
+
+        let (s2, e2, m2, c2) = fs_ports(&home2);
+        let err = import_bundle(&dest, s2.clone(), e2, m2, c2)
+            .await
+            .expect_err("import must refuse a bundle with two overrides for one teammate");
+        let message = err.to_string();
+        assert!(
+            message.contains("ceo") && message.contains("budget override"),
+            "the refusal must name the teammate so an operator can fix the bundle: {message}"
+        );
+
+        // And nothing was written: a refused import must not half-apply.
+        assert!(
+            s2.load(&id).await.unwrap().is_none(),
+            "a rejected bundle must not persist a partial company record"
         );
 
         for dir in [home1, home2, dest] {

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -147,11 +147,35 @@ struct Meta {
     /// through the store, so `#[serde(default)]` keeps those loading.
     #[serde(default)]
     overlay_workflows: Vec<crate::ports::types::OverlayWorkflow>,
+    /// The operator-set per-teammate daily spend caps (issue #343). Absent on
+    /// meta files written before the console could write a budget, so
+    /// `#[serde(default)]` keeps those loading with the manifest in charge.
+    #[serde(default)]
+    overlay_budgets: Vec<crate::ports::types::BudgetOverride>,
     /// The source-template provenance stamped at launch. `None` for companies
     /// provisioned from a raw manifest and for legacy meta files written before
     /// provenance existed (the `#[serde(default)]` keeps those loading).
     #[serde(default)]
     template_provenance: Option<crate::ports::types::TemplateProvenance>,
+}
+
+impl Default for Meta {
+    /// A bundle whose meta file has not been written yet: a running company
+    /// with no operator overlays and no recorded provenance. `lifecycle` is
+    /// `"running"` rather than `String::default()` — an empty lifecycle is not
+    /// a state this runtime has.
+    fn default() -> Self {
+        Self {
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            template_provenance: None,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -194,35 +218,14 @@ impl CompanyStore for FsCompanyStore {
             .map_err(|e| OpenCompanyError::Store(format!("invalid company.toml: {e}")))?;
 
         let meta_src = read_optional(&bundle.meta_json()).await?;
-        let (
-            lifecycle,
-            overlay_agents,
-            overlay_desk_members,
-            overlay_desk_order,
-            overlay_desks,
-            overlay_workflows,
-            template_provenance,
-        ) = if meta_src.trim().is_empty() {
-            (
-                "running".to_string(),
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-                None,
-            )
+        // A bundle with no meta file yet is a running company with no overlays —
+        // which is exactly `Meta::default()`. Carrying that through one value
+        // rather than a positional tuple keeps adding an overlay collection a
+        // one-line change here instead of a four-place one.
+        let meta: Meta = if meta_src.trim().is_empty() {
+            Meta::default()
         } else {
-            let meta: Meta = serde_json::from_str(&meta_src)?;
-            (
-                meta.lifecycle,
-                meta.overlay_agents,
-                meta.overlay_desk_members,
-                meta.overlay_desk_order,
-                meta.overlay_desks,
-                meta.overlay_workflows,
-                meta.template_provenance,
-            )
+            serde_json::from_str(&meta_src)?
         };
 
         let ledger = read_jsonl::<LedgerEntry>(&bundle.ledger_jsonl()).await?;
@@ -231,13 +234,14 @@ impl CompanyStore for FsCompanyStore {
             id: id.clone(),
             manifest,
             ledger,
-            lifecycle,
-            overlay_agents,
-            overlay_desk_members,
-            overlay_desk_order,
-            overlay_desks,
-            overlay_workflows,
-            template_provenance,
+            lifecycle: meta.lifecycle,
+            overlay_agents: meta.overlay_agents,
+            overlay_desk_members: meta.overlay_desk_members,
+            overlay_desk_order: meta.overlay_desk_order,
+            overlay_desks: meta.overlay_desks,
+            overlay_workflows: meta.overlay_workflows,
+            overlay_budgets: meta.overlay_budgets,
+            template_provenance: meta.template_provenance,
         }))
     }
 
@@ -256,6 +260,7 @@ impl CompanyStore for FsCompanyStore {
             overlay_desk_order: record.overlay_desk_order.clone(),
             overlay_desks: record.overlay_desks.clone(),
             overlay_workflows: record.overlay_workflows.clone(),
+            overlay_budgets: record.overlay_budgets.clone(),
             template_provenance: record.template_provenance.clone(),
         };
         write_atomic(&bundle.meta_json(), &serde_json::to_string(&meta)?).await?;
@@ -957,6 +962,7 @@ mod test {
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         };
         store.save(&record).await.unwrap();
@@ -996,6 +1002,7 @@ mod test {
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -308,6 +308,7 @@ impl CompanyStore for MongoStore {
             overlay_desk_order: overlay.desk_order,
             overlay_desks: overlay.desks,
             overlay_workflows: overlay.workflows,
+            overlay_budgets: overlay.budgets,
             template_provenance: overlay.provenance,
         }))
     }
@@ -1957,6 +1958,7 @@ mod test {
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
                 template_provenance: None,
             };
             // Same template name under two tenants: distinct namespaced ids, no

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -373,6 +373,7 @@ impl CompanyStore for SqliteStore {
             overlay_desk_order: overlay.desk_order,
             overlay_desks: overlay.desks,
             overlay_workflows: overlay.workflows,
+            overlay_budgets: overlay.budgets,
             template_provenance: overlay.provenance,
         }))
     }
@@ -2330,6 +2331,7 @@ mod test {
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
                 template_provenance: None,
             })
             .await

--- a/src/workflows/caps/resolver.rs
+++ b/src/workflows/caps/resolver.rs
@@ -268,6 +268,7 @@ mod tests {
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: overlays,
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         }))))
     }

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -1014,6 +1014,7 @@ allow = [{allow}]
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         }
     }

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -230,6 +230,7 @@ description = "Runs Acme."
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         }
     }
@@ -311,6 +312,7 @@ allow = ["*"]
             overlay_desk_order: Vec::new(),
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
             template_provenance: None,
         }
     }


### PR DESCRIPTION
## Summary

An admin can set, change and clear a teammate's daily spend cap from the Team page, and it takes effect **on the next dispatch — no restart, no redeploy**.

#304 made these caps load-bearing: a teammate over its cap refuses dispatch and priced calls park. But the value came only from `company.toml`, which for a hosted tenant is baked into the container image. An operator who hit a cap watched their teammate stop working with no remedy — the only fix was us editing a manifest and redeploying.

## Problem

`build_roster` baked `budget_usd_daily` into `CompanyAgent` and `ApprovalPolicy` at boot, and no write path existed at any layer: the team routes were GET/POST/DELETE/inbox only, `AddMember` had no budget field, and `budgetUsdDaily` was a read-only field on the GraphQL team query.

## Solution

**A store-backed override that wins over the manifest.** The manifest stays the default for a fresh company; a stored value takes precedence once set. Three states, deliberately distinct:

| Stored | Means |
|---|---|
| no entry | the manifest wins |
| `Some(x)` | cap of `x` — **`0.0` is legal** |
| `None` | **explicitly uncapped**, beating a manifest cap |

That third state is why **clearing is not the same as zeroing**, and why an absent key on the wire is a `422` rather than a silent uncap.

**No restart comes free from a mechanism that already existed.** `HarnessPool::ensure` already re-fingerprints five things per turn — MCP config, overlay agents, capability filter, composio, skills — and rebuilds the roster when any change. Budgets simply were never one of them. This adds a sixth axis and points `build_roster` at `effective_budget`. **The dispatch gate and the policy arm are unchanged**: a cap edit flips the fingerprint, `ensure` rebuilds before the next turn, and the next dispatch enforces the new number.

That also lifts #304's limitation that overlay teammates were uncapped.

**Admin means a human admin session.** A machine credential cannot set a cap, so attribution always names a person.

## Submission Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **1774 passed, 0 failed**, 1 ignored
- [x] `cargo check --locked --all-features --all-targets`
- [x] `git diff --stat Cargo.lock` — empty
- [x] `npm ci`, `npm run typecheck`, `npm run build`
- [x] Playwright — 3/3 against a live host, including the pre-existing #304 spec
- [x] Verified end to end on both the UI and the backend

**The no-restart property is proven three ways.**

*By test:* `a_budget_written_through_the_store_is_enforced_on_the_next_dispatch` — one pool, one live store, four phases: manifest $5 already spent → refused; raised to $50 → answers; set to $0 → refused; cleared to explicitly-uncapped → answers despite the $5 already spent. Each phase asserts the fingerprint moved and the company stayed resident.

*By proving the test gates:* bypassing the fingerprint check makes it fail at exactly the right phase — the fast path returns early and the roster keeps the stale cap. Restored and re-verified green. A test that would pass with the feature absent proves nothing.

*By running it:* the offline echo brain bypasses the harness entirely, so verification used a mock OpenAI-compatible endpoint to exercise the real path. Four cap changes through **a single host process, PID unchanged**, with dispatch flipping between a model reply and the spend-cap refusal each time.

Wire contract on that same host: `{}` → 422 · `-1` → 400 · `42` → 200 (beats the manifest) · `0` → 200 (cap `0.0`) · `null` → 200 (no cap, attribution present) · `DELETE` → 200 (manifest value returns, attribution gone) · unknown teammate → 404 · no session → 401.

## Impact

**A bug the plan missed, caught during implementation:** `RuntimeBuilder::build` reconstructs `CompanyRecord` from the seed manifest on boot. Without carrying `overlay_budgets` across, every console-set cap would have silently reverted to the image's value on the next restart — the exact failure this issue exists to end. Fixed and covered.

**A correction to the plan's expected status code:** a platform bearer token gets **401, not 403**. It resolves through `current_user`, which only yields a principal for a human session, so it never reaches the admin check. The security property holds — machine credentials cannot set a cap — but the code differs from what the plan predicted. `require_admin` was reused unchanged rather than altering a contract every existing admin route depends on. Worth a maintainer's view.

**Attribution keys on override existence, not on the cap.** A cap-*removing* override has no cap to sit beside, and that is precisely the case an operator needs to see attributed.

Changing a cap **rebuilds that company's roster**, discarding its in-memory agent sessions — the same accepted trade-off as the five existing freshness axes. In-flight turns finish under the old cap; "next dispatch" is the contract.

The mechanical half of the diff is 60 `CompanyRecord` literal sites. `fs.rs`'s tuple destructuring was collapsed into `Meta::default()` so the next overlay field is a one-line change.

**One commit here is not about budgets:** `test(runs): carry the new overlay field in the run-route fixture`. #242 PR-3 added a `CompanyRecord` literal while this branch added a field to that struct — each green alone, `E0063` in the union. Caught by building the merged tree before opening this PR, not by CI, which never builds the union of two open branches.

`docs/spec/runtime/ports.md` is now 785 lines against the repo's 500-line cap. It was 775 before this branch; splitting it is its own task.

## Related

Closes #343
Follows #304, which shipped the enforcement and the read-only display.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins can set, clear, or restore daily spending caps for teammates.
  * Caps support zero, custom limits, or an explicitly uncapped state and apply on the next dispatch.
  * Teammate records display effective caps, spending, and override attribution.
  * New teammates can receive a daily cap during creation.

* **Documentation**
  * Added API and manifest guidance for budget overrides, defaults, persistence, and precedence.

* **Tests**
  * Added coverage for authorization, validation, persistence, attribution, resets, and runtime budget enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->