### PR TITLE
feat(spine): a card in Done carries a link to what it produced (#339)

### DIFF
--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -117,6 +117,7 @@ async fn main() -> anyhow::Result<()> {
         workflow_runner: opencompany::harness::orchestrator::WorkflowRunnerHandle::default(),
         mcp_failures: opencompany::harness::mcp_probe::McpFailureQueue::default(),
         pending_publishes: Default::default(),
+        workflow_refs: Default::default(),
         approval_requests: opencompany::harness::policy::ApprovalRequestQueue::default(),
         secrets: None,
         web_allowed_domains: Vec::new(),

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -3,8 +3,74 @@
 // the client-side `tasks-sample` illustrative data.
 
 import type { OpenCompanyClient } from "./client";
+import type { ArtifactKind } from "./artifacts";
 import type { RunSummary } from "./runs";
 import type { TurnStepFailure } from "./types";
+
+/**
+ * One deliverable a run published, pinned at the revision **that run** wrote
+ * (issue #339).
+ *
+ * The version is part of the link on purpose. Artifact versions are
+ * append-only and an operator edit appends a new one, so a link naming only the
+ * record would quietly re-point at whatever a human last wrote — turning "what
+ * this task produced" into "what the artifact says now". Pinned, it can never
+ * dangle, and the console can compare it against the latest to say a human has
+ * edited it since.
+ */
+export interface TaskOutputArtifact {
+  artifactId: string;
+  /** The 1-based revision this attempt wrote. */
+  version: number;
+  /** Display title, copied so the card can label its link without a read. */
+  title: string;
+  kind: ArtifactKind;
+}
+
+/** Whether the attempt executed a workflow or authored one. */
+export type TaskOutputAction = "ran" | "created";
+
+/**
+ * A workflow the attempt ran or built (issue #339).
+ *
+ * Deliberately **not** pinned to a graph revision, unlike an artifact: workflow
+ * graphs mutate in place and there is no version history to pin to. The link
+ * opens the workflow as it is now, and `runId` — present only when the attempt
+ * actually executed it — opens the overlay showing what really ran.
+ *
+ * Only ever present on an orchestrator-desk card: `run_workflow` and
+ * `create_workflow` are orchestrator-only tools.
+ */
+export interface TaskOutputWorkflow {
+  workflowId: string;
+  runId?: string;
+  action: TaskOutputAction;
+}
+
+/**
+ * What a card's latest **successful** attempt produced (issue #339, epic #183
+ * §6) — the link that turns a finished card into something you can open.
+ *
+ * `runId` is unconditional, and that is the whole design: an output with no
+ * artifacts and no workflows is not an absence, it is the *trace case*. Plenty
+ * of tasks produce no file — a message sent, a record updated, a question
+ * answered — and for those the attempt's trace **is** the deliverable. It is
+ * also the fallback when an artifact is later deleted.
+ *
+ * Absent entirely on a card that has never succeeded, one moved to Done by
+ * hand, and every card settled before this shipped. Those link to the card
+ * itself rather than to a synthesized output.
+ */
+export interface TaskOutput {
+  /** The attempt that produced it — always present. */
+  runId: string;
+  /** That attempt's 1-based ordinal, for the label. Absent if unreadable. */
+  attempt?: number;
+  /** Epoch-millis the stamp was written. */
+  atMillis: number;
+  artifacts?: TaskOutputArtifact[];
+  workflows?: TaskOutputWorkflow[];
+}
 
 /** A board card as the host returns it. */
 export interface Task {
@@ -28,6 +94,14 @@ export interface Task {
    * is every card created before this shipped.
    */
   originChatId?: string;
+  /**
+   * What this card's latest successful attempt produced (issue #339).
+   *
+   * Carried on the **board** read, not just task detail, because the link is
+   * rendered on the card itself — a board that had to open every card to
+   * discover what it produced would cost one read per card per poll.
+   */
+  output?: TaskOutput;
 }
 
 /** The create body; the host defaults column→`todo`, priority→`medium`. */

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -980,6 +980,12 @@ export function AppShell({
               <WorkflowsView
                 client={client}
                 company={company}
+                // Issue #339: `#/workflows/<workflowId>` names the graph to open
+                // on the canvas, so a finished task card can link to the
+                // workflow it built or ran. Same unvalidated second segment
+                // every other sub-page gets — only this view knows which
+                // workflow ids exist, so it does that check itself.
+                sub={sub}
                 runEventTick={workflowRunTick}
                 runEvents={workflowRunEvents}
               />

--- a/frontend/src/lib/task-output.ts
+++ b/frontend/src/lib/task-output.ts
@@ -1,0 +1,195 @@
+// The card's link to what it produced (issue #339, epic #183 §6).
+//
+// A task that finished used to end as a chat message: prose in a conversation,
+// with no durable thing to open, share, or hand to someone else. The host now
+// stamps every successful attempt with a `TaskOutput`; this module turns that
+// record into the one link a card shows, and into the addresses that link
+// resolves to.
+//
+// # The precedence lives here and nowhere else
+//
+// A card shows **one** primary link — artifact, else workflow, else the run
+// trace — and reaches the rest through the task detail. That primary is
+// *derived* from the stamp on every render rather than persisted alongside it,
+// so it can never contradict the list it came from. This module is the single
+// site of that rule; the host deliberately stores the facts and not the choice.
+//
+// # Why the routes are query strings and not path segments
+//
+// `hooks/use-hash-view.ts` is the app's hash router, and its `canonicalize()`
+// runs on **every** `hashchange`, rewriting the URL to at most `head/sub` — two
+// segments. A third segment (`#/tasks/t-1/artifacts/a-1/3`) is therefore
+// silently replaced away before anything can read it, which would make these
+// links appear to work and then not.
+//
+// `readSegments()` strips everything after `?` before that comparison, and
+// `canonicalize` early-returns when the two-segment path already matches — so a
+// hash **query string** survives untouched. That is load-bearing, not a style
+// choice: do not "tidy" these into path segments.
+
+import type { Task, TaskOutput } from "@/api/tasks";
+
+/** Where a card's link points, and what to call it. */
+export interface TaskLink {
+  /** What is at the other end — drives the icon and the label's voice. */
+  kind: "artifact" | "workflow" | "trace" | "card";
+  /** The `#/…` address, ready for an anchor's `href`. */
+  href: string;
+  /** The operator-facing label. */
+  label: string;
+  /** A longer explanation for the anchor's `title`, when one helps. */
+  hint?: string;
+}
+
+/** `#/tasks/<id>` — the card itself, and the link of last resort. */
+export function cardHref(taskId: string): string {
+  return `#/tasks/${encodeURIComponent(taskId)}`;
+}
+
+/**
+ * `#/tasks/<id>?artifact=<artifactId>&v=<version>` — the task's Artifacts tab,
+ * with that deliverable open at the revision the run wrote.
+ */
+export function artifactHref(
+  taskId: string,
+  artifactId: string,
+  version: number,
+): string {
+  return `${cardHref(taskId)}?artifact=${encodeURIComponent(artifactId)}&v=${version}`;
+}
+
+/**
+ * `#/tasks/<id>?run=<runId>` — the task's Attempts tab, with that attempt's
+ * trace open. This is what "no artifact" resolves to, which is why it is a
+ * first-class address rather than a fallback with no URL.
+ */
+export function traceHref(taskId: string, runId: string): string {
+  return `${cardHref(taskId)}?run=${encodeURIComponent(runId)}`;
+}
+
+/**
+ * `#/workflows/<id>`, plus `?run=<runId>` when the attempt actually executed
+ * it — the canvas, showing what ran rather than only what the graph says now.
+ */
+export function workflowHref(workflowId: string, runId?: string): string {
+  const base = `#/workflows/${encodeURIComponent(workflowId)}`;
+  return runId ? `${base}?run=${encodeURIComponent(runId)}` : base;
+}
+
+/** Everything the stamp points at, in precedence order. */
+function linksFor(taskId: string, output: TaskOutput): TaskLink[] {
+  const links: TaskLink[] = [];
+  for (const artifact of output.artifacts ?? []) {
+    links.push({
+      kind: "artifact",
+      href: artifactHref(taskId, artifact.artifactId, artifact.version),
+      label: `Open ${artifact.title}`,
+      hint: `Opens v${artifact.version} — the version this run produced.`,
+    });
+  }
+  for (const workflow of output.workflows ?? []) {
+    links.push({
+      kind: "workflow",
+      href: workflowHref(workflow.workflowId, workflow.runId),
+      label: `Open workflow ${workflow.workflowId}`,
+      hint:
+        workflow.action === "ran"
+          ? "Opens the workflow on its canvas, showing this run."
+          : "Opens the workflow this task built. It has not been run yet.",
+    });
+  }
+  // Always last, and always present: the attempt is the deliverable when
+  // nothing else is, and the fallback when a published artifact is later
+  // deleted. This is what stops "no artifact" degrading into "no link".
+  links.push({
+    kind: "trace",
+    href: traceHref(taskId, output.runId),
+    label: output.attempt
+      ? `View run trace · attempt ${output.attempt}`
+      : "View run trace",
+    hint: "Opens what this attempt actually did, step by step.",
+  });
+  return links;
+}
+
+/**
+ * The single link a card shows: artifact, else workflow, else the trace.
+ *
+ * A card with no stamp — never succeeded, dragged to Done by hand, or settled
+ * before #339 — falls back to the card itself. That is deliberate and it is
+ * where the epic's *"every card in Done has a link"* honestly stops: nothing
+ * recorded an attempt for those, and synthesizing one would be a lie about
+ * identity. A link to the card is at least true.
+ */
+export function primaryLink(task: Task): TaskLink {
+  if (!task.output) {
+    return {
+      kind: "card",
+      href: cardHref(task.id),
+      label: "Open this task",
+      hint: "This card recorded no attempt, so there is nothing else to open.",
+    };
+  }
+  return linksFor(task.id, task.output)[0];
+}
+
+/**
+ * How many further things this card produced beyond the primary link.
+ *
+ * The trace is not counted: it is always reachable and always last, so
+ * counting it would put a `+1 more` on every single stamped card and mean
+ * nothing. This counts only additional *deliverables*.
+ */
+export function extraOutputCount(task: Task): number {
+  const output = task.output;
+  if (!output) return 0;
+  const deliverables =
+    (output.artifacts?.length ?? 0) + (output.workflows?.length ?? 0);
+  return Math.max(0, deliverables - 1);
+}
+
+/** What a `#/tasks/<id>?…` address asks the detail screen to open. */
+export interface TaskFocus {
+  /** Open this artifact on the Artifacts tab… */
+  artifactId?: string;
+  /** …pinned at this revision, when the address named one. */
+  version?: number;
+  /** Or open this attempt's trace on the Attempts tab. */
+  runId?: string;
+}
+
+/**
+ * Reads the focus out of a `#/tasks/<id>?…` hash.
+ *
+ * Tolerant by construction: a malformed or unknown query yields an empty focus
+ * and the detail screen opens on its default tab. A link that has gone stale
+ * should land somewhere sensible, never on an error.
+ */
+export function readTaskFocus(hash: string): TaskFocus {
+  const query = hash.split("?")[1];
+  if (!query) return {};
+  let params: URLSearchParams;
+  try {
+    params = new URLSearchParams(query);
+  } catch {
+    return {};
+  }
+  const focus: TaskFocus = {};
+  const artifactId = params.get("artifact");
+  if (artifactId) {
+    focus.artifactId = artifactId;
+    const version = Number.parseInt(params.get("v") ?? "", 10);
+    // A version that is not a positive integer is dropped rather than
+    // guessed at, which lands the reader on the newest revision — the same
+    // place they would have arrived with no pin at all.
+    if (Number.isInteger(version) && version > 0) focus.version = version;
+  }
+  const runId = params.get("run");
+  if (runId) focus.runId = runId;
+  return focus;
+}
+
+/** Whether a focus asks for anything at all. */
+export function hasFocus(focus: TaskFocus): boolean {
+  return Boolean(focus.artifactId || focus.runId);
+}

--- a/frontend/src/views/ArtifactsTab.tsx
+++ b/frontend/src/views/ArtifactsTab.tsx
@@ -93,21 +93,41 @@ export function ArtifactsTab({
   client,
   company,
   taskId,
+  openArtifactId,
+  openVersion,
 }: {
   client: OpenCompanyClient;
   company: string | null;
   taskId: string;
+  /**
+   * An artifact the address asked to open (issue #339) — a card's link to the
+   * deliverable its run produced.
+   */
+  openArtifactId?: string;
+  /**
+   * The revision that run wrote. The link is pinned, so the reader lands on
+   * what the *task* produced rather than on whatever a human last edited; the
+   * banner in [`ArtifactDetail`] is what tells them the difference.
+   */
+  openVersion?: number;
 }) {
   const [artifacts, setArtifacts] = useState<ArtifactView[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [openId, setOpenId] = useState<string | null>(null);
+  // The revision a deep link asked for, held here rather than in the detail so
+  // it survives the detail remounting on a poll. Cleared as soon as the reader
+  // picks a version themselves — the pin describes where they arrived, not a
+  // rail they are stuck on.
+  const [pinned, setPinned] = useState<number | null>(null);
 
   // A poll that lands mid-edit would swap the textarea's seed out from under
   // the operator, so the editor freezes the refresh while it is open. The ref
   // (rather than an effect dependency) keeps the timer itself untouched, so
   // closing the editor resumes on the next tick instead of restarting the poll.
   const editingRef = useRef(false);
+  // The `(artifact, version)` a card's link has already been honoured for.
+  const appliedLink = useRef<string | null>(null);
 
   const load = useCallback(
     async (isActive: () => boolean = () => true) => {
@@ -135,6 +155,10 @@ export function ArtifactsTab({
     setLoading(true);
     setArtifacts(null);
     setOpenId(null);
+    setPinned(null);
+    // A different card is a different set of deliverables, so a link already
+    // applied on the previous one must be allowed to apply again here.
+    appliedLink.current = null;
     void load(isActive);
     let timer: number | undefined;
     const stop = () => {
@@ -172,6 +196,40 @@ export function ArtifactsTab({
     [artifacts, openId],
   );
 
+  // Issue #339: honour a card's link once the rows it names have arrived.
+  //
+  // Applied once per distinct `(artifact, version)`, because this tab re-renders
+  // on a four-second poll and re-applying would drag the reader back to the
+  // linked revision every four seconds — including out of an edit they had just
+  // started.
+  const wanted = openArtifactId ? `${openArtifactId}|${openVersion ?? ""}` : null;
+  useEffect(() => {
+    if (!wanted || !openArtifactId) {
+      // Forget it when the address stops naming one, so the same link opened
+      // again later still works.
+      appliedLink.current = null;
+      return;
+    }
+    if (appliedLink.current === wanted) return;
+    // Rows arrive asynchronously; wait for the one the link names rather than
+    // opening a detail panel onto nothing.
+    if (!artifacts?.some((a) => a.id === openArtifactId)) return;
+    appliedLink.current = wanted;
+    setOpenId(openArtifactId);
+    setPinned(openVersion ?? null);
+  }, [wanted, openArtifactId, openVersion, artifacts]);
+
+  // A link naming a deliverable this card no longer has. It degrades to the
+  // list rather than to an error — but it says so, because a link that silently
+  // showed a different artifact would be worse than one that admits the target
+  // is gone. (The card's own link falls back to the run trace for exactly this
+  // case; this covers arriving here from an older copy of the address.)
+  const linkTargetGone = Boolean(
+    openArtifactId &&
+      artifacts !== null &&
+      !artifacts.some((a) => a.id === openArtifactId),
+  );
+
   // Replace one row in place after an append, so the freshly returned artifact
   // (with its now-present `humanEditDiff`) renders before the poll comes round.
   const replace = useCallback((next: ArtifactView) => {
@@ -203,12 +261,24 @@ export function ArtifactsTab({
         </Alert>
       )}
 
+      {linkTargetGone && (
+        <p className="rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-xs text-muted-foreground">
+          The deliverable that link points at is no longer on this card. It may
+          have been deleted since. What the task still has is below.
+        </p>
+      )}
+
       {open ? (
         <ArtifactDetail
           client={client}
           company={company}
           artifact={open}
-          onBack={() => setOpenId(null)}
+          pinnedVersion={pinned}
+          onBack={() => {
+            setOpenId(null);
+            setPinned(null);
+          }}
+          onLeavePin={() => setPinned(null)}
           onAppended={replace}
           onRefresh={refresh}
           onEditingChange={setEditing}
@@ -304,7 +374,9 @@ function ArtifactDetail({
   client,
   company,
   artifact,
+  pinnedVersion,
   onBack,
+  onLeavePin,
   onAppended,
   onRefresh,
   onEditingChange,
@@ -312,13 +384,21 @@ function ArtifactDetail({
   client: OpenCompanyClient;
   company: string | null;
   artifact: ArtifactView;
+  /**
+   * The revision a card's link arrived on (issue #339) — what the *task*
+   * produced, as opposed to what the artifact says now. `null` for every
+   * ordinary open, which follows the newest version exactly as before.
+   */
+  pinnedVersion: number | null;
   onBack: () => void;
+  /** The reader has moved off the pinned revision under their own steam. */
+  onLeavePin: () => void;
   onAppended: (next: ArtifactView) => void;
   onRefresh: () => void;
   onEditingChange: (editing: boolean) => void;
 }) {
   const latest: ArtifactVersion | undefined = artifact.versions[artifact.versions.length - 1];
-  const [selected, setSelected] = useState<number | null>(null);
+  const [selected, setSelected] = useState<number | null>(pinnedVersion);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
   const [saving, setSaving] = useState(false);
@@ -333,6 +413,29 @@ function ArtifactDetail({
     }
     return latest;
   }, [artifact.versions, latest, selected]);
+
+  /**
+   * Whether this panel is still showing the revision a card's link asked for,
+   * *and* a newer one exists.
+   *
+   * Both halves matter. Without the first, the banner would keep claiming a pin
+   * after the reader has clicked through the rail themselves. Without the
+   * second, a link to an untouched deliverable would carry a banner explaining
+   * a difference that does not exist.
+   */
+  const pinnedBehindLatest =
+    pinnedVersion !== null &&
+    selected === pinnedVersion &&
+    latest !== undefined &&
+    latest.version > pinnedVersion;
+  const editedSince = pinnedBehindLatest && latest?.author === "operator";
+
+  function selectVersion(version: number) {
+    setSelected(version);
+    // Moving off the pinned revision retires the banner: from here on the
+    // reader is navigating, not arriving.
+    if (version !== pinnedVersion) onLeavePin();
+  }
 
   useEffect(() => {
     onEditingChange(editing);
@@ -410,10 +513,36 @@ function ArtifactDetail({
         </p>
       </div>
 
+      {pinnedBehindLatest && latest && (
+        // Issue #339: *"a task whose output was later edited by a human still
+        // resolves, and says so."* The link is pinned, so the reader is looking
+        // at what the task produced — and this is the "says so" half, naming
+        // the newer revision and who wrote it rather than leaving the reader to
+        // notice the version rail.
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-xs">
+          <p className="text-muted-foreground">
+            Showing <span className="font-medium text-foreground">v{pinnedVersion}</span> — the
+            version this run produced. v{latest.version} exists
+            {editedSince
+              ? `, edited by ${latest.authorId || "an operator"}`
+              : `, written by ${latest.authorId || "the agent"}`}
+            .
+          </p>
+          <Button
+            variant="link"
+            size="sm"
+            className="h-auto p-0 text-xs"
+            onClick={() => selectVersion(latest.version)}
+          >
+            Go to the latest version
+          </Button>
+        </div>
+      )}
+
       <VersionRail
         versions={artifact.versions}
         shown={shown?.version ?? null}
-        onSelect={(v) => setSelected(v)}
+        onSelect={selectVersion}
         disabled={editing}
       />
 

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -10,6 +10,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactElement,
   type ReactNode,
@@ -76,6 +77,7 @@ import {
   STEP_FAILURE_LABEL,
 } from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
+import { hasFocus, type TaskFocus } from "@/lib/task-output";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -185,10 +187,24 @@ function timeOf(at: number): string {
   });
 }
 
+/**
+ * Which tab a card's output link asks for (issue #339).
+ *
+ * `timeline` for everything else — including a focus that names nothing, which
+ * is every navigation that existed before this — so the screen's default is
+ * untouched by the feature.
+ */
+function tabForFocus(focus?: TaskFocus): string {
+  if (focus?.artifactId) return "artifacts";
+  if (focus?.runId) return "attempts";
+  return "timeline";
+}
+
 export function TaskDetailView({
   client,
   company,
   taskId,
+  focus,
   onBack,
   onNavigate,
   onOpenThread,
@@ -198,6 +214,12 @@ export function TaskDetailView({
   client: OpenCompanyClient;
   company: string | null;
   taskId: string;
+  /**
+   * What the address asked this screen to open (issue #339): a pinned artifact
+   * or an attempt's trace. Empty — the ordinary "open the card" navigation —
+   * lands on the default tab, exactly as before.
+   */
+  focus?: TaskFocus;
   /** Return to the board. */
   onBack: () => void;
   /** Navigate the detail to a neighbouring (lineage) task. */
@@ -216,6 +238,23 @@ export function TaskDetailView({
   const [notFound, setNotFound] = useState(false);
   const [editing, setEditing] = useState(false);
   const [now, setNow] = useState(() => Date.now());
+  // Issue #339: the tab became controlled so a link can land on it. It still
+  // defaults to Timeline for every ordinary open — `tabForFocus` returns that
+  // whenever the address asked for nothing.
+  const [tab, setTab] = useState<string>(() => tabForFocus(focus));
+
+  // Follow a focus that arrives (or changes) after mount: a card link clicked
+  // while this screen is already open, or a back/forward between two links on
+  // the same card. Keyed on the focus's own identity rather than the object,
+  // because the parent rebuilds it on every hash event and an object dependency
+  // would yank the operator back to the linked tab on every re-render.
+  const focusKey = `${focus?.artifactId ?? ""}|${focus?.version ?? ""}|${focus?.runId ?? ""}`;
+  useEffect(() => {
+    if (!hasFocus(focus ?? {})) return;
+    setTab(tabForFocus(focus));
+    // `focus` is read through `focusKey`, which is what actually changed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focusKey]);
 
   // `isActive` is a per-effect-run token, not a shared ref: a superseded run
   // (e.g. taskId A→B) flips its own token to false so an in-flight `load()` from
@@ -405,7 +444,7 @@ export function TaskDetailView({
 
             <LineageRail lineage={detail.lineage} onNavigate={onNavigate} />
 
-            <Tabs defaultValue="timeline">
+            <Tabs value={tab} onValueChange={(next) => setTab(String(next))}>
               <TabsList>
                 <TabsTrigger value="timeline">Timeline</TabsTrigger>
                 <TabsTrigger value="attempts">
@@ -435,6 +474,7 @@ export function TaskDetailView({
                   company={company}
                   runs={detail.runs}
                   now={now}
+                  openRunId={focus?.runId}
                 />
               </TabsContent>
 
@@ -447,6 +487,8 @@ export function TaskDetailView({
                   client={client}
                   company={company}
                   taskId={detail.task.id}
+                  openArtifactId={focus?.artifactId}
+                  openVersion={focus?.version}
                 />
               </TabsContent>
 
@@ -1360,17 +1402,42 @@ function AttemptsTab({
   company,
   runs,
   now,
+  openRunId,
 }: {
   client: OpenCompanyClient;
   company: string | null;
   runs: RunSummary[];
   now: number;
+  /**
+   * An attempt the address asked to open (issue #339) — the *"this task
+   * produced no file"* link, whose deliverable is the trace itself.
+   */
+  openRunId?: string;
 }) {
   const [openId, setOpenId] = useState<string | null>(null);
   const open = useMemo(
     () => runs.find((r) => r.id === openId) ?? null,
     [runs, openId],
   );
+  // Apply a requested attempt once per distinct id. Once, because the parent
+  // re-renders this tab on every four-second poll and re-applying would reopen
+  // a drawer the operator has just closed; per distinct id, so a second link to
+  // a different attempt still lands.
+  const appliedRun = useRef<string | null>(null);
+  useEffect(() => {
+    if (!openRunId) {
+      // Forget the last application when the address stops naming one, so
+      // returning to the same link later opens it again.
+      appliedRun.current = null;
+      return;
+    }
+    if (appliedRun.current === openRunId) return;
+    // Runs arrive with the detail read, so wait for the row to exist rather
+    // than opening a drawer onto nothing.
+    if (!runs.some((r) => r.id === openRunId)) return;
+    appliedRun.current = openRunId;
+    setOpenId(openRunId);
+  }, [openRunId, runs]);
 
   if (runs.length === 0) {
     return (
@@ -1381,6 +1448,11 @@ function AttemptsTab({
     );
   }
 
+  // A link naming an attempt this card does not have: say so rather than
+  // silently showing the list, so a stale link reads as stale instead of as a
+  // broken screen.
+  const missing = Boolean(openRunId && !runs.some((r) => r.id === openRunId));
+
   return (
     <div className="space-y-3">
       <p className="text-xs text-muted-foreground">
@@ -1388,6 +1460,12 @@ function AttemptsTab({
         than once, so several waits on one attempt is the expected record, not a
         fault.
       </p>
+      {missing && (
+        <p className="rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-xs text-muted-foreground">
+          The attempt that link points at is no longer in this card's history.
+          Its other attempts are below.
+        </p>
+      )}
       <ol className="space-y-1.5">
         {runs.map((run) => (
           <AttemptRow

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -1,5 +1,13 @@
 import { type DragEvent, useCallback, useEffect, useRef, useState } from "react";
-import { Loader2, Play, Plus } from "lucide-react";
+import {
+  FileText,
+  ListTree,
+  Loader2,
+  Paperclip,
+  Play,
+  Plus,
+  ScrollText,
+} from "lucide-react";
 
 import { createTask, listTasks, patchTask, type Task } from "@/api/tasks";
 import type { OpenCompanyClient } from "@/api/client";
@@ -19,6 +27,13 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { ADD_TASK_COLUMN, PRIORITY_STYLES, TASK_COLUMNS } from "@/lib/tasks-sample";
+import {
+  extraOutputCount,
+  primaryLink,
+  readTaskFocus,
+  type TaskFocus,
+  type TaskLink,
+} from "@/lib/task-output";
 import { toast } from "sonner";
 import { TaskDetailView } from "./TaskDetailView";
 
@@ -111,6 +126,12 @@ export function TasksView({
   // The open card's id, mirrored in `#/tasks/<id>` so the detail survives a
   // refresh and honors back/forward.
   const [detailId, setDetailId] = useState<string | null>(readTaskDetailId);
+  // What the address asks the detail screen to open (issue #339): a pinned
+  // artifact, or an attempt's trace. Empty for a plain `#/tasks/<id>`, which is
+  // the ordinary "open the card" navigation and lands on the default tab.
+  const [focus, setFocus] = useState<TaskFocus>(() =>
+    readTaskFocus(window.location.hash),
+  );
   const [creating, setCreating] = useState(false);
   const mounted = useRef(true);
   // A real HTML5 drag fires a trailing click; suppress it so a drag never also
@@ -151,7 +172,13 @@ export function TasksView({
 
   // Follow browser back/forward and manual edits of the `#/tasks/<id>` sub-hash.
   useEffect(() => {
-    const onHash = () => setDetailId(readTaskDetailId());
+    const onHash = () => {
+      setDetailId(readTaskDetailId());
+      // Re-read the focus too, so a card link clicked while the detail is
+      // already open (a `+N more` row, or a second card's link) actually moves
+      // the screen rather than only changing the address bar.
+      setFocus(readTaskFocus(window.location.hash));
+    };
     window.addEventListener("hashchange", onHash);
     return () => window.removeEventListener("hashchange", onHash);
   }, []);
@@ -205,10 +232,15 @@ export function TasksView({
   const openDetail = useCallback((id: string) => {
     window.location.hash = `/tasks/${encodeURIComponent(id)}`;
     setDetailId(id);
+    // An ordinary open carries no focus, and must clear any it inherited —
+    // otherwise opening a second card would re-apply the first card's artifact
+    // pin to a screen that has never heard of it.
+    setFocus({});
   }, []);
   const closeDetail = useCallback(() => {
     window.location.hash = "/tasks";
     setDetailId(null);
+    setFocus({});
   }, []);
 
   /**
@@ -293,6 +325,7 @@ export function TasksView({
         client={client}
         company={company}
         taskId={detailId}
+        focus={focus}
         onBack={closeDetail}
         onNavigate={openDetail}
         onOpenThread={onOpenThread}
@@ -514,6 +547,7 @@ function TaskItem({
           <span className="truncate text-xs text-muted-foreground">{task.assignee}</span>
         </div>
       )}
+      {SHOWS_OUTPUT_LINK.has(task.column) && <OutputLinkRow task={task} />}
       {task.column === "paused" && (
         <Button
           variant="outline"
@@ -528,6 +562,70 @@ function TaskItem({
           <Play className="mr-1.5 size-3.5" />
           Resume
         </Button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The columns whose cards show what they produced (issue #339).
+ *
+ * Done **and In review**, which is a correction to how the epic is worded. A
+ * clean success no longer lands in Done — it stops in In review, and Done is
+ * reached only when a person accepts it. So a card that has produced something
+ * spends most of its visible life in In review, and showing the link only in
+ * Done would hide it during exactly the stretch where somebody is deciding
+ * whether to accept the work and needs to read it.
+ *
+ * Not the earlier columns: a card in To-do or In progress either has no output
+ * yet or has one from a superseded attempt, and advertising that mid-run would
+ * suggest the work in flight is already finished.
+ */
+const SHOWS_OUTPUT_LINK = new Set(["in_review", "done"]);
+
+function LinkIcon({ kind }: { kind: TaskLink["kind"] }) {
+  const className = "size-3.5 shrink-0";
+  if (kind === "artifact") return <Paperclip className={className} />;
+  if (kind === "workflow") return <ListTree className={className} />;
+  if (kind === "trace") return <ScrollText className={className} />;
+  return <FileText className={className} />;
+}
+
+/**
+ * One line on a finished card: *here is the thing this task produced*.
+ *
+ * Every card in these columns gets one, including the ones that produced no
+ * file — for those the link opens the attempt's trace, which is the deliverable
+ * when there is no document. A card that recorded no attempt at all links to
+ * itself, which is honest rather than absent.
+ *
+ * The anchor stops its own click from bubbling: the whole card is a button that
+ * opens the detail screen, and without this a click on the link would both
+ * follow the href and fire the card's `onOpen`, racing two navigations.
+ */
+function OutputLinkRow({ task }: { task: Task }) {
+  const link = primaryLink(task);
+  const extra = extraOutputCount(task);
+  return (
+    <div className="mt-3 flex items-center gap-2 border-t pt-2 text-xs">
+      <a
+        href={link.href}
+        title={link.hint}
+        onClick={(e) => e.stopPropagation()}
+        className="flex min-w-0 items-center gap-1.5 text-muted-foreground hover:text-foreground hover:underline"
+      >
+        <LinkIcon kind={link.kind} />
+        <span className="truncate">{link.label}</span>
+      </a>
+      {extra > 0 && (
+        <a
+          href={`#/tasks/${encodeURIComponent(task.id)}`}
+          title="Open the task to see everything it produced."
+          onClick={(e) => e.stopPropagation()}
+          className="shrink-0 text-muted-foreground hover:text-foreground hover:underline"
+        >
+          +{extra} more
+        </a>
       )}
     </div>
   );

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -88,6 +88,51 @@ const NODE_TYPES = { oc: WorkflowNode };
  * fold a fresh array identity on every render. */
 const EMPTY_RUN_EVENTS: CompanyStreamEvent[] = [];
 
+/** `decodeURIComponent` that survives a hand-edited address bar. A lone `%`
+ * makes it throw, and a malformed hash must not take the whole view down —
+ * comparing the raw segment simply fails to match, which is the right outcome. */
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Decompose the hash this view owns: `#/workflows/<workflowId>?run=<runId>`
+ * (issue #339).
+ *
+ * **The run id lives in a query string, not a third path segment, and that is
+ * load-bearing — do not "tidy" it into `#/workflows/<id>/runs/<runId>`.**
+ * `useHashView`'s `canonicalize()` runs on every `hashchange` and rewrites the
+ * hash to at most `head/sub`, so a third segment is silently dropped and the
+ * run id would never survive the first hash event. What saves the query is that
+ * the same function reads the path with everything after `?` stripped and
+ * early-returns once the two segments already match — so it looks at
+ * `workflows/<id>`, finds it identical, and leaves the URL alone, query and
+ * all. Two segments plus a query is the only shape that round-trips.
+ *
+ * Read from `location` rather than from the `sub` prop because the query is
+ * invisible to the router, and because the view's hash writer needs the
+ * *current* URL — not the router's copy of it, which lags a `replaceState` it
+ * never hears about — to know whether a write would be a no-op.
+ */
+function readWorkflowHash(): {
+  /** Whether the hash currently names this view at all. */
+  onWorkflows: boolean;
+  workflowId: string | null;
+  runId: string | null;
+} {
+  const [path, query] = window.location.hash.replace(/^#\/?/, "").split("?");
+  const [head, id] = path.split("/").filter(Boolean);
+  return {
+    onWorkflows: head === "workflows",
+    workflowId: id ? safeDecode(id) : null,
+    runId: query ? new URLSearchParams(query).get("run") : null,
+  };
+}
+
 /**
  * The live Workflows canvas. Reads the company's saved graphs from the host's
  * `…/workflows` routes, lets the operator pick one, renders its real nodes and
@@ -98,11 +143,22 @@ const EMPTY_RUN_EVENTS: CompanyStreamEvent[] = [];
 export function WorkflowsView({
   client,
   company,
+  sub = null,
   runEventTick = 0,
   runEvents = EMPTY_RUN_EVENTS,
 }: {
   client: OpenCompanyClient;
   company: string | null;
+  /**
+   * The second hash segment — `#/workflows/<workflowId>` (issue #339), so a
+   * finished task card can link to the workflow it built or ran and land on
+   * that graph rather than on whichever one happens to sort first.
+   *
+   * Unvalidated, as the router documents: only this view knows which workflow
+   * ids exist, so it resolves the id against the loaded list itself and falls
+   * back to its own default when the id names nothing.
+   */
+  sub?: string | null;
   /**
    * Bumped by the shell on every `workflow_run_finished` SSE event (issue
    * #228), so a run that finishes while this tab is open shows up without a
@@ -247,6 +303,32 @@ export function WorkflowsView({
   // already watched, and one without it still gets the journaled answer.
   const liveRanRef = useRef<Set<string>>(new Set());
 
+  // ---- Issue #339: the canvas as a link target -----------------------------
+  //
+  // The workflow id asked for by the URL. Decoded here so it compares against
+  // the ids in `workflows` — the router hands the segment back exactly as it
+  // sits in the address bar, and the writer below percent-encodes it.
+  const requestedWorkflowId = useMemo(() => (sub ? safeDecode(sub) : null), [sub]);
+  // The run id asked for by `?run=`, which the router does NOT surface: it
+  // reads the hash with everything after `?` stripped, so a query string is
+  // invisible to it (and, crucially, survives its rewrite — see
+  // {@link readWorkflowHash}). Kept in state and refreshed on `hashchange` so a
+  // second card's link landing on an already-open canvas is noticed.
+  const [requestedRunId, setRequestedRunId] = useState<string | null>(
+    () => readWorkflowHash().runId,
+  );
+  useEffect(() => {
+    const onHash = () => setRequestedRunId(readWorkflowHash().runId);
+    window.addEventListener("hashchange", onHash);
+    return () => window.removeEventListener("hashchange", onHash);
+  }, []);
+  // The URL-requested ids this view has already acted on, so each request is
+  // honoured exactly once. Without these, every later re-render that carries a
+  // fresh `workflows` / `runs` array would re-apply the URL and drag the
+  // operator back off whatever they had since selected or cleared.
+  const appliedWorkflowRef = useRef<string | null>(null);
+  const appliedRunRef = useRef<string | null>(null);
+
   // Load the workflow list once, and auto-select the first entry.
   useEffect(() => {
     let live = true;
@@ -255,12 +337,27 @@ export function WorkflowsView({
         const rows = await listWorkflows(client, company);
         if (!live) return;
         setWorkflows(rows);
-        // Keep the selection only if it still exists in the freshly loaded list
-        // (this effect also reruns on company change) — otherwise a stale id
-        // from the previous company would fetch the wrong/nonexistent graph.
-        setSelectedId((prev) =>
-          prev && rows.some((r) => r.id === prev) ? prev : (rows[0]?.id ?? null),
-        );
+        setSelectedId((prev) => {
+          // Issue #339: a workflow id in the URL outranks both the held
+          // selection and the first-row default — the operator followed a link
+          // to *that* graph. Resolved here rather than left to the follow
+          // effect below purely to avoid the flash: selecting `rows[0]` first
+          // and correcting a render later would fetch a graph nobody asked for
+          // and show the wrong name in the picker on the way past.
+          //
+          // `requestedWorkflowId` is read from the closure and deliberately NOT
+          // a dependency: it changes on every picker click (the writer below
+          // mirrors the selection into the hash), and re-running this would
+          // spend a full list round trip on each one. Changes after mount are
+          // the follow effect's job.
+          if (requestedWorkflowId && rows.some((r) => r.id === requestedWorkflowId)) {
+            return requestedWorkflowId;
+          }
+          // Keep the selection only if it still exists in the freshly loaded list
+          // (this effect also reruns on company change) — otherwise a stale id
+          // from the previous company would fetch the wrong/nonexistent graph.
+          return prev && rows.some((r) => r.id === prev) ? prev : (rows[0]?.id ?? null);
+        });
         setError(null);
       } catch (e) {
         if (!live) return;
@@ -272,7 +369,67 @@ export function WorkflowsView({
     return () => {
       live = false;
     };
+    // `requestedWorkflowId` is read above but deliberately not a dependency —
+    // see the comment at the read.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client, company]);
+
+  // Issue #339: follow the URL while the view stays mounted — the operator
+  // clicks a second task card's link without ever leaving this tab, so the
+  // first-load resolution above never runs again.
+  //
+  // Guarded to once per distinct id: this also reruns whenever `workflows` gets
+  // a new array (a create, a rename, a company switch), and re-applying the URL
+  // then would yank the selection back from wherever the operator had moved it.
+  // A no-longer-current `sub` — the operator picked something else, so the hash
+  // no longer matches — is left alone precisely because it was already applied.
+  useEffect(() => {
+    if (!requestedWorkflowId || workflows.length === 0) return;
+    if (appliedWorkflowRef.current === requestedWorkflowId) return;
+    appliedWorkflowRef.current = requestedWorkflowId;
+    if (workflows.some((w) => w.id === requestedWorkflowId)) {
+      setSelectedId(requestedWorkflowId);
+      return;
+    }
+    // Say so rather than silently showing a different graph: the operator
+    // followed a link expecting one specific workflow, and a canvas quietly
+    // painting another one is worse than no canvas at all.
+    toast.error(`This company has no workflow “${requestedWorkflowId}”.`, {
+      description:
+        "It may have been renamed or deleted since the link was made. Showing the current selection instead.",
+    });
+  }, [requestedWorkflowId, workflows]);
+
+  // Issue #339: mirror the selection back into the hash, so whatever is on the
+  // canvas can be copied out of the address bar and shared.
+  //
+  // Reads `location` directly instead of comparing against `sub`: the router's
+  // state lags a `replaceState` it never hears about, and this comparison is
+  // the only thing stopping a write→hashchange→write loop.
+  //
+  // The `?run=` query is preserved implicitly. When the hash already names the
+  // selected workflow this early-returns and never touches the URL, so an
+  // arriving `#/workflows/x?run=r` keeps its run id; when the selection moves
+  // to a different workflow the query is dropped, which is correct — that run
+  // belongs to the graph being left behind.
+  //
+  // Replace vs push is decided by whether the hash already names a workflow.
+  // Filling in a bare `#/workflows` is this view resolving its own default, not
+  // a place the operator has been — pushing it would put an entry in the
+  // history stack that looks identical to the one before it, so their first
+  // Back press out of the tab would appear to do nothing. Moving from one named
+  // workflow to another IS a navigation they took, and Back should undo it.
+  useEffect(() => {
+    if (!selectedId) return;
+    const { onWorkflows, workflowId } = readWorkflowHash();
+    // Another view owns the hash (a company switch mid-navigation, a stale
+    // effect): rewriting it would drag the operator back here.
+    if (!onWorkflows) return;
+    if (workflowId === selectedId) return;
+    const next = `#/workflows/${encodeURIComponent(selectedId)}`;
+    if (workflowId === null) window.history.replaceState(null, "", next);
+    else window.location.hash = next.slice(1);
+  }, [selectedId]);
 
   // Fetch the selected workflow's full graph.
   useEffect(() => {
@@ -363,6 +520,8 @@ export function WorkflowsView({
         // Still THIS workflow's answer — "the host has no history for it" — so
         // the pair agrees and the copilot may proceed, told via `runsKnown`
         // that nothing is known about runs rather than that there were none.
+        // A `?run=` deep link reads the same signal (issue #339): it needs to
+        // hear "the fetch came back empty" rather than wait on one that has.
         setRunsFor(selectedId);
         setHistorySupported(false);
       }
@@ -663,6 +822,57 @@ export function WorkflowsView({
     setOverlayRun(null);
     setActiveRunId(null);
   }, [selectedId, company]);
+
+  // Issue #339: `?run=<runId>` — open the canvas showing that past run.
+  //
+  // Declared AFTER the clear effect above on purpose. Both can fire while a
+  // deep link resolves, and effects run in declaration order, so an overlay set
+  // here would otherwise be wiped by the very selection change that fetched the
+  // history it came from.
+  //
+  // Run ids arrive late by nature: the history is a separate fetch, so this
+  // waits for the SELECTED workflow's own history rather than reading whatever
+  // list is currently in `runs` (which, until then, is the previous
+  // workflow's).
+  useEffect(() => {
+    if (!requestedRunId) {
+      // The link no longer names a run — the operator moved to another
+      // workflow, or the hash was rewritten. Forget what was applied, so the
+      // same id arriving again later reads as a fresh request rather than as an
+      // echo of the one already handled.
+      appliedRunRef.current = null;
+      return;
+    }
+    if (appliedRunRef.current === requestedRunId) return;
+    if (!selectedId || runsFor !== selectedId) return;
+    appliedRunRef.current = requestedRunId;
+    // `runId` is optional on the wire: a row journaled before the entry point
+    // minted correlation ids carries none. Comparing it directly would let a
+    // `requestedRunId` of `undefined` match the first such row — hence the
+    // explicit presence check even though `requestedRunId` is a string here.
+    const match = runs.find((r) => r.runId != null && r.runId === requestedRunId);
+    if (!match) {
+      // Never leave the canvas mid-gesture: it keeps painting the live state,
+      // and the operator is told why the run they asked for isn't on it.
+      toast.error("That run isn't in this workflow's run history.", {
+        description:
+          "It may have aged out of the journal, or belong to a different workflow. The canvas is showing the current state instead.",
+      });
+      return;
+    }
+    if ((match.nodes?.length ?? 0) === 0) {
+      // Same guard the no-live-stream fallback uses: with no per-node trail
+      // there is nothing to paint, and the overlay banner would claim every
+      // node "was never reached" — a statement about the run that isn't true,
+      // only about what was recorded of it.
+      toast.info("That run has no step-by-step trail to show on the canvas.", {
+        description:
+          "It was recorded before per-node progress was journaled. Its delivery rows are in History.",
+      });
+      return;
+    }
+    setOverlayRun(match);
+  }, [requestedRunId, runs, runsFor, selectedId]);
 
   // The Run guard, derived rather than held: the request is in flight, or a run
   // we started has not settled yet.

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -1377,6 +1377,7 @@ mod tests {
             updated_at_millis: 0,
             origin_chat_id: None,
             parent_task_id: None,
+            output: None,
         };
 
         let first = runtime.open_run(&card).await.expect("an attempt is minted");
@@ -1463,6 +1464,7 @@ mod tests {
             updated_at_millis: 0,
             origin_chat_id: None,
             parent_task_id: None,
+            output: None,
         };
 
         // Positive control: on a live runtime the cycle runs, so the row is

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -61,6 +61,7 @@ use crate::harness::run_trace::RunTraceSink;
 use crate::ports::artifacts::{ArtifactAuthor, ArtifactRecord};
 use crate::ports::brain::{Brain, CycleHost};
 use crate::ports::runs::{RunOutcome, RunStatus};
+use crate::ports::tasks::{TaskOutput, TaskOutputArtifact};
 use crate::ports::types::{
     CompanyEvent, CompanyRecord, CompressedTrace, CycleRequest, CycleResult, OutboundMessage,
     TokenUsage, TurnStep, TurnStepKind, TurnStepStatus, Verdict,
@@ -397,6 +398,11 @@ impl HarnessBrain {
         // queue is cleared per turn: a chat turn earlier in this cycle shares
         // these deps, and its staged file must never be attributed to this card.
         self.deps.pending_publishes.clear();
+        // Issue #339, same argument for staged workflow references: an operator
+        // chat turn earlier in this cycle may have run a workflow through the
+        // orchestrator's tool, and that run belongs to the conversation, not to
+        // this card.
+        self.deps.workflow_refs.clear();
 
         // Register the run so an operator can steer it mid-flight. The guard's
         // RAII `Drop` deregisters on every exit path (success, error, redirect
@@ -450,6 +456,10 @@ impl HarnessBrain {
             // part of the loop and never clears, so a nudge cannot discard what
             // the turn it is asking about published.
             self.deps.pending_publishes.clear();
+            // Issue #339: an abandoned redirect's workflow run is abandoned with
+            // it, for the same reason — the card's link must name what the turn
+            // that actually settled produced, not what a discarded one did.
+            self.deps.workflow_refs.clear();
             let outcome = run_turn
                 // A dispatched task card carries no chat bubble (its steps are
                 // discarded into the note), so its live turn frames must not leak
@@ -743,6 +753,105 @@ impl HarnessBrain {
             None => 0,
         };
         let settled = lifecycle::settled_run_status(run_end, parked);
+
+        // ── Issues #244 + #339: record what the run produced, then say so on
+        //    the card — both **before** the one card write ────────────────────
+        //
+        // The queues are drained **unconditionally** so nothing an abandoned
+        // turn staged can leak into the next run, and the drained sets are
+        // recorded only when the run reached its success terminal.
+        //
+        // "Success terminal" is read off the *ending* —
+        // `run_status_for(run_end) == Succeeded`, i.e. the turn finished or
+        // spent its redirect budget — not off `settled`. Parking an approval
+        // relabels who acts next, not whether the agent produced a deliverable,
+        // so a run that wrote a spec and also asked for an authorisation must
+        // not lose the spec.
+        //
+        // **Why this moved above the upsert (issue #339).** The card now
+        // carries a link to what it produced, and that link names artifact
+        // versions that do not exist until they are written — so the artifacts
+        // have to land before the card is persisted, or the single card write
+        // would have to become two.
+        //
+        // **And why recording became best-effort with it.** #244 made a failed
+        // artifact write propagate, on the argument that an explicit publish
+        // that could not be stored is a real failure of the run. That argument
+        // held while this ran *after* the card was persisted. Above the upsert
+        // a `?` would skip the card write entirely and strand the card in
+        // `in_progress` with nothing to re-dispatch it — the exact stranded
+        // state the hand-off arm above exists to prevent, and a far worse
+        // outcome than a missing deliverable record. So the failure is now
+        // logged at `error` (loudly: an operator whose published file did not
+        // store needs to know) and the settle continues.
+        let published = self.deps.pending_publishes.drain();
+        let staged_workflows = self.deps.workflow_refs.drain();
+        let succeeded = lifecycle::run_status_for(run_end) == RunStatus::Succeeded;
+        let recorded: Vec<TaskOutputArtifact> = if succeeded {
+            match self
+                .record_published_artifacts(
+                    &card,
+                    &responder,
+                    published,
+                    sink.as_ref().map(|s| s.run_id()),
+                )
+                .await
+            {
+                Ok(recorded) => recorded,
+                Err(err) => {
+                    tracing::error!(
+                        task_id = %card.id,
+                        agent = %responder,
+                        error = %err,
+                        "[publish] could not record what this run published; the dispatch itself \
+                         still lands"
+                    );
+                    Vec::new()
+                }
+            }
+        } else {
+            if !published.is_empty() || !staged_workflows.is_empty() {
+                tracing::info!(
+                    task_id = %card.id,
+                    staged = published.len(),
+                    workflows = staged_workflows.len(),
+                    ending = ?run_end,
+                    "[publish] the run did not reach its success terminal; staged output is \
+                     discarded rather than recorded"
+                );
+            }
+            Vec::new()
+        };
+        // The completion event (#185) carries the ids, the card (#339) carries
+        // the pinned versions — one recording, two readers, so they cannot
+        // disagree about what the run produced.
+        let artifact_ids: Vec<String> = recorded
+            .iter()
+            .map(|artifact| artifact.artifact_id.clone())
+            .collect();
+
+        // Issue #339: the card's link to its deliverable.
+        //
+        // Only on success, and only when there is an attempt to name: without a
+        // trace sink the run store is unwired or the dispatch minted no row, so
+        // there is no addressable attempt and a stamp would point at nothing.
+        // That degrades to exactly the pre-#339 card, which is the same
+        // fail-silent-not-closed direction `runs: None` already takes.
+        //
+        // Written **wholesale**, overwriting any earlier stamp: this is what
+        // makes "the latest successful attempt" true by construction rather
+        // than by a read-time query. A later failure never reaches here, so a
+        // failed retry cannot erase the link to the success before it.
+        if succeeded && let Some(sink) = sink.as_ref() {
+            card.output = Some(TaskOutput {
+                run_id: sink.run_id().to_string(),
+                attempt: self.attempt_ordinal(sink.run_id()).await,
+                at_millis: now_millis(),
+                artifacts: recorded,
+                workflows: staged_workflows,
+            });
+        }
+
         // `settle()` already wrote a landing at the break point; this is the
         // authoritative overwrite now that the parked count is known. `None`
         // only for a status that is not settled at all, which no ending
@@ -773,43 +882,6 @@ impl HarnessBrain {
             matches!(settled, RunStatus::Failed).then_some(result_text.as_str()),
         )
         .await;
-
-        // Issue #244: record what the agent actually published.
-        //
-        // The queue is drained **unconditionally** so nothing an abandoned turn
-        // staged can leak into the next run, and the drained set is recorded
-        // only when the run reached its success terminal.
-        //
-        // "Success terminal" is read off the *ending* —
-        // `run_status_for(run_end) == Succeeded`, i.e. the turn finished or
-        // spent its redirect budget — not off `settled`. Parking an approval
-        // relabels who acts next, not whether the agent produced a deliverable,
-        // so a run that wrote a spec and also asked for an authorisation must
-        // not lose the spec.
-        //
-        // Recorded before the #185 journal writes below, because the completion
-        // event carries the ids this returns.
-        let published = self.deps.pending_publishes.drain();
-        let artifact_ids = if lifecycle::run_status_for(run_end) == RunStatus::Succeeded {
-            self.record_published_artifacts(
-                &card,
-                &responder,
-                published,
-                sink.as_ref().map(|s| s.run_id()),
-            )
-            .await?
-        } else {
-            if !published.is_empty() {
-                tracing::info!(
-                    task_id = %card.id,
-                    staged = published.len(),
-                    ending = ?run_end,
-                    "[publish] the run did not reach its success terminal; staged files are \
-                     discarded rather than recorded"
-                );
-            }
-            Vec::new()
-        };
 
         // Issue #185: correlate this dispatch's journal trail to its card.
         //
@@ -1175,8 +1247,48 @@ impl HarnessBrain {
             .unwrap_or_else(|| self.responder.clone())
     }
 
+    /// This attempt's 1-based ordinal, for the card's operator-facing link
+    /// label (issue #339) — *"attempt 2"*.
+    ///
+    /// One extra read on a successful settle, and deliberately not free-ridden
+    /// off the `finish_run` that settles the attempt row: that runs *after* the
+    /// card is written, and the card is what needs this. Reordering the settle
+    /// to harvest it would put the run row's terminal status ahead of the
+    /// board's, contradicting the ordering #242 chose on purpose.
+    ///
+    /// Best-effort: `None` on an unwired store, a missing row or a read fault.
+    /// The ordinal is a **label**, never an identity —
+    /// [`TaskOutput::run_id`](crate::ports::tasks::TaskOutput::run_id) still
+    /// addresses the attempt — so a failure here costs a nicety in the link
+    /// text and never the link.
+    async fn attempt_ordinal(&self, run_id: &str) -> Option<u32> {
+        let runs = self.runs.as_ref()?;
+        match runs.get_run(&self.record.id, run_id).await {
+            Ok(run) => run.map(|run| run.attempt),
+            Err(err) => {
+                tracing::warn!(
+                    company = %self.record.id,
+                    run = %run_id,
+                    error = %err,
+                    "[runs] could not read an attempt's ordinal for the card's link; the link \
+                     still names the run"
+                );
+                None
+            }
+        }
+    }
+
     /// Records everything the run published as versioned artifacts, returning
-    /// their ids (issue #244).
+    /// one reference per artifact **pinned at the version this run wrote**
+    /// (issues #244, #339).
+    ///
+    /// # Why the version comes back
+    ///
+    /// The caller stamps these onto the card, and a card link that named only
+    /// the artifact would re-point at whatever a human last edited — silently
+    /// turning "what this task produced" into "what the artifact says now".
+    /// `push_version` already computes the number; before #339 it was
+    /// discarded.
     ///
     /// # Extend by identity, never by recency
     ///
@@ -1197,13 +1309,20 @@ impl HarnessBrain {
     /// [`ArtifactRecord::source`](crate::ports::artifacts::ArtifactRecord::source)
     /// rather than papered over with a guess.
     ///
-    /// # Errors propagate
+    /// # Errors propagate — to the caller, which now contains them
     ///
-    /// Deliberately, and this is a change. The old path returned a silent
-    /// `Ok(())` when the store was missing and swallowed nothing else, which
-    /// meant a failed write to a deliverable an agent had explicitly published
-    /// was indistinguishable from success. An explicit publish that could not be
-    /// stored is a real failure of the run and the operator needs to see it.
+    /// Deliberately, and this was a change in #244. The pre-#244 path returned
+    /// a silent `Ok(())` when the store was missing and swallowed nothing else,
+    /// which meant a failed write to a deliverable an agent had explicitly
+    /// published was indistinguishable from success. An explicit publish that
+    /// could not be stored is a real failure of the run and the operator needs
+    /// to see it, so this still surfaces one.
+    ///
+    /// What changed in #339 is where that failure stops. This now runs
+    /// **before** the card's single write, so `run_task` logs the error at
+    /// `error` and settles the card anyway rather than propagating — a
+    /// bookkeeping fault must not strand a finished card in `in_progress`. The
+    /// error is still raised here; it is simply no longer fatal there.
     ///
     /// A **missing store** is different: `publish_artifact` is not wired at all
     /// without one (see `build.rs`), so a non-empty queue here means something
@@ -1219,7 +1338,7 @@ impl HarnessBrain {
         responder: &str,
         published: Vec<publish::PendingPublish>,
         run_id: Option<&str>,
-    ) -> Result<Vec<String>> {
+    ) -> Result<Vec<TaskOutputArtifact>> {
         if published.is_empty() {
             // The honest, common case: this run produced no file. There is no
             // artifact, and the run trace is the addressable record of what
@@ -1237,7 +1356,7 @@ impl HarnessBrain {
         };
 
         let mut on_card = artifacts.list(&self.record.id, Some(&card.id)).await?;
-        let mut ids = Vec::with_capacity(published.len());
+        let mut written = Vec::with_capacity(published.len());
         for pending in published {
             let at = now_millis();
             // Identity, not recency: the record whose `source` is this exact
@@ -1245,10 +1364,13 @@ impl HarnessBrain {
             let existing = on_card
                 .iter()
                 .position(|a| a.source.as_deref() == Some(pending.source.as_str()));
+            // The revision THIS run wrote (#339). A fresh record is always its
+            // own v1; an extended one takes whatever `push_version` numbered.
+            let mut version = 1;
             let mut record = match existing {
                 Some(index) => {
                     let mut found = on_card.remove(index);
-                    found.push_version(
+                    version = found.push_version(
                         &pending.body,
                         ArtifactAuthor::Agent,
                         responder,
@@ -1286,12 +1408,17 @@ impl HarnessBrain {
                 record.stamp_run(run_id);
             }
             artifacts.upsert(&self.record.id, &record).await?;
-            ids.push(record.id.clone());
+            written.push(TaskOutputArtifact {
+                artifact_id: record.id.clone(),
+                version,
+                title: record.title.clone(),
+                kind: record.kind,
+            });
             // Keep the working set current so two publishes of the same path in
             // one run extend one record rather than opening two.
             on_card.push(record);
         }
-        Ok(ids)
+        Ok(written)
     }
 
     /// Resolves which agent answers an operator message.
@@ -1811,6 +1938,7 @@ description = "Runs Acme."
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
@@ -1964,6 +2092,7 @@ description = "Builds it."
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
@@ -2034,6 +2163,7 @@ members = ["engineer"]
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
@@ -2065,6 +2195,7 @@ members = ["engineer"]
             updated_at_millis: 0,
             origin_chat_id: None,
             parent_task_id: None,
+            output: None,
         }
     }
 
@@ -3083,6 +3214,7 @@ members = ["engineer"]
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
@@ -3826,6 +3958,7 @@ members = ["eng1", "eng2"]
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: failures.clone(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
@@ -3957,6 +4090,7 @@ members = ["eng1", "eng2"]
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: failures.clone(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
@@ -4034,6 +4168,7 @@ members = ["eng1", "eng2"]
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: requests,
             secrets: None,
             web_allowed_domains: Vec::new(),
@@ -4258,6 +4393,7 @@ members = ["eng1", "eng2"]
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: requests,
             secrets: None,
             web_allowed_domains: Vec::new(),
@@ -4766,6 +4902,7 @@ members = ["eng1", "eng2"]
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
@@ -5090,6 +5227,7 @@ members = ["eng1", "eng2"]
             workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -534,6 +534,10 @@ pub fn build_agent(
             // The company store, for the `add_agent` tool to persist overlay
             // teammates through the same path the console `POST .../team` uses.
             deps.store.clone(),
+            // Issue #339: the shared queue `run_workflow` / `create_workflow`
+            // stage onto, so a dispatched card can link to the workflow its
+            // attempt built or ran. Orchestrator-only, like the tools.
+            deps.workflow_refs.clone(),
         ));
     }
 
@@ -1097,6 +1101,7 @@ mod tests {
             workflow_runner: WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),

--- a/src/harness/composio_turn_test.rs
+++ b/src/harness/composio_turn_test.rs
@@ -344,6 +344,7 @@ async fn harness(
         workflow_runner: WorkflowRunnerHandle::default(),
         mcp_failures: McpFailureQueue::default(),
         pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+        workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
         approval_requests: ApprovalRequestQueue::default(),
         secrets: None,
         web_allowed_domains: Vec::new(),

--- a/src/harness/lifecycle.rs
+++ b/src/harness/lifecycle.rs
@@ -370,6 +370,7 @@ mod test {
             updated_at_millis: 0,
             origin_chat_id: None,
             parent_task_id: None,
+            output: None,
         }
     }
 

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -89,6 +89,11 @@ pub mod steer;
 pub mod steps;
 pub mod tool_dispatcher;
 pub mod toolbelt;
+/// Issue #339: the staging queue the orchestrator's `run_workflow` /
+/// `create_workflow` tools push a workflow reference onto and the
+/// [`HarnessBrain`] drains at the end of a dispatch, so a card that built or
+/// ran a workflow can link to it. See [`workflow_refs`].
+pub mod workflow_refs;
 /// End-to-end proof that an agent granted `files` and **not** `shell` can write
 /// a relative path on a company that has never run — the #409 provisioning gap,
 /// which only exists before anything has created the agent's workspace. Covers
@@ -238,6 +243,20 @@ pub struct HarnessDeps {
     /// — every path degrades to "this task produced no artifact", which is a
     /// legitimate outcome rather than a failure.
     pub pending_publishes: crate::harness::publish::PendingPublishQueue,
+    /// The shared queue the orchestrator's `run_workflow` / `create_workflow`
+    /// tools stage a workflow reference onto and the [`HarnessBrain`] drains at
+    /// the end of a dispatch (issue #339) — the workflow half of a card's
+    /// output link.
+    ///
+    /// Same cheap-shared-handle pattern as [`Self::pending_publishes`], and for
+    /// the same structural reason: the tools are built **once per agent** while
+    /// the card varies **per dispatch**, so a tool cannot hold a task id and has
+    /// to hand its work to something that does.
+    ///
+    /// Default is an empty queue, which simply means no card ever links to a
+    /// workflow — the stamp falls back to the attempt's trace, which is a
+    /// complete answer rather than a missing one.
+    pub workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue,
     /// The shared approval-request queue every agent's [`ApprovalPolicy`] pushes
     /// a `RequireApproval` decision onto and the [`HarnessBrain`] drains after a
     /// turn, parking each request through
@@ -1968,6 +1987,7 @@ description = "Builds the product."
                 workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
                 mcp_failures: McpFailureQueue::default(),
                 pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+                workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
                 approval_requests: ApprovalRequestQueue::default(),
                 secrets: None,
                 web_allowed_domains: Vec::new(),
@@ -2033,6 +2053,7 @@ description = "Builds the product."
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
@@ -2323,6 +2344,7 @@ description = "Builds the product."
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
@@ -2485,6 +2507,7 @@ description = "Builds the product."
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: ApprovalRequestQueue::default(),
             secrets: Some(secrets.clone()),
             web_allowed_domains: Vec::new(),
@@ -2799,6 +2822,7 @@ description = "Builds the product."
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
@@ -2958,6 +2982,7 @@ description = "Sets direction."
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),
@@ -3101,6 +3126,7 @@ description = "Sets direction."
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: McpFailureQueue::default(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -60,8 +60,10 @@ use crate::company::{
 };
 use crate::error::OpenCompanyError;
 use crate::harness::lifecycle::ReviewDecision;
+use crate::harness::workflow_refs::WorkflowRefQueue;
 use crate::ports::events::EventLog;
 use crate::ports::facts::FactStore;
+use crate::ports::tasks::{TaskOutputAction, TaskOutputWorkflow};
 use crate::ports::types::{CompanyEvent, CompanyId, EventSeq, OverlayAgent};
 use crate::ports::{CompanyStore, WorkflowRun, WorkflowRunner, generate_id};
 
@@ -1202,6 +1204,7 @@ pub fn orchestrator_tools(
     workflow_runner: WorkflowRunnerHandle,
     run_supervisor: crate::runtime::RunSupervisor,
     store: Arc<dyn CompanyStore>,
+    workflow_refs: WorkflowRefQueue,
 ) -> Vec<Box<dyn Tool>> {
     let mut tools: Vec<Box<dyn Tool>> = vec![Box::new(QueryCompanyTool::new(
         company.clone(),
@@ -1218,6 +1221,7 @@ pub fn orchestrator_tools(
         workflow_runner,
         run_supervisor,
         events.clone(),
+        workflow_refs.clone(),
     )));
     // `create_workflow` (issue #112) shares the same source dir the run tool
     // reads graphs from, plus the store it enables the new id on and the event
@@ -1227,6 +1231,7 @@ pub fn orchestrator_tools(
         workflow_source_dir,
         store.clone(),
         events,
+        workflow_refs,
     )));
     tools.push(Box::new(AddAgentTool::new(company, store)));
     tools
@@ -1313,13 +1318,22 @@ pub struct RunWorkflowTool {
     /// record, exactly as the runner skips the progress events — the two degrade
     /// together, so the pair can never be half-present.
     events: Option<Arc<dyn EventLog>>,
+    /// Issue #339: where a run this tool started is staged, so the dispatched
+    /// card that started it can link to the workflow.
+    ///
+    /// The tool cannot write the card itself — it is built once per agent while
+    /// the card varies per dispatch — so it stages and the brain drains. Pushed
+    /// only after the runner actually returned a run: a refused, unknown or
+    /// failed invocation produced nothing to point at.
+    workflow_refs: WorkflowRefQueue,
 }
 
 impl RunWorkflowTool {
     /// Builds the tool over the company id, its on-disk source directory
     /// (`companies/<name>`, whose `workflows/` subtree holds the seed graphs),
     /// the company store (holding the runtime-authored graph bodies), the
-    /// shared runner handle, and the company's journal.
+    /// shared runner handle, the company's journal, and the shared queue a
+    /// dispatched card's output link is staged on (issue #339).
     pub fn new(
         company: CompanyId,
         source_dir: Option<PathBuf>,
@@ -1327,6 +1341,7 @@ impl RunWorkflowTool {
         runner: WorkflowRunnerHandle,
         run_supervisor: crate::runtime::RunSupervisor,
         events: Option<Arc<dyn EventLog>>,
+        workflow_refs: WorkflowRefQueue,
     ) -> Self {
         Self {
             company,
@@ -1335,6 +1350,7 @@ impl RunWorkflowTool {
             runner,
             run_supervisor,
             events,
+            workflow_refs,
         }
     }
 }
@@ -1492,6 +1508,19 @@ impl Tool for RunWorkflowTool {
                          you're asked to — someone chose to stop it."
                     )));
                 }
+                // Issue #339: this run is something the turn produced, so a
+                // dispatched card that reached here can link to it. Staged
+                // here — *after* the cancelled arm above — because a run an
+                // operator stopped is not a deliverable to advertise on a
+                // card; its partial steps are in the run history either way.
+                // Off a dispatch (an ordinary operator chat turn) nothing ever
+                // drains this and the brain clears it before the next card, so
+                // staging unconditionally cannot mis-attribute.
+                self.workflow_refs.push(TaskOutputWorkflow {
+                    workflow_id: file.id.clone(),
+                    run_id: Some(ctx.run_id.clone()),
+                    action: TaskOutputAction::Ran,
+                });
                 let md = summarize_run(&file, &run);
                 Ok(ToolResult::success_with_markdown(
                     json!({
@@ -1720,24 +1749,35 @@ pub struct CreateWorkflowTool {
     source_dir: Option<PathBuf>,
     store: Arc<dyn CompanyStore>,
     events: Option<Arc<dyn EventLog>>,
+    /// Issue #339: where a graph this tool authored is staged, so a dispatched
+    /// card whose whole job was *"build us a process for this"* links to the
+    /// process rather than to the sentence describing it.
+    ///
+    /// Carries no run id — nothing has executed yet. If the same turn goes on
+    /// to run it, the queue collapses the pair to the run
+    /// ([`WorkflowRefQueue::drain`](crate::harness::workflow_refs::WorkflowRefQueue::drain)).
+    workflow_refs: WorkflowRefQueue,
 }
 
 impl CreateWorkflowTool {
     /// Builds the tool over the company id, its on-disk source directory
     /// (`companies/<name>`, whose `workflows/` subtree the graph lands in), the
-    /// company store (to enable the new id), and the event log (to journal the
-    /// audit event).
+    /// company store (to enable the new id), the event log (to journal the
+    /// audit event), and the shared queue a dispatched card's output link is
+    /// staged on (issue #339).
     pub fn new(
         company: CompanyId,
         source_dir: Option<PathBuf>,
         store: Arc<dyn CompanyStore>,
         events: Option<Arc<dyn EventLog>>,
+        workflow_refs: WorkflowRefQueue,
     ) -> Self {
         Self {
             company,
             source_dir,
             store,
             events,
+            workflow_refs,
         }
     }
 }
@@ -1842,6 +1882,14 @@ impl Tool for CreateWorkflowTool {
         {
             Ok(file) => {
                 tracing::debug!(company = %self.company, workflow = %file.id, "create_workflow: created");
+                // Issue #339: the graph is saved, so it is a real thing this
+                // turn produced and a dispatched card can point at it. Only on
+                // the `Ok` arm — a rejected draft persisted nothing.
+                self.workflow_refs.push(TaskOutputWorkflow {
+                    workflow_id: file.id.clone(),
+                    run_id: None,
+                    action: TaskOutputAction::Created,
+                });
                 let md = format!(
                     "Created workflow **{}** (`{}`). It's enabled and ready to run — use `run_workflow` with id `{}` to execute it.",
                     file.name.trim(),
@@ -2778,6 +2826,7 @@ name = "Morning"
             WorkflowRunnerHandle::default(),
             crate::runtime::RunSupervisor::default(),
             Arc::new(MemStore::default()),
+            WorkflowRefQueue::default(),
         );
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         // Six before #186; `assign_task` + `review_task` make eight.
@@ -2818,6 +2867,7 @@ name = "Morning"
             handle,
             crate::runtime::RunSupervisor::default(),
             None,
+            WorkflowRefQueue::default(),
         );
         let result = tool
             .execute(json!({ "id": "demo", "input": { "seed": 1 } }))
@@ -2830,6 +2880,135 @@ name = "Morning"
         assert!(out.contains("Demo flow"), "{out}");
         assert!(out.contains("did the thing"), "{out}");
         assert!(out.contains("without pausing for approval"), "{out}");
+    }
+
+    /// Issue #339: a run this tool started is staged for the dispatched card
+    /// that started it, carrying the run id so the card's link can open the
+    /// overlay showing what actually executed.
+    #[tokio::test]
+    async fn a_successful_run_stages_a_workflow_reference_for_the_card() {
+        let dir = tempfile::tempdir().unwrap();
+        seed_demo_workflow(dir.path());
+
+        let runner: Arc<dyn WorkflowRunner> = Arc::new(StubRunner::new(WorkflowRun {
+            output: json!({ "nodes": { "worker": { "items": ["did the thing"] } } }),
+            pending_approvals: Vec::new(),
+            deliveries: Vec::new(),
+            cancelled: false,
+        }));
+        let handle = WorkflowRunnerHandle::default();
+        handle.set(&runner);
+        let refs = WorkflowRefQueue::default();
+
+        let tool = RunWorkflowTool::new(
+            CompanyId::new("acme"),
+            Some(dir.path().to_path_buf()),
+            Arc::new(MemStore::default()),
+            handle,
+            crate::runtime::RunSupervisor::default(),
+            None,
+            refs.clone(),
+        );
+        let result = tool
+            .execute(json!({ "id": "demo" }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error, "{result:?}");
+
+        let staged = refs.drain();
+        assert_eq!(staged.len(), 1, "got {staged:?}");
+        assert_eq!(staged[0].workflow_id, "demo");
+        assert_eq!(staged[0].action, TaskOutputAction::Ran);
+        assert!(
+            staged[0].run_id.is_some(),
+            "a run the card links to must name the run that happened"
+        );
+    }
+
+    /// The other half, and the one worth pinning: a run that never happened
+    /// stages nothing. An unknown id, an unwired runner and a failed run all
+    /// produced no deliverable, so a card must not advertise one.
+    #[tokio::test]
+    async fn a_run_that_did_not_happen_stages_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        seed_demo_workflow(dir.path());
+        let refs = WorkflowRefQueue::default();
+
+        // No runner wired.
+        let unwired = RunWorkflowTool::new(
+            CompanyId::new("acme"),
+            Some(dir.path().to_path_buf()),
+            Arc::new(MemStore::default()),
+            WorkflowRunnerHandle::default(),
+            crate::runtime::RunSupervisor::default(),
+            None,
+            refs.clone(),
+        );
+        assert!(
+            unwired
+                .execute(json!({ "id": "demo" }))
+                .await
+                .expect("execute")
+                .is_error
+        );
+
+        // A wired runner, but an id neither source has.
+        let runner: Arc<dyn WorkflowRunner> = Arc::new(StubRunner::empty());
+        let handle = WorkflowRunnerHandle::default();
+        handle.set(&runner);
+        let unknown = RunWorkflowTool::new(
+            CompanyId::new("acme"),
+            Some(dir.path().to_path_buf()),
+            Arc::new(MemStore::default()),
+            handle,
+            crate::runtime::RunSupervisor::default(),
+            None,
+            refs.clone(),
+        );
+        assert!(
+            unknown
+                .execute(json!({ "id": "nope" }))
+                .await
+                .expect("execute")
+                .is_error
+        );
+
+        assert_eq!(refs.queued(), 0, "nothing ran, so nothing may be linked");
+    }
+
+    /// A run an operator stopped is not a deliverable to put on a card. Its
+    /// partial steps stay in the run history either way, so nothing is lost —
+    /// what is avoided is a card advertising work somebody deliberately halted.
+    #[tokio::test]
+    async fn a_cancelled_run_stages_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        seed_demo_workflow(dir.path());
+
+        let runner: Arc<dyn WorkflowRunner> = Arc::new(StubRunner::new(WorkflowRun {
+            output: json!({ "nodes": {} }),
+            pending_approvals: Vec::new(),
+            deliveries: Vec::new(),
+            cancelled: true,
+        }));
+        let handle = WorkflowRunnerHandle::default();
+        handle.set(&runner);
+        let refs = WorkflowRefQueue::default();
+
+        let tool = RunWorkflowTool::new(
+            CompanyId::new("acme"),
+            Some(dir.path().to_path_buf()),
+            Arc::new(MemStore::default()),
+            handle,
+            crate::runtime::RunSupervisor::default(),
+            None,
+            refs.clone(),
+        );
+        let result = tool
+            .execute(json!({ "id": "demo" }))
+            .await
+            .expect("execute");
+        assert!(result.is_error, "a cancelled run reports as a stop");
+        assert_eq!(refs.queued(), 0);
     }
 
     #[tokio::test]
@@ -2853,6 +3032,7 @@ name = "Morning"
             handle,
             crate::runtime::RunSupervisor::default(),
             None,
+            WorkflowRefQueue::default(),
         );
         let result = tool
             .execute(json!({ "id": "demo" }))
@@ -2876,6 +3056,7 @@ name = "Morning"
             WorkflowRunnerHandle::default(),
             crate::runtime::RunSupervisor::default(),
             None,
+            WorkflowRefQueue::default(),
         );
         let result = tool
             .execute(json!({ "id": "demo" }))
@@ -2900,6 +3081,7 @@ name = "Morning"
             handle,
             crate::runtime::RunSupervisor::default(),
             None,
+            WorkflowRefQueue::default(),
         );
         let result = tool
             .execute(json!({ "id": "nope" }))
@@ -2921,6 +3103,7 @@ name = "Morning"
             WorkflowRunnerHandle::default(),
             crate::runtime::RunSupervisor::default(),
             None,
+            WorkflowRefQueue::default(),
         );
         let result = tool.execute(json!({})).await.expect("execute");
         assert!(result.is_error);
@@ -2942,6 +3125,7 @@ name = "Morning"
             handle,
             crate::runtime::RunSupervisor::default(),
             None,
+            WorkflowRefQueue::default(),
         );
         let result = tool
             .execute(json!({ "id": "../secrets" }))
@@ -3005,6 +3189,7 @@ name = "Morning"
             Some(dir.path().to_path_buf()),
             store.clone(),
             None,
+            WorkflowRefQueue::default(),
         );
         let created = create.execute(greeter_body()).await.expect("execute");
         assert!(!created.is_error, "create should succeed: {created:?}");
@@ -3039,6 +3224,7 @@ name = "Morning"
             handle,
             crate::runtime::RunSupervisor::default(),
             None,
+            WorkflowRefQueue::default(),
         );
         let result = run
             .execute(json!({ "id": "greeter" }))
@@ -3051,13 +3237,88 @@ name = "Morning"
         );
     }
 
+    /// Issue #339: the *"build us a process for this"* card. The graph is the
+    /// deliverable, so authoring it stages a link even though nothing has run —
+    /// and when the same turn goes on to run it, the pair collapses to the run,
+    /// which is the stronger link because it can show what executed.
+    #[tokio::test]
+    async fn authoring_a_workflow_stages_a_link_and_running_it_upgrades_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store: Arc<dyn CompanyStore> =
+            Arc::new(MemStore::seeded(record_with_assistant(&company)));
+        let refs = WorkflowRefQueue::default();
+
+        let create = CreateWorkflowTool::new(
+            company.clone(),
+            Some(dir.path().to_path_buf()),
+            store.clone(),
+            None,
+            refs.clone(),
+        );
+        assert!(
+            !create
+                .execute(greeter_body())
+                .await
+                .expect("execute")
+                .is_error
+        );
+        assert_eq!(refs.queued(), 1, "the saved graph is a deliverable");
+
+        // A rejected draft persists nothing, so it must stage nothing either.
+        assert!(
+            create
+                .execute(json!({ "id": "greeter", "name": "Greeter", "nodes": [] }))
+                .await
+                .expect("execute")
+                .is_error
+        );
+        assert_eq!(refs.queued(), 1, "a rejected draft is not a deliverable");
+
+        let runner: Arc<dyn WorkflowRunner> = Arc::new(StubRunner::new(WorkflowRun {
+            output: json!({ "nodes": { "worker": { "items": ["hi"] } } }),
+            pending_approvals: Vec::new(),
+            deliveries: Vec::new(),
+            cancelled: false,
+        }));
+        let handle = WorkflowRunnerHandle::default();
+        handle.set(&runner);
+        let run = RunWorkflowTool::new(
+            company.clone(),
+            Some(dir.path().to_path_buf()),
+            store.clone(),
+            handle,
+            crate::runtime::RunSupervisor::default(),
+            None,
+            refs.clone(),
+        );
+        assert!(
+            !run.execute(json!({ "id": "greeter" }))
+                .await
+                .expect("execute")
+                .is_error
+        );
+
+        let staged = refs.drain();
+        assert_eq!(staged.len(), 1, "one workflow, one link: {staged:?}");
+        assert_eq!(staged[0].workflow_id, "greeter");
+        assert_eq!(staged[0].action, TaskOutputAction::Ran);
+        assert!(staged[0].run_id.is_some());
+    }
+
     #[tokio::test]
     async fn create_workflow_tool_guardrail_failure_is_error_result() {
         let dir = tempfile::tempdir().unwrap();
         let company = CompanyId::new("acme");
         let store: Arc<dyn CompanyStore> =
             Arc::new(MemStore::seeded(record_with_assistant(&company)));
-        let tool = CreateWorkflowTool::new(company, Some(dir.path().to_path_buf()), store, None);
+        let tool = CreateWorkflowTool::new(
+            company,
+            Some(dir.path().to_path_buf()),
+            store,
+            None,
+            WorkflowRefQueue::default(),
+        );
         // Zero triggers — a guardrail failure must be an is_error ToolResult, not
         // a raised anyhow error.
         let result = tool
@@ -3084,7 +3345,13 @@ name = "Morning"
         let company = CompanyId::new("acme");
         let store: Arc<dyn CompanyStore> =
             Arc::new(MemStore::seeded(record_with_assistant(&company)));
-        let tool = CreateWorkflowTool::new(company.clone(), None, store.clone(), None);
+        let tool = CreateWorkflowTool::new(
+            company.clone(),
+            None,
+            store.clone(),
+            None,
+            WorkflowRefQueue::default(),
+        );
         let result = tool
             .execute(json!({
                 "id": "hosted",
@@ -3119,6 +3386,7 @@ name = "Morning"
             handle,
             crate::runtime::RunSupervisor::default(),
             None,
+            WorkflowRefQueue::default(),
         );
         let result = run
             .execute(json!({ "id": "hosted" }))
@@ -3137,6 +3405,7 @@ name = "Morning"
             Some(dir.path().to_path_buf()),
             store,
             None,
+            WorkflowRefQueue::default(),
         );
         // A non-object payload can't deserialize into the create body.
         let result = tool.execute(json!(42)).await.expect("execute");

--- a/src/harness/publish_turn_test.rs
+++ b/src/harness/publish_turn_test.rs
@@ -336,9 +336,32 @@ fn brain(base_url: String, grants: &str, dir: &std::path::Path) -> (HarnessBrain
         template_provenance: None,
     };
     (
-        HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record),
+        // Issue #339: the run store is wired here so a dispatch carrying a
+        // `run_id` has an attempt to record — and therefore an attempt the
+        // card's output link can name. Inert for every dispatch that passes
+        // `run_id: None` (which is all of the pre-#339 tests below), because
+        // `open_trace` needs both halves before it opens a sink.
+        HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record).with_runs(ops.clone()),
         ops,
     )
+}
+
+/// Mints the `Pending` attempt row the dispatch choke point would have minted,
+/// so a cycle can be dispatched under a real run id (issue #339).
+async fn mint_run(ops: &Arc<FsOps>, run_id: &str, task_id: &str) {
+    use crate::ports::RunStore;
+    use crate::ports::runs::NewRun;
+    RunStore::create_run(
+        &**ops,
+        &company(),
+        NewRun {
+            id: run_id.to_string(),
+            task_id: task_id.to_string(),
+            agent_id: AGENT.to_string(),
+        },
+    )
+    .await
+    .expect("mint the attempt row");
 }
 
 fn company() -> CompanyId {
@@ -362,12 +385,22 @@ fn card(id: &str) -> TaskRecord {
 }
 
 fn dispatch(task_id: &str) -> CycleRequest {
+    dispatch_run(task_id, None)
+}
+
+/// A dispatch under a named attempt (issue #339) — what a real choke point
+/// sends, and the only shape that can produce an output stamp.
+fn dispatch_as(task_id: &str, run_id: &str) -> CycleRequest {
+    dispatch_run(task_id, Some(run_id))
+}
+
+fn dispatch_run(task_id: &str, run_id: Option<&str>) -> CycleRequest {
     CycleRequest {
         cycle_id: "cycle-1".to_string(),
         company_id: company(),
         events: vec![CompanyEvent::TaskDispatched {
             task_id: task_id.to_string(),
-            run_id: None,
+            run_id: run_id.map(str::to_string),
         }],
         event_seqs: Vec::new(),
         compressed_history: Vec::new(),
@@ -799,4 +832,304 @@ async fn a_nudge_turn_that_fails_never_fails_the_run() {
         !note.contains("unpublished:"),
         "a nudge that never ran cannot have been declined: {note}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #339: the card's link to what the run produced
+// ---------------------------------------------------------------------------
+//
+// Epic #183 §6. A task that finished used to end as a chat message — prose in a
+// conversation with nothing durable to open, share, or hand to somebody else.
+// These drive the same real dispatch as the tests above, under a real attempt
+// row, and assert the stamp the card comes back carrying.
+
+/// The headline: a run that published a file leaves the card pointing at that
+/// file **at the version this run wrote**, under the attempt that wrote it.
+#[tokio::test]
+async fn a_published_card_links_to_the_version_its_run_wrote() {
+    let (base_url, _script) = spawn_script(vec![
+        write("launch.md", "# Launch spec\nShip on Friday."),
+        publish("launch.md"),
+        Turn::Say("Drafted the launch spec and published it."),
+    ])
+    .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (brain, ops) = brain(base_url, "\"*\"", dir.path());
+    TaskStore::upsert(&*ops, &company(), &card("t-1"))
+        .await
+        .unwrap();
+    mint_run(&ops, "run-1", "t-1").await;
+
+    brain
+        .run_cycle(dispatch_as("t-1", "run-1"), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    let output = card_after(&ops, "t-1")
+        .await
+        .output
+        .expect("a successful run stamps its card");
+    assert_eq!(output.run_id, "run-1");
+    assert_eq!(output.attempt, Some(1), "the first attempt at this card");
+    assert_eq!(output.artifacts.len(), 1, "got {:?}", output.artifacts);
+
+    let linked = &output.artifacts[0];
+    assert_eq!(linked.version, 1, "pinned at what this run wrote");
+    assert_eq!(linked.title, "launch.md");
+    assert_eq!(linked.kind, crate::ports::artifacts::ArtifactKind::Markdown);
+    // The link resolves: the id names a record that is actually on the card.
+    let stored = artifacts_on(&ops, "t-1").await;
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].id, linked.artifact_id);
+    assert!(stored[0].version(linked.version).is_some());
+}
+
+/// *"Every card has a link including tasks that produced no file"* — the
+/// acceptance criterion most easily lost, because the obvious implementation
+/// stamps nothing when there is no artifact.
+///
+/// The agent here writes nothing at all (so no nudge fires) and simply answers.
+/// The trace **is** the deliverable, and the stamp says so.
+#[tokio::test]
+async fn a_task_that_produced_no_file_still_links_to_its_trace() {
+    let (base_url, script) =
+        spawn_script(vec![Turn::Say("Checked it — nothing needed changing.")]).await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (brain, ops) = brain(base_url, "\"*\"", dir.path());
+    TaskStore::upsert(&*ops, &company(), &card("t-1"))
+        .await
+        .unwrap();
+    mint_run(&ops, "run-1", "t-1").await;
+
+    brain
+        .run_cycle(dispatch_as("t-1", "run-1"), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    assert_eq!(
+        nudge_turns(&script),
+        0,
+        "nothing was written to nudge about"
+    );
+    assert!(artifacts_on(&ops, "t-1").await.is_empty(), "no deliverable");
+
+    let output = card_after(&ops, "t-1")
+        .await
+        .output
+        .expect("no artifact must not mean no link");
+    assert_eq!(output.run_id, "run-1");
+    assert!(output.artifacts.is_empty());
+    assert!(output.workflows.is_empty());
+}
+
+/// *"The link is pinned to the attempt that produced it, and a retried task
+/// links to the successful one."*
+///
+/// Two real dispatches under two real attempts. The second republishes, so the
+/// stamp moves wholesale to the second attempt and the second version — nothing
+/// merges, and no read-time query has to decide which attempt wins.
+#[tokio::test]
+async fn a_re_run_repins_the_link_to_the_attempt_that_last_succeeded() {
+    let (base_url, _script) = spawn_script(vec![
+        write("launch.md", "# Launch spec\nDraft."),
+        publish("launch.md"),
+        Turn::Say("First draft published."),
+        write("launch.md", "# Launch spec\nRevised."),
+        publish("launch.md"),
+        Turn::Say("Revised and republished."),
+    ])
+    .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (brain, ops) = brain(base_url, "\"*\"", dir.path());
+    TaskStore::upsert(&*ops, &company(), &card("t-1"))
+        .await
+        .unwrap();
+    mint_run(&ops, "run-1", "t-1").await;
+    brain
+        .run_cycle(dispatch_as("t-1", "run-1"), &NoopHost)
+        .await
+        .expect("run 1");
+
+    let first = card_after(&ops, "t-1").await.output.expect("stamped");
+    assert_eq!(first.artifacts[0].version, 1);
+
+    // Re-dispatch the way a re-run starts: the card comes back to In Progress.
+    let mut again = card_after(&ops, "t-1").await;
+    again.column = COLUMN_IN_PROGRESS.to_string();
+    TaskStore::upsert(&*ops, &company(), &again).await.unwrap();
+    mint_run(&ops, "run-2", "t-1").await;
+    brain
+        .run_cycle(dispatch_as("t-1", "run-2"), &NoopHost)
+        .await
+        .expect("run 2");
+
+    let second = card_after(&ops, "t-1").await.output.expect("re-stamped");
+    assert_eq!(second.run_id, "run-2");
+    assert_eq!(second.attempt, Some(2));
+    assert_eq!(second.artifacts.len(), 1, "one path, one record, one link");
+    assert_eq!(
+        second.artifacts[0].version, 2,
+        "the link must name what THIS run wrote, not the record's first draft"
+    );
+    assert_eq!(
+        second.artifacts[0].artifact_id, first.artifacts[0].artifact_id,
+        "republishing one path extends one record"
+    );
+    // The earlier attempt is not erased — it is still reachable as its own run.
+    assert_ne!(second.run_id, first.run_id);
+}
+
+/// *"A retried task links to the successful one."* The failing half: a later
+/// attempt that fails must leave the previous success's link standing, because
+/// a card whose link vanished on a retry is worse than a card with no link at
+/// all — the deliverable still exists and the operator can no longer find it.
+///
+/// The second dispatch runs against a poisoned endpoint, so the turn errors:
+/// the real `TaskRunEnd::Failed` path, not a simulated one.
+#[tokio::test]
+async fn a_failed_retry_does_not_erase_the_link_to_the_success_before_it() {
+    let (base_url, _script) = spawn_script(vec![
+        write("launch.md", "# Launch spec\nShipped."),
+        publish("launch.md"),
+        Turn::Say("Published."),
+        // Attempt 2 falls over before it produces anything.
+        Turn::Boom,
+    ])
+    .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (brain, ops) = brain(base_url, "\"*\"", dir.path());
+    TaskStore::upsert(&*ops, &company(), &card("t-1"))
+        .await
+        .unwrap();
+    mint_run(&ops, "run-1", "t-1").await;
+    brain
+        .run_cycle(dispatch_as("t-1", "run-1"), &NoopHost)
+        .await
+        .expect("run 1");
+    let succeeded = card_after(&ops, "t-1").await.output.expect("stamped");
+
+    let mut again = card_after(&ops, "t-1").await;
+    again.column = COLUMN_IN_PROGRESS.to_string();
+    TaskStore::upsert(&*ops, &company(), &again).await.unwrap();
+    mint_run(&ops, "run-2", "t-1").await;
+    brain
+        .run_cycle(dispatch_as("t-1", "run-2"), &NoopHost)
+        .await
+        .expect("a failed attempt still completes its cycle");
+
+    let after = card_after(&ops, "t-1").await;
+    assert_eq!(
+        after.column,
+        crate::ports::tasks::COLUMN_TODO,
+        "a failed attempt returns the card to To-do"
+    );
+    let still = after
+        .output
+        .expect("the success's link survives the failure");
+    assert_eq!(still.run_id, succeeded.run_id);
+    assert_eq!(still.artifacts, succeeded.artifacts);
+}
+
+/// *"A task whose output was later edited by a human still resolves, and says
+/// so."*
+///
+/// The host half of that promise: the pin does not move when an operator
+/// appends a version, so the card still names the revision the run produced
+/// while the record grows past it. The console reads exactly this difference —
+/// pinned version versus latest — to say a human edited it since.
+#[tokio::test]
+async fn an_operator_edit_leaves_the_pinned_link_naming_what_the_run_wrote() {
+    use crate::ports::artifacts::ArtifactAuthor;
+
+    let (base_url, _script) = spawn_script(vec![
+        write("launch.md", "# Launch spec\nAgent draft."),
+        publish("launch.md"),
+        Turn::Say("Published."),
+    ])
+    .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (brain, ops) = brain(base_url, "\"*\"", dir.path());
+    TaskStore::upsert(&*ops, &company(), &card("t-1"))
+        .await
+        .unwrap();
+    mint_run(&ops, "run-1", "t-1").await;
+    brain
+        .run_cycle(dispatch_as("t-1", "run-1"), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    let pinned = card_after(&ops, "t-1").await.output.expect("stamped");
+    assert_eq!(pinned.artifacts[0].version, 1);
+
+    // A human edits the deliverable after the run — the console's "Edit as
+    // operator" path, which appends rather than overwriting.
+    let mut record = artifacts_on(&ops, "t-1").await.remove(0);
+    record.push_version(
+        "# Launch spec\nOperator's wording.",
+        ArtifactAuthor::Operator,
+        "operator",
+        99,
+        Some("operator edit before approval".to_string()),
+    );
+    ArtifactStore::upsert(&*ops, &company(), &record)
+        .await
+        .unwrap();
+
+    // The card is untouched: nothing about an edit rewrites the run's stamp.
+    let after = card_after(&ops, "t-1").await.output.expect("still stamped");
+    assert_eq!(
+        after.artifacts[0].version, 1,
+        "the pin does not follow edits"
+    );
+
+    // And it still resolves — to the agent's revision, not the human's.
+    let stored = artifacts_on(&ops, "t-1").await.remove(0);
+    let resolved = stored
+        .version(after.artifacts[0].version)
+        .expect("a pinned version can never dangle: versions are append-only");
+    assert_eq!(resolved.author, ArtifactAuthor::Agent);
+    assert_eq!(resolved.body, "# Launch spec\nAgent draft.");
+    // The newer version is what the console names in its "edited since" line.
+    assert_eq!(stored.latest().unwrap().version, 2);
+    assert_eq!(stored.latest().unwrap().author, ArtifactAuthor::Operator);
+}
+
+/// A dispatch with no attempt row has nothing addressable to point at, so it
+/// stamps nothing rather than inventing an id. Fail silent, not closed: the
+/// card lands exactly as it did before #339, and the artifact is still
+/// recorded.
+#[tokio::test]
+async fn a_dispatch_with_no_attempt_row_stamps_nothing() {
+    let (base_url, _script) = spawn_script(vec![
+        write("launch.md", "# Launch spec"),
+        publish("launch.md"),
+        Turn::Say("Published."),
+    ])
+    .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (brain, ops) = brain(base_url, "\"*\"", dir.path());
+    TaskStore::upsert(&*ops, &company(), &card("t-1"))
+        .await
+        .unwrap();
+
+    // `run_id: None` — the choke point minted no row.
+    brain
+        .run_cycle(dispatch("t-1"), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    let after = card_after(&ops, "t-1").await;
+    assert!(after.output.is_none(), "no attempt, no link to it");
+    assert_eq!(
+        artifacts_on(&ops, "t-1").await.len(),
+        1,
+        "the deliverable is still recorded — only the card's link is missing"
+    );
+    assert_eq!(after.column, crate::ports::tasks::COLUMN_IN_REVIEW);
 }

--- a/src/harness/publish_turn_test.rs
+++ b/src/harness/publish_turn_test.rs
@@ -307,6 +307,7 @@ fn brain(base_url: String, grants: &str, dir: &std::path::Path) -> (HarnessBrain
         workflow_runner: WorkflowRunnerHandle::default(),
         mcp_failures: McpFailureQueue::default(),
         pending_publishes: Default::default(),
+        workflow_refs: Default::default(),
         approval_requests: ApprovalRequestQueue::default(),
         secrets: None,
         web_allowed_domains: Vec::new(),
@@ -356,6 +357,7 @@ fn card(id: &str) -> TaskRecord {
         updated_at_millis: 1,
         origin_chat_id: None,
         parent_task_id: None,
+        output: None,
     }
 }
 

--- a/src/harness/search_turn_test.rs
+++ b/src/harness/search_turn_test.rs
@@ -285,6 +285,7 @@ async fn harness(
         workflow_runner: WorkflowRunnerHandle::default(),
         mcp_failures: McpFailureQueue::default(),
         pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+        workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
         approval_requests: ApprovalRequestQueue::default(),
         secrets: None,
         web_allowed_domains: Vec::new(),

--- a/src/harness/workflow_refs.rs
+++ b/src/harness/workflow_refs.rs
@@ -1,0 +1,210 @@
+//! The workflow half of a card's output link (issue #339, epic #183 §6).
+//!
+//! # Why a queue and not a return value
+//!
+//! Exactly the [`PendingPublishQueue`](crate::harness::publish::PendingPublishQueue)
+//! problem, with exactly the same answer. `run_workflow` and `create_workflow`
+//! are built **once per agent**, while the card they are working varies **per
+//! dispatch** — so neither tool can hold a task id, and neither can reach the
+//! task store. They stage a [`TaskOutputWorkflow`] here; the brain drains it
+//! inside the settle, where it already holds the card.
+//!
+//! # Correlation exists only for the orchestrator desk
+//!
+//! Both tools are orchestrator-only
+//! ([`orchestrator_tools`](crate::harness::orchestrator::orchestrator_tools)),
+//! so a card worked by any other teammate can never stage one. That is a real
+//! limit of the correlation and it is named rather than papered over: workflow
+//! links appear on orchestrator cards and nowhere else. Workflow *runs*
+//! themselves have deliberately zero task correlation
+//! ([`CompanyEvent::WorkflowRunFinished`](crate::ports::types::CompanyEvent)
+//! carries no task id), which is precisely why the correlation has to be
+//! captured here, at the moment the tool runs inside a dispatch, rather than
+//! joined afterwards.
+//!
+//! Compiled only under `feature = "openhuman"`.
+
+use std::sync::{Arc, Mutex};
+
+use crate::ports::tasks::{TaskOutputAction, TaskOutputWorkflow};
+
+/// The most workflow references one card's output stamp keeps.
+///
+/// A bound, not a design constraint. The stamp rides every board poll, so an
+/// agent that ran forty workflows in one turn must not turn a card into a
+/// payload. Far above any plausible real dispatch — and the collapse in
+/// [`WorkflowRefQueue::drain`] already folds repeats of one workflow into a
+/// single entry, so reaching this means forty *distinct* workflows.
+pub const MAX_WORKFLOW_REFS: usize = 20;
+
+/// A shared, in-memory queue of workflow references staged during a dispatch.
+///
+/// Cheap to [`Clone`] (a shared handle); the tools built into the agent and the
+/// brain that drains it see the same queue because
+/// [`HarnessDeps`](crate::harness::HarnessDeps) clones share this handle.
+#[derive(Clone, Default)]
+pub struct WorkflowRefQueue {
+    inner: Arc<Mutex<Vec<TaskOutputWorkflow>>>,
+}
+
+impl WorkflowRefQueue {
+    /// Stages a reference to a workflow this turn ran or authored.
+    pub fn push(&self, reference: TaskOutputWorkflow) {
+        self.inner
+            .lock()
+            .expect("workflow ref queue")
+            .push(reference);
+    }
+
+    /// Empties the queue. Called before each turn so nothing a prior turn — an
+    /// operator chat turn earlier in the same cycle, or an abandoned redirect
+    /// re-run — staged can be attributed to this card.
+    pub fn clear(&self) {
+        self.inner.lock().expect("workflow ref queue").clear();
+    }
+
+    /// How many references are staged, before collapsing.
+    pub fn queued(&self) -> usize {
+        self.inner.lock().expect("workflow ref queue").len()
+    }
+
+    /// Drains every staged reference, emptying the queue and collapsing the raw
+    /// list into what the card should carry.
+    pub fn drain(&self) -> Vec<TaskOutputWorkflow> {
+        let raw = std::mem::take(&mut *self.inner.lock().expect("workflow ref queue"));
+        collapse(raw)
+    }
+}
+
+/// Folds the raw staged list into one entry per workflow, newest-first-wins on
+/// having actually run, capped at [`MAX_WORKFLOW_REFS`].
+///
+/// # Why collapse at all
+///
+/// The common shape is an agent that authors a graph and then runs it in the
+/// same turn — two entries naming one workflow. The card shows *one* link, and
+/// "created" is the weaker of the two answers: a run has a run id, so it can
+/// open the overlay showing what actually executed. Keeping both would also
+/// inflate the `+N more` count with a duplicate the operator cannot tell apart.
+///
+/// So per workflow id: the **last** entry that ran wins; failing that, the last
+/// entry at all. Order otherwise follows first appearance, so the list reads in
+/// the order the turn did things rather than in hash order.
+fn collapse(raw: Vec<TaskOutputWorkflow>) -> Vec<TaskOutputWorkflow> {
+    let mut out: Vec<TaskOutputWorkflow> = Vec::new();
+    for reference in raw {
+        match out
+            .iter_mut()
+            .find(|held| held.workflow_id == reference.workflow_id)
+        {
+            // A later *run* supersedes whatever we held; a later *create* does
+            // not overwrite a run we already saw, because the run is the
+            // stronger link.
+            Some(held) if reference.action == TaskOutputAction::Ran => *held = reference,
+            Some(_) => {}
+            None => out.push(reference),
+        }
+    }
+    out.truncate(MAX_WORKFLOW_REFS);
+    out
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn wf(id: &str, run: Option<&str>, action: TaskOutputAction) -> TaskOutputWorkflow {
+        TaskOutputWorkflow {
+            workflow_id: id.to_string(),
+            run_id: run.map(str::to_string),
+            action,
+        }
+    }
+
+    /// The shared-handle property the whole design rests on: the tool pushes
+    /// through one clone, the brain drains through another, and the drain
+    /// empties the queue so a second dispatch starts clean.
+    #[test]
+    fn a_clone_sees_the_same_queue_and_a_drain_empties_it() {
+        let queue = WorkflowRefQueue::default();
+        let tool_side = queue.clone();
+        tool_side.push(wf("digest", Some("wf-1"), TaskOutputAction::Ran));
+        assert_eq!(queue.queued(), 1);
+
+        let drained = queue.drain();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].workflow_id, "digest");
+        assert_eq!(queue.queued(), 0, "a drain must not leak into the next run");
+        assert!(queue.drain().is_empty());
+    }
+
+    /// A redirect abandons the turn that staged, so the queue is cleared per
+    /// turn — a workflow an abandoned re-run started must not be credited to
+    /// the card that eventually settles.
+    #[test]
+    fn clear_discards_an_abandoned_turns_refs() {
+        let queue = WorkflowRefQueue::default();
+        queue.push(wf("stale", None, TaskOutputAction::Created));
+        queue.clear();
+        assert!(queue.drain().is_empty());
+    }
+
+    /// The common shape: author a graph, then run it. One workflow, one link,
+    /// and the link is the one that can show what actually executed.
+    #[test]
+    fn creating_then_running_one_workflow_collapses_to_the_run() {
+        let queue = WorkflowRefQueue::default();
+        queue.push(wf("digest", None, TaskOutputAction::Created));
+        queue.push(wf("digest", Some("wf-1"), TaskOutputAction::Ran));
+
+        let drained = queue.drain();
+        assert_eq!(drained.len(), 1, "got {drained:?}");
+        assert_eq!(drained[0].action, TaskOutputAction::Ran);
+        assert_eq!(drained[0].run_id.as_deref(), Some("wf-1"));
+    }
+
+    /// Run twice: the later run wins, because the card's link should open the
+    /// run that most recently happened rather than an earlier one.
+    #[test]
+    fn a_later_run_supersedes_an_earlier_one() {
+        let queue = WorkflowRefQueue::default();
+        queue.push(wf("digest", Some("wf-1"), TaskOutputAction::Ran));
+        queue.push(wf("digest", Some("wf-2"), TaskOutputAction::Ran));
+        let drained = queue.drain();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].run_id.as_deref(), Some("wf-2"));
+    }
+
+    /// The reverse order must NOT downgrade: authoring a second graph after
+    /// running the first is two workflows, and re-saving one already run keeps
+    /// the run link.
+    #[test]
+    fn a_later_create_does_not_downgrade_a_run() {
+        let queue = WorkflowRefQueue::default();
+        queue.push(wf("digest", Some("wf-1"), TaskOutputAction::Ran));
+        queue.push(wf("digest", None, TaskOutputAction::Created));
+        queue.push(wf("weekly", None, TaskOutputAction::Created));
+
+        let drained = queue.drain();
+        assert_eq!(drained.len(), 2, "got {drained:?}");
+        assert_eq!(drained[0].workflow_id, "digest");
+        assert_eq!(
+            drained[0].run_id.as_deref(),
+            Some("wf-1"),
+            "a re-save must not erase the link to the run"
+        );
+        // First-appearance order, so the list reads as the turn happened.
+        assert_eq!(drained[1].workflow_id, "weekly");
+    }
+
+    /// The bound, so a pathological turn cannot turn a board poll into a
+    /// payload. Distinct workflows past the cap are dropped, not merged.
+    #[test]
+    fn the_staged_list_is_capped() {
+        let queue = WorkflowRefQueue::default();
+        for i in 0..MAX_WORKFLOW_REFS + 5 {
+            queue.push(wf(&format!("wf-{i}"), None, TaskOutputAction::Created));
+        }
+        assert_eq!(queue.drain().len(), MAX_WORKFLOW_REFS);
+    }
+}

--- a/src/harness/workspace_provision_turn_test.rs
+++ b/src/harness/workspace_provision_turn_test.rs
@@ -274,6 +274,7 @@ fn build_brain(
         workflow_runner: WorkflowRunnerHandle::default(),
         mcp_failures: McpFailureQueue::default(),
         pending_publishes: Default::default(),
+        workflow_refs: Default::default(),
         approval_requests: ApprovalRequestQueue::default(),
         secrets: None,
         web_allowed_domains: Vec::new(),
@@ -305,6 +306,7 @@ fn card(id: &str, assignee: &str) -> TaskRecord {
         updated_at_millis: 1,
         origin_chat_id: None,
         parent_task_id: None,
+        output: None,
     }
 }
 

--- a/src/harness/workspace_turn_test.rs
+++ b/src/harness/workspace_turn_test.rs
@@ -274,6 +274,7 @@ async fn harness(
         workflow_runner: WorkflowRunnerHandle::default(),
         mcp_failures: McpFailureQueue::default(),
         pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+        workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
         approval_requests: ApprovalRequestQueue::default(),
         secrets: None,
         web_allowed_domains: Vec::new(),

--- a/src/ports/tasks.rs
+++ b/src/ports/tasks.rs
@@ -10,6 +10,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use crate::Result;
+use crate::ports::artifacts::ArtifactKind;
 use crate::ports::runs::RunStatus;
 use crate::ports::types::CompanyId;
 
@@ -235,6 +236,160 @@ where
     Ok(migrate_column(String::deserialize(deserializer)?))
 }
 
+// ---------------------------------------------------------------------------
+// What the card produced (issue #339, epic #183 §6)
+// ---------------------------------------------------------------------------
+
+/// What one attempt at a card produced — the card's link to its deliverable.
+///
+/// # Why the card carries this at all
+///
+/// Every ingredient already existed and nothing tied them to the card. Attempts
+/// are first-class ([`RunRecord`](crate::ports::runs::RunRecord)); a published
+/// file is a versioned [`ArtifactRecord`](crate::ports::artifacts::ArtifactRecord)
+/// whose versions carry the producing
+/// [`run_id`](crate::ports::artifacts::ArtifactVersion::run_id); the completion
+/// event carries the artifact ids. But a *card* had no output field, so the end
+/// of a task was a chat message: prose in a conversation, with no durable thing
+/// to open, share, or hand to somebody else. This is that thing.
+///
+/// # `run_id` is unconditional, and that is the whole design
+///
+/// An output with **no** artifacts and **no** workflows is not an absence — it
+/// is the *trace case*, and it is the common one. Plenty of tasks produce no
+/// file (a message sent, a record updated, a question answered), and for those
+/// the attempt's trace **is** the deliverable. Making `run_id` mandatory is what
+/// stops "no artifact" degrading into "no link", which is the failure epic #183
+/// §6 exists to close. It is also the fallback when an artifact is later
+/// deleted: the pinned artifact link dangles, the trace does not.
+///
+/// # Which attempt, and why nothing has to choose
+///
+/// The latest **successful** one, by construction rather than by query: only a
+/// settle that reached its success terminal writes this, and a later success
+/// overwrites it wholesale. So a retried task links to the success, a failed
+/// retry after a success never erases the link to that success, and earlier
+/// attempts stay reachable through the card's own attempt list. No read-time
+/// join decides it, so there is nothing for two readers to disagree about.
+///
+/// # One primary link, derived and never stored
+///
+/// The card shows a single link; the precedence is **artifact > workflow >
+/// trace**, and anything beyond the first is reached through the task detail.
+/// That primary is computed from this record at render time and deliberately
+/// *not* persisted as a field, so it can never contradict the list it was
+/// derived from. The console owns that derivation
+/// (`frontend/src/api/tasks.ts`); this record owns the facts it derives from.
+///
+/// Additive on the wire, like [`TaskRecord::origin_chat_id`] and
+/// [`TaskRecord::parent_task_id`]: every backend stores a card as a JSON blob
+/// (`task_json` on sqlite, a document on MongoDB, a JSON array in the fs
+/// bundle), so this needs **no migration** and a card written before it existed
+/// loads with `None`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskOutput {
+    /// The attempt that produced it — always present, and the link of last
+    /// resort (see the type's docs).
+    pub run_id: String,
+    /// That attempt's 1-based ordinal, for the operator-facing label
+    /// (*"attempt 2"*).
+    ///
+    /// `None` when the run row could not be read at stamp time. The ordinal is
+    /// a label, never an identity: `run_id` addresses the attempt either way, so
+    /// a failed read costs a nicety and never a link.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attempt: Option<u32>,
+    /// Epoch-millis the stamp was written (the moment the attempt settled).
+    pub at_millis: u64,
+    /// Every artifact the attempt published, pinned at the version it wrote.
+    ///
+    /// Bounded by what the agent explicitly published — one entry per
+    /// `publish_artifact` call, typically one to three. Empty is the trace case.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<TaskOutputArtifact>,
+    /// Every workflow the attempt ran or authored.
+    ///
+    /// Only ever non-empty for an orchestrator-desk card: `run_workflow` and
+    /// `create_workflow` are orchestrator-only tools, so a card worked by any
+    /// other teammate cannot produce one. That is a real limit of the
+    /// correlation, not of the record.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub workflows: Vec<TaskOutputWorkflow>,
+}
+
+/// One published deliverable, pinned to the exact revision this attempt wrote.
+///
+/// # Why the version is part of the link
+///
+/// Artifact versions are append-only and an operator edit is *a new version by
+/// a different author* ([`ArtifactRecord`](crate::ports::artifacts::ArtifactRecord)),
+/// so a `(artifact_id, version)` pair can never dangle and never silently start
+/// meaning something else. A link to the record alone would quietly re-point at
+/// whatever a human last wrote, which is exactly the case epic #183 §6 asks to
+/// keep truthful: *a task whose output was later edited by a human still
+/// resolves, and says so.* Pinning is what makes the "says so" possible — the
+/// console can compare the pinned version against the latest and name the
+/// difference.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskOutputArtifact {
+    /// The artifact record's id.
+    pub artifact_id: String,
+    /// The 1-based revision this attempt wrote.
+    pub version: u32,
+    /// The artifact's display title, copied so the card can label its link
+    /// without a second read on every board poll.
+    pub title: String,
+    /// What it holds, so the console picks a renderer without opening it.
+    pub kind: ArtifactKind,
+}
+
+/// What an attempt did with a workflow.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TaskOutputAction {
+    /// It executed the graph.
+    Ran,
+    /// It authored and saved the graph.
+    Created,
+}
+
+impl TaskOutputAction {
+    /// The stable wire word, for logs.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TaskOutputAction::Ran => "ran",
+            TaskOutputAction::Created => "created",
+        }
+    }
+}
+
+/// A workflow the attempt ran or built.
+///
+/// # Deliberately **not** pinned to a graph revision
+///
+/// Unlike an artifact, a workflow graph mutates in place — there is no version
+/// history to pin to, and inventing one would mean snapshotting graphs on every
+/// edit, which this codebase does not do. So the link opens the workflow *as it
+/// is now*, and when the attempt actually executed it, [`Self::run_id`] opens
+/// the run overlay showing what really ran. That is the honest limit: a graph
+/// edited after the fact will not match the run, and the run record is what
+/// says what happened. Naming that beats hiding it behind a link that pretends
+/// to be pinned.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskOutputWorkflow {
+    /// The workflow's id (its `workflows/<id>.toml` stem).
+    pub workflow_id: String,
+    /// The workflow run this attempt started, when it ran one. `None` for a
+    /// workflow the attempt only authored — nothing has executed yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    /// Whether the attempt ran it or created it.
+    pub action: TaskOutputAction,
+}
+
 /// One card on the company's task board.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -293,6 +448,22 @@ pub struct TaskRecord {
     /// board needs migrating.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_task_id: Option<String>,
+    /// What the card's latest **successful** attempt produced (issue #339) —
+    /// the link that turns a finished card into something you can open.
+    ///
+    /// Written by the dispatch settle and only when the attempt reached its
+    /// success terminal; a failed or cancelled settle leaves the previous stamp
+    /// alone, so a retry that fails never erases the link to the success before
+    /// it. See [`TaskOutput`] for which attempt wins and why nothing has to
+    /// choose at read time.
+    ///
+    /// `None` for a card that has never succeeded, for one moved to Done by
+    /// hand, and for every card settled before this field existed. Those degrade
+    /// to a link to the card itself rather than to a synthesized output —
+    /// fabricating an attempt id for a card that never recorded one would be a
+    /// lie about identity, which is the one thing the epic's link must not be.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output: Option<TaskOutput>,
 }
 
 /// Durable per-company task board. Company A's tasks MUST be invisible to
@@ -524,5 +695,115 @@ mod test {
         for column in BOARD_COLUMNS {
             assert_eq!(migrate_column(column.to_string()), column);
         }
+    }
+
+    fn plain_card() -> TaskRecord {
+        TaskRecord {
+            id: "t-1".to_string(),
+            title: "Draft the spec".to_string(),
+            note: None,
+            column: COLUMN_IN_REVIEW.to_string(),
+            priority: "medium".to_string(),
+            assignee: "maya".to_string(),
+            updated_at_millis: 7,
+            origin_chat_id: None,
+            parent_task_id: None,
+            output: None,
+        }
+    }
+
+    /// Issue #339: the whole stamp round-trips as camelCase, and — the part
+    /// that matters — a card written before it existed still loads, with
+    /// `None`. All three backends persist a card as an opaque JSON blob, so a
+    /// `#[serde(default)]` field is the entire migration.
+    #[test]
+    fn an_output_stamp_round_trips_and_is_absent_on_a_legacy_card() {
+        let mut card = plain_card();
+        card.output = Some(TaskOutput {
+            run_id: "run-2".to_string(),
+            attempt: Some(2),
+            at_millis: 99,
+            artifacts: vec![TaskOutputArtifact {
+                artifact_id: "a-1".to_string(),
+                version: 3,
+                title: "Launch spec".to_string(),
+                kind: ArtifactKind::Markdown,
+            }],
+            workflows: vec![TaskOutputWorkflow {
+                workflow_id: "digest".to_string(),
+                run_id: Some("wf-run-1".to_string()),
+                action: TaskOutputAction::Ran,
+            }],
+        });
+
+        let json = serde_json::to_string(&card).expect("serialize");
+        assert!(json.contains(r#""runId":"run-2""#), "{json}");
+        assert!(json.contains(r#""artifactId":"a-1""#), "{json}");
+        assert!(json.contains(r#""action":"ran""#), "{json}");
+        assert_eq!(card, serde_json::from_str(&json).expect("round trip"));
+
+        // Exactly the blob a pre-#339 build persisted: no `output` key at all.
+        let legacy = r#"{
+            "id": "t-1",
+            "title": "Draft the spec",
+            "column": "done",
+            "priority": "medium",
+            "assignee": "maya",
+            "updatedAtMillis": 7
+        }"#;
+        let loaded: TaskRecord = serde_json::from_str(legacy).expect("a legacy card parses");
+        assert_eq!(
+            loaded.output, None,
+            "a card that never recorded an attempt must not be given a synthesized one"
+        );
+        // And an unstamped card carries no empty scaffolding on the wire.
+        let round_tripped = serde_json::to_string(&loaded).expect("serialize");
+        assert!(!round_tripped.contains("output"), "{round_tripped}");
+    }
+
+    /// The trace case, pinned as its own test because it is the acceptance
+    /// criterion most easily lost: *"every card has a link including tasks that
+    /// produced no file."* An output with neither artifacts nor workflows is a
+    /// complete, valid stamp — the attempt is the deliverable — so `runId` must
+    /// survive a round trip on its own, with both lists omitted entirely.
+    #[test]
+    fn a_task_that_produced_no_file_still_carries_a_link() {
+        let mut card = plain_card();
+        card.output = Some(TaskOutput {
+            run_id: "run-1".to_string(),
+            attempt: Some(1),
+            at_millis: 5,
+            artifacts: Vec::new(),
+            workflows: Vec::new(),
+        });
+
+        let json = serde_json::to_string(&card).expect("serialize");
+        assert!(json.contains(r#""runId":"run-1""#), "{json}");
+        assert!(!json.contains("artifacts"), "{json}");
+        assert!(!json.contains("workflows"), "{json}");
+
+        let back: TaskRecord = serde_json::from_str(&json).expect("round trip");
+        let output = back.output.expect("the stamp survives with no deliverable");
+        assert_eq!(output.run_id, "run-1");
+        assert!(output.artifacts.is_empty());
+        assert!(output.workflows.is_empty());
+    }
+
+    /// The attempt ordinal is a label, not an identity: a stamp written when
+    /// the run row could not be read still addresses its attempt.
+    #[test]
+    fn an_unknown_attempt_ordinal_still_leaves_an_addressable_link() {
+        let output = TaskOutput {
+            run_id: "run-9".to_string(),
+            attempt: None,
+            at_millis: 5,
+            artifacts: Vec::new(),
+            workflows: Vec::new(),
+        };
+        let json = serde_json::to_string(&output).expect("serialize");
+        assert!(!json.contains("attempt"), "{json}");
+        let back: TaskOutput = serde_json::from_str(&json).expect("round trip");
+        assert_eq!(back.run_id, "run-9");
+        assert_eq!(back.attempt, None);
     }
 }

--- a/src/runtime/advance.rs
+++ b/src/runtime/advance.rs
@@ -143,6 +143,7 @@ mod test {
             updated_at_millis: 1,
             origin_chat_id: None,
             parent_task_id: None,
+            output: None,
         }
     }
 

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1403,6 +1403,12 @@ impl RuntimeBuilder {
                                 mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
                                 pending_publishes:
                                     crate::harness::publish::PendingPublishQueue::default(),
+                                // Issue #339: the workflow half of a card's
+                                // output link, staged by the orchestrator's
+                                // workflow tools and drained by the same
+                                // dispatch settle that drains the publishes.
+                                workflow_refs:
+                                    crate::harness::workflow_refs::WorkflowRefQueue::default(),
                                 // Issue #243: share the runtime's grant set, so a
                                 // grant the runtime mints on approve is the one
                                 // this agent's policy redeems on re-issue.

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -2442,6 +2442,7 @@ mod test {
             updated_at_millis: 1,
             origin_chat_id: None,
             parent_task_id: None,
+            output: None,
         };
 
         let first_boot = RuntimeBuilder::new(home.clone(), manifest.clone())

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1566,6 +1566,9 @@ impl<'a> CycleHostImpl<'a> {
             // is a chat-turn delegation, so no task is in scope to be the
             // parent. Lineage is set through the task API's `parentTaskId`.
             parent_task_id: None,
+            // Nothing has run yet, so there is no deliverable to point at
+            // (issue #339). The first successful settle stamps it.
+            output: None,
         };
         self.rt.tasks().upsert(&self.company, &card).await?;
         Ok(ToolResult {
@@ -1654,6 +1657,9 @@ impl<'a> CycleHostImpl<'a> {
             // is a chat-turn delegation, so no task is in scope to be the
             // parent. Lineage is set through the task API's `parentTaskId`.
             parent_task_id: None,
+            // Nothing has run yet, so there is no deliverable to point at
+            // (issue #339). The first successful settle stamps it.
+            output: None,
         };
         self.rt.tasks().upsert(&self.company, &card).await?;
         Ok(ToolResult {
@@ -2145,6 +2151,9 @@ mod test {
                     updated_at_millis: 1,
                     origin_chat_id: None,
                     parent_task_id: None,
+                    // Nothing has run yet, so there is no deliverable to point at
+                    // (issue #339). The first successful settle stamps it.
+                    output: None,
                 },
             )
             .await
@@ -2198,6 +2207,9 @@ mod test {
                     updated_at_millis: 1,
                     origin_chat_id: None,
                     parent_task_id: None,
+                    // Nothing has run yet, so there is no deliverable to point at
+                    // (issue #339). The first successful settle stamps it.
+                    output: None,
                 },
             )
             .await
@@ -4751,6 +4763,9 @@ mod test {
                     updated_at_millis: 0,
                     origin_chat_id: None,
                     parent_task_id: None,
+                    // Nothing has run yet, so there is no deliverable to point at
+                    // (issue #339). The first successful settle stamps it.
+                    output: None,
                 },
             )
             .await
@@ -4813,6 +4828,9 @@ mod test {
                     updated_at_millis: 0,
                     origin_chat_id: None,
                     parent_task_id: None,
+                    // Nothing has run yet, so there is no deliverable to point at
+                    // (issue #339). The first successful settle stamps it.
+                    output: None,
                 },
             )
             .await

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -596,6 +596,9 @@ impl<'a> DelegationRunner<'a> {
                     // scope and still writes `None`; lineage for those is written
                     // through the task API's `parentTaskId` instead.
                     parent_task_id: self.task.clone(),
+                    // Nothing has run yet, so there is no deliverable to point
+                    // at (issue #339). The first successful settle stamps it.
+                    output: None,
                 };
                 tasks.upsert(self.company, &card).await?;
                 // Issue #246: report the card so the caller can surface it. The

--- a/src/server/graphql/tasks.rs
+++ b/src/server/graphql/tasks.rs
@@ -8,7 +8,21 @@ use super::pagination::Page;
 use crate::company::runtime::CompanyRuntime;
 use crate::ports::tasks::TaskRecord;
 
-/// One card on the company's task board. Mirrors [`TaskRecord`].
+/// One card on the company's task board. Mirrors [`TaskRecord`] — **partially,
+/// and on purpose**.
+///
+/// This projection is deliberately narrower than the REST `TaskCard`: it has
+/// never carried `parentTaskId`, `originChatId`, or the note-adjacent detail
+/// the console's screens read, because the GraphQL surface answers *"what is on
+/// the board"* rather than *"what happened to this card"*.
+///
+/// The output link (issue #339) is omitted for the same reason and is a real
+/// gap, named rather than hidden: it is a **console link** — it resolves to
+/// artifact-viewer and run-trace routes that only the operator console has —
+/// so projecting it here would publish addresses no GraphQL consumer can
+/// follow. A consumer that wants a card's deliverable should read the artifact
+/// and run surfaces directly. Widen this the day a GraphQL client needs the
+/// correlation itself rather than the link.
 #[derive(SimpleObject)]
 #[graphql(name = "Task")]
 pub struct TaskGql {

--- a/src/server/graphql/tasks.rs
+++ b/src/server/graphql/tasks.rs
@@ -8,21 +8,22 @@ use super::pagination::Page;
 use crate::company::runtime::CompanyRuntime;
 use crate::ports::tasks::TaskRecord;
 
-/// One card on the company's task board. Mirrors [`TaskRecord`] — **partially,
-/// and on purpose**.
-///
-/// This projection is deliberately narrower than the REST `TaskCard`: it has
-/// never carried `parentTaskId`, `originChatId`, or the note-adjacent detail
-/// the console's screens read, because the GraphQL surface answers *"what is on
-/// the board"* rather than *"what happened to this card"*.
-///
-/// The output link (issue #339) is omitted for the same reason and is a real
-/// gap, named rather than hidden: it is a **console link** — it resolves to
-/// artifact-viewer and run-trace routes that only the operator console has —
-/// so projecting it here would publish addresses no GraphQL consumer can
-/// follow. A consumer that wants a card's deliverable should read the artifact
-/// and run surfaces directly. Widen this the day a GraphQL client needs the
-/// correlation itself rather than the link.
+// This projection is deliberately narrower than the REST `TaskCard`, and every
+// doc comment in it lands verbatim in the committed SDL snapshot — so the
+// reasoning lives here, in plain comments, rather than bloating the published
+// schema.
+//
+// It has never carried `parentTaskId` or `originChatId`: the GraphQL surface
+// answers *"what is on the board"* rather than *"what happened to this card"*.
+//
+// The output link (issue #339) is omitted for the same reason, and it is a real
+// gap named rather than hidden: it is a **console link** — it resolves to
+// artifact-viewer and run-trace routes that only the operator console has — so
+// projecting it here would publish addresses no GraphQL consumer can follow. A
+// consumer that wants a card's deliverable reads the artifact and run surfaces
+// directly. Widen this the day a GraphQL client needs the correlation itself
+// rather than the link.
+/// One card on the company's task board. Mirrors [`TaskRecord`].
 #[derive(SimpleObject)]
 #[graphql(name = "Task")]
 pub struct TaskGql {

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -646,6 +646,7 @@ async fn tasks_page_reflects_upserts_and_column_filter() {
                 updated_at_millis: 1_700_000_000_000,
                 origin_chat_id: None,
                 parent_task_id: None,
+                output: None,
             },
         )
         .await

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1008,6 +1008,9 @@ async fn run_chat(
             updated_at_millis: crate::ports::now_millis(),
             origin_chat_id: None,
             parent_task_id: None,
+            // Nothing has run yet, so there is no deliverable to point at
+            // (issue #339). The first successful settle stamps it.
+            output: None,
         };
         if let Err(err) = runtime.upsert_task(&record).await {
             tracing::warn!(error = %err, "failed to open task card for chat request");

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1893,6 +1893,7 @@ mod test {
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),

--- a/src/server/ops/task_export/test.rs
+++ b/src/server/ops/task_export/test.rs
@@ -40,6 +40,11 @@ fn card(title: &str) -> TaskCard {
         updated_at: T0 + 600_000,
         parent_task_id: None,
         origin_chat_id: None,
+        // The export document is deliberately link-free (issue #339): it is
+        // read offline, by people who never saw the board, so a console hash
+        // route would be a dead address in it. The deliverable itself is what
+        // the export would have to carry, and that is a different change.
+        output: None,
     }
 }
 

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -82,6 +82,17 @@ pub(crate) struct TaskCard {
     /// shape is unchanged.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) origin_chat_id: Option<String>,
+    /// What the card's latest successful attempt produced (issue #339) — the
+    /// link that turns a finished card into something the operator can open.
+    ///
+    /// Rides the **board** read, not just task detail, because the link is
+    /// rendered on the card itself: a board that had to open every card to find
+    /// out what it produced would be N reads per poll. It is bounded — one
+    /// entry per published file, one per workflow — and omitted entirely for a
+    /// card that has never succeeded, so the existing wire shape is unchanged
+    /// for every card that carried no output before this.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) output: Option<crate::ports::tasks::TaskOutput>,
 }
 
 impl From<TaskRecord> for TaskCard {
@@ -96,6 +107,7 @@ impl From<TaskRecord> for TaskCard {
             updated_at: t.updated_at_millis,
             parent_task_id: t.parent_task_id,
             origin_chat_id: t.origin_chat_id,
+            output: t.output,
         }
     }
 }

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -312,6 +312,9 @@ async fn create_task(
             .map(|id| id.trim().to_string())
             .filter(|id| !id.is_empty()),
         parent_task_id: body.parent_task_id,
+        // Nothing has run yet, so there is no deliverable to point at
+        // (issue #339). The first successful settle stamps it.
+        output: None,
     };
     company.runtime.upsert_task(&record).await?;
     Ok(Json(record.into()))

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -587,6 +587,7 @@ async fn steer_task_validates_statuses_and_journals_acceptance() {
                 updated_at_millis: 1,
                 origin_chat_id: None,
                 parent_task_id: None,
+                output: None,
             },
         )
         .await
@@ -3175,6 +3176,7 @@ async fn task_detail_assembles_timeline_and_lineage() {
         updated_at_millis: 1,
         origin_chat_id: None,
         parent_task_id: parent.map(str::to_string),
+        output: None,
     };
     for t in [
         card("t-parent", "Parent", None),
@@ -3354,6 +3356,7 @@ fn discussion_card(id: &str, title: &str) -> TaskRecord {
         updated_at_millis: 1,
         origin_chat_id: None,
         parent_task_id: None,
+        output: None,
     }
 }
 
@@ -3755,6 +3758,7 @@ async fn task_export_serves_a_readable_document_and_alters_nothing() {
                 updated_at_millis: 1,
                 origin_chat_id: None,
                 parent_task_id: None,
+                output: None,
             },
         )
         .await
@@ -3867,6 +3871,7 @@ async fn task_timeline_scopes_approvals_to_the_run_window() {
                 updated_at_millis: 1,
                 origin_chat_id: None,
                 parent_task_id: None,
+                output: None,
             },
         )
         .await
@@ -3965,6 +3970,7 @@ async fn dispatched_task(
                 updated_at_millis: 1,
                 origin_chat_id: None,
                 parent_task_id: None,
+                output: None,
             },
         )
         .await
@@ -4408,6 +4414,7 @@ async fn a_second_task_in_the_same_window_does_not_absorb_the_first_s_approvals(
                 updated_at_millis: 1,
                 origin_chat_id: None,
                 parent_task_id: None,
+                output: None,
             },
         )
         .await

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -488,6 +488,95 @@ async fn a_task_created_from_a_thread_remembers_and_reads_back_that_thread() {
     assert!(blank.get("originChatId").is_none(), "{blank}");
 }
 
+/// Issue #339: the card's output link reaches the console on **both** reads.
+///
+/// The board read matters as much as task detail here, and that is the whole
+/// point: the link is rendered on the card, so a board that had to open every
+/// card to discover what it produced would cost N reads per four-second poll.
+///
+/// A card that never succeeded omits the key entirely rather than sending
+/// `null`, so the pre-#339 wire shape is unchanged for every card the board
+/// created — which is also what the console reads as "link to the card itself".
+#[tokio::test]
+async fn a_stamped_card_hands_its_output_link_to_both_reads() {
+    use crate::ports::artifacts::ArtifactKind;
+    use crate::ports::tasks::{
+        TaskOutput, TaskOutputAction, TaskOutputArtifact, TaskOutputWorkflow,
+    };
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+
+    // A card the board created: no attempt has run, so no link.
+    let (_, plain) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks",
+        Some(json!({"title": "Typed on the board"})),
+    )
+    .await;
+    assert!(
+        plain.get("output").is_none(),
+        "a card that never succeeded must not grow the key: {plain}"
+    );
+    let id = plain["id"].as_str().unwrap().to_string();
+
+    // Stamp it the way a successful settle does, through the plain store port.
+    let company = CompanyId::new("acme");
+    let runtime = state.registry().get(&company).unwrap();
+    let mut card = runtime
+        .tasks()
+        .list(&company)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|t| t.id == id)
+        .expect("card");
+    card.output = Some(TaskOutput {
+        run_id: "run-2".to_string(),
+        attempt: Some(2),
+        at_millis: 42,
+        artifacts: vec![TaskOutputArtifact {
+            artifact_id: "a-1".to_string(),
+            version: 3,
+            title: "Launch spec".to_string(),
+            kind: ArtifactKind::Markdown,
+        }],
+        workflows: vec![TaskOutputWorkflow {
+            workflow_id: "digest".to_string(),
+            run_id: Some("wf-1".to_string()),
+            action: TaskOutputAction::Ran,
+        }],
+    });
+    runtime.tasks().upsert(&company, &card).await.unwrap();
+
+    // The board read — the one the card's own link is rendered from.
+    let (_, board) = send(&state, "GET", "/api/v1/company/tasks", None).await;
+    let listed = board
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["id"] == json!(id))
+        .expect("the card is on the board");
+    assert_eq!(listed["output"]["runId"], "run-2");
+    assert_eq!(listed["output"]["attempt"], 2);
+    assert_eq!(listed["output"]["artifacts"][0]["artifactId"], "a-1");
+    assert_eq!(
+        listed["output"]["artifacts"][0]["version"], 3,
+        "the link must carry the version the run wrote, not just the record"
+    );
+    assert_eq!(listed["output"]["artifacts"][0]["kind"], "markdown");
+    assert_eq!(listed["output"]["workflows"][0]["workflowId"], "digest");
+    assert_eq!(listed["output"]["workflows"][0]["action"], "ran");
+
+    // …and task detail, where the operator opens what the link points at.
+    let (status, detail) = send(&state, "GET", &format!("/api/v1/company/tasks/{id}"), None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(detail["task"]["output"]["runId"], "run-2");
+    assert_eq!(detail["task"]["output"]["artifacts"][0]["version"], 3);
+}
+
 /// Issue #246 spend gate, at the HTTP boundary. The transcript's "Add to
 /// board" action omits `column` on purpose so the *server* decides where a
 /// chat-created card lands — and the one thing that must never happen is that

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -701,6 +701,7 @@ pub async fn assert_task_store(tasks: Arc<dyn TaskStore>) {
         updated_at_millis: at,
         origin_chat_id: None,
         parent_task_id: None,
+        output: None,
     };
 
     tasks.upsert(&alpha, &task("t1", "todo", 1)).await.unwrap();

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -517,6 +517,7 @@ description = "Runs Acme."
             workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
             mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
             pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
             approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
             secrets: None,
             web_allowed_domains: Vec::new(),


### PR DESCRIPTION
## Summary

Epic #183 §6, the last station: **a card that finished now carries a link to what it produced.**

Until now a task that reached the end of the spine ended as a chat message. Every ingredient existed — attempts are first-class records, a published file is a versioned artifact whose versions carry the producing run id, the completion event carries the artifact ids — but nothing tied any of it to the *card*, and the console could not address an artifact, a run trace or a workflow by URL at all. The deliverable was a transcript.

A successful settle now stamps the card with a `TaskOutput`: the attempt that produced the result, any artifacts it published **pinned at the version that run wrote**, and any workflows it ran or built. The board renders one link per finished card, and that link opens the thing rather than the conversation.

Closes #339.

### The three design answers, as shipped

**One link or several.** One primary on the card, precedence **artifact > workflow > trace**, with `+N more` into the task detail. The stamp stores the full bounded set (publishing is explicit and per-file, so one to three entries in practice); the primary is *derived* at render time and deliberately never persisted, so it cannot disagree with the list it came from. That derivation lives in exactly one place — `frontend/src/lib/task-output.ts`.

**Which attempt.** The latest successful one, **by construction rather than by query**: only a settle that reached its success terminal writes the stamp, and a later success overwrites it wholesale. So a retried task links to the success, a failed retry never erases the link to the success before it, earlier attempts stay reachable through the card's own attempt list, and no read-time join has to pick a winner.

**After the thing changes.** Artifact links are `(artifactId, version)`-pinned. Versions are append-only and an operator edit appends a new one, so a pinned link can never dangle and never quietly starts meaning something else. When the pinned version is behind the latest, the artifact viewer says so in words — *"Showing v1 — the version this run produced. v2 exists, edited by operator"* — with one click to the latest. Workflow links are deliberately **not** pinned (see Impact).

## Problem

- `TaskRecord` had no output field, so the board had nothing to render and no way to know what a card produced.
- Workflow runs carry **zero** task correlation by design (`WorkflowRunFinished` has no task id), so a card that built or ran a workflow could not be joined to it after the fact.
- The console's only deep link was `#/tasks/<id>`. The artifact viewer, the run-trace drawer and the workflow canvas were all component-state-only — nothing about a deliverable was addressable.
- Most sharply: *"no artifact"* had no answer at all. A task that sent a message or updated a record produced nothing to file, and the obvious implementation gives those cards no link.

## Solution

**Host**

- `ports/tasks.rs` — `TaskOutput { runId, attempt?, atMillis, artifacts[], workflows[] }` on `TaskRecord`, additive with `#[serde(default)]`. Every backend stores a card as a JSON blob, so this needs **no migration** and a pre-#339 card loads with `None`.
  `runId` is **unconditional**, and that is the whole design: an output with no artifacts and no workflows is not an absence, it is the *trace case* — the attempt **is** the deliverable. That is what stops "no artifact" degrading into "no link", and it is the fallback if an artifact is later deleted.
- `harness/workflow_refs.rs` (new) — the correlation has to be captured at the moment a tool runs inside a dispatch, because it cannot be joined afterwards. Tools are built once per agent while the card varies per dispatch, so `run_workflow` / `create_workflow` stage a reference on a shared queue the brain drains at the settle — the `PendingPublishQueue` pattern exactly. The queue collapses repeats (one entry per workflow; a run beats a create because a run can show what actually executed) and caps the list so a runaway turn cannot turn a board poll into a payload.
- `harness/brain.rs` — the settle reorder. Artifact recording and the workflow drain now run **before** the card's single write, because the link names artifact versions that do not exist until they are written. `push_version`'s return value — discarded until now — is what pins each link to the exact revision this run produced.
- `server/ops/tasks.rs` — `TaskCard` gains `output`, so it rides the **board** read and not only task detail.

**Console**

- One compact link row on each card, with per-kind icons and `stopPropagation` so it does not double-fire the card's own open handler.
- Task detail's tabs became controlled so a link can land on one; the artifact opens pinned, the run drawer opens on the named attempt.
- The Workflows canvas became addressable (`#/workflows/<id>`, plus `?run=<runId>` for the past-run overlay).

## Submission Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings` (default lane, the one CI runs)
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — **2126 passed, 0 failed**
- [x] `cargo test --locked --lib` — **1455 passed, 0 failed**
- [x] `cargo check --locked --all-features --all-targets`
- [x] `git diff --stat Cargo.lock` — empty
- [x] Console: `npm ci`, `npm run typecheck`, `npm run typecheck:e2e`, `npm run build` (there is no lint script in this repo, so none is claimed)
- [x] Verified manually in a browser against a running host — see below

### Verified in a real browser, not only in tests

A `cargo`-built host serving the built console (`companies/e2e_harness`, fs store), driven with Playwright. All four acceptance cases, plus the operator-edit round trip performed **through the UI** rather than seeded:

| # | Case | Result |
|---|---|---|
| 1 | A publishing card → link opens the artifact **pinned at v1** | Landed on the Artifacts tab with `launch.md` open at v1. Banner read *"Showing v1 — the version this run produced. v2 exists, edited by operator."* One click reached the latest, and the banner correctly retired once the reader had moved off the pin. |
| 2 | A card that produced **no file** | Link opened the Attempts tab with attempt 2's trace drawer showing its steps. |
| 3 | An orchestrator card that ran a workflow | Link switched views and painted that workflow's graph on the canvas. |
| 4 | A card with **no recorded attempt** (legacy / hand-dragged) | Degraded to *"Open this task"* rather than to nothing. |
| 5 | Human edit **after** the run | Opened an untouched deliverable via its pinned link (no banner, correctly), clicked *Edit as operator*, saved a new version, reopened the same link: still resolves to v1, now says *"v2 exists, edited by operator"*, with the churn diff below. Zero console errors. |

Board state as rendered: every card in In review and Done carried a link — `View run trace · attempt 2`, `Open launch.md +1 more`, `Open this task`, `Open workflow weekly_digest`. An unplanned confirmation came from three stray cards other Playwright specs had left on that board: never dispatched, no attempt, and each correctly showing `Open this task` rather than nothing.

I also ran the **whole existing Playwright suite** against that host: 68 passed, 7 failed. I then rebuilt the console from base `e11bf7f` and re-ran those 7 against the identical host — **they fail identically on base**. All seven need a mocked LLM backend or a company with source-defined workflows, neither of which my local host had. No regression.

All five cases were re-run after the rebase onto current `main` (below), against a freshly built host and console. Still green.

New automated coverage: 6 end-to-end brain tests driving a real dispatch (real `HarnessPool`, real `build_agent`, real turn loop, real fs stores; only the model's choices scripted) covering the pinned stamp, the trace case, the re-run re-pin, the failed-retry non-erasure, the operator-edit pin, and the no-attempt-row case; plus queue, tool and REST-boundary tests.

## Impact

**What degrades, and how**

- **Legacy and hand-dragged cards.** *"Every card in Done has a link"* is not achievable in the strong sense for cards settled before this or dragged to Done by a person: nothing recorded an attempt for them. They fall back to a link to the card itself. Synthesizing an attempt id would be a lie about identity, which is the one thing this link must not be.
- **Deleted artifacts.** The card's own link falls back to the trace (this is why `runId` is unconditional). Arriving from an older copy of an address lands on the artifact list with a line saying the target is gone.
- **Workflow links are not pinned to a graph revision.** Graphs mutate in place and there is no version history to pin to; pinning would need graph snapshots this codebase does not take. The link opens the workflow *as it is now*, and `runId` opens the overlay showing what actually ran. A graph edited after the fact will not match the run — stated rather than hidden.
- **Workflow correlation is orchestrator-only.** `run_workflow` and `create_workflow` are orchestrator-only tools, so a card worked by any other teammate can never carry a workflow link.
- **A dispatch with no attempt row stamps nothing** (fail-silent, not fail-closed): the deliverable is still recorded, only the card's link is missing — the same direction `runs: None` already takes.
- **The export document stays link-free.** It is read offline by people who never saw the board, so a console route would be a dead address in it. Carrying the deliverable itself is a different change.
- **GraphQL keeps its narrower `Task` projection.** The link resolves to console routes no GraphQL consumer can follow. Reasoning is beside the code rather than in the published SDL.

**Where the plan was wrong, and what I did instead**

1. **The routes.** The plan specified `#/tasks/<id>/artifacts/<artifactId>/<version>`. That cannot work: `use-hash-view.ts`'s `canonicalize()` runs on every `hashchange` and `replaceState`s the URL down to at most `head/sub` — **two segments** — so a third segment is silently replaced away before anything can read it. The links would have appeared to work and then not. Shipped as hash **query strings** (`#/tasks/<id>?artifact=<id>&v=<n>`), which survive untouched because `readSegments()` strips everything after `?` before that comparison and `canonicalize` then early-returns. Written down at both sites that rely on it, because the obvious "tidy-up" is to convert them back to path segments.
2. **`readTaskDetailId` needed no change.** The plan expected to extend it to sub-routes; it already splits on `[/?]`, so the query form works as-is.
3. **`attempt` cannot be free.** The plan typed it `u32`. Its only cheap source is `finish_run`'s return value, which lands *after* the card is written — harvesting it would put the run row's terminal status ahead of the board's, contradicting an ordering #242 chose deliberately. It is a best-effort `get_run` and therefore `Option<u32>`, documented as a **label, never an identity**: `runId` addresses the attempt regardless, so a read fault costs the words "attempt 2" and never the link.
4. **Artifact recording had to become non-fatal.** The plan called this out and it is worth restating: above the card upsert, a propagated store fault would skip the card write and strand a finished card in `in_progress` with nothing to re-dispatch it. It now logs at `error` and settles anyway. #244's "errors propagate" intent is preserved *in the function*; the ordering change is what moved where the failure stops.
5. **No `PendingWorkflowRef` type.** Unlike a publish (which needs id-minting and versioning), a workflow reference is complete at push time, so the queue stages the wire type directly.
6. **A dropped scope item.** The plan proposed a Rust-side primary-link helper. Precedence is implemented in TypeScript only — one implementation site beats a hand-maintained two-language mirror, and nothing on the host needs the choice.

**Pushback on the issue, which I accept and shipped**

Success does **not** land in Done. `Succeeded → in_review`; Done is reached only by a person. So the stamp is written at *settle*, not at Done-entry, and the link row renders on **In review as well as Done** — which is where a card with output spends the stretch while somebody decides whether to accept the work and needs to read it.

**Rebased onto current `main`** after #374, #411, #409, #403, #410, #407/#412 and #303 landed. Two conflicts, both resolved in main's favour rather than mine:

- `harness/mod.rs` — a pure ordering collision with #409's new test module; both kept.
- `WorkflowsView.tsx` — #303 moved the layout constants into `workflows/graph.ts` (mine dropped) and, more usefully, had already introduced **`runsFor`** for exactly what my `runsLoadedFor` was tracking: which workflow the loaded run history belongs to. I deleted my duplicate state and read theirs, so the deep link and the copilot share one signal instead of two that can disagree.

The rebase also brought in two feature-gated fixtures this branch had never compiled (`workspace_provision_turn_test`, and `composio_turn_test`, which only builds under `--all-features`); both widened mechanically in their own commit.

**Incidental finding, not fixed here:** the Workflows picker renders blank while the canvas paints correctly. I confirmed this reproduces on base `e11bf7f` — it is pre-existing and out of scope for this PR.

## Related

Closes #339. Epic #183 §6. Builds on #242 (attempts), #244 (`publish_artifact`), #337 (a settled run moves its card), #307 (version rail and human-edit diff).
