### PR TITLE
fix(workflows): show the selected workflow in the picker, and make the suite that covers it runnable (#406)

### DIFF
--- a/companies/e2e_harness/company.toml
+++ b/companies/e2e_harness/company.toml
@@ -1,9 +1,13 @@
 # The end-to-end test harness company.
 #
-# A copy of `companies/openhuman_demo` with one addition: a `[users] admins`
-# list, so the Playwright wiring suite (frontend/test/e2e) can log in through
-# the real magic-link flow and drive the operator console against a running
-# host. See `frontend/test/e2e/wiring.spec.ts`.
+# A copy of `companies/openhuman_demo` with two additions:
+#
+#   * a `[users] admins` list, so the Playwright wiring suite
+#     (frontend/test/e2e) can log in through the real magic-link flow and drive
+#     the operator console against a running host — see
+#     `frontend/test/e2e/wiring.spec.ts`;
+#   * `workflows/committed.toml`, a source-defined workflow the console must
+#     refuse to edit or delete — see `frontend/test/e2e/workflow-edit-delete.spec.ts`.
 #
 # Every [[agent]] becomes one live openhuman agent when built with the
 # `openhuman` feature and an inference credential is present. Without a

--- a/companies/e2e_harness/workflows/committed.toml
+++ b/companies/e2e_harness/workflows/committed.toml
@@ -1,0 +1,49 @@
+# Workflow graph: committed — the e2e suite's *source-defined* fixture.
+#
+# Its whole job is to be a workflow the console must REFUSE to change: it lives
+# in the company source tree, so the host answers 409 to a `PUT` and to a
+# `DELETE` on it, and `workflow-edit-delete.spec.ts` asserts the console says so
+# before the click (Edit and Delete disabled, both explaining that the remedy is
+# to edit `workflows/committed.toml` in the company repository).
+#
+# The spec has referenced this file by name — "Committed flow", and the path in
+# the disabled-button title — since it was written, but the file itself was
+# never committed, so both of its source-defined cases failed against a live
+# host. Nothing noticed, because the suite is typechecked by CI and run by
+# nobody (issue #406). It is deliberately *not* listed in `[workflows].enabled`
+# in ../company.toml: the console lists every `workflows/*.toml` it finds, and
+# leaving it disabled keeps it out of the scheduler while the suite runs.
+#
+# Keep the id, the name and the two node ids stable — the spec pins all four.
+
+id = "committed"
+name = "Committed flow"
+description = "A workflow defined in the company source tree, so the console may not edit or delete it."
+
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Every weekday morning"
+summary = "The schedule fires."
+schedule = "0 9 * * MON-FRI"
+
+[[node]]
+id = "draft"
+kind = "agent"
+name = "Draft the note"
+summary = "Turn the morning's notes into a short written update."
+agent = "writer"
+
+[[node]]
+id = "done"
+kind = "output"
+name = "Hand it to the operator"
+summary = "Park the draft for review."
+
+[[edge]]
+from = "start"
+to = "draft"
+
+[[edge]]
+from = "draft"
+to = "done"

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -160,6 +160,19 @@ harness and a mocked inference backend — and one needs an external MCP server:
 Point `PW_HOST_BINARY` at a feature-gated build, or `PW_BASE_URL` at a host you
 brought up yourself, to cover those.
 
+The managed host starts from an **empty** environment and is handed only what it
+needs, so an inherited `OPENCOMPANY_PUBLIC_URL`, `OPENCOMPANY_MAIL_*`,
+`OPENCOMPANY_STORAGE` or `OPENCOMPANY_TENANT_ID` cannot quietly change what you
+are testing — the first two would stop the host echoing the sign-in code and
+strand the suite in bootstrap. Name anything else it should receive, such as a
+feature-gated build's inference credentials, in `PW_HOST_PASSTHROUGH` (a
+space-separated list of variable names).
+
+`PW_HOST_DATA_DIR` is wiped at the start of each run, so a run only ever deletes
+inside `../target/e2e`. Point it anywhere else and it is reused as it stands,
+with a line saying so — a mistyped or inherited value cannot take a directory
+you care about with it.
+
 The `dist/` can be served as static files by any web server (or mounted by the
 OpenCompany host); use `window.OPENCOMPANY_CONFIG` to point it at the API.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -143,6 +143,23 @@ that it holds: `workflow-edit-delete.spec.ts` spent months red against a fixture
 that was never committed, and nothing reported it. Run the suite before touching
 a view it covers.
 
