### PR TITLE
fix(harness): an agent without shell can write a file, because its workspace now exists (#409)

### DIFF
--- a/docs/spec/runtime/storage.md
+++ b/docs/spec/runtime/storage.md
@@ -55,6 +55,7 @@ locations instead of ad-hoc paths:
   files/       ← instance-shared files (exports, attachments)
   logs/        ← instance logs
   tmp/         ← ephemeral scratch, cleared on startup by default
+  harness/     ← agent + workflow sandboxes (see below; minted on demand)
 ```
 
 Per-company state (each bundle's own `memory/`/`context/`) lives under
@@ -64,6 +65,39 @@ the shared subdirectories and — unless `[workspace].clear_tmp_on_startup` is
 `false` — empties `tmp/` so no stale scratch survives a restart. Because the hosting model runs **one container per tenant** with its
 own `OPENCOMPANY_DATA_DIR`, this root *is* the per-tenant workspace — no separate
 per-tenant path prefix is needed.
+
+### Agent sandboxes (`<home>/harness`)
+
+The tree an agent's file tools actually act in hangs off the **home**, not off a
+bundle, and is deliberately **not** pre-created by `DataLayout::ensure` — the
+same rule `companies/` follows: whoever owns a subtree mints it on demand.
+
+```text
+<home>/harness/<company>/
+  <agent>/workspace/                      ← one agent's sandbox
+  <agent>/skill-catalog/                  ← its materialized skill bundles
+  _workflow/<workflow>/<run>/workspace/   ← one workflow run's sandbox
+```
+
+An agent's sandbox is named by `harness::build::agent_workspace` and created by
+`harness::build::ensure_agent_workspace`; a workflow run's is named and created
+by `workflows::caps`. It must exist **before** the agent acts, not merely by the
+time it finishes. OpenHuman's `validate_parent_path` resolves a relative write
+against the sandbox, then walks up to the deepest *existing* ancestor to
+canonicalize it; with the sandbox absent that walk climbs past it and lands
+outside, so the write is refused as `Resolved parent path escapes workspace` for
+a path that is plainly inside. The runtime writes its own bookkeeping there
+(session transcripts, the TinyAgents journal), creating the directory as a side
+effect — but only at the *end* of a turn, so it never helps the turn that needed
+it. An agent holding `shell` never saw this: its first command creates the
+directory before anything validates a path (issue #409).
+
+Hence two creation points, not one. `build_agent` mints the sandbox before any
+`SecurityPolicy` is constructed over it; the dispatch path re-ensures it every
+turn. The second is not redundant — a roster is built once, cached behind
+fingerprints and handed across an in-place rebuild, so a sandbox removed under a
+live host (a restored data dir, a boot that raced an unmounted volume) would
+otherwise stay missing for the life of the process.
 
 ### Choosing the root (`src/store/paths.rs`)
 

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -159,29 +159,32 @@ pub fn build_agent(
         deps.context.clone(),
     ));
 
-    let workspace = agent_workspace(&deps.workspace_root, company, &manifest_agent.id);
-    // Create it now, before any tool is bound to it.
-    //
-    // Not a convenience — the file tools do not work without it. OpenHuman's
-    // `validate_parent_path` resolves a relative write against `action_dir`,
-    // then walks up to the deepest **existing** ancestor to canonicalize. With
-    // the workspace absent, that walk climbs past it to `workspace_root`, which
-    // is outside the sandbox, and the write is refused as *"Resolved parent
-    // path escapes workspace"*. So an agent granted `files` but not `shell`
-    // could not write a relative path at all until its first shell call
-    // happened to create the directory as a side effect.
+    // Create the sandbox now, before any tool — or any `SecurityPolicy` — is
+    // bound to it. See [`ensure_agent_workspace`] for why an absent directory
+    // breaks relative writes outright, and why creating it late is not the same
+    // as creating it here.
     //
     // Best-effort: a failure here is logged, not fatal. The tools then behave
-    // exactly as they did before, and the agent is still perfectly able to run
-    // a turn that touches no files.
-    if let Err(err) = std::fs::create_dir_all(&workspace) {
-        tracing::warn!(
-            company = %company,
-            agent = %manifest_agent.id,
-            error = %err,
-            "[build] could not create the agent workspace; file tools will refuse relative paths"
-        );
-    }
+    // exactly as they did before, the dispatch path gets a second attempt just
+    // before the agent acts, and the agent is still perfectly able to run a turn
+    // that touches no files. The message names the real condition — a directory
+    // that could not be created — rather than leaving the operator with the
+    // guard's traversal wording as the only clue.
+    let workspace = match ensure_agent_workspace(&deps.workspace_root, company, &manifest_agent.id)
+    {
+        Ok(workspace) => workspace,
+        Err(err) => {
+            let workspace = agent_workspace(&deps.workspace_root, company, &manifest_agent.id);
+            tracing::warn!(
+                company = %company,
+                agent = %manifest_agent.id,
+                workspace = %workspace.display(),
+                error = %err,
+                "[build] could not create the agent workspace; file tools will refuse relative paths"
+            );
+            workspace
+        }
+    };
 
     // Intrinsic memory tools: every agent can deliberately store and recall over
     // its own company memory, complementing the automatic retrieve→inject→store
@@ -619,13 +622,62 @@ pub(crate) fn grants_cover(grants: &[String], namespace: &str) -> bool {
 
 /// One agent's sandbox directory: `{root}/{company}/{agent}/workspace`.
 ///
-/// A named function rather than a repeated `join` chain because two callers now
-/// need to agree on it exactly: [`build_agent`], which sandboxes the file tools
-/// to it, and the brain's #244 unpublished-file scan, which snapshots it. A
-/// second transcription of the layout would make the scan silently look at the
-/// wrong directory — reporting nothing, forever, with no error anywhere.
+/// A named function rather than a repeated `join` chain because three callers
+/// now need to agree on it exactly: [`build_agent`], which sandboxes the file
+/// tools to it; the brain's #244 unpublished-file scan, which snapshots it; and
+/// [`ensure_agent_workspace`], which creates it. A second transcription of the
+/// layout would make the scan silently look at the wrong directory — reporting
+/// nothing, forever, with no error anywhere.
+///
+/// Naming only — this never touches the disk. Anything that needs the directory
+/// to *exist* goes through [`ensure_agent_workspace`].
 pub fn agent_workspace(root: &Path, company: &CompanyId, agent_id: &str) -> PathBuf {
     root.join(company.as_ref()).join(agent_id).join("workspace")
+}
+
+/// Create one agent's sandbox directory, returning the path
+/// [`agent_workspace`] names. Idempotent.
+///
+/// The single **creation** site for the agent-workspace layout, and not a
+/// convenience: the file tools do not work without the directory. OpenHuman's
+/// `validate_parent_path` resolves a relative write against `action_dir`, then
+/// walks up to the deepest *existing* ancestor to canonicalize it. With the
+/// workspace absent that walk climbs straight past it — through `{agent}/` and
+/// `{company}/` to the workspace root — and the ancestor it lands on is,
+/// correctly, outside the agent's own sandbox. The write is then refused as
+/// *"Resolved parent path escapes workspace"* for a path that is plainly inside
+/// it (issue #409).
+///
+/// Nothing else mints this directory. `<home>/harness` is deliberately absent
+/// from [`DataLayout::ensure`](crate::store::DataLayout::ensure), which
+/// pre-creates only the instance-shared trees; per-company and per-agent trees
+/// are minted on demand by whoever owns them, the same rule `companies/`
+/// follows. The near miss is
+/// [`EffectiveSkills::materialize`](crate::harness::skills::EffectiveSkills),
+/// which creates `{agent}/skill-catalog/` — a *sibling* of `workspace`, so it
+/// makes the walk stop one level higher and refuse just the same.
+///
+/// Called from two places, because one is not enough:
+///
+///  * [`build_agent`], before any [`SecurityPolicy`] is constructed over the
+///    path. Ordering matters beyond the guard: the per-workspace audit logger
+///    keys its process-global registry on the *canonicalized* workspace path and
+///    falls back to the raw one when the directory is missing, so a workspace
+///    created late can be registered twice under one physical directory.
+///  * the dispatch path ([`HarnessPool::run`](crate::harness::HarnessPool::run)
+///    and friends), because a roster is built once and then cached behind
+///    fingerprints and handed across an in-place rebuild — so a workspace that
+///    disappears after the roster was built (a restored/wiped data dir, an
+///    operator clearing the tree, a boot that raced a not-yet-mounted volume)
+///    would otherwise stay missing for the life of the process.
+pub fn ensure_agent_workspace(
+    root: &Path,
+    company: &CompanyId,
+    agent_id: &str,
+) -> std::io::Result<PathBuf> {
+    let workspace = agent_workspace(root, company, agent_id);
+    std::fs::create_dir_all(&workspace)?;
+    Ok(workspace)
 }
 
 /// A [`SecurityPolicy`] that sandboxes an agent's file tools to `workspace` and
@@ -730,6 +782,183 @@ mod tests {
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(names.contains(&"file_read"), "got {names:?}");
         assert!(names.contains(&"file_write"), "got {names:?}");
+    }
+
+    // --- Agent-workspace provisioning (issue #409) --------------------------
+
+    #[test]
+    fn ensure_agent_workspace_mints_the_whole_chain_and_is_idempotent() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let company = CompanyId::new("acme");
+
+        // Nothing under the root exists yet — not the company segment, not the
+        // agent segment. This is a company that has never run.
+        let named = agent_workspace(root.path(), &company, "ceo");
+        assert!(!named.exists(), "precondition: nothing minted yet");
+
+        let made = ensure_agent_workspace(root.path(), &company, "ceo").expect("first ensure");
+        assert_eq!(made, named, "creation and naming must agree exactly");
+        assert!(made.is_dir());
+
+        // Idempotent: a second call on an existing tree is a success, not an
+        // `AlreadyExists` error — the dispatch path calls this on every turn.
+        let again = ensure_agent_workspace(root.path(), &company, "ceo").expect("second ensure");
+        assert_eq!(again, made);
+        assert!(again.is_dir());
+    }
+
+    /// The bug, pinned. With the workspace absent, `validate_parent_path` walks
+    /// up past it to an ancestor that really *is* outside the sandbox and
+    /// refuses a plainly-inside relative path — the refusal an agent granted
+    /// `files` but not `shell` used to hit on every write.
+    #[tokio::test]
+    async fn a_missing_workspace_makes_a_plain_relative_write_look_like_an_escape() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let workspace = agent_workspace(root.path(), &CompanyId::new("acme"), "ceo");
+        assert!(!workspace.exists(), "precondition: never provisioned");
+
+        let policy = workspace_security(&workspace);
+        let err = policy
+            .validate_parent_path("notes.md")
+            .await
+            .expect_err("a missing workspace refuses the write");
+        assert!(
+            err.contains("escapes workspace"),
+            "the guard blames traversal for a missing directory: {err}"
+        );
+    }
+
+    /// The fix. The same policy over an *ensured* workspace resolves the same
+    /// relative path, inside the sandbox.
+    #[tokio::test]
+    async fn an_ensured_workspace_resolves_a_relative_write_inside_the_sandbox() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let workspace =
+            ensure_agent_workspace(root.path(), &CompanyId::new("acme"), "ceo").expect("ensure");
+
+        let policy = workspace_security(&workspace);
+        let resolved = policy
+            .validate_parent_path("notes.md")
+            .await
+            .expect("an existing workspace accepts a relative write");
+
+        let canonical = workspace.canonicalize().expect("canonicalize");
+        assert!(
+            resolved.starts_with(&canonical),
+            "{} is not inside {}",
+            resolved.display(),
+            canonical.display()
+        );
+        assert_eq!(
+            resolved.file_name().and_then(|n| n.to_str()),
+            Some("notes.md")
+        );
+
+        // A nested path whose parent does not exist yet still resolves — the
+        // guard only ever needed *some* existing ancestor inside the sandbox.
+        let nested = policy
+            .validate_parent_path("reports/q3/summary.md")
+            .await
+            .expect("a not-yet-created subdirectory still resolves");
+        assert!(nested.starts_with(&canonical));
+    }
+
+    /// Provisioning does not loosen the guard: a genuine escape is still
+    /// refused — and it comes back **word for word** the same as the
+    /// missing-workspace refusal above. That is why #409 was filed rather than
+    /// closed by the one-line create.
+    ///
+    /// Reaching the resolved-parent arm with a real escape takes some care,
+    /// which is itself part of the finding. A symlink whose *immediate* parent
+    /// resolves (`escape/loot.txt`) is caught earlier, by the string-level
+    /// symlink check, with a different and perfectly clear message. The arm
+    /// under test is reached only when no existing ancestor can be canonicalized
+    /// up front: a symlink out of the sandbox plus a not-yet-created
+    /// subdirectory under it. So in a `workspace_only` agent sandbox this
+    /// wording fires for exactly two conditions — a hostile symlink and a
+    /// workspace that was never created — and says "escapes workspace" for both.
+    ///
+    /// Pinned here so a wording change upstream surfaces in this repo instead of
+    /// drifting silently.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_real_escape_and_a_missing_workspace_are_refused_in_identical_words() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let workspace =
+            ensure_agent_workspace(root.path(), &CompanyId::new("acme"), "ceo").expect("ensure");
+        std::os::unix::fs::symlink(outside.path(), workspace.join("escape")).expect("symlink");
+
+        let policy = workspace_security(&workspace);
+
+        // The easy half: the immediate parent resolves, so the string-level
+        // symlink check refuses it first — clearly, and distinguishably.
+        let shallow = policy
+            .validate_parent_path("escape/loot.txt")
+            .await
+            .expect_err("a symlink out of the sandbox is refused");
+        assert!(
+            shallow.contains("Path not allowed by security policy"),
+            "expected the string-level refusal: {shallow}"
+        );
+
+        // The arm this issue is about: nothing up front can be canonicalized,
+        // so the ancestor walk runs and lands outside the sandbox.
+        let deep = policy
+            .validate_parent_path("escape/nested/loot.txt")
+            .await
+            .expect_err("a real escape must still be refused");
+        assert!(
+            deep.contains("Resolved parent path escapes workspace"),
+            "expected the resolved-parent refusal: {deep}"
+        );
+
+        // The same arm, reached instead by a workspace nobody ever created.
+        let absent = agent_workspace(root.path(), &CompanyId::new("acme"), "nobody");
+        let missing = workspace_security(&absent)
+            .validate_parent_path("notes.md")
+            .await
+            .expect_err("a missing workspace refuses too");
+        assert!(
+            missing.contains("Resolved parent path escapes workspace"),
+            "{missing}"
+        );
+
+        // Verbatim identical up to the path each names. A reader given either
+        // one goes looking for a traversal attempt; only one of them is.
+        let strip = |m: &str| {
+            m.split_once("escapes workspace: ")
+                .map(|(head, _)| head.to_string())
+                .unwrap_or_default()
+        };
+        assert_eq!(
+            strip(&deep),
+            strip(&missing),
+            "an attack and an unprovisioned directory should not read alike"
+        );
+    }
+
+    /// A `..` traversal is refused earlier, by the string-level check, and
+    /// *does* read differently — so the ambiguity above is specifically about
+    /// the resolved-parent arm, not about every refusal.
+    #[tokio::test]
+    async fn a_dot_dot_traversal_is_refused_with_a_distinguishable_message() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let workspace =
+            ensure_agent_workspace(root.path(), &CompanyId::new("acme"), "ceo").expect("ensure");
+
+        let err = workspace_security(&workspace)
+            .validate_parent_path("../../loot.txt")
+            .await
+            .expect_err("a traversal is refused");
+        assert!(
+            err.contains("Path not allowed by security policy"),
+            "expected the string-level refusal: {err}"
+        );
+        assert!(
+            !err.contains("escapes workspace"),
+            "this arm is already distinguishable: {err}"
+        );
     }
 
     #[test]

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -78,6 +78,13 @@ pub mod steer;
 pub mod steps;
 pub mod tool_dispatcher;
 pub mod toolbelt;
+/// End-to-end proof that an agent granted `files` and **not** `shell` can write
+/// a relative path on a company that has never run — the #409 provisioning gap,
+/// which only exists before anything has created the agent's workspace. Covers
+/// a manifest teammate and a runtime overlay teammate, and pins that a traversal
+/// out of a provisioned sandbox is still refused. Test-only.
+#[cfg(test)]
+mod workspace_provision_turn_test;
 pub mod workspace_tools;
 /// End-to-end proof that the #237 workspace tools are reachable from a real
 /// turn, with only the model's choices stubbed. Test-only.
@@ -1173,6 +1180,32 @@ impl HarnessPool {
                     ))
                 })?
         };
+
+        // Renew the agent's sandbox directory at the moment it acts (issue
+        // #409). `build_agent` already created it, but a roster is built once
+        // and then cached behind fingerprints — and handed *across* an in-place
+        // rebuild — so a workspace that goes missing afterwards (a restored or
+        // wiped data dir, an operator clearing the tree, a boot that raced a
+        // not-yet-mounted volume) would otherwise stay missing for the life of
+        // the process, and every relative file write would be refused as if it
+        // had tried to escape the sandbox. Two syscalls on the already-exists
+        // path, against a turn that is about to call a model — not worth
+        // deferring off the runtime thread.
+        //
+        // Deliberately not fatal, for the same reason `build_agent`'s attempt is
+        // not: an agent with no file grant runs a perfectly good turn without
+        // this directory. The `error!` (not `warn!`) records the one condition
+        // under which the misdirecting guard message can still be reached, so it
+        // is greppable next to the refusal it explains.
+        if let Err(error) = build::ensure_agent_workspace(&deps.workspace_root, company, agent_id) {
+            tracing::error!(
+                company = %company,
+                agent = agent_id,
+                workspace = %build::agent_workspace(&deps.workspace_root, company, agent_id).display(),
+                %error,
+                "[harness] could not create the agent workspace before dispatch; relative file writes will be refused (the refusal will read as a workspace escape, but the cause is this missing directory)"
+            );
+        }
 
         // Plan-level total-token ceiling (issue #188): a HARD dispatch refusal
         // that never reaches the model once the tenant's total period spend

--- a/src/harness/workspace_provision_turn_test.rs
+++ b/src/harness/workspace_provision_turn_test.rs
@@ -1,0 +1,510 @@
+//! End-to-end proof that an agent granted `files` and **not** `shell` can write
+//! a relative path on a company that has never run (issue #409).
+//!
+//! The policy-level tests in [`build`](crate::harness::build) pin what the guard
+//! does with a missing directory. They cannot tell you whether a real agent ever
+//! reaches that state, and the whole bug is a state that only exists *before
+//! anything has run*: the first thing a `shell` command does is create the
+//! working directory as a side effect, so an agent holding that grant never sees
+//! it. The difference between a working and a broken agent was a grant that
+//! looks unrelated to files.
+//!
+//! So this drives the **real** brain through `run_cycle` on a `TaskDispatched`
+//! event, with a real `HarnessPool`, real `build_agent`, real `HostedProvider`
+//! (`tool_calling: true`, so the turn runs on the production native tool loop),
+//! and a workspace root that starts out completely empty. Only the model's
+//! choices are scripted, against a loopback OpenAI-compatible endpoint.
+//!
+//! Three shapes are covered, matching the three ways an agent's storage first
+//! comes into existence: a manifest teammate on a company that has never run, a
+//! teammate on a company whose bundle was just minted, and an overlay teammate
+//! added at runtime with no manifest row at all.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use axum::Json;
+use axum::routing::post;
+use serde_json::{Value, json};
+
+use crate::company::CompanyManifest;
+use crate::company::credentials::Credential;
+use crate::harness::mcp_probe::McpFailureQueue;
+use crate::harness::orchestrator::{DelegationQueue, WorkflowRunnerHandle};
+use crate::harness::policy::ApprovalRequestQueue;
+use crate::harness::provider::{HostedProvider, HostedProviderConfig};
+use crate::harness::{HarnessBrain, HarnessDeps, HarnessPool};
+use crate::ports::brain::{Brain, CycleHost};
+use crate::ports::tasks::{COLUMN_IN_PROGRESS, TaskRecord, TaskStore};
+use crate::ports::types::{
+    ApprovalId, CompanyEvent, CompanyId, CompanyRecord, ContextOp, ContextOpResult, CycleRequest,
+    Effect, EffectDisposition, OverlayAgent, ToolCall, ToolResult,
+};
+use crate::store::{FsCompanyStore, FsContextStore, FsOps};
+
+/// The manifest teammate this fixture dispatches to.
+const AGENT: &str = "writer";
+
+/// A teammate that exists only as a runtime overlay — no manifest row.
+const OVERLAY_AGENT: &str = "analyst";
+
+/// The relative path the scripted model writes to. Deliberately nested: the
+/// parent does not exist either, which is the ordinary case for a first write.
+const REL_PATH: &str = "notes/hello.md";
+
+const BODY: &str = "the first thing this agent ever wrote";
+
+/// The refusal this issue is about, verbatim enough to match on.
+const ESCAPE_REFUSAL: &str = "escapes workspace";
+
+// ---------------------------------------------------------------------------
+// The scripted model
+// ---------------------------------------------------------------------------
+
+/// A loopback OpenAI-compatible endpoint that always tries to write one file.
+///
+/// Deliberately **stateless** rather than a scripted queue of turns. These tests
+/// run more than one cycle against the same endpoint, and a turn does not always
+/// take the same number of model round trips — a queue silently slides out of
+/// alignment and hands the second cycle the first cycle's closing text, so the
+/// write under test never happens and the test reports a missing file instead of
+/// the truth. The rule here is per-request and cannot drift: **answer with the
+/// tool call, unless we have just been handed a tool result, in which case
+/// close the turn with text.**
+struct Script {
+    /// The relative path the model asks to write on every turn.
+    path: String,
+    /// Every request body the harness sent, for post-hoc assertions.
+    seen: Mutex<Vec<Value>>,
+}
+
+/// Whether the request's last message is a tool result — i.e. the model has
+/// already had its call answered and should now finish.
+fn just_got_a_tool_result(body: &Value) -> bool {
+    body.get("messages")
+        .and_then(Value::as_array)
+        .and_then(|m| m.last())
+        .and_then(|last| last.get("role"))
+        .and_then(Value::as_str)
+        == Some("tool")
+}
+
+async fn spawn_script(path: &str) -> (String, Arc<Script>) {
+    let script = Arc::new(Script {
+        path: path.to_string(),
+        seen: Mutex::new(Vec::new()),
+    });
+    let handle = Arc::clone(&script);
+    let app = axum::Router::new().route(
+        "/chat/completions",
+        post(move |Json(body): Json<Value>| {
+            let script = Arc::clone(&handle);
+            async move {
+                script.seen.lock().unwrap().push(body.clone());
+                let message = if just_got_a_tool_result(&body) {
+                    json!({ "role": "assistant", "content": "Wrote the note." })
+                } else {
+                    let args = json!({ "path": script.path, "content": BODY });
+                    json!({
+                        "role": "assistant",
+                        "content": null,
+                        "tool_calls": [{
+                            "id": "call-file_write",
+                            "type": "function",
+                            "function": { "name": "file_write", "arguments": args.to_string() }
+                        }]
+                    })
+                };
+                (
+                    axum::http::StatusCode::OK,
+                    Json(json!({
+                        "choices": [{ "index": 0, "message": message }],
+                        "usage": { "prompt_tokens": 12, "completion_tokens": 4 }
+                    })),
+                )
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{addr}"), script)
+}
+
+/// Every tool name the scripted model was offered.
+fn advertised_tools(script: &Script) -> Vec<String> {
+    let mut names: Vec<String> = script
+        .seen
+        .lock()
+        .unwrap()
+        .iter()
+        .filter_map(|body| body.get("tools").and_then(Value::as_array).cloned())
+        .flatten()
+        .filter_map(|tool| {
+            tool.get("function")?
+                .get("name")?
+                .as_str()
+                .map(str::to_string)
+        })
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// Everything the harness fed back to the model as a `tool` message — i.e. what
+/// the tool actually answered. This is where a refusal shows up.
+fn tool_results(script: &Script) -> Vec<String> {
+    script
+        .seen
+        .lock()
+        .unwrap()
+        .iter()
+        .flat_map(|body| {
+            body.get("messages")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default()
+        })
+        .filter(|m| m.get("role").and_then(Value::as_str) == Some("tool"))
+        .filter_map(|m| m.get("content").and_then(Value::as_str).map(str::to_string))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// The fixture
+// ---------------------------------------------------------------------------
+
+struct NoopHost;
+
+#[async_trait]
+impl CycleHost for NoopHost {
+    async fn call_tool(&self, _call: ToolCall) -> crate::Result<ToolResult> {
+        Ok(ToolResult {
+            ok: true,
+            output: Value::Null,
+        })
+    }
+    async fn context_op(&self, _op: ContextOp) -> crate::Result<ContextOpResult> {
+        Ok(ContextOpResult::Text(String::new()))
+    }
+    async fn emit_effect(&self, _effect: Effect) -> crate::Result<EffectDisposition> {
+        Ok(EffectDisposition::Executed)
+    }
+    async fn park_effect(&self, _effect: Effect) -> crate::Result<ApprovalId> {
+        Ok(ApprovalId::new("appr-parked"))
+    }
+}
+
+/// A one-agent company granted `files` and **nothing else**. No `shell`: that
+/// omission is the entire point — with `shell` the workspace is created as a
+/// side effect of the first command and the bug is invisible.
+fn manifest() -> CompanyManifest {
+    toml::from_str(&format!(
+        r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+
+[tools]
+allow = ["files"]
+
+[[agent]]
+id = "{AGENT}"
+role = "Writer"
+"#
+    ))
+    .expect("manifest parses")
+}
+
+fn company() -> CompanyId {
+    CompanyId::new("acme")
+}
+
+fn record(overlays: Vec<OverlayAgent>) -> CompanyRecord {
+    CompanyRecord {
+        id: company(),
+        manifest: manifest(),
+        ledger: Vec::new(),
+        lifecycle: "running".to_string(),
+        overlay_agents: overlays,
+        overlay_desk_members: Vec::new(),
+        overlay_desk_order: Vec::new(),
+        overlay_desks: Vec::new(),
+        overlay_workflows: Vec::new(),
+        overlay_budgets: Vec::new(),
+        template_provenance: None,
+    }
+}
+
+/// Wire a real brain against the scripted endpoint, rooted at `dir`.
+fn build_brain(
+    base_url: String,
+    dir: &std::path::Path,
+    overlays: Vec<OverlayAgent>,
+) -> (HarnessBrain, Arc<FsOps>) {
+    let ops = Arc::new(FsOps::new(dir));
+    let deps = HarnessDeps {
+        provider: Arc::new(HostedProvider::new(HostedProviderConfig {
+            base_url,
+            credential: Credential::from_value("stub-key"),
+            extra_headers: Vec::new(),
+        })),
+        provider_slug: "managed".to_string(),
+        context: Arc::new(FsContextStore::new(dir)),
+        store: Arc::new(FsCompanyStore::new(dir)),
+        meter: Some(ops.clone()),
+        // The agent workspaces hang off here. Nothing has created a single
+        // directory under it — that is the precondition under test.
+        workspace_root: dir.join("harness"),
+        model_override: Some("stub-model".to_string()),
+        tasks: Some(ops.clone()),
+        artifacts: None,
+        skills: None,
+        skills_source_dir: None,
+        skills_registry: Arc::from([]),
+        mcp_servers: Vec::new(),
+        facts: None,
+        events: None,
+        delegations: DelegationQueue::default(),
+        workflow_runner: WorkflowRunnerHandle::default(),
+        mcp_failures: McpFailureQueue::default(),
+        pending_publishes: Default::default(),
+        approval_requests: ApprovalRequestQueue::default(),
+        secrets: None,
+        web_allowed_domains: Vec::new(),
+        capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+        workflow_source_dir: None,
+        plan: None,
+        media: None,
+        composio: None,
+        steer: crate::company::steer::InflightRegistry::default(),
+        run_supervisor: crate::runtime::RunSupervisor::default(),
+        delivery: None,
+        workspace: None,
+        search: None,
+    };
+    (
+        HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record(overlays)),
+        ops,
+    )
+}
+
+fn card(id: &str, assignee: &str) -> TaskRecord {
+    TaskRecord {
+        id: id.to_string(),
+        title: "Write the first note".to_string(),
+        note: None,
+        column: COLUMN_IN_PROGRESS.to_string(),
+        priority: "medium".to_string(),
+        assignee: assignee.to_string(),
+        updated_at_millis: 1,
+        origin_chat_id: None,
+        parent_task_id: None,
+    }
+}
+
+fn dispatch(task_id: &str) -> CycleRequest {
+    CycleRequest {
+        cycle_id: "cycle-1".to_string(),
+        company_id: company(),
+        events: vec![CompanyEvent::TaskDispatched {
+            task_id: task_id.to_string(),
+            run_id: None,
+        }],
+        event_seqs: Vec::new(),
+        compressed_history: Vec::new(),
+        roster: Vec::new(),
+        context_index: Vec::new(),
+    }
+}
+
+/// Run one dispatched card to `assignee` with the model scripted to write
+/// [`REL_PATH`], and hand back what the tool answered plus the workspace root.
+async fn run_write_turn(
+    dir: &std::path::Path,
+    assignee: &str,
+    overlays: Vec<OverlayAgent>,
+) -> (Arc<Script>, std::path::PathBuf) {
+    let (base_url, script) = spawn_script(REL_PATH).await;
+
+    let (brain, ops) = build_brain(base_url, dir, overlays);
+    TaskStore::upsert(&*ops, &company(), &card("t-1", assignee))
+        .await
+        .unwrap();
+
+    brain
+        .run_cycle(dispatch("t-1"), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    let workspace =
+        crate::harness::build::agent_workspace(&dir.join("harness"), &company(), assignee);
+    (script, workspace)
+}
+
+/// The tool answered, the bytes landed, and nothing was refused as an escape.
+fn assert_the_write_landed(script: &Script, workspace: &std::path::Path) {
+    let results = tool_results(script);
+    assert!(
+        !results.iter().any(|r| r.contains(ESCAPE_REFUSAL)),
+        "the write was refused as a sandbox escape: {results:?}"
+    );
+    let written = workspace.join(REL_PATH);
+    assert!(
+        written.is_file(),
+        "nothing was written at {} (tool said: {results:?})",
+        written.display()
+    );
+    assert_eq!(
+        std::fs::read_to_string(&written).expect("read back"),
+        BODY,
+        "the file exists but does not hold what the agent wrote"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The headline
+// ---------------------------------------------------------------------------
+
+/// A company that has never run. No workspace root, no company directory, no
+/// agent directory — nothing on disk at all. The agent holds `files` and not
+/// `shell`, so nothing incidental has created its working directory, and every
+/// relative write used to come back *"Resolved parent path escapes workspace"*.
+#[tokio::test]
+async fn an_agent_with_files_and_no_shell_writes_on_a_company_that_has_never_run() {
+    let dir = tempfile::tempdir().unwrap();
+    assert!(
+        !dir.path().join("harness").exists(),
+        "precondition: the workspace root does not exist"
+    );
+
+    let (script, workspace) = run_write_turn(dir.path(), AGENT, Vec::new()).await;
+
+    // The grant shape this issue turns on: file tools present, shell absent.
+    let advertised = advertised_tools(&script);
+    assert!(
+        advertised.contains(&"file_write".to_string()),
+        "file_write was never advertised: {advertised:?}"
+    );
+    assert!(
+        !advertised.contains(&"shell".to_string()),
+        "this agent must NOT hold shell — with it the bug is invisible: {advertised:?}"
+    );
+
+    assert_the_write_landed(&script, &workspace);
+}
+
+/// The same proof for a teammate that has **no manifest row** — an overlay agent
+/// added at runtime through the console or the orchestrator's `add_agent` tool.
+/// Adding one writes a store record and touches no filesystem at all, so its
+/// workspace is minted only when the roster is next rebuilt.
+#[tokio::test]
+async fn an_overlay_teammate_added_at_runtime_writes_on_its_first_turn() {
+    let dir = tempfile::tempdir().unwrap();
+    let overlay = OverlayAgent {
+        id: OVERLAY_AGENT.to_string(),
+        name: "Analyst".to_string(),
+        role: "Analyst".to_string(),
+        description: Some("Reads the numbers.".to_string()),
+    };
+
+    let (script, workspace) = run_write_turn(dir.path(), OVERLAY_AGENT, vec![overlay]).await;
+
+    assert!(
+        workspace.ends_with(std::path::Path::new(OVERLAY_AGENT).join("workspace")),
+        "the overlay teammate must get its own sandbox: {}",
+        workspace.display()
+    );
+    assert_the_write_landed(&script, &workspace);
+}
+
+/// A workspace that disappears *after* the roster was built is repaired before
+/// the next turn's tools run.
+///
+/// This is the half `build_agent` alone cannot cover. A roster is built once and
+/// then cached behind fingerprints — and handed across an in-place rebuild — so
+/// on the second cycle `build_agent` never runs again. The runtime does write
+/// its own bookkeeping into the workspace (session transcripts, the TinyAgents
+/// journal), which re-creates the directory as a side effect, but that happens
+/// at the *end* of a turn: without a dispatch-time guarantee the write in the
+/// very next turn is refused, exactly as it was on a company that had never run.
+///
+/// Real shapes this covers: a restored or wiped data directory under a live
+/// host, an operator clearing the tree, a boot that raced a not-yet-mounted
+/// volume.
+#[tokio::test]
+async fn a_workspace_removed_under_a_live_host_is_repaired_before_the_next_write() {
+    let dir = tempfile::tempdir().unwrap();
+    let (base_url, script) = spawn_script(REL_PATH).await;
+
+    let (brain, ops) = build_brain(base_url, dir.path(), Vec::new());
+    TaskStore::upsert(&*ops, &company(), &card("t-1", AGENT))
+        .await
+        .unwrap();
+    brain
+        .run_cycle(dispatch("t-1"), &NoopHost)
+        .await
+        .expect("first cycle");
+
+    let workspace =
+        crate::harness::build::agent_workspace(&dir.path().join("harness"), &company(), AGENT);
+    assert_the_write_landed(&script, &workspace);
+
+    // The tree goes away under a running host. The roster in the pool is
+    // unchanged, so nothing rebuilds it.
+    std::fs::remove_dir_all(&workspace).expect("remove the workspace");
+    assert!(!workspace.exists());
+
+    // A second card, because the first one settled: the point is a *later* turn
+    // on the same live pool, not a re-run of the same dispatch.
+    TaskStore::upsert(&*ops, &company(), &card("t-2", AGENT))
+        .await
+        .unwrap();
+    brain
+        .run_cycle(dispatch("t-2"), &NoopHost)
+        .await
+        .expect("second cycle");
+
+    assert_the_write_landed(&script, &workspace);
+}
+
+/// Provisioning is not a licence: the same freshly-provisioned agent still
+/// cannot reach outside its sandbox. A `..` traversal is refused, and the
+/// refusal reaches the model rather than silently succeeding.
+#[tokio::test]
+async fn a_traversal_from_a_provisioned_workspace_is_still_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let (base_url, script) = spawn_script("../../../../loot.md").await;
+
+    let (brain, ops) = build_brain(base_url, dir.path(), Vec::new());
+    TaskStore::upsert(&*ops, &company(), &card("t-1", AGENT))
+        .await
+        .unwrap();
+    brain
+        .run_cycle(dispatch("t-1"), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    let results = tool_results(&script);
+    assert!(
+        results
+            .iter()
+            .any(|r| r.contains("Path not allowed by security policy")),
+        "a traversal must be refused: {results:?}"
+    );
+    // The refusal reads nothing like the missing-workspace one, because it is
+    // caught by the string-level check before any path is resolved.
+    assert!(
+        !results.iter().any(|r| r.contains(ESCAPE_REFUSAL)),
+        "a `..` traversal must not be reported as a resolved-parent escape: {results:?}"
+    );
+    assert!(
+        !dir.path().join("loot.md").exists(),
+        "the traversal wrote outside the sandbox"
+    );
+}


### PR DESCRIPTION
## Summary

An agent granted `files` but **not** `shell` could not write a relative path at
all. Every attempt came back *"Resolved parent path escapes workspace"* — for a
path plainly inside its own sandbox.

The sandbox directory was never created. OpenHuman's `validate_parent_path`
resolves a relative write against the sandbox, then walks up to the deepest
*existing* ancestor to canonicalize it; with the sandbox absent that walk climbs
past it and lands on a parent that genuinely is outside. The guard was working as
designed on the path it was handed. An agent holding `shell` never saw this,
because its first command creates the working directory as a side effect before
anything validates a path — so the difference between a working and a broken
agent was a grant that looks unrelated to files.

PR #408 already made `build_agent` create the directory, because #244 could not
proceed without it. This finishes the job: it establishes a single owner for the
creation, closes the case that one-line fix cannot cover, and documents the
layout. Closes #409.

### Where provisioning belongs, and why

`agent_workspace` was already the single place the layout is *named*. There was
no single place it was *created* — nothing created it at all. The new
`ensure_agent_workspace` sits beside it as the single creation site, and is
called from two points:

- **`build_agent`**, before any `SecurityPolicy` is constructed over the path.
  Ordering matters beyond the guard: the per-workspace audit logger keys its
  process-global registry on the *canonicalized* workspace path and falls back to
  the raw one when the directory is missing, so a late-created workspace can be
  registered twice for one physical directory.
- **the dispatch path** (`run_inner`, the single funnel for operator chat,
  dispatched tasks, steered and background turns). This is the half `build_agent`
  cannot cover: a roster is built once, cached behind six fingerprints, and
  **handed across an in-place rebuild** (`rebuild_company` passes the live
  `HarnessPool` through `RuntimeHandover`), so `build_agent` may never run again
  for the life of the process. A sandbox that disappears afterwards would leave
  every relative write refused until a restart.

`build_agent` is the right *first* owner, and this follows the codebase's own
precedent: `DataLayout::ensure` deliberately does not pre-create `companies/`
either — "the fs store owns it and mints each bundle on demand". The gap was that
nothing was minting the harness tree at all.

Both attempts stay best-effort, for the reason #408 gave: an agent with no file
grant runs a perfectly good turn without the directory, so a failure must not
fail the turn. The dispatch-time failure logs at `error!` and names the real
condition, so the one case that can still reach the misdirecting guard message
has a greppable explanation sitting next to it.

### Every path that reaches the guard before provisioning

Traced end to end; only the first is changed, and the rest are listed because the
issue asked for all of them.

| Path | Reaches the guard unprovisioned? | Why |
| --- | --- | --- |
| Manifest teammate, company that has never run | **Yes — fixed here** | `build_roster` → `build_agent`; roster is built lazily on the first cycle, not at boot |
| Overlay teammate added at runtime (console `POST {scope}/team`, orchestrator `add_agent`) | **Yes — fixed here** | Both write a store record and touch **zero** filesystem; the sandbox is minted only when the overlay fingerprint next rebuilds the roster, which also goes through `build_agent` |
| Restored / imported company (`opencompany import`) | **Yes — fixed here** | `restore_fs_artifacts` copies only `secrets/` and `keys/` into the bundle; nothing under the harness tree is recreated. Same for any `sqlite`/`mongodb` boot, where the record exists in the DB and the sandbox does not |
| Sandbox removed under a live host; in-place rebuild | **Yes — fixed here (dispatch half)** | The fingerprint fast path reuses the cached roster, so `build_agent` never re-runs. The provider/model axis is not fingerprinted at all, so an inference-config rebuild does not rebuild the roster either |
| Freshly created company via `POST /api/v1/companies` | **No** | That route does not call `with_harness`, so the company has no `HarnessPool` and `workspace_root` is never reached. Worth knowing, not worth changing here |
| Workflow run (`{root}/{company}/_workflow/…/workspace`) | **No** | `build_capabilities` already creates it before `exec_security` binds |
| Skill catalogue (`{agent}/skill-catalog/`) | **No, and it is the near miss** | `EffectiveSkills::materialize` creates a *sibling* of `workspace`, so it makes the ancestor walk stop one level higher and refuse just the same |

### The error-message half: filed upstream, not shipped here

`validate_parent_path` lives in the vendored `vendor/openhuman` submodule. **No
submodule change is in this PR and the pin is untouched** — `git diff main...HEAD
-- vendor/` is empty.

Filed as **tinyhumansai/openhuman#5416**. Building the test for it turned up
something sharper than expected: in a `workspace_only` agent sandbox, the
*resolved-parent* arm is reached by only two conditions — a symlink escape whose
immediate parent cannot be canonicalized, and a workspace that does not exist.
Every easier escape (`..`, absolute paths, symlinks whose parent resolves) is
caught earlier by `is_path_string_allowed` with a different and perfectly clear
message. So the ambiguous wording fires *mostly* for the missing-directory case,
and it ships with a workaround line telling the reader to raise the agent's
autonomy tier — which cannot create a directory.

`a_real_escape_and_a_missing_workspace_are_refused_in_identical_words` pins that
state here, so the upstream wording change surfaces in this repo instead of
drifting silently.

## API Or Behavior Changes

- **New public function** `harness::build::ensure_agent_workspace(root, company,
  agent_id) -> io::Result<PathBuf>`. `agent_workspace` is unchanged and stays
  naming-only.
- **Behavioral**: an agent's sandbox is created before every dispatched turn, not
  only when its roster is built. Two syscalls on the already-exists path, against
  a turn that is about to call a model.
- No change to what is permitted. A traversal, an absolute path and a symlink
  escape are refused exactly as before — pinned by tests on both the policy and
  the real-turn paths.

## Tests

All gates run locally on this branch:

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --locked --no-deps --all-targets -- -D warnings` | pass (default lane, the one CI runs) |
| `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` | pass |
| `cargo test --locked --features openhuman,tinycortex --lib` | **2034 passed**, 0 failed, 1 ignored |
| `cargo test --locked --lib` (default features) | **1424 passed**, 0 failed, 1 ignored |
| `cargo check --locked --all-features --all-targets` | pass |
| `git diff --stat Cargo.lock` | empty |

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets` (covered by `cargo check --all-features --all-targets` plus the two clippy lanes over `--all-targets`)
- [x] `cargo test`

### New tests

`src/harness/build.rs` — the guard's semantics on both sides of the fix: a
missing workspace makes a plain relative write look like an escape; an ensured
one resolves it inside the sandbox (including a not-yet-created subdirectory); a
`..` traversal is refused with a distinguishable message; and a real symlink
escape and a missing workspace come back in identical words.

`src/harness/workspace_provision_turn_test.rs` — the real thing, because the bug
is a state that only exists before anything has run. Drives the real brain
through `run_cycle` with a real `HarnessPool`, real `build_agent`, real
`HostedProvider` on the native tool loop, and a workspace root that starts empty;
only the model's choices are scripted, against a loopback OpenAI-compatible
endpoint. Covers a manifest teammate on a never-run company, an overlay teammate
with no manifest row, a sandbox removed under a live host, and a traversal that
must still be refused.

**Each half was verified to be load-bearing by removing it.** Deleting
`build_agent`'s creation fails the two never-run tests with the exact refusal from
the issue; deleting the dispatch renewal fails the removed-under-a-live-host test
the same way. The one test that passed against known-broken code was thrown away
rather than kept.

### Live verification (real host, not in-process)

Built `opencompany` with `--features openhuman` and ran `serve` against a
one-agent company whose `[tools] allow = ["files"]` — no `shell` — pointed at a
loopback OpenAI-compatible endpoint that emits one `file_write` for
`notes/hello.md`, driven over `POST /api/v1/company/chat`.

1. **Never-run company.** Before the first turn the harness tree did not exist —
   boot creates `companies/ memory/ store/ files/ logs/ tmp/` and not `harness/`.
   The turn returned `tool_call: ok` and `notes/hello.md` landed with the right
   bytes.
2. **Freshly provisioned bundle.** Same run: the company bundle was minted at
   boot and the sandbox still did not exist until the agent was built.
3. **Overlay teammate.** Covered by the real-turn test rather than the live host
   (adding one over HTTP writes a store record and touches no filesystem, so the
   filesystem-visible behaviour is identical).
4. **Removed under a live host.** `rm -rf` the sandbox mid-session, chat again →
   `tool_call: ok`, file back. Without the dispatch renewal this is the case that
   stays broken until restart.
5. **Genuine traversal.** Repointed the endpoint at `../../../../../loot.md` →
   refused with `Path not allowed by security policy`, no `loot.md` anywhere on
   disk, and the refusal reads nothing like the missing-workspace one.
6. **Provisioning actually failing.** Removed the sandbox and made its parent
   read-only → the new `error!` fired naming the workspace and the io error, and
   the turn's tool step reported an error rather than silently succeeding.
   Restoring permissions self-healed on the next turn.

## Documentation

`docs/spec/runtime/storage.md` gains an **Agent sandboxes (`<home>/harness`)**
section. The spec previously mentioned that tree only in the migration notes, as
"a runtime tree that hangs off the home" — it never said who creates it, and
`DataLayout` deliberately does not. Nothing did, which is how the directory came
to exist only as a side effect of an agent's first shell command. The section
records the layout, both owners, and why the sandbox must exist *before* the
agent acts rather than by the time it finishes.

## Related

Closes #409. Follows #408 (`e11bf7f`), which shipped the minimal `build_agent`
create for #244. Upstream half: tinyhumansai/openhuman#5416.
