### PR TITLE
fix(chat): scope a channel to its own members, and say when a link names a channel that isn't here (#369, #370)

### DIFF
--- a/frontend/src/lib/desks.ts
+++ b/frontend/src/lib/desks.ts
@@ -13,6 +13,21 @@ export interface Desk {
   blurb: string;
   /** Avatar tone key. The main line uses the brand mark instead. */
   tone?: string;
+  /**
+   * The desk's own members, as roster teammate ids, in the host's order —
+   * `members[0]` is the lead. Optional on purpose: the static desks below have
+   * no membership at all, and "this desk's membership is unknown" has to stay
+   * distinguishable from "this desk has nobody on it". A consumer that finds
+   * it absent should fall back to the company-wide roster rather than render
+   * an empty channel (issue #369).
+   */
+  members?: string[];
+  /**
+   * The subset of {@link members} added through the operator overlay rather
+   * than declared in the manifest. Carried through so a later surface can tell
+   * the removable members from the blueprint ones without refetching.
+   */
+  overlayMembers?: string[];
 }
 
 /** The main line plus a few focused desks. */

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -1,10 +1,21 @@
-import { useCallback, useEffect, useMemo, useState, type Dispatch, type SetStateAction } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+} from "react";
 import { toast } from "sonner";
 
 import { listPeople, me as fetchMe, type Person } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
 import { setInboxEnabled } from "@/api/inbox";
 import { ApiError, type TeamMemberDto, type TurnStep } from "@/api/types";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { type ChatMessage, makeMessage } from "@/lib/chat";
 import { defaultDesks, type Desk } from "@/lib/desks";
 import { fromDto, newMember, starterTeam, type TeamMember } from "@/lib/team";
