### PR TITLE
feat(approvals): say what is being approved, and stop one decision from locking the rest (#372, #373)

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -183,6 +183,28 @@ export interface ApprovalSummary {
    * heuristic for it, and for nothing else.
    */
   task?: { link: "task"; id: string } | { link: "unlinked" };
+  /**
+   * The roster teammate whose blocked tool call this is (#372). Mirrors
+   * `Effect::agent`: present exactly when the effect came from a harness tool
+   * call, absent for a native effect the runtime performs itself.
+   *
+   * Optional because the host may predate the field — an old host omits it, and
+   * the card then names no asker rather than showing a raw id or a guess.
+   */
+  agent?: string | null;
+  /**
+   * What the effect will actually do — the tool call's arguments (#372).
+   *
+   * Already redacted and bounded by the host
+   * (`src/runtime/approval_display.rs`): credential-named keys arrive as the
+   * literal string `"[redacted]"`, long strings are truncated, and an oversized
+   * subtree arrives as `"[unrenderable]"`. The console never has to decide what
+   * is safe to show, and must not try to "unredact" anything.
+   *
+   * `unknown` rather than a shape: the payload is an arbitrary tool argument
+   * object, so every read of it is a narrowing one.
+   */
+  payload?: unknown;
 }
 
 export type Verdict = "approve" | "deny";

--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -111,11 +111,109 @@ export function effectDone(kind: string, amountUsd?: number | null): string {
     : "Did something that cannot be undone";
 }
 
+/**
+ * Gated **tool** names → what using that tool means, in plain language (#372).
+ *
+ * Kept apart from {@link EFFECT_LABELS} on purpose. That table's entries are
+ * business effects, which are self-describing at kind level: `payment.send`
+ * without its amount still tells an operator what is about to happen. A tool
+ * name does not — `shell` without its command is meaningless — so these labels
+ * only ever appear *above* the payload block that says what the tool will do.
+ * Keeping them out of `EFFECT_LABELS` also leaves the
+ * `EFFECT_LABELS`/`EFFECT_DONE_LABELS` `satisfies` mirror undisturbed.
+ */
+const TOOL_LABELS: Readonly<Record<string, string>> = {
+  shell: "Run a terminal command",
+  glob: "Search files in its workspace",
+};
+
+/**
+ * What an approval is asking for, in plain language (#372).
+ *
+ * Resolution order, and why the last two rungs differ:
+ *
+ * 1. the effect glossary — a business effect, phrased as it always was;
+ * 2. {@link TOOL_LABELS} — a gated tool we have words for;
+ * 3. an unmapped kind **with** an `agent` — it came from a tool call, so we can
+ *    at least say a teammate wants to use a tool;
+ * 4. an unmapped kind with no agent — a native effect nobody has named.
+ *
+ * The title-cased fallback in {@link effectAction} is never reached from here.
+ * That fallback is what put "Glob" and "Shell" — raw runtime identifiers — in
+ * front of an operator, which is the bug #372 opens with and which the glossary
+ * rule at the top of this file forbids. `effectAction` itself is deliberately
+ * left alone so no other surface shifts under this change.
+ */
+export function approvalAction(a: ApprovalSummary): string {
+  return (
+    labelFor(EFFECT_LABELS, a.kind) ??
+    labelFor(TOOL_LABELS, a.kind) ??
+    (a.agent ? "Use one of its tools" : "Do something that needs your sign-off")
+  );
+}
+
 /** A one-line, human summary of what needs approval. */
 export function approvalSummary(a: ApprovalSummary): string {
-  const action = effectAction(a.kind);
+  const action = approvalAction(a);
   if (a.amount_usd != null) return `${action} — ${money(a.amount_usd)}`;
   return action;
+}
+
+/** One line of an approval's payload preview: a label and its value. */
+export interface PayloadLine {
+  label: string;
+  value: string;
+}
+
+/**
+ * The payload the host sent, as lines an operator can read (#372).
+ *
+ * The values are already redacted and bounded host-side, so this function's
+ * only job is presentation. Two shapes:
+ *
+ * * a kind we know the argument names of (`shell`, `glob`) gets its meaningful
+ *   arguments in a fixed, readable order — the command first, because that is
+ *   the thing being consented to;
+ * * anything else falls back to `key: value` over the payload's own top-level
+ *   entries, which is still concrete and still safe.
+ *
+ * Nested objects and arrays are re-serialized as compact JSON rather than
+ * dropped: an operator approving a structured call needs to see the structure.
+ * Returns `[]` when there is nothing to show, which is also what an **old
+ * host** produces (it omits `payload` entirely) — callers render the pre-#372
+ * one-line card in that case.
+ */
+export function payloadLines(a: ApprovalSummary): PayloadLine[] {
+  const payload = a.payload;
+  if (payload == null) return [];
+  if (typeof payload !== "object") return [{ label: "value", value: renderValue(payload) }];
+  if (Array.isArray(payload)) return [{ label: "items", value: renderValue(payload) }];
+
+  const entries = Object.entries(payload as Record<string, unknown>);
+  if (entries.length === 0) return [];
+
+  // Preferred ordering for the kinds whose argument names we know. Unlisted
+  // arguments still follow — this promotes, it never hides.
+  const preferred = PAYLOAD_KEY_ORDER[a.kind] ?? [];
+  const rank = (key: string) => {
+    const i = preferred.indexOf(key);
+    return i === -1 ? preferred.length : i;
+  };
+  return entries
+    .filter(([, value]) => value != null && value !== "")
+    .sort(([a1], [b1]) => rank(a1) - rank(b1))
+    .map(([label, value]) => ({ label, value: renderValue(value) }));
+}
+
+/** Which arguments lead the preview, per tool. Presentation only. */
+const PAYLOAD_KEY_ORDER: Readonly<Record<string, string[]>> = {
+  shell: ["command", "cwd", "timeout"],
+  glob: ["pattern", "path"],
+};
+
+function renderValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value) ?? String(value);
 }
 
 export function money(usd: number): string {

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -9,6 +9,7 @@ import {
   FileText,
   Globe,
   KeyRound,
+  Loader2,
   Mail,
   MessageSquare,
   Repeat,
@@ -22,7 +23,7 @@ import {
 import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
-import { ApiError, type ApprovalSummary } from "@/api/types";
+import { ApiError, type ApprovalSummary, type Verdict } from "@/api/types";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import type { CompanyFeed } from "@/hooks/use-company";
@@ -61,13 +62,35 @@ interface Props {
 
 /** The approvals inbox: the few things the company parked for the operator. */
 export function ApprovalsView({ client, company, feed, onResolved, onGoToConversation }: Props) {
-  const [busy, setBusy] = useState<string | null>(null);
+  // Issue #373: in-flight state is per approval, not a single module-wide slot.
+  //
+  // Approving is not a quick write — the host mints a grant and re-dispatches
+  // the agent, holding the POST open for a whole turn (#243) — so two decisions
+  // being in flight at once is a legitimate state the operator can reach, and
+  // one the host already handles by serialising them behind its per-company
+  // lock. The old `string | null` could not represent it, which is why deciding
+  // one card greyed out every other card on the screen until a hard reload.
+  //
+  // A map rather than a set of ids because the verdict has to survive the wait:
+  // an approve and a decline are different promises to the operator ("the agent
+  // is doing it" vs "recorded"), and the card says which one it is waiting on.
+  const [inFlight, setInFlight] = useState<ReadonlyMap<string, Verdict>>(() => new Map());
   const { approvals, now } = feed;
   const askerNames = useAskerNames(client, company, approvals);
 
-  async function decide(a: ApprovalSummary, verdict: "approve" | "deny") {
-    if (busy) return;
-    setBusy(a.id);
+  const markInFlight = (id: string, verdict: Verdict | null) =>
+    setInFlight((prev) => {
+      const next = new Map(prev);
+      if (verdict) next.set(id, verdict);
+      else next.delete(id);
+      return next;
+    });
+
+  async function decide(a: ApprovalSummary, verdict: Verdict) {
+    // Per-row guard: only a double-press on THIS card is ignored. The global
+    // early return that used to live here made every other card inert too.
+    if (inFlight.has(a.id)) return;
+    markInFlight(a.id, verdict);
     try {
       await client.resolveApproval(a.id, verdict, undefined, company);
       // Issue #243: approving no longer just records a verdict — it hands the
@@ -91,7 +114,12 @@ export function ApprovalsView({ client, company, feed, onResolved, onGoToConvers
       onResolved(`Couldn't record your decision — ${msg}`);
       toast.error(`Couldn't record your decision — ${msg}`);
     } finally {
-      setBusy(null);
+      // Unconditional, and keyed on the id rather than clearing a single slot:
+      // the feed refreshes on its own schedule and routinely drops the decided
+      // row while its request is still open, so the flag has to be removable
+      // whether or not the row it belongs to still exists. Deleting a key that
+      // is already gone is a no-op, which is the point.
+      markInFlight(a.id, null);
     }
   }
 
@@ -116,9 +144,7 @@ export function ApprovalsView({ client, company, feed, onResolved, onGoToConvers
                   approval={a}
                   now={now}
                   askerNames={askerNames}
-                  isBusy={busy === a.id}
-                  dimmed={busy !== null && busy !== a.id}
-                  disabled={busy !== null}
+                  deciding={inFlight.get(a.id) ?? null}
                   onDecide={(verdict) => void decide(a, verdict)}
                 />
               ))}
@@ -152,18 +178,15 @@ function ApprovalCard({
   approval: a,
   now,
   askerNames,
-  isBusy,
-  dimmed,
-  disabled,
+  deciding,
   onDecide,
 }: {
   approval: ApprovalSummary;
   now: number;
   askerNames: Map<string, string>;
-  isBusy: boolean;
-  dimmed: boolean;
-  disabled: boolean;
-  onDecide: (verdict: "approve" | "deny") => void;
+  /** The verdict this card is waiting on, or `null` when it is idle (#373). */
+  deciding: Verdict | null;
+  onDecide: (verdict: Verdict) => void;
 }) {
   const Icon = KIND_ICONS[a.kind] ?? ShieldCheck;
   const lines = useMemo(() => payloadLines(a), [a]);
@@ -172,8 +195,10 @@ function ApprovalCard({
   // operator can at least tell two askers apart.
   const asker = a.agent ? (askerNames.get(a.agent) ?? a.agent) : null;
 
+  // No cross-card dimming: another card being decided is not this card's
+  // business, and treating it as such is the visual half of the #373 bug.
   return (
-    <Card className={cn("transition-opacity", dimmed && "opacity-60")}>
+    <Card>
       <CardContent className="flex flex-col gap-3 py-4">
         <div className="flex items-start gap-4">
           <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
@@ -185,12 +210,30 @@ function ApprovalCard({
               <p className="text-xs font-medium text-muted-foreground">{money(a.amount_usd)}</p>
             )}
           </div>
+          {/* Disabled on THIS card's own state only — a decision in flight on
+              another card leaves these live. That is the whole of #373's
+              first cause. */}
           <div className="flex shrink-0 gap-2">
-            <Button variant="outline" size="sm" disabled={disabled} onClick={() => onDecide("deny")}>
-              <X className="size-4" /> Decline
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={deciding !== null}
+              onClick={() => onDecide("deny")}
+            >
+              {deciding === "deny" ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <X className="size-4" />
+              )}{" "}
+              Decline
             </Button>
-            <Button size="sm" disabled={disabled} onClick={() => onDecide("approve")}>
-              <Check className="size-4" /> Approve
+            <Button size="sm" disabled={deciding !== null} onClick={() => onDecide("approve")}>
+              {deciding === "approve" ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Check className="size-4" />
+              )}{" "}
+              Approve
             </Button>
           </div>
         </div>
@@ -219,10 +262,15 @@ function ApprovalCard({
             </>
           )}
           <span>{timeAgo(a.at_millis, now)}</span>
-          {isBusy && (
+          {/* Honest copy for a request that spans an agent turn (#373): an
+              approve is not done when the button stops spinning, it is handed
+              to the agent. A decline IS terminal, so it only has to record. */}
+          {deciding && (
             <>
               <span aria-hidden>·</span>
-              <span>Working on it…</span>
+              <span className="text-foreground">
+                {deciding === "approve" ? "Waiting for the agent…" : "Recording…"}
+              </span>
             </>
           )}
         </div>

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   AtSign,
   Check,
+  ChevronDown,
+  ChevronUp,
   CreditCard,
   FileSignature,
   FileText,
@@ -13,6 +15,7 @@ import {
   RefreshCw,
   Rocket,
   ShieldCheck,
+  SquareKanban,
   type LucideIcon,
   X,
 } from "lucide-react";
@@ -23,7 +26,7 @@ import { ApiError, type ApprovalSummary } from "@/api/types";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import type { CompanyFeed } from "@/hooks/use-company";
-import { approvalSummary, money, timeAgo } from "@/lib/language";
+import { approvalAction, approvalSummary, money, payloadLines, timeAgo } from "@/lib/language";
 import { cn } from "@/lib/utils";
 
 const KIND_ICONS: Record<string, LucideIcon> = {
@@ -40,6 +43,14 @@ const KIND_ICONS: Record<string, LucideIcon> = {
   "key.rotate": KeyRound,
 };
 
+/**
+ * How much of a payload is shown before it is clamped. Past either bound the
+ * block collapses behind a "Show everything" toggle — a queue of approvals has
+ * to stay scannable, and a forty-line argument object buries the next card.
+ */
+const PREVIEW_LINES = 3;
+const PREVIEW_VALUE_CHARS = 160;
+
 interface Props {
   client: OpenCompanyClient;
   company: string | null;
@@ -52,6 +63,7 @@ interface Props {
 export function ApprovalsView({ client, company, feed, onResolved, onGoToConversation }: Props) {
   const [busy, setBusy] = useState<string | null>(null);
   const { approvals, now } = feed;
+  const askerNames = useAskerNames(client, company, approvals);
 
   async function decide(a: ApprovalSummary, verdict: "approve" | "deny") {
     if (busy) return;
@@ -92,49 +104,217 @@ export function ApprovalsView({ client, company, feed, onResolved, onGoToConvers
           <>
             <div className="mb-4 flex items-baseline justify-between">
               <h2 className="text-sm font-medium text-muted-foreground">
-                {approvals.length === 1 ? "1 thing needs your approval" : `${approvals.length} things need your approval`}
+                {approvals.length === 1
+                  ? "1 thing needs your approval"
+                  : `${approvals.length} things need your approval`}
               </h2>
             </div>
             <div className="flex flex-col gap-3">
-              {approvals.map((a) => {
-                const Icon = KIND_ICONS[a.kind] ?? ShieldCheck;
-                const isBusy = busy === a.id;
-                return (
-                  <Card key={a.id} className={cn("transition-opacity", busy && !isBusy && "opacity-60")}>
-                    <CardContent className="flex items-center gap-4 py-4">
-                      <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
-                        <Icon className="size-5" />
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate font-medium">{approvalSummary(a)}</p>
-                        <p className="text-xs text-muted-foreground">
-                          {a.amount_usd != null && <span className="font-medium">{money(a.amount_usd)} · </span>}
-                          {timeAgo(a.at_millis, now)}
-                        </p>
-                      </div>
-                      <div className="flex shrink-0 gap-2">
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          disabled={busy !== null}
-                          onClick={() => void decide(a, "deny")}
-                        >
-                          <X className="size-4" /> Decline
-                        </Button>
-                        <Button size="sm" disabled={busy !== null} onClick={() => void decide(a, "approve")}>
-                          <Check className="size-4" /> Approve
-                        </Button>
-                      </div>
-                    </CardContent>
-                  </Card>
-                );
-              })}
+              {approvals.map((a) => (
+                <ApprovalCard
+                  key={a.id}
+                  approval={a}
+                  now={now}
+                  askerNames={askerNames}
+                  isBusy={busy === a.id}
+                  dimmed={busy !== null && busy !== a.id}
+                  disabled={busy !== null}
+                  onDecide={(verdict) => void decide(a, verdict)}
+                />
+              ))}
             </div>
           </>
         )}
       </div>
     </div>
   );
+}
+
+/**
+ * One parked approval, told in full (#372).
+ *
+ * The card answers the four questions an operator needs before they can decide
+ * — what will happen, who is asking, what it is for, and how long it has waited
+ * — and it answers the first one *concretely*, with the tool call's own
+ * arguments, because that is the thing being consented to. Before this it said
+ * "Shell", which asks someone to authorise an action they cannot see.
+ *
+ * Laid out vertically rather than as one row: the payload block needs the full
+ * width, and the stacked form leaves the slot #374's per-approval scope control
+ * will occupy.
+ *
+ * **An old host degrades to the pre-#372 card by construction.** It omits
+ * `payload` and `agent` from the wire, so the payload block and the "Asked by"
+ * line simply do not render and what is left is the headline, the amount and
+ * the relative time — exactly what shipped before.
+ */
+function ApprovalCard({
+  approval: a,
+  now,
+  askerNames,
+  isBusy,
+  dimmed,
+  disabled,
+  onDecide,
+}: {
+  approval: ApprovalSummary;
+  now: number;
+  askerNames: Map<string, string>;
+  isBusy: boolean;
+  dimmed: boolean;
+  disabled: boolean;
+  onDecide: (verdict: "approve" | "deny") => void;
+}) {
+  const Icon = KIND_ICONS[a.kind] ?? ShieldCheck;
+  const lines = useMemo(() => payloadLines(a), [a]);
+  const taskId = a.task?.link === "task" ? a.task.id : null;
+  // An id the roster does not know still beats no attribution at all — the
+  // operator can at least tell two askers apart.
+  const asker = a.agent ? (askerNames.get(a.agent) ?? a.agent) : null;
+
+  return (
+    <Card className={cn("transition-opacity", dimmed && "opacity-60")}>
+      <CardContent className="flex flex-col gap-3 py-4">
+        <div className="flex items-start gap-4">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
+            <Icon className="size-5" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="font-medium">{approvalAction(a)}</p>
+            {a.amount_usd != null && (
+              <p className="text-xs font-medium text-muted-foreground">{money(a.amount_usd)}</p>
+            )}
+          </div>
+          <div className="flex shrink-0 gap-2">
+            <Button variant="outline" size="sm" disabled={disabled} onClick={() => onDecide("deny")}>
+              <X className="size-4" /> Decline
+            </Button>
+            <Button size="sm" disabled={disabled} onClick={() => onDecide("approve")}>
+              <Check className="size-4" /> Approve
+            </Button>
+          </div>
+        </div>
+
+        {lines.length > 0 && <PayloadBlock lines={lines} />}
+
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+          {asker && (
+            <>
+              <span>
+                Asked by <span className="font-medium text-foreground">{asker}</span>
+              </span>
+              <span aria-hidden>·</span>
+            </>
+          )}
+          {taskId && (
+            <>
+              <a
+                href={`#/tasks/${encodeURIComponent(taskId)}`}
+                className="flex w-fit items-center gap-1 rounded-full bg-accent px-2 py-0.5 font-medium text-accent-foreground transition-opacity hover:opacity-80"
+              >
+                <SquareKanban className="size-3 shrink-0" />
+                Open the card
+              </a>
+              <span aria-hidden>·</span>
+            </>
+          )}
+          <span>{timeAgo(a.at_millis, now)}</span>
+          {isBusy && (
+            <>
+              <span aria-hidden>·</span>
+              <span>Working on it…</span>
+            </>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * The tool call's own arguments, verbatim (#372).
+ *
+ * Monospace and wrapping rather than truncating: a shell command cut off
+ * mid-flag is exactly as un-decidable as no command at all, and `break-all` is
+ * what keeps a long unbroken path or URL inside the card. Everything here was
+ * redacted and bounded by the host, so `[redacted]` is a value the console
+ * renders — never one it computes.
+ */
+function PayloadBlock({ lines }: { lines: { label: string; value: string }[] }) {
+  const [expanded, setExpanded] = useState(false);
+  const clampable =
+    lines.length > PREVIEW_LINES || lines.some((l) => l.value.length > PREVIEW_VALUE_CHARS);
+  const shown = expanded || !clampable ? lines : lines.slice(0, PREVIEW_LINES);
+
+  return (
+    <div className="rounded-lg border bg-muted/40 px-3 py-2">
+      <div
+        className={cn(
+          "space-y-1 font-mono text-xs break-all whitespace-pre-wrap",
+          clampable && !expanded && "max-h-24 overflow-hidden",
+        )}
+      >
+        {shown.map((line) => (
+          <div key={line.label}>
+            <span className="text-muted-foreground">{line.label}: </span>
+            <span className="text-foreground">{line.value}</span>
+          </div>
+        ))}
+      </div>
+      {clampable && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="mt-1.5 flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {expanded ? <ChevronUp className="size-3" /> : <ChevronDown className="size-3" />}
+          {expanded ? "Show less" : "Show everything"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Agent id → display name, for the "Asked by" line.
+ *
+ * One roster read per company, not one per card: the ids on the queue are
+ * roster ids, and the roster is small and stable. A host without the roster
+ * route 404s, which is caught here — the card then shows the raw id rather than
+ * dropping the attribution, because "which teammate asked" stays useful even
+ * when we cannot pretty-print it.
+ */
+function useAskerNames(
+  client: OpenCompanyClient,
+  company: string | null,
+  approvals: ApprovalSummary[],
+): Map<string, string> {
+  const [names, setNames] = useState<Map<string, string>>(new Map());
+  // Keyed on the set of asker ids rather than on `approvals` itself: the feed
+  // hands us a fresh array on every poll, and depending on the array would
+  // refetch the roster every few seconds for a roster that rarely changes.
+  const askerKey = useMemo(
+    () =>
+      Array.from(new Set(approvals.map((a) => a.agent).filter((id): id is string => !!id)))
+        .sort()
+        .join(","),
+    [approvals],
+  );
+
+  useEffect(() => {
+    if (!askerKey) return;
+    let live = true;
+    void (async () => {
+      const roster = await client.listTeam(company).catch(() => []);
+      if (!live) return;
+      setNames(new Map(roster.map((m) => [m.id, m.name?.trim() || m.role])));
+    })();
+    return () => {
+      live = false;
+    };
+  }, [client, company, askerKey]);
+
+  return names;
 }
 
 function EmptyApprovals({ onGoToConversation }: { onGoToConversation: () => void }) {

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -872,16 +872,23 @@ impl CompanyRuntime {
     }
 
     /// The approvals currently awaiting the operator.
+    ///
+    /// The single projection point for [`ApprovalSummary`], and therefore the
+    /// single place issue #372's `agent` + `payload` are filled in. The payload
+    /// is redacted and bounded **here**, before it is a summary at all, so no
+    /// caller can accidentally serialize the raw effect.
     pub fn pending_approvals(&self) -> Vec<ApprovalSummary> {
         self.journal
             .pending()
             .into_iter()
             .map(|p| ApprovalSummary {
                 id: p.id,
-                kind: p.effect.kind,
+                kind: p.effect.kind.clone(),
                 amount_usd: p.effect.amount_usd,
                 at_millis: p.at_millis,
                 task: p.task,
+                agent: p.effect.agent.clone(),
+                payload: crate::runtime::approval_display::display_payload(&p.effect),
             })
             .collect()
     }

--- a/src/runtime/approval_display.rs
+++ b/src/runtime/approval_display.rs
@@ -1,0 +1,431 @@
+//! Issue #372: projecting a parked [`Effect`]'s payload into something an
+//! operator can read on the approval card — safely, and **host-side**.
+//!
+//! # Why the payload has to be shown at all
+//!
+//! An approval card that says only `Shell` asks the operator to authorise an
+//! action they cannot see. The only rational responses are to approve
+//! everything or refuse everything, and both defeat the gate. The payload of a
+//! harness-projected effect *is* the thing being consented to — it is the
+//! verbatim tool-call argument object
+//! ([`ApprovalPolicy::effect_for`](crate::harness::policy::ApprovalPolicy::effect_for)),
+//! and issue #243 even lets the operator amend it before approving. So the
+//! default here is **show it in full**: a `shell` command and a `glob` pattern
+//! reach the card exactly as the agent wrote them.
+//!
+//! # The redaction rule, stated once
+//!
+//! The denylist below is a *safety net around* that default, not the policy.
+//! An object entry whose key names a credential — by segment or by suffix, on a
+//! normalised form of the key — is replaced by a fixed [`REDACTED`] marker; the
+//! entry itself stays so the shape of the payload is still legible. Everything
+//! else is copied through. Matching is deliberately over-eager (a
+//! `session_id` is redacted; `author` is not, because `authorization` is a
+//! whole segment and `author` is not a suffix of it) — over-redaction is the
+//! safe direction, an unlisted key holding a secret is not.
+//!
+//! Redaction runs at **projection**, in
+//! [`CompanyRuntime::pending_approvals`](crate::company::runtime::CompanyRuntime::pending_approvals),
+//! so a secret never crosses the wire at all. This mirrors the guarantee
+//! `src/harness/steps.rs` keeps for turn steps, and is tested the same way:
+//! [`planted_secret_never_reaches_display_payload`] plants a fake credential at
+//! the top level, nested in an object, and inside an array, and asserts it
+//! appears nowhere in the serialized result.
+//!
+//! # Bounds
+//!
+//! A payload is agent-authored free text and is therefore bounded before it is
+//! handed to a browser: strings are truncated at [`MAX_STRING_CHARS`] (on a
+//! character boundary — never a byte slice), and the walk fails **closed** to
+//! [`UNRENDERABLE`] past [`MAX_DEPTH`] or [`MAX_NODES`] rather than emitting an
+//! unbounded blob.
+
+use serde_json::{Map, Value};
+
+use crate::ports::types::Effect;
+
+/// What replaces a value whose key names a credential.
+pub const REDACTED: &str = "[redacted]";
+
+/// What replaces a subtree too deep or too large to render.
+pub const UNRENDERABLE: &str = "[unrenderable]";
+
+/// Longest string carried to the card, in characters. Anything longer is
+/// truncated and marked with an ellipsis.
+const MAX_STRING_CHARS: usize = 2_000;
+
+/// Deepest nesting walked before failing closed.
+const MAX_DEPTH: usize = 8;
+
+/// Most values walked before failing closed. Bounds breadth the way
+/// [`MAX_DEPTH`] bounds depth — a flat 100k-entry array is as unrenderable as a
+/// deeply nested one.
+const MAX_NODES: usize = 512;
+
+/// Single normalised segments that name a credential. A key is redacted when
+/// any of its segments equals one of these, or ends with one (so `mytoken` and
+/// `x-api-key` are both caught).
+const DENY_SEGMENTS: &[&str] = &[
+    "secret",
+    "secrets",
+    "token",
+    "tokens",
+    "password",
+    "passwords",
+    "passwd",
+    "apikey",
+    "apikeys",
+    "authorization",
+    "bearer",
+    "credential",
+    "credentials",
+    "session",
+    "cookie",
+    "cookies",
+    "signature",
+    "privatekey",
+];
+
+/// Multi-segment phrases that name a credential only when their segments are
+/// adjacent. Kept apart from [`DENY_SEGMENTS`] so `key`, `access` and `client`
+/// stay usable on their own — `key.rotate`'s payload should still be readable.
+const DENY_PHRASES: &[&[&str]] = &[
+    &["api", "key"],
+    &["private", "key"],
+    &["public", "key"],
+    &["secret", "key"],
+    &["access", "key"],
+    &["access", "token"],
+    &["client", "secret"],
+    &["auth", "key"],
+    &["signing", "key"],
+];
+
+/// The operator-facing view of a parked effect's payload, or `None` when there
+/// is nothing to show.
+///
+/// `None` means "this effect carries no arguments" — a null, an empty object,
+/// an empty array or an empty string — and the console renders the card exactly
+/// as it did before this field existed. That is the same shape an **old host**
+/// produces (the field is omitted from the wire entirely), which is what makes
+/// the change additive in both directions.
+pub fn display_payload(effect: &Effect) -> Option<Value> {
+    if is_empty(&effect.payload) {
+        return None;
+    }
+    let mut budget = MAX_NODES;
+    Some(walk(&effect.payload, 0, &mut budget))
+}
+
+/// Whether a payload carries nothing worth putting on a card.
+fn is_empty(value: &Value) -> bool {
+    match value {
+        Value::Null => true,
+        Value::String(s) => s.trim().is_empty(),
+        Value::Object(map) => map.is_empty(),
+        Value::Array(items) => items.is_empty(),
+        _ => false,
+    }
+}
+
+/// Recursively copies `value`, redacting credential-named entries and failing
+/// closed past the depth/node bounds.
+fn walk(value: &Value, depth: usize, budget: &mut usize) -> Value {
+    if depth > MAX_DEPTH || *budget == 0 {
+        return Value::String(UNRENDERABLE.to_string());
+    }
+    *budget -= 1;
+
+    match value {
+        Value::String(s) => Value::String(truncate(s)),
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|item| walk(item, depth + 1, budget))
+                .collect(),
+        ),
+        Value::Object(map) => {
+            let mut out = Map::with_capacity(map.len());
+            for (key, item) in map {
+                if is_sensitive_key(key) {
+                    // The key stays so the payload's shape is still legible;
+                    // only the value is dropped. The walk does NOT descend —
+                    // a redacted subtree could hide the secret one level down.
+                    out.insert(key.clone(), Value::String(REDACTED.to_string()));
+                    continue;
+                }
+                out.insert(key.clone(), walk(item, depth + 1, budget));
+            }
+            Value::Object(out)
+        }
+        // Numbers, booleans and null are copied verbatim: they are bounded by
+        // construction and carry no free text.
+        other => other.clone(),
+    }
+}
+
+/// Truncates on a **character** boundary, reserving room for the ellipsis.
+///
+/// Byte-slicing here would panic mid-codepoint on any payload with non-ASCII
+/// text, which agent-authored arguments routinely carry.
+fn truncate(s: &str) -> String {
+    if s.chars().count() <= MAX_STRING_CHARS {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(MAX_STRING_CHARS).collect();
+    out.push('…');
+    out
+}
+
+/// Whether an object key names a credential.
+///
+/// The key is normalised first — lowercased, camelCase split, every
+/// non-alphanumeric run treated as a separator — so `clientSecret`,
+/// `CLIENT_SECRET`, `client-secret` and `client.secret` all reduce to the same
+/// segments. Then:
+///
+/// * any segment equal to, or ending with, a [`DENY_SEGMENTS`] entry, or
+/// * any adjacent run of segments matching a [`DENY_PHRASES`] entry
+///
+/// redacts. Suffix matching is why `mytoken` is caught; whole-segment matching
+/// is why `author` is not (it is neither equal to nor suffixed by
+/// `authorization`).
+fn is_sensitive_key(key: &str) -> bool {
+    let segments = normalise_key(key);
+    if segments
+        .iter()
+        .any(|seg| DENY_SEGMENTS.iter().any(|deny| seg.ends_with(deny)))
+    {
+        return true;
+    }
+    DENY_PHRASES.iter().any(|phrase| {
+        segments
+            .windows(phrase.len())
+            .any(|window| window.iter().zip(phrase.iter()).all(|(a, b)| a == b))
+    })
+}
+
+/// Splits a key into lowercase alphanumeric segments, breaking on
+/// non-alphanumeric runs **and** on camelCase humps.
+fn normalise_key(key: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut prev_lower_or_digit = false;
+
+    for ch in key.chars() {
+        if !ch.is_alphanumeric() {
+            if !current.is_empty() {
+                segments.push(std::mem::take(&mut current));
+            }
+            prev_lower_or_digit = false;
+            continue;
+        }
+        if ch.is_uppercase() && prev_lower_or_digit && !current.is_empty() {
+            segments.push(std::mem::take(&mut current));
+        }
+        current.extend(ch.to_lowercase());
+        prev_lower_or_digit = ch.is_lowercase() || ch.is_numeric();
+    }
+    if !current.is_empty() {
+        segments.push(current);
+    }
+    segments
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ports::types::EffectGroup;
+
+    /// An obvious fake. Never a real credential shape that could be mistaken
+    /// for one in a log or a diff.
+    const FAKE_SECRET: &str = "NOT-A-REAL-KEY-planted-for-tests";
+
+    fn effect(payload: Value) -> Effect {
+        Effect {
+            kind: "shell".into(),
+            group: EffectGroup::Other,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: false,
+            payload,
+            agent: Some("engineer".into()),
+            run_id: None,
+        }
+    }
+
+    fn rendered(payload: Value) -> String {
+        serde_json::to_string(&display_payload(&effect(payload)).expect("a payload")).unwrap()
+    }
+
+    /// SECURITY: the guarantee this module exists to keep. A planted credential
+    /// at the top level, nested in an object, and inside an array must appear
+    /// in **no** serialized output.
+    #[test]
+    fn planted_secret_never_reaches_display_payload() {
+        let out = rendered(serde_json::json!({
+            "command": "deploy.sh",
+            "api_key": FAKE_SECRET,
+            "env": { "GITHUB_TOKEN": FAKE_SECRET, "HOME": "/workspace" },
+            "headers": [
+                { "Authorization": format!("Bearer {FAKE_SECRET}") },
+                { "name": "accept", "value": "application/json" }
+            ],
+        }));
+
+        assert!(!out.contains(FAKE_SECRET), "secret leaked into: {out}");
+        // The non-sensitive siblings survive — this is a redactor, not a mute.
+        assert!(out.contains("deploy.sh"));
+        assert!(out.contains("application/json"));
+        assert_eq!(out.matches(REDACTED).count(), 3);
+    }
+
+    /// The point of #372: a shell command reaches the card verbatim.
+    #[test]
+    fn shell_command_is_shown_in_full() {
+        let payload = serde_json::json!({
+            "command": "cargo test --locked --features openhuman -- --nocapture",
+        });
+        let out = display_payload(&effect(payload)).unwrap();
+        assert_eq!(
+            out["command"],
+            Value::String("cargo test --locked --features openhuman -- --nocapture".into())
+        );
+    }
+
+    /// ...and so do a glob's pattern and path.
+    #[test]
+    fn glob_pattern_and_path_are_shown_in_full() {
+        let out = display_payload(&effect(
+            serde_json::json!({ "pattern": "**/*.rs", "path": "src/runtime" }),
+        ))
+        .unwrap();
+        assert_eq!(out["pattern"], Value::String("**/*.rs".into()));
+        assert_eq!(out["path"], Value::String("src/runtime".into()));
+    }
+
+    /// The denylist must not eat ordinary words that merely share a prefix.
+    #[test]
+    fn ordinary_keys_survive_the_denylist() {
+        for key in [
+            // `author` is the canonical false positive: a bare-substring rule
+            // over `authorization` would eat it.
+            "author",
+            "authors",
+            "authored_by",
+            "command",
+            "pattern",
+            "path",
+            "keyword",
+            "keys",
+            "accessed_at",
+            "client_name",
+            "amount_usd",
+        ] {
+            assert!(!is_sensitive_key(key), "{key} should not be redacted");
+        }
+    }
+
+    /// ...and must catch every spelling of a credential key we can name.
+    #[test]
+    fn credential_keys_are_redacted_in_every_spelling() {
+        for key in [
+            "api_key",
+            "apiKey",
+            "APIKEY",
+            "x-api-key",
+            "GITHUB_TOKEN",
+            "access_token",
+            "clientSecret",
+            "CLIENT_SECRET",
+            "client.secret",
+            "Authorization",
+            "password",
+            "passwd",
+            "private_key",
+            "credentials",
+            "session",
+            "mytoken",
+            "bearer",
+        ] {
+            assert!(is_sensitive_key(key), "{key} should be redacted");
+        }
+    }
+
+    /// A redacted key is not descended into — a secret one level below a
+    /// credential-named object must not escape through the child walk.
+    #[test]
+    fn a_redacted_subtree_is_not_descended() {
+        let out = rendered(serde_json::json!({
+            "credentials": { "nested": { "deeper": FAKE_SECRET } },
+        }));
+        assert!(!out.contains(FAKE_SECRET));
+        assert!(!out.contains("deeper"));
+    }
+
+    #[test]
+    fn long_strings_are_truncated_on_a_character_boundary() {
+        // Multi-byte throughout: a byte slice here would panic mid-codepoint.
+        let long: String = "é".repeat(MAX_STRING_CHARS + 500);
+        let out = display_payload(&effect(serde_json::json!({ "command": long }))).unwrap();
+        let shown = out["command"].as_str().unwrap();
+        assert_eq!(shown.chars().count(), MAX_STRING_CHARS + 1);
+        assert!(shown.ends_with('…'));
+    }
+
+    #[test]
+    fn a_string_at_the_cap_is_left_alone() {
+        let exact = "x".repeat(MAX_STRING_CHARS);
+        let out =
+            display_payload(&effect(serde_json::json!({ "command": exact.clone() }))).unwrap();
+        assert_eq!(out["command"], Value::String(exact));
+    }
+
+    #[test]
+    fn excessive_depth_fails_closed() {
+        let mut deep = serde_json::json!(FAKE_SECRET);
+        for _ in 0..(MAX_DEPTH + 4) {
+            deep = serde_json::json!({ "next": deep });
+        }
+        let out = serde_json::to_string(&display_payload(&effect(deep)).unwrap()).unwrap();
+        assert!(!out.contains(FAKE_SECRET), "secret escaped the depth bound");
+        assert!(out.contains(UNRENDERABLE));
+    }
+
+    #[test]
+    fn excessive_breadth_fails_closed() {
+        let wide: Vec<Value> = (0..(MAX_NODES + 50))
+            .map(|i| Value::String(format!("item-{i}")))
+            .collect();
+        let out = serde_json::to_string(
+            &display_payload(&effect(serde_json::json!({ "items": wide }))).unwrap(),
+        )
+        .unwrap();
+        assert!(out.contains(UNRENDERABLE));
+    }
+
+    #[test]
+    fn empty_payloads_render_nothing() {
+        for payload in [
+            Value::Null,
+            serde_json::json!({}),
+            serde_json::json!([]),
+            serde_json::json!("   "),
+        ] {
+            assert!(display_payload(&effect(payload)).is_none());
+        }
+    }
+
+    /// Scalars are copied verbatim — the amount an operator is approving is
+    /// exactly the number the agent asked for.
+    #[test]
+    fn scalars_are_copied_verbatim() {
+        let out = display_payload(&effect(
+            serde_json::json!({ "amount_usd": 42.5, "dry_run": false, "note": null }),
+        ))
+        .unwrap();
+        assert_eq!(out["amount_usd"], serde_json::json!(42.5));
+        assert_eq!(out["dry_run"], Value::Bool(false));
+        assert_eq!(out["note"], Value::Null);
+    }
+}

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -2006,6 +2006,109 @@ mod test {
         assert!(!rt.journal.is_executed(&format!("approval:{id}")));
     }
 
+    // --- What the card says (issue #372) ------------------------------------
+
+    /// A harness-projected park reaches the operator naming its asker and what
+    /// it will actually do — the whole point of #372, where the card used to say
+    /// only "Shell".
+    #[tokio::test]
+    async fn a_harness_park_projects_its_agent_and_payload() {
+        const FAKE_SECRET: &str = "NOT-A-REAL-KEY-planted-for-tests";
+        let home_dir = tmp_home();
+        let (rt, _id) = park_one(
+            home_dir.path().to_path_buf(),
+            harness_effect(
+                "engineer",
+                "shell",
+                serde_json::json!({
+                    "command": "./deploy.sh --staging",
+                    "env": { "API_KEY": FAKE_SECRET },
+                }),
+            ),
+        )
+        .await;
+
+        let pending = rt.pending_approvals();
+        assert_eq!(pending.len(), 1);
+        let summary = &pending[0];
+        assert_eq!(summary.agent.as_deref(), Some("engineer"));
+
+        let payload = summary.payload.as_ref().expect("the arguments are carried");
+        // The command is verbatim: it IS the thing being consented to.
+        assert_eq!(payload["command"], "./deploy.sh --staging");
+        // ...and the planted credential never leaves the host.
+        let wire = serde_json::to_string(summary).unwrap();
+        assert!(
+            !wire.contains(FAKE_SECRET),
+            "secret reached the wire: {wire}"
+        );
+        assert!(wire.contains(crate::runtime::approval_display::REDACTED));
+    }
+
+    /// A **native** effect the runtime performs itself names no asker, and an
+    /// argument-less one carries no payload — so the card renders exactly as it
+    /// did before #372 rather than inventing an agent. This is also the shape a
+    /// journal-replayed pre-#243 park takes.
+    #[tokio::test]
+    async fn a_native_park_projects_no_agent_and_no_payload() {
+        let home_dir = tmp_home();
+        let (rt, _id) = park_one(
+            home_dir.path().to_path_buf(),
+            Effect {
+                kind: "filing.submit".into(),
+                group: EffectGroup::Sign,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: serde_json::Value::Null,
+                agent: None,
+                run_id: None,
+            },
+        )
+        .await;
+
+        let pending = rt.pending_approvals();
+        assert_eq!(pending.len(), 1);
+        assert!(pending[0].agent.is_none());
+        assert!(pending[0].payload.is_none());
+    }
+
+    /// The wire stays **additive**: absent fields are omitted entirely, so the
+    /// JSON an old console receives is byte-identical to the pre-#372 shape and
+    /// its unknown-key tolerance is never exercised.
+    #[tokio::test]
+    async fn absent_display_fields_are_omitted_from_the_wire() {
+        let home_dir = tmp_home();
+        let (rt, _id) = park_one(
+            home_dir.path().to_path_buf(),
+            Effect {
+                kind: "filing.submit".into(),
+                group: EffectGroup::Sign,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: serde_json::Value::Null,
+                agent: None,
+                run_id: None,
+            },
+        )
+        .await;
+
+        let wire: serde_json::Value =
+            serde_json::to_value(&rt.pending_approvals()[0]).expect("serializes");
+        let keys: Vec<&str> = wire
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(|k| k.as_str())
+            .collect();
+        assert!(!keys.contains(&"agent"), "agent leaked as null: {keys:?}");
+        assert!(
+            !keys.contains(&"payload"),
+            "payload leaked as null: {keys:?}"
+        );
+    }
+
     /// Approve-with-edit mints against the **amended** arguments.
     ///
     /// Granting the original would let the agent re-issue the very call the

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -12,6 +12,11 @@
 //!   trigger nodes (issue #169). Both share the [`cron`] matcher and [`Clock`].
 //! - The [`journal`] backs at-most-once effects and the durable approval queue.
 
+/// Issue #372: the host-side projection of a parked effect's payload onto the
+/// approval card — shown in full by default, with a credential-key denylist as
+/// the safety net, and bounded so an agent-authored blob cannot reach a
+/// browser unbounded. See [`approval_display`].
+pub mod approval_display;
 /// Brain-agnostic resolution of a task card's `assignee` against the full
 /// roster — teammates, overlay teammates and desks (issue #205). Shared by the
 /// harness dispatch path and the REST write boundary so the board's assignee

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -100,4 +100,27 @@ pub struct ApprovalSummary {
     /// pre-#333 approval serializes as it always did.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub task: Option<TaskLink>,
+    /// The roster teammate whose blocked tool call this approval was parked for
+    /// (issue #372), mirroring [`Effect::agent`](crate::ports::types::Effect::agent).
+    ///
+    /// `Some(id)` is exactly "projected from a harness tool call" — the console
+    /// renders "Asked by <name>". `None` is a *native* effect the runtime
+    /// performs itself, or a park journaled before #243 stamped the field, and
+    /// the card names no asker rather than inventing one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    /// What the effect will actually do, as an operator-readable copy of its
+    /// payload (issue #372) — the tool-call arguments for a harness effect.
+    ///
+    /// Redacted and bounded host-side by
+    /// [`display_payload`](crate::runtime::approval_display::display_payload),
+    /// so no credential crosses the wire and no unbounded blob reaches a
+    /// browser. `None` when the effect carries no arguments.
+    ///
+    /// Both new fields are omitted when absent, which is what keeps the wire
+    /// additive: an old console ignores the unknown keys, and a new console
+    /// treats their absence as "old host" and renders the card exactly as it
+    /// did before.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload: Option<serde_json::Value>,
 }


### PR DESCRIPTION
## Summary

An approval card now says **what** is being approved, **who** asked, and **what for** — and deciding one approval no longer disables the others.

Observed on a staging tenant: two cards were parked, reading in full **"Glob"** and **"Shell"**. That is the entire description an operator got before authorising a tool call. The only rational responses are approve-everything or refuse-everything, and both defeat the gate.

## API Or Behavior Changes

**Wire (additive).** `ApprovalSummary` gains two fields, both `skip_serializing_if = "Option::is_none"`:

| Field | Meaning |
|---|---|
| `agent` | the roster teammate that asked — `Some` only when the effect came from a harness tool call |
| `payload` | the effect's arguments, credential-redacted host-side |

Omitted when absent, so an old console ignores them and this console treats absence as "old host" and renders exactly today's single-line card. Verified by stripping both fields from the wire in flight: no payload block, no asker line, still decidable, zero page errors.

**The information was already on the host.** `PendingApproval` embeds the full `Effect`, whose `payload` is the verbatim tool arguments and whose `agent` is the requester. `pending_approvals()` — the only `ApprovalSummary` construction site in the tree — was dropping both. No new data had to be threaded through the runtime.

**Redaction rule, stated rather than assumed.** A tool-call payload *is* the thing being consented to, and #243 lets the operator amend it before approving, so the default is show-in-full: a shell command and a glob pattern render verbatim. A credential-key denylist is the safety net, not the policy, and it runs **host-side at projection**, so a secret never crosses the wire. Keys are normalised (camelCase split, separators folded) and matched by **whole segment or suffix**, not substring — `api_key`, `GITHUB_TOKEN` and `clientSecret` redact; `author` survives. A redacted subtree is not descended into. Strings truncate on a char boundary; depth and node bounds fail closed to `[unrenderable]`.

**Behaviour.** Both buttons previously gated on the module-wide "any decision in flight" flag while a per-row flag already existed one line above. Approving is not a quick write either — the POST is held open for a full agent re-dispatch cycle under the per-company serial lock. Together those meant one decision locked the whole screen until it returned.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib`
- [x] `cargo check --locked --all-features --all-targets`
- [x] `git diff --stat Cargo.lock` — empty
- [x] `npm ci`, `npm run typecheck`, `npm run build`
- [x] Verified end to end on both the UI and the backend

15 new Rust tests, including the planted-secret case at top level, nested, and inside an array, plus a wire-omission test proving the additive contract.

**Verified against a real park, not a seeded row.** A scratchpad mock OpenAI-compatible endpoint answered every turn with a `shell` tool call carrying a planted **fake** credential. `GET …/approvals` returned the command verbatim with `api_key` and a nested `GITHUB_TOKEN` both `[redacted]` and `NODE_ENV` untouched.

**The two-approval walk was observed, not assumed.** The mock stalled 7s so the in-flight window was real, and the resolve POSTs were instrumented so "still open" is a measurement:

- Approve card 0 → POST opens. Within 1s the feed drops the decided row — the issue's exact symptom.
- From t=1s to t=4s, with that POST still open, the remaining card's Approve **and** Decline stayed enabled.
- At t=4s the remaining card was declined with the first POST still open and **no reload**. Its id was a *new* park minted by the re-dispatched turn — which is the "force the re-dispatched turn to park a second approval" case the issue asks for.
- Both settled, queue drained, no reload at any point.

## Documentation

No spec doc changes. The redaction rule is documented at the function that enforces it, beside its tests, rather than in prose that can drift from the denylist.

## Impact

**The suspected deadlock was investigated and ruled out.** A gated tool call is blocked *inline* — the model is fed a refusal and the turn continues; effects park *after* the turn. So a re-dispatched turn can park a new approval, but parking never holds the cycle open, and the request always settles. The reported "disabled until a hard reload" was a long-held POST times a whole-screen disable, not a wedge. **#373 therefore needs no host change** — the per-row fix alone makes a freshly-parked card immediately decidable, which is the walk above.

**Two departures from the plan, both deliberate:**

The per-row state is a map keyed by verdict rather than a `Set<string>`. The honest copy requirement — "Waiting for the agent…" on approve versus "Recording…" on decline — needs the verdict to survive the wait, which a set cannot carry.

`effectAction` in `frontend/src/lib/language.ts` is now a **dead export**. `approvalSummary` was its only caller and now routes through the new `approvalAction`, which resolves glossary → tool table → agent-aware generic, so the title-cased fallback is unreachable for approvals. It was left in place because the plan called for not disturbing other surfaces or the `EFFECT_LABELS ↔ EFFECT_DONE_LABELS` mirror — flagging it so it reads as a decision rather than an oversight.

**Named scope-outs, not fixed here:** the Task Detail Approvals tab still renders the bare `kind`, and `ApprovalGql` gains no fields. Both compile unchanged; parity is a follow-up. Cosmetic and noted: `ApprovalsView` unmounts on a tab switch so the in-flight map resets while the POST continues — React no-ops the late setState and the toast still fires.

**Room left for #374.** The `agent` field is already the "this teammate" half of a scoped grant, the card's vertical layout reserves the slot for a scope selector, and the redactor is reusable for a standing-grants list. #374 should need an additive field, not a rewrite.

## Related

Closes #372
Closes #373

Builds on #243 (single-use, argument-exact grants) and #333 (approvals linked to their task).
Followed by #374, which adds an operator-chosen grant scope to this same card.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approval cards now show clearer action labels, requester details, task links, timing, and relevant tool arguments.
  * Sensitive information is automatically redacted, and long or complex payloads are safely limited with expandable previews.
  * Multiple approval decisions can be processed independently without disabling the entire approval queue.

* **Bug Fixes**
  * Approval confirmations now clearly distinguish ongoing execution from declined requests.
  * Requester details remain reliable when roster information is delayed or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->