+### What a default-feature host cannot cover
+
+The host `test/e2e/host.sh` starts is the default feature set, which boots the
+offline echo brain. That is enough for the great majority of the suite, but four
+specs need an agent that actually executes — a build with the `openhuman`
+harness and a mocked inference backend — and one needs an external MCP server:
+
+| Spec | Needs |
+|------|-------|
+| `wiring.spec.ts` | the harness + a mock LLM backend echoing `__MOCK_LLM__` |
+| `chat-to-card.spec.ts` (card chip) | an orchestrator that opens a card |
+| `workflow-run-history.spec.ts` (durable history) | a workflow run that executes |
+| `mcp.spec.ts` | `PW_MCP_SERVER` pointing at a live MCP server |
+
+Point `PW_HOST_BINARY` at a feature-gated build, or `PW_BASE_URL` at a host you
+brought up yourself, to cover those.
+
 The `dist/` can be served as static files by any web server (or mounted by the
 OpenCompany host); use `window.OPENCOMPANY_CONFIG` to point it at the API.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -113,9 +113,35 @@ the `Console` job of `.github/workflows/ci.yml`.
 `typecheck` covers `src/` and nothing else — `tsconfig.app.json` is
 `include: ["src"]`. The end-to-end suite is a separate TypeScript project
 ([`tsconfig.e2e.json`](tsconfig.e2e.json)) with its own script, so a broken spec
-fails on its own rather than blocking `npm run build`. Type-checking the specs
-is not the same as running them — `npm run e2e` drives a live host and stays out
-of CI, so `typecheck:e2e` is all the automated coverage `test/e2e/` gets.
+fails on its own rather than blocking `npm run build`.
+
+## End-to-end suite
+
+```sh
+cargo build --locked --bin opencompany   # once, from the repository root
+npm run e2e                              # boots a host, signs in, runs test/e2e/
+npm run e2e -- workflow-edit-delete.spec.ts   # one file
+npm run e2e:headed                       # watch it drive the browser
+```
+
+The specs drive a **real** host — the Rust binary serving this app's `dist/` —
+so one has to exist. With `PW_BASE_URL` unset,
+[`playwright.config.ts`](playwright.config.ts) starts one itself through
+[`test/e2e/host.sh`](test/e2e/host.sh): the `e2e_harness` company, a freshly
+built console bundle, and an isolated data root under `../target/e2e/`, wiped
+each run. It does not build the binary — that is minutes of silence, and a test
+harness that looks like it has hung is worse than one that tells you what to
+run.
+
+Set `PW_BASE_URL` to drive a host you brought up yourself and the config stays
+out of the way entirely: no `webServer`, and `PW_STORAGE_STATE` decides whether
+the suite signs in.
+
+**CI type-checks these specs and runs none of them** (`typecheck:e2e` is all the
+automated coverage `test/e2e/` gets). Type-checking proves a spec compiles, not
+that it holds: `workflow-edit-delete.spec.ts` spent months red against a fixture
+that was never committed, and nothing reported it. Run the suite before touching
+a view it covers.
 
 The `dist/` can be served as static files by any web server (or mounted by the
 OpenCompany host); use `window.OPENCOMPANY_CONFIG` to point it at the API.

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,16 +1,65 @@
 import { defineConfig } from "@playwright/test";
