### PR TITLE
fix(chat): a failed step says what actually happened, and a parked one is not a failure (#411)

### DIFF
--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -240,10 +240,13 @@ pub struct OutboundMessage {
 }
 
 pub struct TurnStep {
-    pub kind: TurnStepKind,      // tool_call | thinking | note
-    pub status: TurnStepStatus,  // ok | error | running
-    pub label: String,           // display_label, else the tool name
-    pub detail: Option<String>,  // whitelisted enrichment, or a scrubbed cause
+    pub kind: TurnStepKind,           // tool_call | thinking | note
+    pub status: TurnStepStatus,       // ok | error | running | awaiting_approval
+    pub label: String,                // display_label, else the tool name
+    pub detail: Option<String>,       // WHAT IT WAS DOING — redacted arguments
+    pub result: Option<String>,       // WHAT CAME BACK — a summary, or a cause
+    pub failure: Option<TurnStepFailure>,  // WHY IT STOPPED — typed
+    pub truncated: bool,              // the result was cut before it was read
     pub elapsed_ms: Option<u64>,
 }
 ```
@@ -255,12 +258,45 @@ console distinguishes it from a tool-backed one, and how a silently-failed MCP
 call becomes visible (surfaced as an `error` step on the operator bubble rather
 than a vague acknowledgement).
 
-Security: `steps` never carry raw tool arguments, tool output, or call ids —
-only a safe label, a whitelisted/scrubbed detail, and an elapsed time. They are
-never written to the memory store (`memory_loop::outcome_chunk` stays
+A step answers three questions (issue #411). Before it did, a failure was the
+single sentence "Something went wrong with this action.", and a call *blocked
+pending approval*, an *unauthorized* response and a *truncated* result all
+rendered identically:
+
+- **`detail` — what it was doing.** The call's arguments, so two reads of two
+  different files stop looking alike.
+- **`result` — what came back.** An intrinsic OpenCompany tool's own message; a
+  shape (`"12 items"`, `"4.2k characters"`) for anything else; a
+  plain-language cause on a failure.
+- **`failure` — why it stopped**, as a typed `TurnStepFailure`
+  (`unauthorized` · `timeout` · `declined` · `blocked_by_policy` ·
+  `missing_permission` · `missing_app` · `unavailable` · `failed`), projected
+  from OpenHuman's `ToolFailureClass` in one exhaustive match. The console
+  renders a known state; it never pattern-matches the prose in `result`.
+
+Two statuses are **not** failures and must not be counted as such
+(`TurnStepStatus::is_failure` is the one place that question is answered):
+`running` (in flight when the trace stopped) and `awaiting_approval` (the
+approval gate parked the call — it is waiting on a person). `truncated` marks a
+result the harness cut (issue #410): a *success* whose answer is incomplete,
+which no status word can express.
+
+Security: `steps` never carry raw tool **output** or call ids. Arguments reach
+`detail` only through `runtime::approval_display::redact` — the same host-side
+redactor an approval card uses (issue #372), reused rather than re-derived, so
+one denylist governs both surfaces. That is safe because a gated call's
+arguments *are* the parked effect's payload the card already shows; it also
+means #372's documented limit applies here too (the denylist matches on keys, so
+a credential hidden in free text under a benign key is shown on both surfaces by
+the same rule). A remote tool's output never contributes content — only a shape.
+Steps are never written to the memory store (`memory_loop::outcome_chunk` stays
 text-only), so a step detail can never be retrieved and re-injected into a later
 turn. The fold + scrub lives in `src/harness/steps.rs` (compiled under the
 `openhuman` feature). Non-harness brains (echo, medulla) emit no steps.
+
+The same `TurnStep` rows are persisted per attempt by the run trace (issue #242)
+and rendered on **both** surfaces — the chat bubble and the task Attempts tab —
+from one projection, so the two cannot tell an operator different stories.
 
 ## ToolProvider
 

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -4,6 +4,7 @@
 
 import type { OpenCompanyClient } from "./client";
 import type { RunSummary } from "./runs";
+import type { TurnStepFailure } from "./types";
 
 /** A board card as the host returns it. */
 export interface Task {
@@ -92,8 +93,12 @@ export type TimelineKind =
  * glitch: the trace is written *as the turn executes*, so a host killed
  * mid-tool-call leaves that call recorded exactly as it stood. It means
  * in-flight-when-the-trace-stopped — render it as such, never as a failure.
+ *
+ * `awaiting_approval` (#411) is the other non-failure: the call was gated and
+ * is waiting on a person. Use {@link isFailedStep} rather than testing for
+ * "not ok", which would sweep both of these in as failures.
  */
-export type StepStatus = "ok" | "error" | "running";
+export type StepStatus = "ok" | "error" | "running" | "awaiting_approval";
 
 /**
  * One entry on a task's timeline (#185) — the same scrubbed vocabulary the host
@@ -117,8 +122,22 @@ export interface TimelineEntry {
   kind: TimelineKind;
   /** A short, past-tense human label rendered verbatim. */
   label: string;
-  /** Optional scrubbed detail; expands under the row when present. */
+  /**
+   * Optional scrubbed detail; expands under the row when present. On a run
+   * step this is **what the call was doing** — its arguments, redacted
+   * host-side and bounded (#411).
+   */
   detail?: string;
+  /**
+   * On a run step: **what came back** — a shape summary, an intrinsic tool's
+   * own message, or a failure's plain-language cause (#411). Absent on
+   * task-timeline entries, which have no such notion.
+   */
+  result?: string;
+  /** On a run step: the typed reason it did not succeed (#411). */
+  failure?: TurnStepFailure;
+  /** On a run step: the result was cut before the agent read all of it (#410). */
+  truncated?: boolean;
   /**
    * How a run-trace step ended (#242). Absent on task-timeline entries, which
    * have no such notion — so `undefined` means "not a step", never "unknown

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -33,23 +33,96 @@ export interface CompanyStatus {
 /** What kind of processing step this is (drives the timeline icon). */
 export type TurnStepKind = "tool_call" | "thinking" | "note";
 
-/** How a processing step ended. */
-export type TurnStepStatus = "ok" | "error" | "running";
+/**
+ * How a processing step ended.
+ *
+ * `awaiting_approval` (#411) is **not** a failure: the call was gated and is
+ * waiting on a person. It used to arrive as `error`, which made the one step an
+ * operator could act on look like the one thing that had crashed. Anything
+ * counting failures must key on `error` alone — see {@link isFailedStep}.
+ */
+export type TurnStepStatus = "ok" | "error" | "running" | "awaiting_approval";
+
+/**
+ * Why a step did not succeed, in the failure's own terms (#411). Mirrors
+ * `TurnStepFailure` in `src/ports/types.rs`.
+ *
+ * Rendered by lookup, never by reading the prose in `result` — the whole point
+ * is that the console switches on a known state instead of pattern-matching a
+ * sentence. Absent on a success, on a step still `running`, and on a parked
+ * one (its status already says what it is).
+ */
+export type TurnStepFailure =
+  | "declined"
+  | "blocked_by_policy"
+  | "unauthorized"
+  | "missing_permission"
+  | "missing_app"
+  | "timeout"
+  | "unavailable"
+  | "failed";
 
 /**
  * One visible step in an agent turn's processing timeline. Mirrors `TurnStep`
  * in `src/ports/types.rs`. The host folds and scrubs these from the turn's
- * progress stream: `label`/`detail` never carry raw tool arguments, tool
- * output, or call ids — only a safe label and an optional scrubbed detail.
+ * progress stream: nothing here carries raw tool output or call ids, and
+ * arguments reach `detail` only through the host-side redactor an approval card
+ * already uses (#372).
  */
 export interface TurnStep {
   kind: TurnStepKind;
   status: TurnStepStatus;
   label: string;
-  /** A muted, scrubbed detail (e.g. an MCP `server · tool`, a failure cause). */
+  /**
+   * **What the step was doing** — its arguments, redacted host-side and
+   * bounded (#411). This is what tells two calls to the same tool apart.
+   */
   detail?: string;
+  /**
+   * **What came back** — a shape summary (`"12 items"`), an intrinsic tool's
+   * own message, or a failure's plain-language cause (#411). Never a remote
+   * body's content.
+   */
+  result?: string;
+  /** The typed reason the step did not succeed (#411). */
+  failure?: TurnStepFailure;
+  /** The result was cut before the agent could read all of it (#410). */
+  truncated?: boolean;
   /** How long a tool call took, in milliseconds, when known. */
   elapsedMs?: number;
+}
+
+/**
+ * Short, operator-facing copy for each {@link TurnStepFailure}, plus the word
+ * for a parked step.
+ *
+ * One table, used by both render surfaces (the chat bubble's step timeline and
+ * the task Attempts tab), so a failure cannot be named two different things
+ * depending on where you happen to be looking at it.
+ */
+export const STEP_FAILURE_LABEL: Record<TurnStepFailure, string> = {
+  declined: "Declined",
+  blocked_by_policy: "Blocked by policy",
+  unauthorized: "Unauthorized",
+  missing_permission: "Missing permission",
+  missing_app: "App unavailable",
+  timeout: "Timed out",
+  unavailable: "Service unavailable",
+  failed: "Failed",
+};
+
+/** The word for a step waiting on a person. Not a failure. */
+export const AWAITING_APPROVAL_LABEL = "Awaiting approval";
+
+/**
+ * Whether a step counts as **failed**.
+ *
+ * The single place the question is answered on the client, mirroring
+ * `TurnStepStatus::is_failure` on the host. A parked step is deliberately not a
+ * failure (#411).
+ */
+export function isFailedStep(status: TurnStepStatus | undefined): boolean {
+  return status === "error";
 }
 
 /** One channel reply from a cycle. */

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -12,6 +12,7 @@ import {
   useMemo,
   useState,
   type ReactElement,
+  type ReactNode,
 } from "react";
 import {
   AlertCircle,
@@ -69,7 +70,11 @@ import {
   type RunStatus,
   type RunSummary,
 } from "@/api/runs";
-import { ApiError } from "@/api/types";
+import {
+  AWAITING_APPROVAL_LABEL,
+  ApiError,
+  STEP_FAILURE_LABEL,
+} from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
 import {
   AlertDialog,
@@ -1058,6 +1063,10 @@ const KIND_ICON: Record<TimelineKind, ReactElement> = {
 function rowIcon(kind: TimelineKind, status?: StepStatus): ReactElement {
   if (status === "running")
     return <Loader2 className="size-3.5 animate-spin" />;
+  // A parked step is waiting on a person, not broken — it takes the hourglass
+  // the waiting band already uses, never the failure icon (#411).
+  if (status === "awaiting_approval")
+    return <Hourglass className="size-3.5" />;
   if (status === "error") return <AlertCircle className="size-3.5" />;
   return KIND_ICON[kind];
 }
@@ -1065,6 +1074,8 @@ function rowIcon(kind: TimelineKind, status?: StepStatus): ReactElement {
 function kindTone(kind: TimelineKind, status?: StepStatus): string {
   // Outcome first, for the same reason `rowIcon` reads it first.
   if (status === "running") return "text-sky-600 dark:text-sky-400";
+  if (status === "awaiting_approval")
+    return "text-amber-600 dark:text-amber-400";
   if (status === "error") return "text-rose-600 dark:text-rose-400";
   switch (kind) {
     case "completed":
@@ -1157,9 +1168,72 @@ function WaitingBand({ millis, live }: { millis: number; live: boolean }) {
   );
 }
 
+/**
+ * A step's expanded body: **what it was doing** above **what came back** (#411).
+ *
+ * Labelled, because the two used to be one anonymous string and an operator had
+ * no way to tell an argument from an answer. `detail` on a journal entry has no
+ * second half, so it renders alone exactly as it did before.
+ */
+function StepBody({ entry }: { entry: TimelineEntry }) {
+  return (
+    <div className="space-y-1">
+      {entry.detail && (
+        <div>
+          {entry.result && (
+            <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">
+              Called with
+            </div>
+          )}
+          <pre className="whitespace-pre-wrap break-words font-mono text-[11px] text-muted-foreground">
+            {entry.detail}
+          </pre>
+        </div>
+      )}
+      {entry.result && (
+        <div>
+          {entry.detail && (
+            <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">
+              Result
+            </div>
+          )}
+          <pre className="whitespace-pre-wrap break-words font-mono text-[11px] text-muted-foreground">
+            {entry.result}
+            {entry.truncated && " (cut short)"}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** A small state chip on a timeline row. Mirrors the chat timeline's. */
+function StepStateChip({
+  tone,
+  children,
+}: {
+  tone: "amber" | "rose";
+  children: ReactNode;
+}) {
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded px-1 py-px text-[10px] font-medium",
+        tone === "amber"
+          ? "bg-amber-500/15 text-amber-700 dark:text-amber-400"
+          : "bg-rose-500/15 text-rose-700 dark:text-rose-400",
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
 function TimelineRow({ group }: { group: TimelineGroup }) {
   const [open, setOpen] = useState(false);
-  const details = group.entries.filter((e) => e.detail);
+  // A step that only reports what came back is still worth expanding — "how far
+  // did it get" lives in `result`, not just in `detail` (#411).
+  const details = group.entries.filter((e) => e.detail || e.result);
   const expandable = details.length > 0 || group.count > 1;
   const first = group.entries[0];
 
@@ -1179,18 +1253,41 @@ function TimelineRow({ group }: { group: TimelineGroup }) {
         <span className="min-w-0 flex-1 truncate font-medium">
           {group.label}
         </span>
+        {/* The typed state a step reached, by lookup rather than by reading its
+            prose (#411). Only on a single row — a ×N group's entries can differ
+            and one chip would have to speak for all of them. */}
+        {group.count === 1 && first.status === "awaiting_approval" && (
+          <StepStateChip tone="amber">{AWAITING_APPROVAL_LABEL}</StepStateChip>
+        )}
+        {group.count === 1 && first.failure && (
+          <StepStateChip tone="rose">
+            {STEP_FAILURE_LABEL[first.failure]}
+          </StepStateChip>
+        )}
+        {group.count === 1 && first.truncated && (
+          <StepStateChip tone="amber">Result cut</StepStateChip>
+        )}
         {group.count > 1 && (
           <Badge variant="outline" className="shrink-0 font-normal">
             ×{group.count}
           </Badge>
         )}
-        {/* A run step's own duration (#242); journal entries carry none. */}
-        {group.count === 1 && first.elapsedMs !== undefined && (
-          <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
-            {first.elapsedMs < 1000
-              ? `${first.elapsedMs}ms`
-              : formatDuration(first.elapsedMs)}
+        {/* A run step's own duration (#242); journal entries carry none. A
+            gated call never ran, so its 0ms is the absence of a measurement
+            rather than a fast one (#411). */}
+        {group.count === 1 && first.status === "awaiting_approval" ? (
+          <span className="shrink-0 text-[11px] text-muted-foreground">
+            didn't run
           </span>
+        ) : (
+          group.count === 1 &&
+          first.elapsedMs !== undefined && (
+            <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+              {first.elapsedMs < 1000
+                ? `${first.elapsedMs}ms`
+                : formatDuration(first.elapsedMs)}
+            </span>
+          )
         )}
         <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
           {timeOf(first.atMillis)}
@@ -1210,21 +1307,10 @@ function TimelineRow({ group }: { group: TimelineGroup }) {
                   <div className="mb-0.5 text-muted-foreground">
                     {timeOf(e.atMillis)}
                   </div>
-                  {e.detail && (
-                    <pre className="whitespace-pre-wrap break-words font-mono text-[11px] text-muted-foreground">
-                      {e.detail}
-                    </pre>
-                  )}
+                  <StepBody entry={e} />
                 </div>
               ))
-            : details.map((e) => (
-                <pre
-                  key={e.seq}
-                  className="whitespace-pre-wrap break-words font-mono text-[11px] text-muted-foreground"
-                >
-                  {e.detail}
-                </pre>
-              ))}
+            : details.map((e) => <StepBody key={e.seq} entry={e} />)}
         </div>
       )}
     </li>

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -1241,7 +1241,7 @@ function TimelineRow({ group }: { group: TimelineGroup }) {
     <li className="rounded-lg border bg-card">
       <button
         className={cn(
-          "flex w-full items-center gap-2 px-3 py-2 text-left text-xs",
+          "flex w-full flex-wrap items-center gap-2 px-3 py-2 text-left text-xs",
           expandable ? "cursor-pointer" : "cursor-default",
         )}
         disabled={!expandable}
@@ -1250,7 +1250,10 @@ function TimelineRow({ group }: { group: TimelineGroup }) {
         <span className={cn("shrink-0", kindTone(group.kind, group.status))}>
           {rowIcon(group.kind, group.status)}
         </span>
-        <span className="min-w-0 flex-1 truncate font-medium">
+        {/* A floor, not just `min-w-0`: a row carrying a state chip AND a
+            duration would otherwise squeeze the label to "Workspa…", hiding
+            the one thing that says which step this is. */}
+        <span className="min-w-[7rem] flex-1 truncate font-medium">
           {group.label}
         </span>
         {/* The typed state a step reached, by lookup rather than by reading its

--- a/frontend/src/views/chat/StepTimeline.tsx
+++ b/frontend/src/views/chat/StepTimeline.tsx
@@ -1,7 +1,23 @@
 import { useState } from "react";
-import { AlertTriangle, Brain, ChevronDown, ChevronRight, SquareKanban, Wrench, type LucideIcon } from "lucide-react";
+import {
+  AlertTriangle,
+  Brain,
+  ChevronDown,
+  ChevronRight,
+  Hourglass,
+  Scissors,
+  SquareKanban,
+  Wrench,
+  type LucideIcon,
+} from "lucide-react";
 
-import type { TurnStep, TurnStepKind } from "@/api/types";
+import {
+  AWAITING_APPROVAL_LABEL,
+  STEP_FAILURE_LABEL,
+  isFailedStep,
+  type TurnStep,
+  type TurnStepKind,
+} from "@/api/types";
 import { cn } from "@/lib/utils";
 
 /**
@@ -25,9 +41,13 @@ export function StepTimeline({
   steps: TurnStep[];
   defaultOpen?: boolean;
 }) {
-  const failed = steps.filter((s) => s.status === "error").length;
+  const failed = steps.filter((s) => isFailedStep(s.status)).length;
+  // A parked step is counted and surfaced separately — it is not a failure, and
+  // it is the most actionable thing in the list, so it must not hide behind a
+  // collapsed summary either (#411).
+  const parked = steps.filter((s) => s.status === "awaiting_approval").length;
   const hasError = failed > 0;
-  const [open, setOpen] = useState(defaultOpen || hasError);
+  const [open, setOpen] = useState(defaultOpen || hasError || parked > 0);
 
   if (steps.length === 0) return null;
 
@@ -39,13 +59,18 @@ export function StepTimeline({
         aria-expanded={open}
         className={cn(
           "flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] font-medium transition-colors hover:bg-accent/60",
-          hasError ? "text-destructive" : "text-muted-foreground",
+          hasError
+            ? "text-destructive"
+            : parked > 0
+              ? "text-amber-600 dark:text-amber-400"
+              : "text-muted-foreground",
         )}
       >
         {open ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
         <span>
           {steps.length} step{steps.length === 1 ? "" : "s"}
           {failed > 0 && ` · ${failed} failed`}
+          {parked > 0 && ` · ${parked} awaiting approval`}
         </span>
       </button>
       {open && (
@@ -60,22 +85,66 @@ export function StepTimeline({
 }
 
 function StepRow({ step }: { step: TurnStep }) {
-  const error = step.status === "error";
-  const Icon = stepIcon(step.kind);
+  const error = isFailedStep(step.status);
+  const parked = step.status === "awaiting_approval";
+  const Icon = parked ? Hourglass : stepIcon(step.kind);
   return (
     <li
       className={cn(
-        "flex items-center gap-1.5 text-[11px] leading-relaxed",
-        error ? "text-destructive" : "text-muted-foreground",
+        "flex flex-col gap-0.5 text-[11px] leading-relaxed",
+        error
+          ? "text-destructive"
+          : parked
+            ? "text-amber-600 dark:text-amber-400"
+            : "text-muted-foreground",
       )}
     >
-      <Icon className={cn("size-3 shrink-0", step.status === "running" && "animate-pulse")} />
-      <span className={cn("font-medium", !error && "text-foreground/80")}>{step.label}</span>
-      {step.detail && <span className="min-w-0 truncate">— {step.detail}</span>}
-      {typeof step.elapsedMs === "number" && (
-        <span className="ml-auto shrink-0 tabular-nums opacity-70">{formatElapsed(step.elapsedMs)}</span>
+      <div className="flex items-center gap-1.5">
+        <Icon className={cn("size-3 shrink-0", step.status === "running" && "animate-pulse")} />
+        <span className={cn("font-medium", !error && !parked && "text-foreground/80")}>
+          {step.label}
+        </span>
+        {/* The typed state, rendered by lookup — never by reading `result`. */}
+        {parked && <StepChip tone="amber">{AWAITING_APPROVAL_LABEL}</StepChip>}
+        {step.failure && <StepChip tone="rose">{STEP_FAILURE_LABEL[step.failure]}</StepChip>}
+        {step.truncated && (
+          <StepChip tone="amber">
+            <Scissors className="size-2.5 shrink-0" aria-hidden />
+            Result cut
+          </StepChip>
+        )}
+        {step.detail && <span className="min-w-0 truncate">— {step.detail}</span>}
+        <span className="ml-auto shrink-0 tabular-nums opacity-70">
+          {formatElapsed(step.elapsedMs, step.status)}
+        </span>
+      </div>
+      {/* What came back, on its own line: it is the answer to "how far did we
+          get", and inlining it would push the arguments off the row. */}
+      {step.result && (
+        <span className="min-w-0 truncate pl-[18px] opacity-80">{step.result}</span>
       )}
     </li>
+  );
+}
+
+function StepChip({
+  tone,
+  children,
+}: {
+  tone: "amber" | "rose";
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      className={cn(
+        "flex shrink-0 items-center gap-1 rounded px-1 py-px text-[10px] font-medium",
+        tone === "amber"
+          ? "bg-amber-500/15 text-amber-700 dark:text-amber-400"
+          : "bg-rose-500/15 text-rose-700 dark:text-rose-400",
+      )}
+    >
+      {children}
+    </span>
   );
 }
 
@@ -92,7 +161,17 @@ function stepIcon(kind: TurnStepKind): LucideIcon {
   }
 }
 
-function formatElapsed(ms: number): string {
+/**
+ * A step's duration.
+ *
+ * A gated call never ran, so it reports `0ms` — which read identically to a
+ * fast success and was one of the things #411 called out. Say "didn't run"
+ * instead: a duration of zero on a step that never left the process is not a
+ * measurement, it is the absence of one.
+ */
+function formatElapsed(ms: number | undefined, status: TurnStep["status"]): string {
+  if (status === "awaiting_approval") return "didn't run";
+  if (typeof ms !== "number") return "";
   return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`;
 }
 

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -1332,6 +1332,7 @@ impl HarnessBrain {
                 label: format!("MCP: {} unavailable", failure.server),
                 detail: Some(failure.scrubbed_message.clone()),
                 elapsed_ms: None,
+                ..TurnStep::default()
             });
             if let Some(events) = self.deps.events.as_ref() {
                 // Best-effort **per failure**. `drain` is a `mem::take`, so the

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -83,6 +83,17 @@ use crate::ports::UsageMeter;
 use crate::ports::types::{CompanyId, Effect, EffectGroup};
 use crate::runtime::grants::{GrantSet, GrantedCall};
 
+/// The name openhuman knows this policy by, and the name it stamps into the
+/// refusal it hands the model when a call is gated
+/// (`"…requires approval under policy 'opencompany-approval'"`).
+///
+/// A constant rather than a literal because issue #411's step classifier keys
+/// on it: that is how a parked call is told apart from every other blocked one
+/// and rendered as *waiting on you* rather than as a crash. Naming it here
+/// means the producer and the reader share one definition instead of two
+/// copies of a string that can silently drift.
+pub const POLICY_NAME: &str = "opencompany-approval";
+
 /// Most approval requests parked out of a single turn. A model that keeps
 /// re-trying a blocked tool (openhuman feeds it a refusal and lets it continue)
 /// must not be able to flood the operator's queue, so the drain is bounded the
@@ -608,7 +619,7 @@ impl ApprovalPolicy {
 #[async_trait]
 impl ToolPolicy for ApprovalPolicy {
     fn name(&self) -> &str {
-        "opencompany-approval"
+        POLICY_NAME
     }
 
     async fn check(&self, request: &ToolPolicyRequest) -> ToolPolicyDecision {

--- a/src/harness/steps.rs
+++ b/src/harness/steps.rs
@@ -12,23 +12,59 @@
 //!
 //! Compiled only under `feature = "openhuman"`.
 //!
+//! ## What a step answers (issue #411)
+//!
+//! A step used to be a name, a duration and — on failure — the words "Something
+//! went wrong with this action." Three different, differently-fixable failures
+//! rendered identically, and the host knew which was which the whole time. A
+//! step now answers three questions instead of none:
+//!
+//! * **What was it doing** — [`TurnStep::detail`], a bounded rendering of the
+//!   call's arguments, so two reads of two different files stop looking alike.
+//! * **What came back** — [`TurnStep::result`]: an intrinsic tool's own message,
+//!   or for everything else a *shape* (`"12 items"`, `"2.4k characters"`) and
+//!   never its content.
+//! * **Why it stopped** — [`TurnStep::failure`], a **typed**
+//!   [`TurnStepFailure`], mapped from OpenHuman's `ToolFailureClass` in one
+//!   exhaustive `match`. The console renders a known state; it never
+//!   pattern-matches prose.
+//!
+//! Plus two states that were previously invisible:
+//!
+//! * **Parked, not broken.** A call the approval policy gated is
+//!   [`TurnStepStatus::AwaitingApproval`], not an error, and is not counted as
+//!   one. See [`is_awaiting_approval`] for how it is recognised — and for why
+//!   the two needles it keys on are each pinned by a test.
+//! * **Cut, not complete.** A result the harness truncated sets
+//!   [`TurnStep::truncated`] (issue #410). A success whose answer is incomplete
+//!   is a state no status word can express, which is exactly how #410 stayed
+//!   hidden.
+//!
 //! ## Security (the whole reason this is a separate, unit-tested module)
 //!
-//! The wire shape carries **no raw tool arguments, no tool output, and no call
-//! ids** — only a label, an optional scrubbed detail, and an elapsed time. Three
-//! rules enforce that:
+//! The wire shape carries **no raw tool output and no call ids**. Arguments are
+//! carried, but only through the host's *existing* redactor:
 //!
 //! * **Label** comes from the tool's server-computed `display_label`, else its
 //!   tool *name* — never from arguments or output.
-//! * **Detail on success** is *whitelist-only* enrichment: a fixed per-tool set
-//!   of structural fields (`mcp_call_tool → server·tool`, `delegate_to_desk →
-//!   desk`, `spawn_task → title`). An unknown tool contributes nothing, and the
-//!   nested remote `arguments` of an MCP call are never read — that is exactly
-//!   the re-injection surface this avoids.
-//! * **Detail on failure** is the classifier's plain-language
-//!   [`cause_plain`](oh::tool_status::ClassifiedFailure::cause_plain) when
-//!   present, else the `sanitize_tool_output` **class** string (`"tool: failed
-//!   (timeout)"`) — never the remote error text.
+//! * **Detail** (arguments) is passed through
+//!   [`approval_display::redact`](crate::runtime::approval_display::redact) —
+//!   issue #372's host-side redactor — and then bounded. This is a deliberate
+//!   widening of the old whitelist-only rule, and it is **not** a second
+//!   redaction surface: an approval card already shows an operator this exact
+//!   object, because a gated call's arguments *are* the parked effect's payload
+//!   ([`ApprovalPolicy::effect_for`](crate::harness::policy::ApprovalPolicy::effect_for)).
+//!   Re-deriving a stricter rule here would have created the drift the issue
+//!   forbids. It follows that #372's documented limit applies here too: the
+//!   denylist matches on **keys**, so a credential hidden in free text under a
+//!   benign key is shown, on both surfaces, by the same rule.
+//! * **Result on success** is never the output's content for a remote tool —
+//!   only its shape. An intrinsic OpenCompany tool's output *is*
+//!   OpenCompany-authored operator copy, so it is surfaced bounded, exactly as
+//!   its failure message already was.
+//! * **Result on failure** is the classifier's plain-language
+//!   [`cause_plain`](oh::tool_status::ClassifiedFailure::cause_plain), or an
+//!   intrinsic tool's own message — never the remote error text.
 //!
 //! The unit test `planted_secret_never_reaches_serialized_steps` proves it end
 //! to end: a secret planted in a tool's output, its nested arguments, and its
@@ -41,21 +77,17 @@
 use openhuman_core::openhuman as oh;
 use serde_json::Value;
 
-use oh::agent::hooks::sanitize_tool_output;
 use oh::agent::progress::AgentProgress;
-use oh::tool_status::ClassifiedFailure;
+use oh::tool_status::{ClassifiedFailure, ToolFailureClass};
 
-use crate::ports::types::{TurnStep, TurnStepKind, TurnStepStatus};
+use crate::harness::policy::POLICY_NAME;
+use crate::ports::types::{TurnStep, TurnStepFailure, TurnStepKind, TurnStepStatus};
+use crate::runtime::approval_display;
 use crate::turn_stream::TurnStreamEvent;
 
 /// Hard cap on the number of steps carried back to the operator. A runaway turn
 /// (a tight tool loop) is truncated to this many, plus one omission note.
 const MAX_STEPS: usize = 50;
-
-/// A `spawn_task` title is truncated to this many chars before it becomes a
-/// step detail — a title is agent-authored free text, so it is bounded even
-/// though it is whitelisted.
-const TITLE_MAX: usize = 80;
 
 /// Fold an ordered progress stream into the scrubbed [`TurnStep`] timeline.
 ///
@@ -92,8 +124,7 @@ pub fn fold_steps(events: Vec<AgentProgress>) -> Vec<TurnStep> {
                     kind: TurnStepKind::ToolCall,
                     status: TurnStepStatus::Running,
                     label: label_for(display_label, &tool_name),
-                    detail: None,
-                    elapsed_ms: None,
+                    ..TurnStep::default()
                 };
                 running.insert(call_id, steps.len());
                 steps.push(step);
@@ -109,32 +140,29 @@ pub fn fold_steps(events: Vec<AgentProgress>) -> Vec<TurnStep> {
                 ..
             } => {
                 thinking_open = false;
-                let status = if success {
-                    TurnStepStatus::Ok
-                } else {
-                    TurnStepStatus::Error
-                };
-                let detail = if success {
-                    enrich_detail(&tool_name, arguments.as_ref())
-                } else {
-                    error_detail(failure.as_ref(), &output, &tool_name)
-                };
+                let done = complete(
+                    &tool_name,
+                    success,
+                    &output,
+                    arguments.as_ref(),
+                    failure.as_ref(),
+                );
 
                 if let Some(idx) = running.remove(&call_id) {
                     // Finalize the paired start in place, keeping its label.
                     let step = &mut steps[idx];
-                    step.status = status;
                     step.elapsed_ms = Some(elapsed_ms);
-                    step.detail = detail;
+                    done.apply(step);
                 } else {
                     // A completion with no observed start — surface it standalone.
-                    steps.push(TurnStep {
+                    let mut step = TurnStep {
                         kind: TurnStepKind::ToolCall,
-                        status,
                         label: humanize(&tool_name),
-                        detail,
                         elapsed_ms: Some(elapsed_ms),
-                    });
+                        ..TurnStep::default()
+                    };
+                    done.apply(&mut step);
+                    steps.push(step);
                 }
             }
             // The first thinking delta of a run opens one label-only step.
@@ -145,8 +173,7 @@ pub fn fold_steps(events: Vec<AgentProgress>) -> Vec<TurnStep> {
                     kind: TurnStepKind::Thinking,
                     status: TurnStepStatus::Ok,
                     label: "Thinking".to_string(),
-                    detail: None,
-                    elapsed_ms: None,
+                    ..TurnStep::default()
                 });
                 thinking_open = true;
             }
@@ -172,8 +199,7 @@ pub fn fold_steps(events: Vec<AgentProgress>) -> Vec<TurnStep> {
                 "{omitted} more step{} omitted",
                 if omitted == 1 { "" } else { "s" }
             ),
-            detail: None,
-            elapsed_ms: None,
+            ..TurnStep::default()
         });
     }
 
