### PR TITLE
feat(approvals): let a permission stick — one tool, one teammate, until a deadline (#374)

### DIFF
--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -112,6 +112,80 @@ and replayed on boot, so a restart between approving and re-issuing does not
 drop the approval. Consumed and expired grants are folded out on replay: a
 resurrected single-use grant would not be single-use.
 
+### Standing grants: this tool, for this teammate, until a deadline
+
+Single-use is the right default and was, for a while, the only scope — which
+made it the whole design. An agent reaching for the same tool repeatedly
+produced a stream of near-identical cards, and the operator's rational escapes
+were approving blind or switching the company to `full`, throwing the gate away
+to stop it nagging. So an approve now carries a **scope**:
+
+- **just this once** — the default, and byte-identical to the single-use grant
+  above. Needs no interaction: a body with no `scope` key is exactly the
+  pre-#374 request.
+- **this tool, for this teammate** — a **standing grant**, with a mandatory
+  duration of 1 hour, 8 hours, or 7 days.
+
+A standing grant is a distinct type from a single-use one, not a scope flag on
+it, and both differences are load-bearing: it has **no arguments field**, so it
+cannot argument-match or be widened into doing so; and its **expiry is not
+optional**, so it cannot live forever. The duration is stored as an absolute
+epoch-millis deadline, capped at 7 days server-side — a request past the cap is
+a **400, never a silent clamp**, because quietly shortening a duration would
+leave the operator believing a permission is live when it lapsed days earlier.
+
+Expiry is enforced at **redemption**, under the same lock as the match, and also
+swept on the scheduler's maintenance tick. The sweep is housekeeping and an
+operator notice; it is never the enforcement, or "for one hour" would mean
+"until the next tick after one hour".
+
+#### What can never be granted broadly
+
+Exactly the tools whose consequence group is the catch-all `Other`. Anything the
+classifier calls **Spend, Send, Sign, Publish, Hire or Identity** stays a
+per-call decision, forever, with nobody having to remember to add it to a list —
+the rule delegates to the taxonomy at the top of this document rather than
+keeping a second hand-written set of "safe" tools, which would be written once
+and then silently accrue every new tool by omission.
+
+The console hides the control for a card it cannot be used on; that is UX. The
+**enforcement** is host-side at mint time, so a hand-rolled request for a
+standing grant on a Send-group tool is a 400 rather than a permission. Native
+effects are refused too: the runtime performs those itself, so "this tool, for
+this teammate" names neither of the two things it needs.
+
+A refused scope changes nothing at all — the approval stays parked and no
+verdict is journaled — so the operator can simply approve it once instead.
+
+Known and deliberate: `shell` classifies as `Other` and is therefore grantable.
+Narrowing it belongs in the classifier — giving shell a consequence class — not
+in a second ad-hoc exclusion list, which is the drift this design exists to
+avoid. It is operator opt-in, time-boxed, revocable, and both `never_do` and the
+`readonly` brake outrank it.
+
+#### Listing and revoking
+
+`GET {scope}/grants` lists the live standing permissions; `DELETE
+{scope}/grants/{gid}` takes one back, 404 when it is already gone. Both are
+journaled with the **resolving operator's real identity**, so "who opened this
+up" is answerable later. Revocation takes effect on the tool's **next** call — a
+call already admitted is not aborted, because there is no abort lever inside an
+agent's turn and killing one mid-call is the lifecycle anti-pattern; the next
+policy check finds nothing and re-parks.
+
+The list carries no arguments, because a standing grant has none — so it opens
+no second redaction surface.
+
+Lifecycle records: `StandingGrantMinted` → `StandingGrantRevoked` |
+`StandingGrantExpired`. Replay folds out revoked and expired grants *and*
+anything already past its deadline, so a host that was down across an expiry
+cannot hand the permission back on boot.
+
+Per-use auditing is tracing-only in v1: mint, revoke and expiry are journaled
+with actor and timestamps, but each admitted call writes no journal record.
+Defensible because a standing grant only ever admits `Other`-group tools and
+never a priced call; a per-use record is additive later.
+
 ### Precedence at the tool gate
 
 A tool call is decided in this order:
@@ -121,9 +195,16 @@ A tool call is decided in this order:
    deliberately: a grant is an operator saying yes to one call, `never_do` is
    the company saying not ever, and the standing rule is the one meant to
    survive a socially engineered operator.
-2. a live **grant** matching agent + tool + exact arguments → allow, once.
-3. `[policy].always_approve` → park.
-4. mode dispatch (`readonly` / `supervised` / `full`).
+2. a live **single-use grant** matching agent + tool + exact arguments →
+   allow, once.
+3. a live **standing grant** matching agent + tool, unexpired → allow. Placed
+   immediately below single-use consumption so a matching single-use grant
+   still *burns*: masking it would leave the operator's one-off approval to
+   expire and be announced as "the agent didn't act", about a call that ran.
+   This arm refuses a **priced** call (a declared amount, a metered read), so a
+   standing grant can never admit money by placement rather than by promise.
+4. `[policy].always_approve` → park.
+5. mode dispatch (`readonly` / `supervised` / `full`).
 
 The grant sits **above** `always_approve` on purpose. A tool on that list still
 parks the first time, which is what the list is for; but once the operator has

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -30,10 +30,12 @@ import {
   type FeedbackResponse,
   type FeedbackSummary,
   type FinancesDto,
+  type GrantScope,
   type InboxDto,
   type InboxMessageDto,
   type ResolveReceipt,
   type SetBudgetInput,
+  type StandingGrant,
   type TeamMemberDto,
   type UsageDto,
   type Verdict,
@@ -342,17 +344,52 @@ export class OpenCompanyClient {
     verdict: Verdict,
     note?: string,
     company?: string | null,
-    options: { detach?: boolean } = {},
+    options: { detach?: boolean; scope?: GrantScope } = {},
   ): Promise<ChatResponse | ResolveReceipt> {
-    const body: { verdict: Verdict; note?: string; detach?: boolean } = { verdict };
+    const body: {
+      verdict: Verdict;
+      note?: string;
+      detach?: boolean;
+      scope?: "once" | "tool";
+      expires_in_millis?: number;
+    } = { verdict };
     if (note) body.note = note;
     if (options.detach) body.detach = true;
+    // Issue #374. The `once` scope is sent as *nothing at all*, not as
+    // `scope: "once"`: the omitted-field form is what an old host understands,
+    // so a new console against an old host keeps working instead of 400ing on a
+    // key that host has never heard of. Only the broader scope is ever on the
+    // wire, and it always carries its duration — the host rejects it otherwise.
+    if (options.scope?.kind === "tool") {
+      body.scope = "tool";
+      body.expires_in_millis = options.scope.expiresInMillis;
+    }
     const answer = await this.request<unknown>(
       "POST",
       `${this.scope(company)}/approvals/${encodeURIComponent(approvalId)}`,
       body,
     );
     return isResolveReceipt(answer) ? answer : (answer as ChatResponse);
+  }
+
+  /** The live standing permissions, newest first (#374). */
+  listGrants(company?: string | null): Promise<StandingGrant[]> {
+    return this.request<StandingGrant[]>("GET", `${this.scope(company)}/grants`);
+  }
+
+  /**
+   * Take a standing permission back (#374).
+   *
+   * Effective on the tool's **next** call — a call already underway is not
+   * aborted. A 404 means it was already gone (revoked elsewhere, or expired),
+   * which the caller should treat as success: the permission is not live either
+   * way, and the list refresh will show that.
+   */
+  revokeGrant(grantId: string, company?: string | null): Promise<void> {
+    return this.request<void>(
+      "DELETE",
+      `${this.scope(company)}/grants/${encodeURIComponent(grantId)}`,
+    );
   }
 
   /** Capture feedback (optionally preview the exact issue body first). */

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -193,6 +193,21 @@ export interface ApprovalSummary {
    */
   agent?: string | null;
   /**
+   * Whether the operator may grant this tool **broadly** — one standing
+   * permission covering any arguments until a deadline (#374).
+   *
+   * `true` exactly when the effect came from a harness tool call and its
+   * consequence group is the catch-all one. Anything that spends, sends, signs,
+   * publishes, hires or touches identity stays a per-call decision, so the scope
+   * control is not rendered for it.
+   *
+   * **This is a hint, not the boundary.** The host re-checks the same rule when
+   * the resolve arrives and answers 400, so ignoring this field buys nothing.
+   * Optional and defaulting to absent, which is how an old host degrades: no
+   * field, no control, approve-once exactly as before.
+   */
+  broadly_grantable?: boolean;
+  /**
    * What the effect will actually do — the tool call's arguments (#372).
    *
    * Already redacted and bounded by the host
@@ -234,6 +249,42 @@ export interface ResolveReceipt {
 }
 
 export type Verdict = "approve" | "deny";
+
+/**
+ * What an approve buys (#374).
+ *
+ * `once` is the default and needs no interaction: one call, with exactly the
+ * arguments the operator saw. `tool` is the broader option, and its duration is
+ * mandatory — there is no unbounded form, on the wire or in the UI.
+ */
+export type GrantScope = { kind: "once" } | { kind: "tool"; expiresInMillis: number };
+
+/** The duration options offered with the broader scope. Nothing else is valid. */
+export const GRANT_DURATIONS: { label: string; millis: number }[] = [
+  { label: "1 hour", millis: 60 * 60 * 1000 },
+  { label: "8 hours", millis: 8 * 60 * 60 * 1000 },
+  { label: "7 days", millis: 7 * 24 * 60 * 60 * 1000 },
+];
+
+/**
+ * One standing permission, as `GET {scope}/grants` returns it (#374).
+ *
+ * Carries **no arguments** — a standing grant has none, which is what makes it
+ * structurally unable to be widened into an argument-matching rule, and why this
+ * list needs no redaction of its own.
+ */
+export interface StandingGrant {
+  id: string;
+  /** The teammate it was granted to. */
+  agent: string;
+  /** The tool it admits, with any arguments. */
+  tool: string;
+  /** Who granted it: a signed-in user, or the platform credential. */
+  granted_by: { kind: string; id: string };
+  at_millis: number;
+  /** Epoch-millis it stops admitting calls. */
+  expires_at_millis: number;
+}
 
 export type FeedbackCategory =
   | "wrong-output"

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -35,7 +35,7 @@ import {
 } from "lucide-react";
 
 import type { OpenCompanyClient } from "@/api/client";
-import type { ApprovalSummary } from "@/api/types";
+import { GRANT_DURATIONS, type ApprovalSummary, type GrantScope } from "@/api/types";
 import { approvalAction, money, payloadLines, timeAgo } from "@/lib/language";
 import { cn } from "@/lib/utils";
 
@@ -194,6 +194,112 @@ export function ApprovalPayload({ approval }: { approval: ApprovalSummary }) {
       )}
     </div>
   );
+}
+
+/**
+ * The scope control: what this approve buys (#374).
+ *
+ * Rendered **only** when the host marked the card `broadly_grantable`, so the
+ * operator is never offered a choice the host would refuse. That is UX, not the
+ * boundary — the host re-checks and answers 400 — but offering an option that
+ * cannot work is its own kind of lie.
+ *
+ * Two options, and the default needs no interaction at all: doing nothing
+ * approves once, exactly as before this existed. Picking the broader option
+ * forces a duration, because there is no unbounded form to fall back to; the
+ * radio and the duration are one control rather than two so an operator cannot
+ * arrive at "for a period, unspecified".
+ *
+ * Lives here rather than in either view because both surfaces that decide an
+ * approval must say the same thing about what a decision means. Two copies of
+ * this wording would drift, and the half that drifted would be the one somebody
+ * was reading when it mattered.
+ */
+export function ApprovalScopeControl({
+  approval: a,
+  askerNames,
+  scope,
+  onChange,
+  disabled,
+}: {
+  approval: ApprovalSummary;
+  /** Roster names, so the sentence says who — the same map the meta line uses. */
+  askerNames: Map<string, string>;
+  scope: GrantScope;
+  onChange: (scope: GrantScope) => void;
+  disabled?: boolean;
+}) {
+  const name = `scope-${a.id}`;
+  if (!a.broadly_grantable) return null;
+
+  return (
+    <fieldset
+      disabled={disabled}
+      className="rounded-lg border bg-muted/30 px-3 py-2 text-sm disabled:opacity-60"
+    >
+      <legend className="px-1 text-xs text-muted-foreground">If you approve</legend>
+      <div className="flex flex-col gap-1.5">
+        <label className="flex items-center gap-2">
+          <input
+            type="radio"
+            name={name}
+            checked={scope.kind === "once"}
+            onChange={() => onChange({ kind: "once" })}
+            className="size-3.5 accent-primary"
+          />
+          <span>Just this once</span>
+        </label>
+        <label className="flex flex-wrap items-center gap-2">
+          <input
+            type="radio"
+            name={name}
+            checked={scope.kind === "tool"}
+            // Picking the broader scope commits to a duration immediately —
+            // the first option, not an empty one — so there is no state in
+            // which "for a period" is selected with no period.
+            onChange={() =>
+              onChange({ kind: "tool", expiresInMillis: GRANT_DURATIONS[0].millis })
+            }
+            className="size-3.5 accent-primary"
+          />
+          <span>Let {askerLabel(a, askerNames)} use this tool for</span>
+          <select
+            value={scope.kind === "tool" ? scope.expiresInMillis : GRANT_DURATIONS[0].millis}
+            disabled={scope.kind !== "tool"}
+            onChange={(e) =>
+              onChange({ kind: "tool", expiresInMillis: Number(e.target.value) })
+            }
+            aria-label="How long this permission lasts"
+            className="rounded-md border bg-background px-1.5 py-0.5 text-xs disabled:opacity-50"
+          >
+            {GRANT_DURATIONS.map((d) => (
+              <option key={d.millis} value={d.millis}>
+                {d.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      {scope.kind === "tool" && (
+        <p className="mt-1.5 px-1 text-xs text-muted-foreground">
+          It won't ask again for this tool until then — with any arguments. You can take it
+          back from Standing permissions at any time.
+        </p>
+      )}
+    </fieldset>
+  );
+}
+
+/**
+ * Who the broader scope would be granted to, by name.
+ *
+ * Falls back to the raw agent id, then to "this teammate". Naming the wrong
+ * teammate would be worse than naming none, so this only ever narrows from what
+ * the host actually said — it never guesses.
+ */
+function askerLabel(a: ApprovalSummary, askerNames: Map<string, string>): string {
+  if (!a.agent) return "this teammate";
+  return askerNames.get(a.agent) ?? a.agent;
 }
 
 /**

--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -152,6 +152,20 @@ export function approvalAction(a: ApprovalSummary): string {
   );
 }
 
+/**
+ * What a tool does, in plain language, from its identifier alone (#374).
+ *
+ * The Standing permissions list has no approval to hand to
+ * {@link approvalAction} — the card it came from was resolved and is gone — but
+ * the glossary rule at the top of this file still applies: an operator must
+ * never be shown `workspace_write` and asked to reason about it. Same first two
+ * rungs as {@link approvalAction}, with a fallback that names a tool without
+ * pretending to know which one.
+ */
+export function toolAction(kind: string): string {
+  return labelFor(EFFECT_LABELS, kind) ?? labelFor(TOOL_LABELS, kind) ?? "Use one of its tools";
+}
+
 /** A one-line, human summary of what needs approval. */
 export function approvalSummary(a: ApprovalSummary): string {
   const action = approvalAction(a);

--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -125,6 +125,20 @@ export function effectDone(kind: string, amountUsd?: number | null): string {
 const TOOL_LABELS: Readonly<Record<string, string>> = {
   shell: "Run a terminal command",
   glob: "Search files in its workspace",
+  // Issue #374 added a second reader of these labels — the Standing permissions
+  // list — where the payload block that used to disambiguate an unlabelled tool
+  // does not exist. Two permissions both reading "Use one of its tools" would be
+  // indistinguishable, so the tools that can actually hold one (the catch-all
+  // `Other` group) need real words rather than the generic fallback.
+  workspace_write: "Edit a note in its workspace",
+  workspace_read: "Read a note in its workspace",
+  workspace_list: "List its workspace notes",
+  memory_store: "Save something to its memory",
+  memory_recall: "Look something up in its memory",
+  web_fetch: "Fetch a web page",
+  query_company: "Look up something about the company",
+  // `mcp_registry_tool_call` is deliberately absent: EFFECT_LABELS already
+  // names it and is consulted first, so an entry here would be unreachable.
 };
 
 /**

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -92,7 +92,7 @@ export function ApprovalsView({ client, company, feed, onResolved, onGoToConvers
   const [inFlight, setInFlight] = useState<ReadonlyMap<string, Verdict>>(() => new Map());
   const { approvals, now } = feed;
   const askerNames = useAskerNames(client, company, approvals);
-  const { grants, refreshGrants } = useStandingGrants(client, company);
+  const { grants, granterNames, refreshGrants } = useStandingGrants(client, company);
 
   const markInFlight = (id: string, verdict: Verdict | null) =>
     setInFlight((prev) => {
@@ -209,6 +209,7 @@ export function ApprovalsView({ client, company, feed, onResolved, onGoToConvers
           grants={grants}
           now={now}
           askerNames={askerNames}
+          granterNames={granterNames}
           onRevoke={async (id) => {
             try {
               await client.revokeGrant(id, company);
@@ -244,6 +245,10 @@ export function ApprovalsView({ client, company, feed, onResolved, onGoToConvers
  */
 function useStandingGrants(client: OpenCompanyClient, company: string | null) {
   const [grants, setGrants] = useState<StandingGrant[]>([]);
+  // Actor id → what to call them. Without this the row reads "granted by
+  // 019fd3d1bddf-000000000005", which is a runtime identifier in front of an
+  // operator — the thing the glossary rule forbids, and useless besides.
+  const [granterNames, setGranterNames] = useState<Map<string, string>>(new Map());
 
   const refreshGrants = useCallback(async () => {
     const next = await client.listGrants(company).catch(() => [] as StandingGrant[]);
@@ -256,6 +261,31 @@ function useStandingGrants(client: OpenCompanyClient, company: string | null) {
       const next = await client.listGrants(company).catch(() => [] as StandingGrant[]);
       if (live) setGrants(next);
     })();
+    // Who the granter ids belong to. Two reads, both allowed to fail: the
+    // roster is admin-only, so a member sees no names and the row falls back to
+    // a neutral phrase rather than to a raw id.
+    void (async () => {
+      const [me, users] = await Promise.all([
+        client
+          .get<{ id: string; email: string; displayName?: string }>(
+            `${client.scopeFor(company)}/auth/me`,
+          )
+          .catch(() => null),
+        client
+          .get<{ id: string; email: string; display_name?: string }[]>(
+            `${client.scopeFor(company)}/users`,
+          )
+          .catch(() => []),
+      ]);
+      if (!live) return;
+      const names = new Map<string, string>();
+      for (const u of users) names.set(u.id, u.display_name?.trim() || u.email);
+      // "you" outranks the roster name: an operator reading their own audit
+      // trail should not have to recognise their own user id or email.
+      if (me) names.set(me.id, "you");
+      setGranterNames(names);
+    })();
+
     // Slow on purpose. Mint and revoke from another browser are only
     // poll-visible in v1 (there is no event for them), and a permission list is
     // not something an operator watches change — a minute is well inside the
@@ -267,7 +297,7 @@ function useStandingGrants(client: OpenCompanyClient, company: string | null) {
     };
   }, [client, company, refreshGrants]);
 
-  return { grants, refreshGrants };
+  return { grants, granterNames, refreshGrants };
 }
 
 /**
@@ -281,11 +311,14 @@ function StandingPermissions({
   grants,
   now,
   askerNames,
+  granterNames,
   onRevoke,
 }: {
   grants: StandingGrant[];
   now: number;
   askerNames: Map<string, string>;
+  /** Actor id → display name; empty when the roster read was not permitted. */
+  granterNames: Map<string, string>;
   onRevoke: (id: string) => Promise<void>;
 }) {
   // Per row, not one flag for the section — #373's lesson: a single in-flight
@@ -321,7 +354,7 @@ function StandingPermissions({
                   <p className="text-xs text-muted-foreground">
                     {askerNames.get(g.agent) ?? g.agent} ·{" "}
                     {expired ? "expired" : `expires ${untilLabel(g.expires_at_millis, now)}`} ·
-                    granted {timeAgo(g.at_millis, now)} by {g.granted_by.id}
+                    granted {timeAgo(g.at_millis, now)} by {granterLabel(g, granterNames)}
                   </p>
                 </div>
                 <Button
@@ -345,6 +378,19 @@ function StandingPermissions({
       </div>
     </section>
   );
+}
+
+/**
+ * What to call whoever granted a permission.
+ *
+ * Never the raw actor id: that is a runtime identifier, and showing one to an
+ * operator is both against the glossary rule and useless — nobody recognises a
+ * uuid. When the roster cannot be read (a member, not an admin) the row says
+ * "someone with admin access", which is less information but not misleading.
+ */
+function granterLabel(g: StandingGrant, granterNames: Map<string, string>): string {
+  if (g.granted_by.kind !== "user") return "an automation";
+  return granterNames.get(g.granted_by.id) ?? "someone with admin access";
 }
 
 /** "in 42m" / "in 6h" / "in 3d" — how long a permission has left. */

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -1,19 +1,26 @@
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Check, Loader2, ShieldCheck, X } from "lucide-react";
 import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
-import { ApiError, type ApprovalSummary, type Verdict } from "@/api/types";
+import {
+  ApiError,
+  type ApprovalSummary,
+  type GrantScope,
+  type StandingGrant,
+  type Verdict,
+} from "@/api/types";
 import {
   ApprovalHeadline,
   ApprovalMeta,
   ApprovalPayload,
+  ApprovalScopeControl,
   useAskerNames,
 } from "@/components/approval-card";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import type { CompanyFeed } from "@/hooks/use-company";
-import { approvalSummary } from "@/lib/language";
+import { approvalSummary, timeAgo, toolAction } from "@/lib/language";
 
 /**
  * Below this, a lost connection cannot have outlived the fast part of a resolve.
@@ -85,6 +92,7 @@ export function ApprovalsView({ client, company, feed, onResolved, onGoToConvers
   const [inFlight, setInFlight] = useState<ReadonlyMap<string, Verdict>>(() => new Map());
   const { approvals, now } = feed;
   const askerNames = useAskerNames(client, company, approvals);
+  const { grants, refreshGrants } = useStandingGrants(client, company);
 
   const markInFlight = (id: string, verdict: Verdict | null) =>
     setInFlight((prev) => {
@@ -94,30 +102,37 @@ export function ApprovalsView({ client, company, feed, onResolved, onGoToConvers
       return next;
     });
 
-  async function decide(a: ApprovalSummary, verdict: Verdict) {
+  async function decide(a: ApprovalSummary, verdict: Verdict, scope: GrantScope) {
     // Per-row guard: only a double-press on THIS card is ignored. The global
     // early return that used to live here made every other card inert too.
     if (inFlight.has(a.id)) return;
     markInFlight(a.id, verdict);
     const startedAt = Date.now();
     try {
-      await client.resolveApproval(a.id, verdict, undefined, company);
+      await client.resolveApproval(a.id, verdict, undefined, company, { scope });
       // Issue #243: approving no longer just records a verdict — it hands the
       // agent a single-use grant and re-dispatches it to make the call. The old
       // "Approved: …" read as "done", which was the exact lie that made the
       // missing re-dispatch invisible: the operator saw a success toast for work
       // that had silently dead-ended. Say what is actually happening instead.
       // Declining IS terminal, so its wording is unchanged.
+      // Say which scope actually landed. "Approved" alone would read the same
+      // for a one-off and for a week-long permission, and the operator has to be
+      // able to tell those apart from the confirmation they just got.
       const line =
-        verdict === "approve"
-          ? `Approved — the agent is completing the action: ${approvalSummary(a)}`
-          : `Declined: ${approvalSummary(a)}`;
+        verdict !== "approve"
+          ? `Declined: ${approvalSummary(a)}`
+          : scope.kind === "tool"
+            ? `Approved — ${toolAction(a.kind).toLowerCase()} won't ask again until this permission expires. Take it back under Standing permissions.`
+            : `Approved — the agent is completing the action: ${approvalSummary(a)}`;
       onResolved(line);
       toast.success(line);
       // The agent's reply arrives as a journaled `AgentReply` on its own thread,
       // so no extra plumbing is needed here — the existing feed refresh plus the
       // per-agent DM thread (#151) surface it.
       void feed.refresh();
+      // A tool-scoped approve minted a permission, so the list below is stale.
+      if (scope.kind === "tool") void refreshGrants();
     } catch (err) {
       // Issue #380: a failed request is not the same as a failed decision.
       //
@@ -180,15 +195,165 @@ export function ApprovalsView({ client, company, feed, onResolved, onGoToConvers
                   now={now}
                   askerNames={askerNames}
                   deciding={inFlight.get(a.id) ?? null}
-                  onDecide={(verdict) => void decide(a, verdict)}
+                  onDecide={(verdict, scope) => void decide(a, verdict, scope)}
                 />
               ))}
             </div>
           </>
         )}
+
+        {/* Below the queue, and shown even when the queue is empty — a standing
+            permission with nothing currently parked is exactly the state an
+            operator most needs to be able to find and take back. */}
+        <StandingPermissions
+          grants={grants}
+          now={now}
+          askerNames={askerNames}
+          onRevoke={async (id) => {
+            try {
+              await client.revokeGrant(id, company);
+              toast.success("Permission revoked — this tool will ask again from its next call.");
+            } catch (err) {
+              // A 404 means it was already gone (revoked elsewhere, or expired).
+              // The operator's intent is satisfied either way, so this is not an
+              // error to them — only a stale list, which the refresh below fixes.
+              if (err instanceof ApiError && err.status === 404) {
+                toast.info("That permission was already gone.");
+              } else {
+                const msg = err instanceof ApiError ? err.message : "something went wrong";
+                toast.error(`Couldn't revoke it — ${msg}`);
+                throw err;
+              }
+            } finally {
+              void refreshGrants();
+            }
+          }}
+        />
       </div>
     </div>
   );
+}
+
+/**
+ * The live standing permissions, polled alongside the approvals feed (#374).
+ *
+ * Its own read rather than a field on the feed: grants change on operator
+ * action, not on company activity, so they do not need the feed's cadence — and
+ * a host that predates the route 404s, which is caught here so the section
+ * simply does not appear rather than breaking the page.
+ */
+function useStandingGrants(client: OpenCompanyClient, company: string | null) {
+  const [grants, setGrants] = useState<StandingGrant[]>([]);
+
+  const refreshGrants = useCallback(async () => {
+    const next = await client.listGrants(company).catch(() => [] as StandingGrant[]);
+    setGrants(next);
+  }, [client, company]);
+
+  useEffect(() => {
+    let live = true;
+    void (async () => {
+      const next = await client.listGrants(company).catch(() => [] as StandingGrant[]);
+      if (live) setGrants(next);
+    })();
+    // Slow on purpose. Mint and revoke from another browser are only
+    // poll-visible in v1 (there is no event for them), and a permission list is
+    // not something an operator watches change — a minute is well inside the
+    // shortest duration on offer.
+    const timer = setInterval(() => void refreshGrants(), 60_000);
+    return () => {
+      live = false;
+      clearInterval(timer);
+    };
+  }, [client, company, refreshGrants]);
+
+  return { grants, refreshGrants };
+}
+
+/**
+ * What the operator has opened up, and how to take it back (#374).
+ *
+ * Renders nothing when there is nothing standing — including against a host
+ * that has no grants route at all, which reads back as an empty list. The
+ * section appearing is itself the signal that something is open.
+ */
+function StandingPermissions({
+  grants,
+  now,
+  askerNames,
+  onRevoke,
+}: {
+  grants: StandingGrant[];
+  now: number;
+  askerNames: Map<string, string>;
+  onRevoke: (id: string) => Promise<void>;
+}) {
+  // Per row, not one flag for the section — #373's lesson: a single in-flight
+  // slot makes deciding one row freeze every other row on the screen.
+  const [revoking, setRevoking] = useState<ReadonlySet<string>>(() => new Set());
+  if (grants.length === 0) return null;
+
+  const mark = (id: string, busy: boolean) =>
+    setRevoking((prev) => {
+      const next = new Set(prev);
+      if (busy) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+
+  return (
+    <section className="mt-8">
+      <h2 className="mb-1 text-sm font-medium text-muted-foreground">Standing permissions</h2>
+      <p className="mb-3 text-xs text-muted-foreground">
+        Tools you've let a teammate use without asking each time. Each one expires on its own;
+        you can end it sooner.
+      </p>
+      <div className="flex flex-col gap-2">
+        {grants.map((g) => {
+          const busy = revoking.has(g.id);
+          const expired = g.expires_at_millis <= now;
+          return (
+            <Card key={g.id}>
+              <CardContent className="flex flex-wrap items-center gap-3 py-3">
+                <div className="min-w-0 flex-1">
+                  {/* Phrased, never the raw identifier — the glossary rule. */}
+                  <p className="truncate text-sm font-medium">{toolAction(g.tool)}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {askerNames.get(g.agent) ?? g.agent} ·{" "}
+                    {expired ? "expired" : `expires ${untilLabel(g.expires_at_millis, now)}`} ·
+                    granted {timeAgo(g.at_millis, now)} by {g.granted_by.id}
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={busy}
+                  onClick={() => {
+                    mark(g.id, true);
+                    void onRevoke(g.id)
+                      .catch(() => {})
+                      .finally(() => mark(g.id, false));
+                  }}
+                >
+                  {busy ? <Loader2 className="size-4 animate-spin" /> : <X className="size-4" />}{" "}
+                  Revoke
+                </Button>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+/** "in 42m" / "in 6h" / "in 3d" — how long a permission has left. */
+function untilLabel(atMillis: number, now: number): string {
+  const mins = Math.max(0, Math.round((atMillis - now) / 60_000));
+  if (mins < 60) return `in ${mins}m`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `in ${hours}h`;
+  return `in ${Math.round(hours / 24)}d`;
 }
 
 /**
@@ -221,8 +386,14 @@ function ApprovalCard({
   askerNames: Map<string, string>;
   /** The verdict this card is waiting on, or `null` when it is idle (#373). */
   deciding: Verdict | null;
-  onDecide: (verdict: Verdict) => void;
+  onDecide: (verdict: Verdict, scope: GrantScope) => void;
 }) {
+  // Per-card, like the in-flight verdict and for the same reason: two cards can
+  // be open at once and each carries its own decision. Defaults to `once`, so a
+  // card decided without touching the control behaves exactly as it did before
+  // #374 — the scope is opt-in at every level, including this one.
+  const [scope, setScope] = useState<GrantScope>({ kind: "once" });
+
   // No cross-card dimming: another card being decided is not this card's
   // business, and treating it as such is the visual half of the #373 bug.
   return (
@@ -239,7 +410,9 @@ function ApprovalCard({
                 variant="outline"
                 size="sm"
                 disabled={deciding !== null}
-                onClick={() => onDecide("deny")}
+                /* A decline never carries a scope — there is nothing to grant,
+                   and the host refuses the pairing anyway. */
+                onClick={() => onDecide("deny", { kind: "once" })}
               >
                 {deciding === "deny" ? (
                   <Loader2 className="size-4 animate-spin" />
@@ -248,7 +421,11 @@ function ApprovalCard({
                 )}{" "}
                 Decline
               </Button>
-              <Button size="sm" disabled={deciding !== null} onClick={() => onDecide("approve")}>
+              <Button
+                size="sm"
+                disabled={deciding !== null}
+                onClick={() => onDecide("approve", scope)}
+              >
                 {deciding === "approve" ? (
                   <Loader2 className="size-4 animate-spin" />
                 ) : (
@@ -261,6 +438,14 @@ function ApprovalCard({
         />
 
         <ApprovalPayload approval={a} />
+
+        <ApprovalScopeControl
+          approval={a}
+          askerNames={askerNames}
+          scope={scope}
+          onChange={setScope}
+          disabled={deciding !== null}
+        />
 
         <ApprovalMeta
           approval={a}

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -62,7 +62,7 @@ pub(crate) async fn join_follow_up(
 }
 use crate::runtime::CycleRunner;
 use crate::runtime::cycle::ResolveReceipt;
-use crate::runtime::grants::{GRANT_TTL_MILLIS, GrantSet};
+use crate::runtime::grants::{GRANT_TTL_MILLIS, GrantId, GrantScope, GrantSet, StandingGrant};
 use crate::runtime::journal::{ApprovalOrigin, ExecutedEffect, RuntimeJournal};
 use crate::runtime::types::{ApprovalSummary, CompanyStatus, CycleReport};
 use crate::server::ops::mailer::MailSender;
@@ -776,7 +776,9 @@ impl CompanyRuntime {
         verdict: Verdict,
         by: Actor,
     ) -> Result<CycleReport> {
-        let (_, follow_up) = self.resolve_approval_spawned(id, verdict, by).await?;
+        let (_, follow_up) = self
+            .resolve_approval_spawned(id, verdict, by, GrantScope::Once)
+            .await?;
         join_follow_up(follow_up).await
     }
 
@@ -808,15 +810,21 @@ impl CompanyRuntime {
     /// follow-up cycle: a resolution that journaled the verdict and then failed
     /// to run its follow-up would leave the brain permanently unaware of an
     /// approval the operator had already granted.
+    /// `scope` is what the operator's approve buys (issue #374):
+    /// [`GrantScope::Once`] is the default and the pre-#374 behaviour byte for
+    /// byte; [`GrantScope::Tool`] mints a standing permission instead. A scope
+    /// the runtime must not honour is refused **before** the gate is touched, so
+    /// the approval stays parked and no verdict is journaled.
     pub async fn resolve_approval_spawned(
         self: &Arc<Self>,
         id: &ApprovalId,
         verdict: Verdict,
         by: Actor,
+        scope: GrantScope,
     ) -> Result<(ResolveReceipt, JoinHandle<Result<CycleReport>>)> {
         self.ensure_accepting()?;
         let receipt = CycleRunner::new(self)
-            .settle_approval(id, verdict, by)
+            .settle_approval(id, verdict, by, scope)
             .await?;
         Ok((receipt.clone(), self.spawn_follow_up(receipt)))
     }
@@ -991,7 +999,86 @@ impl CompanyRuntime {
             }
             ids.push(grant.approval_id);
         }
+
+        // Issue #374: standing grants lapse on the same maintenance tick.
+        //
+        // The sweep is housekeeping and an operator notice, never the
+        // enforcement — `GrantSet::match_standing` refuses an expired grant
+        // under the redemption lock, so "for one hour" means one hour and not
+        // "until the next tick after one hour". What this adds is the durable
+        // record and the line telling the operator a permission they granted has
+        // run out, so its silent return to asking is explained rather than
+        // mysterious.
+        for grant in self.grants.sweep_standing(now) {
+            self.journal.record_standing_expired(&grant.id, now).await?;
+            self.announce_to_operator(&format!(
+                "The standing permission for `{}` on `{}` has expired — it will ask for approval \
+                 again from now on.",
+                grant.tool, grant.agent
+            ))
+            .await;
+        }
         Ok(ids)
+    }
+
+    /// Every live standing permission, newest first (issue #374) — what the
+    /// console's "Standing permissions" section lists.
+    pub fn standing_grants(&self) -> Vec<StandingGrant> {
+        self.grants.standing()
+    }
+
+    /// Revokes a standing permission (issue #374), journaling who took it back
+    /// and when. `false` when there was nothing to revoke — already gone, swept,
+    /// or revoked from another browser — which the route answers as a 404 rather
+    /// than claiming to have done something.
+    ///
+    /// Takes effect on the **next** policy check. An already-admitted call is
+    /// not aborted: there is no abort lever inside an agent's turn, and killing
+    /// one mid-call is the lifecycle anti-pattern. The next check finds nothing
+    /// and re-parks.
+    pub async fn revoke_standing_grant(&self, id: &GrantId, by: Actor) -> Result<bool> {
+        let Some(grant) = self.grants.revoke_standing(id) else {
+            return Ok(false);
+        };
+        // Live-set removal first here, unlike minting. The orders are opposite on
+        // purpose and both fail safe: a crash while minting must not leave a
+        // permission live but unrecorded, and a crash while revoking must not
+        // leave one live that the operator has already been told is gone.
+        self.journal
+            .record_standing_revoked(id, by, now_millis())
+            .await?;
+        tracing::debug!(
+            grant_id = %id,
+            tool = %grant.tool,
+            agent = %grant.agent,
+            "[approval] revoked a standing grant; the next call re-parks"
+        );
+        Ok(true)
+    }
+
+    /// Best-effort one-liner on the operator channel.
+    ///
+    /// Best-effort by design, matching the approval and grant sweeps: a delivery
+    /// fault must not undo a state change that has already happened in memory
+    /// and in the journal.
+    async fn announce_to_operator(&self, text: &str) {
+        for channel in &self.channels {
+            if channel.channel_id() == crate::runtime::channel::OPERATOR_CHANNEL {
+                if let Err(e) = channel
+                    .send(crate::ports::types::OutboundMessage {
+                        task_id: None,
+                        channel: crate::runtime::channel::OPERATOR_CHANNEL.to_string(),
+                        text: text.to_string(),
+                        steps: Vec::new(),
+                        reply_to: None,
+                    })
+                    .await
+                {
+                    tracing::warn!(error = %e, "an operator notice failed to send");
+                }
+                break;
+            }
+        }
     }
 
     /// Replays the journal to rebuild the executed-key set, the approval queue,
@@ -1063,6 +1150,13 @@ impl CompanyRuntime {
                 agent: p.effect.agent.clone(),
                 payload: crate::runtime::approval_display::display_payload(&p.effect),
                 thread: p.thread,
+                // Issue #374. Both halves matter: a native effect has no
+                // teammate and no tool to grant, and a named consequence group
+                // stays a per-call decision. Read off the parked effect, so the
+                // control is offered on exactly the classification the card
+                // itself is showing.
+                broadly_grantable: p.effect.agent.is_some()
+                    && p.effect.group.is_broadly_grantable(),
             })
             .collect()
     }

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -154,20 +154,58 @@ impl HarnessBrain {
         &self,
         approval_id: &crate::ports::types::ApprovalId,
     ) -> Result<Option<OutboundMessage>> {
-        let Some(grant) = self.deps.approval_requests.grants().peek(approval_id) else {
+        // What the resolution actually minted, whichever scope it was (#374).
+        //
+        // Both scopes have to be looked up here or the broader one is inert: it
+        // arms a permission and then never re-dispatches the agent that was
+        // waiting on it, so the parked call the operator just approved is one
+        // the agent never re-issues. Peeking only the single-use set — the
+        // pre-#374 behaviour — silently no-ops on a miss, which is right for
+        // every legitimate miss and catastrophic for this one.
+        struct Redispatch {
+            agent: String,
+            tool: String,
+            instruction: String,
+            origin_thread: Option<String>,
+        }
+
+        let grants = self.deps.approval_requests.grants();
+        let grant = if let Some(grant) = grants.peek(approval_id) {
+            // Re-issue verbatim. The grant admits ONE call matching these
+            // arguments exactly, so any drift the model introduces will simply
+            // re-park — the instruction is emphatic because a re-worded argument
+            // silently costs the operator a second approval round-trip.
+            let args = serde_json::to_string(&grant.args).unwrap_or_else(|_| "{}".to_string());
+            Redispatch {
+                instruction: format!(
+                    "Operator approved your `{tool}` call. Re-issue it now with EXACTLY these \
+                     arguments: {args}. Do not modify them.",
+                    tool = grant.tool,
+                ),
+                tool: grant.tool,
+                agent: grant.agent,
+                origin_thread: grant.origin_thread,
+            }
+        } else if let Some(standing) = grants.peek_standing_by_approval(approval_id) {
+            // No exact-arguments pin, and deliberately so: a standing grant
+            // admits any arguments, which is precisely what the operator
+            // consented to by choosing this scope. Pinning them anyway would
+            // make the broader scope behave like the narrow one on its first
+            // call and confuse the model about what it is allowed to do next.
+            Redispatch {
+                instruction: format!(
+                    "Operator granted your use of `{tool}` until further notice. Re-issue your \
+                     call now.",
+                    tool = standing.tool,
+                ),
+                tool: standing.tool,
+                agent: standing.agent,
+                origin_thread: standing.origin_thread,
+            }
+        } else {
             return Ok(None);
         };
-
-        // Re-issue verbatim. The grant admits ONE call matching these arguments
-        // exactly, so any drift the model introduces will simply re-park — the
-        // instruction is emphatic because a re-worded argument silently costs the
-        // operator a second approval round-trip.
-        let args = serde_json::to_string(&grant.args).unwrap_or_else(|_| "{}".to_string());
-        let instruction = format!(
-            "Operator approved your `{tool}` call. Re-issue it now with EXACTLY these \
-             arguments: {args}. Do not modify them.",
-            tool = grant.tool,
-        );
+        let instruction = grant.instruction.clone();
 
         let guard = self.deps.steer.register(
             &self.record.id,
@@ -4427,6 +4465,133 @@ members = ["eng1", "eng2"]
         let legacy = replies_for(None).await;
         assert_eq!(legacy.len(), 1);
         assert_eq!(legacy[0].0, "ceo");
+    }
+
+    /// Issue #374: a resolution that minted only a STANDING grant must still
+    /// re-dispatch the agent.
+    ///
+    /// This is the feature's happy path, and it was the one real gap in the
+    /// plan. `redispatch_granted_call` peeked only the single-use set and
+    /// no-ops silently on a miss — correct for every legitimate miss (a deny, a
+    /// native effect, a legacy park) and catastrophic here: the operator picks
+    /// the broader scope, the permission is armed, and the call they were
+    /// looking at never runs. It would have looked exactly like #243's original
+    /// bug, one scope over.
+    #[tokio::test]
+    async fn a_standing_grant_also_redispatches_its_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let log: Arc<dyn crate::ports::EventLog> =
+            Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf()));
+        let requests = crate::harness::policy::ApprovalRequestQueue::default();
+        requests
+            .grants()
+            .grant_standing(crate::runtime::grants::StandingGrant {
+                id: crate::runtime::grants::GrantId::new("g1"),
+                agent: "ceo".into(),
+                tool: "workspace_write".into(),
+                granted_by: crate::ports::types::Actor {
+                    kind: crate::ports::types::ActorKind::User,
+                    id: "user-1".into(),
+                },
+                approval_id: ApprovalId::new("appr-1"),
+                at_millis: now_millis(),
+                expires_at_millis: now_millis() + 60 * 60 * 1000,
+                origin_thread: None,
+            });
+        let brain = brain_with_queue_and_events(dir.path(), requests, log.clone());
+
+        let result = brain
+            .run_cycle(
+                cycle_over(vec![approval_resolved("appr-1", Verdict::Approve)]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        assert_eq!(result.channel_responses.len(), 1);
+        let bubble = &result.channel_responses[0];
+        assert_eq!(bubble.channel, "ceo");
+        assert_ne!(
+            bubble.text, "Acknowledged.",
+            "a standing grant must re-dispatch, not fall through to the no-op"
+        );
+        assert!(bubble.text.contains("workspace_write"), "{}", bubble.text);
+        // No exact-arguments pin: a standing grant admits any arguments, which
+        // is what the operator consented to by choosing this scope. Telling the
+        // model to reproduce a specific argument object would make the broad
+        // scope behave like the narrow one.
+        assert!(
+            !bubble.text.contains("Do not modify them"),
+            "a standing grant must not pin arguments: {}",
+            bubble.text
+        );
+
+        // And it is journaled, so the echo survives a refresh.
+        let stored = log
+            .read_from(&CompanyId::new("acme"), crate::ports::EventSeq::new(0), 100)
+            .await
+            .unwrap();
+        assert_eq!(
+            stored
+                .iter()
+                .filter(|e| matches!(e.event, CompanyEvent::AgentReply { .. }))
+                .count(),
+            1
+        );
+    }
+
+    /// The routing half of #379 holds for the broader scope too: the
+    /// continuation lands in the thread the operator asked in, not the agent's
+    /// own line.
+    #[tokio::test]
+    async fn a_standing_grant_replies_into_the_thread_it_was_raised_in() {
+        let dir = tempfile::tempdir().unwrap();
+        let log: Arc<dyn crate::ports::EventLog> =
+            Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf()));
+        let requests = crate::harness::policy::ApprovalRequestQueue::default();
+        requests
+            .grants()
+            .grant_standing(crate::runtime::grants::StandingGrant {
+                id: crate::runtime::grants::GrantId::new("g1"),
+                agent: "ceo".into(),
+                tool: "workspace_write".into(),
+                granted_by: crate::ports::types::Actor {
+                    kind: crate::ports::types::ActorKind::User,
+                    id: "user-1".into(),
+                },
+                approval_id: ApprovalId::new("appr-1"),
+                at_millis: now_millis(),
+                expires_at_millis: now_millis() + 60 * 60 * 1000,
+                // A DESK channel, whose lead is `ceo` — the exact pair that
+                // diverges.
+                origin_thread: Some("desk-ops".into()),
+            });
+        let brain = brain_with_queue_and_events(dir.path(), requests, log.clone());
+
+        brain
+            .run_cycle(
+                cycle_over(vec![approval_resolved("appr-1", Verdict::Approve)]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        let stored = log
+            .read_from(&CompanyId::new("acme"), crate::ports::EventSeq::new(0), 100)
+            .await
+            .unwrap();
+        let threads: Vec<String> = stored
+            .iter()
+            .filter_map(|e| match &e.event {
+                CompanyEvent::AgentReply { chat_id, .. } => Some(chat_id.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            threads,
+            vec!["desk-ops".to_string()],
+            "the work resumes where the operator approved it, not in the lead's DM"
+        );
     }
 
     /// A DENIED approval runs no turn. "No" must never re-dispatch anything.

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -931,31 +931,20 @@ fn top_level_keys(args: &serde_json::Value) -> Vec<&str> {
     }
 }
 
-/// May this tool be granted **broadly** — one standing permission covering any
-/// arguments until a deadline (issue #374)?
-///
-/// One predicate, delegating to [`classify_group`], because a second hand-kept
-/// list of "safe tools" is precisely the drift the issue forbids: it would be
-/// written once, and then every new tool would default into it by omission.
-/// Instead the answer falls out of the consequence taxonomy the codebase
-/// already maintains — anything the classifier calls Spend, Send, Sign,
-/// Publish, Hire or Identity stays a per-call decision, forever, without anyone
-/// remembering to add it here.
-///
-/// **The console hiding the control is UX; this is the enforcement.** It is
-/// checked host-side at mint time, so a hand-rolled request for a standing
-/// grant on `composio_execute` is a 400 rather than a permission.
-///
-/// A known and deliberate consequence: `shell` classifies as `Other` and is
-/// therefore grantable. Narrowing it belongs in [`classify_group`] — giving
-/// shell a consequence class — not in a second ad-hoc exclusion list here. It
-/// is operator opt-in, time-boxed, revocable, and both the `never_do` slot and
-/// the `readonly` brake outrank it.
-pub(crate) fn broadly_grantable(tool_name: &str) -> bool {
-    classify_group(tool_name).is_broadly_grantable()
-}
-
 /// Map a tool name onto the supervised [`EffectGroup`] taxonomy.
+///
+/// Since issue #374 this classification decides one more thing: whether a tool
+/// can be given a **standing** grant. The rule is
+/// [`EffectGroup::is_broadly_grantable`] — only the catch-all `Other` — and it
+/// is applied to the group recorded on the *parked effect*, which is the value
+/// this function produced at projection time. So there is one classifier and
+/// one rule, and the operator is checked against the same classification their
+/// card was showing.
+///
+/// That also means a tool landing in `Other` by omission now grants more than
+/// it used to. The `deploy` and `filing` arms below exist because of exactly
+/// that; a misclassification *toward* a consequence group is the safe
+/// direction, and the tests pin both.
 fn classify_group(tool_name: &str) -> EffectGroup {
     let name = tool_name.to_ascii_lowercase();
     if name == "mcp_registry_tool_call" {
@@ -2528,7 +2517,7 @@ mod tests {
     /// What may be granted broadly is exactly `EffectGroup::Other`, derived —
     /// never listed. A second hand-kept list is the drift the issue forbids.
     #[test]
-    fn broadly_grantable_is_exactly_the_other_group() {
+    fn what_may_be_granted_broadly_is_exactly_the_other_group() {
         for tool in [
             "workspace_write",
             "workspace_read",
@@ -2537,7 +2526,7 @@ mod tests {
             "web_fetch",
         ] {
             assert!(
-                broadly_grantable(tool),
+                classify_group(tool).is_broadly_grantable(),
                 "{tool} classifies as Other and is grantable"
             );
         }
@@ -2547,7 +2536,7 @@ mod tests {
         // misclassified tool loses the broader scope and keeps asking, rather
         // than gaining a scope it should not have. Pinned so the asymmetry is
         // deliberate rather than discovered.
-        assert!(!broadly_grantable("read_file"));
+        assert!(!classify_group("read_file").is_broadly_grantable());
         for tool in [
             "composio_execute",
             "composio_authorize",
@@ -2563,7 +2552,7 @@ mod tests {
             "deploy_site",
         ] {
             assert!(
-                !broadly_grantable(tool),
+                !classify_group(tool).is_broadly_grantable(),
                 "{tool} carries a consequence group and must stay a per-call decision"
             );
         }

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -433,6 +433,46 @@ impl ApprovalPolicy {
         None
     }
 
+    /// Matches a live **standing** grant for this agent and tool (issue #374),
+    /// leaving it in place — a standing grant is not spent by being used.
+    ///
+    /// Two conditions beyond the match itself, and both are the arm's safety
+    /// rather than decoration:
+    ///
+    /// * **A policy with no agent bound can never match**, the same
+    ///   short-circuit [`consume_grant`](Self::consume_grant) takes, so every
+    ///   non-harness construction site behaves exactly as it did before.
+    /// * **A priced call is refused outright**, even holding a grant. The mint
+    ///   side already refuses to grant anything outside
+    ///   [`EffectGroup::Other`](crate::ports::types::EffectGroup::Other), so a
+    ///   `Spend`-group tool can never reach here; this covers the *other* way a
+    ///   call becomes priced, which the tool name cannot predict — an `Other`
+    ///   tool invoked with a declared `amount_usd`. Refusing here means the call
+    ///   falls through to the budget and mode arms below and parks, so a
+    ///   standing grant cannot admit money **by placement**, not by promise.
+    fn standing_grant_allows(&self, tool: &str, args: &serde_json::Value) -> bool {
+        let Some(agent) = self.agent.as_deref() else {
+            return false;
+        };
+        if Self::is_priced_call(tool, Self::amount_usd(args)) {
+            return false;
+        }
+        let Some(grant) =
+            self.requests
+                .grants()
+                .match_standing(agent, tool, crate::ports::now_millis())
+        else {
+            return false;
+        };
+        log::debug!(
+            "[approval] tool '{tool}' allowed by standing grant {} for agent '{agent}' \
+             (expires at {})",
+            grant.id,
+            grant.expires_at_millis
+        );
+        true
+    }
+
     /// Does this tool call **spend money**? The predicate the daily budget arm
     /// gates on (issue #304).
     ///
@@ -675,6 +715,33 @@ impl ToolPolicy for ApprovalPolicy {
             return ToolPolicyDecision::Allow;
         }
 
+        // 2b. A live STANDING grant: the operator opened this tool up for this
+        //     teammate until a deadline (issue #374). Any arguments, unlimited
+        //     calls, until it expires or is revoked.
+        //
+        // IMMEDIATELY BELOW the single-use check and nowhere else. Above it, a
+        // standing grant would mask consumption: the operator's one-off approval
+        // would sit unredeemed until its TTL and then be announced as "the agent
+        // didn't act" — a lie about a call that ran. The single-use grant must
+        // burn if it matches, so it is asked first.
+        //
+        // Everything ABOVE stays above, and for unchanged reasons: `never_do`'s
+        // reserved slot outranks a standing grant exactly as it outranks a
+        // single-use one — more so, since this one admits many calls — and the
+        // `readonly` brake denies before either is consulted, leaving the grant
+        // intact for when the brake is released.
+        //
+        // What keeps this narrow is decided at MINT time, not here:
+        // `broadly_grantable` refuses to grant anything outside
+        // `EffectGroup::Other`, so no Spend / Send / Sign / Publish / Hire /
+        // Identity tool can have a standing grant to match. The one thing the
+        // tool name cannot predict — an `Other` tool carrying a declared amount
+        // — is refused inside `standing_grant_allows`, so this arm can never
+        // admit money.
+        if self.standing_grant_allows(tool, &request.arguments) {
+            return ToolPolicyDecision::Allow;
+        }
+
         // 2. `always_approve` wins over everything else, including Full autonomy.
         if self.always_requires_approval(tool) {
             return self.require_approval(
@@ -864,6 +931,30 @@ fn top_level_keys(args: &serde_json::Value) -> Vec<&str> {
     }
 }
 
+/// May this tool be granted **broadly** — one standing permission covering any
+/// arguments until a deadline (issue #374)?
+///
+/// One predicate, delegating to [`classify_group`], because a second hand-kept
+/// list of "safe tools" is precisely the drift the issue forbids: it would be
+/// written once, and then every new tool would default into it by omission.
+/// Instead the answer falls out of the consequence taxonomy the codebase
+/// already maintains — anything the classifier calls Spend, Send, Sign,
+/// Publish, Hire or Identity stays a per-call decision, forever, without anyone
+/// remembering to add it here.
+///
+/// **The console hiding the control is UX; this is the enforcement.** It is
+/// checked host-side at mint time, so a hand-rolled request for a standing
+/// grant on `composio_execute` is a 400 rather than a permission.
+///
+/// A known and deliberate consequence: `shell` classifies as `Other` and is
+/// therefore grantable. Narrowing it belongs in [`classify_group`] — giving
+/// shell a consequence class — not in a second ad-hoc exclusion list here. It
+/// is operator opt-in, time-boxed, revocable, and both the `never_do` slot and
+/// the `readonly` brake outrank it.
+pub(crate) fn broadly_grantable(tool_name: &str) -> bool {
+    classify_group(tool_name).is_broadly_grantable()
+}
+
 /// Map a tool name onto the supervised [`EffectGroup`] taxonomy.
 fn classify_group(tool_name: &str) -> EffectGroup {
     let name = tool_name.to_ascii_lowercase();
@@ -895,7 +986,14 @@ fn classify_group(tool_name: &str) -> EffectGroup {
         EffectGroup::Send
     } else if name.contains("sign") || name.contains("file") {
         EffectGroup::Sign
-    } else if name.contains("publish") || name.contains("post") {
+    } else if name.contains("publish") || name.contains("post") || name.contains("deploy") {
+        // `deploy` is new with issue #374 and closes the one consequence class
+        // the heuristics missed. `approvals.md` has always listed website
+        // deploys under Publish, but no arm matched the word, so a `deploy_site`
+        // tool classified as `Other` — which now means something it did not
+        // before: `Other` is exactly the set that can be granted standing. A
+        // deploy is externally visible and not reversible by the company alone,
+        // so it stays a per-call decision.
         EffectGroup::Publish
     } else if name.contains("hire") || name.contains("contract") {
         EffectGroup::Hire
@@ -2209,5 +2307,264 @@ mod tests {
             ToolPolicyDecision::Allow,
             "a free call never reaches the budget arm, so a meter outage cannot gate it"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Standing grants (issue #374)
+    // -----------------------------------------------------------------------
+
+    fn standing(
+        agent: &str,
+        tool: &str,
+        expires_at_millis: u64,
+    ) -> crate::runtime::grants::StandingGrant {
+        crate::runtime::grants::StandingGrant {
+            id: crate::runtime::grants::GrantId::new("g1"),
+            agent: agent.to_string(),
+            tool: tool.to_string(),
+            granted_by: crate::ports::types::Actor {
+                kind: crate::ports::types::ActorKind::User,
+                id: "user-1".to_string(),
+            },
+            approval_id: crate::ports::types::ApprovalId::new("appr-1"),
+            at_millis: 1_000,
+            expires_at_millis,
+        }
+    }
+
+    /// Far enough ahead that wall-clock drift during a test run cannot reach it.
+    fn far_future() -> u64 {
+        crate::ports::now_millis() + 60 * 60 * 1000
+    }
+
+    /// The issue in one test: the same tool, called repeatedly with different
+    /// arguments, stops asking.
+    #[tokio::test]
+    async fn a_standing_grant_admits_repeat_calls_with_any_arguments() {
+        let (p, grants) = granting_policy("supervised", &[], "ops");
+        grants.grant_standing(standing("ops", "workspace_write", far_future()));
+
+        for args in [
+            serde_json::json!({ "path": "notes/a.md", "body": "one" }),
+            serde_json::json!({ "path": "notes/b.md", "body": "two" }),
+            serde_json::json!({}),
+        ] {
+            assert_eq!(
+                p.check(&request("workspace_write", args.clone())).await,
+                ToolPolicyDecision::Allow,
+                "a standing grant admits any arguments: {args}"
+            );
+        }
+        assert_eq!(
+            grants.standing_count(),
+            1,
+            "using a standing grant must not spend it"
+        );
+    }
+
+    /// An expired standing grant is refused at redemption, not merely swept.
+    ///
+    /// The sweep runs on the scheduler's maintenance tick; between two ticks a
+    /// lapsed grant would otherwise keep admitting calls, and "for one hour" has
+    /// to mean one hour.
+    #[tokio::test]
+    async fn an_expired_standing_grant_re_parks() {
+        let (p, grants) = granting_policy("supervised", &[], "ops");
+        // Already past — and deliberately left in the set, so this proves the
+        // redemption check rather than the sweep.
+        grants.grant_standing(standing("ops", "workspace_write", 1));
+
+        assert!(matches!(
+            p.check(&request("workspace_write", serde_json::json!({})))
+                .await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
+        assert_eq!(grants.standing_count(), 1, "the sweep did not run here");
+    }
+
+    #[tokio::test]
+    async fn a_standing_grant_is_scoped_to_its_agent_and_tool() {
+        let (p, grants) = granting_policy("supervised", &[], "marketing");
+        // Granted to a different teammate.
+        grants.grant_standing(standing("ops", "workspace_write", far_future()));
+        assert!(matches!(
+            p.check(&request("workspace_write", serde_json::json!({})))
+                .await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
+
+        let (p, grants) = granting_policy("supervised", &[], "ops");
+        grants.grant_standing(standing("ops", "workspace_write", far_future()));
+        // A different tool for the right teammate.
+        assert!(matches!(
+            p.check(&request("send_email", serde_json::json!({}))).await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
+    }
+
+    /// The single-use grant burns first, even when a standing grant would also
+    /// have admitted the call.
+    ///
+    /// Ordering, not coincidence. If the standing arm ran first the operator's
+    /// one-off approval would sit unredeemed until its TTL and then be announced
+    /// as "the agent didn't act within 15 minutes" — a notice about work that
+    /// had already happened, which is worse than no notice at all.
+    #[tokio::test]
+    async fn the_single_use_grant_is_consumed_first() {
+        let (p, grants) = granting_policy("supervised", &[], "ops");
+        let args = serde_json::json!({ "path": "notes/a.md" });
+        grants.grant(granted("ops", "workspace_write", args.clone()));
+        grants.grant_standing(standing("ops", "workspace_write", far_future()));
+
+        assert_eq!(
+            p.check(&request("workspace_write", args)).await,
+            ToolPolicyDecision::Allow
+        );
+        assert_eq!(grants.live_count(), 0, "the single-use grant burned");
+        assert_eq!(grants.standing_count(), 1);
+        assert_eq!(
+            grants.drain_consumed().len(),
+            1,
+            "the consumption is journaled, so no phantom expiry notice follows"
+        );
+    }
+
+    /// A standing grant can never admit money — by placement, not by promise.
+    ///
+    /// The mint side refuses to grant anything outside `EffectGroup::Other`, so
+    /// no Spend-group tool can have one. This covers the other way a call
+    /// becomes priced, which the tool name cannot predict: an `Other` tool
+    /// invoked with a declared amount. It must fall through to the budget and
+    /// mode arms and park.
+    #[tokio::test]
+    async fn a_standing_grant_refuses_a_priced_call() {
+        let (p, grants) = granting_policy("supervised", &[], "ops");
+        grants.grant_standing(standing("ops", "workspace_write", far_future()));
+
+        // Same tool, same grant — the only difference is a declared amount.
+        assert_eq!(
+            p.check(&request(
+                "workspace_write",
+                serde_json::json!({ "path": "a" })
+            ))
+            .await,
+            ToolPolicyDecision::Allow
+        );
+        assert!(
+            matches!(
+                p.check(&request(
+                    "workspace_write",
+                    serde_json::json!({ "path": "a", "amount_usd": 25.0 })
+                ))
+                .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "a declared amount must park even under a standing grant"
+        );
+
+        // And the metered read, which is priced without declaring anything.
+        let (p, grants) = granting_policy("supervised", &[], "ops");
+        grants.grant_standing(standing(
+            "ops",
+            crate::harness::search::WEB_SEARCH_TOOL,
+            far_future(),
+        ));
+        assert_ne!(
+            p.check(&request(
+                crate::harness::search::WEB_SEARCH_TOOL,
+                serde_json::json!({ "query": "x" })
+            ))
+            .await,
+            ToolPolicyDecision::Deny {
+                reason: String::new()
+            },
+            "sanity: this asserts the arm was not reached, not the tier's answer"
+        );
+    }
+
+    /// `readonly` outranks a standing grant, and leaves it intact.
+    ///
+    /// Same argument as the single-use case: the brake is the emergency stop,
+    /// not a question, and consent does not survive it. But the grant is not
+    /// destroyed — the call never ran, so the operator's permission is still
+    /// there when the brake comes off.
+    #[tokio::test]
+    async fn readonly_outranks_a_standing_grant_and_leaves_it_intact() {
+        let (p, grants) = granting_policy("readonly", &[], "ops");
+        grants.grant_standing(standing("ops", "workspace_write", far_future()));
+
+        assert!(matches!(
+            p.check(&request("workspace_write", serde_json::json!({})))
+                .await,
+            ToolPolicyDecision::Deny { .. }
+        ));
+        assert_eq!(
+            grants.standing_count(),
+            1,
+            "a denied call must not destroy the permission it never used"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unbound_policy_ignores_standing_grants_entirely() {
+        let queue = ApprovalRequestQueue::default();
+        let grants = queue.grants();
+        let p = policy("supervised", &[], None).with_requests(queue);
+        grants.grant_standing(standing("ops", "send_email", far_future()));
+
+        assert!(matches!(
+            p.check(&request("send_email", serde_json::json!({}))).await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
+    }
+
+    /// What may be granted broadly is exactly `EffectGroup::Other`, derived —
+    /// never listed. A second hand-kept list is the drift the issue forbids.
+    #[test]
+    fn broadly_grantable_is_exactly_the_other_group() {
+        for tool in [
+            "workspace_write",
+            "workspace_read",
+            "shell",
+            "mcp_registry_tool_call",
+            "read_file",
+        ] {
+            assert!(
+                broadly_grantable(tool),
+                "{tool} classifies as Other and is grantable"
+            );
+        }
+        for tool in [
+            "composio_execute",
+            "composio_authorize",
+            "pay_invoice",
+            "transfer_funds",
+            "send_email",
+            "media_generate_image",
+            crate::harness::search::WEB_SEARCH_TOOL,
+            "publish_post",
+            "contract_accept",
+            "handle_register",
+            "filing_submit",
+            "deploy_site",
+        ] {
+            assert!(
+                !broadly_grantable(tool),
+                "{tool} carries a consequence group and must stay a per-call decision"
+            );
+        }
+    }
+
+    /// Issue #374 adds the `deploy` arm. `approvals.md` has always listed
+    /// website deploys under Publish, but no arm matched the word, so a deploy
+    /// tool classified as `Other` — which now means something it did not before:
+    /// `Other` is exactly the set that can be granted standing.
+    #[test]
+    fn a_deploy_classifies_as_publish() {
+        assert_eq!(classify_group("deploy_site"), EffectGroup::Publish);
+        assert_eq!(classify_group("website_deploy"), EffectGroup::Publish);
+        // And the arms it sits beside are unmoved.
+        assert_eq!(classify_group("publish_post"), EffectGroup::Publish);
+        assert_eq!(classify_group("workspace_write"), EffectGroup::Other);
     }
 }

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -984,7 +984,13 @@ fn classify_group(tool_name: &str) -> EffectGroup {
         EffectGroup::Spend
     } else if name.contains("email") || name.contains("send") || name.contains("message") {
         EffectGroup::Send
-    } else if name.contains("sign") || name.contains("file") {
+    } else if name.contains("sign") || name.contains("file") || name.contains("filing") {
+        // `filing` is the second arm issue #374 adds, found the same way as
+        // `deploy` and for the same reason. `approvals.md` lists `filing.submit`
+        // under Sign, but the substring above is `file`, which `filing` does not
+        // contain — so a `filing_submit` tool classified as `Other`, and `Other`
+        // now means "may be granted for a week". No such tool exists today, so
+        // this closes the gap before it can be walked into rather than after.
         EffectGroup::Sign
     } else if name.contains("publish") || name.contains("post") || name.contains("deploy") {
         // `deploy` is new with issue #374 and closes the one consequence class
@@ -2329,6 +2335,7 @@ mod tests {
             approval_id: crate::ports::types::ApprovalId::new("appr-1"),
             at_millis: 1_000,
             expires_at_millis,
+            origin_thread: None,
         }
     }
 
@@ -2527,13 +2534,20 @@ mod tests {
             "workspace_read",
             "shell",
             "mcp_registry_tool_call",
-            "read_file",
+            "web_fetch",
         ] {
             assert!(
                 broadly_grantable(tool),
                 "{tool} classifies as Other and is grantable"
             );
         }
+        // The classifier is substring heuristics, and it errs toward a
+        // consequence group — `read_file` matches the `file` arm and lands in
+        // `Sign` despite being a pure read. That is the SAFE direction: a
+        // misclassified tool loses the broader scope and keeps asking, rather
+        // than gaining a scope it should not have. Pinned so the asymmetry is
+        // deliberate rather than discovered.
+        assert!(!broadly_grantable("read_file"));
         for tool in [
             "composio_execute",
             "composio_authorize",

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -797,6 +797,28 @@ pub enum EffectGroup {
     Other,
 }
 
+impl EffectGroup {
+    /// May a tool in this group be granted **broadly** — one standing
+    /// permission covering any arguments until a deadline (issue #374)?
+    ///
+    /// Only [`Other`](Self::Other). Every named group is a consequence the
+    /// operator has to see per call: Spend moves money, Send reaches a
+    /// counterparty, Sign and Publish are externally visible and not reversible
+    /// by the company alone, Hire commits it to someone, Identity changes who it
+    /// is. None of those are things to hand over for a week at a time.
+    ///
+    /// **This is the rule; it lives here so there is one of it.** The tool-name
+    /// → group mapping is `classify_group` in `crate::harness::policy`, which
+    /// compiles only under the `openhuman` feature, while the three places that
+    /// enforce this — the mint path, the approval summary the card reads, and
+    /// the resolve route's 400 — are all in the default build. Expressing the
+    /// rule twice across that seam is exactly the drift the issue forbids, so
+    /// both sides call this.
+    pub fn is_broadly_grantable(&self) -> bool {
+        matches!(self, Self::Other)
+    }
+}
+
 /// A side effect the brain wants to perform, submitted to the approval gate.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Effect {

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -44,7 +44,7 @@ use crate::runtime::delegation_tools::{
     DELEGATE_TO_DESK_TOOL, DelegateArgs, SPAWN_TASK_TOOL, SpawnTaskArgs, desk_lead,
     unknown_desk_message,
 };
-use crate::runtime::grants::GrantedCall;
+use crate::runtime::grants::{GrantId, GrantScope, GrantedCall, StandingGrant};
 use crate::runtime::journal::{ExecutedEffect, TaskLink};
 use crate::runtime::types::CycleReport;
 use crate::server::ops::mailer::{MailCredentials, OutboundEmail};
@@ -541,7 +541,20 @@ working on):\n{}\n]",
         id: &ApprovalId,
         verdict: Verdict,
         by: Actor,
+        scope: GrantScope,
     ) -> Result<ResolveReceipt> {
+        // Issue #374: a broader scope is validated BEFORE the gate is touched.
+        //
+        // The order is the whole safety story of a bad scope request. Validating
+        // after `resolve_outcome` would have already dropped the approval from
+        // the parked queue and journaled a verdict, so a request naming an
+        // ungrantable tool would leave the operator with no card to re-decide
+        // and a resolution they never got the effect of. Checked first, a bad
+        // request changes nothing at all: the approval stays parked, no verdict
+        // is journaled, and the operator can simply approve it "once" instead.
+        if let GrantScope::Tool { .. } = scope {
+            self.check_broadly_grantable(id)?;
+        }
         let outcome = self
             .rt
             .approval_gate
@@ -551,7 +564,8 @@ working on):\n{}\n]",
         }
         self.rt.journal.record_resolved(id).await?;
         if let ResolveOutcome::Approved(effect) = outcome {
-            self.settle_approved_effect(id, effect).await?;
+            self.settle_approved_effect(id, effect, by.clone(), scope)
+                .await?;
         }
         // The follow-up event, so the brain learns the verdict. Returning it
         // (rather than appending it here) keeps the event logged exactly once:
@@ -595,7 +609,55 @@ working on):\n{}\n]",
     /// the safe direction. The reverse order would lose the operator's approval
     /// entirely on a crash, and the agent would come back asking for a
     /// permission it had already been given.
-    async fn settle_approved_effect(&self, id: &ApprovalId, effect: Effect) -> Result<()> {
+    /// Refuses a broad-scope request the runtime must not honour (issue #374),
+    /// **without touching the gate or the journal**.
+    ///
+    /// Two refusals, both read off the parked effect:
+    ///
+    /// * **native** (`agent: None`) — there is no tool and no agent to grant to.
+    ///   The runtime performs these itself; "this tool, for this teammate" names
+    ///   neither of the two things it needs.
+    /// * **not broadly grantable** — the effect's group is not
+    ///   [`EffectGroup::Other`](crate::ports::types::EffectGroup::Other), so it
+    ///   is a consequence the operator has to see per call.
+    ///
+    /// The group is read off the **parked effect** rather than re-derived from
+    /// the tool name, which is both cheaper and more honest: it is the
+    /// classification the card showed the operator, so what they see is what is
+    /// checked. It is also what lets this run in the default build, where the
+    /// harness classifier does not compile.
+    ///
+    /// An unknown or already-resolved id falls through to the ordinary
+    /// already-resolved path rather than erroring here — a double-click on the
+    /// scoped button must stay the no-op it is on the plain one.
+    fn check_broadly_grantable(&self, id: &ApprovalId) -> Result<()> {
+        let Some(effect) = self.rt.approval_gate.parked_effect(id) else {
+            return Ok(());
+        };
+        if effect.agent.is_none() {
+            return Err(OpenCompanyError::InvalidRequest(format!(
+                "'{}' is performed by the runtime itself, so there is no teammate's tool use to \
+                 grant; approve it once instead",
+                effect.kind
+            )));
+        }
+        if !effect.group.is_broadly_grantable() {
+            return Err(OpenCompanyError::InvalidRequest(format!(
+                "'{}' cannot be granted for a period — it is a {:?} action, which stays a \
+                 per-call decision; approve it once instead",
+                effect.kind, effect.group
+            )));
+        }
+        Ok(())
+    }
+
+    async fn settle_approved_effect(
+        &self,
+        id: &ApprovalId,
+        effect: Effect,
+        by: Actor,
+        scope: GrantScope,
+    ) -> Result<()> {
         let Some(agent) = effect.agent.clone() else {
             let key = format!("approval:{id}");
             // The card that asked for this sign-off (issue #351). It is not
@@ -610,7 +672,57 @@ working on):\n{}\n]",
                 .and_then(|task| task.task_id().map(str::to_string));
             return execute_effect_once(self.rt, &key, &effect, task_id.as_deref()).await;
         };
-        self.mint_grant(id, agent, effect).await
+        match scope {
+            GrantScope::Once => self.mint_grant(id, agent, effect).await,
+            GrantScope::Tool { expires_at_millis } => {
+                self.mint_standing_grant(id, agent, effect, by, expires_at_millis)
+                    .await
+            }
+        }
+    }
+
+    /// Journals then arms a **standing** grant: this tool, for this teammate,
+    /// until `expires_at_millis` (issue #374).
+    ///
+    /// Deliberately mints **only** the standing grant. Minting a single-use one
+    /// alongside it would be redundant — the standing grant already admits the
+    /// re-issued call — and worse than redundant: the single-use grant would go
+    /// unredeemed, and fifteen minutes later the TTL sweep would tell the
+    /// operator "the agent didn't act", about work that ran immediately.
+    ///
+    /// Same journal-before-live-set ordering, and the same crash direction, as
+    /// [`mint_grant`](Self::mint_grant): a crash between the two replays as
+    /// granted rather than losing the operator's decision.
+    async fn mint_standing_grant(
+        &self,
+        id: &ApprovalId,
+        agent: String,
+        effect: Effect,
+        by: Actor,
+        expires_at_millis: u64,
+    ) -> Result<()> {
+        let grant = StandingGrant {
+            id: GrantId::generate(),
+            agent,
+            // The tool, and nothing about the arguments. A standing grant has no
+            // `args` field to copy them into — that is the type's whole point.
+            tool: effect.kind.clone(),
+            granted_by: by,
+            approval_id: id.clone(),
+            at_millis: now_millis(),
+            expires_at_millis,
+        };
+        self.rt.journal.record_standing_granted(&grant).await?;
+        tracing::debug!(
+            approval_id = %id,
+            grant_id = %grant.id,
+            tool = %effect.kind,
+            agent = %grant.agent,
+            expires_at_millis,
+            "[approval] minted a standing grant; this tool will not ask again until it expires"
+        );
+        self.rt.grants.grant_standing(grant);
+        Ok(())
     }
 
     /// Journals then arms a single-use grant for `(agent, effect.kind,
@@ -750,8 +862,15 @@ working on):\n{}\n]",
         // re-issue the very call the operator edited, silently discarding the
         // edit — which is worse than not supporting amend at all, because the
         // operator would have every reason to believe their change took effect.
+        //
+        // Always `GrantScope::Once`. An argument edit and a standing grant are
+        // contradictory requests: the edit says "this exact call, with my
+        // correction", the standing grant says "any arguments, for a week". The
+        // route rejects the pairing as a 400, so this arm never sees a broader
+        // scope, and hard-coding it here means it cannot acquire one by accident.
         if let Some(effect) = &executed {
-            self.settle_approved_effect(id, effect.clone()).await?;
+            self.settle_approved_effect(id, effect.clone(), by.clone(), GrantScope::Once)
+                .await?;
         }
 
         // The follow-up event, so the brain learns the approval resolved (with
@@ -776,6 +895,14 @@ working on):\n{}\n]",
     pub async fn recover(&self) -> Result<()> {
         self.rt.journal.load().await?;
         self.rt.grants.rehydrate(self.rt.journal.replayed_grants());
+        // Issue #374: standing grants outlive a restart too — a week-long
+        // permission that evaporated on every deploy would be worse than not
+        // offering one. Anything already past its deadline is folded out by the
+        // replay itself, so a host that was down across an expiry cannot hand
+        // the permission back.
+        self.rt
+            .grants
+            .rehydrate_standing(self.rt.journal.replayed_standing_grants(now_millis()));
         Ok(())
     }
 
@@ -4691,5 +4818,316 @@ mod test {
             "done cards are not surfaced as open work: {:?}",
             seen[0]
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Standing grants (issue #374)
+    // -----------------------------------------------------------------------
+
+    /// A harness tool call the operator IS allowed to grant broadly: an
+    /// `EffectGroup::Other` effect with no declared amount.
+    ///
+    /// `harness_effect` deliberately uses `Sign` and a real amount, because it
+    /// exists to prove the effect was not executed. Both would refuse a broad
+    /// scope, so the grantable case needs its own fixture.
+    fn grantable_effect(agent: &str, tool: &str, args: serde_json::Value) -> Effect {
+        Effect {
+            kind: tool.into(),
+            group: EffectGroup::Other,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: args,
+            agent: Some(agent.to_string()),
+            run_id: None,
+        }
+    }
+
+    fn in_an_hour() -> u64 {
+        now_millis() + 60 * 60 * 1000
+    }
+
+    fn tool_scope() -> GrantScope {
+        GrantScope::Tool {
+            expires_at_millis: in_an_hour(),
+        }
+    }
+
+    /// Parks `effect` the way a blocked harness tool call actually parks —
+    /// through `park_effect`, which bypasses the manifest gate's `evaluate`.
+    ///
+    /// `park_one` cannot serve here: it routes through `emit_effect`, and the
+    /// manifest gate auto-allows `EffectGroup::Other` under supervised. That is
+    /// correct for a native effect and irrelevant to a harness one, whose park
+    /// decision was already made inside the agent's turn by `ApprovalPolicy`.
+    async fn park_one_blocked_tool_call(
+        home: std::path::PathBuf,
+        effect: Effect,
+    ) -> (Arc<CompanyRuntime>, ApprovalId) {
+        let rt = Arc::new(
+            RuntimeBuilder::new(home, manifest("supervised"))
+                .with_brain(Arc::new(ParkingBrain { effect }))
+                .build()
+                .await
+                .unwrap(),
+        );
+        let report = rt
+            .run_cycle(vec![CompanyEvent::OperatorMessage {
+                text: "do it".into(),
+                by: None,
+                chat: None,
+            }])
+            .await
+            .unwrap();
+        assert_eq!(report.parked.len(), 1);
+        let id = report.parked[0].clone();
+        (rt, id)
+    }
+
+    /// The headline: approving with the broader scope arms a standing grant, and
+    /// mints **no** single-use grant beside it.
+    ///
+    /// The second half is not tidiness. A redundant single-use grant would go
+    /// unredeemed — the standing grant already admits the re-issued call — and
+    /// fifteen minutes later the TTL sweep would tell the operator "the agent
+    /// didn't act", about work that ran immediately.
+    #[tokio::test]
+    async fn approving_with_a_tool_scope_mints_a_standing_grant_and_no_single_use_one() {
+        let home_dir = tmp_home();
+        let (rt, id) = park_one_blocked_tool_call(
+            home_dir.path().to_path_buf(),
+            grantable_effect("ops", "workspace_write", serde_json::json!({ "path": "a" })),
+        )
+        .await;
+
+        let (_, follow_up) = rt
+            .resolve_approval_spawned(&id, Verdict::Approve, operator(), tool_scope())
+            .await
+            .unwrap();
+        let _ = crate::company::runtime::join_follow_up(follow_up).await;
+
+        assert_eq!(rt.grants.standing_count(), 1);
+        assert_eq!(
+            rt.grants.live_count(),
+            0,
+            "no single-use grant is left behind to expire noisily"
+        );
+        let listed = rt.standing_grants();
+        assert_eq!(listed[0].tool, "workspace_write");
+        assert_eq!(listed[0].agent, "ops");
+        assert_eq!(listed[0].approval_id, id, "provenance back to the card");
+        assert_eq!(
+            listed[0].granted_by.id, "owner",
+            "the resolving actor is recorded, not a placeholder"
+        );
+    }
+
+    /// A scope the runtime must not honour changes **nothing**: the approval is
+    /// still parked and no verdict was journaled.
+    ///
+    /// This is why the check runs before `resolve_outcome`. Validating after it
+    /// would have dropped the card from the queue and recorded a resolution,
+    /// leaving the operator with nothing to re-decide and a verdict whose effect
+    /// never happened.
+    #[tokio::test]
+    async fn a_refused_scope_leaves_the_approval_parked_and_unjournaled() {
+        for effect in [
+            // A named consequence group — stays a per-call decision.
+            harness_effect("finance", "composio_execute", serde_json::json!({})),
+            // A native effect — no teammate and no tool to grant.
+            Effect {
+                kind: EMAIL_SEND_KIND.into(),
+                group: EffectGroup::Other,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: serde_json::json!({ "channel": "operator", "text": "hi" }),
+                agent: None,
+                run_id: None,
+            },
+        ] {
+            let home_dir = tmp_home();
+            let (rt, id) =
+                park_one_blocked_tool_call(home_dir.path().to_path_buf(), effect.clone()).await;
+
+            let err = rt
+                .resolve_approval_spawned(&id, Verdict::Approve, operator(), tool_scope())
+                .await
+                .expect_err("a scope the host cannot honour is refused");
+            assert!(
+                matches!(err, OpenCompanyError::InvalidRequest(_)),
+                "refusal must be a bad-request, not a server fault: {err:?}"
+            );
+
+            assert_eq!(
+                rt.pending_approvals().len(),
+                1,
+                "the card is still there to be decided: {}",
+                effect.kind
+            );
+            assert_eq!(rt.grants.standing_count(), 0);
+            assert_eq!(rt.grants.live_count(), 0);
+
+            // And the card is still decidable — nothing about the refused
+            // request consumed it. Declining rather than approving, so this
+            // asserts the queue state without dragging in whether the host has
+            // a mailer wired for the native case.
+            rt.resolve_approval(&id, Verdict::Deny, operator())
+                .await
+                .unwrap();
+            assert!(rt.pending_approvals().is_empty());
+        }
+    }
+
+    /// The default scope is byte-identical to pre-#374 behaviour.
+    ///
+    /// The existing suite passing untouched is the real proof; this pins the
+    /// negative the suite cannot state — that no number of ordinary approvals
+    /// ever *infers* a standing grant. A "we noticed you approve this a lot"
+    /// heuristic is the silent accumulation the issue forbids.
+    #[tokio::test]
+    async fn repeated_ordinary_approvals_never_infer_a_standing_grant() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let effect = grantable_effect("ops", "workspace_write", serde_json::json!({ "path": "a" }));
+
+        let rt = Arc::new(
+            RuntimeBuilder::new(home, manifest("supervised"))
+                .with_brain(Arc::new(ParkingBrain {
+                    effect: effect.clone(),
+                }))
+                .build()
+                .await
+                .unwrap(),
+        );
+
+        for _ in 0..5 {
+            let report = rt
+                .run_cycle(vec![CompanyEvent::OperatorMessage {
+                    text: "do it".into(),
+                    by: None,
+                    chat: None,
+                }])
+                .await
+                .unwrap();
+            let id = report.parked[0].clone();
+            rt.resolve_approval(&id, Verdict::Approve, operator())
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(
+            rt.grants.standing_count(),
+            0,
+            "a standing grant is only ever asked for, never inferred"
+        );
+    }
+
+    /// Standing grants survive a restart, and revoking one is durable too.
+    #[tokio::test]
+    async fn a_standing_grant_replays_on_boot_and_a_revoked_one_does_not() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (rt, id) = park_one_blocked_tool_call(
+            home.clone(),
+            grantable_effect("ops", "workspace_write", serde_json::json!({ "path": "a" })),
+        )
+        .await;
+
+        let (_, follow_up) = rt
+            .resolve_approval_spawned(&id, Verdict::Approve, operator(), tool_scope())
+            .await
+            .unwrap();
+        let _ = crate::company::runtime::join_follow_up(follow_up).await;
+        let grant_id = rt.standing_grants()[0].id.clone();
+
+        // A fresh runtime over the same home rehydrates it.
+        let rt2 = Arc::new(
+            RuntimeBuilder::new(home.clone(), manifest("supervised"))
+                .build()
+                .await
+                .unwrap(),
+        );
+        rt2.recover().await.unwrap();
+        assert_eq!(rt2.grants.standing_count(), 1);
+        assert_eq!(rt2.standing_grants()[0].id, grant_id);
+
+        // Revoke, then boot again: it must stay gone.
+        assert!(
+            rt2.revoke_standing_grant(&grant_id, operator())
+                .await
+                .unwrap()
+        );
+        assert_eq!(rt2.grants.standing_count(), 0);
+        assert!(
+            !rt2.revoke_standing_grant(&grant_id, operator())
+                .await
+                .unwrap(),
+            "revoking twice reports nothing to revoke"
+        );
+
+        let rt3 = Arc::new(
+            RuntimeBuilder::new(home, manifest("supervised"))
+                .build()
+                .await
+                .unwrap(),
+        );
+        rt3.recover().await.unwrap();
+        assert_eq!(
+            rt3.grants.standing_count(),
+            0,
+            "a restart must not hand back a permission the operator took away"
+        );
+    }
+
+    /// The maintenance sweep retires a lapsed standing grant and journals it.
+    #[tokio::test]
+    async fn the_sweep_expires_a_lapsed_standing_grant() {
+        let home_dir = tmp_home();
+        let (rt, id) = park_one_blocked_tool_call(
+            home_dir.path().to_path_buf(),
+            grantable_effect("ops", "workspace_write", serde_json::json!({})),
+        )
+        .await;
+
+        // Already past its deadline the moment it is minted.
+        let (_, follow_up) = rt
+            .resolve_approval_spawned(
+                &id,
+                Verdict::Approve,
+                operator(),
+                GrantScope::Tool {
+                    expires_at_millis: 1,
+                },
+            )
+            .await
+            .unwrap();
+        let _ = crate::company::runtime::join_follow_up(follow_up).await;
+        assert_eq!(rt.grants.standing_count(), 1);
+
+        rt.sweep_expired_grants().await.unwrap();
+        assert_eq!(rt.grants.standing_count(), 0);
+    }
+
+    /// The summary carries the flag only where the control is actually
+    /// offerable — and the card's own classification is what decides it.
+    #[tokio::test]
+    async fn the_summary_marks_only_broadly_grantable_cards() {
+        let home_dir = tmp_home();
+        let (rt, _) = park_one_blocked_tool_call(
+            home_dir.path().to_path_buf(),
+            grantable_effect("ops", "workspace_write", serde_json::json!({})),
+        )
+        .await;
+        assert!(rt.pending_approvals()[0].broadly_grantable);
+
+        // A named consequence group is not offerable.
+        let home_dir = tmp_home();
+        let (rt, _) = park_one(
+            home_dir.path().to_path_buf(),
+            harness_effect("finance", "composio_execute", serde_json::json!({})),
+        )
+        .await;
+        assert!(!rt.pending_approvals()[0].broadly_grantable);
     }
 }

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -711,6 +711,10 @@ working on):\n{}\n]",
             approval_id: id.clone(),
             at_millis: now_millis(),
             expires_at_millis,
+            // Issue #379: where the operator asked, so the re-dispatched turn's
+            // reply lands back in that conversation. Read off the retained
+            // origin, exactly as `mint_grant` does.
+            origin_thread: self.rt.journal.approval_thread(id).flatten(),
         };
         self.rt.journal.record_standing_granted(&grant).await?;
         tracing::debug!(

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -62,9 +62,10 @@
 //!   forever. The issue forbids silent accumulation, and a type that cannot
 //!   express "no expiry" cannot regress into it.
 //!
-//! What it never covers is decided elsewhere, once: `broadly_grantable` in
-//! `crate::harness::policy` delegates to the existing consequence taxonomy, so
-//! only `EffectGroup::Other` tools can be granted this way — never Spend, Send,
+//! What it never covers is decided elsewhere, once:
+//! [`EffectGroup::is_broadly_grantable`](crate::ports::types::EffectGroup::is_broadly_grantable)
+//! applied to the group already recorded on the parked effect, so only
+//! `EffectGroup::Other` tools can be granted this way — never Spend, Send,
 //! Sign, Publish, Hire or Identity.
 //!
 //! ## Durability

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -44,21 +44,48 @@
 //!   consent to an action now, not a standing authorisation; without this, a
 //!   grant minted today would still fire if the same call surfaced next month.
 //!
+//! ## The second scope: a standing grant (issue #374)
+//!
+//! Single-use is the right *default* and was for a while the only mode, which
+//! made it the whole design. An agent reaching for the same tool a dozen times
+//! produced a dozen near-identical cards, and the operator's rational escapes
+//! were approving blind or switching the company to `full` — throwing the gate
+//! away to stop it nagging. So there is now a second scope the operator can
+//! pick: [`StandingGrant`], "this tool, for this teammate, until a deadline".
+//!
+//! It is a **distinct type**, not a scope enum on [`GrantedCall`], and both
+//! differences are load-bearing:
+//!
+//! * it has **no `args` field**, so it is structurally incapable of
+//!   argument-matching or of being widened into one later;
+//! * its expiry is **not optional**, so it is structurally incapable of living
+//!   forever. The issue forbids silent accumulation, and a type that cannot
+//!   express "no expiry" cannot regress into it.
+//!
+//! What it never covers is decided elsewhere, once:
+//! [`broadly_grantable`](crate::harness::policy::broadly_grantable) delegates to
+//! the existing consequence taxonomy, so only `EffectGroup::Other` tools can be
+//! granted this way — never Spend, Send, Sign, Publish, Hire or Identity.
+//!
 //! ## Durability
 //!
-//! The live set is in-memory, but its lifecycle is journaled
-//! (`ApprovalGranted` / `GrantConsumed` / `GrantExpired`) and replayed on boot
-//! via [`RuntimeJournal::replayed_grants`](crate::runtime::journal::RuntimeJournal::replayed_grants),
-//! so a restart between "operator approved" and "agent re-issued" does not
-//! silently drop the approval. Consumed and expired grants are folded *out* on
-//! replay, so a restart can never resurrect one that already fired.
+//! Both sets are in-memory, but their lifecycles are journaled
+//! (`ApprovalGranted` / `GrantConsumed` / `GrantExpired` for single-use;
+//! `StandingGrantMinted` / `StandingGrantRevoked` / `StandingGrantExpired` for
+//! standing) and replayed on boot via
+//! [`RuntimeJournal::replayed_grants`](crate::runtime::journal::RuntimeJournal::replayed_grants)
+//! and its standing counterpart, so a restart between "operator approved" and
+//! "agent re-issued" does not silently drop the approval. Consumed, revoked and
+//! expired grants are folded *out* on replay, so a restart can never resurrect
+//! one that already fired or one the operator took back.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
 
-use crate::ports::types::ApprovalId;
+use crate::ports::generate_id;
+use crate::ports::types::{Actor, ApprovalId};
 
 /// How long an unredeemed grant stays live: 15 minutes.
 ///
@@ -100,6 +127,112 @@ pub struct GrantedCall {
     pub origin_thread: Option<String>,
 }
 
+/// The hard ceiling on a standing grant's life: 7 days.
+///
+/// A request past this is a **400**, never a silent clamp. Quietly shortening a
+/// duration the operator chose would leave them believing a permission is live
+/// when it lapsed days earlier — the failure this issue exists to stop, in the
+/// opposite direction.
+pub const MAX_STANDING_GRANT_MILLIS: u64 = 7 * 24 * 60 * 60 * 1000;
+
+/// A standing grant's own id.
+///
+/// Separate from [`ApprovalId`] because the two have different lifetimes: the
+/// approval is resolved and gone, the grant it minted outlives it and is what
+/// the operator later revokes. Keying revocation on the approval id would tie
+/// the revoke route to a record that is, from the operator's side, history.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct GrantId(String);
+
+impl GrantId {
+    /// Wraps an existing grant id string.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// Mints a fresh grant id.
+    pub fn generate() -> Self {
+        Self(generate_id())
+    }
+}
+
+impl From<String> for GrantId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl AsRef<str> for GrantId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for GrantId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// What an operator's approve actually buys (issue #374).
+///
+/// Two options, and only two. Count-based ("the next 5 calls") was rejected: it
+/// reintroduces the annoyance nondeterministically and needs a durable decrement
+/// on the hot path. "For this session" was rejected because the runtime has no
+/// operator-session object that an agent's work spans — it would be a fiction.
+/// "Forever" is what the issue forbids.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum GrantScope {
+    /// Today's behaviour, byte for byte: one call, argument-exact, agent-scoped.
+    /// The default, and what every caller that says nothing gets.
+    #[default]
+    Once,
+    /// This tool, for this teammate, with any arguments, until
+    /// `expires_at_millis` — an absolute epoch-millis deadline.
+    Tool {
+        /// Absolute epoch-millis the grant stops admitting calls.
+        expires_at_millis: u64,
+    },
+}
+
+/// A standing permission: one tool, one teammate, until a deadline (issue #374).
+///
+/// Deliberately **not** a variant of [`GrantedCall`]. See the module docs: no
+/// `args` and a non-optional expiry are the two properties that make this type
+/// unable to become the thing the issue warns about.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StandingGrant {
+    /// This grant's id — what a revoke addresses.
+    pub id: GrantId,
+    /// The roster agent allowed to redeem it. Nobody else matches.
+    pub agent: String,
+    /// The tool it admits, with any arguments.
+    pub tool: String,
+    /// Who granted it. Journaled so "who opened this up" is answerable later.
+    pub granted_by: Actor,
+    /// The approval whose resolution minted it — the provenance the brain's
+    /// re-dispatch joins on, and the audit link back to the card the operator
+    /// was looking at when they decided.
+    pub approval_id: ApprovalId,
+    /// Epoch-millis it was minted.
+    pub at_millis: u64,
+    /// Absolute epoch-millis it stops admitting calls. Not an optional, and not
+    /// a duration: an absolute deadline survives a restart without arithmetic,
+    /// and a required field cannot be omitted into immortality.
+    pub expires_at_millis: u64,
+}
+
+impl StandingGrant {
+    /// Whether this grant still admits calls at `now_millis`.
+    ///
+    /// Strictly `<`, so the deadline instant itself is already past. Checked at
+    /// redemption under the grant lock as well as swept periodically — the sweep
+    /// is housekeeping and an operator notice, never the enforcement.
+    pub fn is_live_at(&self, now_millis: u64) -> bool {
+        now_millis < self.expires_at_millis
+    }
+}
+
 /// The live grant set: a cheap shared handle, the same pattern as
 /// [`ApprovalRequestQueue`](crate::harness::policy::ApprovalRequestQueue).
 ///
@@ -124,6 +257,14 @@ struct GrantState {
     /// in the safe direction: the operator is asked again rather than the tool
     /// firing again unasked.
     consumed: Vec<ApprovalId>,
+    /// Standing grants (issue #374), keyed by their own id.
+    ///
+    /// A second map rather than a second variant in `live`: the two are matched
+    /// on different keys (approval id vs grant id), matched by different
+    /// predicates (argument-exact vs tool-and-agent), and have opposite
+    /// redemption semantics (remove vs leave). Fusing them would put a branch on
+    /// every operation of both.
+    standing: HashMap<GrantId, StandingGrant>,
 }
 
 impl GrantSet {
@@ -206,12 +347,123 @@ impl GrantSet {
     pub fn live_count(&self) -> usize {
         self.inner.lock().expect("grant set poisoned").live.len()
     }
+
+    // -----------------------------------------------------------------------
+    // Standing grants (issue #374)
+    // -----------------------------------------------------------------------
+
+    /// Arms a standing grant.
+    pub fn grant_standing(&self, grant: StandingGrant) {
+        self.inner
+            .lock()
+            .expect("grant set poisoned")
+            .standing
+            .insert(grant.id.clone(), grant);
+    }
+
+    /// Matches an unexpired standing grant for `(agent, tool)` **without**
+    /// removing it — that is the whole difference from [`consume`](Self::consume).
+    ///
+    /// Expiry is enforced *here*, under the same lock as the match, rather than
+    /// being left to the sweep. The sweep runs on the scheduler's maintenance
+    /// tick; between two ticks a lapsed grant would otherwise keep admitting
+    /// calls, and "until 5pm" has to mean 5pm rather than "until the next tick
+    /// after 5pm".
+    ///
+    /// Deterministic when several grants could match — the same agent and tool
+    /// granted twice — by taking the one that expires **last**: the operator's
+    /// most recent intent is the more permissive one they are living with, and
+    /// picking arbitrarily out of a `HashMap` would make redemption depend on
+    /// hash order.
+    pub fn match_standing(
+        &self,
+        agent: &str,
+        tool: &str,
+        now_millis: u64,
+    ) -> Option<StandingGrant> {
+        let state = self.inner.lock().expect("grant set poisoned");
+        state
+            .standing
+            .values()
+            .filter(|g| g.agent == agent && g.tool == tool && g.is_live_at(now_millis))
+            .max_by_key(|g| g.expires_at_millis)
+            .cloned()
+    }
+
+    /// Revokes a standing grant, returning it when there was one.
+    ///
+    /// `None` means it was already gone — revoked by another browser tab, or
+    /// swept — which the route reports as a 404 rather than pretending to have
+    /// done something.
+    pub fn revoke_standing(&self, id: &GrantId) -> Option<StandingGrant> {
+        self.inner
+            .lock()
+            .expect("grant set poisoned")
+            .standing
+            .remove(id)
+    }
+
+    /// Reads a standing grant by the approval that minted it.
+    ///
+    /// The brain's re-dispatch needs this: it is handed an approval id and has
+    /// to find the permission that resolution created, whichever scope it was.
+    pub fn peek_standing_by_approval(&self, approval_id: &ApprovalId) -> Option<StandingGrant> {
+        self.inner
+            .lock()
+            .expect("grant set poisoned")
+            .standing
+            .values()
+            .find(|g| &g.approval_id == approval_id)
+            .cloned()
+    }
+
+    /// Every live standing grant, newest first — what the console lists.
+    pub fn standing(&self) -> Vec<StandingGrant> {
+        let state = self.inner.lock().expect("grant set poisoned");
+        let mut out: Vec<StandingGrant> = state.standing.values().cloned().collect();
+        out.sort_by(|a, b| b.at_millis.cmp(&a.at_millis).then_with(|| a.id.cmp(&b.id)));
+        out
+    }
+
+    /// Removes every standing grant whose deadline has passed, returning them so
+    /// the caller can journal each expiry.
+    pub fn sweep_standing(&self, now_millis: u64) -> Vec<StandingGrant> {
+        let mut state = self.inner.lock().expect("grant set poisoned");
+        let expired: Vec<GrantId> = state
+            .standing
+            .values()
+            .filter(|g| !g.is_live_at(now_millis))
+            .map(|g| g.id.clone())
+            .collect();
+        expired
+            .into_iter()
+            .filter_map(|id| state.standing.remove(&id))
+            .collect()
+    }
+
+    /// Seeds the standing map from a journal replay (boot recovery).
+    pub fn rehydrate_standing(&self, grants: impl IntoIterator<Item = StandingGrant>) {
+        let mut state = self.inner.lock().expect("grant set poisoned");
+        for grant in grants {
+            state.standing.insert(grant.id.clone(), grant);
+        }
+    }
+
+    /// How many standing grants are live (tests / observability).
+    pub fn standing_count(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("grant set poisoned")
+            .standing
+            .len()
+    }
 }
 
 impl std::fmt::Debug for GrantSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GrantSet")
             .field("live", &self.live_count())
+            .field("standing", &self.standing_count())
             .finish_non_exhaustive()
     }
 }
@@ -354,5 +606,153 @@ mod test {
         assert_eq!(winners.load(std::sync::atomic::Ordering::SeqCst), 1);
         assert_eq!(set.live_count(), 0);
         assert_eq!(set.drain_consumed().len(), 1, "one consumption journaled");
+    }
+
+    // -----------------------------------------------------------------------
+    // Standing grants (issue #374)
+    // -----------------------------------------------------------------------
+
+    fn operator() -> Actor {
+        Actor {
+            kind: crate::ports::types::ActorKind::User,
+            id: "user-1".to_string(),
+        }
+    }
+
+    fn standing(id: &str, agent: &str, tool: &str, expires_at_millis: u64) -> StandingGrant {
+        StandingGrant {
+            id: GrantId::new(id),
+            agent: agent.to_string(),
+            tool: tool.to_string(),
+            granted_by: operator(),
+            approval_id: ApprovalId::new(format!("approval-{id}")),
+            at_millis: 1_000,
+            expires_at_millis,
+        }
+    }
+
+    /// The whole point of the scope: the tool stops asking, whatever the
+    /// arguments, until the deadline.
+    #[test]
+    fn a_standing_grant_admits_varying_arguments_until_it_expires() {
+        let set = GrantSet::default();
+        set.grant_standing(standing("g1", "ops", "shell", 10_000));
+
+        assert!(set.match_standing("ops", "shell", 2_000).is_some());
+        // Matching does not depend on arguments at all — there are none to
+        // depend on. Two different calls, same admission.
+        assert!(set.match_standing("ops", "shell", 9_999).is_some());
+        assert_eq!(
+            set.standing_count(),
+            1,
+            "redeeming a standing grant must not remove it — that is single-use's job"
+        );
+
+        // The deadline instant itself is already past.
+        assert!(set.match_standing("ops", "shell", 10_000).is_none());
+        assert!(set.match_standing("ops", "shell", 10_001).is_none());
+    }
+
+    #[test]
+    fn a_standing_grant_is_scoped_to_its_agent_and_its_tool() {
+        let set = GrantSet::default();
+        set.grant_standing(standing("g1", "ops", "shell", 10_000));
+
+        assert!(
+            set.match_standing("marketing", "shell", 2_000).is_none(),
+            "another teammate is not who the operator granted"
+        );
+        assert!(
+            set.match_standing("ops", "workspace_write", 2_000)
+                .is_none(),
+            "another tool is not what the operator granted"
+        );
+    }
+
+    #[test]
+    fn revoking_a_standing_grant_stops_it_matching() {
+        let set = GrantSet::default();
+        set.grant_standing(standing("g1", "ops", "shell", 10_000));
+        assert!(set.match_standing("ops", "shell", 2_000).is_some());
+
+        let revoked = set.revoke_standing(&GrantId::new("g1")).expect("was live");
+        assert_eq!(revoked.tool, "shell");
+        assert!(set.match_standing("ops", "shell", 2_000).is_none());
+        assert_eq!(set.standing_count(), 0);
+        assert!(
+            set.revoke_standing(&GrantId::new("g1")).is_none(),
+            "revoking twice reports nothing to revoke rather than pretending"
+        );
+    }
+
+    /// A single-use grant must burn even when a standing grant would also have
+    /// admitted the call.
+    ///
+    /// The ordering is enforced by the policy arm, but the primitives have to
+    /// make it expressible: `consume` is what removes, and a standing match
+    /// never touches the single-use set. If a standing match ran first, the
+    /// operator's one-off approval would sit live until its TTL and then be
+    /// announced as "the agent never acted" — a lie about work that ran.
+    #[test]
+    fn a_single_use_grant_still_burns_while_a_standing_grant_is_live() {
+        let set = GrantSet::default();
+        let args = serde_json::json!({ "cmd": "ls" });
+        set.grant(call("a1", "ops", "shell", args.clone()));
+        set.grant_standing(standing("g1", "ops", "shell", 10_000));
+
+        assert!(set.consume("ops", "shell", &args).is_some());
+        assert_eq!(set.live_count(), 0, "the single-use grant burned");
+        assert_eq!(set.standing_count(), 1, "the standing grant is untouched");
+        assert_eq!(set.drain_consumed().len(), 1);
+    }
+
+    #[test]
+    fn sweep_standing_removes_only_lapsed_grants() {
+        let set = GrantSet::default();
+        set.grant_standing(standing("old", "ops", "shell", 5_000));
+        set.grant_standing(standing("new", "ops", "workspace_write", 50_000));
+
+        let expired = set.sweep_standing(10_000);
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].id, GrantId::new("old"));
+        assert_eq!(set.standing_count(), 1);
+        assert!(
+            set.match_standing("ops", "workspace_write", 10_000)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn the_longest_lived_match_wins_so_redemption_is_not_hash_order() {
+        let set = GrantSet::default();
+        set.grant_standing(standing("short", "ops", "shell", 5_000));
+        set.grant_standing(standing("long", "ops", "shell", 50_000));
+
+        let matched = set.match_standing("ops", "shell", 1_000).expect("matches");
+        assert_eq!(matched.id, GrantId::new("long"));
+    }
+
+    #[test]
+    fn standing_grants_rehydrate_and_are_findable_by_their_approval() {
+        let set = GrantSet::default();
+        set.rehydrate_standing([
+            standing("g1", "ops", "shell", 10_000),
+            standing("g2", "legal", "workspace_write", 10_000),
+        ]);
+        assert_eq!(set.standing_count(), 2);
+
+        let found = set
+            .peek_standing_by_approval(&ApprovalId::new("approval-g2"))
+            .expect("provenance is queryable");
+        assert_eq!(found.agent, "legal");
+        assert!(
+            set.peek_standing_by_approval(&ApprovalId::new("nope"))
+                .is_none()
+        );
+
+        // Newest first, and `at_millis` ties break on id so the list is stable.
+        let listed = set.standing();
+        assert_eq!(listed.len(), 2);
+        assert_eq!(listed[0].id, GrantId::new("g1"));
     }
 }

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -62,10 +62,10 @@
 //!   forever. The issue forbids silent accumulation, and a type that cannot
 //!   express "no expiry" cannot regress into it.
 //!
-//! What it never covers is decided elsewhere, once:
-//! [`broadly_grantable`](crate::harness::policy::broadly_grantable) delegates to
-//! the existing consequence taxonomy, so only `EffectGroup::Other` tools can be
-//! granted this way — never Spend, Send, Sign, Publish, Hire or Identity.
+//! What it never covers is decided elsewhere, once: `broadly_grantable` in
+//! `crate::harness::policy` delegates to the existing consequence taxonomy, so
+//! only `EffectGroup::Other` tools can be granted this way — never Spend, Send,
+//! Sign, Publish, Hire or Identity.
 //!
 //! ## Durability
 //!

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -220,6 +220,22 @@ pub struct StandingGrant {
     /// a duration: an absolute deadline survives a restart without arithmetic,
     /// and a required field cannot be omitted into immortality.
     pub expires_at_millis: u64,
+    /// The chat thread the approval was raised in (issue #379), carried for the
+    /// same reason [`GrantedCall::origin_thread`] is: so the re-dispatched
+    /// turn's reply is journaled back into the conversation that asked for it.
+    ///
+    /// **Routing only, never part of the match** — matching is `(agent, tool,
+    /// unexpired)` and nothing else. A desk channel and a direct message to that
+    /// channel's lead are answered by the same teammate, so without this the
+    /// continuation of a channel's request would land in the lead's private
+    /// line: the operator approves in one place and the work resumes in another
+    /// they are not looking at.
+    ///
+    /// `None` for an approval with no conversation behind it, and on a grant
+    /// replayed from a line written before this field existed. Both fall back to
+    /// [`agent`](Self::agent), which is right for a DM.
+    #[serde(default)]
+    pub origin_thread: Option<String>,
 }
 
 impl StandingGrant {
@@ -628,6 +644,7 @@ mod test {
             approval_id: ApprovalId::new(format!("approval-{id}")),
             at_millis: 1_000,
             expires_at_millis,
+            origin_thread: None,
         }
     }
 

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -25,8 +25,8 @@ use tokio::sync::Mutex as TokioMutex;
 
 use crate::Result;
 use crate::error::OpenCompanyError;
-use crate::ports::types::{ApprovalId, Effect};
-use crate::runtime::grants::GrantedCall;
+use crate::ports::types::{Actor, ApprovalId, Effect};
+use crate::runtime::grants::{GrantId, GrantedCall, StandingGrant};
 pub use crate::runtime::types::TaskLink;
 use crate::store::fs::{PathLocks, append_line};
 
@@ -178,6 +178,42 @@ enum JournalRecord {
     GrantExpired {
         /// The expired grant's approval id.
         id: ApprovalId,
+        /// Epoch-millis the expiry was recorded.
+        at_millis: u64,
+    },
+    /// A **standing** grant minted because the operator chose the broader scope
+    /// on an approval: this tool, for this teammate, until a deadline (#374).
+    ///
+    /// Carries the grant whole, like
+    /// [`ApprovalGranted`](Self::ApprovalGranted), because this line is the only
+    /// durable answer to "who opened this tool up, when, off which card, and
+    /// until when". `StandingGrant::granted_by` is the operator's real identity,
+    /// not the placeholder the resolve route used to hardcode.
+    ///
+    /// Written *before* the grant reaches the live set, the same crash direction
+    /// `ApprovalGranted` takes.
+    StandingGrantMinted {
+        /// The standing grant, whole.
+        grant: StandingGrant,
+    },
+    /// A standing grant the operator took back (#374).
+    ///
+    /// Takes effect on the **next** policy check — an already-admitted call is
+    /// not aborted, because there is no abort lever inside an agent's turn and
+    /// killing one mid-call is the lifecycle anti-pattern this codebase avoids
+    /// elsewhere. The next check finds nothing and re-parks.
+    StandingGrantRevoked {
+        /// The revoked grant's id.
+        id: GrantId,
+        /// Who revoked it.
+        by: Actor,
+        /// Epoch-millis the revocation was recorded.
+        at_millis: u64,
+    },
+    /// A standing grant that reached its deadline (#374).
+    StandingGrantExpired {
+        /// The expired grant's id.
+        id: GrantId,
         /// Epoch-millis the expiry was recorded.
         at_millis: u64,
     },
@@ -394,6 +430,13 @@ struct State {
     /// consumed or expired entry here would re-arm a tool call that already ran
     /// (or that the operator was already told had lapsed) on every restart.
     grants: HashMap<ApprovalId, GrantedCall>,
+    /// Standing grants minted and not yet revoked or expired (issue #374).
+    ///
+    /// Removed from on both terminal records for the same reason as
+    /// [`grants`](Self::grants): a replayed entry is handed straight back to the
+    /// live set, so retaining a revoked one would hand back a permission the
+    /// operator explicitly took away — on every restart, silently.
+    standing_grants: HashMap<GrantId, StandingGrant>,
 }
 
 impl State {
@@ -627,6 +670,15 @@ impl RuntimeJournal {
             }
             JournalRecord::GrantExpired { id, .. } => {
                 state.grants.remove(&id);
+            }
+            JournalRecord::StandingGrantMinted { grant } => {
+                state.standing_grants.insert(grant.id.clone(), grant);
+            }
+            JournalRecord::StandingGrantRevoked { id, .. } => {
+                state.standing_grants.remove(&id);
+            }
+            JournalRecord::StandingGrantExpired { id, .. } => {
+                state.standing_grants.remove(&id);
             }
         }
     }
@@ -970,6 +1022,77 @@ impl RuntimeJournal {
             .expect("journal state poisoned")
             .grants
             .values()
+            .cloned()
+            .collect()
+    }
+
+    /// Records a minted standing grant (issue #374).
+    ///
+    /// Called *before* the grant enters the live set, so the ordering failure
+    /// mode is "recorded but not live" — which replay fixes — rather than "live
+    /// but not recorded", which would leave a permission nobody can see or
+    /// revoke.
+    pub async fn record_standing_granted(&self, grant: &StandingGrant) -> Result<()> {
+        self.state
+            .lock()
+            .expect("journal state poisoned")
+            .standing_grants
+            .insert(grant.id.clone(), grant.clone());
+        self.append(&JournalRecord::StandingGrantMinted {
+            grant: grant.clone(),
+        })
+        .await
+    }
+
+    /// Records that the operator revoked a standing grant (issue #374).
+    pub async fn record_standing_revoked(
+        &self,
+        id: &GrantId,
+        by: Actor,
+        at_millis: u64,
+    ) -> Result<()> {
+        self.state
+            .lock()
+            .expect("journal state poisoned")
+            .standing_grants
+            .remove(id);
+        self.append(&JournalRecord::StandingGrantRevoked {
+            id: id.clone(),
+            by,
+            at_millis,
+        })
+        .await
+    }
+
+    /// Records that a standing grant reached its deadline (issue #374).
+    pub async fn record_standing_expired(&self, id: &GrantId, at_millis: u64) -> Result<()> {
+        self.state
+            .lock()
+            .expect("journal state poisoned")
+            .standing_grants
+            .remove(id);
+        self.append(&JournalRecord::StandingGrantExpired {
+            id: id.clone(),
+            at_millis,
+        })
+        .await
+    }
+
+    /// Every standing grant still live according to the journal, with anything
+    /// already past its deadline folded out (issue #374).
+    ///
+    /// The expiry filter matters beyond tidiness: the sweep only runs while the
+    /// process is up, so a host that was down across a grant's deadline has no
+    /// `StandingGrantExpired` line for it. Replaying on `at_millis` alone would
+    /// hand a lapsed permission back to the live set, and a restart would be a
+    /// way to resurrect one — the exact silent accumulation this issue forbids.
+    pub fn replayed_standing_grants(&self, now_millis: u64) -> Vec<StandingGrant> {
+        self.state
+            .lock()
+            .expect("journal state poisoned")
+            .standing_grants
+            .values()
+            .filter(|g| g.is_live_at(now_millis))
             .cloned()
             .collect()
     }
@@ -1867,6 +1990,132 @@ mod test {
         assert!(raw.contains("ApprovalGranted"));
         assert!(raw.contains("GrantConsumed"));
         assert!(raw.contains("GrantExpired"));
+    }
+
+    fn standing(id: &str, tool: &str, expires_at_millis: u64) -> StandingGrant {
+        StandingGrant {
+            id: GrantId::new(id),
+            agent: "ops".into(),
+            tool: tool.into(),
+            granted_by: Actor {
+                kind: crate::ports::types::ActorKind::User,
+                id: "user-42".into(),
+            },
+            approval_id: ApprovalId::new(format!("appr-{id}")),
+            at_millis: 1_000,
+            expires_at_millis,
+        }
+    }
+
+    /// Issue #374: a standing grant survives a restart, with its expiry and the
+    /// operator who granted it intact.
+    #[tokio::test]
+    async fn a_standing_grant_replays_across_a_restart() {
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
+        let journal = RuntimeJournal::new(&path);
+
+        journal
+            .record_standing_granted(&standing("g1", "shell", 100_000))
+            .await
+            .unwrap();
+
+        let reloaded = RuntimeJournal::new(&path);
+        reloaded.load().await.unwrap();
+        let replayed = reloaded.replayed_standing_grants(2_000);
+        assert_eq!(replayed.len(), 1);
+        assert_eq!(replayed[0].id, GrantId::new("g1"));
+        assert_eq!(replayed[0].tool, "shell");
+        assert_eq!(replayed[0].expires_at_millis, 100_000);
+        assert_eq!(
+            replayed[0].granted_by.id, "user-42",
+            "who opened this tool up is the point of the record"
+        );
+    }
+
+    /// Revoked, expired, and *silently lapsed* standing grants all stay gone.
+    ///
+    /// The third case is the one only replay can catch: the sweep runs while the
+    /// process is up, so a host that was down across a deadline never wrote a
+    /// `StandingGrantExpired` line. Replaying on the record alone would hand the
+    /// permission back, making a restart a way to resurrect one.
+    #[tokio::test]
+    async fn revoked_expired_and_lapsed_standing_grants_are_not_rehydrated() {
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
+        let journal = RuntimeJournal::new(&path);
+
+        for g in [
+            standing("revoked", "shell", 100_000),
+            standing("expired", "workspace_write", 100_000),
+            standing("lapsed", "web_fetch", 3_000),
+            standing("live", "shell", 100_000),
+        ] {
+            journal.record_standing_granted(&g).await.unwrap();
+        }
+
+        journal
+            .record_standing_revoked(
+                &GrantId::new("revoked"),
+                Actor {
+                    kind: crate::ports::types::ActorKind::User,
+                    id: "user-42".into(),
+                },
+                5_000,
+            )
+            .await
+            .unwrap();
+        journal
+            .record_standing_expired(&GrantId::new("expired"), 5_000)
+            .await
+            .unwrap();
+
+        let reloaded = RuntimeJournal::new(&path);
+        reloaded.load().await.unwrap();
+        // `lapsed` has no terminal record at all — only its deadline stops it.
+        let replayed = reloaded.replayed_standing_grants(10_000);
+        assert_eq!(replayed.len(), 1);
+        assert_eq!(replayed[0].id, GrantId::new("live"));
+
+        let raw = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(raw.contains("StandingGrantMinted"));
+        assert!(raw.contains("StandingGrantRevoked"));
+        assert!(raw.contains("StandingGrantExpired"));
+    }
+
+    /// A journal written before #374 decodes unchanged, and replays no standing
+    /// grants. The forward-only half — an old binary cannot read a new journal —
+    /// is the same contract every prior variant addition made.
+    #[tokio::test]
+    async fn a_pre_374_journal_decodes_and_yields_no_standing_grants() {
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
+        let journal = RuntimeJournal::new(&path);
+
+        journal
+            .record_parked(
+                &ApprovalId::new("appr-old"),
+                &effect(),
+                500,
+                TaskLink::Unlinked,
+                None,
+            )
+            .await
+            .unwrap();
+        journal
+            .record_granted(&grant("appr-old", 1_000))
+            .await
+            .unwrap();
+
+        let reloaded = RuntimeJournal::new(&path);
+        reloaded.load().await.unwrap();
+        assert_eq!(reloaded.pending().len(), 1);
+        assert_eq!(
+            reloaded.replayed_grants().len(),
+            1,
+            "the single-use path replays byte-identically"
+        );
+        assert!(reloaded.replayed_standing_grants(2_000).is_empty());
     }
 
     /// The grant records must not disturb the approval-queue fold they share a

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -2004,6 +2004,7 @@ mod test {
             approval_id: ApprovalId::new(format!("appr-{id}")),
             at_millis: 1_000,
             expires_at_millis,
+            origin_thread: None,
         }
     }
 

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -139,4 +139,24 @@ pub struct ApprovalSummary {
     /// page and in no thread, exactly as before.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thread: Option<String>,
+    /// Whether the operator may grant this tool **broadly** — one standing
+    /// permission covering any arguments until a deadline (issue #374).
+    ///
+    /// `true` exactly when the effect came from a harness tool call *and* its
+    /// group is
+    /// [`EffectGroup::Other`](crate::ports::types::EffectGroup::Other). The
+    /// console renders the scope control only then, so the operator is never
+    /// offered a choice the host would refuse.
+    ///
+    /// **This flag is UX, not enforcement.** The host re-checks the same rule
+    /// when the resolve arrives, and answers 400 — a console that ignored this
+    /// field, or a hand-rolled request, gets no further than one that respects
+    /// it.
+    ///
+    /// Skipped when `false`, which is the common case, so a card that cannot be
+    /// granted broadly serializes exactly as it did before this field existed —
+    /// and an old console, which reads no such field, degrades to today's
+    /// approve-once behaviour by construction.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub broadly_grantable: bool,
 }

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -33,10 +33,11 @@ use crate::ports::types::{
     Actor, ActorKind, ApprovalId, CompanyEvent, CompanyId, OutboundMessage, OverlayDesk,
     OverlayDeskMember, OverlayDeskOrder, StoredEvent, TurnStep, Verdict,
 };
-use crate::runtime::grants::GrantScope;
+use crate::runtime::grants::{GrantId, GrantScope, MAX_STANDING_GRANT_MILLIS};
 use crate::runtime::types::{ApprovalSummary, CompanyStatus, CycleReport};
 use crate::server::chat_history::{MessageView, Viewer, history_for_desk};
 use crate::server::error::ApiError;
+use crate::server::graphql::auth::GqlAuth;
 use crate::server::ops::language::{self, DEFAULT_DESK};
 use crate::server::ops::{ScopedCompany, scoped};
 use crate::server::platform_auth::{CompanyAuth, authorize_address, refuse_until_password_changed};
@@ -83,6 +84,10 @@ pub fn router() -> Router<AppState> {
         // the attention-worthy events already on the company's event log, under
         // both scope forms.
         .merge(scoped("/events", get(company_events)))
+        // Standing permissions (issue #374): what the operator has opened up,
+        // and how to take it back. Registered under both scope forms.
+        .merge(scoped("/grants", get(list_grants)))
+        .merge(scoped("/grants/{gid}", delete(revoke_grant)))
 }
 
 /// One desk (group chat) as the console renders it. Mirrors `DeskDto` in
@@ -1362,6 +1367,180 @@ struct ResolveApproval {
     /// over a decision that was recorded seconds earlier (issue #380).
     #[serde(default)]
     detach: bool,
+    /// What this approval buys (issue #374). Absent is
+    /// [`ResolveScope::Once`] — today's behaviour, so every existing caller is
+    /// unaffected without changing a byte of its body.
+    #[serde(default)]
+    scope: Option<ResolveScope>,
+    /// How long a `tool`-scoped grant lasts, in milliseconds from now.
+    ///
+    /// **Mandatory with `scope: "tool"`, and capped at seven days.** A request
+    /// past the cap is a 400, never a silent clamp: quietly shortening a
+    /// duration the operator chose would leave them believing a permission is
+    /// live when it lapsed days earlier.
+    #[serde(default)]
+    expires_in_millis: Option<u64>,
+}
+
+/// The wire form of [`GrantScope`].
+///
+/// A closed enum rather than a free string, so an unrecognised scope is a
+/// deserialization failure at the edge instead of something that silently
+/// degrades to `once` — an operator who asked for a standing permission and
+/// quietly got a single call would not find out until the next card appeared.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum ResolveScope {
+    /// One call, argument-exact. The default.
+    Once,
+    /// This tool, for this teammate, until `expires_in_millis` from now.
+    Tool,
+}
+
+/// Validates the requested scope and turns it into a [`GrantScope`] with an
+/// absolute deadline (issue #374).
+///
+/// Every refusal here happens **before** the runtime is touched, so a bad
+/// request leaves the approval parked and journals no verdict. The contradictions
+/// are refused rather than resolved in the caller's favour:
+///
+/// * **with a deny** — a scope describes what an approval grants, and a deny
+///   grants nothing. Honouring one would be inventing consent out of a refusal.
+/// * **with `amended_payload`** — an argument edit is by definition an
+///   exact-call approval ("this, but with my correction"), and a standing grant
+///   admits any arguments. The two say opposite things about the same request.
+/// * **with no duration, or zero** — the expiry is mandatory. A grant with no
+///   deadline is the silent accumulation this issue exists to prevent.
+/// * **past the cap** — 400, never a clamp. See
+///   [`MAX_STANDING_GRANT_MILLIS`].
+///
+/// A duration on `once` is refused too: it would otherwise be dropped on the
+/// floor, leaving the operator believing they had bought a week.
+fn grant_scope(body: &ResolveApproval) -> Result<GrantScope, ApiError> {
+    let bad = |msg: &str| ApiError(OpenCompanyError::InvalidRequest(msg.to_string()));
+    match body.scope.unwrap_or(ResolveScope::Once) {
+        ResolveScope::Once => {
+            if body.expires_in_millis.is_some() {
+                return Err(bad(
+                    "expires_in_millis only applies to scope \"tool\"; a single-use approval \
+                     covers one call and does not last",
+                ));
+            }
+            Ok(GrantScope::Once)
+        }
+        ResolveScope::Tool => {
+            if body.verdict == Verdict::Deny {
+                return Err(bad("a scope cannot accompany a deny verdict"));
+            }
+            if body.amended_payload.is_some() {
+                return Err(bad(
+                    "amended_payload cannot accompany scope \"tool\": editing the arguments \
+                     approves one exact call, while a standing grant admits any arguments",
+                ));
+            }
+            let Some(duration) = body.expires_in_millis.filter(|d| *d > 0) else {
+                return Err(bad(
+                    "scope \"tool\" requires a positive expires_in_millis; a standing \
+                     permission must have a deadline",
+                ));
+            };
+            if duration > MAX_STANDING_GRANT_MILLIS {
+                return Err(bad(&format!(
+                    "expires_in_millis must be at most {MAX_STANDING_GRANT_MILLIS} \
+                     (seven days); asked for {duration}"
+                )));
+            }
+            Ok(GrantScope::Tool {
+                // Absolute, resolved once here. A duration re-based on every
+                // read would drift, and a deadline is what the operator was
+                // shown.
+                expires_at_millis: crate::ports::now_millis().saturating_add(duration),
+            })
+        }
+    }
+}
+
+/// One standing permission, as the console lists it (issue #374).
+///
+/// Carries **no arguments**, because a standing grant has none — so this route
+/// opens no second redaction surface and #372's payload redactor keeps its
+/// single call site.
+#[derive(Debug, Serialize)]
+struct StandingGrantDto {
+    /// The grant id — what `DELETE …/grants/{gid}` addresses.
+    id: String,
+    /// The teammate it was granted to.
+    agent: String,
+    /// The tool it admits.
+    tool: String,
+    /// Who granted it: a signed-in user, or the platform credential.
+    granted_by: Actor,
+    /// Epoch-millis it was granted.
+    at_millis: u64,
+    /// Epoch-millis it stops admitting calls.
+    expires_at_millis: u64,
+}
+
+impl From<crate::runtime::grants::StandingGrant> for StandingGrantDto {
+    fn from(g: crate::runtime::grants::StandingGrant) -> Self {
+        Self {
+            id: g.id.to_string(),
+            agent: g.agent,
+            tool: g.tool,
+            granted_by: g.granted_by,
+            at_millis: g.at_millis,
+            expires_at_millis: g.expires_at_millis,
+        }
+    }
+}
+
+/// `GET {scope}/grants` — the live standing permissions, newest first.
+async fn list_grants(scope: ScopedCompany) -> Json<Vec<StandingGrantDto>> {
+    Json(
+        scope
+            .runtime
+            .standing_grants()
+            .into_iter()
+            .map(StandingGrantDto::from)
+            .collect(),
+    )
+}
+
+/// `DELETE {scope}/grants/{gid}` — take a standing permission back.
+///
+/// Takes effect on the **next** policy check; a call already admitted is not
+/// aborted. 404 when there is nothing to revoke — already revoked, or expired —
+/// rather than reporting success over a no-op.
+async fn revoke_grant(
+    scope: ScopedCompany,
+    Path(params): Path<std::collections::HashMap<String, String>>,
+) -> Result<StatusCode, ApiError> {
+    let gid = params
+        .get("gid")
+        .cloned()
+        .ok_or_else(|| ApiError(OpenCompanyError::InvalidRequest("missing grant id".into())))?;
+    // The machine credential has no person behind it, the same distinction every
+    // other operator write draws.
+    let by = scope.actor.clone().unwrap_or_else(platform_actor);
+    let revoked = scope
+        .runtime
+        .revoke_standing_grant(&GrantId::new(gid.clone()), by)
+        .await?;
+    if revoked {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(ApiError(OpenCompanyError::NotFound(format!(
+            "standing permission {gid}"
+        ))))
+    }
+}
+
+/// The actor for a request carrying a machine credential rather than a person.
+fn platform_actor() -> Actor {
+    Actor {
+        kind: ActorKind::Operator,
+        id: "platform".to_string(),
+    }
 }
 
 /// The answer to a detached resolve: the verdict is durable, that is all this
@@ -1386,12 +1565,12 @@ async fn run_resolve(
     runtime: Arc<CompanyRuntime>,
     approval_id: String,
     body: ResolveApproval,
+    actor: Actor,
 ) -> Result<Response, ApiError> {
     runtime.ensure_running().await?;
-    let actor = Actor {
-        kind: ActorKind::Operator,
-        id: "operator".to_string(),
-    };
+    // Issue #374: validated before the runtime is touched, so a refused scope
+    // leaves the approval parked with no verdict journaled.
+    let scope = grant_scope(&body)?;
     let id = ApprovalId::new(approval_id);
     // The verdict is settled inline; only the follow-up cycle is on the handle.
     // So by the time this returns — in either mode — the decision is journaled
@@ -1409,7 +1588,7 @@ async fn run_resolve(
         }
         (verdict, None) => {
             runtime
-                .resolve_approval_spawned(&id, verdict, actor, GrantScope::Once)
+                .resolve_approval_spawned(&id, verdict, actor, scope)
                 .await?
         }
     };
@@ -1458,9 +1637,29 @@ async fn resolve_approval(
         return Err(resp);
     }
     let runtime = lookup(&state, &id).map_err(IntoResponse::into_response)?;
-    run_resolve(&state, &company, runtime, aid, body)
+    let actor = resolving_actor(auth);
+    run_resolve(&state, &company, runtime, aid, body, actor)
         .await
         .map_err(IntoResponse::into_response)
+}
+
+/// Who is resolving this approval (issue #374).
+///
+/// Both resolve handlers used to hardcode `Actor { kind: Operator, id:
+/// "operator" }` while already holding the authenticated principal — so the
+/// journal recorded every verdict as having come from the same anonymous
+/// "operator", on a multi-user company where several people can decide. That was
+/// tolerable while the record was one verdict; a standing grant is a permission
+/// that outlives the decision and that someone else will later find and have to
+/// account for, so "who opened this up" has to be a real answer.
+fn resolving_actor(auth: GqlAuth) -> Actor {
+    match auth {
+        GqlAuth::User(user) => Actor {
+            kind: ActorKind::User,
+            id: user.user_id,
+        },
+        GqlAuth::Platform(_) => platform_actor(),
+    }
 }
 
 /// `POST /api/v1/company/approvals/{aid}` (single-company alias).
@@ -1478,7 +1677,8 @@ async fn resolve_approval_single(
     if let Some(resp) = refuse_until_password_changed(&auth) {
         return Err(resp);
     }
-    run_resolve(&state, &id, runtime, aid, body)
+    let actor = resolving_actor(auth);
+    run_resolve(&state, &id, runtime, aid, body, actor)
         .await
         .map_err(IntoResponse::into_response)
 }
@@ -3857,5 +4057,247 @@ mod test {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // -----------------------------------------------------------------------
+    // Standing permissions (issue #374)
+    // -----------------------------------------------------------------------
+
+    /// Every contradictory or unbounded scope request is a 400, and none of them
+    /// reaches the runtime.
+    ///
+    /// The approval id is deliberately one that does not exist: each of these
+    /// must be refused at the edge, so the fact that resolving a missing
+    /// approval would otherwise be a harmless no-op never gets a chance to mask
+    /// a body that should not have been accepted.
+    #[tokio::test]
+    async fn a_contradictory_or_unbounded_scope_is_refused() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+
+        let day: u64 = 24 * 60 * 60 * 1000;
+        for (label, body) in [
+            (
+                "a scope cannot ride a deny",
+                format!(r#"{{"verdict":"deny","scope":"tool","expires_in_millis":{day}}}"#),
+            ),
+            (
+                "an argument edit and a standing grant contradict",
+                format!(
+                    r#"{{"verdict":"approve","scope":"tool","expires_in_millis":{day},"amended_payload":{{"to":"x"}}}}"#
+                ),
+            ),
+            (
+                "the deadline is mandatory",
+                r#"{"verdict":"approve","scope":"tool"}"#.to_string(),
+            ),
+            (
+                "zero is not a duration",
+                r#"{"verdict":"approve","scope":"tool","expires_in_millis":0}"#.to_string(),
+            ),
+            (
+                "past the seven-day cap is refused, never clamped",
+                format!(
+                    r#"{{"verdict":"approve","scope":"tool","expires_in_millis":{}}}"#,
+                    MAX_STANDING_GRANT_MILLIS + 1
+                ),
+            ),
+            (
+                "a duration is meaningless on the once scope",
+                format!(r#"{{"verdict":"approve","scope":"once","expires_in_millis":{day}}}"#),
+            ),
+        ] {
+            let response = router(state.clone())
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/api/v1/company/approvals/appr-missing")
+                        .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                        .header("content-type", "application/json")
+                        .body(Body::from(body))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::BAD_REQUEST,
+                "{label}: must be refused at the edge"
+            );
+        }
+
+        // An unrecognised scope is refused too, one layer earlier: `ResolveScope`
+        // is a closed enum, so axum's JSON extractor rejects it as 422 before
+        // any handler runs. The status differs from the checks above; what
+        // matters is that it is never silently downgraded to `once`, which would
+        // hand an operator a single call when they asked for a standing one.
+        let response = router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/company/approvals/appr-missing")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"verdict":"approve","scope":"forever"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+        // Exactly at the cap is fine — the boundary is inclusive.
+        let response = router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/company/approvals/appr-missing")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(format!(
+                        r#"{{"verdict":"approve","scope":"tool","expires_in_millis":{MAX_STANDING_GRANT_MILLIS}}}"#
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_ne!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// The default body — no `scope` key at all — is accepted exactly as before.
+    #[tokio::test]
+    async fn an_omitted_scope_is_the_pre_374_request() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/company/approvals/appr-missing")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"verdict":"approve"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// The grants list is empty on a fresh company, and revoking something that
+    /// is not there is a 404 rather than a cheerful no-op.
+    #[tokio::test]
+    async fn the_grants_list_starts_empty_and_revoking_nothing_is_a_404() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+
+        let response = router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/company/grants")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value.as_array().unwrap().len(), 0);
+
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/api/v1/company/grants/nope")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// A standing grant is listed with the authenticated user's id, is revocable,
+    /// and revoking is idempotent-by-404. Both scope forms answer.
+    #[tokio::test]
+    async fn a_standing_grant_is_listed_under_its_granter_and_can_be_revoked() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+
+        runtime
+            .grants
+            .grant_standing(crate::runtime::grants::StandingGrant {
+                id: crate::runtime::grants::GrantId::new("g1"),
+                agent: "ops".into(),
+                tool: "workspace_write".into(),
+                granted_by: Actor {
+                    kind: ActorKind::User,
+                    id: "user-7".into(),
+                },
+                approval_id: ApprovalId::new("appr-1"),
+                at_millis: 1_000,
+                expires_at_millis: crate::ports::now_millis() + 60 * 60 * 1000,
+                origin_thread: None,
+            });
+
+        // Both addressing forms list it.
+        for uri in ["/api/v1/company/grants", "/api/v1/companies/acme/grants"] {
+            let response = router(state.clone())
+                .oneshot(
+                    Request::builder()
+                        .uri(uri)
+                        .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK, "{uri}");
+            let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(value[0]["id"], "g1", "{uri}");
+            assert_eq!(value[0]["tool"], "workspace_write");
+            assert_eq!(value[0]["agent"], "ops");
+            assert_eq!(
+                value[0]["granted_by"]["id"], "user-7",
+                "the list names who actually granted it"
+            );
+            assert!(
+                value[0].get("payload").is_none() && value[0].get("args").is_none(),
+                "a standing grant has no arguments, so the list opens no redaction surface"
+            );
+        }
+
+        // Revoke, then it is gone and a second revoke is a 404.
+        let response = router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/api/v1/company/grants/g1")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        assert_eq!(runtime.standing_grants().len(), 0);
+
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/api/v1/company/grants/g1")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -33,6 +33,7 @@ use crate::ports::types::{
     Actor, ActorKind, ApprovalId, CompanyEvent, CompanyId, OutboundMessage, OverlayDesk,
     OverlayDeskMember, OverlayDeskOrder, StoredEvent, TurnStep, Verdict,
 };
+use crate::runtime::grants::GrantScope;
 use crate::runtime::types::{ApprovalSummary, CompanyStatus, CycleReport};
 use crate::server::chat_history::{MessageView, Viewer, history_for_desk};
 use crate::server::error::ApiError;
@@ -1408,7 +1409,7 @@ async fn run_resolve(
         }
         (verdict, None) => {
             runtime
-                .resolve_approval_spawned(&id, verdict, actor)
+                .resolve_approval_spawned(&id, verdict, actor, GrantScope::Once)
                 .await?
         }
     };


### PR DESCRIPTION
## Summary

Granting a permission now sticks. Approving a blocked tool call has always
minted a **single-use, argument-exact** grant (#243) — the right default, but
until now the only scope there was, so an agent reaching for the same tool
repeatedly produced a stream of near-identical cards and the operator's rational
escapes were approving blind or switching the company to `full`, throwing the
gate away to stop it nagging.

An approve now carries a scope. Four decisions as shipped:

1. **Two options.** *Just this once* — the default, byte-identical to today,
   needing no interaction and no new key on the wire. *This tool, for this
   teammate* — with a mandatory duration picker (1 hour / 8 hours / 7 days),
   rendered only when the host marks the approval broadly grantable.
2. **Expiry is a mandatory fixed duration**, stored as absolute epoch-millis and
   capped at 7 days server-side — **400 past the cap, never a silent clamp**.
   Enforced at redemption *under the grant lock*, not merely swept, so "for one
   hour" means one hour rather than "until the next maintenance tick".
   Rejected: "session" (the runtime has no operator-session object an agent's
   work spans — it would be a fiction), count-based (reintroduces the annoyance
   nondeterministically and needs durable decrements on the hot path), forever
   (the issue forbids silent accumulation).
3. **What can never be granted broadly**: anything whose consequence group is not
   `Other` — Spend, Send, Sign, Publish, Hire, Identity. One rule
   (`EffectGroup::is_broadly_grantable`), delegating to the taxonomy the codebase
   already maintains, so no second hand-kept list of "safe tools" can drift. The
   card hiding the control is UX; **the 400 is the enforcement**.
4. **Listing and revoking** live in a *Standing permissions* section on the
   Approvals page, backed by `GET …/grants` and `DELETE …/grants/{gid}`.
   Revoking journals who and when and takes effect on the **next** call — an
   already-admitted call is not aborted, because there is no abort lever inside
   an agent turn and killing one mid-call is the lifecycle anti-pattern.

A standing grant is a **distinct type**, not a scope flag on `GrantedCall`: it
has **no `args` field** (structurally incapable of argument-matching or of being
widened into it) and a **non-optional expiry** (structurally incapable of living
forever).

Closes #374

## API Or Behavior Changes

**Additive, and old/new degrade to today's behaviour in both directions.**

- `POST {scope}/approvals/{aid}` accepts optional `scope: "once" | "tool"` and
  `expires_in_millis`. Absent = today. The console sends *nothing* for `once`
  rather than `scope:"once"`, so a new console against an old host still works.
- 400 matrix: scope with `deny`; scope with `amended_payload` (an argument edit
  is an exact-call approval — the two contradict); missing/zero/over-7d expiry;
  a duration on `once`; a native effect; a non-grantable tool. An unknown scope
  string is a 422 from the JSON layer — refused, never downgraded to `once`.
  **Every refusal happens before the gate is touched**, so a bad request leaves
  the approval parked with no verdict journaled.
- `GET {scope}/grants`, `DELETE {scope}/grants/{gid}` (204 / 404), both scope
  forms. The list carries no arguments — standing grants have none — so this
  opens no second redaction surface and #372's redactor keeps its single call site.
- `ApprovalSummary` gains `broadly_grantable` (skipped when false).
- **Attribution fixed**: both resolve handlers hardcoded
  `Actor { kind: Operator, id: "operator" }` while already holding the
  authenticated principal. They now derive the real actor (user id, or
  `platform` for a machine credential) and thread it to resolutions, mints and
  revocations.
- Journal gains `StandingGrantMinted` / `StandingGrantRevoked` /
  `StandingGrantExpired`. Old journals decode unchanged and `GrantedCall` is
  untouched, so pre-existing grants replay byte-identically. Forward-only: an old
  binary cannot replay a new journal — the same contract every prior variant
  addition made.
- `classify_group` gains two arms, `deploy` → Publish and `filing` → Sign. Both
  close cases where a consequence-carrying name fell into `Other`, which now
  means something it did not before: `Other` is exactly the set that can be
  granted standing.

## Tests

Both feature lanes, plus the frontend gates (this repo uses **npm**, and has no
lint script):

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings` (default lane)
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 2056 passed
- [x] `cargo test --locked --lib` — 1444 passed
- [x] `cargo check --locked --all-features --all-targets`
- [x] `git diff --stat Cargo.lock` empty — no new dependencies
- [x] `npm ci`, `npm run typecheck`, `npm run typecheck:e2e`, `npm run build`

New coverage: standing match admits varying arguments until expiry and refuses on
wrong agent/tool/expiry; **single-use burns first with both live** (so the
one-off approval cannot be masked and then announced as "the agent didn't act");
the standing arm **refuses a priced call**; the `readonly` brake outranks it and
leaves it intact; scope=Tool journals-then-arms and mints no single-use grant;
native/non-grantable rejection **leaves the approval parked**; **N repeated
ordinary approvals mint zero standing grants** (never inferred, pinned); standing
re-dispatch runs the turn and replies into the thread it was raised in; the full
400 matrix; DELETE→re-park and 404 idempotency; journal round-trip, old-journal
decode, and revoked/expired/**silently lapsed** grants all folded out on replay.

### Manual verification (browser and backend, on a running host)

Real harness (`--features openhuman`) against a scripted OpenAI-compatible mock
emitting gated `workspace_write` calls, on a `supervised` company:

1. Call parks → card shows `broadly_grantable: true`.
2. Approve with **this tool, 1 hour** → `/grants` lists it under the
   **authenticated user's id**; journal has exactly one `StandingGrantMinted`
   and **no** `ApprovalGranted`; the agent is re-dispatched and the turn runs.
3. Second call, **completely different arguments** → **no card**; policy log
   shows the standing grant admitting it.
4. Revoke → 204, repeat → 404.
5. Third call → **parks again**.
6. Regression: plain approve (no `scope` key) mints no standing grant and the
   next call parks again.
7. Live 400 matrix — all six body-level refusals, and the approval **stayed
   parked** with `/grants` empty through all of them.

In the browser (Playwright against the built console): the scope control renders
only on a grantable card, picking it forces a duration, the explainer appears,
approving shows the Standing permissions section, and Revoke removes it and
empties `/grants`.

## Documentation

`docs/spec/company-brain/approvals.md` gains a **Standing grants** subsection
(scopes, expiry model, what can never be granted broadly, listing/revoking,
journal records, the audit limitation) and an updated gate-precedence list
placing the standing arm immediately below single-use consumption. 272 lines,
within the 500 cap. `events.md` and `ports.md` untouched — no new `CompanyEvent`
(grants are pull-only) and grants are runtime-internal.

## Risks and limitations, stated plainly

- **`shell` is `Other`-group and therefore grantable.** Deliberate: the fix for
  shell, if wanted, is *classifying* shell — giving it a consequence class — not
  a second ad-hoc exclusion list, which is exactly the drift this design avoids.
  It is operator opt-in, time-boxed, revocable, and both the `never_do` reserved
  slot and the `readonly` brake outrank it.
- **Per-use audit is tracing-only.** Mint, revoke and expiry are journaled with
  actor and timestamps, but each admitted call writes no journal record.
  Defensible because a standing grant admits only `Other`-group tools and never a
  priced call; a per-use record is additive later.
- **`classify_group` is substring heuristics.** Misclassification *toward* a
  consequence group is the safe direction (a tool loses the broad scope and keeps
  asking); the dangerous direction is why the `deploy` and `filing` arms ship
  here. `read_file` matching the `file` arm and landing in `Sign` is pinned as a
  deliberate safe-direction quirk.
- **Multi-operator staleness**: a mint or revoke from another browser is
  poll-visible only (60s); there is no SSE event for grants in v1.

## Where the plan was wrong

- **`broadly_grantable(tool)` in `src/harness/policy.rs` could not be the single
  source.** That module compiles only under the `openhuman` feature, while all
  three enforcement points — the mint path, the approval summary, the resolve
  route's 400 — are in the default build. The rule now lives un-gated on
  `EffectGroup::is_broadly_grantable` and is applied to the group **already
  recorded on the parked effect**, which is better than re-deriving from the tool
  name: it is the classification the card showed the operator. The tool-name
  wrapper had no production caller once that landed and was deleted rather than
  given a synthetic one.
- **`StandingGrant` needed `origin_thread`.** The plan's field list omitted it,
  which would have regressed #379: a channel's continuation would be journaled
  into the desk lead's private DM. Carried as routing only, never part of the match.
- **A second `classify_group` arm was required.** The plan authorised one
  (`deploy`); `filing_submit` was found to land in `Other` for the same reason
  (`Sign` matches `file`, which `filing` does not contain).
- **The chat inline card does not offer the scope control in this PR** — see
  Follow-ups.

## Follow-ups

- **Chat surface**: `ApprovalRow` can offer the same shared control, but the
  chosen scope has to be threaded through `MessageTimeline.tsx` → `ChatView.tsx`
  → `app-shell.tsx`, all of which belong to other in-flight branches (#411,
  #407-412). Left untouched rather than silently dropping the operator's choice
  on that path; the chat card keeps today's approve-once behaviour, and a
  standing grant granted from the Approvals page applies everywhere regardless.
  It is a one-line prop thread once those land.
- A per-use journal record for standing-grant admissions, if the audit trail is
  wanted at call granularity.
