### PR TITLE
feat(chat): raise an approval in the conversation that needs it, and resume the work there (#379)

### DIFF
--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -136,6 +136,38 @@ Note this is the *tool* gate (`ApprovalPolicy`), which is a different path from
 the *effect* gate (`ManifestApprovalGate::evaluate`) the taxonomy above
 describes. A harness tool call parks directly and never reaches `evaluate`.
 
+## Where the request is raised (issue #379)
+
+An approval is not only a queue entry; it is an interruption of a conversation.
+So a park records **which conversation** — `ApprovalParked.thread`, stamped by
+the cycle from its own trigger events, surfaced on `ApprovalSummary.thread`, and
+carried onto `GrantedCall.origin_thread` when the approval mints a grant.
+
+The id is `OperatorMessage.chat`: a desk id for a channel, a roster agent id for
+a direct message. `Effect.agent` cannot stand in for it, and that is the whole
+reason the field exists — a desk channel and a direct message to that desk's
+lead are answered by the same teammate, so a request placed by asker would be
+raised inside the wrong one of the two.
+
+It follows the work rather than the queue entry. A resolution inherits the
+thread of the approval it settles, so a follow-up turn that needs a **second**
+sign-off re-parks in the channel the first was asked in instead of falling out
+of the conversation. And the redeemed grant's continuation is journaled into
+that thread too — approving something visibly causes the next thing to happen,
+in the place the operator was already reading.
+
+The stamp is refused rather than guessed. A cycle batching two conversations,
+or an addressed turn beside an unaddressed one, or beside a task dispatch,
+stamps nothing. An approval with no thread — a workflow delivery, a scheduler
+tick, anything parked before this shipped — belongs to no conversation and is
+shown on the Approvals page alone, which is where every approval was shown
+before. The page always lists everything; the in-conversation card is additive.
+
+The event log carries the park itself (`CompanyEvent::ApprovalParked`) so the
+card can appear live. It is deliberately thin — an id, a dotted kind, a thread —
+because the effect's payload is redacted in exactly one place and must not
+acquire a second. A reader re-reads the approvals feed for the rest.
+
 ## Delegation levels (standing rules)
 
 Prosumers adjust the fence in plain language, which compiles to policy:

--- a/docs/spec/runtime/events.md
+++ b/docs/spec/runtime/events.md
@@ -33,7 +33,10 @@ Two properties are load-bearing everywhere below:
 ## Variants
 
 `CompanyEvent` variants: `OperatorMessage`, `WebhookReceived`,
-`ScheduleFired`, `A2aTaskReceived`, `ApprovalResolved`, `FeedbackFiled`,
+`ScheduleFired`, `A2aTaskReceived`, `ApprovalParked` (issue #379 — an effect
+is now waiting on the operator; see [In-conversation
+approvals](#in-conversation-approvals-issue-379)), `ApprovalResolved`,
+`FeedbackFiled`,
 `PaymentReceived`, `LifecycleChanged`, `AgentReply`, `MemoryFactDeleted`,
 `TaskDispatched`, `McpCallFailed`, `WorkflowCreated` (a new saved workflow
 graph was authored + enabled via the console `POST …/workflows` route or the
@@ -172,6 +175,71 @@ rotated-away park line silently makes its approval unreadable.
 The field is additive on the same contract as the rest — a pre-#333 line
 replays with no link and keeps the old run-window correlation, so existing
 history still renders.
+
+### In-conversation approvals (issue #379)
+
+A parked approval had no event at all — parking was journal-only — so a console
+learned about a new request when its approvals feed next polled. That is far too
+late to raise the request *inside the conversation that produced it*, which is
+where an operator is actually looking when their agent stops to ask.
+
+Two additions, both on the pattern above.
+
+**`CompanyEvent::ApprovalParked`**, appended best-effort at the single park
+choke point (`CycleHostImpl::park`) immediately after the journal write
+succeeds. The journal is the binding record of what is parked; the event is an
+advisory nudge, so a failed log write never undoes a park that already
+happened — the same division `sweep_expired_approvals` draws for expiry.
+
+It carries **an id, a dotted kind, and a thread — nothing else**. No payload and
+no asker, deliberately: the parked effect's arguments are redacted and bounded
+in exactly one place (`pending_approvals`, issue #372), and a payload-bearing
+durable event would open a second surface that has to redact, and eventually
+will not. A reader reacts by re-reading the approvals feed and renders from the
+redacted `ApprovalSummary`. That costs one round trip between the frame and the
+card, and buys one redaction surface instead of two.
+
+**`ApprovalParked.thread` on the journal record**, stamped at park time from the
+cycle's own trigger events by `cycle_thread_id` — the sibling of #333's
+`cycle_task_id`, same exhaustive-match discipline, same refusal to guess. It
+also surfaces on `PendingApproval`, `ApprovalOrigin` and `ApprovalSummary`, and
+is copied onto `GrantedCall.origin_thread` when an approval mints a grant.
+
+The id is read off `OperatorMessage.chat`, which is the only field that can do
+this job. `Effect.agent` cannot: a desk channel and a direct message to that
+desk's lead are answered by the same teammate, so placing a card by asker raises
+one conversation's request inside the other. `chat` carries a desk id for a
+channel and a roster agent id for a DM — **different strings even when the same
+agent answers both**.
+
+It inherits through a resolution, exactly as the task link does: an
+`ApprovalResolved` whose approval was itself raised in a thread keeps that
+thread, so a follow-up turn that needs a *second* sign-off re-parks in the
+channel the first one was asked in rather than falling out of the conversation.
+
+A plain `Option<String>`, not a two-armed link like `task`, and for a precise
+reason: nothing downstream falls back to a heuristic when it is absent. An
+approval with no thread matches no channel filter and stays Approvals-page-only,
+which is exactly today's behaviour. So "no conversation produced this" and
+"written before #379" need not be told apart — both are correct as the same
+answer, which is the condition #333's enum exists to handle and this does not
+have.
+
+A batch is ambiguous — and stamps nothing — when it names two different threads,
+or when it carries an addressed chat turn alongside work that is its own (a task
+dispatch, a webhook, a schedule tick, an inbound A2A task). An **unaddressed**
+operator message (`chat: None`) is itself a rival rather than a neutral
+pass-through: it went to the orchestrator with no conversation of its own, so a
+batch holding one cannot say which conversation a parked effect came from.
+
+**The redemption reply is routed by this thread too**, and that is a bug fix
+rather than a new capability. `redispatch_granted_call` journaled the
+continuation `AgentReply` with `chat_id: grant.agent` — correct for a DM by
+coincidence, and wrong for a desk channel, where the agent's continuation landed
+in the desk lead's private line instead of the channel the operator asked in. It
+now uses `grant.origin_thread`, falling back to the agent when there is none,
+which is the previous behaviour kept for exactly the cases it was already right
+for.
 
 ### What a retry would repeat (issue #351)
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -32,6 +32,7 @@ import {
   type FinancesDto,
   type InboxDto,
   type InboxMessageDto,
+  type ResolveReceipt,
   type SetBudgetInput,
   type TeamMemberDto,
   type UsageDto,
@@ -317,19 +318,41 @@ export class OpenCompanyClient {
   }
 
   /** Approve or deny a parked approval; returns the follow-up reply. */
-  resolveApproval(
+  /**
+   * Resolve a parked approval.
+   *
+   * Two answer shapes, chosen by `detach` (#383):
+   *
+   * * **default** — the response holds the follow-up turn's replies
+   *   (`ChatResponse`). The Approvals page wants this: it is not sitting in a
+   *   transcript, so the body is its only sight of what happened next.
+   * * **detached** — the response is a receipt (`ResolveReceipt`) and the
+   *   continuation arrives on the event stream's `agent_reply` frame instead.
+   *   The **inline chat card** must use this (#379): rendering the POST body
+   *   *and* receiving the SSE echo would deliver one reply to the channel
+   *   twice, and detach has exactly one delivery path so the race cannot exist.
+   *
+   * The parse is deliberately tolerant rather than trusting the flag. A host
+   * that predates #383 ignores `detach` and answers with `responses` anyway, so
+   * the caller is handed whichever shape actually arrived — and never a receipt
+   * fabricated from a body that isn't one.
+   */
+  async resolveApproval(
     approvalId: string,
     verdict: Verdict,
     note?: string,
     company?: string | null,
-  ): Promise<ChatResponse> {
-    const body: { verdict: Verdict; note?: string } = { verdict };
+    options: { detach?: boolean } = {},
+  ): Promise<ChatResponse | ResolveReceipt> {
+    const body: { verdict: Verdict; note?: string; detach?: boolean } = { verdict };
     if (note) body.note = note;
-    return this.request<ChatResponse>(
+    if (options.detach) body.detach = true;
+    const answer = await this.request<unknown>(
       "POST",
       `${this.scope(company)}/approvals/${encodeURIComponent(approvalId)}`,
       body,
     );
+    return isResolveReceipt(answer) ? answer : (answer as ChatResponse);
   }
 
   /** Capture feedback (optionally preview the exact issue body first). */
@@ -643,4 +666,20 @@ function httpError(res: Response, text: string): ApiError {
     console.debug(`[api] ${res.status} ${res.url}: unrecognised error body`, err.detail);
   }
   return err;
+}
+
+/**
+ * Whether a resolve answered with a **receipt** rather than the follow-up
+ * turn's replies (#383).
+ *
+ * Structural, not a flag read. `detach: true` is a *request*, and a host that
+ * predates the option ignores it and answers with `responses` — trusting the
+ * request would then have the caller read `recorded` off a body that has no
+ * such key and report a decision as unrecorded. Distinguishing on `recorded`
+ * versus `responses` reads what actually arrived.
+ */
+function isResolveReceipt(answer: unknown): answer is ResolveReceipt {
+  if (typeof answer !== "object" || answer === null) return false;
+  const body = answer as Record<string, unknown>;
+  return typeof body.recorded === "boolean" && !Array.isArray(body.responses);
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -205,6 +205,32 @@ export interface ApprovalSummary {
    * object, so every read of it is a narrowing one.
    */
   payload?: unknown;
+  /**
+   * The chat thread this approval was raised in (#379) — the **host** thread id,
+   * which is a desk id for a channel and a roster agent id for a direct message.
+   * Resolve it to a console channel id with `channelIdForThread`.
+   *
+   * Not derivable from {@link agent}: a desk channel and a direct message to
+   * that desk's lead are answered by the same teammate, so placing a card by
+   * asker would raise one conversation's request inside the other.
+   *
+   * Absent for an approval no conversation produced (a workflow delivery, a
+   * scheduler tick) and for one parked before the field existed. Both mean the
+   * same thing here: it matches no channel and belongs to the Approvals page
+   * alone, exactly as every approval did before this shipped.
+   */
+  thread?: string | null;
+}
+
+/**
+ * The answer to a **detached** resolve (#383): the verdict is durable, and that
+ * is all it claims. The agent's continuation arrives afterwards on the event
+ * stream's `agent_reply` frame.
+ */
+export interface ResolveReceipt {
+  recorded: boolean;
+  /** There was nothing left to resolve — a double-click, not a failure. */
+  alreadyResolved: boolean;
 }
 
 export type Verdict = "approve" | "deny";

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -56,6 +56,7 @@ import {
   channelIdForThread,
   deskFromDto,
   dmChannelId,
+  type DecidedApproval,
   type Transcripts,
 } from "@/views/chat/model";
 import { Conversation } from "@/views/Conversation";
@@ -292,13 +293,15 @@ export function AppShell({
   //
   // `deciding` is the request in flight, per approval — a map, not a single
   // slot, because deciding one card must not freeze the others (#373's bug, one
-  // surface over). `decided` is the verdict already witnessed, from either
-  // surface: a resolved approval leaves `feed.approvals` on the next refresh, so
-  // without this the card would vanish mid-glance instead of settling.
+  // surface over). `decided` is what has already been witnessed, from either
+  // surface, and it keeps the **whole summary** rather than just the verdict:
+  // the host drops a resolved approval from the feed at once, so a console
+  // holding only a verdict has nothing left to draw and the card blinks out of
+  // the thread the instant it is decided.
   const [decidingApprovals, setDecidingApprovals] = useState<ReadonlyMap<string, Verdict>>(
     () => new Map(),
   );
-  const [decidedApprovals, setDecidedApprovals] = useState<Record<string, Verdict>>({});
+  const [decidedApprovals, setDecidedApprovals] = useState<Record<string, DecidedApproval>>({});
 
   const pending = feed.status.pending_approvals;
 
@@ -760,7 +763,7 @@ export function AppShell({
     markDeciding(approval.id, verdict);
     try {
       await client.resolveApproval(approval.id, verdict, undefined, company, { detach: true });
-      setDecidedApprovals((prev) => ({ ...prev, [approval.id]: verdict }));
+      setDecidedApprovals((prev) => ({ ...prev, [approval.id]: { verdict, approval } }));
       toast.success(
         verdict === "approve"
           ? "Approved — the agent is completing the action."
@@ -814,9 +817,15 @@ export function AppShell({
     onApprovalEvent: (event: CompanyStreamEvent) => {
       if (event.type === "approval_resolved") {
         const verdict: Verdict = event.verdict === "approve" ? "approve" : "deny";
-        setDecidedApprovals((prev) =>
-          prev[event.approvalId] ? prev : { ...prev, [event.approvalId]: verdict },
-        );
+        // Snapshot the summary from the feed as it stands *now* — before the
+        // refresh below drops it. An id this console never had a summary for
+        // records nothing, which is right: there is no card to settle.
+        const approval = feed.approvals.find((a) => a.id === event.approvalId);
+        if (approval) {
+          setDecidedApprovals((prev) =>
+            prev[event.approvalId] ? prev : { ...prev, [event.approvalId]: { verdict, approval } },
+          );
+        }
       }
       void feed.refresh();
     },

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -11,7 +11,13 @@ import {
 } from "lucide-react";
 
 import type { OpenCompanyClient } from "@/api/client";
-import type { CompanyStatus, TurnStep } from "@/api/types";
+import {
+  ApiError,
+  type ApprovalSummary,
+  type CompanyStatus,
+  type TurnStep,
+  type Verdict,
+} from "@/api/types";
 import {
   Sidebar,
   SidebarContent,
@@ -278,6 +284,21 @@ export function AppShell({
   const activeTurnThreadRef = useRef<string | null>(null);
   const pendingPostThreadsRef = useRef<Set<string>>(new Set());
   const feed = useCompany(client, company, initialStatus);
+  // Issue #379: the inline approval cards' console-local state, owned here
+  // rather than in `ChatView` for the same reason `transcripts` is — the shell
+  // mounts and unmounts that view per route, and an operator who approves in a
+  // channel then steps over to Approvals must not come back to a card that has
+  // forgotten what they did.
+  //
+  // `deciding` is the request in flight, per approval — a map, not a single
+  // slot, because deciding one card must not freeze the others (#373's bug, one
+  // surface over). `decided` is the verdict already witnessed, from either
+  // surface: a resolved approval leaves `feed.approvals` on the next refresh, so
+  // without this the card would vanish mid-glance instead of settling.
+  const [decidingApprovals, setDecidingApprovals] = useState<ReadonlyMap<string, Verdict>>(
+    () => new Map(),
+  );
+  const [decidedApprovals, setDecidedApprovals] = useState<Record<string, Verdict>>({});
 
   const pending = feed.status.pending_approvals;
 
@@ -346,6 +367,10 @@ export function AppShell({
     setLastViewedChannel({});
     setUnreadSince(Date.now());
     activeChatChannelRef.current = null;
+    // Another company's approval ids are another namespace, and a settled card
+    // must not survive the switch as a ghost in the new company's channels.
+    setDecidedApprovals({});
+    setDecidingApprovals(new Map());
 
     const hydrate = (threadId: string) => {
       client
@@ -517,6 +542,28 @@ export function AppShell({
     setThreadMessages(activeThreadId, (m) => [...m, makeMessage("system", line)]);
   };
 
+  /**
+   * A system line into the channel that owns `threadId`, falling back to
+   * {@link noteSystem}'s "wherever the operator is" rule when the thread names
+   * no channel this company has (issue #379).
+   *
+   * The addressed form exists because an inline decision has a *known* home: the
+   * conversation the card was raised in. Filing it under "the last channel
+   * looked at" would put a decline into whatever the operator happened to open
+   * next — #368's bug, re-introduced one surface over.
+   */
+  const noteInChannel = (threadId: string | null | undefined, line: string) => {
+    const target = threadId ? chatChannelByThread[threadId] : undefined;
+    if (!target) {
+      noteSystem(line);
+      return;
+    }
+    setTranscripts((t) => ({
+      ...t,
+      [target]: [...(t[target] ?? []), makeMessage("system", line)],
+    }));
+  };
+
   // Inject an `AgentReply` pushed over the SSE feed (issue #66) into its desk
   // thread's transcript. Dedupe against our own optimistic echo: the backend
   // journals an `AgentReply` for the operator's own chat turn too, and
@@ -677,6 +724,64 @@ export function AppShell({
     });
   }, []);
 
+  const markDeciding = useCallback((id: string, verdict: Verdict | null) => {
+    setDecidingApprovals((prev) => {
+      const next = new Map(prev);
+      if (verdict) next.set(id, verdict);
+      else next.delete(id);
+      return next;
+    });
+  }, []);
+
+  /**
+   * Decide an approval from inside the conversation it was raised in (#379).
+   *
+   * **Detached** (`detach: true`), unlike the Approvals page. The default
+   * resolve answers with the follow-up turn's replies, and this card sits in a
+   * transcript that is *already* subscribed to the `agent_reply` frame — so
+   * rendering the body too would put one continuation into the channel twice.
+   * Detach has exactly one delivery path, so the race cannot arise. The page
+   * keeps the default shape, because it has no transcript and the body is its
+   * only sight of what happened next.
+   *
+   * The witnessed verdict is recorded before the refresh settles anything, so
+   * the card says what the operator chose rather than snapping back to two live
+   * buttons. The refresh in `finally` is the reconciliation: the host drops the
+   * approval from the queue in its first step, so the queue either loses this
+   * card — proving the verdict landed — or keeps it, showing a decision that
+   * still needs making.
+   *
+   * Not memoized: it closes over `feed` and `noteInChannel`, and it is only ever
+   * called from an event handler, so a `useCallback` here would buy a stale
+   * closure and nothing else.
+   */
+  const decideApproval = async (approval: ApprovalSummary, verdict: Verdict) => {
+    if (decidingApprovals.has(approval.id)) return;
+    markDeciding(approval.id, verdict);
+    try {
+      await client.resolveApproval(approval.id, verdict, undefined, company, { detach: true });
+      setDecidedApprovals((prev) => ({ ...prev, [approval.id]: verdict }));
+      toast.success(
+        verdict === "approve"
+          ? "Approved — the agent is completing the action."
+          : "Declined — recorded.",
+      );
+      // A decline ends the thread's story, and silence would read as a stall.
+      // An approve needs no line: the continuation lands as a real reply, which
+      // is the whole point of deciding here.
+      if (verdict === "deny") {
+        noteInChannel(approval.thread, "Declined — the agent will not take that action.");
+      }
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : "something went wrong";
+      toast.error(`Couldn't record your decision — ${msg}`);
+      noteInChannel(approval.thread, `Couldn't record your decision — ${msg}`);
+    } finally {
+      markDeciding(approval.id, null);
+      void feed.refresh();
+    }
+  };
+
   // The active push half of the attention surface: SSE-driven toasts + chat
   // injection, plus a rising-edge "needs a sign-off" toast off the poll's
   // pending count. Degrades silently to the `useCompany` poll when the host has
@@ -694,6 +799,27 @@ export function AppShell({
       setWorkflowRunEvents((prev) => [...prev, event].slice(-WORKFLOW_EVENT_WINDOW));
       if (event.type === "workflow_run_finished") setWorkflowRunTick((n) => n + 1);
     }, []),
+    // Issue #379. Both frames do the same one thing — re-read the approvals
+    // feed — and that is deliberate: the park frame is thin by design (no
+    // payload, no asker), so the redacted summary on the feed is the only place
+    // a card's content may come from. One round trip, in exchange for one
+    // redaction surface instead of two.
+    //
+    // The resolution half is what settles an inline card decided on the
+    // Approvals page, or in another tab, without a reload.
+    //
+    // Not memoized, for the same reason as `decideApproval`: `useEvents` keeps
+    // its callbacks in refs it refreshes every render, so a plain arrow costs no
+    // stream re-open and cannot go stale over the refresh it calls.
+    onApprovalEvent: (event: CompanyStreamEvent) => {
+      if (event.type === "approval_resolved") {
+        const verdict: Verdict = event.verdict === "approve" ? "approve" : "deny";
+        setDecidedApprovals((prev) =>
+          prev[event.approvalId] ? prev : { ...prev, [event.approvalId]: verdict },
+        );
+      }
+      void feed.refresh();
+    },
   });
 
   return (
@@ -766,6 +892,12 @@ export function AppShell({
               liveStepsByThread={liveStepsByThread}
               unread={unread}
               onChannelViewed={onChannelViewed}
+              approvals={feed.approvals}
+              chatChannelByThread={chatChannelByThread}
+              now={feed.now}
+              onDecideApproval={(approval, verdict) => void decideApproval(approval, verdict)}
+              decidingApprovals={decidingApprovals}
+              decidedApprovals={decidedApprovals}
             />
           )}
           {view === "conversation" && (

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -1,0 +1,239 @@
+// The body of an approval card, shared by the two surfaces that decide one
+// (issue #379): the Approvals page and the inline card in the conversation the
+// request came from.
+//
+// Extracted rather than duplicated because the two must say the *same thing*.
+// The whole point of raising a request in the conversation is that it is the
+// same request, told in full — what will happen, who is asking, what it is for,
+// how long it has waited. Two copies of that would drift, and the half that
+// drifted would be the one nobody was reading when it mattered.
+//
+// What is deliberately NOT here: the action buttons and the deciding state.
+// The page's buttons resolve with the default response shape; the inline card's
+// resolve detached (#391), because a body-delivered reply plus its SSE echo
+// would put one continuation into the channel twice. Same content, different
+// verbs — so the verbs stay with their owners.
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  AtSign,
+  ChevronDown,
+  ChevronUp,
+  CreditCard,
+  FileSignature,
+  FileText,
+  Globe,
+  KeyRound,
+  Mail,
+  MessageSquare,
+  Repeat,
+  RefreshCw,
+  Rocket,
+  ShieldCheck,
+  SquareKanban,
+  type LucideIcon,
+} from "lucide-react";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { ApprovalSummary } from "@/api/types";
+import { approvalAction, money, payloadLines, timeAgo } from "@/lib/language";
+import { cn } from "@/lib/utils";
+
+const KIND_ICONS: Record<string, LucideIcon> = {
+  "payment.send": CreditCard,
+  "subscription.start": Repeat,
+  "email.send": Mail,
+  "dm.external": MessageSquare,
+  "filing.submit": FileText,
+  "contract.accept": FileSignature,
+  "external.publish": Globe,
+  "website.deploy": Rocket,
+  "handle.register": AtSign,
+  "handle.renew": RefreshCw,
+  "key.rotate": KeyRound,
+};
+
+/**
+ * How much of a payload is shown before it is clamped. Past either bound the
+ * block collapses behind a "Show everything" toggle — a queue of approvals has
+ * to stay scannable, and a forty-line argument object buries the next card.
+ */
+const PREVIEW_LINES = 3;
+const PREVIEW_VALUE_CHARS = 160;
+
+/** The glyph for an effect kind; a shield for one this console doesn't know. */
+export function approvalIcon(kind: string): LucideIcon {
+  return KIND_ICONS[kind] ?? ShieldCheck;
+}
+
+/**
+ * The headline row: the glyph, what will happen, and the amount when there is
+ * one. Takes its actions as a slot so each surface supplies its own.
+ */
+export function ApprovalHeadline({
+  approval: a,
+  actions,
+}: {
+  approval: ApprovalSummary;
+  actions?: React.ReactNode;
+}) {
+  const Icon = approvalIcon(a.kind);
+  return (
+    <div className="flex items-start gap-4">
+      <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
+        <Icon className="size-5" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="font-medium">{approvalAction(a)}</p>
+        {a.amount_usd != null && (
+          <p className="text-xs font-medium text-muted-foreground">{money(a.amount_usd)}</p>
+        )}
+      </div>
+      {actions && <div className="flex shrink-0 gap-2">{actions}</div>}
+    </div>
+  );
+}
+
+/**
+ * The footer line: who asked, which card it belongs to, how long it has waited,
+ * and whatever status the surface wants to append.
+ */
+export function ApprovalMeta({
+  approval: a,
+  now,
+  askerNames,
+  status,
+}: {
+  approval: ApprovalSummary;
+  now: number;
+  askerNames: Map<string, string>;
+  /** Trailing status text ("Waiting for the agent…", "Approved"), if any. */
+  status?: React.ReactNode;
+}) {
+  const taskId = a.task?.link === "task" ? a.task.id : null;
+  // An id the roster does not know still beats no attribution at all — the
+  // operator can at least tell two askers apart.
+  const asker = a.agent ? (askerNames.get(a.agent) ?? a.agent) : null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+      {asker && (
+        <>
+          <span>
+            Asked by <span className="font-medium text-foreground">{asker}</span>
+          </span>
+          <span aria-hidden>·</span>
+        </>
+      )}
+      {taskId && (
+        <>
+          <a
+            href={`#/tasks/${encodeURIComponent(taskId)}`}
+            className="flex w-fit items-center gap-1 rounded-full bg-accent px-2 py-0.5 font-medium text-accent-foreground transition-opacity hover:opacity-80"
+          >
+            <SquareKanban className="size-3 shrink-0" />
+            Open the card
+          </a>
+          <span aria-hidden>·</span>
+        </>
+      )}
+      <span>{timeAgo(a.at_millis, now)}</span>
+      {status && (
+        <>
+          <span aria-hidden>·</span>
+          <span className="text-foreground">{status}</span>
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The tool call's own arguments, verbatim (#372) — `null` when the effect
+ * carries none, so a caller can skip the block entirely.
+ *
+ * Monospace and wrapping rather than truncating: a shell command cut off
+ * mid-flag is exactly as un-decidable as no command at all, and `break-all` is
+ * what keeps a long unbroken path or URL inside the card. Everything here was
+ * redacted and bounded by the host, so `[redacted]` is a value the console
+ * renders — never one it computes.
+ */
+export function ApprovalPayload({ approval }: { approval: ApprovalSummary }) {
+  const lines = useMemo(() => payloadLines(approval), [approval]);
+  const [expanded, setExpanded] = useState(false);
+  if (lines.length === 0) return null;
+
+  const clampable =
+    lines.length > PREVIEW_LINES || lines.some((l) => l.value.length > PREVIEW_VALUE_CHARS);
+  const shown = expanded || !clampable ? lines : lines.slice(0, PREVIEW_LINES);
+
+  return (
+    <div className="rounded-lg border bg-muted/40 px-3 py-2">
+      <div
+        className={cn(
+          "space-y-1 font-mono text-xs break-all whitespace-pre-wrap",
+          clampable && !expanded && "max-h-24 overflow-hidden",
+        )}
+      >
+        {shown.map((line) => (
+          <div key={line.label}>
+            <span className="text-muted-foreground">{line.label}: </span>
+            <span className="text-foreground">{line.value}</span>
+          </div>
+        ))}
+      </div>
+      {clampable && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="mt-1.5 flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {expanded ? <ChevronUp className="size-3" /> : <ChevronDown className="size-3" />}
+          {expanded ? "Show less" : "Show everything"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Agent id → display name, for the "Asked by" line.
+ *
+ * One roster read per company, not one per card: the ids on the queue are
+ * roster ids, and the roster is small and stable. A host without the roster
+ * route 404s, which is caught here — the card then shows the raw id rather than
+ * dropping the attribution, because "which teammate asked" stays useful even
+ * when we cannot pretty-print it.
+ */
+export function useAskerNames(
+  client: OpenCompanyClient,
+  company: string | null,
+  approvals: ApprovalSummary[],
+): Map<string, string> {
+  const [names, setNames] = useState<Map<string, string>>(new Map());
+  // Keyed on the set of asker ids rather than on `approvals` itself: the feed
+  // hands us a fresh array on every poll, and depending on the array would
+  // refetch the roster every few seconds for a roster that rarely changes.
+  const askerKey = useMemo(
+    () =>
+      Array.from(new Set(approvals.map((a) => a.agent).filter((id): id is string => !!id)))
+        .sort()
+        .join(","),
+    [approvals],
+  );
+
+  useEffect(() => {
+    if (!askerKey) return;
+    let live = true;
+    void (async () => {
+      const roster = await client.listTeam(company).catch(() => []);
+      if (!live) return;
+      setNames(new Map(roster.map((m) => [m.id, m.name?.trim() || m.role])));
+    })();
+    return () => {
+      live = false;
+    };
+  }, [client, company, askerKey]);
+
+  return names;
+}

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -36,6 +36,27 @@ export type CompanyStreamEvent =
       status: string;
       message: string;
     }
+  // A request just parked (issue #379), so a console watching the conversation
+  // it came from can raise the card live instead of waiting for its next
+  // approvals poll.
+  //
+  // Deliberately thin, and mirrored from the host: an id, the effect's dotted
+  // kind, and the chat thread it was raised in. There is **no payload and no
+  // asker** here on purpose — the effect's arguments are redacted in exactly one
+  // place (`GET …/approvals`), so the console reacts to this frame by refreshing
+  // that feed and renders the card from the redacted summary.
+  //
+  // `chatId` is absent when no conversation produced the approval (a workflow
+  // delivery, a scheduler tick, anything parked before #379). Such an approval
+  // matches no channel and stays on the Approvals page, exactly as before.
+  | {
+      type: "approval_parked";
+      seq: number;
+      atMillis: number;
+      approvalId: string;
+      kind: string;
+      chatId?: string;
+    }
   | { type: "approval_resolved"; seq: number; atMillis: number; approvalId: string; verdict: string }
   | { type: "lifecycle_changed"; seq: number; atMillis: number; from: string; to: string }
   | { type: "payment_received"; seq: number; atMillis: number; amountUsd: number; memo: string }
@@ -156,6 +177,18 @@ interface Options {
    * new outcome exists.
    */
   onWorkflowRunEvent?: (event: CompanyStreamEvent) => void;
+  /**
+   * Called for each approval-lifecycle frame (`approval_parked`,
+   * `approval_resolved`) so the shell can refresh the approvals feed live
+   * (issue #379).
+   *
+   * Both directions matter and for opposite reasons. A **park** is what puts a
+   * card into the conversation as it happens — the whole point of the issue.
+   * A **resolution** is what settles a card decided from the *other* surface:
+   * approve on the Approvals page and the inline copy has to stop offering
+   * buttons for a decision that is already made.
+   */
+  onApprovalEvent?: (event: CompanyStreamEvent) => void;
 }
 
 /**
@@ -176,6 +209,7 @@ export function useEvents(
     onTaskEvent,
     onTurnEvent,
     onWorkflowRunEvent,
+    onApprovalEvent,
   }: Options,
 ): void {
   // Keep the latest callbacks without re-opening the stream when they change.
@@ -195,6 +229,10 @@ export function useEvents(
   useEffect(() => {
     onWorkflowRunEventRef.current = onWorkflowRunEvent;
   }, [onWorkflowRunEvent]);
+  const onApprovalEventRef = useRef(onApprovalEvent);
+  useEffect(() => {
+    onApprovalEventRef.current = onApprovalEvent;
+  }, [onApprovalEvent]);
 
   // The rising-edge detector for pending approvals. Seeded with the current
   // value so we only toast on an *increase* observed while mounted, never on the
@@ -247,6 +285,7 @@ export function useEvents(
         onTaskEventRef.current,
         onTurnEventRef.current,
         onWorkflowRunEventRef.current,
+        onApprovalEventRef.current,
       );
     };
 
@@ -276,6 +315,7 @@ function handleEvent(
   onTaskEvent?: (e: CompanyStreamEvent) => void,
   onTurnEvent?: (e: CompanyStreamEvent) => void,
   onWorkflowRunEvent?: (e: CompanyStreamEvent) => void,
+  onApprovalEvent?: (e: CompanyStreamEvent) => void,
 ): void {
   switch (event.type) {
     // Live turn frames drive the in-flight tool timeline — no toast, they render
@@ -313,7 +353,17 @@ function handleEvent(
         taskId: event.taskId,
       });
       break;
+    // Issue #379. No toast: the rising-edge "needs a sign-off" toast off the
+    // poll already covers the attention half, and the card appearing in the
+    // channel IS the notification. Two of them for one request would be the
+    // noise this issue exists to remove.
+    case "approval_parked":
+      onApprovalEvent?.(event);
+      break;
     case "approval_resolved":
+      // Refresh first, then say so. The refresh is what settles an inline card
+      // whose decision was made on the Approvals page (or in another tab).
+      onApprovalEvent?.(event);
       toast(event.verdict === "approve" ? "Approval granted" : "Approval denied", {
         description: "An approval was just resolved.",
       });

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -1,56 +1,19 @@
-import { useEffect, useMemo, useState } from "react";
-import {
-  AtSign,
-  Check,
-  ChevronDown,
-  ChevronUp,
-  CreditCard,
-  FileSignature,
-  FileText,
-  Globe,
-  KeyRound,
-  Loader2,
-  Mail,
-  MessageSquare,
-  Repeat,
-  RefreshCw,
-  Rocket,
-  ShieldCheck,
-  SquareKanban,
-  type LucideIcon,
-  X,
-} from "lucide-react";
+import { useState } from "react";
+import { Check, Loader2, ShieldCheck, X } from "lucide-react";
 import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
 import { ApiError, type ApprovalSummary, type Verdict } from "@/api/types";
+import {
+  ApprovalHeadline,
+  ApprovalMeta,
+  ApprovalPayload,
+  useAskerNames,
+} from "@/components/approval-card";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import type { CompanyFeed } from "@/hooks/use-company";
-import { approvalAction, approvalSummary, money, payloadLines, timeAgo } from "@/lib/language";
-import { cn } from "@/lib/utils";
-
-const KIND_ICONS: Record<string, LucideIcon> = {
-  "payment.send": CreditCard,
-  "subscription.start": Repeat,
-  "email.send": Mail,
-  "dm.external": MessageSquare,
-  "filing.submit": FileText,
-  "contract.accept": FileSignature,
-  "external.publish": Globe,
-  "website.deploy": Rocket,
-  "handle.register": AtSign,
-  "handle.renew": RefreshCw,
-  "key.rotate": KeyRound,
-};
-
-/**
- * How much of a payload is shown before it is clamped. Past either bound the
- * block collapses behind a "Show everything" toggle — a queue of approvals has
- * to stay scannable, and a forty-line argument object buries the next card.
- */
-const PREVIEW_LINES = 3;
-const PREVIEW_VALUE_CHARS = 160;
+import { approvalSummary } from "@/lib/language";
 
 /**
  * Below this, a lost connection cannot have outlived the fast part of a resolve.
@@ -260,181 +223,59 @@ function ApprovalCard({
   deciding: Verdict | null;
   onDecide: (verdict: Verdict) => void;
 }) {
-  const Icon = KIND_ICONS[a.kind] ?? ShieldCheck;
-  const lines = useMemo(() => payloadLines(a), [a]);
-  const taskId = a.task?.link === "task" ? a.task.id : null;
-  // An id the roster does not know still beats no attribution at all — the
-  // operator can at least tell two askers apart.
-  const asker = a.agent ? (askerNames.get(a.agent) ?? a.agent) : null;
-
   // No cross-card dimming: another card being decided is not this card's
   // business, and treating it as such is the visual half of the #373 bug.
   return (
     <Card>
       <CardContent className="flex flex-col gap-3 py-4">
-        <div className="flex items-start gap-4">
-          <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
-            <Icon className="size-5" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <p className="font-medium">{approvalAction(a)}</p>
-            {a.amount_usd != null && (
-              <p className="text-xs font-medium text-muted-foreground">{money(a.amount_usd)}</p>
-            )}
-          </div>
-          {/* Disabled on THIS card's own state only — a decision in flight on
-              another card leaves these live. That is the whole of #373's
-              first cause. */}
-          <div className="flex shrink-0 gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={deciding !== null}
-              onClick={() => onDecide("deny")}
-            >
-              {deciding === "deny" ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                <X className="size-4" />
-              )}{" "}
-              Decline
-            </Button>
-            <Button size="sm" disabled={deciding !== null} onClick={() => onDecide("approve")}>
-              {deciding === "approve" ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                <Check className="size-4" />
-              )}{" "}
-              Approve
-            </Button>
-          </div>
-        </div>
-
-        {lines.length > 0 && <PayloadBlock lines={lines} />}
-
-        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-          {asker && (
+        <ApprovalHeadline
+          approval={a}
+          /* Disabled on THIS card's own state only — a decision in flight on
+             another card leaves these live. That is the whole of #373's
+             first cause. */
+          actions={
             <>
-              <span>
-                Asked by <span className="font-medium text-foreground">{asker}</span>
-              </span>
-              <span aria-hidden>·</span>
-            </>
-          )}
-          {taskId && (
-            <>
-              <a
-                href={`#/tasks/${encodeURIComponent(taskId)}`}
-                className="flex w-fit items-center gap-1 rounded-full bg-accent px-2 py-0.5 font-medium text-accent-foreground transition-opacity hover:opacity-80"
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={deciding !== null}
+                onClick={() => onDecide("deny")}
               >
-                <SquareKanban className="size-3 shrink-0" />
-                Open the card
-              </a>
-              <span aria-hidden>·</span>
+                {deciding === "deny" ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <X className="size-4" />
+                )}{" "}
+                Decline
+              </Button>
+              <Button size="sm" disabled={deciding !== null} onClick={() => onDecide("approve")}>
+                {deciding === "approve" ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Check className="size-4" />
+                )}{" "}
+                Approve
+              </Button>
             </>
-          )}
-          <span>{timeAgo(a.at_millis, now)}</span>
-          {/* Honest copy for a request that spans an agent turn (#373): an
-              approve is not done when the button stops spinning, it is handed
-              to the agent. A decline IS terminal, so it only has to record. */}
-          {deciding && (
-            <>
-              <span aria-hidden>·</span>
-              <span className="text-foreground">
-                {deciding === "approve" ? "Waiting for the agent…" : "Recording…"}
-              </span>
-            </>
-          )}
-        </div>
+          }
+        />
+
+        <ApprovalPayload approval={a} />
+
+        <ApprovalMeta
+          approval={a}
+          now={now}
+          askerNames={askerNames}
+          /* Honest copy for a request that spans an agent turn (#373): an
+             approve is not done when the button stops spinning, it is handed
+             to the agent. A decline IS terminal, so it only has to record. */
+          status={
+            deciding ? (deciding === "approve" ? "Waiting for the agent…" : "Recording…") : undefined
+          }
+        />
       </CardContent>
     </Card>
   );
-}
-
-/**
- * The tool call's own arguments, verbatim (#372).
- *
- * Monospace and wrapping rather than truncating: a shell command cut off
- * mid-flag is exactly as un-decidable as no command at all, and `break-all` is
- * what keeps a long unbroken path or URL inside the card. Everything here was
- * redacted and bounded by the host, so `[redacted]` is a value the console
- * renders — never one it computes.
- */
-function PayloadBlock({ lines }: { lines: { label: string; value: string }[] }) {
-  const [expanded, setExpanded] = useState(false);
-  const clampable =
-    lines.length > PREVIEW_LINES || lines.some((l) => l.value.length > PREVIEW_VALUE_CHARS);
-  const shown = expanded || !clampable ? lines : lines.slice(0, PREVIEW_LINES);
-
-  return (
-    <div className="rounded-lg border bg-muted/40 px-3 py-2">
-      <div
-        className={cn(
-          "space-y-1 font-mono text-xs break-all whitespace-pre-wrap",
-          clampable && !expanded && "max-h-24 overflow-hidden",
-        )}
-      >
-        {shown.map((line) => (
-          <div key={line.label}>
-            <span className="text-muted-foreground">{line.label}: </span>
-            <span className="text-foreground">{line.value}</span>
-          </div>
-        ))}
-      </div>
-      {clampable && (
-        <button
-          type="button"
-          onClick={() => setExpanded((v) => !v)}
-          className="mt-1.5 flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
-        >
-          {expanded ? <ChevronUp className="size-3" /> : <ChevronDown className="size-3" />}
-          {expanded ? "Show less" : "Show everything"}
-        </button>
-      )}
-    </div>
-  );
-}
-
-/**
- * Agent id → display name, for the "Asked by" line.
- *
- * One roster read per company, not one per card: the ids on the queue are
- * roster ids, and the roster is small and stable. A host without the roster
- * route 404s, which is caught here — the card then shows the raw id rather than
- * dropping the attribution, because "which teammate asked" stays useful even
- * when we cannot pretty-print it.
- */
-function useAskerNames(
-  client: OpenCompanyClient,
-  company: string | null,
-  approvals: ApprovalSummary[],
-): Map<string, string> {
-  const [names, setNames] = useState<Map<string, string>>(new Map());
-  // Keyed on the set of asker ids rather than on `approvals` itself: the feed
-  // hands us a fresh array on every poll, and depending on the array would
-  // refetch the roster every few seconds for a roster that rarely changes.
-  const askerKey = useMemo(
-    () =>
-      Array.from(new Set(approvals.map((a) => a.agent).filter((id): id is string => !!id)))
-        .sort()
-        .join(","),
-    [approvals],
-  );
-
-  useEffect(() => {
-    if (!askerKey) return;
-    let live = true;
-    void (async () => {
-      const roster = await client.listTeam(company).catch(() => []);
-      if (!live) return;
-      setNames(new Map(roster.map((m) => [m.id, m.name?.trim() || m.role])));
-    })();
-    return () => {
-      live = false;
-    };
-  }, [client, company, askerKey]);
-
-  return names;
 }
 
 function EmptyApprovals({ onGoToConversation }: { onGoToConversation: () => void }) {

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -14,13 +14,14 @@ import { toast } from "sonner";
 import { listPeople, me as fetchMe, type Person } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
 import { setInboxEnabled } from "@/api/inbox";
-import { ApiError, type TeamMemberDto, type TurnStep } from "@/api/types";
+import { ApiError, type ApprovalSummary, type TeamMemberDto, type TurnStep, type Verdict } from "@/api/types";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { type ChatMessage, makeMessage } from "@/lib/chat";
 import { defaultDesks, type Desk } from "@/lib/desks";
 import { fromDto, newMember, starterTeam, type TeamMember } from "@/lib/team";
 import { cn } from "@/lib/utils";
+import { useAskerNames } from "@/components/approval-card";
 import { AddMemberDialog, type NewMemberFields } from "./chat/AddMemberDialog";
 import { BudgetDialog } from "./chat/BudgetDialog";
 import { ChannelRail } from "./chat/ChannelRail";
@@ -32,6 +33,7 @@ import { ThreadPanel } from "./chat/ThreadPanel";
 import {
   buildChannels,
   buildTimeline,
+  buildTimelineItems,
   channelMembers,
   channelTitle,
   deskFromDto,
@@ -84,6 +86,30 @@ interface Props {
    * unaddressed line belongs after this view is gone (issue #368).
    */
   onChannelViewed?: (channelId: string) => void;
+  /**
+   * Every approval currently awaiting the operator, straight off the shell's
+   * feed, plus the host thread → channel map that places them (#379).
+   *
+   * Passed whole and filtered here rather than pre-filtered upstream, because
+   * the filter needs the channel actually on screen — which this view resolves,
+   * not the shell. An approval whose `thread` names no channel this company has
+   * (a workflow delivery, a scheduler tick, anything parked before #379) simply
+   * matches nothing and stays on the Approvals page, which is the whole
+   * additive contract.
+   */
+  approvals?: ApprovalSummary[];
+  chatChannelByThread?: Record<string, string>;
+  /** Now, for a card's "waiting N minutes" line. */
+  now?: number;
+  /**
+   * Decide an approval from inside the conversation. Owned by the shell so the
+   * witnessed verdict survives this view unmounting — the operator can walk to
+   * Approvals and back mid-turn.
+   */
+  onDecideApproval?: (approval: ApprovalSummary, verdict: Verdict) => void;
+  /** The verdict each card is waiting on, and the ones already witnessed. */
+  decidingApprovals?: ReadonlyMap<string, Verdict>;
+  decidedApprovals?: Record<string, Verdict>;
 }
 
 /**
@@ -112,6 +138,12 @@ export function ChatView({
   liveStepsByThread,
   unread,
   onChannelViewed,
+  approvals,
+  chatChannelByThread,
+  now,
+  onDecideApproval,
+  decidingApprovals,
+  decidedApprovals,
 }: Props) {
   const [members, setMembers] = useState<TeamMember[]>([]);
   const [loadingTeam, setLoadingTeam] = useState(true);
@@ -328,6 +360,56 @@ export function ChatView({
   const entries = useMemo(
     () => (channel ? buildTimeline(messages, channel) : []),
     [messages, channel],
+  );
+
+  /**
+   * The approvals raised in the channel on screen (#379).
+   *
+   * **Derived, never appended.** The cards come from server state on every
+   * render, so a pending one survives a reload — better than the transcripts it
+   * sits among, which are still console-local (#364), and deliberately not
+   * dependent on that being fixed.
+   *
+   * An approval with no `thread`, or one naming a thread this company has no
+   * channel for, resolves to `null` and matches nothing. That is how a workflow
+   * delivery or a scheduler tick stays Approvals-page-only.
+   *
+   * `desks` gates the derivation for the same reason it gates the channel list
+   * (#393): before `/desks` answers, every thread id looks unknown, and placing
+   * cards against a half-built channel set is the first-paint swap #370
+   * describes one surface over.
+   */
+  const channelApprovals = useMemo(() => {
+    if (!desks || !channel || !approvals?.length) return [];
+    const byThread = chatChannelByThread ?? {};
+    return approvals.filter((a) => a.thread && byThread[a.thread] === channel.id);
+  }, [desks, channel, approvals, chatChannelByThread]);
+
+  /**
+   * A card the operator decided is kept on screen even once the feed has
+   * dropped it, so the decision visibly lands instead of the card vanishing
+   * mid-glance. The shell owns the witnessed map; this only re-hydrates the
+   * summary the row needs to keep rendering.
+   */
+  const settledApprovals = useMemo(() => {
+    if (!decidedApprovals || !channel) return [];
+    const live = new Set(channelApprovals.map((a) => a.id));
+    const byThread = chatChannelByThread ?? {};
+    return (approvals ?? [])
+      .filter((a) => !live.has(a.id) && decidedApprovals[a.id])
+      .filter((a) => a.thread && byThread[a.thread] === channel.id);
+  }, [decidedApprovals, channel, channelApprovals, approvals, chatChannelByThread]);
+
+  const askerNames = useAskerNames(client, company, channelApprovals);
+
+  const items = useMemo(
+    () =>
+      buildTimelineItems(
+        entries,
+        [...channelApprovals, ...settledApprovals],
+        decidedApprovals ?? {},
+      ),
+    [entries, channelApprovals, settledApprovals, decidedApprovals],
   );
 
   // An open thread only makes sense while its parent is on screen; switching
@@ -591,12 +673,16 @@ export function ChatView({
             )}
             <MessageTimeline
               channel={channel}
-              entries={entries}
+              items={items}
               openThreadId={openThreadId}
               typing={sending && !openThreadId}
               liveSteps={openThreadId ? undefined : liveSteps}
               onOpenThread={setOpenThreadId}
               onReact={react}
+              now={now}
+              askerNames={askerNames}
+              decidingApprovals={decidingApprovals}
+              onDecideApproval={onDecideApproval}
             />
             <MessageComposer
               placeholder={`Message ${channelTitle(channel)}`}

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -41,6 +41,7 @@ import {
   findChannel,
   firstChannel,
   toggleReaction,
+  type DecidedApproval,
   type Transcripts,
 } from "./chat/model";
 
@@ -109,7 +110,7 @@ interface Props {
   onDecideApproval?: (approval: ApprovalSummary, verdict: Verdict) => void;
   /** The verdict each card is waiting on, and the ones already witnessed. */
   decidingApprovals?: ReadonlyMap<string, Verdict>;
-  decidedApprovals?: Record<string, Verdict>;
+  decidedApprovals?: Record<string, DecidedApproval>;
 }
 
 /**
@@ -386,19 +387,22 @@ export function ChatView({
   }, [desks, channel, approvals, chatChannelByThread]);
 
   /**
-   * A card the operator decided is kept on screen even once the feed has
-   * dropped it, so the decision visibly lands instead of the card vanishing
-   * mid-glance. The shell owns the witnessed map; this only re-hydrates the
-   * summary the row needs to keep rendering.
+   * Cards the operator has already decided, which the feed no longer carries.
+   *
+   * The host drops a resolved approval from `GET …/approvals` at once, so these
+   * cannot be re-derived from `approvals` — they come from the shell's witnessed
+   * map, which keeps the last-seen summary precisely so a decided card can
+   * settle in place rather than blinking out of the thread.
    */
   const settledApprovals = useMemo(() => {
-    if (!decidedApprovals || !channel) return [];
+    if (!decidedApprovals || !channel || !desks) return [];
     const live = new Set(channelApprovals.map((a) => a.id));
     const byThread = chatChannelByThread ?? {};
-    return (approvals ?? [])
-      .filter((a) => !live.has(a.id) && decidedApprovals[a.id])
+    return Object.values(decidedApprovals)
+      .map((d) => d.approval)
+      .filter((a) => !live.has(a.id))
       .filter((a) => a.thread && byThread[a.thread] === channel.id);
-  }, [decidedApprovals, channel, channelApprovals, approvals, chatChannelByThread]);
+  }, [decidedApprovals, channel, desks, channelApprovals, chatChannelByThread]);
 
   const askerNames = useAskerNames(client, company, channelApprovals);
 

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -1,0 +1,121 @@
+// A parked approval, raised inside the conversation that produced it (#379).
+//
+// The same content the Approvals page shows — headline, payload, asker, waiting
+// time, all from `@/components/approval-card` — laid out as a channel row so it
+// reads as part of the thread rather than as a panel bolted beside it.
+//
+// The one thing it does differently is how it resolves: **detached** (#391).
+// The default resolve answers with the follow-up turn's replies, and rendering
+// those here would put the continuation into the channel once from the POST
+// body and again from its SSE echo. Detach has exactly one delivery path, so
+// the duplicate-bubble race #391 deliberately left open outside chat POSTs
+// cannot exist here.
+
+import { Check, Loader2, X } from "lucide-react";
+
+import type { ApprovalSummary, Verdict } from "@/api/types";
+import {
+  ApprovalHeadline,
+  ApprovalMeta,
+  ApprovalPayload,
+} from "@/components/approval-card";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/** What the card says once a verdict has been witnessed. */
+function settledLabel(verdict: Verdict): string {
+  // Mirrors the wording the Approvals page files into the transcript, and for
+  // the same reason: approving is not "done", it hands the agent a single-use
+  // grant and re-dispatches it. A decline IS terminal.
+  return verdict === "approve"
+    ? "Approved — the agent is completing the action"
+    : "Declined — recorded, and nothing will run";
+}
+
+export function ApprovalRow({
+  approval,
+  now,
+  askerNames,
+  deciding,
+  decided,
+  onDecide,
+}: {
+  approval: ApprovalSummary;
+  now: number;
+  askerNames: Map<string, string>;
+  /** The verdict this card is waiting on, or `null` when idle. */
+  deciding: Verdict | null;
+  /** A verdict already witnessed — from this console or from the page. */
+  decided: Verdict | null;
+  onDecide: (verdict: Verdict) => void;
+}) {
+  return (
+    <div className="px-4 py-2">
+      <div
+        role="group"
+        aria-label="Approval request"
+        data-approval-id={approval.id}
+        className={cn(
+          "rounded-xl border bg-card px-4 py-3 shadow-sm",
+          // A settled card steps back rather than disappearing: the operator
+          // has to be able to see their own decision land.
+          decided && "opacity-70",
+        )}
+      >
+        <div className="flex flex-col gap-3">
+          <ApprovalHeadline
+            approval={approval}
+            actions={
+              decided ? undefined : (
+                <>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={deciding !== null}
+                    onClick={() => onDecide("deny")}
+                  >
+                    {deciding === "deny" ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <X className="size-4" />
+                    )}{" "}
+                    Decline
+                  </Button>
+                  <Button
+                    size="sm"
+                    disabled={deciding !== null}
+                    onClick={() => onDecide("approve")}
+                  >
+                    {deciding === "approve" ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <Check className="size-4" />
+                    )}{" "}
+                    Approve
+                  </Button>
+                </>
+              )
+            }
+          />
+
+          <ApprovalPayload approval={approval} />
+
+          <ApprovalMeta
+            approval={approval}
+            now={now}
+            askerNames={askerNames}
+            status={
+              decided
+                ? settledLabel(decided)
+                : deciding
+                  ? deciding === "approve"
+                    ? "Waiting for the agent…"
+                    : "Recording…"
+                  : undefined
+            }
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -1,15 +1,21 @@
 import { useEffect, useRef } from "react";
 
-import type { TurnStep } from "@/api/types";
+import type { ApprovalSummary, TurnStep, Verdict } from "@/api/types";
 import { cn } from "@/lib/utils";
+import { ApprovalRow } from "./ApprovalRow";
 import { Avatar } from "./Avatar";
 import { MessageRow } from "./MessageRow";
 import { StepTimeline } from "./StepTimeline";
-import { channelTitle, type Channel, type TimelineEntry } from "./model";
+import { channelTitle, type Channel, type TimelineItem } from "./model";
 
 interface Props {
   channel: Channel;
-  entries: TimelineEntry[];
+  /**
+   * The channel's rows: messages, and the approvals raised in this channel
+   * interleaved among them by time (#379). A card is its own kind rather than a
+   * message — see {@link TimelineItem}.
+   */
+  items: TimelineItem[];
   /** The message whose thread is open, if any — that row stays highlighted. */
   openThreadId: string | null;
   /** Someone on the company side is composing a reply. */
@@ -23,6 +29,13 @@ interface Props {
   liveSteps?: TurnStep[];
   onOpenThread: (messageId: string) => void;
   onReact: (messageId: string, emoji: string) => void;
+  /** Now, for the cards' "waiting N minutes" line. Owned by the shell's feed. */
+  now?: number;
+  /** Agent id → display name, for a card's "Asked by" line. */
+  askerNames?: Map<string, string>;
+  /** The verdict each inline card is currently waiting on. */
+  decidingApprovals?: ReadonlyMap<string, Verdict>;
+  onDecideApproval?: (approval: ApprovalSummary, verdict: Verdict) => void;
 }
 
 /**
@@ -35,12 +48,16 @@ interface Props {
  */
 export function MessageTimeline({
   channel,
-  entries,
+  items,
   openThreadId,
   typing,
   liveSteps,
   onOpenThread,
   onReact,
+  now,
+  askerNames,
+  decidingApprovals,
+  onDecideApproval,
 }: Props) {
   const scroller = useRef<HTMLDivElement>(null);
   const liveStepCount = liveSteps?.length ?? 0;
@@ -50,24 +67,37 @@ export function MessageTimeline({
     if (!el) return;
     el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
     // Each new tool row grows the block at the bottom, so the scroll has to
-    // follow it as the turn works, not only when the reply lands.
-  }, [entries.length, typing, liveStepCount]);
+    // follow it as the turn works, not only when the reply lands. A card
+    // arriving counts too — it is the thing the operator has to act on.
+  }, [items.length, typing, liveStepCount]);
 
   return (
     <div ref={scroller} className="flex-1 overflow-y-auto">
       <div className="flex min-h-full flex-col justify-end pb-4">
-        <ChannelIntro channel={channel} empty={entries.length === 0} />
-        {entries.map((entry) => (
-          <div key={entry.message.id}>
-            {entry.dayLabel && <DayDivider label={entry.dayLabel} />}
-            <MessageRow
-              entry={entry}
-              threadOpen={entry.message.id === openThreadId}
-              onOpenThread={onOpenThread}
-              onReact={onReact}
+        <ChannelIntro channel={channel} empty={items.length === 0} />
+        {items.map((item) =>
+          item.kind === "message" ? (
+            <div key={item.key}>
+              {item.entry.dayLabel && <DayDivider label={item.entry.dayLabel} />}
+              <MessageRow
+                entry={item.entry}
+                threadOpen={item.entry.message.id === openThreadId}
+                onOpenThread={onOpenThread}
+                onReact={onReact}
+              />
+            </div>
+          ) : (
+            <ApprovalRow
+              key={item.key}
+              approval={item.approval}
+              now={now ?? Date.now()}
+              askerNames={askerNames ?? EMPTY_NAMES}
+              deciding={decidingApprovals?.get(item.approval.id) ?? null}
+              decided={item.decided}
+              onDecide={(verdict) => onDecideApproval?.(item.approval, verdict)}
             />
-          </div>
-        ))}
+          ),
+        )}
         {liveStepCount > 0 ? (
           <LiveTurnRow channel={channel} steps={liveSteps ?? []} />
         ) : (
@@ -77,6 +107,9 @@ export function MessageTimeline({
     </div>
   );
 }
+
+/** Stable identity so a missing `askerNames` cannot churn the card's props. */
+const EMPTY_NAMES: Map<string, string> = new Map();
 
 function DayDivider({ label }: { label: string }) {
   return (

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -1,7 +1,7 @@
 // The chat workspace's data model: channels, direct messages, and the grouping
 // rules the timeline reads. Everything here is pure — the view owns the state.
 
-import type { DeskDto } from "@/api/types";
+import type { ApprovalSummary, DeskDto, Verdict } from "@/api/types";
 import type { ChatMessage } from "@/lib/chat";
 import { defaultDesks, type Desk } from "@/lib/desks";
 import { initials as nameInitials, type TeamMember } from "@/lib/team";
@@ -325,6 +325,75 @@ export function buildTimeline(messages: ChatMessage[], channel: Channel): Timeli
   }
 
   return entries;
+}
+
+/**
+ * One row of a channel, which is no longer only a message (#379).
+ *
+ * A parked approval is a **distinct kind**, not a synthetic `ChatMessage`. It
+ * has to be: a card is decidable, carries live server state, and settles into a
+ * terminal state — none of which a message row can represent, and faking one
+ * would mean inventing an id, a sender and a body for something that is not an
+ * utterance. Keeping it separate is also what lets the card *derive* from
+ * `feed.approvals` rather than being appended once and then going stale.
+ *
+ * Both kinds carry `at` so the two streams interleave on real time, which is
+ * the only ordering that reads correctly: the request appears where the
+ * conversation was when it was raised.
+ */
+export type TimelineItem =
+  | { kind: "message"; key: string; at: number; entry: TimelineEntry }
+  | {
+      kind: "approval";
+      key: string;
+      at: number;
+      approval: ApprovalSummary;
+      /**
+       * The verdict this console has witnessed for the card, if any.
+       *
+       * A decided approval leaves `feed.approvals` on the next refresh, so
+       * without this the card would simply vanish mid-glance — an abrupt
+       * unmount that reads as the request having been lost. Holding the
+       * witnessed verdict lets it settle into a terminal state instead.
+       */
+      decided: Verdict | null;
+    };
+
+/**
+ * Interleave a channel's messages and the approvals raised in it, oldest first.
+ *
+ * `approvals` is expected to be pre-filtered to this channel by the caller —
+ * the thread→channel mapping lives in the shell, which owns the desk list and
+ * the roster, and this module stays pure.
+ *
+ * A `decided` card is kept even once the feed has dropped it, so the operator
+ * sees their own decision land rather than the card disappearing.
+ */
+export function buildTimelineItems(
+  entries: TimelineEntry[],
+  approvals: ApprovalSummary[],
+  decided: Record<string, Verdict> = {},
+): TimelineItem[] {
+  const items: TimelineItem[] = entries.map((entry) => ({
+    kind: "message" as const,
+    key: entry.message.id,
+    at: entry.message.at,
+    entry,
+  }));
+  for (const approval of approvals) {
+    items.push({
+      kind: "approval",
+      key: `approval:${approval.id}`,
+      at: approval.at_millis,
+      approval,
+      decided: decided[approval.id] ?? null,
+    });
+  }
+  // Stable within a millisecond: a card raised by the very turn whose reply
+  // shares its timestamp should sit after that reply, not shuffle between
+  // renders. `sort` is stable in every engine this ships to, so equal `at`
+  // keeps insertion order — messages first, then cards.
+  return items.sort((a, b) => a.at - b.at);
 }
 
 /* ---- formatting ---- */

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -328,6 +328,21 @@ export function buildTimeline(messages: ChatMessage[], channel: Channel): Timeli
 }
 
 /**
+ * An approval this console has watched being decided (#379).
+ *
+ * The **summary is kept, not just the verdict**, and that is the whole point:
+ * the host drops a resolved approval from `GET …/approvals` immediately, so a
+ * console holding only the verdict has nothing left to draw and the card blinks
+ * out of the thread the moment it is decided — which reads as the request
+ * having been lost, not answered. Keeping the last-seen summary is what lets it
+ * settle in place instead.
+ */
+export interface DecidedApproval {
+  verdict: Verdict;
+  approval: ApprovalSummary;
+}
+
+/**
  * One row of a channel, which is no longer only a message (#379).
  *
  * A parked approval is a **distinct kind**, not a synthetic `ChatMessage`. It
@@ -372,7 +387,7 @@ export type TimelineItem =
 export function buildTimelineItems(
   entries: TimelineEntry[],
   approvals: ApprovalSummary[],
-  decided: Record<string, Verdict> = {},
+  decided: Record<string, DecidedApproval> = {},
 ): TimelineItem[] {
   const items: TimelineItem[] = entries.map((entry) => ({
     kind: "message" as const,
@@ -386,7 +401,7 @@ export function buildTimelineItems(
       key: `approval:${approval.id}`,
       at: approval.at_millis,
       approval,
-      decided: decided[approval.id] ?? null,
+      decided: decided[approval.id]?.verdict ?? null,
     });
   }
   // Stable within a millisecond: a card raised by the very turn whose reply

--- a/frontend/test/e2e/chat-inline-approval.spec.ts
+++ b/frontend/test/e2e/chat-inline-approval.spec.ts
@@ -1,0 +1,267 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+/**
+ * End-to-end proof for issue #379 — a request for sign-off is raised in the
+ * conversation that produced it, decided there, and the work visibly resumes
+ * there.
+ *
+ * Before this, an approval appeared only on a separate page, was decided in
+ * isolation, and whatever happened next happened somewhere the operator was not
+ * looking. Approving was an act of faith: a button greyed out, a toast
+ * appeared, and nothing in the thread said the work had continued.
+ *
+ * The approvals feed and the event stream are **mocked**, and deliberately so.
+ * Parking a real one needs a model that decides to make a policy-gated call,
+ * and none of what is under test here is the parking — it is the *placement*
+ * (which channel a card belongs to, and which it must not appear in), the
+ * *verb* (an inline decision must detach, or the continuation is delivered
+ * twice), and the *settling* (a decision made on the page must not leave a
+ * stale card offering buttons in the channel).
+ *
+ * Like the rest of `test/e2e` this needs a running host and is not a CI gate —
+ * the Playwright config declares no `webServer`.
+ */
+
+/** The harness manifest's two desks. A desk's id is both its channel id and its
+ * host thread id, which is exactly the coincidence a DM does not share. */
+const ENGINEERING = { id: "engineering", channel: "engineering-desk" };
+const CONTENT = { id: "content", channel: "content-desk" };
+
+/**
+ * A request raised in the Engineering channel. `thread` is the host thread id;
+ * everything else is the shape `GET …/approvals` answers with.
+ */
+const IN_ENGINEERING = {
+  id: "appr-inline-1",
+  kind: "payment.send",
+  amount_usd: 42.5,
+  at_millis: Date.now(),
+  task: { link: "unlinked" },
+  agent: "engineer",
+  payload: { to: "vendor@example.test", amount_usd: 42.5 },
+  thread: ENGINEERING.id,
+};
+
+/**
+ * A request with no conversation behind it — a workflow delivery or a scheduler
+ * tick. It carries no `thread`, so it must match no channel and live on the
+ * Approvals page alone. This is the additive half of the contract.
+ */
+const PAGE_ONLY = {
+  id: "appr-page-only",
+  kind: "email.send",
+  amount_usd: null,
+  at_millis: Date.now(),
+  task: { link: "unlinked" },
+};
+
+test.beforeEach(async ({ page }) => {
+  // Skip the first-run tour, whose modal would swallow the clicks below.
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+});
+
+/**
+ * Answer the approvals feed. Matched by suffix rather than by full path: the
+ * console addresses a *named* company while the host also answers a
+ * single-company alias, and a pattern pinned to one of them stops intercepting —
+ * silently — the moment the deployment shape changes.
+ */
+async function serveApprovals(page: Page, approvals: unknown[]) {
+  await page.route("**/approvals", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(approvals),
+    }),
+  );
+}
+
+async function openChannel(page: Page, channelId: string) {
+  await page.goto(`/#/chat/${channelId}`);
+  await expect(page.getByPlaceholder(/^Message /)).toBeVisible({ timeout: 30_000 });
+}
+
+/** The inline card for one approval, wherever it is rendered. */
+function card(page: Page, approvalId: string): Locator {
+  return page.locator(`[data-approval-id="${approvalId}"]`);
+}
+
+test("a request raised in a channel appears in that channel, and only there", async ({ page }) => {
+  await serveApprovals(page, [IN_ENGINEERING, PAGE_ONLY]);
+
+  await openChannel(page, ENGINEERING.id);
+  await expect(card(page, IN_ENGINEERING.id)).toBeVisible({ timeout: 30_000 });
+  // Told in full, the same as on the page — the payload is the thing being
+  // consented to, so a card without it asks for a blind signature.
+  await expect(card(page, IN_ENGINEERING.id)).toContainText("vendor@example.test");
+
+  // The trap, in both directions. A card belongs to the conversation that
+  // raised it; a desk channel and a DM to its lead resolve to the same agent,
+  // so a console placing cards by asker would leak one into the other.
+  await openChannel(page, CONTENT.id);
+  await expect(card(page, IN_ENGINEERING.id)).toHaveCount(0);
+
+  // And the approval no conversation produced is in neither channel.
+  await expect(card(page, PAGE_ONLY.id)).toHaveCount(0);
+  await openChannel(page, ENGINEERING.id);
+  await expect(card(page, PAGE_ONLY.id)).toHaveCount(0);
+});
+
+test("the Approvals page still shows everything, including the inline one", async ({ page }) => {
+  // Inline is an addition, not a replacement. The page is the one surface that
+  // must never filter — an approval that reached no channel has to be somewhere.
+  await serveApprovals(page, [IN_ENGINEERING, PAGE_ONLY]);
+
+  await page.goto("/#/approvals");
+  await expect(page.getByText("2 things need your approval")).toBeVisible({ timeout: 30_000 });
+});
+
+test("deciding inline detaches, and the continuation lands in the same channel", async ({
+  page,
+}) => {
+  await serveApprovals(page, [IN_ENGINEERING]);
+
+  // Capture the resolve body: an inline decision MUST send `detach: true`.
+  // Without it the host answers with the follow-up turn's replies *and* pushes
+  // the same reply over SSE, so the continuation reaches the channel twice.
+  const bodies: unknown[] = [];
+  await page.route("**/approvals/*", (route) => {
+    bodies.push(route.request().postDataJSON());
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ recorded: true, alreadyResolved: false }),
+    });
+  });
+
+  // The continuation, as the host would push it: an `agent_reply` on the desk
+  // thread the approval was raised in. This is the assertion the whole issue
+  // turns on — approving visibly causes the next thing to happen, in the place
+  // the operator was already reading.
+  const CONTINUATION = "Paid the vendor invoice.";
+  await page.route("**/events", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream", "cache-control": "no-cache" },
+      body:
+        `data: ${JSON.stringify({
+          type: "agent_reply",
+          seq: 1,
+          atMillis: Date.now(),
+          chatId: ENGINEERING.id,
+          agentId: "engineer",
+          text: CONTINUATION,
+        })}\n\n`,
+    }),
+  );
+
+  await openChannel(page, ENGINEERING.id);
+  await card(page, IN_ENGINEERING.id).getByRole("button", { name: "Approve" }).click();
+
+  await expect
+    .poll(() => bodies.length, { timeout: 30_000 })
+    .toBeGreaterThan(0);
+  expect(bodies[0]).toMatchObject({ verdict: "approve", detach: true });
+
+  // The card settles rather than vanishing, so the decision visibly lands.
+  await expect(card(page, IN_ENGINEERING.id)).toContainText(
+    /Approved — the agent is completing the action/,
+    { timeout: 30_000 },
+  );
+  // And the work resumes here, exactly once.
+  await expect(page.getByText(CONTINUATION)).toHaveCount(1, { timeout: 30_000 });
+});
+
+test("declining inline says so in the thread rather than leaving it stalled", async ({ page }) => {
+  await serveApprovals(page, [IN_ENGINEERING]);
+  await page.route("**/approvals/*", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ recorded: true, alreadyResolved: false }),
+    }),
+  );
+
+  await openChannel(page, ENGINEERING.id);
+  await card(page, IN_ENGINEERING.id).getByRole("button", { name: "Decline" }).click();
+
+  // A decline is terminal and produces no continuation, so silence would read
+  // as a stall. The line is addressed to this channel, not to "wherever the
+  // operator last looked".
+  await expect(
+    page.getByText(/Declined — the agent will not take that action/),
+  ).toBeVisible({ timeout: 30_000 });
+});
+
+test("a decision made on the Approvals page settles the inline card, with no reload", async ({
+  page,
+}) => {
+  await serveApprovals(page, [IN_ENGINEERING]);
+
+  // The host's resolution frame, as another surface (the page, another tab)
+  // would produce it. The inline card has to stop offering buttons for a
+  // decision that is already made.
+  await page.route("**/events", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream", "cache-control": "no-cache" },
+      body:
+        `data: ${JSON.stringify({
+          type: "approval_resolved",
+          seq: 1,
+          atMillis: Date.now(),
+          approvalId: IN_ENGINEERING.id,
+          verdict: "approve",
+        })}\n\n`,
+    }),
+  );
+
+  await openChannel(page, ENGINEERING.id);
+
+  await expect(card(page, IN_ENGINEERING.id)).toContainText(
+    /Approved — the agent is completing the action/,
+    { timeout: 30_000 },
+  );
+  await expect(card(page, IN_ENGINEERING.id).getByRole("button", { name: "Approve" })).toHaveCount(
+    0,
+  );
+});
+
+test("a parked approval raises its card live, without a reload", async ({ page }) => {
+  // The feed is empty when the channel opens; the park frame is what makes the
+  // console re-read it. That round trip is the design: the frame is thin on
+  // purpose (no payload, no asker), so the card's content can only come from
+  // the one place the host redacts.
+  let served = 0;
+  await page.route("**/approvals", (route) => {
+    served += 1;
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(served <= 1 ? [] : [IN_ENGINEERING]),
+    });
+  });
+  await page.route("**/events", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream", "cache-control": "no-cache" },
+      body:
+        `data: ${JSON.stringify({
+          type: "approval_parked",
+          seq: 1,
+          atMillis: Date.now(),
+          approvalId: IN_ENGINEERING.id,
+          kind: IN_ENGINEERING.kind,
+          chatId: ENGINEERING.id,
+        })}\n\n`,
+    }),
+  );
+
+  await openChannel(page, ENGINEERING.id);
+  await expect(card(page, IN_ENGINEERING.id)).toBeVisible({ timeout: 30_000 });
+});

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -59,6 +59,20 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             task.to_string(),
             "a2a.task_received",
         ),
+        // Issue #379: the brain is told a request is now waiting, so it can
+        // reason about being blocked rather than only learning when the verdict
+        // arrives. The kind is the effect's type name; the payload is not here
+        // and never should be — the operator has not consented to it yet.
+        CompanyEvent::ApprovalParked {
+            approval_id,
+            effect_kind,
+            ..
+        } => (
+            Role::System,
+            "approvals".to_string(),
+            format!("parked {effect_kind} approval {approval_id}"),
+            "approval.parked",
+        ),
         CompanyEvent::ApprovalResolved {
             approval_id,
             verdict,

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -1007,6 +1007,7 @@ impl CompanyRuntime {
                 task: p.task,
                 agent: p.effect.agent.clone(),
                 payload: crate::runtime::approval_display::display_payload(&p.effect),
+                thread: p.thread,
             })
             .collect()
     }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -210,15 +210,28 @@ impl HarnessBrain {
         // the thread from the event log, and without this the operator would
         // approve, watch the agent answer, refresh, and find the answer gone.
         //
-        // `chat_id` is the AGENT id (not the approval id) so `chat_history::owns`
-        // routes it into that desk's thread — the same thread the original
-        // request came from, which is where the operator is looking.
+        // `chat_id` is the thread the approval was RAISED in (issue #379), not
+        // the agent id. Those agree for a direct message and diverge for a desk
+        // channel — a channel's request and a DM to that channel's lead are
+        // answered by the same teammate — so keying on the agent quietly
+        // delivered a channel's continuation into the lead's private line. The
+        // operator approved in one place and the work resumed in another they
+        // were not looking at, which is the whole failure this issue names.
+        //
+        // Falls back to the agent when the grant carries no origin thread: a
+        // pre-#379 journal line, or an approval with no conversation behind it.
+        // That is exactly the previous behaviour, kept for exactly the cases it
+        // was already right for.
+        let reply_thread = grant
+            .origin_thread
+            .clone()
+            .unwrap_or_else(|| grant.agent.clone());
         if let Some(events) = self.deps.events.as_ref()
             && let Err(err) = events
                 .append(
                     &self.record.id,
                     CompanyEvent::AgentReply {
-                        chat_id: grant.agent.clone(),
+                        chat_id: reply_thread.clone(),
                         agent_id: grant.agent.clone(),
                         text: text.clone(),
                         steps: Vec::new(),
@@ -3799,6 +3812,88 @@ members = ["eng1", "eng2"]
         );
         assert_eq!(replies[0].1, "ceo");
         assert_eq!(replies[0].2, bubble.text);
+    }
+
+    /// Issue #379, and a live bug before it: the continuation must be journaled
+    /// into the thread the operator **asked in**, not the agent's own line.
+    ///
+    /// The two are the same string for a direct message and diverge for a desk
+    /// channel — the channel and a DM to that channel's lead are answered by the
+    /// same teammate — so keying on the agent quietly delivered a channel's
+    /// continuation into the lead's private DM. The operator approved in one
+    /// place and the work resumed somewhere they were not looking.
+    ///
+    /// Asserted in **both directions**, because one alone would pass on a
+    /// mistake: a desk-origin reply must not appear in the lead's DM history,
+    /// and a DM-origin reply must not appear in the desk's.
+    #[tokio::test]
+    async fn a_redeemed_grant_replies_in_the_thread_the_approval_was_raised_in() {
+        async fn replies_for(origin: Option<&str>) -> Vec<(String, String)> {
+            let dir = tempfile::tempdir().unwrap();
+            let log: Arc<dyn crate::ports::EventLog> =
+                Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf()));
+            let requests = crate::harness::policy::ApprovalRequestQueue::default();
+            requests
+                .grants()
+                .grant(crate::runtime::grants::GrantedCall {
+                    approval_id: ApprovalId::new("appr-1"),
+                    agent: "ceo".into(),
+                    tool: "composio_execute".into(),
+                    args: serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
+                    at_millis: now_millis(),
+                    origin_thread: origin.map(str::to_string),
+                });
+            let brain = brain_with_queue_and_events(dir.path(), requests, log.clone());
+            brain
+                .run_cycle(
+                    cycle_over(vec![approval_resolved("appr-1", Verdict::Approve)]),
+                    &NoopHost,
+                )
+                .await
+                .expect("cycle runs");
+            log.read_from(&CompanyId::new("acme"), crate::ports::EventSeq::new(0), 100)
+                .await
+                .unwrap()
+                .iter()
+                .filter_map(|e| match &e.event {
+                    CompanyEvent::AgentReply {
+                        chat_id, agent_id, ..
+                    } => Some((chat_id.clone(), agent_id.clone())),
+                    _ => None,
+                })
+                .collect()
+        }
+
+        // Raised in a desk channel: the continuation belongs to the channel.
+        let desk = replies_for(Some("desk-finance")).await;
+        assert_eq!(desk.len(), 1);
+        assert_eq!(
+            desk[0].0, "desk-finance",
+            "a channel's approval must resume in that channel",
+        );
+        assert_ne!(
+            desk[0].0, "ceo",
+            "and must NOT land in the desk lead's private DM — the bug this fixes",
+        );
+        // The asker is still credited: only the destination changed.
+        assert_eq!(desk[0].1, "ceo");
+
+        // Raised in a direct message with that same lead: the mirror image. Same
+        // agent, different thread, and the desk channel must not see it.
+        let dm = replies_for(Some("ceo")).await;
+        assert_eq!(dm.len(), 1);
+        assert_eq!(dm[0].0, "ceo");
+        assert_ne!(
+            dm[0].0, "desk-finance",
+            "a private line's approval must not resume in the desk channel",
+        );
+
+        // No origin thread — a pre-#379 grant, or an approval with no
+        // conversation behind it. Falls back to the agent, which is exactly the
+        // previous behaviour, kept for the cases it was already right for.
+        let legacy = replies_for(None).await;
+        assert_eq!(legacy.len(), 1);
+        assert_eq!(legacy[0].0, "ceo");
     }
 
     /// A DENIED approval runs no turn. "No" must never re-dispatch anything.

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -3740,6 +3740,7 @@ members = ["eng1", "eng2"]
                 tool: "composio_execute".into(),
                 args: args.clone(),
                 at_millis: now_millis(),
+                origin_thread: None,
             });
         let brain = brain_with_queue_and_events(dir.path(), requests, log.clone());
 