@@ -254,8 +280,7 @@ impl StepTrace {
                         kind: TurnStepKind::ToolCall,
                         status: TurnStepStatus::Running,
                         label,
-                        detail: None,
-                        elapsed_ms: None,
+                        ..TurnStep::default()
                     },
                 ))
             }
@@ -270,32 +295,27 @@ impl StepTrace {
                 ..
             } => {
                 self.thinking_open = false;
-                let status = if *success {
-                    TurnStepStatus::Ok
-                } else {
-                    TurnStepStatus::Error
-                };
-                let detail = if *success {
-                    enrich_detail(tool_name, arguments.as_ref())
-                } else {
-                    error_detail(failure.as_ref(), output, tool_name)
-                };
+                let done = complete(
+                    tool_name,
+                    *success,
+                    output,
+                    arguments.as_ref(),
+                    failure.as_ref(),
+                );
                 let (seq, label) = match self.running.remove(call_id) {
                     Some(found) => found,
                     // No observed start — surface it standalone, exactly as the
                     // fold does.
                     None => (self.claim(), humanize(tool_name)),
                 };
-                Some((
-                    seq,
-                    TurnStep {
-                        kind: TurnStepKind::ToolCall,
-                        status,
-                        label,
-                        detail,
-                        elapsed_ms: Some(*elapsed_ms),
-                    },
-                ))
+                let mut step = TurnStep {
+                    kind: TurnStepKind::ToolCall,
+                    label,
+                    elapsed_ms: Some(*elapsed_ms),
+                    ..TurnStep::default()
+                };
+                done.apply(&mut step);
+                Some((seq, step))
             }
             AgentProgress::ThinkingDelta { .. } if !self.thinking_open => {
                 self.thinking_open = true;
@@ -305,8 +325,7 @@ impl StepTrace {
                         kind: TurnStepKind::Thinking,
                         status: TurnStepStatus::Ok,
                         label: "Thinking".to_string(),
-                        detail: None,
-                        elapsed_ms: None,
+                        ..TurnStep::default()
                     },
                 ))
             }