+import { mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const storageState = process.env.PW_STORAGE_STATE;
+// `package.json` is `"type": "module"`, so this file is ESM and `__dirname`
+// does not exist here — it type-checks against `@types/node` and then throws at
+// load. Which is the whole lesson of #406 in one line.
+const here = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Playwright config for the operator-console end-to-end suite.
  *
- * The suite drives a *running* OpenCompany host (the Rust binary serving the
- * built `frontend/dist` via `OPENCOMPANY_CONSOLE_DIR`) at `PW_BASE_URL`,
- * defaulting to the binary's own default bind. Bringing that host up — with a
- * mocked LLM backend — is the harness's job, not this config's, so no
- * `webServer` is declared here.
+ * The suite drives a *running* OpenCompany host — the Rust binary serving the
+ * built `frontend/dist` via `OPENCOMPANY_CONSOLE_DIR`. There are two ways to
+ * get one, and `PW_BASE_URL` alone decides which applies:
+ *
+ * **`PW_BASE_URL` set** — you brought your own host and this config touches
+ * nothing else: no `webServer`, and `PW_STORAGE_STATE` keeps its exact former
+ * meaning (unset ⇒ no `globalSetup` ⇒ no sign-in). Unchanged contract.
+ *
+ * **`PW_BASE_URL` unset** — the config brings a host up itself through
+ * `test/e2e/host.sh` and authenticates against it, so `npm run e2e` is the
+ * whole command. It needs `target/debug/opencompany` to exist; `host.sh` says
+ * so, and says how, rather than failing obscurely.
+ *
+ * That second path exists because of issue #406. This suite is typechecked by
+ * CI (`npm run typecheck:e2e`) and executed by nobody, which is how
+ * `workflow-edit-delete.spec.ts` came to reference a fixture that was never
+ * committed and stay red indefinitely without one report. Typechecking a spec
+ * proves it compiles, not that it holds. Running it was possible before this —
+ * but only if you already knew which four environment variables to set, and a
+ * suite that is hard to start is a suite nobody starts.
+ *
+ * CI still does not run it. That needs the vendored submodules, a Rust
+ * toolchain and a built binary, none of which the Node-only `Console` job has,
+ * so it is a lane of its own rather than something smuggled in here.
  */
+
+const providedBaseURL = process.env.PW_BASE_URL;
+
+/** Whether this config is responsible for the host, as opposed to driving yours. */
+const managesHost = !providedBaseURL;
+
+const baseURL = providedBaseURL || "http://127.0.0.1:8080";
+
+/**
+ * Where the shared signed-in session lands. Defaulted only when we manage the
+ * host: against a host we started, every spec needs a session and there is no
+ * reason to make the caller name a path for it. Against yours, an unset
+ * variable keeps its existing meaning.
+ */
+const storageState =
+  process.env.PW_STORAGE_STATE ||
+  (managesHost ? resolve(here, "../target/e2e/storage-state.json") : undefined);
+
+// `global-setup.ts` writes that file but does not create its directory, and
+// `target/e2e/` does not exist on a clean checkout.
+if (storageState) {
+  mkdirSync(dirname(storageState), { recursive: true });
+}
+
 export default defineConfig({
   testDir: "./test/e2e",
   globalSetup: storageState ? "./test/e2e/global-setup.ts" : undefined,
@@ -19,9 +68,27 @@ export default defineConfig({
   timeout: 60_000,
   reporter: [["list"]],
   use: {
-    baseURL: process.env.PW_BASE_URL || "http://127.0.0.1:8080",
+    baseURL,
     storageState,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
   },
+  webServer: managesHost
+    ? {
+        command: "./test/e2e/host.sh",
+        url: `${baseURL}/healthz`,
+        // A host already listening on the default bind is almost always the one
+        // you are developing against, so drive it rather than fight it for the
+        // port. In CI that would mean silently testing something unknown.
+        reuseExistingServer: !process.env.CI,
+        // Covers a cold `npm run build` for the console bundle plus the host's
+        // own boot, with room to spare.
+        timeout: 180_000,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          PW_HOST_BIND: new URL(baseURL).host,
+        },
+      }
+    : undefined,
 });

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -690,6 +690,15 @@ export function WorkflowsView({
 
   const selected = workflows.find((w) => w.id === selectedId) ?? null;
 
+  // id → display name, for the toolbar picker's closed state. A workflow's id
+  // is not its name, and the trigger renders the raw value unless it is handed
+  // this mapping — issue #270, where the closed picker read
+  // `e2e_conflict_1785687393855` while the open popup read "Conflict probe".
+  const workflowLabels = useMemo(
+    () => Object.fromEntries(workflows.map((w) => [w.id, w.name])),
+    [workflows],
+  );
+
   // The full node model (kind/name/summary/agent/config) for the clicked node,
   // looked up from the loaded graph so the inspector shows fields the laid-out
   // canvas node data doesn't carry (agent, config, …).
@@ -738,21 +747,32 @@ export function WorkflowsView({
         </div>
         <div className="flex items-center gap-2">
           <Select
-            value={selectedId ?? undefined}
+            // Issue #406, half one. NOT `selectedId ?? undefined`: Base UI
+            // decides controlled-vs-uncontrolled ONCE, on the first render,
+            // from `value !== undefined` — and on that render the list has not
+            // arrived, so `selectedId` is still null. Handing it `undefined`
+            // there locked the picker uncontrolled for its whole life, and
+            // every selection this view makes for itself — the auto-select
+            // when the list lands, a card in Browse, the re-select after a
+            // delete — then moved `selectedId` without ever reaching the
+            // picker, which went on rendering its own untouched initial value.
+            // Clicking an option worked, which is why only the operator saw
+            // this. `null` is Base UI's own "nothing is selected", so passing
+            // it keeps the picker controlled from the first render on.
+            value={selectedId}
             onValueChange={(v) => setSelectedId(v)}
             disabled={loadingList || workflows.length === 0}
+            // Issue #406, half two. This map is what makes the trigger show a
+            // name instead of an id (#270). It replaces a `SelectValue`
+            // function child that did the same lookup by hand — because a
+            // function child ALSO overrides `placeholder`, which is how an
+            // empty selection came to render nothing at all rather than "Pick
+            // a workflow". Formatting through `items` leaves the placeholder
+            // reachable.
+            items={workflowLabels}
           >
             <SelectTrigger className="h-8 w-56">
-              {/* The trigger renders the raw value unless told otherwise, and a
-                  workflow's id is not its name — the closed picker showed
-                  `e2e_conflict_1785687393855` where the popup showed "Conflict
-                  probe". Resolve it back through the list the popup is built
-                  from; fall back to the id if the list has not arrived yet. */}
-              <SelectValue placeholder={loadingList ? "Loading…" : "Pick a workflow"}>
-                {(selected) =>
-                  workflows.find((w) => w.id === selected)?.name ?? String(selected ?? "")
-                }
-              </SelectValue>
+              <SelectValue placeholder={loadingList ? "Loading…" : "Pick a workflow"} />
             </SelectTrigger>
             <SelectContent>
               {workflows.map((w) => (

--- a/frontend/test/e2e/global-setup.ts
+++ b/frontend/test/e2e/global-setup.ts
@@ -21,7 +21,13 @@ const VERIFY_PATH = "/api/v1/company/auth/verify";
  * from a broken host, which is exactly what issue #271 sent people chasing.
  */
 export default async function globalSetup(config: FullConfig) {
-  const storageState = process.env.PW_STORAGE_STATE;
+  // Read the RESOLVED path off the config, not `process.env.PW_STORAGE_STATE`.
+  // The config now defaults it when it is the one bringing the host up (issue
+  // #406), and reading the raw variable meant this returned early in exactly
+  // that case — writing no session, and leaving every spec to fail on a
+  // storage-state file nobody had created. The env var still wins where it is
+  // set: the config honours it first.
+  const storageState = config.projects[0]?.use.storageState as string | undefined;
   if (!storageState) return;
 
   const baseURL = config.projects[0]?.use.baseURL as string | undefined;

--- a/frontend/test/e2e/host.sh
+++ b/frontend/test/e2e/host.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Brings up the OpenCompany host the end-to-end suite drives, so that running
+# the suite is one command rather than an incantation nobody remembers.
+#
+# Playwright starts this as its `webServer` whenever `PW_BASE_URL` is NOT set
+# (see ../../playwright.config.ts). Set `PW_BASE_URL` and this script is not
+# used at all — a host you brought up yourself stays entirely your business.
+#
+# It deliberately does NOT build the Rust binary. `cargo build` on a cold target
+# directory is minutes of silence, and a test harness that appears to hang is
+# worse than one that tells you what to run. It DOES rebuild the console bundle,
+# which takes about two seconds and is the difference between testing your
+# working tree and testing whatever `dist/` happened to hold — a stale bundle is
+# how a suite comes to report on code that is not the code under test.
+#
+# Env:
+#   PW_HOST_BIND            address to bind         (default 127.0.0.1:8080)
+#   PW_HOST_COMPANY         company to load         (default companies/e2e_harness)
+#   PW_HOST_DATA_DIR        instance data root      (default target/e2e/data, wiped each run)
+#   PW_HOST_BINARY          path to the binary      (default target/debug/opencompany)
+#   PW_SKIP_CONSOLE_BUILD   set to 1 to reuse the existing frontend/dist
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/../../.." && pwd)"
+
+bind="${PW_HOST_BIND:-127.0.0.1:8080}"
+company="${PW_HOST_COMPANY:-$root/companies/e2e_harness}"
+data_dir="${PW_HOST_DATA_DIR:-$root/target/e2e/data}"
+binary="${PW_HOST_BINARY:-$root/target/debug/opencompany}"
+
+if [[ ! -x "$binary" ]]; then
+  cat >&2 <<EOF
+[e2e host] No OpenCompany binary at:
+    $binary
+
+The suite drives the real host, so one has to be built first. From the
+repository root:
+
+    cargo build --locked --bin opencompany
+
+That is the default feature set, which is all this suite needs — the harness
+company boots on the offline echo brain. Point PW_HOST_BINARY elsewhere to use
+a release build or a feature-gated one.
+EOF
+  exit 1
+fi
+
+if [[ "${PW_SKIP_CONSOLE_BUILD:-}" != "1" ]]; then
+  echo "[e2e host] building the console bundle (PW_SKIP_CONSOLE_BUILD=1 to skip)" >&2
+  ( cd "$root/frontend" && npm run build >&2 )
+fi
+
+if [[ ! -f "$root/frontend/dist/index.html" ]]; then
+  echo "[e2e host] no console bundle at $root/frontend/dist — run 'npm run build' in frontend/." >&2
+  exit 1
+fi
+
+# A fresh instance root per run. The specs create and delete their own
+# workflows, but a run that failed half way leaves them behind, and the next run
+# should not have to reason about what the last one left.
+rm -rf "$data_dir"
+mkdir -p "$data_dir"
+
+echo "[e2e host] serving $company on $bind (data: $data_dir)" >&2
+
+# Loopback bind and no OPENCOMPANY_PUBLIC_URL, both load-bearing: the host only
+# echoes a magic-link `dev_code` when it does not look routable, and
+# global-setup.ts signs the whole suite in with that code.
+cd "$root"
+exec env \
+  OPENCOMPANY_CONSOLE_DIR="$root/frontend/dist" \
+  OPENCOMPANY_DATA_DIR="$data_dir" \
+  "$binary" serve --bind "$bind" --company "$company"

--- a/frontend/test/e2e/host.sh
+++ b/frontend/test/e2e/host.sh
@@ -17,8 +17,10 @@
 # Env:
 #   PW_HOST_BIND            address to bind         (default 127.0.0.1:8080)
 #   PW_HOST_COMPANY         company to load         (default companies/e2e_harness)
-#   PW_HOST_DATA_DIR        instance data root      (default target/e2e/data, wiped each run)
+#   PW_HOST_DATA_DIR        instance data root      (default target/e2e/data; wiped
+#                           each run ONLY while it stays inside target/e2e — see below)
 #   PW_HOST_BINARY          path to the binary      (default target/debug/opencompany)
+#   PW_HOST_PASSTHROUGH     space-separated extra variable names to forward to the host
 #   PW_SKIP_CONSOLE_BUILD   set to 1 to reuse the existing frontend/dist
 
 set -euo pipefail
@@ -58,19 +60,85 @@ if [[ ! -f "$root/frontend/dist/index.html" ]]; then
   exit 1
 fi
 
-# A fresh instance root per run. The specs create and delete their own
-# workflows, but a run that failed half way leaves them behind, and the next run
-# should not have to reason about what the last one left.
-rm -rf "$data_dir"
+# ---------------------------------------------------------------------------
+# The instance data root, which this script DELETES.
+# ---------------------------------------------------------------------------
+# A fresh root per run: the specs create and delete their own workflows, but a
+# run that failed half way leaves them behind, and the next run should not have
+# to reason about what the last one left.
+#
+# Because it deletes, where PW_HOST_DATA_DIR is allowed to point is a safety
+# question and not a convenience one. A value that is mistyped — or simply
+# inherited from a shell that set it for something else — must not be able to
+# take a home directory with it.
+#
+# The rule: a run only ever deletes INSIDE `target/e2e`, the repository's own
+# scratch area. Both paths are canonicalised first (`cd` + `pwd -P`), so
+# neither a `..` nor a symlink can walk out of it. Anywhere else is still
+# usable — pointing the host at a data root you keep is a legitimate thing to
+# want — it is simply reused as it stands, and the run says so rather than
+# quietly removing it.
 mkdir -p "$data_dir"
+data_dir="$(cd "$data_dir" && pwd -P)"
+
+scratch="$root/target/e2e"
+mkdir -p "$scratch"
+scratch="$(cd "$scratch" && pwd -P)"
+
+# `"$scratch"/?*`, not `"$scratch"*`: a sibling `target/e2e-of-my-own` must not
+# match, and neither must `$scratch` itself — playwright.config.ts writes the
+# suite's storage state directly into it, and this runs before global-setup.
+if [[ "$data_dir" == "$scratch"/?* ]]; then
+  rm -rf -- "$data_dir"
+  mkdir -p "$data_dir"
+else
+  echo "[e2e host] data root is not inside the repository's target/e2e scratch area;" >&2
+  echo "[e2e host] reusing it as it stands rather than deleting it." >&2
+fi
 
 echo "[e2e host] serving $company on $bind (data: $data_dir)" >&2
 
-# Loopback bind and no OPENCOMPANY_PUBLIC_URL, both load-bearing: the host only
-# echoes a magic-link `dev_code` when it does not look routable, and
-# global-setup.ts signs the whole suite in with that code.
+# ---------------------------------------------------------------------------
+# The host's environment, built up rather than inherited.
+# ---------------------------------------------------------------------------
+# `env VAR=…` keeps everything the caller already had, and several inherited
+# variables do not fail the run — they change what the host IS, and the suite
+# then fails somewhere else entirely. `OPENCOMPANY_PUBLIC_URL`, or any
+# `OPENCOMPANY_MAIL_*` transport, stops the host echoing the magic-link
+# `dev_code`; that code is the only way global-setup.ts can sign the suite in,
+# so the run dies in bootstrap pointing at nothing. `OPENCOMPANY_STORAGE` and
+# `OPENCOMPANY_TENANT_ID` are worse: they would move the host onto a different
+# backend, and it would come up.
+#
+# So `env -i`, and name what goes in. A denylist has to grow every time another
+# variable gains the power to break this, and is wrong in the meantime without
+# anyone knowing. An allowlist can only be wrong by omission, which shows up as
+# a host that will not start — loudly, once, on the person who can fix it.
+#
+# PW_HOST_PASSTHROUGH is the escape hatch that keeps the allowlist honest: a
+# feature-gated binary supplied through PW_HOST_BINARY needs its inference
+# credentials, and those arrive by environment.
+host_env=(
+  "OPENCOMPANY_CONSOLE_DIR=$root/frontend/dist"
+  "OPENCOMPANY_DATA_DIR=$data_dir"
+)
+
+passthrough=(HOME PATH TMPDIR TZ LANG LC_ALL RUST_LOG RUST_BACKTRACE)
+if [[ -n "${PW_HOST_PASSTHROUGH:-}" ]]; then
+  # Deliberate word splitting: this variable is a list of variable NAMES.
+  # shellcheck disable=SC2206
+  passthrough+=(${PW_HOST_PASSTHROUGH})
+fi
+
+for name in "${passthrough[@]}"; do
+  # `${!name+x}` is "set, even if empty" — an empty HOME is still a decision the
+  # caller made, and dropping it would silently substitute a different one.
+  if [[ -n "${!name+x}" ]]; then
+    host_env+=("$name=${!name}")
+  fi
+done
+
+# Loopback bind, and now a guaranteed-absent OPENCOMPANY_PUBLIC_URL: both
+# load-bearing for the `dev_code` echo the sign-in depends on.
 cd "$root"
-exec env \
-  OPENCOMPANY_CONSOLE_DIR="$root/frontend/dist" \
-  OPENCOMPANY_DATA_DIR="$data_dir" \
-  "$binary" serve --bind "$bind" --company "$company"
+exec env -i "${host_env[@]}" "$binary" serve --bind "$bind" --company "$company"


### PR DESCRIPTION
## Summary

The Workflows toolbar picker rendered **blank** — neither the selected
workflow's name nor the placeholder — so an operator could not tell which
workflow the canvas below belonged to. Fixed, and verified in a browser against
a live host.

The issue also flagged that `workflow-edit-delete.spec.ts` pins this behaviour
and is red on `main` while nobody sees it, because Playwright specs are
type-checked by CI and executed by nothing. That half is addressed too: the
suite now starts its own host, so `npm run e2e` is the whole command, and the
fixture it had always assumed but never had is committed. All 8 tests in that
file pass.

Closes #406.

### Where the bug actually lived

The issue was written against the pre-#405 `WorkflowsView.tsx`. After that
refactor the picker is still in `WorkflowsView.tsx` — it did not move into any
of the seven extracted modules — so the location held. The diagnosis in the
issue is only half right, and the difference matters:

* **Half one, which the issue did not name.** The picker was bound
  `value={selectedId ?? undefined}`. Base UI resolves controlled-vs-uncontrolled
  **once, on the first render**, from `value !== undefined`. On that render the
  workflow list has not arrived and `selectedId` is `null`, so `undefined` went
  in and the picker was pinned *uncontrolled for its entire lifetime*. Every
  selection the view makes for itself then moved `selectedId` and never reached
  the picker: the auto-select when the list lands, a card in the new Browse
  index, the re-select after a delete, the select after a create.
* **Half two, which the issue did name.** `SelectValue` had a function child
  resolving id → name by hand. A function child also overrides `placeholder`, so
  an empty selection rendered nothing rather than "Pick a workflow".

Together: blank whether or not something was selected.

**Clicking an option in the picker always worked**, because that path writes Base
UI's own internal state directly. That is why only the operator ever saw this —
and why the existing spec, which reaches the picker exclusively by clicking, was
never going to catch it. The issue's claim that
`expect(combobox).toContainText(name)` is the failing assertion is not what is
happening: that assertion sits on the one path that worked. See the Tests
section for what was actually red.

### What changed

`value={selectedId}` — `null` is Base UI's own "nothing is selected", so the
picker stays controlled from the first render on. And the id → name mapping now
goes through the root's `items` prop instead of a function child, which keeps
#270's fix (a workflow's id is not its name) while leaving `placeholder`
reachable. `items` is read only by `SelectValue`; the popup is still built from
the explicit `SelectItem` children.

### The suite that could not fail

`workflow-edit-delete.spec.ts` has selected a workflow named `Committed flow`
and asserted the disabled Edit/Delete buttons name `workflows/committed.toml`
since the day it was written. **That fixture was never committed.** Two of its
eight tests had therefore never passed anywhere, ever. Nothing reported it,
because CI type-checks these specs and runs none of them.

So: the fixture is added to `companies/e2e_harness`, and `npm run e2e` now boots
its own host (harness company, freshly built console bundle, isolated data root
under `target/e2e/`) and signs in against it, rather than requiring four
environment variables nobody remembers. Setting `PW_BASE_URL` opts out entirely
and preserves the previous contract byte for byte.

That does **not** put the suite in CI — that needs the vendored submodules, a
Rust toolchain and a built binary, none of which the Node-only `Console` job has,
so it is a lane of its own. Filed as #428 with the measured current state and
what each remaining failure needs.

## API Or Behavior Changes

* **Workflows picker** — shows the selected workflow's name in every state, and
  "Pick a workflow" / "Loading…" when there is no selection. Previously blank.
  No API change.
* **`npm run e2e`** — with `PW_BASE_URL` unset it now starts a host instead of
  failing to connect. With `PW_BASE_URL` set, unchanged: no `webServer`, and
  `PW_STORAGE_STATE` keeps its exact former meaning.
* **`global-setup.ts`** reads the resolved storage-state path off the Playwright
  config rather than `process.env.PW_STORAGE_STATE` directly. The environment
  variable still wins where set — the config honours it first.
* **`companies/e2e_harness`** gains `workflows/committed.toml`. Deliberately not
  in `[workflows].enabled`: the console lists every `workflows/*.toml` it finds,
  so the fixture appears in the picker without the scheduler firing it during a
  suite run.

### The managed host's contract (revised after review)

* **`PW_HOST_DATA_DIR` is wiped, so where it may point is bounded.** A run only
  ever deletes inside the repository's own `target/e2e` scratch area; both paths
  are canonicalised first, so neither a `..` nor a symlink walks out of it, and
  the scratch root itself is excluded because the config writes the suite's
  storage state into it. A path outside stays usable and is reused as it stands,
  with a line saying so — a mistyped or inherited value cannot take a directory
  you care about with it.
* **The host starts from an empty environment** (`env -i` plus an allowlist),
  not the caller's. An inherited `OPENCOMPANY_PUBLIC_URL` or `OPENCOMPANY_MAIL_*`
  stops the host echoing the magic-link code the suite signs in with, and
  `OPENCOMPANY_STORAGE` / `OPENCOMPANY_TENANT_ID` are worse — they move the host
  onto a different backend and it comes up, so the suite reports on something
  nobody meant to test.
* **`PW_HOST_PASSTHROUGH`** (new) — a space-separated list of variable names to
  forward, so a feature-gated build supplied through `PW_HOST_BINARY` can still
  receive its inference credentials.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (`--locked --no-deps`)
- [x] `cargo build --locked --bin opencompany` (clippy `--all-targets` covers the rest)
- [x] `cargo test --locked --lib` — 1424 passed, 0 failed
- [x] `git diff Cargo.lock` — empty
- [x] `npm ci`, `npm run typecheck`, `npm run typecheck:e2e`, `npm run build`
      (no lint script exists in this package) — re-run after the review round

### Browser verification

Chromium against a live host, reading the picker's text in the four states.
**Before** the fix, then **after**, same script, same host:

| State | Before | After |
|---|---|---|
| no workflows at all | `""` | `"Pick a workflow"` |
| auto-selected on page load | `""` | the workflow's name |
| picked from the Browse index (#405) | `""` | the workflow's name |
| clicked in the picker itself | the name | the name |

The last row is the control: it passed before the fix, which is exactly why the
existing spec never caught this.

### The spec, run manually

`workflow-edit-delete.spec.ts`, against a live host:

* **On `main`, before any change here — 6 passed, 2 failed.** Both failures are
  the missing `Committed flow` fixture: with no workflow present the picker is
  disabled and `selectWorkflow` times out clicking it. Not the picker bug, and
  not the `toContainText` assertion the issue names.
* **On this branch — 8 passed**, re-run after the review round on both paths:
  the managed `webServer` path with no `PW_*` set at all, and the `PW_BASE_URL`
  opt-out against a host brought up by hand.

Worth noting one thing the blank picker was doing to this file: the
`confirming the delete…` test asserts `not.toContainText(name)`. Against a
picker that rendered nothing, that held vacuously. It passed for the wrong
reason.

### The two review findings, verified not assumed

Both were real; both fixed in `805896c`.

*Data-root confinement* — four cases: a decoy directory holding a file is
refused and the file survives; `target/e2e/../../frontend` is refused and the
source tree survives (this is the case a plain string-prefix test would have
accepted, so it is what shows the canonicalisation working); the scratch root
itself is refused; the default path is still wiped.

*Environment allowlist* — a caller exporting `OPENCOMPANY_PUBLIC_URL`,
`OPENCOMPANY_MAIL_SMTP_HOST`, `OPENCOMPANY_STORAGE`, `OPENCOMPANY_TENANT_ID` and
an unrelated secret leaks **none** of them, and the spec passes 8/8 from that
same poisoned shell. Forwarding `OPENCOMPANY_PUBLIC_URL` back through
`PW_HOST_PASSTHROUGH` reproduces the failure exactly — `200 {"sent":true}`, no
`dev_code`, global-setup throws — so the guard is load-bearing rather than
decorative.

### The whole suite, run manually

First full run against a default-feature host: **70 passed, 5 failed, 2 skipped,
4.7 minutes.** Four of the five need something the default build has no way to
provide — an agent that actually executes (`wiring.spec.ts`,
`chat-to-card.spec.ts`, `workflow-run-history.spec.ts`) or an external MCP server
(`mcp.spec.ts`). The fifth,
`oauth-onboarding-resume.spec.ts:69` — "the tour resumes on the Connections stop
after a redirect" — is a **genuine product failure**, pre-existing and unrelated
to this change. It is recorded in #428 rather than fixed here; a tour bug is not
this PR's subject and bundling it would make neither reviewable.

## Documentation

* `frontend/README.md` gains an **End-to-end suite** section: the two commands,
  what the config brings up, what `PW_BASE_URL` opts out of, the warning that CI
  type-checks these specs and runs none of them, a table naming the four specs a
  default-feature host cannot cover and what each needs, and — after the review
  round — the managed host's environment and deletion rules, including
  `PW_HOST_PASSTHROUGH`.
* `companies/e2e_harness/company.toml`'s header now lists both of its deltas
  from `openhuman_demo`, not just the `[users] admins` one.
* `frontend/playwright.config.ts` and `frontend/test/e2e/host.sh` carry the
  reasoning inline, including why the environment is an allowlist rather than a
  denylist.
* #428 filed for the CI lane, with the measured pass/fail state above and what
  is required to make it viable.
