### PR TITLE
feat(chat): threads, reactions and message ids that outlive the browser (#364)

### DIFF
--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -19,6 +19,9 @@ POST   /api/v1/companies                       boot from an uploaded manifest (p
 GET    /api/v1/companies/{id}                  status: charter, roster, budget burn,
                                                lifecycle state, tiny.place state
 POST   /api/v1/companies/{id}/chat             operator message → event; SSE reply stream
+GET    /api/v1/companies/{id}/chat/history     one desk's transcript (?desk=<thread>)
+POST   /api/v1/companies/{id}/chat/messages/{seq}/reactions
+                                               { "emoji": "👍", "on": true } → 204
 GET    /api/v1/companies/{id}/events?since=SEQ SSE stream of events/effects (work feed)
 GET    /api/v1/companies/{id}/approvals        pending approvals
 POST   /api/v1/companies/{id}/approvals/{aid}  { "verdict": "approve"|"deny", "note": "…",
@@ -277,6 +280,29 @@ scope; SSE (`/chat` streaming, the `/events` work feed) is not yet wired.
      catch-all applies only when General is the desk being *read*. So an
      addressed thread is isolated from the team's chat in both directions.
   3. `GET /chat/history?desk=<thread>` therefore replays exactly that thread.
+
+- **A message has a durable id, and things can refer to it (issue #364).**
+  `POST /chat` answers with `messageId` — the sequence position the operator's
+  own message was journaled under — and stamps the same on each reply bubble.
+  Two things name a message by that id:
+
+  - The `parent` field on the `/chat` body makes the send a **thread reply**.
+    It is journaled onto both the `OperatorMessage` and the replies it draws,
+    so the whole exchange comes back under the same row on the next read. A
+    `parent` that is not a message id is a `400`, never a silently-flattened
+    thread — a reply that quietly lands in the channel reads as a lost reply.
+  - `POST /chat/messages/{seq}/reactions` sets or clears **one person's** one
+    reaction. `on` is explicit rather than a toggle, which is what makes a
+    retry or a double tap idempotent. The target must be a chat message —
+    anything else is a `404`, so the log can never hold a reaction no reader
+    could render — and the emoji is bounded and refused if it carries control
+    characters. Authorized through the same gate a send passes: reacting is
+    writing into a transcript, so it can be neither easier nor harder than
+    saying something in it.
+
+  Both project through the shared `MessageView`, so REST and GraphQL cannot
+  disagree about the shape of a thread or who reacted. Reactions are
+  deliberately absent from the `/events` stream — see [events.md](events.md).
 
   The copilot addresses `workflow-copilot:<workflowId>` (a `:` cannot occur in
   a manifest desk id, so it can never collide with a real desk, and it does not

--- a/docs/spec/runtime/events.md
+++ b/docs/spec/runtime/events.md
@@ -90,6 +90,39 @@ break the byte-identical round-trip, so the claim is incomplete but never wrong.
 Both `chat/history` surfaces (REST and GraphQL) project it from the shared
 `MessageView`, so the chip survives a transcript reload on either.
 
+### Threads and reactions (issue #364)
+
+A transcript survived a reload; the structure *on* it did not.
+
+**A thread is a parent id, not an object.** `OperatorMessage` and `AgentReply`
+each gain `parent: Option<EventSeq>` — the position of the message replied to. A
+thread object would need a lifecycle, a membership, and a second addressing
+scheme beside `chat`, for zero rendering benefit: the console already folds a
+transcript by parent, so a thread *is* "the messages pointing at this one". The
+answer to a threaded question takes the **same parent as the question** — both
+halves belong under the row the thread hangs off, and pointing the answer at the
+question would nest a thread inside a thread.
+
+**A reaction is a per-person row, event-sourced.** `ReactionToggled
+{ message_seq, emoji, on, by }`. A count answers neither question the console
+asks — *who* reacted, and *have I* — and a mutable tally cannot live on an
+append-only log. Reads fold the last event per `(message, actor, emoji)`; a row
+that ends `off` is dropped, not kept as a zero. `on` is explicit, which is what
+makes the route idempotent under a retry or two consoles racing.
+
+`OutboundMessage` gains `message_id`, stamped by the chat route **after**
+journaling — a brain emits an answer, it does not know where it will land in the
+log. It is the enabler for both: before it, a sent bubble had only a
+browser-minted counter, so anything durable naming it named nothing.
+
+All three are additive on the terms above, and **nothing is migrated or
+backfilled**: a pre-#364 message loads unparented, which is the truth about it.
+`ReactionToggled` is **deliberately not projected** onto `/events` — the frame
+would have to carry the reacting person and that stream has no per-viewer
+projection to resolve an actor into a label. Pinned by a test rather than left
+to the deny-by-default fall-through, so a later decision to stream reactions is
+made out loud.
+
 ### Per-task approval correlation (issue #333)
 
 `ApprovalResolved` carries an id, a verdict and an actor — never a task — so

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -219,10 +219,43 @@ export class OpenCompanyClient {
    * unknown ids fall to the orchestrator, so callers can always pass the active
    * thread id safely.
    */
-  chat(text: string, company?: string | null, chat?: string | null): Promise<ChatResponse> {
-    const body: { text: string; chat?: string } = { text };
+  chat(
+    text: string,
+    company?: string | null,
+    chat?: string | null,
+    /**
+     * The host-side id of the message being replied to, making this a thread
+     * reply rather than a new line in the channel (issue #364). Never a console
+     * id — callers strip the `h` prefix with `toHostMessageId` first.
+     */
+    parent?: string | null,
+  ): Promise<ChatResponse> {
+    const body: { text: string; chat?: string; parent?: string } = { text };
     if (chat) body.chat = chat;
+    if (parent) body.parent = parent;
     return this.request<ChatResponse>("POST", `${this.scope(company)}/chat`, body);
+  }
+
+  /**
+   * Set or clear one reaction on one message (issue #364).
+   *
+   * `on` is explicit rather than a toggle so the call is idempotent: a retry or
+   * a double tap converges on what the caller asked for instead of flipping
+   * twice. `messageSeq` is the host-side id (no `h` prefix). Hosts that predate
+   * the route return 404 — callers roll their optimistic change back and say
+   * the host can't keep reactions.
+   */
+  reactToMessage(
+    messageSeq: string,
+    emoji: string,
+    on: boolean,
+    company?: string | null,
+  ): Promise<void> {
+    return this.request<void>(
+      "POST",
+      `${this.scope(company)}/chat/messages/${encodeURIComponent(messageSeq)}/reactions`,
+      { emoji, on },
+    );
   }
 
   /**

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -148,6 +148,13 @@ export interface OutboundMessage {
    * wrong. The bubble's `steps` timeline still shows every spawn.
    */
   taskId?: string;
+  /**
+   * The durable id this reply was journaled under (issue #364) — the id
+   * `chat/history` will return for it. Absent on a reply the host could not
+   * journal, and on a host that predates the field; either way the console
+   * treats the bubble as un-threadable rather than inventing an id for it.
+   */
+  messageId?: string;
 }
 
 /** Channel-specific reply addressing. Mirrors `ReplyTo` in `src/ports/types.rs`. */
@@ -231,11 +238,38 @@ export interface ChatHistoryMessageDto {
    * renders identically whichever surface hydrated the transcript.
    */
   taskId?: string;
+  /**
+   * The message this one replies to (issue #364), by that message's own `id`.
+   * Absent for a message posted straight into the channel — which is every
+   * message journaled before threads were persisted.
+   */
+  parentId?: string;
+  /**
+   * Who reacted to this message with what (issue #364), one row per person per
+   * emoji. Absent when nobody has, and on a host that predates the field.
+   */
+  reactions?: ChatReactionDto[];
+}
+
+/** One person's reaction. Mirrors `ChatReactionDto` in `src/server/operator.rs`. */
+export interface ChatReactionDto {
+  emoji: string;
+  /** Who reacted, as a display label — never a raw user id. */
+  by: string;
+  /** Whether the reading viewer is the one who reacted. */
+  mine: boolean;
 }
 
 /** Response of `/chat` and approval-resolution routes. */
 export interface ChatResponse {
   responses: OutboundMessage[];
+  /**
+   * The durable id the operator's own message was journaled under (issue #364)
+   * — the id `chat/history` will return for it. Absent on a host that predates
+   * the field, which the console reads as "this message cannot be threaded or
+   * reacted to" rather than guessing an id.
+   */
+  messageId?: string;
 }
 
 /** One parked approval from `/approvals`. */

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -45,7 +45,7 @@ import { type AgentReplyEvent, type CompanyStreamEvent, useEvents } from "@/hook
 import { useHashView } from "@/hooks/use-hash-view";
 import { toast } from "sonner";
 
-import { type ChatMessage, fromHistory, makeMessage } from "@/lib/chat";
+import { type ChatMessage, fromHistory, hostMessageId, makeMessage } from "@/lib/chat";
 import { CONNECTION_PROVIDERS } from "@/lib/connections";
 import { defaultDesks, type Desk } from "@/lib/desks";
 import { writeLastChannel } from "@/lib/last-channel";
@@ -643,6 +643,11 @@ export function AppShell({
             makeMessage("company", event.text, {
               channel: event.agentId,
               taskId: event.taskId,
+              // Issue #364: a reply to a thread joins that thread live, instead
+              // of appearing in the channel and moving on the next reload. The
+              // host names the parent by its own id, so it takes the same
+              // namespace prefix a hydrated line does.
+              parentId: event.parentId ? hostMessageId(event.parentId) : undefined,
             }),
           ],
         };

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -24,6 +24,12 @@ export type CompanyStreamEvent =
        * chat reply.
        */
       taskId?: string;
+      /**
+       * The message this reply belongs under (issue #364) — its thread inside
+       * the channel. Absent for a reply in the channel itself, and on a host
+       * that predates persisted threads.
+       */
+      parentId?: string;
     }
   | { type: "task_dispatched"; seq: number; atMillis: number; taskId: string }
   | { type: "task_steered"; seq: number; atMillis: number; taskId: string; action: string }
@@ -151,6 +157,12 @@ export interface AgentReplyEvent {
   text: string;
   /** The board card this reply opened (issue #246), when it opened one. */
   taskId?: string;
+  /**
+   * The **host-side** id of the message this reply belongs under (issue #364).
+   * Namespaced into a console id by the injector, which is what knows about the
+   * `h` prefix.
+   */
+  parentId?: string;
 }
 
 interface Options {
@@ -359,6 +371,9 @@ function handleEvent(
         // not POST for, e.g. an inbound Telegram turn — carries its "card
         // opened" chip too, rather than only the locally-awaited copy.
         taskId: event.taskId,
+        // Issue #364: and lands in the same thread a reload would put it in,
+        // rather than arriving in the channel and jumping on the next refresh.
+        parentId: event.parentId,
       });
       break;
     // Issue #379. No toast: the rising-edge "needs a sign-off" toast off the

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -1,5 +1,14 @@
 import type { ChatHistoryMessageDto, TurnStep } from "@/api/types";
 
+/** One person's reaction on one line. Mirrors `ChatReactionDto` on the host. */
+export interface Reaction {
+  emoji: string;
+  /** Who reacted, as a display label — never a raw user id. */
+  by: string;
+  /** Whether the reader is the one who reacted. */
+  mine: boolean;
+}
+
 /** One line in the conversation with the company. */
 export interface ChatMessage {
   id: string;
@@ -15,10 +24,21 @@ export interface ChatMessage {
   /**
    * The message this one replies to. A line with a parent is a thread reply:
    * it stays out of the channel timeline and renders inside the thread panel.
+   *
+   * Always another line's `id`, so it moves with {@link reconcileIds} when an
+   * optimistic id is replaced by the durable one the host assigned.
    */
   parentId?: string;
-  /** Emoji → count. Absent until someone reacts. */
-  reactions?: Record<string, number>;
+  /**
+   * Who reacted to this line with what — one row per person per emoji, not a
+   * count (issue #364).
+   *
+   * A count could not say who reacted, and could not tell the reader whether
+   * one of the reactions was their own, which is what makes a chip a toggle.
+   * The renderer groups these into chips; nothing groups a count back into
+   * people. Absent until someone reacts.
+   */
+  reactions?: Reaction[];
   /**
    * The scrubbed processing steps behind a company reply (tool calls, thinking,
    * surfaced failures), rendered as a timeline above the bubble. Absent/empty
@@ -67,7 +87,14 @@ export function titleFromMessage(text: string): string {
 let seq = 0;
 const nextId = () => `m${seq++}`;
 
-/** Build a stamped message. `at` is injected so callers stay pure/testable. */
+/**
+ * Build a stamped message. `at` is injected so callers stay pure/testable.
+ *
+ * `messageId` is the host's own id for the line, when the caller already has
+ * one — a reply that came back from the chat POST does. Passing it means the
+ * bubble is born durable and can be replied to or reacted on immediately,
+ * rather than waiting for a reconciliation it does not need.
+ */
 export function makeMessage(
   from: ChatMessage["from"],
   text: string,
@@ -77,10 +104,11 @@ export function makeMessage(
     parentId?: string;
     steps?: TurnStep[];
     taskId?: string;
+    messageId?: string;
   } = {},
 ): ChatMessage {
   return {
-    id: nextId(),
+    id: opts.messageId ? hostMessageId(opts.messageId) : nextId(),
     from,
     text,
     at: opts.at ?? Date.now(),
@@ -102,10 +130,17 @@ export function fromHistory(entries: ChatHistoryMessageDto[]): ChatMessage[] {
   return entries.map((entry) => {
     const from: ChatMessage["from"] = entry.mine ? "you" : "company";
     return {
-      id: `h${entry.id}`,
+      id: hostMessageId(entry.id),
       from,
       text: entry.text,
       at: entry.atMillis,
+      // The host names the parent by its own id, which lives in the same
+      // namespace as `entry.id` — so it takes the same prefix, or the reply
+      // would point at a line no console id matches (issue #364).
+      parentId: entry.parentId ? hostMessageId(entry.parentId) : undefined,
+      // Reactions come through whoever the host said reacted; nothing is
+      // inferred here, `mine` included.
+      reactions: entry.reactions?.length ? entry.reactions : undefined,
       // A sent message never carries a channel; only attribute one when the
       // line came from someone/something else, mirroring `ChatPane.send`.
       channel: from === "company" ? entry.channel : undefined,
@@ -118,4 +153,70 @@ export function fromHistory(entries: ChatHistoryMessageDto[]): ChatMessage[] {
       taskId: from === "company" ? entry.taskId : undefined,
     };
   });
+}
+
+/**
+ * The console id for a message the host has journaled (issue #364).
+ *
+ * Two id namespaces meet in a transcript, and keeping them apart is the whole
+ * job of this prefix: `m<n>` is a browser-minted counter that means nothing
+ * outside this tab, and `h<seq>` is the host's own sequence position, which any
+ * reader — a reload, a second operator — resolves to the same message. The `h`
+ * is what lets {@link isHostMessageId} tell "saved" from "not saved yet"
+ * without asking the server.
+ */
+export function hostMessageId(seq: string): string {
+  return `h${seq}`;
+}
+
+/** Whether an id names a message the host has journaled. */
+export function isHostMessageId(id: string | undefined): boolean {
+  return !!id && id.startsWith("h");
+}
+
+/**
+ * The host-side id an `h`-prefixed console id names, or `null` for a local one.
+ *
+ * The inverse of {@link hostMessageId}, used when a durable id has to go back
+ * over the wire — a thread reply's parent, a reaction's target.
+ */
+export function toHostMessageId(id: string | undefined): string | null {
+  return isHostMessageId(id) ? id!.slice(1) : null;
+}
+
+/**
+ * Replace an optimistic message id with the durable one the host assigned, and
+ * re-point anything that was already replying to it (issue #364).
+ *
+ * The subtle half is the re-parenting, and it is why this is a named function
+ * with its own tests rather than three lines inside a `setState`. A send is
+ * rendered before the POST resolves, so a fast operator can open a thread on
+ * that bubble and reply to it while its id is still the local counter. Swapping
+ * only the parent's own id would leave those replies pointing at an id that no
+ * longer exists — they would silently drop out of the thread and reappear in
+ * the channel, which reads as the console losing them.
+ *
+ * Pure and total: unknown ids pass through, and a list with nothing to change
+ * is returned as-is so React sees no new array.
+ */
+export function reconcileIds(
+  messages: ChatMessage[],
+  localId: string,
+  hostSeq: string,
+): ChatMessage[] {
+  const nextId = hostMessageId(hostSeq);
+  if (nextId === localId) return messages;
+  let changed = false;
+  const next = messages.map((m) => {
+    const isTarget = m.id === localId;
+    const isChild = m.parentId === localId;
+    if (!isTarget && !isChild) return m;
+    changed = true;
+    return {
+      ...m,
+      ...(isTarget ? { id: nextId } : {}),
+      ...(isChild ? { parentId: nextId } : {}),
+    };
+  });
+  return changed ? next : messages;
 }

--- a/frontend/src/lib/team.ts
+++ b/frontend/src/lib/team.ts
@@ -81,11 +81,42 @@ export function fromDto(dto: TeamMemberDto): TeamMember {
   };
 }
 
-let n = 0;
-const id = () => `member-${n++}`;
+/**
+ * A stable id for a teammate the console invented (issue #364).
+ *
+ * Derived from the role, not minted from a counter. The counter was the reason
+ * nothing about a console-only teammate survived a reload: `member-3` named a
+ * different person on the next mount — or nobody — so the DM's URL, its unread
+ * count, and the transcript the host journaled under that id all pointed at
+ * someone else. A role slug is the same on every mount of every tab.
+ *
+ * The hash suffix is not decoration. Slugifying keeps only `[a-z0-9]`, so a
+ * role written in a non-Latin script slugifies to nothing and two roles that
+ * slugify alike collide — and a collision here means two teammates sharing one
+ * DM, with their messages merged. The hash of the full role keeps the id
+ * readable *and* distinct.
+ */
+export function localMemberId(role: string): string {
+  const trimmed = role.trim();
+  const slug = trimmed.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+  return `member-${slug ? `${slug}-` : ""}${roleHash(trimmed)}`;
+}
+
+function roleHash(role: string): string {
+  let hash = 0;
+  for (let i = 0; i < role.length; i++) hash = (hash * 31 + role.charCodeAt(i)) | 0;
+  return (hash >>> 0).toString(36);
+}
 
 function member(name: string, role: string, description: string): TeamMember {
-  return { id: id(), name, role, description, tone: toneFor(name), inboxEnabled: false };
+  return {
+    id: localMemberId(role),
+    name,
+    role,
+    description,
+    tone: toneFor(name),
+    inboxEnabled: false,
+  };
 }
 
 /**
@@ -113,9 +144,17 @@ export function starterTeam(): TeamMember[] {
   ];
 }
 
-/** Create a member from operator-entered fields. */
+/**
+ * Create a member from operator-entered fields, for a host with no team write
+ * plane — so the id is console-derived and, since issue #364, reload-stable.
+ *
+ * Keyed on the **name** rather than the role: an operator adding a teammate by
+ * hand is naming a person, and two of them may well share a role ("Engineer").
+ * The starter roster keys on role because that is what distinguishes its
+ * fabricated rows.
+ */
 export function newMember(fields: { name: string; role: string; description: string }): TeamMember {
-  const memberId = id();
+  const memberId = localMemberId(fields.name);
   return {
     id: memberId,
     name: fields.name.trim(),

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -17,7 +17,12 @@ import { setInboxEnabled } from "@/api/inbox";
 import { ApiError, type ApprovalSummary, type TeamMemberDto, type TurnStep, type Verdict } from "@/api/types";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { type ChatMessage, makeMessage } from "@/lib/chat";
+import {
+  makeMessage,
+  reconcileIds,
+  toHostMessageId,
+  type ChatMessage,
+} from "@/lib/chat";
 import { defaultDesks, type Desk } from "@/lib/desks";
 import { readLastChannel } from "@/lib/last-channel";
 import { fromDto, newMember, starterTeam, type TeamMember } from "@/lib/team";
@@ -41,6 +46,7 @@ import {
   dmChannelId,
   findChannel,
   firstChannel,
+  resolveDmChannelId,
   toggleReaction,
   type DecidedApproval,
   type Transcripts,
@@ -361,16 +367,30 @@ export function ChatView({
   // channel `firstChannel` returns when they hadn't. It never selected anything
   // the line below wouldn't; it only made "main" look like a real channel id
   // (issue #368).
-  const channel = desks ? (findChannel(sections, sub) ?? firstChannel(sections)) : null;
+  /**
+   * A `#/chat/dm:…` link minted before issue #364 re-keyed DMs onto the
+   * teammate's id, mapped onto the id that channel has now.
+   *
+   * One release of grace for a bookmarked or pasted link. Resolution only —
+   * nothing is ever addressed or stored under the old id, so this shim can be
+   * deleted without leaving anything stranded.
+   */
+  const resolvedSub =
+    sub && !findChannel(sections, sub) ? resolveDmChannelId(sub, members) : null;
+  const channel = desks
+    ? (findChannel(sections, resolvedSub ?? sub) ?? firstChannel(sections))
+    : null;
   /**
    * The hash named a channel this company doesn't have, and the first-channel
    * fallback answered instead.
    *
    * Only meaningful once the desks are in: before that, *every* id looks
    * unknown. Derived rather than stored, so it clears itself the moment the
-   * hash changes — there is no stale banner to dismiss.
+   * hash changes — there is no stale banner to dismiss. A legacy DM link that
+   * the shim above resolved is not unknown; it found its channel.
    */
-  const unknownChannel = desks && sub && !findChannel(sections, sub) ? sub : null;
+  const unknownChannel =
+    desks && sub && !resolvedSub && !findChannel(sections, sub) ? sub : null;
 
   /**
    * Who is in the channel on screen — `null` when it names no membership, in
@@ -516,6 +536,21 @@ export function ChatView({
    * counts the company, which is all it can honestly claim.
    */
   const headerCount = active.kind === "dm" ? 2 : (inChannel?.length ?? members.length);
+  /**
+   * The teammate on the other end of this DM exists only in the console (issue
+   * #364) — a starter-roster row, or one added while the host had no team write
+   * plane.
+   *
+   * Worth saying out loud, and worth being precise about *what* is local. The
+   * transcript is not: the DM is addressed by a reload-stable id now, so the
+   * host journals it and gives it back. What is missing is the other half of the
+   * conversation — there is no such agent on the company, so nothing on the
+   * roster answers. Claiming the whole channel was console-local would be the
+   * old, wrong story; saying nothing would leave an operator waiting for a reply
+   * that is never coming.
+   */
+  const consoleOnlyMember =
+    active.kind === "dm" && !fromHost && active.member ? active.member.name : null;
 
   const append = (channelId: string, ...added: ChatMessage[]) =>
     setTranscripts((t) => ({ ...t, [channelId]: [...(t[channelId] ?? []), ...added] }));
@@ -523,12 +558,20 @@ export function ChatView({
   /**
    * Post a line and thread the company's answer back into the same place.
    * `parentId` set means the exchange stays inside the thread panel.
+   *
+   * The thread is now a fact about the transcript, not about this browser: the
+   * parent goes to the host with the message, and both halves come back under
+   * it on the next reload (issue #364). A parent that has no durable id yet is
+   * dropped from the request rather than sent as a local counter the host
+   * cannot resolve — the row's own actions are disabled in that window, so this
+   * is the belt to that brace.
    */
   async function send(text: string, parentId?: string) {
     if (sending) return;
     const target = active.id;
     const chatId = activeThreadId;
-    append(target, makeMessage("you", text, { parentId }));
+    const local = makeMessage("you", text, { parentId });
+    append(target, local);
     setSending(true);
     // Claim the thread for the duration of the POST. The backend journals an
     // `AgentReply` for our own turn too and pushes it over SSE mid-await, so
@@ -536,13 +579,28 @@ export function ChatView({
     // below — two bubbles for one turn.
     if (chatId) onSendStart?.(chatId);
     try {
-      const reply = await client.chat(text, company, chatId);
+      const reply = await client.chat(text, company, chatId, toHostMessageId(parentId));
       const replies = reply.responses.length
         ? reply.responses.map((r) =>
-            makeMessage("company", r.text, { channel: r.channel, parentId, steps: r.steps, taskId: r.taskId }),
+            makeMessage("company", r.text, {
+              channel: r.channel,
+              parentId,
+              steps: r.steps,
+              taskId: r.taskId,
+              messageId: r.messageId,
+            }),
           )
         : [makeMessage("system", "(no reply)", { parentId })];
       append(target, ...replies);
+      // Swap the optimistic id for the durable one the host assigned, so this
+      // bubble can be replied to and reacted on straight away — and so anything
+      // that started replying to it mid-flight follows it (`reconcileIds`).
+      if (reply.messageId) {
+        setTranscripts((t) => ({
+          ...t,
+          [target]: reconcileIds(t[target] ?? [], local.id, reply.messageId!),
+        }));
+      }
       onReply?.();
     } catch (err) {
       const msg = err instanceof ApiError ? err.message : "something went wrong";
@@ -553,13 +611,40 @@ export function ChatView({
     }
   }
 
-  function react(messageId: string, emoji: string) {
-    setTranscripts((t) => ({
-      ...t,
-      [active.id]: (t[active.id] ?? []).map((m) =>
-        m.id === messageId ? { ...m, reactions: toggleReaction(m.reactions, emoji) } : m,
-      ),
-    }));
+  /**
+   * Set or clear the operator's own reaction on a message (issue #364).
+   *
+   * Optimistic, then reconciled by failure: the chip flips at once because a
+   * reaction that waits for a round trip feels broken, and rolls back if the
+   * host refuses. It never guesses — a host with no reactions route says so,
+   * once, instead of leaving a chip that will be gone on the next reload.
+   */
+  async function react(messageId: string, emoji: string) {
+    const seq = toHostMessageId(messageId);
+    if (!seq) return;
+    const before = transcripts[active.id] ?? [];
+    const on = !before.some(
+      (m) => m.id === messageId && m.reactions?.some((r) => r.emoji === emoji && r.mine),
+    );
+    const apply = (rows: ChatMessage[]) =>
+      rows.map((m) =>
+        m.id === messageId
+          ? { ...m, reactions: toggleReaction(m.reactions, emoji, "you") }
+          : m,
+      );
+    setTranscripts((t) => ({ ...t, [active.id]: apply(t[active.id] ?? []) }));
+    try {
+      await client.reactToMessage(seq, emoji, on, company);
+    } catch (error) {
+      setTranscripts((t) => ({ ...t, [active.id]: apply(t[active.id] ?? []) }));
+      toast.error(
+        error instanceof ApiError && error.status === 404
+          ? "This host doesn't keep reactions yet."
+          : error instanceof Error
+            ? error.message
+            : "Couldn't save that reaction.",
+      );
+    }
   }
 
   /**
@@ -723,6 +808,19 @@ export function ChatView({
               decidingApprovals={decidingApprovals}
               onDecideApproval={onDecideApproval}
             />
+            {consoleOnlyMember && (
+              <p
+                role="status"
+                className="flex shrink-0 items-center gap-1.5 border-t bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground"
+              >
+                <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
+                <span className="min-w-0">
+                  <span className="font-medium text-foreground">{consoleOnlyMember}</span> only
+                  exists in this console — the company has no such teammate, so nobody answers
+                  here. The transcript is still saved and survives a reload.
+                </span>
+              </p>
+            )}
             <MessageComposer
               placeholder={`Message ${channelTitle(channel)}`}
               disabled={sending}

--- a/frontend/src/views/chat/ChannelRail.tsx
+++ b/frontend/src/views/chat/ChannelRail.tsx
@@ -6,6 +6,17 @@ import { cn } from "@/lib/utils";
 import { Avatar } from "./Avatar";
 import type { Channel, ChannelSection } from "./model";
 
+/**
+ * What an unread badge actually claims (issue #364).
+ *
+ * The one thing on this rail that is still console-local: unread is derived
+ * here from when this tab last looked at a channel, because the host has no
+ * read-receipt surface. Transcripts, threads and reactions are all the host's
+ * now — this is not, and it says so rather than letting an operator read the
+ * badge as "unread by my team".
+ */
+const UNREAD_IS_LOCAL = "Estimated in this browser — unread is not tracked on the company.";
+
 interface Props {
   sections: ChannelSection[];
   activeId: string | null;
@@ -89,7 +100,10 @@ function Section({
         />
         <span className="truncate">{section.label}</span>
         {hiddenUnread > 0 && (
-          <span className="ml-auto rounded-full bg-primary px-1.5 text-[10px] font-semibold leading-4 text-primary-foreground">
+          <span
+            title={UNREAD_IS_LOCAL}
+            className="ml-auto rounded-full bg-primary px-1.5 text-[10px] font-semibold leading-4 text-primary-foreground"
+          >
             {hiddenUnread > 99 ? "99+" : hiddenUnread}
           </span>
         )}
@@ -148,6 +162,11 @@ function ChannelRow({
       {hasUnread && (
         <span
           data-testid="channel-unread"
+          // Issue #364: unread is derived in this browser from what this tab has
+          // seen — the host keeps no read receipts. Two consoles will disagree,
+          // and a badge that quietly means something narrower than it looks is
+          // worse than one that says so.
+          title={UNREAD_IS_LOCAL}
           className="shrink-0 rounded-full bg-primary px-1.5 text-[10px] font-semibold leading-4 text-primary-foreground"
         >
           {unread > 99 ? "99+" : unread}

--- a/frontend/src/views/chat/MessageRow.tsx
+++ b/frontend/src/views/chat/MessageRow.tsx
@@ -2,12 +2,15 @@ import { MessageSquareReply } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/markdown";
-import type { ChatMessage } from "@/lib/chat";
+import { isHostMessageId, type ChatMessage } from "@/lib/chat";
 import { cn } from "@/lib/utils";
 import { Avatar } from "./Avatar";
 import {
   formatTime,
+  hasReacted,
   QUICK_REACTIONS,
+  reactionChips,
+  type ReactionChip,
   type Sender,
   type TimelineEntry,
 } from "./model";
@@ -22,6 +25,27 @@ interface Props {
 }
 
 /**
+ * Why replying and reacting are unavailable on a row, or `undefined` when they
+ * are not (issue #364).
+ *
+ * Derived from the row's own id rather than passed down, because the id *is*
+ * the answer: a thread reply and a reaction both have to name a message the
+ * host has journaled, and only an `h`-prefixed id names one. A row still
+ * carrying its optimistic counter (the POST has not landed) or one from a host
+ * with no durable ids at all cannot be named by either.
+ *
+ * The reason is a sentence, not a boolean, because a control that just stops
+ * working reads as a bug. This is the on-screen label for the one thing about
+ * this feature that is genuinely conditional on the host.
+ */
+function actionsUnavailableFor(message: ChatMessage): string | undefined {
+  if (isHostMessageId(message.id)) return undefined;
+  return message.from === "system"
+    ? "Console-only line — there is nothing saved to reply to."
+    : "Not saved yet — a reply or a reaction needs a message this company has stored.";
+}
+
+/**
  * One line in the channel.
  *
  * The layout is a fixed avatar gutter plus a flexible body, which is what
@@ -32,6 +56,8 @@ interface Props {
  */
 export function MessageRow({ entry, threadOpen, onOpenThread, onReact }: Props) {
   const { message, sender, continuation, replies } = entry;
+  const chips = reactionChips(message.reactions);
+  const actionsUnavailable = actionsUnavailableFor(message);
 
   if (sender.kind === "system") {
     return (
@@ -69,8 +95,12 @@ export function MessageRow({ entry, threadOpen, onOpenThread, onReact }: Props) 
         {message.steps && message.steps.length > 0 && <StepTimeline steps={message.steps} />}
         {message.taskId && <CardChip taskId={message.taskId} />}
 
-        {message.reactions && (
-          <Reactions reactions={message.reactions} onReact={(e) => onReact(message.id, e)} />
+        {chips.length > 0 && (
+          <Reactions
+            chips={chips}
+            disabledReason={actionsUnavailable}
+            onReact={(e) => onReact(message.id, e)}
+          />
         )}
 
         {replies.length > 0 && (
@@ -91,6 +121,8 @@ export function MessageRow({ entry, threadOpen, onOpenThread, onReact }: Props) 
       <ActionBar
         onReply={() => onOpenThread(message.id)}
         onReact={(emoji) => onReact(message.id, emoji)}
+        reacted={(emoji) => hasReacted(message.reactions, emoji)}
+        disabledReason={actionsUnavailable}
       />
     </article>
   );
@@ -107,25 +139,44 @@ function AuthorLine({ sender, at }: { sender: Sender; at: number }) {
   );
 }
 
+/**
+ * The reaction chips under a line.
+ *
+ * Each chip carries a count *and* names everyone behind it in its tooltip —
+ * "who reacted" is most of what a reaction is for, and a bare count answers
+ * none of it. The reader's own chip is highlighted, which is what makes it
+ * legible as a toggle rather than a tally that only goes up.
+ */
 function Reactions({
-  reactions,
+  chips,
+  disabledReason,
   onReact,
 }: {
-  reactions: Record<string, number>;
+  chips: ReactionChip[];
+  disabledReason?: string;
   onReact: (emoji: string) => void;
 }) {
   return (
     <div className="mt-1 flex flex-wrap gap-1">
-      {Object.entries(reactions).map(([emoji, count]) => (
+      {chips.map((chip) => (
         <button
-          key={emoji}
+          key={chip.emoji}
           type="button"
-          onClick={() => onReact(emoji)}
-          className="flex items-center gap-1 rounded-full border border-primary/40 bg-primary/10 px-2 py-0.5 text-xs transition-colors hover:bg-primary/20"
-          aria-label={`Remove ${emoji} reaction`}
+          disabled={!!disabledReason}
+          onClick={() => onReact(chip.emoji)}
+          title={disabledReason ?? `${chip.by.join(", ")} reacted with ${chip.emoji}`}
+          className={cn(
+            "flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs transition-colors",
+            chip.mine
+              ? "border-primary/40 bg-primary/10 hover:bg-primary/20"
+              : "border-border bg-muted/60 hover:bg-muted",
+            disabledReason && "cursor-not-allowed opacity-60 hover:bg-inherit",
+          )}
+          aria-pressed={chip.mine}
+          aria-label={`${chip.emoji} — ${chip.by.join(", ")}`}
         >
-          <span aria-hidden>{emoji}</span>
-          <span className="tabular-nums text-[11px] font-medium">{count}</span>
+          <span aria-hidden>{chip.emoji}</span>
+          <span className="tabular-nums text-[11px] font-medium">{chip.count}</span>
         </button>
       ))}
     </div>
@@ -136,18 +187,32 @@ function Reactions({
 function ActionBar({
   onReply,
   onReact,
+  reacted,
+  disabledReason,
 }: {
   onReply: () => void;
   onReact: (emoji: string) => void;
+  /** Whether the reader has already reacted with an emoji, to mark the button. */
+  reacted: (emoji: string) => boolean;
+  /** Why both actions are unavailable, shown as the tooltip when they are. */
+  disabledReason?: string;
 }) {
+  const disabled = !!disabledReason;
   return (
     <div className="absolute -top-3 right-4 z-10 hidden items-center gap-0.5 rounded-lg border bg-popover p-0.5 shadow-sm group-hover/message:flex group-focus-within/message:flex">
       {QUICK_REACTIONS.map((emoji) => (
         <button
           key={emoji}
           type="button"
+          disabled={disabled}
           onClick={() => onReact(emoji)}
-          className="flex size-7 items-center justify-center rounded-md text-sm transition-colors hover:bg-accent"
+          title={disabledReason}
+          aria-pressed={reacted(emoji)}
+          className={cn(
+            "flex size-7 items-center justify-center rounded-md text-sm transition-colors hover:bg-accent",
+            reacted(emoji) && "bg-primary/10",
+            disabled && "cursor-not-allowed opacity-50 hover:bg-transparent",
+          )}
           aria-label={`React with ${emoji}`}
         >
           <span aria-hidden>{emoji}</span>
@@ -158,9 +223,10 @@ function ActionBar({
         variant="ghost"
         size="icon"
         className="size-7"
+        disabled={disabled}
         onClick={onReply}
         aria-label="Reply in thread"
-        title="Reply in thread"
+        title={disabledReason ?? "Reply in thread"}
       >
         <MessageSquareReply className="size-4" />
       </Button>

--- a/frontend/src/views/chat/README.md
+++ b/frontend/src/views/chat/README.md
@@ -11,7 +11,9 @@ the desks the two shared without ever being connected.
 channel is linkable and survives a refresh.
 
 - A desk's channel id is the host's desk id, which is also its chat thread id.
-- A DM is `dm:<slug-of-name>` — e.g. `#/chat/dm:designer`.
+- A DM is `dm:<teammate-id>` — e.g. `#/chat/dm:designer` for a host roster
+  agent, or `#/chat/dm:member-product-manager-1f3k` for a teammate this console
+  invented.
 - A host with no `.../desks` route falls back to `#general`, `#strategy`,
   `#creative`, `#front-desk` (`lib/desks.ts`).
 
@@ -23,9 +25,15 @@ the timeline, so the URL and the content never disagree silently. A `/desks`
 failure that isn't "this host has none" (404 or an empty list) is a retryable
 error state, not invented channels.
 
-DM ids key on the teammate's **name**, not their roster id: the starter roster
-mints ids from a module counter (`lib/team.ts`), so those differ between two
-calls in the same session and a saved link would point at the wrong person.
+DM ids key on the teammate's **id** (issue #364). A host roster agent has always
+had a stable one; a console-invented teammate now does too — `lib/team.ts`
+derives it from the role (or, for a hand-added teammate, the name) rather than
+minting it from a counter. Keying on the id means renaming somebody does not
+move their DM's URL or orphan the history already journaled under it.
+
+Ids minted before #364 were `dm:<slug-of-name>-<hash>`. `resolveDmChannelId`
+still resolves those for one release so a saved link lands, but nothing is ever
+addressed or stored under one.
 
 ## What is real and what is console-local
 
@@ -33,15 +41,32 @@ Every channel and DM posts to the **same** company chat endpoint. A channel
 scopes a transcript and fixes the company side's identity; it is not a separate
 backend, and there is no per-channel routing on the host.
 
-Console-local, because the host has no surface for them yet:
+**Real — the host's, and reload-visible to every operator** (issue #364):
 
 | | |
 |---|---|
-| Threads | A reply carries `parentId` and stays out of the channel timeline. |
-| Reactions | Toggled on the message in memory; not persisted anywhere. |
-| Unread counts | The rail renders them, but nothing ever arrives in a channel you are not looking at — every reply answers a line you just sent. `ChatView` passes `{}`. |
+| Transcripts | Journaled by the host and rehydrated from `GET {scope}/chat/history` on load. This has been true since #65 — the "per-session memory" this file used to claim was already out of date. |
+| Channel scoping | Every message carries the desk it was sent to, and the host filters server-side. Two people in two channels are not in the same room, and have not been since #53/#65. |
+| Threads | A reply posts its `parent` — the parent message's own id — and comes back under it. Both halves of the exchange hang off the row the thread opened from. |
+| Reactions | One durable row per person per emoji, so a chip says who reacted and whether one of them was you. `POST {scope}/chat/messages/{seq}/reactions` with an explicit `on`, which makes a retry idempotent. |
+| Message ids | A sent message comes back with the id it was journaled under (`messageId`), which is what a thread reply or a reaction names. Until the id lands the row's reply/react actions are disabled and say why. |
 
-Transcripts are per-session memory. Closing the tab drops them.
+**Still console-local:**
+
+| | |
+|---|---|
+| Unread counts | Derived here from when this tab last looked at a channel — the host keeps no read receipts, so two consoles will disagree. The badge's tooltip says so. |
+| A console-only teammate's other half | A starter-roster teammate is not on the company, so nothing answers their DM. The transcript is still saved; a notice above the composer says which half is missing. |
+
+Reactions are deliberately **not** on the SSE feed: the frame would have to
+carry the reacting person, and that stream has no per-viewer projection to turn
+an actor into a label. They arrive on the next read.
+
+Nothing was migrated. A message journaled before #364 loads with no parent and
+no reactions, which is the truth about it. History journaled under the old
+counter-minted `member-N` teammate ids stays orphaned — there is no honest
+mapping from `member-3` to a person, and inventing one would be worse than the
+loss.
 
 ## Membership
 

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -2,7 +2,7 @@
 // rules the timeline reads. Everything here is pure — the view owns the state.
 
 import type { ApprovalSummary, DeskDto, Verdict } from "@/api/types";
-import type { ChatMessage } from "@/lib/chat";
+import type { ChatMessage, Reaction } from "@/lib/chat";
 import { defaultDesks, type Desk } from "@/lib/desks";
 import { initials as nameInitials, type TeamMember } from "@/lib/team";
 
@@ -119,22 +119,47 @@ export function buildChannels(members: TeamMember[], desks: Desk[] = defaultDesk
 /**
  * A DM's channel id, and so its URL.
  *
- * Keyed on the teammate's name rather than their roster id: the starter roster
- * mints ids from a module counter (`lib/team.ts`), so they differ between two
- * calls in the same session and a `#/chat/dm:member-3` link would point at a
- * different person — or nobody — on the next mount.
+ * Keyed on the teammate's **id**, which is now the one stable thing about them
+ * (issue #364). A host roster entry has always had a stable agent id; what was
+ * missing was a stable id for a console-invented teammate, and `lib/team.ts`'s
+ * counter was why this used to key on the name instead.
  *
- * The slug alone is not enough: it keeps only `[a-z0-9]`, so a name written
- * entirely in a non-Latin script slugifies to nothing, and two names that
- * slugify alike (or both empty) would collide onto the same id — the second
- * teammate's DM becomes unreachable and their messages merge with the
- * first's. A short hash of the full name, appended after the slug, keeps the
- * id both name-derived and unique.
+ * Keying on the name had a cost that only shows up later: renaming a teammate
+ * silently moved their DM to a new URL and orphaned every message already
+ * journaled under the old one. An id does not change when a person's name does,
+ * which is the entire reason to prefer it.
  */
 export function dmChannelId(member: TeamMember): string {
+  return `dm:${member.id}`;
+}
+
+/**
+ * The name-derived DM id this console minted before issue #364.
+ *
+ * Kept for one release, and for one purpose: a `#/chat/dm:ada-1f3k` link that
+ * somebody bookmarked or pasted into a ticket still has to land on Ada's DM.
+ * Only {@link resolveDmChannelId} calls it — nothing addresses a channel by it,
+ * so no new state is ever written under a legacy id.
+ */
+export function legacyDmChannelId(member: TeamMember): string {
   const name = member.name.trim();
   const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
   return `dm:${slug ? `${slug}-` : ""}${nameHash(name)}`;
+}
+
+/**
+ * The current DM channel id a URL segment names, or `null` when it names no
+ * DM this company has.
+ *
+ * Resolves the current id first, then the pre-#364 name-derived form, so an old
+ * link keeps working without the old id ever becoming addressable again.
+ */
+export function resolveDmChannelId(id: string, members: TeamMember[]): string | null {
+  if (!id.startsWith("dm:")) return null;
+  const match = members.find(
+    (m) => dmChannelId(m) === id || legacyDmChannelId(m) === id,
+  );
+  return match ? dmChannelId(match) : null;
 }
 
 function nameHash(name: string): string {
@@ -436,16 +461,64 @@ export function formatDay(at: number): string {
 /** The palette the hover bar offers, in the order it offers them. */
 export const QUICK_REACTIONS = ["👍", "🎉", "👀", "✅", "❤️"] as const;
 
-/** Toggle one emoji on a message, returning the next reaction map. */
+/**
+ * Toggle the reader's own reaction, leaving everyone else's alone (issue #364).
+ *
+ * Reactions are per-person rows now, so a toggle adds or removes exactly one —
+ * the reader's. It used to replace a count, which meant tapping an emoji
+ * somebody else had already used silently wiped their reaction.
+ *
+ * `label` is how the reader will be shown in the chip's tooltip until the host
+ * says otherwise. Returns `undefined` for an empty result so a message with no
+ * reactions carries no key at all.
+ */
 export function toggleReaction(
-  reactions: Record<string, number> | undefined,
+  reactions: Reaction[] | undefined,
   emoji: string,
-): Record<string, number> | undefined {
-  const next = { ...(reactions ?? {}) };
-  if (next[emoji]) {
-    delete next[emoji];
-  } else {
-    next[emoji] = 1;
+  label: string,
+): Reaction[] | undefined {
+  const rows = reactions ?? [];
+  const mine = rows.some((r) => r.emoji === emoji && r.mine);
+  const next = mine
+    ? rows.filter((r) => !(r.emoji === emoji && r.mine))
+    : [...rows, { emoji, by: label, mine: true }];
+  return next.length ? next : undefined;
+}
+
+/** Whether the reader has already reacted to a message with this emoji. */
+export function hasReacted(reactions: Reaction[] | undefined, emoji: string): boolean {
+  return !!reactions?.some((r) => r.emoji === emoji && r.mine);
+}
+
+/** One emoji's chip: its rows collapsed into a count and a who-list. */
+export interface ReactionChip {
+  emoji: string;
+  count: number;
+  /** Whether one of the rows is the reader's. */
+  mine: boolean;
+  /** Everyone who reacted with it, in the order the host listed them. */
+  by: string[];
+}
+
+/**
+ * Group per-person reaction rows into the chips the row renders.
+ *
+ * Chips keep first-reacted order rather than sorting by count, so a message's
+ * reactions do not reshuffle under the reader as others react.
+ */
+export function reactionChips(reactions: Reaction[] | undefined): ReactionChip[] {
+  const chips: ReactionChip[] = [];
+  const byEmoji = new Map<string, ReactionChip>();
+  for (const row of reactions ?? []) {
+    let chip = byEmoji.get(row.emoji);
+    if (!chip) {
+      chip = { emoji: row.emoji, count: 0, mine: false, by: [] };
+      byEmoji.set(row.emoji, chip);
+      chips.push(chip);
+    }
+    chip.count += 1;
+    chip.mine ||= row.mine;
+    chip.by.push(row.by);
   }
-  return Object.keys(next).length ? next : undefined;
+  return chips;
 }

--- a/src/brain/echo.rs
+++ b/src/brain/echo.rs
@@ -47,6 +47,7 @@ impl Brain for EchoBrain {
         for event in &req.events {
             if let CompanyEvent::OperatorMessage { text, .. } = event {
                 channel_responses.push(OutboundMessage {
+                    message_id: None,
                     task_id: None,
                     channel: "operator".to_string(),
                     text: format!("You said: {text}"),
@@ -76,6 +77,7 @@ impl Brain for EchoBrain {
                     (format!("webhook on {channel}"), None)
                 };
                 channel_responses.push(OutboundMessage {
+                    message_id: None,
                     task_id: None,
                     channel: channel.clone(),
                     text,
@@ -86,6 +88,7 @@ impl Brain for EchoBrain {
         }
         if channel_responses.is_empty() {
             channel_responses.push(OutboundMessage {
+                message_id: None,
                 task_id: None,
                 channel: "operator".to_string(),
                 text: "Acknowledged.".to_string(),
@@ -180,6 +183,7 @@ mod test {
         let result = brain
             .run_cycle(
                 request(vec![CompanyEvent::OperatorMessage {
+                    parent: None,
                     text: "hi".into(),
                     by: None,
                     chat: None,

--- a/src/brain/hosted/test.rs
+++ b/src/brain/hosted/test.rs
@@ -108,6 +108,7 @@ fn operator_request() -> CycleRequest {
         cycle_id: "unused".into(),
         company_id: CompanyId::new("acme"),
         events: vec![CompanyEvent::OperatorMessage {
+            parent: None,
             text: "hi".into(),
             by: None,
             chat: None,
@@ -521,6 +522,7 @@ async fn e2e_operator_message_drives_tool_call_and_gated_send_dm() {
 
     let report = rt
         .run_cycle(vec![CompanyEvent::OperatorMessage {
+            parent: None,
             text: "how are we doing".into(),
             by: None,
             chat: None,
@@ -572,6 +574,7 @@ async fn e2e_supervised_effect_parks_and_acks_not_ok() {
 
     let report = rt
         .run_cycle(vec![CompanyEvent::OperatorMessage {
+            parent: None,
             text: "file it".into(),
             by: None,
             chat: None,
@@ -637,6 +640,7 @@ async fn e2e_reported_usage_lands_on_the_usage_meter() {
         .unwrap();
 
     rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+        parent: None,
         text: "how are we doing".into(),
         by: None,
         chat: None,
@@ -722,6 +726,7 @@ async fn e2e_hosted_catalog_advertises_delegation_tools() {
         .unwrap();
 
     rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+        parent: None,
         text: "hi".into(),
         by: None,
         chat: None,
@@ -768,6 +773,7 @@ async fn e2e_spawn_task_tool_call_opens_a_board_card() {
         .unwrap();
 
     rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+        parent: None,
         text: "open a task to ship invoicing".into(),
         by: None,
         chat: None,
@@ -821,6 +827,7 @@ async fn e2e_delegate_to_desk_tool_call_writes_a_handoff_card() {
         .unwrap();
 
     rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+        parent: None,
         text: "have engineering build invoicing".into(),
         by: None,
         chat: None,
@@ -872,6 +879,7 @@ async fn e2e_a_cycle_without_usage_frames_meters_nothing() {
         .unwrap();
 
     rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+        parent: None,
         text: "hello".into(),
         by: None,
         chat: None,

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -118,6 +118,26 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("Deleted memory fact {fact_id}"),
             "memory.fact_deleted",
         ),
+        // Issue #364. Written for completeness, not for a live path: this
+        // function normalizes a cycle's *input* events, and a reaction is
+        // appended straight to the log by its route — it drives no cycle, so a
+        // brain never sees one here. Spelled out rather than swept into a
+        // wildcard so the next variant that IS a stimulus cannot inherit a
+        // silent default. `by` is dropped, as every other arm drops it.
+        CompanyEvent::ReactionToggled {
+            message_seq,
+            emoji,
+            on,
+            ..
+        } => (
+            Role::System,
+            "operator".to_string(),
+            format!(
+                "{} {emoji} on message {message_seq}",
+                if *on { "Reacted" } else { "Un-reacted" }
+            ),
+            "reaction.toggled",
+        ),
         // Issue #403. Worth telling the brain, because it changes what the
         // brain can *do*: a cleared credential is why a tool it had yesterday
         // stops answering today, and without this that reads as an unexplained
@@ -370,6 +390,7 @@ pub(crate) fn channel_message_from_effect(effect: &Effect) -> Option<OutboundMes
         .or_else(|| payload_str(payload, "message"))?
         .to_string();
     Some(OutboundMessage {
+        message_id: None,
         task_id: None,
         channel,
         text,

--- a/src/brain/sidecar/test.rs
+++ b/src/brain/sidecar/test.rs
@@ -107,6 +107,7 @@ fn operator_request() -> CycleRequest {
         cycle_id: "unused".into(),
         company_id: CompanyId::new("acme"),
         events: vec![CompanyEvent::OperatorMessage {
+            parent: None,
             text: "hi".into(),
             by: None,
             chat: None,
@@ -511,6 +512,7 @@ async fn e2e_inference_then_gated_send_dm_drives_a_channel_response() {
 
     let report = rt
         .run_cycle(vec![CompanyEvent::OperatorMessage {
+            parent: None,
             text: "how are we doing".into(),
             by: None,
             chat: None,
@@ -558,6 +560,7 @@ async fn e2e_supervised_effect_parks_through_the_real_gate() {
 
     let report = rt
         .run_cycle(vec![CompanyEvent::OperatorMessage {
+            parent: None,
             text: "file it".into(),
             by: None,
             chat: None,

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -980,6 +980,7 @@ impl CompanyRuntime {
                 if channel.channel_id() == crate::runtime::channel::OPERATOR_CHANNEL {
                     if let Err(e) = channel
                         .send(crate::ports::types::OutboundMessage {
+                            message_id: None,
                             task_id: None,
                             channel: crate::runtime::channel::OPERATOR_CHANNEL.to_string(),
                             text: text.clone(),
@@ -1066,6 +1067,11 @@ impl CompanyRuntime {
             if channel.channel_id() == crate::runtime::channel::OPERATOR_CHANNEL {
                 if let Err(e) = channel
                     .send(crate::ports::types::OutboundMessage {
+                        // A channel send, not a journaled chat reply: there is
+                        // no `AgentReply` behind this line and so no sequence
+                        // position to name (issue #364). Same as the grant-expiry
+                        // notice above, which this generalizes.
+                        message_id: None,
                         task_id: None,
                         channel: crate::runtime::channel::OPERATOR_CHANNEL.to_string(),
                         text: text.to_string(),

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -276,6 +276,7 @@ impl HarnessBrain {
                 .append(
                     &self.record.id,
                     CompanyEvent::AgentReply {
+                        parent: None,
                         chat_id: reply_thread.clone(),
                         agent_id: grant.agent.clone(),
                         text: text.clone(),
@@ -293,6 +294,7 @@ impl HarnessBrain {
         }
 
         Ok(Some(OutboundMessage {
+            message_id: None,
             task_id: None,
             channel: grant.agent.clone(),
             text,
@@ -1121,6 +1123,7 @@ impl HarnessBrain {
             .append(
                 &self.record.id,
                 CompanyEvent::AgentReply {
+                    parent: None,
                     chat_id: card.id.clone(),
                     agent_id: responder.to_string(),
                     text: result_text.clone(),
@@ -1592,6 +1595,7 @@ impl Brain for HarnessBrain {
                     // steps on the operator bubble — one surface, one renderer.
                     self.surface_mcp_failures(&mut operator_steps, None).await?;
                     channel_responses.push(OutboundMessage {
+                        message_id: None,
                         // Issue #246: when the turn opened a board card, say so
                         // on the bubble it opened it from. Before this a
                         // `spawn_task` was invisible in chat — the card landed
@@ -1641,6 +1645,7 @@ impl Brain for HarnessBrain {
         // The runtime requires at least one channel response per cycle.
         if channel_responses.is_empty() {
             channel_responses.push(OutboundMessage {
+                message_id: None,
                 task_id: None,
                 channel: "operator".to_string(),
                 text: "Acknowledged.".to_string(),
@@ -1847,6 +1852,7 @@ description = "Runs Acme."
         let result = brain
             .run_cycle(
                 request(vec![CompanyEvent::OperatorMessage {
+                    parent: None,
                     text: "status?".into(),
                     by: None,
                     chat: None,
@@ -3409,6 +3415,7 @@ members = ["eng1", "eng2"]
         let result = brain
             .run_cycle(
                 request(vec![CompanyEvent::OperatorMessage {
+                    parent: None,
                     text: "we should announce this".into(),
                     by: None,
                     chat: None,
@@ -3466,6 +3473,7 @@ members = ["eng1", "eng2"]
         let result = brain
             .run_cycle(
                 request(vec![CompanyEvent::OperatorMessage {
+                    parent: None,
                     text: "two things".into(),
                     by: None,
                     chat: None,
@@ -3509,6 +3517,7 @@ members = ["eng1", "eng2"]
         let result = brain
             .run_cycle(
                 request(vec![CompanyEvent::OperatorMessage {
+                    parent: None,
                     text: "status?".into(),
                     by: None,
                     chat: None,
@@ -5129,6 +5138,7 @@ members = ["eng1", "eng2"]
         let result = brain
             .run_cycle(
                 request(vec![CompanyEvent::OperatorMessage {
+                    parent: None,
                     text: "why is the site down?".into(),
                     by: None,
                     chat: None,
@@ -5193,6 +5203,7 @@ members = ["eng1", "eng2"]
         let result = brain
             .run_cycle(
                 request(vec![CompanyEvent::OperatorMessage {
+                    parent: None,
                     text: "handle it".into(),
                     by: None,
                     chat: None,
@@ -5231,6 +5242,7 @@ members = ["eng1", "eng2"]
         let result = brain
             .run_cycle(
                 request(vec![CompanyEvent::OperatorMessage {
+                    parent: None,
                     text: "status?".into(),
                     by: None,
                     chat: None,

--- a/src/harness/lifecycle.rs
+++ b/src/harness/lifecycle.rs
@@ -345,6 +345,7 @@ pub fn relay_reply(
     origin_chat_id: String,
 ) -> OutboundMessage {
     OutboundMessage {
+        message_id: None,
         task_id: None,
         channel: orchestrator.to_string(),
         text: relay_text(card, responder, orchestrator),

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -581,6 +581,21 @@ fn summarize_event(event: &CompanyEvent) -> String {
         CompanyEvent::PaymentReceived { amount_usd, .. } => format!("payment ${amount_usd:.2}"),
         CompanyEvent::LifecycleChanged { from, to, .. } => format!("lifecycle {from} → {to}"),
         CompanyEvent::MemoryFactDeleted { .. } => "memory fact deleted".to_string(),
+        // Issue #364. The emoji is carried — a reaction with the emoji taken out
+        // says nothing at all — and it is the one part of a reaction that cannot
+        // be free text: the route bounds it and refuses control characters. The
+        // message it is about is named by sequence position, which is an
+        // ordinal, and `by` is dropped for the same reason every arm here drops
+        // it: a user id is neither one-line-worthy nor insight.
+        CompanyEvent::ReactionToggled {
+            message_seq,
+            emoji,
+            on,
+            ..
+        } => {
+            let verb = if *on { "reacted" } else { "un-reacted" };
+            format!("{verb} {emoji} on message {message_seq}")
+        }
         // Issue #403. The change word and the toolkit slug are both fixed
         // vocabulary, so neither can carry anything a company typed. `by` is
         // dropped: this is a non-sensitive one-liner for the insight surface,

--- a/src/openhuman/channel.rs
+++ b/src/openhuman/channel.rs
@@ -67,6 +67,7 @@ mod test {
         assert_eq!(adapter.channel_id(), "email");
         adapter
             .send(OutboundMessage {
+                message_id: None,
                 task_id: None,
                 channel: "email".into(),
                 text: "hello".into(),
@@ -96,6 +97,7 @@ mod test {
         let adapter = OpenHumanChannelAdapter::new("email", rpc);
         let err = adapter
             .send(OutboundMessage {
+                message_id: None,
                 task_id: None,
                 channel: "email".into(),
                 text: "hi".into(),

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -238,6 +238,21 @@ pub enum CompanyEvent {
         /// migrating.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         chat: Option<String>,
+        /// The message this one replies to, as that message's own sequence
+        /// position (issue #364) — what makes a thread reply survive a reload.
+        ///
+        /// A **parent id, not a thread object**: the console already folds a
+        /// transcript by parent, so a thread is exactly "the messages pointing
+        /// at this one". Recording it that way costs one optional field and
+        /// needs no lifecycle, no membership, and no second addressing scheme
+        /// beside `chat`, which stays the channel the whole thread lives in.
+        ///
+        /// `None` on a message posted straight into a channel — which is every
+        /// message journaled before this field existed, and correctly so: they
+        /// were never thread replies. Additive on exactly the `by` / `chat`
+        /// terms above, so no stored record migrates.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent: Option<EventSeq>,
     },
     /// An inbound webhook fired.
     WebhookReceived {
@@ -363,6 +378,54 @@ pub enum CompanyEvent {
         /// record needs migrating.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         task_id: Option<String>,
+        /// The message this reply belongs under, as that message's own sequence
+        /// position (issue #364).
+        ///
+        /// Set to the **operator message's** parent, not to the operator
+        /// message itself: a reply typed inside a thread and the answer it
+        /// draws are two halves of one exchange, and both belong under the row
+        /// the thread hangs off. Pointing the answer at the question would nest
+        /// a thread inside a thread, which the transcript has no way to render.
+        ///
+        /// `None` for a reply in the channel itself and for every reply
+        /// journaled before this field existed. Additive on the same terms as
+        /// `task_id` above.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent: Option<EventSeq>,
+    },
+    /// A reaction was set or cleared on one chat message (issue #364).
+    ///
+    /// **Per-user rows, event-sourced.** A reaction is a fact about a person —
+    /// "who reacted" is most of what a reaction is for — so the durable record
+    /// is one line per person per emoji rather than a count, and the count is
+    /// derived on read. A count could not answer "did I already react?" for
+    /// anyone but the last writer, and a mutable tally on an append-only log
+    /// would have to be rewritten in place, which this log cannot do.
+    ///
+    /// `on` is explicit rather than implied-toggle so the write is
+    /// **idempotent**: a retried request, a double tap, or two consoles racing
+    /// converge on the state the caller asked for instead of flipping twice.
+    /// Folding keeps the last event per `(message, actor, emoji)`.
+    ReactionToggled {
+        /// The message reacted to, by its sequence position — the same id
+        /// `chat/history` returns for that message.
+        ///
+        /// Deliberately not validated as still-existing on read: the log is
+        /// append-only, so a message named here was real when the reaction was
+        /// made. A reaction whose message is not in the desk being read simply
+        /// folds into nothing.
+        message_seq: EventSeq,
+        /// The emoji, as the console sent it. Length-bounded and rejected for
+        /// control characters at the route, so a journal line can never carry a
+        /// blob or a newline dressed as a reaction.
+        emoji: String,
+        /// Whether the reaction is now set (`true`) or cleared (`false`).
+        on: bool,
+        /// Who reacted. `None` for a machine/platform credential, which has no
+        /// person behind it — read back as "operator", exactly as
+        /// `OperatorMessage`'s `by` is.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        by: Option<Actor>,
     },
     /// The Operator deleted a durable memory fact. Journaled for the audit trail
     /// per the Operator-rights section of `docs/spec/company-brain/memory.md`.
@@ -1329,6 +1392,25 @@ pub struct OutboundMessage {
     /// would be a trap for whoever wires the next reader.
     #[serde(default, rename = "taskId", skip_serializing_if = "Option::is_none")]
     pub task_id: Option<String>,
+    /// The durable id this bubble was journaled under (issue #364) — the
+    /// sequence position of its `AgentReply`, which is the same id
+    /// `chat/history` returns for it on a later reload.
+    ///
+    /// The enabler for everything durable that references a message. Until this
+    /// existed a freshly-sent bubble had only a browser-minted counter id, so a
+    /// thread reply or a reaction made against it named something no other
+    /// reader — a reload, a second operator — could resolve.
+    ///
+    /// **Stamped by the chat route after journaling, not produced by a brain.**
+    /// A brain emits an answer; it does not know where the answer will land in
+    /// the log, and every non-chat delivery path (a channel send, a workflow
+    /// step) journals nothing at all and correctly leaves this `None`.
+    ///
+    /// Additive and omitted when absent, so an old console ignores it and a new
+    /// console reads its absence as "this host predates durable message ids"
+    /// and says so rather than offering an action that cannot persist.
+    #[serde(default, rename = "messageId", skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
 }
 
 /// One visible step in an agent turn's processing timeline, surfaced in the
@@ -2365,6 +2447,7 @@ mod test {
     #[test]
     fn outbound_message_steps_are_additive_and_omitted_when_empty() {
         let no_steps = OutboundMessage {
+            message_id: None,
             task_id: None,
             channel: "operator".to_string(),
             text: "hi".to_string(),
@@ -2379,6 +2462,7 @@ mod test {
         assert!(legacy.steps.is_empty());
 
         let with_steps = OutboundMessage {
+            message_id: None,
             task_id: None,
             channel: "operator".to_string(),
             text: "done".to_string(),
@@ -2403,6 +2487,7 @@ mod test {
     #[test]
     fn outbound_message_task_id_is_additive_and_omitted_when_absent() {
         let no_card = OutboundMessage {
+            message_id: None,
             task_id: None,
             channel: "operator".to_string(),
             text: "hi".to_string(),
@@ -2420,6 +2505,7 @@ mod test {
         assert!(legacy.task_id.is_none());
 
         let with_card = OutboundMessage {
+            message_id: None,
             task_id: Some("t-42".to_string()),
             channel: "operator".to_string(),
             text: "opened one".to_string(),
@@ -2451,6 +2537,7 @@ mod test {
 
         // A tool-less reply serializes without the `steps` key.
         let tool_less = CompanyEvent::AgentReply {
+            parent: None,
             task_id: None,
             chat_id: "main".to_string(),
             agent_id: "ceo".to_string(),
@@ -2462,6 +2549,7 @@ mod test {
 
         // A reply with a timeline round-trips it.
         let with_steps = CompanyEvent::AgentReply {
+            parent: None,
             task_id: None,
             chat_id: "main".to_string(),
             agent_id: "ceo".to_string(),
@@ -2500,6 +2588,7 @@ mod test {
 
         // An untagged reply keeps the legacy wire shape exactly.
         let untagged = CompanyEvent::AgentReply {
+            parent: None,
             chat_id: "main".to_string(),
             agent_id: "ceo".to_string(),
             text: "hi".to_string(),
@@ -2513,6 +2602,7 @@ mod test {
 
         // A dispatch-produced reply carries the key and round-trips.
         let tagged = CompanyEvent::AgentReply {
+            parent: None,
             chat_id: "t-1".to_string(),
             agent_id: "ceo".to_string(),
             text: "done".to_string(),
@@ -2595,6 +2685,101 @@ mod test {
         );
     }
 
+    /// Issue #364: a thread parent round-trips, and a message journaled before
+    /// threads existed still replays — as unparented, which is the truth about
+    /// it and not a default standing in for one.
+    ///
+    /// The legacy blobs are asserted verbatim because they are exactly what is
+    /// already on disk in every company's log. A message that never was a thread
+    /// reply must serialize byte-for-byte as it always did, so export/import and
+    /// the cross-backend round-trip need no migration.
+    #[test]
+    fn a_thread_parent_round_trips_and_a_pre_thread_line_still_loads() {
+        for legacy in [
+            r#"{"kind":"OperatorMessage","text":"hi"}"#,
+            r#"{"kind":"AgentReply","chat_id":"main","agent_id":"ceo","text":"hi"}"#,
+        ] {
+            let event: CompanyEvent = serde_json::from_str(legacy).unwrap();
+            match &event {
+                CompanyEvent::OperatorMessage { parent, .. }
+                | CompanyEvent::AgentReply { parent, .. } => assert!(
+                    parent.is_none(),
+                    "a pre-#364 line was never a thread reply: {legacy}"
+                ),
+                other => panic!("unexpected variant: {other:?}"),
+            }
+            assert_eq!(
+                serde_json::to_string(&event).unwrap(),
+                legacy,
+                "an unparented message must serialize exactly as it did before"
+            );
+        }
+
+        let threaded = CompanyEvent::OperatorMessage {
+            parent: Some(EventSeq::new(41)),
+            text: "a follow-up".into(),
+            by: None,
+            chat: Some("studio".into()),
+        };
+        let json = serde_json::to_string(&threaded).unwrap();
+        assert!(json.contains(r#""parent":41"#), "{json}");
+        assert_eq!(
+            serde_json::from_str::<CompanyEvent>(&json).unwrap(),
+            threaded
+        );
+
+        let answered = CompanyEvent::AgentReply {
+            parent: Some(EventSeq::new(41)),
+            task_id: None,
+            chat_id: "studio".into(),
+            agent_id: "ceo".into(),
+            text: "on it".into(),
+            steps: Vec::new(),
+        };
+        let json = serde_json::to_string(&answered).unwrap();
+        assert!(json.contains(r#""parent":41"#), "{json}");
+        assert_eq!(
+            serde_json::from_str::<CompanyEvent>(&json).unwrap(),
+            answered
+        );
+    }
+
+    /// Issue #364: a reaction round-trips, and an unattributed one adds no
+    /// `by` key — the same additive contract every optional actor here keeps.
+    #[test]
+    fn a_reaction_round_trips() {
+        let anonymous = CompanyEvent::ReactionToggled {
+            message_seq: EventSeq::new(4),
+            emoji: "👍".into(),
+            on: true,
+            by: None,
+        };
+        let json = serde_json::to_string(&anonymous).unwrap();
+        assert_eq!(
+            json,
+            r#"{"kind":"ReactionToggled","message_seq":4,"emoji":"👍","on":true}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<CompanyEvent>(&json).unwrap(),
+            anonymous
+        );
+
+        let attributed = CompanyEvent::ReactionToggled {
+            message_seq: EventSeq::new(4),
+            emoji: "🎉".into(),
+            on: false,
+            by: Some(Actor {
+                kind: ActorKind::User,
+                id: "u1".into(),
+            }),
+        };
+        let json = serde_json::to_string(&attributed).unwrap();
+        assert_eq!(
+            serde_json::from_str::<CompanyEvent>(&json).unwrap(),
+            attributed
+        );
+    }
+
     #[test]
     fn an_operator_message_journaled_before_attribution_still_loads() {
         // Exactly what is already on disk in every existing company's event
@@ -2604,6 +2789,7 @@ mod test {
         assert_eq!(
             event,
             CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "hi".into(),
                 by: None,
                 chat: None,
@@ -2617,6 +2803,7 @@ mod test {
         // export/import and the fs/sqlite/mongo round-trip stay green without
         // touching a single stored record.
         let event = CompanyEvent::OperatorMessage {
+            parent: None,
             text: "hi".into(),
             by: None,
             chat: None,
@@ -2630,6 +2817,7 @@ mod test {
     #[test]
     fn an_attributed_message_round_trips_with_its_actor() {
         let event = CompanyEvent::OperatorMessage {
+            parent: None,
             text: "hi".into(),
             by: Some(Actor {
                 kind: ActorKind::User,
@@ -2658,6 +2846,7 @@ mod test {
     fn company_event_variants_round_trip_tagged() {
         let events = vec![
             CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "hi".into(),
                 by: None,
                 chat: None,

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -3228,6 +3228,7 @@ mod test {
         // lead `eng2`, not the blueprint lead `eng1`.
         runtime
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "who leads?".to_string(),
                 by: None,
                 chat: Some("eng".to_string()),

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -73,6 +73,7 @@ mod test {
         assert_eq!(channel.channel_id(), "operator");
         channel
             .send(OutboundMessage {
+                message_id: None,
                 task_id: None,
                 channel: "operator".into(),
                 text: "hello".into(),

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -186,6 +186,11 @@ impl<'a> CycleRunner<'a> {
         }
 
         let cycle_id = crate::ports::generate_id();
+        // Issue #364: the report carries the input seqs too, so the chat route
+        // can tell the console the durable id of the message it just sent. The
+        // brain needs the same list, and it is the append loop above — the one
+        // place that knows it — that produced it.
+        let input_seqs = event_seqs.clone();
         let request = CycleRequest {
             cycle_id: cycle_id.clone(),
             company_id: company.clone(),
@@ -277,6 +282,7 @@ impl<'a> CycleRunner<'a> {
             executed_effects,
             parked,
             persisted_seq,
+            input_seqs,
         })
     }
 
@@ -811,10 +817,12 @@ working on):\n{}\n]",
                 text: "This approval was already resolved.".to_string(),
                 steps: Vec::new(),
                 reply_to: None,
+                message_id: None,
             }],
             executed_effects: Vec::new(),
             parked: Vec::new(),
             persisted_seq: None,
+            input_seqs: Vec::new(),
         }
     }
 
@@ -1032,6 +1040,7 @@ async fn perform_effect(rt: &CompanyRuntime, effect: &Effect) -> Result<()> {
             if adapter.channel_id() == channel {
                 adapter
                     .send(OutboundMessage {
+                        message_id: None,
                         task_id: None,
                         channel: channel.to_string(),
                         text: text.to_string(),
@@ -1204,6 +1213,10 @@ fn cycle_task_id(
             | CompanyEvent::AgentReply { .. }
             | CompanyEvent::ApprovalParked { .. }
             | CompanyEvent::MemoryFactDeleted { .. }
+            // A reaction (issue #364) is a reader's response to a message that
+            // already exists. It starts no work and rivals no conversation, so
+            // it passes through exactly like every other record here.
+            | CompanyEvent::ReactionToggled { .. }
             // A credential or connection change (issue #403) is a record of an
             // admin's decision, not a stimulus: it names no card and competes
             // with none.
@@ -1308,6 +1321,10 @@ fn cycle_thread_id(
             | CompanyEvent::AgentReply { .. }
             | CompanyEvent::ApprovalParked { .. }
             | CompanyEvent::MemoryFactDeleted { .. }
+            // A reaction (issue #364) is a reader's response to a message that
+            // already exists. It starts no work and rivals no conversation, so
+            // it passes through exactly like every other record here.
+            | CompanyEvent::ReactionToggled { .. }
             // A credential or connection change (issue #403) is a record of an
             // admin's decision, not a stimulus: it names no card and competes
             // with none.
@@ -1820,6 +1837,7 @@ mod test {
                 if let CompanyEvent::OperatorMessage { text, .. } = event {
                     host.emit_effect(self.effect.clone()).await?;
                     responses.push(OutboundMessage {
+                        message_id: None,
                         task_id: None,
                         channel: "operator".into(),
                         text: format!("handled: {text}"),
@@ -1852,6 +1870,7 @@ mod test {
                 if let CompanyEvent::OperatorMessage { text, .. } = event {
                     host.park_effect(self.effect.clone()).await?;
                     responses.push(OutboundMessage {
+                        message_id: None,
                         task_id: None,
                         channel: "operator".into(),
                         text: format!("that needs your approval: {text}"),
@@ -1880,6 +1899,7 @@ mod test {
             Ok(CycleResult {
                 channel_responses: vec![
                     OutboundMessage {
+                        message_id: None,
                         task_id: None,
                         channel: "operator".into(),
                         text: "orchestrator".into(),
@@ -1887,6 +1907,7 @@ mod test {
                         reply_to: None,
                     },
                     OutboundMessage {
+                        message_id: None,
                         task_id: None,
                         // Addressed by *agent id*: no adapter answers to this.
                         channel: "maya".into(),
@@ -1923,6 +1944,7 @@ mod test {
             .unwrap();
 
         rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            parent: None,
             text: "hand it off".into(),
             by: None,
             chat: None,
@@ -1988,6 +2010,7 @@ mod test {
             }
             Ok(CycleResult {
                 channel_responses: vec![OutboundMessage {
+                    message_id: None,
                     task_id: None,
                     channel: "operator".into(),
                     text: "settled".into(),
@@ -2330,6 +2353,7 @@ mod test {
 
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "hi".into(),
                 by: None,
                 chat: None,
@@ -2352,6 +2376,7 @@ mod test {
         assert_eq!(
             stored[0].event,
             CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "hi".into(),
                 by: None,
                 chat: None
@@ -2428,6 +2453,7 @@ mod test {
 
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "file it".into(),
                 by: None,
                 chat: None,
@@ -2487,6 +2513,7 @@ mod test {
         );
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "do it".into(),
                 by: None,
                 chat: None,
@@ -2550,6 +2577,7 @@ mod test {
         );
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "do it".into(),
                 by: None,
                 chat: None,
@@ -2809,6 +2837,7 @@ mod test {
         );
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "do it".into(),
                 by: None,
                 chat: None,
@@ -2974,6 +3003,7 @@ mod test {
 
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "file it".into(),
                 by: None,
                 chat: None,
@@ -3052,6 +3082,7 @@ mod test {
 
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "send that email".into(),
                 by: None,
                 chat: None,
@@ -3107,6 +3138,7 @@ mod test {
                 .unwrap();
             let report = rt
                 .run_cycle(vec![CompanyEvent::OperatorMessage {
+                    parent: None,
                     text: "file it".into(),
                     by: None,
                     chat: None,
@@ -3166,6 +3198,7 @@ mod test {
 
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "file it".into(),
                 by: None,
                 chat: None,
@@ -3233,6 +3266,7 @@ mod test {
 
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "file it".into(),
                 by: None,
                 chat: None,
@@ -3276,6 +3310,7 @@ mod test {
         async fn run_cycle(&self, req: CycleRequest, _host: &dyn CycleHost) -> Result<CycleResult> {
             Ok(CycleResult {
                 channel_responses: vec![OutboundMessage {
+                    message_id: None,
                     task_id: None,
                     channel: "operator".into(),
                     text: "thought about it".into(),
@@ -3319,6 +3354,7 @@ mod test {
             .unwrap();
 
         rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            parent: None,
             text: "how are we doing".into(),
             by: None,
             chat: None,
@@ -3539,11 +3575,13 @@ mod test {
 
         let (ra, rb) = tokio::join!(
             one.run_cycle(vec![CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "a".into(),
                 by: None,
                 chat: None
             }]),
             two.run_cycle(vec![CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "b".into(),
                 by: None,
                 chat: None
@@ -3593,6 +3631,7 @@ mod test {
             .unwrap();
 
         rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            parent: None,
             text: "send it".into(),
             by: None,
             chat: None,
@@ -4174,6 +4213,7 @@ mod test {
         };
 
         let chat = || CompanyEvent::OperatorMessage {
+            parent: None,
             text: "hi".into(),
             by: None,
             chat: None,
@@ -4312,11 +4352,13 @@ mod test {
             _ => None,
         };
         let addressed = |chat: &str| CompanyEvent::OperatorMessage {
+            parent: None,
             text: "pay the invoice".into(),
             by: None,
             chat: Some(chat.to_string()),
         };
         let unaddressed = || CompanyEvent::OperatorMessage {
+            parent: None,
             text: "hi".into(),
             by: None,
             chat: None,
@@ -4444,6 +4486,7 @@ mod test {
                 output: String::new(),
             },
             CompanyEvent::AgentReply {
+                parent: None,
                 chat_id: "desk-ops".into(),
                 agent_id: "ops".into(),
                 text: "done".into(),
@@ -4758,6 +4801,7 @@ mod test {
 
         // Asking the desk directly (by name) surfaces the handed task...
         rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            parent: None,
             text: "what are you working on?".into(),
             by: None,
             chat: Some("Engineering".into()),
@@ -4768,6 +4812,7 @@ mod test {
         // ...and asking with no address (the orchestrator) does NOT get the
         // desk's briefing folded into it.
         rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            parent: None,
             text: "status?".into(),
             by: None,
             chat: None,
@@ -4818,6 +4863,7 @@ mod test {
             .await
             .unwrap();
         rt.run_cycle(vec![CompanyEvent::OperatorMessage {
+            parent: None,
             text: "what's up?".into(),
             by: None,
             chat: Some("eng".into()),
@@ -4885,6 +4931,7 @@ mod test {
         );
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "do it".into(),
                 by: None,
                 chat: None,
@@ -5016,6 +5063,7 @@ mod test {
         for _ in 0..5 {
             let report = rt
                 .run_cycle(vec![CompanyEvent::OperatorMessage {
+                    parent: None,
                     text: "do it".into(),
                     by: None,
                     chat: None,

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -330,6 +330,7 @@ mod test {
             for event in &req.events {
                 if let CompanyEvent::ScheduleFired { prompt, .. } = event {
                     responses.push(OutboundMessage {
+                        message_id: None,
                         task_id: None,
                         channel: "operator".into(),
                         text: format!("scheduled: {prompt}"),

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -58,6 +58,25 @@ pub struct CycleReport {
     pub parked: Vec<ApprovalId>,
     /// The sequence of the last event appended this cycle, if any.
     pub persisted_seq: Option<EventSeq>,
+    /// The sequence each of this cycle's **input** events was journaled under,
+    /// in the order they were handed in (issue #364).
+    ///
+    /// `persisted_seq` next door is the *last* append and cannot answer this:
+    /// by the time a cycle returns it names whatever the cycle wrote last, not
+    /// the operator message that started it. Without a per-input seq the chat
+    /// route has no durable id for the message the operator just sent, so a
+    /// thread reply or a reaction made against it names a browser-minted
+    /// counter that nothing else can resolve.
+    ///
+    /// Read off the append loop, which already computes it — the alternative
+    /// (journaling the message in the route before calling the runtime) would
+    /// either double-journal it or move the append out of the one place that
+    /// orders it against the rest of the cycle.
+    ///
+    /// Empty on a synthetic report (an already-resolved approval) and on a
+    /// report deserialized from before this field existed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub input_seqs: Vec<EventSeq>,
 }
 
 /// A compact status snapshot for a running company.

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
-use crate::ports::types::{ActorKind, CompanyEvent, EventSeq, StoredEvent, TurnStep};
+use crate::ports::types::{Actor, ActorKind, CompanyEvent, EventSeq, StoredEvent, TurnStep};
 use crate::server::ops::language::DEFAULT_DESK as GENERAL_DESK;
 
 /// The console's default/orchestrator thread id
@@ -99,6 +99,114 @@ pub struct MessageView {
     /// (issue #65's whole point). `None` on operator messages and on every
     /// reply journaled before the field existed.
     pub task_id: Option<String>,
+    /// The message this one replies to (issue #364), by that message's own id —
+    /// what makes a thread survive a reload rather than living in one browser.
+    ///
+    /// `None` on a message posted straight into the channel, which is every
+    /// message journaled before threads were persisted.
+    pub parent_id: Option<String>,
+    /// Who reacted to this message with what (issue #364), one row per person
+    /// per emoji, oldest reaction first.
+    ///
+    /// Rows rather than a tally, because a tally cannot answer the two
+    /// questions the console actually asks of a reaction — *who* reacted, and
+    /// *have I* — and the second is what makes the chip a toggle rather than an
+    /// ever-increasing counter. Grouping rows into a count is the renderer's
+    /// job; deriving names from a count is impossible.
+    pub reactions: Vec<ReactionView>,
+}
+
+/// One person's reaction to one message, as a reader sees it.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ReactionView {
+    /// The emoji.
+    pub emoji: String,
+    /// Who reacted, as a display label — never a raw user id, for the same
+    /// reason [`author_labels`] never hands out an email.
+    pub by_label: String,
+    /// Whether this row is the viewer's own. Relative to the [`Viewer`], on the
+    /// same terms [`MessageView::mine`] is.
+    pub mine: bool,
+}
+
+/// How a reaction's author is keyed while folding.
+///
+/// A signed-in person keys on their user id; anything else — a platform
+/// credential, an event journaled before attribution existed — keys on the one
+/// shared "operator" identity, which is the same collapse
+/// [`MessageView::project`] makes for authorship. Two different machine
+/// credentials therefore share a reaction row, which is correct: they are the
+/// same principal as far as this company's history is concerned.
+fn reaction_actor_key(by: &Option<Actor>) -> String {
+    match by {
+        Some(actor) if actor.kind == ActorKind::User => format!("user:{}", actor.id),
+        _ => "operator".to_string(),
+    }
+}
+
+/// Folds every [`CompanyEvent::ReactionToggled`] in a log into per-message
+/// reaction rows, keyed by the reacted-to message's id.
+///
+/// Last event per `(message, actor, emoji)` wins — that is what makes the
+/// route's explicit `on` flag idempotent — and a row that ends up `off` is
+/// dropped entirely rather than kept as a zero. Order is first-set order, so a
+/// message's chips do not reshuffle between reads.
+fn fold_reactions(
+    stored: &[StoredEvent],
+    viewer: &Viewer,
+    authors: &HashMap<String, String>,
+) -> HashMap<String, Vec<ReactionView>> {
+    // (message, actor, emoji) → (position among first-seen keys, currently on).
+    let mut state: HashMap<(u64, String, String), (usize, bool)> = HashMap::new();
+    let mut seen = 0usize;
+    for event in stored {
+        let CompanyEvent::ReactionToggled {
+            message_seq,
+            emoji,
+            on,
+            by,
+        } = &event.event
+        else {
+            continue;
+        };
+        let key = (message_seq.value(), reaction_actor_key(by), emoji.clone());
+        match state.get_mut(&key) {
+            Some(slot) => slot.1 = *on,
+            None => {
+                state.insert(key, (seen, *on));
+                seen += 1;
+            }
+        }
+    }
+
+    let mut rows: Vec<(usize, u64, String, String)> = state
+        .into_iter()
+        .filter(|(_, (_, on))| *on)
+        .map(|((message, actor, emoji), (order, _))| (order, message, actor, emoji))
+        .collect();
+    rows.sort_unstable();
+
+    let mut out: HashMap<String, Vec<ReactionView>> = HashMap::new();
+    for (_, message, actor, emoji) in rows {
+        let (by_label, mine) = match actor.strip_prefix("user:") {
+            Some(user_id) => (
+                authors
+                    .get(user_id)
+                    .cloned()
+                    .unwrap_or_else(|| "someone".to_string()),
+                *viewer == Viewer::User(user_id.to_string()),
+            ),
+            None => ("operator".to_string(), matches!(viewer, Viewer::Operator)),
+        };
+        out.entry(message.to_string())
+            .or_default()
+            .push(ReactionView {
+                emoji,
+                by_label,
+                mine,
+            });
+    }
+    out
 }
 
 impl MessageView {
@@ -119,6 +227,7 @@ impl MessageView {
                 text,
                 steps,
                 task_id,
+                parent,
                 ..
             } => MessageView {
                 id,
@@ -129,8 +238,12 @@ impl MessageView {
                 mine: false,
                 steps,
                 task_id,
+                parent_id: parent.map(|seq| seq.value().to_string()),
+                reactions: Vec::new(),
             },
-            CompanyEvent::OperatorMessage { text, by, .. } => {
+            CompanyEvent::OperatorMessage {
+                text, by, parent, ..
+            } => {
                 let (author, mine) = match &by {
                     // Sent by a signed-in human.
                     Some(actor) if actor.kind == ActorKind::User => {
@@ -154,6 +267,8 @@ impl MessageView {
                     mine,
                     steps: Vec::new(),
                     task_id: None,
+                    parent_id: parent.map(|seq| seq.value().to_string()),
+                    reactions: Vec::new(),
                 }
             }
             // `owns` never admits other variants into a history.
@@ -166,6 +281,8 @@ impl MessageView {
                 mine: false,
                 steps: Vec::new(),
                 task_id: None,
+                parent_id: None,
+                reactions: Vec::new(),
             },
         }
     }
@@ -220,12 +337,22 @@ pub async fn history_for_desk(
     // One roster read per history, not one per message: the scan above is
     // already O(log), and an N+1 on top of it would be worse.
     let authors = author_labels(runtime).await?;
+    // Issue #364: reactions ride the same full-log read the messages do — a
+    // second pass over a list already in memory, not a second query. Folded
+    // before the messages are consumed, and attached only to messages this desk
+    // owns, so a reaction can no more cross a desk boundary than the message it
+    // is about can.
+    let mut reactions = fold_reactions(&stored, viewer, &authors);
 
     let mut messages: Vec<MessageView> = stored
         .into_iter()
         .filter(|event| owns(desk_id, desk_name, &event.event))
         .filter(|event| before_seq.is_none_or(|before| event.seq.value() < before))
         .map(|event| MessageView::project(event, viewer, &authors))
+        .map(|mut view| {
+            view.reactions = reactions.remove(&view.id).unwrap_or_default();
+            view
+        })
         .collect();
 
     let total = messages.len() as i32;
@@ -243,6 +370,7 @@ mod test {
 
     fn agent_reply(chat_id: &str) -> CompanyEvent {
         CompanyEvent::AgentReply {
+            parent: None,
             task_id: None,
             chat_id: chat_id.to_string(),
             agent_id: "ceo".to_string(),
@@ -282,6 +410,7 @@ mod test {
     #[test]
     fn general_desk_owns_every_operator_message() {
         let event = CompanyEvent::OperatorMessage {
+            parent: None,
             text: "hi".to_string(),
             by: Some(Actor {
                 kind: ActorKind::User,
@@ -298,6 +427,7 @@ mod test {
     #[test]
     fn main_thread_owns_operator_messages_it_stored() {
         let event = CompanyEvent::OperatorMessage {
+            parent: None,
             text: "hi".to_string(),
             by: None,
             chat: Some(MAIN_THREAD_ID.to_string()),
@@ -313,6 +443,7 @@ mod test {
     #[test]
     fn desk_addressed_operator_message_belongs_to_that_desk() {
         let event = CompanyEvent::OperatorMessage {
+            parent: None,
             text: "hi".to_string(),
             by: None,
             chat: Some("strategy".to_string()),
@@ -321,9 +452,154 @@ mod test {
         assert!(!owns(MAIN_THREAD_ID, MAIN_THREAD_ID, &event));
     }
 
+    /* ---- issue #364: threads and reactions ---- */
+
+    fn user(id: &str) -> Option<Actor> {
+        Some(Actor {
+            kind: ActorKind::User,
+            id: id.to_string(),
+        })
+    }
+
+    fn at(seq: u64, event: CompanyEvent) -> StoredEvent {
+        StoredEvent {
+            seq: EventSeq::new(seq),
+            company: crate::ports::types::CompanyId::new("acme"),
+            event,
+            at_millis: 1_700_000_000_000 + seq,
+        }
+    }
+
+    fn reaction(seq: u64, message: u64, emoji: &str, on: bool, by: Option<Actor>) -> StoredEvent {
+        at(
+            seq,
+            CompanyEvent::ReactionToggled {
+                message_seq: EventSeq::new(message),
+                emoji: emoji.to_string(),
+                on,
+                by,
+            },
+        )
+    }
+
+    fn labels() -> HashMap<String, String> {
+        HashMap::from([
+            ("u1".to_string(), "Ada".to_string()),
+            ("u2".to_string(), "Grace".to_string()),
+        ])
+    }
+
+    /// Two people reacting with the same emoji are two rows, not a count of
+    /// two, and only the reader's own row is `mine` — which is the whole reason
+    /// the durable record is per-person.
+    #[test]
+    fn reactions_fold_into_one_row_per_person() {
+        let log = vec![
+            reaction(10, 4, "👍", true, user("u1")),
+            reaction(11, 4, "👍", true, user("u2")),
+        ];
+        let folded = fold_reactions(&log, &Viewer::User("u1".to_string()), &labels());
+        let rows = folded.get("4").expect("message 4 has reactions");
+        assert_eq!(
+            rows,
+            &vec![
+                ReactionView {
+                    emoji: "👍".to_string(),
+                    by_label: "Ada".to_string(),
+                    mine: true,
+                },
+                ReactionView {
+                    emoji: "👍".to_string(),
+                    by_label: "Grace".to_string(),
+                    mine: false,
+                },
+            ]
+        );
+
+        // The same log read by the other person flips only `mine`.
+        let folded = fold_reactions(&log, &Viewer::User("u2".to_string()), &labels());
+        let mine: Vec<bool> = folded["4"].iter().map(|r| r.mine).collect();
+        assert_eq!(mine, vec![false, true]);
+    }
+
+    /// The last event per (message, person, emoji) wins, so a clear removes the
+    /// row and a repeated set leaves exactly one — which is what makes the
+    /// route's explicit `on` flag idempotent rather than a toggle that drifts.
+    #[test]
+    fn reactions_fold_to_the_last_event_per_person_and_emoji() {
+        let log = vec![
+            reaction(10, 4, "👍", true, user("u1")),
+            reaction(11, 4, "👍", true, user("u1")),
+            reaction(12, 4, "🎉", true, user("u1")),
+            reaction(13, 4, "🎉", false, user("u1")),
+        ];
+        let folded = fold_reactions(&log, &Viewer::User("u1".to_string()), &labels());
+        let emojis: Vec<&str> = folded["4"].iter().map(|r| r.emoji.as_str()).collect();
+        assert_eq!(emojis, vec!["👍"], "a cleared reaction leaves no row");
+    }
+
+    /// A reaction made with a machine credential reads back as the operator's,
+    /// exactly as an unattributed message does — the same collapse `project`
+    /// makes for authorship, so the two surfaces cannot disagree about who a
+    /// credential is.
+    #[test]
+    fn an_unattributed_reaction_belongs_to_the_operator() {
+        let log = vec![reaction(10, 4, "👀", true, None)];
+        let folded = fold_reactions(&log, &Viewer::Operator, &labels());
+        assert_eq!(folded["4"][0].by_label, "operator");
+        assert!(folded["4"][0].mine);
+        // …and is nobody's own when a signed-in person reads it.
+        let folded = fold_reactions(&log, &Viewer::User("u1".to_string()), &labels());
+        assert!(!folded["4"][0].mine);
+    }
+
+    /// A thread parent survives projection on both halves of an exchange, as
+    /// the message id a reader can resolve rather than a raw sequence number.
+    #[test]
+    fn project_carries_the_thread_parent() {
+        let operator = MessageView::project(
+            at(
+                12,
+                CompanyEvent::OperatorMessage {
+                    parent: Some(EventSeq::new(4)),
+                    text: "a follow-up".to_string(),
+                    by: None,
+                    chat: Some("studio".to_string()),
+                },
+            ),
+            &Viewer::Operator,
+            &labels(),
+        );
+        assert_eq!(operator.parent_id.as_deref(), Some("4"));
+
+        let reply = MessageView::project(
+            at(
+                13,
+                CompanyEvent::AgentReply {
+                    parent: Some(EventSeq::new(4)),
+                    task_id: None,
+                    chat_id: "studio".to_string(),
+                    agent_id: "ceo".to_string(),
+                    text: "on it".to_string(),
+                    steps: Vec::new(),
+                },
+            ),
+            &Viewer::Operator,
+            &labels(),
+        );
+        assert_eq!(reply.parent_id.as_deref(), Some("4"));
+
+        // A message with no parent is in the channel, not in a thread — which
+        // is every message journaled before threads were persisted.
+        let plain =
+            MessageView::project(at(14, agent_reply("studio")), &Viewer::Operator, &labels());
+        assert!(plain.parent_id.is_none());
+    }
+
     #[test]
     fn legacy_operator_message_without_chat_stays_on_general() {
         let event = CompanyEvent::OperatorMessage {
+            parent: None,
             text: "hi".to_string(),
             by: None,
             chat: None,

--- a/src/server/graphql/company.rs
+++ b/src/server/graphql/company.rs
@@ -27,7 +27,7 @@ use super::{
 use crate::company::runtime::CompanyRuntime;
 use crate::ports::types::CompanyId;
 use crate::ports::types::TurnStep;
-use crate::server::chat_history::{self, MessageView, Viewer};
+use crate::server::chat_history::{self, MessageView, ReactionView, Viewer};
 
 /// The aggregation-root handle over one company. See the module docs.
 pub struct CompanyGql {
@@ -481,6 +481,38 @@ pub struct MessageGql {
     /// agree on which messages carry a card. Null on operator messages and on
     /// every reply journaled before the field existed.
     pub task_id: Option<ID>,
+    /// The message this one replies to (issue #364) — a thread reply rather
+    /// than a new line in the channel. Null for a message posted straight into
+    /// the channel, which is every message journaled before threads were
+    /// persisted. Same [`MessageView`] field the REST route reads, so the two
+    /// surfaces cannot disagree about the shape of a thread.
+    pub parent_id: Option<ID>,
+    /// Who reacted to this message with what (issue #364), one row per person
+    /// per emoji. Empty when nobody has.
+    pub reactions: Vec<MessageReactionGql>,
+}
+
+/// One person's reaction on a history message (issue #364). GraphQL mirror of
+/// the REST `reactions` array, so the two surfaces carry the same rows.
+#[derive(SimpleObject)]
+#[graphql(name = "MessageReaction")]
+pub struct MessageReactionGql {
+    /// The emoji.
+    pub emoji: String,
+    /// Who reacted, as a display label — never a raw user id.
+    pub by: String,
+    /// Whether the reading viewer is the one who reacted.
+    pub mine: bool,
+}
+
+impl From<ReactionView> for MessageReactionGql {
+    fn from(view: ReactionView) -> Self {
+        MessageReactionGql {
+            emoji: view.emoji,
+            by: view.by_label,
+            mine: view.mine,
+        }
+    }
 }
 
 /// One scrubbed step in a reply's processing timeline. GraphQL mirror of the
@@ -528,6 +560,12 @@ impl From<MessageView> for MessageGql {
             mine: view.mine,
             steps: view.steps.into_iter().map(MessageStepGql::from).collect(),
             task_id: view.task_id.map(ID),
+            parent_id: view.parent_id.map(ID),
+            reactions: view
+                .reactions
+                .into_iter()
+                .map(MessageReactionGql::from)
+                .collect(),
         }
     }
 }

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -494,6 +494,19 @@ type Message {
 	every reply journaled before the field existed.
 	"""
 	taskId: ID
+	"""
+	The message this one replies to (issue #364) — a thread reply rather
+	than a new line in the channel. Null for a message posted straight into
+	the channel, which is every message journaled before threads were
+	persisted. Same [`MessageView`] field the REST route reads, so the two
+	surfaces cannot disagree about the shape of a thread.
+	"""
+	parentId: ID
+	"""
+	Who reacted to this message with what (issue #364), one row per person
+	per emoji. Empty when nobody has.
+	"""
+	reactions: [MessageReaction!]!
 }
 
 """
@@ -508,6 +521,25 @@ type MessagePage {
 	The total number of items across all pages (before offset/limit).
 	"""
 	total: Int!
+}
+
+"""
+One person's reaction on a history message (issue #364). GraphQL mirror of
+the REST `reactions` array, so the two surfaces carry the same rows.
+"""
+type MessageReaction {
+	"""
+	The emoji.
+	"""
+	emoji: String!
+	"""
+	Who reacted, as a display label — never a raw user id.
+	"""
+	by: String!
+	"""
+	Whether the reading viewer is the one who reacted.
+	"""
+	mine: Boolean!
 }
 
 """

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -443,6 +443,7 @@ async fn chat_history_finds_agent_replies_under_general_and_main() {
         .append(
             runtime.id(),
             crate::ports::types::CompanyEvent::AgentReply {
+                parent: None,
                 task_id: None,
                 chat_id: "General".to_string(),
                 agent_id: "maya".to_string(),
@@ -457,6 +458,7 @@ async fn chat_history_finds_agent_replies_under_general_and_main() {
         .append(
             runtime.id(),
             crate::ports::types::CompanyEvent::AgentReply {
+                parent: None,
                 task_id: None,
                 chat_id: "main".to_string(),
                 agent_id: "maya".to_string(),
@@ -506,6 +508,7 @@ async fn chat_history_projects_the_card_a_reply_opened() {
             .append(
                 runtime.id(),
                 crate::ports::types::CompanyEvent::AgentReply {
+                    parent: None,
                     task_id,
                     chat_id: "General".to_string(),
                     agent_id: "maya".to_string(),
@@ -538,6 +541,93 @@ async fn chat_history_projects_the_card_a_reply_opened() {
     assert!(
         plain["taskId"].is_null(),
         "an ordinary reply carries no card: {plain}"
+    );
+}
+
+/// Issue #364 + #65: a thread parent and a message's reactions are projected on
+/// **both** history surfaces, from the one shared `MessageView`.
+///
+/// The same parity rule #246 is held to one test up. A console that hydrates a
+/// transcript over GraphQL must see the same threads and the same reactions the
+/// REST route returns, or the two doors show different conversations.
+#[tokio::test]
+async fn chat_history_projects_threads_and_reactions() {
+    use crate::ports::types::CompanyEvent;
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_rich_company(&home).await;
+    let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+    let root = runtime
+        .events()
+        .append(
+            runtime.id(),
+            CompanyEvent::AgentReply {
+                parent: None,
+                task_id: None,
+                chat_id: "General".to_string(),
+                agent_id: "maya".to_string(),
+                text: "the root".to_string(),
+                steps: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+    runtime
+        .events()
+        .append(
+            runtime.id(),
+            CompanyEvent::AgentReply {
+                parent: Some(root),
+                task_id: None,
+                chat_id: "General".to_string(),
+                agent_id: "maya".to_string(),
+                text: "in the thread".to_string(),
+                steps: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+    runtime
+        .events()
+        .append(
+            runtime.id(),
+            CompanyEvent::ReactionToggled {
+                message_seq: root,
+                emoji: "👍".to_string(),
+                on: true,
+                by: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let app = router(state);
+    let value = query(
+        app,
+        r#"{"query":"{ company(id:\"acme\"){ chat(id:\"general\"){ history(first: 10) { items { id text parentId reactions { emoji by mine } } } } } }"}"#,
+    )
+    .await;
+    let items = value["data"]["company"]["chat"]["history"]["items"]
+        .as_array()
+        .unwrap();
+    let root_id = root.value().to_string();
+    let parent = items
+        .iter()
+        .find(|m| m["text"] == "the root")
+        .expect("the root is in history");
+    assert!(parent["parentId"].is_null(), "the root is not a reply");
+    assert_eq!(parent["reactions"][0]["emoji"], "👍");
+    assert_eq!(parent["reactions"][0]["by"], "operator");
+    let threaded = items
+        .iter()
+        .find(|m| m["text"] == "in the thread")
+        .expect("the threaded reply is in history");
+    assert_eq!(threaded["parentId"], root_id);
+    assert_eq!(
+        threaded["reactions"].as_array().unwrap().len(),
+        0,
+        "an un-reacted message carries no rows: {threaded}"
     );
 }
 

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -30,12 +30,12 @@ use crate::AppState;
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
 use crate::ports::types::{
-    Actor, ActorKind, ApprovalId, CompanyEvent, CompanyId, OutboundMessage, OverlayDesk,
+    Actor, ActorKind, ApprovalId, CompanyEvent, CompanyId, EventSeq, OutboundMessage, OverlayDesk,
     OverlayDeskMember, OverlayDeskOrder, StoredEvent, TurnStep, Verdict,
 };
 use crate::runtime::grants::{GrantId, GrantScope, MAX_STANDING_GRANT_MILLIS};
 use crate::runtime::types::{ApprovalSummary, CompanyStatus, CycleReport};
-use crate::server::chat_history::{MessageView, Viewer, history_for_desk};
+use crate::server::chat_history::{MessageView, ReactionView, Viewer, history_for_desk};
 use crate::server::error::ApiError;
 use crate::server::graphql::auth::GqlAuth;
 use crate::server::ops::language::{self, DEFAULT_DESK};
@@ -50,6 +50,12 @@ pub fn router() -> Router<AppState> {
         .route("/api/v1/companies/{id}", get(company_status))
         .route("/api/v1/companies/{id}/chat", post(operator_chat))
         .route("/api/v1/companies/{id}/chat/history", get(chat_history))
+        // Set or clear one reaction on one message (issue #364). Not registered
+        // through `scoped` because the two forms take different path tuples.
+        .route(
+            "/api/v1/companies/{id}/chat/messages/{seq}/reactions",
+            post(react_to_message_scoped),
+        )
         .route("/api/v1/companies/{id}/approvals", get(list_approvals))
         .route(
             "/api/v1/companies/{id}/approvals/{aid}",
@@ -58,6 +64,10 @@ pub fn router() -> Router<AppState> {
         // Single-company aliases (no id; resolved via the sole registered company).
         .route("/api/v1/company/chat", post(operator_chat_single))
         .route("/api/v1/company/chat/history", get(chat_history_single))
+        .route(
+            "/api/v1/company/chat/messages/{seq}/reactions",
+            post(react_to_message_single),
+        )
         .route("/api/v1/company/approvals", get(list_approvals_single))
         .route(
             "/api/v1/company/approvals/{aid}",
@@ -615,8 +625,12 @@ async fn company_events(
 /// domain fields that already exist on the [`CompanyEvent`], and any variant not
 /// explicitly listed — `OperatorMessage` (the operator's own echo),
 /// `WebhookReceived` / `A2aTaskReceived` (raw third-party payloads),
-/// `ScheduleFired`, `FeedbackFiled`, `MemoryFactDeleted` — is dropped so nothing
-/// unexpected (or secret-bearing) ever reaches the console. The actor (`by`) on
+/// `ScheduleFired`, `FeedbackFiled`, `MemoryFactDeleted`, `ReactionToggled` —
+/// is dropped so nothing unexpected (or secret-bearing) ever reaches the
+/// console. `ReactionToggled` is dropped on purpose rather than by oversight
+/// (issue #364): a reaction carries the reacting *person*, this stream has no
+/// per-viewer projection to resolve one into a label, and a reaction is
+/// reload-visible, which is all the issue asks for. The actor (`by`) on
 /// `ApprovalResolved` / `LifecycleChanged` is intentionally omitted: the console
 /// renders the attention item without it, and it can carry a user id.
 ///
@@ -640,11 +654,19 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             text,
             steps,
             task_id,
+            parent,
         } => {
             let mut o = envelope("agent_reply");
             o["chatId"] = json!(chat_id);
             o["agentId"] = json!(agent_id);
             o["text"] = json!(text);
+            // Issue #364: which thread inside the channel this reply belongs
+            // to, so a console watching live folds it under the same row a
+            // reload would. Omitted for a reply in the channel itself, so the
+            // legacy frame is unchanged.
+            if let Some(parent) = parent {
+                o["parentId"] = json!(parent.value().to_string());
+            }
             // Scrubbed timeline (same shape the POST body carries); omitted
             // when empty so a tool-less reply's wire form is unchanged.
             if !steps.is_empty() {
@@ -951,13 +973,33 @@ struct ChatMessage {
     /// The desk the message is addressed to. Defaults to the "General" desk.
     #[serde(default)]
     chat: Option<String>,
+    /// The message this one replies to, by its id (issue #364) — a thread reply
+    /// rather than a new line in the channel.
+    ///
+    /// A string, not a number, because that is what every other message id on
+    /// this API is: `chat/history` returns `id: "42"`, and a console that had to
+    /// remember which surface wanted which type would eventually get it wrong.
+    /// Parsed to a sequence position here, and a value that is not one is a 400
+    /// rather than a silently-dropped thread.
+    #[serde(default)]
+    parent: Option<String>,
 }
 
 /// A chat or approval-resolution response: the company's channel replies.
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct ChatResponse {
     /// Channel responses produced by the cycle.
     responses: Vec<OutboundMessage>,
+    /// The durable id the operator's own message was journaled under (issue
+    /// #364), so the console can replace the local id it minted optimistically
+    /// with one a reload — or another operator — can resolve.
+    ///
+    /// Omitted when the cycle journaled nothing, and by every host predating
+    /// this field; a console that finds it missing knows not to offer actions
+    /// that would need it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message_id: Option<String>,
 }
 
 /// Runs one operator-chat cycle, returning the report and, when a complaint
@@ -967,6 +1009,7 @@ async fn run_chat(
     runtime: Arc<CompanyRuntime>,
     message: ChatMessage,
     by: Option<Actor>,
+    parent: Option<EventSeq>,
 ) -> Result<(CycleReport, Option<String>), ApiError> {
     runtime.ensure_running().await?;
     // Operator-chat feedback intent: a complaint phrase ("that was wrong — flag
@@ -1020,6 +1063,9 @@ async fn run_chat(
             // Thread the addressed desk through so the orchestrator brain can
             // route to that desk's lead member (issue #53).
             chat: message.chat,
+            // …and the message being replied to, so the thread is a fact about
+            // the transcript rather than about one browser (issue #364).
+            parent,
         }])
         .await?;
     Ok((report, feedback_note))
@@ -1038,19 +1084,36 @@ async fn chat_and_emit(
         .chat
         .clone()
         .unwrap_or_else(|| crate::server::ops::language::DEFAULT_DESK.to_string());
-    let (report, feedback_note) = run_chat(runtime.clone(), message, by).await?;
+    // Issue #364: a thread reply names its parent by id. Rejected here rather
+    // than dropped, so a console sending a malformed parent learns that its
+    // reply would have landed in the channel instead of quietly finding it
+    // there later.
+    let parent = match message.parent.as_deref() {
+        Some(raw) => Some(parse_message_id(raw)?),
+        None => None,
+    };
+    let (mut report, feedback_note) = run_chat(runtime.clone(), message, by, parent).await?;
     emit_cycle_webhooks(state, id, &report).await;
     if let Some(note) = feedback_note {
         emit_feedback_webhook(state, id, &note).await;
     }
     // Journal each reply against the addressed desk so desk history can be read
     // back (GraphQL `Chat.history`, WS2c). Single-responder in v1.
-    for response in &report.responses {
-        let _ = runtime
+    //
+    // The append's returned sequence used to be discarded. It is the reply's
+    // durable id (issue #364) — the same id `chat/history` gives it on the next
+    // reload — so it goes back on the bubble, and a reaction or a thread reply
+    // made against a bubble the operator can still see names something every
+    // other reader can resolve.
+    for response in &mut report.responses {
+        let journaled = runtime
             .events()
             .append(
                 id,
                 CompanyEvent::AgentReply {
+                    // The answer joins the thread its question was asked in,
+                    // rather than opening one under the question (issue #364).
+                    parent,
                     // Issue #246: carry the card this turn opened onto the
                     // durable record, so the console's "card opened" chip
                     // survives a transcript reload instead of living only on
@@ -1070,10 +1133,39 @@ async fn chat_and_emit(
                 },
             )
             .await;
+        // Best-effort, exactly as it always was: a journal failure must not
+        // sink a reply the operator can already read. It only costs the bubble
+        // its durable id, which the console reads as "not saved" and refuses to
+        // thread or react on — the honest degradation.
+        match journaled {
+            Ok(seq) => response.message_id = Some(seq.value().to_string()),
+            Err(err) => tracing::warn!(
+                error = %err,
+                "failed to journal a chat reply; the bubble has no durable id"
+            ),
+        }
     }
     Ok(Json(ChatResponse {
+        // The operator's own message is the cycle's single input event, so its
+        // sequence is the first the cycle journaled (issue #364).
+        message_id: report.input_seqs.first().map(|seq| seq.value().to_string()),
         responses: report.responses,
     }))
+}
+
+/// Parses a message id from the wire into the sequence position it names.
+///
+/// Message ids are stringified sequence positions everywhere this API exposes
+/// them, so this is the one place that turns one back — and the one place that
+/// refuses. A 400 rather than a silent `None`: a thread reply whose parent was
+/// dropped lands in the channel instead, which looks to the operator like the
+/// reply went missing.
+fn parse_message_id(raw: &str) -> Result<EventSeq, ApiError> {
+    raw.trim().parse::<u64>().map(EventSeq::new).map_err(|_| {
+        ApiError(OpenCompanyError::InvalidRequest(format!(
+            "'{raw}' is not a message id"
+        )))
+    })
 }
 
 /// Resolves who is sending a chat message.
@@ -1181,6 +1273,39 @@ struct ChatHistoryMessageDto {
     /// existed — so the legacy shape is unchanged.
     #[serde(skip_serializing_if = "Option::is_none")]
     task_id: Option<String>,
+    /// The message this one replies to (issue #364), so a thread survives a
+    /// reload instead of collapsing into the channel. Omitted on a message
+    /// posted straight into the channel — which is every message journaled
+    /// before threads were persisted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_id: Option<String>,
+    /// Who reacted to this message with what (issue #364), one row per person
+    /// per emoji. Omitted when nobody has, keeping the legacy shape.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    reactions: Vec<ChatReactionDto>,
+}
+
+/// One person's reaction on a history message. Mirrors `Reaction` in
+/// `frontend/src/lib/chat.ts`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ChatReactionDto {
+    /// The emoji.
+    emoji: String,
+    /// Who reacted, as a display label — never a raw user id.
+    by: String,
+    /// Whether the reading viewer is the one who reacted.
+    mine: bool,
+}
+
+impl From<ReactionView> for ChatReactionDto {
+    fn from(view: ReactionView) -> Self {
+        Self {
+            emoji: view.emoji,
+            by: view.by_label,
+            mine: view.mine,
+        }
+    }
 }
 
 impl From<MessageView> for ChatHistoryMessageDto {
@@ -1194,6 +1319,12 @@ impl From<MessageView> for ChatHistoryMessageDto {
             mine: view.mine,
             steps: view.steps,
             task_id: view.task_id,
+            parent_id: view.parent_id,
+            reactions: view
+                .reactions
+                .into_iter()
+                .map(ChatReactionDto::from)
+                .collect(),
         }
     }
 }
@@ -1303,6 +1434,132 @@ async fn chat_history_single(
     let runtime = sole(&state).map_err(IntoResponse::into_response)?;
     let id = runtime.id().clone();
     chat_history_response(&state, &id, runtime, &headers, query).await
+}
+
+/// Body for `POST {scope}/chat/messages/{seq}/reactions` (issue #364).
+#[derive(Debug, Deserialize)]
+struct ReactionBody {
+    /// The emoji to set or clear.
+    emoji: String,
+    /// `true` to set the reaction, `false` to clear it. Explicit rather than a
+    /// toggle so the request is idempotent: a retry, a double tap, or two
+    /// consoles racing all converge on what the caller asked for.
+    on: bool,
+}
+
+/// The longest emoji this route accepts, in bytes.
+///
+/// A ZWJ sequence (a flag, a family, a profession with a skin tone) is a
+/// handful of code points, so the cap has to be well above one character — but
+/// this field ends up in an append-only journal read by the operator
+/// projection, and nothing about "a reaction" needs more room than a grapheme
+/// cluster or two.
+const REACTION_MAX_BYTES: usize = 64;
+
+/// Checks an emoji is something a person could have tapped.
+///
+/// Deliberately **not** a Unicode emoji-property check: the console's palette is
+/// its own, a future one may offer more, and refusing an emoji this host has
+/// never heard of would break that for no safety gain. What it does refuse is
+/// what would make a reaction a smuggling channel — an empty string, a blob, and
+/// any control character (a newline in particular, which would let one journal
+/// line pretend to be two).
+fn validate_emoji(emoji: &str) -> Result<(), ApiError> {
+    let invalid = |why: &str| {
+        Err(ApiError(OpenCompanyError::InvalidRequest(format!(
+            "a reaction {why}"
+        ))))
+    };
+    if emoji.trim().is_empty() {
+        return invalid("needs an emoji");
+    }
+    if emoji.len() > REACTION_MAX_BYTES {
+        return invalid("must be a single emoji, not a message");
+    }
+    if emoji.chars().any(char::is_control) {
+        return invalid("cannot contain control characters");
+    }
+    Ok(())
+}
+
+/// Shared body for both scope forms of the reaction route.
+///
+/// Authorized through [`chat_actor`] — the same gate a *send* passes. Reacting
+/// is writing into a company's transcript, so it can be neither easier nor
+/// harder than saying something in it.
+async fn react_to_message(
+    state: &AppState,
+    company: &CompanyId,
+    runtime: Arc<CompanyRuntime>,
+    headers: &HeaderMap,
+    seq: String,
+    body: ReactionBody,
+) -> Result<StatusCode, Response> {
+    let by = chat_actor(headers, state, company).await?;
+    let message_seq = parse_message_id(&seq).map_err(IntoResponse::into_response)?;
+    validate_emoji(&body.emoji).map_err(IntoResponse::into_response)?;
+    // The target must be a message. Without this the route would happily hang a
+    // reaction off an approval, a lifecycle change, or a sequence position that
+    // has never existed — none of which any reader could render, and all of
+    // which would sit in the log forever claiming otherwise.
+    let target = runtime
+        .events()
+        .read_from(company, message_seq, 1)
+        .await
+        .map_err(|e| ApiError(e).into_response())?;
+    let is_message = target
+        .first()
+        .filter(|stored| stored.seq == message_seq)
+        .is_some_and(|stored| {
+            matches!(
+                stored.event,
+                CompanyEvent::OperatorMessage { .. } | CompanyEvent::AgentReply { .. }
+            )
+        });
+    if !is_message {
+        return Err(
+            ApiError(OpenCompanyError::NotFound(format!("no chat message {seq}"))).into_response(),
+        );
+    }
+    runtime
+        .events()
+        .append(
+            company,
+            CompanyEvent::ReactionToggled {
+                message_seq,
+                emoji: body.emoji,
+                on: body.on,
+                by,
+            },
+        )
+        .await
+        .map_err(|e| ApiError(e).into_response())?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `POST /api/v1/companies/{id}/chat/messages/{seq}/reactions` — set or clear
+/// one reaction on one message (issue #364).
+async fn react_to_message_scoped(
+    State(state): State<AppState>,
+    Path((id, seq)): Path<(String, String)>,
+    headers: HeaderMap,
+    Json(body): Json<ReactionBody>,
+) -> Result<StatusCode, Response> {
+    let company = CompanyId::new(&id);
+    let runtime = lookup(&state, &id).map_err(IntoResponse::into_response)?;
+    react_to_message(&state, &company, runtime, &headers, seq, body).await
+}
+
+/// `POST /api/v1/company/chat/messages/{seq}/reactions` (single-company alias).
+async fn react_to_message_single(
+    State(state): State<AppState>,
+    Path(seq): Path<String>,
+    headers: HeaderMap,
+    Json(body): Json<ReactionBody>,
+) -> Result<StatusCode, Response> {
+    let runtime = sole(&state).map_err(IntoResponse::into_response)?;
+    let id = runtime.id().clone();
+    react_to_message(&state, &id, runtime, &headers, seq, body).await
 }
 
 /// `GET /api/v1/companies/{id}/approvals`.
@@ -1620,6 +1877,7 @@ async fn run_resolve(
     let report = crate::company::runtime::join_follow_up(follow_up).await?;
     emit_cycle_webhooks(state, company, &report).await;
     Ok(Json(ChatResponse {
+        message_id: None,
         responses: report.responses,
     })
     .into_response())
@@ -2568,6 +2826,7 @@ mod test {
             .append(
                 runtime.id(),
                 CompanyEvent::AgentReply {
+                    parent: None,
                     task_id: None,
                     chat_id: "General".to_string(),
                     agent_id: "ceo".to_string(),
@@ -2582,6 +2841,7 @@ mod test {
             .append(
                 runtime.id(),
                 CompanyEvent::AgentReply {
+                    parent: None,
                     task_id: None,
                     chat_id: "main".to_string(),
                     agent_id: "ceo".to_string(),
@@ -2637,6 +2897,7 @@ mod test {
             .append(
                 runtime.id(),
                 CompanyEvent::AgentReply {
+                    parent: None,
                     task_id: None,
                     chat_id: "main".to_string(),
                     agent_id: "ceo".to_string(),
@@ -2703,6 +2964,7 @@ mod test {
                 .append(
                     runtime.id(),
                     CompanyEvent::AgentReply {
+                        parent: None,
                         task_id,
                         chat_id: "main".to_string(),
                         agent_id: "ceo".to_string(),
@@ -2776,6 +3038,365 @@ mod test {
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(value.as_array().unwrap().len(), 0);
+    }
+
+    /* ---- issue #364: durable ids, threads, reactions, channel isolation ---- */
+
+    /// Posts a chat message and returns the decoded `ChatResponse` body.
+    async fn post_chat(app: &Router, cookie: &str, body: &str) -> serde_json::Value {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/company/chat")
+                    .header("cookie", cookie)
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "chat POST failed");
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    /// Reads a desk's history. `desk` empty reads the default General thread.
+    async fn get_history(app: &Router, cookie: &str, desk: &str) -> Vec<serde_json::Value> {
+        let uri = if desk.is_empty() {
+            "/api/v1/company/chat/history".to_string()
+        } else {
+            format!("/api/v1/company/chat/history?desk={desk}")
+        };
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .header("cookie", cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        value.as_array().cloned().unwrap_or_default()
+    }
+
+    /// Sets or clears one reaction, returning the status.
+    async fn post_reaction(
+        app: &Router,
+        cookie: &str,
+        seq: &str,
+        emoji: &str,
+        on: bool,
+    ) -> StatusCode {
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/v1/company/chat/messages/{seq}/reactions"))
+                    .header("cookie", cookie)
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "emoji": emoji, "on": on }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .status()
+    }
+
+    /// The enabler for everything else in #364: a sent message comes back with
+    /// the durable id it was journaled under, on both halves of the exchange —
+    /// the operator's own line and each reply — and those ids are the same ones
+    /// `chat/history` returns on the next read.
+    #[tokio::test]
+    async fn chat_response_carries_durable_message_ids() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_company(&home, "running").await;
+        let app = router(state);
+        let cookie = crate::server::test_support::fixed_cookie("acme");
+
+        let sent = post_chat(&app, &cookie, r#"{"text":"hi"}"#).await;
+        let mine = sent["messageId"].as_str().expect("own message id");
+        let reply = sent["responses"][0]["messageId"]
+            .as_str()
+            .expect("reply message id");
+        assert_ne!(mine, reply, "the two halves are separate journal lines");
+
+        let history = get_history(&app, &cookie, "").await;
+        let ids: Vec<&str> = history.iter().map(|m| m["id"].as_str().unwrap()).collect();
+        assert!(ids.contains(&mine), "own id absent from history: {ids:?}");
+        assert!(
+            ids.contains(&reply),
+            "reply id absent from history: {ids:?}"
+        );
+    }
+
+    /// A thread reply survives a reload: the parent id posted with the message
+    /// comes back on both the operator's line and the answer it drew, so a
+    /// rehydrating console folds the exchange under the same row it was typed
+    /// under instead of flattening it into the channel.
+    #[tokio::test]
+    async fn thread_replies_survive_a_history_reload() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_company(&home, "running").await;
+        let app = router(state);
+        let cookie = crate::server::test_support::fixed_cookie("acme");
+
+        let root = post_chat(&app, &cookie, r#"{"text":"the plan"}"#).await;
+        let root_id = root["messageId"].as_str().unwrap().to_string();
+
+        let threaded = post_chat(
+            &app,
+            &cookie,
+            &serde_json::json!({ "text": "a follow-up", "parent": root_id }).to_string(),
+        )
+        .await;
+        assert!(
+            threaded["responses"][0]["messageId"]
+                .as_str()
+                .is_some_and(|id| id != root_id),
+            "the answer is its own journal line, not the root's"
+        );
+
+        let history = get_history(&app, &cookie, "").await;
+        let parented: Vec<(&str, Option<&str>)> = history
+            .iter()
+            .map(|m| (m["text"].as_str().unwrap(), m["parentId"].as_str()))
+            .collect();
+        // The root sits in the channel; both halves of the threaded exchange
+        // hang off it — the answer under the row the thread opened from, not
+        // under the question, so a thread never nests inside a thread.
+        assert!(
+            parented.contains(&("the plan", None)),
+            "root should be unparented: {parented:?}"
+        );
+        assert!(
+            parented.contains(&("a follow-up", Some(root_id.as_str()))),
+            "threaded message lost its parent: {parented:?}"
+        );
+        assert!(
+            parented
+                .iter()
+                .any(|(text, parent)| *text == "You said: a follow-up"
+                    && *parent == Some(root_id.as_str())),
+            "the reply to a threaded message left the thread: {parented:?}"
+        );
+    }
+
+    /// A parent that is not a message id is a 400, not a silently-flattened
+    /// thread: a reply that quietly lands in the channel reads to the operator
+    /// as a reply that went missing.
+    #[tokio::test]
+    async fn chat_rejects_a_parent_that_is_not_a_message_id() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_company(&home, "running").await;
+        let app = router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/company/chat")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"text":"hi","parent":"m3"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// A reaction records who reacted and survives a reload; clearing it removes
+    /// the row; and setting the same reaction twice leaves exactly one row —
+    /// the explicit `on` flag is what makes the write idempotent.
+    #[tokio::test]
+    async fn reactions_persist_are_attributed_and_are_idempotent() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_company(&home, "running").await;
+        let app = router(state);
+        let cookie = crate::server::test_support::fixed_cookie("acme");
+
+        let sent = post_chat(&app, &cookie, r#"{"text":"ship it"}"#).await;
+        let target = sent["messageId"].as_str().unwrap().to_string();
+
+        assert_eq!(
+            post_reaction(&app, &cookie, &target, "👍", true).await,
+            StatusCode::NO_CONTENT
+        );
+        // Twice, deliberately: a retry or a double tap must not double the row.
+        assert_eq!(
+            post_reaction(&app, &cookie, &target, "👍", true).await,
+            StatusCode::NO_CONTENT
+        );
+
+        let history = get_history(&app, &cookie, "").await;
+        let reacted = history
+            .iter()
+            .find(|m| m["id"].as_str() == Some(target.as_str()))
+            .expect("the reacted-to message is still in history");
+        let rows = reacted["reactions"].as_array().expect("reactions present");
+        assert_eq!(rows.len(), 1, "one row per person per emoji: {rows:?}");
+        assert_eq!(rows[0]["emoji"], "👍");
+        assert_eq!(rows[0]["mine"], true, "the reader is the one who reacted");
+        assert!(
+            rows[0]["by"].as_str().is_some_and(|by| !by.is_empty()),
+            "a reaction names who made it: {rows:?}"
+        );
+
+        // Clearing drops the row entirely rather than leaving a zero behind.
+        assert_eq!(
+            post_reaction(&app, &cookie, &target, "👍", false).await,
+            StatusCode::NO_CONTENT
+        );
+        let history = get_history(&app, &cookie, "").await;
+        let cleared = history
+            .iter()
+            .find(|m| m["id"].as_str() == Some(target.as_str()))
+            .unwrap();
+        assert!(
+            cleared.get("reactions").is_none(),
+            "a cleared reaction leaves no row: {cleared:?}"
+        );
+    }
+
+    /// A reaction may only name a chat message. A sequence position that holds
+    /// something else — or nothing at all — is a 404, so the log can never carry
+    /// a reaction no reader could render.
+    #[tokio::test]
+    async fn reactions_refuse_a_target_that_is_not_a_message() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_company(&home, "running").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let not_a_message = runtime
+            .events()
+            .append(
+                runtime.id(),
+                CompanyEvent::FeedbackFiled {
+                    note: "unrelated".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        let app = router(state);
+        let cookie = crate::server::test_support::fixed_cookie("acme");
+
+        assert_eq!(
+            post_reaction(
+                &app,
+                &cookie,
+                &not_a_message.value().to_string(),
+                "👍",
+                true
+            )
+            .await,
+            StatusCode::NOT_FOUND
+        );
+        // A sequence position nothing has ever occupied.
+        assert_eq!(
+            post_reaction(&app, &cookie, "99999", "👍", true).await,
+            StatusCode::NOT_FOUND
+        );
+        // And a target that is not a sequence position at all.
+        assert_eq!(
+            post_reaction(&app, &cookie, "m3", "👍", true).await,
+            StatusCode::BAD_REQUEST
+        );
+    }
+
+    /// A reaction is a journal line read by the operator projection, so it takes
+    /// an emoji and not a payload: empty, oversized, and control-character
+    /// bodies are all refused.
+    #[tokio::test]
+    async fn reactions_refuse_a_body_that_is_not_an_emoji() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_company(&home, "running").await;
+        let app = router(state);
+        let cookie = crate::server::test_support::fixed_cookie("acme");
+
+        let sent = post_chat(&app, &cookie, r#"{"text":"hi"}"#).await;
+        let target = sent["messageId"].as_str().unwrap().to_string();
+
+        for bad in ["", "   ", "yes\nno", &"x".repeat(REACTION_MAX_BYTES + 1)] {
+            assert_eq!(
+                post_reaction(&app, &cookie, &target, bad, true).await,
+                StatusCode::BAD_REQUEST,
+                "accepted a non-emoji reaction: {bad:?}"
+            );
+        }
+        // A multi-code-point emoji is still one reaction, and is accepted.
+        assert_eq!(
+            post_reaction(&app, &cookie, &target, "👩‍💻", true).await,
+            StatusCode::NO_CONTENT
+        );
+    }
+
+    /// Regression for the third acceptance item of #364, which the console's
+    /// own scoping already satisfied but nothing pinned: a message posted in one
+    /// channel must be absent from another, end to end through the route — not
+    /// only in the `owns` predicate. Reactions ride the same boundary.
+    #[tokio::test]
+    async fn a_message_in_one_channel_is_absent_from_another() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_manifest(&home, desk_manifest()).await;
+        let app = router(state);
+        let cookie = crate::server::test_support::fixed_cookie("acme");
+
+        let in_studio = post_chat(&app, &cookie, r#"{"text":"studio only","chat":"studio"}"#).await;
+        let studio_id = in_studio["messageId"].as_str().unwrap().to_string();
+        post_chat(&app, &cookie, r#"{"text":"general only"}"#).await;
+        assert_eq!(
+            post_reaction(&app, &cookie, &studio_id, "👀", true).await,
+            StatusCode::NO_CONTENT
+        );
+
+        let studio: Vec<String> = get_history(&app, &cookie, "studio")
+            .await
+            .iter()
+            .map(|m| m["text"].as_str().unwrap().to_string())
+            .collect();
+        let general = get_history(&app, &cookie, "").await;
+        let general_texts: Vec<&str> = general
+            .iter()
+            .map(|m| m["text"].as_str().unwrap())
+            .collect();
+
+        assert!(
+            studio.iter().any(|t| t == "studio only"),
+            "the desk lost its own message: {studio:?}"
+        );
+        assert!(
+            !studio.iter().any(|t| t == "general only"),
+            "a General message leaked into the desk: {studio:?}"
+        );
+        assert!(
+            general_texts.contains(&"general only"),
+            "General lost its own message: {general_texts:?}"
+        );
+        assert!(
+            !general_texts.contains(&"studio only"),
+            "a desk message leaked into General: {general_texts:?}"
+        );
+        // The reaction is on the desk's message, so it is not visible from a
+        // channel that cannot see the message it is about.
+        assert!(
+            general.iter().all(|m| m.get("reactions").is_none()),
+            "a reaction crossed a channel boundary: {general:?}"
+        );
     }
 
     #[tokio::test]
@@ -3500,6 +4121,7 @@ mod test {
     fn projects_agent_reply_with_chat_fields_and_steps() {
         use crate::ports::types::{TurnStep, TurnStepKind, TurnStepStatus};
         let v = super::project_event(&stored(CompanyEvent::AgentReply {
+            parent: None,
             task_id: None,
             chat_id: "General".into(),
             agent_id: "ceo".into(),
@@ -3523,6 +4145,48 @@ mod test {
         // The scrubbed timeline rides along so a live listener sees the steps.
         assert_eq!(v["steps"][0]["label"], "Reading messages");
         assert_eq!(v["steps"][0]["status"], "ok");
+        // A channel reply names no thread, so the legacy frame is unchanged.
+        assert!(v.get("parentId").is_none(), "unexpected parentId: {v}");
+    }
+
+    /// A threaded reply carries its parent onto the live frame (issue #364), so
+    /// a console watching the stream folds it under the same row a reload would
+    /// — otherwise a thread answer arrives live in the channel and then jumps
+    /// into the thread on the next refresh.
+    #[test]
+    fn projects_agent_reply_with_its_thread_parent() {
+        let v = super::project_event(&stored(CompanyEvent::AgentReply {
+            parent: Some(EventSeq::new(4)),
+            task_id: None,
+            chat_id: "General".into(),
+            agent_id: "ceo".into(),
+            text: "in the thread".into(),
+            steps: Vec::new(),
+        }))
+        .expect("agent_reply is an attention signal");
+        assert_eq!(v["parentId"], "4");
+    }
+
+    /// A reaction is deliberately NOT on the attention stream (issue #364).
+    ///
+    /// Pinned rather than left to the deny-by-default fall-through, because the
+    /// omission is a decision and not an oversight: the frame would have to
+    /// carry the reacting person, and this stream has no per-viewer projection
+    /// to turn an actor into a label. Reload-visibility is what the issue asks
+    /// for. If someone later decides reactions should stream, this test is
+    /// where they say so out loud.
+    #[test]
+    fn projects_nothing_for_a_reaction() {
+        assert!(
+            super::project_event(&stored(CompanyEvent::ReactionToggled {
+                message_seq: EventSeq::new(4),
+                emoji: "👍".into(),
+                on: true,
+                by: None,
+            }))
+            .is_none(),
+            "a reaction must not reach the console over SSE"
+        );
     }
 
     /// Issue #379: the park frame carries an id, a kind and the channel — and
@@ -3579,6 +4243,7 @@ mod test {
     #[test]
     fn projects_agent_reply_omits_empty_steps() {
         let v = super::project_event(&stored(CompanyEvent::AgentReply {
+            parent: None,
             task_id: None,
             chat_id: "General".into(),
             agent_id: "ceo".into(),
@@ -3600,6 +4265,7 @@ mod test {
     #[test]
     fn projects_task_id_only_when_the_event_is_correlated() {
         let reply = super::project_event(&stored(CompanyEvent::AgentReply {
+            parent: None,
             task_id: Some("t-1".into()),
             chat_id: "t-1".into(),
             agent_id: "ceo".into(),
@@ -3982,6 +4648,7 @@ mod test {
         // still drops everything it dropped before.
         let dropped = [
             CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "hi".into(),
                 by: None,
                 chat: None,

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -3192,6 +3192,7 @@ async fn task_detail_assembles_timeline_and_lineage() {
         },
         // Tagged to this task — admitted.
         CompanyEvent::AgentReply {
+            parent: None,
             chat_id: "t-1".into(),
             agent_id: "ceo".into(),
             text: "on it".into(),
@@ -3200,6 +3201,7 @@ async fn task_detail_assembles_timeline_and_lineage() {
         },
         // An ordinary chat reply — excluded.
         CompanyEvent::AgentReply {
+            parent: None,
             chat_id: "General".into(),
             agent_id: "ceo".into(),
             text: "unrelated chatter".into(),
@@ -3208,6 +3210,7 @@ async fn task_detail_assembles_timeline_and_lineage() {
         },
         // Tagged to a different task — excluded.
         CompanyEvent::AgentReply {
+            parent: None,
             chat_id: "t-other".into(),
             agent_id: "ceo".into(),
             text: "someone else's work".into(),
@@ -3769,6 +3772,7 @@ async fn task_export_serves_a_readable_document_and_alters_nothing() {
             run_id: None,
         },
         CompanyEvent::AgentReply {
+            parent: None,
             chat_id: "t-1".into(),
             agent_id: "writer".into(),
             text: "First draft is up.".into(),

--- a/src/server/provision/test.rs
+++ b/src/server/provision/test.rs
@@ -682,6 +682,7 @@ impl Brain for EffectBrain {
             if let CompanyEvent::OperatorMessage { text, .. } = event {
                 host.emit_effect(self.effect.clone()).await?;
                 responses.push(OutboundMessage {
+                    message_id: None,
                     task_id: None,
                     channel: "operator".into(),
                     text: format!("handled: {text}"),

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -167,6 +167,7 @@ pub async fn assert_isolation_by_company(
         .append(
             &alpha,
             CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "a".into(),
                 by: None,
                 chat: None,
@@ -293,6 +294,7 @@ pub async fn assert_append_only_event_and_ledger(
         .append(
             &id,
             CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "e0".into(),
                 by: None,
                 chat: None,
@@ -304,6 +306,7 @@ pub async fn assert_append_only_event_and_ledger(
         .append(
             &id,
             CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "e1".into(),
                 by: None,
                 chat: None,
@@ -321,6 +324,7 @@ pub async fn assert_append_only_event_and_ledger(
         .append(
             &id,
             CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "e2".into(),
                 by: None,
                 chat: None,
@@ -354,6 +358,7 @@ pub async fn assert_monotonic_event_seq(events: Arc<dyn EventLog>) {
             .append(
                 &alpha,
                 CompanyEvent::OperatorMessage {
+                    parent: None,
                     text: format!("a{expected}"),
                     by: None,
                     chat: None,
@@ -369,6 +374,7 @@ pub async fn assert_monotonic_event_seq(events: Arc<dyn EventLog>) {
         .append(
             &beta,
             CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "b0".into(),
                 by: None,
                 chat: None,
@@ -421,6 +427,7 @@ pub async fn assert_export_totality(
     let mut appended = Vec::new();
     for i in 0..4 {
         let ev = CompanyEvent::OperatorMessage {
+            parent: None,
             text: format!("event {i}"),
             by: None,
             chat: None,

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -649,6 +649,7 @@ mod test {
         let id = runtime.id().clone();
         runtime
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "kick off".into(),
                 by: None,
                 chat: None,
@@ -1313,6 +1314,7 @@ mod test {
         let id = runtime.id().clone();
         runtime
             .run_cycle(vec![CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "hi".into(),
                 by: None,
                 chat: None,

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -1038,6 +1038,7 @@ mod test {
             .append(
                 &id,
                 CompanyEvent::OperatorMessage {
+                    parent: None,
                     text: "a".into(),
                     by: None,
                     chat: None,
@@ -1049,6 +1050,7 @@ mod test {
             .append(
                 &id,
                 CompanyEvent::OperatorMessage {
+                    parent: None,
                     text: "b".into(),
                     by: None,
                     chat: None,
@@ -1077,6 +1079,7 @@ mod test {
         log.append(
             &id,
             CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "hi".into(),
                 by: None,
                 chat: None,
@@ -1088,6 +1091,7 @@ mod test {
         assert_eq!(
             received.event,
             CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "hi".into(),
                 by: None,
                 chat: None

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2340,6 +2340,7 @@ mod test {
             .append(
                 &id,
                 CompanyEvent::OperatorMessage {
+                    parent: None,
                     text: "hi".into(),
                     by: None,
                     chat: None,
@@ -2391,6 +2392,7 @@ mod test {
         s.append(
             &id,
             CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "hi".into(),
                 by: None,
                 chat: None,
@@ -2402,6 +2404,7 @@ mod test {
         assert_eq!(
             received.event,
             CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "hi".into(),
                 by: None,
                 chat: None
@@ -2487,6 +2490,7 @@ mod test {
             s.append(
                 &id,
                 CompanyEvent::OperatorMessage {
+                    parent: None,
                     text: "persist".into(),
                     by: None,
                     chat: None,
@@ -2502,6 +2506,7 @@ mod test {
         assert_eq!(
             events[0].event,
             CompanyEvent::OperatorMessage {
+                parent: None,
                 text: "persist".into(),
                 by: None,
                 chat: None,

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -845,6 +845,7 @@ async fn post_to_channel(
     };
     adapter
         .send(OutboundMessage {
+            message_id: None,
             task_id: None,
             channel: channel_id.to_string(),
             text: format!("{subject}\n\n{text}"),


### PR DESCRIPTION
## Summary

Threads and reactions were console-local: a thread reply flattened into the
channel on reload, and a reaction was invisible to everyone — including its own
author's next page load. This makes both facts about the company's transcript
rather than about one browser, and gives a message a durable id so anything can
refer to it at all.

**Two of the issue's three premises were already false on `main`,** and the
honest thing is to say so rather than re-fix them:

- **Channel scoping was already persisted.** Since #53/#65 every message carries
  its desk and the host filters server-side (`chat_history::owns`). "Two people
  in two channels are in the same room" has not been true for some time. What it
  lacked was a regression test pinning it end-to-end through the route; that is
  added here.
- **Transcripts already survived a reload.** The shell rehydrates every desk
  channel and DM from `chat/history`. The chat README claiming "per-session
  memory" needed the truth-up more than the code did.

So the work that was genuinely missing: persisted threads, persisted per-actor
reactions, a durable message id to hang either on, and reload-stable ids for
console-invented teammates.

### The three design answers, as shipped

**Channel — object or tag?** Already both, correctly layered; neither was added.
The object is the desk (manifest `group_chats` + the operator overlay, carrying
members/lead/purpose); the message carries a tag naming it
(`OperatorMessage.chat` / `AgentReply.chat_id`), filtered server-side. #379's
`ApprovalParked.thread` had already converged on "thread id = desk id or roster
agent id". Deliverable: a regression test and a doc correction.

**Threads — a parent id, not a thread object.** `OperatorMessage` and
`AgentReply` gain `parent`, the sequence position of the message replied to. A
thread object would need a lifecycle, a membership and a second addressing
scheme beside `chat`, for zero rendering benefit — the console already folds a
transcript by parent, so a thread *is* "the messages pointing at this one". The
answer to a threaded question takes the **question's** parent, not the question:
both halves belong under the row the thread hangs off, and pointing the answer
at the question would nest a thread inside a thread.

**Reactions — per-user rows, event-sourced.** `ReactionToggled { message_seq,
emoji, on, by }`, folded at read time (last event per `(message, actor, emoji)`)
into rows carrying who reacted and whether it was you. A count answers neither
question the console actually asks, and a mutable tally cannot live on an
append-only log. `on` is explicit rather than an implied toggle, which is what
makes a retry, a double tap, or two consoles racing converge instead of flip.

### Migration — no journal rewrite, no backfill

Legacy events deserialize with `parent = None` and no reactions, which is the
truth about them: they were never thread replies. Pre-#53 messages keep folding
into General through the existing legacy arms; **no channel is fabricated for a
message that never had one.** Export/import round-trips stay byte-identical
(pinned by a test asserting the legacy JSON verbatim). Legacy DM URLs get a
one-release resolver shim.

**One stated loss:** history journaled under the old counter-minted roster ids
(`member-3`) is already orphaned today and stays orphaned. There is no honest
mapping from `member-3` to a person, and inventing one would violate the issue's
own migration rule. Documented in the chat README rather than papered over.

### What stays console-local, and how it says so on screen

| | Where it says so |
|---|---|
| Unread counts — derived in this browser; the host keeps no read receipts, so two consoles will disagree | Tooltip on every unread badge (`ChannelRail`) |
| A console-only teammate has no one to answer — the transcript **is** saved, but nobody on the roster is on the other end | Notice above the composer in that DM (`ChatView`) |
| A message not yet journaled cannot be replied to or reacted on | Reply/react controls disabled with the reason as their tooltip (`MessageRow`) |

Reactions are deliberately **not** on the SSE stream: the frame would have to
carry the reacting person and that stream has no per-viewer projection to
resolve an actor into a label. Reload-visibility is what the issue asks for.
Pinned by a test rather than left to the deny-by-default fall-through, so a
later decision to stream them is made out loud.

Closes #364

## API Or Behavior Changes

All additive; no stored record migrates and no existing caller changes.

- `POST {scope}/chat` — accepts `parent` (a message id) making the send a thread
  reply; answers with `messageId`, and `messageId` on each reply bubble. A
  `parent` that is not a message id is a `400`, never a silently-flattened
  thread.
- `POST {scope}/chat/messages/{seq}/reactions` — **new.** `{emoji, on}` → `204`.
  Same auth gate as a send. `404` if the target is not a chat message; `400` for
  an empty, oversized, or control-character emoji.
- `GET {scope}/chat/history` — messages gain `parentId` and `reactions[]`
  (`{emoji, by, mine}`), both omitted when absent.
- GraphQL `Message` gains `parentId` and `reactions` (SDL snapshot regenerated).
- SSE `agent_reply` gains `parentId` when the reply is in a thread.
- `CompanyEvent::ReactionToggled` added; `OperatorMessage`/`AgentReply` gain
  `parent`; `OutboundMessage` gains `messageId`; `CycleReport` gains
  `input_seqs`.
- Console: a DM's channel id is now `dm:<teammate-id>` rather than
  `dm:<slug-of-name>`, so renaming a teammate no longer moves their DM's URL or
  orphans its history. Pre-existing links resolve for one release.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (also with
      `--features openhuman,tinycortex`)
- [x] `cargo build --all-targets` (also `cargo check --all-features
      --all-targets`; `Cargo.lock` unchanged)
- [x] `cargo test` — 1447 default / 2073 with `openhuman,tinycortex`, 0 failed

Console: `npm ci`, `npm run typecheck`, `npm run typecheck:e2e`, `npm run build`
— all clean. (This package has no lint or test script; none is claimed.)

New coverage: the reaction fold (per-person rows, last-event-wins, unattributed
→ operator), parent projection on both variants, legacy-JSON round-trip,
durable ids on both halves of an exchange, threads surviving a history reload,
reaction idempotence and attribution, target/emoji refusals, the SSE
`parentId`/reaction-dropped pair, GraphQL parity, and an end-to-end
channel-isolation regression through the route.

### Manual verification — a running host, two signed-in operators

Two genuinely distinct authenticated sessions (an admin and an invited member)
against a live `serve`, over the real HTTP API:

- a thread reply made by one is visible to the other on a fresh read, with both
  halves of the exchange under the same parent, and the root itself unparented;
- a reaction records who made it; two people using the same emoji produce two
  rows, not a count of two, with `mine` correctly flipped per reader; a repeat
  is idempotent; clearing removes only that person's row;
- a message posted in one channel is absent from the other, in both directions,
  and a reaction does not cross the boundary;
- a console-only teammate's DM round-trips its transcript and does not leak into
  a real channel;
- **after a full process restart**, the thread structure and the reaction
  (author included) replay intact from the log;
- refusals behave: malformed parent `400`, non-message target `404`, oversized
  and newline-bearing emoji `400`.

The built console was served from the same host and its bundle loads; the new
route correctly `401`s without a session.

**Not done, and not claimed:** driving two real browsers side by side. The
two-operator behaviour above was exercised at the API layer with two real
sessions, not through two rendered consoles. The console changes are covered by
typecheck and build only — this package has no test runner, so `reconcileIds`
ships without the unit test its risk deserves (see below).

## Documentation

- `docs/spec/runtime/events.md` — the thread/reaction shapes and why each was
  chosen; the migration answer; why reactions stay off the SSE stream.
- `docs/spec/runtime/api.md` — the reactions route, `parent`/`messageId` on
  `/chat`, and the refusal semantics.
- `frontend/src/views/chat/README.md` — corrected: transcripts and channel
  scoping were already the host's; threads and reactions now are; unread and a
  console-only teammate's other half are what remain local. Records the
  `member-N` orphan loss.

---

### Flagged for review

- **`CycleReport.input_seqs` touches runtime internals.** The alternative —
  pre-journaling the operator's message in the route — was rejected because it
  would either double-journal it or move the append out of the one place that
  orders it against the rest of the cycle. Worth a second opinion.
- **`reconcileIds` is the likeliest bug site** and ships untested. It is
  isolated as one pure function precisely so it can be tested, but the console
  package has no test runner and adding one as a side effect of this issue would
  create a gate CI does not run. Happy to add vitest in a follow-up if wanted.
- **`brain.rs` and `cycle.rs` were touched minimally** given the branches in
  flight there: `brain.rs` got two one-line `parent: None` literal brushes plus
  `message_id: None` on its `OutboundMessage` literals — nothing in the settle
  path. `cycle.rs` got `input_seqs` and a `ReactionToggled` arm in the two
  exhaustive record-vs-trigger matches, away from the approval-settle path.
  `MessageTimeline.tsx` and `StepTimeline.tsx` are untouched — the disabled-
  action reason is derived inside `MessageRow` from the row's own id rather than
  threaded through as a prop.

- **Rebased onto `53b53b8`** (was cut at `47c0c45`). Three PRs landed in between
  — #411 step traces, #374 standing grants, #406 workflows picker — and the
  branch merged cleanly but did not compile against them: three struct literals
  written after the cut lacked the fields this PR makes required. Each was
  looked at rather than filled in mechanically, since a wrong `None` here
  silently loses a thread relationship, which is the exact bug class this PR
  exists to fix:
  - `company/runtime.rs` `announce_to_operator` (new in #374) — a channel send
    that journals no `AgentReply`, so there is no sequence position to name.
    `message_id: None` is correct, and it is the exact sibling of the
    grant-expiry notice above it. **Correct by contract, not convenience.**
  - `runtime/cycle.rs` ×2 (#374 standing-grant fixtures) — cycles driven by an
    unaddressed `"do it"` with `chat: None`, testing approval scope, not chat
    structure. `parent: None` is the truth: neither was a thread reply.

  Folded into the first commit so every commit still compiles on the new base.
  All gates re-run on the rebased tree, and the two-operator live scenario plus
  the restart-durability replay were re-run rather than assumed — identical
  results. Nothing in the merge changed behaviour already verified.

- **Follow-up the merge made visible (not a regression, not fixed here):** an
  approval raised inside a *thread* has its post-approval continuation reply
  land in the channel, not the thread. `GrantedCall::origin_thread` and
  `ApprovalParked.thread` both carry a **channel** id (a desk or roster agent),
  never a message, so there is nothing to thread it under. Invisible before
  this PR because threads did not persist. Fixing it means widening those
  records to carry an origin *message*, which is #374/#379 territory — worth its
  own issue rather than a quiet scope expansion here.