@@ -104,7 +115,18 @@ export function ChatView({
   const [members, setMembers] = useState<TeamMember[]>([]);
   const [loadingTeam, setLoadingTeam] = useState(true);
   const [fromHost, setFromHost] = useState(false);
-  const [desks, setDesks] = useState<Desk[]>(defaultDesks());
+  /**
+   * The company's channels — `null` until `/desks` has answered.
+   *
+   * Seeding this with `defaultDesks()` is what made every deep link flash
+   * `#general`: the first render of every mount resolved the hash against the
+   * fabricated `main`/`strategy`/`creative`/`frontdesk` set, then swapped under
+   * the operator once the real desks landed (issue #370). `null` means "not
+   * answered yet", so nothing resolves against a set the company doesn't have.
+   */
+  const [desks, setDesks] = useState<Desk[] | null>(null);
+  /** Set when `/desks` failed for a reason that isn't "this host has none". */
+  const [desksError, setDesksError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const [openThreadId, setOpenThreadId] = useState<string | null>(null);
   const [membersOpen, setMembersOpen] = useState(false);
@@ -214,33 +236,63 @@ export function ChatView({
     }
   }
 
-  // The company's real desks, when the host exposes them — a company with its
-  // own desks gets its own channels instead of the generic strategy/creative/
-  // front-desk trio. Hosts without `.../desks` yet 404; the static defaults
-  // still work then (the existing Conversation path has the same fallback).
-  useEffect(() => {
-    let live = true;
-    void (async () => {
-      try {
-        const dtos = await client.listDesks(company);
-        if (live) setDesks(dtos.length ? dtos.map(deskFromDto) : defaultDesks());
-      } catch {
-        if (live) setDesks(defaultDesks());
+  // Only the newest load may write. Two loads can be in flight at once — a
+  // company switch, or a Retry over a request that is merely slow rather than
+  // dead — and a stale answer landing last would replace the current company's
+  // channels with the previous one's.
+  const desksRun = useRef(0);
+
+  /**
+   * The company's real desks, when the host exposes them — a company with its
+   * own desks gets its own channels instead of the generic strategy/creative/
+   * front-desk trio.
+   *
+   * Two outcomes are *not* failures and fall back to the static defaults: a
+   * host with no `.../desks` route at all (404, the pre-#53 shape the
+   * Conversation path also tolerates) and a host that answers with no desks.
+   * Both mean "this company has no desks surface", which the defaults exist
+   * for. Anything else — a 500, a timeout, an offline tab — is a genuine
+   * failure, and pinning the fabricated desks on top of it is what made a
+   * broken `/desks` permanently show `#general` while the URL claimed a real
+   * desk (issue #370). Those surface as an error the operator can retry.
+   */
+  const loadDesks = useCallback(async () => {
+    const run = ++desksRun.current;
+    setDesks(null);
+    setDesksError(null);
+    try {
+      const dtos = await client.listDesks(company);
+      if (run !== desksRun.current) return;
+      setDesks(dtos.length ? dtos.map(deskFromDto) : defaultDesks());
+    } catch (error) {
+      if (run !== desksRun.current) return;
+      if (error instanceof ApiError && error.status === 404) {
+        setDesks(defaultDesks());
+        return;
       }
-    })();
-    return () => {
-      live = false;
-    };
+      setDesksError(
+        error instanceof Error ? error.message : "Couldn't load this company's channels.",
+      );
+    }
   }, [client, company]);
 
-  const sections = useMemo(() => buildChannels(members, desks), [members, desks]);
+  useEffect(() => {
+    void loadDesks();
+  }, [loadDesks]);
+
+  // No channels exist until the host has answered. Resolving against a
+  // half-built list is exactly the first-paint swap issue #370 describes.
+  const sections = useMemo(
+    () => (desks ? buildChannels(members, desks) : []),
+    [members, desks],
+  );
   // The hash's channel, else the first one that exists. There used to be a
   // literal "main" between the two — an id only the *fallback* desks carry, so
   // it matched nothing once a company's real desks loaded and matched the same
   // channel `firstChannel` returns when they hadn't. It never selected anything
   // the line below wouldn't; it only made "main" look like a real channel id
   // (issue #368).
-  const channel = findChannel(sections, sub) ?? firstChannel(sections);
+  const channel = desks ? (findChannel(sections, sub) ?? firstChannel(sections)) : null;
 
   /**
    * Who is in the channel on screen — `null` when it names no membership, in
@@ -282,7 +334,35 @@ export function ChatView({
     if (channel) onChannelViewed?.(channel.id);
   }, [channel?.id, messages.length, onChannelViewed]);
 
-  if (!channel) return null;
+  // Three ways to have no channel on screen, which used to be one blank pane.
+  // Which one it is, is the whole point: "still loading" and "this company has
+  // nothing" are different facts and only one of them is worth acting on.
+  if (desksError) {
+    return (
+      <EmptyPane
+        title="Couldn't load this company's channels"
+        body={desksError}
+        action={{ label: "Retry", onClick: () => void loadDesks() }}
+      />
+    );
+  }
+  if (!desks) return <LoadingPane />;
+  if (!channel) {
+    return (
+      <EmptyPane
+        title="No channels yet"
+        body="This company has no desks and nobody on its roster, so there is nothing to talk to. Add a teammate and their direct message shows up here."
+        action={{ label: "Add a teammate", onClick: () => setAddOpen(true) }}
+        after={
+          <AddMemberDialog
+            open={addOpen}
+            onOpenChange={setAddOpen}
+            onAdd={(fields) => void addMember(fields)}
+          />
+        }
+      />
+    );
+  }
   // A local the closures below can capture as non-null: TypeScript hoists
   // function declarations, so the guard above does not narrow inside them.
   const active = channel;
@@ -550,6 +630,60 @@ export function ChatView({
           if (target) void applyBudget(target, cap);
         }}
       />
+    </div>
+  );
+}
+
+/**
+ * The pane while `/desks` is still out.
+ *
+ * Shaped like the workspace it is about to become — a header bar and message
+ * rows — so the real channel does not arrive as a jump. It exists to say "not
+ * yet", which is the one thing the old blank pane could not distinguish from
+ * "never".
+ */
+function LoadingPane() {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex h-13 shrink-0 items-center gap-2 border-b px-3">
+        <Skeleton className="size-4 rounded" />
+        <Skeleton className="h-4 w-32 rounded" />
+      </div>
+      <div className="flex-1 space-y-3 p-4">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 rounded-lg" />
+        ))}
+      </div>
+      <span className="sr-only">Loading channels…</span>
+    </div>
+  );
+}
+
+/** A whole-pane state: a headline, a sentence, and at most one thing to do. */
+function EmptyPane({
+  title,
+  body,
+  action,
+  after,
+}: {
+  title: string;
+  body: string;
+  action?: { label: string; onClick: () => void };
+  /** Rendered alongside — a dialog the action opens, which needs to mount. */
+  after?: ReactNode;
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
+      <div className="max-w-sm space-y-1.5">
+        <h2 className="text-base font-semibold tracking-tight">{title}</h2>
+        <p className="text-sm text-muted-foreground">{body}</p>
+      </div>
+      {action && (
+        <Button variant="outline" size="sm" onClick={action.onClick}>
+          {action.label}
+        </Button>
+      )}
+      {after}
     </div>
   );
 }

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -20,6 +20,7 @@ import { ThreadPanel } from "./chat/ThreadPanel";
 import {
   buildChannels,
   buildTimeline,
+  channelMembers,
   channelTitle,
   deskFromDto,
   dmChannelId,
@@ -241,6 +242,26 @@ export function ChatView({
   // (issue #368).
   const channel = findChannel(sections, sub) ?? firstChannel(sections);
 
+  /**
+   * Who is in the channel on screen — `null` when it names no membership, in
+   * which case the pane falls back to the whole roster (issue #369).
+   *
+   * A desk's membership comes from the host. A DM's is the one teammate on the
+   * other end: it has no `memberIds` (nothing in the model claims a DM has a
+   * roster), so the two-person case is stated here rather than faked upstream.
+   */
+  const inChannel = useMemo(() => {
+    if (!channel) return null;
+    if (channel.kind === "dm") return channel.member ? [channel.member] : null;
+    return channelMembers(channel, members);
+  }, [channel, members]);
+
+  const outsideChannel = useMemo(() => {
+    if (!inChannel) return members;
+    const inside = new Set(inChannel.map((m) => m.id));
+    return members.filter((m) => !inside.has(m.id));
+  }, [inChannel, members]);
+
   const messages = channel ? (transcripts[channel.id] ?? []) : [];
   const entries = useMemo(
     () => (channel ? buildTimeline(messages, channel) : []),
@@ -274,6 +295,16 @@ export function ChatView({
   // addresses its lead. It is also the id every live turn frame carries.
   const activeThreadId = active.kind === "channel" ? active.id : active.member?.id;
   const liveSteps = activeThreadId ? liveStepsByThread?.[activeThreadId] : undefined;
+  /**
+   * The count beside the channel title.
+   *
+   * A DM is stated as 2 rather than derived: it is a two-person conversation,
+   * but the operator has no roster row, so counting rows would say 1 and
+   * inventing a "You" row to make the arithmetic work would be worse. A desk
+   * counts its own members; a channel with no membership of its own still
+   * counts the company, which is all it can honestly claim.
+   */
+  const headerCount = active.kind === "dm" ? 2 : (inChannel?.length ?? members.length);
 
   const append = (channelId: string, ...added: ChatMessage[]) =>
     setTranscripts((t) => ({ ...t, [channelId]: [...(t[channelId] ?? []), ...added] }));
@@ -448,7 +479,7 @@ export function ChatView({
       >
         <ChatHeader
           channel={channel}
-          memberCount={members.length}
+          memberCount={headerCount}
           membersOpen={membersOpen}
           onToggleMembers={() => setMembersOpen((o) => !o)}
           onOpenRail={() => setMobilePane("rail")}
@@ -485,7 +516,9 @@ export function ChatView({
 
           {membersOpen && (
             <MembersPane
-              members={members}
+              channelMembers={inChannel}
+              others={outsideChannel}
+              leadId={active.kind === "channel" ? active.memberIds?.[0] : undefined}
               loading={loadingTeam}
               fromHost={fromHost}
               onToggleInbox={(m) => void toggleMemberInbox(m)}

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
   type SetStateAction,
 } from "react";
+import { TriangleAlert } from "lucide-react";
 import { toast } from "sonner";
 
 import { listPeople, me as fetchMe, type Person } from "@/api/auth";
@@ -293,6 +294,15 @@ export function ChatView({
   // the line below wouldn't; it only made "main" look like a real channel id
   // (issue #368).
   const channel = desks ? (findChannel(sections, sub) ?? firstChannel(sections)) : null;
+  /**
+   * The hash named a channel this company doesn't have, and the first-channel
+   * fallback answered instead.
+   *
+   * Only meaningful once the desks are in: before that, *every* id looks
+   * unknown. Derived rather than stored, so it clears itself the moment the
+   * hash changes — there is no stale banner to dismiss.
+   */
+  const unknownChannel = desks && sub && !findChannel(sections, sub) ? sub : null;
 
   /**
    * Who is in the channel on screen — `null` when it names no membership, in
@@ -567,6 +577,18 @@ export function ChatView({
 
         <div className="flex min-h-0 flex-1">
           <div className="flex min-w-0 flex-1 flex-col">
+            {unknownChannel && (
+              <p
+                role="status"
+                className="flex shrink-0 items-center gap-1.5 border-b bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground"
+              >
+                <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
+                <span className="min-w-0 truncate">
+                  <span className="font-medium text-foreground">#{unknownChannel}</span> isn&apos;t a
+                  channel here — showing {channelTitle(active)} instead.
+                </span>
+              </p>
+            )}
             <MessageTimeline
               channel={channel}
               entries={entries}

--- a/frontend/src/views/chat/MembersPane.tsx
+++ b/frontend/src/views/chat/MembersPane.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { Mail, MessageSquare, MoreHorizontal, UserPlus, Wallet } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -15,7 +16,27 @@ import { cn } from "@/lib/utils";
 import { Avatar } from "./Avatar";
 
 interface Props {
-  members: TeamMember[];
+  /**
+   * Who is in the channel on screen, lead first — or `null` when the channel
+   * names no membership of its own (a fallback desk on a host without
+   * `.../desks`). `null` renders one plain roster list, which is what this pane
+   * did for every channel before issue #369.
+   */
+  channelMembers: TeamMember[] | null;
+  /**
+   * Everyone else on the roster. The roster-wide surface stays reachable — you
+   * still need it to open somebody's DM or add a teammate — it just stops being
+   * presented as this channel's membership. When `channelMembers` is `null`
+   * this is the whole roster.
+   */
+  others: TeamMember[];
+  /**
+   * The desk's lead (`DeskDto.members[0]`) — the routing target for this
+   * channel, badged rather than left implicit. Matched by id, so a lead who is
+   * no longer on the roster simply goes unbadged instead of promoting whoever
+   * happens to be first.
+   */
+  leadId?: string;
   loading: boolean;
   /** True when the roster came from the host rather than the starter set. */
   fromHost: boolean;
@@ -43,16 +64,24 @@ interface Props {
 }
 
 /**
- * The right-hand member pane — the company's roster, where a chat workspace
- * expects it.
+ * The right-hand member pane — who is in this channel, and the rest of the
+ * company under it.
  *
  * This replaces the standalone Team page: everything that page could do lives
  * on a row here (give an agent an inbox, drop them from the roster) or on the
  * Add button, and a row now also opens that teammate's DM, which the page
  * could not do at all.
+ *
+ * The two sections exist because those are two different questions. "Who is in
+ * this room" is what a channel header is for, and answering it with the whole
+ * company answered nothing (issue #369). But the roster-wide actions still have
+ * to live somewhere, so the rest of the company keeps its rows — visually
+ * subordinate, and never labelled as this channel's membership.
  */
 export function MembersPane({
-  members,
+  channelMembers,
+  others,
+  leadId,
   loading,
   fromHost,
   onToggleInbox,
@@ -65,18 +94,21 @@ export function MembersPane({
   onResetBudget,
   setByLabel,
 }: Props) {
+  const total = (channelMembers?.length ?? 0) + others.length;
+  // Both scopes on one line, so the pane never leaves you guessing which of the
+  // two numbers the header's count refers to.
+  const subtitle = channelMembers
+    ? `${channelMembers.length} in this channel · ${total} in the company`
+    : `${total} ${total === 1 ? "agent" : "agents"} · ${
+        fromHost ? "defined by this company" : "starter roster"
+      }`;
+
   return (
     <aside className="flex w-72 shrink-0 flex-col border-l bg-background">
       <header className="flex h-13 shrink-0 items-center gap-2 border-b px-3">
         <div className="min-w-0 flex-1">
           <h2 className="text-sm font-semibold tracking-tight">Team</h2>
-          <p className="truncate text-xs text-muted-foreground">
-            {loading
-              ? "Loading…"
-              : `${members.length} ${members.length === 1 ? "agent" : "agents"} · ${
-                  fromHost ? "defined by this company" : "starter roster"
-                }`}
-          </p>
+          <p className="truncate text-xs text-muted-foreground">{loading ? "Loading…" : subtitle}</p>
         </div>
         <Button
           variant="ghost"
@@ -98,32 +130,70 @@ export function MembersPane({
             ))}
           </div>
         ) : (
-          <ul className="flex flex-col gap-px">
-            {members.map((m) => (
-              <li key={m.id}>
-                <MemberRow
-                  member={m}
-                  inboxOn={m.inboxEnabled}
-                  onToggleInbox={() => onToggleInbox(m)}
-                  onRemove={() => onRemove(m.id)}
-                  onMessage={() => onMessage(m)}
-                  canEditBudget={canEditBudget}
-                  onEditBudget={() => onEditBudget(m)}
-                  onRemoveCap={() => onRemoveCap(m)}
-                  onResetBudget={() => onResetBudget(m)}
-                  setByLabel={setByLabel(m)}
-                />
-              </li>
-            ))}
-          </ul>
+          (() => {
+            const rows = (list: TeamMember[]) => (
+              <ul className="flex flex-col gap-px">
+                {list.map((m) => (
+                  <li key={m.id}>
+                    <MemberRow
+                      member={m}
+                      lead={m.id === leadId}
+                      inboxOn={m.inboxEnabled}
+                      onToggleInbox={() => onToggleInbox(m)}
+                      onRemove={() => onRemove(m.id)}
+                      onMessage={() => onMessage(m)}
+                      canEditBudget={canEditBudget}
+                      onEditBudget={() => onEditBudget(m)}
+                      onRemoveCap={() => onRemoveCap(m)}
+                      onResetBudget={() => onResetBudget(m)}
+                      setByLabel={setByLabel(m)}
+                    />
+                  </li>
+                ))}
+              </ul>
+            );
+
+            // No membership to scope to — one plain roster, as before.
+            if (!channelMembers) return rows(others);
+
+            return (
+              <>
+                <SectionLabel className="text-foreground">In this channel</SectionLabel>
+                {channelMembers.length > 0 ? (
+                  rows(channelMembers)
+                ) : (
+                  <p className="px-2 py-1.5 text-xs text-muted-foreground">
+                    Nobody is on this desk yet.
+                  </p>
+                )}
+
+                {others.length > 0 && (
+                  <div className="mt-2 border-t pt-2">
+                    <SectionLabel className="text-muted-foreground">Everyone else</SectionLabel>
+                    {rows(others)}
+                  </div>
+                )}
+              </>
+            );
+          })()
         )}
       </div>
     </aside>
   );
 }
 
+/** A section heading inside the pane's scroll body. */
+function SectionLabel({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <h3 className={cn("px-2 pb-1 text-[11px] font-medium uppercase tracking-wide", className)}>
+      {children}
+    </h3>
+  );
+}
+
 function MemberRow({
   member,
+  lead,
   inboxOn,
   onToggleInbox,
   onRemove,
@@ -135,6 +205,8 @@ function MemberRow({
   setByLabel,
 }: {
   member: TeamMember;
+  /** The desk's lead — badged, since this channel routes to them. */
+  lead?: boolean;
   inboxOn: boolean;
   onToggleInbox: () => void;
   onRemove: () => void;
@@ -160,6 +232,11 @@ function MemberRow({
         <span className="min-w-0">
           <span className="flex items-center gap-1">
             <span className="truncate text-sm font-medium">{member.name}</span>
+            {lead && (
+              <span className="shrink-0 rounded border px-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                Lead
+              </span>
+            )}
             {inboxOn && (
               <Mail className="size-3 shrink-0 text-muted-foreground" aria-label="Has an inbox" />
             )}

--- a/frontend/src/views/chat/README.md
+++ b/frontend/src/views/chat/README.md
@@ -8,11 +8,20 @@ the desks the two shared without ever being connected.
 ## Routing
 
 `#/chat/<channelId>` — the channel id is the hash's second segment, so a
-channel is linkable and survives a refresh. An unknown id falls back to
-`general` rather than erroring.
+channel is linkable and survives a refresh.
 
-- Desks are `#general`, `#strategy`, `#creative`, `#front-desk` (`lib/desks.ts`).
+- A desk's channel id is the host's desk id, which is also its chat thread id.
 - A DM is `dm:<slug-of-name>` — e.g. `#/chat/dm:designer`.
+- A host with no `.../desks` route falls back to `#general`, `#strategy`,
+  `#creative`, `#front-desk` (`lib/desks.ts`).
+
+Nothing resolves until `/desks` has answered — the view holds a loading state
+rather than resolving against the fallback desks and swapping under you, which
+is what made every deep link flash `#general` (issue #370). An id that doesn't
+resolve *after* they land opens the first channel and says so in a notice above
+the timeline, so the URL and the content never disagree silently. A `/desks`
+failure that isn't "this host has none" (404 or an empty list) is a retryable
+error state, not invented channels.
 
 DM ids key on the teammate's **name**, not their roster id: the starter roster
 mints ids from a module counter (`lib/team.ts`), so those differ between two

--- a/frontend/src/views/chat/README.md
+++ b/frontend/src/views/chat/README.md
@@ -34,6 +34,20 @@ Console-local, because the host has no surface for them yet:
 
 Transcripts are per-session memory. Closing the tab drops them.
 
+## Membership
+
+A desk's members come from the host (`GET {scope}/desks` → `members`, lead
+first). They scope the header's count and the member pane, so a two-person desk
+reads as two people rather than as the whole company (issue #369). A DM is a
+two-person line: the header states 2, and the pane shows the teammate on the
+other end.
+
+The fallback desks in `lib/desks.ts` carry no membership — there is none to
+carry — so a channel built from them falls back to the whole roster, and the
+pane renders one plain list. The rest of the company is always one section
+below, so adding a teammate or opening somebody's DM never needs a different
+surface.
+
 ## Files
 
 | | |
@@ -45,7 +59,7 @@ Transcripts are per-session memory. Closing the tab drops them.
 | `MessageRow.tsx` | One line — avatar gutter, author, body, reactions, hover action bar. |
 | `MessageComposer.tsx` | The composer dock; also used compact in the thread panel. |
 | `ThreadPanel.tsx` | Replies to one message, with their own composer. |
-| `MembersPane.tsx` | The roster — what the Team page used to be. |
+| `MembersPane.tsx` | Who is in this channel, then the rest of the roster. |
 | `AddMemberDialog.tsx` | Define a teammate. |
 
 `../ChatView.tsx` owns the state and composes them.

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -12,10 +12,22 @@ import { initials as nameInitials, type TeamMember } from "@/lib/team";
  * the desk's name and the blurb falls back to its description — the id is
  * the one field that must survive untouched, since it doubles as the chat
  * thread id `send` addresses.
+ *
+ * `members` / `overlayMembers` come through as the host sent them, order
+ * included — `members[0]` is the desk's lead, and the rest is the hierarchy the
+ * company declared. Dropping them here is what made every channel show the
+ * whole company (issue #369).
  */
 export function deskFromDto(d: DeskDto): Desk {
   const slug = d.name.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
-  return { id: d.id, channel: slug || d.id, name: d.name, blurb: d.description ?? "" };
+  return {
+    id: d.id,
+    channel: slug || d.id,
+    name: d.name,
+    blurb: d.description ?? "",
+    members: d.members,
+    overlayMembers: d.overlayMembers,
+  };
 }
 
 /**
@@ -45,6 +57,17 @@ export interface Channel {
   tone?: string;
   /** The roster entry behind a DM, when there is one. */
   member?: TeamMember;
+  /**
+   * Who is in this channel, as roster teammate **ids** in the desk's own order
+   * (lead first). Ids rather than resolved `TeamMember`s so this model stays
+   * pure and a channel never goes stale when the roster reloads — resolve with
+   * {@link channelMembers}.
+   *
+   * Absent for DMs (a two-person line needs no list) and for the static
+   * fallback desks, which have no membership concept; a consumer that finds it
+   * absent falls back to the whole roster (issue #369).
+   */
+  memberIds?: string[];
 }
 
 export interface ChannelSection {
@@ -75,6 +98,7 @@ export function buildChannels(members: TeamMember[], desks: Desk[] = defaultDesk
     kind: "channel" as const,
     purpose: d.blurb,
     tone: d.tone,
+    memberIds: d.members,
   }));
 
   const dms: Channel[] = members.map((m) => ({
@@ -167,6 +191,25 @@ export function firstChannel(sections: ChannelSection[]): Channel | null {
     if (s.channels.length > 0) return s.channels[0];
   }
   return null;
+}
+
+/**
+ * A channel's own members, resolved against the roster — `null` when the
+ * channel names no membership (a DM, or a fallback desk), which is the caller's
+ * cue to fall back to the whole roster rather than draw an empty pane.
+ *
+ * Maps over the **ids**, not over the roster: the desk's order is meaningful —
+ * `memberIds[0]` is the lead — and filtering the roster would silently reorder
+ * everyone into roster order and lose that. An id with no roster row (a
+ * teammate removed since the desks were fetched) drops out rather than
+ * rendering a placeholder for somebody who isn't there.
+ */
+export function channelMembers(channel: Channel, roster: TeamMember[]): TeamMember[] | null {
+  if (!channel.memberIds) return null;
+  const byId = new Map(roster.map((m) => [m.id, m]));
+  return channel.memberIds
+    .map((id) => byId.get(id))
+    .filter((m): m is TeamMember => m !== undefined);
 }
 
 /** How a channel is titled in the header and the rail. */

--- a/frontend/test/e2e/chat-channel-membership.spec.ts
+++ b/frontend/test/e2e/chat-channel-membership.spec.ts
@@ -1,0 +1,271 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * End-to-end proof for issues #369 and #370 — a channel says who is in *it*,
+ * and never shows you a different channel without saying so.
+ *
+ * #369: the header's count and the member pane both read the flat company
+ * roster, so every channel claimed the same members — a two-person desk in a
+ * seventeen-person company said 17, and so did a one-to-one DM.
+ *
+ * #370: `desks` was seeded with the static fallback set rather than treated as
+ * unloaded, so a deep link resolved against fabricated channels and flashed
+ * `#general` before swapping; a blanket `catch` made that permanent when
+ * `/desks` failed; and an unresolvable channel id opened a different channel
+ * in silence while the address bar kept naming the missing one.
+ *
+ * Unlike the live-host specs beside it, this one **mocks the operator API**
+ * with `page.route`. Both defects are in what the console does with the host's
+ * answer — per-desk membership it was discarding, and load states it was
+ * collapsing — so the interesting inputs are a desk whose members differ from
+ * the roster, a slow `/desks`, and a broken `/desks`. Only a stub can produce
+ * those on demand. The page itself still comes from whatever `PW_BASE_URL`
+ * serves the console, like the rest of the suite.
+ *
+ * Verified to fail against the pre-fix build: five of these seven go red.
+ */
+
+const COMPANY = "acme";
+
+/** A roster deliberately much larger than any one desk — that gap is the bug. */
+const ROSTER = Array.from({ length: 17 }, (_, i) => ({
+  id: `agent-${i + 1}`,
+  name: `Agent ${i + 1}`,
+  role: `Role ${i + 1}`,
+}));
+
+const DESKS = [
+  {
+    id: "engineering",
+    name: "Engineering",
+    description: "Ships the product",
+    // Lead first, and NOT in roster order: `members[0]` is the lead, so a fix
+    // that sorts or filters the roster instead of walking these ids would
+    // badge the wrong person here.
+    members: ["agent-3", "agent-1"],
+  },
+  {
+    id: "content",
+    name: "Content",
+    description: "Writes things",
+    // `agent-99` is not on the roster — a teammate removed since the desks were
+    // fetched. It must drop out rather than render a row for nobody.
+    members: ["agent-5", "agent-6", "agent-7", "agent-99"],
+  },
+];
+
+type DesksMode = "ok" | "404" | "500" | "slow";
+
+/** Every chat POST the console made, so the send path can be asserted on. */
+const sentChats: { text: string; chat?: string }[] = [];
+
+/**
+ * Stub the operator API.
+ *
+ * `mode` is read through a getter rather than captured, so a test can flip a
+ * failing `/desks` to a healthy one and exercise the Retry button.
+ */
+async function mockApi(page: Page, mode: () => DesksMode) {
+  // The first-run product tour renders a modal over the console and swallows
+  // every click beneath it. Answer "already skipped" for any company id.
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+
+  await page.route("**/api/v1/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const json = (body: unknown, status = 200) =>
+      route.fulfill({ status, contentType: "application/json", body: JSON.stringify(body) });
+    const status = { id: COMPANY, name: "Acme", lifecycle: "running", pending_approvals: 0 };
+
+    if (path === "/api/v1/companies") return json([status]);
+    if (path === `/api/v1/companies/${COMPANY}`) return json(status);
+
+    if (path.endsWith("/desks")) {
+      switch (mode()) {
+        case "404":
+          return json({ error: "not_found", message: "no desks surface" }, 404);
+        case "500":
+          return json({ error: "internal", message: "desks are broken" }, 500);
+        case "slow":
+          await new Promise((r) => setTimeout(r, 2500));
+          return json(DESKS);
+        default:
+          return json(DESKS);
+      }
+    }
+
+    if (path.endsWith("/team")) return json(ROSTER);
+    if (path.endsWith("/chat")) {
+      const body = route.request().postDataJSON() as { text: string; chat?: string };
+      sentChats.push(body);
+      return json({ responses: [{ text: `echo: ${body.text}`, channel: body.chat }] });
+    }
+    if (path.endsWith("/events")) {
+      return route.fulfill({ status: 200, contentType: "text/event-stream", body: "" });
+    }
+    if (path.endsWith("/me")) return json({ id: "op", email: "op@example.com", role: "member" });
+    return json([]);
+  });
+}
+
+/** The header's member toggle — its label ends in "members". */
+const membersToggle = (page: Page) => page.getByRole("button", { name: /members$/i });
+
+/** The member pane; the channel rail is the other `complementary` on screen. */
+const pane = (page: Page) => page.getByRole("complementary").last();
+
+/**
+ * Open the pane if it is shut.
+ *
+ * Not a plain click: the pane's open state lives in `ChatView`, and switching
+ * channels is a hash-only navigation that does not remount it — so a second
+ * click would close what the first opened.
+ */
+async function openPane(page: Page) {
+  if ((await membersToggle(page).getAttribute("aria-pressed")) !== "true") {
+    await membersToggle(page).click();
+  }
+  await expect(page.getByRole("heading", { name: "Team" })).toBeVisible();
+}
+
+async function openChannel(page: Page, channelId: string) {
+  await page.goto(`/#/chat/${channelId}`);
+  await expect(page.getByPlaceholder(/^Message /)).toBeVisible({ timeout: 30_000 });
+}
+
+test("#369 each desk counts and lists its own members, not the company", async ({ page }) => {
+  await mockApi(page, () => "ok");
+
+  await openChannel(page, "engineering");
+  await expect(membersToggle(page)).toHaveText(/2/);
+  await openPane(page);
+  await expect(pane(page)).toContainText("2 in this channel · 17 in the company");
+  await expect(pane(page).getByRole("heading", { name: "In this channel" })).toBeVisible();
+  await expect(pane(page).getByRole("heading", { name: "Everyone else" })).toBeVisible();
+
+  // The desk's own order survives: the lead is `members[0]`, not whoever the
+  // roster happens to list first.
+  const inChannel = pane(page).locator("ul").first();
+  await expect(inChannel.locator("li")).toHaveCount(2);
+  await expect(inChannel.locator("li").first()).toContainText("Agent 3");
+  await expect(inChannel.locator("li").first()).toContainText("Lead");
+  await expect(inChannel.locator("li").nth(1)).toContainText("Agent 1");
+  await expect(inChannel.locator("li").nth(1)).not.toContainText("Lead");
+  // The rest of the company is still reachable, one section down.
+  await expect(pane(page).locator("ul").nth(1).locator("li")).toHaveCount(15);
+
+  // A second desk reads differently — and the id with no roster row is gone.
+  await openChannel(page, "content");
+  await expect(membersToggle(page)).toHaveText(/3/);
+  await openPane(page);
+  await expect(pane(page)).toContainText("3 in this channel · 17 in the company");
+  await expect(pane(page).locator("ul").first().locator("li")).toHaveCount(3);
+  await expect(pane(page)).not.toContainText("Agent 99");
+});
+
+test("#369 a DM reads as two people, not as the whole company", async ({ page }) => {
+  await mockApi(page, () => "ok");
+  await openChannel(page, "engineering");
+  await openPane(page);
+
+  // Agent 4 is on no desk, so this row is in "Everyone else" — which proves
+  // that section's actions still work as well as opening the DM.
+  await pane(page).getByText("Agent 4", { exact: true }).click();
+  await expect(page.getByPlaceholder("Message Agent 4")).toBeVisible();
+  // Two: the teammate and the operator, who has no roster row of their own.
+  await expect(membersToggle(page)).toHaveText(/2/);
+  await expect(pane(page).locator("ul").first().locator("li")).toHaveCount(1);
+});
+
+test("#369 a host with no desks surface still shows the whole roster", async ({ page }) => {
+  await mockApi(page, () => "404");
+  await openChannel(page, "general");
+
+  // The fallback desks have no membership to scope to, so this is unchanged
+  // behaviour on purpose — one plain roster, no "in this channel" claim.
+  await expect(membersToggle(page)).toHaveText(/17/);
+  await openPane(page);
+  await expect(pane(page)).toContainText("17 agents");
+  await expect(pane(page).getByRole("heading", { name: "In this channel" })).toHaveCount(0);
+  await expect(pane(page).locator("ul").first().locator("li")).toHaveCount(17);
+});
+
+test("#370 a deep link never flashes a channel the company doesn't have", async ({ page }) => {
+  // Record every composer placeholder the page renders, in-page and on every
+  // frame. An out-of-process poll misses a flash that lasts a single paint,
+  // which is exactly the length of the one under test.
+  await page.addInitScript(() => {
+    (window as unknown as { __placeholders: string[] }).__placeholders = [];
+    const tick = () => {
+      const seen = (window as unknown as { __placeholders: string[] }).__placeholders;
+      const p = document
+        .querySelector("textarea[placeholder], input[placeholder]")
+        ?.getAttribute("placeholder");
+      if (p && seen[seen.length - 1] !== p) seen.push(p);
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  });
+  await mockApi(page, () => "slow");
+
+  await page.goto("/#/chat/engineering");
+  await expect(page.getByPlaceholder("Message #engineering")).toBeVisible({ timeout: 30_000 });
+
+  const seen = await page.evaluate(
+    () => (window as unknown as { __placeholders: string[] }).__placeholders,
+  );
+  // Before the fix this read ["Message #general", "Message #engineering"].
+  expect(seen).toEqual(["Message #engineering"]);
+});
+
+test("#370 an unknown channel opens the first one and says so", async ({ page }) => {
+  await mockApi(page, () => "ok");
+  await openChannel(page, "does-not-exist");
+
+  const notice = page.getByRole("status");
+  await expect(notice).toContainText("#does-not-exist");
+  await expect(notice).toContainText("isn't a channel here");
+  await expect(notice).toContainText("#engineering");
+  // The hash is left alone deliberately — rewriting it needs replace-semantics
+  // the shell does not thread through yet, and a push would fight the back
+  // button. The notice is what closes the gap between URL and content.
+  expect(page.url()).toContain("#/chat/does-not-exist");
+
+  // It is derived from the hash, so navigating clears it with no dismiss.
+  await page.getByRole("complementary").first().getByRole("button", { name: /content/i }).click();
+  await expect(page.getByRole("status")).toHaveCount(0);
+});
+
+test("#370 a broken /desks is a retryable error, not invented channels", async ({ page }) => {
+  let mode: DesksMode = "500";
+  await mockApi(page, () => mode);
+
+  await page.goto("/#/chat/engineering");
+  await expect(page.getByText("Couldn't load this company's channels")).toBeVisible({
+    timeout: 30_000,
+  });
+  // The old blanket catch pinned the fabricated desks here, so the view showed
+  // #general while the hash claimed a real desk, permanently.
+  await expect(page.getByText("#general")).toHaveCount(0);
+
+  mode = "ok";
+  await page.getByRole("button", { name: "Retry" }).click();
+  await expect(page.getByPlaceholder("Message #engineering")).toBeVisible({ timeout: 30_000 });
+});
+
+test("the send path and the thread id it addresses are undisturbed", async ({ page }) => {
+  sentChats.length = 0;
+  await mockApi(page, () => "ok");
+  await openChannel(page, "content");
+
+  await page.getByPlaceholder("Message #content").fill("ping");
+  await page.getByPlaceholder("Message #content").press("Enter");
+  await expect(page.getByText("echo: ping")).toBeVisible({ timeout: 30_000 });
+  // A desk's channel id doubles as its host thread id; none of the above may
+  // change what the composer addresses.
+  expect(sentChats.at(-1)).toEqual({ text: "ping", chat: "content" });
+});


### PR DESCRIPTION
## Summary

A channel now shows the people actually on it, and a link to a channel that doesn't exist says so instead of quietly opening a different one.

Reproduced on a staging tenant before any code was written: every channel — including one-to-one messages — listed all **17** roster members regardless of which desk it was.

## API Or Behavior Changes

**#369 — the host was already sending this and the console threw it away.** `GET …/desks` returns each desk's `members` (with `members[0]` as the lead) and `overlayMembers`. `deskFromDto` kept only id, name and description and dropped both, so the flat company roster went to the channel header and the members pane for every channel.

Now `Desk` and `Channel` carry the membership through, and a pure `channelMembers` maps over the **ids** — preserving desk order, so lead-first and hierarchy survive — dropping any id with no roster row. `MembersPane` renders "In this channel", lead badged by id match rather than by position, over a subordinate "Everyone else" that keeps every row action and the Add button, so the roster-wide surface stays reachable without being presented as channel membership.

Fallback desks (a host with no desks surface) keep today's single full-roster section deliberately — those are generic company-wide lines with no membership concept.

**#370 — three states that were one.** `desks` is now `Desk[] | null` rather than seeded with fabricated defaults, and `sections`/`channel` compute only once it resolves — which kills the `#general` first-paint flash **structurally** rather than by racing it. A 404 and an empty list both still fall back to the static desks, because both are the documented "this host has no desks surface" case; anything else now sets an error. The old `return null` became loading / error-with-Retry / a real empty state. The fetch is lifted into a `useCallback` with a run-counter guard so a stale or retried response can't overwrite the current company.

An unknown channel id now renders a `role="status"` notice above the timeline naming the id that was asked for and the channel actually shown. It derives from the hash, so it self-clears on navigation.

## Tests

- [x] `npm run typecheck`
- [x] `npm run typecheck:e2e`
- [x] `npm run build`
- [ ] `cargo` — N/A: no Rust file is touched.

No lint or component-test script exists in this repo; neither is claimed.

**Seven Playwright cases, and the suite was proven to gate:** checking out the pre-fix files turns **5 of 7 red**. The flash case is the clearest — it records `["Message #general", "Message #engineering"]` before the fix and `["Message #engineering"]` after.

**A first version of that test was thrown away for passing on broken code.** It polled from outside the page, which let the flash happen between polls. The committed version records placeholders per animation frame *in-page*. A test that passes against the bug is worse than no test.

No host was running and a live host needs cargo, so verification drove the real UI in a real browser — Vite plus Playwright with the operator API stubbed. That is also the only way to produce the inputs that matter here: a desk whose members differ from the roster, a slow `/desks`, and a broken `/desks`. Covered: differing per-desk counts (2 and 3), the lead badged as `members[0]` and deliberately not roster-first, a member id absent from the roster dropping 4→3, a DM reading 2, a 404 host showing all 17 unchanged, no `#general` flash, the notice naming both ids without back-button ping-pong, error→Retry recovery, and the send path still addressing the right thread.

## Documentation

`frontend/src/views/chat/README.md` — routing and membership sections updated.

## Impact

**One behaviour trade-off a reviewer should see named:** a non-404 `/desks` failure now costs the operator their direct messages too, because the error pane replaces the whole view. Before, they got fabricated channels. That is the intent — honest failure over invented channels — but it is a real change, not strictly an improvement.

**Honest scope on #370:** with `[] → defaultDesks()` retained, the empty-state branch is defensive rather than reachable on today's inputs. The live fixes are the loading gate, the error state and the notice. Three branches, two of them reachable.

**One addition beyond the approved plan.** The plan fixed the DM *header* count but specified the pane only for desks. #369 explicitly complains that a DM "lists the entire roster beside it", so shipping the plan as written would have closed the issue with half the DM defect intact. A DM's membership is now the teammate alone — pane shows one row, header still says 2, since the operator has no roster row and inventing a "You" row would be worse. Three lines; flag it if you disagree.

**One commit deliberately dropped.** The plan offered a free change giving real desks distinct tinted avatars instead of all wearing the brand mark. It changes visual identity with no issue behind it, in a PR about membership and routing, and would have a reviewer arguing about avatar colours in the wrong place. Worth its own issue.

**Not touched:** #311's desk-management surface, and `ApprovalsView.tsx` / `client.ts` / `MessageRow.tsx` / `ThreadPanel.tsx`, all of which were being edited concurrently elsewhere.

## Related

Closes #369
Closes #370

Follows #366, which fixed the hard-coded channel id, and #367/#368 (PR #378), on which this was developed and then rebased.

Deliberately deferred: canonicalising the URL when a channel id doesn't resolve. It needs replace-semantics threaded through the navigation layer, and push-based navigation would recreate the back-button ping-pong the hash router's own docs warn about. The notice discloses the substitution; correcting the address bar is a follow-up.
