### PR TITLE
fix(approvals): run an approval's follow-up cycle off the HTTP connection (#383, #380)

### DIFF
--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -52,6 +52,33 @@ effect emitted ─▶ evaluate ─▶ Allow ─▶ execute, journal
   is a no-op with a fixed reply. It writes no journal record and runs no
   follow-up cycle.
 
+### Settling the verdict is not running the follow-up
+
+Resolving is two halves with very different durations, and the runtime keeps
+them apart:
+
+1. **Settle** — record the verdict, journal it, mint the grant (or execute the
+   native effect). Milliseconds. When it returns, the operator's decision is
+   permanent.
+2. **Follow-up cycle** — a full agent turn, so the brain learns the verdict and
+   re-issues the granted call. Can take minutes.
+
+The follow-up always runs on its **own task**, which the resolve then awaits.
+That makes it drop-safe: a client that disappears mid-turn — a closed tab, or a
+reverse proxy giving up on a slow upstream — abandons the *waiting*, not the
+work. Fused, the two halves meant a dropped connection cancelled the
+re-dispatch after the grant had already been spent, so the operator's approval
+bought nothing and the conversation never resumed.
+
+A resolve can also **detach** (`"detach": true`), answering the moment the
+verdict is durable rather than holding the response open for the turn. The
+continuation then arrives on the event stream's `agent_reply` frame. The
+blocking form remains the default and its response body is unchanged.
+
+A follow-up cycle that *fails* is logged host-side and leaves a recoverable
+state, never a stranded one: the verdict and grant are already durable, and
+re-approving is the idempotent no-op above, so a retry mints no second grant.
+
 ## Approving a blocked tool call: single-use grants
 
 Two different things park on this queue and they need opposite treatment.

--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -21,7 +21,8 @@ GET    /api/v1/companies/{id}                  status: charter, roster, budget b
 POST   /api/v1/companies/{id}/chat             operator message → event; SSE reply stream
 GET    /api/v1/companies/{id}/events?since=SEQ SSE stream of events/effects (work feed)
 GET    /api/v1/companies/{id}/approvals        pending approvals
-POST   /api/v1/companies/{id}/approvals/{aid}  { "verdict": "approve"|"deny", "note": "…" }
+POST   /api/v1/companies/{id}/approvals/{aid}  { "verdict": "approve"|"deny", "note": "…",
+                                               "detach": false }
 POST   /api/v1/companies/{id}/feedback         submit feedback (see feedback-loop/)
 GET    /api/v1/companies/{id}/feedback         past reports (no operator words)
 GET    /api/v1/companies/{id}/memory/traces    inspect working memory (debug)
@@ -31,6 +32,21 @@ POST   /api/v1/companies/{id}/pause            pause / resume lifecycle transiti
 
 Single-company (prosumer) mode aliases everything under `/api/v1/company/...`
 with no `{id}`.
