### PR TITLE
fix(chat): chat tab renders blank once real desks load

### DIFF
--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -321,7 +321,10 @@ function handleEvent(
       // error against today's union, and the host can already send a status
       // this console's type doesn't name yet.
       const pendingStatus: string = "pending";
-      const undelivered = event.deliveries.filter(
+      // `deliveries` is host-controlled and may be absent on an event shape this
+      // console's types don't name yet (see note above) — default to empty so a
+      // missing field can never throw and blank the subscriber.
+      const undelivered = (event.deliveries ?? []).filter(
         (d) => d.status !== "sent" && d.status !== pendingStatus,
       ).length;
       if (undelivered > 0) {

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -25,6 +25,7 @@ import {
   deskFromDto,
   dmChannelId,
   findChannel,
+  firstChannel,
   toggleReaction,
   type Transcripts,
 } from "./chat/model";
@@ -203,7 +204,10 @@ export function ChatView({
   }, [client, company]);
 
   const sections = useMemo(() => buildChannels(members, desks), [members, desks]);
-  const channel = findChannel(sections, sub) ?? findChannel(sections, DEFAULT_CHANNEL);
+  const channel =
+    findChannel(sections, sub) ??
+    findChannel(sections, DEFAULT_CHANNEL) ??
+    firstChannel(sections);
 
   const messages = channel ? (transcripts[channel.id] ?? []) : [];
   const entries = useMemo(

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -131,6 +131,21 @@ export function findChannel(sections: ChannelSection[], id: string | null): Chan
   return null;
 }
 
+/**
+ * The first channel across all sections, or `null` when there are none.
+ * Used as the last-resort selection so the chat never renders blank while any
+ * channel exists — the hard-coded {@link DEFAULT_CHANNEL} ("main") only exists
+ * in the fallback desks, so once a company's real desks load (ids drawn from
+ * the roster, never "main") it no longer matches and the view would otherwise
+ * bail to null.
+ */
+export function firstChannel(sections: ChannelSection[]): Channel | null {
+  for (const s of sections) {
+    if (s.channels.length > 0) return s.channels[0];
+  }
+  return null;
+}
+
 /** How a channel is titled in the header and the rail. */
 export function channelTitle(channel: Channel): string {
   return channel.kind === "dm" ? channel.name : `#${channel.name}`;


### PR DESCRIPTION
## Summary

The **Chat** tab renders a blank pane for any hosted company. Two independent frontend defects on `main`, both fixed here.

## Problem

1. **Blank pane (the visible bug).** `ChatView` picks the active channel as `findChannel(sub) ?? findChannel(DEFAULT_CHANNEL)` where `DEFAULT_CHANNEL = "main"`. `"main"` only exists in the **fallback** desks (`lib/desks.ts`). Once a company's **real** desks load from `/desks` (channel ids come from the roster — `product_manager`, `designer`, … never `"main"`), neither the route nor `"main"` matches, `channel` resolves to `null`, and `ChatView`'s `if (!channel) return null` blanks the entire pane. Confirmed live: the chat subtree (rail/header/composer) is absent from the DOM, all 20 API calls are `200` — it's a client selection bug, not a data/backend failure.
2. **Uncaught events crash.** `use-events.ts` did `event.deliveries.filter(...)` with no guard. `deliveries` is host-controlled and can be absent on an event shape the console's types don't name yet — the code's own comment warned of exactly this. It threw `TypeError: Cannot read properties of undefined (reading 'filter')`, observed right after `[events] connecting`.

## API Or Behavior Changes

None (backend/contract unchanged). Behavior fix only:
- New `firstChannel(sections)` helper (`views/chat/model.ts`); `ChatView` channel selection now falls back to it, so the view renders whenever *any* channel exists — only truly channel-less companies show nothing.
- `use-events.ts` defaults `deliveries` to `[]` before filtering.

## Tests

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- Manual: the fallback makes the reported blank impossible while any desk/DM channel exists (every hosted company). Verified via live diagnosis (DOM empty + the two exceptions above) that these are the two failure points.

## Documentation

None needed — no API, config, or contract change.

## Related

Chat workspace rebuild (#361). Blanks the Chat tab for every tenant on current `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented workflow delivery errors when delivery information is missing.
  * Ensured the chat view selects an available channel instead of appearing blank when preferred channels are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->