### PR TITLE
fix(composio): a narrowable, self-describing action catalogue — the listing was cut to 300 bytes (#410)

### DIFF
--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -37,10 +37,20 @@
 //!
 //! ## Write-only credential
 //!
-//! The token is write-only. Whatever value a call resolves is fed to [`scrub`] as
-//! a known secret, so it cannot survive into **any** `ToolResult` (success or
-//! error); it is absent from every tracing line and from the [`Debug`] impl. Only
-//! non-secret status (backend URL, toolkit allowlist) is ever surfaced.
+//! The token is write-only. Whatever value a call resolves is fed to
+//! [`redact`](crate::harness::mcp_probe::redact) (successes) or
+//! [`scrub`](crate::harness::mcp_probe::scrub) (errors) as a known secret, so it
+//! cannot survive into **any** `ToolResult`; it is absent from every tracing
+//! line and from the [`Debug`] impl. Only non-secret status (backend URL,
+//! toolkit allowlist) is ever surfaced.
+//!
+//! ## Result sizing (issue #410)
+//!
+//! Successes go through `redact` + a **body** budget, never through `scrub`.
+//! `scrub` caps at 300 bytes — correct for the one-line MCP failure sentence it
+//! was built for, and the reason every Composio result used to arrive as a
+//! silent fragment. See `scrubbed_ok` below and
+//! [`composio_catalog`](crate::harness::composio_catalog).
 
 use std::sync::Arc;
 
@@ -215,7 +225,8 @@ mod live {
     use async_trait::async_trait;
     use serde_json::{Value, json};
 
-    use crate::harness::mcp_probe::scrub;
+    use crate::harness::composio_catalog as catalog;
+    use crate::harness::mcp_probe::{redact, scrub};
     use crate::metering::record_oauth_call;
     use crate::ports::UsageMeter;
     use crate::ports::now_millis;
@@ -316,13 +327,29 @@ mod live {
         Ok((client, vec![token]))
     }
 
-    /// Serialize a successful response to JSON, then scrub it against the tenant
-    /// token before it can reach the agent. Text-only output — the structured
-    /// value is dropped so a credential the backend might reflect can never ride
-    /// out in a JSON field.
-    fn scrubbed_ok(value: Value, secrets: &[String]) -> ToolResult {
+    /// Serialize a successful response to JSON, redact the tenant token out of
+    /// it, and bound it to a *body* budget before it reaches the agent.
+    /// Text-only output — the structured value is dropped so a credential the
+    /// backend might reflect can never ride out in a JSON field.
+    ///
+    /// # Why not `scrub` (issue #410)
+    ///
+    /// This used to call [`scrub`], whose third pass caps its output at
+    /// [`SCRUB_MAX_BYTES`](crate::harness::mcp_probe::SCRUB_MAX_BYTES) — 300
+    /// bytes, the right size for the one-line MCP failure sentence it was built
+    /// for and a catastrophe for a tool body. Every Composio result was cut to
+    /// 300 bytes and terminated with a bare `…`: an action listing became the
+    /// first action and half of its schema, and `composio_execute` returned 300
+    /// bytes of whatever the provider actually said. Nothing in the result said
+    /// it was a fragment, so the agent had no reason to ask differently and
+    /// reissued the identical call until the repetition guard stopped the run.
+    ///
+    /// [`redact`] keeps the security half — the token replacement and the URL
+    /// query strip — verbatim and unconditional; only the length decision moves
+    /// here, where it can be sized for a body and describe its own cut.
+    fn scrubbed_ok(value: Value, secrets: &[String], what: &str) -> ToolResult {
         let text = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
-        ToolResult::success(scrub(&text, secrets))
+        ToolResult::success(catalog::bound_body(redact(&text, secrets), what))
     }
 
     /// A scrubbed error result — the tenant token is stripped from any error
@@ -415,24 +442,23 @@ mod live {
         }
 
         fn description(&self) -> &str {
-            "List the Composio toolkits (integrations such as Gmail, Slack, GitHub) available to this company. Read-only."
+            catalog::list_toolkits_description()
         }
 
         fn parameters_schema(&self) -> Value {
-            json!({
-                "type": "object",
-                "properties": {},
-                "additionalProperties": false
-            })
+            catalog::list_toolkits_parameters_schema()
         }
 
         fn permission_level(&self) -> PermissionLevel {
             PermissionLevel::ReadOnly
         }
 
-        async fn execute(&self, _args: Value) -> Result<ToolResult> {
+        async fn execute(&self, args: Value) -> Result<ToolResult> {
+            let request = catalog::ToolkitListRequest::parse(&args);
             tracing::debug!(
                 allowlist = ?self.toolkits,
+                search = ?request.search,
+                limit = request.limit,
                 "[composio] list_toolkits"
             );
             let (client, secrets) = match live_call(&self.config).await {
@@ -451,10 +477,38 @@ mod live {
                         resp.catalog
                             .retain(|entry| toolkit_allowed(&self.toolkits, &entry.slug));
                     }
-                    Ok(scrubbed_ok(
-                        serde_json::to_value(&resp).unwrap_or(Value::Null),
-                        &secrets,
-                    ))
+                    // Issue #410: bounded, self-describing rendering rather than
+                    // the whole catalogue as pretty JSON. Composio publishes
+                    // several hundred toolkits, each with prose and a categories
+                    // array, so this listing is the same silent-cut class as the
+                    // action listing one level down.
+                    let catalogued: Vec<catalog::CatalogToolkit> = resp
+                        .catalog
+                        .iter()
+                        .map(|entry| catalog::CatalogToolkit {
+                            slug: entry.slug.clone(),
+                            name: entry.name.clone(),
+                            description: entry.description.clone().unwrap_or_default(),
+                            connected: entry.enabled,
+                        })
+                        .collect();
+                    // Backends predating the dynamic catalogue send only the
+                    // slug allowlist; render those slugs rather than nothing.
+                    let toolkits: Vec<catalog::CatalogToolkit> = if catalogued.is_empty() {
+                        resp.toolkits
+                            .iter()
+                            .map(|slug| catalog::CatalogToolkit {
+                                slug: slug.clone(),
+                                name: String::new(),
+                                description: String::new(),
+                                connected: None,
+                            })
+                            .collect()
+                    } else {
+                        catalogued
+                    };
+                    let rendered = catalog::render_toolkits(&toolkits, &request);
+                    Ok(ToolResult::success(redact(&rendered, &secrets)))
                 }
                 Err(err) => Ok(scrubbed_err(
                     "composio_list_toolkits failed",
@@ -517,6 +571,7 @@ mod live {
                     Ok(scrubbed_ok(
                         serde_json::to_value(&resp).unwrap_or(Value::Null),
                         &secrets,
+                        "connections list",
                     ))
                 }
                 Err(err) => Ok(scrubbed_err(
@@ -542,21 +597,11 @@ mod live {
         }
 
         fn description(&self) -> &str {
-            "List the callable Composio actions (function schemas) for one or more toolkits. Pass `toolkits` (array of slugs) to narrow; omit to list every allowed toolkit's actions. Read-only."
+            catalog::list_tools_description()
         }
 
         fn parameters_schema(&self) -> Value {
-            json!({
-                "type": "object",
-                "properties": {
-                    "toolkits": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "Toolkit slugs to list actions for (e.g. `gmail`, `slack`, `github`)."
-                    }
-                },
-                "additionalProperties": false
-            })
+            catalog::list_tools_parameters_schema()
         }
 
         fn permission_level(&self) -> PermissionLevel {
@@ -591,9 +636,17 @@ mod live {
                     .filter(|t| toolkit_allowed(&self.toolkits, t))
                     .collect()
             };
+            // The narrowing + rendering request (issue #410). Toolkit resolution
+            // above is a security decision (allowlist intersection) and stays
+            // here; `search` / `detail` / `limit` are presentation and live in
+            // the pure catalogue module.
+            let request = catalog::ListRequest::parse(&args, effective.clone());
             tracing::debug!(
                 effective = ?effective,
                 allowlist = ?self.toolkits,
+                search = ?request.search,
+                detail = ?request.detail,
+                limit = request.limit,
                 "[composio] list_tools"
             );
 
@@ -617,10 +670,24 @@ mod live {
                             toolkit_allowed(&self.toolkits, &slug_toolkit(&schema.function.name))
                         });
                     }
-                    Ok(scrubbed_ok(
-                        serde_json::to_value(&resp).unwrap_or(Value::Null),
-                        &secrets,
-                    ))
+                    // Issue #410: render through the bounded, self-describing
+                    // catalogue view rather than dumping the whole response as
+                    // pretty JSON. A hundred-action toolkit serialized whole is
+                    // hundreds of kilobytes; the harness's shared tool-result
+                    // budget then cut it on a byte boundary, leaving the agent a
+                    // fragment with nothing in it saying so.
+                    let actions: Vec<catalog::CatalogAction> = resp
+                        .tools
+                        .iter()
+                        .map(|schema| catalog::CatalogAction {
+                            toolkit: slug_toolkit(&schema.function.name),
+                            slug: schema.function.name.clone(),
+                            description: schema.function.description.clone().unwrap_or_default(),
+                            parameters: schema.function.parameters.clone(),
+                        })
+                        .collect();
+                    let rendered = catalog::render(&actions, &request);
+                    Ok(ToolResult::success(redact(&rendered, &secrets)))
                 }
                 Err(err) => Ok(scrubbed_err("composio_list_tools failed", &err, &secrets)),
             }
@@ -692,6 +759,7 @@ mod live {
                 Ok(resp) => Ok(scrubbed_ok(
                     serde_json::to_value(&resp).unwrap_or(Value::Null),
                     &secrets,
+                    "authorization response",
                 )),
                 Err(err) => Ok(scrubbed_err("composio_authorize failed", &err, &secrets)),
             }
@@ -713,7 +781,7 @@ mod live {
         }
 
         fn description(&self) -> &str {
-            "Run a Composio action by its slug (e.g. `GMAIL_SEND_EMAIL`) with a JSON `arguments` object. Use `composio_list_tools` first to discover the slug and its parameters."
+            "Run a Composio action by its slug (e.g. `GMAIL_SEND_EMAIL`) with a JSON `arguments` object. Discover the slug first with `composio_list_tools({\"search\": \"<words>\"})`, then read its parameters with `composio_list_tools({\"search\": \"<SLUG>\", \"detail\": \"schemas\"})`. Never guess a slug that was not listed."
         }
 
         fn parameters_schema(&self) -> Value {
@@ -781,6 +849,7 @@ mod live {
                     Ok(scrubbed_ok(
                         serde_json::to_value(&resp).unwrap_or(Value::Null),
                         &secrets,
+                        &format!("`{tool}` output"),
                     ))
                 }
                 Err(err) => Ok(scrubbed_err("composio_execute failed", &err, &secrets)),

--- a/src/harness/composio_catalog.rs
+++ b/src/harness/composio_catalog.rs
@@ -1,0 +1,1142 @@
+//! Issue #410 — how a Composio action catalogue is *narrowed* and *rendered*
+//! for an agent, and why every cut it makes describes itself.
+//!
+//! ## The failure this exists to stop
+//!
+//! `composio_list_tools` serialized the backend's whole `ComposioToolsResponse`
+//! with `serde_json::to_string_pretty` and passed it to
+//! [`scrub`](crate::harness::mcp_probe::scrub) on the way out. `scrub` is the
+//! MCP *message* sanitiser: its third pass caps at
+//! [`SCRUB_MAX_BYTES`](crate::harness::mcp_probe::SCRUB_MAX_BYTES) — **300
+//! bytes**, the right size for a one-line failure sentence and three orders of
+//! magnitude too small for a catalogue.
+//!
+//! So a 260-action catalogue reached the model as this, verbatim:
+//!
+//! ```text
+//! {
+//!   "tools": [
+//!     {
+//!       "type": "function",
+//!       "function": {
+//!         "name": "GITHUB_ACTION_000",
+//!         "description": "Performs repository operation number 0. This action…
+//! ```
+//!
+//! The first action, half of its schema, and a bare `…`. Every Composio tool was
+//! affected, `composio_execute` included — a successful provider call returned
+//! 300 bytes of whatever it actually said.
+//!
+//! That is worse than a small listing. The agent can see that actions exist but
+//! cannot read the name or the parameters of the one it needs, and — because the
+//! fragment does not say it is a fragment — it has no reason to ask differently.
+//! It reissues the identical call, gets the identical fragment, and is halted by
+//! the repetition guard. **A silent cut is what turns one failure into a retry
+//! loop.**
+//!
+//! The fix is in two halves. The *security* half of `scrub` (credential
+//! redaction, URL-query stripping) is unconditional and moves to
+//! [`redact`](crate::harness::mcp_probe::redact), which never shortens. The
+//! *length* half moves here, where a body can be sized as a body and a cut can
+//! describe itself.
+//!
+//! ## The shape
+//!
+//! Two axes, both generic — nothing here knows what a "GitHub" is:
+//!
+//! * **Narrowing.** `search` matches whitespace-separated words,
+//!   case-insensitively, against the action slug *and* its description; every
+//!   word must match (AND), so `list issues` finds `GITHUB_LIST_ISSUES` without
+//!   also dragging in every action whose description mentions "list".
+//!   `toolkits` still narrows by toolkit, and `limit` bounds the count.
+//! * **Progressive disclosure.** [`Detail::Names`] (the default) renders one
+//!   line per action — slug plus a clipped description. It is cheap enough that
+//!   a whole toolkit fits, which is what lets an agent *discover* a slug.
+//!   [`Detail::Schemas`] renders the full JSON parameter schema for the few
+//!   actions that matched, which is what lets it *call* one. That is the
+//!   two-step an agent actually reasons in: find the name, then read the
+//!   arguments.
+//!
+//! ## The invariant
+//!
+//! [`render`] bounds its own output — by count *and* by
+//! [`MAX_RENDER_BYTES`] — and **never cuts an entry in half**. It stops at a
+//! whole-entry boundary, so it always knows exactly how many entries it
+//! dropped, and it always says so, in the result, naming the argument to pass
+//! next. The budget also sits below the *next* cut downstream — the agent
+//! harness's shared 16 KiB per-tool-result budget, which truncates on a byte
+//! boundary — so the notice the model reads is the one that counted itself,
+//! never an anonymous byte slice. The turn tests assert that directly, on the
+//! wire.
+//!
+//! One deliberate exception: the **first** entry is always emitted whole, even
+//! if it alone exceeds the budget. A schemas listing whose only match is a
+//! single huge schema must still deliver that schema; returning "0 of 1 shown"
+//! would be a correctly-described way of being useless.
+//!
+//! ## Why this module is not behind the `composio` feature
+//!
+//! Everything here is pure: no network, no credential, no `openhuman` Composio
+//! type. The live tools in [`composio`](crate::harness::composio) are gated on
+//! the opt-in `composio` feature, and **CI never builds that feature** (it runs
+//! `--features openhuman,tinycortex`; `--all-features` is a `cargo check`, not a
+//! `cargo test`). Keeping the narrowing and the truncation notice out here means
+//! the behaviour this issue is about is exercised by the test lane that actually
+//! runs, rather than by a lane that only type-checks.
+
+use serde_json::{Value, json};
+
+use openhuman_core::openhuman as oh;
+
+/// Default number of actions a [`Detail::Names`] listing renders.
+///
+/// Sized to hold a whole large toolkit in one call — the point of the names
+/// view is that discovery does not need a second round-trip.
+pub const NAMES_DEFAULT_LIMIT: usize = 200;
+
+/// Ceiling an explicit `limit` is clamped to in [`Detail::Names`] mode.
+pub const NAMES_MAX_LIMIT: usize = 400;
+
+/// Default number of actions a [`Detail::Schemas`] listing renders. Small on
+/// purpose: a single Composio parameter schema routinely runs to a few
+/// kilobytes, so "show me five" is already a large result.
+pub const SCHEMAS_DEFAULT_LIMIT: usize = 5;
+
+/// Ceiling an explicit `limit` is clamped to in [`Detail::Schemas`] mode.
+pub const SCHEMAS_MAX_LIMIT: usize = 20;
+
+/// Byte budget for the rendered body, before the header and the truncation
+/// notice are added.
+///
+/// Chosen to stay comfortably under the agent harness's shared per-tool-result
+/// budget (16 KiB at the time of writing) so that **this** module's cut — the
+/// one that counts what it dropped and names the argument to narrow with — is
+/// the cut the model sees. If the two ever swap places the notice is still
+/// emitted; it just risks being clipped, which the header (rendered first)
+/// guards against.
+pub const MAX_RENDER_BYTES: usize = 11 * 1024;
+
+/// Characters of an action's description kept on a [`Detail::Names`] line.
+const DESCRIPTION_PREVIEW_CHARS: usize = 140;
+
+/// Byte budget for a Composio tool body this module cannot structure — an
+/// action's provider output, a connections list.
+///
+/// Same order as [`MAX_RENDER_BYTES`] and for the same reason: large enough
+/// that a real answer survives, small enough that the harness's own anonymous
+/// cut never fires first.
+pub const MAX_BODY_BYTES: usize = 12 * 1024;
+
+/// Bounds an unstructured tool body, appending a trailer that says it was cut,
+/// by how much, and what to do about it.
+///
+/// The counterpart to [`render`] for payloads with no entries to count: a
+/// provider's action output. There is no generic argument that makes *that*
+/// smaller — the narrowing lives in the action's own parameters — so the
+/// trailer says exactly that rather than inventing an argument that does not
+/// exist. Naming the size and the cause is still the difference between an
+/// agent that adjusts and an agent that repeats itself.
+///
+/// `what` names the payload for the trailer, e.g. `"GITHUB_LIST_ISSUES output"`.
+pub fn bound_body(body: String, what: &str) -> String {
+    if body.len() <= MAX_BODY_BYTES {
+        return body;
+    }
+    let mut end = MAX_BODY_BYTES;
+    while end > 0 && !body.is_char_boundary(end) {
+        end -= 1;
+    }
+    let dropped = body.len() - end;
+    let mut out = body[..end].to_string();
+    out.push_str(&format!(
+        "\n\n[TRUNCATED — the {what} was {dropped} bytes longer than this and the rest was NOT \
+         shown. What you can see above is incomplete; do not treat it as the whole answer, and do \
+         not repeat this call unchanged. Ask the action itself for less — a page size, a limit, a \
+         date range or a filter argument — or request a specific record by id.]\n"
+    ));
+    out
+}
+
+/// How much detail one listing renders per action.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum Detail {
+    /// `SLUG — one-line description`. Cheap; the discovery view.
+    #[default]
+    Names,
+    /// The full JSON parameter schema. Expensive; the call-it view.
+    Schemas,
+}
+
+impl Detail {
+    /// Parses the `detail` argument. Anything unrecognised (including a missing
+    /// value) is [`Detail::Names`] — the cheap, complete view is the safe
+    /// default, and a typo must never silently produce a 200-schema answer.
+    pub fn parse(raw: Option<&str>) -> Self {
+        match raw
+            .map(str::trim)
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "schemas" | "schema" | "full" => Self::Schemas,
+            _ => Self::Names,
+        }
+    }
+
+    /// The default entry count for this mode.
+    fn default_limit(self) -> usize {
+        match self {
+            Self::Names => NAMES_DEFAULT_LIMIT,
+            Self::Schemas => SCHEMAS_DEFAULT_LIMIT,
+        }
+    }
+
+    /// The ceiling an explicit `limit` is clamped to in this mode.
+    fn max_limit(self) -> usize {
+        match self {
+            Self::Names => NAMES_MAX_LIMIT,
+            Self::Schemas => SCHEMAS_MAX_LIMIT,
+        }
+    }
+}
+
+/// One callable Composio action, flattened out of the backend's function-schema
+/// envelope so this module owns no upstream type (and so it compiles without
+/// the `composio` feature).
+#[derive(Clone, Debug, PartialEq)]
+pub struct CatalogAction {
+    /// The action slug, e.g. `GITHUB_LIST_ISSUES` — what `composio_execute`
+    /// takes.
+    pub slug: String,
+    /// The toolkit the slug belongs to, lowercased (`github`).
+    pub toolkit: String,
+    /// The human-readable description, or empty when the backend published
+    /// none.
+    pub description: String,
+    /// The JSON schema of the action's input parameters, when published.
+    pub parameters: Option<Value>,
+}
+
+/// A parsed `composio_list_tools` request.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ListRequest {
+    /// Toolkit slugs the caller asked for (already intersected with the tenant
+    /// allowlist by the caller).
+    pub toolkits: Vec<String>,
+    /// Lowercased search words. Every word must match the slug or the
+    /// description.
+    pub search: Vec<String>,
+    /// How much per action to render.
+    pub detail: Detail,
+    /// Entry cap, already clamped to the mode's ceiling.
+    pub limit: usize,
+}
+
+impl ListRequest {
+    /// Parses the tool arguments. `toolkits` is *not* read here — the live tool
+    /// intersects it with the tenant allowlist before the request is built, and
+    /// that resolution is a security decision this module must not duplicate.
+    pub fn parse(args: &Value, toolkits: Vec<String>) -> Self {
+        let detail = Detail::parse(args.get("detail").and_then(Value::as_str));
+        let search = args
+            .get("search")
+            .and_then(Value::as_str)
+            .map(search_terms)
+            .unwrap_or_default();
+        let limit = args
+            .get("limit")
+            .and_then(Value::as_u64)
+            .map(|n| (n as usize).clamp(1, detail.max_limit()))
+            .unwrap_or_else(|| detail.default_limit());
+        Self {
+            toolkits,
+            search,
+            detail,
+            limit,
+        }
+    }
+
+    /// Whether `action` survives this request's `search` words. Toolkit
+    /// narrowing happens upstream (server-side, and again against the
+    /// allowlist), so it is deliberately not re-applied here.
+    fn matches(&self, action: &CatalogAction) -> bool {
+        self.search.iter().all(|term| {
+            action.slug.to_ascii_lowercase().contains(term)
+                || action.description.to_ascii_lowercase().contains(term)
+                || action.toolkit.contains(term)
+        })
+    }
+}
+
+/// Splits a raw `search` argument into lowercased words.
+///
+/// Underscores are separators too, so `GITHUB_LIST_ISSUES` pasted back in as a
+/// search term still matches itself (the words `github`, `list` and `issues`
+/// are all contained in the slug), which is how the agent asks for one specific
+/// schema after reading the names view.
+fn search_terms(raw: &str) -> Vec<String> {
+    raw.split(|c: char| c.is_whitespace() || c == '_' || c == ',')
+        .map(str::trim)
+        .filter(|term| !term.is_empty())
+        .map(|term| term.to_ascii_lowercase())
+        .collect()
+}
+
+/// The name of the tool this module renders for. Kept here so the rendered
+/// guidance and the tool registration cannot drift apart.
+pub const LIST_TOOLS_TOOL: &str = "composio_list_tools";
+
+/// Renders the agent-facing listing for `actions` under `request`.
+///
+/// `actions` is the complete set the backend returned for the requested
+/// toolkits, already filtered to the tenant allowlist. The rendering is
+/// self-bounding: see the module docs for the invariant.
+pub fn render(actions: &[CatalogAction], request: &ListRequest) -> String {
+    let available = actions.len();
+    let matched: Vec<&CatalogAction> = actions.iter().filter(|a| request.matches(a)).collect();
+
+    if matched.is_empty() {
+        return render_empty(available, request);
+    }
+
+    let (body, shown, last_shown, terse) = match request.detail {
+        Detail::Schemas => {
+            let (body, shown, last) = fill(&matched, request.limit, render_schema_block);
+            (body, shown, last, false)
+        }
+        // Names mode prefers *completeness* over prose. Try slug + description
+        // first; if that would drop entries, re-render slug-only, which is
+        // roughly six times denser and usually fits the whole catalogue. "List
+        // action names (cheap, complete), then fetch one schema on demand" is
+        // the shape the issue asks for, and a complete list of slugs is what
+        // makes the second step possible.
+        Detail::Names => {
+            let (body, shown, last) = fill(&matched, request.limit, render_name_line);
+            if shown == matched.len() {
+                (body, shown, last, false)
+            } else {
+                let (terse_body, terse_shown, terse_last) =
+                    fill(&matched, request.limit, render_slug_line);
+                if terse_shown > shown {
+                    (terse_body, terse_shown, terse_last, true)
+                } else {
+                    (body, shown, last, false)
+                }
+            }
+        }
+    };
+
+    let dropped = matched.len() - shown;
+    let mut out = render_header(available, matched.len(), shown, request);
+    if terse {
+        out.push_str(
+            "(Descriptions omitted so more of the list fits — ask for one action's description \
+             and parameters with `detail: \"schemas\"`.)\n\n",
+        );
+    }
+    out.push_str(&body);
+    if dropped > 0 {
+        out.push_str(&render_cut_notice(dropped, &last_shown, request));
+    }
+    out
+}
+
+/// Renders entries with `entry_of` until `limit` or [`MAX_RENDER_BYTES`] is
+/// reached, never splitting one. Returns the body, how many were rendered, and
+/// the slug the list was cut after.
+///
+/// The **first** entry always goes in whole, even if it alone blows the budget:
+/// a schemas listing that matched exactly one huge schema must still hand it
+/// over, and "0 of 1 shown" is a correctly-described way of being useless.
+fn fill(
+    matched: &[&CatalogAction],
+    limit: usize,
+    entry_of: fn(&CatalogAction) -> String,
+) -> (String, usize, String) {
+    let mut body = String::new();
+    let mut shown = 0usize;
+    let mut last_shown = String::new();
+    for action in matched.iter().take(limit) {
+        let entry = entry_of(action);
+        if shown > 0 && body.len() + entry.len() > MAX_RENDER_BYTES {
+            break;
+        }
+        body.push_str(&entry);
+        last_shown = action.slug.clone();
+        shown += 1;
+    }
+    (body, shown, last_shown)
+}
+
+/// The header every listing opens with: what was available, what matched, what
+/// is being shown, and — always — how to get from here to a callable slug.
+fn render_header(available: usize, matched: usize, shown: usize, request: &ListRequest) -> String {
+    let scope = match request.toolkits.as_slice() {
+        [] => "every connected toolkit".to_string(),
+        toolkits => toolkits.join(", "),
+    };
+    let filter = if request.search.is_empty() {
+        String::new()
+    } else {
+        format!(" matching `{}`", request.search.join(" "))
+    };
+    let mut header = format!(
+        "Composio actions in {scope} — {available} available, {matched}{filter}, showing {shown}.\n"
+    );
+    match request.detail {
+        Detail::Names => header.push_str(&format!(
+            "Each line is `SLUG — description`. Read one action's parameters before calling it:\n  \
+             {LIST_TOOLS_TOOL}({{\"search\": \"<SLUG>\", \"detail\": \"schemas\"}})\n\n"
+        )),
+        Detail::Schemas => header.push_str(
+            "Each block is one action's callable slug and its JSON input schema. Pass the slug \
+             to `composio_execute` as `tool`.\n\n",
+        ),
+    }
+    header
+}
+
+/// One `Detail::Names` line.
+fn render_name_line(action: &CatalogAction) -> String {
+    let description = action
+        .description
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if description.is_empty() {
+        format!("{}\n", action.slug)
+    } else {
+        format!(
+            "{} — {}\n",
+            action.slug,
+            oh::util::truncate_with_suffix(&description, DESCRIPTION_PREVIEW_CHARS, "…")
+        )
+    }
+}
+
+/// One `Detail::Names` line with the description dropped — the dense fallback
+/// that lets a whole large catalogue be listed completely.
+fn render_slug_line(action: &CatalogAction) -> String {
+    format!("{}\n", action.slug)
+}
+
+/// One `Detail::Schemas` block: the slug, the description, and the verbatim
+/// input schema. Rendered as compact JSON — pretty-printing a Composio schema
+/// triples its size for no gain to a model that reads it as text.
+fn render_schema_block(action: &CatalogAction) -> String {
+    let schema = action
+        .parameters
+        .clone()
+        .unwrap_or_else(|| json!({"type": "object", "properties": {}}));
+    let mut block = format!("## {}\n", action.slug);
+    let description = action
+        .description
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if !description.is_empty() {
+        block.push_str(&format!("{description}\n"));
+    }
+    block.push_str(&format!(
+        "parameters: {}\n\n",
+        serde_json::to_string(&schema).unwrap_or_else(|_| "{}".to_string())
+    ));
+    block
+}
+
+/// The notice a cut listing carries. Says it was cut, how much was dropped,
+/// where the cut fell, and the exact arguments that make the next call smaller.
+///
+/// This is the whole point of the module: an agent that can read this has a
+/// reason to change its request, so it never re-issues the identical call into
+/// the repetition guard.
+fn render_cut_notice(dropped: usize, last_shown: &str, request: &ListRequest) -> String {
+    let max = request.detail.max_limit();
+    let plural = if dropped == 1 { "" } else { "s" };
+    format!(
+        "\n[TRUNCATED — this listing is NOT complete. {dropped} more matching action{plural} were \
+         not shown (the list was cut after `{last_shown}`). Do NOT repeat this call unchanged; it \
+         will return the same partial list. Narrow it instead:\n  \
+         • `search`: words matched against the action slug and description, e.g. \
+         {LIST_TOOLS_TOOL}({{\"search\": \"list issues\"}})\n  \
+         • `toolkits`: restrict to one toolkit, e.g. \
+         {LIST_TOOLS_TOOL}({{\"toolkits\": [\"github\"]}})\n  \
+         • `limit`: raise the cap (max {max}) if you truly need more at once.]\n"
+    )
+}
+
+/// The answer when nothing matched. A completed listing that found nothing is a
+/// fact, and saying so plainly — with the search that produced it — is what
+/// stops the agent guessing a slug or retrying the same words.
+fn render_empty(available: usize, request: &ListRequest) -> String {
+    let scope = match request.toolkits.as_slice() {
+        [] => "every connected toolkit".to_string(),
+        toolkits => toolkits.join(", "),
+    };
+    if available == 0 {
+        return format!(
+            "Composio actions in {scope} — none. This toolkit has no callable actions available to \
+             this company (it may not be connected). Check `composio_list_connections`, and do not \
+             guess an action slug.\n"
+        );
+    }
+    format!(
+        "Composio actions in {scope} — {available} available, 0 matching `{search}`.\n\
+         Nothing matched those words. Try fewer or different words (the search matches the action \
+         slug and its description), or list everything with \
+         {LIST_TOOLS_TOOL}({{\"toolkits\": [\"<slug>\"]}}). Do NOT guess a slug that was not \
+         listed.\n",
+        search = request.search.join(" ")
+    )
+}
+
+/// The `parameters_schema` JSON for `composio_list_tools`.
+///
+/// Lives here so the argument names the model is told about are the same
+/// literals [`ListRequest::parse`] reads and [`render_cut_notice`] tells it to
+/// use. A filter the model never discovers is the same bug as no filter at all.
+pub fn list_tools_parameters_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "toolkits": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Toolkit slugs to list actions for (e.g. `gmail`, `slack`, `github`). Omit to search every connected toolkit."
+            },
+            "search": {
+                "type": "string",
+                "description": "Narrow the listing to actions whose slug or description contains ALL of these words (case-insensitive), e.g. `list issues` or `send email`. Pass an exact slug here with `detail: \"schemas\"` to read just that action's parameters."
+            },
+            "detail": {
+                "type": "string",
+                "enum": ["names", "schemas"],
+                "description": "`names` (default) lists `SLUG — description` lines: cheap, use it to discover the action you need. `schemas` returns the full JSON input schema for the matching actions: use it once you know the slug, before calling `composio_execute`."
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Maximum actions to return (default 200 for `names`, 5 for `schemas`)."
+            }
+        },
+        "additionalProperties": false
+    })
+}
+
+// ---------------------------------------------------------------------------
+// The toolkit listing
+// ---------------------------------------------------------------------------
+//
+// Same class of bug, one level up (issue #410 point 4): `composio_list_toolkits`
+// serialized the backend's whole catalogue — Composio publishes several hundred
+// toolkits, each with a name, a description, a categories array and a logo URL —
+// as pretty JSON with no filter and no bound. It is rarer to blow the budget
+// than the action listing is, but it is the *same* silent cut, so it gets the
+// same treatment rather than a note in a follow-up issue.
+
+/// Tool name for the toolkit listing, for the same reason [`LIST_TOOLS_TOOL`]
+/// is a constant.
+pub const LIST_TOOLKITS_TOOL: &str = "composio_list_toolkits";
+
+/// Default number of toolkits one listing renders.
+pub const TOOLKITS_DEFAULT_LIMIT: usize = 200;
+
+/// Ceiling an explicit `limit` is clamped to when listing toolkits.
+pub const TOOLKITS_MAX_LIMIT: usize = 500;
+
+/// One integration this company could use, flattened out of the backend's
+/// catalogue entry. The logo URL is deliberately dropped: it is display
+/// metadata for the console, and it costs an agent tokens to read a URL it can
+/// never act on.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CatalogToolkit {
+    /// Toolkit slug, e.g. `googlecalendar` — what `composio_authorize` and the
+    /// `toolkits` argument take.
+    pub slug: String,
+    /// Human-readable name, or empty when the backend published none.
+    pub name: String,
+    /// Short description, or empty.
+    pub description: String,
+    /// Whether this company is connected to it, when known.
+    pub connected: Option<bool>,
+}
+
+/// A parsed `composio_list_toolkits` request.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ToolkitListRequest {
+    /// Lowercased search words matched against slug, name and description.
+    pub search: Vec<String>,
+    /// Entry cap, already clamped.
+    pub limit: usize,
+}
+
+impl ToolkitListRequest {
+    /// Parses the tool arguments, defaulting and clamping rather than failing.
+    pub fn parse(args: &Value) -> Self {
+        let search = args
+            .get("search")
+            .and_then(Value::as_str)
+            .map(search_terms)
+            .unwrap_or_default();
+        let limit = args
+            .get("limit")
+            .and_then(Value::as_u64)
+            .map(|n| (n as usize).clamp(1, TOOLKITS_MAX_LIMIT))
+            .unwrap_or(TOOLKITS_DEFAULT_LIMIT);
+        Self { search, limit }
+    }
+
+    fn matches(&self, toolkit: &CatalogToolkit) -> bool {
+        self.search.iter().all(|term| {
+            toolkit.slug.to_ascii_lowercase().contains(term)
+                || toolkit.name.to_ascii_lowercase().contains(term)
+                || toolkit.description.to_ascii_lowercase().contains(term)
+        })
+    }
+}
+
+/// Renders the agent-facing toolkit listing, bounded and self-describing on the
+/// same terms as [`render`].
+pub fn render_toolkits(toolkits: &[CatalogToolkit], request: &ToolkitListRequest) -> String {
+    let available = toolkits.len();
+    let matched: Vec<&CatalogToolkit> = toolkits.iter().filter(|t| request.matches(t)).collect();
+
+    if available == 0 {
+        return "Composio toolkits — none available to this company. No integration can be used \
+                or connected until the operator configures one.\n"
+            .to_string();
+    }
+    if matched.is_empty() {
+        return format!(
+            "Composio toolkits — {available} available, 0 matching `{search}`.\n\
+             Nothing matched those words. Try fewer or different words, or call \
+             {LIST_TOOLKITS_TOOL}({{}}) to see everything. Do NOT guess a toolkit slug.\n",
+            search = request.search.join(" ")
+        );
+    }
+
+    let mut body = String::new();
+    let mut shown = 0usize;
+    let mut last_shown = "";
+    for toolkit in matched.iter().take(request.limit) {
+        let mut entry = toolkit.slug.clone();
+        if !toolkit.name.is_empty() && !toolkit.name.eq_ignore_ascii_case(&toolkit.slug) {
+            entry.push_str(&format!(" ({})", toolkit.name));
+        }
+        match toolkit.connected {
+            Some(true) => entry.push_str(" [connected]"),
+            Some(false) => entry.push_str(" [not connected]"),
+            None => {}
+        }
+        let description = toolkit
+            .description
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        if !description.is_empty() {
+            entry.push_str(&format!(
+                " — {}",
+                oh::util::truncate_with_suffix(&description, DESCRIPTION_PREVIEW_CHARS, "…")
+            ));
+        }
+        entry.push('\n');
+        if shown > 0 && body.len() + entry.len() > MAX_RENDER_BYTES {
+            break;
+        }
+        body.push_str(&entry);
+        last_shown = &toolkit.slug;
+        shown += 1;
+    }
+
+    let filter = if request.search.is_empty() {
+        String::new()
+    } else {
+        format!(" matching `{}`", request.search.join(" "))
+    };
+    let mut out = format!(
+        "Composio toolkits — {available} available, {matched}{filter}, showing {shown}.\n\
+         Each line is `slug (name) — description`. List a toolkit's callable actions with \
+         {LIST_TOOLS_TOOL}({{\"toolkits\": [\"<slug>\"]}}).\n\n",
+        matched = matched.len()
+    );
+    out.push_str(&body);
+    let dropped = matched.len() - shown;
+    if dropped > 0 {
+        let plural = if dropped == 1 { "" } else { "s" };
+        out.push_str(&format!(
+            "\n[TRUNCATED — this listing is NOT complete. {dropped} more matching toolkit{plural} \
+             were not shown (the list was cut after `{last_shown}`). Do NOT repeat this call \
+             unchanged; it will return the same partial list. Narrow it with \
+             {LIST_TOOLKITS_TOOL}({{\"search\": \"<words>\"}}), or raise `limit` (max \
+             {TOOLKITS_MAX_LIMIT}).]\n"
+        ));
+    }
+    out
+}
+
+/// The `parameters_schema` JSON for `composio_list_toolkits`.
+pub fn list_toolkits_parameters_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "search": {
+                "type": "string",
+                "description": "Narrow the listing to toolkits whose slug, name or description contains ALL of these words (case-insensitive), e.g. `calendar` or `issue tracker`."
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Maximum toolkits to return (default 200)."
+            }
+        },
+        "additionalProperties": false
+    })
+}
+
+/// The `composio_list_toolkits` description shown to the model.
+pub fn list_toolkits_description() -> &'static str {
+    "List the Composio toolkits (integrations such as Gmail, Slack, GitHub, Notion) available to \
+     this company, with whether each is connected. Pass `search` words to narrow a large \
+     catalogue; a truncated result always says so and how to narrow it. Use \
+     `composio_list_tools` next to see one toolkit's callable actions. Read-only."
+}
+
+/// The `composio_list_tools` description shown to the model.
+pub fn list_tools_description() -> &'static str {
+    "Discover the callable Composio actions (Gmail, Slack, GitHub, Notion, …) this company can \
+     use. Two steps: call it with `search` words (and optionally `toolkits`) to list matching \
+     `SLUG — description` lines, then call it again with `detail: \"schemas\"` for the one slug \
+     you need to read its parameters before `composio_execute`. Large catalogues are truncated; \
+     the result always says so and how to narrow it. Read-only."
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A catalogue of `count` synthetic actions for `toolkit`, each with a
+    /// realistically chunky description and parameter schema.
+    fn catalogue(toolkit: &str, count: usize) -> Vec<CatalogAction> {
+        (0..count)
+            .map(|i| CatalogAction {
+                slug: format!("{}_ACTION_{i:03}", toolkit.to_ascii_uppercase()),
+                toolkit: toolkit.to_string(),
+                description: format!(
+                    "Performs operation {i} on the {toolkit} account. {}",
+                    "Long upstream prose that Composio publishes for every action. ".repeat(4)
+                ),
+                parameters: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "owner": {"type": "string", "description": "x".repeat(200)},
+                        "repo": {"type": "string", "description": "y".repeat(200)},
+                    },
+                    "required": ["owner"]
+                })),
+            })
+            .collect()
+    }
+
+    fn request(search: &str, detail: Detail, toolkits: &[&str]) -> ListRequest {
+        ListRequest {
+            toolkits: toolkits.iter().map(|t| t.to_string()).collect(),
+            search: search_terms(search),
+            detail,
+            limit: detail.default_limit(),
+        }
+    }
+
+    /// The headline invariant: a listing too big to render says so, says how
+    /// much it dropped, and names the argument that makes the next call
+    /// smaller. Without this the agent has no reason to change its request.
+    #[test]
+    fn an_oversized_listing_says_it_was_cut_and_how_to_narrow_it() {
+        let actions = catalogue("github", 300);
+        let out = render(&actions, &request("", Detail::Names, &["github"]));
+
+        assert!(out.contains("300 available"), "{out}");
+        assert!(
+            out.contains("TRUNCATED"),
+            "the cut must be announced: {out}"
+        );
+        assert!(
+            out.contains("100 more matching actions were not shown"),
+            "the notice must count what it dropped: {out}"
+        );
+        assert!(
+            out.contains("`search`") && out.contains("`toolkits`") && out.contains("`limit`"),
+            "the notice must name the arguments that narrow it: {out}"
+        );
+        assert!(
+            out.contains("Do NOT repeat this call unchanged"),
+            "the notice must break the retry loop explicitly: {out}"
+        );
+    }
+
+    /// Names mode prefers a *complete* list of slugs over a partial list with
+    /// prose. A 150-action toolkit does not fit with descriptions (they alone
+    /// run past the byte budget) but fits comfortably without them — so the
+    /// agent gets every slug it might need, plus the pointer to `detail:
+    /// "schemas"` for the one it picks.
+    #[test]
+    fn names_mode_drops_descriptions_rather_than_actions() {
+        let actions = catalogue("github", 150);
+        let out = render(&actions, &request("", Detail::Names, &["github"]));
+
+        assert!(out.contains("showing 150"), "{out}");
+        assert!(
+            !out.contains("TRUNCATED"),
+            "nothing had to be dropped: {out}"
+        );
+        assert!(out.contains("Descriptions omitted"), "{out}");
+        assert!(
+            out.contains("GITHUB_ACTION_149"),
+            "the last slug must be present: {out}"
+        );
+        assert!(
+            !out.contains("Long upstream prose"),
+            "the dense fallback must not carry descriptions: {out}"
+        );
+        assert!(out.len() < 16 * 1024, "{} bytes", out.len());
+    }
+
+    /// The bound is real, not advisory — and it is a whole-entry bound, so the
+    /// dropped count in the notice is exact rather than approximate.
+    #[test]
+    fn rendering_stays_inside_its_byte_budget_and_never_splits_an_entry() {
+        // 300 schema blocks at ~500 bytes each is far past the budget.
+        let actions = catalogue("gmail", 300);
+        let mut request = request("", Detail::Schemas, &["gmail"]);
+        request.limit = SCHEMAS_MAX_LIMIT;
+        let out = render(&actions, &request);
+
+        assert!(
+            out.len() < 16 * 1024,
+            "the rendered listing must stay under the harness tool-result cap: {} bytes",
+            out.len()
+        );
+        // Every block that IS present is complete: its trailing newline pair and
+        // its `parameters:` line both survived.
+        let blocks = out.matches("## GMAIL_ACTION_").count();
+        assert_eq!(
+            out.matches("parameters: {").count(),
+            blocks,
+            "an entry was cut in half: {out}"
+        );
+        assert!(blocks >= 1, "at least one schema must be delivered: {out}");
+    }
+
+    /// A listing that fits is not decorated with a truncation notice — the
+    /// notice has to mean something.
+    #[test]
+    fn a_complete_listing_carries_no_truncation_notice() {
+        let actions = catalogue("linear", 12);
+        let out = render(&actions, &request("", Detail::Names, &["linear"]));
+        assert!(out.contains("showing 12"), "{out}");
+        assert!(!out.contains("TRUNCATED"), "{out}");
+    }
+
+    /// Narrowing is generic: the same words find the one action in a
+    /// hundred-slug catalogue for any toolkit, with no per-provider table.
+    #[test]
+    fn search_narrows_to_one_action_on_any_toolkit() {
+        let mut actions = catalogue("github", 120);
+        actions.push(CatalogAction {
+            slug: "GITHUB_LIST_ISSUES".to_string(),
+            toolkit: "github".to_string(),
+            description: "List issues in a repository.".to_string(),
+            parameters: Some(json!({"type": "object", "properties": {"repo": {"type": "string"}}})),
+        });
+        let mut other = catalogue("notion", 130);
+        other.push(CatalogAction {
+            slug: "NOTION_SEARCH_PAGES".to_string(),
+            toolkit: "notion".to_string(),
+            description: "Search pages in the workspace.".to_string(),
+            parameters: Some(
+                json!({"type": "object", "properties": {"query": {"type": "string"}}}),
+            ),
+        });
+
+        let github = render(
+            &actions,
+            &request("list issues", Detail::Schemas, &["github"]),
+        );
+        assert!(github.contains("GITHUB_LIST_ISSUES"), "{github}");
+        assert!(
+            github.contains("\"repo\""),
+            "the schema must be present: {github}"
+        );
+        assert!(
+            !github.contains("TRUNCATED"),
+            "one match is not a cut: {github}"
+        );
+
+        let notion = render(
+            &other,
+            &request("search pages", Detail::Schemas, &["notion"]),
+        );
+        assert!(notion.contains("NOTION_SEARCH_PAGES"), "{notion}");
+        assert!(notion.contains("\"query\""), "{notion}");
+    }
+
+    /// An exact slug read back from the names view resolves to that one schema
+    /// — the second half of the two-step, and the reason `_` is a search
+    /// separator.
+    #[test]
+    fn an_exact_slug_pasted_into_search_returns_that_schema() {
+        let mut actions = catalogue("slack", 90);
+        actions.push(CatalogAction {
+            slug: "SLACK_POST_MESSAGE".to_string(),
+            toolkit: "slack".to_string(),
+            description: "Post a message to a channel.".to_string(),
+            parameters: Some(
+                json!({"type": "object", "properties": {"channel": {"type": "string"}}}),
+            ),
+        });
+        let out = render(
+            &actions,
+            &request("SLACK_POST_MESSAGE", Detail::Schemas, &["slack"]),
+        );
+        assert!(out.contains("SLACK_POST_MESSAGE"), "{out}");
+        assert!(out.contains("\"channel\""), "{out}");
+        assert!(out.contains("showing 1"), "{out}");
+    }
+
+    /// No match is reported as a fact, with the words that produced it, and
+    /// with an explicit instruction not to invent a slug.
+    #[test]
+    fn no_match_is_stated_plainly_rather_than_returned_empty() {
+        let actions = catalogue("gmail", 40);
+        let out = render(
+            &actions,
+            &request("quantum teleport", Detail::Names, &["gmail"]),
+        );
+        assert!(out.contains("0 matching `quantum teleport`"), "{out}");
+        assert!(out.contains("Do NOT guess a slug"), "{out}");
+        assert!(!out.contains("TRUNCATED"), "nothing was cut: {out}");
+    }
+
+    /// An empty catalogue is a different fact from an empty search, and points
+    /// at the connection rather than at the search words.
+    #[test]
+    fn an_empty_catalogue_points_at_the_connection() {
+        let out = render(&[], &request("", Detail::Names, &["github"]));
+        assert!(out.contains("none"), "{out}");
+        assert!(out.contains("composio_list_connections"), "{out}");
+    }
+
+    /// A single schema larger than the whole budget is still delivered — a
+    /// correctly-described way of being useless is still useless.
+    #[test]
+    fn a_single_oversized_schema_is_still_delivered_whole() {
+        let actions = vec![CatalogAction {
+            slug: "GIANT_ACTION".to_string(),
+            toolkit: "giant".to_string(),
+            description: "One enormous schema.".to_string(),
+            parameters: Some(json!({"type": "object", "blob": "z".repeat(MAX_RENDER_BYTES * 2)})),
+        }];
+        let out = render(&actions, &request("", Detail::Schemas, &["giant"]));
+        assert!(out.contains("GIANT_ACTION"), "{out}");
+        assert!(
+            out.contains(&"z".repeat(1000)),
+            "the only matching schema must survive whole"
+        );
+        assert!(!out.contains("TRUNCATED"), "nothing was dropped: {out}");
+    }
+
+    /// Argument parsing: the defaults are the cheap ones, an over-large `limit`
+    /// is clamped rather than rejected, and an unknown `detail` degrades to the
+    /// names view instead of dumping 200 schemas.
+    #[test]
+    fn arguments_default_and_clamp_rather_than_failing() {
+        let names = ListRequest::parse(&json!({}), vec!["github".into()]);
+        assert_eq!(names.detail, Detail::Names);
+        assert_eq!(names.limit, NAMES_DEFAULT_LIMIT);
+        assert!(names.search.is_empty());
+
+        let schemas = ListRequest::parse(&json!({"detail": "schemas"}), Vec::new());
+        assert_eq!(schemas.limit, SCHEMAS_DEFAULT_LIMIT);
+
+        let clamped = ListRequest::parse(&json!({"detail": "schemas", "limit": 9999}), Vec::new());
+        assert_eq!(clamped.limit, SCHEMAS_MAX_LIMIT);
+
+        let typo = ListRequest::parse(&json!({"detail": "everything"}), Vec::new());
+        assert_eq!(
+            typo.detail,
+            Detail::Names,
+            "an unknown detail must not dump schemas"
+        );
+
+        let terms = ListRequest::parse(&json!({"search": "  List   Issues "}), Vec::new());
+        assert_eq!(terms.search, vec!["list".to_string(), "issues".to_string()]);
+    }
+
+    /// The advertised argument names and the ones the parser reads are the same
+    /// literals — a filter the model is told about but the tool ignores would
+    /// be the same bug wearing a different hat.
+    #[test]
+    fn the_advertised_schema_matches_the_arguments_the_parser_reads() {
+        let schema = list_tools_parameters_schema();
+        let properties = schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("properties object");
+        for key in ["toolkits", "search", "detail", "limit"] {
+            assert!(properties.contains_key(key), "`{key}` is not advertised");
+        }
+        let description = list_tools_description();
+        assert!(description.contains("search"), "{description}");
+        assert!(description.contains("schemas"), "{description}");
+        assert!(
+            description.contains("truncated"),
+            "the model must be told results can be cut: {description}"
+        );
+
+        let toolkits = list_toolkits_parameters_schema();
+        let properties = toolkits
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("properties object");
+        for key in ["search", "limit"] {
+            assert!(properties.contains_key(key), "`{key}` is not advertised");
+        }
+        assert!(list_toolkits_description().contains("search"));
+    }
+
+    // ── the root cause: a message cap applied to a body ────────────────
+
+    /// The regression guard for #410's actual root cause.
+    ///
+    /// A tool body must never be sized by
+    /// [`SCRUB_MAX_BYTES`](crate::harness::mcp_probe::SCRUB_MAX_BYTES). That
+    /// constant is a 300-byte cap on a one-line operator message, and routing a
+    /// successful Composio result through it is what turned a 260-action
+    /// catalogue into "the first action and half of its schema, ending in `…`".
+    /// This pins the two halves apart: redaction never shortens, the body bound
+    /// is orders of magnitude larger than the message bound, and a bounded body
+    /// says so.
+    #[test]
+    fn a_tool_body_is_bounded_as_a_body_not_as_a_message() {
+        use crate::harness::mcp_probe::{SCRUB_MAX_BYTES, redact, scrub};
+
+        let body = format!("secret-token {}", "payload ".repeat(4_000));
+        let secrets = vec!["secret-token".to_string()];
+
+        // Redaction still redacts — that half was never the bug.
+        let redacted = redact(&body, &secrets);
+        assert!(
+            !redacted.contains("secret-token"),
+            "the token survived redaction"
+        );
+        assert!(redacted.contains("•••"));
+        // …and it does NOT shorten. The old path lost 99% of the payload here.
+        assert!(
+            redacted.len() > SCRUB_MAX_BYTES * 10,
+            "redact must not apply the message cap: {} bytes",
+            redacted.len()
+        );
+        assert!(
+            scrub(&body, &secrets).len() <= SCRUB_MAX_BYTES + 3,
+            "scrub keeps the message cap for the messages it was built for"
+        );
+
+        // The body bound is a body bound, and it announces itself.
+        const {
+            assert!(
+                MAX_BODY_BYTES > SCRUB_MAX_BYTES * 20,
+                "a body budget sized like a message budget is the bug"
+            )
+        };
+        let bounded = bound_body(redacted.clone(), "`GITHUB_LIST_ISSUES` output");
+        assert!(
+            bounded.contains("TRUNCATED"),
+            "an oversized body must say so"
+        );
+        assert!(
+            bounded.contains("bytes longer than this"),
+            "the notice must quantify what was lost: {bounded}"
+        );
+        assert!(bounded.contains("`GITHUB_LIST_ISSUES` output"), "{bounded}");
+
+        // A body that fits is returned untouched — no decoration, no marker.
+        let small = "a short provider response".to_string();
+        assert_eq!(bound_body(small.clone(), "output"), small);
+    }
+
+    // ── the toolkit listing ────────────────────────────────────────────
+
+    fn toolkit_catalogue(count: usize) -> Vec<CatalogToolkit> {
+        (0..count)
+            .map(|i| CatalogToolkit {
+                slug: format!("toolkit{i:03}"),
+                name: format!("Toolkit {i}"),
+                description: "An integration with a long upstream description. ".repeat(4),
+                connected: Some(i % 3 == 0),
+            })
+            .collect()
+    }
+
+    /// The toolkit catalogue is the same bug one level up, so it gets the same
+    /// self-describing cut.
+    #[test]
+    fn an_oversized_toolkit_listing_says_it_was_cut_and_how_to_narrow_it() {
+        let toolkits = toolkit_catalogue(400);
+        let out = render_toolkits(&toolkits, &ToolkitListRequest::parse(&json!({})));
+        assert!(out.contains("400 available"), "{out}");
+        assert!(out.contains("TRUNCATED"), "{out}");
+        assert!(
+            out.contains("more matching toolkits were not shown"),
+            "{out}"
+        );
+        assert!(
+            out.contains("`search`") || out.contains("\"search\""),
+            "{out}"
+        );
+        assert!(
+            out.len() < 16 * 1024,
+            "the listing must stay under the harness cap: {} bytes",
+            out.len()
+        );
+    }
+
+    /// Narrowing and the connected marker, which is what an agent actually
+    /// needs before it reaches for `composio_authorize`.
+    #[test]
+    fn toolkit_search_narrows_and_marks_connection_state() {
+        let mut toolkits = toolkit_catalogue(50);
+        toolkits.push(CatalogToolkit {
+            slug: "googlecalendar".to_string(),
+            name: "Google Calendar".to_string(),
+            description: "Read and write calendar events.".to_string(),
+            connected: Some(true),
+        });
+        let out = render_toolkits(
+            &toolkits,
+            &ToolkitListRequest::parse(&json!({"search": "calendar"})),
+        );
+        assert!(
+            out.contains("googlecalendar (Google Calendar) [connected]"),
+            "{out}"
+        );
+        assert!(out.contains("showing 1"), "{out}");
+        assert!(!out.contains("TRUNCATED"), "{out}");
+    }
+
+    /// A company with no integrations at all is a different fact from a search
+    /// that matched nothing, and both are stated rather than returned empty.
+    #[test]
+    fn an_empty_toolkit_catalogue_and_an_empty_search_read_differently() {
+        let none = render_toolkits(&[], &ToolkitListRequest::parse(&json!({})));
+        assert!(none.contains("none available"), "{none}");
+
+        let no_match = render_toolkits(
+            &toolkit_catalogue(5),
+            &ToolkitListRequest::parse(&json!({"search": "zzz"})),
+        );
+        assert!(no_match.contains("0 matching `zzz`"), "{no_match}");
+        assert!(
+            no_match.contains("Do NOT guess a toolkit slug"),
+            "{no_match}"
+        );
+    }
+}