@@ -3817,6 +3818,7 @@ members = ["eng1", "eng2"]
                 tool: "composio_execute".into(),
                 args: serde_json::json!({}),
                 at_millis: now_millis(),
+                origin_thread: None,
             });
         let brain = brain_with_queue_and_events(dir.path(), requests, log.clone());
 

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -549,6 +549,16 @@ fn summarize_event(event: &CompanyEvent) -> String {
         // into what is a pure function over one event — real coupling for a
         // non-load-bearing insight string. The id is carried instead, which is
         // enough to correlate against the approvals surface and costs nothing.
+        // Issue #379. Same reasoning as the resolution arm below: the id, and
+        // only the id, plus the effect's dotted kind — which is a type name, not
+        // a payload. The thread it was raised in is deliberately not named: a
+        // thread id is a desk or a roster agent, and this string is a
+        // non-sensitive one-liner, not a routing surface.
+        CompanyEvent::ApprovalParked {
+            approval_id,
+            effect_kind,
+            ..
+        } => format!("approval {approval_id} parked ({effect_kind})"),
         CompanyEvent::ApprovalResolved {
             approval_id,
             verdict,

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -1475,6 +1475,7 @@ mod tests {
             tool: tool.to_string(),
             args,
             at_millis: 1_000,
+            origin_thread: None,
         }
     }
 
@@ -1679,6 +1680,7 @@ mod tests {
             tool: "composio_execute".into(),
             args: args.clone(),
             at_millis: 1_000,
+            origin_thread: None,
         });
 
         queue.clear();

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -260,6 +260,41 @@ pub enum CompanyEvent {
         /// The task payload.
         task: serde_json::Value,
     },
