### PR TITLE
fix(console): a lost answer is not a lost decision, and never render an upstream error body (#380)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -84,15 +84,13 @@ export class OpenCompanyClient {
     }
 
     const text = await res.text();
-    const data = text ? safeJson(text) : undefined;
     if (!res.ok) {
-      const envelope = data as ApiErrorBody | undefined;
       // Let the app react to an expired or revoked session. Auth routes opt out
       // (they 401 as a normal answer) so a failed login cannot loop the view.
       if (res.status === 401 && !path.includes("/auth/")) this.onUnauthorized?.();
-      throw new ApiError(res.status, envelope?.code ?? `http_${res.status}`, envelope?.error ?? res.statusText);
+      throw httpError(res, text);
     }
-    return data as T;
+    return (text ? parseJson(text) : undefined) as T;
   }
 
   /** Whether a specific company is being operated (vs single-company mode). */
@@ -113,10 +111,11 @@ export class OpenCompanyClient {
   /**
    * A GET whose answer is a document, not JSON (issue #352).
    *
-   * `request` runs every response through `safeJson`, which turns a non-JSON
-   * body into an `{error, code:"unparseable"}` object rather than throwing — so
-   * a route that answers HTML needs its own reader. Same auth, same
-   * `credentials: "include"`, same 401 handling; only the parsing differs.
+   * `request` parses every successful response as JSON and hands back
+   * `undefined` when it is not — so a route that answers HTML needs its own
+   * reader to see the body at all. Same auth, same `credentials: "include"`,
+   * same 401 handling, and since #380 the same `httpError` on the failure
+   * path; only the success-path parsing differs.
    *
    * Returns the host's own `Content-Disposition` filename alongside the body.
    * The host already names the file; without this the caller has to invent a
@@ -135,9 +134,8 @@ export class OpenCompanyClient {
     }
     const text = await res.text();
     if (!res.ok) {
-      const envelope = safeJson(text) as ApiErrorBody | undefined;
       if (res.status === 401) this.onUnauthorized?.();
-      throw new ApiError(res.status, envelope?.code ?? `http_${res.status}`, envelope?.error ?? res.statusText);
+      throw httpError(res, text);
     }
     return { text, filename: attachmentFilename(res.headers.get("content-disposition")) };
   }
@@ -567,10 +565,82 @@ function attachmentFilename(header: string | null): string | undefined {
   return name && name !== "." && name !== ".." ? name : undefined;
 }
 
-function safeJson(text: string): unknown {
+/** How much of an unrecognised body is kept on `ApiError.detail`. */
+const DETAIL_CHARS = 2_000;
+
+/**
+ * `JSON.parse`, or `undefined` when the body is not JSON.
+ *
+ * This used to be `safeJson`, which failed **open**: an unparseable body became
+ * `{ error: text, code: "unparseable" }`, so the body itself arrived at the
+ * throw sites below wearing the shape of the host's error envelope and was
+ * taken as the operator-facing message. On a hosted tenant that meant an nginx
+ * `504` page — `<html><head><title>…`, padding comments and all — was rendered
+ * as the reason a request failed (issue #380). Returning `undefined` is what
+ * makes the fallback below reachable.
+ */
+function parseJson(text: string): unknown {
   try {
     return JSON.parse(text);
   } catch {
-    return { error: text, code: "unparseable" };
+    return undefined;
   }
+}
+
+/**
+ * The host's `{error, code}` envelope, or `undefined` when the body is not one.
+ *
+ * Both fields are required and both must be strings, matching `ApiErrorBody`
+ * and what the host actually emits (`server/error.rs` serialises
+ * `{error: Display, code: &str}` for every route). Anything else — a bare JSON
+ * string, an array, a `null`, a proxy's JSON-shaped health blob — is not our
+ * envelope, and guessing at it is how an arbitrary upstream body becomes UI
+ * prose. The strictness is the point: this predicate is the only thing standing
+ * between a foreign response body and `ApiError.message`.
+ */
+function errorEnvelope(text: string): ApiErrorBody | undefined {
+  const parsed = parseJson(text);
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const { error, code } = parsed as Record<string, unknown>;
+  if (typeof error !== "string" || typeof code !== "string") return undefined;
+  return { error, code };
+}
+
+/**
+ * A short, safe description of a status the host refused on.
+ *
+ * `statusText` first, but it cannot be the whole answer: HTTP/2 and HTTP/3
+ * carry no reason phrase, so `res.statusText` is `""` on most hosted
+ * deployments — exactly the tenants that sit behind the proxy this bug came
+ * from. Falling back to `statusText` alone would have traded an HTML dump for a
+ * blank message, so `HTTP 504` is the floor.
+ */
+function statusMessage(res: Response): string {
+  return res.statusText.trim() || `HTTP ${res.status}`;
+}
+
+/**
+ * The `ApiError` for a response the host refused (issue #380).
+ *
+ * Shared by `request` and `getDocument`, which had drifted into two
+ * byte-identical copies of this logic — so the bug existed twice and had to be
+ * fixed twice. One function means the next change to error handling cannot land
+ * on only one of the two readers.
+ */
+function httpError(res: Response, text: string): ApiError {
+  const envelope = errorEnvelope(text);
+  const err = new ApiError(
+    res.status,
+    envelope?.code ?? `http_${res.status}`,
+    envelope?.error ?? statusMessage(res),
+    envelope !== undefined,
+  );
+  // Not discarded, just not rendered. A proxy error page is the only clue to
+  // which hop gave up, which is worth keeping for a bug report even though it
+  // is worthless as prose.
+  if (!envelope && text.trim()) {
+    err.detail = text.slice(0, DETAIL_CHARS);
+    console.debug(`[api] ${res.status} ${res.url}: unrecognised error body`, err.detail);
+  }
+  return err;
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -656,10 +656,36 @@ export interface ApiErrorBody {
 }
 
 export class ApiError extends Error {
+  /**
+   * The raw response body, kept only when it was **not** the host's envelope
+   * (issue #380) — a proxy's error page, an HTML 502, a plain-text upstream
+   * failure.
+   *
+   * Diagnostic only, and deliberately not part of `message`: `message` is
+   * rendered to operators as prose, and an arbitrary upstream body is not
+   * prose. Nothing in the console renders this field; it exists so that
+   * "which hop failed" survives for whoever is reading a bug report, and it is
+   * bounded by the client so a megabyte error page is not retained on an Error
+   * that may sit in state for the life of the view.
+   */
+  detail?: string;
+
   constructor(
     public status: number,
     public code: string,
     message: string,
+    /**
+     * Whether `code` and `message` came from the host's own `{error, code}`
+     * envelope, rather than being synthesised from the status line (#380).
+     *
+     * This is the difference between "the host considered the request and
+     * refused" and "something between the browser and the host gave up", and
+     * callers cannot recover it from `status` alone: the host itself answers
+     * 503 while quiescing and 502 on an upstream transport failure, so those
+     * codes are ambiguous on the wire and unambiguous here. `ApprovalsView`
+     * turns on exactly this to decide whether a decision may still have landed.
+     */
+    public readonly fromHost: boolean = false,
   ) {
     super(message);
     this.name = "ApiError";

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -52,6 +52,32 @@ const KIND_ICONS: Record<string, LucideIcon> = {
 const PREVIEW_LINES = 3;
 const PREVIEW_VALUE_CHARS = 160;
 
+/**
+ * Whether the host may have carried out this request despite the error (#380).
+ *
+ * The console genuinely cannot tell "the verdict never landed" from "the
+ * verdict landed and the continuation timed out" — but it can tell who
+ * answered, and that is enough to stop lying in the common case.
+ *
+ * **The host answered in its own envelope** (`fromHost`): it considered the
+ * request and refused, so nothing landed, whatever the status was. This is the
+ * arm that matters for correctness — the host returns 503 while quiescing and
+ * 502 on an upstream transport failure, so a status-only check would read those
+ * clean refusals as timeouts and tell the operator a decision was recorded when
+ * it provably was not.
+ *
+ * **Nothing answered, or a proxy did**: a dropped connection or an aborted
+ * request (`network_error`), or a 502/503/504 that did not come from the host —
+ * which on a hosted tenant is a reverse proxy that could not get a reply out of
+ * an upstream it had already handed the request to. The verdict very probably
+ * landed, and `feed.refresh()` at the call site settles it either way.
+ */
+function mayHaveLanded(err: unknown): boolean {
+  if (!(err instanceof ApiError)) return false;
+  if (err.fromHost) return false;
+  return err.code === "network_error" || err.status >= 502;
+}
+
 interface Props {
   client: OpenCompanyClient;
   company: string | null;
@@ -110,9 +136,35 @@ export function ApprovalsView({ client, company, feed, onResolved, onGoToConvers
       // per-agent DM thread (#151) surface it.
       void feed.refresh();
     } catch (err) {
-      const msg = err instanceof ApiError ? err.message : "something went wrong";
-      onResolved(`Couldn't record your decision — ${msg}`);
-      toast.error(`Couldn't record your decision — ${msg}`);
+      // Issue #380: a failed request is not the same as a failed decision.
+      //
+      // The host resolves in four steps — drop the approval from the parked
+      // queue, journal the verdict durably, mint the grant, then run a whole
+      // follow-up agent turn — and only the last one is slow. So when the
+      // answer is lost in transit it is lost *after* the verdict is durable,
+      // and "Couldn't record your decision" is a lie that invites the one
+      // response that cannot help: approving again.
+      if (mayHaveLanded(err)) {
+        const line =
+          verdict === "approve"
+            ? "Approved — the host didn't answer in time, but your decision was recorded. The agent may still be working; no need to approve again."
+            : "Declined — the host didn't answer in time, but your decision was recorded. No need to decline again.";
+        onResolved(line);
+        // Neither a success nor an error: the verdict is durable, the
+        // continuation is unknown. A green tick would overclaim and a red
+        // cross is the bug being fixed.
+        toast.info(line);
+        // The reconciliation, and the reason the copy above can be this
+        // confident: the host removes the approval from the queue in step one,
+        // so a refresh either drops this card — proving the verdict landed —
+        // or leaves it, showing the operator a decision that still needs
+        // making. The queue is the answer the response body never delivered.
+        void feed.refresh();
+      } else {
+        const msg = err instanceof ApiError ? err.message : "something went wrong";
+        onResolved(`Couldn't record your decision — ${msg}`);
+        toast.error(`Couldn't record your decision — ${msg}`);
+      }
     } finally {
       // Unconditional, and keyed on the id rather than clearing a single slot:
       // the feed refreshes on its own schedule and routinely drops the decided

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -53,29 +53,48 @@ const PREVIEW_LINES = 3;
 const PREVIEW_VALUE_CHARS = 160;
 
 /**
+ * Below this, a lost connection cannot have outlived the fast part of a resolve.
+ *
+ * Generous on purpose: the fast part is three local writes, so anything past a
+ * second or two of *waiting* was waiting on the agent turn. The number only has
+ * to separate "failed before it started" from "failed after it was underway".
+ */
+const RESOLVE_SLOW_ENOUGH_MS = 2_000;
+
+/**
  * Whether the host may have carried out this request despite the error (#380).
  *
  * The console genuinely cannot tell "the verdict never landed" from "the
  * verdict landed and the continuation timed out" — but it can tell who
- * answered, and that is enough to stop lying in the common case.
+ * answered, and roughly how long it waited, and that is enough to stop lying in
+ * the cases that actually occur.
  *
  * **The host answered in its own envelope** (`fromHost`): it considered the
  * request and refused, so nothing landed, whatever the status was. This is the
- * arm that matters for correctness — the host returns 503 while quiescing and
- * 502 on an upstream transport failure, so a status-only check would read those
- * clean refusals as timeouts and tell the operator a decision was recorded when
- * it provably was not.
+ * arm that matters most for correctness — the host returns 503 while quiescing
+ * and 502 on an upstream transport failure, so a status-only check would read
+ * those clean refusals as timeouts and tell the operator a decision was
+ * recorded when it provably was not.
  *
- * **Nothing answered, or a proxy did**: a dropped connection or an aborted
- * request (`network_error`), or a 502/503/504 that did not come from the host —
- * which on a hosted tenant is a reverse proxy that could not get a reply out of
- * an upstream it had already handed the request to. The verdict very probably
- * landed, and `feed.refresh()` at the call site settles it either way.
+ * **A proxy answered** (502/503/504 with no envelope): on a hosted tenant that
+ * is a reverse proxy that could not get a reply out of an upstream it had
+ * already handed the request to. The verdict very probably landed.
+ *
+ * **Nothing answered**: only evidence of a slow turn if it was actually slow.
+ * An instant rejection is an offline browser or a refused connection, where the
+ * request never reached the host — and saying "your decision was recorded"
+ * there would be a fresh lie in place of the one being fixed. Hence the
+ * elapsed-time floor: the inference is "recorded *before* the delay", so it
+ * needs a delay to stand on.
+ *
+ * Either way `feed.refresh()` at the call site settles it, since the host drops
+ * the approval from the queue before anything slow happens.
  */
-function mayHaveLanded(err: unknown): boolean {
+function mayHaveLanded(err: unknown, elapsedMs: number): boolean {
   if (!(err instanceof ApiError)) return false;
   if (err.fromHost) return false;
-  return err.code === "network_error" || err.status >= 502;
+  if (err.status >= 502) return true;
+  return err.code === "network_error" && elapsedMs >= RESOLVE_SLOW_ENOUGH_MS;
 }
 
 interface Props {
@@ -117,6 +136,7 @@ export function ApprovalsView({ client, company, feed, onResolved, onGoToConvers
     // early return that used to live here made every other card inert too.
     if (inFlight.has(a.id)) return;
     markInFlight(a.id, verdict);
+    const startedAt = Date.now();
     try {
       await client.resolveApproval(a.id, verdict, undefined, company);
       // Issue #243: approving no longer just records a verdict — it hands the
@@ -144,7 +164,7 @@ export function ApprovalsView({ client, company, feed, onResolved, onGoToConvers
       // answer is lost in transit it is lost *after* the verdict is durable,
       // and "Couldn't record your decision" is a lie that invites the one
       // response that cannot help: approving again.
-      if (mayHaveLanded(err)) {
+      if (mayHaveLanded(err, Date.now() - startedAt)) {
         const line =
           verdict === "approve"
             ? "Approved — the host didn't answer in time, but your decision was recorded. The agent may still be working; no need to approve again."

--- a/frontend/test/e2e/approval-timeout-honesty.spec.ts
+++ b/frontend/test/e2e/approval-timeout-honesty.spec.ts
@@ -1,0 +1,314 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Regression proof for #380 — a slow approval that dies at the proxy.
+ *
+ * Reported from a hosted tenant: an operator approved something, the request
+ * sat open for a full agent turn, nginx gave up at its default read timeout and
+ * answered its own `504` page. The console then rendered
+ *
+ *     Couldn't record your decision — <html><head><title>504 Gateway Time-out…
+ *
+ * which is two bugs wearing one message.
+ *
+ * **The copy was false.** `CompanyRuntime::resolve_approval` does four things:
+ * drops the approval from the parked queue, journals the verdict durably, mints
+ * the single-use grant, then runs a whole follow-up agent turn. Only the last is
+ * slow, so a proxy that gives up has given up *after* the verdict is durable.
+ * "Couldn't record your decision" invited the one response that cannot help —
+ * approving again.
+ *
+ * **The body was rendered verbatim.** `safeJson` failed open, turning any
+ * unparseable body into `{error: text, code: "unparseable"}`, which then read as
+ * the host's own error envelope. Not approvals-specific: it applied to every
+ * route on both readers.
+ *
+ * ## What is faked here, and what is not
+ *
+ * The proxy is faked. These tests fulfil the resolve request from Playwright
+ * with the byte-for-byte body nginx emits, rather than standing a real reverse
+ * proxy in front of the host and waiting out a real timeout — the console's
+ * behaviour is a pure function of the response it gets, and a fabricated one is
+ * both faster and deterministic. What is real: the host, the console bundle, the
+ * session, and the polling feed the queue assertion depends on.
+ *
+ * The approvals *list* is faked too, because parking a real approval needs an
+ * agent turn that decides to call a gated tool — which needs an inference
+ * credential and is not deterministic. The shape served here is the host's own
+ * `ApprovalSummary`.
+ *
+ * Like the rest of `test/e2e`, this drives a running host and is not wired into
+ * CI (the Playwright config declares no `webServer`); `npm run typecheck:e2e`
+ * compiles it, nothing runs it automatically. It is a reproduction and a
+ * written-down contract, not a merge gate.
+ */
+
+/** The page nginx serves on a read timeout, padding comments and all. */
+const NGINX_504 = [
+  "<html>",
+  "<head><title>504 Gateway Time-out</title></head>",
+  "<body>",
+  "<center><h1>504 Gateway Time-out</h1></center>",
+  "<hr><center>nginx/1.24.0</center>",
+  "</body>",
+  "</html>",
+  // nginx pads short error pages so IE and Chrome show the real one rather than
+  // their own. This is the part that made the old console message enormous.
+  ...Array.from(
+    { length: 6 },
+    () => "<!-- a padding to disable MSIE and Chrome friendly error page -->",
+  ),
+].join("\n");
+
+/** An upstream that closed the connection, as the proxy reports it. */
+const NGINX_502 = [
+  "<html>",
+  "<head><title>502 Bad Gateway</title></head>",
+  "<body>",
+  "<center><h1>502 Bad Gateway</h1></center>",
+  "<hr><center>nginx/1.24.0</center>",
+  "</body>",
+  "</html>",
+].join("\n");
+
+const APPROVAL_ID = "e2e-380-approval";
+
+/**
+ * Route matchers by pathname rather than by glob.
+ *
+ * The client serves two deployment shapes from one code path — single-company
+ * (`/api/v1/company/…`) and platform (`/api/v1/companies/{id}/…`) — and which
+ * one the console picks depends on the host it is pointed at. Matching on the
+ * tail of the pathname keeps this spec working against either, which a literal
+ * prefix glob silently does not: it matches nothing and the test then fails on
+ * an empty queue rather than on the behaviour under test.
+ */
+const isApprovalList = (url: URL) => /\/approvals$/.test(url.pathname);
+const isApprovalResolve = (url: URL) => /\/approvals\/[^/]+$/.test(url.pathname);
+const isTaskExport = (url: URL) => /\/tasks\/[^/]+\/export$/.test(url.pathname);
+const isTaskDetail = (url: URL) => /\/tasks\/[^/]+$/.test(url.pathname);
+const isTaskList = (url: URL) => /\/tasks$/.test(url.pathname);
+
+/** One parked approval, in the host's own `ApprovalSummary` shape. */
+function parkedApproval() {
+  return {
+    id: APPROVAL_ID,
+    kind: "payment.send",
+    amount_usd: 42.5,
+    at_millis: Date.now() - 30_000,
+    task: { link: "unlinked" as const },
+    agent: "finance",
+    payload: { to: "acme-supplies", memo: "invoice 8812" },
+  };
+}
+
+/**
+ * The first-run product tour opens a modal over a fresh console and would
+ * intercept every click below. Answer "already skipped" for whatever company id
+ * the host resolves to, rather than hard-coding the harness's.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+});
+
+const toasts = (page: Page) => page.locator("[data-sonner-toast]");
+const approvalCard = (page: Page) =>
+  page.getByText("acme-supplies", { exact: false });
+
+/**
+ * Serve one parked approval until `resolved` flips, then serve an empty queue —
+ * which is what the real host does, since `resolve_outcome` removes the
+ * approval from the parked map in step one, before anything slow happens.
+ */
+async function stubQueue(page: Page): Promise<{ resolve: () => void }> {
+  let resolved = false;
+  await page.route(isApprovalList, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(resolved ? [] : [parkedApproval()]),
+    });
+  });
+  return { resolve: () => (resolved = true) };
+}
+
+/** Land on the approvals queue with the stubbed card visible. */
+async function openApprovals(page: Page) {
+  await page.goto("/#/approvals");
+  await expect(approvalCard(page)).toBeVisible({ timeout: 15_000 });
+}
+
+test("a proxy timeout does not claim the decision failed, and clears the card", async ({
+  page,
+}) => {
+  const queue = await stubQueue(page);
+  await page.route(isApprovalResolve, async (route) => {
+    // The verdict is already durable host-side by the time the proxy gives up,
+    // so the queue drops it even though this request "fails".
+    queue.resolve();
+    await route.fulfill({
+      status: 504,
+      contentType: "text/html",
+      body: NGINX_504,
+    });
+  });
+
+  await openApprovals(page);
+  await page.getByRole("button", { name: "Approve" }).click();
+
+  const message = toasts(page).first();
+  await expect(message).toBeVisible({ timeout: 10_000 });
+  const text = (await message.innerText()).trim();
+
+  // The headline assertion: the old copy is gone.
+  expect(text).not.toContain("Couldn't record your decision");
+  // ...and it is replaced by something that says the verdict landed and the
+  // continuation did not, rather than asserting plain success.
+  expect(text).toContain("your decision was recorded");
+  expect(text).toContain("may still be working");
+  // Defect 2, on the exact body that produced the field report.
+  expect(text).not.toContain("<");
+
+  // The queue reconciles. The bound is deliberately under the feed's 5s poll
+  // (`POLL_MS` in `use-company.ts`) so that passing means the fix's own
+  // `feed.refresh()` cleared the card, not the next scheduled tick.
+  await expect(approvalCard(page)).toHaveCount(0, { timeout: 2_500 });
+});
+
+test("a declined approval that times out reads as recorded, not failed", async ({
+  page,
+}) => {
+  const queue = await stubQueue(page);
+  await page.route(isApprovalResolve, async (route) => {
+    queue.resolve();
+    await route.fulfill({
+      status: 502,
+      contentType: "text/html",
+      body: NGINX_502,
+    });
+  });
+
+  await openApprovals(page);
+  await page.getByRole("button", { name: "Decline" }).click();
+
+  const message = toasts(page).first();
+  await expect(message).toBeVisible({ timeout: 10_000 });
+  const text = (await message.innerText()).trim();
+
+  expect(text).not.toContain("Couldn't record your decision");
+  expect(text).toContain("your decision was recorded");
+  // A decline is terminal — there is no agent left working on it, and the copy
+  // must not imply otherwise.
+  expect(text).not.toContain("may still be working");
+  expect(text).not.toContain("<");
+  await expect(approvalCard(page)).toHaveCount(0, { timeout: 2_500 });
+});
+
+test("a host refusal still reports honestly, with no markup in the message", async ({
+  page,
+}) => {
+  // 500 is below the gateway band and carries no host envelope, so this takes
+  // the "the host refused" arm — the one that still renders `ApiError.message`
+  // as prose. That makes it the isolated acceptance test for defect 2: only the
+  // fail-closed parse can keep this HTML out of the rendered string.
+  const queue = await stubQueue(page);
+  await page.route(isApprovalResolve, async (route) => {
+    await route.fulfill({
+      status: 500,
+      contentType: "text/html",
+      body: NGINX_504.replace(/504 Gateway Time-out/g, "500 Internal Server Error"),
+    });
+  });
+  void queue;
+
+  await openApprovals(page);
+  await page.getByRole("button", { name: "Approve" }).click();
+
+  const message = toasts(page).first();
+  await expect(message).toBeVisible({ timeout: 10_000 });
+  const text = (await message.innerText()).trim();
+
+  // The failure is still reported as a failure — this arm is correct copy.
+  expect(text).toContain("Couldn't record your decision");
+  // But the reason is the status line, never the body.
+  expect(text).not.toContain("<");
+  expect(text).not.toContain("nginx");
+  expect(text).not.toContain("padding");
+
+  // The approval was genuinely not resolved, so it stays on the queue.
+  await expect(approvalCard(page)).toBeVisible();
+});
+
+test("an unparseable body on the document reader falls back to the status line", async ({
+  page,
+}) => {
+  // The second throw site. `getDocument` is the reader for host-rendered
+  // documents (#352) and had its own byte-identical copy of the error path, so
+  // #380 existed twice; both now share `httpError`. Driving it through the task
+  // record export is the only way to reach that copy from the UI.
+  const task = {
+    id: "e2e-380-task",
+    title: "Reconcile the August ledger",
+    column: "todo",
+    priority: "medium",
+    assignee: "finance",
+    updatedAt: Date.now() - 60_000,
+  };
+  const detail = {
+    task,
+    timeline: [],
+    durations: {
+      workedMillis: 0,
+      workedLive: false,
+      waitingMillis: 0,
+      waitingLive: false,
+      asOfMillis: Date.now(),
+    },
+    approvals: [],
+    irreversibleEffects: [],
+    historyIncomplete: false,
+    discussion: [],
+    discussionHasMore: false,
+    lineage: { children: [] },
+    runs: [],
+  };
+  await page.route(isTaskList, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([task]),
+    });
+  });
+  await page.route(isTaskDetail, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(detail),
+    });
+  });
+  await page.route(isTaskExport, async (route) => {
+    // A plain-text upstream failure: not JSON, not the host's envelope, and the
+    // exact shape the old `safeJson` would have promoted to `error`.
+    await route.fulfill({
+      status: 502,
+      contentType: "text/plain",
+      body: "upstream connect error or disconnect/reset before headers",
+    });
+  });
+
+  await page.goto(`/#/tasks/${task.id}`);
+  await page.getByRole("button", { name: "Export" }).click({ timeout: 15_000 });
+
+  const message = toasts(page).first();
+  await expect(message).toBeVisible({ timeout: 10_000 });
+  const text = (await message.innerText()).trim();
+
+  // The upstream's prose is not the console's prose.
+  expect(text).not.toContain("upstream connect error");
+  expect(text).not.toContain("<");
+});

--- a/frontend/test/e2e/approval-timeout-honesty.spec.ts
+++ b/frontend/test/e2e/approval-timeout-honesty.spec.ts
@@ -244,6 +244,33 @@ test("a host refusal still reports honestly, with no markup in the message", asy
   await expect(approvalCard(page)).toBeVisible();
 });
 
+test("a connection that fails instantly is still reported as a failure", async ({
+  page,
+}) => {
+  // The other side of the honesty coin. An offline browser or a refused
+  // connection rejects immediately, which means the request never reached the
+  // host and the verdict cannot have been recorded — so the timeout copy would
+  // be a fresh lie in place of the one #380 removed. Only a *slow* failure
+  // supports the "recorded before the delay" inference.
+  const queue = await stubQueue(page);
+  await page.route(isApprovalResolve, (route) => route.abort("failed"));
+  void queue;
+
+  await openApprovals(page);
+  await page.getByRole("button", { name: "Approve" }).click();
+
+  const message = toasts(page).first();
+  await expect(message).toBeVisible({ timeout: 10_000 });
+  const text = (await message.innerText()).trim();
+
+  expect(text).toContain("Couldn't record your decision");
+  expect(text).not.toContain("your decision was recorded");
+  expect(text).not.toContain("<");
+
+  // Nothing was decided, so nothing leaves the queue.
+  await expect(approvalCard(page)).toBeVisible();
+});
+
 test("an unparseable body on the document reader falls back to the status line", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

The console no longer tells an operator their decision failed when it was recorded, and no longer renders an upstream error page as prose.

Reported from a hosted tenant: an operator approved something and got back

> Couldn't record your decision — `<html><head><title>504 Gateway Time-out</title></head>…`

— the entire nginx page, padding comments and all. And the message was false: the verdict had been recorded, journaled and granted before the proxy gave up.

## API Or Behavior Changes

**Defect 2 — `safeJson` now fails closed.** It used to fail *open*: an unparseable body became `{ error: text, code: "unparseable" }`, and the request layer took `envelope?.error` as the `ApiError` message. So any non-JSON error response from **any** route — a proxy page, an HTML 502, a plain-text upstream failure — became prose the UI rendered. A strict predicate now decides whether the body really is the host's `{error, code}` envelope; anything else falls back to the status line. The raw body is kept on `ApiError.detail`, which is never rendered, plus a `console.debug`.

The two throw sites were byte-identical copies, so the bug existed **twice**. They now share one `httpError`.

**Defect 1 — a lost answer is not a lost decision.** A failure whose answer did not come from the host now reads as recorded-with-agent-still-working, and refreshes the queue:

> **Approved** — the host didn't answer in time, but your decision was recorded. The agent may still be working; no need to approve again.
>
> **Declined** — the host didn't answer in time, but your decision was recorded. No need to decline again.

Decline drops the "still working" clause because a denial is terminal — claiming an agent is working on it would be a new falsehood. It is an info toast, not success or error: a green tick would overclaim, a red cross is the bug being fixed. The "no need to approve again" sentence is the point of the whole change, since retrying is the natural response to the old message.

**The confidence rests on the queue refresh, not on the copy.** The host removes the approval from the parked map in step one, so the card either clears — proving the verdict landed — or stays, showing a decision that still needs making.

## Tests

- [x] `npm run typecheck`
- [x] `npm run typecheck:e2e`
- [x] `npm run build`
- [ ] `cargo` — N/A: no Rust file is touched. `Cargo.lock` and submodule pins unchanged.

No lint or component-test script exists in this repo; neither is claimed.

**Reproduced end to end, with the boundary stated precisely.** The real Rust host was booted with the real console, authenticated through the real magic-link flow, and driven with Playwright. What is simulated is the *response*: Playwright fulfils the resolve request with the byte-for-byte nginx `504` page, rather than standing up nginx and waiting out a real read timeout. There was no proxy in front of the local host, and the console's behaviour is a pure function of the response it receives — this is the injected-failure substitute, not a real timeout.

**The tests were verified to gate.** Reverting the three source files to the parent commit and re-running fails them all, printing the exact field symptom including all six padding comments. Restoring the fix returns them to green.

The re-approval safety claim was confirmed against the live host rather than by reading: `POST …/approvals/never-parked-380` returns `200 {"responses":[{"text":"This approval was already resolved."}]}` — no second grant, no journal write, no cycle.

**Caveat worth stating:** these five specs live in `frontend/test/e2e/`, which CI typechecks but never runs (no `webServer` in the Playwright config). They are a reproduction and a written-down contract, not a merge gate — the same standing as the existing specs.

## Documentation

No spec doc changes. The envelope predicate and the timeout inference are documented where they are enforced.

## Impact

**Two corrections to the issue this closes**, both of which would have shipped bugs:

**1. The classifier cannot key on the status code.** The issue implies a gateway-class status identifies the timeout case. It does not — the host itself returns `503` for `Quiescing` and `502` for transport failures. Keying on status would tell an operator "your decision was recorded" on a clean host refusal where it provably was not. It keys on whether the host's JSON envelope was present, which the defect-2 fix makes detectable.

**2. Treating every network error as probably-landed introduces a new lie.** The issue's framing — "a network timeout means the latter is at least as likely" — holds for a request that hung, not one that failed instantly. An offline browser rejects immediately and never reached the host. The inference now requires the request to have actually been slow; that is its own commit with its own test.

Two smaller findings: `resolve_outcome` *removes* the parked entry up front, which is stronger than the issue's "records the verdict" and is what makes the queue reconciliation trustworthy; and `res.statusText` is `""` under HTTP/2, so a statusText-only fallback would have traded an HTML dump for a blank message — hence the `HTTP 504` floor.

**Defect 3 is not here and does not need to be.** The synchronous resolve that caused the timeout is fixed by #391, already merged: the follow-up cycle now runs off the connection. That is what makes this PR's copy *true* rather than merely kinder — the continuation genuinely survives the disconnect now.

## Related

Closes #380

Fixes defects 1 and 2. Defect 3 — the synchronous resolve holding the connection for a whole agent turn — shipped in #391.
Developed on top of #375 and rebased onto its squash.
