### PR TITLE
fix(chat): deliver live events to the Chat tab, and address the decision line to a real channel (#367, #368)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   FolderClosed,
   LayoutDashboard,
@@ -214,6 +214,16 @@ export function AppShell({
   // out to hydrate each channel and used to throw it away — leaving the shell
   // unable to say which channel an incoming event belongs to (issue #367).
   const [chatChannelByThread, setChatChannelByThread] = useState<Record<string, string>>({});
+  // The chat channel the operator last had on screen. A ref, not state,
+  // because it outlives `ChatView`: it is what an unaddressed system line is
+  // addressed to after the operator has walked off to Approvals (issue #368).
+  const activeChatChannelRef = useRef<string | null>(null);
+  // When each channel was last looked at, and the floor for a channel never
+  // looked at. Together with `transcripts` these *derive* the unread counts
+  // below — nothing increments a counter, so a message that turns out to be a
+  // duplicate cannot leave a badge behind for a line that was never added.
+  const [lastViewedChannel, setLastViewedChannel] = useState<Record<string, number>>({});
+  const [unreadSince, setUnreadSince] = useState(() => Date.now());
   const [threads, setThreads] = useState(defaultThreads);
   const [activeThreadId, setActiveThreadId] = useState("main");
   // A monotonic nonce bumped on every task-lifecycle SSE event, so the
@@ -307,8 +317,12 @@ export function AppShell({
     let cancelled = false;
     // Another company's channel ids are another namespace. Drop this one's
     // addressing up front rather than routing the next company's events into
-    // channels that no longer exist.
+    // channels that no longer exist, and start the unread floor again so the
+    // incoming company's rehydrated history isn't counted as news.
     setChatChannelByThread({});
+    setLastViewedChannel({});
+    setUnreadSince(Date.now());
+    activeChatChannelRef.current = null;
 
     const hydrate = (threadId: string) => {
       client
@@ -400,6 +414,41 @@ export function AppShell({
       cancelled = true;
     };
   }, [client, company]);
+
+  /**
+   * Unread per channel, for the channel rail's badges (issue #367 — the rail
+   * has always rendered them, it was handed a hard-coded empty map).
+   *
+   * Derived from the transcripts rather than counted as messages arrive. A
+   * counter would have to be incremented from inside the injection, which only
+   * finds out whether it actually appended anything inside a state updater —
+   * and an updater that also bumped a second piece of state would be an impure
+   * one, which React is free to run twice. Deriving sidesteps that entirely and
+   * is self-correcting: whatever is in the channel and newer than the last look
+   * at it is unread, by definition.
+   *
+   * Your own lines never count. Neither does anything older than the floor,
+   * which is why a page load's worth of rehydrated history arrives read.
+   */
+  const unread = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const [channelId, messages] of Object.entries(transcripts)) {
+      const since = lastViewedChannel[channelId] ?? unreadSince;
+      const count = messages.filter((m) => m.from !== "you" && m.at > since).length;
+      if (count > 0) counts[channelId] = count;
+    }
+    return counts;
+  }, [transcripts, lastViewedChannel, unreadSince]);
+
+  /**
+   * `ChatView` reporting which channel is on screen — on every switch, and
+   * again as the open channel's transcript grows so a line read as it lands
+   * doesn't leave a badge behind.
+   */
+  const onChannelViewed = useCallback((channelId: string) => {
+    activeChatChannelRef.current = channelId;
+    setLastViewedChannel((v) => ({ ...v, [channelId]: Date.now() }));
+  }, []);
 
   const setThreadMessages = (
     threadId: string,
@@ -662,6 +711,8 @@ export function AppShell({
               onSendStart={onSendStart}
               onSendEnd={onSendEnd}
               liveStepsByThread={liveStepsByThread}
+              unread={unread}
+              onChannelViewed={onChannelViewed}
             />
           )}
           {view === "conversation" && (

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -41,12 +41,18 @@ import { toast } from "sonner";
 
 import { type ChatMessage, fromHistory, makeMessage } from "@/lib/chat";
 import { CONNECTION_PROVIDERS } from "@/lib/connections";
-import { defaultDesks } from "@/lib/desks";
-import { fromDto } from "@/lib/team";
+import { defaultDesks, type Desk } from "@/lib/desks";
+import { fromDto, type TeamMember } from "@/lib/team";
 import { agentDmThreads, defaultThreads, threadsFromDesks } from "@/lib/threads";
 import { Overview } from "@/views/Overview";
 import { ChatView } from "@/views/ChatView";
-import { DEFAULT_CHANNEL, deskFromDto, dmChannelId, type Transcripts } from "@/views/chat/model";
+import {
+  channelIdForThread,
+  DEFAULT_CHANNEL,
+  deskFromDto,
+  dmChannelId,
+  type Transcripts,
+} from "@/views/chat/model";
 import { Conversation } from "@/views/Conversation";
 import { TeamView } from "@/views/TeamView";
 import { ApprovalsView } from "@/views/ApprovalsView";
@@ -159,6 +165,24 @@ function connectErrorMessage(code: string, provider: string | null): string {
   }
 }
 
+/**
+ * Every host thread id this company can be addressed on, mapped to the chat
+ * channel that renders it.
+ *
+ * The shell needs this the moment anything arrives that it did not send: an SSE
+ * frame names a *thread*, `transcripts` is keyed by *channel*, and only the
+ * desk list plus the roster can bridge the two. Built once per company beside
+ * the transcript hydration that already resolves the same pairing.
+ */
+function channelMap(desks: Desk[], members: TeamMember[]): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const threadId of [...desks.map((d) => d.id), ...members.map((m) => m.id)]) {
+    const channelId = channelIdForThread(threadId, desks, members);
+    if (channelId) map[threadId] = channelId;
+  }
+  return map;
+}
+
 interface Props {
   client: OpenCompanyClient;
   company: string | null;
@@ -185,6 +209,11 @@ export function AppShell({
   // mounts and unmounts `ChatView` per route, so component-local state there
   // would be discarded on every trip away from Chat and back.
   const [transcripts, setTranscripts] = useState<Transcripts>({});
+  // Host thread id → chat channel id, for every channel this company has.
+  // Resolved by the desks/roster effect below, which already works the pairing
+  // out to hydrate each channel and used to throw it away — leaving the shell
+  // unable to say which channel an incoming event belongs to (issue #367).
+  const [chatChannelByThread, setChatChannelByThread] = useState<Record<string, string>>({});
   const [threads, setThreads] = useState(defaultThreads);
   const [activeThreadId, setActiveThreadId] = useState("main");
   // A monotonic nonce bumped on every task-lifecycle SSE event, so the
@@ -276,6 +305,10 @@ export function AppShell({
   // the operator's first message on a fresh page load.
   useEffect(() => {
     let cancelled = false;
+    // Another company's channel ids are another namespace. Drop this one's
+    // addressing up front rather than routing the next company's events into
+    // channels that no longer exist.
+    setChatChannelByThread({});
 
     const hydrate = (threadId: string) => {
       client
@@ -347,15 +380,20 @@ export function AppShell({
         resolved.forEach((t) => hydrate(t.id));
 
         const chatDesks = desks.length ? desks.map(deskFromDto) : defaultDesks();
+        const roster = team.map(fromDto);
+        // Keep the addressing this loop resolves, not just its side effect.
+        setChatChannelByThread(channelMap(chatDesks, roster));
         chatDesks.forEach((d) => hydrateChannel(d.id, d.id));
-        team.map(fromDto).forEach((m) => hydrateChannel(dmChannelId(m), m.id));
+        roster.forEach((m) => hydrateChannel(dmChannelId(m), m.id));
       })
       .catch(() => {
         // Host without `/desks`, or offline — keep the static default
         // threads, but the operator/General line still deserves a
         // rehydration attempt (it's the one every deployment has).
+        const fallbackDesks = defaultDesks();
         defaultThreads().forEach((t) => hydrate(t.id));
-        defaultDesks().forEach((d) => hydrateChannel(d.id, d.id));
+        setChatChannelByThread(channelMap(fallbackDesks, []));
+        fallbackDesks.forEach((d) => hydrateChannel(d.id, d.id));
       });
 
     return () => {
@@ -392,35 +430,74 @@ export function AppShell({
   // identical company line already present in the thread's recent tail. Only
   // desks that exist as a thread receive an injection; an unmatched chatId is a
   // no-op rather than polluting the wrong thread.
-  const injectAgentReply = useCallback((event: AgentReplyEvent) => {
-    // The operator's own chat turn is delivered synchronously by the awaited
-    // POST (and that copy carries the steps timeline). The backend ALSO journals
-    // an `AgentReply` for it, which arrives over SSE — first, mid-await — so a
-    // blind inject here would double the bubble. Suppress the echo for any
-    // thread with a POST in flight; the POST reply is authoritative. The
-    // recent-tail content check below still guards a late echo that lands just
-    // after the POST resolved.
-    if (pendingPostThreadsRef.current.has(event.chatId)) return;
-    setThreads((ts) =>
-      ts.map((t) => {
-        if (t.id !== event.chatId) return t;
-        const dup = t.messages
+  const injectAgentReply = useCallback(
+    (event: AgentReplyEvent) => {
+      // The operator's own chat turn is delivered synchronously by the awaited
+      // POST (and that copy carries the steps timeline). The backend ALSO journals
+      // an `AgentReply` for it, which arrives over SSE — first, mid-await — so a
+      // blind inject here would double the bubble. Suppress the echo for any
+      // thread with a POST in flight; the POST reply is authoritative. The
+      // recent-tail content check below still guards a late echo that lands just
+      // after the POST resolved.
+      if (pendingPostThreadsRef.current.has(event.chatId)) return;
+      setThreads((ts) =>
+        ts.map((t) => {
+          if (t.id !== event.chatId) return t;
+          const dup = t.messages
+            .slice(-8)
+            .some((m) => m.from === "company" && m.text === event.text);
+          if (dup) return t;
+          return {
+            ...t,
+            messages: [
+              ...t.messages,
+              makeMessage("company", event.text, {
+                channel: event.agentId,
+                taskId: event.taskId,
+              }),
+            ],
+          };
+        }),
+      );
+
+      // …and into the Chat workspace's transcripts, which is a *different*
+      // store (issue #367). Chat became the nav-listed surface in #361 while
+      // this injection kept writing only to the parked Conversation's threads,
+      // so anything the console did not POST for — an inbound Telegram turn, a
+      // background desk turn — reached Chat only on a page reload.
+      //
+      // The event names a thread; `chatChannelByThread` is the only thing that
+      // knows which channel renders it. An id no channel owns is a no-op, the
+      // same as the thread store above: better silent than in the wrong place.
+      const channelId = chatChannelByThread[event.chatId];
+      if (!channelId) return;
+      setTranscripts((t) => {
+        const existing = t[channelId] ?? [];
+        // The same recent-tail content dedupe the thread store uses, and for
+        // the same reason: local ids are ephemeral counters and rehydrated ones
+        // are `h`-prefixed, so neither side of the race can be matched by id.
+        // The cost is that two genuinely identical company lines inside eight
+        // messages collapse into one — a price the thread store already pays.
+        const dup = existing
           .slice(-8)
           .some((m) => m.from === "company" && m.text === event.text);
         if (dup) return t;
         return {
           ...t,
-          messages: [
-            ...t.messages,
+          [channelId]: [
+            ...existing,
             makeMessage("company", event.text, {
               channel: event.agentId,
               taskId: event.taskId,
             }),
           ],
         };
-      }),
-    );
-  }, []);
+      });
+    },
+    // `useEvents` holds its callbacks in refs, so this identity churning as the
+    // map lands cannot re-open the SSE stream.
+    [chatChannelByThread],
+  );
 
   // Mark/unmark a thread's in-flight POST. `onSendStart` also resets its live
   // timeline so a fresh turn starts clean; `onSendEnd` clears it because the
@@ -573,6 +650,8 @@ export function AppShell({
               onReply={() => void feed.refresh()}
               transcripts={transcripts}
               setTranscripts={setTranscripts}
+              onSendStart={onSendStart}
+              onSendEnd={onSendEnd}
             />
           )}
           {view === "conversation" && (

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -493,6 +493,15 @@ export function AppShell({
           ],
         };
       });
+
+      // The reply is the end of that turn, so its live tool rows have served
+      // their purpose — the folded steps on the reply are the durable record.
+      // `onSendEnd` does this for a turn this console POSTed; a turn it did not
+      // has no send to end, and without this its rows would sit under the
+      // channel until the next turn on the same thread replaced them.
+      setLiveStepsByThread((prev) =>
+        prev[event.chatId]?.length ? { ...prev, [event.chatId]: [] } : prev,
+      );
     },
     // `useEvents` holds its callbacks in refs, so this identity churning as the
     // map lands cannot re-open the SSE stream.
@@ -652,6 +661,7 @@ export function AppShell({
               setTranscripts={setTranscripts}
               onSendStart={onSendStart}
               onSendEnd={onSendEnd}
+              liveStepsByThread={liveStepsByThread}
             />
           )}
           {view === "conversation" && (

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -48,7 +48,6 @@ import { Overview } from "@/views/Overview";
 import { ChatView } from "@/views/ChatView";
 import {
   channelIdForThread,
-  DEFAULT_CHANNEL,
   deskFromDto,
   dmChannelId,
   type Transcripts,
@@ -214,6 +213,10 @@ export function AppShell({
   // out to hydrate each channel and used to throw it away — leaving the shell
   // unable to say which channel an incoming event belongs to (issue #367).
   const [chatChannelByThread, setChatChannelByThread] = useState<Record<string, string>>({});
+  // This company's first desk channel — the same channel `ChatView` lands on
+  // when the hash names none, and so where a line with nowhere else to go is
+  // still somewhere the operator will find it.
+  const [firstDeskChannelId, setFirstDeskChannelId] = useState<string | null>(null);
   // The chat channel the operator last had on screen. A ref, not state,
   // because it outlives `ChatView`: it is what an unaddressed system line is
   // addressed to after the operator has walked off to Approvals (issue #368).
@@ -320,6 +323,7 @@ export function AppShell({
     // channels that no longer exist, and start the unread floor again so the
     // incoming company's rehydrated history isn't counted as news.
     setChatChannelByThread({});
+    setFirstDeskChannelId(null);
     setLastViewedChannel({});
     setUnreadSince(Date.now());
     activeChatChannelRef.current = null;
@@ -397,6 +401,7 @@ export function AppShell({
         const roster = team.map(fromDto);
         // Keep the addressing this loop resolves, not just its side effect.
         setChatChannelByThread(channelMap(chatDesks, roster));
+        setFirstDeskChannelId(chatDesks[0]?.id ?? null);
         chatDesks.forEach((d) => hydrateChannel(d.id, d.id));
         roster.forEach((m) => hydrateChannel(dmChannelId(m), m.id));
       })
@@ -407,6 +412,7 @@ export function AppShell({
         const fallbackDesks = defaultDesks();
         defaultThreads().forEach((t) => hydrate(t.id));
         setChatChannelByThread(channelMap(fallbackDesks, []));
+        setFirstDeskChannelId(fallbackDesks[0]?.id ?? null);
         fallbackDesks.forEach((d) => hydrateChannel(d.id, d.id));
       });
 
@@ -458,16 +464,37 @@ export function AppShell({
       ts.map((t) => (t.id === threadId ? { ...t, messages: updater(t.messages) } : t)),
     );
 
-  // Approval decisions and other events land in a transcript rather than
-  // vanishing. Both chat surfaces get the line: Chat's `main` channel gets it
-  // appended directly (the shell owns `transcripts`, not `ChatView`, so this
-  // survives `ChatView` unmounting), and the parked Conversation appends to
-  // its active thread.
+  /**
+   * Approval decisions and other unaddressed lines land in a transcript rather
+   * than vanishing. Both chat surfaces get the line: Chat appends it to a
+   * channel, and the parked Conversation to its active thread. The shell owns
+   * `transcripts`, not `ChatView`, so the write survives that view unmounting —
+   * which it always has, because these lines are written from Approvals.
+   *
+   * The channel is resolved, not assumed (issue #368). This used to append to
+   * the literal `"main"`, which is the id of the first *fallback* desk and of
+   * nothing else: a company with its own desks has channel ids taken verbatim
+   * from its manifest, so every decision line — the failures included, which is
+   * the half that matters — was filed under a key no channel renders.
+   *
+   * In order: the channel the operator last had open, which survives the walk
+   * over to Approvals and is where they will look first; else this company's
+   * first desk channel, the same first-match `ChatView` lands on when the hash
+   * names none (issue #366); else there is genuinely no channel to write to, so
+   * the line stays out of `transcripts` and the toast `ApprovalsView` raises
+   * alongside this call is what surfaces the decision. Never a dead bucket.
+   *
+   * Either way the channel it lands in shows an unread badge until the operator
+   * opens it, so the line says where it went rather than waiting to be found.
+   */
   const noteSystem = (line: string) => {
-    setTranscripts((t) => ({
-      ...t,
-      [DEFAULT_CHANNEL]: [...(t[DEFAULT_CHANNEL] ?? []), makeMessage("system", line)],
-    }));
+    const target = activeChatChannelRef.current ?? firstDeskChannelId;
+    if (target) {
+      setTranscripts((t) => ({
+        ...t,
+        [target]: [...(t[target] ?? []), makeMessage("system", line)],
+      }));
+    }
     setThreadMessages(activeThreadId, (m) => [...m, makeMessage("system", line)]);
   };
 

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -46,6 +46,15 @@ interface Props {
    */
   transcripts: Transcripts;
   setTranscripts: Dispatch<SetStateAction<Transcripts>>;
+  /**
+   * Called around the awaited chat POST with the **host thread id** it was sent
+   * on, so the shell can suppress the SSE echo of our own turn while it is in
+   * flight. Without this bracket the shell's live injection and the awaited
+   * reply below both render and the bubble doubles — the exact duplicate-bubble
+   * race the Conversation surface already brackets against.
+   */
+  onSendStart?: (threadId: string) => void;
+  onSendEnd?: (threadId: string) => void;
 }
 
 /**
@@ -69,6 +78,8 @@ export function ChatView({
   onReply,
   transcripts,
   setTranscripts,
+  onSendStart,
+  onSendEnd,
 }: Props) {
   const [members, setMembers] = useState<TeamMember[]>([]);
   const [loadingTeam, setLoadingTeam] = useState(true);
@@ -227,6 +238,14 @@ export function ChatView({
   // A local the closures below can capture as non-null: TypeScript hoists
   // function declarations, so the guard above does not narrow inside them.
   const active = channel;
+  // The host thread this channel is addressed on. A real desk channel's id
+  // doubles as its thread id (`deskFromDto`), so addressing by it routes to
+  // that desk's lead. A DM's id is console-local (`dmChannelId`), not a host
+  // thread — but `chat` also accepts a roster teammate id directly
+  // (`responder_for` in `src/harness/brain.rs`), which is exactly what a DM's
+  // `member.id` is, so a DM addresses that teammate the same way a desk
+  // addresses its lead. It is also the id every live turn frame carries.
+  const activeThreadId = active.kind === "channel" ? active.id : active.member?.id;
 
   const append = (channelId: string, ...added: ChatMessage[]) =>
     setTranscripts((t) => ({ ...t, [channelId]: [...(t[channelId] ?? []), ...added] }));
@@ -238,17 +257,15 @@ export function ChatView({
   async function send(text: string, parentId?: string) {
     if (sending) return;
     const target = active.id;
+    const chatId = activeThreadId;
     append(target, makeMessage("you", text, { parentId }));
     setSending(true);
+    // Claim the thread for the duration of the POST. The backend journals an
+    // `AgentReply` for our own turn too and pushes it over SSE mid-await, so
+    // without this the shell injects that echo *and* the awaited reply lands
+    // below — two bubbles for one turn.
+    if (chatId) onSendStart?.(chatId);
     try {
-      // A real desk channel's id doubles as its thread id (`deskFromDto`), so
-      // addressing by it routes to that desk's lead. A DM's id is
-      // console-local (`dmChannelId`), not a host thread — but `chat` also
-      // accepts a roster teammate id directly (`responder_for` in
-      // `src/harness/brain.rs`), which is exactly what a DM's `member.id`
-      // is, so a DM addresses that teammate the same way a desk addresses
-      // its lead.
-      const chatId = active.kind === "channel" ? active.id : active.member?.id;
       const reply = await client.chat(text, company, chatId);
       const replies = reply.responses.length
         ? reply.responses.map((r) =>
@@ -261,6 +278,7 @@ export function ChatView({
       const msg = err instanceof ApiError ? err.message : "something went wrong";
       append(target, makeMessage("system", `Couldn't send — ${msg}`, { parentId }));
     } finally {
+      if (chatId) onSendEnd?.(chatId);
       setSending(false);
     }
   }

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -62,6 +62,15 @@ interface Props {
    * started, which is most of what issue #367 is about.
    */
   liveStepsByThread?: Record<string, TurnStep[]>;
+  /** Channel id → unread count, for the rail's badges. Owned by the shell. */
+  unread?: Record<string, number>;
+  /**
+   * Reports the channel actually on screen — which the hash need not name,
+   * since it may have been resolved by the first-channel fallback. The shell
+   * clears that channel's unread count and remembers it as where an
+   * unaddressed line belongs after this view is gone (issue #368).
+   */
+  onChannelViewed?: (channelId: string) => void;
 }
 
 /**
@@ -88,6 +97,8 @@ export function ChatView({
   onSendStart,
   onSendEnd,
   liveStepsByThread,
+  unread,
+  onChannelViewed,
 }: Props) {
   const [members, setMembers] = useState<TeamMember[]>([]);
   const [loadingTeam, setLoadingTeam] = useState(true);
@@ -241,6 +252,14 @@ export function ChatView({
   useEffect(() => {
     setOpenThreadId(null);
   }, [channel?.id]);
+
+  // Whoever owns the unread counts needs to know what is actually being looked
+  // at. Re-runs as the open channel's transcript grows, not only on a switch:
+  // a reply that lands while you are reading the channel is read, and should
+  // not leave a badge on the channel you are sitting in.
+  useEffect(() => {
+    if (channel) onChannelViewed?.(channel.id);
+  }, [channel?.id, messages.length, onChannelViewed]);
 
   if (!channel) return null;
   // A local the closures below can capture as non-null: TypeScript hoists
@@ -416,11 +435,7 @@ export function ChatView({
       <ChannelRail
         sections={sections}
         activeId={channel.id}
-        // Nothing arrives in a channel you are not looking at yet — every
-        // reply answers a line you just sent. The rail renders unread counts
-        // already, so this is the one seam to fill when the host starts
-        // pushing messages of its own.
-        unread={{}}
+        unread={unread ?? {}}
         onSelect={selectChannel}
         className={cn("md:flex", mobilePane === "rail" ? "flex" : "hidden")}
       />

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -4,7 +4,7 @@ import { toast } from "sonner";
 import { listPeople, me as fetchMe, type Person } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
 import { setInboxEnabled } from "@/api/inbox";
-import { ApiError, type TeamMemberDto } from "@/api/types";
+import { ApiError, type TeamMemberDto, type TurnStep } from "@/api/types";
 import { type ChatMessage, makeMessage } from "@/lib/chat";
 import { defaultDesks, type Desk } from "@/lib/desks";
 import { fromDto, newMember, starterTeam, type TeamMember } from "@/lib/team";
@@ -55,6 +55,13 @@ interface Props {
    */
   onSendStart?: (threadId: string) => void;
   onSendEnd?: (threadId: string) => void;
+  /**
+   * The in-flight tool timeline the shell folds out of the live turn frames,
+   * keyed by **host thread id** — so this view has to resolve its channel to a
+   * thread to read it (see `activeThreadId`). Covers turns this console never
+   * started, which is most of what issue #367 is about.
+   */
+  liveStepsByThread?: Record<string, TurnStep[]>;
 }
 
 /**
@@ -80,6 +87,7 @@ export function ChatView({
   setTranscripts,
   onSendStart,
   onSendEnd,
+  liveStepsByThread,
 }: Props) {
   const [members, setMembers] = useState<TeamMember[]>([]);
   const [loadingTeam, setLoadingTeam] = useState(true);
@@ -246,6 +254,7 @@ export function ChatView({
   // `member.id` is, so a DM addresses that teammate the same way a desk
   // addresses its lead. It is also the id every live turn frame carries.
   const activeThreadId = active.kind === "channel" ? active.id : active.member?.id;
+  const liveSteps = activeThreadId ? liveStepsByThread?.[activeThreadId] : undefined;
 
   const append = (channelId: string, ...added: ChatMessage[]) =>
     setTranscripts((t) => ({ ...t, [channelId]: [...(t[channelId] ?? []), ...added] }));
@@ -437,6 +446,7 @@ export function ChatView({
               entries={entries}
               openThreadId={openThreadId}
               typing={sending && !openThreadId}
+              liveSteps={openThreadId ? undefined : liveSteps}
               onOpenThread={setOpenThreadId}
               onReact={react}
             />

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -21,7 +21,6 @@ import {
   buildChannels,
   buildTimeline,
   channelTitle,
-  DEFAULT_CHANNEL,
   deskFromDto,
   dmChannelId,
   findChannel,
@@ -204,10 +203,13 @@ export function ChatView({
   }, [client, company]);
 
   const sections = useMemo(() => buildChannels(members, desks), [members, desks]);
-  const channel =
-    findChannel(sections, sub) ??
-    findChannel(sections, DEFAULT_CHANNEL) ??
-    firstChannel(sections);
+  // The hash's channel, else the first one that exists. There used to be a
+  // literal "main" between the two — an id only the *fallback* desks carry, so
+  // it matched nothing once a company's real desks loaded and matched the same
+  // channel `firstChannel` returns when they hadn't. It never selected anything
+  // the line below wouldn't; it only made "main" look like a real channel id
+  // (issue #368).
+  const channel = findChannel(sections, sub) ?? firstChannel(sections);
 
   const messages = channel ? (transcripts[channel.id] ?? []) : [];
   const entries = useMemo(

--- a/frontend/src/views/chat/ChannelRail.tsx
+++ b/frontend/src/views/chat/ChannelRail.tsx
@@ -146,7 +146,10 @@ function ChannelRow({
       <ChannelIcon channel={channel} />
       <span className="min-w-0 flex-1 truncate">{channel.name}</span>
       {hasUnread && (
-        <span className="shrink-0 rounded-full bg-primary px-1.5 text-[10px] font-semibold leading-4 text-primary-foreground">
+        <span
+          data-testid="channel-unread"
+          className="shrink-0 rounded-full bg-primary px-1.5 text-[10px] font-semibold leading-4 text-primary-foreground"
+        >
           {unread > 99 ? "99+" : unread}
         </span>
       )}

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef } from "react";
 
+import type { TurnStep } from "@/api/types";
 import { cn } from "@/lib/utils";
 import { Avatar } from "./Avatar";
 import { MessageRow } from "./MessageRow";
+import { StepTimeline } from "./StepTimeline";
 import { channelTitle, type Channel, type TimelineEntry } from "./model";
 
 interface Props {
@@ -12,6 +14,13 @@ interface Props {
   openThreadId: string | null;
   /** Someone on the company side is composing a reply. */
   typing: boolean;
+  /**
+   * The tool rows of a turn running *right now* on this channel's thread, off
+   * the transient `tool_call` / `tool_result` / `thinking` frames. Present
+   * whether or not this console started the turn, which is the point — a turn
+   * an inbound message kicked off shows its work here too (issue #367).
+   */
+  liveSteps?: TurnStep[];
   onOpenThread: (messageId: string) => void;
   onReact: (messageId: string, emoji: string) => void;
 }
@@ -29,16 +38,20 @@ export function MessageTimeline({
   entries,
   openThreadId,
   typing,
+  liveSteps,
   onOpenThread,
   onReact,
 }: Props) {
   const scroller = useRef<HTMLDivElement>(null);
+  const liveStepCount = liveSteps?.length ?? 0;
 
   useEffect(() => {
     const el = scroller.current;
     if (!el) return;
     el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
-  }, [entries.length, typing]);
+    // Each new tool row grows the block at the bottom, so the scroll has to
+    // follow it as the turn works, not only when the reply lands.
+  }, [entries.length, typing, liveStepCount]);
 
   return (
     <div ref={scroller} className="flex-1 overflow-y-auto">
@@ -55,7 +68,11 @@ export function MessageTimeline({
             />
           </div>
         ))}
-        {typing && <TypingRow channel={channel} />}
+        {liveStepCount > 0 ? (
+          <LiveTurnRow channel={channel} steps={liveSteps ?? []} />
+        ) : (
+          typing && <TypingRow channel={channel} />
+        )}
       </div>
     </div>
   );
@@ -94,6 +111,30 @@ function ChannelIntro({ channel, empty }: { channel: Channel; empty: boolean }) 
           ? `This is the start of your direct message with ${channel.name} — ${lower(channel.purpose)}.`
           : `This is the very beginning of ${channelTitle(channel)}. ${sentence(channel.purpose)}`}
       </p>
+    </div>
+  );
+}
+
+/**
+ * What the company is doing right now, in place of the typing dots.
+ *
+ * Same avatar gutter as a message row so the work reads as coming from the
+ * voice that will answer, and the same {@link StepTimeline} the finished reply
+ * renders — so the rows do not re-draw differently the instant the turn ends.
+ */
+function LiveTurnRow({ channel, steps }: { channel: Channel; steps: TurnStep[] }) {
+  return (
+    <div className="flex items-start gap-2.5 px-4 py-1">
+      <Avatar
+        name={channel.voice ?? channel.name}
+        tone={channel.tone}
+        company={channel.kind === "channel" && channel.id === "main"}
+        className="size-9 shrink-0"
+      />
+      <div className="min-w-0 flex-1">
+        <StepTimeline steps={steps} defaultOpen />
+        <span className="sr-only">Working…</span>
+      </div>
     </div>
   );
 }

--- a/frontend/src/views/chat/StepTimeline.tsx
+++ b/frontend/src/views/chat/StepTimeline.tsx
@@ -11,11 +11,23 @@ import { cn } from "@/lib/utils";
  * buried. Renders nothing when there are no steps (a memory-served / tool-less
  * reply). Ported from the retired Conversation page (issue #246) so the chat
  * workspace keeps the same tool-call visibility it had.
+ *
+ * `defaultOpen` is for the *live* timeline of a turn still running (issue
+ * #367): there the rows are the content — they are what says the company is
+ * working and on what — so they start open rather than behind a count. A
+ * finished reply's steps stay collapsed, where they are supporting detail.
+ * Either way the operator's own toggle wins from the first click.
  */
-export function StepTimeline({ steps }: { steps: TurnStep[] }) {
+export function StepTimeline({
+  steps,
+  defaultOpen = false,
+}: {
+  steps: TurnStep[];
+  defaultOpen?: boolean;
+}) {
   const failed = steps.filter((s) => s.status === "error").length;
   const hasError = failed > 0;
-  const [open, setOpen] = useState(hasError);
+  const [open, setOpen] = useState(defaultOpen || hasError);
 
   if (steps.length === 0) return null;
 

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -122,6 +122,31 @@ function nameHash(name: string): string {
   return (hash >>> 0).toString(36);
 }
 
+/**
+ * The chat channel a **host thread id** belongs to, or `null` when this
+ * company has no channel that owns it.
+ *
+ * This is the one subtle rule in the chat's addressing, kept in one place so a
+ * caller cannot get it wrong twice. A desk's channel id *is* its thread id —
+ * {@link deskFromDto} leaves `DeskDto.id` untouched precisely so addressing the
+ * channel routes to that desk. A DM's is not: its channel id is the
+ * console-local {@link dmChannelId}, while the thread id the host journals
+ * under (and `chat` / `chat/history` take) is the roster teammate's agent id.
+ *
+ * Anything routing a host-side event — which always names a *thread* — into
+ * {@link Transcripts} has to make that distinction. Issue #367 is what the
+ * console looks like when it doesn't.
+ */
+export function channelIdForThread(
+  threadId: string,
+  desks: Desk[],
+  members: TeamMember[],
+): string | null {
+  if (desks.some((d) => d.id === threadId)) return threadId;
+  const member = members.find((m) => m.id === threadId);
+  return member ? dmChannelId(member) : null;
+}
+
 export function findChannel(sections: ChannelSection[], id: string | null): Channel | null {
   if (!id) return null;
   for (const s of sections) {

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -25,9 +25,6 @@ export function deskFromDto(d: DeskDto): Desk {
  */
 export type Transcripts = Record<string, ChatMessage[]>;
 
-/** The channel a fresh session lands on, and where an unaddressed system line goes. */
-export const DEFAULT_CHANNEL = "main";
-
 export type ChannelKind = "channel" | "dm";
 
 export interface Channel {
@@ -158,11 +155,12 @@ export function findChannel(sections: ChannelSection[], id: string | null): Chan
 
 /**
  * The first channel across all sections, or `null` when there are none.
- * Used as the last-resort selection so the chat never renders blank while any
- * channel exists — the hard-coded {@link DEFAULT_CHANNEL} ("main") only exists
- * in the fallback desks, so once a company's real desks load (ids drawn from
- * the roster, never "main") it no longer matches and the view would otherwise
- * bail to null.
+ *
+ * The last-resort selection, so the chat never renders blank while any channel
+ * exists (issue #366), and the address of last resort for a line with no
+ * channel of its own (issue #368). Both used to reach for a literal `"main"`
+ * instead — an id carried only by the first *fallback* desk, so it matched
+ * nothing at all on a company with desks of its own.
  */
 export function firstChannel(sections: ChannelSection[]): Channel | null {
   for (const s of sections) {

--- a/frontend/test/e2e/chat-approval-line.spec.ts
+++ b/frontend/test/e2e/chat-approval-line.spec.ts
@@ -1,0 +1,150 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+/**
+ * End-to-end proof for issue #368 — the line recording an approval decision is
+ * written somewhere the operator can actually see it.
+ *
+ * It used to be appended to the literal `"main"`, which is the id of the first
+ * *fallback* desk and of no channel on a company that defines its own. The
+ * harness company defines `engineering` and `content` and nothing called
+ * `main`, so both halves of the decision landed in a transcript bucket no
+ * channel renders — the failure copy included, which is the half that matters:
+ * a sign-off that did not go through looked exactly like one that did.
+ *
+ * The approvals themselves are mocked, and deliberately so. Parking a real one
+ * needs a model that decides to make a costly call, and this is a test about
+ * where the console *files the answer*, not about what the company asks for.
+ * The decision POST is mocked for the same reason on the failure path: a host
+ * that refuses the write is the case that has to stay visible, and it cannot be
+ * provoked on demand.
+ *
+ * Needs a running host and is not a CI gate, like the rest of `test/e2e`.
+ */
+
+const ENGINEERING = "engineering";
+
+/** One parked approval, in the shape `GET …/approvals` answers. */
+const PARKED = [
+  {
+    id: "appr-e2e-1",
+    kind: "payment.send",
+    amount_usd: 42.5,
+    at_millis: Date.now(),
+    task: { link: "unlinked" },
+  },
+];
+
+test.beforeEach(async ({ page }) => {
+  // Skip the first-run tour, whose modal would swallow the clicks below.
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+  // The poll that feeds the approvals inbox. Answered for the whole test, so
+  // the card is there whenever the operator arrives.
+  //
+  // Matched by suffix rather than by full path: the console addresses a *named*
+  // company (`/api/v1/companies/<id>/…`) while the host also answers a
+  // single-company alias, and a pattern pinned to one of them stops
+  // intercepting — silently — the moment the deployment shape changes.
+  await page.route("**/approvals", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(PARKED) }),
+  );
+});
+
+/**
+ * The console body, excluding the toast layer.
+ *
+ * `ApprovalsView` raises a toast carrying the very same sentence it hands the
+ * shell, and a toast is not the fix — the whole complaint in #368 is that a
+ * decision was *only* ever a toast. Scoping here is what makes these
+ * assertions about the transcript rather than about the notification.
+ */
+function console_(page: Page): Locator {
+  return page.getByRole("main").first();
+}
+
+/**
+ * Moves between views the way an operator does — through the sidebar. A
+ * fragment-only `page.goto` is a same-document navigation the console may or
+ * may not have re-rendered by the time the next locator is queried; the nav
+ * button is both deterministic and the path the issue actually describes.
+ */
+async function navigate(page: Page, label: string, expectView: RegExp) {
+  await page.locator(`[data-tour="nav-${label.toLowerCase()}"]`).getByRole("button").click();
+  await expect(page).toHaveURL(expectView);
+}
+
+/**
+ * Walks the operator through the console the way the issue describes it: open a
+ * channel first (so there is a "last channel" to address), then go and decide.
+ */
+async function decideFrom(page: Page, channelId: string, action: "Approve" | "Decline") {
+  await page.goto(`/#/chat/${channelId}`);
+  await expect(page.getByPlaceholder(/^Message /)).toBeVisible({ timeout: 30_000 });
+
+  await navigate(page, "Approvals", /#\/approvals/);
+  const button = page.getByRole("button", { name: action });
+  await expect(button).toBeVisible({ timeout: 30_000 });
+  await button.click();
+}
+
+test("the line recording a decision is visible in a real channel", async ({ page }) => {
+  await page.route("**/approvals/*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ responses: [] }),
+    }),
+  );
+
+  await decideFrom(page, ENGINEERING, "Approve");
+
+  // Back in the channel the operator was last in — the console keeps that
+  // across the trip to Approvals, which is the whole of the fix.
+  await navigate(page, "Chat", /#\/chat/);
+  await expect(console_(page).getByText(/Approved — the agent is completing the action/)).toBeVisible({
+    timeout: 30_000,
+  });
+});
+
+test("a decision the host refuses says so in the same channel", async ({ page }) => {
+  await page.route("**/approvals/*", (route) =>
+    route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "the store is unavailable", code: "store_failed" }),
+    }),
+  );
+
+  await decideFrom(page, ENGINEERING, "Approve");
+
+  await navigate(page, "Chat", /#\/chat/);
+  // The half that used to be indistinguishable from success.
+  await expect(console_(page).getByText(/Couldn't record your decision/)).toBeVisible({
+    timeout: 30_000,
+  });
+});
+
+test("with no channel ever opened, the decision still reaches the first desk", async ({ page }) => {
+  // The fallback arm: an operator who goes straight to Approvals has no "last
+  // channel". The line has to land on the company's first desk — the same one
+  // Chat opens on — rather than in a bucket nothing renders.
+  await page.route("**/approvals/*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ responses: [] }),
+    }),
+  );
+
+  await page.goto("/#/approvals");
+  const decline = page.getByRole("button", { name: "Decline" });
+  await expect(decline).toBeVisible({ timeout: 30_000 });
+  await decline.click();
+
+  await navigate(page, "Chat", /#\/chat/);
+  await expect(console_(page).getByText(/^Declined:/)).toBeVisible({ timeout: 30_000 });
+});

--- a/frontend/test/e2e/chat-live-events.spec.ts
+++ b/frontend/test/e2e/chat-live-events.spec.ts
@@ -1,0 +1,213 @@
+import { expect, test, type APIRequestContext, type Locator, type Page } from "@playwright/test";
+
+/**
+ * End-to-end proof for issue #367 — the Chat tab receives what the company
+ * says, not only what this browser tab typed.
+ *
+ * `#361` made Chat the nav-listed surface while every live writer stayed
+ * pointed at the parked Conversation, so a channel showed the console's own
+ * turns and nothing else: an inbound reply appeared only after a reload, a
+ * running turn showed a generic dot instead of its tool rows, and the rail's
+ * unread badges were fed a hard-coded empty map.
+ *
+ * Three of the four tests drive a **live host** (`companies/e2e_harness`) and a
+ * real SSE stream, because the defect was in the addressing between a host
+ * *thread* id and a console *channel* id — a mocked stream would have agreed
+ * with whatever the console believed. The last one mocks `…/events` on purpose:
+ * the offline echo brain calls no tools, so the only way to put real
+ * `tool_call` / `tool_result` frames on the wire without a model is to write
+ * them, and what is under test there is the rendering, not the plumbing.
+ *
+ * Like the rest of `test/e2e` this needs a running host and is not a CI gate —
+ * the Playwright config declares no `webServer`.
+ */
+
+/**
+ * The single-company alias the host answers on. Used only for the out-of-band
+ * POSTs below — the console itself addresses the company by name
+ * (`/api/v1/companies/<id>/…`), which is why the route patterns further down
+ * match by suffix instead.
+ */
+const SCOPE = "/api/v1/company";
+
+/** The harness manifest's two desks. Their ids are their channel ids. */
+const ENGINEERING = { id: "engineering", channel: "engineering-desk" };
+const CONTENT = { id: "content", channel: "content-desk" };
+
+/**
+ * The first-run product tour renders a modal over the console and swallows
+ * every click beneath it. Answer "already skipped" for whatever company id the
+ * host resolves to rather than hard-coding the harness's.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+});
+
+/** Opens one channel by id and waits for its transcript to be on screen. */
+async function openChannel(page: Page, channelId: string) {
+  await page.goto(`/#/chat/${channelId}`);
+  await expect(page.getByPlaceholder(/^Message /)).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * A channel's row in the rail, located by the name the rail renders.
+ *
+ * Not an exact name match: an unread badge is inside the same button, so the
+ * row's accessible name grows a count the moment the thing under test happens —
+ * and an exact matcher would stop resolving exactly when it matters.
+ */
+function railRow(page: Page, channelName: string): Locator {
+  return page.getByRole("complementary").first().getByRole("button", { name: channelName });
+}
+
+/** Every non-system bubble currently rendered in the open channel. */
+function bubbles(page: Page): Locator {
+  return page.locator("article[data-message-id]");
+}
+
+/**
+ * The bubble count, once the channel's rehydration has stopped adding to it.
+ *
+ * A channel opens empty and fills from `chat/history` a moment later, so a
+ * count taken on arrival is a count of nothing — and every "one more bubble
+ * than before" assertion below would be measuring the hydration instead of the
+ * reply. Waits for two equal readings rather than a fixed sleep.
+ */
+async function settledBubbleCount(page: Page): Promise<number> {
+  let last = -1;
+  await expect
+    .poll(
+      async () => {
+        const current = await bubbles(page).count();
+        const settled = current === last;
+        last = current;
+        return settled;
+      },
+      { intervals: [400, 400, 400, 400, 400, 400, 400, 400], timeout: 20_000 },
+    )
+    .toBe(true);
+  return last;
+}
+
+/**
+ * Says something to a desk from **outside the browser**, over the same session.
+ *
+ * This is the whole point of the first two tests: nothing the page did produced
+ * this turn, so the only way its reply can reach the channel is the SSE stream.
+ * It stands in for the inbound Telegram turn / background desk turn from the
+ * issue, which cannot be triggered from a test.
+ */
+async function sayFromElsewhere(request: APIRequestContext, deskId: string, text: string) {
+  const response = await request.post(`${SCOPE}/chat`, { data: { text, chat: deskId } });
+  expect(
+    response.ok(),
+    `posting to ${deskId} failed: ${response.status()} ${await response.text()}`,
+  ).toBeTruthy();
+}
+
+test("a reply the console never asked for lands in the open channel, with no reload", async ({
+  page,
+  request,
+}) => {
+  await openChannel(page, ENGINEERING.id);
+  const before = await settledBubbleCount(page);
+
+  const marker = `inbound-${Date.now()}`;
+  await sayFromElsewhere(request, ENGINEERING.id, marker);
+
+  // The offline brain answers "You said: <text>", so the marker rides back in
+  // the reply. Only the company's half arrives here — the operator line of a
+  // turn this console did not send is not ours to draw.
+  await expect(page.getByText(`You said: ${marker}`)).toBeVisible({ timeout: 60_000 });
+  await expect(bubbles(page)).toHaveCount(before + 1);
+});
+
+test("a reply to a channel you are not on leaves an unread badge, and opening it clears the badge", async ({
+  page,
+  request,
+}) => {
+  // Sit on the Content desk; the reply below is addressed to Engineering.
+  await openChannel(page, CONTENT.id);
+
+  const marker = `unread-${Date.now()}`;
+  await sayFromElsewhere(request, ENGINEERING.id, marker);
+
+  const badge = railRow(page, ENGINEERING.channel).getByTestId("channel-unread");
+  await expect(badge).toBeVisible({ timeout: 60_000 });
+
+  // Opening the channel both shows the line and settles the badge — an unread
+  // count that never clears is the same failure as one that never appears.
+  await railRow(page, ENGINEERING.channel).click();
+  await expect(page.getByText(`You said: ${marker}`)).toBeVisible({ timeout: 30_000 });
+  await expect(badge).toHaveCount(0);
+});
+
+test("a turn sent from the composer renders exactly one company bubble", async ({ page }) => {
+  // The regression guard for the duplicate-bubble race, and the reason the
+  // send bracket had to ship in the same commit as the SSE injection: the host
+  // journals an `AgentReply` for the console's own turn too and pushes it over
+  // SSE *while the POST is still in flight*. Without the bracket the injected
+  // echo and the awaited reply both render and one turn answers twice.
+  await openChannel(page, ENGINEERING.id);
+  const before = await settledBubbleCount(page);
+
+  const marker = `composer-${Date.now()}`;
+  await page.getByPlaceholder(/^Message /).fill(marker);
+  await page.keyboard.press("Enter");
+
+  // Your line plus one reply — never three rows.
+  await expect(bubbles(page)).toHaveCount(before + 2, { timeout: 60_000 });
+  await expect(page.getByText(`You said: ${marker}`)).toHaveCount(1);
+
+  // A late echo would land after the POST resolved, so settle before believing
+  // the count above.
+  await page.waitForTimeout(3_000);
+  await expect(bubbles(page)).toHaveCount(before + 2);
+  await expect(page.getByText(`You said: ${marker}`)).toHaveCount(1);
+});
+
+test("a running turn shows its tool rows in the channel", async ({ page }) => {
+  // The one test that writes its own stream. The frames below are the exact
+  // shape `src/turn_stream.rs` puts on the wire and `use-events.ts` types; the
+  // offline brain this suite runs against calls no tools, so there is no live
+  // turn to watch without inventing one. What is being proved is that a frame
+  // carrying a desk's thread id reaches *that channel's* timeline — which is
+  // what Chat never did.
+  const frames = [
+    { type: "tool_call", seq: 1, chatId: ENGINEERING.id, toolCallId: "t1", label: "workspace_list" },
+    {
+      type: "tool_result",
+      seq: 2,
+      chatId: ENGINEERING.id,
+      toolCallId: "t1",
+      label: "workspace_list",
+      status: "ok",
+      elapsedMs: 120,
+    },
+    { type: "tool_call", seq: 3, chatId: ENGINEERING.id, toolCallId: "t2", label: "workspace_read" },
+  ];
+  await page.route("**/events", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream", "cache-control": "no-cache" },
+      body: frames.map((f) => `data: ${JSON.stringify(f)}\n\n`).join(""),
+    }),
+  );
+
+  await openChannel(page, ENGINEERING.id);
+
+  // The rows themselves, not a typing dot — and the finished one keeps the
+  // elapsed time the frame carried.
+  await expect(page.getByText("workspace_list").first()).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByText("workspace_read").first()).toBeVisible();
+  await expect(page.getByText("Replying…")).toHaveCount(0);
+
+  // Addressed, not broadcast: the other desk's channel shows none of it.
+  await openChannel(page, CONTENT.id);
+  await expect(page.getByText("workspace_list")).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

The Chat tab receives live events again, and the line confirming an approval decision is written to a channel that exists.

#361 promoted `ChatView` to the primary chat surface and moved the older `Conversation` into `HIDDEN_VIEWS` — but every live writer stayed pointed at `Conversation`'s store. Chat has been **write-only since then**: it reads its history on page load and never again. An agent reply not caused by your own message — a scheduled turn, a teammate acting, inbound Telegram, another operator — never appeared. Confirmed on a staging tenant before any code was written.

## API Or Behavior Changes

Frontend only. No route, payload or host change.

**#367 — live delivery.** `injectAgentReply` wrote only `setThreads`; it now writes `transcripts` as well. `liveStepsByThread` / `onSendStart` / `onSendEnd` went only to `Conversation`; `ChatView` now gets them too. Consequences: pushed replies land without a reload, a running turn's tool timeline renders in its channel, and the rail carries real unread counts instead of the hard-coded `{}` — whose comment asserted nothing arrives unprompted, which the inbound-Telegram path contradicts. That comment is gone.

**The in-flight send bracket ships in the same commit as the injection, deliberately.** `onSendStart`/`onSendEnd` mark a thread's POST so the injection suppresses the SSE echo of the operator's own turn. Wiring one without the other reintroduces the duplicate-bubble race, a defect this repo has had before. A spec guards it.

**#368 — the decision line.** `noteSystem` appended to `transcripts["main"]`. `"main"` is the id of the first *static fallback* desk; real channel ids come verbatim from manifest desks, so on any real company that bucket renders nowhere — and the console then navigates the operator to Chat to read a line that isn't there. The failure copy went to the same dead bucket, making a refused sign-off visually identical to a successful one. It now addresses the last-viewed channel, falls back to the first desk channel, and writes nothing at all when a company genuinely has no channels — never a dead bucket. The toasts remain.

**`DEFAULT_CHANNEL` is deleted outright.** This literal has now caused three bugs (#366, #368, #367's resolution path). Addressing is centralised in one pure `channelIdForThread`, which encodes the subtle contract: a desk answers to its own id, a DM's channel key is *not* its thread id.

## Tests

- [x] `npm run typecheck`
- [x] `npm run typecheck:e2e`
- [x] `npm run build`
- [ ] `cargo fmt` / `clippy` / `test` — N/A: no Rust file is touched.

No lint or unit-test script exists in this repo; neither is claimed.

**7/7 new Playwright specs green** against a live host (`companies/e2e_harness`, offline echo brain, console served from `dist`).

**The specs were proven to be guards, not decoration.** `main`'s `frontend/src` was checked out, rebuilt, and the same suite re-run: **5 of 7 fail there**, including both #367 arms and both #368 arms. The two that pass on `main` pass honestly — the exactly-one-bubble test guards a code path that did not exist before (nothing was injected, so nothing could double), and one approval spec passed only because Chromium served a cached `index.html`; a fresh probe against the pre-fix build found the decision line nowhere in the console, confirming it is a real guard.

**What was verified by hand rather than automated**, stated plainly:

- **The DM path.** Posted to `chat: "engineer"` from outside the browser, watched it land in the Engineer DM under the right voice, and confirmed the badge appears on that DM from another channel. Not in the committed specs.
- **The live tool timeline.** The echo brain calls no tools, so no frames exist to observe. Rather than leave it unproven, `…/events` was mocked with hand-written `tool_call`/`tool_result` frames in the exact shape `use-events.ts` types; the spec asserts the rows render in the addressed channel and **not** in the other one. **No model override and no mocked inference backend was used** — this is a transport-level proof, not an end-to-end one.

Full existing e2e suite: 17 failures, a **byte-identical set on `main`** — all from a bare host lacking the scripted LLM backend, workflows and MCP the older specs expect. No regressions.

Union-built against the other open chat-adjacent branch (`fix/372-373-approval-cards`, PR #375): merges clean, typecheck and build both pass on the union. Per-PR CI never builds that union.

## Documentation

No spec doc changes. The addressing contract is documented at `channelIdForThread`, beside the tests that pin it, rather than in prose that can drift.

## Impact

**One deviation from the approved plan.** The plan called for `unread` as a counter bumped inside the injection. It is **derived** instead — per-channel last-viewed stamps compared against the transcripts. A counter has to be bumped from the injection, which only learns whether it actually appended anything *inside* the state updater; bumping a second piece of state from there makes the updater impure, and this app runs under `StrictMode`, which invokes updaters twice. Deriving removes the hazard and is self-correcting. `ChannelRail` still receives the same `Record<string, number>`, and #368's "bump unread for the target channel" falls out for free.

**Two smaller judgment calls.** Commit order runs model → resolution → shell/inject/send-bracket → live steps → unread → `noteSystem` (which deletes `DEFAULT_CHANNEL`) → specs, so **every commit compiles**; deleting the export first would have broken five of them. And `onChannelViewed` fires on transcript growth as well as channel switch, so a reply read as it lands doesn't leave a badge on the channel you are already sitting in.

**Two files outside the plan, both additive.** `StepTimeline` gained `defaultOpen?: boolean` — live rows are the content while a turn runs, so they start expanded, while a finished reply's steps stay collapsed. `ChannelRail` gained a test id on the badge, no behaviour change, so the spec can locate the count as itself.

**Accepted, unchanged:** content-tail dedupe is heuristic and will collapse two genuinely identical replies within 8 messages — the same as the threads store does today. A host whose `/team` 404s drops DM SSE replies in `transcripts`; that is a no-op today too, so not a regression. Resetting `transcripts` on a company switch is a pre-existing separate concern, left alone.

**For #375's author** (concurrent, no conflict): the decision copy is now visible in two places — the toast and the transcript — rather than one.

## Related

Closes #367
Closes #368

Follows #366, which fixed the same defect class one layer down.
Precedes #369 and #370, which rewrite these same two files and land next, rebased on this.
Follow-up filed: #377 — routing `desk_task_completed` into Chat. **The plan's premise there was wrong and the issue says so:** `desk` is the *responder agent id* (`engineer`, not `engineering`), so it matches no channel id either way, and its `output` is the same string already journaled as the `AgentReply` this PR now renders — routing it naively would say everything twice. The issue reframes it as "what should a completed dispatch add that the reply didn't" and asks for a `chatId` on the projection.