+    /// An effect was parked for the operator's sign-off (issue #379).
+    ///
+    /// The counterpart to [`ApprovalResolved`](Self::ApprovalResolved), and the
+    /// reason it exists: parking was journal-only, so a console learned about a
+    /// new request only when its feed next polled — far too late to raise the
+    /// request inside the conversation that produced it.
+    ///
+    /// **Deliberately thin.** An id, a dotted kind, and the thread it came from
+    /// — no payload, no asker. The parked effect's arguments are redacted and
+    /// bounded exactly once, in
+    /// [`pending_approvals`](crate::company::CompanyRuntime::pending_approvals),
+    /// and putting them on a durable event would open a second surface that has
+    /// to redact. A reader reacts to this by re-reading the approvals feed,
+    /// which is where the safe projection lives.
+    ApprovalParked {
+        /// The approval now awaiting the operator.
+        approval_id: ApprovalId,
+        /// The parked effect's dotted kind, e.g. `payment.send`. Enough for a
+        /// reader to decide whether it cares before it re-reads the feed.
+        ///
+        /// Named `effect_kind` rather than `kind` because `CompanyEvent` is
+        /// serialized internally-tagged **under `kind`** — a variant field of
+        /// that name collides with the tag and does not compile. The projected
+        /// SSE frame calls it `kind` regardless: that envelope discriminates on
+        /// `type`, so the short name is free there.
+        effect_kind: String,
+        /// The chat thread the parking cycle was answering — a desk id for a
+        /// channel, a roster agent id for a direct message.
+        ///
+        /// `None` when no conversation produced it (a workflow delivery, a
+        /// scheduler tick, an ambiguous batch), which is also every park
+        /// journaled before this existed. Omitted from the wire when absent.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        thread: Option<String>,
+    },
     /// An operator resolved a parked approval.
     ApprovalResolved {
         /// The approval that was resolved.

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1100,10 +1100,9 @@ fn cycle_thread_id(
             // (`chat: None`) went to the orchestrator with no conversation of its
             // own — a rival, not a neutral pass-through, for the same reason a
             // non-card turn rivals a card above.
-            CompanyEvent::OperatorMessage { chat, .. } => match chat {
-                Some(chat) => Some(chat.clone()),
-                None => return None,
-            },
+            // `?` rather than a match: an unaddressed message short-circuits the
+            // whole scan to `None`, which is the rival behaviour described above.
+            CompanyEvent::OperatorMessage { chat, .. } => Some(chat.as_ref()?.clone()),
             CompanyEvent::ApprovalResolved { approval_id, .. } => {
                 match approval_thread(approval_id) {
                     // Resolved an approval raised in a conversation: this cycle

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -209,6 +209,9 @@ impl<'a> CycleRunner<'a> {
             // never pruned, and a cycle needs the link for at most the couple of
             // `ApprovalResolved` ids in its own batch.
             cycle_task_id(&request.events, |id| self.rt.journal.approval_task(id)),
+            // Issue #379: and which conversation, on the same terms — read off
+            // the same trigger events, from the same retained origins.
+            cycle_thread_id(&request.events, |id| self.rt.journal.approval_thread(id)),
         );
         let result = self.rt.brain.run_cycle(request, &host).await;
         // Issue #242: the terminality backstop. Whatever the brain did — settled
@@ -580,6 +583,11 @@ working on):\n{}\n]",
             // policy's match "the exact call the operator saw".
             args: effect.payload.clone(),
             at_millis: now_millis(),
+            // Issue #379: where the operator asked, carried onto the grant so
+            // the re-dispatched turn's reply lands back in that conversation.
+            // Read off the retained origin, not this call's caller — an approval
+            // is resolved from a surface that knows only an id.
+            origin_thread: self.rt.journal.approval_thread(id).flatten(),
         };
         self.rt.journal.record_granted(&grant).await?;
         self.rt.grants.grant(grant);
@@ -1014,8 +1022,14 @@ fn cycle_task_id(
             // Records of something that already happened, not triggers for new
             // work: they neither name a card nor compete with one, so they pass
             // through without affecting the stamp.
+            //
+            // `ApprovalParked` (issue #379) is emphatically a record: it is
+            // *this* function's own output reaching the log, appended after the
+            // park it describes. Treating it as a trigger would make a cycle
+            // that parks twice disqualify its own second stamp.
             CompanyEvent::LifecycleChanged { .. }
             | CompanyEvent::AgentReply { .. }
+            | CompanyEvent::ApprovalParked { .. }
             | CompanyEvent::MemoryFactDeleted { .. }
             | CompanyEvent::McpCallFailed { .. }
             | CompanyEvent::WorkflowCreated { .. }
@@ -1026,6 +1040,103 @@ fn cycle_task_id(
             // a workflow walking its graph, not stimuli for a new cycle. They
             // name no card and compete with none, so they pass through exactly
             // like the run outcome they bracket.
+            | CompanyEvent::WorkflowRunStarted { .. }
+            | CompanyEvent::WorkflowNodeFinished { .. }
+            | CompanyEvent::TaskSteered { .. }
+            | CompanyEvent::TaskDiscussionPosted { .. }
+            | CompanyEvent::DeskTaskCompleted { .. } => continue,
+        };
+        let Some(candidate) = candidate else { continue };
+        match &found {
+            Some(existing) if existing != &candidate => return None,
+            Some(_) => {}
+            None => found = Some(candidate),
+        }
+    }
+    found
+}
+
+/// The chat thread a cycle is answering, read off its own trigger events
+/// (issue #379) — the correlation key every approval this cycle parks carries,
+/// and the one thing that lets a request be raised in the conversation that
+/// produced it.
+///
+/// The sibling of [`cycle_task_id`], and deliberately the same shape, because
+/// it is the same problem one axis over: a cycle is the unit of batching, not
+/// of conversation, and stamping an approval with a thread it did not come from
+/// puts a private request into a channel (or a channel's into a private line).
+///
+/// Two ways a cycle belongs to a thread, and both are a real id:
+///
+/// * an [`OperatorMessage`](CompanyEvent::OperatorMessage) carrying `chat` —
+///   the desk id for a channel, the roster agent id for a direct message. That
+///   field is precisely the disambiguator [`Effect::agent`] cannot be: a desk
+///   channel and a DM to that desk's lead are answered by the same agent and
+///   are **different strings** here;
+/// * an [`ApprovalResolved`](CompanyEvent::ApprovalResolved) event whose
+///   approval was itself parked in a thread. Approving a gated tool call
+///   re-dispatches the agent (issue #243), and if that follow-up turn needs a
+///   *second* sign-off, the re-park belongs in the channel the first one was
+///   asked in — not nowhere.
+///
+/// **An ambiguous batch yields `None`**, and an unaddressed operator message is
+/// itself a rival: it names no thread, so a batch holding one plus an addressed
+/// message cannot say which conversation a parked effect came from. As with
+/// `cycle_task_id`, no stamp means "no channel owns this", which lands the
+/// approval on the Approvals page alone — today's behaviour, and never a guess.
+///
+/// The match is **exhaustive on purpose** — no wildcard. Every variant is one
+/// of: names a thread, rivals a thread, or is a record of something that
+/// already happened. A new *inbound trigger* silently defaulting to "harmless"
+/// is exactly how a request leaks into the wrong conversation.
+fn cycle_thread_id(
+    events: &[CompanyEvent],
+    approval_thread: impl Fn(&ApprovalId) -> Option<Option<String>>,
+) -> Option<String> {
+    let mut found: Option<String> = None;
+    for event in events {
+        let candidate = match event {
+            // The one event that names a thread outright. An unaddressed message
+            // (`chat: None`) went to the orchestrator with no conversation of its
+            // own — a rival, not a neutral pass-through, for the same reason a
+            // non-card turn rivals a card above.
+            CompanyEvent::OperatorMessage { chat, .. } => match chat {
+                Some(chat) => Some(chat.clone()),
+                None => return None,
+            },
+            CompanyEvent::ApprovalResolved { approval_id, .. } => {
+                match approval_thread(approval_id) {
+                    // Resolved an approval raised in a conversation: this cycle
+                    // continues that conversation's work.
+                    Some(Some(thread)) => Some(thread),
+                    // Known to have come from no conversation — a rival turn,
+                    // so the batch is ambiguous.
+                    Some(None) => return None,
+                    // No origin recorded at all: nothing is claimed either way,
+                    // so it neither stamps nor blocks.
+                    None => continue,
+                }
+            }
+            // Inbound triggers that are their own work, riding the same batch as
+            // an addressed chat turn. Their parked effects are not that
+            // conversation's.
+            CompanyEvent::TaskDispatched { .. }
+            | CompanyEvent::WebhookReceived { .. }
+            | CompanyEvent::ScheduleFired { .. }
+            | CompanyEvent::A2aTaskReceived { .. }
+            | CompanyEvent::PaymentReceived { .. }
+            | CompanyEvent::FeedbackFiled { .. } => return None,
+            // Records of something that already happened, not stimuli for new
+            // work: they name no thread and compete with none.
+            CompanyEvent::LifecycleChanged { .. }
+            | CompanyEvent::AgentReply { .. }
+            | CompanyEvent::ApprovalParked { .. }
+            | CompanyEvent::MemoryFactDeleted { .. }
+            | CompanyEvent::McpCallFailed { .. }
+            | CompanyEvent::WorkflowCreated { .. }
+            | CompanyEvent::WorkflowUpdated { .. }
+            | CompanyEvent::WorkflowDeleted { .. }
+            | CompanyEvent::WorkflowRunFinished { .. }
             | CompanyEvent::WorkflowRunStarted { .. }
             | CompanyEvent::WorkflowNodeFinished { .. }
             | CompanyEvent::TaskSteered { .. }
@@ -1060,6 +1171,16 @@ struct CycleHostImpl<'a> {
     /// delegated to, an email it tried to send — the approval belongs to the
     /// task whose dispatch opened this cycle, and to no other.
     task_id: Option<String>,
+    /// The chat thread this cycle is answering, when it is answering one
+    /// (issue #379) — stamped onto every approval the cycle parks, and what
+    /// lets the request be raised in that conversation instead of only on the
+    /// Approvals page.
+    ///
+    /// Computed once, from the cycle's own trigger events, by
+    /// [`cycle_thread_id`]. `None` for a cycle with no conversation behind it (a
+    /// dispatched card, a scheduler tick, a workflow delivery) and for an
+    /// ambiguous batch — both of which leave the approval where it is today.
+    thread_id: Option<String>,
 }
 
 impl<'a> CycleHostImpl<'a> {
@@ -1068,6 +1189,7 @@ impl<'a> CycleHostImpl<'a> {
         cycle_id: String,
         rt: &'a CompanyRuntime,
         task_id: Option<String>,
+        thread_id: Option<String>,
     ) -> Self {
         Self {
             company,
@@ -1077,6 +1199,7 @@ impl<'a> CycleHostImpl<'a> {
             executed: StdMutex::new(Vec::new()),
             parked: StdMutex::new(Vec::new()),
             task_id,
+            thread_id,
         }
     }
 
@@ -1132,8 +1255,45 @@ impl<'a> CycleHostImpl<'a> {
                 &effect,
                 now_millis(),
                 TaskLink::from_task_id(self.task_id.as_deref()),
+                self.thread_id.clone(),
             )
             .await?;
+        // Issue #379: tell every subscribed console a request just parked, so an
+        // inline card can appear in the conversation *as it happens* rather than
+        // on the next poll of the approvals feed.
+        //
+        // Strictly **after** the journal write, and best-effort — the same
+        // division `sweep_expired_approvals` draws. The journal is the binding
+        // record of what is parked; the event is an advisory nudge, and a failed
+        // log write must not undo a park that already happened (the queue would
+        // then hold an effect no record describes). A console that misses the
+        // frame still sees the approval on its next feed refresh.
+        //
+        // Deliberately **thin**: an id, a kind and a thread. The payload is not
+        // here because `pending_approvals()` is the single place #372's
+        // host-side redaction runs, and a payload-bearing durable event would
+        // open a second surface that has to redact — and eventually will not.
+        // The console reacts by refreshing the feed and renders from the
+        // redacted summary. One round trip, on purpose.
+        if let Err(err) = self
+            .rt
+            .events
+            .append(
+                &self.company,
+                CompanyEvent::ApprovalParked {
+                    approval_id: approval_id.clone(),
+                    effect_kind: effect.kind.clone(),
+                    thread: self.thread_id.clone(),
+                },
+            )
+            .await
+        {
+            tracing::warn!(
+                approval_id = %approval_id,
+                error = %err,
+                "approval parked and journaled, but its event-log entry failed",
+            );
+        }
         self.parked
             .lock()
             .expect("parked poisoned")
@@ -1144,6 +1304,7 @@ impl<'a> CycleHostImpl<'a> {
             approval_id = %approval_id,
             cycle = %self.cycle_id,
             task = self.task_id.as_deref().unwrap_or("-"),
+            thread = self.thread_id.as_deref().unwrap_or("-"),
             "[cycle] parked effect for operator approval"
         );
         Ok(approval_id)
@@ -2437,6 +2598,7 @@ mod test {
             tool: "composio_execute".into(),
             args: serde_json::json!({ "to": "a@b.test" }),
             at_millis: 0,
+            origin_thread: None,
         });
         // A fresh one, to prove the sweep is selective rather than a flush.
         rt.grants.grant(GrantedCall {
@@ -2445,6 +2607,7 @@ mod test {
             tool: "workspace_write".into(),
             args: serde_json::json!({}),
             at_millis: now_millis(),
+            origin_thread: None,
         });
 
         let expired = rt.sweep_expired_grants().await.unwrap();
@@ -3188,7 +3351,13 @@ mod test {
         };
         let approval_id = rt.approvals.park(rt.id(), effect.clone()).await.unwrap();
         rt.journal
-            .record_parked(&approval_id, &effect, now_millis(), TaskLink::Unlinked)
+            .record_parked(
+                &approval_id,
+                &effect,
+                now_millis(),
+                TaskLink::Unlinked,
+                None,
+            )
             .await
             .unwrap();
 
@@ -3255,7 +3424,13 @@ mod test {
         };
         let approval_id = rt.approvals.park(rt.id(), effect.clone()).await.unwrap();
         rt.journal
-            .record_parked(&approval_id, &effect, now_millis(), TaskLink::Unlinked)
+            .record_parked(
+                &approval_id,
+                &effect,
+                now_millis(),
+                TaskLink::Unlinked,
+                None,
+            )
             .await
             .unwrap();
 
@@ -3305,7 +3480,7 @@ mod test {
                 .unwrap();
             let id = rt.approvals.park(rt.id(), effect.clone()).await.unwrap();
             rt.journal
-                .record_parked(&id, &effect, now_millis(), TaskLink::Unlinked)
+                .record_parked(&id, &effect, now_millis(), TaskLink::Unlinked, None)
                 .await
                 .unwrap();
             id
@@ -3424,7 +3599,7 @@ mod test {
             .build()
             .await
             .unwrap();
-        let host = CycleHostImpl::new(rt.id().clone(), "cyc-nomail".into(), &rt, None);
+        let host = CycleHostImpl::new(rt.id().clone(), "cyc-nomail".into(), &rt, None, None);
 
         let res = host
             .send_email(serde_json::json!({ "to": "x@ext.com", "subject": "s", "body": "b" }))
@@ -3447,7 +3622,7 @@ mod test {
             .build()
             .await
             .unwrap();
-        let host = CycleHostImpl::new(rt.id().clone(), "cyc-bad".into(), &rt, None);
+        let host = CycleHostImpl::new(rt.id().clone(), "cyc-bad".into(), &rt, None, None);
 
         let res = host
             .send_email(serde_json::json!({ "subject": "s", "body": "b" }))
@@ -3470,7 +3645,7 @@ mod test {
             .build()
             .await
             .unwrap();
-        let host = CycleHostImpl::new(rt.id().clone(), "cyc-park".into(), &rt, None);
+        let host = CycleHostImpl::new(rt.id().clone(), "cyc-park".into(), &rt, None, None);
 
         let res = host
             .send_email(serde_json::json!({ "to": "new@ext.com", "subject": "s", "body": "b" }))
@@ -3500,6 +3675,7 @@ mod test {
             "cyc-task".into(),
             &rt,
             Some("t-42".to_string()),
+            None,
         );
 
         // A cold recipient parks — the same path a card's turn takes.
@@ -3547,7 +3723,7 @@ mod test {
             .build()
             .await
             .unwrap();
-        let host = CycleHostImpl::new(rt.id().clone(), "cyc-chat".into(), &rt, None);
+        let host = CycleHostImpl::new(rt.id().clone(), "cyc-chat".into(), &rt, None, None);
 
         host.send_email(serde_json::json!({ "to": "new@ext.com", "subject": "s", "body": "b" }))
             .await
@@ -3559,6 +3735,110 @@ mod test {
             pending[0].task,
             Some(TaskLink::Unlinked),
             "an unlinked park must say so, not leave the link absent",
+        );
+    }
+
+    /// Issue #379: an effect parked by a desk channel's turn carries that
+    /// channel onto the summary the console reads, **and** announces itself on
+    /// the event log so an inline card can appear without waiting for a poll.
+    #[tokio::test]
+    async fn a_chat_cycle_stamps_its_thread_and_announces_the_park() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let sender = Arc::new(RecordingMailSender::new());
+        let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
+            .with_mail(CompanyMail {
+                sender: sender.clone(),
+                smtp: test_smtp("ceo@acme.test"),
+            })
+            .build()
+            .await
+            .unwrap();
+        let host = CycleHostImpl::new(
+            rt.id().clone(),
+            "cyc-thread".into(),
+            &rt,
+            None,
+            Some("desk-finance".to_string()),
+        );
+
+        host.send_email(serde_json::json!({ "to": "new@ext.com", "subject": "s", "body": "b" }))
+            .await
+            .unwrap();
+
+        let pending = rt.pending_approvals();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(
+            pending[0].thread,
+            Some("desk-finance".to_string()),
+            "the parked approval must name the conversation that asked for it",
+        );
+
+        let logged = rt
+            .events()
+            .read_from(rt.id(), EventSeq::new(0), 50)
+            .await
+            .unwrap();
+        let parked: Vec<_> = logged
+            .iter()
+            .filter_map(|e| match &e.event {
+                CompanyEvent::ApprovalParked {
+                    approval_id,
+                    effect_kind,
+                    thread,
+                } => Some((approval_id.clone(), effect_kind.clone(), thread.clone())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(parked.len(), 1, "exactly one park announcement: {logged:?}");
+        assert_eq!(parked[0].0, pending[0].id);
+        assert_eq!(parked[0].1, "email.send");
+        assert_eq!(parked[0].2, Some("desk-finance".to_string()));
+    }
+
+    /// The same park with no conversation behind it announces itself with **no
+    /// thread**, which is what keeps it Approvals-page-only. Inline is additive,
+    /// never a replacement (#379).
+    #[tokio::test]
+    async fn a_threadless_park_announces_itself_without_a_channel() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let sender = Arc::new(RecordingMailSender::new());
+        let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
+            .with_mail(CompanyMail {
+                sender: sender.clone(),
+                smtp: test_smtp("ceo@acme.test"),
+            })
+            .build()
+            .await
+            .unwrap();
+        let host = CycleHostImpl::new(rt.id().clone(), "cyc-none".into(), &rt, None, None);
+
+        host.send_email(serde_json::json!({ "to": "new@ext.com", "subject": "s", "body": "b" }))
+            .await
+            .unwrap();
+
+        let pending = rt.pending_approvals();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].thread, None);
+        // And it is omitted from the serialized summary entirely, so an older
+        // console sees the wire shape it already knows.
+        let wire = serde_json::to_value(&pending[0]).unwrap();
+        assert!(
+            wire.get("thread").is_none(),
+            "an approval with no conversation must not carry an empty thread key: {wire}",
+        );
+
+        let logged = rt
+            .events()
+            .read_from(rt.id(), EventSeq::new(0), 50)
+            .await
+            .unwrap();
+        assert!(
+            logged
+                .iter()
+                .any(|e| matches!(&e.event, CompanyEvent::ApprovalParked { thread: None, .. })),
+            "the park is still announced, it simply names no channel: {logged:?}",
         );
     }
 
@@ -3706,6 +3986,177 @@ mod test {
         );
     }
 
+    /// The conversation key (#379): which chat thread a cycle is answering, read
+    /// off its own trigger events.
+    ///
+    /// The trap this exists to close is the one `Effect::agent` cannot: a desk
+    /// channel and a direct message to that desk's lead are answered by the same
+    /// teammate and are **different threads**. `OperatorMessage.chat` is the only
+    /// field that tells them apart, which is why the stamp is read from there.
+    #[test]
+    fn cycle_thread_id_reads_an_addressed_message_inherits_a_resolution_and_refuses_to_guess() {
+        use crate::ports::types::{Actor, ActorKind, ApprovalId, Verdict};
+
+        // The lookup a live cycle does per id, stubbed: `appr-desk` was raised in
+        // a desk channel, `appr-dm` in a direct message, `appr-none` had no
+        // conversation behind it (or is a pre-#379 line — the same answer, on
+        // purpose), and anything else has no origin at all.
+        let approval_thread = |id: &ApprovalId| match id.as_ref() {
+            "appr-desk" => Some(Some("desk-finance".to_string())),
+            "appr-dm" => Some(Some("agent-cfo".to_string())),
+            "appr-none" => Some(None),
+            _ => None,
+        };
+        let addressed = |chat: &str| CompanyEvent::OperatorMessage {
+            text: "pay the invoice".into(),
+            by: None,
+            chat: Some(chat.to_string()),
+        };
+        let unaddressed = || CompanyEvent::OperatorMessage {
+            text: "hi".into(),
+            by: None,
+            chat: None,
+        };
+        let resolved = |id: &str| CompanyEvent::ApprovalResolved {
+            approval_id: ApprovalId::new(id),
+            verdict: Verdict::Approve,
+            by: Actor {
+                kind: ActorKind::Operator,
+                id: "owner".into(),
+            },
+        };
+        let dispatched = || CompanyEvent::TaskDispatched {
+            task_id: "t-1".into(),
+            run_id: None,
+        };
+
+        // An addressed message names the thread outright.
+        assert_eq!(
+            cycle_thread_id(&[addressed("desk-finance")], approval_thread),
+            Some("desk-finance".into()),
+        );
+        // The whole point, stated as an assertion: the desk channel and a DM to
+        // that desk's lead are different stamps, even though the same agent
+        // answers both.
+        assert_eq!(
+            cycle_thread_id(&[addressed("agent-cfo")], approval_thread),
+            Some("agent-cfo".into()),
+        );
+        // A follow-up cycle inherits the thread from the approval it resolves, so
+        // a turn needing a second sign-off re-parks in the same channel.
+        assert_eq!(
+            cycle_thread_id(&[resolved("appr-desk")], approval_thread),
+            Some("desk-finance".into()),
+        );
+        assert_eq!(
+            cycle_thread_id(&[resolved("appr-dm")], approval_thread),
+            Some("agent-cfo".into()),
+        );
+        // An approval with no origin at all claims nothing — and does not block.
+        assert_eq!(
+            cycle_thread_id(
+                &[resolved("appr-unknown"), addressed("desk-finance")],
+                approval_thread
+            ),
+            Some("desk-finance".into()),
+        );
+        // An unaddressed message went to the orchestrator with no conversation of
+        // its own. It is a rival, not a pass-through.
+        assert_eq!(cycle_thread_id(&[unaddressed()], approval_thread), None);
+        assert_eq!(
+            cycle_thread_id(&[addressed("desk-finance"), unaddressed()], approval_thread),
+            None,
+            "an unaddressed turn batched with an addressed one must not borrow its channel",
+        );
+        // Two different threads in one batch: refuse rather than raise one
+        // conversation's request inside the other.
+        assert_eq!(
+            cycle_thread_id(
+                &[addressed("desk-finance"), addressed("agent-cfo")],
+                approval_thread,
+            ),
+            None,
+        );
+        // The same thread twice is not ambiguous.
+        assert_eq!(
+            cycle_thread_id(
+                &[addressed("desk-finance"), resolved("appr-desk")],
+                approval_thread,
+            ),
+            Some("desk-finance".into()),
+        );
+        // A resolution known to have come from no conversation is a rival too.
+        assert_eq!(
+            cycle_thread_id(
+                &[addressed("desk-finance"), resolved("appr-none")],
+                approval_thread,
+            ),
+            None,
+        );
+        // Inbound triggers that are their own work disqualify the batch, exactly
+        // as a rival chat turn does for the card stamp.
+        for rival in [
+            dispatched(),
+            CompanyEvent::ScheduleFired {
+                cron: "* * * * *".into(),
+                prompt: "tick".into(),
+            },
+            CompanyEvent::WebhookReceived {
+                channel: "stripe".into(),
+                body: serde_json::json!({}),
+            },
+            CompanyEvent::A2aTaskReceived {
+                from: "peer".into(),
+                task: serde_json::json!({}),
+            },
+            CompanyEvent::PaymentReceived {
+                amount_usd: 10.0,
+                memo: "invoice".into(),
+            },
+            CompanyEvent::FeedbackFiled {
+                note: "it mis-filed".into(),
+            },
+        ] {
+            assert_eq!(
+                cycle_thread_id(&[addressed("desk-finance"), rival.clone()], approval_thread),
+                None,
+                "{rival:?} is its own work and must not inherit the channel",
+            );
+        }
+        // A record of something that already happened is not a rival — including
+        // this cycle's own park event, which is appended after the park it
+        // describes and would otherwise disqualify a second one.
+        for record in [
+            CompanyEvent::ApprovalParked {
+                approval_id: ApprovalId::new("appr-desk"),
+                effect_kind: "payment.send".into(),
+                thread: Some("desk-finance".into()),
+            },
+            CompanyEvent::DeskTaskCompleted {
+                task_id: "t-9".into(),
+                desk: "ops".into(),
+                column: "done".into(),
+                output: String::new(),
+            },
+            CompanyEvent::AgentReply {
+                chat_id: "desk-ops".into(),
+                agent_id: "ops".into(),
+                text: "done".into(),
+                steps: Vec::new(),
+                task_id: None,
+            },
+        ] {
+            assert_eq!(
+                cycle_thread_id(
+                    &[addressed("desk-finance"), record.clone()],
+                    approval_thread
+                ),
+                Some("desk-finance".into()),
+                "{record:?} is a record, not a trigger, and must not disqualify the batch",
+            );
+        }
+    }
+
     #[tokio::test]
     async fn send_email_sends_for_established_recipient() {
         let home_dir = tmp_home();
@@ -3736,7 +4187,7 @@ mod test {
             )
             .await
             .unwrap();
-        let host = CycleHostImpl::new(rt.id().clone(), "cyc-send".into(), &rt, None);
+        let host = CycleHostImpl::new(rt.id().clone(), "cyc-send".into(), &rt, None, None);
 
         let res = host
             .send_email(serde_json::json!({ "to": "known@ext.com", "subject": "s", "body": "b" }))
@@ -3800,7 +4251,7 @@ mod test {
         }
         file(501, "known@ext.com").await;
 
-        let host = CycleHostImpl::new(rt.id().clone(), "cyc-deep".into(), &rt, None);
+        let host = CycleHostImpl::new(rt.id().clone(), "cyc-deep".into(), &rt, None, None);
         let res = host
             .send_email(serde_json::json!({ "to": "known@ext.com", "subject": "s", "body": "b" }))
             .await
@@ -3886,7 +4337,7 @@ mod test {
             .build()
             .await
             .unwrap();
-        let host = CycleHostImpl::new(rt.id().clone(), "cyc".into(), &rt, None);
+        let host = CycleHostImpl::new(rt.id().clone(), "cyc".into(), &rt, None, None);
 
         let res = host
             .spawn_task(serde_json::json!({ "title": "  Ship it ", "assignee": " eng " }))
@@ -3920,7 +4371,7 @@ mod test {
             .build()
             .await
             .unwrap();
-        let host = CycleHostImpl::new(rt.id().clone(), "cyc".into(), &rt, None);
+        let host = CycleHostImpl::new(rt.id().clone(), "cyc".into(), &rt, None, None);
 
         // Known desk (by name) → card assigned to the resolved desk id, lead noted.
         let ok = host
@@ -3956,7 +4407,7 @@ mod test {
             .build()
             .await
             .unwrap();
-        let host = CycleHostImpl::new(rt.id().clone(), "cyc".into(), &rt, None);
+        let host = CycleHostImpl::new(rt.id().clone(), "cyc".into(), &rt, None, None);
 
         // Reached through the CycleHost trait exactly as the hosted brain does.
         let res = host

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -82,6 +82,22 @@ pub struct GrantedCall {
     pub args: serde_json::Value,
     /// Epoch-millis the grant was minted, for TTL expiry.
     pub at_millis: u64,
+    /// The chat thread the approval was raised in (issue #379) — copied off the
+    /// approval's origin when the grant is minted, so the re-dispatched turn's
+    /// reply is journaled back into the conversation that asked for it.
+    ///
+    /// Deliberately **not** part of the redemption match: the operator approved
+    /// a call, not a location, and a grant that failed to match because the
+    /// turn came back on a different thread would silently re-park. It rides
+    /// along purely as routing.
+    ///
+    /// `None` when the parked approval carried no thread (a workflow delivery,
+    /// a scheduler tick) and on a grant replayed from a journal line written
+    /// before this field existed. Both fall back to
+    /// [`agent`](Self::agent) — today's behaviour, which is right for a DM and
+    /// was never right for a desk channel.
+    #[serde(default)]
+    pub origin_thread: Option<String>,
 }
 
 /// The live grant set: a cheap shared handle, the same pattern as
@@ -211,6 +227,7 @@ mod test {
             tool: tool.to_string(),
             args,
             at_millis: 1_000,
+            origin_thread: None,
         }
     }
 

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -92,6 +92,26 @@ enum JournalRecord {
         /// replay instead of failing to parse.
         #[serde(default)]
         task: Option<TaskLink>,
+        /// Which **chat thread** produced the parking cycle (issue #379) — the
+        /// desk id for a channel, the roster agent id for a direct message.
+        ///
+        /// The correlation key that lets an approval be raised in the
+        /// conversation that asked for it. [`Effect::agent`] cannot do that job:
+        /// a desk channel and a direct message to that desk's lead resolve to
+        /// the same agent id, so placing the card by asker would raise a
+        /// channel's request inside the lead's private DM.
+        ///
+        /// A plain `Option<String>` rather than a [`TaskLink`]-style enum,
+        /// because nothing downstream falls back to a heuristic when it is
+        /// absent: an approval with no thread matches no channel filter and
+        /// stays Approvals-page-only, which is exactly today's behaviour. So
+        /// "parked by a host that did not record threads" and "parked by a turn
+        /// with no conversation behind it" need not be told apart — both mean
+        /// "no channel owns this", and both are correct.
+        ///
+        /// `#[serde(default)]` is what lets a pre-#379 line replay.
+        #[serde(default)]
+        thread: Option<String>,
     },
     /// A parked approval that has since been resolved (approved or denied).
     ApprovalResolved {
@@ -175,6 +195,14 @@ pub struct PendingApproval {
     /// Which board task this approval was parked for (issue #333). `None` only
     /// for a journal line written before the link existed — see [`TaskLink`].
     pub task: Option<TaskLink>,
+    /// The chat thread that produced the parking cycle (issue #379) — a desk id
+    /// for a channel, a roster agent id for a direct message.
+    ///
+    /// `None` for a pre-#379 journal line *and* for every park with no
+    /// conversation behind it (a workflow delivery, a scheduler tick, a cycle
+    /// whose triggers were ambiguous). Both are the same fact downstream: no
+    /// channel owns this approval, so it is shown on the Approvals page only.
+    pub thread: Option<String>,
 }
 
 /// What an approval *was*, retained for the whole life of the journal — after
@@ -221,6 +249,15 @@ pub struct ApprovalOrigin {
     /// a workflow delivery, a scheduler tick, and the hosted brain's own gate.
     /// That is why it cannot be the only key — see [`task`](Self::task).
     pub run_id: Option<String>,
+    /// The chat thread the parking cycle answered (issue #379).
+    ///
+    /// The **conversation-level** key, and orthogonal to the two above: a chat
+    /// turn has a thread and no card, a dispatched card has a card and no
+    /// thread, and a desk turn triggered from a channel has both. Retained here
+    /// (not only on the live queue) so a *resolved* approval's origin thread is
+    /// still recoverable — which is what lets a follow-up cycle's own re-park
+    /// stay in the channel the first sign-off was asked in.
+    pub thread: Option<String>,
 }
 
 /// One approval currently waiting in the in-memory queue.
@@ -230,6 +267,9 @@ struct ParkedApproval {
     at_millis: u64,
     /// `None` only for a journal line written before #333.
     task: Option<TaskLink>,
+    /// The chat thread that parked it (issue #379); `None` when no conversation
+    /// produced it, or on a pre-#379 line.
+    thread: Option<String>,
 }
 
 /// A side effect that was **committed to run** (issue #351): what it was, which
@@ -536,6 +576,7 @@ impl RuntimeJournal {
                 effect,
                 at_millis,
                 task,
+                thread,
             } => {
                 state.retain_approval_effect(&id, &effect);
                 state.origins.insert(
@@ -545,6 +586,7 @@ impl RuntimeJournal {
                         kind: effect.kind.clone(),
                         task: task.clone(),
                         run_id: effect.run_id.clone(),
+                        thread: thread.clone(),
                     },
                 );
                 state.parked.insert(
@@ -553,6 +595,7 @@ impl RuntimeJournal {
                         effect,
                         at_millis,
                         task,
+                        thread,
                     },
                 );
             }
@@ -625,12 +668,19 @@ impl RuntimeJournal {
     /// it is, [`TaskLink::Task`] or [`TaskLink::Unlinked`], so that a missing
     /// link can only ever mean "written before #333". A caller with an
     /// `Option<&str>` in hand converts with [`TaskLink::from_task_id`].
+    ///
+    /// `thread` **is** an `Option`, and deliberately so (issue #379): unlike the
+    /// task link, nothing downstream distinguishes "no conversation produced
+    /// this" from "this host does not record conversations". Both mean no
+    /// channel owns the approval, and both correctly leave it on the Approvals
+    /// page alone.
     pub async fn record_parked(
         &self,
         id: &ApprovalId,
         effect: &Effect,
         at_millis: u64,
         task: TaskLink,
+        thread: Option<String>,
     ) -> Result<()> {
         {
             let mut state = self.state.lock().expect("journal state poisoned");
@@ -641,6 +691,7 @@ impl RuntimeJournal {
                     kind: effect.kind.clone(),
                     task: Some(task.clone()),
                     run_id: effect.run_id.clone(),
+                    thread: thread.clone(),
                 },
             );
             state.parked.insert(
@@ -649,6 +700,7 @@ impl RuntimeJournal {
                     effect: effect.clone(),
                     at_millis,
                     task: Some(task.clone()),
+                    thread: thread.clone(),
                 },
             );
             state.retain_approval_effect(id, effect);
@@ -658,6 +710,7 @@ impl RuntimeJournal {
             effect: effect.clone(),
             at_millis,
             task: Some(task),
+            thread,
         })
         .await
     }
@@ -828,6 +881,26 @@ impl RuntimeJournal {
             .map(|o| o.task.clone())
     }
 
+    /// The chat thread recorded for one approval (issue #379), read the same
+    /// per-id way as [`approval_task`](Self::approval_task) and for the same
+    /// reason — the origins map is unbounded, and a cycle needs at most the
+    /// couple of ids in its own batch.
+    ///
+    /// The outer `Option` is "no such approval"; the inner is "no conversation
+    /// behind it" (which a pre-#379 line is indistinguishable from, by design).
+    /// Reading it off the retained origin rather than the live queue is what
+    /// makes it answerable *after* the approval resolved — the case
+    /// [`cycle_thread_id`](crate::runtime::cycle) needs so a second sign-off
+    /// re-parks in the channel the first one was asked in.
+    pub fn approval_thread(&self, id: &ApprovalId) -> Option<Option<String>> {
+        self.state
+            .lock()
+            .expect("journal state poisoned")
+            .origins
+            .get(id)
+            .map(|o| o.thread.clone())
+    }
+
     /// Records a minted single-use grant (issue #243).
     ///
     /// Called *before* the grant enters the live set, so the ordering failure
@@ -912,6 +985,7 @@ impl RuntimeJournal {
                 effect: parked.effect.clone(),
                 at_millis: parked.at_millis,
                 task: parked.task.clone(),
+                thread: parked.thread.clone(),
             })
             .collect();
         out.sort_by(|a, b| {
@@ -1214,7 +1288,13 @@ mod test {
         let id = ApprovalId::new("appr-tool");
 
         journal
-            .record_parked(&id, &effect(), 1_000, TaskLink::Task { id: "t-1".into() })
+            .record_parked(
+                &id,
+                &effect(),
+                1_000,
+                TaskLink::Task { id: "t-1".into() },
+                None,
+            )
             .await
             .unwrap();
         journal.record_resolved(&id).await.unwrap();
@@ -1276,7 +1356,7 @@ mod test {
         };
 
         journal
-            .record_parked(&id, &parked, 1_000, TaskLink::Unlinked)
+            .record_parked(&id, &parked, 1_000, TaskLink::Unlinked, None)
             .await
             .unwrap();
         journal.record_resolved(&id).await.unwrap();
@@ -1317,6 +1397,7 @@ mod test {
                 },
                 1_000,
                 TaskLink::Unlinked,
+                None,
             )
             .await
             .unwrap();
@@ -1348,7 +1429,7 @@ mod test {
         let journal = RuntimeJournal::new(&path);
         let id = ApprovalId::new("appr-1");
         journal
-            .record_parked(&id, &effect(), now_millis(), TaskLink::Unlinked)
+            .record_parked(&id, &effect(), now_millis(), TaskLink::Unlinked, None)
             .await
             .unwrap();
         assert_eq!(journal.pending().len(), 1);
@@ -1385,7 +1466,13 @@ mod test {
         let theirs = ApprovalId::new("appr-theirs");
         let orphan = ApprovalId::new("appr-orphan");
         journal
-            .record_parked(&mine, &effect(), 1_000, TaskLink::Task { id: "t-1".into() })
+            .record_parked(
+                &mine,
+                &effect(),
+                1_000,
+                TaskLink::Task { id: "t-1".into() },
+                None,
+            )
             .await
             .unwrap();
         journal
@@ -1394,12 +1481,13 @@ mod test {
                 &effect(),
                 1_100,
                 TaskLink::Task { id: "t-2".into() },
+                None,
             )
             .await
             .unwrap();
         // No card behind it (a workflow delivery, an operator-chat turn).
         journal
-            .record_parked(&orphan, &effect(), 1_200, TaskLink::Unlinked)
+            .record_parked(&orphan, &effect(), 1_200, TaskLink::Unlinked, None)
             .await
             .unwrap();
 
@@ -1426,6 +1514,7 @@ mod test {
                 kind: "filing.submit".into(),
                 task: Some(TaskLink::Task { id: "t-1".into() }),
                 run_id: None,
+                thread: None,
             }),
         );
         assert_eq!(
@@ -1478,7 +1567,7 @@ mod test {
         // fact, written explicitly, and must not read back as the legacy shape.
         let fresh = ApprovalId::new("appr-new");
         journal
-            .record_parked(&fresh, &effect(), 5_000, TaskLink::Unlinked)
+            .record_parked(&fresh, &effect(), 5_000, TaskLink::Unlinked, None)
             .await
             .unwrap();
         assert_eq!(
@@ -1497,6 +1586,96 @@ mod test {
         );
     }
 
+    /// A park line written before #379 has no `thread` key. It must replay as
+    /// "no thread" rather than failing to parse — which is what leaves every
+    /// already-parked approval on the Approvals page and in no channel, exactly
+    /// as it was before this shipped.
+    ///
+    /// The second half is the one that has to keep working after the resolution:
+    /// the thread is read off the retained origin, so it survives the queue
+    /// removal. That is what lets a follow-up cycle's own re-park stay in the
+    /// channel the first sign-off was asked in.
+    #[tokio::test]
+    async fn a_pre_379_parked_line_replays_with_no_thread_and_a_stamped_one_survives_resolution() {
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
+        let legacy = serde_json::json!({
+            "record": "ApprovalParked",
+            "id": "appr-legacy",
+            "effect": effect(),
+            "at_millis": 4_000,
+            "task": { "link": "unlinked" },
+        });
+        tokio::fs::write(&path, format!("{legacy}\n"))
+            .await
+            .unwrap();
+
+        let journal = RuntimeJournal::new(&path);
+        journal.load().await.expect("a pre-#379 line still replays");
+        let legacy_id = ApprovalId::new("appr-legacy");
+        assert_eq!(journal.pending().len(), 1);
+        assert_eq!(
+            journal.pending()[0].thread,
+            None,
+            "no key means no conversation owns it",
+        );
+        assert_eq!(journal.approval_thread(&legacy_id), Some(None));
+        assert_eq!(
+            journal.approval_task(&legacy_id),
+            Some(Some(TaskLink::Unlinked)),
+            "the #333 link is untouched by the new field",
+        );
+
+        // A park stamped with the desk channel that produced it.
+        let stamped = ApprovalId::new("appr-desk");
+        journal
+            .record_parked(
+                &stamped,
+                &effect(),
+                5_000,
+                TaskLink::Unlinked,
+                Some("desk-finance".to_string()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            journal
+                .pending()
+                .iter()
+                .find(|p| p.id == stamped)
+                .unwrap()
+                .thread,
+            Some("desk-finance".to_string()),
+        );
+
+        // Resolving drains the queue but must not drain the origin thread —
+        // the follow-up cycle reads it back from here.
+        journal.record_resolved(&stamped).await.unwrap();
+        assert!(journal.pending().iter().all(|p| p.id != stamped));
+        assert_eq!(
+            journal.approval_thread(&stamped),
+            Some(Some("desk-finance".to_string())),
+        );
+
+        // And it round-trips through a reload, from the raw line.
+        let raw = tokio::fs::read_to_string(&path).await.unwrap();
+        let stamped_line = raw
+            .lines()
+            .find(|l| l.contains("appr-desk"))
+            .expect("the stamped park was appended");
+        assert!(
+            stamped_line.contains(r#""thread":"desk-finance""#),
+            "a thread-stamped park must say so on disk: {stamped_line}",
+        );
+        let reloaded = RuntimeJournal::new(&path);
+        reloaded.load().await.unwrap();
+        assert_eq!(
+            reloaded.approval_thread(&stamped),
+            Some(Some("desk-finance".to_string())),
+        );
+        assert_eq!(reloaded.approval_thread(&legacy_id), Some(None));
+    }
+
     #[tokio::test]
     async fn expired_record_removes_parked_and_survives_reload() {
         let dir = tmp_dir();
@@ -1504,7 +1683,7 @@ mod test {
         let journal = RuntimeJournal::new(&path);
         let id = ApprovalId::new("appr-exp");
         journal
-            .record_parked(&id, &effect(), now_millis(), TaskLink::Unlinked)
+            .record_parked(&id, &effect(), now_millis(), TaskLink::Unlinked, None)
             .await
             .unwrap();
         assert_eq!(journal.pending().len(), 1);
@@ -1528,7 +1707,7 @@ mod test {
         let journal = RuntimeJournal::new(&path);
         let id = ApprovalId::new("appr-amend");
         journal
-            .record_parked(&id, &effect(), now_millis(), TaskLink::Unlinked)
+            .record_parked(&id, &effect(), now_millis(), TaskLink::Unlinked, None)
             .await
             .unwrap();
 
@@ -1569,11 +1748,11 @@ mod test {
         let resolved = ApprovalId::new("appr-resolved");
         let expired = ApprovalId::new("appr-expired");
         journal
-            .record_parked(&resolved, &effect(), 1_000, TaskLink::Unlinked)
+            .record_parked(&resolved, &effect(), 1_000, TaskLink::Unlinked, None)
             .await
             .unwrap();
         journal
-            .record_parked(&expired, &effect(), 2_000, TaskLink::Unlinked)
+            .record_parked(&expired, &effect(), 2_000, TaskLink::Unlinked, None)
             .await
             .unwrap();
 
@@ -1604,6 +1783,7 @@ mod test {
             tool: "composio_execute".into(),
             args: serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
             at_millis,
+            origin_thread: None,
         }
     }
 
@@ -1700,7 +1880,7 @@ mod test {
 
         let parked_id = ApprovalId::new("appr-parked");
         journal
-            .record_parked(&parked_id, &effect(), 500, TaskLink::Unlinked)
+            .record_parked(&parked_id, &effect(), 500, TaskLink::Unlinked, None)
             .await
             .unwrap();
         journal

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -123,4 +123,20 @@ pub struct ApprovalSummary {
     /// did before.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub payload: Option<serde_json::Value>,
+    /// The chat thread this approval was raised in (issue #379) — a desk id for
+    /// a channel, a roster agent id for a direct message.
+    ///
+    /// The key that lets the console draw the request as a card *inside* that
+    /// conversation. Not derivable from [`agent`](Self::agent): a desk channel
+    /// and a direct message to that desk's lead are answered by the same
+    /// teammate, so placing the card by asker would raise one conversation's
+    /// request inside the other.
+    ///
+    /// `None` — and omitted from the wire — for an approval with no
+    /// conversation behind it (a workflow delivery, a scheduler tick) and for
+    /// every park journaled before this field existed. Both mean the same
+    /// thing to a reader: no channel owns it, so it appears on the Approvals
+    /// page and in no thread, exactly as before.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread: Option<String>,
 }

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -694,6 +694,31 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             o["column"] = json!(column);
             o
         }
+        // Issue #379: a request just parked, so a console watching the
+        // conversation it came from can raise the card live instead of waiting
+        // for its next approvals poll.
+        //
+        // Three keys and no more — deny-by-default, like every other arm here.
+        // No `payload`: the effect's arguments are redacted exactly once, in
+        // `pending_approvals`, and this frame deliberately does not become a
+        // second place that has to. No `agent` either: the console reads the
+        // asker off the same refreshed summary. What is here is only enough to
+        // decide *whether* to refresh and *where* the card belongs.
+        CompanyEvent::ApprovalParked {
+            approval_id,
+            effect_kind,
+            thread,
+        } => {
+            let mut o = envelope("approval_parked");
+            o["approvalId"] = json!(approval_id.as_ref());
+            o["kind"] = json!(effect_kind);
+            // Omitted when no conversation produced it, so a page-only approval
+            // is page-only on the wire too.
+            if let Some(thread) = thread {
+                o["chatId"] = json!(thread);
+            }
+            o
+        }
         CompanyEvent::ApprovalResolved {
             approval_id,
             verdict,
@@ -3284,6 +3309,57 @@ mod test {
         // The scrubbed timeline rides along so a live listener sees the steps.
         assert_eq!(v["steps"][0]["label"], "Reading messages");
         assert_eq!(v["steps"][0]["status"], "ok");
+    }
+
+    /// Issue #379: the park frame carries an id, a kind and the channel — and
+    /// **nothing else**.
+    ///
+    /// The negative half is the load-bearing one. The effect's arguments are
+    /// redacted in exactly one place (`pending_approvals`), and if this frame
+    /// ever grew a `payload` key it would become a second surface that has to
+    /// redact and one day will not. Asserting the absence is what makes that a
+    /// build failure rather than a leak.
+    #[test]
+    fn projects_approval_parked_with_a_channel_and_no_payload() {
+        let v = super::project_event(&stored(CompanyEvent::ApprovalParked {
+            approval_id: ApprovalId::new("appr-1"),
+            effect_kind: "payment.send".into(),
+            thread: Some("desk-finance".into()),
+        }))
+        .expect("a parked approval is an attention signal");
+        assert_eq!(v["type"], "approval_parked");
+        assert_eq!(v["approvalId"], "appr-1");
+        assert_eq!(v["kind"], "payment.send");
+        assert_eq!(v["chatId"], "desk-finance");
+        for forbidden in ["payload", "agent", "amountUsd", "effect", "args"] {
+            assert!(
+                v.get(forbidden).is_none(),
+                "the park frame must stay thin — `{forbidden}` leaked: {v}",
+            );
+        }
+        assert_eq!(
+            v.as_object().unwrap().len(),
+            6,
+            "type, seq, atMillis, approvalId, kind, chatId — and nothing more: {v}",
+        );
+    }
+
+    /// A park with no conversation behind it omits the channel entirely, so a
+    /// console filtering by thread matches it nowhere and it stays on the
+    /// Approvals page (#379).
+    #[test]
+    fn projects_approval_parked_without_a_channel_when_no_thread_produced_it() {
+        let v = super::project_event(&stored(CompanyEvent::ApprovalParked {
+            approval_id: ApprovalId::new("appr-cron"),
+            effect_kind: "email.send".into(),
+            thread: None,
+        }))
+        .expect("a parked approval is an attention signal");
+        assert_eq!(v["type"], "approval_parked");
+        assert!(
+            v.get("chatId").is_none(),
+            "a page-only approval must carry no channel: {v}",
+        );
     }
 
     #[test]

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -4000,6 +4000,7 @@ async fn task_timeline_reports_the_wait_an_approval_actually_caused() {
             &parked_effect(),
             parked_at,
             TaskLink::Task { id: "t-1".into() },
+            None,
         )
         .await
         .unwrap();
@@ -4081,6 +4082,7 @@ async fn expired_approval_is_labelled_as_an_expiry_and_carries_its_wait() {
             &parked_effect(),
             parked_at,
             TaskLink::Task { id: "t-1".into() },
+            None,
         )
         .await
         .unwrap();
@@ -4135,6 +4137,7 @@ async fn a_wait_that_began_before_dispatch_is_clamped_to_the_run_window() {
             &parked_effect(),
             dispatched_at - 3_600_000,
             TaskLink::Task { id: "t-1".into() },
+            None,
         )
         .await
         .unwrap();
@@ -4195,6 +4198,7 @@ async fn a_currently_parked_approval_surfaces_as_a_live_wait() {
             &parked_effect(),
             parked_at,
             TaskLink::Task { id: "t-1".into() },
+            None,
         )
         .await
         .unwrap();
@@ -4294,6 +4298,7 @@ async fn a_parked_approval_appears_on_its_own_task() {
             &parked_effect(),
             parked_at,
             TaskLink::Task { id: "t-1".into() },
+            None,
         )
         .await
         .unwrap();
@@ -4378,6 +4383,7 @@ async fn a_second_task_in_the_same_window_does_not_absorb_the_first_s_approvals(
                 &parked_effect(),
                 dispatched_at + 5,
                 TaskLink::Task { id: owner.into() },
+                None,
             )
             .await
             .unwrap();
@@ -4452,6 +4458,7 @@ async fn a_resolved_approval_reports_its_verdict_and_wait_on_the_tab() {
             &parked_effect(),
             parked_at,
             TaskLink::Task { id: "t-1".into() },
+            None,
         )
         .await
         .unwrap();
@@ -4521,6 +4528,7 @@ async fn a_task_with_no_approvals_of_its_own_reports_an_empty_list() {
             TaskLink::Task {
                 id: "t-other".into(),
             },
+            None,
         )
         .await
         .unwrap();
@@ -4566,6 +4574,7 @@ async fn an_unlinked_approval_is_not_absorbed_by_the_running_card() {
             &parked_effect(),
             dispatched_at + 5,
             TaskLink::Unlinked,
+            None,
         )
         .await
         .unwrap();
@@ -4637,6 +4646,7 @@ async fn the_attempt_id_outranks_the_card_link_when_both_are_present() {
             &under_run("run-b"),
             dispatched_at + 5,
             TaskLink::Unlinked,
+            None,
         )
         .await
         .unwrap();
@@ -4649,6 +4659,7 @@ async fn the_attempt_id_outranks_the_card_link_when_both_are_present() {
             &under_run("run-c"),
             dispatched_at + 6,
             TaskLink::Task { id: "t-1".into() },
+            None,
         )
         .await
         .unwrap();

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -670,6 +670,9 @@ async fn park_effect(
             &effect,
             now_millis(),
             crate::runtime::journal::TaskLink::Unlinked,
+            // Issue #379: a workflow delivery has no conversation behind it, so
+            // there is no thread to raise it in. It stays Approvals-page-only.
+            None,
         )
         .await
     {


### PR DESCRIPTION
## Summary

An approval raised by a chat turn now appears **in the channel that produced it**, is decidable there, and the agent's continuation lands in that same channel — so approving visibly causes the next thing to happen where you are already reading.

It also fixes a live bug found while building it: **approving in a desk channel sent the agent's continuation to the desk lead's private DM.**

## API Or Behavior Changes

**The misrouting fix.** `redispatch_granted_call` journaled the continuation reply with `chat_id: grant.agent` — correct for a direct message *by coincidence*, wrong for a desk channel. Confirmed twice: by reverting the fix and watching the test fail, and on a running host.

```
assertion `left == right` failed: a channel's approval must resume in that channel
  left: "ceo"           ← the desk lead's private DM
 right: "desk-finance"  ← the channel the operator approved in
```

It is its own micro-commit (`f1dd7ac`) but **could not land first** — it depends on `GrantedCall.origin_thread`, which depends on the journal's thread stamp. The dependency runs bottom-up, so the fix sits at the top of the stack rather than the base. Still one expression plus its test, and cherry-pickable once `a623d20` is in.

**A conversation identity, recorded at park time.** `thread: Option<String>` (`#[serde(default)]`) on the `ApprovalParked` journal record, `PendingApproval`, `ApprovalOrigin` and `GrantedCall.origin_thread`; surfaced as an omitted-when-absent `thread` on `ApprovalSummary`. Stamped from the turn's own trigger, which already distinguishes a desk from a DM to that desk's lead — the exact case that cannot be derived afterwards. It yields `None` rather than guessing on an ambiguous batch.

**A thin `CompanyEvent::ApprovalParked`**, projected as an `approval_parked` frame carrying **approval id, kind and chat id only — no payload, no agent**. A fat event was rejected because `pending_approvals()` is deliberately the single place the redaction from #375 runs; a payload-bearing durable event would open a second redaction surface. The console reacts by refreshing the feed and rendering from the refreshed summary.

**The inline card resolves with `detach: true`** (#391's receipt), not the default response shape — which would deliver the reply twice to chat, once on the body and once as the live echo. Detach has exactly one delivery path, so the race never exists. The Approvals page keeps the default shape, untouched.

**Approvals with no thread** — workflow deliveries, scheduler ticks, anything parked before this ships — match no channel and stay **Approvals-page only, exactly as today**. Inline is purely additive.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **1931 passed**
- [x] `cargo test --locked --lib` (default features) — **1377 passed**
- [x] `cargo check --locked --all-features --all-targets`
- [x] `git diff --stat Cargo.lock` — empty
- [x] `npm ci`, `npm run typecheck`, `npm run typecheck:e2e`, `npm run build`
- [x] Verified end to end on both the UI and the backend

**Union-built against `feat/383b-workflow-run-handles` (PR #399): zero conflicts.** Union gates green — 1953 and 1396 tests, clippy, all-features, frontend build. Per-PR CI never builds that union.

**Manual, on a real build**, using a mock OpenAI-compatible endpoint and a scratch company configured to produce genuine parked approvals: ask in a desk channel → the card parks in-channel with its redacted payload and "Asked by Engineer" → approve inline (receipt `{"recorded":true,"alreadyResolved":false}`) → the card settles to "Approved — the agent is completing the action" → the continuation lands in that channel, **once**. Also verified: the decline line, the DM mirror, absence from both the lead's DM and the other desk, a page-side resolution settling the inline card live, a pending card surviving a reload, and an unaddressed turn parking with **no `thread` key at all** — page-only, as designed.

## Documentation

`docs/spec/runtime/events.md` (now 421 lines) and `docs/spec/company-brain/approvals.md` (191). **`ports.md` untouched** — already over the repo's 500-line cap.

## Impact

**Two things the plan got wrong, both caught in the build:**

`kind` as a field name on the event variant **does not compile**. `CompanyEvent` is serde-tagged internally *under `kind`*, so the field collides with the tag. It is `effect_kind`; the projected frame still calls it `kind`, because that envelope discriminates on `type`.

**Keeping only the witnessed verdict was not enough.** The host drops a resolved approval from `/approvals` immediately, so there was no summary left to draw and the card blinked out of the thread mid-conversation. The mocked spec passed because it asserted the transient state — only the real build showed it. The map now keeps the last-seen summary alongside the verdict.

**Reload behaviour, stated honestly.** A *pending* inline card **survives** a reload, because it derives from server state — better than the transcripts it sits among (#364 is unfixed and this does not depend on it). What evaporates is only the console-local decision residue: after an approve the rehydrated history shows the continuation, because it is journaled; after a decline the record lives on the journal and in Approvals history. Journaling synthetic decline lines was rejected — #390's turn-level events are the proper home.

**A trap worth knowing:** the console's existing recent-tail dedupe in `injectAgentReply` suppresses a continuation whose text is byte-identical to a bubble in the last 8 messages. A mock returning the same string for both turns had its continuation silently swallowed — which looks exactly like this feature being broken.

## Related

Closes #379

Depends on and builds upon #375 (payload + requesting agent on the wire), #378 (live delivery into a channel), #391 (`detach`), #393 (channel membership and the loading gate).
Part of #183 — the approve station, in the place the spine actually starts.
Adjacent: #374 will add a grant scope to this same card; #364 (console-local transcripts) is unfixed and deliberately not depended on.
