### PR TITLE
feat(workflows): show a run progressing node by node, live and in history (#371)

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -79,6 +79,7 @@ L0  Substrate       api.tinyhumans.ai, openhuman-core, tiny.place, filesystem
 | [company-brain/memory.md](company-brain/memory.md) | Long-term memory and retention |
 | [runtime/README.md](runtime/README.md) | Kernel architecture and crate layout |
 | [runtime/ports.md](runtime/ports.md) | Port trait contracts (normative) |
+| [runtime/events.md](runtime/events.md) | `CompanyEvent` vocabulary + journal correlation rules |
 | [runtime/manifest.md](runtime/manifest.md) | `company.toml` schema, `agents.toml` compatibility |
 | [runtime/lifecycle.md](runtime/lifecycle.md) | Company state machine and durability |
 | [runtime/api.md](runtime/api.md) | HTTP surface and auth model |

--- a/docs/spec/runtime/README.md
+++ b/docs/spec/runtime/README.md
@@ -9,6 +9,8 @@ system sits behind a port trait.
 Supporting docs:
 
 - [ports.md](ports.md) — the port trait contracts (normative)
+- [events.md](events.md) — the `CompanyEvent` vocabulary those ports carry, and
+  the run/task/approval correlation rules a journal reader folds on
 - [manifest.md](manifest.md) — `company.toml` schema
 - [lifecycle.md](lifecycle.md) — company state machine and durability
 - [rebuild.md](rebuild.md) — replacing a registered runtime in place (quiesce →

--- a/docs/spec/runtime/events.md
+++ b/docs/spec/runtime/events.md
@@ -1,0 +1,353 @@
+# Company Events
+
+The `CompanyEvent` vocabulary carried by the [`EventLog`](ports.md#eventlog)
+port, and the correlation rules that let a reader fold one company's
+append-only journal back into per-task, per-approval and per-run views.
+
+Split out of [`ports.md`](ports.md) (issue #371), which had grown past this
+repo's 500-line cap for a Markdown file. That file still owns the *port
+contracts* — the traits and their method signatures; this one owns the *event
+vocabulary* those traits carry, which is the half that keeps growing.
+
+## The journal's shape
+
+Append-only, replayable, **single-writer**, and company-scoped. Boot replays the
+tail to rebuild in-flight state. Every variant is serialized internally-tagged
+under `kind`, so each JSONL line is self-describing.
+
+Two properties are load-bearing everywhere below:
+
+* **Additive-only.** A new variant, or a new field carrying
+  `#[serde(default, skip_serializing_if = …)]`, cannot change how an
+  already-persisted line loads or how an existing event serializes. That is
+  what lets the vocabulary grow with no journal migration and no break in the
+  cross-backend export/import round-trip. The cost is accepted and stated: an
+  **older binary cannot decode a newer journal's variants** — the same posture
+  every variant addition has shipped with.
+* **One writer per company.** The journal is opened by exactly one process, and
+  a rebuild inherits the open handle rather than reopening it (two handles
+  interleave a record and its newline onto one line and brick the next replay).
+  Several boot-time sweeps rest on this; see
+  [Interrupted runs](#interrupted-runs-issue-371).
+
+## Variants
+
+`CompanyEvent` variants: `OperatorMessage`, `WebhookReceived`,
+`ScheduleFired`, `A2aTaskReceived`, `ApprovalResolved`, `FeedbackFiled`,
+`PaymentReceived`, `LifecycleChanged`, `AgentReply`, `MemoryFactDeleted`,
+`TaskDispatched`, `McpCallFailed`, `WorkflowCreated` (a new saved workflow
+graph was authored + enabled via the console `POST …/workflows` route or the
+orchestrator's `create_workflow` tool; journaled best-effort after persist),
+`TaskSteered` (an operator paused, cancelled, or redirected an in-flight task
+or delegation), `DeskTaskCompleted` (a dispatched board task finished its run —
+the terminal anchor a per-task timeline ends on; "completed" means the run
+stopped, not that it succeeded, and `column` carries where the card landed),
+`TaskDiscussionPosted` (a human posted to a card's discussion thread, issue
+#335 — the Discussion tab's whole store, folded back out by
+`GET …/tasks/{task_id}` beside that card's timeline), `WorkflowUpdated` /
+`WorkflowDeleted` (issue #259 — a saved graph was replaced wholesale or removed;
+neither carries the TOML body, deliberately, since the journal reaches readers
+that have no business holding agent prompts or destination addresses),
+`WorkflowRunFinished` (issue #228 — the durable record of what a run did, from
+every entry point) and, from issue #371, `WorkflowRunStarted` /
+`WorkflowNodeFinished` (the per-node progress trail; see
+[Workflow run progress](#workflow-run-progress-issue-371)).
+
+### Per-task event correlation (issue #185)
+
+The journal is company-scoped, so the events a dispatch *produces* cannot be
+filtered back to their task by shape alone. `AgentReply` and `McpCallFailed`
+therefore carry an optional `task_id`, stamped by the harness when the
+producing turn ran inside a `TaskDispatched` cycle and absent for an ordinary
+chat turn. Together with the `TaskDispatched` / `DeskTaskCompleted` anchors,
+that is what `GET …/tasks/{task_id}` filters on to assemble a task's timeline.
+
+Both fields are additive — `#[serde(default, skip_serializing_if = …)]` — so
+every already-persisted event loads unchanged and an untagged event serializes
+byte-for-byte as it did before the field existed. No stored log needs
+migrating, and the cross-backend export/import round-trip is unaffected.
+
+`TaskRecord` gains `parent_task_id` on the same contract, recording the
+task-to-task edge that `origin_chat_id` (a *conversation*, shared by every
+sibling spawned in that thread, and absent entirely on a board-native card)
+cannot express. It is the parent half of the Task Detail screen's lineage.
+
+`OutboundMessage` gains `task_id` on the same contract (issue #246): the card a
+chat turn **opened**, so the console can say a card exists instead of leaving an
+operator to notice it on the board. It is journaled onto that turn's
+`AgentReply.task_id`, which widens that field's meaning from "the dispatch that
+produced this reply" to "the card this reply is about" — a card-creating reply
+now also appears on that card's timeline, which is the lineage an operator
+wants and costs no schema change. A turn that opens several cards reports the
+**first**: the journal field is a single optional id, and widening it would
+break the byte-identical round-trip, so the claim is incomplete but never wrong.
+Both `chat/history` surfaces (REST and GraphQL) project it from the shared
+`MessageView`, so the chip survives a transcript reload on either.
+
+### Per-task approval correlation (issue #333)
+
+`ApprovalResolved` carries an id, a verdict and an actor — never a task — so
+the same problem reaches the approval queue, and worse: a *parked* approval has
+no event at all. A task's Approvals tab could therefore only filter the
+timeline for resolutions that happened to fall inside the card's run window,
+which showed nothing while an approval was actually waiting and let a second
+card worked in that window absorb the first's sign-offs.
+
+The link is recorded where the approval is: the runtime journal's
+`ApprovalParked` record gains a `task` field, stamped by the cycle that parked
+the effect. A cycle knows which card it is working from its own trigger
+events — a `TaskDispatched`, or an `ApprovalResolved` whose approval was itself
+parked for a card, which is how a run needing two sign-offs keeps the link
+through the first.
+
+`task` is a two-armed link, not an optional id, and the distinction is the
+whole correctness of the feature:
+
+| On disk | Means | Read side |
+| --- | --- | --- |
+| `{"link":"task","id":"t-1"}` | that card owns it | shows on `t-1`, and only there |
+| `{"link":"unlinked"}` | no card owns it | shows on no card |
+| *absent* | written before #333 | falls back to the run window |
+
+An optional id collapses the middle row into the last one, and the middle row
+is not an edge case: every workflow delivery, operator-chat turn and scheduler
+tick parks unlinked. Treating those as "unknown" sends each of them to whatever
+card happened to be running, along with that card's `waitingSince` — the exact
+misattribution this issue exists to end. So a host from #333 onward always
+writes one of the first two, and absence means one thing only.
+
+#### Which key is authoritative
+
+Two keys correlate an approval to work, and they are kept **both**:
+`Effect.run_id` (issue #242) is **attempt-level**, and `ApprovalParked.task` is
+**card-level**. The read side resolves them in this order:
+
+```text
+card = if let Some(run_id) = effect.run_id { run_store.get(run_id).task_id }  // authoritative
+       else { approval_parked.task }                                          // fallback
+// neither recorded → genuinely unlinked, and NOT the run-window fallback
+```
+
+`run_id` wins wherever it is present because a `RunRecord` names its card, so a
+run id resolves to a task — while a task id can never say which *attempt*
+parked an approval. #183 settled that repeat trips through review are normal,
+so two attempts on one card is the expected case, and only `run_id` separates
+them.
+
+It cannot be the only key, though: `run_id` is `None` by design for every park
+with no attempt behind it — a chat turn, a workflow delivery, a scheduler tick,
+and the hosted brain's own gate — whereas `task` is stamped in
+`CycleHostImpl::park`, which *every* park path passes through. Neither key is a
+superset of the other, so "pick one" is not available. The card-level key also
+inherits through a resolution (an `ApprovalResolved` whose approval was itself
+parked for a card keeps that card), which the attempt-level one does not do.
+
+This is why the three-state link above is load-bearing rather than pedantic:
+with two keys, "unlinked because chat-parked — no run and no card" has to stay
+distinguishable from "not stamped because it predates #333", and only the
+second may fall back to the run window.
+
+A batch is ambiguous — and stamps nothing — when it names two different cards,
+or when it carries a card's dispatch alongside a turn that is its own work (an
+operator message, a webhook, a schedule tick, an inbound A2A task, or a
+resolution of an approval known to belong to no card). A cycle is a unit of
+batching, not of work, so "the card this cycle is for" is only well defined
+when nothing else rides along. Issue #357 guards the same seam per *attempt*
+with a queue-position boundary; this rule only has to stop the cross-turn leak.
+
+The journal keeps a per-approval origin index (park instant, effect kind,
+task link) because the parked effect is dropped from the queue on resolution
+and nothing else can answer what a resolved approval was.
+`GET …/tasks/{task_id}` returns `approvals[]` from it, joined by id.
+
+**That index is unbounded.** It holds one entry per approval ever parked, for
+the life of the process, and is never pruned — resolution and expiry remove the
+queue entry but deliberately not the origin. #333 widens each entry from a
+`u64` to a `u64` plus two `String`s (the effect kind, and the task id when
+linked). No journal rotation exists today, so replaying every `ApprovalParked`
+line on `load` is the only path to rebuild it, and it is the correct one. If
+rotation is ever added, this index is the first thing that must survive it: a
+rotated-away park line silently makes its approval unreadable.
+
+The field is additive on the same contract as the rest — a pre-#333 line
+replays with no link and keeps the old run-window correlation, so existing
+history still renders.
+
+### What a retry would repeat (issue #351)
+
+Re-entering a run re-runs its effects, and the two facts needed to warn about
+that already existed separately: the gate classifies `Sign` / `Publish` /
+`Identity` / capped `Spend` / first-contact `Send` as the effects it refuses to
+wave through, and the journal's executed-key set records what was committed to
+run. Neither reached the operator, because the key is opaque — it answers "has
+this run?" and nothing else.
+
+`EffectExecuted` therefore carries an optional `ExecutedEffect` alongside the
+key: the effect kind, its amount, the board task it ran for, and whether the
+gate called it irreversible. The classification is made **at execution time**,
+by `ManifestApprovalGate::is_irreversible` (which delegates to the supervised
+taxonomy, so there is one copy of the rules), and it is deliberately
+mode-independent: a `full`-mode company executes a filing without ever parking
+it, which is precisely when a retry dialog is the only warning anyone gets.
+
+There is **no payload**. The record is read back onto an operator's screen
+through `GET …/tasks/{task_id}`, which scrubs by construction, so recipients and
+message bodies are never retained in the first place.
+
+The task attribution comes from the cycle that ran the effect. Under
+`supervised` an irreversible effect never executes in the cycle that emitted it
+— it parks, and the operator's approval opens a fresh cycle carrying only
+`ApprovalResolved` — so `ApprovalParked` also gains an optional `task_id`, and
+the approved execution reads the card back off it. Without that, every effect
+that went through the approval gate the way the policy intends would be
+attributed to nothing.
+
+**Committed, not completed.** The record is written *before* the effect is
+performed — that ordering is the at-most-once guarantee — and a failed perform
+leaves it standing. So an entry means "this was committed, and the runtime will
+never re-attempt it", which is what the warning needs: the operator has to
+assume it happened, because nothing will finish it and nothing will retry it. It
+does not mean the effect is known to have completed, and the dialog's wording
+says so rather than rendering the list as flat fact.
+
+**Approved tool calls are described at redemption.** An approved effect carrying
+an `agent` is settled by minting a single-use grant, not by
+`execute_effect_once` — the tool then runs inside the agent's next turn — so it
+writes no `EffectExecuted` line at all. `GrantConsumed` therefore carries the
+same optional `ExecutedEffect`, built from the park record (retained past
+resolution, payload scrubbed, superseded by an approve-with-edit) joined to the
+gate's classification. It is attached at **redemption** rather than at minting,
+because a grant that expires unredeemed is a call that never ran and must not
+appear on a warning.
+
+**A journal that cannot describe itself says so.** Both fields are additive: a
+line written before #351 replays as a committed key with no description, which
+keeps the at-most-once guarantee exact and simply contributes no warning. That
+makes an empty list ambiguous on an upgraded company, so replay raises a
+company-wide flag when it reads an undescribed executed key, surfaced as
+`historyIncomplete` on `GET …/tasks/{task_id}`. With it set the console confirms
+a retry regardless and says earlier activity cannot be described, instead of
+presenting the gap as an all-clear. The flag is company-wide rather than
+per-task by necessity — an undescribed record carries no card either. The
+related pre-#351 case it cannot detect directly: an approval parked before the
+upgrade has no `task_id`, and that record is byte-identical to a legitimately
+card-less park written today, so flagging it would misreport every company that
+has ever parked an approval from operator chat.
+
+**Scope.** Task Detail only. The board's own re-dispatch — dragging a card back
+into `in_progress` (`company/runtime.rs`, `upsert_task` → `dispatch_task`) — has
+the same shape and now has this read available to it, and is deliberately left
+for a follow-up rather than half-gated here.
+
+## Workflow run progress (issue #371)
+
+A workflow run used to journal exactly one line, `WorkflowRunFinished`, written
+after the run returned. Between pressing Run and that line there was no record
+at all: a long run was indistinguishable from a wedged one, and a run that died
+at the fourth of six nodes recorded only that it died.
+
+Three variants now bracket a run:
+
+| Variant | Written by | When |
+| --- | --- | --- |
+| `WorkflowRunStarted` | the workflow runner | before the engine call |
+| `WorkflowNodeFinished` | the runner's `RunObserver` | as each non-trigger node finishes |
+| `WorkflowRunFinished` | the **caller**, via `record_run_finished` | after the run returns, on both arms |
+
+### Why the journal rather than a dedicated store
+
+A chat turn emits dozens of steps per message; a workflow run emits **one event
+per non-trigger node** — roughly eight for a six-node graph. At that volume the
+journal is the right carrier, and it already feeds the operator SSE
+projection — so **one append serves both the live half and the durable half**
+through a single write path. A dedicated store would need a second writer and a
+second read path to deliver the same two answers.
+
+The alternative considered and rejected was adopting issue #242's `RunRecord` /
+`RunStepRecord`. `RunRecord` requires a `task_id`, an `agent_id` and a per-task
+attempt ordinal; a workflow run has none of those, so it would need a synthetic
+task id — a lie leaking into every `RunStore` consumer, all of which assume a
+run keys to a board card. `RunStepRecord`'s payload is a `TurnStep`, which has
+no node-id field at all.
+
+The accepted cost is journal growth of ~(N+1) lines per run, and a
+`GET …/workflows/runs` fold that is already O(journal). A dedicated store stays
+the known escape hatch if cron volume ever demands it.
+
+### What these events deliberately do not carry
+
+**No node output and no error text.** The engine's `ExecutionStep` carries the
+node's output items; `WorkflowNodeFinished` carries a node id, a two-valued
+status and a duration, and `WorkflowNodeStatus` has no `String` arm — so there
+is no `format!` that could put a node's own words on the journal. This is the
+same stance the live turn-progress frames take on tool args, and it matters
+because the journal is read by the operator SSE projection *and* wired out to
+the inference sidecar.
+
+Nothing is lost: the run-level failure reason already lands on
+`WorkflowRunFinished.error`, which is a tenant-scoped surface.
+
+### Run-id correlation
+
+`WorkflowRunStarted` and `WorkflowNodeFinished` **require** a `run_id`;
+`WorkflowRunFinished` has always carried an optional one and now populates it.
+That shared id is what lets a reader group a run's node rows with its outcome,
+and what lets the console overlay one past run's states onto the canvas.
+
+**The entry point mints it, not the runner.** On the error arm the runner
+returns nothing that could carry an id, and that is exactly the run whose
+per-node trail is worth correlating — so the id is minted above the call, in a
+`WorkflowRunContext` threaded through `WorkflowRunner::run`. Every entry point
+(the console's run route, the cron scheduler, the orchestrator's `run_workflow`
+tool) therefore stamps one id across both halves on every path.
+
+`WorkflowRunContext` is a crate-internal port type with no serde impl. Putting
+it in the trait signature is deliberate: it makes the compiler enumerate every
+entry point, so one cannot quietly journal an uncorrelatable run.
+
+### Ordering guarantee
+
+A run's lines are always `Started < Node… < Finished`. The first part is
+ordering by construction; the last is enforced — the runner drops its progress
+channel and **joins the collector before returning**, so every node line is
+durable before the caller writes the outcome. Without that join the two would
+race and a fold could attach a node to a run it had already rendered as
+finished.
+
+Lines of *different* runs may interleave (two workflows can run at once), which
+is why the read-side fold groups on run id rather than on adjacency.
+
+### Interrupted runs (issue #371)
+
+Because the start is written before the engine call, a host that dies mid-run
+leaves a start with no finish. At boot that is provably dead work, on three
+invariants: every entry point drives its run future **in this process**, exactly
+one process owns the journal, and no entry point has run yet. So
+`sweep_interrupted_runs` settles each unmatched start with a synthetic
+`WorkflowRunFinished` carrying an "interrupted by a host restart" error — the
+start's own `workflow_id`, `scheduled` flag and `run_id` are carried over, so
+the nodes that did complete still group under it.
+
+This is what keeps the read side honest: `GET …/workflows/runs` folds a start
+without a finish as `running: true`, and that claim is only true because runs
+that will never finish are settled at the next boot.
+
+**It must not run on a rebuild.** The argument above holds at boot and is false
+once a company has been serving: a scheduler-spawned run survives a live runtime
+swap, so sweeping mid-life would stamp "interrupted" on a run still walking its
+graph, whose real outcome would then land afterwards — two contradictory
+finishes for one run id. The call site is gated on the handover being absent,
+exactly like `reap_orphaned_runs`. Same lesson as #290.
+
+### An engine constraint worth knowing
+
+tinyflows' `RunObserver` has `on_step_finish` and **no `on_step_start`**, so
+there is no "node started" event to journal. A console showing which node is
+*currently* executing derives it from the graph topology it already holds
+(mark the successors of a finished node), which is a good-faith frontier rather
+than ground truth — after a branch point it briefly marks both arms. A true
+start hook needs a vendored tinyflows change and is tracked separately.
+
+A failing node, by contrast, **is** reported exactly: a node that dies under the
+default `stop` policy still emits a step with `Error` status before the run
+ends, so failure attribution is exact rather than inferred.

--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -147,7 +147,8 @@ pub trait CompanyStore: Send + Sync {
 
 ## EventLog
 
-Append-only, replayable. Boot replays the tail to rebuild in-flight state.
+Append-only, replayable, single-writer per company. Boot replays the tail to
+rebuild in-flight state.
 
 ```rust
 // src/ports/events.rs
@@ -159,205 +160,22 @@ pub trait EventLog: Send + Sync {
 }
 ```
 
-`CompanyEvent` variants: `OperatorMessage`, `WebhookReceived`,
-`ScheduleFired`, `A2aTaskReceived`, `ApprovalResolved`, `FeedbackFiled`,
-`PaymentReceived`, `LifecycleChanged`, `AgentReply`, `MemoryFactDeleted`,
-`TaskDispatched`, `McpCallFailed`, `WorkflowCreated` (a new saved workflow
-graph was authored + enabled via the console `POST …/workflows` route or the
-orchestrator's `create_workflow` tool; journaled best-effort after persist),
-`TaskSteered` (an operator paused, cancelled, or redirected an in-flight task
-or delegation), `DeskTaskCompleted` (a dispatched board task finished its run —
-the terminal anchor a per-task timeline ends on; "completed" means the run
-stopped, not that it succeeded, and `column` carries where the card landed),
-`TaskDiscussionPosted` (a human posted to a card's discussion thread, issue
-#335 — the Discussion tab's whole store, folded back out by
-`GET …/tasks/{task_id}` beside that card's timeline).
+**The `CompanyEvent` vocabulary lives in
+[`events.md`](events.md)** — every variant, the additive-serialization contract
+they all share, and the correlation rules that fold a company-scoped journal
+back into per-task, per-approval and per-run views:
 
-### Per-task event correlation (issue #185)
+* [Variants](events.md#variants)
+* [Per-task event correlation (issue #185)](events.md#per-task-event-correlation-issue-185)
+* [Per-task approval correlation (issue #333)](events.md#per-task-approval-correlation-issue-333)
+* [What a retry would repeat (issue #351)](events.md#what-a-retry-would-repeat-issue-351)
+* [Workflow run progress (issue #371)](events.md#workflow-run-progress-issue-371)
 
-The journal is company-scoped, so the events a dispatch *produces* cannot be
-filtered back to their task by shape alone. `AgentReply` and `McpCallFailed`
-therefore carry an optional `task_id`, stamped by the harness when the
-producing turn ran inside a `TaskDispatched` cycle and absent for an ordinary
-chat turn. Together with the `TaskDispatched` / `DeskTaskCompleted` anchors,
-that is what `GET …/tasks/{task_id}` filters on to assemble a task's timeline.
+It was split out (issue #371) because this file had grown past the repo's
+500-line cap for a Markdown file, and the event vocabulary is the half that
+keeps growing: this file owns the port *traits*, that one owns the *payloads*
+they carry.
 
-Both fields are additive — `#[serde(default, skip_serializing_if = …)]` — so
-every already-persisted event loads unchanged and an untagged event serializes
-byte-for-byte as it did before the field existed. No stored log needs
-migrating, and the cross-backend export/import round-trip is unaffected.
-
-`TaskRecord` gains `parent_task_id` on the same contract, recording the
-task-to-task edge that `origin_chat_id` (a *conversation*, shared by every
-sibling spawned in that thread, and absent entirely on a board-native card)
-cannot express. It is the parent half of the Task Detail screen's lineage.
-
-`OutboundMessage` gains `task_id` on the same contract (issue #246): the card a
-chat turn **opened**, so the console can say a card exists instead of leaving an
-operator to notice it on the board. It is journaled onto that turn's
-`AgentReply.task_id`, which widens that field's meaning from "the dispatch that
-produced this reply" to "the card this reply is about" — a card-creating reply
-now also appears on that card's timeline, which is the lineage an operator
-wants and costs no schema change. A turn that opens several cards reports the
-**first**: the journal field is a single optional id, and widening it would
-break the byte-identical round-trip, so the claim is incomplete but never wrong.
-Both `chat/history` surfaces (REST and GraphQL) project it from the shared
-`MessageView`, so the chip survives a transcript reload on either.
-
-### Per-task approval correlation (issue #333)
-
-`ApprovalResolved` carries an id, a verdict and an actor — never a task — so
-the same problem reaches the approval queue, and worse: a *parked* approval has
-no event at all. A task's Approvals tab could therefore only filter the
-timeline for resolutions that happened to fall inside the card's run window,
-which showed nothing while an approval was actually waiting and let a second
-card worked in that window absorb the first's sign-offs.
-
-The link is recorded where the approval is: the runtime journal's
-`ApprovalParked` record gains a `task` field, stamped by the cycle that parked
-the effect. A cycle knows which card it is working from its own trigger
-events — a `TaskDispatched`, or an `ApprovalResolved` whose approval was itself
-parked for a card, which is how a run needing two sign-offs keeps the link
-through the first.
-
-`task` is a two-armed link, not an optional id, and the distinction is the
-whole correctness of the feature:
-
-| On disk | Means | Read side |
-| --- | --- | --- |
-| `{"link":"task","id":"t-1"}` | that card owns it | shows on `t-1`, and only there |
-| `{"link":"unlinked"}` | no card owns it | shows on no card |
-| *absent* | written before #333 | falls back to the run window |
-
-An optional id collapses the middle row into the last one, and the middle row
-is not an edge case: every workflow delivery, operator-chat turn and scheduler
-tick parks unlinked. Treating those as "unknown" sends each of them to whatever
-card happened to be running, along with that card's `waitingSince` — the exact
-misattribution this issue exists to end. So a host from #333 onward always
-writes one of the first two, and absence means one thing only.
-
-#### Which key is authoritative
-
-Two keys correlate an approval to work, and they are kept **both**:
-`Effect.run_id` (issue #242) is **attempt-level**, and `ApprovalParked.task` is
-**card-level**. The read side resolves them in this order:
-
-```text
-card = if let Some(run_id) = effect.run_id { run_store.get(run_id).task_id }  // authoritative
-       else { approval_parked.task }                                          // fallback
-// neither recorded → genuinely unlinked, and NOT the run-window fallback
-```
-
-`run_id` wins wherever it is present because a `RunRecord` names its card, so a
-run id resolves to a task — while a task id can never say which *attempt*
-parked an approval. #183 settled that repeat trips through review are normal,
-so two attempts on one card is the expected case, and only `run_id` separates
-them.
-
-It cannot be the only key, though: `run_id` is `None` by design for every park
-with no attempt behind it — a chat turn, a workflow delivery, a scheduler tick,
-and the hosted brain's own gate — whereas `task` is stamped in
-`CycleHostImpl::park`, which *every* park path passes through. Neither key is a
-superset of the other, so "pick one" is not available. The card-level key also
-inherits through a resolution (an `ApprovalResolved` whose approval was itself
-parked for a card keeps that card), which the attempt-level one does not do.
-
-This is why the three-state link above is load-bearing rather than pedantic:
-with two keys, "unlinked because chat-parked — no run and no card" has to stay
-distinguishable from "not stamped because it predates #333", and only the
-second may fall back to the run window.
-
-A batch is ambiguous — and stamps nothing — when it names two different cards,
-or when it carries a card's dispatch alongside a turn that is its own work (an
-operator message, a webhook, a schedule tick, an inbound A2A task, or a
-resolution of an approval known to belong to no card). A cycle is a unit of
-batching, not of work, so "the card this cycle is for" is only well defined
-when nothing else rides along. Issue #357 guards the same seam per *attempt*
-with a queue-position boundary; this rule only has to stop the cross-turn leak.
-
-The journal keeps a per-approval origin index (park instant, effect kind,
-task link) because the parked effect is dropped from the queue on resolution
-and nothing else can answer what a resolved approval was.
-`GET …/tasks/{task_id}` returns `approvals[]` from it, joined by id.
-
-**That index is unbounded.** It holds one entry per approval ever parked, for
-the life of the process, and is never pruned — resolution and expiry remove the
-queue entry but deliberately not the origin. #333 widens each entry from a
-`u64` to a `u64` plus two `String`s (the effect kind, and the task id when
-linked). No journal rotation exists today, so replaying every `ApprovalParked`
-line on `load` is the only path to rebuild it, and it is the correct one. If
-rotation is ever added, this index is the first thing that must survive it: a
-rotated-away park line silently makes its approval unreadable.
-
-The field is additive on the same contract as the rest — a pre-#333 line
-replays with no link and keeps the old run-window correlation, so existing
-history still renders.
-
-### What a retry would repeat (issue #351)
-
-Re-entering a run re-runs its effects, and the two facts needed to warn about
-that already existed separately: the gate classifies `Sign` / `Publish` /
-`Identity` / capped `Spend` / first-contact `Send` as the effects it refuses to
-wave through, and the journal's executed-key set records what was committed to
-run. Neither reached the operator, because the key is opaque — it answers "has
-this run?" and nothing else.
-
-`EffectExecuted` therefore carries an optional `ExecutedEffect` alongside the
-key: the effect kind, its amount, the board task it ran for, and whether the
-gate called it irreversible. The classification is made **at execution time**,
-by `ManifestApprovalGate::is_irreversible` (which delegates to the supervised
-taxonomy, so there is one copy of the rules), and it is deliberately
-mode-independent: a `full`-mode company executes a filing without ever parking
-it, which is precisely when a retry dialog is the only warning anyone gets.
-
-There is **no payload**. The record is read back onto an operator's screen
-through `GET …/tasks/{task_id}`, which scrubs by construction, so recipients and
-message bodies are never retained in the first place.
-
-The task attribution comes from the cycle that ran the effect. Under
-`supervised` an irreversible effect never executes in the cycle that emitted it
-— it parks, and the operator's approval opens a fresh cycle carrying only
-`ApprovalResolved` — so `ApprovalParked` also gains an optional `task_id`, and
-the approved execution reads the card back off it. Without that, every effect
-that went through the approval gate the way the policy intends would be
-attributed to nothing.
-
-**Committed, not completed.** The record is written *before* the effect is
-performed — that ordering is the at-most-once guarantee — and a failed perform
-leaves it standing. So an entry means "this was committed, and the runtime will
-never re-attempt it", which is what the warning needs: the operator has to
-assume it happened, because nothing will finish it and nothing will retry it. It
-does not mean the effect is known to have completed, and the dialog's wording
-says so rather than rendering the list as flat fact.
-
-**Approved tool calls are described at redemption.** An approved effect carrying
-an `agent` is settled by minting a single-use grant, not by
-`execute_effect_once` — the tool then runs inside the agent's next turn — so it
-writes no `EffectExecuted` line at all. `GrantConsumed` therefore carries the
-same optional `ExecutedEffect`, built from the park record (retained past
-resolution, payload scrubbed, superseded by an approve-with-edit) joined to the
-gate's classification. It is attached at **redemption** rather than at minting,
-because a grant that expires unredeemed is a call that never ran and must not
-appear on a warning.
-
-**A journal that cannot describe itself says so.** Both fields are additive: a
-line written before #351 replays as a committed key with no description, which
-keeps the at-most-once guarantee exact and simply contributes no warning. That
-makes an empty list ambiguous on an upgraded company, so replay raises a
-company-wide flag when it reads an undescribed executed key, surfaced as
-`historyIncomplete` on `GET …/tasks/{task_id}`. With it set the console confirms
-a retry regardless and says earlier activity cannot be described, instead of
-presenting the gap as an all-clear. The flag is company-wide rather than
-per-task by necessity — an undescribed record carries no card either. The
-related pre-#351 case it cannot detect directly: an approval parked before the
-upgrade has no `task_id`, and that record is byte-identical to a legitimately
-card-less park written today, so flagging it would misreport every company that
-has ever parked an approval from operator chat.
-
-**Scope.** Task Detail only. The board's own re-dispatch — dragging a card back
-into `in_progress` (`company/runtime.rs`, `upsert_task` → `dispatch_task`) — has
-the same shape and now has this read available to it, and is deliberately left
-for a follow-up rather than half-gated here.
 
 ## MemoryStore
 

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -175,6 +175,25 @@ export interface WorkflowRunResult {
    * so a response from a host predating issue #170 still parses.
    */
   deliveries?: DeliveryReport[];
+  /**
+   * The run's correlation id (issue #371). Optional on the type so a response
+   * from a host predating #371 still parses.
+   *
+   * The console needs it because the run's progress events arrive over SSE
+   * *while this request is still in flight*: without it, a cron fire that
+   * overlapped the manual run could not be told apart from the run being
+   * awaited, and its frames would repaint the canvas.
+   */
+  runId?: string;
+}
+
+/** One node's outcome inside a run (issue #371). */
+export interface WorkflowRunNode {
+  nodeId: string;
+  /** Whether the node succeeded or errored. */
+  status: "ok" | "error";
+  /** Wall-clock duration of the node's execution, in milliseconds. */
+  elapsedMs: number;
 }
 
 /**
@@ -202,6 +221,21 @@ export interface WorkflowRunOutcome {
   pendingApprovals: string[];
   /** Set when the run failed outright instead of finishing with rows. */
   error?: string;
+  /**
+   * Per-node progress, in the order the nodes finished (issue #371). Absent on
+   * a run journaled before #371 — so an empty/absent list means "no per-node
+   * trail", never "the run did nothing".
+   */
+  nodes?: WorkflowRunNode[];
+  /** When the run started. Absent on a pre-#371 row, whose only time is the finish. */
+  startedAtMillis?: number;
+  /**
+   * True for a run that started and has not settled.
+   *
+   * Trustworthy only because the host settles runs its previous process left
+   * open, at boot — so nothing sits here spinning forever.
+   */
+  running?: boolean;
 }
 
 export function listWorkflows(

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -127,6 +127,11 @@ const HIDDEN_VIEWS: View[] = [
 
 const VIEWS: View[] = [...NAV.map((i) => i.view), ...HIDDEN_VIEWS];
 
+/** How many workflow run-progress frames (issue #371) the shell keeps for the
+ * Workflows canvas. A run emits roughly one per node, so this holds many runs'
+ * worth — it exists to bound a long-lived tab, not to ration frames. */
+const WORKFLOW_EVENT_WINDOW = 300;
+
 /**
  * Operator-facing copy for a `connect_error` code from the host's OAuth
  * callback (issue #300). The host sends a stable code rather than the
@@ -194,12 +199,20 @@ export function AppShell({
   // refreshes its run history live. Same shape as `taskEventTick` — a counter,
   // not the payload, so the view owns what it refetches.
   const [workflowRunTick, setWorkflowRunTick] = useState(0);
-  // Issue #371: the run-progress frame ITSELF, not just a nonce. The canvas
-  // paints per-node state, so unlike the tick above it needs the payload — a
-  // counter cannot say which node of which run just finished. Kept beside the
-  // tick rather than replacing it: the tick still drives the history refetch,
-  // which is a refetch and wants no payload.
-  const [workflowRunEvent, setWorkflowRunEvent] = useState<CompanyStreamEvent | null>(null);
+  // Issue #371: a rolling WINDOW of run-progress frames, not just a nonce.
+  //
+  // The canvas paints per-node state, so unlike the tick above it needs the
+  // payload — a counter cannot say which node of which run just finished. It is
+  // a list rather than a "latest event" slot because two frames routinely land
+  // inside one React batch (a transform node finishes in under a millisecond),
+  // and a single slot silently drops the earlier one. Losing a
+  // `workflow_run_started` that way strands every node frame behind it, which
+  // is exactly the bug this shape removes rather than narrows.
+  //
+  // Bounded so a long-lived tab cannot grow it without limit. The cap is orders
+  // of magnitude above a run's ~N+2 frames; if it ever did cut a run's start,
+  // the view simply shows no live state and the run history still has it.
+  const [workflowRunEvents, setWorkflowRunEvents] = useState<CompanyStreamEvent[]>([]);
   // The live tool timeline, per thread, built from the transient `tool_call` /
   // `tool_result` SSE frames while a turn runs (mirrors OpenHuman's live tool
   // rows). Cleared when the turn's final reply — carrying the authoritative
@@ -512,11 +525,11 @@ export function AppShell({
     onTaskEvent: useCallback(() => setTaskEventTick((n) => n + 1), []),
     onTurnEvent,
     onWorkflowRunEvent: useCallback((event: CompanyStreamEvent) => {
-      // Both halves. The tick refreshes the durable history; the event drives
+      // Both halves. The tick refreshes the durable history; the frames drive
       // the live canvas. Progress frames are far more frequent than outcomes,
       // so only an outcome bumps the tick — refetching history once per node
       // would be N round trips per run for a list that has not changed yet.
-      setWorkflowRunEvent(event);
+      setWorkflowRunEvents((prev) => [...prev, event].slice(-WORKFLOW_EVENT_WINDOW));
       if (event.type === "workflow_run_finished") setWorkflowRunTick((n) => n + 1);
     }, []),
   });
@@ -651,7 +664,7 @@ export function AppShell({
                 client={client}
                 company={company}
                 runEventTick={workflowRunTick}
-                runEvent={workflowRunEvent}
+                runEvents={workflowRunEvents}
               />
             </Suspense>
           )}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -194,6 +194,12 @@ export function AppShell({
   // refreshes its run history live. Same shape as `taskEventTick` — a counter,
   // not the payload, so the view owns what it refetches.
   const [workflowRunTick, setWorkflowRunTick] = useState(0);
+  // Issue #371: the run-progress frame ITSELF, not just a nonce. The canvas
+  // paints per-node state, so unlike the tick above it needs the payload — a
+  // counter cannot say which node of which run just finished. Kept beside the
+  // tick rather than replacing it: the tick still drives the history refetch,
+  // which is a refetch and wants no payload.
+  const [workflowRunEvent, setWorkflowRunEvent] = useState<CompanyStreamEvent | null>(null);
   // The live tool timeline, per thread, built from the transient `tool_call` /
   // `tool_result` SSE frames while a turn runs (mirrors OpenHuman's live tool
   // rows). Cleared when the turn's final reply — carrying the authoritative
@@ -505,7 +511,14 @@ export function AppShell({
     onAgentReply: injectAgentReply,
     onTaskEvent: useCallback(() => setTaskEventTick((n) => n + 1), []),
     onTurnEvent,
-    onWorkflowRunEvent: useCallback(() => setWorkflowRunTick((n) => n + 1), []),
+    onWorkflowRunEvent: useCallback((event: CompanyStreamEvent) => {
+      // Both halves. The tick refreshes the durable history; the event drives
+      // the live canvas. Progress frames are far more frequent than outcomes,
+      // so only an outcome bumps the tick — refetching history once per node
+      // would be N round trips per run for a list that has not changed yet.
+      setWorkflowRunEvent(event);
+      if (event.type === "workflow_run_finished") setWorkflowRunTick((n) => n + 1);
+    }, []),
   });
 
   return (
@@ -638,6 +651,7 @@ export function AppShell({
                 client={client}
                 company={company}
                 runEventTick={workflowRunTick}
+                runEvent={workflowRunEvent}
               />
             </Suspense>
           )}

--- a/frontend/src/components/workflow-node.tsx
+++ b/frontend/src/components/workflow-node.tsx
@@ -1,29 +1,85 @@
 import { Handle, type NodeProps, Position } from "@xyflow/react";
 
-import { COLOR_CLASSES, type WorkflowNodeData } from "@/lib/workflow-sample";
+import {
+  COLOR_CLASSES,
+  RUN_STATE_CLASSES,
+  type NodeRunState,
+  type WorkflowNodeData,
+} from "@/lib/workflow-sample";
 import { cn } from "@/lib/utils";
 
-/** A custom xyflow node: emoji + colored header, name, and a one-line summary. */
+/** The word shown on a node's run-state badge. */
+const RUN_STATE_LABEL: Record<NodeRunState, string> = {
+  running: "running",
+  ok: "done",
+  error: "failed",
+};
+
+/** Badge tint per run state — read alongside the ring, never instead of it, so
+ * the state does not rely on colour alone. */
+const RUN_STATE_BADGE: Record<NodeRunState, string> = {
+  running: "bg-sky-500/15 text-sky-700 dark:text-sky-300",
+  ok: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
+  error: "bg-red-500/15 text-red-700 dark:text-red-300",
+};
+
+/** A custom xyflow node: emoji + colored header, name, and a one-line summary.
+ *
+ * Issue #371 layers a run state on top: a ring around the card and a word in
+ * the header, so an operator watching a run can see where it has got to. The
+ * resting node — no run being shown — renders exactly as it did before. */
 export function WorkflowNode({ data, selected }: NodeProps) {
   const d = data as WorkflowNodeData;
   const colors = COLOR_CLASSES[d.color];
+  const runState = d.runState;
   return (
     <div
       className={cn(
-        "min-w-[180px] max-w-[240px] rounded-xl border-2 bg-card shadow-sm",
+        "min-w-[180px] max-w-[240px] rounded-xl border-2 bg-card shadow-sm transition-shadow",
         colors.border,
+        runState && RUN_STATE_CLASSES[runState],
         selected && "ring-2 ring-primary/40",
       )}
+      data-run-state={runState}
     >
       <Handle type="target" position={Position.Left} className="!size-2 !border-2 !bg-background" />
       <div className={cn("flex items-center gap-2 rounded-t-[10px] px-3 py-2", colors.chip)}>
         <span className="text-base leading-none" aria-hidden>
           {d.emoji}
         </span>
-        <div className="min-w-0 truncate text-sm font-semibold">{d.name}</div>
+        <div className="min-w-0 flex-1 truncate text-sm font-semibold">{d.name}</div>
+        {runState && (
+          <span
+            className={cn(
+              "shrink-0 rounded px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide",
+              RUN_STATE_BADGE[runState],
+            )}
+            // "running" is a derived frontier, not something the engine reports.
+            // Saying so on hover is cheaper than being subtly wrong in silence.
+            title={
+              runState === "running"
+                ? "Reached this node — the engine reports nodes only as they finish, so this is where the run should be now."
+                : runState === "error"
+                  ? "This node failed."
+                  : "This node finished."
+            }
+          >
+            {RUN_STATE_LABEL[runState]}
+          </span>
+        )}
       </div>
-      <div className="px-3 py-2 text-[11px] leading-snug text-muted-foreground">{d.summary}</div>
+      <div className="px-3 py-2 text-[11px] leading-snug text-muted-foreground">
+        {d.summary}
+        {typeof d.elapsedMs === "number" && (
+          <span className="ml-1 font-mono opacity-70">· {formatElapsed(d.elapsedMs)}</span>
+        )}
+      </div>
       <Handle type="source" position={Position.Right} className="!size-2 !border-2 !bg-background" />
     </div>
   );
+}
+
+/** A compact duration: sub-second in ms, else seconds to one decimal. */
+function formatElapsed(ms: number): string {
+  return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`;
 }

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -53,6 +53,34 @@ export type CompanyStreamEvent =
       pendingApprovals: string[];
       /** Present only when the run failed outright. */
       error?: string;
+      /** The run's correlation id (issue #371). Absent on a pre-#371 row. */
+      runId?: string;
+    }
+  // Issue #371: the live per-node progress trail. A run announces itself, then
+  // reports each non-trigger node as it finishes, so the canvas can show which
+  // nodes are done while the run is still going — the whole point of the issue.
+  //
+  // There is deliberately no *node started* frame: the engine's observer has no
+  // such hook, so "currently executing" is derived from the graph topology the
+  // console already holds.
+  | {
+      type: "workflow_run_started";
+      seq: number;
+      atMillis: number;
+      workflowId: string;
+      runId: string;
+      scheduled: boolean;
+    }
+  | {
+      type: "workflow_node_finished";
+      seq: number;
+      atMillis: number;
+      workflowId: string;
+      runId: string;
+      nodeId: string;
+      /** Widened past the host's two words so an unknown status can't be a type error. */
+      status: string;
+      elapsedMs: number;
     }
   // The transient live turn-progress frames (`src/turn_stream.rs`): a tool call
   // just started (status `running`) or finished (status `ok`/`error`). These are
@@ -339,6 +367,18 @@ function handleEvent(
       }
       break;
     }
+    // Issue #371: progress frames route to the same subscriber the finished
+    // event does, and deliberately raise NO toast. Progress is not an attention
+    // signal — a six-node run would fire eight toasts and train the operator to
+    // dismiss the one that matters. The canvas is where this belongs.
+    //
+    // These arms exist because this file has already been bitten by events
+    // falling through to `default:` and vanishing; a new event type without an
+    // arm here is silently dropped, with nothing to debug.
+    case "workflow_run_started":
+    case "workflow_node_finished":
+      onWorkflowRunEvent?.(event);
+      break;
     default:
       // An unknown/forward event kind: ignore rather than surface noise.
       break;

--- a/frontend/src/lib/workflow-sample.ts
+++ b/frontend/src/lib/workflow-sample.ts
@@ -13,7 +13,34 @@ export interface WorkflowNodeData extends Record<string, unknown> {
   summary: string;
   emoji: string;
   color: NodeColor;
+  /**
+   * How this node fared in the run being shown (issue #371) — the live one, or
+   * a past run overlaid from the history panel. Absent when no run is being
+   * shown, which is the resting state and must look exactly as it did before.
+   */
+  runState?: NodeRunState;
+  /** Wall-clock duration of the node's execution, once it has finished. */
+  elapsedMs?: number;
 }
+
+/**
+ * A node's state within one run (issue #371).
+ *
+ * `running` is **derived**, not reported: the engine's observer has an
+ * `on_step_finish` hook and no `on_step_start`, so the console marks the
+ * successors of a finished node as running rather than being told. It is
+ * therefore a good-faith frontier, not ground truth — after a branch point it
+ * briefly marks both arms until one of them finishes. `ok` and `error` are
+ * reported by the engine and are exact.
+ */
+export type NodeRunState = "running" | "ok" | "error";
+
+/** Ring + glow per run state, layered over the node's own kind accent. */
+export const RUN_STATE_CLASSES: Record<NodeRunState, string> = {
+  running: "ring-2 ring-sky-500/70 shadow-sky-500/20 animate-pulse",
+  ok: "ring-2 ring-emerald-500/60",
+  error: "ring-2 ring-red-500/80",
+};
 
 /** Per-kind emoji + accent, mirroring OpenHuman's node-kind metadata. */
 export const NODE_KIND_META: Record<string, { emoji: string; color: NodeColor }> = {

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Background,
   BackgroundVariant,
@@ -66,6 +66,10 @@ import {
 
 const NODE_TYPES = { oc: WorkflowNode };
 
+/** A stable empty default for `runEvents`, so an omitted prop does not hand the
+ * fold a fresh array identity on every render. */
+const EMPTY_RUN_EVENTS: CompanyStreamEvent[] = [];
+
 /** Horizontal gap between layers and vertical gap between nodes in a layer. */
 const COL_GAP = 300;
 const ROW_GAP = 150;
@@ -81,7 +85,7 @@ export function WorkflowsView({
   client,
   company,
   runEventTick = 0,
-  runEvent = null,
+  runEvents = EMPTY_RUN_EVENTS,
 }: {
   client: OpenCompanyClient;
   company: string | null;
@@ -93,14 +97,19 @@ export function WorkflowsView({
    */
   runEventTick?: number;
   /**
-   * The latest workflow run frame off the SSE stream (issue #371) — a run
-   * starting, a node finishing, or a run settling.
+   * A rolling window of workflow run frames off the SSE stream (issue #371) —
+   * runs starting, nodes finishing, runs settling.
    *
-   * Unlike `runEventTick` this carries the payload, because the canvas paints
+   * Unlike `runEventTick` these carry the payload, because the canvas paints
    * per-node state and a counter cannot say which node of which run just
    * finished. The two coexist: the tick still drives the history refetch.
+   *
+   * A **window**, not a latest-event slot: two frames routinely arrive inside
+   * one React batch, and a slot drops the earlier one. The canvas state is
+   * folded from the window rather than accumulated frame by frame, so a
+   * coalesced render can never lose a node.
    */
-  runEvent?: CompanyStreamEvent | null;
+  runEvents?: CompanyStreamEvent[];
 }) {
   const { resolvedTheme } = useTheme();
   const [workflows, setWorkflows] = useState<WorkflowSummary[]>([]);
@@ -150,15 +159,10 @@ export function WorkflowsView({
   // Bumped by the conflict banner's Reload, to re-fetch the selected graph (and
   // with it a fresh `version`) without changing the selection.
   const [graphTick, setGraphTick] = useState(0);
-  // Issue #371: what the run currently on screen has done, per node.
-  //
-  // `liveRunId` is the run these states belong to. It exists because a company
-  // can have two runs in flight — an operator pressing Run while a cron fire is
-  // mid-graph — and both stream onto the same SSE connection. Without it, the
-  // cron run's node frames would repaint the canvas the operator is watching.
-  const [liveRunId, setLiveRunId] = useState<string | null>(null);
-  const [nodeRunState, setNodeRunState] = useState<Record<string, NodeRunState>>({});
-  const [nodeElapsed, setNodeElapsed] = useState<Record<string, number>>({});
+  // Issue #371: the frontier painted between pressing Run and the first frame
+  // arriving, so the canvas answers the click immediately. Cleared as soon as
+  // the fold below has a run of its own to show.
+  const [optimistic, setOptimistic] = useState<Record<string, NodeRunState> | null>(null);
   // A past run selected from the history panel, overlaid on the canvas. When
   // set it WINS over the live state — the operator asked to look at that run.
   // This is what makes a scheduled run's failure point visible after the fact,
@@ -172,6 +176,10 @@ export function WorkflowsView({
   // journaled gets them the same per-node answer, just at the end instead of
   // during. Cleared as soon as it is used, or when live frames made it moot.
   const [awaitingRunId, setAwaitingRunId] = useState<string | null>(null);
+  // Run ids the live fold has actually seen frames for. The fallback above
+  // consults it so a console WITH a working stream never double-paints a run it
+  // already watched, and one without it still gets the journaled answer.
+  const liveRanRef = useRef<Set<string>>(new Set());
 
   // Load the workflow list once, and auto-select the first entry.
   useEffect(() => {
@@ -272,11 +280,11 @@ export function WorkflowsView({
           const mine = rows.find((r) => r.runId === awaitingRunId);
           if (mine) {
             setAwaitingRunId(null);
-            setNodeRunState((prev) => {
-              const reported = Object.values(prev).some((st) => st !== "running");
-              if (!reported && (mine.nodes?.length ?? 0) > 0) setOverlayRun(mine);
-              return prev;
-            });
+            // Only when the live fold never adopted this run — i.e. no frame
+            // for it ever arrived. With a live stream this is a no-op.
+            if (!liveRanRef.current.has(mine.runId ?? "") && (mine.nodes?.length ?? 0) > 0) {
+              setOverlayRun(mine);
+            }
           }
         }
       } catch (e) {
@@ -303,8 +311,7 @@ export function WorkflowsView({
     // the first frame. The `workflow_run_started` frame re-sets the same thing
     // a moment later, which is idempotent.
     setOverlayRun(null);
-    setNodeElapsed({});
-    setNodeRunState(graph ? initialRunState(graph) : {});
+    setOptimistic(graph ? initialRunState(graph) : null);
     // Trimmed once here so the echoed request and the payload the host receives
     // can never disagree.
     const asked = request.trim();
@@ -327,13 +334,9 @@ export function WorkflowsView({
       // A run that failed is journaled too (#228), and is the outcome most
       // worth finding again later — so refresh the history on this path as well.
       setRunsTick((n) => n + 1);
-      // Nothing is executing any more. Drop the derived marks so a failed run
-      // does not leave a node pulsing "running" forever; the reported ok/error
-      // ones stay, because they are how far it got.
-      setNodeRunState((prev) =>
-        Object.fromEntries(Object.entries(prev).filter(([, st]) => st !== "running")),
-      );
-      setLiveRunId(null);
+      // Drop the optimistic frontier so a failed run does not leave a node
+      // pulsing "running" forever. The fold owns anything actually reported.
+      setOptimistic(null);
     } finally {
       setRunning(false);
     }
@@ -412,93 +415,45 @@ export function WorkflowsView({
     toast.success("Workflow created.");
   }, []);
 
-  // Issue #371: fold the live SSE progress frames into per-node canvas state.
+  // Issue #371: the live canvas state, FOLDED from the frame window rather than
+  // accumulated frame by frame.
   //
-  // Everything here is guarded on the frame belonging to the workflow on screen
-  // AND (after the start) to the run we adopted, because one SSE connection
-  // carries every run of every workflow in the company.
-  useEffect(() => {
-    if (!runEvent || !selectedId) return;
+  // A fold is what makes this correct under React batching: several frames can
+  // land in one render, and an accumulating reducer would see only the last —
+  // losing a `workflow_run_started` that way strands every node frame behind
+  // it. Recomputing from the window instead has no such state to lose.
+  const liveRun = useMemo(
+    () => foldLiveRun(runEvents, selectedId, graph),
+    [runEvents, selectedId, graph],
+  );
 
-    switch (runEvent.type) {
-      case "workflow_run_started": {
-        if (runEvent.workflowId !== selectedId) return;
-        // Adopt this run and start from a clean canvas. A rerun must not leave
-        // the previous run's marks behind — they would read as this run's.
-        setLiveRunId(runEvent.runId);
-        setOverlayRun(null);
-        // The trigger fired by definition — the run exists — and the engine
-        // reports no step for it, so nothing else would ever mark it. Its
-        // successors are where execution is now.
-        setNodeRunState(graph ? initialRunState(graph) : {});
-        setNodeElapsed({});
-        return;
-      }
-      case "workflow_node_finished": {
-        if (runEvent.workflowId !== selectedId || runEvent.runId !== liveRunId) return;
-        const finished = runEvent.nodeId;
-        // Trust the host's word, but do not let an unknown one paint a node as
-        // succeeded: anything that is not "ok" is treated as a failure.
-        const state: NodeRunState = runEvent.status === "ok" ? "ok" : "error";
-        setNodeRunState((prev) => {
-          const next = { ...prev, [finished]: state };
-          // Advance the frontier. Only a successful node hands execution on —
-          // a failed one under the default `stop` policy ends the run, and
-          // lighting up its successors would claim work that never happened.
-          if (state === "ok" && graph) {
-            for (const id of successorsOf(graph, finished)) {
-              if (!next[id]) next[id] = "running";
-            }
-          }
-          return next;
-        });
-        setNodeElapsed((prev) => ({ ...prev, [finished]: runEvent.elapsedMs }));
-        return;
-      }
-      case "workflow_run_finished": {
-        if (runEvent.workflowId !== selectedId) return;
-        // A pre-#371 host sends no runId; treat that as "the run on screen"
-        // rather than ignoring it, else the canvas would spin forever.
-        if (runEvent.runId && liveRunId && runEvent.runId !== liveRunId) return;
-        // Clear the derived "running" marks — nothing is executing any more —
-        // but KEEP the reported ok/error ones. That residue is the answer to
-        // "how far did it get?", and it stays until a reselect or a rerun.
-        setNodeRunState((prev) =>
-          Object.fromEntries(
-            Object.entries(prev).filter(([, state]) => state !== "running"),
-          ),
-        );
-        setLiveRunId(null);
-        return;
-      }
-      default:
-        return;
-    }
-    // `graph` is read inside, but is deliberately NOT a dependency: a graph
-    // re-fetch mid-run would replay the last frame and could resurrect cleared
-    // marks. The selection effect below is what resets state on a graph change.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [runEvent, selectedId, liveRunId]);
+  // The optimistic frontier is only for the gap before the first frame. Once
+  // the fold has adopted a run, it is the authority — and that run is recorded
+  // so the no-stream fallback knows it was watched live.
+  useEffect(() => {
+    if (!liveRun) return;
+    liveRanRef.current.add(liveRun.runId);
+    setOptimistic(null);
+  }, [liveRun]);
 
   // Switching workflow (or company) clears the canvas: another graph's node ids
   // are meaningless here, and a stale mark on a same-named node would be a lie.
   useEffect(() => {
-    setNodeRunState({});
-    setNodeElapsed({});
-    setLiveRunId(null);
+    setOptimistic(null);
     setOverlayRun(null);
   }, [selectedId, company]);
 
-  // What the canvas actually paints. An overlaid past run wins over the live
-  // state — selecting a history row is an explicit "show me that one".
-  const paintedStates = useMemo<Record<string, NodeRunState>>(
-    () => (overlayRun ? statesFromRun(overlayRun) : nodeRunState),
-    [overlayRun, nodeRunState],
-  );
-  const paintedElapsed = useMemo<Record<string, number>>(
-    () => (overlayRun ? elapsedFromRun(overlayRun) : nodeElapsed),
-    [overlayRun, nodeElapsed],
-  );
+  // What the canvas actually paints, in priority order: a past run the operator
+  // explicitly asked to see, else the live fold, else the optimistic frontier.
+  const paintedStates = useMemo<Record<string, NodeRunState>>(() => {
+    if (overlayRun) return statesFromRun(overlayRun);
+    if (liveRun) return liveRun.states;
+    return optimistic ?? {};
+  }, [overlayRun, liveRun, optimistic]);
+  const paintedElapsed = useMemo<Record<string, number>>(() => {
+    if (overlayRun) return elapsedFromRun(overlayRun);
+    return liveRun?.elapsed ?? {};
+  }, [overlayRun, liveRun]);
 
   const { nodes, edges } = useMemo(
     () =>
@@ -733,11 +688,7 @@ export function WorkflowsView({
               <span className="text-xs">
                 Showing the {overlayRun.scheduled ? "scheduled" : "manual"} run from{" "}
                 {new Date(overlayRun.atMillis).toLocaleString()}
-                {overlayRun.error
-                  ? failedNodeOf(overlayRun)
-                    ? ` — it failed at “${nodeName(graph, failedNodeOf(overlayRun)!)}”.`
-                    : " — it failed before any node ran."
-                  : "."}{" "}
+                {overlayRun.error ? ` — ${failureLocation(overlayRun, graph)}` : "."}{" "}
                 Unmarked nodes were never reached.
               </span>
               <Button size="sm" variant="outline" onClick={() => setOverlayRun(null)}>
@@ -1434,6 +1385,92 @@ function NodeResultCard({ node }: { node: NodeResult }) {
   );
 }
 
+/** The result of folding the SSE frame window down to one run's canvas state. */
+interface LiveRun {
+  runId: string;
+  states: Record<string, NodeRunState>;
+  elapsed: Record<string, number>;
+  /** False once the run has settled — its ok/error marks stay, its running ones go. */
+  active: boolean;
+}
+
+/** Folds the run-progress frame window (issue #371) into the canvas state for
+ * the workflow on screen.
+ *
+ * Pure, and recomputed from scratch on every window change. That is the point:
+ * an accumulating reducer loses frames that arrive inside one React batch,
+ * which for a graph with a sub-millisecond transform node is the normal case.
+ *
+ * Only the MOST RECENT run of the selected workflow is folded, and every frame
+ * is matched on its run id. One SSE connection carries every run in the
+ * company, so without that a cron fire would repaint a canvas an operator is
+ * watching, and two concurrent runs of the same graph would interleave into one
+ * incoherent picture. */
+function foldLiveRun(
+  events: CompanyStreamEvent[],
+  selectedId: string | null,
+  graph: WorkflowGraph | null,
+): LiveRun | null {
+  if (!selectedId || !graph) return null;
+
+  // The last start for this workflow wins — a rerun supersedes the run before.
+  let startIndex = -1;
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (e.type === "workflow_run_started" && e.workflowId === selectedId) {
+      startIndex = i;
+      break;
+    }
+  }
+  if (startIndex === -1) return null;
+  const started = events[startIndex];
+  if (started.type !== "workflow_run_started") return null;
+
+  const runId = started.runId;
+  // The trigger fired by definition, and the engine reports no step for it, so
+  // nothing else would ever mark it. Its successors are where execution is now.
+  const states = initialRunState(graph);
+  const elapsed: Record<string, number> = {};
+  let active = true;
+
+  for (let i = startIndex + 1; i < events.length; i++) {
+    const e = events[i];
+    if (e.type === "workflow_node_finished") {
+      if (e.runId !== runId) continue;
+      // Anything that is not "ok" is treated as a failure: an unknown status
+      // word from a newer host must never paint a node as succeeded.
+      const state: NodeRunState = e.status === "ok" ? "ok" : "error";
+      states[e.nodeId] = state;
+      elapsed[e.nodeId] = e.elapsedMs;
+      // Advance the frontier. Only a successful node hands execution on — a
+      // failed one under the default `stop` policy ends the run, and lighting
+      // up its successors would claim work that never happened.
+      if (state === "ok") {
+        for (const id of successorsOf(graph, e.nodeId)) {
+          if (!states[id]) states[id] = "running";
+        }
+      }
+      continue;
+    }
+    if (e.type === "workflow_run_finished" && e.workflowId === selectedId) {
+      // A pre-#371 host sends no runId; treat that as "the run on screen"
+      // rather than ignoring it, else the canvas would spin forever.
+      if (!e.runId || e.runId === runId) active = false;
+    }
+  }
+
+  if (!active) {
+    // Nothing is executing any more, so the derived marks go. The REPORTED
+    // ok/error ones stay — they are the answer to "how far did it get?" — until
+    // a reselect or a rerun.
+    for (const [id, state] of Object.entries(states)) {
+      if (state === "running") delete states[id];
+    }
+  }
+
+  return { runId, states, elapsed, active };
+}
+
 /** A node's display name, falling back to its id when the graph is not loaded
  * (a company switch mid-overlay) — never a blank quote. */
 function nodeName(graph: WorkflowGraph | null, nodeId: string): string {
@@ -1481,6 +1518,28 @@ function elapsedFromRun(run: WorkflowRunOutcome): Record<string, number> {
   const out: Record<string, number> = {};
   for (const node of run.nodes ?? []) out[node.nodeId] = node.elapsedMs;
   return out;
+}
+
+/** Where a failed run stopped, in plain words (issue #371).
+ *
+ * Three genuinely different cases, and collapsing them fabricates precision:
+ *
+ * * a node reported `error` — the engine names it, so say it exactly;
+ * * nodes ran but none errored — an **interrupted** run, whose synthetic
+ *   outcome was written by the boot sweep and belongs to no node. Saying "it
+ *   failed at X" here would blame a node that succeeded, and saying "before any
+ *   node ran" would contradict the marks on the canvas;
+ * * nothing ran at all — a graph that would not compile, or a capability that
+ *   could not be built.
+ */
+function failureLocation(run: WorkflowRunOutcome, graph: WorkflowGraph | null): string {
+  const failed = failedNodeOf(run);
+  if (failed) return `it failed at “${nodeName(graph, failed)}”.`;
+  const ran = run.nodes?.length ?? 0;
+  if (ran > 0) {
+    return `it stopped after ${ran} node${ran === 1 ? "" : "s"}, without any of them reporting a failure.`;
+  }
+  return "it failed before any node ran.";
 }
 
 /** The node a run failed at, when its trail names one (issue #371).

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -25,10 +25,12 @@ import {
   type DeliveryStatus,
   type WorkflowGraph,
   type WorkflowNode as WorkflowNodeModel,
+  type WorkflowRunNode,
   type WorkflowRunOutcome,
   type WorkflowRunResult,
   type WorkflowSummary,
 } from "@/api/workflows";
+import type { CompanyStreamEvent } from "@/hooks/use-events";
 import type { OpenCompanyClient } from "@/api/client";
 import { ApiError } from "@/api/types";
 import {
@@ -56,7 +58,11 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { WorkflowNode } from "@/components/workflow-node";
 import { WorkflowCreateDialog } from "@/views/WorkflowCreateDialog";
-import { nodeKindMeta, type WorkflowNodeData } from "@/lib/workflow-sample";
+import {
+  nodeKindMeta,
+  type NodeRunState,
+  type WorkflowNodeData,
+} from "@/lib/workflow-sample";
 
 const NODE_TYPES = { oc: WorkflowNode };
 
@@ -75,6 +81,7 @@ export function WorkflowsView({
   client,
   company,
   runEventTick = 0,
+  runEvent = null,
 }: {
   client: OpenCompanyClient;
   company: string | null;
@@ -85,6 +92,15 @@ export function WorkflowsView({
    * view a cron fired.
    */
   runEventTick?: number;
+  /**
+   * The latest workflow run frame off the SSE stream (issue #371) — a run
+   * starting, a node finishing, or a run settling.
+   *
+   * Unlike `runEventTick` this carries the payload, because the canvas paints
+   * per-node state and a counter cannot say which node of which run just
+   * finished. The two coexist: the tick still drives the history refetch.
+   */
+  runEvent?: CompanyStreamEvent | null;
 }) {
   const { resolvedTheme } = useTheme();
   const [workflows, setWorkflows] = useState<WorkflowSummary[]>([]);
@@ -134,6 +150,28 @@ export function WorkflowsView({
   // Bumped by the conflict banner's Reload, to re-fetch the selected graph (and
   // with it a fresh `version`) without changing the selection.
   const [graphTick, setGraphTick] = useState(0);
+  // Issue #371: what the run currently on screen has done, per node.
+  //
+  // `liveRunId` is the run these states belong to. It exists because a company
+  // can have two runs in flight — an operator pressing Run while a cron fire is
+  // mid-graph — and both stream onto the same SSE connection. Without it, the
+  // cron run's node frames would repaint the canvas the operator is watching.
+  const [liveRunId, setLiveRunId] = useState<string | null>(null);
+  const [nodeRunState, setNodeRunState] = useState<Record<string, NodeRunState>>({});
+  const [nodeElapsed, setNodeElapsed] = useState<Record<string, number>>({});
+  // A past run selected from the history panel, overlaid on the canvas. When
+  // set it WINS over the live state — the operator asked to look at that run.
+  // This is what makes a scheduled run's failure point visible after the fact,
+  // which is the half of the issue a live canvas alone cannot answer.
+  const [overlayRun, setOverlayRun] = useState<WorkflowRunOutcome | null>(null);
+  // The run this view just POSTed, held until its history row arrives.
+  //
+  // The fallback for a console with no live stream: if `/events` 404s or the
+  // connection dropped, no progress frame ever lands and the canvas would stay
+  // blank for a run the operator watched happen. Overlaying the row the host
+  // journaled gets them the same per-node answer, just at the end instead of
+  // during. Cleared as soon as it is used, or when live frames made it moot.
+  const [awaitingRunId, setAwaitingRunId] = useState<string | null>(null);
 
   // Load the workflow list once, and auto-select the first entry.
   useEffect(() => {
@@ -226,6 +264,21 @@ export function WorkflowsView({
         if (!live) return;
         setRuns(rows);
         setHistorySupported(true);
+        // Issue #371, the no-live-stream fallback. If the run we just POSTed is
+        // in this page and nothing was ever *reported* live (only the frontier
+        // we derived ourselves), overlay the journaled row so the operator
+        // still gets the per-node answer.
+        if (awaitingRunId) {
+          const mine = rows.find((r) => r.runId === awaitingRunId);
+          if (mine) {
+            setAwaitingRunId(null);
+            setNodeRunState((prev) => {
+              const reported = Object.values(prev).some((st) => st !== "running");
+              if (!reported && (mine.nodes?.length ?? 0) > 0) setOverlayRun(mine);
+              return prev;
+            });
+          }
+        }
       } catch (e) {
         if (!live) return;
         // Degrade quietly: an older host simply has no history to show.
@@ -237,11 +290,21 @@ export function WorkflowsView({
     return () => {
       live = false;
     };
+    // `awaitingRunId` is read but deliberately not a dependency: it is cleared
+    // inside, and listing it would re-run this fetch on that clear.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client, company, selectedId, runsTick, runEventTick]);
 
   const run = useCallback(async () => {
     if (!selectedId) return;
     setRunning(true);
+    // Issue #371: clear the previous run's marks and paint the opening frontier
+    // immediately, so the canvas responds to the click rather than waiting on
+    // the first frame. The `workflow_run_started` frame re-sets the same thing
+    // a moment later, which is idempotent.
+    setOverlayRun(null);
+    setNodeElapsed({});
+    setNodeRunState(graph ? initialRunState(graph) : {});
     // Trimmed once here so the echoed request and the payload the host receives
     // can never disagree.
     const asked = request.trim();
@@ -254,6 +317,7 @@ export function WorkflowsView({
       );
       setRanWith(asked);
       setResult(res);
+      setAwaitingRunId(res.runId ?? null);
       // The run is journaled host-side (#228); pull the history forward so the
       // chip and the panel reflect it immediately.
       setRunsTick((n) => n + 1);
@@ -263,10 +327,17 @@ export function WorkflowsView({
       // A run that failed is journaled too (#228), and is the outcome most
       // worth finding again later — so refresh the history on this path as well.
       setRunsTick((n) => n + 1);
+      // Nothing is executing any more. Drop the derived marks so a failed run
+      // does not leave a node pulsing "running" forever; the reported ok/error
+      // ones stay, because they are how far it got.
+      setNodeRunState((prev) =>
+        Object.fromEntries(Object.entries(prev).filter(([, st]) => st !== "running")),
+      );
+      setLiveRunId(null);
     } finally {
       setRunning(false);
     }
-  }, [client, company, selectedId, request]);
+  }, [client, company, selectedId, request, graph]);
 
   // Issue #259: remove the selected workflow.
   //
@@ -341,7 +412,101 @@ export function WorkflowsView({
     toast.success("Workflow created.");
   }, []);
 
-  const { nodes, edges } = useMemo(() => (graph ? layout(graph) : { nodes: [], edges: [] }), [graph]);
+  // Issue #371: fold the live SSE progress frames into per-node canvas state.
+  //
+  // Everything here is guarded on the frame belonging to the workflow on screen
+  // AND (after the start) to the run we adopted, because one SSE connection
+  // carries every run of every workflow in the company.
+  useEffect(() => {
+    if (!runEvent || !selectedId) return;
+
+    switch (runEvent.type) {
+      case "workflow_run_started": {
+        if (runEvent.workflowId !== selectedId) return;
+        // Adopt this run and start from a clean canvas. A rerun must not leave
+        // the previous run's marks behind — they would read as this run's.
+        setLiveRunId(runEvent.runId);
+        setOverlayRun(null);
+        // The trigger fired by definition — the run exists — and the engine
+        // reports no step for it, so nothing else would ever mark it. Its
+        // successors are where execution is now.
+        setNodeRunState(graph ? initialRunState(graph) : {});
+        setNodeElapsed({});
+        return;
+      }
+      case "workflow_node_finished": {
+        if (runEvent.workflowId !== selectedId || runEvent.runId !== liveRunId) return;
+        const finished = runEvent.nodeId;
+        // Trust the host's word, but do not let an unknown one paint a node as
+        // succeeded: anything that is not "ok" is treated as a failure.
+        const state: NodeRunState = runEvent.status === "ok" ? "ok" : "error";
+        setNodeRunState((prev) => {
+          const next = { ...prev, [finished]: state };
+          // Advance the frontier. Only a successful node hands execution on —
+          // a failed one under the default `stop` policy ends the run, and
+          // lighting up its successors would claim work that never happened.
+          if (state === "ok" && graph) {
+            for (const id of successorsOf(graph, finished)) {
+              if (!next[id]) next[id] = "running";
+            }
+          }
+          return next;
+        });
+        setNodeElapsed((prev) => ({ ...prev, [finished]: runEvent.elapsedMs }));
+        return;
+      }
+      case "workflow_run_finished": {
+        if (runEvent.workflowId !== selectedId) return;
+        // A pre-#371 host sends no runId; treat that as "the run on screen"
+        // rather than ignoring it, else the canvas would spin forever.
+        if (runEvent.runId && liveRunId && runEvent.runId !== liveRunId) return;
+        // Clear the derived "running" marks — nothing is executing any more —
+        // but KEEP the reported ok/error ones. That residue is the answer to
+        // "how far did it get?", and it stays until a reselect or a rerun.
+        setNodeRunState((prev) =>
+          Object.fromEntries(
+            Object.entries(prev).filter(([, state]) => state !== "running"),
+          ),
+        );
+        setLiveRunId(null);
+        return;
+      }
+      default:
+        return;
+    }
+    // `graph` is read inside, but is deliberately NOT a dependency: a graph
+    // re-fetch mid-run would replay the last frame and could resurrect cleared
+    // marks. The selection effect below is what resets state on a graph change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runEvent, selectedId, liveRunId]);
+
+  // Switching workflow (or company) clears the canvas: another graph's node ids
+  // are meaningless here, and a stale mark on a same-named node would be a lie.
+  useEffect(() => {
+    setNodeRunState({});
+    setNodeElapsed({});
+    setLiveRunId(null);
+    setOverlayRun(null);
+  }, [selectedId, company]);
+
+  // What the canvas actually paints. An overlaid past run wins over the live
+  // state — selecting a history row is an explicit "show me that one".
+  const paintedStates = useMemo<Record<string, NodeRunState>>(
+    () => (overlayRun ? statesFromRun(overlayRun) : nodeRunState),
+    [overlayRun, nodeRunState],
+  );
+  const paintedElapsed = useMemo<Record<string, number>>(
+    () => (overlayRun ? elapsedFromRun(overlayRun) : nodeElapsed),
+    [overlayRun, nodeElapsed],
+  );
+
+  const { nodes, edges } = useMemo(
+    () =>
+      graph
+        ? layout(graph, paintedStates, paintedElapsed)
+        : { nodes: [], edges: [] },
+    [graph, paintedStates, paintedElapsed],
+  );
 
   const selected = workflows.find((w) => w.id === selectedId) ?? null;
 
@@ -558,6 +723,31 @@ export function WorkflowsView({
         </div>
       )}
 
+      {/* Issue #371: the canvas is showing a PAST run, not the live one. Said
+          plainly, with the way out attached — an unexplained ring on a node
+          would otherwise read as the current state of the workflow. */}
+      {overlayRun && (
+        <div className="px-4 pt-3">
+          <Alert data-testid="workflow-overlay-banner">
+            <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
+              <span className="text-xs">
+                Showing the {overlayRun.scheduled ? "scheduled" : "manual"} run from{" "}
+                {new Date(overlayRun.atMillis).toLocaleString()}
+                {overlayRun.error
+                  ? failedNodeOf(overlayRun)
+                    ? ` — it failed at “${nodeName(graph, failedNodeOf(overlayRun)!)}”.`
+                    : " — it failed before any node ran."
+                  : "."}{" "}
+                Unmarked nodes were never reached.
+              </span>
+              <Button size="sm" variant="outline" onClick={() => setOverlayRun(null)}>
+                Clear
+              </Button>
+            </AlertDescription>
+          </Alert>
+        </div>
+      )}
+
       <div className="relative flex-1">
         {loadingList || loadingGraph ? (
           <div className="absolute inset-0 p-4">
@@ -612,6 +802,12 @@ export function WorkflowsView({
           runs={runs}
           workflowName={selected?.name ?? selectedId ?? ""}
           onClose={() => setHistoryOpen(false)}
+          selectedRunSeq={overlayRun?.seq ?? null}
+          onSelectRun={(picked) =>
+            // Clicking the row already shown clears it, so the control is a
+            // toggle rather than a one-way trip into overlay mode.
+            setOverlayRun((prev) => (prev?.seq === picked.seq ? null : picked))
+          }
         />
       )}
 
@@ -930,10 +1126,16 @@ function RunHistoryPanel({
   runs,
   workflowName,
   onClose,
+  selectedRunSeq,
+  onSelectRun,
 }: {
   runs: WorkflowRunOutcome[];
   workflowName: string;
   onClose: () => void;
+  /** The run currently overlaid on the canvas, if any (issue #371). */
+  selectedRunSeq: number | null;
+  /** Overlay this run's per-node states on the canvas (issue #371). */
+  onSelectRun: (run: WorkflowRunOutcome) => void;
 }) {
   return (
     <div className="border-t bg-card/60" data-testid="workflow-run-history">
@@ -958,7 +1160,12 @@ function RunHistoryPanel({
         ) : (
           <div className="space-y-2">
             {runs.map((run) => (
-              <RunHistoryRow key={run.seq} run={run} />
+              <RunHistoryRow
+                key={run.seq}
+                run={run}
+                selected={run.seq === selectedRunSeq}
+                onSelect={() => onSelectRun(run)}
+              />
             ))}
           </div>
         )}
@@ -967,11 +1174,30 @@ function RunHistoryPanel({
   );
 }
 
-/** One finished run: a summary line, and its delivery rows underneath. */
-function RunHistoryRow({ run }: { run: WorkflowRunOutcome }) {
+/** One finished run: a summary line, its per-node trail, and its delivery rows.
+ *
+ * Clicking it overlays that run's node states on the canvas (issue #371) —
+ * which is what makes a scheduled run's failure point visible, the case the
+ * live canvas by definition cannot cover because nobody was watching. */
+function RunHistoryRow({
+  run,
+  selected,
+  onSelect,
+}: {
+  run: WorkflowRunOutcome;
+  selected: boolean;
+  onSelect: () => void;
+}) {
   const tone = runTone(run);
+  const nodes = run.nodes ?? [];
+  const failedNode = failedNodeOf(run);
   return (
-    <div className="rounded-lg border bg-background/40 p-2" data-testid="workflow-run-row">
+    <div
+      className={`rounded-lg border bg-background/40 p-2 ${
+        selected ? "ring-2 ring-primary/40" : ""
+      }`}
+      data-testid="workflow-run-row"
+    >
       <div className="mb-1 flex flex-wrap items-center gap-2">
         <span className={`size-1.5 rounded-full ${tone.dot}`} />
         <Badge variant="outline" className="h-4 px-1.5 text-[10px] font-normal">
@@ -989,13 +1215,49 @@ function RunHistoryRow({ run }: { run: WorkflowRunOutcome }) {
             {run.pendingApprovals.length === 1 ? "" : "s"}
           </Badge>
         )}
+        {run.running && (
+          <Badge
+            variant="outline"
+            className="h-4 px-1.5 text-[10px] font-normal border-sky-500/40 bg-sky-500/10"
+          >
+            running
+          </Badge>
+        )}
+        {nodes.length > 0 && (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="ml-auto h-5 px-2 text-[10px]"
+            onClick={onSelect}
+            aria-pressed={selected}
+            data-testid="workflow-run-overlay-toggle"
+          >
+            {selected ? "Hide on canvas" : "Show on canvas"}
+          </Button>
+        )}
       </div>
+
+      {/* Issue #371: the per-node trail, which is what turns "it failed" into
+          "it failed HERE". Absent for a run journaled before #371 — those rows
+          render exactly as they always did. */}
+      {nodes.length > 0 && (
+        <div className="mb-1 flex flex-wrap gap-1" data-testid="workflow-run-nodes">
+          {nodes.map((node) => (
+            <RunNodeChip key={`${node.nodeId}-${node.elapsedMs}`} node={node} />
+          ))}
+        </div>
+      )}
       {run.error ? (
         // The outcome that used to be quietest of all: a run that died left one
         // host-stdout warning and nothing an operator could ever find.
         <Alert variant="destructive" className="py-2">
           <AlertDescription className="text-[11px]">
-            This run failed: {run.error}
+            {/* Name the node when the trail names one — the engine reports a
+                failing node as an errored step, so this is exact. When it does
+                not (a graph that would not compile, a capability that could not
+                be built), say nothing about nodes rather than guessing. */}
+            {failedNode ? `This run failed at “${failedNode}”: ` : "This run failed: "}
+            {run.error}
           </AlertDescription>
         </Alert>
       ) : run.deliveries.length > 0 ? (
@@ -1008,6 +1270,26 @@ function RunHistoryRow({ run }: { run: WorkflowRunOutcome }) {
         </p>
       )}
     </div>
+  );
+}
+
+/** One node's outcome in a history row: its id, how it went, how long it took. */
+function RunNodeChip({ node }: { node: WorkflowRunNode }) {
+  const ok = node.status === "ok";
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] ${
+        ok
+          ? "border-emerald-500/40 bg-emerald-500/10"
+          : "border-red-500/50 bg-red-500/10"
+      }`}
+    >
+      <span className={`size-1.5 rounded-full ${ok ? "bg-emerald-500" : "bg-red-500"}`} />
+      <span className="font-medium">{node.nodeId}</span>
+      <span className="font-mono opacity-70">
+        {node.elapsedMs < 1000 ? `${node.elapsedMs}ms` : `${(node.elapsedMs / 1000).toFixed(1)}s`}
+      </span>
+    </span>
   );
 }
 
@@ -1152,10 +1434,77 @@ function NodeResultCard({ node }: { node: NodeResult }) {
   );
 }
 
+/** A node's display name, falling back to its id when the graph is not loaded
+ * (a company switch mid-overlay) — never a blank quote. */
+function nodeName(graph: WorkflowGraph | null, nodeId: string): string {
+  return graph?.nodes.find((n) => n.id === nodeId)?.name ?? nodeId;
+}
+
+/** The node ids `from` hands execution to. */
+function successorsOf(graph: WorkflowGraph, from: string): string[] {
+  return graph.edges.filter((e) => e.from === from).map((e) => e.to);
+}
+
+/** The canvas state a run starts in (issue #371): every trigger marked done,
+ * its successors marked running.
+ *
+ * Both halves are derived rather than reported. The engine emits no step for a
+ * trigger node — it is the thing that fired, not a thing that ran — and it has
+ * no `on_step_start` hook at all, so "where is it now" has to come from the
+ * graph. After a branch point this briefly marks more than one arm; that
+ * corrects itself as the real finishes arrive. */
+function initialRunState(graph: WorkflowGraph): Record<string, NodeRunState> {
+  const state: Record<string, NodeRunState> = {};
+  for (const node of graph.nodes) {
+    if (node.kind !== "trigger") continue;
+    state[node.id] = "ok";
+    for (const id of successorsOf(graph, node.id)) state[id] = "running";
+  }
+  return state;
+}
+
+/** The per-node states of a PAST run, for overlaying it on the canvas.
+ *
+ * No `running` ever comes out of this: the run is over. A node the run never
+ * reached simply has no entry, so it renders unmarked — "not reached" and not
+ * "still to come", which for a failed run is the honest reading. */
+function statesFromRun(run: WorkflowRunOutcome): Record<string, NodeRunState> {
+  const state: Record<string, NodeRunState> = {};
+  for (const node of run.nodes ?? []) {
+    state[node.nodeId] = node.status === "ok" ? "ok" : "error";
+  }
+  return state;
+}
+
+/** Per-node durations of a past run, keyed for the canvas. */
+function elapsedFromRun(run: WorkflowRunOutcome): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const node of run.nodes ?? []) out[node.nodeId] = node.elapsedMs;
+  return out;
+}
+
+/** The node a run failed at, when its trail names one (issue #371).
+ *
+ * The engine reports a failing node as an `error` step before the run ends, so
+ * this is exact rather than inferred. `null` when the run failed with no
+ * errored node — a graph that would not compile, a capability that could not be
+ * built — where naming a node would be a fabrication. */
+function failedNodeOf(run: WorkflowRunOutcome): string | null {
+  return (run.nodes ?? []).find((n) => n.status !== "ok")?.nodeId ?? null;
+}
+
 /** Lays a saved graph out left→right by longest-path depth, stacking siblings
  * vertically within each layer. Cycles are bounded by an iteration cap, so a
- * back edge never loops forever. */
-function layout(graph: WorkflowGraph): { nodes: Node<WorkflowNodeData>[]; edges: Edge[] } {
+ * back edge never loops forever.
+ *
+ * `runStates` / `elapsed` (issue #371) tint each node with what the run on
+ * screen did. Both default to empty, which is the resting canvas — identical to
+ * how it rendered before #371. */
+function layout(
+  graph: WorkflowGraph,
+  runStates: Record<string, NodeRunState> = {},
+  elapsed: Record<string, number> = {},
+): { nodes: Node<WorkflowNodeData>[]; edges: Edge[] } {
   const depth = new Map<string, number>(graph.nodes.map((n) => [n.id, 0]));
   for (let i = 0; i < graph.nodes.length; i++) {
     let changed = false;
@@ -1186,6 +1535,8 @@ function layout(graph: WorkflowGraph): { nodes: Node<WorkflowNodeData>[]; edges:
         summary: n.summary ?? (n.agent ? `Agent: ${n.agent}` : ""),
         emoji: meta.emoji,
         color: meta.color,
+        runState: runStates[n.id],
+        elapsedMs: elapsed[n.id],
       },
     };
   });

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -219,6 +219,30 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             };
             (Role::System, "workflow".to_string(), body, "workflow.run")
         }
+        // Issue #371's per-node progress trail. Structural ids and a duration —
+        // that is the entire payload, by construction — so wiring it out could
+        // leak nothing even if we wanted it to. It is still excluded, because
+        // the sidecar reads company activity for *insight*, and "node 4 of 6
+        // took 1.2s" is telemetry: it would spend the wire budget on the
+        // finest-grained events the journal produces while saying nothing about
+        // what the company did. The run's own `WorkflowRunFinished` arm above
+        // already carries that.
+        CompanyEvent::WorkflowRunStarted { workflow_id, .. } => (
+            Role::System,
+            "workflow".to_string(),
+            format!("Run of workflow {workflow_id} started"),
+            "workflow.run.started",
+        ),
+        CompanyEvent::WorkflowNodeFinished {
+            workflow_id,
+            node_id,
+            ..
+        } => (
+            Role::System,
+            "workflow".to_string(),
+            format!("Workflow {workflow_id} finished node {node_id}"),
+            "workflow.node",
+        ),
     };
     WireEvent {
         seq,

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -63,7 +63,7 @@ use crate::harness::lifecycle::ReviewDecision;
 use crate::ports::events::EventLog;
 use crate::ports::facts::FactStore;
 use crate::ports::types::{CompanyEvent, CompanyId, EventSeq, OverlayAgent};
-use crate::ports::{CompanyStore, WorkflowRun, WorkflowRunner, generate_id};
+use crate::ports::{CompanyStore, WorkflowRun, WorkflowRunContext, WorkflowRunner, generate_id};
 
 /// The manifest cognition-tier that marks the orchestrator agent.
 pub const ORCHESTRATOR_TIER: &str = "orchestrator";
@@ -611,6 +611,20 @@ fn summarize_event(event: &CompanyEvent) -> String {
                 }
             }
         }
+        // Issue #371's progress trail. Summarized, not surfaced: the insight
+        // tail has ten slots and a six-node run would take eight of them to say
+        // things the run's own finished line already says better. The arms exist
+        // because the match is exhaustive, and they hold the same no-payload
+        // rule as their neighbours — node ids and durations only, which is all
+        // these events carry.
+        CompanyEvent::WorkflowRunStarted { workflow_id, .. } => {
+            format!("workflow run started: {workflow_id}")
+        }
+        CompanyEvent::WorkflowNodeFinished {
+            workflow_id,
+            node_id,
+            ..
+        } => format!("workflow {workflow_id} finished node {node_id}"),
     }
 }
 
@@ -1157,6 +1171,7 @@ pub fn orchestrator_tools(
         workflow_source_dir.clone(),
         store.clone(),
         workflow_runner,
+        events.clone(),
     )));
     // `create_workflow` (issue #112) shares the same source dir the run tool
     // reads graphs from, plus the store it enables the new id on and the event
@@ -1230,24 +1245,40 @@ pub struct RunWorkflowTool {
     /// bodies — the only place a hosted tenant's workflows live (issue #168).
     store: Arc<dyn CompanyStore>,
     runner: WorkflowRunnerHandle,
+    /// The company's journal, so an agent-initiated run records an outcome like
+    /// every other entry point (issues #228, #371).
+    ///
+    /// This tool journaled **nothing** before #371 — a gap #228 left open when
+    /// it made the console's and the scheduler's runs durable. That was merely
+    /// an inconsistency then; it stops being harmless once the runner emits a
+    /// `WorkflowRunStarted`, because an unjournaled finish would leave every
+    /// agent-initiated run reading as interrupted, and the boot sweep would
+    /// dutifully stamp a failure on runs that succeeded.
+    ///
+    /// `None` (the default build, and the tool's own tests) simply skips the
+    /// record, exactly as the runner skips the progress events — the two degrade
+    /// together, so the pair can never be half-present.
+    events: Option<Arc<dyn EventLog>>,
 }
 
 impl RunWorkflowTool {
     /// Builds the tool over the company id, its on-disk source directory
     /// (`companies/<name>`, whose `workflows/` subtree holds the seed graphs),
-    /// the company store (holding the runtime-authored graph bodies), and the
-    /// shared runner handle.
+    /// the company store (holding the runtime-authored graph bodies), the
+    /// shared runner handle, and the company's journal.
     pub fn new(
         company: CompanyId,
         source_dir: Option<PathBuf>,
         store: Arc<dyn CompanyStore>,
         runner: WorkflowRunnerHandle,
+        events: Option<Arc<dyn EventLog>>,
     ) -> Self {
         Self {
             company,
             source_dir,
             store,
             runner,
+            events,
         }
     }
 }
@@ -1352,7 +1383,13 @@ impl Tool for RunWorkflowTool {
         };
 
         tracing::debug!(company = %self.company, workflow = %wid, runner = true, "run_workflow: invoking runner");
-        match runner.run(&self.company, &file, input).await {
+        // Issue #371: an agent-initiated run is a run like any other, so it
+        // mints a context and journals an outcome on BOTH arms. Not scheduled —
+        // an agent asking for a run is closer to an operator pressing Run than
+        // to a cron fire, and the flag drives exactly that distinction in the
+        // console.
+        let ctx = WorkflowRunContext::new(false);
+        match runner.run(&self.company, &file, input, &ctx).await {
             Ok(run) => {
                 tracing::debug!(
                     company = %self.company,
@@ -1360,6 +1397,17 @@ impl Tool for RunWorkflowTool {
                     pending = run.pending_approvals.len(),
                     "run_workflow: run succeeded"
                 );
+                if let Some(events) = self.events.as_ref() {
+                    crate::runtime::record_run_finished(
+                        events,
+                        &self.company,
+                        &wid,
+                        false,
+                        &ctx.run_id,
+                        Ok(&run),
+                    )
+                    .await;
+                }
                 let md = summarize_run(&file, &run);
                 Ok(ToolResult::success_with_markdown(
                     json!({
@@ -1371,6 +1419,17 @@ impl Tool for RunWorkflowTool {
             }
             Err(err) => {
                 tracing::debug!(company = %self.company, workflow = %wid, error = %err, "run_workflow: run failed");
+                if let Some(events) = self.events.as_ref() {
+                    crate::runtime::record_run_finished(
+                        events,
+                        &self.company,
+                        &wid,
+                        false,
+                        &ctx.run_id,
+                        Err(err.to_string().as_str()),
+                    )
+                    .await;
+                }
                 Ok(ToolResult::error(format!(
                     "Workflow `{wid}` failed to run: {err}"
                 )))
@@ -2494,6 +2553,7 @@ name = "Morning"
             _company: &CompanyId,
             workflow: &WorkflowFile,
             _input: Value,
+            _ctx: &WorkflowRunContext,
         ) -> crate::Result<WorkflowRun> {
             self.calls.lock().unwrap().push(workflow.id.clone());
             Ok(self.run.clone())
@@ -2580,6 +2640,7 @@ name = "Morning"
             Some(dir.path().to_path_buf()),
             Arc::new(MemStore::default()),
             handle,
+            None,
         );
         let result = tool
             .execute(json!({ "id": "demo", "input": { "seed": 1 } }))
@@ -2612,6 +2673,7 @@ name = "Morning"
             Some(dir.path().to_path_buf()),
             Arc::new(MemStore::default()),
             handle,
+            None,
         );
         let result = tool
             .execute(json!({ "id": "demo" }))
@@ -2633,6 +2695,7 @@ name = "Morning"
             Some(dir.path().to_path_buf()),
             Arc::new(MemStore::default()),
             WorkflowRunnerHandle::default(),
+            None,
         );
         let result = tool
             .execute(json!({ "id": "demo" }))
@@ -2655,6 +2718,7 @@ name = "Morning"
             Some(dir.path().to_path_buf()),
             Arc::new(MemStore::default()),
             handle,
+            None,
         );
         let result = tool
             .execute(json!({ "id": "nope" }))
@@ -2674,6 +2738,7 @@ name = "Morning"
             None,
             Arc::new(MemStore::default()),
             WorkflowRunnerHandle::default(),
+            None,
         );
         let result = tool.execute(json!({})).await.expect("execute");
         assert!(result.is_error);
@@ -2693,6 +2758,7 @@ name = "Morning"
             Some(std::path::PathBuf::from("/tmp")),
             Arc::new(MemStore::default()),
             handle,
+            None,
         );
         let result = tool
             .execute(json!({ "id": "../secrets" }))
@@ -2787,6 +2853,7 @@ name = "Morning"
             Some(dir.path().to_path_buf()),
             store.clone(),
             handle,
+            None,
         );
         let result = run
             .execute(json!({ "id": "greeter" }))
@@ -2859,7 +2926,7 @@ name = "Morning"
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
-        let run = RunWorkflowTool::new(company, None, store, handle);
+        let run = RunWorkflowTool::new(company, None, store, handle, None);
         let result = run
             .execute(json!({ "id": "hosted" }))
             .await

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -61,7 +61,7 @@ pub use types::*;
 pub use usage::{SampleKind, UsageMeter, UsageSample};
 pub use users::{InviteRecord, UserRecord, UserRole, UserStatus, UserStore, normalize_email};
 pub use workflow_runner::{
-    DeliveryReason, DeliveryReport, DeliveryStatus, WorkflowRun, WorkflowRunner,
+    DeliveryReason, DeliveryReport, DeliveryStatus, WorkflowRun, WorkflowRunContext, WorkflowRunner,
 };
 pub use workspace::{NodeKind, WorkspaceNode, WorkspaceStore};
 

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -609,6 +609,87 @@ pub enum CompanyEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         error: Option<String>,
     },
+    /// A workflow run began (issue #371) — the opening bracket of a run's
+    /// per-node progress trail.
+    ///
+    /// Before this, a run reported once, at the end. Between pressing Run and
+    /// the drawer appearing there was no signal at all: a long run was
+    /// indistinguishable from a wedged one, and a run that died at the fourth of
+    /// six nodes said only that it died. This event and
+    /// [`WorkflowNodeFinished`](Self::WorkflowNodeFinished) are the trail, and
+    /// they ride the journal rather than a side channel because the journal
+    /// already feeds the live operator SSE projection — **one append serves both
+    /// the live half and the durable half**, so a scheduled run nobody watched
+    /// reads back exactly as a watched one did.
+    ///
+    /// This is deliberately **not** [issue #242's `RunRecord`](Self::TaskDispatched).
+    /// That record keys to a board task with an attempt ordinal; a workflow run
+    /// has neither, and minting a synthetic task id to borrow the shape would
+    /// leak a lie into every `RunStore` consumer.
+    ///
+    /// [`run_id`](Self::WorkflowRunStarted::run_id) is **required** here (unlike
+    /// on `WorkflowRunFinished`, where it stays optional for the rows written
+    /// before entry points minted one). It is the correlation key: a run's node
+    /// events and its finished event share it, so the fold can group them and
+    /// the console can overlay one past run's states onto the canvas.
+    ///
+    /// Additive: old journals never carry it, and its presence changes how no
+    /// existing variant serializes.
+    WorkflowRunStarted {
+        /// The workflow graph that is running (its `workflows/<id>.toml` stem).
+        workflow_id: String,
+        /// The run's correlation id, minted by the entry point.
+        run_id: String,
+        /// Whether a cron schedule started this run rather than an operator.
+        scheduled: bool,
+    },
+    /// One non-trigger node of a workflow run finished (issue #371), reported by
+    /// the engine's `RunObserver` as the graph is walked.
+    ///
+    /// One event per node — roughly eight for a six-node graph, against the
+    /// dozens of steps a single chat turn emits — which is why the journal is
+    /// the right carrier at this volume rather than a dedicated store.
+    ///
+    /// **No node output and no error text ride this event.** That is the same
+    /// scrubbing stance the live turn-progress frames take: the journal is read
+    /// by the operator SSE projection and wired to the inference sidecar, and a
+    /// node's raw items are exactly the payload none of those readers need. The
+    /// run-level failure reason already lands on
+    /// [`WorkflowRunFinished::error`](Self::WorkflowRunFinished) — a tenant-scoped
+    /// surface — so nothing is lost by keeping this one structural.
+    ///
+    /// There is no matching *started* event, and that is an engine constraint
+    /// rather than a choice: tinyflows' `RunObserver` has `on_step_finish` but
+    /// no `on_step_start`, so "currently executing" is derived client-side from
+    /// the graph topology the console already holds.
+    WorkflowNodeFinished {
+        /// The workflow graph that is running.
+        workflow_id: String,
+        /// The run this node belongs to — the same id its
+        /// [`WorkflowRunStarted`](Self::WorkflowRunStarted) carries.
+        run_id: String,
+        /// The graph node that just finished.
+        node_id: String,
+        /// Whether the node succeeded or errored.
+        status: WorkflowNodeStatus,
+        /// Wall-clock duration of the node's execution, in milliseconds.
+        elapsed_ms: u64,
+    },
+}
+
+/// How one workflow node's execution came out (issue #371).
+///
+/// A closed two-value set on purpose: it is the entire payload of
+/// [`CompanyEvent::WorkflowNodeFinished`] beyond the structural ids, and having
+/// no `String` arm is what guarantees, by construction, that a node's own error
+/// text cannot reach the journal or the wire through this event.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WorkflowNodeStatus {
+    /// The node executed and produced output.
+    Ok,
+    /// The node's executor errored (after any retries were exhausted).
+    Error,
 }
 
 /// A `CompanyEvent` durably appended to the log with its sequence and time.
@@ -3056,6 +3137,87 @@ mod test {
         assert!(!out.contains("deliveries"), "{out}");
         assert!(!out.contains("pending_approvals"), "{out}");
         assert!(!out.contains("error"), "{out}");
+    }
+
+    /// Issue #371's opening bracket round-trips through the JSONL the journal
+    /// puts every event through.
+    #[test]
+    fn workflow_run_started_round_trips() {
+        let event = CompanyEvent::WorkflowRunStarted {
+            workflow_id: "digest".to_string(),
+            run_id: "run-1".to_string(),
+            scheduled: true,
+        };
+        assert_eq!(round_trip(&event), event);
+    }
+
+    /// Both node outcomes round-trip, including the elapsed reading — the field
+    /// that turns "it finished" into "it took this long", which is what tells a
+    /// slow run from a wedged one.
+    #[test]
+    fn workflow_node_finished_round_trips_both_statuses() {
+        for status in [WorkflowNodeStatus::Ok, WorkflowNodeStatus::Error] {
+            let event = CompanyEvent::WorkflowNodeFinished {
+                workflow_id: "digest".to_string(),
+                run_id: "run-1".to_string(),
+                node_id: "ceo".to_string(),
+                status,
+                elapsed_ms: 1234,
+            };
+            assert_eq!(round_trip(&event), event);
+        }
+    }
+
+    /// Every field on both #371 variants is required, and that is the point:
+    /// the correlation id is what groups a run's nodes with its outcome, so a
+    /// line without one would be unfoldable. Nothing is `skip_serializing_if`,
+    /// so the wire form is fully self-describing.
+    #[test]
+    fn workflow_progress_variants_serialize_every_field() {
+        let started = serde_json::to_string(&CompanyEvent::WorkflowRunStarted {
+            workflow_id: "digest".to_string(),
+            run_id: "run-1".to_string(),
+            scheduled: false,
+        })
+        .expect("serialize");
+        assert_eq!(
+            started,
+            r#"{"kind":"WorkflowRunStarted","workflow_id":"digest","run_id":"run-1","scheduled":false}"#
+        );
+
+        let node = serde_json::to_string(&CompanyEvent::WorkflowNodeFinished {
+            workflow_id: "digest".to_string(),
+            run_id: "run-1".to_string(),
+            node_id: "ceo".to_string(),
+            status: WorkflowNodeStatus::Error,
+            elapsed_ms: 7,
+        })
+        .expect("serialize");
+        assert_eq!(
+            node,
+            r#"{"kind":"WorkflowNodeFinished","workflow_id":"digest","run_id":"run-1","node_id":"ceo","status":"error","elapsed_ms":7}"#
+        );
+    }
+
+    /// The replay guarantee #371 rests on, stated as a test: adding these two
+    /// variants cannot change how an already-persisted line loads. A journal
+    /// written before #371 contains neither `kind`, and the pre-#371 wire form
+    /// of the variant they sit beside still decodes byte-for-byte as it did.
+    #[test]
+    fn pre_371_journal_lines_are_unaffected_by_the_new_variants() {
+        let line = r#"{"kind":"WorkflowRunFinished","workflow_id":"digest","scheduled":true,"pending_approvals":["review"]}"#;
+        let event: CompanyEvent = serde_json::from_str(line).expect("pre-#371 line loads");
+        assert_eq!(
+            event,
+            CompanyEvent::WorkflowRunFinished {
+                workflow_id: "digest".to_string(),
+                scheduled: true,
+                run_id: None,
+                deliveries: Vec::new(),
+                pending_approvals: vec!["review".to_string()],
+                error: None,
+            }
+        );
     }
 
     /// Issue #259's two variants pin their wire shape the same way

--- a/src/ports/workflow_runner.rs
+++ b/src/ports/workflow_runner.rs
@@ -243,11 +243,55 @@ pub struct DeliveryReport {
     pub reason: DeliveryReason,
 }
 
+/// What the *caller* knows about a run that the runner cannot work out for
+/// itself (issue #371).
+///
+/// # Why the entry point mints the id rather than the runner
+///
+/// The run id correlates a run's progress events with its outcome, and the
+/// outcome is journaled by the **caller** —
+/// [`record_run_finished`](crate::runtime::record_run_finished) — on *both*
+/// arms. On the error arm the runner returns nothing at all, so a runner-minted
+/// id would be lost exactly when it is most needed: a failed run's node events
+/// would be orphaned from the `WorkflowRunFinished` that carries the reason it
+/// failed, and the console could not say how far the run got before it died.
+/// Minting here, above the call, is what makes the two halves share one id on
+/// every path.
+///
+/// This is a **crate-internal port type**, not a wire type: it has no serde
+/// impl and no HTTP surface. Adding it to
+/// [`WorkflowRunner::run`](WorkflowRunner::run) makes the compiler enumerate
+/// every entry point, which is the whole point — an entry point that forgot to
+/// mint an id would silently journal an uncorrelatable run.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkflowRunContext {
+    /// The correlation id for this run, minted by the entry point.
+    pub run_id: String,
+    /// Whether a cron schedule started this run rather than an operator. Rides
+    /// the run's [`WorkflowRunStarted`](crate::ports::types::CompanyEvent)
+    /// event so the console can tell a nobody-was-watching run from a Run-button
+    /// one *while it is happening*, not only once it settles.
+    pub scheduled: bool,
+}
+
+impl WorkflowRunContext {
+    /// A context with a freshly minted run id.
+    ///
+    /// `scheduled` says whether a cron started the run rather than an operator.
+    pub fn new(scheduled: bool) -> Self {
+        Self {
+            run_id: crate::ports::ids::generate_id(),
+            scheduled,
+        }
+    }
+}
+
 /// Runs a company's workflow graph to completion.
 ///
 /// `company` names the tenant whose roster the run's agent nodes execute on;
 /// `workflow` is the parsed graph; `input` is the trigger payload (an arbitrary
-/// JSON value seeded as the trigger node's item).
+/// JSON value seeded as the trigger node's item); `ctx` carries the caller's run
+/// id and whether a cron started the run.
 #[async_trait]
 pub trait WorkflowRunner: Send + Sync {
     /// Runs `workflow` for `company` with the trigger `input`, returning the
@@ -257,5 +301,6 @@ pub trait WorkflowRunner: Send + Sync {
         company: &CompanyId,
         workflow: &WorkflowFile,
         input: Value,
+        ctx: &WorkflowRunContext,
     ) -> Result<WorkflowRun>;
 }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -993,6 +993,27 @@ impl RuntimeBuilder {
             );
         }
 
+        // Issue #371, the workflow-side equivalent of the sweep above, and it
+        // rests on the same three invariants: a workflow run is journaled with a
+        // start before the engine call, every entry point drives the run future
+        // in this process, and one process owns this journal. So a start with no
+        // finish at boot is a run that died with the last host, and settling it
+        // is what keeps `GET …/workflows/runs` honest when it folds an unmatched
+        // start as `running: true`.
+        //
+        // Gated on the handover for exactly the reason the run reaper is: a
+        // scheduler-spawned workflow run survives a live runtime swap, and
+        // sweeping mid-life would stamp "interrupted by a host restart" on a run
+        // still walking its graph — whose real outcome would then land after the
+        // synthetic one, leaving two contradictory finishes for one run id.
+        //
+        // It reads the journal rather than a store, so it is deliberately placed
+        // after `journal.load()` above and, like it, is best-effort: a failure is
+        // logged inside the sweep and never stops a company booting.
+        if handover.is_none() {
+            crate::runtime::sweep_interrupted_runs(&events, &id).await;
+        }
+
         // The policy gate, rehydrated from the journal replay above so approvals
         // survive a restart with their original ids.
         //

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -972,6 +972,12 @@ fn cycle_task_id(
             | CompanyEvent::WorkflowUpdated { .. }
             | CompanyEvent::WorkflowDeleted { .. }
             | CompanyEvent::WorkflowRunFinished { .. }
+            // Issue #371: a run's start and its per-node finishes are records of
+            // a workflow walking its graph, not stimuli for a new cycle. They
+            // name no card and compete with none, so they pass through exactly
+            // like the run outcome they bracket.
+            | CompanyEvent::WorkflowRunStarted { .. }
+            | CompanyEvent::WorkflowNodeFinished { .. }
             | CompanyEvent::TaskSteered { .. }
             | CompanyEvent::TaskDiscussionPosted { .. }
             | CompanyEvent::DeskTaskCompleted { .. } => continue,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -75,7 +75,7 @@ pub use registry::CompanyRegistry;
 pub use scheduler::{Clock, CompanyScheduler, FakeClock, SystemClock};
 pub use tools::StubToolProvider;
 pub use types::{ApprovalSummary, CompanyStatus, CycleReport};
-pub use workflow_outcome::record_run_finished;
+pub use workflow_outcome::{record_run_finished, sweep_interrupted_runs};
 pub use workflow_scheduler::WorkflowScheduler;
 
 // The assembly struct lives under `company/` to match the `ports.md` sketch

--- a/src/runtime/workflow_outcome.rs
+++ b/src/runtime/workflow_outcome.rs
@@ -23,18 +23,44 @@
 //! It deliberately does **not** replace the scheduler's log lines. Those remain
 //! the platform team's diagnostic on host stdout; this event is the *operator's*
 //! surface, read back through `GET …/workflows/runs`.
+//!
+//! **Issue #371** added the other end of the same record. A run now also
+//! journals a [`CompanyEvent::WorkflowRunStarted`] before the engine call and a
+//! [`CompanyEvent::WorkflowNodeFinished`] per node as the graph is walked (both
+//! written by the workflow runner), all sharing the `run_id` the entry point
+//! mints and hands to [`record_run_finished`]. That correlation is what lets the
+//! read side group a run's nodes with its outcome — and it is why a start with
+//! no finish is meaningful, which [`sweep_interrupted_runs`] settles at boot.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::ports::EventLog;
-use crate::ports::types::{CompanyEvent, CompanyId};
+use crate::ports::types::{CompanyEvent, CompanyId, EventSeq};
 use crate::ports::workflow_runner::{DeliveryReport, WorkflowRun};
+
+/// The error stamped on a run the host never got to finish (issue #371).
+///
+/// Phrased as a host fact rather than a workflow fault: nothing about the graph
+/// went wrong, the process holding it went away. An operator reading this in the
+/// history should go looking at the deployment, not at their nodes.
+pub const INTERRUPTED_BY_RESTART: &str = concat!(
+    "this run was interrupted by a host restart and never finished; ",
+    "the nodes recorded against it are the ones that completed before it stopped"
+);
 
 /// Journals a finished workflow run, best-effort.
 ///
 /// `scheduled` says whether a cron started the run rather than an operator —
 /// the distinction is the point, since a scheduled run is the
 /// nobody-was-watching case this record exists for.
+///
+/// `run_id` correlates this outcome with the run's
+/// [`WorkflowRunStarted`](CompanyEvent::WorkflowRunStarted) and every
+/// [`WorkflowNodeFinished`](CompanyEvent::WorkflowNodeFinished) between them
+/// (issue #371). The caller mints it, because on the error arm the runner
+/// returns nothing that could carry one — and a failed run's per-node trail is
+/// exactly the one worth correlating.
 ///
 /// `outcome` is what the [`WorkflowRunner`](crate::ports::WorkflowRunner)
 /// returned, error included: a run that failed outright is recorded too, and is
@@ -46,6 +72,7 @@ pub async fn record_run_finished(
     company: &CompanyId,
     workflow_id: &str,
     scheduled: bool,
+    run_id: &str,
     outcome: Result<&WorkflowRun, &str>,
 ) {
     let (deliveries, pending_approvals, error): (Vec<DeliveryReport>, Vec<String>, Option<String>) =
@@ -57,10 +84,10 @@ pub async fn record_run_finished(
     let event = CompanyEvent::WorkflowRunFinished {
         workflow_id: workflow_id.to_string(),
         scheduled,
-        // Neither entry point mints a run id today. Kept on the event so #242's
-        // first-class run — or any future correlated entry point — needs no
-        // migration to start populating it.
-        run_id: None,
+        // Issue #371 started populating this reserved field. The event's own
+        // wire shape is unchanged — it has always carried an optional `run_id` —
+        // so a reader predating #371 still decodes every line it could before.
+        run_id: Some(run_id.to_string()),
         deliveries,
         pending_approvals,
         error,
@@ -76,6 +103,111 @@ pub async fn record_run_finished(
             %err,
             "workflow run outcome could not be journaled; the run itself was unaffected"
         );
+    }
+}
+
+/// Terminates workflow runs a previous host process left open (issue #371).
+///
+/// # Why an unterminated start is provably dead
+///
+/// Issue #371 made a run journal a
+/// [`WorkflowRunStarted`](CompanyEvent::WorkflowRunStarted) *before* the engine
+/// call, so a host that dies mid-run leaves a start with no matching finish.
+/// Every entry point — the console's run route, the cron scheduler, the
+/// orchestrator's `run_workflow` tool — drives the run future **inside this
+/// process**, and exactly one process owns a company's journal (it is a
+/// single-writer log). So at boot, before any of those entry points can have
+/// started anything, an unmatched start cannot belong to a live run: there are
+/// no live runs. No timeout heuristic is needed, for the same reason
+/// [`reap_orphaned_runs`](crate::ports::runs::reap_orphaned_runs) needs none.
+///
+/// This is what keeps the read side honest. `GET …/workflows/runs` folds a
+/// start without a finish as `running: true`, and that claim is only true
+/// because this sweep settles the ones that will never finish — otherwise a run
+/// killed last week would show a spinner forever.
+///
+/// # It must NOT run on a rebuild
+///
+/// The argument above holds at boot and is false the moment a company has been
+/// serving. A scheduler-spawned run survives a live runtime swap
+/// ([`rebuild_company`](crate::runtime::rebuild_company)), so sweeping mid-life
+/// would stamp "interrupted by a host restart" on a run that is still walking
+/// its graph — and then its real finish would land afterwards, leaving two
+/// contradictory outcomes for one run id. The caller gates on the handover being
+/// absent; see the call site in the runtime builder. Same lesson as #290.
+///
+/// Best-effort throughout: a read or append failure is logged and swallowed,
+/// because record-keeping must never stop a company from booting.
+pub async fn sweep_interrupted_runs(events: &Arc<dyn EventLog>, company: &CompanyId) {
+    let stored = match events
+        .read_from(company, EventSeq::new(0), usize::MAX)
+        .await
+    {
+        Ok(stored) => stored,
+        Err(err) => {
+            tracing::warn!(
+                %company,
+                %err,
+                "could not read the journal to sweep interrupted workflow runs"
+            );
+            return;
+        }
+    };
+
+    // One pass, keyed on run id: a start inserts, a finish removes. Whatever is
+    // left started and never settled. `HashMap` rather than two sets because the
+    // synthetic finish needs the start's `workflow_id` and `scheduled` flag, and
+    // those live only on the start.
+    let mut open: HashMap<String, (String, bool)> = HashMap::new();
+    for stored in stored {
+        match stored.event {
+            CompanyEvent::WorkflowRunStarted {
+                workflow_id,
+                run_id,
+                scheduled,
+            } => {
+                open.insert(run_id, (workflow_id, scheduled));
+            }
+            CompanyEvent::WorkflowRunFinished {
+                run_id: Some(run_id),
+                ..
+            } => {
+                open.remove(&run_id);
+            }
+            // A pre-#371 finished row carries no run id and therefore closes
+            // nothing. That is correct rather than a gap: it also had no start
+            // to be matched against, so no such run can be sitting in `open`.
+            _ => {}
+        }
+    }
+
+    if open.is_empty() {
+        return;
+    }
+
+    // Sorted so the appended order is deterministic — a `HashMap` iteration
+    // order would make the journal's tail differ run to run for no reason, and
+    // tests would have to sort around it.
+    let mut interrupted: Vec<(String, (String, bool))> = open.into_iter().collect();
+    interrupted.sort_by(|a, b| a.0.cmp(&b.0));
+
+    for (run_id, (workflow_id, scheduled)) in interrupted {
+        tracing::info!(
+            %company,
+            workflow = %workflow_id,
+            %run_id,
+            scheduled,
+            "settling a workflow run left open by a previous host process"
+        );
+        record_run_finished(
+            events,
+            company,
+            &workflow_id,
+            scheduled,
+            &run_id,
+            Err(INTERRUPTED_BY_RESTART),
+        )
+        .await;
     }
 }
 
@@ -143,7 +275,7 @@ mod test {
             vec!["review".to_string()],
         );
 
-        record_run_finished(&events, &company, "digest", true, Ok(&run)).await;
+        record_run_finished(&events, &company, "digest", true, "run-1", Ok(&run)).await;
 
         let events = journaled(&events, &company).await;
         assert_eq!(events.len(), 1);
@@ -181,6 +313,7 @@ mod test {
             &company,
             "digest",
             true,
+            "run-1",
             Err("agent node `worker` had no inference source"),
         )
         .await;
@@ -211,12 +344,162 @@ mod test {
         let company = CompanyId::new("acme");
         let run = run_with(Vec::new(), Vec::new());
 
-        record_run_finished(&events, &company, "digest", false, Ok(&run)).await;
+        record_run_finished(&events, &company, "digest", false, "run-1", Ok(&run)).await;
 
         let events = journaled(&events, &company).await;
         let CompanyEvent::WorkflowRunFinished { scheduled, .. } = &events[0] else {
             panic!("expected a WorkflowRunFinished");
         };
         assert!(!*scheduled);
+    }
+
+    /// Issue #371: the outcome now carries the caller's run id, which is the
+    /// only thing tying it to the run's start and per-node events.
+    #[tokio::test]
+    async fn the_outcome_carries_the_callers_run_id() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        let run = run_with(Vec::new(), Vec::new());
+
+        record_run_finished(&events, &company, "digest", false, "run-42", Ok(&run)).await;
+
+        let events = journaled(&events, &company).await;
+        let CompanyEvent::WorkflowRunFinished { run_id, .. } = &events[0] else {
+            panic!("expected a WorkflowRunFinished");
+        };
+        assert_eq!(run_id.as_deref(), Some("run-42"));
+    }
+
+    /// Appends a `WorkflowRunStarted` for `run_id`.
+    async fn start(events: &Arc<dyn EventLog>, company: &CompanyId, run_id: &str, scheduled: bool) {
+        events
+            .append(
+                company,
+                CompanyEvent::WorkflowRunStarted {
+                    workflow_id: "digest".to_string(),
+                    run_id: run_id.to_string(),
+                    scheduled,
+                },
+            )
+            .await
+            .expect("append");
+    }
+
+    /// The case the sweep exists for: a host died mid-run, leaving a start with
+    /// no finish. Boot settles it — with the *start's* own workflow id and
+    /// scheduled flag, and the same run id, so the console can still group the
+    /// nodes that did complete under it.
+    #[tokio::test]
+    async fn an_interrupted_run_is_settled_at_boot() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        start(&events, &company, "run-dead", true).await;
+        // One node got through before the host went away — the whole point of
+        // the record is that this survives.
+        events
+            .append(
+                &company,
+                CompanyEvent::WorkflowNodeFinished {
+                    workflow_id: "digest".to_string(),
+                    run_id: "run-dead".to_string(),
+                    node_id: "ceo".to_string(),
+                    status: crate::ports::types::WorkflowNodeStatus::Ok,
+                    elapsed_ms: 12,
+                },
+            )
+            .await
+            .expect("append");
+
+        sweep_interrupted_runs(&events, &company).await;
+
+        let events = journaled(&events, &company).await;
+        assert_eq!(events.len(), 3, "the sweep appends exactly one row");
+        let CompanyEvent::WorkflowRunFinished {
+            workflow_id,
+            scheduled,
+            run_id,
+            error,
+            ..
+        } = &events[2]
+        else {
+            panic!("expected a WorkflowRunFinished, got {:?}", events[2]);
+        };
+        assert_eq!(workflow_id, "digest");
+        assert!(*scheduled, "the flag is carried from the start event");
+        assert_eq!(run_id.as_deref(), Some("run-dead"));
+        assert_eq!(error.as_deref(), Some(INTERRUPTED_BY_RESTART));
+    }
+
+    /// A run that started and finished normally is left alone — otherwise every
+    /// boot would append a duplicate, contradictory outcome to healthy history.
+    #[tokio::test]
+    async fn a_completed_run_is_left_alone() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        let run = run_with(Vec::new(), Vec::new());
+        start(&events, &company, "run-ok", false).await;
+        record_run_finished(&events, &company, "digest", false, "run-ok", Ok(&run)).await;
+
+        sweep_interrupted_runs(&events, &company).await;
+
+        assert_eq!(
+            journaled(&events, &company).await.len(),
+            2,
+            "the sweep appended nothing"
+        );
+    }
+
+    /// A journal written before #371 carries finished rows with no run id and no
+    /// starts at all. It must sweep to a no-op: those runs are history, not
+    /// in-flight work, and stamping them "interrupted" would rewrite the past.
+    #[tokio::test]
+    async fn a_pre_371_journal_sweeps_to_nothing() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        events
+            .append(
+                &company,
+                CompanyEvent::WorkflowRunFinished {
+                    workflow_id: "digest".to_string(),
+                    scheduled: true,
+                    run_id: None,
+                    deliveries: Vec::new(),
+                    pending_approvals: Vec::new(),
+                    error: None,
+                },
+            )
+            .await
+            .expect("append");
+
+        sweep_interrupted_runs(&events, &company).await;
+
+        assert_eq!(journaled(&events, &company).await.len(), 1);
+    }
+
+    /// Several open runs are all settled, and each keeps its own identity — a
+    /// scheduled one stays scheduled, a manual one stays manual.
+    #[tokio::test]
+    async fn every_open_run_is_settled_with_its_own_flags() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        start(&events, &company, "run-a", true).await;
+        start(&events, &company, "run-b", false).await;
+
+        sweep_interrupted_runs(&events, &company).await;
+
+        let settled: Vec<(String, bool)> = journaled(&events, &company)
+            .await
+            .into_iter()
+            .filter_map(|e| match e {
+                CompanyEvent::WorkflowRunFinished {
+                    run_id, scheduled, ..
+                } => Some((run_id.unwrap_or_default(), scheduled)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            settled,
+            vec![("run-a".to_string(), true), ("run-b".to_string(), false)]
+        );
     }
 }

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -81,6 +81,7 @@ use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 
 use crate::company::{WorkflowFile, list_workflows_union};
+use crate::ports::WorkflowRunContext;
 use crate::ports::types::CompanyId;
 use crate::ports::{DeliveryReport, DeliveryStatus};
 use crate::runtime::CompanyRegistry;
@@ -339,7 +340,14 @@ impl WorkflowScheduler {
                     // schedule for the life of the process with no log line.
                     let _claim = claim;
                     let (company, workflow_id) = key;
-                    match runner.run(&company, &workflow, input).await {
+                    // Issue #371: minted here so this run's progress events and
+                    // its outcome share one id — including on the `Err` arm
+                    // below, where the runner hands back nothing that could
+                    // carry one. `scheduled: true` rides the run's
+                    // `WorkflowRunStarted`, so the console can mark a cron fire
+                    // as such *while it runs*, not only once it settles.
+                    let ctx = WorkflowRunContext::new(true);
+                    match runner.run(&company, &workflow, input, &ctx).await {
                         Ok(run) => {
                             // A manual run hands `deliveries` back in the HTTP
                             // response and the console renders it. A scheduled
@@ -426,8 +434,15 @@ impl WorkflowScheduler {
                             // which on a hosted tenant is emphatically not the
                             // operator. This is the record the tenant's own
                             // console reads back, after the fact, on reload.
-                            record_run_finished(&events, &company, &workflow_id, true, Ok(&run))
-                                .await;
+                            record_run_finished(
+                                &events,
+                                &company,
+                                &workflow_id,
+                                true,
+                                &ctx.run_id,
+                                Ok(&run),
+                            )
+                            .await;
                         }
                         Err(err) => {
                             tracing::warn!(
@@ -444,6 +459,7 @@ impl WorkflowScheduler {
                                 &company,
                                 &workflow_id,
                                 true,
+                                &ctx.run_id,
                                 Err(err.to_string().as_str()),
                             )
                             .await;
@@ -807,6 +823,7 @@ mod test {
             company: &CompanyId,
             workflow: &WorkflowFile,
             input: Value,
+            _ctx: &crate::ports::WorkflowRunContext,
         ) -> crate::Result<WorkflowRun> {
             self.started.lock().unwrap().push(Recorded {
                 company: company.as_ref().to_string(),
@@ -852,6 +869,7 @@ mod test {
             _company: &CompanyId,
             _workflow: &WorkflowFile,
             _input: Value,
+            _ctx: &crate::ports::WorkflowRunContext,
         ) -> crate::Result<WorkflowRun> {
             self.attempts.fetch_add(1, Ordering::SeqCst);
             Err(crate::error::OpenCompanyError::Config(self.message.clone()))
@@ -1896,6 +1914,7 @@ to = "done"
                 _company: &CompanyId,
                 _workflow: &WorkflowFile,
                 _input: Value,
+                _ctx: &crate::ports::WorkflowRunContext,
             ) -> crate::Result<WorkflowRun> {
                 self.calls.fetch_add(1, Ordering::SeqCst);
                 panic!("the runner blew up mid-run");

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -771,26 +771,70 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
         // (see `RunWorkflowResponse` in `super::ops::workflows`). The stream is
         // operator-authenticated and company-scoped, like that response.
         //
-        // `runId` is deliberately not projected: it is always `None` today, so
-        // emitting it would put a permanently-null key on the wire.
+        // `runId` was not projected before issue #371, because it was always
+        // `None` and emitting it would have put a permanently-null key on the
+        // wire. Now every entry point mints one, and the console needs it: it is
+        // what ties this settle-frame to the progress frames it has been
+        // painting, so a cron run finishing mid-manual-run clears the right
+        // canvas. Still omitted when absent, for the pre-#371 rows.
         CompanyEvent::WorkflowRunFinished {
             workflow_id,
             scheduled,
+            run_id,
             deliveries,
             pending_approvals,
             error,
-            ..
         } => {
             let mut o = envelope("workflow_run_finished");
             o["workflowId"] = json!(workflow_id);
             o["scheduled"] = json!(scheduled);
             o["deliveries"] = json!(deliveries);
             o["pendingApprovals"] = json!(pending_approvals);
+            if let Some(run_id) = run_id {
+                o["runId"] = json!(run_id);
+            }
             // Omitted rather than null on a run that finished, so the console's
             // "did this fail?" check is a presence check.
             if let Some(error) = error {
                 o["error"] = json!(error);
             }
+            o
+        }
+        // Issue #371: the live half of per-node progress. This is what turns the
+        // console from "the button spins" into "node 3 of 6 just finished" —
+        // and it costs the wire nothing it did not already carry, because every
+        // projected field is structural.
+        //
+        // There is nothing to scrub here and that is by construction, not by
+        // omission: the events themselves carry no node output and no error
+        // text (see `CompanyEvent::WorkflowNodeFinished`), so this arm could not
+        // leak a payload even if it forwarded the event wholesale. Contrast the
+        // `workflow_run_finished` arm above, which has to *choose* what to
+        // forward because its event carries operator-only delivery rows.
+        CompanyEvent::WorkflowRunStarted {
+            workflow_id,
+            run_id,
+            scheduled,
+        } => {
+            let mut o = envelope("workflow_run_started");
+            o["workflowId"] = json!(workflow_id);
+            o["runId"] = json!(run_id);
+            o["scheduled"] = json!(scheduled);
+            o
+        }
+        CompanyEvent::WorkflowNodeFinished {
+            workflow_id,
+            run_id,
+            node_id,
+            status,
+            elapsed_ms,
+        } => {
+            let mut o = envelope("workflow_node_finished");
+            o["workflowId"] = json!(workflow_id);
+            o["runId"] = json!(run_id);
+            o["nodeId"] = json!(node_id);
+            o["status"] = json!(status);
+            o["elapsedMs"] = json!(elapsed_ms);
             o
         }
         // Not an attention signal, or carries a raw payload we never put on the
@@ -3002,6 +3046,91 @@ mod test {
         .expect("workflow_run_finished is an attention signal");
         assert_eq!(v["error"], "no inference source for agent node `worker`");
         assert_eq!(v["deliveries"].as_array().unwrap().len(), 0);
+    }
+
+    /// Issue #371: the live per-node trail. Both arms project, both carry the
+    /// run id that ties them to the run's settle-frame, and — the point — the
+    /// node arm carries a status and a duration and nothing else.
+    #[test]
+    fn projects_the_per_node_progress_trail() {
+        let started = super::project_event(&stored(CompanyEvent::WorkflowRunStarted {
+            workflow_id: "digest".into(),
+            run_id: "run-1".into(),
+            scheduled: true,
+        }))
+        .expect("workflow_run_started reaches the console");
+        assert_eq!(started["type"], "workflow_run_started");
+        assert_eq!(started["workflowId"], "digest");
+        assert_eq!(started["runId"], "run-1");
+        assert_eq!(started["scheduled"], true);
+
+        let node = super::project_event(&stored(CompanyEvent::WorkflowNodeFinished {
+            workflow_id: "digest".into(),
+            run_id: "run-1".into(),
+            node_id: "ceo".into(),
+            status: crate::ports::types::WorkflowNodeStatus::Error,
+            elapsed_ms: 1234,
+        }))
+        .expect("workflow_node_finished reaches the console");
+        assert_eq!(node["type"], "workflow_node_finished");
+        assert_eq!(node["runId"], "run-1");
+        assert_eq!(node["nodeId"], "ceo");
+        assert_eq!(node["status"], "error");
+        assert_eq!(node["elapsedMs"], 1234);
+
+        // The scrubbing claim, stated as a test: an errored node projects a
+        // status word and NOTHING that could carry the node's own words. The
+        // event type has no field to hold them, so this can only regress by
+        // widening the event — which is the point of keeping it closed.
+        let mut keys: Vec<&str> = node
+            .as_object()
+            .expect("object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            [
+                "atMillis",
+                "elapsedMs",
+                "nodeId",
+                "runId",
+                "seq",
+                "status",
+                "type",
+                "workflowId",
+            ],
+            "the node frame carries only structural fields: {node}"
+        );
+    }
+
+    /// Issue #371 also starts projecting the run id on the settle-frame — the
+    /// key that lets the console clear the right canvas when two runs overlap.
+    /// Still omitted for a pre-#371 row, so no permanently-null key appears.
+    #[test]
+    fn projects_the_run_id_on_a_finished_run_only_when_there_is_one() {
+        let with_id = super::project_event(&stored(CompanyEvent::WorkflowRunFinished {
+            workflow_id: "digest".into(),
+            scheduled: false,
+            run_id: Some("run-9".into()),
+            deliveries: Vec::new(),
+            pending_approvals: Vec::new(),
+            error: None,
+        }))
+        .expect("projected");
+        assert_eq!(with_id["runId"], "run-9");
+
+        let legacy = super::project_event(&stored(CompanyEvent::WorkflowRunFinished {
+            workflow_id: "digest".into(),
+            scheduled: false,
+            run_id: None,
+            deliveries: Vec::new(),
+            pending_approvals: Vec::new(),
+            error: None,
+        }))
+        .expect("projected");
+        assert!(legacy.get("runId").is_none(), "{legacy}");
     }
 
     #[test]

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -83,7 +83,10 @@ use crate::company::{
     workflow_version,
 };
 use crate::error::OpenCompanyError;
-use crate::ports::types::{CompanyEvent, CompanyRecord, EventSeq, OverlayWorkflow};
+use crate::ports::WorkflowRunContext;
+use crate::ports::types::{
+    CompanyEvent, CompanyRecord, EventSeq, OverlayWorkflow, WorkflowNodeStatus,
+};
 use crate::runtime::cron::{CivilTime, CronExpr};
 use crate::runtime::record_run_finished;
 use crate::server::error::ApiError;
@@ -744,6 +747,14 @@ struct RunWorkflowResponse {
     /// where an operator learns a report was NOT delivered — a delivery failure
     /// never fails the run, so it has nowhere else to surface.
     deliveries: Vec<crate::ports::DeliveryReport>,
+    /// The run's correlation id (issue #371).
+    ///
+    /// Additive, and the console needs it for one specific reason: the run's
+    /// progress events arrive over SSE *while this request is still in flight*,
+    /// so without an id handed back the console cannot be certain the frames it
+    /// has been painting belong to the run it just awaited rather than a cron
+    /// fire that overlapped it.
+    run_id: String,
 }
 
 /// `POST …/workflows/{wid}/run` (both scope forms).
@@ -787,7 +798,15 @@ async fn run_workflow(
         })?;
 
     let input = body.map(|Json(b)| b.input).unwrap_or(Value::Null);
-    let run = match runner.run(company.id(), &file, input).await {
+    // Issue #371: minted HERE, above the call, not inside the runner. The error
+    // arm below journals an outcome for a run that returned nothing at all, and
+    // that outcome has to carry the same id as the progress events the run
+    // already emitted — otherwise a failed run's nodes would be orphaned from
+    // the record that says why it failed, which is the exact case the issue is
+    // about ("a run that fails at the fourth of six nodes reports only that it
+    // failed").
+    let ctx = WorkflowRunContext::new(false);
+    let run = match runner.run(company.id(), &file, input, &ctx).await {
         Ok(run) => run,
         Err(err) => {
             // Issue #228: a manual run that dies is journaled too, before the
@@ -798,6 +817,7 @@ async fn run_workflow(
                 company.id(),
                 &wid,
                 false,
+                &ctx.run_id,
                 Err(err.to_string().as_str()),
             )
             .await;
@@ -816,6 +836,7 @@ async fn run_workflow(
         company.id(),
         &wid,
         false,
+        &ctx.run_id,
         Ok(&run),
     )
     .await;
@@ -824,6 +845,7 @@ async fn run_workflow(
         output: run.output,
         pending_approvals: run.pending_approvals,
         deliveries: run.deliveries,
+        run_id: ctx.run_id,
     }))
 }
 
@@ -969,6 +991,37 @@ struct WorkflowRunOutcome {
     /// Set when the run failed outright instead of finishing with rows.
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+    /// Per-node progress for this run, in the order the nodes finished (issue
+    /// #371). Empty for a run journaled before #371, and for one whose nodes all
+    /// failed to journal — so an empty list means "no per-node trail", never
+    /// "the run did nothing".
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    nodes: Vec<WorkflowRunNode>,
+    /// When the run *started*, from its `WorkflowRunStarted` row (issue #371).
+    /// Absent on a pre-#371 row, whose only timestamp is the finish.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    started_at_millis: Option<u64>,
+    /// `true` for a run that has started and not yet settled.
+    ///
+    /// Honest rather than optimistic, and only because of the boot sweep: a run
+    /// whose host died is settled with an "interrupted" outcome at the next
+    /// start, so nothing sits here spinning forever. Omitted when false, which
+    /// keeps every settled row's wire shape as short as it was.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    running: bool,
+}
+
+/// One node's outcome inside a run (issue #371).
+///
+/// Structural only — id, status, duration. The node's own output and error text
+/// are deliberately absent from the event this is folded from, so they cannot
+/// appear here either.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowRunNode {
+    node_id: String,
+    status: WorkflowNodeStatus,
+    elapsed_ms: u64,
 }
 
 /// `GET …/workflows/runs?workflow=&limit=` — the company's finished workflow
@@ -1002,44 +1055,132 @@ async fn list_runs(
         .await
         .map_err(ApiError)?;
 
-    let mut runs: Vec<WorkflowRunOutcome> = stored
-        .into_iter()
-        .filter_map(|stored| {
-            let CompanyEvent::WorkflowRunFinished {
-                workflow_id,
-                scheduled,
-                run_id,
-                deliveries,
-                pending_approvals,
-                error,
-            } = stored.event
-            else {
-                return None;
-            };
-            // The `?workflow=` filter is applied here rather than after the
-            // `limit` cut, so asking for one workflow returns that workflow's
-            // most recent N — not "whichever of the last N happen to match".
-            if query
-                .workflow
-                .as_deref()
-                .is_some_and(|wanted| wanted != workflow_id)
-            {
-                return None;
-            }
-            Some(WorkflowRunOutcome {
-                seq: stored.seq.value(),
-                at_millis: stored.at_millis,
-                workflow_id,
-                scheduled,
-                run_id,
-                deliveries,
-                pending_approvals,
-                error,
-            })
-        })
-        .collect();
+    // Issue #371 turned this from a filter into a **group-by-run fold**: a run
+    // now contributes up to N+2 rows (a start, one per node, a finish) instead
+    // of one, and they have to come back as a single history entry.
+    //
+    // The invariant that keeps it simple: the journal is append-only and
+    // single-writer, so a run's rows are ordered `Started < Node… < Finished` —
+    // the runner drains and joins its progress collector before returning, which
+    // is what makes the last part true rather than a race. Rows of *different*
+    // runs may interleave (two workflows can run at once), so the grouping is
+    // keyed on run id rather than on adjacency.
+    //
+    // A pre-#371 finished row has no run id and no start, so it simply folds to
+    // itself — one row in, one entry out, exactly as before.
+    let mut runs: Vec<WorkflowRunOutcome> = Vec::new();
+    let mut index: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    // The `?workflow=` filter is applied per event rather than after the `limit`
+    // cut, so asking for one workflow returns that workflow's most recent N —
+    // not "whichever of the last N happen to match".
+    let wanted = query.workflow.as_deref();
+    let matches = |workflow_id: &str| wanted.is_none_or(|w| w == workflow_id);
 
-    // Newest first: a history panel leads with the run that just happened.
+    for stored in stored {
+        let seq = stored.seq.value();
+        let at_millis = stored.at_millis;
+        match stored.event {
+            CompanyEvent::WorkflowRunStarted {
+                workflow_id,
+                run_id,
+                scheduled,
+            } => {
+                if !matches(&workflow_id) {
+                    continue;
+                }
+                index.insert(run_id.clone(), runs.len());
+                runs.push(WorkflowRunOutcome {
+                    // The start's own position and time key the entry. The
+                    // finish overwrites `at_millis` below so a settled run still
+                    // sorts and displays by when it *ended*, as it always has;
+                    // `seq` likewise, so ordering is unchanged for settled runs.
+                    seq,
+                    at_millis,
+                    workflow_id,
+                    scheduled,
+                    run_id: Some(run_id),
+                    deliveries: Vec::new(),
+                    pending_approvals: Vec::new(),
+                    error: None,
+                    nodes: Vec::new(),
+                    started_at_millis: Some(at_millis),
+                    // Flipped off by the finish. A start that never gets one is
+                    // a run in flight — or one the boot sweep has yet to settle.
+                    running: true,
+                });
+            }
+            CompanyEvent::WorkflowNodeFinished {
+                workflow_id,
+                run_id,
+                node_id,
+                status,
+                elapsed_ms,
+            } => {
+                if !matches(&workflow_id) {
+                    continue;
+                }
+                // A node whose start is missing (a journal truncated below it,
+                // or a `?workflow=` filter that cannot match) has no entry to
+                // attach to. Dropped rather than synthesising a headless run.
+                if let Some(entry) = index.get(&run_id).and_then(|i| runs.get_mut(*i)) {
+                    entry.nodes.push(WorkflowRunNode {
+                        node_id,
+                        status,
+                        elapsed_ms,
+                    });
+                }
+            }
+            CompanyEvent::WorkflowRunFinished {
+                workflow_id,
+                scheduled,
+                run_id,
+                deliveries,
+                pending_approvals,
+                error,
+            } => {
+                if !matches(&workflow_id) {
+                    continue;
+                }
+                // Settle the open entry when there is one…
+                if let Some(entry) = run_id
+                    .as_ref()
+                    .and_then(|id| index.get(id))
+                    .and_then(|i| runs.get_mut(*i))
+                {
+                    entry.seq = seq;
+                    entry.at_millis = at_millis;
+                    entry.deliveries = deliveries;
+                    entry.pending_approvals = pending_approvals;
+                    entry.error = error;
+                    entry.running = false;
+                    continue;
+                }
+                // …else stand alone. Two ways to get here, both legitimate: a
+                // pre-#371 row (no run id, no start), and a #371 row whose start
+                // fell off the readable journal. Either way the entry looks
+                // exactly like the pre-#371 shape — no nodes, no start time, not
+                // running — so old history renders unchanged.
+                runs.push(WorkflowRunOutcome {
+                    seq,
+                    at_millis,
+                    workflow_id,
+                    scheduled,
+                    run_id,
+                    deliveries,
+                    pending_approvals,
+                    error,
+                    nodes: Vec::new(),
+                    started_at_millis: None,
+                    running: false,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    // Newest first: a history panel leads with the run that just happened. The
+    // `limit` now cuts *runs* rather than journal rows, which is the number the
+    // caller was asking about all along.
     runs.reverse();
     runs.truncate(limit);
     Ok(Json(runs))
@@ -1575,6 +1716,7 @@ mod tests {
                 detail: "never written in".into(),
                 reason: crate::ports::DeliveryReason::RecipientNotEstablished,
             }],
+            run_id: "run-1".into(),
         })
         .unwrap();
         assert_eq!(json["deliveries"][0]["node"], "done");
@@ -1603,6 +1745,7 @@ mod tests {
                 detail: "waiting for you in Approvals".into(),
                 reason: crate::ports::DeliveryReason::ParkedForApproval,
             }],
+            run_id: "run-1".into(),
         })
         .unwrap();
         assert_eq!(json["deliveries"][0]["status"], "pending");
@@ -1616,9 +1759,13 @@ mod tests {
             output: Value::Null,
             pending_approvals: Vec::new(),
             deliveries: Vec::new(),
+            run_id: "run-1".into(),
         })
         .unwrap();
         assert_eq!(json["deliveries"], serde_json::json!([]));
+        // Issue #371: the correlation id rides the response in camelCase, so the
+        // console can tie the frames it painted mid-request to the run it awaited.
+        assert_eq!(json["runId"], "run-1");
     }
 
     #[test]
@@ -1655,7 +1802,7 @@ mod tests {
         use axum::http::{Request, StatusCode};
         use tower::ServiceExt;
 
-        use super::super::{CompanyEvent, DEFAULT_RUN_LIMIT};
+        use super::super::{CompanyEvent, DEFAULT_RUN_LIMIT, WorkflowNodeStatus};
         use crate::company::CompanyManifest;
         use crate::ports::CompanyStore;
         use crate::ports::types::{CompanyId, CompanyRecord};
@@ -2076,6 +2223,265 @@ mod tests {
                 "no inference source for agent node `worker`"
             );
             assert_eq!(body[0]["deliveries"].as_array().unwrap().len(), 0);
+        }
+
+        // ── Issue #371: the per-node progress fold ─────────────────────────
+
+        /// Journals a `WorkflowRunStarted`, the way the runner does before the
+        /// engine call.
+        async fn journal_start(
+            state: &AppState,
+            id: &CompanyId,
+            workflow_id: &str,
+            run_id: &str,
+            scheduled: bool,
+        ) {
+            let runtime = state.registry().get(id).expect("registered");
+            runtime
+                .events()
+                .append(
+                    id,
+                    CompanyEvent::WorkflowRunStarted {
+                        workflow_id: workflow_id.to_string(),
+                        run_id: run_id.to_string(),
+                        scheduled,
+                    },
+                )
+                .await
+                .expect("append");
+        }
+
+        /// Journals one `WorkflowNodeFinished`, the way the run observer does.
+        async fn journal_node(
+            state: &AppState,
+            id: &CompanyId,
+            workflow_id: &str,
+            run_id: &str,
+            node_id: &str,
+            status: WorkflowNodeStatus,
+        ) {
+            let runtime = state.registry().get(id).expect("registered");
+            runtime
+                .events()
+                .append(
+                    id,
+                    CompanyEvent::WorkflowNodeFinished {
+                        workflow_id: workflow_id.to_string(),
+                        run_id: run_id.to_string(),
+                        node_id: node_id.to_string(),
+                        status,
+                        elapsed_ms: 42,
+                    },
+                )
+                .await
+                .expect("append");
+        }
+
+        /// Journals a finished outcome carrying a run id, the way every entry
+        /// point does post-#371.
+        async fn journal_finish(
+            state: &AppState,
+            id: &CompanyId,
+            workflow_id: &str,
+            run_id: &str,
+            scheduled: bool,
+            error: Option<&str>,
+        ) {
+            let runtime = state.registry().get(id).expect("registered");
+            runtime
+                .events()
+                .append(
+                    id,
+                    CompanyEvent::WorkflowRunFinished {
+                        workflow_id: workflow_id.to_string(),
+                        scheduled,
+                        run_id: Some(run_id.to_string()),
+                        deliveries: Vec::new(),
+                        pending_approvals: Vec::new(),
+                        error: error.map(str::to_string),
+                    },
+                )
+                .await
+                .expect("append");
+        }
+
+        /// **The issue's durable half at the HTTP boundary.** A run's start,
+        /// its per-node rows and its outcome come back as ONE history entry
+        /// carrying the node trail — which is what makes a scheduled run's
+        /// failure point readable after the fact.
+        #[tokio::test]
+        async fn run_history_groups_a_runs_nodes_under_one_entry() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+
+            journal_start(&state, &id, "digest", "run-1", true).await;
+            journal_node(
+                &state,
+                &id,
+                "digest",
+                "run-1",
+                "ceo",
+                WorkflowNodeStatus::Ok,
+            )
+            .await;
+            journal_node(
+                &state,
+                &id,
+                "digest",
+                "run-1",
+                "send",
+                WorkflowNodeStatus::Error,
+            )
+            .await;
+            journal_finish(&state, &id, "digest", "run-1", true, Some("send failed")).await;
+
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            let rows = body.as_array().expect("array");
+            assert_eq!(rows.len(), 1, "four journal rows fold to one run: {body}");
+
+            assert_eq!(rows[0]["runId"], "run-1");
+            assert_eq!(rows[0]["error"], "send failed");
+            assert!(rows[0].get("running").is_none(), "a settled run: {body}");
+            assert!(rows[0]["startedAtMillis"].is_number(), "{body}");
+
+            // In finish order, with the status and duration the canvas paints.
+            let nodes = rows[0]["nodes"].as_array().expect("nodes");
+            assert_eq!(nodes.len(), 2);
+            assert_eq!(nodes[0]["nodeId"], "ceo");
+            assert_eq!(nodes[0]["status"], "ok");
+            assert_eq!(nodes[0]["elapsedMs"], 42);
+            assert_eq!(nodes[1]["nodeId"], "send");
+            assert_eq!(nodes[1]["status"], "error");
+        }
+
+        /// A run whose host died leaves a start with no finish, and it folds as
+        /// `running: true` with the nodes it did complete. Honest only because
+        /// the boot sweep settles such runs — see `sweep_interrupted_runs`.
+        #[tokio::test]
+        async fn run_history_reports_an_unsettled_run_as_running() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+
+            journal_start(&state, &id, "digest", "run-live", false).await;
+            journal_node(
+                &state,
+                &id,
+                "digest",
+                "run-live",
+                "ceo",
+                WorkflowNodeStatus::Ok,
+            )
+            .await;
+
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            assert_eq!(body[0]["running"], true, "{body}");
+            assert_eq!(body[0]["nodes"].as_array().unwrap().len(), 1);
+            assert!(body[0].get("error").is_none(), "{body}");
+        }
+
+        /// **The compatibility claim, pinned.** A journal written before #371
+        /// carries finished rows with no run id and no starts. Those fold
+        /// exactly as they always did — one row in, one entry out, no `nodes`
+        /// key, no `running` key, no `startedAtMillis`.
+        #[tokio::test]
+        async fn run_history_folds_pre_371_rows_unchanged() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+
+            journal_run(&state, &id, "digest", true, Vec::new(), None).await;
+
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            let rows = body.as_array().expect("array");
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0]["workflowId"], "digest");
+            assert!(rows[0].get("nodes").is_none(), "{body}");
+            assert!(rows[0].get("running").is_none(), "{body}");
+            assert!(rows[0].get("startedAtMillis").is_none(), "{body}");
+            assert!(rows[0].get("runId").is_none(), "{body}");
+        }
+
+        /// Two runs interleaving on one journal — the shape two concurrent
+        /// workflows produce — attach their nodes to the right entry. This is
+        /// why the fold groups on run id rather than on row adjacency.
+        #[tokio::test]
+        async fn run_history_keeps_interleaved_runs_apart() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+
+            journal_start(&state, &id, "a", "run-a", false).await;
+            journal_start(&state, &id, "b", "run-b", false).await;
+            journal_node(&state, &id, "b", "run-b", "b1", WorkflowNodeStatus::Ok).await;
+            journal_node(&state, &id, "a", "run-a", "a1", WorkflowNodeStatus::Ok).await;
+            journal_finish(&state, &id, "a", "run-a", false, None).await;
+            journal_finish(&state, &id, "b", "run-b", false, None).await;
+
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            let rows = body.as_array().expect("array");
+            assert_eq!(rows.len(), 2, "{body}");
+            let by_id = |run: &str| {
+                rows.iter()
+                    .find(|r| r["runId"] == run)
+                    .unwrap_or_else(|| panic!("{run} missing: {body}"))
+                    .clone()
+            };
+            assert_eq!(by_id("run-a")["nodes"][0]["nodeId"], "a1");
+            assert_eq!(by_id("run-a")["nodes"].as_array().unwrap().len(), 1);
+            assert_eq!(by_id("run-b")["nodes"][0]["nodeId"], "b1");
+            assert_eq!(by_id("run-b")["nodes"].as_array().unwrap().len(), 1);
+        }
+
+        /// `?limit=` now cuts **runs**, not journal rows — the number the caller
+        /// was asking about all along. Without the group-aware cut, a limit of 2
+        /// over three 4-row runs would return fragments.
+        #[tokio::test]
+        async fn run_history_limit_counts_runs_not_journal_rows() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+
+            for i in 0..3 {
+                let run = format!("run-{i}");
+                journal_start(&state, &id, "digest", &run, false).await;
+                journal_node(&state, &id, "digest", &run, "ceo", WorkflowNodeStatus::Ok).await;
+                journal_node(&state, &id, "digest", &run, "done", WorkflowNodeStatus::Ok).await;
+                journal_finish(&state, &id, "digest", &run, false, None).await;
+            }
+
+            let response = router(state)
+                .oneshot(request(
+                    "GET",
+                    "/api/v1/company/workflows/runs?limit=2",
+                    None,
+                ))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            let rows = body.as_array().expect("array");
+            assert_eq!(rows.len(), 2, "{body}");
+            // Newest first, and each one whole.
+            assert_eq!(rows[0]["runId"], "run-2");
+            assert_eq!(rows[0]["nodes"].as_array().unwrap().len(), 2);
+            assert_eq!(rows[1]["runId"], "run-1");
         }
 
         /// `?workflow=` narrows to one graph, and does so BEFORE the limit cut —

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -16,8 +16,8 @@ use crate::Result;
 use crate::company::WorkflowFile;
 use crate::error::OpenCompanyError;
 use crate::harness::{HarnessDeps, HarnessPool};
-use crate::ports::types::{CompanyId, CompanyRecord};
-use crate::ports::{WorkflowRun, WorkflowRunner};
+use crate::ports::types::{CompanyEvent, CompanyId, CompanyRecord, WorkflowNodeStatus};
+use crate::ports::{WorkflowRun, WorkflowRunContext, WorkflowRunner};
 
 /// How deeply a workflow may re-enter itself before the run is refused
 /// (issue #151 part a).
@@ -28,6 +28,14 @@ use crate::ports::{WorkflowRun, WorkflowRunner};
 /// and the cost of being wrong is asymmetric: refusing a deep run returns a
 /// readable tool error, while allowing it aborts the host.
 pub(crate) const MAX_WORKFLOW_DEPTH: usize = 4;
+
+/// How long a settling run waits for its node-progress events to finish
+/// reaching the journal (issue #371).
+///
+/// The drain is normally instant — the channel is already closed and only
+/// in-flight appends remain — so this bound never fires in practice. It exists
+/// to keep a progress-reporting stall from ever becoming a *run* stall.
+const PROGRESS_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 tokio::task_local! {
     /// How many workflow runs are already on this call chain.
@@ -65,6 +73,7 @@ pub async fn run_workflow(
     record: &CompanyRecord,
     workflow: &WorkflowFile,
     input: Value,
+    ctx: &WorkflowRunContext,
 ) -> Result<WorkflowRun> {
     // Issue #151 part a: refuse an unbounded re-entry before it takes the host
     // down. `run_workflow` is an orchestrator tool, and a workflow `agent` node
@@ -94,9 +103,55 @@ pub async fn run_workflow(
     WORKFLOW_DEPTH
         .scope(
             depth + 1,
-            run_workflow_inner(pool, deps, record, workflow, input),
+            run_workflow_inner(pool, deps, record, workflow, input, ctx),
         )
         .await
+}
+
+/// One node's finish, as the engine's observer callback hands it over to the
+/// async collector (issue #371).
+///
+/// Deliberately three scalars and no `ExecutionStep`: the engine's step carries
+/// the node's `output` items, and this hop exists partly to make it *impossible*
+/// for that payload to reach the journal — the same stance the live turn frames
+/// take on tool args. What is not carried cannot leak.
+struct NodeProgress {
+    node_id: String,
+    status: WorkflowNodeStatus,
+    elapsed_ms: u64,
+}
+
+/// A [`RunObserver`](tinyflows::observability::RunObserver) that forwards each
+/// node finish onto an unbounded channel.
+///
+/// The channel is the whole reason this type exists. Observer callbacks are
+/// **synchronous** (the engine invokes them inline, across threads) while
+/// [`EventLog::append`] is async, so the callback cannot journal directly. It
+/// also must not block: a node handler stalled on a disk write would make
+/// observability change the run's timing, which is exactly what an observer is
+/// not allowed to do. Unbounded is safe at this volume — one message per
+/// non-trigger node, ~8 for a six-node graph — and it means a slow journal can
+/// never apply backpressure to the engine.
+struct ProgressObserver {
+    tx: tokio::sync::mpsc::UnboundedSender<NodeProgress>,
+}
+
+impl tinyflows::observability::RunObserver for ProgressObserver {
+    fn on_step_finish(&self, step: &tinyflows::observability::ExecutionStep) {
+        // A closed receiver means the collector already stopped (the run is
+        // settling, or `deps.events` was never wired). Dropping the frame is
+        // correct: progress reporting must never disturb the run.
+        let _ = self.tx.send(NodeProgress {
+            node_id: step.node_id.clone(),
+            status: match step.status {
+                tinyflows::observability::StepStatus::Success => WorkflowNodeStatus::Ok,
+                tinyflows::observability::StepStatus::Error => WorkflowNodeStatus::Error,
+            },
+            // `u128` millis is the engine's type; a node running longer than
+            // 584 million years is not the failure mode worth a `Result`.
+            elapsed_ms: u64::try_from(step.duration_ms).unwrap_or(u64::MAX),
+        });
+    }
 }
 
 /// The run itself, always executed inside a [`WORKFLOW_DEPTH`] scope so a
@@ -107,10 +162,17 @@ async fn run_workflow_inner(
     record: &CompanyRecord,
     workflow: &WorkflowFile,
     input: Value,
+    ctx: &WorkflowRunContext,
 ) -> Result<WorkflowRun> {
     let graph = super::translate::translate(workflow);
     let compiled = tinyflows::compiler::compile(&graph).map_err(map_engine_error)?;
-    let run_id = uuid::Uuid::new_v4().to_string();
+    // Issue #371: the caller's run id, not a freshly minted one. Correlating the
+    // run's progress events with the `WorkflowRunFinished` the caller journals
+    // requires both halves to share an id, and only the caller can supply one
+    // that survives the error arm (where this function returns nothing at all).
+    // A side win: the run's `_workflow/` workspace directory, which is named
+    // from this id, becomes correlatable with the journal for the first time.
+    let run_id = ctx.run_id.clone();
     // Issue #154: the operator's run request rides the trigger payload. Pull it
     // out before the input is handed to the engine so every agent node's turn
     // message carries the topic — a node's authored `prompt` is the same on
@@ -120,12 +182,118 @@ async fn run_workflow_inner(
     // the capability bundle. Delivery is host-side and post-engine, so it is not
     // a capability — the engine never learns a report has a destination.
     let delivery = deps.delivery.clone();
+    // Issue #371: likewise read the journal off `deps` before it moves. `None`
+    // (the default build, and every existing test) degrades the whole progress
+    // path to a no-op — no started event, a `NoopObserver`, no collector.
+    let events = deps.events.clone();
     let capabilities =
         super::caps::build_capabilities(pool, deps, record, &workflow.id, &run_id, run_request)
             .await;
-    let outcome = tinyflows::engine::run(&compiled, input, &capabilities)
-        .await
-        .map_err(map_engine_error)?;
+
+    // The opening bracket, appended BEFORE the engine call so a run killed
+    // mid-flight leaves a start with no finish — which is precisely the shape
+    // the boot sweep looks for. Best-effort, like every other journal write on
+    // this path: losing the record is worth a log line, never a failed run.
+    if let Some(events) = events.as_ref() {
+        let started = CompanyEvent::WorkflowRunStarted {
+            workflow_id: workflow.id.clone(),
+            run_id: run_id.clone(),
+            scheduled: ctx.scheduled,
+        };
+        if let Err(err) = events.append(&record.id, started).await {
+            tracing::warn!(
+                company = %record.id,
+                workflow = %workflow.id,
+                %run_id,
+                %err,
+                "workflow: run-started progress event could not be journaled; the run is unaffected"
+            );
+        }
+    }
+
+    // Drive the engine with an observer when there is somewhere to put the
+    // frames, and exactly as before when there is not.
+    let outcome = match events.as_ref() {
+        None => tinyflows::engine::run(&compiled, input, &capabilities)
+            .await
+            .map_err(map_engine_error)?,
+        Some(events) => {
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<NodeProgress>();
+            let collector = tokio::spawn({
+                let events = events.clone();
+                let company = record.id.clone();
+                let workflow_id = workflow.id.clone();
+                let run_id = run_id.clone();
+                async move {
+                    while let Some(progress) = rx.recv().await {
+                        let event = CompanyEvent::WorkflowNodeFinished {
+                            workflow_id: workflow_id.clone(),
+                            run_id: run_id.clone(),
+                            node_id: progress.node_id,
+                            status: progress.status,
+                            elapsed_ms: progress.elapsed_ms,
+                        };
+                        if let Err(err) = events.append(&company, event).await {
+                            tracing::warn!(
+                                %company,
+                                workflow = %workflow_id,
+                                %run_id,
+                                %err,
+                                "workflow: node progress event could not be journaled; the run is \
+                                 unaffected"
+                            );
+                        }
+                    }
+                }
+            });
+
+            let observer: Arc<dyn tinyflows::observability::RunObserver> =
+                Arc::new(ProgressObserver { tx });
+            let outcome =
+                tinyflows::engine::run_with_observer(&compiled, input, &capabilities, &observer)
+                    .await;
+
+            // Drop the last sender, then join — in that order, and before
+            // anything else. The drop closes the channel so the collector's
+            // `recv()` returns `None` and its loop ends; the join then waits for
+            // every already-sent frame to reach the journal. This is what makes
+            // the ordering guarantee true: every `WorkflowNodeFinished` is
+            // durably appended before the caller's `WorkflowRunFinished`, so a
+            // reader folding the journal never sees a run settle before its
+            // nodes land. Without the join the two would race and a fold could
+            // attach a node to the run *after* it had been rendered as finished.
+            //
+            // The drop closes the channel only if ours is the **last** `Arc` —
+            // true today, because the engine's per-node handler clones die with
+            // the graph inside `run_with_observer`. The bounded wait is there so
+            // that stays a *performance* assumption rather than a liveness one:
+            // if a future engine ever parked a clone somewhere longer-lived,
+            // this would log and move on instead of wedging the run (and the
+            // whole host process behind it) forever on a join that never
+            // returns. Frames already sent still reach the journal either way —
+            // they would just land after the finished event.
+            drop(observer);
+            match tokio::time::timeout(PROGRESS_DRAIN_TIMEOUT, collector).await {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => tracing::warn!(
+                    company = %record.id,
+                    workflow = %workflow.id,
+                    %run_id,
+                    %err,
+                    "workflow: the node-progress collector did not shut down cleanly"
+                ),
+                Err(_) => tracing::warn!(
+                    company = %record.id,
+                    workflow = %workflow.id,
+                    %run_id,
+                    "workflow: node progress events did not drain in time; the run's finished \
+                     record may be journaled ahead of them"
+                ),
+            }
+
+            outcome.map_err(map_engine_error)?
+        }
+    };
 
     // Route every reached `output` node's report to its configured destination.
     // Deliberately here rather than in the HTTP handler: the orchestrator's
@@ -180,6 +348,7 @@ impl WorkflowRunner for HarnessWorkflowRunner {
         _company: &CompanyId,
         workflow: &WorkflowFile,
         input: Value,
+        ctx: &WorkflowRunContext,
     ) -> Result<WorkflowRun> {
         // Idempotent: builds the roster on first use, a no-op after. The run
         // addresses the record's own company; `_company` is the routed scope,
@@ -191,6 +360,7 @@ impl WorkflowRunner for HarnessWorkflowRunner {
             &self.record,
             workflow,
             input,
+            ctx,
         )
         .await
     }
@@ -384,6 +554,7 @@ to = "done"
             &rec,
             &file,
             serde_json::json!({ "brief": "launch" }),
+            &WorkflowRunContext::new(false),
         )
         .await
         .expect("workflow runs");
@@ -447,6 +618,7 @@ to = "done"
             &record(),
             &file,
             serde_json::json!({ "brief": "quarterly numbers" }),
+            &WorkflowRunContext::new(false),
         )
         .await
         .expect("workflow runs");
@@ -481,6 +653,7 @@ to = "done"
             &record(),
             &file,
             serde_json::json!({}),
+            &WorkflowRunContext::new(false),
         )
         .await
         .expect("an undeliverable report must not fail the run");
@@ -507,9 +680,15 @@ to = "done"
         let runner = HarnessWorkflowRunner::new(pool, deps(dir.path()), rec.clone());
 
         let file = parse_workflow(GREET).expect("workflow parses");
-        let run = WorkflowRunner::run(&runner, &rec.id, &file, serde_json::json!({}))
-            .await
-            .expect("workflow runs");
+        let run = WorkflowRunner::run(
+            &runner,
+            &rec.id,
+            &file,
+            serde_json::json!({}),
+            &WorkflowRunContext::new(false),
+        )
+        .await
+        .expect("workflow runs");
         assert!(run.output.to_string().contains("hello-marker"));
     }
 
@@ -545,6 +724,7 @@ to = "done"
             &record(),
             &file,
             serde_json::json!({}),
+            &WorkflowRunContext::new(false),
         )
         .await
         .expect_err("missing trigger rejected");
@@ -596,6 +776,7 @@ to = "done"
             &tools_record(),
             &file,
             serde_json::json!({ "seed": 1 }),
+            &WorkflowRunContext::new(false),
         )
         .await
         .expect("workflow runs");
@@ -656,6 +837,7 @@ to = "done"
             &tools_record(),
             &file,
             serde_json::json!({ "seed": 1 }),
+            &WorkflowRunContext::new(false),
         )
         .await
         .expect("run completes despite the failing node");
@@ -713,6 +895,7 @@ label = "error"
             &tools_record(),
             &file,
             serde_json::json!({ "seed": 1 }),
+            &WorkflowRunContext::new(false),
         )
         .await
         .expect("run completes via the recovery route");
@@ -769,6 +952,7 @@ to = "done"
             &tools_record(),
             &file,
             serde_json::json!({ "seed": 1 }),
+            &WorkflowRunContext::new(false),
         )
         .await
         .expect("run pauses cleanly");
@@ -818,6 +1002,7 @@ to = "done"
             &tools_record(),
             &file,
             serde_json::json!({ "seed": 1 }),
+            &WorkflowRunContext::new(false),
         )
         .await
         .expect_err("the SSRF guard must block the loopback request");
