### PR TITLE
fix(chat): render message bodies as markdown

### DIFF
--- a/frontend/src/views/chat/MessageRow.tsx
+++ b/frontend/src/views/chat/MessageRow.tsx
@@ -1,6 +1,7 @@
 import { MessageSquareReply } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Markdown } from "@/components/markdown";
 import type { ChatMessage } from "@/lib/chat";
 import { cn } from "@/lib/utils";
 import { Avatar } from "./Avatar";
@@ -63,7 +64,7 @@ export function MessageRow({ entry, threadOpen, onOpenThread, onReact }: Props) 
 
       <div className="flex min-w-0 flex-1 flex-col">
         {!continuation && <AuthorLine sender={sender} at={message.at} />}
-        <p className="whitespace-pre-wrap break-words text-sm leading-6">{message.text}</p>
+        <Markdown className="text-sm leading-6 break-words prose-p:my-0 prose-pre:my-1.5 prose-ul:my-1 prose-ol:my-1 prose-headings:my-1">{message.text}</Markdown>
 
         {message.steps && message.steps.length > 0 && <StepTimeline steps={message.steps} />}
         {message.taskId && <CardChip taskId={message.taskId} />}

--- a/frontend/src/views/chat/ThreadPanel.tsx
+++ b/frontend/src/views/chat/ThreadPanel.tsx
@@ -1,6 +1,7 @@
 import { X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Markdown } from "@/components/markdown";
 import type { ChatMessage } from "@/lib/chat";
 import { Avatar } from "./Avatar";
 import { MessageComposer } from "./MessageComposer";
@@ -83,7 +84,7 @@ function Line({ channel, message }: { channel: Channel; message: ChatMessage }) 
             {formatTime(message.at)}
           </span>
         </div>
-        <p className="whitespace-pre-wrap break-words text-sm leading-6">{message.text}</p>
+        <Markdown className="text-sm leading-6 break-words prose-p:my-0 prose-pre:my-1.5 prose-ul:my-1 prose-ol:my-1 prose-headings:my-1">{message.text}</Markdown>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Chat messages now render markdown instead of leaking literal `**bold**`, lists, links, and code fences.

## Problem
Both the channel timeline (`MessageRow`) and thread replies (`ThreadPanel`) rendered `message.text` inside a raw `<p>`. Any markdown an agent or user wrote showed up verbatim — `**bold**`, `- lists`, `[links]()`, and ``` code fences ``` all leaked as plain text. Every other surface (workspace, memory, workflows) already renders markdown via the shared component; chat was the odd one out.

## Solution
Route both message bodies through the shared `Markdown` renderer (`react-markdown` + `remark-gfm`), the same recipe workspace/memory/workflow surfaces use — one renderer, one look, both themes via `dark:prose-invert`. Prose spacing is tightened (`prose-p:my-0`, small list/code/heading margins) so single-line chat messages stay dense and don't gain paragraph gaps. System pills (the centered status text) stay raw on purpose.

## Submission Checklist
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [ ] Unit tests — N/A: no test script in `frontend/`; presentational change verified via build + live staging
- [x] Change scoped to the two chat message-body render sites only

## Impact
Chat becomes readable when agents format output — bold, bullet lists, links, inline/block code all render. No API or data-shape change; purely presentational, frontend-only.

## Related
Follows #366 (chat blank-channel fallback) — same chat surface.