### PR TITLE
fix(connections): show providers you can actually connect, and give one answer per provider (#397, #316, #396)

### DIFF
--- a/companies/agentic_marketing_agency/company.toml
+++ b/companies/agentic_marketing_agency/company.toml
@@ -85,7 +85,11 @@ description = "Acquisition and lifecycle."
 members = ["paid_ads_manager", "email_marketer"]
 
 # Integrations to prioritize wiring. Intent only — scopes and why, never
-# secrets. The manager injects real OAuth credentials at runtime.
+# secrets. Nothing here provisions a credential: the manager injects no
+# OPENCOMPANY_OAUTH_* variable into a tenant, so the native Connect flow is the
+# self-hosted hatch only (see src/server/ops/connections.rs). On the hosted
+# platform, agents reach Gmail / Slack / GitHub through Composio, which
+# authenticates with the instance's own platform identity.
 [[connection]]
 provider = "slack"
 priority = "high"

--- a/frontend/src/api/composio.ts
+++ b/frontend/src/api/composio.ts
@@ -34,8 +34,26 @@ export interface ComposioStatus {
   credentialSource: ComposioCredentialSource;
   /** The effective Composio backend URL (non-secret). */
   backendUrl: string;
-  /** The manifest toolkit allowlist (empty = defer to the backend allowlist). */
+  /** The manifest toolkit allowlist verbatim (empty = defer to the backend allowlist). */
   toolkits: string[];
+  /**
+   * Whether this company is in **open mode** — an empty manifest allowlist,
+   * which means the backend's own allowlist governs and every toolkit it
+   * permits is reachable (issue #397).
+   *
+   * The host tells us rather than letting us infer it: an empty `toolkits`
+   * means *allow everything*, which is the opposite of what an empty list
+   * reads as. Gating provider rows on `toolkits.length > 0` was exactly that
+   * misreading, and it left 19 of 20 shipped templates with nothing to click.
+   */
+  openMode: boolean;
+  /**
+   * The toolkits to render as provider rows — the manifest list when non-empty,
+   * else a curated starting set. In open mode this is a suggestion, not a
+   * limit: any slug the backend permits can still be authorized, which is what
+   * the "other provider" field is for.
+   */
+  effectiveToolkits: string[];
 }
 
 /** A mutating response: the resulting status plus a plain-language note. */

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -400,6 +400,22 @@ export interface ConnectionState {
   credentialSource?: ConnectionCredentialSource;
   /** The connected account label, when known (e.g. an email or workspace). */
   account?: string;
+  /**
+   * Which namespace(s) report this provider connected — `native` for the
+   * host's own `oauth/{provider}` catalog, `composio` for a Composio
+   * connection. Empty when not connected (issue #316).
+   *
+   * The host reconciles both namespaces into one row, so the page can no
+   * longer show the same provider twice with two different answers. Optional
+   * so a host predating this field still parses.
+   */
+  via?: ("native" | "composio")[];
+  /**
+   * A Composio path exists for this company but could not be read, so
+   * `connected: false` means "we could not check", not "no". Render that
+   * distinction rather than a confident disconnected state.
+   */
+  unverified?: boolean;
 }
 
 /** Response of `POST .../connections/{provider}/start`: where to send the user. */

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -168,6 +168,19 @@ export function ConnectionsView({ client, company }: Props) {
 
         <ChannelsSection client={client} company={company} />
 
+        {load === "ready" && (
+          <Alert data-testid="connections-catalog-advisory">
+            <Info className="size-4" />
+            <AlertTitle>Agents reach these providers through Composio</AlertTitle>
+            <AlertDescription>
+              Connecting below records the account against this company, but the tool belt your
+              agents actually run on is wired in the Composio section above — that is where a
+              connection becomes something an agent can do. Connect Gmail, GitHub or Slack there
+              first (issue #396).
+            </AlertDescription>
+          </Alert>
+        )}
+
         {load === "loading" ? (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
@@ -257,6 +270,12 @@ function ConnectionCard({
   const source = state?.credentialSource;
   const managedByPlatform = source === "attested" || (platformManaged && source === undefined);
   const noRoute = source === "none";
+  // Which namespace actually backs this connection. `native` alone means the
+  // credential sits in the host's catalog, which no agent tool reads yet — worth
+  // distinguishing from a Composio connection, which is a live capability.
+  const via = state?.via ?? [];
+  const nativeOnly = connected && via.length > 0 && !via.includes("composio");
+  const unverified = state?.unverified === true;
   return (
     <Card className={cn(connected && "border-primary/30")}>
       <CardContent className="flex h-full flex-col gap-3 py-4">
@@ -274,6 +293,17 @@ function ConnectionCard({
             <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
               {connected && state?.account ? state.account : provider.description}
             </p>
+            {connected && via.length > 0 && (
+              <p className="mt-0.5 text-xs text-muted-foreground" data-testid={`connection-via-${provider.id}`}>
+                via {via.join(" + ")}
+                {nativeOnly && " — stored here; agents use the Composio connection"}
+              </p>
+            )}
+            {!connected && unverified && (
+              <p className="mt-0.5 text-xs text-amber-600 dark:text-amber-400">
+                Couldn&apos;t check the Composio connection — state unknown.
+              </p>
+            )}
           </div>
         </div>
         <div className="mt-auto">

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -70,6 +70,13 @@ export function ComposioSection({ client, company }: Props) {
   // Only meaningful in the attested state, where the paste card is an override
   // rather than the way in.
   const [showOverride, setShowOverride] = useState(false);
+  // Open mode only: a slug typed into the "another provider" field. Open mode
+  // permits every toolkit the backend allows, and the curated rows are a
+  // starting point rather than the whole set (issue #397).
+  const [otherToolkit, setOtherToolkit] = useState("");
+  // Slugs connected through that field this session, so they get a row of their
+  // own instead of vanishing after a successful sign-in.
+  const [extraToolkits, setExtraToolkits] = useState<string[]>([]);
 
   const requestGeneration = useRef(0);
   const pollTimers = useRef<Record<string, number>>({});
@@ -86,8 +93,10 @@ export function ComposioSection({ client, company }: Props) {
   const refreshConnections = useCallback(
     async (s: ComposioStatus) => {
       // Listing connections needs *a* credential — any tier. With none there is
-      // nothing to authorize against, and the call 409s.
-      if (s.credentialSource === "none" || s.toolkits.length === 0) {
+      // nothing to authorize against, and the call 409s. Keyed off the
+      // EFFECTIVE list, not the manifest one: in open mode the manifest list is
+      // empty precisely because everything is allowed (issue #397).
+      if (s.credentialSource === "none" || s.effectiveToolkits.length === 0) {
         setConnected({});
         return;
       }
@@ -121,6 +130,8 @@ export function ComposioSection({ client, company }: Props) {
     setStatus(null);
     setConnected({});
     setShowOverride(false);
+    setOtherToolkit("");
+    setExtraToolkits([]);
     setLoad("loading");
     void refresh();
   }, [refresh]);
@@ -206,7 +217,12 @@ export function ComposioSection({ client, company }: Props) {
   const byoToken = status?.credentialSource === "static";
   // No credential of any tier: there is nothing to authorize a provider against.
   const noCredential = status?.credentialSource === "none";
-  const showProviders = load === "ready" && status !== null && status.toolkits.length > 0;
+  // Issue #397: gate on the EFFECTIVE list. The old gate read
+  // `toolkits.length > 0`, and an empty manifest list means "defer to the
+  // backend allowlist" — allow everything — so the one value meaning *every
+  // provider* rendered *no* providers on 19 of 20 shipped templates.
+  const showProviders = load === "ready" && status !== null && status.effectiveToolkits.length > 0;
+  const openMode = status?.openMode === true;
   // In the attested state the paste card is a deliberate override; everywhere
   // else it is the only way to connect, so it is always on screen.
   const showTokenCard = !attested || showOverride || byoToken;
@@ -266,8 +282,18 @@ export function ComposioSection({ client, company }: Props) {
                     authorize against. Paste a token below first.
                   </p>
                 )}
+                {openMode && (
+                  <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+                    This company allows <span className="font-medium">any</span> provider Composio
+                    offers — these are the common ones. Connect a different provider by its slug
+                    below.
+                  </p>
+                )}
                 <ul className="divide-y divide-border">
-                  {status.toolkits.map((toolkit) => {
+                  {[
+                    ...status.effectiveToolkits,
+                    ...extraToolkits.filter((t) => !status.effectiveToolkits.includes(t)),
+                  ].map((toolkit) => {
                     const isConnected = connected[toolkit.toLowerCase()] === true;
                     const isSigningIn = signingIn === toolkit;
                     return (
@@ -296,6 +322,36 @@ export function ComposioSection({ client, company }: Props) {
                     );
                   })}
                 </ul>
+                {openMode && (
+                  <div className="flex items-end gap-2 border-t border-border pt-3">
+                    <div className="flex-1 space-y-1">
+                      <Label htmlFor="composio-other-toolkit" className="text-xs">
+                        Another provider
+                      </Label>
+                      <Input
+                        id="composio-other-toolkit"
+                        autoComplete="off"
+                        placeholder="composio toolkit slug, e.g. hubspot"
+                        value={otherToolkit}
+                        disabled={noCredential}
+                        onChange={(e) => setOtherToolkit(e.target.value)}
+                      />
+                    </div>
+                    <Button
+                      variant="outline"
+                      disabled={signingIn !== null || noCredential || !otherToolkit.trim()}
+                      onClick={() => {
+                        const slug = otherToolkit.trim().toLowerCase();
+                        setOtherToolkit("");
+                        setExtraToolkits((t) => (t.includes(slug) ? t : [...t, slug]));
+                        void signIn(slug);
+                      }}
+                    >
+                      <LogIn className="size-4" />
+                      Sign in
+                    </Button>
+                  </div>
+                )}
               </CardContent>
             </Card>
           )}

--- a/src/server/graphql/connections.rs
+++ b/src/server/graphql/connections.rs
@@ -8,7 +8,6 @@ use async_graphql::SimpleObject;
 
 use crate::company::dns::DomainStatus;
 use crate::company::runtime::CompanyRuntime;
-use crate::server::ops::connections_read::HostConnectRoutes;
 use crate::server::ops::smtp::{SmtpCredentials, SmtpStatus};
 
 /// The reserved SecretStore key holding the JSON domain status.
@@ -109,42 +108,29 @@ impl From<SmtpStatus> for SmtpStatusGql {
 }
 
 /// Resolves `Company.connections`: manifest intent merged with OAuth status.
+///
+/// Delegates the whole decision to
+/// [`project_connections`](crate::server::ops::connections_read::project_connections),
+/// the same function the REST plane serves, and only maps the result into the
+/// GraphQL type. The two planes previously ran duplicate copies of the loop —
+/// which is how they were free to drift, and why a provider could answer one
+/// thing over REST and another over GraphQL (issue #316).
 pub(crate) async fn resolve_connections(
     runtime: &Arc<CompanyRuntime>,
 ) -> async_graphql::Result<Vec<ConnectionStateGql>> {
-    let Some(record) = runtime.store().load(runtime.id()).await? else {
-        return Ok(Vec::new());
-    };
-    let mut out = Vec::with_capacity(record.manifest.connections.len());
-    // Host-level, so resolved once rather than per connection below.
-    let host = HostConnectRoutes::from_env();
-    for connection in &record.manifest.connections {
-        let key = format!("oauth/{}", connection.provider);
-        let (connected, account) = match runtime.secrets().get(runtime.id(), &key).await? {
-            Some(value) if !value.expose().trim().is_empty() => {
-                let account = serde_json::from_str::<serde_json::Value>(value.expose())
-                    .ok()
-                    .and_then(|json| {
-                        json.get("account")
-                            .and_then(|a| a.as_str())
-                            .map(str::to_string)
-                    });
-                (true, account)
-            }
-            _ => (false, None),
-        };
-        out.push(ConnectionStateGql {
-            credential_source: host
-                .route_from_env(&connection.provider, connected)
-                .as_str()
-                .to_string(),
-            provider: connection.provider.clone(),
-            connected,
-            account,
-            reason: connection.reason.clone(),
-        });
-    }
-    Ok(out)
+    Ok(
+        crate::server::ops::connections_read::project_connections(runtime.as_ref())
+            .await?
+            .into_iter()
+            .map(|row| ConnectionStateGql {
+                credential_source: row.credential_source.as_str().to_string(),
+                provider: row.provider,
+                connected: row.connected,
+                account: row.account,
+                reason: row.reason,
+            })
+            .collect(),
+    )
 }
 
 /// Resolves `Company.domain`, returning null when no domain is configured.

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -48,6 +48,59 @@ use crate::server::ops::{ScopedCompany, scoped};
 const SWITCH_NOTE: &str =
     "Agents pick up the new Composio token on their next turn — no restart needed.";
 
+/// The providers the console offers when a company is in **open mode** (issue
+/// #397).
+///
+/// An empty `[tools.composio].toolkits` means "defer to the backend's
+/// server-enforced allowlist" — i.e. *every* toolkit is permitted, roughly a
+/// hundred slugs. The console previously read that same empty list as "offer
+/// nothing", so the one value meaning *allow everything* rendered zero provider
+/// rows on 19 of 20 shipped templates.
+///
+/// Two things are wrong with simply listing all hundred: the console does not
+/// know the backend's allowlist without a network round-trip on a page-load
+/// path, and a hundred rows is its own usability problem. So open mode offers
+/// this curated set — the toolkits a company actually reaches for first, each of
+/// which is in the backend's default allowlist — and the console pairs it with a
+/// free-text field that can authorize **any** slug the backend permits. The
+/// curated list is a starting point, never a ceiling: nothing here narrows what
+/// the backend or the agent-side allowlist admits.
+///
+/// This is a **console affordance only**. Agent-side toolkit admission is
+/// [`toolkit_allowed`](crate::harness::composio), which still treats an empty
+/// manifest list as "allow every toolkit" — unchanged by this constant.
+pub(crate) const OPEN_MODE_TOOLKITS: &[&str] = &[
+    "gmail",
+    "googlecalendar",
+    "googledrive",
+    "github",
+    "slack",
+    "notion",
+    "linear",
+    "discord",
+];
+
+/// The toolkits the console should offer for a company, and whether that answer
+/// came from open mode.
+///
+/// A non-empty manifest allowlist is authoritative and is offered verbatim — a
+/// company that deliberately narrowed its belt sees exactly what it chose.
+/// Empty means open mode, which offers [`OPEN_MODE_TOOLKITS`].
+///
+/// Returning the pair (rather than letting the console infer open mode from an
+/// empty list) is the whole point of the fix: the console must never again have
+/// to guess which of the two opposite meanings an empty list carries.
+fn effective_toolkits(manifest: &[String]) -> (bool, Vec<String>) {
+    if manifest.is_empty() {
+        (
+            true,
+            OPEN_MODE_TOOLKITS.iter().map(|s| (*s).to_string()).collect(),
+        )
+    } else {
+        (false, manifest.to_vec())
+    }
+}
+
 /// Builds the Composio management route fragment.
 ///
 /// The read/write-token plane (`GET …/composio`, `PUT …/composio/token`) is
@@ -86,8 +139,24 @@ struct ComposioStatusDto {
     credential_source: CredentialSource,
     /// The effective Composio backend URL (env override or default). Non-secret.
     backend_url: String,
-    /// The manifest toolkit allowlist (empty = defer to the backend allowlist).
+    /// The manifest toolkit allowlist verbatim (empty = defer to the backend
+    /// allowlist, i.e. open mode). Kept as-is so an operator can still see what
+    /// the manifest literally says; the console renders
+    /// [`Self::effective_toolkits`] instead.
     toolkits: Vec<String>,
+    /// Whether this company is in **open mode** — an empty manifest allowlist,
+    /// meaning the backend's own allowlist governs and every toolkit it permits
+    /// is reachable (issue #397).
+    ///
+    /// The console needs this told to it rather than inferred: an empty
+    /// `toolkits` means *allow everything*, which is the opposite of what an
+    /// empty list reads as.
+    open_mode: bool,
+    /// The toolkits the console offers as provider rows — the manifest list when
+    /// it is non-empty, else the curated [`OPEN_MODE_TOOLKITS`] starting set. In
+    /// open mode this is a suggestion, not a limit: any slug the backend permits
+    /// can still be authorized.
+    effective_toolkits: Vec<String>,
 }
 
 /// A mutating response: the resulting status plus the switch reminder.
@@ -177,12 +246,15 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<ComposioStatusDto,
         )
     };
     let credential_source = credential_source_for(stored, &env);
+    let (open_mode, effective) = effective_toolkits(&toolkits);
     Ok(ComposioStatusDto {
         in_build: cfg!(feature = "composio"),
         granted,
         credential_source,
         backend_url: backend_url_or_default(env_url, api_url),
         toolkits,
+        open_mode,
+        effective_toolkits: effective,
     })
 }
 
@@ -413,6 +485,61 @@ mod tests {
         (status, value, raw)
     }
 
+    /// Issue #397: an **empty** manifest allowlist means "defer to the backend"
+    /// — allow everything — so the status must report open mode and hand the
+    /// console a non-empty starting set. The old console gate keyed off
+    /// `toolkits.length > 0` and therefore rendered nothing in exactly the case
+    /// where everything is permitted.
+    #[tokio::test]
+    async fn an_empty_toolkit_list_is_open_mode_and_still_offers_providers() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        // No `[tools.composio]` section at all — the shape 19 of 20 templates ship.
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"composio\"]\n",
+        )
+        .await;
+
+        let (status, dto, _) = send(&state, "GET", "/api/v1/company/composio", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(dto["granted"], true);
+        assert_eq!(dto["toolkits"], json!([]), "the manifest list is verbatim");
+        assert_eq!(dto["openMode"], true);
+        let offered = dto["effectiveToolkits"]
+            .as_array()
+            .expect("open mode carries an effective toolkit list");
+        assert!(
+            !offered.is_empty(),
+            "open mode means allow-everything, so the console must be offered providers"
+        );
+        assert!(
+            offered.iter().any(|t| t == "github"),
+            "the curated set covers the common providers: {offered:?}"
+        );
+    }
+
+    /// The other half of #397: a company that deliberately narrowed its belt
+    /// sees exactly what it chose, and is NOT in open mode. A fix that offered
+    /// the curated set to everyone would silently widen every restrictive
+    /// manifest.
+    #[tokio::test]
+    async fn an_explicit_toolkit_list_is_offered_verbatim_and_is_not_open_mode() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"composio\"]\n[tools.composio]\ntoolkits = [\"gmail\"]\n",
+        )
+        .await;
+
+        let (status, dto, _) = send(&state, "GET", "/api/v1/company/composio", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(dto["openMode"], false);
+        assert_eq!(dto["effectiveToolkits"], json!(["gmail"]));
+        assert_eq!(dto["toolkits"], json!(["gmail"]));
+    }
+
     /// The `credentialSource` matrix as the console consumes it, plus the
     /// write-only contract. Runs with no platform identity in the environment, so
     /// the instance contributes nothing and the company's own token is the only
@@ -527,6 +654,8 @@ mod tests {
             credential_source: CredentialSource::Attested,
             backend_url: "https://api.tinyhumans.ai".to_string(),
             toolkits: vec!["gmail".to_string()],
+            open_mode: false,
+            effective_toolkits: vec!["gmail".to_string()],
         };
         let json = serde_json::to_value(&dto).unwrap();
         assert_eq!(json["credentialSource"], "attested");
@@ -538,7 +667,9 @@ mod tests {
                 "granted",
                 "credentialSource",
                 "backendUrl",
-                "toolkits"
+                "toolkits",
+                "openMode",
+                "effectiveToolkits"
             ],
             "the read shape must stay exactly this: {keys:?}"
         );

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -94,7 +94,10 @@ fn effective_toolkits(manifest: &[String]) -> (bool, Vec<String>) {
     if manifest.is_empty() {
         (
             true,
-            OPEN_MODE_TOOLKITS.iter().map(|s| (*s).to_string()).collect(),
+            OPEN_MODE_TOOLKITS
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect(),
         )
     } else {
         (false, manifest.to_vec())
@@ -310,7 +313,7 @@ async fn connections(company: ScopedCompany) -> Result<Json<Vec<ConnectionDto>>,
 /// token nor a platform identity — in which case the operator must paste a token
 /// before OAuth.
 #[cfg(feature = "composio")]
-async fn resolve_tenant(
+pub(crate) async fn resolve_tenant(
     runtime: &CompanyRuntime,
 ) -> Result<crate::harness::composio::TenantComposio, ApiError> {
     use crate::app::config::EnvSource;

--- a/src/server/ops/connections.rs
+++ b/src/server/ops/connections.rs
@@ -50,9 +50,11 @@ use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
+use crate::AppConfig;
 use crate::AppState;
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
+use crate::ports::normalize_email;
 use crate::ports::now_millis;
 use crate::ports::types::{CompanyId, SecretValue};
 use crate::server::error::ApiError;
@@ -266,6 +268,33 @@ fn connect_error(state: &AppState, code: &str, provider: Option<&str>) -> Respon
     console_redirect(state, &params)
 }
 
+/// Bounces back on an account mismatch (issue #316: one operator, one
+/// connected account), naming both the account the provider handed back and
+/// the address(es) this company expects, so the console can tell the operator
+/// exactly why the connect was refused.
+///
+/// Built directly on [`console_redirect`] rather than folded into
+/// [`connect_error`]: every other failure code is deliberately detail-free —
+/// the provider's own error text must never ride in the URL (see
+/// `connect_error`'s doc) — but this code's whole point is to name two email
+/// addresses. Only email addresses ever reach this function; token material
+/// never does.
+fn connect_account_mismatch(
+    state: &AppState,
+    provider: &str,
+    connected: &str,
+    expected: &str,
+) -> Response {
+    let params = format!(
+        "connect_error={}&provider={}&connected_account={}&expected_account={}",
+        urlencode("account_mismatch"),
+        urlencode(provider),
+        urlencode(connected),
+        urlencode(expected),
+    );
+    console_redirect(state, &params)
+}
+
 // ---------------------------------------------------------------------------
 // Signed state nonce
 // ---------------------------------------------------------------------------
@@ -449,6 +478,16 @@ async fn callback(State(state): State<AppState>, uri: Uri) -> Response {
     match exchange_code(&state, &config, &code).await {
         Ok(token_json) => {
             let account = extract_account(&token_json);
+            if let Some((connected, expected)) =
+                account_mismatch(state.config(), &runtime, account.as_deref()).await
+            {
+                tracing::warn!(
+                    provider,
+                    connected = %connected,
+                    "oauth callback: connected account does not match this company's operator"
+                );
+                return connect_account_mismatch(&state, &provider, &connected, &expected);
+            }
             let stored = json!({ "token": token_json, "account": account });
             if let Err(err) = runtime
                 .secrets()
@@ -517,6 +556,56 @@ fn extract_account(token: &serde_json::Value) -> Option<String> {
         .and_then(|team| team.get("name"))
         .and_then(|v| v.as_str())
         .map(str::to_string)
+}
+
+/// Whether `account` — the label [`extract_account`] pulled from a token
+/// response — belongs to someone other than this company's operator (issue
+/// #316: one operator, one connected account).
+///
+/// This enforces identity at **connect time only**. It has no way to detect a
+/// live account swap at the provider after the token is already stored, and
+/// it does not drive a reconnect flow — both are out of scope for this slice.
+///
+/// Refuses to guess whenever the comparison would not be meaningful, and only
+/// ever returns a mismatch on a genuine, comparable email mismatch:
+/// - `account` is `None` — e.g. GitHub's token response carries no `login`,
+///   only `access_token`/`scope`/`token_type`, so there is nothing to
+///   compare. Not a mismatch: stored as today.
+/// - `account` is not shaped like an email — Slack hands back a workspace
+///   name (`team.name`), GitHub a login handle; neither is comparable to an
+///   operator's email address, and a naive `!=` here would refuse every Slack
+///   and GitHub connect. Not a mismatch: stored as today.
+/// - the company has no known operator address, or the lookup itself fails —
+///   there is nothing to compare against. Not a mismatch: stored as today.
+///
+/// Only when `account` is itself a normalizable email address AND the company
+/// has at least one known operator address AND it matches none of them does
+/// this return `Some((connected, expected))` for the caller to refuse with.
+async fn account_mismatch(
+    config: &AppConfig,
+    runtime: &CompanyRuntime,
+    account: Option<&str>,
+) -> Option<(String, String)> {
+    let connected = normalize_email(account?);
+    if connected.is_empty() || !connected.contains('@') {
+        // Not an email at all (a Slack workspace name, a GitHub login) — no
+        // comparable operator address exists to check it against.
+        return None;
+    }
+    let admins = match crate::server::users::routes::bootstrap_admins(config, runtime).await {
+        Ok(admins) => admins,
+        Err(err) => {
+            tracing::warn!(
+                "oauth callback: could not load operator addresses to compare a connected \
+                 account against: {err}"
+            );
+            return None;
+        }
+    };
+    if admins.is_empty() || admins.iter().any(|a| normalize_email(a) == connected) {
+        return None;
+    }
+    Some((connected, admins.join(", ")))
 }
 
 // ---------------------------------------------------------------------------
@@ -1044,6 +1133,233 @@ mod test {
                 std::env::remove_var(format!("OPENCOMPANY_OAUTH_{key}_{suffix}"));
             }
         }
+    }
+
+    // ---- account identity at connect time (issue #316) --------------------
+
+    /// Builds an isolated in-memory company runtime whose manifest names
+    /// `admins` as `[users].admins` — the operator addresses a connected
+    /// account is checked against.
+    async fn test_runtime_with_admins(admins: &[&str]) -> (Arc<CompanyRuntime>, tempfile::TempDir) {
+        let home = tempfile::Builder::new()
+            .prefix("oc-acct-")
+            .tempdir()
+            .expect("tempdir");
+        let admins_toml = admins
+            .iter()
+            .map(|a| format!("{a:?}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let manifest: CompanyManifest = toml::from_str(&format!(
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[users]\nadmins = [{admins_toml}]\n"
+        ))
+        .unwrap();
+        let runtime = RuntimeBuilder::new(home.path().to_path_buf(), manifest)
+            .with_id(CompanyId::new("acme"))
+            .build()
+            .await
+            .unwrap();
+        (Arc::new(runtime), home)
+    }
+
+    /// Spins up a local HTTP server that answers every POST with `body` as
+    /// JSON, standing in for a provider's token endpoint. Returns the address
+    /// to point `OPENCOMPANY_OAUTH_<P>_TOKEN_URL` at.
+    async fn mock_token_endpoint(body: serde_json::Value) -> std::net::SocketAddr {
+        let app = Router::new().route(
+            "/token",
+            post(move || {
+                let body = body.clone();
+                async move { Json(body) }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        addr
+    }
+
+    /// Registers a unique provider's app credentials pointing its token URL at
+    /// `addr`, and returns the provider name + env key so the caller can clean
+    /// up afterwards.
+    fn configure_provider_env(addr: std::net::SocketAddr) -> (String, String) {
+        let provider = unique_provider();
+        let key = provider.to_ascii_uppercase();
+        // SAFETY: unique per-test provider name → no cross-test env collision.
+        unsafe {
+            std::env::set_var(format!("OPENCOMPANY_OAUTH_{key}_ID"), "cid");
+            std::env::set_var(format!("OPENCOMPANY_OAUTH_{key}_SECRET"), "csec");
+            std::env::set_var(
+                format!("OPENCOMPANY_OAUTH_{key}_AUTHORIZE_URL"),
+                "http://x/a",
+            );
+            std::env::set_var(
+                format!("OPENCOMPANY_OAUTH_{key}_TOKEN_URL"),
+                format!("http://{addr}/token"),
+            );
+        }
+        (provider, key)
+    }
+
+    fn clear_provider_env(key: &str) {
+        unsafe {
+            for suffix in ["ID", "SECRET", "AUTHORIZE_URL", "TOKEN_URL"] {
+                std::env::remove_var(format!("OPENCOMPANY_OAUTH_{key}_{suffix}"));
+            }
+        }
+    }
+
+    /// A connected account matching the company's operator address connects
+    /// and stores as before — the baseline this slice must not break.
+    #[tokio::test]
+    async fn callback_matching_account_connects_and_stores() {
+        let (runtime, _home) = test_runtime_with_admins(&["ada@example.com"]).await;
+        let state = AppState::new(AppConfig::default());
+        state
+            .registry()
+            .insert(CompanyId::new("acme"), runtime.clone());
+
+        let addr = mock_token_endpoint(json!({ "email": "ada@example.com" })).await;
+        let (provider, key) = configure_provider_env(addr);
+
+        let nonce = encode_state(
+            &test_state_secret(),
+            "acme",
+            &provider,
+            now_millis() + STATE_TTL_MS,
+        );
+        let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
+        let loc = location(&resp);
+        assert!(
+            loc.contains(&format!("connected={provider}")),
+            "expected a matching account to connect: {loc}"
+        );
+        assert!(!loc.contains("connect_error="), "{loc}");
+
+        let stored = runtime
+            .secrets()
+            .get(runtime.id(), &oauth_key(&provider))
+            .await
+            .unwrap()
+            .expect("token stored");
+        assert!(
+            stored.expose().contains("ada@example.com"),
+            "stored secret missing the connected account: {}",
+            stored.expose()
+        );
+
+        clear_provider_env(&key);
+    }
+
+    /// A connected account that is a comparable email but matches none of the
+    /// company's operator addresses is refused: nothing is stored, and the
+    /// redirect names both the connected and expected addresses (issue #316).
+    #[tokio::test]
+    async fn callback_mismatched_email_account_is_refused() {
+        let (runtime, _home) = test_runtime_with_admins(&["ada@example.com"]).await;
+        let state = AppState::new(AppConfig::default());
+        state
+            .registry()
+            .insert(CompanyId::new("acme"), runtime.clone());
+
+        let addr = mock_token_endpoint(json!({ "email": "eve@example.com" })).await;
+        let (provider, key) = configure_provider_env(addr);
+
+        let nonce = encode_state(
+            &test_state_secret(),
+            "acme",
+            &provider,
+            now_millis() + STATE_TTL_MS,
+        );
+        let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
+        let loc = location(&resp);
+        assert!(loc.contains("connect_error=account_mismatch"), "{loc}");
+        assert!(loc.contains(&format!("provider={provider}")), "{loc}");
+        assert!(
+            loc.contains(&urlencode("eve@example.com")),
+            "redirect must name the connected account: {loc}"
+        );
+        assert!(
+            loc.contains(&urlencode("ada@example.com")),
+            "redirect must name the expected operator address: {loc}"
+        );
+
+        assert!(
+            is_blanked(&runtime, &provider).await,
+            "a mismatched account must not be stored"
+        );
+
+        clear_provider_env(&key);
+    }
+
+    /// GitHub's token response carries no `login` at all — just
+    /// `access_token`/`scope`/`token_type` — so [`extract_account`] returns
+    /// `None`. With nothing to compare, the connect must still succeed; this
+    /// is the regression guard for the "cannot compare, so do not refuse"
+    /// rule.
+    #[tokio::test]
+    async fn callback_token_without_account_still_connects() {
+        let (runtime, _home) = test_runtime_with_admins(&["ada@example.com"]).await;
+        let state = AppState::new(AppConfig::default());
+        state
+            .registry()
+            .insert(CompanyId::new("acme"), runtime.clone());
+
+        let addr = mock_token_endpoint(json!({
+            "access_token": "gho_mock",
+            "scope": "repo",
+            "token_type": "bearer",
+        }))
+        .await;
+        let (provider, key) = configure_provider_env(addr);
+
+        let nonce = encode_state(
+            &test_state_secret(),
+            "acme",
+            &provider,
+            now_millis() + STATE_TTL_MS,
+        );
+        let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
+        let loc = location(&resp);
+        assert!(
+            loc.contains(&format!("connected={provider}")),
+            "an account-less token response must still connect: {loc}"
+        );
+        assert!(!loc.contains("connect_error="), "{loc}");
+
+        clear_provider_env(&key);
+    }
+
+    /// Slack's token response names the workspace under `team.name`, not the
+    /// operator's address. A label that isn't shaped like an email is not
+    /// comparable, so the connect must still succeed — a naive `!=` here
+    /// would break every Slack connect.
+    #[tokio::test]
+    async fn callback_non_email_account_still_connects() {
+        let (runtime, _home) = test_runtime_with_admins(&["ada@example.com"]).await;
+        let state = AppState::new(AppConfig::default());
+        state
+            .registry()
+            .insert(CompanyId::new("acme"), runtime.clone());
+
+        let addr = mock_token_endpoint(json!({ "team": { "name": "Acme Workspace" } })).await;
+        let (provider, key) = configure_provider_env(addr);
+
+        let nonce = encode_state(
+            &test_state_secret(),
+            "acme",
+            &provider,
+            now_millis() + STATE_TTL_MS,
+        );
+        let resp = call_callback(state, &format!("code=abc&state={}", urlencode(&nonce))).await;
+        let loc = location(&resp);
+        assert!(
+            loc.contains(&format!("connected={provider}")),
+            "a non-email account label must still connect: {loc}"
+        );
+        assert!(!loc.contains("connect_error="), "{loc}");
+
+        clear_provider_env(&key);
     }
 
     // ---- disconnect / best-effort revoke ----------------------------------

--- a/src/server/ops/connections_read.rs
+++ b/src/server/ops/connections_read.rs
@@ -77,6 +77,15 @@ struct ConnectionStateDto {
     /// when not connected or when the stored blob carries no account.
     #[serde(skip_serializing_if = "Option::is_none")]
     account: Option<String>,
+    /// Which namespace(s) report this provider connected — `native` for the
+    /// `oauth/{provider}` catalog, `composio` for a Composio connection. Empty
+    /// when not connected. `github` and `gmail` exist in both, so this is what
+    /// turns two disagreeing surfaces into one answer (issue #316).
+    via: Vec<&'static str>,
+    /// A Composio path exists for this company but could not be read, so
+    /// `connected: false` means "unknown", not "no". The console must not render
+    /// a confident disconnected state over an unanswered probe.
+    unverified: bool,
 }
 
 /// Can a Connect click for `provider` possibly succeed on this host, and by
@@ -191,28 +200,140 @@ pub fn router() -> Router<AppState> {
     scoped("/connections", get(list))
 }
 
-/// Projects each manifest connection into its non-secret status by reading the
-/// `oauth/{provider}` secret. Mirrors
-/// [`resolve_connections`](crate::server::graphql::connections::resolve_connections):
-/// only `provider` / `connected` / `credentialSource` / `account` ever leave
-/// this function — the token blob stays in the
-/// [`SecretStore`](crate::ports::SecretStore), and `credentialSource` is a tier
-/// name, never a credential and never a path.
-async fn project(runtime: &CompanyRuntime) -> Result<Vec<ConnectionStateDto>, ApiError> {
-    let Some(record) = runtime.store().load(runtime.id()).await.map_err(ApiError)? else {
+// ---------------------------------------------------------------------------
+// Reconciliation across connection namespaces (issue #316)
+// ---------------------------------------------------------------------------
+
+/// What Composio says about this company's connections.
+///
+/// Three states, not two, because "we could not ask" and "it said no" are
+/// different answers and collapsing them is the bug: reporting a failed probe as
+/// *not connected* is precisely the contradictory display #316 is about.
+///
+/// Without the `composio` feature only [`NotApplicable`](Self::NotApplicable) is
+/// ever constructed — there is no second namespace in that build — so the other
+/// two are genuinely dead there. The allow is scoped to exactly that build
+/// rather than blanket, so if a live variant stops being constructed in the
+/// `composio` build the compiler still says so.
+#[cfg_attr(not(feature = "composio"), allow(dead_code))]
+enum ComposioView {
+    /// There is no Composio path to reconcile against — the feature is not in
+    /// this build, the company does not grant `composio`, or no credential of
+    /// any tier resolves. Silence here is correct, not missing information.
+    NotApplicable,
+    /// A Composio path exists but could not be read (network, backend error).
+    /// Providers it might have covered are reported as *unverified* rather than
+    /// disconnected.
+    Unavailable,
+    /// Composio answered: toolkit slug → connected.
+    Known(std::collections::BTreeMap<String, bool>),
+}
+
+/// The Composio toolkit slug a catalog/manifest provider id corresponds to.
+///
+/// Composio slugs are lowercase and unpunctuated (`googlecalendar`), while this
+/// console's provider ids are hyphenated (`google-calendar`). Normalizing both
+/// sides through one rule is what lets `github` and `gmail` — which exist in
+/// **both** namespaces — resolve to a single row instead of two surfaces
+/// disagreeing on screen.
+fn toolkit_slug(provider: &str) -> String {
+    provider
+        .chars()
+        .filter(char::is_ascii_alphanumeric)
+        .collect::<String>()
+        .to_ascii_lowercase()
+}
+
+/// One provider's reconciled state — the single answer both read planes serve.
+///
+/// Built once, in one place, so the REST projection and the GraphQL resolver
+/// cannot drift apart: they map this into their own wire types and add nothing
+/// of their own to the decision.
+pub(crate) struct ProviderConnection {
+    /// The provider id, as the manifest and console catalog spell it.
+    pub(crate) provider: String,
+    /// Connected through **any** namespace — the one coherent answer.
+    pub(crate) connected: bool,
+    /// Which route a Connect would take on this host.
+    pub(crate) credential_source: CredentialSource,
+    /// The connected account label, when known. Never token material.
+    pub(crate) account: Option<String>,
+    /// The namespaces that report this provider connected: `native` (the
+    /// `oauth/{provider}` catalog) and/or `composio`. Empty when not connected.
+    pub(crate) via: Vec<&'static str>,
+    /// A Composio path exists but could not be read, so `connected: false` here
+    /// means "we do not know", not "no". The console must say so rather than
+    /// showing a confident disconnected state.
+    pub(crate) unverified: bool,
+    /// The manifest's stated reason for wanting this connection, when declared.
+    pub(crate) reason: Option<String>,
+}
+
+/// Ask Composio which toolkits this company has connected.
+///
+/// Best-effort by construction: a company that does not grant `composio`, a
+/// build without the feature, or a missing credential all yield
+/// [`ComposioView::NotApplicable`], and a live probe that errors yields
+/// [`ComposioView::Unavailable`]. Nothing here can fail the connections page.
+#[cfg(feature = "composio")]
+async fn composio_view(runtime: &CompanyRuntime) -> ComposioView {
+    let granted = match runtime.store().load(runtime.id()).await {
+        Ok(Some(record)) => crate::company::grants_composio_explicit(&record.manifest.tools.allow),
+        _ => false,
+    };
+    if !granted {
+        return ComposioView::NotApplicable;
+    }
+    let Ok(config) = super::composio::resolve_tenant(runtime).await else {
+        // No credential of any tier resolves, so there is no Composio path to
+        // reconcile against — not a failure to report.
+        return ComposioView::NotApplicable;
+    };
+    match crate::harness::composio::list_connection_states(&config).await {
+        Ok(states) => ComposioView::Known(
+            states
+                .into_iter()
+                .map(|(toolkit, connected)| (toolkit_slug(&toolkit), connected))
+                .collect(),
+        ),
+        Err(err) => {
+            // The message is already scrubbed of the tenant credential by
+            // `list_connection_states`; log at debug and degrade.
+            tracing::debug!("[connections] composio probe failed: {err}");
+            ComposioView::Unavailable
+        }
+    }
+}
+
+/// Without the `composio` feature there is no second namespace to reconcile
+/// against, so every provider's answer is the native one alone.
+#[cfg(not(feature = "composio"))]
+async fn composio_view(_runtime: &CompanyRuntime) -> ComposioView {
+    ComposioView::NotApplicable
+}
+
+/// Projects a company's connections into one reconciled row per provider.
+///
+/// The union of two namespaces: the manifest's declared connections (whose
+/// state is the `oauth/{provider}` secret) and any provider Composio reports
+/// connected. `github` and `gmail` live in both, which is why they used to be
+/// shown twice with different answers.
+pub(crate) async fn project_connections(
+    runtime: &CompanyRuntime,
+) -> Result<Vec<ProviderConnection>, crate::error::OpenCompanyError> {
+    let Some(record) = runtime.store().load(runtime.id()).await? else {
         return Ok(Vec::new());
     };
-    let mut out = Vec::with_capacity(record.manifest.connections.len());
+    let composio = composio_view(runtime).await;
     // Host-level, so resolved once rather than per connection below.
     let host = HostConnectRoutes::from_env();
+
+    let mut out: Vec<ProviderConnection> = Vec::with_capacity(record.manifest.connections.len());
+    let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+
     for connection in &record.manifest.connections {
         let key = format!("oauth/{}", connection.provider);
-        let (connected, account) = match runtime
-            .secrets()
-            .get(runtime.id(), &key)
-            .await
-            .map_err(ApiError)?
-        {
+        let (native, account) = match runtime.secrets().get(runtime.id(), &key).await? {
             Some(value) if !value.expose().trim().is_empty() => {
                 // Read only the `account` label out of the stored blob; the
                 // `token` field is intentionally never touched.
@@ -227,14 +348,80 @@ async fn project(runtime: &CompanyRuntime) -> Result<Vec<ConnectionStateDto>, Ap
             }
             _ => (false, None),
         };
-        out.push(ConnectionStateDto {
-            credential_source: host.route_from_env(&connection.provider, connected),
+
+        let slug = toolkit_slug(&connection.provider);
+        seen.insert(slug.clone());
+        let (composio_connected, unverified) = match &composio {
+            ComposioView::Known(states) => (states.get(&slug).copied().unwrap_or(false), false),
+            // Only unverified if the native side didn't already answer yes: a
+            // provider we know is connected needs no second opinion.
+            ComposioView::Unavailable => (false, !native),
+            ComposioView::NotApplicable => (false, false),
+        };
+
+        let mut via = Vec::new();
+        if native {
+            via.push("native");
+        }
+        if composio_connected {
+            via.push("composio");
+        }
+        out.push(ProviderConnection {
+            credential_source: host.route_from_env(&connection.provider, native),
             provider: connection.provider.clone(),
-            connected,
+            connected: native || composio_connected,
             account,
+            via,
+            unverified,
+            reason: connection.reason.clone(),
         });
     }
+
+    // A provider Composio has connected but the manifest never declared is still
+    // a live capability this company has. Showing it is the difference between a
+    // page that reconciles and a page that reports one namespace and hides the
+    // other.
+    if let ComposioView::Known(states) = &composio {
+        for (slug, connected) in states {
+            if !*connected || seen.contains(slug) {
+                continue;
+            }
+            out.push(ProviderConnection {
+                credential_source: host.route_from_env(slug, false),
+                provider: slug.clone(),
+                connected: true,
+                account: None,
+                via: vec!["composio"],
+                unverified: false,
+                reason: None,
+            });
+        }
+    }
+
     Ok(out)
+}
+
+/// Projects each manifest connection into its non-secret status by reading the
+/// `oauth/{provider}` secret. Mirrors
+/// [`resolve_connections`](crate::server::graphql::connections::resolve_connections):
+/// only `provider` / `connected` / `credentialSource` / `account` ever leave
+/// this function — the token blob stays in the
+/// [`SecretStore`](crate::ports::SecretStore), and `credentialSource` is a tier
+/// name, never a credential and never a path.
+async fn project(runtime: &CompanyRuntime) -> Result<Vec<ConnectionStateDto>, ApiError> {
+    Ok(project_connections(runtime)
+        .await
+        .map_err(ApiError)?
+        .into_iter()
+        .map(|row| ConnectionStateDto {
+            provider: row.provider,
+            connected: row.connected,
+            credential_source: row.credential_source,
+            account: row.account,
+            via: row.via,
+            unverified: row.unverified,
+        })
+        .collect())
 }
 
 /// `GET …/connections` — the company's non-secret connection status list.
@@ -594,15 +781,108 @@ mod tests {
             connected: true,
             credential_source: CredentialSource::Attested,
             account: Some("octocat".to_string()),
+            via: vec!["native"],
+            unverified: false,
         };
         let json = serde_json::to_value(&dto).unwrap();
         assert_eq!(json["credentialSource"], "attested");
         let keys: Vec<&String> = json.as_object().unwrap().keys().collect();
         assert_eq!(
             keys,
-            vec!["provider", "connected", "credentialSource", "account"],
+            vec![
+                "provider",
+                "connected",
+                "credentialSource",
+                "account",
+                "via",
+                "unverified"
+            ],
             "the read shape must stay exactly this: {keys:?}"
         );
+    }
+
+    /// Issue #316: one coherent answer per provider.
+    ///
+    /// Without the `composio` feature there is no second namespace, so every
+    /// row's answer is the native one — and, critically, `unverified` is
+    /// **false**: "there is no Composio path here" must not be reported as "we
+    /// could not check". The `composio` build's live probe is exercised against
+    /// the real backend, not here; what this pins is the reconciliation shape
+    /// both read planes now serve.
+    #[tokio::test]
+    async fn a_provider_in_neither_namespace_reads_disconnected_not_unknown() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+             [[connection]]\nprovider = \"github\"\n\
+             [[connection]]\nprovider = \"slack\"\n",
+        )
+        .await;
+
+        // github connected natively; slack in neither namespace.
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+        runtime
+            .secrets()
+            .set(
+                &id,
+                "oauth/github",
+                SecretValue(
+                    serde_json::json!({
+                        "token": { "access_token": "gho_fake_never_a_real_token" },
+                        "account": "octocat"
+                    })
+                    .to_string(),
+                ),
+            )
+            .await
+            .unwrap();
+
+        let (status, body) = get_connections(&state).await;
+        assert_eq!(status, StatusCode::OK);
+        let list = body.as_array().expect("array body");
+
+        // Exactly one row per provider — never one per namespace.
+        assert_eq!(list.len(), 2, "one row per provider: {body}");
+
+        let github = list
+            .iter()
+            .find(|row| row["provider"] == "github")
+            .expect("a github row");
+        assert_eq!(github["connected"], true);
+        assert_eq!(github["via"], serde_json::json!(["native"]));
+        assert_eq!(github["unverified"], false);
+
+        let slack = list
+            .iter()
+            .find(|row| row["provider"] == "slack")
+            .expect("a slack row");
+        assert_eq!(slack["connected"], false);
+        assert_eq!(
+            slack["via"],
+            serde_json::json!([]),
+            "no namespace claims it"
+        );
+        assert_eq!(
+            slack["unverified"], false,
+            "no Composio path is a known answer, not an unknown one"
+        );
+    }
+
+    /// The provider-id → Composio-slug normalization that lets one provider
+    /// resolve to one row across both namespaces. The console spells ids
+    /// hyphenated (`google-calendar`); Composio spells slugs unpunctuated
+    /// (`googlecalendar`). Without a shared rule these are two providers, and the
+    /// page reports both — which is the #316 symptom.
+    #[test]
+    fn provider_ids_and_composio_slugs_normalize_to_one_key() {
+        use super::toolkit_slug;
+        assert_eq!(toolkit_slug("google-calendar"), "googlecalendar");
+        assert_eq!(toolkit_slug("google-drive"), "googledrive");
+        assert_eq!(toolkit_slug("GitHub"), "github");
+        assert_eq!(toolkit_slug("gmail"), "gmail");
     }
 
     /// A company with no `[[connection]]` entries returns an empty list (200),

--- a/src/server/ops/connections_read.rs
+++ b/src/server/ops/connections_read.rs
@@ -275,12 +275,14 @@ pub(crate) struct ProviderConnection {
 /// build without the feature, or a missing credential all yield
 /// [`ComposioView::NotApplicable`], and a live probe that errors yields
 /// [`ComposioView::Unavailable`]. Nothing here can fail the connections page.
+///
+/// **Bounded on purpose.** This is a network call on a page-load path, so a
+/// backend that stops answering must degrade the Composio half of one row — not
+/// hang the whole Connections page behind a socket with no deadline. The timeout
+/// lands in [`ComposioView::Unavailable`], which the console renders as "could
+/// not check" rather than as a confident disconnected state.
 #[cfg(feature = "composio")]
-async fn composio_view(runtime: &CompanyRuntime) -> ComposioView {
-    let granted = match runtime.store().load(runtime.id()).await {
-        Ok(Some(record)) => crate::company::grants_composio_explicit(&record.manifest.tools.allow),
-        _ => false,
-    };
+async fn composio_view(runtime: &CompanyRuntime, granted: bool) -> ComposioView {
     if !granted {
         return ComposioView::NotApplicable;
     }
@@ -289,26 +291,38 @@ async fn composio_view(runtime: &CompanyRuntime) -> ComposioView {
         // reconcile against — not a failure to report.
         return ComposioView::NotApplicable;
     };
-    match crate::harness::composio::list_connection_states(&config).await {
-        Ok(states) => ComposioView::Known(
+    let probe = crate::harness::composio::list_connection_states(&config);
+    match tokio::time::timeout(COMPOSIO_PROBE_TIMEOUT, probe).await {
+        Ok(Ok(states)) => ComposioView::Known(
             states
                 .into_iter()
                 .map(|(toolkit, connected)| (toolkit_slug(&toolkit), connected))
                 .collect(),
         ),
-        Err(err) => {
+        Ok(Err(err)) => {
             // The message is already scrubbed of the tenant credential by
             // `list_connection_states`; log at debug and degrade.
             tracing::debug!("[connections] composio probe failed: {err}");
             ComposioView::Unavailable
         }
+        Err(_elapsed) => {
+            tracing::debug!("[connections] composio probe timed out");
+            ComposioView::Unavailable
+        }
     }
 }
+
+/// How long the Composio reconciliation probe may take before the page gives up
+/// on it. Chosen to be well inside a human's tolerance for a settings page: the
+/// answer it contributes is one badge per row, and a stale-but-honest "could not
+/// check" beats a page that never paints.
+#[cfg(feature = "composio")]
+const COMPOSIO_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Without the `composio` feature there is no second namespace to reconcile
 /// against, so every provider's answer is the native one alone.
 #[cfg(not(feature = "composio"))]
-async fn composio_view(_runtime: &CompanyRuntime) -> ComposioView {
+async fn composio_view(_runtime: &CompanyRuntime, _granted: bool) -> ComposioView {
     ComposioView::NotApplicable
 }
 
@@ -324,7 +338,11 @@ pub(crate) async fn project_connections(
     let Some(record) = runtime.store().load(runtime.id()).await? else {
         return Ok(Vec::new());
     };
-    let composio = composio_view(runtime).await;
+    let composio = composio_view(
+        runtime,
+        crate::company::grants_composio_explicit(&record.manifest.tools.allow),
+    )
+    .await;
     // Host-level, so resolved once rather than per connection below.
     let host = HostConnectRoutes::from_env();
 


### PR DESCRIPTION
## Summary

The Connections page now shows providers you can actually connect, gives one answer per provider instead of three, and says which path an agent really uses.

The headline defect: **on 19 of 20 templates the page showed no provider rows at all**, because an empty toolkit list means *allow everything* and the console read it as *show nothing*.

## API Or Behavior Changes

**#397 — open mode is now legible.** The status response carries `openMode` and `effectiveToolkits`; the console renders rows from that rather than inferring from a manifest field whose empty case means the opposite of empty. Presentation is a curated eight (`gmail`, `googlecalendar`, `googledrive`, `github`, `slack`, `notion`, `linear`, `discord`) **plus a free-text slug field** that authorizes any toolkit the backend permits — the authorize route already accepts an arbitrary slug, so the long tail is reachable with no backend change. The console cannot learn the ~100-slug allowlist without a network call on page load, and a hundred rows is its own usability problem. **The curated list is a console affordance only — agent-side admission is untouched.**

**#316 — one answer per provider.** `connections_read.rs` gains `project_connections`, the single reconciliation both read planes now call; the GraphQL resolver's duplicate loop is deleted, so it **cannot drift**. Rows carry `via` (`native` / `composio`) and `unverified`.

**#316 — the account check is now enforced.** `extract_account` was computed and stored but never compared. The OAuth callback now refuses a mismatch **before storing**, naming both addresses.

**Deliberately conservative, and the reason matters:** the check refuses only on a *comparable email*. GitHub's token response carries no `login` — it returns `access_token`/`scope`/`token_type` — so `extract_account` yields `None` there, and Slack yields a *workspace name*, not a user. A naive `!=` would have broken every Slack connect while doing nothing for GitHub.

**#396 — the page stops implying the dead catalog is the way in.** A banner states that agents reach providers through Composio. Much of #396's honesty had already shipped via #319's `credentialSource` tri-state, which replaces Connect with "Managed by the platform" on attested hosts and "Not available on this host" for `none`.

**A network probe now runs on a page-load path**, so it is bounded at 5s → `unverified` rather than letting a hung backend hang the Connections page.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings` *(default features)*
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --lib` — **1379 passed**
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **1932 passed**
- [x] `cargo check --locked --all-features --all-targets`
- [x] `git diff --stat Cargo.lock` — empty
- [x] `npm ci`, `npm run typecheck`, `npm run typecheck:e2e`, `npm run build`

No lint or component-test script exists in this repo; neither is claimed.

## Impact

**What was verified about the platform credential, and what was not.**

The audit behind this work claimed the attestation chain "ships dark by default on both sides". **That is false on the app side**, established from smoke1's unauthenticated `/spec`:

```
{"api_url":"https://staging-api.tinyhumans.ai","cycles_available":true}
```

`cycles_available` is `brain_mode == Hosted && credential_available()`, and that resolution is the **same** one `TenantComposio::resolve` falls back to. So a Composio credential does resolve in that pod. `TENANT_FEATURES` in the staging deploy explicitly includes `composio`, so the tools are compiled in. (A bogus hostname returns `tenant not found`, confirming `/spec` is the tenant binary rather than the manager.)

**Still unproven, and stated plainly: the last hop.** Nobody has shown that the backend accepts that identity *and* that a GitHub account is connected to the resulting Composio entity. Every Composio route on staging sits behind an interactive hub OAuth handshake with no headless path, and no TinyHumans platform token exists locally — so this could not be closed from a terminal. **It needs one browser session on the staging tenant**, and it remains the single most valuable outstanding check about connections.

**Four corrections to the brief this was built from:**

- **MCP servers are not invisible on this page** — `McpServersSection` is rendered inside `ConnectionsView`. The "three surfaces" complaint is really two.
- **GitHub carries no `login` in its token response**, as above — the basis for the conservative enforcement.
- **#397 misses two templates** — `openhuman_demo` and `signals_opportunity_studio` do not grant `composio` at all, so rows would be wrong there regardless; the existing `granted` flag already covers that.
- **smoke1 would never have shown the #397 bug** — its company is the one template that sets `toolkits`.

**One judgement call, reverted deliberately.** Gating Connect on catalog tiles the host does not declare was implemented and then backed out: the e2e suite runs against `e2e_harness`, which declares no connections, so it would have stripped every Connect button and broken `oauth-onboarding-resume.spec.ts`'s retry-after-cancel expectation. Playwright could not be run to confirm, so the banner was chosen over silently breaking a pinned behaviour. Worth a maintainer's view.

## Related

Closes #397
Closes #316
Addresses the display half of #396 — the native catalog is **not** wired here, and its code and backend behaviour are untouched, because that needs the token-custody question in #319.