@@ -839,6 +1024,7 @@ to = "done"
             &tools_record(),
             &file,
             input,
+            &WorkflowRunContext::new(false),
         )
         .await
     }
@@ -1148,6 +1334,7 @@ to = "done"
             &tools_record(),
             &file,
             serde_json::json!({ "seed": 1 }),
+            &WorkflowRunContext::new(false),
         )
         .await
         .expect("sub_workflow run completes");
@@ -1195,6 +1382,7 @@ to = "sub"
             &tools_record(),
             &file,
             serde_json::json!({}),
+            &WorkflowRunContext::new(false),
         )
         .await
         .expect_err("a mutual sub_workflow reference must be refused");
@@ -1267,6 +1455,7 @@ to = "done"
             &tools_record(),
             &file,
             serde_json::json!({ "target": "greet_child" }),
+            &WorkflowRunContext::new(false),
         )
         .await
         .expect("dynamic sub_workflow run completes");
@@ -1348,6 +1537,7 @@ to = "done"
                     &tools_record(),
                     &file,
                     Value::Null,
+                    &WorkflowRunContext::new(false),
                 )
                 .await
             })
@@ -1378,10 +1568,239 @@ to = "done"
                     &tools_record(),
                     &file,
                     Value::Null,
+                    &WorkflowRunContext::new(false),
                 )
                 .await
             })
             .await;
         assert!(out.is_ok(), "a run below the limit must execute: {out:?}");