+
+`detach` on the approval resolve chooses what the response waits for. Omitted
+(or `false`) it holds the response open for the agent's follow-up turn and
+answers with that cycle's messages — the long-standing contract, unchanged.
+Set, it answers `200 { "recorded": true, "alreadyResolved": bool }` as soon as
+the verdict is durable and the grant minted, and the continuation arrives on the
+`agent_reply` event-stream frame instead. `alreadyResolved` is a success: a
+second resolve of the same approval is an idempotent no-op that mints no second
+grant.
+
+Either way the resolve survives a dropped connection — the follow-up cycle runs
+on its own task, so it is no longer cancelled when a client or a reverse proxy
+gives up mid-turn. `detach` removes the *wait*; it is not what provides the
+drop-safety. See
+[company-brain/approvals.md](../company-brain/approvals.md#settling-the-verdict-is-not-running-the-follow-up).
 
 ## Console write plane (`src/server/ops/`)
 

--- a/src/brain/hosted/test.rs
+++ b/src/brain/hosted/test.rs
@@ -560,13 +560,15 @@ async fn e2e_supervised_effect_parks_and_acks_not_ok() {
         vec![effect_frame("filing.submit", 0, Value::Null)],
     );
 
-    let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
-        .with_brain_mode(BrainMode::Hosted)
-        .with_credential(SecretValue("th_live".into()))
-        .with_transport(transport.clone())
-        .build()
-        .await
-        .unwrap();
+    let rt = Arc::new(
+        RuntimeBuilder::new(home.clone(), manifest("supervised"))
+            .with_brain_mode(BrainMode::Hosted)
+            .with_credential(SecretValue("th_live".into()))
+            .with_transport(transport.clone())
+            .build()
+            .await
+            .unwrap(),
+    );
 
     let report = rt
         .run_cycle(vec![CompanyEvent::OperatorMessage {

--- a/src/brain/sidecar/test.rs
+++ b/src/brain/sidecar/test.rs
@@ -548,11 +548,13 @@ async fn e2e_supervised_effect_parks_through_the_real_gate() {
     );
     let inference = Arc::new(MockInferenceClient::new());
 
-    let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
-        .with_brain(sidecar_brain_for(transport.clone(), inference))
-        .build()
-        .await
-        .unwrap();
+    let rt = Arc::new(
+        RuntimeBuilder::new(home.clone(), manifest("supervised"))
+            .with_brain(sidecar_brain_for(transport.clone(), inference))
+            .build()
+            .await
+            .unwrap(),
+    );
 
     let report = rt
         .run_cycle(vec![CompanyEvent::OperatorMessage {

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::Mutex as TokioMutex;
+use tokio::task::JoinHandle;
 
 use crate::Result;
 use crate::error::OpenCompanyError;
@@ -41,7 +42,26 @@ use crate::ports::tasks::COLUMN_IN_PROGRESS as IN_PROGRESS;
 fn task_enters_in_progress(prev_column: Option<&str>, next_column: &str) -> bool {
     next_column == IN_PROGRESS && prev_column != Some(IN_PROGRESS)
 }
+
+/// Awaits a spawned follow-up cycle and flattens its two failure modes into one
+/// (issue #383).
+///
+/// A [`JoinError`](tokio::task::JoinError) means the cycle task panicked or was
+/// aborted — neither of which the cycle itself can report. Callers that want to
+/// answer on the response body await through here; callers that have detached
+/// simply drop the handle, which abandons only the waiting.
+pub(crate) async fn join_follow_up(
+    follow_up: JoinHandle<Result<CycleReport>>,
+) -> Result<CycleReport> {
+    match follow_up.await {
+        Ok(report) => report,
+        Err(err) => Err(OpenCompanyError::BackgroundTask(format!(
+            "the follow-up cycle did not finish: {err}"
+        ))),
+    }
+}
 use crate::runtime::CycleRunner;
+use crate::runtime::cycle::ResolveReceipt;
 use crate::runtime::grants::{GRANT_TTL_MILLIS, GrantSet};
 use crate::runtime::journal::{ApprovalOrigin, ExecutedEffect, RuntimeJournal};
 use crate::runtime::types::{ApprovalSummary, CompanyStatus, CycleReport};
@@ -689,20 +709,61 @@ impl CompanyRuntime {
 
     /// Resolves a parked approval and runs a follow-up cycle so the brain learns
     /// the verdict. Returns the follow-up cycle's report.
+    ///
+    /// The verdict is settled inline and the follow-up cycle runs on a **spawned
+    /// task** this then awaits — so the report is the same one callers always
+    /// got, but the cycle producing it no longer lives inside the caller's
+    /// future. See [`resolve_approval_spawned`](Self::resolve_approval_spawned)
+    /// for why that matters.
     pub async fn resolve_approval(
-        &self,
+        self: &Arc<Self>,
         id: &ApprovalId,
         verdict: Verdict,
         by: Actor,
     ) -> Result<CycleReport> {
-        // Checked before the gate is touched, not inside the follow-up cycle: a
-        // resolution that journaled the verdict and then failed to run its
-        // follow-up would leave the brain permanently unaware of an approval the
-        // operator had already granted.
+        let (_, follow_up) = self.resolve_approval_spawned(id, verdict, by).await?;
+        join_follow_up(follow_up).await
+    }
+
+    /// Settles a parked approval's verdict **inline** and runs its follow-up
+    /// cycle on a spawned task, handing back both the receipt and the task's
+    /// handle (issue #383).
+    ///
+    /// The point of the split is drop-safety. This host is plain
+    /// `axum::serve(listener, router(state))`; hyper drops a handler's future the
+    /// moment the peer closes the connection, and a reverse proxy in front of a
+    /// hosted tenant closes it the moment it decides the upstream is too slow.
+    /// Nothing on the old resolve path was spawned, so the follow-up agent turn
+    /// lived inside that future and died with it — after the verdict was
+    /// journaled and after the single-use grant was minted. The operator's
+    /// approval was spent on a re-dispatch that never happened, and the
+    /// conversation never resumed (issue #380, defect 3).
+    ///
+    /// Awaiting a [`JoinHandle`] is drop-safe: dropping the handle abandons the
+    /// *waiting*, not the work. So every caller — including the one that just
+    /// awaits it and answers exactly as before — survives a disconnect, with no
+    /// wire change required to get that.
+    ///
+    /// Spawned cycles still serialise on the runtime's per-company cycle lock
+    /// exactly as inline ones did, so this adds no concurrency. What changes is
+    /// that a burst of resolves all *complete* rather than some being shed by
+    /// dropped connections.
+    ///
+    /// `ensure_accepting` is checked before the gate is touched, not inside the
+    /// follow-up cycle: a resolution that journaled the verdict and then failed
+    /// to run its follow-up would leave the brain permanently unaware of an
+    /// approval the operator had already granted.
+    pub async fn resolve_approval_spawned(
+        self: &Arc<Self>,
+        id: &ApprovalId,
+        verdict: Verdict,
+        by: Actor,
+    ) -> Result<(ResolveReceipt, JoinHandle<Result<CycleReport>>)> {
         self.ensure_accepting()?;
-        CycleRunner::new(self)
-            .resolve_approval(id, verdict, by)
-            .await
+        let receipt = CycleRunner::new(self)
+            .settle_approval(id, verdict, by)
+            .await?;
+        Ok((receipt.clone(), self.spawn_follow_up(receipt)))
     }
 
     /// Resolves a parked approval to an operator-amended effect
@@ -710,16 +771,73 @@ impl CompanyRuntime {
     /// the parked effect, which is then executed. Runs a follow-up cycle so the
     /// brain learns the resolution; the immutable journal records both the
     /// original (parked) and amended effects.
+    ///
+    /// Drop-safe on the same terms as [`resolve_approval`](Self::resolve_approval).
     pub async fn resolve_approval_amended(
-        &self,
+        self: &Arc<Self>,
         id: &ApprovalId,
         amended_payload: serde_json::Value,
         by: Actor,
     ) -> Result<CycleReport> {
+        let (_, follow_up) = self
+            .resolve_approval_amended_spawned(id, amended_payload, by)
+            .await?;
+        join_follow_up(follow_up).await
+    }
+
+    /// The amend counterpart to
+    /// [`resolve_approval_spawned`](Self::resolve_approval_spawned).
+    pub async fn resolve_approval_amended_spawned(
+        self: &Arc<Self>,
+        id: &ApprovalId,
+        amended_payload: serde_json::Value,
+        by: Actor,
+    ) -> Result<(ResolveReceipt, JoinHandle<Result<CycleReport>>)> {
         self.ensure_accepting()?;
-        CycleRunner::new(self)
-            .resolve_approval_amended(id, amended_payload, by)
-            .await
+        let receipt = CycleRunner::new(self)
+            .settle_approval_amended(id, amended_payload, by)
+            .await?;
+        Ok((receipt.clone(), self.spawn_follow_up(receipt)))
+    }
+
+    /// Spawns the follow-up cycle a settled verdict owes, on a task that owns
+    /// its own `Arc<CompanyRuntime>` and so outlives whatever asked for it.
+    ///
+    /// [`ResolveReceipt::AlreadyResolved`] owes no cycle, but still spawns —
+    /// answering with the same synthetic report on a handle of the same shape
+    /// keeps every caller on one path instead of branching on a case that only
+    /// arises from a double-click.
+    ///
+    /// A failed follow-up is logged here rather than swallowed, because the
+    /// detached caller has nowhere to put it. It is genuinely recoverable: the
+    /// verdict and the grant are already durable, and re-approving is a safe
+    /// no-op (`ResolveOutcome::NotParked` → the already-resolved report, per
+    /// issue #243), so the operator can retry without minting a second grant.
+    fn spawn_follow_up(
+        self: &Arc<Self>,
+        receipt: ResolveReceipt,
+    ) -> JoinHandle<Result<CycleReport>> {
+        let rt = Arc::clone(self);
+        tokio::spawn(async move {
+            let event = match receipt {
+                ResolveReceipt::AlreadyResolved => {
+                    return Ok(CycleRunner::new(&rt).already_resolved_report());
+                }
+                ResolveReceipt::Settled(event) => event,
+            };
+            let report = CycleRunner::new(&rt).run(vec![event]).await;
+            if let Err(error) = &report {
+                tracing::error!(
+                    company = %rt.id,
+                    %error,
+                    "[approval] the follow-up cycle after a resolved approval failed; \
+                     the verdict and the grant are already durable, so the agent was \
+                     not told the outcome — re-approving is a safe no-op and will \
+                     re-run it"
+                );
+            }
+            report
+        })
     }
 
     /// Sweeps every parked approval past its TTL, resolving each to a

--- a/src/error.rs
+++ b/src/error.rs
@@ -186,6 +186,17 @@ pub enum OpenCompanyError {
         message: String,
     },
 
+    /// A spawned background task the caller was waiting on panicked or was
+    /// aborted, so its result never arrived (issue #383).
+    ///
+    /// Distinct from a failure *inside* that work, which reports itself through
+    /// its own variant. This one means the work's outcome is unknown — the
+    /// caller's wait ended without an answer. On the approval path the verdict
+    /// it settled is already durable regardless; only the follow-up cycle is
+    /// unaccounted for.
+    #[error("background work did not complete: {0}")]
+    BackgroundTask(String),
+
     /// A port method has no implementation in the current build.
     #[error("port not implemented: {0}")]
     Unimplemented(&'static str),
@@ -252,6 +263,7 @@ impl OpenCompanyError {
             Self::Orchestration { code, .. } => code.clone(),
             Self::Tinyplace { code, .. } => format!("tinyplace_{code}"),
             Self::TinyHumans { code, .. } => format!("tinyhumans_{code}"),
+            Self::BackgroundTask(_) => "background_task".to_string(),
             Self::Unimplemented(_) => "unimplemented".to_string(),
             #[cfg(feature = "openhuman")]
             Self::Harness(_) => "harness_error".to_string(),

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -72,6 +72,32 @@ pub(crate) const RUN_UNSETTLED_ERROR: &str =
 /// row carries the same reason the caller saw rather than a generic one.
 pub(crate) const RUN_CYCLE_FAILED_ERROR: &str = "the dispatch cycle failed";
 
+/// What settling an approval's verdict produced — the outcome of the fast half
+/// of a resolve, before any model is called (issue #383).
+///
+/// Both arms mean the operator's decision is final. They differ only in what is
+/// still owed: `Settled` owes one follow-up cycle, `AlreadyResolved` owes
+/// nothing because a previous resolve already ran it.
+#[derive(Debug, Clone)]
+pub enum ResolveReceipt {
+    /// Nothing was parked under this id — an unknown id, or one a concurrent
+    /// request (or a double-click) already resolved. No journal record was
+    /// written and no cycle is owed. Issue #243 made this a safe no-op rather
+    /// than a second grant; surfacing it here lets the HTTP layer say so.
+    AlreadyResolved,
+    /// The verdict is journaled and any approved effect settled — the grant is
+    /// minted, or the native effect executed. The carried `ApprovalResolved` is
+    /// the event the follow-up cycle must run so the brain learns the verdict.
+    Settled(CompanyEvent),
+}
+
+impl ResolveReceipt {
+    /// Whether this resolve found nothing left to resolve.
+    pub fn already_resolved(&self) -> bool {
+        matches!(self, Self::AlreadyResolved)
+    }
+}
+
 /// Drives cycles for one [`CompanyRuntime`].
 pub struct CycleRunner<'a> {
     rt: &'a CompanyRuntime,
@@ -434,43 +460,62 @@ working on):\n{}\n]",
         }
     }
 
-    /// Resolves a parked approval, executes the effect on approval, and runs a
-    /// follow-up cycle feeding the resolution back to the brain.
+    /// Settles a parked approval's verdict — the **fast half** of resolving one.
+    ///
+    /// Records the outcome on the gate, journals it durably, and settles the
+    /// approved effect (minting the single-use grant, or executing a native
+    /// effect). Everything here is local bookkeeping and a couple of appends; no
+    /// model is called. What it deliberately does *not* do is run the follow-up
+    /// cycle — that is [`ResolveReceipt::Settled`]'s event, handed back for the
+    /// caller to run separately.
+    ///
+    /// The split exists because the two halves have wildly different durations
+    /// and wildly different consequences if they are lost (issue #383). The
+    /// settle is milliseconds and, once it returns, the operator's decision is
+    /// permanent. The follow-up is a full agent turn and can outlast any proxy
+    /// in front of the host. Fusing them meant the HTTP status reported the
+    /// *turn's* fate as though it were the *verdict's*, so a slow turn behind
+    /// nginx read as "couldn't record your decision" over a decision that was
+    /// already journaled and already granted (issue #380, defect 1). Worse,
+    /// because the whole thing lived in the request future, the dropped
+    /// connection took the continuation with it — grant spent, agent never
+    /// re-dispatched (defect 3).
     ///
     /// Resolving an approval that is **not parked** — an unknown id, or one a
-    /// concurrent request already resolved — is a no-op that answers with a
-    /// fixed line (issue #243). It writes no journal record and runs no cycle.
+    /// concurrent request already resolved — is a no-op that yields
+    /// [`ResolveReceipt::AlreadyResolved`] (issue #243). It writes no journal
+    /// record and owes no cycle.
     ///
     /// Before this the double-submit path was indistinguishable from a deny (see
     /// [`ResolveOutcome`]), so a double-clicked approve appended a second
     /// `ApprovalResolved` to the journal and ran a second follow-up cycle over an
     /// approval that no longer existed — burning a model turn to tell the brain
     /// about a resolution it had already been told about.
-    pub async fn resolve_approval(
+    pub async fn settle_approval(
         &self,
         id: &ApprovalId,
         verdict: Verdict,
         by: Actor,
-    ) -> Result<CycleReport> {
+    ) -> Result<ResolveReceipt> {
         let outcome = self
             .rt
             .approval_gate
             .resolve_outcome(id, verdict, by.clone(), now_millis());
         if outcome == ResolveOutcome::NotParked {
-            return Ok(self.already_resolved_report());
+            return Ok(ResolveReceipt::AlreadyResolved);
         }
         self.rt.journal.record_resolved(id).await?;
         if let ResolveOutcome::Approved(effect) = outcome {
             self.settle_approved_effect(id, effect).await?;
         }
-        // Follow-up cycle so the brain learns the verdict. Appending the
-        // resolution here (rather than separately) keeps the event logged once.
-        self.run(vec![CompanyEvent::ApprovalResolved {
+        // The follow-up event, so the brain learns the verdict. Returning it
+        // (rather than appending it here) keeps the event logged exactly once:
+        // the cycle that runs it is the thing that appends it.
+        Ok(ResolveReceipt::Settled(CompanyEvent::ApprovalResolved {
             approval_id: id.clone(),
             verdict,
             by,
-        }])
-        .await
+        }))
     }
 
     /// Applies an approved effect: **mint a grant** when it came from a harness
@@ -591,7 +636,7 @@ working on):\n{}\n]",
     /// "nothing happened" instead of an error, because from the operator's side
     /// a double-submit is not a failure, it is a request whose work was already
     /// done.
-    fn already_resolved_report(&self) -> CycleReport {
+    pub(crate) fn already_resolved_report(&self) -> CycleReport {
         CycleReport {
             cycle_id: generate_id(),
             responses: vec![OutboundMessage {
@@ -607,19 +652,25 @@ working on):\n{}\n]",
         }
     }
 
-    /// Resolves a parked approval to an operator-amended effect
-    /// (approve-with-edit): overlays `amended_payload` onto the parked effect,
-    /// executes the amended version (at-most-once), and runs a follow-up cycle.
+    /// Settles a parked approval to an operator-amended effect
+    /// (approve-with-edit): overlays `amended_payload` onto the parked effect and
+    /// executes the amended version (at-most-once).
+    ///
+    /// The amend counterpart to [`settle_approval`](Self::settle_approval), and
+    /// split from its follow-up cycle for the same reasons (issue #383). It has
+    /// no `AlreadyResolved` arm: an id with nothing parked yields no executable
+    /// effect and simply settles to a resolution the brain is still told about,
+    /// exactly as before.
     ///
     /// Both the original and the amended effect are preserved in the immutable
     /// journal (`ApprovalParked` + `ApprovalAmended`), so the audit trail shows
     /// what the brain requested and what the operator approved.
-    pub async fn resolve_approval_amended(
+    pub async fn settle_approval_amended(
         &self,
         id: &ApprovalId,
         amended_payload: serde_json::Value,
         by: Actor,
-    ) -> Result<CycleReport> {
+    ) -> Result<ResolveReceipt> {
         let now = now_millis();
 
         // Overlay the operator's edit onto the parked effect. A missing id (or
@@ -653,15 +704,14 @@ working on):\n{}\n]",
             self.settle_approved_effect(id, effect.clone()).await?;
         }
 
-        // Follow-up cycle so the brain learns the approval resolved (with an
-        // edit). `CompanyEvent` is closed, so the verdict rides as `Approve`;
+        // The follow-up event, so the brain learns the approval resolved (with
+        // an edit). `CompanyEvent` is closed, so the verdict rides as `Approve`;
         // the edit itself lives in the journal audit trail.
-        self.run(vec![CompanyEvent::ApprovalResolved {
+        Ok(ResolveReceipt::Settled(CompanyEvent::ApprovalResolved {
             approval_id: id.clone(),
             verdict: Verdict::Approve,
             by,
-        }])
-        .await
+        }))
     }
 
     /// Replays the journal to rebuild the executed-key set, the approval queue,
@@ -1896,13 +1946,15 @@ mod test {
             agent: None,
             run_id: None,
         };
-        let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
-            .with_brain(Arc::new(EffectBrain {
-                effect: sign_effect,
-            }))
-            .build()
-            .await
-            .unwrap();
+        let rt = Arc::new(
+            RuntimeBuilder::new(home.clone(), manifest("supervised"))
+                .with_brain(Arc::new(EffectBrain {
+                    effect: sign_effect,
+                }))
+                .build()
+                .await
+                .unwrap(),
+        );
 
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
@@ -1949,12 +2001,20 @@ mod test {
     }
 
     /// Parks `effect` through a real cycle and returns the runtime + approval id.
-    async fn park_one(home: std::path::PathBuf, effect: Effect) -> (CompanyRuntime, ApprovalId) {
-        let rt = RuntimeBuilder::new(home, manifest("supervised"))
-            .with_brain(Arc::new(EffectBrain { effect }))
-            .build()
-            .await
-            .unwrap();
+    /// Returns the runtime behind an `Arc`, as the server's registry holds it:
+    /// resolving an approval spawns its follow-up cycle onto a clone of that
+    /// handle, so the cycle outlives the request that asked for it (issue #383).
+    async fn park_one(
+        home: std::path::PathBuf,
+        effect: Effect,
+    ) -> (Arc<CompanyRuntime>, ApprovalId) {
+        let rt = Arc::new(
+            RuntimeBuilder::new(home, manifest("supervised"))
+                .with_brain(Arc::new(EffectBrain { effect }))
+                .build()
+                .await
+                .unwrap(),
+        );
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
                 text: "do it".into(),
@@ -1966,6 +2026,93 @@ mod test {
         assert_eq!(report.parked.len(), 1);
         let id = report.parked[0].clone();
         (rt, id)
+    }
+
+    /// Parks one tool call, then fails every follow-up turn.
+    struct FailingContinuationBrain {
+        effect: Effect,
+    }
+
+    #[async_trait]
+    impl Brain for FailingContinuationBrain {
+        async fn run_cycle(&self, req: CycleRequest, host: &dyn CycleHost) -> Result<CycleResult> {
+            for event in &req.events {
+                match event {
+                    CompanyEvent::OperatorMessage { .. } => {
+                        host.park_effect(self.effect.clone()).await?;
+                    }
+                    CompanyEvent::ApprovalResolved { .. } => {
+                        return Err(OpenCompanyError::Unimplemented("the follow-up turn failed"));
+                    }
+                    _ => {}
+                }
+            }
+            Ok(CycleResult {
+                channel_responses: Vec::new(),
+                new_traces: vec![CompressedTrace::now(&req.cycle_id, "failing continuation")],
+                ledger_deltas: Vec::new(),
+                token_usage: TokenUsage::default(),
+            })
+        }
+    }
+
+    /// Issue #383: a follow-up cycle that fails leaves a *recoverable* state,
+    /// not a stranded one.
+    ///
+    /// Detaching the cycle means its failure has nowhere to be returned to, so
+    /// the safety net has to be the ordering rather than the caller: the verdict
+    /// is journaled and the grant minted before the turn is ever attempted, and
+    /// re-approving is a no-op that mints no second grant (issue #243). This
+    /// pins all three, so "the runtime logs it and the operator can retry" is a
+    /// property of the code rather than a claim in a PR body.
+    #[tokio::test]
+    async fn a_failed_follow_up_cycle_leaves_the_verdict_and_grant_intact() {
+        let home_dir = tmp_home();
+        let effect = harness_effect("finance", "composio_execute", serde_json::json!({}));
+        let rt = Arc::new(
+            RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest("supervised"))
+                .with_brain(Arc::new(FailingContinuationBrain {
+                    effect: effect.clone(),
+                }))
+                .build()
+                .await
+                .unwrap(),
+        );
+        let report = rt
+            .run_cycle(vec![CompanyEvent::OperatorMessage {
+                text: "do it".into(),
+                by: None,
+                chat: None,
+            }])
+            .await
+            .unwrap();
+        let id = report.parked[0].clone();
+
+        let failed = rt.resolve_approval(&id, Verdict::Approve, operator()).await;
+        assert!(failed.is_err(), "the caller still learns the turn failed");
+
+        // The operator's decision survived it.
+        assert!(
+            rt.pending_approvals().is_empty(),
+            "the verdict was journaled before the turn was attempted"
+        );
+        assert!(rt.grants.peek(&id).is_some(), "and the grant was minted");
+        assert_eq!(rt.grants.live_count(), 1);
+
+        // Retrying is safe: a no-op report, and still exactly one grant.
+        let again = rt
+            .resolve_approval(&id, Verdict::Approve, operator())
+            .await
+            .expect("re-approving is a no-op, not a second failure");
+        assert_eq!(
+            again.responses[0].text,
+            "This approval was already resolved."
+        );
+        assert_eq!(
+            rt.grants.live_count(),
+            1,
+            "a retry after a failed continuation mints no second grant"
+        );
     }
 
     /// The core of #243: approving an agent's blocked tool call mints a
@@ -2077,14 +2224,16 @@ mod test {
         let gate = Arc::new(
             ManifestApprovalGate::new(manifest("supervised").policy.clone()).with_ttl_millis(0),
         );
-        let rt = RuntimeBuilder::new(home, manifest("supervised"))
-            .with_approvals(gate)
-            .with_brain(Arc::new(EffectBrain {
-                effect: harness_effect("finance", "composio_execute", serde_json::json!({})),
-            }))
-            .build()
-            .await
-            .unwrap();
+        let rt = Arc::new(
+            RuntimeBuilder::new(home, manifest("supervised"))
+                .with_approvals(gate)
+                .with_brain(Arc::new(EffectBrain {
+                    effect: harness_effect("finance", "composio_execute", serde_json::json!({})),
+                }))
+                .build()
+                .await
+                .unwrap(),
+        );
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
                 text: "do it".into(),
@@ -2238,13 +2387,15 @@ mod test {
             agent: None,
             run_id: None,
         };
-        let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
-            .with_brain(Arc::new(EffectBrain {
-                effect: sign_effect,
-            }))
-            .build()
-            .await
-            .unwrap();
+        let rt = Arc::new(
+            RuntimeBuilder::new(home.clone(), manifest("supervised"))
+                .with_brain(Arc::new(EffectBrain {
+                    effect: sign_effect,
+                }))
+                .build()
+                .await
+                .unwrap(),
+        );
 
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
@@ -2392,13 +2543,15 @@ mod test {
 
         // A fresh runtime over the same home rehydrates the parked approval and
         // can resolve it by its original id.
-        let rt2 = RuntimeBuilder::new(home.clone(), manifest("supervised"))
-            .with_brain(Arc::new(EffectBrain {
-                effect: sign_effect,
-            }))
-            .build()
-            .await
-            .unwrap();
+        let rt2 = Arc::new(
+            RuntimeBuilder::new(home.clone(), manifest("supervised"))
+                .with_brain(Arc::new(EffectBrain {
+                    effect: sign_effect,
+                }))
+                .build()
+                .await
+                .unwrap(),
+        );
         assert_eq!(rt2.pending_approvals().len(), 1);
         rt2.resolve_approval(&approval_id, Verdict::Deny, operator())
             .await
@@ -2425,14 +2578,16 @@ mod test {
         // A recording operator channel we keep a handle to (Arc-shared buffer).
         let operator_channel = OperatorChannel::new();
         let channels: Vec<Arc<dyn ChannelAdapter>> = vec![Arc::new(operator_channel.clone())];
-        let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
-            .with_brain(Arc::new(EffectBrain {
-                effect: sign_effect,
-            }))
-            .with_channels(channels)
-            .build()
-            .await
-            .unwrap();
+        let rt = Arc::new(
+            RuntimeBuilder::new(home.clone(), manifest("supervised"))
+                .with_brain(Arc::new(EffectBrain {
+                    effect: sign_effect,
+                }))
+                .with_channels(channels)
+                .build()
+                .await
+                .unwrap(),
+        );
 
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
@@ -2896,14 +3051,16 @@ mod test {
         let home_dir = tmp_home();
         let home = home_dir.path().to_path_buf();
         let sender = Arc::new(RecordingMailSender::new());
-        let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
-            .with_mail(CompanyMail {
-                sender: sender.clone(),
-                smtp: test_smtp("ceo@acme.test"),
-            })
-            .build()
-            .await
-            .unwrap();
+        let rt = Arc::new(
+            RuntimeBuilder::new(home.clone(), manifest("full"))
+                .with_mail(CompanyMail {
+                    sender: sender.clone(),
+                    smtp: test_smtp("ceo@acme.test"),
+                })
+                .build()
+                .await
+                .unwrap(),
+        );
 
         // What `park_cold_recipient` builds, field for field.
         let effect = Effect {
@@ -2962,14 +3119,16 @@ mod test {
         let home_dir = tmp_home();
         let home = home_dir.path().to_path_buf();
         let sender = Arc::new(RecordingMailSender::new());
-        let rt = RuntimeBuilder::new(home.clone(), manifest("full"))
-            .with_mail(CompanyMail {
-                sender: sender.clone(),
-                smtp: test_smtp("ceo@acme.test"),
-            })
-            .build()
-            .await
-            .unwrap();
+        let rt = Arc::new(
+            RuntimeBuilder::new(home.clone(), manifest("full"))
+                .with_mail(CompanyMail {
+                    sender: sender.clone(),
+                    smtp: test_smtp("ceo@acme.test"),
+                })
+                .build()
+                .await
+                .unwrap(),
+        );
 
         let effect = Effect {
             kind: EMAIL_SEND_KIND.into(),
@@ -3045,14 +3204,16 @@ mod test {
 
         // Fresh runtime over the same home: boot replay rehydrates the card.
         let sender = Arc::new(RecordingMailSender::new());
-        let rt2 = RuntimeBuilder::new(home.clone(), manifest("full"))
-            .with_mail(CompanyMail {
-                sender: sender.clone(),
-                smtp: test_smtp("ceo@acme.test"),
-            })
-            .build()
-            .await
-            .unwrap();
+        let rt2 = Arc::new(
+            RuntimeBuilder::new(home.clone(), manifest("full"))
+                .with_mail(CompanyMail {
+                    sender: sender.clone(),
+                    smtp: test_smtp("ceo@acme.test"),
+                })
+                .build()
+                .await
+                .unwrap(),
+        );
         let pending = rt2.pending_approvals();
         assert_eq!(pending.len(), 1, "{pending:?}");
         assert_eq!(pending[0].id, approval_id, "the ORIGINAL id, not a new one");

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1266,6 +1266,39 @@ struct ResolveApproval {
     /// An optional payload edit; overlaid onto the parked effect on `approve`.
     #[serde(default)]
     amended_payload: Option<serde_json::Value>,
+    /// Answer as soon as the verdict is durable, rather than holding the
+    /// response open for the agent's follow-up turn (issue #383).
+    ///
+    /// Defaults to `false`, which keeps the response byte-identical to what
+    /// every existing caller receives — a [`ChatResponse`] carrying the
+    /// follow-up cycle's messages. Setting it swaps the body for a
+    /// [`ResolveReceiptDto`] and lets the continuation arrive on the event
+    /// stream's `agent_reply` frame instead, which is where a console that is
+    /// already subscribed would rather read it anyway.
+    ///
+    /// Either way the resolve now survives a dropped connection — the
+    /// drop-safety comes from `CompanyRuntime::resolve_approval_spawned`, not
+    /// from this flag. What the flag buys is not having to *wait*: a turn slower
+    /// than the proxy's read timeout no longer produces a gateway error page
+    /// over a decision that was recorded seconds earlier (issue #380).
+    #[serde(default)]
+    detach: bool,
+}
+
+/// The answer to a detached resolve: the verdict is durable, that is all this
+/// claims. The agent's continuation arrives afterwards on the event stream's
+/// `agent_reply` frame, which the console already projects and consumes.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ResolveReceiptDto {
+    /// Always `true` — a non-`true` receipt is an error response instead.
+    /// Present so the body is self-describing rather than an empty object.
+    recorded: bool,
+    /// Whether there was nothing left to resolve, because a previous request (or
+    /// a double-click) already did. Not a failure: issue #243 made the second
+    /// resolve a no-op that mints no second grant, and saying so lets the console
+    /// render it as the success it is.
+    already_resolved: bool,
 }
 
 async fn run_resolve(
@@ -1274,17 +1307,20 @@ async fn run_resolve(
     runtime: Arc<CompanyRuntime>,
     approval_id: String,
     body: ResolveApproval,
-) -> Result<Json<ChatResponse>, ApiError> {
+) -> Result<Response, ApiError> {
     runtime.ensure_running().await?;
     let actor = Actor {
         kind: ActorKind::Operator,
         id: "operator".to_string(),
     };
     let id = ApprovalId::new(approval_id);
-    let report = match (body.verdict, body.amended_payload) {
+    // The verdict is settled inline; only the follow-up cycle is on the handle.
+    // So by the time this returns — in either mode — the decision is journaled
+    // and any grant is minted.
+    let (receipt, follow_up) = match (body.verdict, body.amended_payload) {
         (Verdict::Approve, Some(payload)) => {
             runtime
-                .resolve_approval_amended(&id, payload, actor)
+                .resolve_approval_amended_spawned(&id, payload, actor)
                 .await?
         }
         (Verdict::Deny, Some(_)) => {
@@ -1292,12 +1328,43 @@ async fn run_resolve(
                 "amended_payload cannot accompany a deny verdict".to_string(),
             )));
         }
-        (verdict, None) => runtime.resolve_approval(&id, verdict, actor).await?,
+        (verdict, None) => {
+            runtime
+                .resolve_approval_spawned(&id, verdict, actor)
+                .await?
+        }
     };
+
+    if body.detach {
+        // Nothing here waits on the turn. The webhook fan-out still owes the
+        // report, so it moves onto its own task rather than being dropped —
+        // a detached resolve must not silently stop notifying subscribers.
+        let state = state.clone();
+        let company = company.clone();
+        tokio::spawn(async move {
+            // A failed cycle already logged itself in `spawn_follow_up`; a
+            // panicked one is worth its own line, since nothing else reports it.
+            match crate::company::runtime::join_follow_up(follow_up).await {
+                Ok(report) => emit_cycle_webhooks(&state, &company, &report).await,
+                Err(OpenCompanyError::BackgroundTask(detail)) => {
+                    tracing::error!(%company, %detail, "[approval] a detached follow-up cycle did not finish");
+                }
+                Err(_) => {}
+            }
+        });
+        return Ok(Json(ResolveReceiptDto {
+            recorded: true,
+            already_resolved: receipt.already_resolved(),
+        })
+        .into_response());
+    }
+
+    let report = crate::company::runtime::join_follow_up(follow_up).await?;
     emit_cycle_webhooks(state, company, &report).await;
     Ok(Json(ChatResponse {
         responses: report.responses,
-    }))
+    })
+    .into_response())
 }
 
 /// `POST /api/v1/companies/{id}/approvals/{aid}`.
@@ -1306,7 +1373,7 @@ async fn resolve_approval(
     State(state): State<AppState>,
     Path((id, aid)): Path<(String, String)>,
     Json(body): Json<ResolveApproval>,
-) -> Result<Json<ChatResponse>, Response> {
+) -> Result<Response, Response> {
     let company = CompanyId::new(&id);
     if let Some(resp) = authorize_address(&state, &auth, &company) {
         return Err(resp);
@@ -1323,7 +1390,7 @@ async fn resolve_approval_single(
     State(state): State<AppState>,
     Path(aid): Path<String>,
     Json(body): Json<ResolveApproval>,
-) -> Result<Json<ChatResponse>, Response> {
+) -> Result<Response, Response> {
     let runtime = sole(&state).map_err(IntoResponse::into_response)?;
     let id = runtime.id().clone();
     if let Some(resp) = authorize_address(&state, &auth, &id) {
@@ -1367,6 +1434,17 @@ mod test {
     }
 
     async fn build_state(home: &std::path::Path, lifecycle: &str, config: AppConfig) -> AppState {
+        build_state_with_brain(home, lifecycle, config, None).await
+    }
+
+    /// [`build_state`], optionally swapping the runtime's cognition. The
+    /// approval-continuation tests need a brain they can stall mid-turn.
+    async fn build_state_with_brain(
+        home: &std::path::Path,
+        lifecycle: &str,
+        config: AppConfig,
+        brain: Option<Arc<dyn crate::ports::brain::Brain>>,
+    ) -> AppState {
         // Pre-seed a record so the builder preserves the requested lifecycle.
         let store = FsCompanyStore::new(home.to_path_buf());
         let id = CompanyId::new("acme");
@@ -1388,11 +1466,11 @@ mod test {
             .await
             .unwrap();
 
-        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest())
-            .with_id(id.clone())
-            .build()
-            .await
-            .unwrap();
+        let mut builder = RuntimeBuilder::new(home.to_path_buf(), manifest()).with_id(id.clone());
+        if let Some(brain) = brain {
+            builder = builder.with_brain(brain);
+        }
+        let runtime = builder.build().await.unwrap();
         let state = AppState::new(config);
         state.registry().insert(id, Arc::new(runtime));
         crate::server::test_support::seed_fixed_admin(&state, "acme").await;
@@ -2581,6 +2659,463 @@ mod test {
         assert!(value["responses"].is_array());
     }
 
+    /// The tool call the operator is asked to sign off. `agent: Some(_)` is what
+    /// makes approving it mint a single-use grant rather than execute it
+    /// (issue #243) — which is the whole reason a lost continuation hurts: the
+    /// grant is spent on a turn that never happens.
+    fn gated_tool_call() -> crate::ports::types::Effect {
+        crate::ports::types::Effect {
+            kind: "composio_execute".into(),
+            group: crate::ports::types::EffectGroup::Sign,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
+            agent: Some("ceo".into()),
+            run_id: None,
+        }
+    }
+
+    /// The dotted kind the stalled brain parks once its follow-up turn gets
+    /// past the barrier. Parking journals durably (`record_parked`), so its
+    /// presence in `pending_approvals()` is proof the continuation reached the
+    /// end of the turn *and* wrote to disk — not merely that a task was alive.
+    const CONTINUATION_MARKER: &str = "continuation.marker";
+
+    /// A brain that parks one gated tool call per operator message and, on the
+    /// follow-up `ApprovalResolved` cycle, blocks mid-turn until the test
+    /// releases it — the shape of a slow agent turn behind a proxy.
+    struct StalledContinuationBrain {
+        /// Fires once the follow-up turn has begun. By this point the verdict
+        /// is journaled and the grant minted, so this is exactly the moment the
+        /// field report's connection died.
+        entered: Arc<tokio::sync::Notify>,
+        /// The test's permission for the turn to finish.
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::ports::brain::Brain for StalledContinuationBrain {
+        async fn run_cycle(
+            &self,
+            req: crate::ports::types::CycleRequest,
+            host: &dyn crate::ports::brain::CycleHost,
+        ) -> crate::Result<crate::ports::types::CycleResult> {
+            for event in &req.events {
+                match event {
+                    CompanyEvent::OperatorMessage { .. } => {
+                        host.park_effect(gated_tool_call()).await?;
+                    }
+                    CompanyEvent::ApprovalResolved { .. } => {
+                        self.entered.notify_one();
+                        self.release.notified().await;
+                        host.park_effect(crate::ports::types::Effect {
+                            kind: CONTINUATION_MARKER.into(),
+                            group: crate::ports::types::EffectGroup::Other,
+                            amount_usd: None,
+                            established_thread: false,
+                            first_time_counterparty: false,
+                            payload: serde_json::json!({}),
+                            agent: None,
+                            run_id: None,
+                        })
+                        .await?;
+                    }
+                    _ => {}
+                }
+            }
+            Ok(crate::ports::types::CycleResult {
+                channel_responses: Vec::new(),
+                new_traces: vec![crate::ports::types::CompressedTrace::now(
+                    &req.cycle_id,
+                    "stalled continuation",
+                )],
+                ledger_deltas: Vec::new(),
+                token_usage: crate::ports::types::TokenUsage::default(),
+            })
+        }
+    }
+
+    fn chat_request(text: &str) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/api/v1/company/chat")
+            .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::json!({ "text": text }).to_string()))
+            .unwrap()
+    }
+
+    /// A resolve against the single-company alias. `scope` lets the same body be
+    /// aimed at the `/companies/{id}` form, which must behave identically.
+    fn resolve_request_scoped(
+        scope: &str,
+        approval_id: &ApprovalId,
+        body: serde_json::Value,
+    ) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri(format!("{scope}/approvals/{approval_id}"))
+            .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    fn resolve_request(approval_id: &ApprovalId, body: serde_json::Value) -> Request<Body> {
+        resolve_request_scoped("/api/v1/company", approval_id, body)
+    }
+
+    /// Whether the stalled brain's follow-up turn has journaled its marker yet.
+    fn continued(runtime: &Arc<CompanyRuntime>) -> bool {
+        runtime
+            .pending_approvals()
+            .iter()
+            .any(|a| a.kind == CONTINUATION_MARKER)
+    }
+
+    /// Waits for the stalled brain's follow-up turn to journal its marker.
+    async fn await_continuation(runtime: &Arc<CompanyRuntime>) -> bool {
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            while !continued(runtime) {
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .is_ok()
+    }
+
+    /// A running company with one tool call parked and a brain that will stall
+    /// on the follow-up turn until `release` is fired.
+    struct StalledCompany {
+        app: axum::Router,
+        runtime: Arc<CompanyRuntime>,
+        approval_id: ApprovalId,
+        /// Fires once the follow-up turn has begun — by which point the verdict
+        /// is journaled and the grant minted.
+        entered: Arc<tokio::sync::Notify>,
+        /// The test's permission for that turn to finish.
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    async fn stalled_company(home: &std::path::Path) -> StalledCompany {
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let state = build_state_with_brain(
+            home,
+            "running",
+            AppConfig::default(),
+            Some(Arc::new(StalledContinuationBrain {
+                entered: entered.clone(),
+                release: release.clone(),
+            })),
+        )
+        .await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let app = router(state);
+
+        let response = app.clone().oneshot(chat_request("do it")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let parked = runtime.pending_approvals();
+        assert_eq!(parked.len(), 1, "the brain parked one tool call");
+        let approval_id = parked[0].id.clone();
+
+        StalledCompany {
+            app,
+            runtime,
+            approval_id,
+            entered,
+            release,
+        }
+    }
+
+    /// **Issue #383 / #380 defect 3 — the keystone.** A client that walks away
+    /// mid-turn must not take the agent's continuation with it.
+    ///
+    /// The host is plain `axum::serve(listener, router(state))` and nothing on
+    /// the resolve path was spawned, so the follow-up agent turn lived *inside*
+    /// the request future. Hyper drops that future the moment the peer closes,
+    /// and nginx closes its upstream connection when it gives up on a slow
+    /// response. So on a hosted tenant the sequence was: verdict recorded,
+    /// journaled, single-use grant minted — and then the re-dispatch the grant
+    /// existed for cancelled mid-flight. The operator's approval was spent and
+    /// the conversation never resumed, which is precisely what #380 reported.
+    ///
+    /// `Router::oneshot` reproduces that cancellation faithfully rather than by
+    /// analogy: the mechanism is the same one hyper uses — the handler future is
+    /// owned by the future the caller is polling, and dropping the latter drops
+    /// the former.
+    #[tokio::test]
+    async fn a_dropped_connection_does_not_cancel_the_follow_up_cycle() {
+        let home_dir = home();
+        let c = stalled_company(home_dir.path()).await;
+
+        // Approve it, then let the connection die once the turn is under way.
+        let mut resolving = Box::pin(c.app.clone().oneshot(resolve_request(
+            &c.approval_id,
+            serde_json::json!({"verdict":"approve"}),
+        )));
+        tokio::select! {
+            _ = &mut resolving => panic!("the resolve answered before the follow-up turn began"),
+            _ = c.entered.notified() => {}
+        }
+        drop(resolving);
+
+        // The verdict is already durable and the grant already spent — this is
+        // the state the operator is left in when the proxy gives up.
+        assert!(
+            !c.runtime
+                .pending_approvals()
+                .iter()
+                .any(|a| a.id == c.approval_id),
+            "the verdict was journaled before the connection dropped"
+        );
+        assert!(
+            c.runtime.grants.peek(&c.approval_id).is_some(),
+            "the single-use grant was minted before the connection dropped"
+        );
+
+        // So the continuation the grant exists for must still complete.
+        c.release.notify_one();
+        assert!(
+            await_continuation(&c.runtime).await,
+            "the follow-up cycle died with the dropped connection: the grant is spent \
+             and the agent never continued"
+        );
+        assert_eq!(
+            c.runtime.grants.live_count(),
+            1,
+            "the continuation minted no second grant"
+        );
+    }
+
+    /// The same proof over a **real socket**, so the keystone rests on hyper's
+    /// actual behaviour rather than on `oneshot` being a good model of it.
+    ///
+    /// This boots the production server — `axum::serve` over a bound
+    /// `TcpListener` — writes the resolve by hand, and then hangs up mid-turn
+    /// the way a proxy does when it gives up on a slow upstream. Hyper reads the
+    /// peer's close while the handler is still pending and drops the request,
+    /// which is precisely the cancellation #380's hosted tenant hit. A graceful
+    /// `FIN` is enough; it does not take a reset.
+    ///
+    /// **The pause after the close is load-bearing.** Hyper does not learn the
+    /// peer is gone the instant the client calls `close` — it learns when its
+    /// connection task next polls the socket and reads EOF. Release the barrier
+    /// before that happens and the turn finishes on its own merits, so the test
+    /// passes whether or not the cycle is drop-safe and proves nothing. Measured
+    /// while building this: without the pause, the pre-fix inline code passed
+    /// this test; with it, the pre-fix code fails and the fix passes.
+    #[tokio::test]
+    async fn a_real_socket_close_does_not_cancel_the_follow_up_cycle() {
+        use tokio::io::AsyncWriteExt;
+
+        let home_dir = home();
+        let c = stalled_company(home_dir.path()).await;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = c.app.clone();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await });
+
+        let body = serde_json::json!({ "verdict": "approve" }).to_string();
+        let request = format!(
+            "POST /api/v1/company/approvals/{} HTTP/1.1\r\n\
+             Host: {addr}\r\n\
+             Cookie: {}\r\n\
+             Content-Type: application/json\r\n\
+             Content-Length: {}\r\n\r\n{body}",
+            c.approval_id,
+            crate::server::test_support::fixed_cookie("acme"),
+            body.len(),
+        );
+        let mut socket = tokio::net::TcpStream::connect(addr).await.unwrap();
+        socket.write_all(request.as_bytes()).await.unwrap();
+        socket.flush().await.unwrap();
+
+        // The turn is under way — the verdict is journaled and the grant minted.
+        // Now the client goes away without ever reading a response, and we wait
+        // for hyper to actually notice (see the note above).
+        c.entered.notified().await;
+        socket.shutdown().await.unwrap();
+        drop(socket);
+        tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+
+        assert!(
+            c.runtime.grants.peek(&c.approval_id).is_some(),
+            "the grant was minted before the socket closed"
+        );
+
+        c.release.notify_one();
+        assert!(
+            await_continuation(&c.runtime).await,
+            "a real peer close cancelled the follow-up cycle: the grant is spent \
+             and the agent never continued"
+        );
+        assert_eq!(c.runtime.grants.live_count(), 1);
+        server.abort();
+    }
+
+    /// `detach` answers on the verdict, not on the turn (issue #383).
+    ///
+    /// This is the half that removes the *wait*, and with it #380's gateway
+    /// timeout: the response is already in the operator's hands while the agent
+    /// is demonstrably still mid-turn. The continuation then arrives on the
+    /// event stream, where the console is already subscribed.
+    #[tokio::test]
+    async fn a_detached_resolve_answers_before_the_turn_finishes() {
+        let home_dir = home();
+        let c = stalled_company(home_dir.path()).await;
+
+        let response = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            c.app.clone().oneshot(resolve_request(
+                &c.approval_id,
+                serde_json::json!({"verdict":"approve","detach":true}),
+            )),
+        )
+        .await
+        .expect("a detached resolve must not wait on the agent turn")
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            value,
+            serde_json::json!({ "recorded": true, "alreadyResolved": false })
+        );
+
+        // The answer really did precede the work: the turn is only now under
+        // way, and is still blocked.
+        c.entered.notified().await;
+        assert!(
+            !continued(&c.runtime),
+            "the turn had already finished, so this proved nothing about waiting"
+        );
+        assert!(
+            c.runtime.grants.peek(&c.approval_id).is_some(),
+            "the grant is minted before the response, not after the turn"
+        );
+
+        c.release.notify_one();
+        assert!(
+            await_continuation(&c.runtime).await,
+            "a detached continuation must still land"
+        );
+        assert_eq!(c.runtime.grants.live_count(), 1);
+    }
+
+    /// The default is unchanged: no `detach` key means the response still
+    /// carries the follow-up cycle's messages, in the same `ChatResponse` shape
+    /// every existing caller parses. Only the drop-safety is new.
+    #[tokio::test]
+    async fn the_default_resolve_still_answers_with_the_cycle_response() {
+        let home_dir = home();
+        let c = stalled_company(home_dir.path()).await;
+
+        // Let the turn through the moment it starts.
+        c.release.notify_one();
+        let response = c
+            .app
+            .clone()
+            .oneshot(resolve_request(
+                &c.approval_id,
+                serde_json::json!({"verdict":"approve"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(
+            value.get("responses").is_some_and(|r| r.is_array()),
+            "the un-detached body is still a ChatResponse, got {value}"
+        );
+        assert!(
+            continued(&c.runtime),
+            "the un-detached resolve waited for the turn, as it always did"
+        );
+        assert_eq!(c.runtime.grants.live_count(), 1);
+    }
+
+    /// A second resolve of the same approval is a success, not a failure, and
+    /// mints nothing (issue #243). `detach` reports that as `alreadyResolved`,
+    /// which is what makes a retry after a timeout safe to *show* as a retry
+    /// rather than as an error — the thing #380's operator had no way to know.
+    #[tokio::test]
+    async fn a_second_resolve_reports_already_resolved_and_mints_nothing() {
+        let home_dir = home();
+        let c = stalled_company(home_dir.path()).await;
+        c.release.notify_one();
+
+        let first = c
+            .app
+            .clone()
+            .oneshot(resolve_request(
+                &c.approval_id,
+                serde_json::json!({"verdict":"approve","detach":true}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+        let bytes = to_bytes(first.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["alreadyResolved"], false);
+        assert!(await_continuation(&c.runtime).await);
+
+        let second = c
+            .app
+            .clone()
+            .oneshot(resolve_request(
+                &c.approval_id,
+                serde_json::json!({"verdict":"approve","detach":true}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::OK);
+        let bytes = to_bytes(second.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            value,
+            serde_json::json!({ "recorded": true, "alreadyResolved": true })
+        );
+        assert_eq!(
+            c.runtime.grants.live_count(),
+            1,
+            "re-approving minted no second grant"
+        );
+    }
+
+    /// Both scope forms carry `detach` identically — the `/companies/{id}` route
+    /// and the single-company alias are the same handler, and a console pointed
+    /// at either must get the same contract.
+    #[tokio::test]
+    async fn detach_works_on_the_company_id_scope_too() {
+        let home_dir = home();
+        let c = stalled_company(home_dir.path()).await;
+        c.release.notify_one();
+
+        let response = c
+            .app
+            .clone()
+            .oneshot(resolve_request_scoped(
+                "/api/v1/companies/acme",
+                &c.approval_id,
+                serde_json::json!({"verdict":"approve","detach":true}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            value,
+            serde_json::json!({ "recorded": true, "alreadyResolved": false })
+        );
+        assert!(await_continuation(&c.runtime).await);
+        assert_eq!(c.runtime.grants.live_count(), 1);
+    }
+
     #[tokio::test]
     async fn deny_with_amended_payload_is_400() {
         let home_dir = home();
@@ -2588,24 +3123,31 @@ mod test {
         let state = state_with_company(&home, "running").await;
         let app = router(state);
 
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/api/v1/company/approvals/missing")
-                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
-                    .header("content-type", "application/json")
-                    .body(Body::from(
-                        r#"{"verdict":"deny","amended_payload":{"text":"edited"}}"#,
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(value["code"], "invalid_request");
+        // The contradiction is rejected before anything is settled, so `detach`
+        // cannot turn it into a `200 { recorded: true }` over a decision that was
+        // never taken (issue #383).
+        for body in [
+            r#"{"verdict":"deny","amended_payload":{"text":"edited"}}"#,
+            r#"{"verdict":"deny","amended_payload":{"text":"edited"},"detach":true}"#,
+        ] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/api/v1/company/approvals/missing")
+                        .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                        .header("content-type", "application/json")
+                        .body(Body::from(body))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "for {body}");
+            let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(value["code"], "invalid_request");
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

An approval's follow-up cycle now runs on its own task instead of on the HTTP connection. Until this, a dropped connection **cancelled the re-dispatch after the grant was already minted** — the operator's approval was spent on work that never happened.

Reported from a hosted tenant (#380): an operator approved something, nginx timed out at 60s, and the conversation never continued.

## API Or Behavior Changes

**No wire change by default.** `resolve_approval` is now settle-inline-then-spawn-then-await, so **every** existing caller becomes drop-safe while returning today's `ChatResponse` byte-identical.

**New opt-in**: `ResolveApproval` gains `#[serde(default)] detach: bool`. With `detach: true` the route answers `200 { recorded, alreadyResolved }` the moment the verdict is durable and the grant is minted; the continuation arrives on the existing `agent_reply` event stream. Both scope forms.

**The split.** `resolve_approval` was one function doing a fast durable half (resolve outcome → journal → mint grant) and a slow half (the follow-up agent turn). It is now `ResolveReceipt` (`AlreadyResolved | Settled(event)`) plus `settle_approval` / `settle_approval_amended`, so the HTTP status comes from the durable half and only the turn is detachable.

Webhook fan-out moves onto its own task when detached, rather than being silently dropped. A panicked or aborted cycle task surfaces as a new `BackgroundTask` error.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **1883 passed, 0 failed**
- [x] `cargo test --locked --lib` (default features) — **1334 passed, 0 failed**
- [x] `cargo check --locked --all-features --all-targets`
- [x] `git diff --stat Cargo.lock` — empty

**The keystone test failed on unmodified `main`, at exactly the diagnostic assertion.** The two before it passed:

- ✅ the approval had left the queue — the verdict was journaled
- ✅ `grants.peek(id)` returned the minted single-use grant
- ❌ the continuation never completed

That is the field report's shape, confirmed executably: **the approval is spent on a re-dispatch that never happens.**

**A second test over a real socket is the ground truth, and it caught a vacuous version of itself.** Written against real `axum::serve` and real TCP, it *passed on the pre-fix code* — releasing the barrier immediately after `close()` let the turn finish before hyper ever polled the socket. Adding a 1.5s pause between the close and the release flipped it: pre-fix fails, fixed passes. That reasoning now lives in the test's doc comment, because without the pause the test silently proves nothing.

Also covered: a *failing* follow-up cycle leaves the verdict and grant durable and the retry a clean no-op; detach returns before the brain finishes; `alreadyResolved` on a double resolve; exactly one grant minted in every mode.

Union-built against PR #389 (`fix/386-journal-torn-line`), which touches the same crate: merges clean, **1888 tests with features and 1339 on default features**, both green. Per-PR CI never builds that union.

## Documentation

`docs/spec/company-brain/approvals.md` and `docs/spec/runtime/api.md` document the settle/follow-up split and `detach`. `ports.md` was not touched — it is already over the repo's line cap.

## Impact

**One correction to the plan, and it is the one that would have shipped a bad test.** The plan asserted hyper cancels when the peer closes. It does — but **not at the moment of the close**. It cancels when its connection task next polls the socket and reads EOF. A graceful `FIN` is enough; it does not take an RST. Without that understanding the real-socket test passes against broken code.

**Two more the plan glossed:**

The amend path has no `AlreadyResolved` arm. The plan said "same split for `resolve_approval_amended`'s tail", but the amend path always runs a follow-up cycle, even for an unknown id — existing, tested behaviour (`amended_approve_resolves_and_returns_responses`). That behaviour is preserved rather than unified, and the asymmetry is documented.

`self: &Arc<Self>` is a breaking signature change, unavoidable for the spawn. It forced `Arc` churn across ~14 test sites in `cycle.rs`, `brain/hosted/test.rs` and `brain/sidecar/test.rs`. No production caller is affected — the registry already holds `Arc<CompanyRuntime>`.

**What this makes possible for #380's other half** (concurrent branch, not in this PR): its honest copy — "approved — the agent is still working" — becomes *true*, because the continuation now genuinely survives the disconnect. The `{recorded, alreadyResolved}` receipt gives it an idempotent, instant success signal.

**Deliberately out of scope:** the chat POST stays synchronous. Its reply-on-response is the console's chat contract and the `agent_reply` duplicate has a known dup-bubble race — widening to chat means resolving that race first, and is its own change.

**One verification not performed, stated plainly.** The manual stalling-mock run on a live host was skipped: parking an approval end to end needs a real model turn to produce a policy-gated tool call, and a mock that sleeps on `/v1/chat/completions` cannot emit one, so the setup could not reach the state under test. The in-process real-socket test is stronger on this exact mechanism — it uses the production `axum::serve` path, is deterministic, and is permanent — and the effort went there. A live-host run would need a company already holding a parked approval before the mock is pointed at it.

## Related

Part of #383 — **PR-A of 2**. PR-B (workflow run handles and cancellation) is stacked on #385 and is not included here.
Fixes defect 3 of #380. Defects 1 and 2 — the false "Couldn't record your decision" message and raw-HTML error rendering — are a separate branch.
Follow-up filed: #390 — a turn-level started/finished journal pair, so a failed detached continuation is observable. Feeds #379.