@@ -364,13 +383,10 @@ pub(crate) fn stream_event_from(
             Some(TurnStreamEvent {
                 kind: "tool_call",
                 seq,
-                agent_id: None,
-                chat_id: None,
                 tool_call_id: Some(call_id.clone()),
                 label: Some(label_for(display_label.clone(), tool_name)),
-                detail: None,
                 status: Some("running"),
-                elapsed_ms: None,
+                ..TurnStreamEvent::default()
             })
         }
         AgentProgress::ToolCallCompleted {
@@ -384,24 +400,28 @@ pub(crate) fn stream_event_from(
             ..
         } => {
             *thinking_open = false;
-            let (status, detail) = if *success {
-                ("ok", enrich_detail(tool_name, arguments.as_ref()))
-            } else {
-                ("error", error_detail(failure.as_ref(), output, tool_name))
-            };
+            let done = complete(
+                tool_name,
+                *success,
+                output,
+                arguments.as_ref(),
+                failure.as_ref(),
+            );
             Some(TurnStreamEvent {
                 kind: "tool_result",
                 seq,
-                agent_id: None,
-                chat_id: None,
                 tool_call_id: Some(call_id.clone()),
                 // A label so a completion with no observed start still renders;
                 // the common case pairs by `tool_call_id` and keeps the running
                 // row's richer label.
                 label: Some(humanize(tool_name)),
-                detail,
-                status: Some(status),
+                detail: done.detail,
+                result: done.result,
+                failure: done.failure,
+                truncated: done.truncated,
+                status: Some(done.status.wire_word()),
                 elapsed_ms: Some(*elapsed_ms),
+                ..TurnStreamEvent::default()
             })
         }
         // The first thinking delta of a run opens ONE coalesced "Thinking" frame,
@@ -414,13 +434,9 @@ pub(crate) fn stream_event_from(
             Some(TurnStreamEvent {
                 kind: "thinking",
                 seq,
-                agent_id: None,
-                chat_id: None,
-                tool_call_id: None,
                 label: Some("Thinking".to_string()),
-                detail: None,
                 status: Some("ok"),
-                elapsed_ms: None,
+                ..TurnStreamEvent::default()
             })
         }
         // Visible assistant text closes a thinking run (the reply is the bubble
@@ -458,34 +474,13 @@ fn humanize(tool_name: &str) -> String {
     }
 }
 
