### PR TITLE
fix(console): draw the graph from the MCP list the host sends, and reopen Chat where you left it (#407, #412)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -48,6 +48,7 @@ import { toast } from "sonner";
 import { type ChatMessage, fromHistory, makeMessage } from "@/lib/chat";
 import { CONNECTION_PROVIDERS } from "@/lib/connections";
 import { defaultDesks, type Desk } from "@/lib/desks";
+import { writeLastChannel } from "@/lib/last-channel";
 import { fromDto, type TeamMember } from "@/lib/team";
 import { agentDmThreads, defaultThreads, threadsFromDesks } from "@/lib/threads";
 import { Overview } from "@/views/Overview";
@@ -498,10 +499,18 @@ export function AppShell({
    * again as the open channel's transcript grows so a line read as it lands
    * doesn't leave a badge behind.
    */
-  const onChannelViewed = useCallback((channelId: string) => {
-    activeChatChannelRef.current = channelId;
-    setLastViewedChannel((v) => ({ ...v, [channelId]: Date.now() }));
-  }, []);
+  const onChannelViewed = useCallback(
+    (channelId: string) => {
+      activeChatChannelRef.current = channelId;
+      setLastViewedChannel((v) => ({ ...v, [channelId]: Date.now() }));
+      // The same fact, persisted, so re-entering Chat returns to the channel
+      // the operator was reading instead of whichever sorts first (issue #412).
+      // The ref above cannot do it: it dies with this mount, and a reload is
+      // exactly one of the trips that has to survive.
+      writeLastChannel(company, channelId);
+    },
+    [company],
+  );
 
   const setThreadMessages = (
     threadId: string,

--- a/frontend/src/lib/last-channel.ts
+++ b/frontend/src/lib/last-channel.ts
@@ -1,0 +1,59 @@
+// Where the operator was last reading, per company (issue #412).
+//
+// The shell already knows which chat channel is on screen — `onChannelViewed`
+// records it so unread counts clear and an unaddressed system line is addressed
+// to the channel the operator was actually looking at (issue #368). That memory
+// lives in a ref, so it dies with the tab: leaving Chat and coming back, or
+// reloading, dropped the operator on whichever channel happened to sort first.
+//
+// This is the same fact, written somewhere it survives a reload. It is a
+// *hint*, never authority: the hash still decides which channel renders (see
+// `ChatView`), so a deep link outranks it and a remembered channel that no
+// longer exists falls through to the same unknown-channel notice as any other
+// stale id (issue #370).
+
+/** Namespaced so a host serving several companies remembers each separately. */
+function keyFor(company: string | null): string {
+  return `oc.chat.last-channel.${company ?? "__default__"}`;
+}
+
+/**
+ * `localStorage`, or `null` where it isn't usable.
+ *
+ * Access itself can throw — Safari's private mode and a "block all cookies"
+ * setting both make the property itself raise rather than return a dud object.
+ * A console that cannot remember a channel must still render one.
+ */
+function storage(): Storage | null {
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/** The channel this company was last read in, or `null` if nothing is remembered. */
+export function readLastChannel(company: string | null): string | null {
+  const value = storage()?.getItem(keyFor(company));
+  return value && value.length > 0 ? value : null;
+}
+
+/**
+ * Remember the channel on screen.
+ *
+ * Skips a write when the value is unchanged: the caller reports the open
+ * channel again on every message that lands in it, and `localStorage` writes
+ * are synchronous — re-writing the same string on every frame of a busy channel
+ * would put disk I/O on the render path for no gain.
+ */
+export function writeLastChannel(company: string | null, channelId: string): void {
+  const store = storage();
+  if (!store) return;
+  const key = keyFor(company);
+  try {
+    if (store.getItem(key) === channelId) return;
+    store.setItem(key, channelId);
+  } catch {
+    // A full or read-only quota is not worth failing a render over.
+  }
+}

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { type ChatMessage, makeMessage } from "@/lib/chat";
 import { defaultDesks, type Desk } from "@/lib/desks";
+import { readLastChannel } from "@/lib/last-channel";
 import { fromDto, newMember, starterTeam, type TeamMember } from "@/lib/team";
 import { cn } from "@/lib/utils";
 import { useAskerNames } from "@/components/approval-card";
@@ -313,6 +314,40 @@ export function ChatView({
   useEffect(() => {
     void loadDesks();
   }, [loadDesks]);
+
+  /**
+   * Re-entering Chat with no channel in the hash returns the operator to the
+   * one they were last reading (issue #412).
+   *
+   * Leaving Chat drops the hash's second segment, so coming back used to fall
+   * straight through to `firstChannel` — which is not memory, it is whichever
+   * channel sorts first, and it cost a re-navigation on every trip.
+   *
+   * The remembered id is written into the **hash**, not held here, for three
+   * reasons: the channel on screen stays shareable, it survives a reload, and a
+   * remembered channel that has since been removed then falls through the exact
+   * same stale-id path as a bad deep link — so it raises the unknown-channel
+   * notice from issue #370 rather than needing a second one, and lands on the
+   * fallback visibly rather than silently. The `onChannelViewed` report for
+   * whatever it fell back to re-remembers that instead, so a vanished channel
+   * corrects itself after one visit.
+   *
+   * A hash that already names a channel is a deep link and always outranks
+   * memory; this only runs when there is nothing to override. The ref makes it
+   * one attempt per bare-hash entry, so it can never fight a navigation.
+   */
+  const restoredFor = useRef<string | null | undefined>(undefined);
+  useEffect(() => {
+    if (sub) {
+      // A channel is named, so the next bare `#/chat` is a fresh re-entry.
+      restoredFor.current = undefined;
+      return;
+    }
+    if (restoredFor.current === company) return;
+    restoredFor.current = company;
+    const remembered = readLastChannel(company);
+    if (remembered) onNavigate(remembered);
+  }, [company, sub, onNavigate]);
 
   // No channels exist until the host has answered. Resolving against a
   // half-built list is exactly the first-paint swap issue #370 describes.

--- a/frontend/src/views/Overview.tsx
+++ b/frontend/src/views/Overview.tsx
@@ -1,11 +1,13 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
+import { TriangleAlert } from "lucide-react";
 
 import { listPeople, type Person } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
+import { discoverMcpTools, listMcpServers } from "@/api/mcp";
 import { listMemory, type MemoryEntry } from "@/api/memory";
 import { listSkills, type Skill } from "@/api/skills";
 import { listTasks, type Task } from "@/api/tasks";
-import type { McpServer, McpTool } from "@/lib/mcp";
+import { ApiError, type McpServer, type McpToolInfo } from "@/api/types";
 import { fromDto, starterTeam, type TeamMember } from "@/lib/team";
 import { adapt, buildMemoryGraph } from "./overview/kg/adapter";
 import { buildKnowledgeGraph } from "./overview/kg/model";
@@ -30,7 +32,18 @@ interface Sources {
   skills: Skill[];
   memories: MemoryEntry[];
   servers: McpServer[];
-  toolsByServer: Record<string, McpTool[]>;
+  /** Server **name** → the tools it advertises. `name` is this API's server key. */
+  toolsByServer: Record<string, McpToolInfo[]>;
+  /**
+   * The MCP read failed for a reason that is not "this host has no MCP".
+   *
+   * Kept apart from an empty `servers` on purpose. A company with no tool
+   * servers and a company whose tool servers we could not reach draw the same
+   * toolless graph, and only one of those is a true statement about the
+   * company — collapsing them is how an outage comes to look like an empty
+   * configuration. The notice below is the difference.
+   */
+  mcpUnreadable: boolean;
 }
 
 const EMPTY: Sources = {
@@ -41,7 +54,23 @@ const EMPTY: Sources = {
   memories: [],
   servers: [],
   toolsByServer: {},
+  mcpUnreadable: false,
 };
+
+/**
+ * Whether a server is worth asking for its tool list.
+ *
+ * Tool discovery opens a live connection to the remote server, so this skips
+ * the ones already known not to answer: disabled, or last probed as broken /
+ * missing its credential. A server never probed is asked once — we cannot know
+ * it works without trying, and refusing to ask would leave a working server's
+ * tools off the graph forever.
+ */
+function worthAsking(server: McpServer): boolean {
+  if (!server.enabled) return false;
+  const status = server.health?.status;
+  return status !== "error" && status !== "needs_config";
+}
 
 /**
  * The command centre: the company's knowledge graph, and nothing else.
@@ -73,19 +102,35 @@ export function Overview({ client, company }: Props) {
         // surface draws no constellation rather than a seeded one — the graph
         // must never claim the company remembers something it doesn't.
         listMemory(client, company).catch(() => [] as MemoryEntry[]),
-        client.listMcpServers(company).catch(() => ({ servers: [] as McpServer[] })),
+        // `.../mcp/servers` answers with a bare array of servers. It used to be
+        // read through a client helper that promised a `{ servers }` wrapper no
+        // host has ever sent, so `mcp.servers` was `undefined` and filtering it
+        // threw — on every host that mounts the route, which is all of them
+        // (issue #407). The wrapper only looked survivable because the failure
+        // path handed back a hand-built `{ servers: [] }`: the tab rendered
+        // exactly when MCP was unreachable, and threw when it worked.
+        listMcpServers(client, company).then(
+          (servers) => ({ servers: servers ?? [], unreadable: false }),
+          (error: unknown) => ({
+            servers: [] as McpServer[],
+            // A host with no MCP surface answers 404. That is a company with no
+            // tool servers — a fact, not a failure, and not worth a warning.
+            // Anything else (offline, 5xx, a body we couldn't parse) means we
+            // genuinely do not know, which is what the notice says.
+            unreadable: !(error instanceof ApiError && error.status === 404),
+          }),
+        ),
       ]);
       if (!live) return;
 
-      // Only a connected server advertises tools; asking a disconnected one
-      // just spends a request to be told nothing.
-      const connected = mcp.servers.filter((s) => s.status === "connected");
       const toolLists = await Promise.all(
-        connected.map((s) =>
-          client
-            .listMcpTools(s.server_id, company)
-            .then((r) => [s.server_id, r.tools] as const)
-            .catch(() => [s.server_id, [] as McpTool[]] as const),
+        mcp.servers.filter(worthAsking).map((s) =>
+          discoverMcpTools(client, company, s.name)
+            .then((tools) => [s.name, tools ?? []] as const)
+            // A host built without the MCP client answers `not_wired`, and a
+            // server can simply be down. Neither is worth failing the graph
+            // over: that server contributes no tools and the rest still draw.
+            .catch(() => [s.name, [] as McpToolInfo[]] as const),
         ),
       );
       if (!live) return;
@@ -98,6 +143,7 @@ export function Overview({ client, company }: Props) {
         memories,
         servers: mcp.servers,
         toolsByServer: Object.fromEntries(toolLists),
+        mcpUnreadable: mcp.unreadable,
       });
     })();
     return () => {
@@ -137,12 +183,28 @@ export function Overview({ client, company }: Props) {
     // The whole viewport: the shell hides its top bar for this view, so there
     // is nothing above to subtract.
     <div
-      className="oc-kg h-svh min-h-0 w-full min-w-0 overflow-hidden"
+      className="oc-kg relative h-svh min-h-0 w-full min-w-0 overflow-hidden"
       // The guided tour's Overview stop anchors here. It used to spotlight the
       // quick-action row this page had before it became the graph; the graph is
       // the page now, so the graph is what gets spotlighted.
       data-tour="overview-graph"
     >
+      {/* An unreadable MCP surface and a company with no tool servers draw the
+          same toolless graph. Saying which one this is turns "this company has
+          no tools" from an assertion the page cannot support into a question
+          the operator knows to go and check. */}
+      {sources.mcpUnreadable && (
+        <p
+          role="status"
+          className="pointer-events-none absolute left-1/2 top-3 z-10 flex max-w-[calc(100%-1.5rem)] -translate-x-1/2 items-center gap-1.5 rounded-md border bg-background/90 px-2.5 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur"
+        >
+          <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
+          <span className="min-w-0 truncate">
+            Couldn&apos;t read this company&apos;s MCP tool servers — tools may be missing from
+            the graph.
+          </span>
+        </p>
+      )}
       <Suspense
         fallback={
           <div className="grid h-full place-items-center text-sm text-muted-foreground">

--- a/frontend/src/views/overview/kg/adapter.ts
+++ b/frontend/src/views/overview/kg/adapter.ts
@@ -29,7 +29,7 @@ import type { Person as HostPerson } from "@/api/auth";
 import type { Skill } from "@/api/skills";
 import type { Task } from "@/api/tasks";
 import type { MemoryEntry } from "@/api/memory";
-import type { McpServer, McpTool } from "@/lib/mcp";
+import type { McpServer, McpToolInfo } from "@/api/types";
 import type { TeamMember } from "@/lib/team";
 import { TASK_COLUMNS } from "@/lib/tasks-sample";
 import type { BrainGraphEdge, BrainGraphNode, MemoryGraph } from "./memory-core";
@@ -178,7 +178,8 @@ export interface AdaptInput {
   tasks: Task[];
   skills: Skill[];
   servers: McpServer[];
-  toolsByServer: Record<string, McpTool[]>;
+  /** Keyed by server **name** — the key `.../mcp/servers` identifies a server by. */
+  toolsByServer: Record<string, McpToolInfo[]>;
   /** The humans who can sign in to this company. */
   people: HostPerson[];
   /** Matches a board card to a roster member; the one real assignment edge. */
@@ -209,8 +210,8 @@ export function adapt(input: AdaptInput): Adapted {
     toolSlugs.push(slug);
   }
   for (const server of input.servers) {
-    for (const tool of input.toolsByServer[server.server_id] ?? []) {
-      const slug = `mcp-${server.server_id}-${tool.name}`;
+    for (const tool of input.toolsByServer[server.name] ?? []) {
+      const slug = `mcp-${server.name}-${tool.name}`;
       toolLabels[slug] = tool.name;
       toolSlugs.push(slug);
     }


### PR DESCRIPTION
## Summary

Two independent console bugs, one PR.

**#407 — the Overview tab threw whenever MCP worked.** `.../mcp/servers` answers with a **bare array**, but the console read it through a `client.ts` helper typed `Promise<{ servers: McpServer[] }>` — a wrapper no host has ever sent. `mcp.servers` was therefore always `undefined`, and `.filter` on it threw. Not an old-host edge case: the route is mounted unconditionally, so this fired on every host, for a company with MCP servers **and** for one with none (which returns `[]`, equally lacking `.servers`).

It survived review because the failure path built its own `{ servers: [] }` — the tab rendered precisely when MCP was *unreachable* and threw when it *worked*. The tools ring has never drawn.

**#412 — Chat always reopened on the first channel.** Leaving Chat drops the hash's second segment, so returning fell through to `firstChannel`. Nothing was remembering anything; it started over each trip and landed on whatever sorted first. The shell already recorded the last-viewed channel (#368) but only in a ref, which dies with the mount — so it could not have survived a reload either.

## API Or Behavior Changes

**Overview (#407)**
- Reads servers via `api/mcp.ts` (bare array, camelCase DTO) instead of the `client.ts` wrapper, and tools via `discoverMcpTools` keyed by server **`name`** — `server_id`/`status`/`tool_count` do not exist on this API. `kg/adapter.ts` keys `toolsByServer` by name to match.
- **The tools ring now populates for the first time.** Discovery is a live outbound call, so it is skipped for servers that are disabled or last probed `error`/`needs_config`; a never-probed server is asked once. Verified against the real `deepwiki` server.
- **Empty and unreadable are no longer the same thing.** A 404 means the host has no MCP surface — genuinely no servers, silent. Any other failure raises a notice ("Couldn't read this company's MCP tool servers — tools may be missing from the graph"), so an outage cannot pass for an empty configuration. This mirrors how `McpServersView`/`ConnectionsView` already treat 404 as *unavailable* rather than *error*.

**Chat (#412)**
- Re-entering Chat with no channel in the hash restores the last-read channel **by writing it into the hash**, not by holding it in state — so it is shareable and survives a reload.
- **Deep links still win.** The restore only runs when the hash names nothing.
- **A vanished channel falls back visibly.** Because the remembered id goes into the hash, it travels the same stale-id path as a bad deep link and raises the **existing** unknown-channel notice from #370 — no second notice was written. The fallback is then what gets remembered, so a removed channel self-corrects after one visit.
- New `lib/last-channel.ts`; `localStorage` access is guarded (private mode makes the property itself throw) and unchanged values are not rewritten, since the shell re-reports the open channel on every message that lands in it.

No Rust changed. No dependency changes.

### The sweep for the same shape (#407)

The failure is a class, not an instance: `request<T>` casts an unparsed body to `T`, so **every** declared return type may be absent — and every guarded array site in the console is guarded because the *type* said `?:`, never because the wire was distrusted. Notable findings:

- **`views/McpServersView.tsx` (Settings → MCP) has the identical bug and is NOT fixed here.** It reads `.servers`/`.tools` off the same phantom wrapper and throws `Cannot read properties of undefined (reading 'length')`. I confirmed in a browser that it fails **identically before and after** this PR — it is pre-existing, not a regression. I deliberately left it out: the whole view targets an API that does not exist (`server_id`, `transport`, `command`, `env_keys`, `/connect`, `/disconnect`), so a `?? []` guard would trade a crash for a settings page that lists nothing and whose buttons hit absent routes. It needs a real port to `api/mcp.ts`, which deserves its own review. Filed as a follow-up.
- The remaining `client.ts` MCP methods (`installMcpServer`, `connectMcpServer`, `disconnectMcpServer`, `listMcpTools`) and `lib/mcp.ts`'s `McpServer` describe that same non-existent API. Same follow-up.
- Overview's sibling fetches (`tasks`, `skills`, `memory`, `people`, team) each `.catch(() => [])`, so a network blip renders as an empty graph — the same empty-vs-unreadable collapse this PR fixes for MCP. The team one falls back to a *fabricated* `starterTeam()`. Not touched here to keep the change reviewable; noted in the follow-up.

## Tests

Frontend gates — the ones this repo actually has (no lint script, no component-test script):

- [x] `npm ci`
- [x] `npm run typecheck`
- [x] `npm run typecheck:e2e`
- [x] `npm run build`
- [x] N/A: `cargo fmt --all -- --check` — no Rust changed.
- [x] N/A: `cargo clippy --all-targets -- -D warnings` — no Rust changed.
- [x] N/A: `cargo build --all-targets` — no Rust changed.
- [x] N/A: `cargo test` — no Rust changed.

**No Playwright spec was written or run.** Specs here are typechecked but never executed (the config has no `webServer`), so one would be evidence of nothing.

### Live verification

Two real hosts (`cargo build --features openhuman,mcp`), driven in real Chromium. To prove the harness actually detects the bugs, the pre-fix console was built from `main` and served side by side against the same hosts.

- host A — `companies/e2e_harness`: desks `engineering` then `content`, plus the live `deepwiki` MCP server
- host B — `companies/agentic_marketing_agency`: no `[[mcp_server]]`
- a proxy injecting 500 / 404 on `.../mcp/servers` for the failure cases

**#407 — Overview**

| Scenario | pre-fix | post-fix |
|---|---|---|
| company **with** MCP | **crash** `Cannot read properties of undefined (reading 'filter')` | clean; also fetches `.../deepwiki/tools` — tools ring populates |
| company **without** MCP (`[]`) | **crash**, same error | clean, no notice |
| MCP read fails (500) | — | clean, **notice shown** |
| no MCP surface (404) | — | clean, **no notice** (treated as empty) |
| Settings → MCP | crash | crash — *pre-existing, see above* |

**#412 — Chat** (`engineering` is the first channel; `content` is what gets read)

| Step | pre-fix | post-fix |
|---|---|---|
| cold load, nothing remembered | engineering | engineering |
| click `#content` | content | content |
| **Tasks → back to Chat** | **engineering** | **content**, hash `#/chat/content` |
| **F5 at bare `#/chat`** | **engineering** | **content**, hash `#/chat/content` |
| F5 at `#/chat/content` | content | content |
| cold deep link ≠ remembered | engineering | engineering — **deep link wins** |
| **remembered channel removed** | engineering, **silent** | engineering + **#370 notice**, hash keeps the stale id, memory self-heals |

Also checked: no uncaught errors across overview / chat / tasks / settings-connections after a genuine reload of each.

One harness correction worth recording: `page.goto` to a URL differing only in the hash does **not** reload, so my first "survives a reload" pass was green for the wrong reason. Re-run with `page.reload()`; the table above is from the corrected run.

### Deliberately left out

- `McpServersView` and the phantom `client.ts` MCP methods (above) — pre-existing, needs its own port.
- The empty-vs-unreadable collapse on Overview's other fetches — same class, wider blast radius.
- #364 (chat transcripts are console-local). Nothing here depends on it: the restore resolves against the channel list, not transcripts.
- Files owned by other in-flight branches were not touched. `MessageTimeline.tsx` / `StepTimeline.tsx` needed no change.

### Shared-file footprint

`components/app-shell.tsx` — two hunks only: the `writeLastChannel` import, and three lines inside the existing `onChannelViewed` callback (plus its `company` dep). No change to the `<ChatView>` prop block or anything else in the shell.

## Documentation

No docs updated. Both changes are console behavior fixes with no public API, route, or architecture change; the reasoning lives in the touched files, which carry the codebase's existing narrative-comment style.

Closes #407
Closes #412