+    }
+
+    // --- issue #371: the per-node progress trail -----------------------------
+
+    /// Deps with a real filesystem journal wired, so the progress path is
+    /// exercised end to end rather than through a double: the claim under test
+    /// is that these events reach disk in an order a reader can rely on.
+    fn deps_with_events(dir: &std::path::Path) -> (HarnessDeps, Arc<dyn crate::ports::EventLog>) {
+        let events: Arc<dyn crate::ports::EventLog> = Arc::new(crate::store::FsEventLog::new(dir));
+        let mut deps = deps(dir);
+        deps.events = Some(events.clone());
+        (deps, events)
+    }
+
+    /// Every event journaled for `company`, oldest first.
+    async fn journaled(
+        events: &Arc<dyn crate::ports::EventLog>,
+        company: &CompanyId,
+    ) -> Vec<CompanyEvent> {
+        events
+            .read_from(company, crate::ports::types::EventSeq::new(0), usize::MAX)
+            .await
+            .expect("read")
+            .into_iter()
+            .map(|s| s.event)
+            .collect()
+    }
+
+    /// The ordering guarantee the whole read side rests on: a run journals its
+    /// start, then one event per non-trigger node **in finish order**, and all
+    /// of them are durable before `run_workflow` returns — so the caller's
+    /// `WorkflowRunFinished` can only ever land after them.
+    ///
+    /// `GREET` is `start → ceo → done`; `start` is the trigger and the engine
+    /// reports no step for it, so exactly two node events are owed.
+    #[tokio::test]
+    async fn a_run_journals_a_start_then_one_event_per_non_trigger_node() {
+        let dir = tempfile::tempdir().unwrap();
+        let pool = Arc::new(HarnessPool::new());
+        let rec = record();
+        let (deps, events) = deps_with_events(dir.path());
+        pool.ensure(&rec, &deps).await.expect("roster builds");
+
+        let file = parse_workflow(GREET).expect("workflow parses");
+        let ctx = WorkflowRunContext::new(false);
+        run_workflow(pool, deps, &rec, &file, Value::Null, &ctx)
+            .await
+            .expect("workflow runs");
+
+        let journal = journaled(&events, &rec.id).await;
+        let trail: Vec<String> = journal
+            .iter()
+            .map(|e| match e {
+                CompanyEvent::WorkflowRunStarted { .. } => "started".to_string(),
+                CompanyEvent::WorkflowNodeFinished { node_id, .. } => format!("node:{node_id}"),
+                other => format!("{other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            trail,
+            vec!["started", "node:ceo", "node:done"],
+            "expected start then one event per non-trigger node, in graph order"
+        );
+
+        // One run id across the whole trail — the correlation the fold groups on.
+        for event in &journal {
+            match event {
+                CompanyEvent::WorkflowRunStarted {
+                    run_id,
+                    workflow_id,
+                    scheduled,
+                } => {
+                    assert_eq!(run_id, &ctx.run_id);
+                    assert_eq!(workflow_id, "greet");
+                    assert!(!scheduled, "a manual run is not flagged scheduled");
+                }
+                CompanyEvent::WorkflowNodeFinished {
+                    run_id,
+                    status,
+                    workflow_id,
+                    ..
+                } => {
+                    assert_eq!(run_id, &ctx.run_id);
+                    assert_eq!(workflow_id, "greet");
+                    assert_eq!(*status, WorkflowNodeStatus::Ok);
+                }
+                other => panic!("unexpected event on the journal: {other:?}"),
+            }
+        }
+    }
+
+    /// The scheduled flag rides the *start*, not only the outcome — which is
+    /// what lets the console mark a cron fire as such while it is still running.
+    #[tokio::test]
+    async fn a_scheduled_run_is_flagged_on_its_start_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let pool = Arc::new(HarnessPool::new());
+        let rec = record();
+        let (deps, events) = deps_with_events(dir.path());
+        pool.ensure(&rec, &deps).await.expect("roster builds");
+
+        let file = parse_workflow(GREET).expect("workflow parses");
+        run_workflow(
+            pool,
+            deps,
+            &rec,
+            &file,
+            Value::Null,
+            &WorkflowRunContext::new(true),
+        )
+        .await
+        .expect("workflow runs");
+
+        let journal = journaled(&events, &rec.id).await;
+        let CompanyEvent::WorkflowRunStarted { scheduled, .. } = &journal[0] else {
+            panic!("expected the start first, got {:?}", journal[0]);
+        };
+        assert!(scheduled);
+    }
+
+    /// The arm the issue is really about: a run that dies partway still leaves
+    /// the nodes that DID complete on the journal, under the same run id the
+    /// caller will stamp on the failure. That pairing is what lets the console
+    /// say how far a failed run got instead of only that it failed.
+    ///
+    /// The graph is `start → ceo → fetch → done`, where `fetch` is an
+    /// `http_request` to loopback that the SSRF guard refuses. `on_error`
+    /// defaults to `stop`, so the run ends there — with `ceo` already recorded.
+    #[tokio::test]
+    async fn a_failed_run_still_journals_the_nodes_that_completed() {
+        let src = r#"
+id = "partial"
+name = "Partial"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "ceo"
+kind = "agent"
+name = "CEO"
+agent = "ceo"
+[[node]]
+id = "fetch"
+kind = "http_request"
+name = "Fetch"
+[node.config]
+method = "GET"
+url = "http://127.0.0.1:9/"
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+[[edge]]
+from = "start"
+to = "ceo"
+[[edge]]
+from = "ceo"
+to = "fetch"
+[[edge]]
+from = "fetch"
+to = "done"
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let pool = Arc::new(HarnessPool::new());
+        let rec = record();
+        let (deps, events) = deps_with_events(dir.path());
+        pool.ensure(&rec, &deps).await.expect("roster builds");
+
+        let file = parse_workflow(src).expect("parses");
+        let ctx = WorkflowRunContext::new(false);
+        let outcome = run_workflow(pool, deps, &rec, &file, Value::Null, &ctx).await;
+        assert!(outcome.is_err(), "the loopback fetch must fail the run");
+
+        let journal = journaled(&events, &rec.id).await;
+        // The start is there, and so is the node that got through before the
+        // failure. `done` is not — an unreached node contributes no row, so
+        // absence means "never reached", never "silently dropped".
+        assert!(matches!(
+            journal.first(),
+            Some(CompanyEvent::WorkflowRunStarted { .. })
+        ));
+        let nodes: Vec<&String> = journal
+            .iter()
+            .filter_map(|e| match e {
+                CompanyEvent::WorkflowNodeFinished { node_id, .. } => Some(node_id),
+                _ => None,
+            })
+            .collect();
+        assert!(nodes.contains(&&"ceo".to_string()), "{nodes:?}");
+        assert!(!nodes.contains(&&"done".to_string()), "{nodes:?}");
+        // Every row shares the caller's id, so the `WorkflowRunFinished` the
+        // caller journals for this failure groups with them.
+        for event in &journal {
+            let run_id = match event {
+                CompanyEvent::WorkflowRunStarted { run_id, .. } => run_id,
+                CompanyEvent::WorkflowNodeFinished { run_id, .. } => run_id,
+                other => panic!("unexpected event: {other:?}"),
+            };
+            assert_eq!(run_id, &ctx.run_id);
+        }
+    }
+
+    /// A build with no journal wired (the default runtime, and every other test
+    /// in this module) runs exactly as it did before #371 — no start, no
+    /// observer, no collector task. The progress path degrades to nothing
+    /// rather than to a half-written trail.
+    #[tokio::test]
+    async fn a_runtime_without_a_journal_records_no_progress() {
+        let dir = tempfile::tempdir().unwrap();
+        let pool = Arc::new(HarnessPool::new());
+        let rec = record();
+        let deps = deps(dir.path());
+        assert!(deps.events.is_none(), "this is the default-build shape");
+        pool.ensure(&rec, &deps).await.expect("roster builds");
+
+        let file = parse_workflow(GREET).expect("workflow parses");
+        let run = run_workflow(
+            pool,
+            deps,
+            &rec,
+            &file,
+            Value::Null,
+            &WorkflowRunContext::new(false),
+        )
+        .await
+        .expect("workflow runs");
+        assert!(run.pending_approvals.is_empty());
     }
 }

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -1765,6 +1765,31 @@ to = "done"
             .collect();
         assert!(nodes.contains(&&"ceo".to_string()), "{nodes:?}");
         assert!(!nodes.contains(&&"done".to_string()), "{nodes:?}");