-/// Whitelist-only success enrichment. Reads a fixed set of structural fields per
-/// known tool from the arguments the crate captured on the *completed* event.
-/// Any other tool — or a missing field — yields `None`. The nested remote
-/// `arguments` of an MCP call are deliberately never read.
-fn enrich_detail(tool_name: &str, arguments: Option<&Value>) -> Option<String> {
-    let args = arguments?;
-    match tool_name {
-        "mcp_call_tool" => {
-            let server = args.get("server").and_then(Value::as_str)?;
-            let tool = args.get("tool").and_then(Value::as_str)?;
-            Some(format!("{server} · {tool}"))
-        }
-        "delegate_to_desk" => args.get("desk").and_then(Value::as_str).map(str::to_string),
-        "spawn_task" => args
-            .get("title")
-            .and_then(Value::as_str)
-            .map(|title| truncate(title, TITLE_MAX)),
-        _ => None,
-    }
-}
-
-/// OpenCompany's own orchestrator tools (issue #112 et al). Their error text is
-/// **OC-authored, operator-facing copy** — the tool's own `ToolResult::error`
-/// message (e.g. "workflow needs exactly one trigger"), not a remote or
-/// untrusted body — so on failure it is safe *and* useful to surface verbatim
-/// (bounded) instead of collapsing to the generic classifier class. Contrast
-/// `mcp_call_tool`, whose output is a remote server body and therefore stays
-/// scrubbed to a class string. Keep this list in lockstep with
+/// OpenCompany's own orchestrator tools (issue #112 et al). Their output is
+/// **OC-authored, operator-facing copy** — the tool's own `ToolResult` message
+/// (e.g. "workflow needs exactly one trigger"), not a remote or untrusted body
+/// — so it is safe *and* useful to surface verbatim (bounded) rather than
+/// collapsing it to a class or a shape. Contrast `mcp_call_tool`, whose output
+/// is a remote server body and therefore never leaves this module as content.
+/// Keep this list in lockstep with
 /// [`orchestrator_tools`](crate::harness::orchestrator::orchestrator_tools).
 const INTRINSIC_TOOLS: &[&str] = &[
     "query_company",
@@ -496,36 +491,315 @@ const INTRINSIC_TOOLS: &[&str] = &[
     "add_agent",
 ];
 
-/// Bound on the OC-authored failure detail surfaced for an intrinsic tool.
-const ERROR_DETAIL_MAX: usize = 200;
+/// Bound on an OC-authored message surfaced as a step result.
+const RESULT_MAX: usize = 200;
 
-/// The detail for a failed tool call.
+/// Bound on the whole rendered argument line.
+const DETAIL_MAX: usize = 140;
+
+/// Bound on one rendered argument *value*, so a single long field cannot
+/// crowd out the fields that distinguish this call from the last one.
+const ARG_VALUE_MAX: usize = 48;
+
+/// How many of an argument object's fields are rendered before the rest become
+/// a `+N more` tail. Enough to tell two calls apart; not a payload dump.
+const MAX_ARG_FIELDS: usize = 4;
+
+/// How deep the argument renderer descends. One level, so an MCP call's nested
+/// remote arguments render as fields rather than as `{3 fields}`, and nothing
+/// below that is walked.
+const MAX_ARG_DEPTH: usize = 1;
+
+/// The needle that identifies OpenHuman's approval-gate refusal, taken from the
+/// `PolicyDenial::ApprovalRequired` render in
+/// `vendor/openhuman/src/openhuman/tinyagents/policy_denial.rs`.
 ///
-/// For an **intrinsic OpenCompany tool** the tool's own output *is* the
-/// actionable, OC-authored reason, so a bounded copy of it is surfaced first —
-/// this is what turns the useless generic "Something went wrong with this
-/// action." into the real cause the operator needs (issue: workflow-create
-/// error masking). For every other tool the rule is unchanged: the classifier's
-/// plain-language cause when present, else the `sanitize_tool_output` **class**
-/// string — never the raw remote error text.
-fn error_detail(
-    failure: Option<&ClassifiedFailure>,
-    output: &str,
+/// This is a string classifier, which is the anti-pattern — the mitigation is
+/// that `approval_needle_still_appears_in_the_vendored_denial_render` reads
+/// that file and fails if the wording drifts, so a rename turns CI red instead
+/// of silently returning every parked call to reading as a crash.
+const APPROVAL_REQUIRED_NEEDLE: &str = "requires approval under policy";
+
+/// What the operator is told when a call is parked. The most actionable line in
+/// the timeline: nothing is broken, and the next move is theirs.
+const AWAITING_APPROVAL_RESULT: &str = "Parked — waiting on your approval before it can run.";
+
+/// Markers the OpenHuman tool pipeline stamps into a result it **cut**, from
+/// the three places that can cut one:
+///
+/// * the per-tool char cap (`middleware.rs`),
+/// * the shared byte budget (`tool_result_artifacts/mod.rs`),
+/// * the artifact envelope that replaces an oversized result with a preview
+///   plus a pointer (same file).
+///
+/// Same string-classifier caveat, same mitigation:
+/// `truncation_markers_still_appear_in_the_vendored_tool_pipeline` reads both
+/// vendored files and fails on drift.
+const TRUNCATION_MARKERS: &[&str] = &[
+    "truncated by tool cap:",
+    "truncated by tool_result_budget",
+    "[tool_result_preview]",
+];
+
+/// Everything a completed tool call contributes to its step, resolved once and
+/// applied identically to the folded timeline, the persisted trace, and the
+/// live stream — so the three views can never tell an operator different
+/// stories about the same call.
+struct Completed {
+    status: TurnStepStatus,
+    detail: Option<String>,
+    result: Option<String>,
+    failure: Option<TurnStepFailure>,
+    truncated: bool,
+}
+
+impl Completed {
+    /// Stamps this outcome onto a step, leaving `kind`, `label` and
+    /// `elapsed_ms` — which the caller owns — untouched.
+    fn apply(self, step: &mut TurnStep) {
+        step.status = self.status;
+        step.detail = self.detail;
+        step.result = self.result;
+        step.failure = self.failure;
+        step.truncated = self.truncated;
+    }
+}
+
+/// Resolve one `ToolCallCompleted` into its status, its typed failure, what it
+/// was doing, and what came back.
+fn complete(
     tool_name: &str,
-) -> Option<String> {
+    success: bool,
+    output: &str,
+    arguments: Option<&Value>,
+    failure: Option<&ClassifiedFailure>,
+) -> Completed {
+    let detail = describe_call(tool_name, arguments);
+
+    if success {
+        return Completed {
+            status: TurnStepStatus::Ok,
+            detail,
+            result: summarize_result(tool_name, output),
+            failure: None,
+            // Only claimed on a success. "The result was cut" is a statement
+            // about a result; a failure's output is an error message, and
+            // reporting a clipped error as a truncated answer would be a
+            // different, false claim.
+            truncated: output_was_truncated(output),
+        };
+    }
+
+    // A gated call is not a failure. Checked before classification because the
+    // classifier has no arm for it and lands it on `Unknown` — which is the
+    // literal "Something went wrong with this action." this issue is about.
+    if is_awaiting_approval(output) {
+        return Completed {
+            status: TurnStepStatus::AwaitingApproval,
+            detail,
+            result: Some(AWAITING_APPROVAL_RESULT.to_string()),
+            failure: None,
+            truncated: false,
+        };
+    }
+
+    // The classifier is the taxonomy. When the harness already ran it, reuse
+    // its verdict; when it did not, run it here rather than falling back to the
+    // coarse `sanitize_tool_output` class string, which could only ever say
+    // "failed (error)".
+    let classified = match failure {
+        Some(f) => f.clone(),
+        None => oh::tool_status::classify(output, false),
+    };
+
+    Completed {
+        status: TurnStepStatus::Error,
+        detail,
+        result: failure_result(tool_name, output, &classified),
+        failure: Some(failure_of(classified.class)),
+        truncated: false,
+    }
+}
+
+/// Map OpenHuman's failure class onto the operator-facing vocabulary.
+///
+/// Exhaustive on purpose: a class added upstream fails to compile here rather
+/// than silently folding into "something went wrong", which is the exact
+/// regression this issue is fixing.
+fn failure_of(class: ToolFailureClass) -> TurnStepFailure {
+    match class {
+        ToolFailureClass::Denied | ToolFailureClass::ApprovalExpired => TurnStepFailure::Declined,
+        ToolFailureClass::BlockedByPolicy => TurnStepFailure::BlockedByPolicy,
+        ToolFailureClass::BadCredentials => TurnStepFailure::Unauthorized,
+        ToolFailureClass::MissingPermission => TurnStepFailure::MissingPermission,
+        ToolFailureClass::MissingApp => TurnStepFailure::MissingApp,
+        ToolFailureClass::Timeout => TurnStepFailure::Timeout,
+        ToolFailureClass::ServiceUnavailable | ToolFailureClass::ModelConnection => {
+            TurnStepFailure::Unavailable
+        }
+        ToolFailureClass::Unknown => TurnStepFailure::Failed,
+    }
+}
+
+/// Whether the model was handed OpenHuman's *approval-required* refusal by
+/// **our** policy.
+///
+/// Both needles are required. The vendored phrase alone would also match a
+/// different `ToolPolicy` on the same host; the policy name alone appears in
+/// every denial our policy issues, including hard denies. Together they mean
+/// precisely "OpenCompany's approval gate parked this call", which is the only
+/// thing that may claim [`TurnStepStatus::AwaitingApproval`].
+fn is_awaiting_approval(output: &str) -> bool {
+    output.contains(APPROVAL_REQUIRED_NEEDLE) && output.contains(POLICY_NAME)
+}
+
+/// Whether the harness cut this result before the agent could read all of it.
+fn output_was_truncated(output: &str) -> bool {
+    TRUNCATION_MARKERS
+        .iter()
+        .any(|marker| output.contains(marker))
+}
+
+/// The plain-language cause for a failed call.
+///
+/// An intrinsic tool's own message wins — it is OC-authored and names the real
+/// problem ("a workflow needs exactly one trigger"), where the classifier can
+/// only offer a category. Everything else gets the classifier's `cause_plain`,
+/// never the raw output.
+fn failure_result(tool_name: &str, output: &str, classified: &ClassifiedFailure) -> Option<String> {
     if INTRINSIC_TOOLS.contains(&tool_name) {
-        let msg = output.trim();
-        if !msg.is_empty() {
-            return Some(truncate(msg, ERROR_DETAIL_MAX));
+        let message = output.trim();
+        if !message.is_empty() {
+            return Some(truncate(message, RESULT_MAX));
         }
     }
-    match failure {
-        Some(f) if !f.cause_plain.trim().is_empty() => Some(f.cause_plain.clone()),
-        _ => {
-            let class = sanitize_tool_output(output, tool_name, false);
-            (!class.trim().is_empty()).then_some(class)
+    let cause = classified.cause_plain.trim();
+    (!cause.is_empty()).then(|| cause.to_string())
+}
+
+/// **What the step was doing**: the call's arguments, redacted by #372's
+/// host-side redactor and rendered as one bounded line.
+///
+/// `None` when the call took no arguments, or when nothing survived rendering —
+/// a step with nothing to say says nothing rather than an empty dash.
+fn describe_call(tool_name: &str, arguments: Option<&Value>) -> Option<String> {
+    let args = arguments?;
+    if matches!(args, Value::Null) {
+        return None;
+    }
+    // Redact FIRST. Everything below only ever reads the redacted copy, so no
+    // rendering path can reach around the denylist.
+    let redacted = approval_display::redact(args);
+
+    // `mcp_call_tool` is reshaped rather than rendered flat: its own fields
+    // name the remote tool (`brave · search`) and its `arguments` field holds
+    // the call that actually distinguishes one invocation from the next. Flat
+    // rendering would spend the whole line on the routing fields and show the
+    // interesting one as `{2 fields}`.
+    if tool_name == "mcp_call_tool" {
+        let head = match (
+            redacted.get("server").and_then(Value::as_str),
+            redacted.get("tool").and_then(Value::as_str),
+        ) {
+            (Some(server), Some(tool)) => Some(format!("{server} · {tool}")),
+            (Some(server), None) => Some(server.to_string()),
+            (None, Some(tool)) => Some(tool.to_string()),
+            (None, None) => None,
+        };
+        let nested = redacted
+            .get("arguments")
+            .and_then(|value| render_value(value, 0));
+        let line = match (head, nested) {
+            (Some(head), Some(nested)) => format!("{head} — {nested}"),
+            (Some(head), None) => head,
+            (None, Some(nested)) => nested,
+            (None, None) => return None,
+        };
+        return Some(truncate(&line, DETAIL_MAX));
+    }
+
+    render_value(&redacted, 0).map(|line| truncate(&line, DETAIL_MAX))
+}
+
+/// Render an **already-redacted** value as one compact line, or `None` when it
+/// carries nothing worth showing.
+fn render_value(value: &Value, depth: usize) -> Option<String> {
+    match value {
+        Value::Null => None,
+        Value::Bool(flag) => Some(flag.to_string()),
+        Value::Number(number) => Some(number.to_string()),
+        Value::String(text) => {
+            // Collapsed to one line first, then bounded: a multi-line argument
+            // must not break the row it is rendered into.
+            let flat = text.replace(['\n', '\r', '\t'], " ");
+            let trimmed = flat.trim();
+            (!trimmed.is_empty()).then(|| truncate(trimmed, ARG_VALUE_MAX))
+        }
+        Value::Array(items) => Some(count_of(items.len(), "item")),
+        Value::Object(map) => {
+            if map.is_empty() {
+                return None;
+            }
+            if depth >= MAX_ARG_DEPTH {
+                return Some(count_of(map.len(), "field"));
+            }
+            let mut parts = Vec::new();
+            for (key, item) in map.iter().take(MAX_ARG_FIELDS) {
+                if let Some(rendered) = render_value(item, depth + 1) {
+                    parts.push(format!("{key}={rendered}"));
+                }
+            }
+            if parts.is_empty() {
+                return None;
+            }
+            let omitted = map.len().saturating_sub(MAX_ARG_FIELDS);
+            if omitted > 0 {
+                parts.push(format!("+{omitted} more"));
+            }
+            Some(parts.join(" · "))
         }
     }
+}
+
+/// **What came back**, on a success.
+///
+/// An intrinsic OpenCompany tool's output is OC-authored copy and is surfaced
+/// bounded. Every other tool's output is a remote body: only its *shape* is
+/// reported, never its content.
+fn summarize_result(tool_name: &str, output: &str) -> Option<String> {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if INTRINSIC_TOOLS.contains(&tool_name) {
+        return Some(truncate(trimmed, RESULT_MAX));
+    }
+    Some(shape_of(trimmed))
+}
+
+/// A content-free description of how much came back: a count when the body is a
+/// JSON collection (the shape that answers "how far did it get"), else a
+/// character size.
+fn shape_of(output: &str) -> String {
+    if let Ok(value) = serde_json::from_str::<Value>(output) {
+        match value {
+            Value::Array(items) => return count_of(items.len(), "item"),
+            Value::Object(map) if !map.is_empty() => return count_of(map.len(), "field"),
+            _ => {}
+        }
+    }
+    let chars = output.chars().count();
+    if chars < 1_000 {
+        count_of(chars, "character")
+    } else {
+        format!("{:.1}k characters", chars as f64 / 1_000.0)
+    }
+}
+
+/// `"1 item"` / `"12 items"` — pluralised counting used by both the argument
+/// renderer and the result shape, so the two read alike.
+fn count_of(count: usize, noun: &str) -> String {
+    format!("{count} {noun}{}", if count == 1 { "" } else { "s" })
 }
 
 /// UTF-8-safe truncation to at most `max` chars, appending `…` when cut.
@@ -541,7 +815,34 @@ fn truncate(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use oh::tool_status::{FailureCategory, ToolFailureClass};
+    use oh::tool_status::FailureCategory;
+
+    /// An obvious fake, in the same shape `approval_display`'s tests use. Never
+    /// a credential pattern that could be mistaken for a real one in a diff.
+    const FAKE_SECRET: &str = "NOT-A-REAL-KEY-planted-for-tests";
+
+    /// The refusal OpenHuman hands the model when *our* approval policy parks a
+    /// call, reproduced in the shape `PolicyDenial::ApprovalRequired::render`
+    /// produces. `PolicyDenial` is crate-private upstream, so this is a copy —
+    /// which is exactly why
+    /// [`approval_needle_still_appears_in_the_vendored_denial_render`] pins the
+    /// needle against the real source.
+    fn approval_refusal(tool: &str) -> String {
+        format!(
+            "Blocked: Tool '{tool}' requires approval under policy '{POLICY_NAME}'. \
+             Reason: '{tool}' has an external effect and this company runs supervised. \
+             Workaround: Ask the user to approve this action, then retry. \
+             Relay this to the user: explain what was blocked and why."
+        )
+    }
+
+    /// Reads a file out of the vendored OpenHuman checkout, for the tests that
+    /// couple a string needle to the source that produces it.
+    fn vendored(relative: &str) -> String {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(relative);
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("vendored source {} is unreadable: {err}", path.display()))
+    }
 
     fn started(call_id: &str, tool: &str, label: Option<&str>) -> AgentProgress {
         AgentProgress::ToolCallStarted {
@@ -600,6 +901,19 @@ mod tests {
         }
     }
 
+    /// Folds a single completed call and hands back its step.
+    fn one(tool: &str, success: bool, output: &str, arguments: Option<Value>) -> TurnStep {
+        let steps = fold_steps(vec![completed(
+            "c1", tool, success, output, arguments, None,
+        )]);
+        assert_eq!(steps.len(), 1, "expected exactly one step: {steps:?}");
+        steps.into_iter().next().expect("a step")
+    }
+
+    // -----------------------------------------------------------------------
+    // Shape of the fold (unchanged by #411)
+    // -----------------------------------------------------------------------
+
     #[test]
     fn pairs_started_and_completed_into_one_step() {
         let steps = fold_steps(vec![
@@ -628,97 +942,6 @@ mod tests {
             completed("c1", "spawn_task", true, "ok", None, None),
         ]);
         assert_eq!(steps[0].label, "Spawn task");
-    }
-
-    #[test]
-    fn enriches_delegate_to_desk_and_spawn_task_from_whitelist() {
-        let steps = fold_steps(vec![
-            completed(
-                "d1",
-                "delegate_to_desk",
-                true,
-                "ok",
-                Some(serde_json::json!({"desk": "engineering", "instruction": "ship it"})),
-                None,
-            ),
-            completed(
-                "s1",
-                "spawn_task",
-                true,
-                "ok",
-                Some(serde_json::json!({"title": "Draft the Q3 plan", "note": "secret-in-note"})),
-                None,
-            ),
-        ]);
-        assert_eq!(steps[0].detail.as_deref(), Some("engineering"));
-        assert_eq!(steps[1].detail.as_deref(), Some("Draft the Q3 plan"));
-    }
-
-    #[test]
-    fn unknown_tool_gets_no_detail() {
-        let steps = fold_steps(vec![completed(
-            "c1",
-            "some_other_tool",
-            true,
-            "ok",
-            Some(serde_json::json!({"anything": "at all"})),
-            None,
-        )]);
-        assert_eq!(steps.len(), 1);
-        assert!(steps[0].detail.is_none(), "unknown tool enriches nothing");
-    }
-
-    #[test]
-    fn spawn_task_title_is_truncated() {
-        let long = "x".repeat(200);
-        let steps = fold_steps(vec![completed(
-            "s1",
-            "spawn_task",
-            true,
-            "ok",
-            Some(serde_json::json!({ "title": long })),
-            None,
-        )]);
-        let detail = steps[0].detail.as_deref().unwrap();
-        assert!(detail.ends_with('…'));
-        assert_eq!(detail.chars().count(), TITLE_MAX + 1);
-    }
-
-    #[test]
-    fn error_uses_cause_plain_when_present() {
-        let steps = fold_steps(vec![completed(
-            "c1",
-            "mcp_call_tool",
-            false,
-            "HTTP 503 upstream exploded at https://x.test?token=SECRET",
-            Some(serde_json::json!({"server": "brave", "tool": "search"})),
-            Some(classified(
-                ToolFailureClass::ServiceUnavailable,
-                "The search service was temporarily unavailable.",
-            )),
-        )]);
-        assert_eq!(steps[0].status, TurnStepStatus::Error);
-        assert_eq!(
-            steps[0].detail.as_deref(),
-            Some("The search service was temporarily unavailable.")
-        );
-    }
-
-    #[test]
-    fn error_without_failure_uses_sanitized_class_not_raw_output() {
-        let steps = fold_steps(vec![completed(
-            "c1",
-            "mcp_call_tool",
-            false,
-            "connection refused talking to 10.0.0.5 with token=SUPERSECRET",
-            None,
-            None,
-        )]);
-        let detail = steps[0].detail.as_deref().unwrap();
-        // A safe class string, never the raw remote text.
-        assert_eq!(detail, "mcp_call_tool: failed (connection_error)");
-        assert!(!detail.contains("SUPERSECRET"));
-        assert!(!detail.contains("10.0.0.5"));
     }
 
     #[test]
@@ -772,54 +995,6 @@ mod tests {
         assert_eq!(note.label, "10 more steps omitted");
     }
 
-    /// SECURITY: a secret planted in a tool's raw output, its nested remote
-    /// `arguments`, and its `display_detail` must appear in **no** serialized
-    /// step. This is the wire-level guarantee the whole module exists to keep.
-    #[test]
-    fn planted_secret_never_reaches_serialized_steps() {
-        const SECRET: &str = "sk-live-PLANTEDSECRET-abc123";
-        let events = vec![
-            // display_detail carries the secret; we never read it.
-            AgentProgress::ToolCallStarted {
-                call_id: "c1".to_string(),
-                tool_name: "mcp_call_tool".to_string(),
-                arguments: Value::Null,
-                iteration: 1,
-                display_label: Some("Calling a remote tool".to_string()),
-                display_detail: Some(format!("auth={SECRET}")),
-            },
-            // Success: nested remote arguments carry the secret; output carries it.
-            completed(
-                "c1",
-                "mcp_call_tool",
-                true,
-                &format!("remote said: {SECRET}"),
-                Some(serde_json::json!({
-                    "server": "brave",
-                    "tool": "search",
-                    "arguments": { "api_key": SECRET }
-                })),
-                None,
-            ),
-            // A failing call whose raw output also carries the secret.
-            completed(
-                "c2",
-                "mcp_call_tool",
-                false,
-                &format!("401 unauthorized token={SECRET}"),
-                Some(serde_json::json!({ "server": "brave", "tool": "search" })),
-                None,
-            ),
-        ];
-        let steps = fold_steps(events);
-        let json = serde_json::to_string(&steps).expect("steps serialize");
-        assert!(
-            !json.contains(SECRET),
-            "a planted secret leaked into the serialized steps: {json}"
-        );
-        assert!(!json.contains("api_key"), "nested arg keys must not leak");
-    }
-
     /// A memory-served answer runs zero steps — the tell that distinguishes it
     /// from a tool-backed one — so an empty stream folds to an empty timeline.
     #[test]
@@ -827,11 +1002,198 @@ mod tests {
         assert!(fold_steps(Vec::new()).is_empty());
     }
 
-    /// The workflow-create error-masking fix: an intrinsic OpenCompany tool's
-    /// failure surfaces its OWN OC-authored message — the actionable reason —
-    /// even when the classifier only offers the generic "Unknown" cause. This is
-    /// what turns "Something went wrong with this action." into "…needs exactly
-    /// one trigger" on the operator bubble.
+    // -----------------------------------------------------------------------
+    // #411: a parked call is not a failure
+    // -----------------------------------------------------------------------
+
+    /// The headline of issue #411. A call the approval gate parked is *waiting
+    /// on a person* — the single most actionable state in the timeline — and it
+    /// rendered as a crash carrying "Something went wrong with this action."
+    #[test]
+    fn a_parked_call_says_so_and_is_not_a_failure() {
+        let step = one("send_email", false, &approval_refusal("send_email"), None);
+
+        assert_eq!(step.status, TurnStepStatus::AwaitingApproval);
+        assert!(
+            !step.status.is_failure(),
+            "a parked call must not be counted as failed"
+        );
+        assert_eq!(
+            step.failure, None,
+            "waiting on a human is not a failure kind"
+        );
+        assert_eq!(step.result.as_deref(), Some(AWAITING_APPROVAL_RESULT));
+        assert!(
+            !step.result.as_deref().unwrap().contains("went wrong"),
+            "the generic copy must be gone: {:?}",
+            step.result
+        );
+    }
+
+    /// The regression this replaces, stated as a property: run the *same*
+    /// refusal through the classifier the old code used, and it lands on
+    /// `Unknown` — i.e. on "Something went wrong with this action.". That is
+    /// why the park needs its own arm ahead of classification, and this test
+    /// fails the day upstream grows a real arm for it (at which point the
+    /// special case can go).
+    #[test]
+    fn the_classifier_alone_still_cannot_recognise_a_parked_call() {
+        let refusal = approval_refusal("send_email");
+        assert_eq!(
+            oh::tool_status::classify(&refusal, false).class,
+            ToolFailureClass::Unknown,
+            "if this now classifies, replace the bespoke arm in `complete` with it"
+        );
+    }
+
+    /// Both needles are required. A refusal from some *other* tool policy on the
+    /// same host is a genuine block, not our park, and must keep reading as one.
+    #[test]
+    fn only_our_own_policys_park_claims_awaiting_approval() {
+        assert!(is_awaiting_approval(&approval_refusal("send_email")));
+        assert!(
+            !is_awaiting_approval(
+                "Blocked: Tool 'shell' requires approval under policy 'some-other-policy'."
+            ),
+            "another policy's approval block is not our park"
+        );
+        assert!(
+            !is_awaiting_approval(
+                "Blocked: Tool 'shell' was denied by policy 'opencompany-approval'."
+            ),
+            "a hard deny from our policy is a failure, not a park"
+        );
+    }
+
+    /// COUPLING: the needle is a string taken from a vendored render, which is
+    /// the anti-pattern this pins. If OpenHuman rewords
+    /// `PolicyDenial::ApprovalRequired`, this fails in CI rather than silently
+    /// returning every parked call to reading as a crash.
+    #[test]
+    fn approval_needle_still_appears_in_the_vendored_denial_render() {
+        let source = vendored("vendor/openhuman/src/openhuman/tinyagents/policy_denial.rs");
+        assert!(
+            source.contains(APPROVAL_REQUIRED_NEEDLE),
+            "'{APPROVAL_REQUIRED_NEEDLE}' is gone from PolicyDenial::render — \
+             re-derive `is_awaiting_approval` against the new wording"
+        );
+    }
+
+    /// COUPLING, the other half: the policy name in the refusal is *ours*, so
+    /// it is pinned to the impl that emits it rather than to a second literal.
+    #[test]
+    fn the_policy_name_the_classifier_keys_on_is_the_one_the_policy_reports() {
+        use crate::company::Policy;
+        use crate::harness::policy::ApprovalPolicy;
+        use oh::agent::tool_policy::ToolPolicy;
+
+        let policy = ApprovalPolicy::new(&Policy::default(), None);
+        assert_eq!(policy.name(), POLICY_NAME);
+    }
+
+    // -----------------------------------------------------------------------
+    // #411: every failure says what it is
+    // -----------------------------------------------------------------------
+
+    /// The three the issue names by hand — unauthorized, timeout, blocked — plus
+    /// the rest of the taxonomy, each arriving as a typed value the console can
+    /// switch on instead of prose it has to read.
+    #[test]
+    fn each_failure_class_maps_to_its_own_operator_facing_kind() {
+        for (class, expected) in [
+            (
+                ToolFailureClass::BadCredentials,
+                TurnStepFailure::Unauthorized,
+            ),
+            (ToolFailureClass::Timeout, TurnStepFailure::Timeout),
+            (
+                ToolFailureClass::BlockedByPolicy,
+                TurnStepFailure::BlockedByPolicy,
+            ),
+            (ToolFailureClass::Denied, TurnStepFailure::Declined),
+            (ToolFailureClass::ApprovalExpired, TurnStepFailure::Declined),
+            (
+                ToolFailureClass::MissingPermission,
+                TurnStepFailure::MissingPermission,
+            ),
+            (ToolFailureClass::MissingApp, TurnStepFailure::MissingApp),
+            (
+                ToolFailureClass::ServiceUnavailable,
+                TurnStepFailure::Unavailable,
+            ),
+            (
+                ToolFailureClass::ModelConnection,
+                TurnStepFailure::Unavailable,
+            ),
+            (ToolFailureClass::Unknown, TurnStepFailure::Failed),
+        ] {
+            assert_eq!(failure_of(class), expected, "class {class:?}");
+        }
+    }
+
+    /// An unauthorized call reads as unauthorized end to end — through the fold,
+    /// not just through the mapping function — and its raw body stays out.
+    #[test]
+    fn an_unauthorized_call_says_unauthorized() {
+        let steps = fold_steps(vec![completed(
+            "c1",
+            "mcp_call_tool",
+            false,
+            &format!("401 unauthorized token={FAKE_SECRET}"),
+            Some(serde_json::json!({ "server": "github", "tool": "list_issues" })),
+            None,
+        )]);
+        assert_eq!(steps[0].status, TurnStepStatus::Error);
+        assert_eq!(steps[0].failure, Some(TurnStepFailure::Unauthorized));
+        assert!(
+            !serde_json::to_string(&steps).unwrap().contains(FAKE_SECRET),
+            "the 401 body must not ride along"
+        );
+    }
+
+    /// A timeout reads as a timeout even when the harness attached no
+    /// classification of its own — the fallback runs the real classifier rather
+    /// than the coarse `tool: failed (…)` string the old code produced.
+    #[test]
+    fn a_timeout_says_timeout_even_without_a_supplied_classification() {
+        let step = one(
+            "mcp_call_tool",
+            false,
+            "the request timed out after 30s",
+            None,
+        );
+        assert_eq!(step.failure, Some(TurnStepFailure::Timeout));
+        assert_eq!(
+            step.result.as_deref(),
+            Some("The action took too long and was stopped.")
+        );
+    }
+
+    #[test]
+    fn error_uses_cause_plain_when_present() {
+        let steps = fold_steps(vec![completed(
+            "c1",
+            "mcp_call_tool",
+            false,
+            "HTTP 503 upstream exploded at https://x.test?token=SECRET",
+            Some(serde_json::json!({"server": "brave", "tool": "search"})),
+            Some(classified(
+                ToolFailureClass::ServiceUnavailable,
+                "The search service was temporarily unavailable.",
+            )),
+        )]);
+        assert_eq!(steps[0].status, TurnStepStatus::Error);
+        assert_eq!(steps[0].failure, Some(TurnStepFailure::Unavailable));
+        assert_eq!(
+            steps[0].result.as_deref(),
+            Some("The search service was temporarily unavailable.")
+        );
+    }
+
+    /// The workflow-create error-masking fix, carried forward: an intrinsic
+    /// OpenCompany tool's failure surfaces its OWN message — the actionable
+    /// reason — even when the classifier only offers the generic cause. It now
+    /// lands in `result` ("what came back") rather than in `detail`.
     #[test]
     fn intrinsic_tool_failure_surfaces_oc_authored_reason() {
         let reason = "Couldn't create the workflow: a workflow needs exactly one trigger";
@@ -843,7 +1205,6 @@ mod tests {
                 false,
                 reason,
                 None,
-                // The generic classifier cause an operator would otherwise see.
                 Some(classified(
                     ToolFailureClass::Unknown,
                     "Something went wrong",
@@ -853,35 +1214,346 @@ mod tests {
         assert_eq!(steps.len(), 1);
         assert_eq!(steps[0].status, TurnStepStatus::Error);
         assert_eq!(
-            steps[0].detail.as_deref(),
+            steps[0].result.as_deref(),
             Some(reason),
             "the intrinsic tool's own message must win over the generic cause"
         );
     }
 
-    /// The security invariant the intrinsic-tool branch must NOT weaken: a
-    /// remote (`mcp_call_tool`) failure still scrubs to a class string — its raw
-    /// output (a remote body that can carry a secret) never becomes the detail.
+    // -----------------------------------------------------------------------
+    // #411: what the step was doing
+    // -----------------------------------------------------------------------
+
+    /// The acceptance criterion, stated exactly as the issue does: two calls to
+    /// the same tool must be distinguishable. Before #411 both of these rendered
+    /// as the bare word "Read file".
     #[test]
-    fn remote_tool_failure_stays_scrubbed_to_class() {
-        const SECRET: &str = "sk-live-REMOTE-9x";
+    fn two_calls_to_the_same_tool_are_distinguishable() {
+        let steps = fold_steps(vec![
+            completed(
+                "c1",
+                "read_file",
+                true,
+                "…",
+                Some(serde_json::json!({ "path": "docs/spec/README.md" })),
+                None,
+            ),
+            completed(
+                "c2",
+                "read_file",
+                true,
+                "…",
+                Some(serde_json::json!({ "path": "src/lib.rs" })),
+                None,
+            ),
+        ]);
+        assert_eq!(steps[0].detail.as_deref(), Some("path=docs/spec/README.md"));
+        assert_eq!(steps[1].detail.as_deref(), Some("path=src/lib.rs"));
+        assert_ne!(steps[0].detail, steps[1].detail);
+    }
+
+    /// ...including two calls to the *same remote* tool, where the routing
+    /// fields are identical and only the nested arguments differ. Rendering
+    /// those flat would show both as `server · tool` and lose the distinction
+    /// entirely.
+    #[test]
+    fn two_mcp_calls_to_one_remote_tool_are_distinguishable() {
+        let steps = fold_steps(vec![
+            completed(
+                "c1",
+                "mcp_call_tool",
+                true,
+                "[]",
+                Some(serde_json::json!({
+                    "server": "github", "tool": "list_issues",
+                    "arguments": { "repo": "opencompany", "state": "open" }
+                })),
+                None,
+            ),
+            completed(
+                "c2",
+                "mcp_call_tool",
+                true,
+                "[]",
+                Some(serde_json::json!({
+                    "server": "github", "tool": "list_issues",
+                    "arguments": { "repo": "landing", "state": "closed" }
+                })),
+                None,
+            ),
+        ]);
+        assert_eq!(
+            steps[0].detail.as_deref(),
+            Some("github · list_issues — repo=opencompany · state=open")
+        );
+        assert_eq!(
+            steps[1].detail.as_deref(),
+            Some("github · list_issues — repo=landing · state=closed")
+        );
+    }
+
+    #[test]
+    fn arguments_render_for_any_tool_not_just_a_whitelist() {
+        let step = one(
+            "some_other_tool",
+            true,
+            "ok",
+            Some(serde_json::json!({ "anything": "at all" })),
+        );
+        assert_eq!(step.detail.as_deref(), Some("anything=at all"));
+    }
+
+    #[test]
+    fn a_call_with_no_arguments_says_nothing() {
+        assert!(one("spawn_task", true, "ok", None).detail.is_none());
+        assert!(
+            one("spawn_task", true, "ok", Some(serde_json::json!({})))
+                .detail
+                .is_none()
+        );
+    }
+
+    /// Bounds, so one verbose field cannot crowd out the fields that carry the
+    /// distinction — and so a multi-line argument cannot break its row.
+    #[test]
+    fn argument_rendering_is_bounded_and_single_line() {
+        let step = one(
+            "spawn_task",
+            true,
+            "ok",
+            Some(serde_json::json!({
+                "title": "x".repeat(200),
+                "note": "first line\nsecond line",
+                "a": 1, "b": 2, "c": 3, "d": 4,
+            })),
+        );
+        let detail = step.detail.as_deref().unwrap();
+        assert!(detail.chars().count() <= DETAIL_MAX + 1, "{detail}");
+        assert!(!detail.contains('\n'), "must stay one line: {detail}");
+        assert!(detail.contains('…'), "the long value is cut: {detail}");
+    }
+
+    #[test]
+    fn deeply_nested_arguments_render_as_a_count_not_a_dump() {
+        let step = one(
+            "some_tool",
+            true,
+            "ok",
+            Some(serde_json::json!({ "outer": { "inner": { "deep": "value" } } })),
+        );
+        assert_eq!(step.detail.as_deref(), Some("outer=1 field"));
+    }
+
+    // -----------------------------------------------------------------------
+    // #411: what came back
+    // -----------------------------------------------------------------------
+
+    /// "How far have we come" was unanswerable when a success was a name and a
+    /// duration. A collection answers it with a count; anything else with a
+    /// size. Neither carries content.
+    #[test]
+    fn a_success_summarises_what_came_back_without_its_content() {
+        let list = one(
+            "mcp_call_tool",
+            true,
+            r#"[{"id":1},{"id":2},{"id":3}]"#,
+            Some(serde_json::json!({ "server": "github", "tool": "list_issues" })),
+        );
+        assert_eq!(list.result.as_deref(), Some("3 items"));
+
+        let object = one("mcp_call_tool", true, r#"{"a":1,"b":2}"#, None);
+        assert_eq!(object.result.as_deref(), Some("2 fields"));
+
+        let prose = one("mcp_call_tool", true, "a plain sentence came back", None);
+        assert_eq!(prose.result.as_deref(), Some("26 characters"));
+
+        let big = one("mcp_call_tool", true, &"x".repeat(4_200), None);
+        assert_eq!(big.result.as_deref(), Some("4.2k characters"));
+
+        let empty = one("mcp_call_tool", true, "   ", None);
+        assert_eq!(empty.result, None, "nothing came back, so nothing is said");
+    }
+
+    /// An intrinsic OpenCompany tool's output is OC-authored operator copy, so a
+    /// success shows it — the same argument that already let its *failures*
+    /// through verbatim.
+    #[test]
+    fn an_intrinsic_tools_success_shows_its_own_message() {
+        let step = one("query_company", true, "3 desks, 2 open cards", None);
+        assert_eq!(step.result.as_deref(), Some("3 desks, 2 open cards"));
+    }
+
+    // -----------------------------------------------------------------------
+    // #410 seen from here: a cut result is legible
+    // -----------------------------------------------------------------------
+
+    /// Issue #410's failure was invisible from the trace: the call succeeded,
+    /// the answer was incomplete, and no status word can say both. The flag
+    /// can.
+    #[test]
+    fn a_cut_result_is_flagged_as_truncated() {
+        for output in [
+            "…the first action\n\n[truncated by tool cap: 8123 more chars not shown]",
+            "…\n\n[… 4096 bytes truncated by tool_result_budget — re-run with a narrower query \
+             to see the rest …]",
+            "[tool_result_preview]\ntool: composio_list_tools\noriginal_bytes: 90000\n",
+        ] {
+            let step = one("composio_list_tools", true, output, None);
+            assert_eq!(
+                step.status,
+                TurnStepStatus::Ok,
+                "a cut result still succeeded"
+            );
+            assert!(step.truncated, "not flagged as cut: {output}");
+        }
+    }
+
+    #[test]
+    fn a_complete_result_is_not_flagged() {
+        assert!(!one("composio_list_tools", true, "[]", None).truncated);
+    }
+
+    /// COUPLING: all three markers are strings lifted from the vendored tool
+    /// pipeline. If any is reworded, this fails rather than letting truncation
+    /// go quiet again — which is precisely how #410 stayed hidden.
+    #[test]
+    fn truncation_markers_still_appear_in_the_vendored_tool_pipeline() {
+        let sources = [
+            vendored("vendor/openhuman/src/openhuman/tinyagents/middleware.rs"),
+            vendored("vendor/openhuman/src/openhuman/agent/harness/tool_result_artifacts/mod.rs"),
+        ]
+        .concat();
+        for marker in TRUNCATION_MARKERS {
+            assert!(
+                sources.contains(marker),
+                "'{marker}' no longer appears in the vendored tool pipeline — \
+                 re-derive `output_was_truncated` against the new wording"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Security
+    // -----------------------------------------------------------------------
+
+    /// SECURITY, and the acceptance criterion the issue spells out: a planted
+    /// credential in **arguments** and in a **result** reaches neither the
+    /// folded steps nor anything serialized from them.
+    ///
+    /// Arguments now ride this surface (bounded, and only through #372's
+    /// redactor), so this covers the top level, a nested object, and an array —
+    /// the three shapes `approval_display` itself is tested on — plus the two
+    /// non-argument channels that were already refused: raw output, and the
+    /// server-supplied `display_detail`.
+    #[test]
+    fn planted_secret_never_reaches_serialized_steps() {
+        let events = vec![
+            // `display_detail` carries the secret; we never read it.
+            AgentProgress::ToolCallStarted {
+                call_id: "c1".to_string(),
+                tool_name: "mcp_call_tool".to_string(),
+                arguments: Value::Null,
+                iteration: 1,
+                display_label: Some("Calling a remote tool".to_string()),
+                display_detail: Some(format!("auth={FAKE_SECRET}")),
+            },
+            // Success: the secret is in the nested remote arguments (top level,
+            // nested, and inside an array) AND in the output body.
+            completed(
+                "c1",
+                "mcp_call_tool",
+                true,
+                &format!("remote said: {FAKE_SECRET}"),
+                Some(serde_json::json!({
+                    "server": "brave",
+                    "tool": "search",
+                    "arguments": {
+                        "api_key": FAKE_SECRET,
+                        "env": { "GITHUB_TOKEN": FAKE_SECRET },
+                        "headers": [{ "Authorization": format!("Bearer {FAKE_SECRET}") }],
+                    }
+                })),
+                None,
+            ),
+            // A failing call whose raw output also carries the secret.
+            completed(
+                "c2",
+                "mcp_call_tool",
+                false,
+                &format!("401 unauthorized token={FAKE_SECRET}"),
+                Some(serde_json::json!({
+                    "server": "brave",
+                    "tool": "search",
+                    "arguments": { "password": FAKE_SECRET }
+                })),
+                None,
+            ),
+            // A parked call: the refusal text quotes the arguments back.
+            completed(
+                "c3",
+                "send_email",
+                false,
+                &format!("{} body={FAKE_SECRET}", approval_refusal("send_email")),
+                Some(serde_json::json!({ "to": "a@b.test", "client_secret": FAKE_SECRET })),
+                None,
+            ),
+        ];
+        let steps = fold_steps(events);
+        let json = serde_json::to_string(&steps).expect("steps serialize");
+        assert!(
+            !json.contains(FAKE_SECRET),
+            "a planted secret leaked into the serialized steps: {json}"
+        );
+        // ...and the redactor really ran, rather than the arguments simply
+        // being dropped: the non-sensitive sibling survives.
+        assert!(
+            json.contains("a@b.test"),
+            "this is a redactor, not a mute: {json}"
+        );
+    }
+
+    /// The invariant the widened argument rendering must not weaken: a remote
+    /// tool's **output** is a body we do not control, and none of it — not even
+    /// bounded — becomes a result.
+    #[test]
+    fn a_remote_results_content_never_becomes_the_result_summary() {
+        let step = one(
+            "mcp_call_tool",
+            true,
+            "the remote said something quite specific and private",
+            None,
+        );
+        let result = step.result.as_deref().unwrap();
+        assert!(
+            !result.contains("private") && !result.contains("remote said"),
+            "a remote body's content leaked into the summary: {result}"
+        );
+        assert_eq!(result, "52 characters");
+    }
+
+    #[test]
+    fn remote_tool_failure_stays_scrubbed() {
         let steps = fold_steps(vec![
             started("c1", "mcp_call_tool", Some("Calling a remote tool")),
             completed(
                 "c1",
                 "mcp_call_tool",
                 false,
-                &format!("401 unauthorized token={SECRET}"),
+                &format!("401 unauthorized token={FAKE_SECRET}"),
                 Some(serde_json::json!({ "server": "brave", "tool": "search" })),
                 None,
             ),
         ]);
-        let detail = steps[0].detail.clone().unwrap_or_default();
+        let rendered = serde_json::to_string(&steps).unwrap();
         assert!(
-            !detail.contains(SECRET),
-            "remote output must never surface as detail: {detail}"
+            !rendered.contains(FAKE_SECRET),
+            "remote output must never surface: {rendered}"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // The incremental trace stays identical to the fold
+    // -----------------------------------------------------------------------
 
     /// Materializes a [`StepTrace`] over `events` the way the run store does:
     /// each yield writes to its ordinal, replacing whatever was there.
@@ -908,9 +1580,10 @@ mod tests {
     }
 
     /// Issue #242: the incremental trace and the final fold are the SAME
-    /// timeline. If they can drift, the persisted run trace and the chat bubble
-    /// tell an operator two different stories about one turn — which is exactly
-    /// the failure the shared scrubbing helpers exist to prevent.
+    /// timeline — which is what makes the chat bubble and the Attempts tab tell
+    /// one story. #411 widened what a step carries, so the park and the cut
+    /// result are in here too: a field enriched on one path only would split
+    /// the two surfaces apart again.
     #[test]
     fn incremental_trace_converges_on_the_folded_timeline() {
         let events = vec![
@@ -922,7 +1595,10 @@ mod tests {
                 "mcp_call_tool",
                 true,
                 "ok",
-                Some(serde_json::json!({ "server": "brave", "tool": "search" })),
+                Some(serde_json::json!({
+                    "server": "brave", "tool": "search",
+                    "arguments": { "query": "rust async" }
+                })),
                 None,
             ),
             text("here you go"),
@@ -936,8 +1612,27 @@ mod tests {
                 None,
                 Some(classified(ToolFailureClass::Timeout, "it timed out")),
             ),
+            // A park.
+            started("c3", "send_email", Some("Send email")),
+            completed(
+                "c3",
+                "send_email",
+                false,
+                &approval_refusal("send_email"),
+                Some(serde_json::json!({ "to": "a@b.test" })),
+                None,
+            ),
+            // A cut result.
+            completed(
+                "c4",
+                "composio_list_tools",
+                true,
+                "…\n\n[truncated by tool cap: 900 more chars not shown]",
+                None,
+                None,
+            ),
             // A completion whose start was never observed — the standalone arm.
-            completed("c3", "query_company", true, "ok", None, None),
+            completed("c5", "query_company", true, "ok", None, None),
         ];
 
         assert_eq!(materialize(&events), fold_steps(events.clone()));
@@ -945,15 +1640,10 @@ mod tests {
 
     /// The one deliberate divergence, stated as a property rather than left to
     /// be discovered: a tool call still in flight when the stream ends is
-    /// persisted `Running`. The fold agrees here (it also leaves an unmatched
-    /// start running), and that is what makes a killed run's partial trace
-    /// honest instead of fabricated.
+    /// persisted `Running`.
     #[test]
     fn an_unfinished_tool_call_is_persisted_as_running() {
-        let events = vec![
-            started("c1", "mcp_call_tool", Some("Searching the web")),
-            // …and the host dies here.
-        ];
+        let events = vec![started("c1", "mcp_call_tool", Some("Searching the web"))];
         let rows = materialize(&events);
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].status, TurnStepStatus::Running);
@@ -962,9 +1652,7 @@ mod tests {
     }
 
     /// Ordinals are run-scoped, not turn-scoped: a second turn on the same
-    /// trace continues where the first stopped. Restarting per turn would make
-    /// turn 2 overwrite turn 1's rows, since the store keys on
-    /// `(run_id, step_seq)`.
+    /// trace continues where the first stopped.
     #[test]
     fn ordinals_continue_across_turns_of_one_run() {
         let mut trace = StepTrace::default();
@@ -972,7 +1660,6 @@ mod tests {
             .push(&started("c1", "spawn_task", None))
             .expect("turn 1 step");
         assert_eq!(first.0, 0);
-        // …turn 1 ends, turn 2 begins on the same run.
         let second = trace
             .push(&started("c9", "spawn_task", None))
             .expect("turn 2 step");
@@ -980,10 +1667,10 @@ mod tests {
         assert_eq!(trace.emitted(), 2);
     }
 
-    /// `stream_event_from` (the live-bus counterpart of `fold_steps`) maps a
-    /// start to a `running` `tool_call` frame and a completion to an `ok`
-    /// `tool_result` frame paired by `tool_call_id`, carrying the same scrubbed
-    /// label/detail the folded timeline would.
+    // -----------------------------------------------------------------------
+    // The live bus carries the same projection
+    // -----------------------------------------------------------------------
+
     #[test]
     fn stream_event_from_maps_start_and_completion() {
         let mut thinking_open = false;
@@ -1003,7 +1690,7 @@ mod tests {
                 "c1",
                 "mcp_call_tool",
                 true,
-                "ok",
+                "[1,2]",
                 Some(serde_json::json!({ "server": "brave", "tool": "search" })),
                 None,
             ),
@@ -1015,14 +1702,45 @@ mod tests {
         assert_eq!(done.status, Some("ok"));
         assert_eq!(done.tool_call_id.as_deref(), Some("c1"));
         assert_eq!(done.detail.as_deref(), Some("brave · search"));
+        assert_eq!(done.result.as_deref(), Some("2 items"));
         assert_eq!(done.elapsed_ms, Some(42));
     }
 
-    /// Thinking coalesces live exactly as it folds: the FIRST delta of a run
-    /// emits one `thinking` frame, consecutive deltas emit nothing, and visible
-    /// text closes the run (no frame). This is what keeps the live step count
-    /// tracking the final folded count instead of jumping up when the reply
-    /// lands.
+    /// The live row must reach the same verdict the folded step does — a park
+    /// that reads as an error for the seconds before the reply lands is the same
+    /// bug, just briefer.
+    #[test]
+    fn stream_event_from_reports_a_park_as_a_park() {
+        let frame = stream_event_from(
+            &completed(
+                "c1",
+                "send_email",
+                false,
+                &approval_refusal("send_email"),
+                None,
+                None,
+            ),
+            0,
+            &mut false,
+        )
+        .expect("frame");
+        assert_eq!(frame.status, Some("awaiting_approval"));
+        assert_eq!(frame.failure, None);
+        assert_eq!(frame.result.as_deref(), Some(AWAITING_APPROVAL_RESULT));
+    }
+
+    #[test]
+    fn stream_event_from_carries_the_typed_failure() {
+        let frame = stream_event_from(
+            &completed("c1", "mcp_call_tool", false, "401 unauthorized", None, None),
+            0,
+            &mut false,
+        )
+        .expect("frame");
+        assert_eq!(frame.status, Some("error"));
+        assert_eq!(frame.failure, Some(TurnStepFailure::Unauthorized));
+    }
+
     #[test]
     fn stream_event_from_coalesces_thinking_and_ignores_text() {
         let mut open = false;
@@ -1030,27 +1748,25 @@ mod tests {
         assert_eq!(first.kind, "thinking");
         assert_eq!(first.label.as_deref(), Some("Thinking"));
         assert!(open, "run is now open");
-        // A consecutive delta while the run is open adds nothing.
         assert!(stream_event_from(&thinking("more"), 1, &mut open).is_none());
-        // Visible text closes the run without a frame of its own.
         assert!(stream_event_from(&text("hello"), 2, &mut open).is_none());
         assert!(!open, "text closed the run");
-        // A fresh thinking run after that opens a new frame.
         assert!(stream_event_from(&thinking("again"), 3, &mut open).is_some());
     }
 
-    /// The live frame is scrubbed exactly like the folded step: a failing remote
-    /// call with a planted secret in its output never serializes that secret.
+    /// The live frame is scrubbed exactly like the folded step.
     #[test]
     fn stream_event_from_never_leaks_remote_output() {
-        const SECRET: &str = "sk-live-STREAM-42";
         let frame = stream_event_from(
             &completed(
                 "c2",
                 "mcp_call_tool",
                 false,
-                &format!("401 token={SECRET}"),
-                Some(serde_json::json!({ "server": "brave", "tool": "search" })),
+                &format!("401 token={FAKE_SECRET}"),
+                Some(serde_json::json!({
+                    "server": "brave", "tool": "search",
+                    "arguments": { "api_key": FAKE_SECRET }
+                })),
                 None,
             ),
             0,
@@ -1059,7 +1775,7 @@ mod tests {
         .expect("frame");
         let json = serde_json::to_string(&frame).expect("frame serialize");
         assert!(
-            !json.contains(SECRET),
+            !json.contains(FAKE_SECRET),
             "a planted secret leaked into a live turn-stream frame: {json}"
         );
     }

--- a/src/ports/runs.rs
+++ b/src/ports/runs.rs
@@ -890,6 +890,7 @@ mod test {
                 label: "Reading messages".to_string(),
                 detail: None,
                 elapsed_ms: Some(12),
+                ..TurnStep::default()
             },
         };
         let json = serde_json::to_string(&record).unwrap();

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -1293,15 +1293,106 @@ pub struct TurnStep {
     /// the tool's server-computed `display_label`, else its tool name — never
     /// from tool arguments or output.
     pub label: String,
-    /// An optional muted detail: whitelisted, scrubbed enrichment (e.g. an MCP
-    /// `server · tool`, a delegated desk, a task title) or a plain-language
-    /// failure cause. **Never** raw tool output or arguments.
+    /// **What the step was doing** — a compact rendering of the call's
+    /// arguments, passed through the *same* host-side redactor an approval card
+    /// uses ([`crate::runtime::approval_display`], issue #372) and then bounded.
+    ///
+    /// This is what makes two calls to the same tool tell apart (issue #411):
+    /// two workspace reads used to render identically because nothing about
+    /// *what* was read reached the operator.
+    ///
+    /// Before #411 this field doubled as the failure cause. That moved to
+    /// [`result`](Self::result), which is where "what came back" belongs;
+    /// already-persisted rows keep whatever string they hold and still render.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
+    /// **What came back** (issue #411).
+    ///
+    /// On success: a *summary* — the intrinsic tool's own OpenCompany-authored
+    /// output (bounded), or for every other tool a structural shape line
+    /// (`"12 items"`, `"2.4 kB"`) and never its content, because a remote body
+    /// is exactly what must not reach this surface.
+    ///
+    /// On a failure or a park: the plain-language cause in the failure's own
+    /// terms — the classifier's `cause_plain`, or the intrinsic tool's own
+    /// message.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<String>,
+    /// The typed reason a step did not succeed (issue #411), so the console
+    /// renders a **known state** rather than parsing prose.
+    ///
+    /// `None` on a success, on a still-`Running` step, and on a step
+    /// [`AwaitingApproval`](TurnStepStatus::AwaitingApproval) — a park is not a
+    /// failure, and its status already says so.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<TurnStepFailure>,
+    /// The result was **cut** before the agent could read all of it (issue
+    /// #410).
+    ///
+    /// Carried as its own typed flag rather than buried in prose, because a
+    /// silently truncated result is a distinct, actionable state: the call
+    /// succeeded, and the answer is still incomplete. That combination is
+    /// invisible in a status word, which is precisely how #410 stayed hidden.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub truncated: bool,
     /// How long the step took in milliseconds, when known (tool calls report it;
     /// thinking/note steps do not).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub elapsed_ms: Option<u64>,
+}
+
+/// `skip_serializing_if` for a `bool` that defaults to `false`, so a step that
+/// was not truncated serializes exactly as it did before the field existed and
+/// every stored row round-trips byte-identically.
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+impl Default for TurnStep {
+    /// A blank tool-call step, so the several construction sites that fill only
+    /// the fields they know can say `..TurnStep::default()` instead of
+    /// restating every optional field. The `kind`/`status` here are
+    /// placeholders that every real caller overrides.
+    fn default() -> Self {
+        Self {
+            kind: TurnStepKind::ToolCall,
+            status: TurnStepStatus::Ok,
+            label: String::new(),
+            detail: None,
+            result: None,
+            failure: None,
+            truncated: false,
+            elapsed_ms: None,
+        }
+    }
+}
+
+impl TurnStepStatus {
+    /// Whether this status means the step **failed**.
+    ///
+    /// The one place the question is answered, so the console's "N failed"
+    /// count, the destructive tone and any host-side tally cannot disagree.
+    /// [`AwaitingApproval`](Self::AwaitingApproval) is deliberately **not** a
+    /// failure: it is work waiting on a person (issue #411).
+    pub fn is_failure(self) -> bool {
+        matches!(self, Self::Error)
+    }
+
+    /// The `snake_case` word this status serializes as.
+    ///
+    /// The live turn-stream frame carries its status as a `&'static str` rather
+    /// than as this enum (it is a dumb transport that models no harness types),
+    /// so it needs the word without a serde round-trip. Deriving it here means
+    /// the live frame and the persisted step cannot disagree about what to call
+    /// the same state.
+    pub fn wire_word(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::Error => "error",
+            Self::Running => "running",
+            Self::AwaitingApproval => "awaiting_approval",
+        }
+    }
 }
 
 /// The kind of a [`TurnStep`], driving its icon in the timeline. Serialized in
@@ -1319,7 +1410,7 @@ pub enum TurnStepKind {
 }
 
 /// How a [`TurnStep`] ended. Serialized in `snake_case` (`ok` / `error` /
-/// `running`).
+/// `running` / `awaiting_approval`).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TurnStepStatus {
@@ -1329,6 +1420,60 @@ pub enum TurnStepStatus {
     Error,
     /// Started but no completion was observed by the end of the turn.
     Running,
+    /// **Gated: waiting on a person** (issue #411).
+    ///
+    /// The approval policy refused the call inline and parked the projected
+    /// effect on the operator's queue. The turn genuinely could not continue —
+    /// but nothing *broke*, and counting it as a failure was the single most
+    /// misleading thing the timeline did: the one step an operator can act on
+    /// rendered as a crash.
+    ///
+    /// A distinct status rather than an [`Error`](Self::Error) carrying a
+    /// reason, because the "N failed" summary and the destructive tone both key
+    /// off the status word. A reason field would have left both still lying.
+    AwaitingApproval,
+}
+
+/// Why a [`TurnStep`] did not succeed, in the failure's own terms (issue #411).
+///
+/// The console renders a *known state* off this instead of pattern-matching the
+/// prose in [`TurnStep::result`] — a classifier keyed on a display string is the
+/// anti-pattern this exists to remove. The variants are a projection of
+/// OpenHuman's own `ToolFailureClass`, mapped in one exhaustive `match` in
+/// [`crate::harness::steps`], so a class added upstream is a compile error here
+/// rather than a silent fall-through to "something went wrong".
+///
+/// Deliberately **narrower** than the upstream class set: it is the vocabulary
+/// an operator can act on, not the vocabulary the classifier reasons in. The
+/// two connectivity classes (`ServiceUnavailable` / `ModelConnection`) collapse
+/// into [`Unavailable`](Self::Unavailable) because "wait, or check the link" is
+/// one action; the two refusal classes (`Denied` / `ApprovalExpired`) collapse
+/// into [`Declined`](Self::Declined) for the same reason.
+///
+/// Serialized in `snake_case`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnStepFailure {
+    /// A person refused the action, or the approval request expired before
+    /// anyone answered. Never retried on its own.
+    Declined,
+    /// The company's own safety settings refused the action outright.
+    BlockedByPolicy,
+    /// The credentials the call needed are missing, expired, or were rejected —
+    /// an unauthorized response. The fix is a reconnect, not a retry.
+    Unauthorized,
+    /// The host lacks an operating-system permission the call needed.
+    MissingPermission,
+    /// A program or application the call needed is not available.
+    MissingApp,
+    /// The call ran past its deadline and was stopped.
+    Timeout,
+    /// A service the call depends on — an upstream API, or the model provider —
+    /// could not be reached.
+    Unavailable,
+    /// Genuinely unclassified. The honest residue, and the *only* case that may
+    /// read as "something went wrong": every state above used to land here.
+    Failed,
 }
 
 // ---------------------------------------------------------------------------
@@ -2119,6 +2264,7 @@ mod test {
             label: "Searching the web".to_string(),
             detail: Some("brave · search".to_string()),
             elapsed_ms: Some(1234),
+            ..TurnStep::default()
         };
         let json = serde_json::to_value(&step).unwrap();
         assert_eq!(json["kind"], "tool_call");
@@ -2139,6 +2285,7 @@ mod test {
             label: "Thinking".to_string(),
             detail: None,
             elapsed_ms: None,
+            ..TurnStep::default()
         };
         let json = serde_json::to_value(&bare).unwrap();
         assert_eq!(json["kind"], "thinking");
@@ -2182,6 +2329,7 @@ mod test {
                 label: "MCP: brave unavailable".to_string(),
                 detail: Some("server rejected the call".to_string()),
                 elapsed_ms: None,
+                ..TurnStep::default()
             }],
             reply_to: None,
         };
@@ -2265,6 +2413,7 @@ mod test {
                 label: "Reading messages".to_string(),
                 detail: None,
                 elapsed_ms: Some(12),
+                ..TurnStep::default()
             }],
         };
         let back: CompanyEvent =

--- a/src/runtime/approval_display.rs
+++ b/src/runtime/approval_display.rs
@@ -113,8 +113,27 @@ pub fn display_payload(effect: &Effect) -> Option<Value> {
     if is_empty(&effect.payload) {
         return None;
     }
+    Some(redact(&effect.payload))
+}
+
+/// The redaction rule above, applied to a **bare** value.
+///
+/// The one seam that lets a second operator-facing surface reuse this rather
+/// than growing a redactor of its own. Issue #411's turn-step trace calls it to
+/// show *what a tool call was doing* — and those arguments are literally the
+/// same object [`display_payload`] shows on the approval card, because
+/// [`ApprovalPolicy::effect_for`](crate::harness::policy::ApprovalPolicy::effect_for)
+/// projects a gated call's arguments straight into `Effect::payload`. One rule,
+/// one denylist, one set of bounds: a key added to [`DENY_SEGMENTS`] tightens
+/// both surfaces at once, and neither can drift away from the other.
+///
+/// Unlike [`display_payload`] this makes no "is there anything worth showing"
+/// judgement — an empty object redacts to an empty object. The caller decides
+/// what to do with nothing, because "nothing" means different things on a card
+/// (omit the section) and in a trace (the call took no arguments).
+pub fn redact(value: &Value) -> Value {
     let mut budget = MAX_NODES;
-    Some(walk(&effect.payload, 0, &mut budget))
+    walk(value, 0, &mut budget)
 }
 
 /// Whether a payload carries nothing worth putting on a card.

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -2095,6 +2095,7 @@ mod test {
                             label: label.to_string(),
                             detail: None,
                             elapsed_ms: None,
+                            ..TurnStep::default()
                         },
                     },
                 )

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -2446,6 +2446,7 @@ mod test {
                         label: "Reading messages".to_string(),
                         detail: None,
                         elapsed_ms: Some(9),
+                        ..TurnStep::default()
                     }],
                 },
             )
@@ -3308,6 +3309,7 @@ mod test {
                 label: "Reading messages".into(),
                 detail: None,
                 elapsed_ms: Some(12),
+                ..TurnStep::default()
             }],
         }))
         .expect("agent_reply is an attention signal");

--- a/src/server/ops/runs.rs
+++ b/src/server/ops/runs.rs
@@ -57,7 +57,7 @@ use serde::{Deserialize, Serialize};
 use crate::AppState;
 use crate::error::OpenCompanyError;
 use crate::ports::runs::{RunFilter, RunRecord, RunStatus, RunStepRecord};
-use crate::ports::types::{TokenUsage, TurnStepKind, TurnStepStatus};
+use crate::ports::types::{TokenUsage, TurnStepFailure, TurnStepKind, TurnStepStatus};
 use crate::server::error::ApiError;
 use crate::server::ops::{ScopedCompany, scoped};
 
@@ -230,18 +230,35 @@ struct RunStepEntry {
     at_millis: u64,
     /// `tool_call` · `thinking` · `note`.
     kind: TurnStepKind,
-    /// `ok` · `error` · `running`.
+    /// `ok` · `error` · `running` · `awaiting_approval`.
     ///
     /// `running` is a real, expected terminal state of a *row*: a killed host
     /// leaves the tool call that was in flight exactly as the sink wrote it.
     /// It means in-flight-when-the-trace-stopped, never failed.
+    ///
+    /// `awaiting_approval` (issue #411) is the other state that is not a
+    /// failure: the call was gated and is waiting on a person. It used to
+    /// arrive here as `error`, which made the one step an operator could act on
+    /// look like the one thing that had crashed.
     status: TurnStepStatus,
     /// A short, server-computed human label. Never derived from tool arguments
     /// or output.
     label: String,
-    /// Whitelisted, already-scrubbed enrichment. Never raw tool output.
+    /// **What the step was doing** — its arguments, already put through issue
+    /// #372's host-side redactor and bounded by the harness (issue #411).
     #[serde(skip_serializing_if = "Option::is_none")]
     detail: Option<String>,
+    /// **What came back** — a shape summary, an intrinsic tool's own message,
+    /// or a failure's plain-language cause (issue #411). Never a remote body.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<String>,
+    /// The typed reason the step did not succeed (issue #411). Absent on a
+    /// success, on a step still `running`, and on a parked one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    failure: Option<TurnStepFailure>,
+    /// The result was cut before the agent could read all of it (issue #410).
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    truncated: bool,
     /// How long the step took, when known (tool calls report it; thinking and
     /// note steps do not).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -257,6 +274,9 @@ impl From<RunStepRecord> for RunStepEntry {
             status: record.step.status,
             label: record.step.label,
             detail: record.step.detail,
+            result: record.step.result,
+            failure: record.step.failure,
+            truncated: record.step.truncated,
             elapsed_ms: record.step.elapsed_ms,
         }
     }
@@ -517,8 +537,8 @@ mod tests {
             kind,
             status,
             label: label.to_string(),
-            detail: None,
             elapsed_ms: matches!(kind, TurnStepKind::ToolCall).then_some(42),
+            ..TurnStep::default()
         }
     }
 

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -1911,6 +1911,7 @@ pub async fn assert_run_store(runs: Arc<dyn crate::ports::runs::RunStore>) {
             label: label.to_string(),
             detail: None,
             elapsed_ms: Some(5),
+            ..TurnStep::default()
         },
     };
 

--- a/src/turn_stream.rs
+++ b/src/turn_stream.rs
@@ -22,13 +22,15 @@
 //! ## Security
 //!
 //! The bus carries only the **already-scrubbed** projection produced by
-//! [`crate::harness::steps`] — a label, an optional whitelisted detail, an
-//! elapsed time, a status. It never carries raw tool arguments, raw tool
-//! output, or an MCP call's nested remote payload, exactly like `fold_steps`.
-//! The mapping that enforces that lives next to `fold_steps` (same helpers, same
-//! rules); this module is a dumb transport and models no openhuman types, so it
-//! stays compiled in the default (non-`openhuman`) build where it simply has no
-//! publishers and every subscription is an empty stream.
+//! [`crate::harness::steps`] — a label, a redacted argument line, a result
+//! *summary*, a typed failure, an elapsed time, a status. It never carries raw
+//! tool output, exactly like `fold_steps`; arguments reach it only through
+//! issue #372's host-side redactor, and a remote body reaches it only as a
+//! shape (issue #411). The mapping that enforces all of that lives next to
+//! `fold_steps` (same helpers, same rules); this module is a dumb transport and
+//! models no openhuman types, so it stays compiled in the default
+//! (non-`openhuman`) build where it simply has no publishers and every
+//! subscription is an empty stream.
 
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
@@ -37,7 +39,7 @@ use futures::stream::BoxStream;
 use serde::Serialize;
 use tokio::sync::broadcast;
 
-use crate::ports::types::CompanyId;
+use crate::ports::types::{CompanyId, TurnStepFailure};
 
 /// Per-company broadcast senders. Created lazily on first publish/subscribe for
 /// a company and kept for the process lifetime (companies are few and long
@@ -87,16 +89,55 @@ pub struct TurnStreamEvent {
     /// name). Never derived from arguments or output.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
-    /// Scrubbed structural detail (whitelisted success enrichment, or the
-    /// classifier's plain-language failure cause). Never raw remote text.
+    /// **What the call was doing** — its arguments, put through issue #372's
+    /// host-side redactor and bounded (issue #411). Never raw remote text.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
-    /// `"running"` on a start, `"ok"`/`"error"` on a completion.
+    /// **What came back** — a success's shape summary or an intrinsic tool's
+    /// own message, or a failure's plain-language cause (issue #411). Never a
+    /// remote body's content.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<String>,
+    /// The typed reason a call did not succeed (issue #411), so a live row
+    /// renders the same known state the final folded step does. `None` on a
+    /// success and on a parked call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure: Option<TurnStepFailure>,
+    /// The result was cut before the agent could read all of it (issue #410).
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub truncated: bool,
+    /// `"running"` on a start; `"ok"` / `"error"` / `"awaiting_approval"` on a
+    /// completion. Sourced from
+    /// [`TurnStepStatus::wire_word`](crate::ports::types::TurnStepStatus::wire_word)
+    /// so the live word and the persisted one cannot drift.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<&'static str>,
     /// Wall-clock the completed call took, on `tool_result` only.
     #[serde(rename = "elapsedMs", skip_serializing_if = "Option::is_none")]
     pub elapsed_ms: Option<u64>,
+}
+
+impl Default for TurnStreamEvent {
+    /// An empty `tool_call` frame, so the mapping in
+    /// [`crate::harness::steps`] can fill only the fields a given event kind
+    /// actually carries via `..Default::default()`. `kind` is a placeholder
+    /// every caller overrides.
+    fn default() -> Self {
+        Self {
+            kind: "tool_call",
+            seq: 0,
+            agent_id: None,
+            chat_id: None,
+            tool_call_id: None,
+            label: None,
+            detail: None,
+            result: None,
+            failure: None,
+            truncated: false,
+            status: None,
+            elapsed_ms: None,
+        }
+    }
 }
 
 impl TurnStreamEvent {
@@ -181,9 +222,8 @@ mod tests {
             chat_id: None,
             tool_call_id: Some("c1".to_string()),
             label: Some("Searching".to_string()),
-            detail: None,
             status: Some("running"),
-            elapsed_ms: None,
+            ..TurnStreamEvent::default()
         }
     }
 
@@ -259,6 +299,9 @@ mod tests {
             tool_call_id: Some("c1".to_string()),
             label: Some("Search".to_string()),
             detail: Some("brave · search".to_string()),
+            result: Some("12 items".to_string()),
+            failure: None,
+            truncated: false,
             status: Some("ok"),
             elapsed_ms: Some(12),
         };


### PR DESCRIPTION
## Summary

A step in an agent's trace could carry a label, a status and a duration. That is
all. So a call **blocked pending approval**, an **unauthorized** response and a
**truncated** result rendered identically — as "Something went wrong with this
action." — while the host knew exactly which was which the whole time.

This introduces a typed classification at the point the flattening was actually
happening, and widens a step to answer three questions instead of none:

| | |
|---|---|
| **What was it doing** | `detail` — the call's arguments, redacted and bounded. Two workspace reads stop looking alike. |
| **What came back** | `result` — an intrinsic tool's own message, or a *shape* (`"12 items"`, `"16.2k characters"`) for anything else. Never a remote body's content. |
| **Why it stopped** | `failure` — a typed `TurnStepFailure` the console switches on, never prose it has to read. |

Plus the two states that had no way to exist:

- **Parked is not a failure.** A gated call is `TurnStepStatus::AwaitingApproval`
  and is counted separately. It is the one step an operator can act on, and it
  was rendering as a crash.
- **Cut is not complete.** `truncated` marks a result the harness cut (#410) — a
  *success* whose answer is incomplete, which no status word can express. That
  combination is precisely how #410 stayed hidden.

Both render sites are updated: the chat bubble **and** the task Attempts tab.

Closes #411

## API Or Behavior Changes

**`TurnStep` gains four fields** (`result`, `failure`, `truncated`, and a new
`TurnStepStatus::AwaitingApproval`). Every field is additive and
omitted-when-empty, so already-persisted rows and journaled replies round-trip
byte-identically. `TurnStep::default()` keeps the existing construction sites to
one line each.

**`TurnStepStatus::is_failure()`** is now the single place "did this fail?" is
answered on the host, mirrored by `isFailedStep` on the client. `AwaitingApproval`
answers **no**. Anything testing "not `ok`" would sweep in both a parked step and
one still running.

**The taxonomy, and why it is narrower than upstream's.** `TurnStepFailure` is a
projection of OpenHuman's `ToolFailureClass` through one exhaustive `match`, so a
class added upstream is a compile error rather than a silent fall-through to
"something went wrong". It is deliberately the vocabulary an operator can *act*
on, not the one the classifier reasons in: `ServiceUnavailable` + `ModelConnection`
collapse to `Unavailable` (one action: wait, or check the link), and `Denied` +
`ApprovalExpired` collapse to `Declined` (one action: none — ask again).

**Where the flattening was.** `src/harness/steps.rs`, in the two lines
`status = if success { Ok } else { Error }` and a single `detail` string. Every
distinction arrived there intact and left collapsed. Notably a parked call had no
classifier arm at all and landed on `Unknown`, whose copy is literally
"Something went wrong with this action." — pinned by
`the_classifier_alone_still_cannot_recognise_a_parked_call`, which will fail the
day upstream grows a real arm, at which point the bespoke branch can go.

**Secrets: #372's redactor is reused, not re-derived.** `display_payload` was
split so `approval_display::redact` can take a bare value, and `steps.rs` calls
it. This is a deliberate widening of the old whitelist-only rule and it is *not*
a second redaction surface: an approval card already shows an operator this exact
object, because a gated call's arguments **are** the parked effect's payload
(`ApprovalPolicy::effect_for`). One denylist now governs both. It follows that
#372's documented limit applies here too — the denylist matches on **keys**, so a
credential hidden in free text under a benign key is shown on both surfaces by
the same rule. A remote tool's *output* still never contributes content, only a
shape.

**Two string classifiers, both pinned.** Recognising a park and recognising a cut
result both key on strings the vendored pipeline emits, which is the anti-pattern
the issue calls out. The mitigation is that each is coupled to its source by a
test that reads the vendored file, so a rewording turns CI red instead of quietly
returning a park to reading as a crash. Verified by mutating each needle and
watching the couplings fail (below). The park additionally requires our *own*
`ApprovalPolicy::POLICY_NAME`, so another policy's approval block on the same host
is not mistaken for our park.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings` — default lane, clean
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — clean
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **2043 passed, 0 failed, 1 ignored**
- [x] `cargo test --locked --lib` — default features, **1424 passed, 0 failed, 1 ignored**
- [x] `cargo check --locked --all-features --all-targets` — clean
- [x] `git diff --stat Cargo.lock` — empty
- [x] Frontend: `npm ci`, `npm run typecheck`, `npm run typecheck:e2e`, `npm run build` — all clean
  (this repo has **no** lint script and **no** component-test script; none claimed)

`src/harness/steps.rs` carries 38 unit tests, including the acceptance criteria
stated as properties: a park is not counted as failed, each class maps to its own
kind, two calls to one tool are distinguishable, a cut result is flagged while
still `ok`, and the incremental trace still converges on the folded timeline with
the new states in it.

**Mutation-checked, because a green test proves nothing on its own.** Reworded the
approval needle and one truncation marker; 6 tests failed, including both
couplings and all three behaviour tests. Restored, all 38 pass again.

### Live verification — a real host, a mock model, a real browser

Not asserted from unit tests. A real `opencompany serve` (`--features
openhuman,mcp`) against a mock OpenAI-compatible endpoint and a mock MCP server,
driven through Chromium. One turn produced **every** state:

| State | Rendered |
|---|---|
| Parked pending approval | `Awaiting approval` chip, hourglass, `didn't run`, "Parked — waiting on your approval before it can run." Counted as `1 awaiting approval`, **not** as failed. A matching live approval appeared in the queue, so the claim is true, not guessed. |
| Unauthorized | `Unauthorized` chip · "The saved sign-in details are missing or no longer valid." |
| Timed out | `Timed out` chip · 5.0s · "The action took too long and was stopped." |
| Truncated | `Result cut` chip on a step still `ok` · "16.2k characters (cut short)" |
| Two calls, one tool | `path=docs/spec/README.md` vs `path=notes/roadmap.md` |
| Success summary | "575 characters" / "539 characters" |

The park was recognised through the **genuine** vendored
`PolicyDenial::ApprovalRequired` render, not a test copy — the thing most worth
confirming.

**Secret redaction, end to end.** An obviously-synthetic credential
(`NOT-A-REAL-KEY-…`) was planted in a tool call's arguments *and* reflected back
in the mock server's 401 body. It appears **nowhere**: not in the chat JSON, not
in the persisted run trace, and not in the text either browser surface actually
rendered (asserted in the driver script, which fails if it appears). The argument
shows as `api_key=[redacted]`, with its non-sensitive sibling `repo=opencompany`
intact — a redactor, not a mute.

**Both surfaces checked.** The chat bubble reads
`8 steps · 4 failed · 1 awaiting approval`; the task Attempts drawer renders the
same six persisted steps with the same chips, and expands each into
`CALLED WITH` / `RESULT`. An operator can answer "what did this run do and what
stopped it" from either one alone.

One UI defect was found this way and fixed: a row carrying both a state chip and
a duration squeezed its label to `Workspa…`, hiding which step it was.

## Documentation

`docs/spec/runtime/ports.md` — the spec still documented the three-field shape
and the whitelist-only scrubbing rule, both of which this changes. Now records
the taxonomy, which two statuses are not failures, and why reusing #372's
redactor is not a second redaction surface (including the limit it inherits).

## Notes for review

**Deliberately left out.**

- **A remote tool's result content.** Only its shape. The redactor matches on
  keys and a remote body has none, so there is no rule that could make its text
  safe. An intrinsic OpenCompany tool's output *is* OC-authored operator copy and
  is surfaced bounded — the same argument that already let its failures through.
- **Retry / re-run affordances.** `TurnStepFailure` says what would fix each
  state, but wiring a button per class is its own change.
- **Localisation.** The failure labels are English source strings in one table
  (`STEP_FAILURE_LABEL`), ready to be keyed by class.
- **`#410`'s truncation itself.** Being fixed in parallel on `work/410`; this
  makes a cut result *legible*, not rarer. No files overlap.

**Shared-file contact.** `src/harness/policy.rs` gains only a `pub const
POLICY_NAME` beside the imports plus a one-line body change in
`ToolPolicy::name()` — nothing structural, nothing near `check()`.
`src/harness/brain.rs` is a single `..TurnStep::default()` line in the
MCP-failure note, away from the settle path.

**Follow-up worth filing.** `docs/spec/runtime/ports.md` is 849 lines against the
repo's 500-line ceiling. Pre-existing and untouched by this split decision;
splitting it is its own change.
