### PR TITLE
fix(ops): require authority to change what a company connects through (#403)

### DIFF
--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -34,6 +34,13 @@ prosumer alias — by the `scoped` helper; the `ScopedCompany` extractor resolve
 the target runtime and enforces authorization per form (platform-or-operator +
 address check for `{id}`, operator + `sole()` for the alias).
 
+### Addressing is not authority
+
+`ScopedCompany` answers *may this principal talk to this company*, and stops
+there. A write that decides something **for** the company — what it reaches the
+world as — takes `AdminScopedCompany` instead. The routes, the reasoning, and
+why this is not a read/write split: [authority.md](authority.md).
+
 | Surface (`ops::*`) | Routes |
 |---|---|
 | `tasks` | `POST …/tasks`, `GET …/tasks`, `GET …/tasks/{id}` (the Task Detail read, #185), `PATCH`/`DELETE …/tasks/{id}`, `GET …/tasks/inflight`, `POST …/tasks/{id}/steer` (#111), `POST …/tasks/{id}/discussion` (#335) |

--- a/docs/modules/server/authority.md
+++ b/docs/modules/server/authority.md
@@ -1,0 +1,47 @@
+# Authority on the write plane (issue #403)
+
+`ScopedCompany` answers *may this principal talk to this company*, and stops
+there — no role check. That is the right guard for the many writes this product
+deliberately leaves open to any member: opening a task, posting to a discussion,
+adding a teammate. It is the wrong guard on its own for a write that decides
+something **for** the company, which is what `AdminScopedCompany` is for. It
+composes `ScopedCompany` with `users::admin::require_admin`, so a route declares
+the authority it needs in its signature rather than in a call a handler has to
+remember to make.
+
+**Who qualifies**, matching the two principals in
+[`config.md`](../../spec/runtime/config.md): a human whose session says they
+administer this company (a member gets `403`), or the machine principal entitled
+to address it — the hosting control plane, which provisions the tenant and holds
+its database credentials, so refusing it a route it already sits above would be
+ceremony rather than a boundary. Neither gets anonymity: `AdminScopedCompany`
+always names an actor (`User` + user id, or `System` + tenant), and the routes
+that use it journal it.
+
+**Which routes.** The line is *the company's outward identity* — what it reaches
+the world as, and which third-party accounts its agents act through:
+
+| Surface | Admin-scoped |
+|---|---|
+| `composio` | `PUT …/composio/token`, `POST …/composio/authorize` |
+| `connections` (`oauth`) | `POST …/connections/{p}/start`, `POST …/connections/{p}/disconnect` |
+| `inference` | `PUT …/inference`, `DELETE …/inference` |
+| `smtp` | `PUT …/smtp`, `POST …/smtp/test` (the caller names the recipient) |
+| `domain` | `PUT …/domain` |
+| `channels` | `PUT`/`DELETE …/channels/telegram`, `POST …/channels/telegram/webhook` |
+| `mcp` | `POST …/mcp/servers`, `PUT`/`DELETE …/mcp/servers/{name}`, `POST …/mcp/servers/{name}/oauth/start` |
+
+Reads on those same surfaces stay open to any member: they carry a tier name and
+non-secret routing, never a credential, and knowing *that* Gmail is connected is
+what lets a member understand why an agent can read mail. So do the probes over
+already-stored config — `POST …/inference/test`, `GET …/mcp/servers/{name}/tools`,
+`POST …/mcp/servers/{name}/test`, `POST …/domain/verify` — which name no
+destination of their own.
+
+This is deliberately **not** a read-scope / write-scope split. "Write" and
+"requires authority" are different questions here and the product answers them
+differently on purpose; an extractor named for the HTTP verb would have to take
+capabilities away from members that are meant to be theirs.
+
+`server::ops::write_test` pins the whole table against a member session, so a
+route joining this plane joins that list too.

--- a/docs/spec/runtime/users.md
+++ b/docs/spec/runtime/users.md
@@ -18,6 +18,14 @@ This is distinct from, and weaker than, the machine credentials in
 | Bootstrap | The manifest's `[users] admins` list |
 | Roles | `admin` (may invite and administer) / `member` |
 
+An `admin` is also what the write plane means by authority over the company: the
+routes that decide what the company reaches the world as — its Composio and
+provider connections, its inference provider and key, its mail identity, its
+Telegram bot, its MCP servers — require one. See
+[the write plane](../../modules/server/authority.md)
+for the table and the reasoning. A `member` reads those surfaces but does not
+change them.
+
 ## Storage
 
 Three ports, all keyed by `CompanyId` like every other:

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 
+import { me as fetchMe } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
 import {
   addMcpServer,
@@ -63,6 +64,16 @@ export function ConnectionsView({ client, company }: Props) {
   const [load, setLoad] = useState<Load>("loading");
   const [states, setStates] = useState<Record<string, ConnectionState>>({});
   const [busy, setBusy] = useState<string | null>(null);
+  // Whether this viewer may change what the company connects through (issue
+  // #403). A connection belongs to the company, so changing one is an admin's
+  // call; reading the page is everyone's.
+  //
+  // **Courtesy, not enforcement.** The host refuses every write on this page
+  // with a 403 whatever this says. All hiding the controls prevents is offering
+  // an operator a button that cannot work — which on this page would be a
+  // particularly poor greeting, since the failure arrives only after they have
+  // pasted a live credential into a form that could never submit it.
+  const [canManage, setCanManage] = useState(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -79,6 +90,22 @@ export function ConnectionsView({ client, company }: Props) {
     setLoad("loading");
     void refresh();
   }, [refresh]);
+
+  useEffect(() => {
+    let live = true;
+    void (async () => {
+      let admin = false;
+      try {
+        admin = (await fetchMe(client, company)).role === "admin";
+      } catch {
+        // No user plane on this host, or not signed in — treat as non-admin.
+      }
+      if (live) setCanManage(admin);
+    })();
+    return () => {
+      live = false;
+    };
+  }, [client, company]);
 
   async function connect(p: ConnectionProvider) {
     if (busy) return;
@@ -160,13 +187,25 @@ export function ConnectionsView({ client, company }: Props) {
           </Alert>
         )}
 
-        <McpServersSection client={client} company={company} />
+        {!canManage && (
+          <Alert data-testid="connections-read-only">
+            <Info className="size-4" />
+            <AlertTitle>Only an admin can change what this company connects through</AlertTitle>
+            <AlertDescription>
+              A connection belongs to the company — it is the account your agents act through — so
+              an admin manages it. You can see everything that is wired here; ask an admin to add,
+              change or remove one.
+            </AlertDescription>
+          </Alert>
+        )}
 
-        <InferenceSection client={client} company={company} />
+        <McpServersSection client={client} company={company} canManage={canManage} />
 
-        <ComposioSection client={client} company={company} />
+        <InferenceSection client={client} company={company} canManage={canManage} />
 
-        <ChannelsSection client={client} company={company} />
+        <ComposioSection client={client} company={company} canManage={canManage} />
+
+        <ChannelsSection client={client} company={company} canManage={canManage} />
 
         {load === "ready" && (
           <Alert data-testid="connections-catalog-advisory">
@@ -203,7 +242,7 @@ export function ConnectionsView({ client, company }: Props) {
                       provider={p}
                       state={states[p.id]}
                       platformManaged={platformManaged}
-                      disabled={load === "unavailable"}
+                      disabled={load === "unavailable" || !canManage}
                       busy={busy === p.id}
                       onConnect={() => void connect(p)}
                       onDisconnect={() => void disconnect(p)}
@@ -374,9 +413,12 @@ type ToolsState =
 function McpServersSection({
   client,
   company,
+  canManage,
 }: {
   client: OpenCompanyClient;
   company: string | null;
+  /** Whether this viewer may add, edit or remove servers (issue #403). */
+  canManage: boolean;
 }) {
   const [load, setLoad] = useState<McpLoad>("loading");
   const [servers, setServers] = useState<McpServer[]>([]);
@@ -627,11 +669,11 @@ function McpServersSection({
                         <span className="ml-auto flex items-center gap-2">
                           <Switch
                             checked={server.enabled}
-                            disabled={busy === server.name}
+                            disabled={busy === server.name || !canManage}
                             onCheckedChange={(v) => void toggle(server, v)}
                             aria-label={`Enable ${server.name}`}
                           />
-                          {health?.authHint === "oauth_required" && (
+                          {health?.authHint === "oauth_required" && canManage && (
                             <Button
                               variant="default"
                               size="sm"
@@ -667,7 +709,7 @@ function McpServersSection({
                           >
                             <ChevronDown className="size-4" /> Tools
                           </Button>
-                          {server.source === "runtime" && (
+                          {server.source === "runtime" && canManage && (
                             <Button
                               variant="ghost"
                               size="sm"
@@ -691,94 +733,101 @@ function McpServersSection({
               </ul>
             )}
 
-            <div className="space-y-2 border-t border-border pt-3">
-              {addError && (
-                <Alert variant="destructive">
-                  <AlertTriangle className="size-4" />
-                  <AlertTitle>Couldn&apos;t add the server</AlertTitle>
-                  <AlertDescription>{addError}</AlertDescription>
-                </Alert>
-              )}
-              <div className="grid gap-2 sm:grid-cols-2 sm:items-end">
-                <div className="space-y-1">
-                  <Label htmlFor="mcp-name" className="text-xs">
-                    Name
-                  </Label>
-                  <Input
-                    id="mcp-name"
-                    value={name}
-                    placeholder="notion"
-                    onChange={(e) => setName(e.target.value)}
-                  />
-                </div>
-                <div className="space-y-1">
-                  <Label htmlFor="mcp-endpoint" className="text-xs">
-                    Endpoint
-                  </Label>
-                  <Input
-                    id="mcp-endpoint"
-                    name="mcp-endpoint-url"
-                    value={endpoint}
-                    placeholder="https://host/mcp"
-                    autoComplete="url"
-                    onChange={(e) => setEndpoint(e.target.value)}
-                  />
-                </div>
-              </div>
-              <div className="grid gap-2 sm:grid-cols-[auto_1fr_1fr_auto] sm:items-end">
-                <div className="space-y-1">
-                  <Label htmlFor="mcp-auth-kind" className="text-xs">
-                    Auth
-                  </Label>
-                  <select
-                    id="mcp-auth-kind"
-                    value={authKind}
-                    onChange={(e) => setAuthKind(e.target.value as McpAuthKind)}
-                    className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-xs"
-                  >
-                    <option value="bearer">Bearer token</option>
-                    <option value="header">Custom header</option>
-                    <option value="query_param">Query parameter</option>
-                  </select>
-                </div>
-                {authKind !== "bearer" && (
+            {/* Adding a server hands the agents a new set of tools, so the
+                whole form goes for a member rather than leaving fields that
+                cannot be submitted (issue #403). Test and Tools above stay:
+                they probe a server an admin already added, and the host
+                deliberately leaves those open. */}
+            {canManage && (
+              <div className="space-y-2 border-t border-border pt-3">
+                {addError && (
+                  <Alert variant="destructive">
+                    <AlertTriangle className="size-4" />
+                    <AlertTitle>Couldn&apos;t add the server</AlertTitle>
+                    <AlertDescription>{addError}</AlertDescription>
+                  </Alert>
+                )}
+                <div className="grid gap-2 sm:grid-cols-2 sm:items-end">
                   <div className="space-y-1">
-                    <Label htmlFor="mcp-auth-field" className="text-xs">
-                      {authKind === "header" ? "Header name" : "Parameter name"}
+                    <Label htmlFor="mcp-name" className="text-xs">
+                      Name
                     </Label>
                     <Input
-                      id="mcp-auth-field"
-                      value={authFieldName}
-                      placeholder={authKind === "header" ? "X-Api-Key" : "apiKey"}
-                      autoComplete="off"
-                      onChange={(e) => setAuthFieldName(e.target.value)}
+                      id="mcp-name"
+                      value={name}
+                      placeholder="notion"
+                      onChange={(e) => setName(e.target.value)}
                     />
                   </div>
-                )}
-                <div className="space-y-1">
-                  <Label htmlFor="mcp-token" className="text-xs">
-                    {authKind === "bearer" ? "Token (optional)" : "Credential value"}
-                  </Label>
-                  <Input
-                    id="mcp-token"
-                    name="mcp-token-secret"
-                    type="password"
-                    value={token}
-                    placeholder="write-only"
-                    autoComplete="new-password"
-                    onChange={(e) => setToken(e.target.value)}
-                  />
+                  <div className="space-y-1">
+                    <Label htmlFor="mcp-endpoint" className="text-xs">
+                      Endpoint
+                    </Label>
+                    <Input
+                      id="mcp-endpoint"
+                      name="mcp-endpoint-url"
+                      value={endpoint}
+                      placeholder="https://host/mcp"
+                      autoComplete="url"
+                      onChange={(e) => setEndpoint(e.target.value)}
+                    />
+                  </div>
                 </div>
-                <Button disabled={busy === "add"} onClick={() => void add()}>
-                  {busy === "add" ? (
-                    <Loader2 className="size-4 animate-spin" />
-                  ) : (
-                    <Plus className="size-4" />
+                <div className="grid gap-2 sm:grid-cols-[auto_1fr_1fr_auto] sm:items-end">
+                  <div className="space-y-1">
+                    <Label htmlFor="mcp-auth-kind" className="text-xs">
+                      Auth
+                    </Label>
+                    <select
+                      id="mcp-auth-kind"
+                      value={authKind}
+                      onChange={(e) => setAuthKind(e.target.value as McpAuthKind)}
+                      className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-xs"
+                    >
+                      <option value="bearer">Bearer token</option>
+                      <option value="header">Custom header</option>
+                      <option value="query_param">Query parameter</option>
+                    </select>
+                  </div>
+                  {authKind !== "bearer" && (
+                    <div className="space-y-1">
+                      <Label htmlFor="mcp-auth-field" className="text-xs">
+                        {authKind === "header" ? "Header name" : "Parameter name"}
+                      </Label>
+                      <Input
+                        id="mcp-auth-field"
+                        value={authFieldName}
+                        placeholder={authKind === "header" ? "X-Api-Key" : "apiKey"}
+                        autoComplete="off"
+                        onChange={(e) => setAuthFieldName(e.target.value)}
+                      />
+                    </div>
                   )}
-                  Add
-                </Button>
+                  <div className="space-y-1">
+                    <Label htmlFor="mcp-token" className="text-xs">
+                      {authKind === "bearer" ? "Token (optional)" : "Credential value"}
+                    </Label>
+                    <Input
+                      id="mcp-token"
+                      name="mcp-token-secret"
+                      type="password"
+                      value={token}
+                      placeholder="write-only"
+                      autoComplete="new-password"
+                      onChange={(e) => setToken(e.target.value)}
+                    />
+                  </div>
+                  <Button disabled={busy === "add"} onClick={() => void add()}>
+                    {busy === "add" ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <Plus className="size-4" />
+                    )}
+                    Add
+                  </Button>
+                </div>
               </div>
-            </div>
+            )}
           </CardContent>
         </Card>
       )}

--- a/frontend/src/views/McpServersView.tsx
+++ b/frontend/src/views/McpServersView.tsx
@@ -2,6 +2,7 @@ import { type FormEvent, useCallback, useEffect, useState } from "react";
 import { ChevronDown, ChevronRight, Info, Loader2, Play, Plug, Trash2, Unplug } from "lucide-react";
 import { toast } from "sonner";
 
+import { me as fetchMe } from "@/api/auth";
 import { ApiError } from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -30,6 +31,10 @@ export function McpServersView({ client, company }: Props) {
   const [args, setArgs] = useState("");
   const [url, setUrl] = useState("");
   const [env, setEnv] = useState("{}");
+  // Installing or removing a server changes what tools the company's agents can
+  // call, so it is an admin's (issue #403). Courtesy only: the host answers 403
+  // whatever this says. Reading the installed set stays open.
+  const [canManage, setCanManage] = useState(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -49,6 +54,22 @@ export function McpServersView({ client, company }: Props) {
     setLoad("loading");
     void refresh();
   }, [refresh]);
+
+  useEffect(() => {
+    let live = true;
+    void (async () => {
+      let admin = false;
+      try {
+        admin = (await fetchMe(client, company)).role === "admin";
+      } catch {
+        // No user plane on this host, or not signed in — treat as non-admin.
+      }
+      if (live) setCanManage(admin);
+    })();
+    return () => {
+      live = false;
+    };
+  }, [client, company]);
 
   async function install(event: FormEvent) {
     event.preventDefault();
@@ -130,80 +151,93 @@ export function McpServersView({ client, company }: Props) {
           </Alert>
         ) : (
           <>
-            <Card>
-              <CardHeader>
-                <CardTitle>Install a server</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <form className="grid gap-4 md:grid-cols-2" onSubmit={install}>
-                  <Field label="Name">
-                    <Input
-                      data-testid="mcp-install-name"
-                      value={name}
-                      onChange={(event) => setName(event.target.value)}
-                      required
-                    />
-                  </Field>
-                  <Field label="Transport">
-                    <select
-                      className="h-8 rounded-lg border border-input bg-background px-2.5 text-sm"
-                      value={transport}
-                      onChange={(event) => setTransport(event.target.value as McpTransport)}
-                    >
-                      <option value="stdio">Local command (stdio)</option>
-                      <option value="http">Remote HTTP</option>
-                    </select>
-                  </Field>
-                  {transport === "stdio" ? (
-                    <>
-                      <Field label="Command">
-                        <Input
-                          data-testid="mcp-install-command"
-                          value={command}
-                          onChange={(event) => setCommand(event.target.value)}
-                          placeholder="node"
-                          required
-                        />
-                      </Field>
-                      <Field label="Arguments">
-                        <Input
-                          data-testid="mcp-install-args"
-                          value={args}
-                          onChange={(event) => setArgs(event.target.value)}
-                          placeholder="/path/to/server.mjs"
-                        />
-                      </Field>
-                    </>
-                  ) : (
-                    <Field label="URL">
+            {!canManage && (
+              <Alert>
+                <Info className="size-4" />
+                <AlertTitle>Only an admin can change this company&apos;s tool servers</AlertTitle>
+                <AlertDescription>
+                  A server here hands every agent a new set of tools, so an admin installs and
+                  removes them. You can see what is installed.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {canManage && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Install a server</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <form className="grid gap-4 md:grid-cols-2" onSubmit={install}>
+                    <Field label="Name">
                       <Input
-                        value={url}
-                        onChange={(event) => setUrl(event.target.value)}
-                        placeholder="https://example.com/mcp"
+                        data-testid="mcp-install-name"
+                        value={name}
+                        onChange={(event) => setName(event.target.value)}
                         required
                       />
                     </Field>
-                  )}
-                  <Field label="Environment JSON" className="md:col-span-2">
-                    <Textarea
-                      value={env}
-                      onChange={(event) => setEnv(event.target.value)}
-                      placeholder='{"API_KEY":"…"}'
-                      rows={3}
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      Values are write-only and never returned by the API.
-                    </p>
-                  </Field>
-                  <div className="md:col-span-2">
-                    <Button data-testid="mcp-install-submit" type="submit" disabled={busy === "install"}>
-                      {busy === "install" && <Loader2 className="size-4 animate-spin" />}
-                      Install server
-                    </Button>
-                  </div>
-                </form>
-              </CardContent>
-            </Card>
+                    <Field label="Transport">
+                      <select
+                        className="h-8 rounded-lg border border-input bg-background px-2.5 text-sm"
+                        value={transport}
+                        onChange={(event) => setTransport(event.target.value as McpTransport)}
+                      >
+                        <option value="stdio">Local command (stdio)</option>
+                        <option value="http">Remote HTTP</option>
+                      </select>
+                    </Field>
+                    {transport === "stdio" ? (
+                      <>
+                        <Field label="Command">
+                          <Input
+                            data-testid="mcp-install-command"
+                            value={command}
+                            onChange={(event) => setCommand(event.target.value)}
+                            placeholder="node"
+                            required
+                          />
+                        </Field>
+                        <Field label="Arguments">
+                          <Input
+                            data-testid="mcp-install-args"
+                            value={args}
+                            onChange={(event) => setArgs(event.target.value)}
+                            placeholder="/path/to/server.mjs"
+                          />
+                        </Field>
+                      </>
+                    ) : (
+                      <Field label="URL">
+                        <Input
+                          value={url}
+                          onChange={(event) => setUrl(event.target.value)}
+                          placeholder="https://example.com/mcp"
+                          required
+                        />
+                      </Field>
+                    )}
+                    <Field label="Environment JSON" className="md:col-span-2">
+                      <Textarea
+                        value={env}
+                        onChange={(event) => setEnv(event.target.value)}
+                        placeholder='{"API_KEY":"…"}'
+                        rows={3}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Values are write-only and never returned by the API.
+                      </p>
+                    </Field>
+                    <div className="md:col-span-2">
+                      <Button data-testid="mcp-install-submit" type="submit" disabled={busy === "install"}>
+                        {busy === "install" && <Loader2 className="size-4 animate-spin" />}
+                        Install server
+                      </Button>
+                    </div>
+                  </form>
+                </CardContent>
+              </Card>
+            )}
 
             <section className="space-y-3">
               <h3 className="font-medium">Installed servers</h3>
@@ -221,6 +255,7 @@ export function McpServersView({ client, company }: Props) {
                     client={client}
                     company={company}
                     busy={busy}
+                    canManage={canManage}
                     onLifecycle={(action) => void lifecycle(server, action)}
                   />
                 ))
@@ -238,12 +273,15 @@ function ServerCard({
   client,
   company,
   busy,
+  canManage,
   onLifecycle,
 }: {
   server: McpServer;
   client: OpenCompanyClient;
   company: string | null;
   busy: string | null;
+  /** Whether this viewer may connect, disconnect or uninstall (issue #403). */
+  canManage: boolean;
   onLifecycle: (action: "connect" | "disconnect" | "uninstall") => void;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -304,29 +342,32 @@ function ServerCard({
             {titleCase(server.status)}
           </Badge>
           <span className="text-xs text-muted-foreground">{server.tool_count} tools</span>
-          {server.status === "connected" ? (
+          {canManage &&
+            (server.status === "connected" ? (
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={busy !== null}
+                onClick={() => onLifecycle("disconnect")}
+              >
+                <Unplug /> Disconnect
+              </Button>
+            ) : (
+              <Button size="sm" disabled={busy !== null} onClick={() => onLifecycle("connect")}>
+                <Plug /> Connect
+              </Button>
+            ))}
+          {canManage && (
             <Button
-              variant="outline"
-              size="sm"
+              variant="ghost"
+              size="icon-sm"
               disabled={busy !== null}
-              onClick={() => onLifecycle("disconnect")}
+              onClick={() => onLifecycle("uninstall")}
+              aria-label={`Uninstall ${server.name}`}
             >
-              <Unplug /> Disconnect
-            </Button>
-          ) : (
-            <Button size="sm" disabled={busy !== null} onClick={() => onLifecycle("connect")}>
-              <Plug /> Connect
+              <Trash2 />
             </Button>
           )}
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            disabled={busy !== null}
-            onClick={() => onLifecycle("uninstall")}
-            aria-label={`Uninstall ${server.name}`}
-          >
-            <Trash2 />
-          </Button>
         </div>
         {server.last_error && <p className="text-sm text-destructive">{server.last_error}</p>}
         {expanded && server.status === "connected" && (

--- a/frontend/src/views/connections/ChannelsSection.tsx
+++ b/frontend/src/views/connections/ChannelsSection.tsx
@@ -20,6 +20,11 @@ import { Label } from "@/components/ui/label";
 interface Props {
   client: OpenCompanyClient;
   company: string | null;
+  /**
+   * Whether this viewer may change the bot the company speaks as (issue #403).
+   * Courtesy only — the host answers 403 regardless.
+   */
+  canManage: boolean;
 }
 
 type Load = "loading" | "ready" | "unavailable";
@@ -37,7 +42,7 @@ type Load = "loading" | "ready" | "unavailable";
  * then, rather than handing the operator a `http://127.0.0.1:<port>/hooks/...`
  * URL that Telegram's servers can never deliver to.
  */
-export function ChannelsSection({ client, company }: Props) {
+export function ChannelsSection({ client, company, canManage }: Props) {
   const [load, setLoad] = useState<Load>("loading");
   const [status, setStatus] = useState<TelegramChannelStatus | null>(null);
   const [botToken, setBotToken] = useState("");
@@ -158,38 +163,47 @@ export function ChannelsSection({ client, company }: Props) {
             </p>
           </div>
 
+          {!canManage && (
+            <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+              This bot token is the identity the company speaks as, so an admin manages it. The
+              status above is the whole picture; ask an admin to change it.
+            </p>
+          )}
+
           {/* The webhook secret sits beside the token only on a host that can
               actually serve a webhook — elsewhere it configures nothing. */}
-          <div className={status?.webhookUrl ? "grid gap-3 sm:grid-cols-2" : "space-y-1"}>
-            <div className="space-y-1">
-              <Label htmlFor="tg-token" className="text-xs">
-                Bot token {status?.tokenSet ? "(stored — leave blank to keep)" : ""}
-              </Label>
-              <Input
-                id="tg-token"
-                type="password"
-                autoComplete="off"
-                placeholder={status?.tokenSet ? "•••••• write-only" : "123456:ABC-DEF…"}
-                value={botToken}
-                onChange={(e) => setBotToken(e.target.value)}
-              />
-            </div>
-            {status?.webhookUrl && (
+          {canManage && (
+            <div className={status?.webhookUrl ? "grid gap-3 sm:grid-cols-2" : "space-y-1"}>
               <div className="space-y-1">
-                <Label htmlFor="tg-secret" className="text-xs">
-                  Webhook secret {status.secretSet ? "(stored — leave blank to keep)" : ""}
+                <Label htmlFor="tg-token" className="text-xs">
+                  Bot token {status?.tokenSet ? "(stored — leave blank to keep)" : ""}
                 </Label>
                 <Input
-                  id="tg-secret"
+                  id="tg-token"
                   type="password"
                   autoComplete="off"
-                  placeholder={status.secretSet ? "•••••• write-only" : "a long random string"}
-                  value={webhookSecret}
-                  onChange={(e) => setWebhookSecret(e.target.value)}
+                  placeholder={status?.tokenSet ? "•••••• write-only" : "123456:ABC-DEF…"}
+                  value={botToken}
+                  onChange={(e) => setBotToken(e.target.value)}
                 />
               </div>
-            )}
-          </div>
+              {status?.webhookUrl && (
+                <div className="space-y-1">
+                  <Label htmlFor="tg-secret" className="text-xs">
+                    Webhook secret {status.secretSet ? "(stored — leave blank to keep)" : ""}
+                  </Label>
+                  <Input
+                    id="tg-secret"
+                    type="password"
+                    autoComplete="off"
+                    placeholder={status.secretSet ? "•••••• write-only" : "a long random string"}
+                    value={webhookSecret}
+                    onChange={(e) => setWebhookSecret(e.target.value)}
+                  />
+                </div>
+              )}
+            </div>
+          )}
 
           {/* How inbound actually arrives, so the operator can tell whether a
               saved token is being used. */}
@@ -205,30 +219,32 @@ export function ChannelsSection({ client, company }: Props) {
             </p>
           )}
 
-          <div className="flex flex-wrap items-center gap-2">
-            <Button disabled={busy !== null} onClick={() => void save()}>
-              {busy === "save" ? <Loader2 className="size-4 animate-spin" /> : <Check className="size-4" />}
-              Save
-            </Button>
-            <Button
-              variant="ghost"
-              disabled={busy !== null || !(status?.tokenSet || status?.secretSet)}
-              onClick={() => void clear()}
-            >
-              {busy === "clear" ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                <Trash2 className="size-4" />
-              )}
-              Clear
-            </Button>
-          </div>
+          {canManage && (
+            <div className="flex flex-wrap items-center gap-2">
+              <Button disabled={busy !== null} onClick={() => void save()}>
+                {busy === "save" ? <Loader2 className="size-4 animate-spin" /> : <Check className="size-4" />}
+                Save
+              </Button>
+              <Button
+                variant="ghost"
+                disabled={busy !== null || !(status?.tokenSet || status?.secretSet)}
+                onClick={() => void clear()}
+              >
+                {busy === "clear" ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Trash2 className="size-4" />
+                )}
+                Clear
+              </Button>
+            </div>
+          )}
 
           {/* The webhook fast-path. Shown only when the host reports a URL
               Telegram can actually deliver to — otherwise offering it would
               hand the operator a dead loopback endpoint (issue #203), and
               registering it would also block the polling that does work. */}
-          {status?.webhookUrl && (
+          {status?.webhookUrl && canManage && (
             <div className="space-y-3 border-t pt-4">
               <div className="space-y-1">
                 <p className="text-xs font-medium">Webhook (optional)</p>

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -21,6 +21,17 @@ import { Skeleton } from "@/components/ui/skeleton";
 interface Props {
   client: OpenCompanyClient;
   company: string | null;
+  /**
+   * Whether this viewer may change what the company connects through (issue
+   * #403) — the credential its agents present, and which provider accounts
+   * they act through.
+   *
+   * **Courtesy, not enforcement.** The host refuses both writes with a 403
+   * whatever this says. What it prevents is offering a Sign in button that
+   * cannot complete, or a token field whose Save is refused only after the
+   * operator has already pasted a live credential into it.
+   */
+  canManage: boolean;
 }
 
 /** Friendly display labels for the common toolkits; slug-cased fallback otherwise. */
@@ -58,7 +69,7 @@ function toolkitLabel(slug: string): string {
  * takes effect on the agents' next turn, no restart. Hidden entirely when the
  * feature is not in the build.
  */
-export function ComposioSection({ client, company }: Props) {
+export function ComposioSection({ client, company, canManage }: Props) {
   const [load, setLoad] = useState<"loading" | "ready" | "unavailable">("loading");
   const [status, setStatus] = useState<ComposioStatus | null>(null);
   const [token, setToken] = useState("");
@@ -225,7 +236,11 @@ export function ComposioSection({ client, company }: Props) {
   const openMode = status?.openMode === true;
   // In the attested state the paste card is a deliberate override; everywhere
   // else it is the only way to connect, so it is always on screen.
-  const showTokenCard = !attested || showOverride || byoToken;
+  // Issue #403: the credential card is an admin's. A member still sees the
+  // status line above ("token set" / "linked via cluster identity"), which is
+  // what tells them why their agents can reach Gmail; what they do not get is a
+  // field that invites them to paste a credential the host will refuse.
+  const showTokenCard = canManage && (!attested || showOverride || byoToken);
 
   return (
     <section className="space-y-3">
@@ -236,7 +251,9 @@ export function ComposioSection({ client, company }: Props) {
         </h3>
       </div>
       <p className="text-sm text-muted-foreground">
-        {attested
+        {!canManage
+          ? "Your agents reach Gmail, Slack & GitHub through Composio. Which account they act through belongs to the company, so an admin manages it — this is what is wired today."
+          : attested
           ? "Give your agents Gmail, Slack & GitHub via Composio. This company is linked through this instance's own cluster identity — there is no key to copy and nothing stored here. Sign in per provider below."
           : "Give your agents Gmail, Slack & GitHub via Composio. Paste this company's Composio OAuth token — it is the identity the backend bills and isolates, stored securely and never shown again — then sign in per provider below. A change takes effect on the next turn, no restart."}
       </p>
@@ -303,6 +320,8 @@ export function ComposioSection({ client, company }: Props) {
                           <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
                             <Check className="size-3" /> connected
                           </span>
+                        ) : !canManage ? (
+                          <span className="text-xs text-muted-foreground">not connected</span>
                         ) : (
                           <Button
                             size="sm"
@@ -322,7 +341,7 @@ export function ComposioSection({ client, company }: Props) {
                     );
                   })}
                 </ul>
-                {openMode && (
+                {openMode && canManage && (
                   <div className="flex items-end gap-2 border-t border-border pt-3">
                     <div className="flex-1 space-y-1">
                       <Label htmlFor="composio-other-toolkit" className="text-xs">
@@ -356,7 +375,7 @@ export function ComposioSection({ client, company }: Props) {
             </Card>
           )}
 
-          {attested && !showTokenCard && (
+          {canManage && attested && !showTokenCard && (
             <Button variant="outline" size="sm" onClick={() => setShowOverride(true)}>
               <KeyRound className="size-4" />
               Use your own Composio account instead

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -93,9 +93,17 @@ type TestState =
 export function InferenceSection({
   client,
   company,
+  canManage,
 }: {
   client: OpenCompanyClient;
   company: string | null;
+  /**
+   * Whether this viewer may change where the company's model calls go (issue
+   * #403). Courtesy only — the host answers 403 regardless; this stops the
+   * console offering a form whose Save cannot land. `Test` stays available: it
+   * probes the config as already stored, and the host leaves it open.
+   */
+  canManage: boolean;
 }) {
   const [load, setLoad] = useState<Load>("loading");
   const [status, setStatus] = useState<InferenceStatus | null>(null);
@@ -335,124 +343,129 @@ export function InferenceSection({
             )}
 
             {/* Switch form. */}
-            <div className="space-y-3 border-t border-border pt-3">
-              <div className="grid gap-2 sm:grid-cols-2 sm:items-end">
-                <div className="space-y-1">
-                  <Label htmlFor="inference-provider" className="text-xs">
-                    Provider
-                  </Label>
-                  <Select
-                    value={provider}
-                    onValueChange={(v) => pickProvider(v as InferenceProvider)}
-                    items={PROVIDER_LABELS}
-                  >
-                    <SelectTrigger id="inference-provider" className="w-full">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {(Object.keys(PROVIDER_LABELS) as InferenceProvider[]).map((p) => (
-                        <SelectItem key={p} value={p}>
-                          {PROVIDER_LABELS[p]}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                {(provider === "ollama" || provider === "openai_compatible") && (
+            {/* The switch form is an admin's: it decides the base URL every
+                agent's prompts travel to and the key they are billed against
+                (issue #403). */}
+            {canManage && (
+              <div className="space-y-3 border-t border-border pt-3">
+                <div className="grid gap-2 sm:grid-cols-2 sm:items-end">
                   <div className="space-y-1">
-                    <Label htmlFor="inference-base-url" className="text-xs">
-                      Base URL
+                    <Label htmlFor="inference-provider" className="text-xs">
+                      Provider
                     </Label>
-                    <Input
-                      id="inference-base-url"
-                      value={baseUrl}
-                      placeholder="https://host/v1"
-                      onChange={(e) => setBaseUrl(e.target.value)}
-                    />
-                  </div>
-                )}
-              </div>
-
-              {provider === "managed" ? (
-                <div className="space-y-2">
-                  <p className="text-xs text-muted-foreground" data-testid="inference-managed-note">
-                    Managed runs on the platform credential, so there is no key to paste here. To
-                    bring your own key, choose OpenRouter or Custom (OpenAI-compatible).
-                  </p>
-                  {managedWouldDiscardKey && (
-                    <div
-                      className="space-y-2 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive"
-                      data-testid="inference-key-conflict"
+                    <Select
+                      value={provider}
+                      onValueChange={(v) => pickProvider(v as InferenceProvider)}
+                      items={PROVIDER_LABELS}
                     >
-                      <p className="flex items-start gap-1.5">
-                        <AlertTriangle className="mt-px size-3.5 shrink-0" />
-                        <span>
-                          You typed a key, and managed can&apos;t store one — saving now would throw
-                          it away. Choose OpenRouter or Custom (OpenAI-compatible) to save it, or
-                          discard it to stay on managed.
-                        </span>
-                      </p>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        data-testid="inference-discard-key"
-                        onClick={() => setKey("")}
-                      >
-                        Discard key
-                      </Button>
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <>
-                  <div className="grid gap-2 sm:grid-cols-2">
-                    {TIERS.map((tier) => (
-                      <div key={tier} className="space-y-1">
-                        <Label htmlFor={`inference-model-${tier}`} className="text-xs">
-                          {tier}
-                        </Label>
-                        <Input
-                          id={`inference-model-${tier}`}
-                          value={models[tier] ?? ""}
-                          placeholder="provider model id"
-                          onChange={(e) => setModel(tier, e.target.value)}
-                        />
-                      </div>
-                    ))}
+                      <SelectTrigger id="inference-provider" className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {(Object.keys(PROVIDER_LABELS) as InferenceProvider[]).map((p) => (
+                          <SelectItem key={p} value={p}>
+                            {PROVIDER_LABELS[p]}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                   </div>
-                  {provider !== "ollama" && (
+                  {(provider === "ollama" || provider === "openai_compatible") && (
                     <div className="space-y-1">
-                      <Label htmlFor="inference-key" className="text-xs">
-                        API key {status?.keyConfigured ? "(leave blank to keep)" : ""}
+                      <Label htmlFor="inference-base-url" className="text-xs">
+                        Base URL
                       </Label>
                       <Input
-                        id="inference-key"
-                        type="password"
-                        value={key}
-                        placeholder="write-only"
-                        autoComplete="off"
-                        onChange={(e) => setKey(e.target.value)}
+                        id="inference-base-url"
+                        value={baseUrl}
+                        placeholder="https://host/v1"
+                        onChange={(e) => setBaseUrl(e.target.value)}
                       />
                     </div>
                   )}
-                </>
-              )}
+                </div>
 
-              <div className="flex items-center gap-2">
-                <Button
-                  data-testid="inference-save"
-                  disabled={busy !== null || managedWouldDiscardKey}
-                  onClick={() => void save()}
-                >
-                  {busy === "save" ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
-                  Save
-                </Button>
-                <Button variant="outline" disabled={busy !== null} onClick={() => void reset()}>
-                  {busy === "reset" ? <Loader2 className="size-4 animate-spin" /> : <RotateCcw className="size-4" />}
-                  Reset to managed
-                </Button>
+                {provider === "managed" ? (
+                  <div className="space-y-2">
+                    <p className="text-xs text-muted-foreground" data-testid="inference-managed-note">
+                      Managed runs on the platform credential, so there is no key to paste here. To
+                      bring your own key, choose OpenRouter or Custom (OpenAI-compatible).
+                    </p>
+                    {managedWouldDiscardKey && (
+                      <div
+                        className="space-y-2 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+                        data-testid="inference-key-conflict"
+                      >
+                        <p className="flex items-start gap-1.5">
+                          <AlertTriangle className="mt-px size-3.5 shrink-0" />
+                          <span>
+                            You typed a key, and managed can&apos;t store one — saving now would throw
+                            it away. Choose OpenRouter or Custom (OpenAI-compatible) to save it, or
+                            discard it to stay on managed.
+                          </span>
+                        </p>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          data-testid="inference-discard-key"
+                          onClick={() => setKey("")}
+                        >
+                          Discard key
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <>
+                    <div className="grid gap-2 sm:grid-cols-2">
+                      {TIERS.map((tier) => (
+                        <div key={tier} className="space-y-1">
+                          <Label htmlFor={`inference-model-${tier}`} className="text-xs">
+                            {tier}
+                          </Label>
+                          <Input
+                            id={`inference-model-${tier}`}
+                            value={models[tier] ?? ""}
+                            placeholder="provider model id"
+                            onChange={(e) => setModel(tier, e.target.value)}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    {provider !== "ollama" && (
+                      <div className="space-y-1">
+                        <Label htmlFor="inference-key" className="text-xs">
+                          API key {status?.keyConfigured ? "(leave blank to keep)" : ""}
+                        </Label>
+                        <Input
+                          id="inference-key"
+                          type="password"
+                          value={key}
+                          placeholder="write-only"
+                          autoComplete="off"
+                          onChange={(e) => setKey(e.target.value)}
+                        />
+                      </div>
+                    )}
+                  </>
+                )}
+
+                <div className="flex items-center gap-2">
+                  <Button
+                    data-testid="inference-save"
+                    disabled={busy !== null || managedWouldDiscardKey}
+                    onClick={() => void save()}
+                  >
+                    {busy === "save" ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+                    Save
+                  </Button>
+                  <Button variant="outline" disabled={busy !== null} onClick={() => void reset()}>
+                    {busy === "reset" ? <Loader2 className="size-4 animate-spin" /> : <RotateCcw className="size-4" />}
+                    Reset to managed
+                  </Button>
+                </div>
               </div>
-            </div>
+            )}
           </CardContent>
         </Card>
       )}

--- a/frontend/test/e2e/connections-authority.spec.ts
+++ b/frontend/test/e2e/connections-authority.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Issue #403 — the Connections page must not offer a member controls the host
+ * refuses.
+ *
+ * The host is the boundary: every write on this page answers `403` for a
+ * member whatever the console renders. What this spec covers is the other
+ * half — that the console does not *invite* the refusal. On this page that
+ * matters more than usual, because the invitation is a password field: an
+ * operator would learn they were not allowed only after pasting a live
+ * credential into a form that could never submit it.
+ *
+ * Drives a real browser against a live host, like the rest of this directory,
+ * and is not a merge gate (the Playwright config declares no `webServer`).
+ *
+ * The suite's shared storage state is the harness **admin**. The member half
+ * signs in separately through the same magic-link flow the product uses, in
+ * its own browser context, so both roles are exercised against one host.
+ */
+
+type Page = import("@playwright/test").Page;
+type APIRequestContext = import("@playwright/test").APIRequestContext;
+
+const MEMBER_EMAIL = "member-403@example.test";
+
+async function openConnections(page: Page) {
+  await page.goto("/#/settings/connections");
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  await skip
+    .waitFor({ state: "visible", timeout: 10_000 })
+    .then(() => skip.click())
+    .catch(() => {
+      /* already seen in this context — nothing to dismiss */
+    });
+}
+
+/**
+ * Invites `MEMBER_EMAIL` as a member and redeems a login code for `context`.
+ *
+ * Idempotent on the invite: a re-run hits `409 already a member`, which is a
+ * success for our purposes — the address can sign in either way.
+ */
+async function signInAsMember(admin: APIRequestContext, context: APIRequestContext) {
+  const invited = await admin.post("/api/v1/company/users/invites", {
+    data: { email: MEMBER_EMAIL, role: "member" },
+  });
+  expect(
+    invited.ok() || invited.status() === 409,
+    `inviting ${MEMBER_EMAIL} failed: ${invited.status()} ${await invited.text()}`,
+  ).toBeTruthy();
+
+  const requested = await context.post("/api/v1/company/auth/request", {
+    data: { email: MEMBER_EMAIL },
+  });
+  const devCode = (await requested.json())?.dev_code as string | undefined;
+  expect(
+    devCode,
+    "no dev_code came back — the host must bind loopback with no mail transport " +
+      "configured for the member half of this spec to sign in",
+  ).toBeTruthy();
+
+  const verified = await context.post("/api/v1/company/auth/verify", {
+    data: { code: devCode },
+  });
+  expect(verified.ok(), `member sign-in failed: ${await verified.text()}`).toBeTruthy();
+  expect((await verified.json()).role).toBe("member");
+}
+
+test("a member sees what is connected but is offered nothing that changes it", async ({
+  page,
+  browser,
+}) => {
+  // Establish the member session in its own context, using the suite's admin
+  // session (this `page`) only to issue the invite.
+  const memberContext = await browser.newContext({ storageState: undefined });
+  try {
+    await signInAsMember(page.request, memberContext.request);
+    const memberPage = await memberContext.newPage();
+    await openConnections(memberPage);
+
+    // The page says why, in the operator's language.
+    await expect(memberPage.getByTestId("connections-read-only")).toBeVisible({ timeout: 30_000 });
+
+    // No credential field anywhere on the page. This is the assertion that
+    // matters most: a member must never be handed somewhere to paste a token.
+    await expect(memberPage.locator("#composio-token")).toHaveCount(0);
+    await expect(memberPage.locator("#tg-token")).toHaveCount(0);
+    await expect(memberPage.locator("#mcp-token")).toHaveCount(0);
+
+    // Nor the controls behind the other refused writes. `exact` matters on the
+    // last two: role-name matching is substring by default, and the Settings
+    // rail carries a "Who can sign in, and as what" item that a loose "Sign in"
+    // matches — which would make this assertion fail for an admin too, and so
+    // prove nothing about either role.
+    await expect(memberPage.getByTestId("inference-save")).toHaveCount(0);
+    const button = (name: string) => memberPage.getByRole("button", { name, exact: true });
+    await expect(button("Save token")).toHaveCount(0);
+    await expect(button("Sign in")).toHaveCount(0);
+    await expect(button("Add")).toHaveCount(0);
+
+    // But the read is intact — a member can still see what the company is
+    // wired to, which is what explains why an agent can reach a provider.
+    await expect(memberPage.getByRole("heading", { name: "Connections" })).toBeVisible();
+    const status = await memberPage.request.get("/api/v1/company/composio");
+    expect(status.ok()).toBeTruthy();
+    expect(await status.text()).not.toContain("token");
+  } finally {
+    await memberContext.close();
+  }
+});
+
+test("an admin is still offered every control on the same page", async ({ page }) => {
+  await openConnections(page);
+
+  // The member's banner is absent, and the credential surfaces are present.
+  await expect(page.getByTestId("connections-read-only")).toHaveCount(0);
+  await expect(page.getByTestId("inference-save")).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator("#tg-token")).toBeVisible();
+  await expect(page.locator("#mcp-name")).toBeVisible();
+});

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -118,6 +118,23 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("Deleted memory fact {fact_id}"),
             "memory.fact_deleted",
         ),
+        // Issue #403. Worth telling the brain, because it changes what the
+        // brain can *do*: a cleared credential is why a tool it had yesterday
+        // stops answering today, and without this that reads as an unexplained
+        // failure. `by` is deliberately dropped — the sidecar needs to know the
+        // company's tool access moved, not which human moved it, and the actor
+        // is a user id. Same omission the operator SSE projection makes.
+        CompanyEvent::ToolAccessChanged {
+            change, toolkit, ..
+        } => (
+            Role::System,
+            "operator".to_string(),
+            match toolkit {
+                Some(toolkit) => format!("Tool access changed: {change} ({toolkit})"),
+                None => format!("Tool access changed: {change}"),
+            },
+            "tool_access.changed",
+        ),
         CompanyEvent::TaskDispatched { task_id, .. } => (
             Role::System,
             "board".to_string(),

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -568,6 +568,16 @@ fn summarize_event(event: &CompanyEvent) -> String {
         CompanyEvent::PaymentReceived { amount_usd, .. } => format!("payment ${amount_usd:.2}"),
         CompanyEvent::LifecycleChanged { from, to, .. } => format!("lifecycle {from} → {to}"),
         CompanyEvent::MemoryFactDeleted { .. } => "memory fact deleted".to_string(),
+        // Issue #403. The change word and the toolkit slug are both fixed
+        // vocabulary, so neither can carry anything a company typed. `by` is
+        // dropped: this is a non-sensitive one-liner for the insight surface,
+        // and a user id is neither one-line-worthy nor insight.
+        CompanyEvent::ToolAccessChanged {
+            change, toolkit, ..
+        } => match toolkit {
+            Some(toolkit) => format!("tool access changed: {change} ({toolkit})"),
+            None => format!("tool access changed: {change}"),
+        },
         CompanyEvent::McpCallFailed { server, tool, .. } => {
             format!("MCP call failed: {server}/{tool}")
         }

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -370,6 +370,43 @@ pub enum CompanyEvent {
         /// The id of the deleted fact.
         fact_id: String,
     },
+    /// An admin changed what this company's agents reach third parties through
+    /// (issue #403): the Composio credential the company presents, or a
+    /// provider connection authorized under it.
+    ///
+    /// Journaled for the audit trail, the same reason
+    /// [`MemoryFactDeleted`](Self::MemoryFactDeleted) is — a company's tool
+    /// access is one of the few things about it that can be changed without
+    /// leaving any other mark, so "how did we come to be connected through
+    /// *that* account" has to be answerable afterwards.
+    ///
+    /// **Deliberately carries no credential and no URL.** A journal line is
+    /// append-only, exported, and read by the operator projection; the token
+    /// is write-only over the whole API and does not stop being so here. A
+    /// stable wire word, an optional toolkit slug, and the person — nothing
+    /// else.
+    ToolAccessChanged {
+        /// What changed, as a stable wire word: `credential_set`,
+        /// `credential_cleared`, or `provider_authorization_started`.
+        ///
+        /// The last is deliberately *started*, not *completed*: Composio runs
+        /// the OAuth on its own side with no callback here, so all this host
+        /// witnesses is that an admin asked for a connect URL for that
+        /// toolkit. Naming it a completed connection would put a claim in the
+        /// audit trail that nothing verified.
+        change: String,
+        /// The toolkit slug for a provider authorization (`gmail`, `slack`, …).
+        /// `None` for a credential change, which is not per-provider.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        toolkit: Option<String>,
+        /// Who made the change. The routes that emit this require an admin
+        /// session, so in practice it is always `Some` and always a person;
+        /// the `Option` matches the
+        /// [`WorkflowCreated`](Self::WorkflowCreated) precedent and lets an
+        /// already-persisted log load unchanged.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        by: Option<Actor>,
+    },
     /// A board task was moved into `in_progress` and dispatched to its assignee
     /// for one agent turn on the embedded runtime. Journaled so the dispatch is
     /// auditable and replayable. Only the `openhuman` `HarnessBrain` acts on it;

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1073,6 +1073,10 @@ fn cycle_task_id(
             | CompanyEvent::AgentReply { .. }
             | CompanyEvent::ApprovalParked { .. }
             | CompanyEvent::MemoryFactDeleted { .. }
+            // A credential or connection change (issue #403) is a record of an
+            // admin's decision, not a stimulus: it names no card and competes
+            // with none.
+            | CompanyEvent::ToolAccessChanged { .. }
             | CompanyEvent::McpCallFailed { .. }
             | CompanyEvent::WorkflowCreated { .. }
             | CompanyEvent::WorkflowUpdated { .. }
@@ -1173,6 +1177,10 @@ fn cycle_thread_id(
             | CompanyEvent::AgentReply { .. }
             | CompanyEvent::ApprovalParked { .. }
             | CompanyEvent::MemoryFactDeleted { .. }
+            // A credential or connection change (issue #403) is a record of an
+            // admin's decision, not a stimulus: it names no card and competes
+            // with none.
+            | CompanyEvent::ToolAccessChanged { .. }
             | CompanyEvent::McpCallFailed { .. }
             | CompanyEvent::WorkflowCreated { .. }
             | CompanyEvent::WorkflowUpdated { .. }

--- a/src/server/ops/channels.rs
+++ b/src/server/ops/channels.rs
@@ -38,7 +38,7 @@ use crate::company::runtime::CompanyRuntime;
 use crate::company::telegram::{TELEGRAM_SECRET_KEY, TELEGRAM_TOKEN_KEY, scrub_token};
 use crate::ports::types::{CompanyId, SecretValue};
 use crate::server::error::ApiError;
-use crate::server::ops::{ScopedCompany, scoped};
+use crate::server::ops::{AdminScopedCompany, ScopedCompany, scoped};
 
 /// The non-secret status of a company's Telegram channel. Carries presence
 /// booleans, how inbound arrives, and the webhook URL when there is a usable
@@ -140,8 +140,12 @@ struct TelegramConfigBody {
 }
 
 /// `PUT …/channels/telegram` — store token and/or secret, return status.
+///
+/// Requires authority over the company (issue #403): this token *is* the bot
+/// the company speaks as, so replacing it moves the company's Telegram voice
+/// to whoever holds the new one.
 async fn put_channel(
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     State(state): State<AppState>,
     Json(body): Json<TelegramConfigBody>,
 ) -> Result<Json<TelegramChannelStatus>, ApiError> {
@@ -187,8 +191,10 @@ async fn put_channel(
 /// cleared credential is stored as the empty string; every read site treats an
 /// empty value as "unset" (the webhook rejects a blank secret, delivery skips a
 /// blank token).
+/// Requires authority over the company (issue #403) — the inverse of the
+/// write above, and no less consequential: it takes the channel down.
 async fn delete_channel(
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     State(state): State<AppState>,
 ) -> Result<Json<TelegramChannelStatus>, ApiError> {
     let runtime = &company.runtime;
@@ -227,7 +233,7 @@ struct SetWebhookResult {
 /// reachable https URL (issue #203): Telegram would accept nothing, or worse
 /// accept a URL it can never deliver to — which also blocks `getUpdates` and so
 /// would take the working polling path down with it.
-async fn set_webhook(company: ScopedCompany, State(state): State<AppState>) -> Response {
+async fn set_webhook(company: AdminScopedCompany, State(state): State<AppState>) -> Response {
     use axum::response::IntoResponse;
 
     let runtime = &company.runtime;

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -975,15 +975,18 @@ mod tests {
         assert_eq!(status, StatusCode::CONFLICT, "{raw}");
     }
 
-    /// A machine credential cannot set the company's Composio token.
+    /// A machine credential may set the company's token — and is **named** in
+    /// the trail when it does.
     ///
-    /// It is a *verified platform* principal, so it clears the addressing
-    /// check that [`ScopedCompany`] applies — and is then refused anyway,
-    /// because a token names no person and this write must be attributable to
-    /// one. The status is `401`, not `403`: the guard resolves a human session
-    /// and there is none.
+    /// This is the deliberate half of the issue's "cannot, or if it may, the
+    /// write is attributed". Refusing the hosting control plane a route it
+    /// already sits above (it provisions the tenant and holds its database
+    /// credentials) would be ceremony, not a boundary, and it would contradict
+    /// the two-principal model in `docs/spec/runtime/config.md`. What it does
+    /// not get is anonymity: the entry names the tenant, so a machine-made
+    /// change is as reviewable afterwards as a human one.
     #[tokio::test]
-    async fn a_machine_credential_cannot_set_the_token() {
+    async fn a_machine_credential_is_named_when_it_sets_the_token() {
         use crate::server::platform_auth::{
             PlatformAuthConfig, PlatformClaims, UnsignedTenantVerifier,
         };
@@ -1000,7 +1003,7 @@ mod tests {
             companies: None,
         });
 
-        let (status, body, raw) = send_as(
+        let (status, _, raw) = send_as(
             &state,
             "PUT",
             "/api/v1/company/composio/token",
@@ -1008,8 +1011,27 @@ mod tests {
             Auth::Bearer(token),
         )
         .await;
-        assert_eq!(status, StatusCode::UNAUTHORIZED, "{raw}");
-        assert_eq!(body["code"], "unauthorized", "{body}");
+        assert_eq!(status, StatusCode::OK, "{raw}");
+
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let events = runtime
+            .events()
+            .read_from(runtime.id(), crate::ports::types::EventSeq::new(0), 100)
+            .await
+            .unwrap();
+        let by = events
+            .iter()
+            .find_map(|stored| match &stored.event {
+                crate::ports::types::CompanyEvent::ToolAccessChanged { by, .. } => by.clone(),
+                _ => None,
+            })
+            .expect("the machine write is journaled");
+        assert_eq!(
+            by.kind,
+            crate::ports::types::ActorKind::System,
+            "a machine is a machine, not a person: {by:?}"
+        );
+        assert_eq!(by.id, "tenant:platform", "the tenant is named: {by:?}");
     }
 
     /// Every accepted change to the company's tool access names the person who

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -23,6 +23,34 @@
 //!   product — it is a hatch, not a deployment mode, and nothing else about
 //!   standalone operation is supported this milestone.
 //!
+//! ## Who a connection belongs to (issue #403)
+//!
+//! **A connection belongs to the company, and is admin-managed.** The account
+//! reached through it is the account the company's *agents* act through, so it
+//! is company property in the same sense the roster and the manifest are — not
+//! the personal property of whichever member happened to click Connect.
+//!
+//! This is not a new position; it is the one the code already took and did not
+//! enforce. The native OAuth plane's connect-time identity check
+//! ([`account_mismatch`](super::connections)) compares the connected account
+//! against `bootstrap_admins` — the company's *admin* addresses — which only
+//! makes sense if a connection is the company's. Issue #316 settled "one
+//! operator, one connected account"; this is the layer above it, and it
+//! resolves the same way.
+//!
+//! Two consequences, both deliberate:
+//!
+//! * **Writes require an admin.** `PUT …/composio/token` and
+//!   `POST …/composio/authorize` take [`AdminScopedCompany`]. A member is
+//!   refused with a message that says why.
+//! * **Reads stay open to any member.** `GET …/composio` and
+//!   `GET …/composio/connections` carry no credential — only a tier name,
+//!   non-secret routing, and which providers are connected. Knowing *that*
+//!   Gmail is connected is what lets a member understand why an agent can read
+//!   mail; being able to change it is the part that needed an owner. The split
+//!   mirrors the roster, where `GET …/team` is open and the budget writes are
+//!   not.
+//!
 //! Either way the token is **write-only** over the API: set through the `token`
 //! field, stored in the secret store under
 //! [`TOKEN_KEY`](crate::company::composio::TOKEN_KEY), and **never** echoed. The
@@ -41,8 +69,9 @@ use crate::AppState;
 use crate::company::composio::{backend_url_or_default, store_token, token_configured};
 use crate::company::credentials::{CredentialSource, TinyhumansTokenSource};
 use crate::company::runtime::CompanyRuntime;
+use crate::ports::types::CompanyEvent;
 use crate::server::error::ApiError;
-use crate::server::ops::{ScopedCompany, scoped};
+use crate::server::ops::{AdminScopedCompany, ScopedCompany, scoped};
 
 /// The reminder attached to every mutating response.
 const SWITCH_NOTE: &str =
@@ -269,18 +298,62 @@ async fn get_status(company: ScopedCompany) -> Result<Json<ComposioStatusDto>, A
 /// `PUT …/composio/token` — set / rotate / clear this company's BYO token. See
 /// the module docs: the hosted path needs no token, and standalone operation
 /// (where this is the only option) is unsupported.
+///
+/// **Admin-only** (issue #403). This is the sharpest write in the module: the
+/// token it stores is the identity every one of the company's agents presents
+/// to Composio, so whoever sets it decides which account those agents act
+/// through. That is a decision made *for* the company, not a member's own, and
+/// [`AdminScopedCompany`] is what says so in the signature.
 async fn set_token(
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     Json(body): Json<SetToken>,
 ) -> Result<Json<MutationResponse>, ApiError> {
     let runtime = company.runtime.as_ref();
     store_token(runtime.id(), runtime.secrets().as_ref(), &body.token)
         .await
         .map_err(ApiError)?;
+    // After the store, so the journal records a completed change. An empty
+    // value is a clear, not a set — the two are worth telling apart in an
+    // audit trail, since one grants access and the other withdraws it.
+    let change = if body.token.trim().is_empty() {
+        "credential_cleared"
+    } else {
+        "credential_set"
+    };
+    journal(&company, change, None).await?;
     Ok(Json(MutationResponse {
         status: effective_status(runtime).await?,
         note: SWITCH_NOTE.to_string(),
     }))
+}
+
+/// Records who changed the company's tool access (issue #403).
+///
+/// Propagates a journal failure rather than swallowing it, unlike the
+/// best-effort workflow journaling. The point of this record is that a change
+/// to what the company's agents connect through is never invisible; an audit
+/// line that quietly fails to be written is the one failure mode that would
+/// defeat it. `MemoryFactDeleted` — the other write journaled *for* the audit
+/// trail — propagates for the same reason.
+async fn journal(
+    company: &AdminScopedCompany,
+    change: &str,
+    toolkit: Option<String>,
+) -> Result<(), ApiError> {
+    company
+        .runtime
+        .events()
+        .append(
+            company.id(),
+            CompanyEvent::ToolAccessChanged {
+                change: change.to_string(),
+                toolkit,
+                by: Some(company.actor()),
+            },
+        )
+        .await
+        .map_err(ApiError)?;
+    Ok(())
 }
 
 /// `POST …/composio/authorize` — begin a per-provider OAuth handoff and return
@@ -290,11 +363,29 @@ async fn set_token(
 /// The console opens the URL and polls [`connections`] until the toolkit
 /// reports connected. Under a non-`composio` build this answers `409 Conflict`
 /// (see [`router`]).
+///
+/// **Admin-only** (issue #403). The connection this begins belongs to the
+/// company — it is the account its agents will act through from then on — so
+/// the person who chooses it has to be someone entitled to choose on the
+/// company's behalf. Note that nothing downstream can re-check this: Composio
+/// runs its own OAuth with no callback here, so unlike the native connections
+/// plane there is no later point at which the connecting identity could be
+/// compared against the company's operators. Connect time is the only boundary
+/// there is.
 async fn authorize(
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     Json(body): Json<AuthorizeBody>,
 ) -> Result<Json<AuthorizeDto>, ApiError> {
-    authorize_impl(company.runtime.as_ref(), body.toolkit).await
+    let dto = authorize_impl(company.runtime.as_ref(), body.toolkit.clone()).await?;
+    // Only once a connect URL was actually minted — a refused or unbuildable
+    // authorize changed nothing and does not belong in the trail.
+    journal(
+        &company,
+        "provider_authorization_started",
+        Some(body.toolkit),
+    )
+    .await?;
+    Ok(dto)
 }
 
 /// `GET …/composio/connections` — the company's per-toolkit connected state,
@@ -465,10 +556,35 @@ mod tests {
         uri: &str,
         body: Option<Value>,
     ) -> (StatusCode, Value, String) {
-        let request = Request::builder()
-            .method(method)
-            .uri(uri)
-            .header("cookie", crate::server::test_support::fixed_cookie("acme"));
+        send_as(
+            state,
+            method,
+            uri,
+            body,
+            Auth::Cookie(crate::server::test_support::fixed_cookie("acme")),
+        )
+        .await
+    }
+
+    /// How a request presents itself, so the role boundary can be driven with
+    /// an admin session, a member session, or a machine credential.
+    enum Auth {
+        Cookie(String),
+        Bearer(String),
+    }
+
+    async fn send_as(
+        state: &AppState,
+        method: &str,
+        uri: &str,
+        body: Option<Value>,
+        auth: Auth,
+    ) -> (StatusCode, Value, String) {
+        let request = Request::builder().method(method).uri(uri);
+        let request = match auth {
+            Auth::Cookie(cookie) => request.header("cookie", cookie),
+            Auth::Bearer(token) => request.header("authorization", format!("Bearer {token}")),
+        };
         let request = match body {
             Some(body) => request
                 .header("content-type", "application/json")
@@ -718,6 +834,243 @@ mod tests {
         .await;
         assert_eq!(status, StatusCode::CONFLICT, "{raw}");
         assert_eq!(body["code"], "conflict", "{body}");
+    }
+
+    // --- Who may change what the company connects through (issue #403) -------
+
+    /// A company granting composio with one provider — the shape every
+    /// authorization test below drives.
+    const GRANTED: &str = "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+         [tools]\nallow = [\"composio\"]\n[tools.composio]\ntoolkits = [\"gmail\"]\n";
+
+    /// The regression this issue is about: a signed-in member who is not an
+    /// admin cannot change what the company's agents connect through — neither
+    /// by replacing the credential they present, nor by starting an OAuth
+    /// handoff that would make their own account the company's connection.
+    ///
+    /// Both halves matter. The reported symptom was the connect flow, but the
+    /// token route is the sharper one: it repoints the company's entire tool
+    /// surface at whatever account the caller controls.
+    #[tokio::test]
+    async fn a_member_cannot_change_what_the_company_connects_through() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), GRANTED).await;
+        let member = crate::server::test_support::seed_session(
+            &state,
+            "acme",
+            crate::ports::UserRole::Member,
+        )
+        .await;
+
+        let (status, body, raw) = send_as(
+            &state,
+            "PUT",
+            "/api/v1/company/composio/token",
+            Some(json!({ "token": TOKEN })),
+            Auth::Cookie(member.clone()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "{raw}");
+        assert_eq!(body["code"], "forbidden", "{body}");
+        assert!(
+            body["error"].as_str().unwrap_or_default().contains("admin"),
+            "the refusal has to say why it was refused: {body}"
+        );
+
+        let (status, body, raw) = send_as(
+            &state,
+            "POST",
+            "/api/v1/company/composio/authorize",
+            Some(json!({ "toolkit": "gmail" })),
+            Auth::Cookie(member.clone()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "{raw}");
+        assert_eq!(body["code"], "forbidden", "{body}");
+
+        // And the refusal is real, not merely a different status: the token
+        // never landed, so the company's credential is untouched.
+        let (_, dto, _) = send(&state, "GET", "/api/v1/company/composio", None).await;
+        assert_eq!(
+            dto["credentialSource"], "none",
+            "a refused write must not have stored anything: {dto}"
+        );
+    }
+
+    /// The other side of the boundary, and the reason this is a role check
+    /// rather than a removal: an admin still does both things. `authorize`
+    /// answering `409` here is the *build* refusing (no `composio` feature),
+    /// which is exactly the point — it got past the guard and failed later, on
+    /// a different axis than the member's `403`.
+    #[tokio::test]
+    async fn an_admin_is_unaffected() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), GRANTED).await;
+
+        let (status, resp, raw) = send(
+            &state,
+            "PUT",
+            "/api/v1/company/composio/token",
+            Some(json!({ "token": TOKEN })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_eq!(resp["status"]["credentialSource"], "static");
+
+        let (status, _, raw) = send(
+            &state,
+            "POST",
+            "/api/v1/company/composio/authorize",
+            Some(json!({ "toolkit": "gmail" })),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::CONFLICT,
+            "an admin reaches the build check, not the role check: {raw}"
+        );
+    }
+
+    /// Reads stay open to any member, and this pins that decision either way.
+    ///
+    /// Knowing *that* Gmail is connected is what lets a member understand why
+    /// an agent can read mail; it carries no credential. Only the ability to
+    /// change it needed an owner. If a future change decides reads are
+    /// sensitive too, this test is the thing that has to be edited on purpose.
+    #[tokio::test]
+    async fn a_member_may_still_read_the_composio_status_and_connections() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), GRANTED).await;
+        let member = crate::server::test_support::seed_session(
+            &state,
+            "acme",
+            crate::ports::UserRole::Member,
+        )
+        .await;
+
+        let (status, dto, raw) = send_as(
+            &state,
+            "GET",
+            "/api/v1/company/composio",
+            None,
+            Auth::Cookie(member.clone()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_eq!(dto["granted"], true);
+        assert!(
+            dto.get("token").is_none(),
+            "a member's read must not carry a credential either: {dto}"
+        );
+
+        // 409 (no client in this build), NOT 403 — the read is not role-gated.
+        let (status, _, raw) = send_as(
+            &state,
+            "GET",
+            "/api/v1/company/composio/connections",
+            None,
+            Auth::Cookie(member),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CONFLICT, "{raw}");
+    }
+
+    /// A machine credential cannot set the company's Composio token.
+    ///
+    /// It is a *verified platform* principal, so it clears the addressing
+    /// check that [`ScopedCompany`] applies — and is then refused anyway,
+    /// because a token names no person and this write must be attributable to
+    /// one. The status is `401`, not `403`: the guard resolves a human session
+    /// and there is none.
+    #[tokio::test]
+    async fn a_machine_credential_cannot_set_the_token() {
+        use crate::server::platform_auth::{
+            PlatformAuthConfig, PlatformClaims, UnsignedTenantVerifier,
+        };
+
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), GRANTED)
+            .await
+            .with_platform_auth(PlatformAuthConfig::new(std::sync::Arc::new(
+                UnsignedTenantVerifier::new("test-platform-secret"),
+            )));
+        let token = UnsignedTenantVerifier::tenant_token(&PlatformClaims {
+            tenant: "tenant:platform".to_string(),
+            scopes: std::collections::HashSet::from(["platform".to_string()]),
+            companies: None,
+        });
+
+        let (status, body, raw) = send_as(
+            &state,
+            "PUT",
+            "/api/v1/company/composio/token",
+            Some(json!({ "token": TOKEN })),
+            Auth::Bearer(token),
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED, "{raw}");
+        assert_eq!(body["code"], "unauthorized", "{body}");
+    }
+
+    /// Every accepted change to the company's tool access names the person who
+    /// made it, so "how did we come to be connected through that account" is
+    /// answerable afterwards.
+    ///
+    /// Set and clear are journaled as distinct words — one grants access and
+    /// the other withdraws it, and an audit trail that conflated them would be
+    /// worth little.
+    #[tokio::test]
+    async fn a_credential_change_records_who_made_it() {
+        use crate::ports::types::{ActorKind, CompanyEvent, EventSeq};
+
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), GRANTED).await;
+
+        for token in [TOKEN, ""] {
+            let (status, _, raw) = send(
+                &state,
+                "PUT",
+                "/api/v1/company/composio/token",
+                Some(json!({ "token": token })),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK, "{raw}");
+        }
+
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let events = runtime
+            .events()
+            .read_from(runtime.id(), EventSeq::new(0), 100)
+            .await
+            .unwrap();
+        let changes: Vec<(String, Option<String>)> = events
+            .iter()
+            .filter_map(|stored| match &stored.event {
+                CompanyEvent::ToolAccessChanged {
+                    change,
+                    toolkit,
+                    by,
+                } => {
+                    let by = by.as_ref().expect("an admin write is always attributed");
+                    assert_eq!(by.kind, ActorKind::User, "attributed to a person");
+                    assert!(!by.id.is_empty(), "the person is named");
+                    Some((change.clone(), toolkit.clone()))
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            changes,
+            vec![
+                ("credential_set".to_string(), None),
+                ("credential_cleared".to_string(), None),
+            ],
+            "a set and a clear are distinct entries in the trail"
+        );
+
+        // The trail is an audit record, not a second place a secret lives.
+        let raw = serde_json::to_string(&events).unwrap();
+        assert!(!raw.contains(TOKEN), "the journal leaked the token: {raw}");
     }
 
     /// `GET …/composio/connections` is likewise always wired and conflicts

--- a/src/server/ops/connections.rs
+++ b/src/server/ops/connections.rs
@@ -58,7 +58,7 @@ use crate::ports::normalize_email;
 use crate::ports::now_millis;
 use crate::ports::types::{CompanyId, SecretValue};
 use crate::server::error::ApiError;
-use crate::server::ops::{ScopedCompany, oauth_key, scoped};
+use crate::server::ops::{AdminScopedCompany, oauth_key, scoped};
 use crate::server::webhook::{DefaultHashSigner, WebhookSigner};
 
 /// How long a signed `state` nonce stays valid.
@@ -387,8 +387,15 @@ fn build_authorize(
 }
 
 /// `POST …/connections/{provider}/start` (both scope forms).
+///
+/// Requires authority over the company (issue #403) — this is the native-hatch
+/// twin of `POST …/composio/authorize`, and the connection it begins is the
+/// company's. Note that the connect-time identity check below
+/// ([`account_mismatch`]) already assumed as much: it compares the connected
+/// account against the company's *admin* addresses. Until now anyone could
+/// reach the flow that check guards; now the two agree.
 async fn start(
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     State(state): State<AppState>,
     Path(ProviderPath { provider }): Path<ProviderPath>,
 ) -> Result<Json<StartResponse>, ApiError> {
@@ -728,8 +735,11 @@ async fn do_disconnect(
 }
 
 /// `POST …/connections/{provider}/disconnect` (both scope forms).
+/// Requires authority over the company (issue #403). Disconnecting deletes the
+/// stored tokens and best-effort revokes them upstream — irreversible, and a
+/// decision about the company's access rather than the caller's.
 async fn disconnect(
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     Path(ProviderPath { provider }): Path<ProviderPath>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     do_disconnect(company.runtime, &provider).await

--- a/src/server/ops/domain.rs
+++ b/src/server/ops/domain.rs
@@ -23,7 +23,7 @@ use crate::company::dns::{self, DomainStatus};
 use crate::company::runtime::CompanyRuntime;
 use crate::ports::types::SecretValue;
 use crate::server::error::ApiError;
-use crate::server::ops::{DOMAIN_KEY, ScopedCompany, scoped};
+use crate::server::ops::{AdminScopedCompany, DOMAIN_KEY, ScopedCompany, scoped};
 
 /// Builds the domain route fragment.
 pub fn router() -> Router<AppState> {
@@ -66,8 +66,12 @@ async fn load_domain(runtime: &CompanyRuntime) -> Result<Option<DomainStatus>, A
 }
 
 /// `PUT …/domain` (both scope forms).
+/// Requires authority over the company (issue #403) — the domain is the
+/// company's mail identity. `POST …/domain/verify` deliberately stays open: it
+/// re-checks DNS for a domain only an admin could have set, and changes nothing
+/// a member could not already read.
 async fn put_domain(
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     Json(body): Json<SetDomain>,
 ) -> Result<Json<DomainStatus>, ApiError> {
     store_domain(company.runtime, &body.domain).await

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -36,7 +36,7 @@ use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
 use crate::ports::UsageMetering;
 use crate::server::error::ApiError;
-use crate::server::ops::{ScopedCompany, scoped};
+use crate::server::ops::{AdminScopedCompany, ScopedCompany, scoped};
 
 /// The reminder attached to a mutating response that the running brain can act
 /// on: a per-tenant provider re-resolves its config each turn, so a switch
@@ -253,9 +253,15 @@ async fn get_status(company: ScopedCompany) -> Result<Json<InferenceStatusDto>, 
 
 /// `PUT …/inference` — set (or replace) the runtime provider override, and
 /// optionally rotate the write-only outbound credential.
+///
+/// Requires authority over the company (issue #403). This route sets the base
+/// URL every agent's prompts and completions travel to, and the key they are
+/// billed against; deciding that is deciding how the company thinks. `POST
+/// …/inference/test` stays open — it probes the config as already stored,
+/// naming no destination of its own.
 async fn set_config(
     State(state): State<AppState>,
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     Json(body): Json<SetInference>,
 ) -> Result<Json<MutationResponse>, ApiError> {
     let runtime = company.runtime.as_ref();
@@ -339,7 +345,9 @@ async fn set_config(
 /// manifest `[inference]` (or the managed default). The stored credential is
 /// left in place (harmless for the managed default; still resolves for a
 /// manifest provider) — clear it explicitly with `PUT { key: "" }`.
-async fn revert_config(company: ScopedCompany) -> Result<Json<MutationResponse>, ApiError> {
+/// Requires authority over the company (issue #403) — same reasoning as the
+/// set: reverting decides which model the company thinks with.
+async fn revert_config(company: AdminScopedCompany) -> Result<Json<MutationResponse>, ApiError> {
     let runtime = company.runtime.as_ref();
     clear_runtime_config(runtime.id(), runtime.secrets().as_ref())
         .await

--- a/src/server/ops/mcp.rs
+++ b/src/server/ops/mcp.rs
@@ -30,7 +30,7 @@ use crate::company::mcp::{
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
 use crate::server::error::ApiError;
-use crate::server::ops::{ScopedCompany, scoped};
+use crate::server::ops::{AdminScopedCompany, ScopedCompany, scoped};
 
 /// The reminder attached to every mutating response: a live agent's tool set is
 /// rebuilt lazily, so an edit reaches agents on the next harness rebuild.
@@ -251,8 +251,17 @@ async fn list_servers(company: ScopedCompany) -> Result<Json<Vec<McpServerDto>>,
 }
 
 /// `POST …/mcp/servers` — add a runtime MCP server (+ optional token).
+///
+/// Requires authority over the company (issue #403). Registering a server hands
+/// the company's agents a new set of tools and an endpoint to call them at, so
+/// it settles what the company can reach — the same question the Composio
+/// routes settle, reached from a different direction. `PUT`/`DELETE` follow for
+/// the same reason (a `PUT` can also swap the auth material on a server the
+/// company already trusts), as does `oauth/start`, which registers a client.
+/// The probes — `GET …/tools`, `POST …/test` — stay open: they exercise a
+/// server an admin already added and name no endpoint of their own.
 async fn add_server(
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     Json(body): Json<AddServer>,
 ) -> Result<Json<MutationResponse>, ApiError> {
     let runtime = company.runtime.as_ref();
@@ -311,7 +320,7 @@ async fn add_server(
 /// `PUT …/mcp/servers/{name}` — update a server (enable/disable, tool lists,
 /// endpoint, or rotate token). A manifest server gets a runtime override entry.
 async fn update_server(
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     Path(NamePath { name }): Path<NamePath>,
     body: Option<Json<UpdateServer>>,
 ) -> Result<Json<MutationResponse>, ApiError> {
@@ -389,7 +398,7 @@ async fn update_server(
 /// `DELETE …/mcp/servers/{name}` — remove a runtime server (409 for a manifest
 /// server, which can only be disabled).
 async fn delete_server(
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     Path(NamePath { name }): Path<NamePath>,
 ) -> Result<StatusCode, ApiError> {
     let runtime = company.runtime.as_ref();
@@ -633,7 +642,7 @@ async fn test_server(company: ScopedCompany, Path(NamePath { name }): Path<NameP
 #[cfg(feature = "mcp")]
 async fn start_oauth(
     axum::extract::State(state): axum::extract::State<AppState>,
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     Path(NamePath { name }): Path<NamePath>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     use crate::company::mcp_oauth;
@@ -666,7 +675,10 @@ async fn start_oauth(
 /// Without the `mcp` feature there is no OAuth transport, so starting a sign-in
 /// is "not wired" (the console's Sign in button degrades gracefully).
 #[cfg(not(feature = "mcp"))]
-async fn start_oauth(company: ScopedCompany, Path(NamePath { name }): Path<NamePath>) -> Response {
+async fn start_oauth(
+    company: AdminScopedCompany,
+    Path(NamePath { name }): Path<NamePath>,
+) -> Response {
     let _ = (company, name);
     crate::server::ops::not_wired("mcp oauth")
 }

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -44,7 +44,7 @@ pub mod workspace;
 #[cfg(feature = "oauth")]
 pub mod connections;
 
-pub(crate) use scope::{ScopedCompany, scoped};
+pub(crate) use scope::{AdminScopedCompany, ScopedCompany, scoped};
 
 #[cfg(test)]
 mod test;

--- a/src/server/ops/scope.rs
+++ b/src/server/ops/scope.rs
@@ -9,6 +9,16 @@
 //! - `…/companies/{id}` → [`CompanyAuth`] + `authorize_address`
 //!   (a tenant token may only address a company it owns).
 //! - `…/company` → [`OperatorAuth`] + [`CompanyRegistry::sole`].
+//!
+//! ## Addressing is not authority
+//!
+//! [`ScopedCompany`] answers "may this principal talk to this company at all",
+//! and nothing more. It is the right guard for the many writes this product
+//! deliberately leaves open to **any** member — sending a chat message, opening
+//! a task, adding a teammate. It is the wrong guard, on its own, for a write
+//! that decides something *on behalf of* the company. For those,
+//! [`AdminScopedCompany`] puts the role check in the handler's signature rather
+//! than leaving it to a call the handler has to remember to make (issue #403).
 
 use std::sync::Arc;
 
@@ -23,8 +33,9 @@ use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
 use crate::ports::types::{Actor, ActorKind, CompanyId};
 use crate::server::error::ApiError;
-use crate::server::graphql::auth::GqlAuth;
+use crate::server::graphql::auth::{GqlAuth, UserPrincipal};
 use crate::server::platform_auth::{CompanyAuth, authorize_address, refuse_until_password_changed};
+use crate::server::users::admin::require_admin;
 
 /// Registers `mr` under both the `{id}` platform form and the single-company
 /// alias. `suffix` is the path after the scope prefix (e.g. `"/tasks"` or
@@ -112,5 +123,56 @@ impl FromRequestParts<AppState> for ScopedCompany {
             GqlAuth::Platform(_) => None,
         };
         Ok(ScopedCompany { runtime, actor })
+    }
+}
+
+/// The company a write targets, resolved exactly as [`ScopedCompany`] does and
+/// then narrowed to a principal who **administers** that company (issue #403).
+///
+/// Use this for a write that settles something on the company's behalf — what
+/// credential its agents present, which third-party account they act through —
+/// as opposed to a write a member makes for themselves. Stating the requirement
+/// in the extractor is the point: a route declares its authority in its
+/// signature, so the guard cannot be lost by editing a handler body, and a new
+/// route cannot acquire this class of gap by simply forgetting a call.
+///
+/// It composes with [`require_admin`] rather than restating it, so "who may
+/// administer this company" stays decided in exactly one place. Note what that
+/// inherits: [`require_admin`] resolves through a **human** session only, so a
+/// machine credential (the platform scope) is refused here as unauthenticated.
+/// That is deliberate — this extractor's whole purpose is to name the person
+/// accountable for the change, and a token names nobody.
+pub(crate) struct AdminScopedCompany {
+    /// The resolved runtime for the addressed company.
+    pub(crate) runtime: Arc<CompanyRuntime>,
+    /// The admin behind the request. Always a real person — see the type docs.
+    pub(crate) admin: UserPrincipal,
+}
+
+impl AdminScopedCompany {
+    /// The addressed company's id.
+    pub(crate) fn id(&self) -> &CompanyId {
+        self.runtime.id()
+    }
+
+    /// The admin as a journal [`Actor`], for attributing the write they made.
+    pub(crate) fn actor(&self) -> Actor {
+        Actor {
+            kind: ActorKind::User,
+            id: self.admin.user_id.clone(),
+        }
+    }
+}
+
+impl FromRequestParts<AppState> for AdminScopedCompany {
+    type Rejection = Response;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let ScopedCompany { runtime, .. } = ScopedCompany::from_request_parts(parts, state).await?;
+        let admin = require_admin(&parts.headers, state, &runtime).await?;
+        Ok(AdminScopedCompany { runtime, admin })
     }
 }

--- a/src/server/ops/scope.rs
+++ b/src/server/ops/scope.rs
@@ -17,8 +17,18 @@
 //! deliberately leaves open to **any** member — sending a chat message, opening
 //! a task, adding a teammate. It is the wrong guard, on its own, for a write
 //! that decides something *on behalf of* the company. For those,
-//! [`AdminScopedCompany`] puts the role check in the handler's signature rather
-//! than leaving it to a call the handler has to remember to make (issue #403).
+//! [`AdminScopedCompany`] puts the authority check in the handler's signature
+//! rather than leaving it to a call the handler has to remember to make (issue
+//! #403).
+//!
+//! Note what the pair is **not**: a read-scope / write-scope split. "Write" and
+//! "requires authority" are different questions here, and this product answers
+//! them differently on purpose — a member may open a task, post to a
+//! discussion, or add a teammate, and gating every write on a role would take
+//! capabilities away that are deliberately theirs. The axis that matters is
+//! whether the write decides something *for the company*, which is why the
+//! second extractor is named for the authority it demands rather than for the
+//! HTTP verb it happens to sit behind.
 
 use std::sync::Arc;
 
@@ -127,26 +137,46 @@ impl FromRequestParts<AppState> for ScopedCompany {
 }
 
 /// The company a write targets, resolved exactly as [`ScopedCompany`] does and
-/// then narrowed to a principal who **administers** that company (issue #403).
+/// then narrowed to a principal entitled to decide **on that company's behalf**
+/// (issue #403).
 ///
-/// Use this for a write that settles something on the company's behalf — what
+/// Use this for a write that settles something for the company — what
 /// credential its agents present, which third-party account they act through —
 /// as opposed to a write a member makes for themselves. Stating the requirement
 /// in the extractor is the point: a route declares its authority in its
 /// signature, so the guard cannot be lost by editing a handler body, and a new
 /// route cannot acquire this class of gap by simply forgetting a call.
 ///
-/// It composes with [`require_admin`] rather than restating it, so "who may
-/// administer this company" stays decided in exactly one place. Note what that
-/// inherits: [`require_admin`] resolves through a **human** session only, so a
-/// machine credential (the platform scope) is refused here as unauthenticated.
-/// That is deliberate — this extractor's whole purpose is to name the person
-/// accountable for the change, and a token names nobody.
+/// ## Who qualifies
+///
+/// Exactly the two principals `docs/spec/runtime/config.md` defines, each held
+/// to what it actually is:
+///
+/// * a **human** whose session says they administer this company. Resolved
+///   through [`require_admin`] rather than restating the rule, so "who may
+///   administer this company" stays decided in one place. A member is `403`.
+/// * the **machine** principal that may address this company — the hosting
+///   control plane. It is *not* refused: it provisions the tenant and holds its
+///   database credentials, so denying it a route it already sits above would be
+///   ceremony rather than a boundary, and it would break the documented
+///   platform principal. What it does not get is anonymity — see below.
+///
+/// ## Attribution is not optional
+///
+/// [`Self::actor`] is infallible by construction: whichever principal got here
+/// is named. A human is [`ActorKind::User`] plus their user id; the machine is
+/// [`ActorKind::System`] plus its tenant. The gap this closes is as much about
+/// unattributed writes as unauthorized ones — a change to what a company
+/// connects through that nobody's name is on is one nobody can review later.
 pub(crate) struct AdminScopedCompany {
     /// The resolved runtime for the addressed company.
     pub(crate) runtime: Arc<CompanyRuntime>,
-    /// The admin behind the request. Always a real person — see the type docs.
-    pub(crate) admin: UserPrincipal,
+    /// The human admin behind the request, when the principal is a person.
+    /// `None` for the machine principal, which is a tenant and not a user.
+    #[allow(dead_code, reason = "carried for handlers that need the person")]
+    pub(crate) admin: Option<UserPrincipal>,
+    /// Who made this change. Always identified — never anonymous.
+    actor: Actor,
 }
 
 impl AdminScopedCompany {
@@ -155,12 +185,9 @@ impl AdminScopedCompany {
         self.runtime.id()
     }
 
-    /// The admin as a journal [`Actor`], for attributing the write they made.
+    /// Who made the change, for attributing it in the journal.
     pub(crate) fn actor(&self) -> Actor {
-        Actor {
-            kind: ActorKind::User,
-            id: self.admin.user_id.clone(),
-        }
+        self.actor.clone()
     }
 }
 
@@ -171,8 +198,37 @@ impl FromRequestParts<AppState> for AdminScopedCompany {
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        let ScopedCompany { runtime, .. } = ScopedCompany::from_request_parts(parts, state).await?;
-        let admin = require_admin(&parts.headers, state, &runtime).await?;
-        Ok(AdminScopedCompany { runtime, admin })
+        // Addressing, company resolution and the temporary-password boundary
+        // are already exactly right; this only adds the authority question on
+        // top of them.
+        let ScopedCompany { runtime, actor } =
+            ScopedCompany::from_request_parts(parts, state).await?;
+        match actor {
+            // A human. `ScopedCompany` keeps the person but drops the role, so
+            // the role has to be re-resolved — which is the whole reason this
+            // class of gap existed.
+            Some(actor) => {
+                let admin = require_admin(&parts.headers, state, &runtime).await?;
+                Ok(AdminScopedCompany {
+                    runtime,
+                    admin: Some(admin),
+                    actor,
+                })
+            }
+            // The machine principal. It already passed `authorize_address`, so
+            // it owns this company (or holds the platform scope). Name it.
+            None => {
+                let CompanyAuth(auth) = CompanyAuth::from_request_parts(parts, state).await?;
+                let actor = Actor {
+                    kind: ActorKind::System,
+                    id: crate::server::platform_auth::acting_tenant(&auth),
+                };
+                Ok(AdminScopedCompany {
+                    runtime,
+                    admin: None,
+                    actor,
+                })
+            }
+        }
     }
 }

--- a/src/server/ops/smtp.rs
+++ b/src/server/ops/smtp.rs
@@ -32,7 +32,7 @@ use crate::ports::types::SecretValue;
 use crate::ports::{generate_id, now_millis};
 use crate::server::error::ApiError;
 use crate::server::ops::mailer::{MailCredentials, OutboundEmail};
-use crate::server::ops::{SMTP_KEY, ScopedCompany, scoped};
+use crate::server::ops::{AdminScopedCompany, SMTP_KEY, scoped};
 
 /// The SMTP security mode. Mirrors the console's `SmtpSecurity`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -145,8 +145,11 @@ async fn store_credentials(
 }
 
 /// `PUT …/smtp` (both scope forms).
+///
+/// Requires authority over the company (issue #403): these credentials are the
+/// address the company's mail goes out as.
 async fn put_smtp(
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     Json(creds): Json<SmtpCredentials>,
 ) -> Result<Json<SmtpStatus>, ApiError> {
     store_credentials(company.runtime, creds).await
@@ -263,8 +266,13 @@ pub fn local_part(address: &str) -> String {
 }
 
 /// `POST …/smtp/test` (both scope forms).
+///
+/// Requires authority over the company (issue #403). Grouped with the write
+/// rather than with the read-only probes because the caller chooses the
+/// recipient: it sends real mail from the company's address to an address
+/// supplied in the request body.
 async fn test_smtp(
-    company: ScopedCompany,
+    company: AdminScopedCompany,
     State(state): State<AppState>,
     body: Option<Json<TestSend>>,
 ) -> Result<Json<TestResult>, Response> {

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -4952,3 +4952,183 @@ async fn concurrent_reparents_cannot_race_a_cycle_onto_the_board() {
         .count();
     assert_eq!(parented, 1, "a cycle reached the board: {board}");
 }
+
+// ---------------------------------------------------------------------------
+// Who may decide on the company's behalf (issue #403)
+// ---------------------------------------------------------------------------
+
+/// Sends with an explicit cookie, so the role boundary can be driven with a
+/// member session rather than the harness admin.
+async fn send_cookie(
+    state: &AppState,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+    cookie: &str,
+) -> (StatusCode, Value) {
+    let request = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("cookie", cookie);
+    let request = match body {
+        Some(body) => request
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap(),
+        None => request.body(Body::empty()).unwrap(),
+    };
+    let response = router(state.clone()).oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, value)
+}
+
+/// Every route that decides what this company reaches the outside world *as* —
+/// which credential it presents, which third-party account its agents act
+/// through, where its mail and its model calls go — refuses a member.
+///
+/// One table rather than a test per module, on purpose. The gap issue #403
+/// reported was not that one route forgot a check; it was that a whole plane
+/// shared an extractor whose name did not suggest "any member may write". A
+/// per-module test would have let the next route added to that plane be added
+/// without one. This list is the plane, and a new route joins it here.
+///
+/// The assertion is `403` specifically, not merely "not 200": a `404` or a
+/// `409` would also be non-200 while meaning the route simply did not run, and
+/// that would pass a test which proves nothing.
+#[tokio::test]
+async fn a_member_cannot_change_what_the_company_reaches_the_world_as() {
+    let home_dir = home();
+    let state = state_with_company(home_dir.path()).await;
+    let member =
+        crate::server::test_support::seed_session(&state, "acme", crate::ports::UserRole::Member)
+            .await;
+
+    let cases: Vec<(&str, &str, Option<Value>)> = vec![
+        // The company's Composio identity, and the accounts its agents use.
+        (
+            "PUT",
+            "/api/v1/company/composio/token",
+            Some(json!({ "token": "x" })),
+        ),
+        (
+            "POST",
+            "/api/v1/company/composio/authorize",
+            Some(json!({ "toolkit": "gmail" })),
+        ),
+        // The model every agent thinks with, and the key it is billed against.
+        (
+            "PUT",
+            "/api/v1/company/inference",
+            Some(json!({ "provider": "openai_compatible", "baseUrl": "https://example.test" })),
+        ),
+        ("DELETE", "/api/v1/company/inference", None),
+        // The company's outbound mail identity — and a send from its address.
+        (
+            "PUT",
+            "/api/v1/company/smtp",
+            Some(
+                json!({ "provider": "smtp", "host": "mail.example.test", "port": 587,
+                         "username": "u", "password": "p", "from": "a@example.test" }),
+            ),
+        ),
+        (
+            "POST",
+            "/api/v1/company/smtp/test",
+            Some(json!({ "to": "elsewhere@example.test" })),
+        ),
+        (
+            "PUT",
+            "/api/v1/company/domain",
+            Some(json!({"domain": "x.test"})),
+        ),
+        // The Telegram bot the company speaks as, and where its updates land.
+        (
+            "PUT",
+            "/api/v1/company/channels/telegram",
+            Some(json!({ "botToken": "x" })),
+        ),
+        ("DELETE", "/api/v1/company/channels/telegram", None),
+        ("POST", "/api/v1/company/channels/telegram/webhook", None),
+        // Which tool servers exist, and the credentials they carry.
+        (
+            "POST",
+            "/api/v1/company/mcp/servers",
+            Some(json!({ "name": "evil", "endpoint": "https://example.test" })),
+        ),
+        (
+            "PUT",
+            "/api/v1/company/mcp/servers/anything",
+            Some(json!({ "endpoint": "https://example.test" })),
+        ),
+        ("DELETE", "/api/v1/company/mcp/servers/anything", None),
+        (
+            "POST",
+            "/api/v1/company/mcp/servers/anything/oauth/start",
+            None,
+        ),
+    ];
+
+    for (method, uri, body) in cases {
+        let (status, response) = send_cookie(&state, method, uri, body, &member).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "{method} {uri} let a member through: {response}"
+        );
+        assert_eq!(
+            response["code"], "forbidden",
+            "{method} {uri} refused without saying why: {response}"
+        );
+    }
+}
+
+/// The other side, on the same table: the harness admin is refused by none of
+/// them on role grounds.
+///
+/// Several answer `409`/`404`/`502` for their own reasons — no feature in this
+/// build, no such server, no reachable host — and that is the point. What must
+/// never appear is `403`, which would mean the guard caught the wrong person
+/// and the fix had quietly removed the capability instead of assigning it.
+#[tokio::test]
+async fn an_admin_is_refused_by_none_of_them() {
+    let home_dir = home();
+    let state = state_with_company(home_dir.path()).await;
+
+    let cases: Vec<(&str, &str, Option<Value>)> = vec![
+        (
+            "PUT",
+            "/api/v1/company/composio/token",
+            Some(json!({ "token": "x" })),
+        ),
+        (
+            "PUT",
+            "/api/v1/company/domain",
+            Some(json!({"domain": "x.test"})),
+        ),
+        (
+            "PUT",
+            "/api/v1/company/channels/telegram",
+            Some(json!({ "botToken": "x" })),
+        ),
+        (
+            "POST",
+            "/api/v1/company/mcp/servers",
+            Some(json!({ "name": "svc", "endpoint": "https://example.test" })),
+        ),
+    ];
+
+    for (method, uri, body) in cases {
+        let (status, response) = send(&state, method, uri, body).await;
+        assert_ne!(
+            status,
+            StatusCode::FORBIDDEN,
+            "{method} {uri} refused an admin: {response}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Changing what a company's agents connect through is now a decision only someone entitled to make it for the company can make, and every such change records who made it.

Any signed-in member could previously connect a third-party account as the company's, and replace the company's Composio credential — pointing the whole tool surface at an account they control. The audit issue #403 asked for found the same shape on thirteen more routes: the Composio credential was one of fourteen ways to change what the company reaches the world as.

Closes #403.

### The ownership decision

**A connection belongs to the company, and is admin-managed.** The account reached through it is the account the company's *agents* act through, so it is company property in the same sense the roster and the manifest are — not the personal property of whichever member clicked Connect.

This is the position the code already took and did not enforce, which is why I did not treat it as an open question. The native OAuth plane's connect-time identity check (`account_mismatch`, shipped for #316) compares the connected account against `bootstrap_admins` — the company's **admin** addresses. That comparison only makes sense if the connection is the company's. #316 settled "one operator, one connected account"; this is the enforcement layer above it, resolving the same way.

Two consequences, both deliberate:

- **Writes require authority.** A member is refused with a message that says why.
- **Reads stay open to any member.** They carry a tier name and non-secret routing, never a credential. Knowing *that* Gmail is connected is what lets a member understand why an agent can read their mail; being able to change it is the part that needed an owner. This mirrors the roster, where `GET …/team` is open and the budget writes are not. A test pins the split, so a future change to it has to be made on purpose.

### The machine principal: named, not refused

I started by refusing machine credentials outright and reverted that. `docs/spec/runtime/config.md` defines exactly two principals, and gives a platform/tenant bearer the routes of the companies its tenant owns; `credential_route_rejects_foreign_tenant` pins it. The hosting control plane provisions the tenant and holds its database credentials, so denying it a route it already sits above is ceremony rather than a boundary.

So it keeps the routes and loses anonymity instead. `AdminScopedCompany::actor()` is infallible: a human is `User` + user id, a machine is `System` + tenant, and the write is journaled either way. This is the issue's own "cannot set a token, **or if it may, the write is attributed**", taking the second branch.

### Attribution

New `CompanyEvent::ToolAccessChanged { change, toolkit, by }`, journaled after the change lands. A stable wire word (`credential_set` / `credential_cleared` / `provider_authorization_started`), an optional toolkit slug, and the actor — no credential, no URL. `provider_authorization_started` is deliberately *started*: Composio runs its own OAuth with no callback here, so all this host witnesses is that a connect URL was minted, and calling it a completed connection would put an unverified claim in the audit trail.

Unlike the best-effort workflow journaling, a journal failure fails the request. An audit line that quietly fails to be written is the one failure mode that defeats the point. `MemoryFactDeleted` — the other write journaled *for* the audit trail — propagates for the same reason.

### On splitting `ScopedCompany` into read-scope and write-scope

Considered and rejected. "Write" and "requires authority" are different questions here and this product answers them differently on purpose: a member may open a task, post to a discussion, or add a teammate. An extractor keyed on the HTTP verb would have taken capabilities away that are deliberately theirs, and it would have been wrong in a way that is harder to see than the gap it replaced. `AdminScopedCompany` is named for the authority it demands instead, and it makes the class hard to reintroduce for the right reason: a route states its authority in its signature, where it cannot be lost by editing a handler body.

## API Or Behavior Changes

**Behavior change.** These now answer `403 {"code":"forbidden"}` for a non-admin member, where they previously answered `200`:

| Surface | Routes |
|---|---|
| `composio` | `PUT …/composio/token`, `POST …/composio/authorize` |
| `connections` (`oauth`) | `POST …/connections/{p}/start`, `POST …/connections/{p}/disconnect` |
| `inference` | `PUT …/inference`, `DELETE …/inference` |
| `smtp` | `PUT …/smtp`, `POST …/smtp/test` |
| `domain` | `PUT …/domain` |
| `channels` | `PUT`/`DELETE …/channels/telegram`, `POST …/channels/telegram/webhook` |
| `mcp` | `POST …/mcp/servers`, `PUT`/`DELETE …/mcp/servers/{name}`, `POST …/mcp/servers/{name}/oauth/start` |

Unchanged: every read on those surfaces, every admin, and every machine principal. `CompanyEvent` gains an additive variant — both new fields are `skip_serializing_if`, so an already-persisted journal loads and re-serializes byte-for-byte, and `project_event` is deny-by-default so nothing new reaches the console feed.

**Console.** The Connections page and the MCP settings page resolve the viewer and hide the controls behind a refused write. Courtesy, not enforcement — the host is the boundary — but it matters here because the invitation is a password field: a member would otherwise learn they were not allowed only after pasting a live credential into a form that could never submit it.

## The audit (#403 point 4), in full

87 routes are registered through the `scoped` helper. Before this PR, exactly **two** applied a role check: `PUT`/`DELETE …/team/{id}/budget`. This PR brings it to sixteen.

**Changed** — the fourteen in the table above. The line is *the company's outward identity*: what it reaches the world as, and which third-party accounts its agents act through.

**Checked and deliberately left open** — probes over configuration an admin already set, which name no destination of their own: `POST …/inference/test`, `GET …/mcp/servers/{name}/tools`, `POST …/mcp/servers/{name}/test`, `POST …/domain/verify`. `POST …/smtp/test` is *not* in this group and is gated, because the caller supplies the recipient and the mail goes out as the company.

**Checked, needs a product decision, filed as #423** rather than swept in here:

- `DELETE …/team/{agent_id}` — the asymmetry is the tell: setting a teammate's cap is admin-only, deleting the teammate is not.
- `POST …/team` — admin-gated only on the cap-carrying branch.
- `POST …/workflows/{wid}/run`, `PUT …/workflows/{wid}`, `POST …/tasks/{id}/steer` — unbounded spend and side effects with no gate on the trigger.
- `POST …/skills`, `POST …/skills/{slug}/install`, `POST …/memory` — content that lands in agent prompts.
- `GET …/inboxes/{key}/messages` — every agent's full inbound mail bodies, to any member.

**Checked and correct as-is** — the rest of the plane: tasks, board, workspace, artifacts, desks, chat, runs, usage, finances. These are the member writes this product means to allow, and gating them would have been the mistake.

I did not fix #423's rows here because each needs an answer to "what is a member", not a mechanical guard, and bundling them would have made both decisions harder to review.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings` (default lane, as CI runs it)
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --lib` — 1431 passed, 0 failed
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 2032 passed, 0 failed
- [x] `cargo check --locked --all-features --all-targets`
- [x] `git diff --stat Cargo.lock` — empty
- [x] `npm run typecheck`, `npm run build` (no lint or component-test script exists in this repo)

### Unit and integration

- `server::ops::composio` — a member refused on both writes with a reason; an admin unaffected (the authorize route reaches the *build* check and answers `409`, a different axis from the member's `403`); reads open to a member; a machine credential accepted and journaled as `System` + tenant; set and clear journaled as distinct attributed entries with no token in the log.
- `server::ops::write_test::a_member_cannot_change_what_the_company_reaches_the_world_as` — one table over all fourteen routes, asserting `403` specifically rather than "not 200", since a `404` or `409` would also be non-200 while proving the route never ran. Its twin asserts an admin is refused by none of them.

**Both were verified to fail without the fix**, not merely to pass with it: reverting every swept extractor to `ScopedCompany` turns the table test red on the first row, and the three Composio guard tests fail while the read tests stay green.

### On a real host, both layers

Built the binary, served a company with a manifest admin, and signed in two real sessions through the magic-link flow — `ada@` (admin) and an invited `bob@` (member):

- **Member** — all fourteen writes answered `403 {"error":"only an admin can do that","code":"forbidden"}`. Reads intact: `GET …/composio`, `…/inference`, `…/channels/telegram`, `…/mcp/servers`, `…/connections` all `200`; `…/composio/connections` `409` (no feature in this build) rather than `403`, which is what makes the read demonstrably not role-gated.
- **Admin** — same routes, no `403` anywhere: token set `200`, domain `200`, telegram set/clear `200`, MCP add `200` / delete `204`, inference set/revert `200`, and Composio authorize `409` from the build check.
- **The journal on disk** — exactly one `ToolAccessChanged` entry, `by: {kind: user, id: <ada's id>}`. The refused member attempt left no entry (a refused write changed nothing). Grepped the journal for both token values: neither present.

### Console, in a browser

New Playwright spec `connections-authority.spec.ts`, run against that live host with the built console. It signs a member in through the real magic-link flow in its own browser context and asserts the page carries the explanation, offers no credential field (`#composio-token`, `#tg-token`, `#mcp-token` all absent) and no control behind a refused write; the admin half asserts the same page is unchanged for them.

Two things worth reporting from that run rather than hiding:

1. The spec initially failed on a "Sign in" button. It was **the test's fault** — role-name matching is substring by default, and the Settings rail carries a "Who can sign in, and as what" item. Fixed with `exact: true`, and noted in the spec so the next person does not re-derive it.
2. My first attempt to prove the spec could fail did not actually ungate the console (the initial `useState` was still overwritten by the effect, and a second attempt failed to compile so the tests ran against a stale `dist`). Once genuinely ungated and rebuilt, the member test fails as it should. I would not have trusted it otherwise.

## Documentation

- `docs/modules/server/authority.md` — new. The ownership decision, the route table, why the machine principal is named rather than refused, and why this is not a read/write split. Its own file because the server README is already over the repo's 500-line cap; linked from it.
- `docs/spec/runtime/users.md` — the roles table now says what an `admin` means on the write plane, linking to the above.
- Module docs on `ops::composio`, `ops::scope`, and each swept handler carry the reasoning at the call site.

## Notes for the reviewer

- **Diff size in the console files** is mostly re-indentation from wrapping existing JSX blocks in `{canManage && (…)}`. There is no reformatting churn: this repo has no Prettier config and its frontend does not match Prettier's output at any print width, so I hand-formatted to the surrounding style rather than running it.
- **One disagreement with the issue.** It suggested a machine credential might simply be refused. I went the other way for the reasons above, and the issue's own wording allows it. Flagging it explicitly since it is the one place I did not do what was asked.