--- a/src/harness/composio_turn_test.rs
+++ b/src/harness/composio_turn_test.rs
@@ -1,0 +1,646 @@
+//! Issue #410 — end-to-end proof that an agent with a connected provider can
+//! *discover* the action it needs and *call* it, unaided, on more than one
+//! toolkit.
+//!
+//! The acceptance in #410 is behavioural, and the unit tests in
+//! [`composio_catalog`](crate::harness::composio_catalog) structurally cannot
+//! reach it: they pin how a listing renders, not whether the rendering ever
+//! reaches a model's context intact. The failure being fixed happened *on the
+//! way out of the tool* — a successful result was passed through the MCP
+//! **message** sanitiser, whose 300-byte cap left the model the first action,
+//! half of its schema, and a bare `…`. Run against the pre-fix code these tests
+//! fail with exactly that fragment.
+//!
+//! So this drives the **real** harness — real `HarnessPool`, real `build_agent`,
+//! real `HostedProvider` on the native tool-calling path, real `ApprovalPolicy`,
+//! real `ComposioClient` — and stubs exactly two things, both at a network
+//! boundary and neither of which we own:
+//!
+//! * the **model's choices**, via a scripted OpenAI-compatible endpoint on
+//!   loopback (the shape [`search_turn_test`](super::search_turn_test)
+//!   established); and
+//! * the **Composio backend**, via a second loopback endpoint serving the real
+//!   `/agent-integrations/composio/tools` and `/execute` routes with a
+//!   *synthesised* catalogue of 120 GitHub and 140 Notion actions. **No Composio
+//!   credential exists here** — the tools talk to the managed backend, so
+//!   stubbing the managed backend stubs the whole provider chain, and
+//!   synthesising the catalogue is the only honest way to prove a generic fix
+//!   without two live hundred-action connections.
+//!
+//! The load-bearing assertions are the ones a unit test cannot make:
+//!
+//! 1. every Composio tool result the model sees stays under the harness's
+//!    16 KiB shared budget, so **our** self-describing cut is the cut, not an
+//!    anonymous downstream byte slice;
+//! 2. a genuinely oversized listing says it was cut, by how much, and which
+//!    argument makes it smaller;
+//! 3. the agent gets from "I need to list issues" to a real
+//!    `composio_execute(GITHUB_LIST_ISSUES)` with no human supplying the slug —
+//!    and does the same on a second, larger, non-GitHub toolkit.
+//!
+//! Gated on the `composio` feature, which CI builds (`--all-features`) but never
+//! *runs*; the narrowing and truncation logic these tests exercise therefore
+//! also carries its own tests in [`composio_catalog`], which the
+//! `--features openhuman,tinycortex` test lane does run.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use axum::extract::Query;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde_json::{Value, json};
+
+use crate::company::CompanyManifest;
+use crate::company::credentials::Credential;
+use crate::harness::composio::TenantComposio;
+use crate::harness::mcp_probe::McpFailureQueue;
+use crate::harness::orchestrator::{DelegationQueue, WorkflowRunnerHandle};
+use crate::harness::policy::ApprovalRequestQueue;
+use crate::harness::provider::{HostedProvider, HostedProviderConfig};
+use crate::harness::{HarnessDeps, HarnessPool};
+use crate::ports::types::{CompanyId, CompanyRecord};
+use crate::store::{FsCompanyStore, FsContextStore};
+
+/// The harness's shared per-tool-result byte budget
+/// (`openhuman::context::DEFAULT_TOOL_RESULT_BUDGET_BYTES`). A Composio result
+/// at or above this is cut by machinery that neither counts what it dropped nor
+/// names an argument to narrow with — which is the whole bug.
+const HARNESS_TOOL_RESULT_BUDGET_BYTES: usize = 16 * 1024;
+
+// ---------------------------------------------------------------------------
+// The scripted model
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+enum Turn {
+    Call { tool: &'static str, args: Value },
+    Say(&'static str),
+}
+
+struct Script {
+    turns: Mutex<Vec<Turn>>,
+    seen: Mutex<Vec<Value>>,
+}
+
+fn tool_call_message(tool: &str, args: &Value) -> Value {
+    json!({
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [{
+            "id": format!("call-{tool}-{}", args.to_string().len()),
+            "type": "function",
+            "function": { "name": tool, "arguments": args.to_string() }
+        }]
+    })
+}
+
+async fn spawn_script(turns: Vec<Turn>) -> (String, Arc<Script>) {
+    let script = Arc::new(Script {
+        turns: Mutex::new(turns),
+        seen: Mutex::new(Vec::new()),
+    });
+    let handle = Arc::clone(&script);
+    let app = Router::new().route(
+        "/chat/completions",
+        post(move |Json(body): Json<Value>| {
+            let script = Arc::clone(&handle);
+            async move {
+                script.seen.lock().unwrap().push(body.clone());
+                let next = {
+                    let mut turns = script.turns.lock().unwrap();
+                    if turns.is_empty() {
+                        None
+                    } else {
+                        Some(turns.remove(0))
+                    }
+                };
+                let next = next.unwrap_or(Turn::Say("done"));
+                let message = match next {
+                    Turn::Say(text) => json!({ "role": "assistant", "content": text }),
+                    Turn::Call { tool, args } => tool_call_message(tool, &args),
+                };
+                Json(json!({
+                    "choices": [{ "index": 0, "message": message }],
+                    "usage": { "prompt_tokens": 12, "completion_tokens": 4 }
+                }))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{addr}"), script)
+}
+
+// ---------------------------------------------------------------------------
+// The stubbed Composio backend
+// ---------------------------------------------------------------------------
+
+/// A synthesised action, shaped like a real Composio function schema: a long
+/// upstream description and a parameter schema with per-property prose. Sizes
+/// are deliberately realistic — this is what makes the catalogue genuinely
+/// oversized rather than artificially so.
+fn action(toolkit: &str, slug: &str, summary: &str) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": slug,
+            "description": format!(
+                "{summary} This action operates on the connected {toolkit} account. \
+                 {}",
+                "Upstream publishes several sentences of prose for every action, which is \
+                 exactly why a whole toolkit's catalogue does not fit in one tool result. "
+                    .repeat(2)
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "owner": { "type": "string", "description": "o".repeat(180) },
+                    "target": { "type": "string", "description": "t".repeat(180) },
+                    "state": { "type": "string", "enum": ["open", "closed", "all"] }
+                },
+                "required": ["owner"]
+            }
+        }
+    })
+}
+
+/// 120 GitHub actions, one of which is the one an agent asked to "list the open
+/// issues" actually needs. The needle sorts nowhere near first — the pre-fix
+/// cut kept whatever sorted first, so a needle at index 97 is the honest case.
+fn github_catalogue() -> Vec<Value> {
+    let mut out: Vec<Value> = (0..120)
+        .map(|i| {
+            action(
+                "github",
+                &format!("GITHUB_ACTION_{i:03}"),
+                &format!("Performs repository operation number {i}."),
+            )
+        })
+        .collect();
+    out[97] = action(
+        "github",
+        "GITHUB_LIST_ISSUES",
+        "List the issues on a repository, optionally filtered by state.",
+    );
+    out
+}
+
+/// 140 Notion actions — the "at least one large toolkit that is not GitHub"
+/// half of the acceptance criteria.
+fn notion_catalogue() -> Vec<Value> {
+    let mut out: Vec<Value> = (0..140)
+        .map(|i| {
+            action(
+                "notion",
+                &format!("NOTION_ACTION_{i:03}"),
+                &format!("Performs workspace operation number {i}."),
+            )
+        })
+        .collect();
+    out[131] = action(
+        "notion",
+        "NOTION_SEARCH_PAGES",
+        "Search the pages in a workspace by query text.",
+    );
+    out
+}
+
+/// What the stub observed, so the tests can assert on the wire rather than on
+/// the model's narration.
+#[derive(Default)]
+struct ComposioStub {
+    /// Every `toolkits=` query string the tool sent to `/tools`.
+    tool_queries: Mutex<Vec<Option<String>>>,
+    /// Every action slug `/execute` was asked to run.
+    executed: Mutex<Vec<String>>,
+    /// How many times `/tools` was called at all.
+    list_calls: AtomicUsize,
+}
+
+async fn spawn_composio_backend() -> (String, Arc<ComposioStub>) {
+    let stub = Arc::new(ComposioStub::default());
+
+    let tools_stub = Arc::clone(&stub);
+    let execute_stub = Arc::clone(&stub);
+    let app = Router::new()
+        .route(
+            "/agent-integrations/composio/tools",
+            get(move |Query(params): Query<Vec<(String, String)>>| {
+                let stub = Arc::clone(&tools_stub);
+                async move {
+                    stub.list_calls.fetch_add(1, Ordering::SeqCst);
+                    let requested = params
+                        .iter()
+                        .find(|(k, _)| k == "toolkits")
+                        .map(|(_, v)| v.clone());
+                    stub.tool_queries.lock().unwrap().push(requested.clone());
+                    // Mirror the real backend: `toolkits=` narrows server-side,
+                    // its absence returns every enabled toolkit's actions.
+                    let mut tools: Vec<Value> = Vec::new();
+                    let wants = |name: &str| {
+                        requested
+                            .as_deref()
+                            .map(|r| r.split(',').any(|t| t.eq_ignore_ascii_case(name)))
+                            .unwrap_or(true)
+                    };
+                    if wants("github") {
+                        tools.extend(github_catalogue());
+                    }
+                    if wants("notion") {
+                        tools.extend(notion_catalogue());
+                    }
+                    Json(json!({ "success": true, "data": { "tools": tools } }))
+                }
+            }),
+        )
+        .route(
+            "/agent-integrations/composio/execute",
+            post(move |Json(body): Json<Value>| {
+                let stub = Arc::clone(&execute_stub);
+                async move {
+                    let tool = body
+                        .get("tool")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    stub.executed.lock().unwrap().push(tool.clone());
+                    Json(json!({
+                        "success": true,
+                        "data": {
+                            "data": { "ran": tool, "items": ["#1 flaky test", "#2 docs typo"] },
+                            "successful": true,
+                            "costUsd": 0.0
+                        }
+                    }))
+                }
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{addr}"), stub)
+}
+
+// ---------------------------------------------------------------------------
+// The harness under test
+// ---------------------------------------------------------------------------
+
+/// A one-agent company that explicitly grants `composio` (the catch-all `*`
+/// deliberately does not) and runs in `full` mode, so `composio_execute` is not
+/// parked for operator approval mid-test.
+fn manifest() -> CompanyManifest {
+    toml::from_str(
+        r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+
+[tools]
+allow = ["composio"]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+tier = "orchestrator"
+"#,
+    )
+    .expect("manifest parses")
+}
+
+async fn harness(
+    model_url: String,
+    composio_url: String,
+    dir: &std::path::Path,
+) -> (HarnessPool, HarnessDeps, CompanyRecord) {
+    let deps = HarnessDeps {
+        provider: Arc::new(HostedProvider::new(HostedProviderConfig {
+            base_url: model_url,
+            credential: Credential::from_value("stub-key"),
+            extra_headers: Vec::new(),
+        })),
+        provider_slug: "managed".to_string(),
+        context: Arc::new(FsContextStore::new(dir)),
+        store: Arc::new(FsCompanyStore::new(dir)),
+        meter: None,
+        workspace_root: dir.to_path_buf(),
+        model_override: Some("stub-model".to_string()),
+        tasks: None,
+        artifacts: None,
+        skills: None,
+        skills_source_dir: None,
+        skills_registry: std::sync::Arc::from([]),
+        mcp_servers: Vec::new(),
+        facts: None,
+        events: None,
+        delegations: DelegationQueue::default(),
+        workflow_runner: WorkflowRunnerHandle::default(),
+        mcp_failures: McpFailureQueue::default(),
+        pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+        approval_requests: ApprovalRequestQueue::default(),
+        secrets: None,
+        web_allowed_domains: Vec::new(),
+        capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+        workflow_source_dir: None,
+        plan: None,
+        media: None,
+        // An empty toolkit allowlist is "defer to the backend" (open mode) —
+        // the worst case for catalogue size, and the case a newly-connected
+        // provider lands in.
+        composio: Some(TenantComposio::new(
+            composio_url,
+            Credential::from_value("stub-tenant-token"),
+            Vec::new(),
+        )),
+        steer: crate::company::steer::InflightRegistry::default(),
+        run_supervisor: crate::runtime::RunSupervisor::default(),
+        delivery: None,
+        search: None,
+        workspace: None,
+    };
+
+    let record = CompanyRecord {
+        id: CompanyId::new("acme"),
+        manifest: manifest(),
+        ledger: Vec::new(),
+        lifecycle: "running".to_string(),
+        overlay_agents: Vec::new(),
+        overlay_desk_members: Vec::new(),
+        overlay_desk_order: Vec::new(),
+        overlay_desks: Vec::new(),
+        overlay_workflows: Vec::new(),
+        overlay_budgets: Vec::new(),
+        template_provenance: None,
+    };
+
+    let pool = HarnessPool::new();
+    pool.ensure(&record, &deps).await.expect("pool ensures");
+    (pool, deps, record)
+}
+
+/// Every tool *result* the harness fed back to the model, in order.
+fn tool_results(script: &Script) -> Vec<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for body in script.seen.lock().unwrap().iter() {
+        for message in body
+            .get("messages")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default()
+        {
+            if message.get("role").and_then(Value::as_str) != Some("tool") {
+                continue;
+            }
+            if let Some(content) = message.get("content").and_then(Value::as_str)
+                && !seen.iter().any(|s| s == content)
+            {
+                seen.push(content.to_string());
+            }
+        }
+    }
+    seen
+}
+
+fn advertised_tools(script: &Script) -> Vec<String> {
+    let mut names: Vec<String> = script
+        .seen
+        .lock()
+        .unwrap()
+        .iter()
+        .filter_map(|body| body.get("tools").and_then(Value::as_array).cloned())
+        .flatten()
+        .filter_map(|tool| {
+            tool.get("function")?
+                .get("name")?
+                .as_str()
+                .map(str::to_string)
+        })
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// The headline acceptance: an agent with live connections to two large
+/// toolkits — 120 GitHub actions and 140 Notion actions, 260 in one open-mode
+/// catalogue — discovers the right slug on **each** and calls it, with no human
+/// supplying a slug and no provider-specific code anywhere in the path.
+///
+/// The script is the agent's reasoning, written out: list what exists, narrow to
+/// the words in the task, read that one action's parameters, call it. Every step
+/// uses only information the previous step's *result* gave it.
+#[tokio::test]
+async fn an_agent_discovers_and_calls_an_action_unaided_on_two_large_toolkits() {
+    let (model_url, script) = spawn_script(vec![
+        // 1. What can I do at all? (open mode: 260 actions)
+        Turn::Call {
+            tool: "composio_list_tools",
+            args: json!({}),
+        },
+        // 2. The task said "issues" — narrow to it and read the parameters.
+        Turn::Call {
+            tool: "composio_list_tools",
+            args: json!({ "search": "list issues", "detail": "schemas" }),
+        },
+        // 3. Call it with the arguments the schema named.
+        Turn::Call {
+            tool: "composio_execute",
+            args: json!({
+                "tool": "GITHUB_LIST_ISSUES",
+                "arguments": { "owner": "acme", "state": "open" }
+            }),
+        },
+        // 4-5. The same two steps on a different, larger, non-GitHub toolkit.
+        Turn::Call {
+            tool: "composio_list_tools",
+            args: json!({ "toolkits": ["notion"], "search": "search pages", "detail": "schemas" }),
+        },
+        Turn::Call {
+            tool: "composio_execute",
+            args: json!({
+                "tool": "NOTION_SEARCH_PAGES",
+                "arguments": { "owner": "acme", "target": "roadmap" }
+            }),
+        },
+        Turn::Say("Two open issues, and the roadmap page."),
+    ])
+    .await;
+    let (composio_url, stub) = spawn_composio_backend().await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (pool, deps, record) = harness(model_url, composio_url, dir.path()).await;
+
+    let outcome = pool
+        .run(
+            &record.id,
+            "ceo",
+            "List our open GitHub issues and find the roadmap page in Notion.",
+            &deps,
+            None,
+        )
+        .await
+        .expect("turn runs");
+    assert!(
+        outcome.reply.contains("Two open issues"),
+        "the turn did not complete: {}",
+        outcome.reply
+    );
+
+    let advertised = advertised_tools(&script);
+    for tool in ["composio_list_tools", "composio_execute"] {
+        assert!(
+            advertised.contains(&tool.to_string()),
+            "`{tool}` was never advertised to the model: {advertised:?}"
+        );
+    }
+
+    let results = tool_results(&script);
+    let joined = results.join("\n=== next tool result ===\n");
+
+    // The discovery step told the agent the listing was incomplete AND how to
+    // narrow it. Without this it has no reason to change its request.
+    assert!(
+        results[0].contains("260 available"),
+        "the first listing must report the true catalogue size: {}",
+        results[0]
+    );
+    assert!(
+        results[0].contains("TRUNCATED") && results[0].contains("`search`"),
+        "the oversized listing must describe its own cut: {}",
+        results[0]
+    );
+
+    // The narrowed step delivered exactly the schema needed to call it.
+    assert!(
+        joined.contains("GITHUB_LIST_ISSUES"),
+        "the needle slug never reached the model: {joined}"
+    );
+    assert!(
+        joined.contains("\"state\"") && joined.contains("\"open\""),
+        "the parameter schema never reached the model: {joined}"
+    );
+    assert!(
+        joined.contains("NOTION_SEARCH_PAGES"),
+        "the second toolkit's needle never reached the model: {joined}"
+    );
+
+    // Both calls actually reached the provider — the acceptance is "calls it",
+    // not "talks about calling it".
+    let executed = stub.executed.lock().unwrap().clone();
+    assert_eq!(
+        executed,
+        vec![
+            "GITHUB_LIST_ISSUES".to_string(),
+            "NOTION_SEARCH_PAGES".to_string()
+        ],
+        "the agent did not reach both providers: {executed:?}"
+    );
+
+    // The generic fix, stated as a wire fact: the second Notion listing carried
+    // `toolkits=notion`, so narrowing happened server-side too rather than by
+    // fetching 260 actions and throwing 259 away.
+    let queries = stub.tool_queries.lock().unwrap().clone();
+    assert!(
+        queries.iter().any(|q| q.as_deref() == Some("notion")),
+        "the toolkit narrowing never reached the backend: {queries:?}"
+    );
+
+    // Nothing the model saw was big enough for the harness's own cut to fire —
+    // so every cut in this turn was one that counted itself and said how to ask
+    // for less.
+    for (index, result) in results.iter().enumerate() {
+        assert!(
+            result.len() < HARNESS_TOOL_RESULT_BUDGET_BYTES,
+            "tool result {index} is {} bytes — at or past the harness budget, which cuts \
+             anonymously: {result}",
+            result.len()
+        );
+    }
+}
+
+/// The retry-loop guard, stated directly: an agent that repeats the identical
+/// oversized listing gets the identical result *and* an explicit instruction not
+/// to. Before the fix the repeated result was a silent fragment, which is why
+/// the agent had no reason to stop and eventually hit the repetition guard.
+#[tokio::test]
+async fn a_repeated_oversized_listing_still_tells_the_agent_to_narrow_instead() {
+    let (model_url, script) = spawn_script(vec![
+        Turn::Call {
+            tool: "composio_list_tools",
+            args: json!({}),
+        },
+        Turn::Call {
+            tool: "composio_list_tools",
+            args: json!({ "toolkits": ["github", "notion"] }),
+        },
+        Turn::Say("I need to narrow the listing."),
+    ])
+    .await;
+    let (composio_url, _stub) = spawn_composio_backend().await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (pool, deps, record) = harness(model_url, composio_url, dir.path()).await;
+    pool.run(&record.id, "ceo", "What can you do?", &deps, None)
+        .await
+        .expect("turn runs");
+
+    let results = tool_results(&script);
+    assert!(
+        results.len() >= 2,
+        "expected two distinct listings: {results:#?}"
+    );
+    for result in &results {
+        assert!(
+            result.contains("Do NOT repeat this call unchanged"),
+            "a cut listing must break the loop it would otherwise cause: {result}"
+        );
+        assert!(
+            result.len() < HARNESS_TOOL_RESULT_BUDGET_BYTES,
+            "{} bytes",
+            result.len()
+        );
+    }
+}
+
+/// A newly-connected provider with a large catalogue works with no
+/// provider-specific change: the same words that found the GitHub action find
+/// the Notion one, and the toolkit slug is never hardcoded anywhere in the path.
+#[tokio::test]
+async fn a_narrowed_listing_on_an_unknown_toolkit_needs_no_provider_specific_code() {
+    let (model_url, script) = spawn_script(vec![
+        Turn::Call {
+            tool: "composio_list_tools",
+            args: json!({ "toolkits": ["notion"], "search": "operation number 42" }),
+        },
+        Turn::Say("Found it."),
+    ])
+    .await;
+    let (composio_url, _stub) = spawn_composio_backend().await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (pool, deps, record) = harness(model_url, composio_url, dir.path()).await;
+    pool.run(&record.id, "ceo", "Find the Notion action.", &deps, None)
+        .await
+        .expect("turn runs");
+
+    let joined = tool_results(&script).join("\n");
+    assert!(
+        joined.contains("NOTION_ACTION_042"),
+        "the search did not find the action on an arbitrary toolkit: {joined}"
+    );
+    assert!(
+        !joined.contains("TRUNCATED"),
+        "a single match is not a cut: {joined}"
+    );
+}

--- a/src/harness/mcp_probe.rs
+++ b/src/harness/mcp_probe.rs
@@ -30,7 +30,12 @@ use crate::company::mcp::{McpHealth, McpServerDecl, McpStatus};
 use crate::harness::mcp::registry_from_decls;
 use crate::ports::now_millis;
 
-/// The maximum byte length of any scrubbed, surfaced message.
+/// The maximum byte length of any scrubbed, surfaced **message**.
+///
+/// Sized for a one-line operator/agent-facing sentence — an MCP failure
+/// summary, a health string. It is **not** a size for a tool *body*: see
+/// [`redact`] for why passing a successful tool result through [`scrub`] is a
+/// bug rather than a conservative choice.
 pub const SCRUB_MAX_BYTES: usize = 300;
 
 /// The shape of an MCP failure, driving both the status tier and the operator
@@ -376,14 +381,39 @@ pub async fn probe_server(decl: &McpServerDecl) -> McpHealth {
 ///    query parameter.
 /// 3. UTF-8-safely truncate to [`SCRUB_MAX_BYTES`].
 pub fn scrub(text: &str, secrets: &[String]) -> String {
+    utf8_truncate(&redact(text, secrets), SCRUB_MAX_BYTES)
+}
+
+/// The **security** half of [`scrub`] — passes 1 and 2 only, with no length
+/// cap. For tool *bodies*, which the caller must bound itself.
+///
+/// # Why this is separate (issue #410)
+///
+/// [`scrub`]'s third pass is a 300-byte message cap, and 300 bytes is right for
+/// the sentence an MCP failure renders to. It is catastrophic for a successful
+/// tool result: `composio_list_tools` routed its whole response through
+/// [`scrub`], so an agent asking what a connected provider could do received the
+/// first ~300 bytes of pretty-printed JSON — the first action and half of its
+/// schema — ending in a bare `…` that says nothing about what was lost or how
+/// to ask for less. The agent could tell actions existed but could not read the
+/// name or parameters of the one it needed, so it reissued the identical call
+/// until the repetition guard halted the run. Every Composio tool was affected,
+/// including `composio_execute`, whose provider output was capped at 300 bytes
+/// too.
+///
+/// Redaction is not the part that was wrong and must never be optional: this
+/// still replaces every known credential with `•••` and strips the query string
+/// off every embedded URL. Only the length decision moves to the caller, which
+/// is the only place that knows what a sensible bound for *that* payload is and
+/// how the agent could ask for a smaller one.
+pub fn redact(text: &str, secrets: &[String]) -> String {
     let mut out = text.to_string();
     for secret in secrets {
         if !secret.is_empty() {
             out = out.replace(secret.as_str(), "•••");
         }
     }
-    out = strip_url_queries(&out);
-    utf8_truncate(&out, SCRUB_MAX_BYTES)
+    strip_url_queries(&out)
 }
 
 /// Remove the entire endpoint credential surface from an agent-visible endpoint

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -39,6 +39,11 @@ pub mod brain;
 pub mod build;
 pub mod capability_budget;
 pub mod composio;
+/// Issue #410: how a Composio action catalogue is narrowed and rendered for an
+/// agent, and why every cut it makes describes itself. Pure and un-gated (the
+/// live tools are behind `composio`, which CI never *runs*) — see
+/// [`composio_catalog`].
+pub mod composio_catalog;
 pub mod cost;
 /// Hosted embeddings compute for the in-pod memory engine's meaning tier (188c2).
 /// Needs the `tinycortex` crate's `EmbeddingBackend` trait, so it links only when

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -44,6 +44,12 @@ pub mod composio;
 /// live tools are behind `composio`, which CI never *runs*) — see
 /// [`composio_catalog`].
 pub mod composio_catalog;
+/// End-to-end proof that #410's narrowable, self-describing Composio listing is
+/// reachable from a real turn on two large toolkits — the harness, the grant
+/// gate, the approval policy and the Composio client are all real; only the
+/// model's choices and the Composio backend are scripted. Test-only.
+#[cfg(all(test, feature = "composio"))]
+mod composio_turn_test;
 pub mod cost;
 /// Hosted embeddings compute for the in-pod memory engine's meaning tier (188c2).
 /// Needs the `tinycortex` crate's `EmbeddingBackend` trait, so it links only when

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -410,6 +410,19 @@ impl Tool for QueryCompanyTool {
                     fact.body.trim()
                 ));
             }
+            // Issue #410, the same silent-cut class one tool over: this list was
+            // capped at FACT_LIMIT with no marker, so a company past twenty facts
+            // handed the orchestrator a partial memory that read as complete —
+            // and the narrowing argument that would have fixed it (`query`) was
+            // never mentioned at the point the cut happened.
+            if facts.len() > FACT_LIMIT {
+                md.push_str(&format!(
+                    "\n[TRUNCATED — {} more fact(s) not shown. This is NOT the whole record. \
+                     Narrow it with `{QUERY_COMPANY_TOOL}({{\"query\": \"<substring>\"}})` before \
+                     concluding a fact is absent.]\n",
+                    facts.len() - FACT_LIMIT
+                ));
+            }
         }
         md.push_str("\n## Recent activity\n");
         if recent.is_empty() {
@@ -2364,6 +2377,69 @@ members = ["nobody"]
             1,
             "a post must not hold a slot of its own: {out}"
         );
+    }
+
+    /// Issue #410, point 4 (audit the same silent-cut class elsewhere): the
+    /// fact list is capped at [`FACT_LIMIT`], and it used to be capped in
+    /// silence. A company past twenty facts handed the orchestrator a partial
+    /// memory that read as complete, so "we have no record of that" was a
+    /// conclusion it could reach from a truncated list. The cut now says it
+    /// happened and names the argument that narrows it.
+    #[tokio::test]
+    async fn query_company_says_when_the_fact_list_was_cut() {
+        use crate::ports::FactStore;
+        use crate::ports::facts::{FactKind, FactRecord};
+
+        struct ManyFacts(usize);
+        #[async_trait]
+        impl FactStore for ManyFacts {
+            async fn list(
+                &self,
+                _company: &CompanyId,
+                _query: Option<&str>,
+                _kind: Option<FactKind>,
+            ) -> crate::Result<Vec<FactRecord>> {
+                Ok((0..self.0)
+                    .map(|i| FactRecord {
+                        id: format!("f-{i}"),
+                        kind: FactKind::Fact,
+                        title: format!("Fact {i}"),
+                        body: format!("Body {i}"),
+                        source: "ceo".to_string(),
+                        updated_at_millis: i as u64,
+                    })
+                    .collect())
+            }
+            async fn upsert(&self, _c: &CompanyId, _f: &FactRecord) -> crate::Result<()> {
+                Ok(())
+            }
+            async fn delete(&self, _c: &CompanyId, _id: &str) -> crate::Result<bool> {
+                Ok(false)
+            }
+        }
+
+        // Exactly at the cap: complete, so no notice.
+        let exact: Arc<dyn FactStore> = Arc::new(ManyFacts(FACT_LIMIT));
+        let out = QueryCompanyTool::new(CompanyId::new("acme"), Some(exact), None, None, None)
+            .execute(json!({}))
+            .await
+            .expect("execute")
+            .output_for_llm(true);
+        assert!(!out.contains("TRUNCATED"), "nothing was cut: {out}");
+
+        // Past the cap: the cut is announced, counted, and points at `query`.
+        let many: Arc<dyn FactStore> = Arc::new(ManyFacts(FACT_LIMIT + 7));
+        let out = QueryCompanyTool::new(CompanyId::new("acme"), Some(many), None, None, None)
+            .execute(json!({}))
+            .await
+            .expect("execute")
+            .output_for_llm(true);
+        assert!(
+            out.contains("TRUNCATED"),
+            "the cut must be announced: {out}"
+        );
+        assert!(out.contains("7 more fact(s) not shown"), "{out}");
+        assert!(out.contains("query_company"), "{out}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #410.

An agent with a live Composio connection could not call anything on it, because it could never read an action's name or parameters. The catalogue was being cut, silently, to **300 bytes**.

The plan assumed the cut came from the agent harness's shared 16 KiB per-tool-result budget. It did not. `composio_list_tools` serialised the backend response and passed it to `mcp_probe::scrub` on the way out — and `scrub` is the *MCP failure-message* sanitiser, whose third pass clamps to `SCRUB_MAX_BYTES = 300`. Right for a one-line operator sentence; three orders of magnitude wrong for a catalogue. This is what the model actually received for a 260-action catalogue, captured verbatim from a real turn run against the pre-fix code:

```
{
  "tools": [
    {
      "type": "function",
      "function": {
        "name": "GITHUB_ACTION_000",
        "description": "Performs repository operation number 0. This action…
```

The first action, half of its schema, and a bare `…`. That matches the issue's description exactly — "cut off after the first action and its partial schema", "the surviving entry is always whichever sorts first", "nothing in the result says it was cut".

Two consequences the issue did not know about:

- **All five Composio tools were affected, not just the listing.** `composio_execute` returned 300 bytes of whatever the provider actually said. A successful "list my open issues" was capped at 300 bytes of issues.
- The 16 KiB budget was never reached, so it was never the problem. It is still the *next* cut downstream, which is why the new bounds are chosen to sit under it.

The fix is generic and lives at the listing mechanism. No provider is named anywhere in it.

## API Or Behavior Changes

**`composio_list_tools`** — new arguments, and a rendered listing instead of raw JSON:

- `search` — whitespace-separated words matched case-insensitively against the action slug *and* its description; all words must match. `_` and `,` are separators too, so a slug read back from the names view (`GITHUB_LIST_ISSUES`) matches itself.
- `detail` — `names` (default) or `schemas`. This is the two-step the issue asked for: `names` renders one `SLUG — description` line per action for discovery, `schemas` returns the full JSON input schema for the few actions that matched, for calling. An unrecognised value degrades to `names` rather than dumping 200 schemas.
- `limit` — clamped, not rejected (200/400 for names, 5/20 for schemas).

`names` mode prefers **completeness over prose**: if slug+description would not fit, it re-renders slug-only, which is ~6× denser and lets a whole large catalogue be listed in full. A complete list of slugs is what makes the second step possible; a partial list with nice descriptions is not.

**`composio_list_toolkits`** — same treatment (`search`, `limit`, rendered listing, connection state per row). Composio publishes several hundred toolkits; it is the same silent cut one level up.

**Every cut now describes itself.** It says it is truncated, counts exactly what was dropped, names the entry it was cut after, says *"Do NOT repeat this call unchanged"*, and gives the literal arguments that narrow it. It never splits an entry, which is what makes the dropped count exact rather than approximate. Sample:

```
[TRUNCATED — this listing is NOT complete. 60 more matching actions were not shown
 (the list was cut after `NOTION_ACTION_119`). Do NOT repeat this call unchanged; it
 will return the same partial list. Narrow it instead:
  • `search`: words matched against the action slug and description, e.g.
    composio_list_tools({"search": "list issues"})
  • `toolkits`: restrict to one toolkit, e.g. composio_list_tools({"toolkits": ["github"]})
  • `limit`: raise the cap (max 400) if you truly need more at once.]
```

**Tool descriptions and parameter schemas** now advertise the filters and warn that results can be truncated. A filter the model never discovers is the same bug; a test pins that the advertised argument names and the ones the parser reads are the same literals.

**`mcp_probe::redact`** — new. `scrub` did two unrelated jobs (redact credentials; clamp to 300 bytes) and callers that needed the first were forced to take the second. `redact` is the security half with no length cap; `scrub` is now defined in terms of it and is byte-identical for every existing caller. Redaction on Composio bodies is unchanged and unconditional — the tenant-isolation tests still pass untouched.

**`query_company`** (issue point 4) — the fact list was capped at 20 in silence, so a company past twenty facts handed the orchestrator a partial memory that read as complete. The cut now announces itself and names `query`.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings` (default lane)
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex,composio --all-targets -- -D warnings`
- [x] `cargo build --all-targets` (covered by `cargo check --locked --all-features --all-targets`)
- [x] `cargo test --locked --lib` — **1424 passed, 0 failed**
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **2041 passed, 0 failed**
- [x] `cargo test --locked --features openhuman,tinycortex,composio --lib` — **2056 passed, 0 failed**
- [x] `cargo test --locked --features openhuman,mcp,telegram --lib harness::build::tests` — 14 passed
- [x] `git diff --stat Cargo.lock` — empty

### The behavioural verification

Unit tests pin how a listing renders; they cannot tell you whether the rendering survives the trip into a model's context, which is where this bug lived. So `composio_turn_test.rs` drives the **real** harness — real `HarnessPool`, real `build_agent`, real grant gate, real `ApprovalPolicy`, real `ComposioClient` on the native tool-calling path — and stubs only the two network boundaries: the model's choices (scripted `/chat/completions` on loopback) and the Composio backend (loopback, serving the real routes). The catalogue is synthesised — **120 GitHub + 140 Notion actions, 260 in one open-mode listing**, with realistic upstream prose and parameter schemas — because that is the honest way to prove a generic fix without two live hundred-action connections.

**Pre-fix, the same tests fail**, with the fragment quoted at the top of this PR. The second test fails in a particularly clean way: the two *distinct* listing calls collapse into one identical string, which is the retry loop from the issue, reproduced.

Post-fix, on the wire, the agent goes task wording → slug → schema → call with nothing supplied by a human, on **both** toolkits:

| step | tool call | result the model saw |
|---|---|---|
| 1 | `composio_list_tools({})` | 4,473 B — `260 available, 260, showing 200` + the TRUNCATED notice |
| 2 | `…({"search": "list issues", "detail": "schemas"})` | 1,218 B — `260 available, 1 matching, showing 1`, schema included |
| 3 | `composio_execute(GITHUB_LIST_ISSUES)` | 203 B — reached the provider |
| 4 | `…({"toolkits": ["notion"], "search": "search pages", "detail": "schemas"})` | 1,187 B — `140 available, 1 matching, showing 1` |
| 5 | `composio_execute(NOTION_SEARCH_PAGES)` | 204 B — reached the provider |

Pre-fix, step 1 was 303 bytes and steps 2–5 never happened (`search` was not even an accepted argument). The test also asserts on the wire that `toolkits=notion` reached the backend (so narrowing is server-side, not fetch-260-and-discard-259), and that **every** result stayed under 16 KiB — i.e. the harness's anonymous cut never fired, so the counted cut is the only cut.

## Documentation

Module-level docs in `composio_catalog.rs`, `composio.rs` and `mcp_probe::redact` carry the root cause, the invariant, and the reasoning for each bound. No `docs/` page covers the Composio tool arguments today, so there was nothing to update there.

## Honest notes

**What the plan got wrong.** It named the harness's 16 KiB budget as the likely culprit and told me to look for a per-tool cap plus a generic one. There is a generic one, but it was never reached — the real cap was a *message* sanitiser reused on a *body*, at 300 bytes, inside this crate. I found it only because the first run of the behavioural test failed with a result far smaller than any of the caps I had been reading. That is the third time on this epic that reading the code led to the wrong cap and running a real turn led to the right one.

**Where the fix lives, and why not in `scrub`.** I did not lower or raise `SCRUB_MAX_BYTES`, and I did not make `scrub` "smart". 300 bytes is correct for what `scrub` is for. The bug was calling it on the wrong kind of value, so the fix is a second function with the security half and no sizing opinion, plus a body budget at the call site that knows what the payload is.

**What I deliberately left out.**

- The `composio` feature is opt-in and **CI never runs it** (`--all-features` is a `cargo check`, not a `cargo test`). Rather than let this land untested in CI, all the narrowing, rendering and truncation-notice logic lives in `composio_catalog.rs`, which compiles under plain `openhuman` and is covered by the lane CI does run (15 tests). The `composio`-gated turn tests are additional, and I ran them locally. I did not add a CI lane in this PR — that is a repo-wide decision about build cost, and worth doing on its own.
- `composio_execute`'s trailer does not invent a narrowing argument. There is no generic one — the narrowing lives in the action's own parameters — so it says that ("ask the action itself for less: a page size, a limit, a date range, or a specific record by id") rather than pointing at a parameter that does not exist.
- I did not add server-side `tags` filtering. The backend's `/tools` route accepts `tags`, but Composio tags are sparse and inconsistent across toolkits, and relying on them would be exactly the per-provider coupling the issue rules out. `search` matches text the backend already publishes for every action.

**Point 4 — the audit.** I swept `src/` for the same class (a value reaching a model, shortened, with no statement of what was lost or how to ask for less). One more instance was on the same mechanism and is fixed here (`query_company`'s fact list). The rest each need their own design, so they are filed rather than silently left:

- **#417** — `workspace_read`: a note between 16 KiB and 64 KiB passes the module's own "not truncated" check, so the agent is told it may overwrite it with "the complete new body" — while having received only ~16 KiB. That is a silent data-loss path on an operator's note, and it breaks the invariant the module documents for itself. Also swallows the closing injection fence.
- **#418** — `run_workflow` returns 120 characters of the *last* item of each node with no count and, unlike this issue, **no way to ask for the rest**.
- **#419** — `spawn_task` / `delegate_to_desk` return "it will happen this turn"; the per-turn cap of 3 then `clear()`s the remainder. A dropped effect, not a dropped rendering.
- **#420** — the tail: `cap_redirect` truncates an operator's mid-turn instruction with *no marker at all*, the memory preamble drops retrieved hits silently, `publish`'s scan sets a `truncated` flag that has zero callers, and `query_company`'s event tail has no count. Also notes a residual on this PR's own fact-list marker: the insight document has no overall size bound, so on a very large company the new marker can itself be cut by the harness budget — a size guard, not a marker change.

**What I disagreed with in the issue.** Only the framing of point 3. The issue offers "list names, then fetch one schema" as something to *consider*; I treated it as load-bearing rather than optional, because bounding without it just produces a well-described partial list. It is also why `names` mode drops descriptions before it drops actions — an agent can work from a complete list of slugs and one schema, and cannot work from two thirds of a list however nicely annotated.