+
+        // **The failing node names itself.** A node that dies under the default
+        // `stop` policy still reports a step, with `Error` status, before the
+        // run ends — so failure attribution on the canvas is exact rather than
+        // inferred from "the last node we saw running". Worth pinning: if the
+        // engine ever stopped reporting the failing step, the console would
+        // silently fall back to guessing, and nothing else would notice.
+        let statuses: Vec<(&String, &WorkflowNodeStatus)> = journal
+            .iter()
+            .filter_map(|e| match e {
+                CompanyEvent::WorkflowNodeFinished {
+                    node_id, status, ..
+                } => Some((node_id, status)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            statuses,
+            vec![
+                (&"ceo".to_string(), &WorkflowNodeStatus::Ok),
+                (&"fetch".to_string(), &WorkflowNodeStatus::Error),
+            ],
+            "the node that failed must be reported as the errored one"
+        );
+
         // Every row shares the caller's id, so the `WorkflowRunFinished` the
         // caller journals for this failure groups with them.
         for event in &journal {


### PR DESCRIPTION
## Summary

A workflow run is now something you can watch. Nodes light up as the engine walks the graph, a failure names the node that failed, and a run nobody watched — a cron firing at 3am — is readable afterwards.

Before this, pressing Run gave a spinner and then a result. Between those two moments the console showed nothing: which node is executing, which have finished, whether the run is progressing or wedged. A long run and a hung one were indistinguishable, and a run that failed at the fourth of six nodes reported only that it failed.

## API Or Behavior Changes

**Two additive `CompanyEvent` variants** — `WorkflowRunStarted` and `WorkflowNodeFinished`, the latter carrying a node id, an `ok`/`error` status and a duration. **No node output and no error text**: `WorkflowNodeStatus` has no `String` arm, so a payload leak through this path is impossible by construction rather than by review. The run-level error still lands on `WorkflowRunFinished`, which is byte-unchanged — its long-reserved `run_id` field is simply populated at last.

**Journal replay is safe**: additive variants cannot appear in already-written journals, no existing variant's serialization changed, and round-trip plus field-omission tests pin it.

**Wire additions are additive**: `WorkflowRunOutcome` gains `nodes` / `startedAtMillis` / `running`, and the run response gains `runId`. Journal rows written before run ids fold exactly as they did.

**The engine already had the hook.** tinyflows exposes `run_with_observer` with an `on_step_finish` giving `{node_id, status, duration_ms}` per non-trigger node — and the runner was installing a `NoopObserver`. This plugs in what was already there. Observer callbacks are sync and journal appends are async, so the runner ferries them over a channel and **joins the collector before returning**, which is what guarantees node rows are durable ahead of the outcome.

**A `WorkflowRunContext` is threaded through `WorkflowRunner::run`** so the compiler enumerates all four entry points, and each mints the run id — meaning the error arm correlates too. A failed run's node trail and its `WorkflowRunFinished{error}` share one id.

**`sweep_interrupted_runs`** settles runs a dead host left open, gated on the handover exactly like `reap_orphaned_runs` — at boot it is sound, mid-rebuild it would settle live runs as dead.

**The orchestrator's `run_workflow` tool now journals its outcome**, closing a #228 hole. Without it, every agent-initiated run would read as interrupted once Started events exist.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **1896 passed, 0 failed**, 1 ignored
- [x] `cargo check --locked --all-features --all-targets`
- [x] `git diff --stat Cargo.lock` — empty
- [x] `npm ci`, `npm run typecheck`, `npm run build`
- [x] Verified end to end on both the UI and the backend

No lint or component-test script exists in this repo; neither is claimed.

**All four walks were run against a live host with the real console in Chromium**, and none of them needed an inference backend — a `trigger → transform → tool_call → agent(echo) → output` graph runs fully offline:

| Walk | Result |
|---|---|
| Live | `shape 0ms → export 1ms → ceo 2062ms → done` progressing mid-run; CEO ringed `RUNNING` while the other three read `DONE` |
| Kill mid-run | SIGKILL between node events left a start with no finish; restart settled it, and history + canvas show the two completed nodes with `ceo`/`report` unmarked |
| Scheduled | a 1-minute cron fired unattended; per-node history readable afterwards, flagged `scheduled=true` |
| Failing node | `Fetch something` ringed red, history reading `This run failed at "fetch"` |

Union-built against the two other open branches — PR #378 (`fix/367-368-chat-live-events`) and PR #375 (`fix/372-373-approval-cards`): all three merge clean, and the union passes fmt, clippy, **1911 tests** and the frontend build. Per-PR CI never builds that union, which is how `main` has been broken before.

## Documentation

`docs/spec/runtime/ports.md` was **995 lines against the repo's 500-line cap**. The event vocabulary now lives in a new `docs/spec/runtime/events.md` (353 lines) documenting every variant, the run-id correlation and the boot sweep. ports.md is down to 813 — still over, but this PR reduced it rather than growing it.

## Impact

**Two corrections to the approved plan, both found by probing rather than assuming:**

**1. Failure attribution is exact, not best-effort.** The plan expected the engine to report failures only at run level, so the canvas would have to guess "last running node". Probing showed a node dying under the default `stop` policy still emits an `Error` step before the run ends. So the canvas **names the failing node**, pinned by a test, and the UI wording follows the truth rather than hedging.

**2. The `running` marker is still derived**, because there is no `on_step_start` hook — the badge says so on hover rather than implying a precision the engine does not provide.

**A bug no gate caught, found only by driving the browser.** The shell first handed the view a single "latest event" slot, and React batching silently dropped frames — losing `workflow_run_started` stranded every node frame behind it. Typecheck green, build green, tests green, canvas dead. Fixed by folding canvas state from a bounded event window with a pure function. The same walk exposed a dishonest banner — "failed before any node ran" displayed over a canvas showing two completed nodes — on interrupted runs; it now distinguishes the three real cases.

**Accepted trade-off:** roughly one extra journal event per node per run, and `list_runs` is already an O(journal) fold. At workflow volumes (one event per node, triggered by an operator or a cron) this is the right substrate; a chat turn's dozens of steps per message is what forced #242 into a dedicated store, and that pressure does not exist here. If cron volume ever demands it, moving run history off the journal fold is the known escape hatch.

**Deliberately not adopted: #242's `RunRecord`/`RunStepRecord`.** The split noted at `ports.rs` was re-derived rather than inherited, and it holds: `RunRecord` requires a `task_id`, an `agent_id` and a per-task attempt ordinal, so a workflow run would need a synthetic task id that leaks into every consumer (#337, #333, #244, the Attempts UI) — all of which assume a run keys to a board card. `RunStepRecord`'s payload is `TurnStep`, which has no node-id field; adding one pollutes a chat-turn decode contract.

## Related

Closes #371

Follows #228, which made run outcomes durable — this extends the same argument from the run to its nodes.

Follow-ups filed, not implemented:
- #382 — `on_step_start` in the vendored engine, for a true executing marker
- #383 — async run handles and cancellation. **Now load-bearing beyond this issue:** #380 reports a hosted approval timing out at the proxy because its POST is held open for a full agent turn, which is the same synchronous shape.
- #384 — the workflow create/update/delete stream arms still falling through `default:` in the console
