### PR TITLE
fix(workflows): a workflow run can finally park an approval (#395)

### DIFF
--- a/docs/modules/runtime/README.md
+++ b/docs/modules/runtime/README.md
@@ -48,6 +48,27 @@ count dropping to zero — so a schedule saved later onto a still-unwired compan
 is reported rather than swallowed by the latch. A company with no scheduled
 workflows and no runner is not misconfigured and stays silent.
 
+`workflow_spawn.rs` owns the two things every entry point that *starts* a
+workflow run owes it: minting the run id through the `RunSupervisor` (so the id
+the console correlates SSE frames on is also the address a cancel is sent to),
+and journalling the outcome through `record_run_finished` on **both** arms with
+the `RunGuard` held across the write. The console run route and the
+approved-gate resume arm both go through `WorkflowSpawn`, so they cannot drift.
+It holds four cloned handles rather than an `Arc<CompanyRuntime>`, which is what
+lets a caller with only a `&CompanyRuntime` start a run. The cron scheduler
+above keeps its own spawn body — it wraps the same two steps in a schedule claim
+and a per-delivery log sweep that only make sense for a fire nobody is watching.
+
+`workflow_resume.rs` is what approving a paused `requires_approval` node
+actually does (issue #395). The engine **settles** a paused run rather than
+suspending it, so there is nothing to resume: the module reads the workflow id,
+node id and trigger input off the parked `workflow.approve` effect, unions the
+gate id into the input's `approvals` array, and starts a fresh supervised run.
+That makes it restart-durable for free — the parked card is self-contained, so
+journal replay is all a continuation needs — at the documented cost that
+upstream nodes re-execute. See
+[`docs/spec/company-brain/approvals.md`](../../spec/company-brain/approvals.md).
+
 ## Background listeners
 
 Two per-company background loops sit beside the scheduler, both spawned in

--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -217,6 +217,48 @@ Note this is the *tool* gate (`ApprovalPolicy`), which is a different path from
 the *effect* gate (`ManifestApprovalGate::evaluate`) the taxonomy above
 describes. A harness tool call parks directly and never reaches `evaluate`.
 
+## Approvals inside a workflow run (issue #395)
+
+A workflow run is not a cycle, and for a long time that meant nothing a run
+parked ever reached this queue. Two distinct holes, both now closed.
+
+**A gated tool call inside an `agent` node.** The node's turn runs on the same
+pool and the same `ApprovalPolicy` as chat, so a blocked call *was* recorded on
+the shared request queue — but the only drain lived inside `run_cycle` behind a
+`CycleHost`, which the workflow path never reaches. The request sat there until
+the next chat cycle cleared the queue, and the operator was never asked. The
+node now takes a queue boundary before its turn, claims only the tail its own
+turn added, and parks each entry. Approving one is the ordinary single-use grant
+above: the workflow has already finished with the refusal narrated, so the
+approved call **runs standalone** and does not feed downstream nodes.
+
+**A node marked `requires_approval`.** The engine reports these as node ids on
+the run outcome, which reached the HTTP response and the `WorkflowRunFinished`
+line — neither of which is an approval. Each pending gate now parks a
+`workflow.approve` effect carrying the workflow id, the node id and the trigger
+input, deduped on that triple so a re-run does not stack a second card for one
+decision. It is a **native** effect (no `agent`), so approving performs it
+rather than minting a grant.
+
+### Approving a paused gate re-runs the workflow
+
+The engine **settles** a paused run — nothing holds a task, a connection or a
+continuation. So there is nothing to resume, and "continue" necessarily means
+starting a fresh supervised run with the approved gate id unioned into the
+trigger input's `approvals` array. The parked effect carries everything that
+needs, which is what makes it survive a restart: journal replay rehydrates the
+card and approving it still continues the work.
+
+The cost is stated rather than hidden: **upstream nodes re-execute**. Agent
+nodes re-spend tokens, and a reached `output` node **re-delivers** — a
+warm-recipient email sends again, because the established-thread check is
+state-based, not run-based. A gate normally sits *before* the side-effecting
+node it guards, which is the entire reason to author one, so this is acceptable
+for now; it is a real constraint on where a gate belongs in a graph.
+
+A gate nobody decides ages out on the ordinary TTL to a default deny. Since the
+paused run settled long ago, that costs nothing and cancels nothing.
+
 ## Where the request is raised (issue #379)
 
 An approval is not only a queue entry; it is an interruption of a conversation.

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -31,6 +31,7 @@ import {
   Rocket,
   ShieldCheck,
   SquareKanban,
+  Workflow,
   type LucideIcon,
 } from "lucide-react";
 
@@ -51,6 +52,7 @@ const KIND_ICONS: Record<string, LucideIcon> = {
   "handle.register": AtSign,
   "handle.renew": RefreshCw,
   "key.rotate": KeyRound,
+  "workflow.approve": Workflow,
 };
 
 /**

--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -51,6 +51,12 @@ const EFFECT_LABELS = {
   mcp_registry_tool_call: "Use a connected tool",
   media_generate_image: "Generate an image",
   media_generate_video: "Generate a video",
+  // A workflow run that paused on a step marked "needs approval" (#395). The
+  // card is journal-driven like every other, so it renders through the existing
+  // projection — but without a glossary entry it fell through to "Do something
+  // that needs your sign-off", which tells an operator nothing about what they
+  // are about to restart. The payload names the workflow and the step.
+  "workflow.approve": "Continue a paused workflow",
 };
 
 export function effectAction(kind: string): string {
@@ -90,6 +96,7 @@ const EFFECT_DONE_LABELS = {
   mcp_registry_tool_call: "Used a connected tool",
   media_generate_image: "Generated an image",
   media_generate_video: "Generated a video",
+  "workflow.approve": "Continued a paused workflow",
 } satisfies Record<keyof typeof EFFECT_LABELS, string>;
 
 /**

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -119,12 +119,20 @@ export function ApprovalsView({ client, company, feed, onResolved, onGoToConvers
       // Say which scope actually landed. "Approved" alone would read the same
       // for a one-off and for a week-long permission, and the operator has to be
       // able to tell those apart from the confirmation they just got.
+      //
+      // …and only say "the agent" when there IS one (#395). A card with no
+      // `agent` is one the runtime performs itself — a paused workflow gate, a
+      // cold-recipient report — and naming an agent there is the same shape of
+      // small lie the wording above exists to remove. The work is still in
+      // flight either way, so both halves say so; only the actor changes.
       const line =
         verdict !== "approve"
           ? `Declined: ${approvalSummary(a)}`
           : scope.kind === "tool"
             ? `Approved — ${toolAction(a.kind).toLowerCase()} won't ask again until this permission expires. Take it back under Standing permissions.`
-            : `Approved — the agent is completing the action: ${approvalSummary(a)}`;
+            : a.agent
+              ? `Approved — the agent is completing the action: ${approvalSummary(a)}`
+              : `Approved — carrying it out now: ${approvalSummary(a)}`;
       onResolved(line);
       toast.success(line);
       // The agent's reply arrives as a journaled `AgentReply` on its own thread,

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -205,6 +205,38 @@ impl ApprovalRequestQueue {
         drained
     }
 
+    /// Splits off every request queued **at or after** `from`, leaving the ones
+    /// below it in place (issue #395).
+    ///
+    /// # Why this exists next to [`drain`](Self::drain)
+    ///
+    /// `drain` is a *cycle-end* verb: it takes the front of the queue and
+    /// **clears whatever is left**, which is correct when the cycle owns the
+    /// whole queue and is about to finish with it. A workflow agent node owns
+    /// no such thing. It runs on the same shared
+    /// [`HarnessDeps`](crate::harness::HarnessDeps) as the chat cycles, and a
+    /// cycle may be part-way through its own turn when the node's turn parks a
+    /// request. Calling `drain` there would steal that cycle's entries and then
+    /// wipe the rest — one workflow node silently swallowing another
+    /// conversation's pending approvals.
+    ///
+    /// So this takes only the tail the caller is entitled to. The boundary is
+    /// valid for exactly the reason [`queued`](Self::queued) is documented to
+    /// be one: [`push`](Self::push) only ever appends, so a position taken
+    /// before the turn stays the line between "somebody else parked that" and
+    /// "this turn did".
+    ///
+    /// A `from` past the end yields nothing rather than panicking, so a caller
+    /// that raced a [`clear`](Self::clear) degrades to parking nothing instead
+    /// of aborting the run.
+    pub fn take_from(&self, from: usize) -> Vec<ApprovalRequest> {
+        let mut guard = self.inner.lock().expect("approval request queue");
+        if from >= guard.len() {
+            return Vec::new();
+        }
+        guard.split_off(from)
+    }
+
     /// Builds a queue whose grant set is one the caller already holds.
     ///
     /// The runtime mints and sweeps grants and the policy redeems them, so both
@@ -1852,6 +1884,98 @@ mod tests {
     fn a_dispatch_that_parked_nothing_claims_nothing() {
         let queue = ApprovalRequestQueue::default();
         assert_eq!(queue.stamp_run(queue.queued(), "run-1"), 0);
+    }
+
+    // --- `take_from`: a workflow node's own tail, and nobody else's (#395) ----
+
+    /// The regression this method exists for. A workflow agent node parks its
+    /// gated calls while a chat cycle is part-way through its own turn; taking
+    /// the tail must leave that cycle's entries exactly where they were, and
+    /// `drain` would not — it takes from the front and clears the rest.
+    #[test]
+    fn taking_from_a_boundary_leaves_everything_below_it_untouched() {
+        let queue = ApprovalRequestQueue::default();
+        let queued = |kind: &str| ApprovalRequest {
+            tool: kind.to_string(),
+            reason: "gated".to_string(),
+            effect: Effect {
+                kind: kind.to_string(),
+                group: EffectGroup::Other,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: serde_json::json!({ "kind": kind }),
+                agent: Some("ceo".to_string()),
+                run_id: None,
+            },
+        };
+
+        // A chat cycle's own turn parked this one and has not drained yet.
+        queue.push(queued("chat.thing"));
+        let boundary = queue.queued();
+        // The workflow node's turn parks two.
+        queue.push(queued("node.thing"));
+        queue.push(queued("node.other"));
+
+        let taken = queue.take_from(boundary);
+        assert_eq!(
+            taken.iter().map(|r| r.tool.as_str()).collect::<Vec<_>>(),
+            vec!["node.thing", "node.other"],
+            "only the node's own tail comes back"
+        );
+        assert_eq!(
+            queue.queued(),
+            1,
+            "the chat cycle's entry is still queued for its own drain"
+        );
+        assert_eq!(
+            queue.drain(10)[0].tool,
+            "chat.thing",
+            "…and it is the same entry, not a survivor of a clear-and-rebuild"
+        );
+    }
+
+    /// A node whose turn parked nothing takes nothing — and a boundary past the
+    /// end (a `clear` raced in between) yields nothing rather than panicking.
+    #[test]
+    fn taking_from_the_end_or_past_it_yields_nothing() {
+        let queue = ApprovalRequestQueue::default();
+        assert!(queue.take_from(queue.queued()).is_empty());
+        assert!(queue.take_from(0).is_empty());
+        assert!(
+            queue.take_from(9_000).is_empty(),
+            "a boundary past the end must not panic — a raced clear degrades to \
+             parking nothing"
+        );
+    }
+
+    /// The append-only property the boundary rests on: a push while the node's
+    /// turn is running lands *after* the boundary, never before it, so the
+    /// entitlement split can never mis-attribute an entry downward.
+    #[test]
+    fn pushes_only_ever_append_so_a_boundary_stays_valid() {
+        let queue = ApprovalRequestQueue::default();
+        let queued = |kind: &str| ApprovalRequest {
+            tool: kind.to_string(),
+            reason: "gated".to_string(),
+            effect: Effect {
+                kind: kind.to_string(),
+                group: EffectGroup::Other,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: serde_json::json!({ "kind": kind }),
+                agent: None,
+                run_id: None,
+            },
+        };
+        queue.push(queued("a"));
+        let boundary = queue.queued();
+        for kind in ["b", "c", "d"] {
+            queue.push(queued(kind));
+        }
+        assert_eq!(queue.take_from(boundary).len(), 3);
+        assert_eq!(queue.queued(), 1);
     }
 
     /// A queue nobody installed stays inert — the default policy behaves exactly

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1070,6 +1070,16 @@ async fn perform_effect(rt: &CompanyRuntime, effect: &Effect) -> Result<()> {
             .unwrap_or_default();
         send_company_email(rt, to, subject, body).await?;
     }
+    // Issue #395: an approved workflow gate. The paused run is long settled —
+    // the engine returns rather than suspending — so "continue" means starting a
+    // fresh supervised run with the gate id in the trigger input's `approvals`.
+    // At-most-once comes free from the `approval:<id>` key above; deny and TTL
+    // expiry never reach here, and since nothing was held open, nothing running
+    // is the complete outcome. See `workflow_resume` for why this is a re-run
+    // and what that costs.
+    if effect.kind == crate::runtime::WORKFLOW_APPROVE_KIND {
+        crate::runtime::workflow_resume::resume_from_effect(rt, effect).await?;
+    }
     Ok(())
 }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -78,7 +78,13 @@ pub mod types;
 /// the console's run route and the cron [`WorkflowScheduler`] so a run's history
 /// is uniform no matter what started it. See [`workflow_outcome`].
 pub mod workflow_outcome;
+/// Issue #395: resuming a workflow run that paused on a `requires_approval`
+/// node, once the operator has signed the gate off. See [`workflow_resume`].
+pub mod workflow_resume;
 pub mod workflow_scheduler;
+/// Issue #395: the supervisor-registration + outcome-journalling discipline
+/// every workflow entry point owes, in one place. See [`workflow_spawn`].
+pub mod workflow_spawn;
 
 pub use advance::{SYSTEM_ATTRIBUTION, advance_settled_card, append_result};
 pub use builder::{RuntimeBuilder, company_id_from_name};
@@ -93,7 +99,9 @@ pub use scheduler::{Clock, CompanyScheduler, FakeClock, SystemClock};
 pub use tools::StubToolProvider;
 pub use types::{ApprovalSummary, CompanyStatus, CycleReport};
 pub use workflow_outcome::{record_run_finished, sweep_interrupted_runs};
+pub use workflow_resume::WORKFLOW_APPROVE_KIND;
 pub use workflow_scheduler::WorkflowScheduler;
+pub use workflow_spawn::WorkflowSpawn;
 
 // The assembly struct lives under `company/` to match the `ports.md` sketch
 // (`src/company/runtime.rs`); re-export it here as the kernel's public surface.

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -68,8 +68,8 @@
 use serde_json::{Map, Value};
 
 use crate::Result;
-use crate::company::runtime::CompanyRuntime;
 use crate::company::load_workflow_union;
+use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
 use crate::ports::types::Effect;
 use crate::runtime::workflow_spawn::WorkflowSpawn;
@@ -181,7 +181,11 @@ pub fn already_parked(journal: &crate::runtime::journal::RuntimeJournal, effect:
 pub async fn resume_from_effect(runtime: &CompanyRuntime, effect: &Effect) -> Result<()> {
     let workflow_id = required_str(effect, PAYLOAD_WORKFLOW_ID)?;
     let node_id = required_str(effect, PAYLOAD_NODE_ID)?;
-    let input = effect.payload.get(PAYLOAD_INPUT).cloned().unwrap_or(Value::Null);
+    let input = effect
+        .payload
+        .get(PAYLOAD_INPUT)
+        .cloned()
+        .unwrap_or(Value::Null);
 
     // Through the runtime's own accessor so a build without workflow execution
     // gives an honest error instead of a compile-time edge — this module is in
@@ -202,13 +206,12 @@ pub async fn resume_from_effect(runtime: &CompanyRuntime, effect: &Effect) -> Re
         .await?
         .map(|record| record.overlay_workflows)
         .unwrap_or_default();
-    let workflow = load_workflow_union(runtime.source_dir(), &overlays, workflow_id)?.ok_or_else(
-        || {
+    let workflow =
+        load_workflow_union(runtime.source_dir(), &overlays, workflow_id)?.ok_or_else(|| {
             OpenCompanyError::CompanyNotFound(format!(
                 "workflow {workflow_id} (it was approved, but the graph no longer exists)"
             ))
-        },
-    )?;
+        })?;
 
     let input = with_approval(input, node_id);
     // The handle is dropped on purpose. The task holds its own guard, journals
@@ -318,7 +321,11 @@ mod tests {
     fn a_different_gate_input_or_workflow_is_a_different_decision() {
         let base = effect("digest", "gate", serde_json::json!({ "request": "x" }));
         for other in [
-            effect("digest", "second-gate", serde_json::json!({ "request": "x" })),
+            effect(
+                "digest",
+                "second-gate",
+                serde_json::json!({ "request": "x" }),
+            ),
             effect("other", "gate", serde_json::json!({ "request": "x" })),
             effect("digest", "gate", serde_json::json!({ "request": "y" })),
         ] {
@@ -450,11 +457,14 @@ mod decide_tests {
             input: Value,
             ctx: &WorkflowRunContext,
         ) -> crate::Result<WorkflowRun> {
-            self.started.lock().expect("recording runner").push(StartedRun {
-                workflow_id: workflow.id.clone(),
-                input,
-                run_id: ctx.run_id.clone(),
-            });
+            self.started
+                .lock()
+                .expect("recording runner")
+                .push(StartedRun {
+                    workflow_id: workflow.id.clone(),
+                    input,
+                    run_id: ctx.run_id.clone(),
+                });
             Ok(WorkflowRun {
                 output: json!({ "ok": true }),
                 pending_approvals: Vec::new(),
@@ -522,7 +532,10 @@ mode = "full"
     async fn runtime(
         home: &std::path::Path,
         with_runner: bool,
-    ) -> (Arc<crate::company::runtime::CompanyRuntime>, Arc<RecordingRunner>) {
+    ) -> (
+        Arc<crate::company::runtime::CompanyRuntime>,
+        Arc<RecordingRunner>,
+    ) {
         let mut rt = RuntimeBuilder::new(home.to_path_buf(), manifest())
             .with_seed_dir(home.to_path_buf())
             .build()

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -393,3 +393,348 @@ mod tests {
         assert!(required_str(&e, PAYLOAD_WORKFLOW_ID).is_err());
     }
 }
+
+/// The decide path, end to end over a real runtime (issue #395).
+///
+/// These sit apart from the unit tests above because they need the whole
+/// machine: a real [`CompanyRuntime`], a real approval gate, a real journal on
+/// disk, and a [`WorkflowRunner`](crate::ports::WorkflowRunner) that records
+/// what it was asked to run.
+///
+/// The runner is the only double, and it is the right one to fake: what is under
+/// test is *whether a run is started, with what input, and how many times* —
+/// never what the engine then does with the graph, which the engine's own suite
+/// and `workflows::runner` already cover. Faking it also puts these tests in the
+/// **default lane**, which is where this module compiles and where CI's headline
+/// clippy/test run lives.
+#[cfg(test)]
+mod decide_tests {
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use serde_json::{Value, json};
+
+    use super::*;
+    use crate::company::CompanyManifest;
+    use crate::ports::types::{Actor, ActorKind, ApprovalId, CompanyId, Verdict};
+    use crate::ports::{WorkflowRun, WorkflowRunContext, WorkflowRunner};
+    use crate::runtime::RuntimeBuilder;
+    use crate::runtime::journal::TaskLink;
+
+    /// What the resume actually asked for.
+    #[derive(Clone, Debug)]
+    struct StartedRun {
+        workflow_id: String,
+        input: Value,
+        run_id: String,
+    }
+
+    /// A runner that records every run it is handed and settles immediately.
+    #[derive(Default)]
+    struct RecordingRunner {
+        started: Mutex<Vec<StartedRun>>,
+    }
+
+    impl RecordingRunner {
+        fn started(&self) -> Vec<StartedRun> {
+            self.started.lock().expect("recording runner").clone()
+        }
+    }
+
+    #[async_trait]
+    impl WorkflowRunner for RecordingRunner {
+        async fn run(
+            &self,
+            _company: &CompanyId,
+            workflow: &crate::company::WorkflowFile,
+            input: Value,
+            ctx: &WorkflowRunContext,
+        ) -> crate::Result<WorkflowRun> {
+            self.started.lock().expect("recording runner").push(StartedRun {
+                workflow_id: workflow.id.clone(),
+                input,
+                run_id: ctx.run_id.clone(),
+            });
+            Ok(WorkflowRun {
+                output: json!({ "ok": true }),
+                pending_approvals: Vec::new(),
+                deliveries: Vec::new(),
+                cancelled: false,
+            })
+        }
+    }
+
+    const GATED_TOML: &str = r#"
+id = "gated"
+name = "Gated"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "gate"
+kind = "output"
+name = "Gate"
+requires_approval = true
+[[edge]]
+from = "start"
+to = "gate"
+"#;
+
+    fn manifest() -> CompanyManifest {
+        toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[[agent]]
+id = "ceo"
+role = "Chief"
+
+[policy]
+mode = "full"
+"#,
+        )
+        .expect("manifest parses")
+    }
+
+    fn operator() -> Actor {
+        Actor {
+            kind: ActorKind::Operator,
+            id: "owner".into(),
+        }
+    }
+
+    /// A seeded home whose `workflows/` directory holds the gated graph, so the
+    /// resume's loader finds it exactly as the console run route would.
+    fn seed_home() -> tempfile::TempDir {
+        let dir = tempfile::Builder::new()
+            .prefix("opencompany-resume-")
+            .tempdir()
+            .expect("tempdir");
+        let workflows = dir.path().join("workflows");
+        std::fs::create_dir_all(&workflows).expect("workflows dir");
+        std::fs::write(workflows.join("gated.toml"), GATED_TOML).expect("seed graph");
+        dir
+    }
+
+    /// A runtime with the recording runner installed and the graph on disk.
+    async fn runtime(
+        home: &std::path::Path,
+        with_runner: bool,
+    ) -> (Arc<crate::company::runtime::CompanyRuntime>, Arc<RecordingRunner>) {
+        let mut rt = RuntimeBuilder::new(home.to_path_buf(), manifest())
+            .with_seed_dir(home.to_path_buf())
+            .build()
+            .await
+            .expect("runtime builds");
+        let runner = Arc::new(RecordingRunner::default());
+        if with_runner {
+            rt.set_workflow_runner(runner.clone());
+        }
+        (Arc::new(rt), runner)
+    }
+
+    /// Parks a gate card the way the workflow runner does, returning its id.
+    async fn park_gate(
+        rt: &Arc<crate::company::runtime::CompanyRuntime>,
+        input: Value,
+    ) -> ApprovalId {
+        let effect = gate_effect("gated", "gate", &input, "run-that-paused");
+        let id = rt
+            .approvals
+            .park(rt.id(), effect.clone())
+            .await
+            .expect("parks");
+        rt.journal()
+            .record_parked(
+                &id,
+                &effect,
+                crate::ports::now_millis(),
+                TaskLink::Unlinked,
+                None,
+            )
+            .await
+            .expect("journals");
+        id
+    }
+
+    /// The resume spawns its run on a detached task, so give it a moment to be
+    /// recorded. Bounded so a genuine failure fails rather than hangs.
+    async fn wait_for_runs(runner: &Arc<RecordingRunner>, want: usize) -> Vec<StartedRun> {
+        for _ in 0..200 {
+            let started = runner.started();
+            if started.len() >= want {
+                return started;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        runner.started()
+    }
+
+    /// The headline: approving a parked gate starts a **new** run, carrying the
+    /// gate id in the trigger input's `approvals` so the node that paused now
+    /// proceeds.
+    #[tokio::test]
+    async fn approving_a_gate_starts_a_continuation_run() {
+        let home = seed_home();
+        let (rt, runner) = runtime(home.path(), true).await;
+        let id = park_gate(&rt, json!({ "request": "quarterly numbers" })).await;
+        assert_eq!(rt.pending_approvals().len(), 1);
+
+        rt.resolve_approval(&id, Verdict::Approve, operator())
+            .await
+            .expect("resolves");
+
+        let started = wait_for_runs(&runner, 1).await;
+        assert_eq!(started.len(), 1, "approving must start exactly one run");
+        assert_eq!(started[0].workflow_id, "gated");
+        // The gate is approved…
+        assert_eq!(started[0].input["approvals"], json!(["gate"]));
+        // …and the operator's original topic survives, so the re-run does the
+        // same work rather than a blank one.
+        assert_eq!(started[0].input["request"], "quarterly numbers");
+        // A new causal root, not the paused run's id.
+        assert_ne!(started[0].run_id, "run-that-paused");
+        assert!(rt.pending_approvals().is_empty(), "the card is decided");
+    }
+
+    /// Denying starts nothing. The paused run was already settled, so "nothing
+    /// runs" is the whole outcome — there is no task to cancel.
+    #[tokio::test]
+    async fn denying_a_gate_starts_nothing() {
+        let home = seed_home();
+        let (rt, runner) = runtime(home.path(), true).await;
+        let id = park_gate(&rt, json!({ "request": "x" })).await;
+
+        rt.resolve_approval(&id, Verdict::Deny, operator())
+            .await
+            .expect("resolves");
+
+        // Give a spurious spawn the same window the approve test allows.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert!(runner.started().is_empty(), "a denied gate must not run");
+        assert!(rt.pending_approvals().is_empty());
+    }
+
+    /// Approving twice — a double-click, or a retried request — starts one run.
+    /// At-most-once comes from `execute_effect_once`'s `approval:<id>` key; this
+    /// pins that the resume arm really is under it.
+    #[tokio::test]
+    async fn approving_twice_starts_one_run() {
+        let home = seed_home();
+        let (rt, runner) = runtime(home.path(), true).await;
+        let id = park_gate(&rt, json!({ "request": "x" })).await;
+
+        rt.resolve_approval(&id, Verdict::Approve, operator())
+            .await
+            .expect("first resolve");
+        let _ = rt.resolve_approval(&id, Verdict::Approve, operator()).await;
+
+        let started = wait_for_runs(&runner, 1).await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert_eq!(
+            runner.started().len(),
+            1,
+            "a second approve must not start a second run: {started:?}"
+        );
+    }
+
+    /// A host restart between the park and the approval must lose nothing. The
+    /// parked effect is self-contained and the journal replays it, so a fresh
+    /// runtime over the same home still resumes.
+    #[tokio::test]
+    async fn a_gate_parked_before_a_restart_still_resumes_after_it() {
+        let home = seed_home();
+        {
+            let (rt, _) = runtime(home.path(), true).await;
+            park_gate(&rt, json!({ "request": "survives" })).await;
+        } // the "process" goes away
+
+        // A fresh runtime over the same home, rehydrated from the journal.
+        let (rt, runner) = runtime(home.path(), true).await;
+        rt.recover().await.expect("replay rehydrates the park");
+        let pending = rt.pending_approvals();
+        let card = pending
+            .iter()
+            .find(|a| a.kind == WORKFLOW_APPROVE_KIND)
+            .expect("the gate survived the restart");
+
+        rt.resolve_approval(&card.id, Verdict::Approve, operator())
+            .await
+            .expect("resolves");
+
+        let started = wait_for_runs(&runner, 1).await;
+        assert_eq!(started.len(), 1);
+        assert_eq!(started[0].input["approvals"], json!(["gate"]));
+        assert_eq!(started[0].input["request"], "survives");
+    }
+
+    /// A gate nobody decided expires to a default deny, and an expired card can
+    /// never start a run.
+    ///
+    /// The TTL clock is driven explicitly rather than by waiting: `sweep_expired`
+    /// takes `now` as a parameter, so a far-future reading exercises the real
+    /// expiry path on the real gate. What it proves is structural — expiry
+    /// removes the parked effect, so a later approve resolves to `NotParked` and
+    /// `settle_approved_effect` (the only route to `perform_effect`) is never
+    /// reached. This is the "nothing is ever held open" claim: the paused run
+    /// settled long ago, and its card ages out like any other.
+    #[tokio::test]
+    async fn an_undecided_gate_expires_and_starts_nothing() {
+        let home = seed_home();
+        let (rt, runner) = runtime(home.path(), true).await;
+        let id = park_gate(&rt, json!({ "request": "x" })).await;
+
+        let expired = rt
+            .approval_gate
+            .sweep_expired(crate::ports::now_millis() + crate::policy::DEFAULT_TTL_MILLIS + 1);
+        assert_eq!(expired, vec![id.clone()], "the gate ages out like any card");
+
+        // Approving after expiry is the already-resolved no-op, not a run.
+        rt.resolve_approval(&id, Verdict::Approve, operator())
+            .await
+            .expect("an expired card resolves as already-resolved, not an error");
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert!(
+            runner.started().is_empty(),
+            "an expired gate must never start a continuation run"
+        );
+    }
+
+    /// A build with no workflow execution says so at the moment the operator
+    /// clicks Approve, rather than leaving them watching for a run that will
+    /// never appear.
+    #[tokio::test]
+    async fn approving_on_a_build_with_no_runner_says_so() {
+        let home = seed_home();
+        let (rt, _) = runtime(home.path(), false).await;
+        let id = park_gate(&rt, json!({ "request": "x" })).await;
+
+        let err = rt
+            .resolve_approval(&id, Verdict::Approve, operator())
+            .await
+            .expect_err("must surface the gap");
+        assert!(
+            err.to_string().contains("no workflow execution"),
+            "the message must name the gap: {err}"
+        );
+    }
+
+    /// A gate whose graph was deleted between parking and approving names that,
+    /// rather than failing with something the operator cannot act on.
+    #[tokio::test]
+    async fn approving_a_gate_whose_graph_is_gone_names_it() {
+        let home = seed_home();
+        let (rt, runner) = runtime(home.path(), true).await;
+        let id = park_gate(&rt, json!({ "request": "x" })).await;
+        std::fs::remove_file(home.path().join("workflows").join("gated.toml")).expect("delete");
+
+        let err = rt
+            .resolve_approval(&id, Verdict::Approve, operator())
+            .await
+            .expect_err("must surface the missing graph");
+        assert!(err.to_string().contains("gated"), "{err}");
+        assert!(runner.started().is_empty());
+    }
+}

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -1,0 +1,395 @@
+//! Issue #395: continuing a workflow run the operator has signed off.
+//!
+//! # The hole this closes
+//!
+//! A workflow node marked `requires_approval` pauses the run: the tinyflows
+//! engine settles with the gate's node id on its outcome's
+//! `pending_approvals`. Those ids
+//! reached exactly two places — the run route's HTTP response and the
+//! `WorkflowRunFinished` journal line — and **neither is an approval**. The
+//! Approvals page reads the runtime journal's `pending()`, which lists parked
+//! [`Effect`]s, so it was empty by construction however many gates a run
+//! paused on. An operator watching a run they expected to be gated saw "All
+//! clear" while the run sat unresumable forever.
+//!
+//! The run side of the fix is `park_pending_gates` in the workflow runner —
+//! every pending gate becomes a parked [`WORKFLOW_APPROVE_KIND`] effect (a
+//! `#[cfg(feature = "openhuman")]` module, which is why it is not linked here).
+//! This module is the other half:
+//! what approving one of those cards actually *does*.
+//!
+//! # Resume is a re-run, because a paused run is settled
+//!
+//! This is the fact the whole design turns on, and it is easy to get wrong.
+//! A paused tinyflows run is **not suspended**. Nothing holds a task, a
+//! connection, or a continuation — the engine returns, the future completes,
+//! and the run is over. `engine::resume` is not a resumption primitive either:
+//! it unions the newly-approved gate ids into `input["approvals"]` and calls
+//! `run()` again. The gate node reads that array (at
+//! `state["run"]["trigger"]["approvals"]`) and, finding its own id, proceeds
+//! instead of pausing.
+//!
+//! So the host can do exactly that itself, with no new engine entry point: put
+//! the node id into the trigger input's `approvals` array and start an ordinary
+//! run. Three things fall out of it for free —
+//!
+//! * **restart durability.** The parked effect carries the whole input, so a
+//!   host that dies between the park and the approval loses nothing: journal
+//!   replay rehydrates the card and approving it still resumes.
+//! * **no live-run registry.** The alternative — holding a `ResumableRun` in a
+//!   map keyed by run id — is in-memory, so it dies on restart while the
+//!   durable parked approval outlives it. The operator would approve a card
+//!   pointing at a continuation that no longer exists.
+//! * **observability and cancellation.** The re-run is a normal supervised run,
+//!   so it journals per-node progress and is stoppable, which neither
+//!   `ResumableRun::resume` nor `resume_with_checkpointer` currently offers
+//!   alongside an observer.
+//!
+//! # What it costs, stated plainly
+//!
+//! **Upstream nodes re-execute.** That is the engine's documented semantic for
+//! resume, not something added here, but it is real: agent nodes re-spend
+//! tokens, and a reached `output` node **re-delivers** — a warm-recipient email
+//! will send a second time, because the established-thread check is state-based
+//! rather than run-based. This is acceptable for v1 because a gate normally
+//! sits *before* the side-effecting node it is gating, which is the entire
+//! reason to author one. It is not acceptable silently, which is why it is
+//! written here, in the PR, and nowhere hidden.
+//!
+//! # At-most-once, deny, and expiry
+//!
+//! Nothing extra is owed. The resume arm hangs off `perform_effect`, which only
+//! runs under [`execute_effect_once`](crate::runtime::cycle)'s
+//! `approval:<id>` key, so a double-approve spawns one run. A denied or
+//! TTL-expired approval never reaches `perform_effect` at all, and since the
+//! paused run is already settled, "nothing runs" is the complete outcome — no
+//! task to cancel, no connection to close.
+
+use serde_json::{Map, Value};
+
+use crate::Result;
+use crate::company::runtime::CompanyRuntime;
+use crate::company::load_workflow_union;
+use crate::error::OpenCompanyError;
+use crate::ports::types::Effect;
+use crate::runtime::workflow_spawn::WorkflowSpawn;
+
+/// The effect kind a paused `requires_approval` node parks as (issue #395).
+///
+/// A constant rather than a literal because three places key on it — the park
+/// in the workflow runner, the dedupe that keeps a re-run from stacking a
+/// second card for the same gate, and the `perform_effect` arm that resumes it.
+/// Three copies of a magic string is three chances for one of them to drift and
+/// fail silently, which for this kind means an approval nobody acts on.
+pub const WORKFLOW_APPROVE_KIND: &str = "workflow.approve";
+
+/// The payload key holding the workflow whose run paused.
+pub const PAYLOAD_WORKFLOW_ID: &str = "workflow_id";
+/// The payload key holding the gate node awaiting sign-off.
+pub const PAYLOAD_NODE_ID: &str = "node_id";
+/// The payload key holding the trigger input the paused run was started with.
+pub const PAYLOAD_INPUT: &str = "input";
+
+/// Builds the effect a paused gate parks as.
+///
+/// Shared by the runner (which parks it) and this module's tests, so the shape
+/// the resume arm reads is the shape the park writes — by construction rather
+/// than by two matching literals.
+///
+/// [`EffectGroup::Other`](crate::ports::types::EffectGroup::Other) with
+/// `agent: None` is the honest classification and it decides two things
+/// downstream. `agent: None` routes the approval to
+/// `execute_effect_once` — the native path — rather than minting a tool grant,
+/// which is right: no teammate asked for this and there is no tool call to
+/// re-issue. And because
+/// [`ApprovalSummary::broadly_grantable`](crate::runtime::ApprovalSummary) requires an agent,
+/// the console never offers "let it do this for a period" on a card where that
+/// would mean nothing.
+pub fn gate_effect(workflow_id: &str, node_id: &str, input: &Value, run_id: &str) -> Effect {
+    Effect {
+        kind: WORKFLOW_APPROVE_KIND.to_string(),
+        group: crate::ports::types::EffectGroup::Other,
+        amount_usd: None,
+        established_thread: false,
+        first_time_counterparty: false,
+        payload: serde_json::json!({
+            PAYLOAD_WORKFLOW_ID: workflow_id,
+            PAYLOAD_NODE_ID: node_id,
+            // The whole trigger input, so the parked card is self-contained and
+            // a resume needs nothing but the journal. This is what makes
+            // approve-after-restart work.
+            PAYLOAD_INPUT: input.clone(),
+        }),
+        // Native, not a teammate's tool call — see the doc above.
+        agent: None,
+        // The run that paused. Not the run the approval will start (which does
+        // not exist yet); this is the causal ancestor, and it is what lets the
+        // console tie the card back to the run history the operator was
+        // watching.
+        run_id: Some(run_id.to_string()),
+    }
+}
+
+/// Whether two parked gate effects describe the **same** pending decision.
+///
+/// Identity is `(kind, workflow_id, node_id, input)` — all four, and each earns
+/// its place. Two runs of the same graph with *different* inputs are genuinely
+/// two decisions and must both be asked about; two runs with the same input
+/// reaching the same gate are one decision asked twice, and stacking them turns
+/// a re-runnable workflow into an approvals queue the operator learns to
+/// rubber-stamp.
+///
+/// `run_id` is deliberately **not** part of it: it differs by construction on
+/// every re-run, so including it would make the dedupe a no-op.
+fn is_same_gate(a: &Effect, b: &Effect) -> bool {
+    a.kind == b.kind
+        && a.kind == WORKFLOW_APPROVE_KIND
+        && [PAYLOAD_WORKFLOW_ID, PAYLOAD_NODE_ID, PAYLOAD_INPUT]
+            .iter()
+            .all(|key| a.payload.get(*key) == b.payload.get(*key))
+}
+
+/// True when `effect` names a gate the journal is already holding a card for.
+pub fn already_parked(journal: &crate::runtime::journal::RuntimeJournal, effect: &Effect) -> bool {
+    journal
+        .pending()
+        .iter()
+        .any(|parked| is_same_gate(&parked.effect, effect))
+}
+
+/// Resumes the workflow run a parked [`WORKFLOW_APPROVE_KIND`] effect describes,
+/// by starting a fresh supervised run with the gate approved.
+///
+/// # Why a **new** supervised run rather than a continuation of the old one
+///
+/// Because there is no old one to continue — see the module docs. A re-run is a
+/// new causal root, so it gets its own [`RunSupervisor`](crate::runtime::RunSupervisor)
+/// registration (it must be stoppable like any other run) and its own
+/// `WorkflowRunFinished` (the operator gets two rows: the run that paused, and
+/// the run that finished the job). Reusing the paused run's id would produce a
+/// second finish for one id and make the run history self-contradictory.
+///
+/// # Errors
+///
+/// Propagated rather than swallowed, and that is a deliberate choice about who
+/// hears about the failure. `execute_effect_once` has already committed the
+/// approval by the time this runs, so the runtime will never retry it — if the
+/// graph has since been deleted, or this build has no workflow execution, the
+/// operator must be told at the moment they click Approve rather than left
+/// watching for a run that will never appear. Same stance the `email.send` arm
+/// beside it takes.
+pub async fn resume_from_effect(runtime: &CompanyRuntime, effect: &Effect) -> Result<()> {
+    let workflow_id = required_str(effect, PAYLOAD_WORKFLOW_ID)?;
+    let node_id = required_str(effect, PAYLOAD_NODE_ID)?;
+    let input = effect.payload.get(PAYLOAD_INPUT).cloned().unwrap_or(Value::Null);
+
+    // Through the runtime's own accessor so a build without workflow execution
+    // gives an honest error instead of a compile-time edge — this module is in
+    // the default build, where `src/workflows` does not exist at all.
+    let Some(runner) = runtime.workflow_runner().cloned() else {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "approved the gate on workflow `{workflow_id}`, but this runtime has no workflow \
+             execution wired, so there is nothing to continue"
+        )));
+    };
+
+    // The same seed ∪ overlay union the run route loads through, so a graph
+    // authored on a hosted tenant (no source directory) resumes exactly like a
+    // committed one.
+    let overlays = runtime
+        .store()
+        .load(runtime.id())
+        .await?
+        .map(|record| record.overlay_workflows)
+        .unwrap_or_default();
+    let workflow = load_workflow_union(runtime.source_dir(), &overlays, workflow_id)?.ok_or_else(
+        || {
+            OpenCompanyError::CompanyNotFound(format!(
+                "workflow {workflow_id} (it was approved, but the graph no longer exists)"
+            ))
+        },
+    )?;
+
+    let input = with_approval(input, node_id);
+    // The handle is dropped on purpose. The task holds its own guard, journals
+    // its own outcome and deregisters itself; awaiting it here would hold the
+    // approvals request open for the length of a whole workflow run, which is
+    // the drop-safety failure issue #380 already paid for once.
+    let (run_id, _handle) = WorkflowSpawn::new(runtime, runner).spawn(workflow, input, false);
+    tracing::info!(
+        company = %runtime.id(),
+        workflow = %workflow_id,
+        node = %node_id,
+        %run_id,
+        "workflow: an approved gate started a continuation run; upstream nodes re-execute"
+    );
+    Ok(())
+}
+
+/// Unions `node_id` into the trigger input's `approvals` array.
+///
+/// Mirrors `engine::resume`'s own merge, including its tolerances: a non-object
+/// input is replaced by a fresh object carrying just the approvals (there is
+/// nowhere else to put them), a non-array or absent `approvals` starts an empty
+/// set rather than panicking, non-string entries are dropped, and an id already
+/// present is not duplicated.
+///
+/// Preserving prior approvals is what makes a graph with **two** gates work:
+/// approving the second must not un-approve the first, or the re-run pauses at
+/// the gate the operator already cleared and the workflow can never finish.
+fn with_approval(input: Value, node_id: &str) -> Value {
+    let mut approvals: Vec<String> = input
+        .get("approvals")
+        .and_then(Value::as_array)
+        .map(|list| {
+            list.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    if !approvals.iter().any(|id| id == node_id) {
+        approvals.push(node_id.to_string());
+    }
+
+    match input {
+        Value::Object(mut map) => {
+            map.insert("approvals".to_string(), serde_json::json!(approvals));
+            Value::Object(map)
+        }
+        _ => {
+            let mut map = Map::new();
+            map.insert("approvals".to_string(), serde_json::json!(approvals));
+            Value::Object(map)
+        }
+    }
+}
+
+/// Reads a required string off the parked payload, naming the key when it is
+/// missing — a parked effect this malformed is a host bug, and the operator
+/// clicking Approve needs to know it is not their graph.
+fn required_str<'e>(effect: &'e Effect, key: &str) -> Result<&'e str> {
+    effect
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            OpenCompanyError::InvalidRequest(format!(
+                "this approval is a workflow gate but its record carries no `{key}`, so there is \
+                 no run to continue"
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn effect(workflow: &str, node: &str, input: Value) -> Effect {
+        gate_effect(workflow, node, &input, "run-1")
+    }
+
+    #[test]
+    fn the_parked_effect_is_native_and_self_contained() {
+        let e = effect("digest", "gate", serde_json::json!({ "request": "topic" }));
+        assert_eq!(e.kind, WORKFLOW_APPROVE_KIND);
+        // Native: routes to `execute_effect_once`, not to a tool grant — and
+        // keeps the console from offering a standing permission that would mean
+        // nothing.
+        assert!(e.agent.is_none());
+        // Self-contained: everything a resume needs survives a restart in the
+        // journal, with no live state anywhere.
+        assert_eq!(e.payload[PAYLOAD_WORKFLOW_ID], "digest");
+        assert_eq!(e.payload[PAYLOAD_NODE_ID], "gate");
+        assert_eq!(e.payload[PAYLOAD_INPUT]["request"], "topic");
+        assert_eq!(e.run_id.as_deref(), Some("run-1"));
+    }
+
+    #[test]
+    fn the_same_gate_on_the_same_input_is_one_decision() {
+        let a = effect("digest", "gate", serde_json::json!({ "request": "x" }));
+        let mut b = effect("digest", "gate", serde_json::json!({ "request": "x" }));
+        // A re-run mints a new run id; that must not make it a second card.
+        b.run_id = Some("run-2".to_string());
+        assert!(is_same_gate(&a, &b));
+    }
+
+    #[test]
+    fn a_different_gate_input_or_workflow_is_a_different_decision() {
+        let base = effect("digest", "gate", serde_json::json!({ "request": "x" }));
+        for other in [
+            effect("digest", "second-gate", serde_json::json!({ "request": "x" })),
+            effect("other", "gate", serde_json::json!({ "request": "x" })),
+            effect("digest", "gate", serde_json::json!({ "request": "y" })),
+        ] {
+            assert!(
+                !is_same_gate(&base, &other),
+                "these are two decisions and both must be asked about: {other:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn approving_a_gate_adds_it_to_the_trigger_inputs_approvals() {
+        let out = with_approval(serde_json::json!({ "request": "topic" }), "gate");
+        assert_eq!(out["request"], "topic", "the original input is preserved");
+        assert_eq!(out["approvals"], serde_json::json!(["gate"]));
+    }
+
+    #[test]
+    fn a_second_gate_does_not_un_approve_the_first() {
+        // The two-gate graph. Without the union the re-run pauses at the gate
+        // the operator already cleared and the workflow can never finish.
+        let first = with_approval(serde_json::json!({ "request": "topic" }), "gate-a");
+        let second = with_approval(first, "gate-b");
+        assert_eq!(second["approvals"], serde_json::json!(["gate-a", "gate-b"]));
+    }
+
+    #[test]
+    fn approving_the_same_gate_twice_does_not_duplicate_it() {
+        let once = with_approval(serde_json::json!({}), "gate");
+        let twice = with_approval(once, "gate");
+        assert_eq!(twice["approvals"], serde_json::json!(["gate"]));
+    }
+
+    #[test]
+    fn a_non_object_input_still_yields_a_resumable_one() {
+        // `engine::resume`'s own tolerance: there is nowhere to put the array on
+        // a bare string or null, so it becomes a fresh object holding just the
+        // approvals rather than a panic or a lost gate.
+        for input in [
+            Value::Null,
+            serde_json::json!("a bare topic"),
+            serde_json::json!(42),
+            serde_json::json!(["not", "an", "object"]),
+            // A malformed `approvals` starts an empty set rather than erroring.
+            serde_json::json!({ "approvals": "gate" }),
+        ] {
+            let out = with_approval(input.clone(), "gate");
+            assert_eq!(
+                out["approvals"],
+                serde_json::json!(["gate"]),
+                "input {input} must still produce a resumable trigger"
+            );
+        }
+    }
+
+    #[test]
+    fn non_string_entries_in_a_prior_approvals_array_are_dropped() {
+        let out = with_approval(serde_json::json!({ "approvals": ["a", 7, null] }), "b");
+        assert_eq!(out["approvals"], serde_json::json!(["a", "b"]));
+    }
+
+    #[test]
+    fn a_malformed_gate_record_names_the_key_it_is_missing() {
+        let mut e = effect("digest", "gate", Value::Null);
+        e.payload = serde_json::json!({ PAYLOAD_NODE_ID: "gate" });
+        let err = required_str(&e, PAYLOAD_WORKFLOW_ID).expect_err("must refuse");
+        assert!(err.to_string().contains(PAYLOAD_WORKFLOW_ID), "{err}");
+
+        // A blank id is as unusable as a missing one and must not reach the
+        // loader as an empty filename.
+        e.payload = serde_json::json!({ PAYLOAD_WORKFLOW_ID: "   " });
+        assert!(required_str(&e, PAYLOAD_WORKFLOW_ID).is_err());
+    }
+}

--- a/src/runtime/workflow_spawn.rs
+++ b/src/runtime/workflow_spawn.rs
@@ -1,0 +1,148 @@
+//! Starting a supervised workflow run, in one place (issue #395).
+//!
+//! Two things have to happen around every workflow run an entry point starts,
+//! and neither is optional:
+//!
+//! 1. the run id is minted **through the [`RunSupervisor`]**, which registers
+//!    its stop signal — that id is the address `POST …/workflows/runs/{id}/cancel`
+//!    sends to, so a run started any other way is one an operator cannot stop;
+//! 2. the outcome is journaled through
+//!    [`record_run_finished`] on **both** arms, holding the
+//!    [`RunGuard`](super::RunGuard) across the write, so a run that failed is
+//!    recorded exactly as loudly as one that succeeded.
+//!
+//! That discipline lived inside the console run route's private
+//! `spawn_workflow_run`. Issue #395 added a second entry point — resuming a
+//! `requires_approval` node the operator signed off, which is a **new run** and
+//! therefore owes the same two things — and a second copy of a rule this
+//! specific is a rule that drifts. So it moves here, and both callers construct
+//! a [`WorkflowSpawn`] instead.
+//!
+//! # What this deliberately does not own
+//!
+//! The cron [`WorkflowScheduler`](super::WorkflowScheduler) keeps its own spawn
+//! body. It wraps the same two steps in a schedule *claim* and a per-delivery
+//! log sweep that only make sense for a fire nobody is watching, and folding
+//! those in here would make this helper a union of two jobs rather than the
+//! shared floor of one. It is a candidate for a later pass, not this one.
+//!
+//! # Owned parts, not the runtime
+//!
+//! [`WorkflowSpawn`] holds four cloned handles rather than an
+//! `Arc<CompanyRuntime>`. The spawned task genuinely needs nothing else, and
+//! taking only what it needs is what lets the resume arm — which reaches this
+//! from `perform_effect`, holding a bare `&CompanyRuntime` — start a run at all
+//! without threading a self-referential `Arc` through the runtime.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+use tokio::task::JoinHandle;
+
+use crate::Result;
+use crate::company::WorkflowFile;
+use crate::company::runtime::CompanyRuntime;
+use crate::ports::types::CompanyId;
+use crate::ports::{EventLog, WorkflowRun, WorkflowRunner};
+use crate::runtime::RunSupervisor;
+use crate::runtime::workflow_outcome::record_run_finished;
+
+/// Everything starting a supervised workflow run needs, and nothing else.
+#[derive(Clone)]
+pub struct WorkflowSpawn {
+    company: CompanyId,
+    events: Arc<dyn EventLog>,
+    supervisor: RunSupervisor,
+    runner: Arc<dyn WorkflowRunner>,
+}
+
+impl WorkflowSpawn {
+    /// Reads the three shared handles off `runtime` and pairs them with the
+    /// runner the caller already resolved.
+    ///
+    /// The runner is a parameter rather than read from
+    /// [`CompanyRuntime::workflow_runner`] because the caller has to decide what
+    /// its absence *means* — the console route distinguishes "this build has no
+    /// workflow execution" from "this boot has none because inference was
+    /// configured after start", and answers two different statuses. Swallowing
+    /// that distinction into an `Option<Self>` here would push both callers back
+    /// onto one unhelpful message.
+    pub fn new(runtime: &CompanyRuntime, runner: Arc<dyn WorkflowRunner>) -> Self {
+        Self {
+            company: runtime.id().clone(),
+            events: runtime.events().clone(),
+            supervisor: runtime.run_supervisor().clone(),
+            runner,
+        }
+    }
+
+    /// Registers a run, spawns it, and returns its id alongside the task.
+    ///
+    /// `scheduled` says whether a cron started it, and rides both the run's
+    /// `WorkflowRunStarted` and its `WorkflowRunFinished` — one parameter
+    /// feeding both, so the pair can never disagree about what kind of run it
+    /// was.
+    ///
+    /// The returned [`JoinHandle`] may be awaited (the console's synchronous
+    /// mode) or dropped (its detached mode, and the resume arm). Dropping it
+    /// abandons the *waiting*, never the work: the task holds its own guard,
+    /// journals its own outcome, and deregisters itself on every exit path
+    /// including an unwind.
+    pub fn spawn(
+        self,
+        workflow: WorkflowFile,
+        input: Value,
+        scheduled: bool,
+    ) -> (String, JoinHandle<Result<WorkflowRun>>) {
+        // Issue #371 mints the id above the runner so the error arm can still
+        // correlate; issue #383 mints it HERE, through the supervisor, so the
+        // same id is also an address an operator can send "stop" to.
+        // Deliberately not a second identifier — the run id the console already
+        // correlates SSE frames on IS the cancellation handle.
+        let (ctx, guard) = self.supervisor.begin(&workflow.id, scheduled);
+        let run_id = ctx.run_id.clone();
+        let handle = tokio::spawn(async move {
+            // Held for the whole run INCLUDING the journal write below, so the
+            // window in which a cancel is accepted matches the window in which
+            // it can still do anything. Dropping on every exit path, unwind
+            // included, is why this is a guard rather than a call at the end.
+            let _guard = guard;
+            let result = self
+                .runner
+                .run(&self.company, &workflow, input, &ctx)
+                .await;
+            // Issue #228: journaled on BOTH arms. The caller may well have
+            // closed the tab; the record is what is still there tomorrow.
+            let outcome = match result.as_ref() {
+                Ok(run) => Ok(run),
+                Err(err) => Err(err.to_string()),
+            };
+            match outcome {
+                Ok(run) => {
+                    record_run_finished(
+                        &self.events,
+                        &self.company,
+                        &workflow.id,
+                        scheduled,
+                        &ctx.run_id,
+                        Ok(run),
+                    )
+                    .await;
+                }
+                Err(err) => {
+                    record_run_finished(
+                        &self.events,
+                        &self.company,
+                        &workflow.id,
+                        scheduled,
+                        &ctx.run_id,
+                        Err(err.as_str()),
+                    )
+                    .await;
+                }
+            }
+            result
+        });
+        (run_id, handle)
+    }
+}

--- a/src/runtime/workflow_spawn.rs
+++ b/src/runtime/workflow_spawn.rs
@@ -107,10 +107,7 @@ impl WorkflowSpawn {
             // it can still do anything. Dropping on every exit path, unwind
             // included, is why this is a guard rather than a call at the end.
             let _guard = guard;
-            let result = self
-                .runner
-                .run(&self.company, &workflow, input, &ctx)
-                .await;
+            let result = self.runner.run(&self.company, &workflow, input, &ctx).await;
             // Issue #228: journaled on BOTH arms. The caller may well have
             // closed the tab; the record is what is still there tomorrow.
             let outcome = match result.as_ref() {

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -25,7 +25,7 @@
 //! [`DeliveryReport`](crate::ports::DeliveryReport) rows lived in the console
 //! drawer until it was dismissed, and a scheduled run's reached only host
 //! stdout. The run route now journals every finished run through
-//! [`record_run_finished`] — the same helper the cron
+//! [`record_run_finished`](crate::runtime::record_run_finished) — the same helper the cron
 //! [`WorkflowScheduler`](crate::runtime::WorkflowScheduler) calls, so history is
 //! uniform whatever started the run — and `GET /workflows/runs` folds those
 //! events back out, newest first.
@@ -87,7 +87,6 @@ use crate::ports::types::{
     CompanyEvent, CompanyRecord, EventSeq, OverlayWorkflow, WorkflowNodeStatus,
 };
 use crate::runtime::cron::{CivilTime, CronExpr};
-use crate::runtime::record_run_finished;
 use crate::server::error::ApiError;
 use crate::server::ops::{ScopedCompany, scoped};
 
@@ -858,7 +857,7 @@ impl IntoResponse for RunWorkflowOk {
 /// would break the guard is spawning *inside* an existing run's chain — which is
 /// why the orchestrator's `run_workflow` tool deliberately does NOT use this.
 fn spawn_workflow_run(
-    runtime: std::sync::Arc<crate::company::runtime::CompanyRuntime>,
+    runtime: &crate::company::runtime::CompanyRuntime,
     runner: std::sync::Arc<dyn crate::ports::WorkflowRunner>,
     workflow: WorkflowFile,
     input: Value,
@@ -866,49 +865,11 @@ fn spawn_workflow_run(
     String,
     tokio::task::JoinHandle<crate::Result<crate::ports::WorkflowRun>>,
 ) {
-    // Issue #371 mints the id above the runner so the error arm can still
-    // correlate; issue #383 mints it HERE, through the supervisor, so the same
-    // id is also an address an operator can send "stop" to. Deliberately not a
-    // second identifier — the run id the console already correlates SSE frames
-    // on IS the cancellation handle.
-    let (ctx, guard) = runtime.run_supervisor().begin(&workflow.id, false);
-    let run_id = ctx.run_id.clone();
-    let handle = tokio::spawn(async move {
-        // Held for the whole run INCLUDING the journal write below, so the
-        // window in which a cancel is accepted matches the window in which it
-        // can still do anything. Dropping on every exit path, unwind included,
-        // is why this is a guard rather than a call at the end.
-        let _guard = guard;
-        let result = runner.run(runtime.id(), &workflow, input, &ctx).await;
-        // Issue #228: journaled on BOTH arms. The caller may well have closed
-        // the tab; the record is what is still there tomorrow.
-        match result.as_ref() {
-            Ok(run) => {
-                record_run_finished(
-                    runtime.events(),
-                    runtime.id(),
-                    &workflow.id,
-                    false,
-                    &ctx.run_id,
-                    Ok(run),
-                )
-                .await;
-            }
-            Err(err) => {
-                record_run_finished(
-                    runtime.events(),
-                    runtime.id(),
-                    &workflow.id,
-                    false,
-                    &ctx.run_id,
-                    Err(err.to_string().as_str()),
-                )
-                .await;
-            }
-        }
-        result
-    });
-    (run_id, handle)
+    // Issue #395: the supervisor registration and the both-arms outcome
+    // journalling that used to live here now live in `WorkflowSpawn`, because
+    // approving a paused workflow gate starts a run too and owes exactly the
+    // same two things. One copy of the discipline, two entry points.
+    crate::runtime::WorkflowSpawn::new(runtime, runner).spawn(workflow, input, false)
 }
 
 /// `POST …/workflows/{wid}/run` (both scope forms).
@@ -958,7 +919,7 @@ async fn run_workflow(
     // modes cannot drift in what they start. Issue #228's journalling now lives
     // inside the task rather than around this await.
     let (run_id, handle) =
-        spawn_workflow_run(company.runtime.clone(), runner.clone(), file, body.input);
+        spawn_workflow_run(company.runtime.as_ref(), runner.clone(), file, body.input);
 
     if detach {
         // Returned before the engine has walked a node. From here the client

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -275,6 +275,16 @@ impl HarnessAgentRunner {
     /// already happened, the model was already told it was refused, and failing
     /// the node here would discard a completed turn's work over a queue write.
     /// Same stance `park_approval_requests` takes, for the same reason.
+    ///
+    /// # A run cancelled mid-turn parks nothing, deliberately
+    ///
+    /// Stopping a run drops the engine future *mid-await* (issue #383), which
+    /// takes this call with it — so a call the policy had already gated stays on
+    /// the shared queue and the next chat cycle's `clear` discards it. That is
+    /// the intended outcome, not a residual leak: an operator who stopped a run
+    /// is not asking to be asked about the work they stopped. It is the same
+    /// judgement `cancelled_run` makes in reporting no `pending_approvals`, and
+    /// the same one `park_pending_gates` makes in skipping a cancelled run.
     async fn park_gated_calls(&self, from: usize) {
         let queue = &self.deps.approval_requests;
         // Issue #242's stamp, applied at the boundary the run owns: this is

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -157,6 +157,7 @@ pub async fn build_capabilities(
             pool,
             deps,
             company,
+            run_id.to_string(),
             run_request,
         ))),
     }
@@ -200,6 +201,10 @@ pub struct HarnessAgentRunner {
     pool: Arc<HarnessPool>,
     deps: HarnessDeps,
     company: CompanyId,
+    /// The run these agent nodes belong to (issue #395), stamped onto every
+    /// approval this node's turn parks so the Approvals page can say which
+    /// workflow run is waiting on the operator.
+    run_id: String,
     /// What the operator asked for on this run (issue #154), when they supplied
     /// it. A node's `prompt` is authored into the graph and is the same on every
     /// run, so without this the run's topic never reaches the teammate doing the
@@ -209,18 +214,136 @@ pub struct HarnessAgentRunner {
 
 impl HarnessAgentRunner {
     /// Builds a runner over an already-populated pool for `company`, carrying
-    /// the operator's run request (issue #154) when one was supplied.
+    /// the run's id (issue #395) and the operator's run request (issue #154)
+    /// when one was supplied.
     pub fn new(
         pool: Arc<HarnessPool>,
         deps: HarnessDeps,
         company: CompanyId,
+        run_id: String,
         run_request: Option<String>,
     ) -> Self {
         Self {
             pool,
             deps,
             company,
+            run_id,
             run_request,
+        }
+    }
+
+    /// Parks every approval-gated tool call this node's turn just recorded
+    /// (issue #395) — the drain the workflow path never had.
+    ///
+    /// # The hole this closes
+    ///
+    /// [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy) is installed
+    /// pool-wide on every roster agent with the shared
+    /// [`ApprovalRequestQueue`](crate::harness::policy::ApprovalRequestQueue),
+    /// so a gated tool call inside a workflow agent node **was** recorded. But
+    /// the only drain in the codebase is
+    /// [`park_approval_requests`](crate::harness::HarnessBrain), which lives
+    /// inside `run_cycle` and needs a
+    /// [`CycleHost`](crate::ports::brain::CycleHost). This path —
+    /// `run_agent` → [`HarnessPool::run_background`] → `run_inner` — never goes
+    /// near a cycle, so nothing drained, and the next chat cycle's
+    /// [`clear`](crate::harness::policy::ApprovalRequestQueue::clear) threw the
+    /// request away. The queue's own doc names this case. The leak was
+    /// prevented; the parking was never added. That is why the Approvals page
+    /// stayed "All clear" through a run an operator watched get gated.
+    ///
+    /// # Boundary, not drain
+    ///
+    /// `from` is taken *before* the turn, and only the tail above it is claimed
+    /// — see
+    /// [`take_from`](crate::harness::policy::ApprovalRequestQueue::take_from).
+    /// The queue is shared with whatever chat cycle happens to be running, and
+    /// `drain` would take that cycle's entries and clear the rest.
+    ///
+    /// This narrows the shared-queue race to a turn-sized window; it does not
+    /// eliminate it. If a chat turn pushes *while* this node's turn is running,
+    /// its request lands above the boundary and is parked here — with this
+    /// run's id stamped on it. The real fix is a per-run queue, which means
+    /// re-plumbing `ApprovalPolicy` installation out of `build_roster`; that is
+    /// deliberately out of scope for #395. The failure mode is a mis-attributed
+    /// `run_id` on a card that is otherwise correct and decidable, which is
+    /// strictly better than the request vanishing.
+    ///
+    /// # Never fails the node
+    ///
+    /// A park that errors is logged per entry and the loop continues. The turn
+    /// already happened, the model was already told it was refused, and failing
+    /// the node here would discard a completed turn's work over a queue write.
+    /// Same stance `park_approval_requests` takes, for the same reason.
+    async fn park_gated_calls(&self, from: usize) {
+        let queue = &self.deps.approval_requests;
+        // Issue #242's stamp, applied at the boundary the run owns: this is
+        // where an approval learns which workflow run is waiting on it.
+        queue.stamp_run(from, &self.run_id);
+        let requests = queue.take_from(from);
+        if requests.is_empty() {
+            return;
+        }
+
+        let Some(parking) = self
+            .deps
+            .delivery
+            .as_ref()
+            .and_then(|delivery| delivery.parking.as_ref())
+        else {
+            // Loud: these requests are already off the queue and are the only
+            // trace of calls the operator will never be asked about.
+            tracing::error!(
+                company = %self.company,
+                run_id = %self.run_id,
+                requests = requests.len(),
+                "workflow agent node: gated tool calls could NOT be parked — this runtime has \
+                 no approvals queue wired; the operator will not be asked about them"
+            );
+            return;
+        };
+
+        let cap = crate::harness::policy::MAX_APPROVAL_REQUESTS_PER_TURN;
+        if requests.len() > cap {
+            // Bounded exactly as the cycle drain is: a model that keeps
+            // re-trying a blocked tool must not be able to flood the queue.
+            tracing::warn!(
+                company = %self.company,
+                run_id = %self.run_id,
+                discarded = requests.len() - cap,
+                "workflow agent node: more gated tool calls than one turn may park; the excess \
+                 was discarded"
+            );
+        }
+        for request in requests.into_iter().take(cap) {
+            // The delivery precedent: a workflow run has no board card behind it
+            // and no conversation to raise the request in, so it is recorded
+            // explicitly unlinked (#333) and stays Approvals-page-only (#379).
+            match parking
+                .park_and_journal(
+                    &self.company,
+                    request.effect,
+                    crate::runtime::journal::TaskLink::Unlinked,
+                    None,
+                )
+                .await
+            {
+                Ok(approval_id) => tracing::info!(
+                    company = %self.company,
+                    run_id = %self.run_id,
+                    tool = %request.tool,
+                    approval_id = %approval_id,
+                    "workflow agent node: parked a gated tool call for operator approval"
+                ),
+                Err(err) => tracing::error!(
+                    company = %self.company,
+                    run_id = %self.run_id,
+                    tool = %request.tool,
+                    %err,
+                    "workflow agent node: failed to park a gated tool call; the operator will \
+                     not be asked about it"
+                ),
+            }
         }
     }
 }
@@ -240,10 +363,20 @@ impl AgentRunner for HarnessAgentRunner {
             agent = agent_ref,
             "workflow agent node: routing to harness pool"
         );
+        // Issue #395: where this turn's own approval requests begin, taken
+        // BEFORE the turn so the queue's append-only property makes it a valid
+        // entitlement boundary.
+        let from = self.deps.approval_requests.queued();
         let outcome = self
             .pool
             .run_background(&self.company, agent_ref, &message, &self.deps)
-            .await
+            .await;
+        // Drained on BOTH arms, deliberately. A turn that errored may still have
+        // had a tool call gated before it failed, and that request is just as
+        // real — leaving it on the queue hands it to the next chat cycle's
+        // `clear()`, which is the exact disappearance this issue is about.
+        self.park_gated_calls(from).await;
+        let outcome = outcome
             .map_err(|e| EngineError::Capability(format!("harness agent '{agent_ref}': {e}")))?;
         // Mirror the engine's `{ json, text, raw }` envelope shape: expose the
         // reply as `text` so a downstream `=item.text` binding resolves. A

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -118,7 +118,8 @@ use crate::company::WorkflowFile;
 use crate::company::runtime::CompanyMail;
 use crate::company::{WorkflowDestinationDef, WorkflowNodeKind};
 use crate::ports::types::{
-    Actor, ActorKind, CompanyId, CompanyRecord, Effect, EffectGroup, OutboundMessage, Verdict,
+    Actor, ActorKind, ApprovalId, CompanyId, CompanyRecord, Effect, EffectGroup, OutboundMessage,
+    Verdict,
 };
 use crate::ports::{
     ApprovalGate, ChannelAdapter, DeliveryReason, DeliveryReport, DeliveryStatus, EmailRecord,
@@ -567,8 +568,21 @@ async fn park_cold_recipient(
         run_id: None,
     };
 
-    match park_effect(parking, &record.id, effect).await {
-        Ok(()) => {
+    // No board task is behind a workflow delivery, so the approval is parked
+    // explicitly unlinked (issue #333) — recorded as "belongs to no card" rather
+    // than left blank, so no task's Approvals tab adopts it by happening to be
+    // mid-run when it parked. Issue #379: it has no conversation behind it
+    // either, so there is no thread to raise it in; it stays Approvals-page-only.
+    match parking
+        .park_and_journal(
+            &record.id,
+            effect,
+            crate::runtime::journal::TaskLink::Unlinked,
+            None,
+        )
+        .await
+    {
+        Ok(_) => {
             tracing::info!(
                 company = %record.id,
                 node = %node_id,
@@ -613,97 +627,112 @@ async fn park_cold_recipient(
     }
 }
 
-/// Parks `effect` on the gate and journals it — **both halves or neither**.
-///
-/// The gate is in-memory; the journal is the durable record `/approvals` reads
-/// and boot replay rehydrates. A gate entry the journal never recorded is the
-/// worst of the three possible outcomes: it shows up in the operator's queue
-/// now, vanishes on the next restart, and backs a `pending` row that promises a
-/// card which no longer exists.
-///
-/// Bundling the two handles in [`DeliveryParking`] makes the *mis-wiring* of
-/// that state unrepresentable, but it does nothing about a **partial failure at
-/// runtime** — `park` succeeding and `record_parked` erroring (a full disk, a
-/// read-only volume, a serialization fault). So the journal write is treated as
-/// the commit point: if it fails, the gate entry is retracted before returning
-/// the error, and the caller degrades to the `skipped` row it already emits for
-/// a parking failure.
-///
-/// Retraction has to undo **two** things, because a failed `record_parked` has
-/// already mutated the journal's in-memory queue (it inserts before it appends,
-/// so the entry is live even though nothing reached disk):
-///
-/// 1. [`ApprovalGate::resolve`] with [`Verdict::Deny`] — the trait's only
-///    removal verb, and the honest one: this effect must never execute. It is
-///    attributed to [`ActorKind::System`](crate::ports::types::ActorKind::System)
-///    (the runtime itself, as boot replay and the TTL sweep are) rather than to
-///    an operator who made no such decision.
-/// 2. [`RuntimeJournal::record_resolved`] — which also removes before it
-///    appends, so it clears the in-memory queue entry that would otherwise show
-///    the operator a card `/approvals` lists but the gate can no longer
-///    execute. Its own append will usually fail for the same reason the first
-///    one did; that is fine and expected, since there is no `ApprovalParked`
-///    line on disk for it to pair with anyway.
-///
-/// The ordering cannot simply be inverted to dodge this: `record_parked` needs
-/// the [`ApprovalId`](crate::ports::types::ApprovalId) that `park` mints, so the
-/// gate write must come first.
-///
-/// Both rollback steps deliberately ignore their own errors and the **original**
-/// journal error propagates — the report is reported unsent either way, and
-/// losing the real cause behind a cleanup error would make the failure harder to
-/// diagnose, not easier.
-async fn park_effect(
-    parking: &DeliveryParking,
-    company: &CompanyId,
-    effect: Effect,
-) -> Result<(), crate::error::OpenCompanyError> {
-    let approval_id = parking.approvals.park(company, effect.clone()).await?;
-    if let Err(err) = parking
-        .journal
-        // No board task is behind a workflow delivery, so the approval is
-        // parked explicitly unlinked (issue #333) — recorded as "belongs to no
-        // card" rather than left blank, so no task's Approvals tab adopts it by
-        // happening to be mid-run when it parked.
-        .record_parked(
-            &approval_id,
-            &effect,
-            now_millis(),
-            crate::runtime::journal::TaskLink::Unlinked,
-            // Issue #379: a workflow delivery has no conversation behind it, so
-            // there is no thread to raise it in. It stays Approvals-page-only.
-            None,
-        )
-        .await
-    {
-        // Roll back to "never parked". Both steps deliberately swallow their own
-        // errors — `err` below is the one worth surfacing.
-        if let Err(rollback) = parking
-            .approvals
-            .resolve(
-                &approval_id,
-                Verdict::Deny,
-                Actor {
-                    kind: ActorKind::System,
-                    id: "workflow-delivery".to_string(),
-                },
-            )
+impl DeliveryParking {
+    /// Parks `effect` on the gate and journals it — **both halves or neither**.
+    ///
+    /// The gate is in-memory; the journal is the durable record `/approvals`
+    /// reads and boot replay rehydrates. A gate entry the journal never recorded
+    /// is the worst of the three possible outcomes: it shows up in the
+    /// operator's queue now, vanishes on the next restart, and backs a `pending`
+    /// row that promises a card which no longer exists.
+    ///
+    /// Bundling the two handles in [`DeliveryParking`] makes the *mis-wiring* of
+    /// that state unrepresentable, but it does nothing about a **partial failure
+    /// at runtime** — `park` succeeding and `record_parked` erroring (a full
+    /// disk, a read-only volume, a serialization fault). So the journal write is
+    /// treated as the commit point: if it fails, the gate entry is retracted
+    /// before returning the error, and the caller degrades to whatever it does
+    /// when parking is unavailable.
+    ///
+    /// Retraction has to undo **two** things, because a failed `record_parked`
+    /// has already mutated the journal's in-memory queue (it inserts before it
+    /// appends, so the entry is live even though nothing reached disk):
+    ///
+    /// 1. [`ApprovalGate::resolve`] with [`Verdict::Deny`] — the trait's only
+    ///    removal verb, and the honest one: this effect must never execute. It
+    ///    is attributed to
+    ///    [`ActorKind::System`](crate::ports::types::ActorKind::System) (the
+    ///    runtime itself, as boot replay and the TTL sweep are) rather than to
+    ///    an operator who made no such decision.
+    /// 2. [`RuntimeJournal::record_resolved`] — which also removes before it
+    ///    appends, so it clears the in-memory queue entry that would otherwise
+    ///    show the operator a card `/approvals` lists but the gate can no longer
+    ///    execute. Its own append will usually fail for the same reason the
+    ///    first one did; that is fine and expected, since there is no
+    ///    `ApprovalParked` line on disk for it to pair with anyway.
+    ///
+    /// The ordering cannot simply be inverted to dodge this: `record_parked`
+    /// needs the [`ApprovalId`](crate::ports::types::ApprovalId) that `park`
+    /// mints, so the gate write must come first.
+    ///
+    /// Both rollback steps deliberately ignore their own errors and the
+    /// **original** journal error propagates — the effect is unparked either
+    /// way, and losing the real cause behind a cleanup error would make the
+    /// failure harder to diagnose, not easier.
+    ///
+    /// # Why this is `pub(crate)` rather than a private free function (#395)
+    ///
+    /// It was private to this module while cold-recipient delivery was the only
+    /// caller. Issue #395 found two more places that must park an effect from
+    /// *outside* a cycle — a workflow agent node's gated tool call, and a
+    /// `requires_approval` node the engine paused on — and neither has a
+    /// [`CycleHost`](crate::ports::brain::CycleHost) to reach
+    /// [`park_effect`](crate::ports::brain::CycleHost::park_effect) through.
+    ///
+    /// Widening `CycleHost` for them would have been the wrong seam: that trait
+    /// is the *cycle's* whole effect surface, and a workflow run is not a cycle.
+    /// What all three callers actually share is this transaction. So it becomes
+    /// a method on the bundle that already carries both handles — and which is
+    /// already threaded down the workflow path as
+    /// [`HarnessDeps::delivery`](crate::harness::HarnessDeps)`.parking`.
+    ///
+    /// `task_link` and `thread` are parameters rather than the hardcoded
+    /// `Unlinked` / `None` delivery used, because they are the two facts only
+    /// the caller knows: which board card owns the request, and which
+    /// conversation to raise it in.
+    pub(crate) async fn park_and_journal(
+        &self,
+        company: &CompanyId,
+        effect: Effect,
+        task_link: crate::runtime::journal::TaskLink,
+        thread: Option<String>,
+    ) -> Result<ApprovalId, crate::error::OpenCompanyError> {
+        let approval_id = self.approvals.park(company, effect.clone()).await?;
+        if let Err(err) = self
+            .journal
+            .record_parked(&approval_id, &effect, now_millis(), task_link, thread)
             .await
         {
-            tracing::error!(
-                company = %company,
-                error = %rollback,
-                "workflow delivery: a parked effect could not be journaled AND could not be \
-                 retracted from the approval gate; it may linger in the queue until restart"
-            );
+            // Roll back to "never parked". Both steps deliberately swallow their
+            // own errors — `err` below is the one worth surfacing.
+            if let Err(rollback) = self
+                .approvals
+                .resolve(
+                    &approval_id,
+                    Verdict::Deny,
+                    Actor {
+                        kind: ActorKind::System,
+                        id: "workflow-delivery".to_string(),
+                    },
+                )
+                .await
+            {
+                tracing::error!(
+                    company = %company,
+                    error = %rollback,
+                    "workflow: a parked effect could not be journaled AND could not be \
+                     retracted from the approval gate; it may linger in the queue until restart"
+                );
+            }
+            // Clears the in-memory queue entry `record_parked` inserted before
+            // it failed to write. Its append will usually fail too — expected,
+            // and ignored: there is no `ApprovalParked` line on disk to pair
+            // with.
+            let _ = self.journal.record_resolved(&approval_id).await;
+            return Err(err);
         }
-        // Clears the in-memory queue entry `record_parked` inserted before it
-        // failed to write. Its append will usually fail too — expected, and
-        // ignored: there is no `ApprovalParked` line on disk to pair with.
-        let _ = parking.journal.record_resolved(&approval_id).await;
-        return Err(err);
+        Ok(approval_id)
     }
-    Ok(())
 }
 
 /// The active admins' email addresses, in store order. An unreadable user store

--- a/src/workflows/gated_tool_turn_test.rs
+++ b/src/workflows/gated_tool_turn_test.rs
@@ -283,7 +283,9 @@ async fn a_gated_tool_call_inside_a_workflow_node_parks_for_approval() {
     let card = pending
         .iter()
         .find(|p| p.effect.kind == "shell")
-        .unwrap_or_else(|| panic!("the gated shell call should be waiting on the operator: {pending:?}"));
+        .unwrap_or_else(|| {
+            panic!("the gated shell call should be waiting on the operator: {pending:?}")
+        });
 
     // `agent: Some` is what routes approval to a single-use grant and a
     // re-dispatch, rather than to the native executor — which for a tool call

--- a/src/workflows/gated_tool_turn_test.rs
+++ b/src/workflows/gated_tool_turn_test.rs
@@ -1,0 +1,359 @@
+//! Issue #395, hole 1 — end-to-end proof that a tool call gated *inside a
+//! workflow agent node* reaches the operator's Approvals page and stays there.
+//!
+//! # Why a unit test could not have caught this
+//!
+//! Every part of the mechanism already worked in isolation, and each had tests.
+//! [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy) recorded the
+//! blocked call on the shared queue — tested. The queue stamped run ids and
+//! deduped — tested.
+//! [`DeliveryParking`](crate::workflows::DeliveryParking) parked and journaled
+//! transactionally — tested. What was missing was the *join*: nothing on the
+//! workflow path ever drained the queue, because the only drain lives inside
+//! `run_cycle` behind a [`CycleHost`](crate::ports::brain::CycleHost) and
+//! `run_agent` → [`HarnessPool::run_background`](crate::harness::HarnessPool)
+//! never goes near a cycle. The request was recorded, then thrown away by the
+//! next chat cycle's `clear()`. Green tests, empty Approvals page.
+//!
+//! So this drives the **real** path — real graph, real `run_workflow`, real
+//! `HarnessAgentRunner`, real `HarnessPool`, real `ApprovalPolicy`, real gate
+//! and real on-disk journal — and stubs exactly one thing, at the one boundary
+//! that needs a credential: the model's *choices*, via a scripted
+//! OpenAI-compatible endpoint on loopback. That is the shape
+//! [`workspace_turn_test`](crate::harness::workspace_turn_test) established.
+//!
+//! The load-bearing assertion is the last one:
+//! [`the_parked_request_survives_a_later_chat_cycle`]. Parking the request is
+//! only half the fix — a card that a subsequent conversation wipes is the same
+//! bug with a longer fuse.
+
+use std::sync::{Arc, Mutex};
+
+use axum::Json;
+use axum::routing::post;
+use serde_json::{Value, json};
+
+use crate::company::credentials::Credential;
+use crate::company::{CompanyManifest, parse_workflow};
+use crate::harness::mcp_probe::McpFailureQueue;
+use crate::harness::orchestrator::{DelegationQueue, WorkflowRunnerHandle};
+use crate::harness::policy::ApprovalRequestQueue;
+use crate::harness::provider::{HostedProvider, HostedProviderConfig};
+use crate::harness::{HarnessDeps, HarnessPool};
+use crate::ports::WorkflowRunContext;
+use crate::ports::types::{CompanyId, CompanyRecord};
+use crate::runtime::journal::RuntimeJournal;
+use crate::store::{FsCompanyStore, FsContextStore, FsInboxStore, FsOps};
+use crate::workflows::delivery::{DeliveryParking, WorkflowDeliveryDeps};
+
+/// A graph whose single working node is an agent turn — the exact shape a
+/// company authors when it wants a teammate to do something on a schedule.
+const AGENT_GRAPH: &str = r#"
+id = "gated"
+name = "Gated"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "work"
+kind = "agent"
+name = "Work"
+summary = "Export the quarterly numbers."
+agent = "ceo"
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+[[edge]]
+from = "start"
+to = "work"
+[[edge]]
+from = "work"
+to = "done"
+"#;
+
+/// What the scripted model does on each successive call.
+#[derive(Clone, Debug)]
+enum Turn {
+    /// Emit a native tool call the policy will gate.
+    Call { tool: &'static str, args: Value },
+    /// Finish with plain assistant text.
+    Say(&'static str),
+}
+
+/// A scripted OpenAI-compatible `/chat/completions` endpoint.
+struct Script {
+    turns: Mutex<Vec<Turn>>,
+}
+
+/// Serve the script on loopback and return its base URL.
+async fn spawn_script(turns: Vec<Turn>) -> String {
+    let script = Arc::new(Script {
+        turns: Mutex::new(turns),
+    });
+    let app = axum::Router::new().route(
+        "/chat/completions",
+        post(move |Json(_body): Json<Value>| {
+            let script = Arc::clone(&script);
+            async move {
+                let next = {
+                    let mut turns = script.turns.lock().unwrap();
+                    if turns.is_empty() {
+                        None
+                    } else {
+                        Some(turns.remove(0))
+                    }
+                };
+                // Running off the end of the script means the loop went round
+                // more times than expected; end the turn rather than hang.
+                let message = match next.unwrap_or(Turn::Say("done")) {
+                    Turn::Say(text) => json!({ "role": "assistant", "content": text }),
+                    Turn::Call { tool, args } => json!({
+                        "role": "assistant",
+                        "content": null,
+                        "tool_calls": [{
+                            "id": format!("call-{tool}"),
+                            "type": "function",
+                            "function": { "name": tool, "arguments": args.to_string() }
+                        }]
+                    }),
+                };
+                Json(json!({
+                    "choices": [{ "index": 0, "message": message }],
+                    "usage": { "prompt_tokens": 12, "completion_tokens": 4 }
+                }))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    format!("http://{addr}")
+}
+
+/// A one-agent company that gates `shell`.
+///
+/// `always_approve` rather than `mode = "supervised"` deliberately: it parks
+/// under **`full`** autonomy, which is the strongest form of the claim. A test
+/// that only parks under `supervised` leaves open the reading that the
+/// classifier did the work; this one shows the request is recorded on the queue
+/// whatever the tier, which is exactly what
+/// `always_approve_records_the_request_even_under_full_autonomy` pins one layer
+/// down — and what this test then follows all the way to a journal card.
+fn manifest() -> CompanyManifest {
+    toml::from_str(
+        r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+always_approve = ["shell"]
+
+[tools]
+allow = ["shell"]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+tier = "orchestrator"
+"#,
+    )
+    .expect("manifest parses")
+}
+
+/// Deps with the production approvals wiring: a real gate over the manifest's
+/// `[policy]` and a real on-disk journal, both reachable through the same
+/// `delivery.parking` bundle the runtime builder wires.
+fn deps(base_url: String, dir: &std::path::Path) -> (HarnessDeps, Arc<RuntimeJournal>) {
+    let policy = toml::from_str("mode = \"full\"\n").expect("valid [policy] block");
+    let gate = Arc::new(crate::policy::ManifestApprovalGate::new(policy));
+    let journal = Arc::new(RuntimeJournal::new(dir.join("journal.jsonl")));
+    let deps = HarnessDeps {
+        provider: Arc::new(HostedProvider::new(HostedProviderConfig {
+            base_url,
+            credential: Credential::from_value("stub-key"),
+            extra_headers: Vec::new(),
+        })),
+        provider_slug: "managed".to_string(),
+        context: Arc::new(FsContextStore::new(dir)),
+        store: Arc::new(FsCompanyStore::new(dir)),
+        meter: None,
+        workspace_root: dir.to_path_buf(),
+        model_override: Some("stub-model".to_string()),
+        tasks: None,
+        artifacts: None,
+        skills: None,
+        skills_source_dir: None,
+        skills_registry: std::sync::Arc::from([]),
+        mcp_servers: Vec::new(),
+        facts: None,
+        events: None,
+        delegations: DelegationQueue::default(),
+        workflow_runner: WorkflowRunnerHandle::default(),
+        mcp_failures: McpFailureQueue::default(),
+        pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+        workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
+        approval_requests: ApprovalRequestQueue::default(),
+        secrets: None,
+        web_allowed_domains: Vec::new(),
+        capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+        workflow_source_dir: None,
+        plan: None,
+        media: None,
+        composio: None,
+        steer: crate::company::steer::InflightRegistry::default(),
+        run_supervisor: crate::runtime::RunSupervisor::default(),
+        delivery: Some(WorkflowDeliveryDeps {
+            mail: None,
+            inbox: Arc::new(FsInboxStore::new(dir)),
+            users: Arc::new(FsOps::new(dir)),
+            channels: Vec::new(),
+            parking: Some(DeliveryParking {
+                approvals: gate,
+                journal: journal.clone(),
+            }),
+        }),
+        workspace: None,
+        search: None,
+    };
+    (deps, journal)
+}
+
+fn record() -> CompanyRecord {
+    CompanyRecord {
+        id: CompanyId::new("acme"),
+        manifest: manifest(),
+        ledger: Vec::new(),
+        lifecycle: "running".to_string(),
+        overlay_agents: Vec::new(),
+        overlay_desk_members: Vec::new(),
+        overlay_desk_order: Vec::new(),
+        overlay_desks: Vec::new(),
+        overlay_workflows: Vec::new(),
+        overlay_budgets: Vec::new(),
+        template_provenance: None,
+    }
+}
+
+/// Runs the agent graph once against a script that calls `shell` and then
+/// answers, returning the journal and the run's id.
+async fn run_gated(dir: &std::path::Path) -> (Arc<RuntimeJournal>, HarnessDeps, String) {
+    let base_url = spawn_script(vec![
+        Turn::Call {
+            tool: "shell",
+            args: json!({ "command": "echo quarterly" }),
+        },
+        Turn::Say("I was not allowed to run that."),
+    ])
+    .await;
+    let (deps, journal) = deps(base_url, dir);
+    let record = record();
+    let pool = Arc::new(HarnessPool::new());
+    pool.ensure(&record, &deps).await.expect("roster builds");
+
+    let file = parse_workflow(AGENT_GRAPH).expect("graph parses");
+    let ctx = WorkflowRunContext::new(false);
+    let run_id = ctx.run_id.clone();
+    super::runner::run_workflow(
+        pool,
+        deps.clone(),
+        &record,
+        &file,
+        json!({ "request": "quarterly numbers" }),
+        &ctx,
+    )
+    .await
+    .expect("the run completes — a gated tool refuses the call, it does not fail the node");
+    (journal, deps, run_id)
+}
+
+/// The headline. A tool call gated inside a workflow agent node must leave a
+/// card on the Approvals page — which reads the journal, so "on the page" means
+/// "in `journal.pending()`".
+#[tokio::test]
+async fn a_gated_tool_call_inside_a_workflow_node_parks_for_approval() {
+    let dir = tempfile::tempdir().unwrap();
+    let (journal, _deps, run_id) = run_gated(dir.path()).await;
+
+    let pending = journal.pending();
+    let card = pending
+        .iter()
+        .find(|p| p.effect.kind == "shell")
+        .unwrap_or_else(|| panic!("the gated shell call should be waiting on the operator: {pending:?}"));
+
+    // `agent: Some` is what routes approval to a single-use grant and a
+    // re-dispatch, rather than to the native executor — which for a tool call
+    // would ledger a phantom spend and run nothing.
+    assert_eq!(
+        card.effect.agent.as_deref(),
+        Some("ceo"),
+        "the card must name the teammate that asked, so approving can re-issue the call"
+    );
+    // Issue #242's stamp, applied at the workflow run's boundary.
+    assert_eq!(
+        card.effect.run_id.as_deref(),
+        Some(run_id.as_str()),
+        "the card must name the run waiting on it"
+    );
+    // The tool's own arguments, verbatim — this is the thing being consented to.
+    assert_eq!(card.effect.payload["command"], "echo quarterly");
+}
+
+/// The regression this issue is actually about. Parking is only half the fix:
+/// the shared queue is cleared at the top of **every** chat cycle, and before
+/// #395 a workflow's request sat on it waiting to be wiped by the next
+/// conversation. A card in the journal is independent of that queue, and this
+/// asserts it.
+#[tokio::test]
+async fn the_parked_request_survives_a_later_chat_cycle() {
+    let dir = tempfile::tempdir().unwrap();
+    let (journal, deps, _run_id) = run_gated(dir.path()).await;
+    assert!(
+        journal.pending().iter().any(|p| p.effect.kind == "shell"),
+        "precondition: the request parked"
+    );
+
+    // Exactly what `HarnessBrain::run_cycle` does at the top of every cycle.
+    deps.approval_requests.clear();
+
+    assert!(
+        journal.pending().iter().any(|p| p.effect.kind == "shell"),
+        "the operator's card must outlive the in-memory queue it came from — this is the \
+         disappearance the issue reported"
+    );
+    assert_eq!(
+        deps.approval_requests.queued(),
+        0,
+        "and nothing is left on the queue for a later cycle to park a second time"
+    );
+}
+
+/// A workflow node whose turn calls nothing gated parks nothing. The drain must
+/// be invisible to every run that was already working.
+#[tokio::test]
+async fn a_node_that_gates_nothing_parks_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let base_url = spawn_script(vec![Turn::Say("Here are the numbers.")]).await;
+    let (deps, journal) = deps(base_url, dir.path());
+    let record = record();
+    let pool = Arc::new(HarnessPool::new());
+    pool.ensure(&record, &deps).await.expect("roster builds");
+
+    let file = parse_workflow(AGENT_GRAPH).expect("graph parses");
+    super::runner::run_workflow(
+        pool,
+        deps,
+        &record,
+        &file,
+        Value::Null,
+        &WorkflowRunContext::new(false),
+    )
+    .await
+    .expect("the run completes");
+
+    assert!(journal.pending().is_empty());
+}

--- a/src/workflows/mod.rs
+++ b/src/workflows/mod.rs
@@ -15,6 +15,10 @@
 
 pub mod caps;
 pub mod delivery;
+/// Issue #395: end-to-end proof that a tool call gated inside a workflow agent
+/// node reaches the Approvals page and survives the next chat cycle.
+#[cfg(test)]
+mod gated_tool_turn_test;
 pub mod runner;
 pub mod translate;
 

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -178,6 +178,11 @@ async fn run_workflow_inner(
     // message carries the topic — a node's authored `prompt` is the same on
     // every run and cannot say what was asked this time.
     let run_request = super::caps::run_request_text(&input);
+    // Issue #395: the trigger payload, kept before the engine consumes it. A
+    // paused gate's approval card has to carry the input the run was started
+    // with, because resuming means re-running the graph with that same input
+    // plus the approval — see `crate::runtime::workflow_resume`.
+    let trigger_input = input.clone();
     // Issue #170: the delivery ports are read off `deps` BEFORE it moves into
     // the capability bundle. Delivery is host-side and post-engine, so it is not
     // a capability — the engine never learns a report has a destination.
@@ -361,6 +366,25 @@ async fn run_workflow_inner(
         }
     };
 
+    // Issue #395: turn every gate the engine paused on into a decidable
+    // approval. Deliberately here, beside the delivery call and for the same
+    // reason: all three entry points — the console route, the cron scheduler,
+    // and the orchestrator's `run_workflow` tool — come through this function,
+    // and a scheduled run is exactly the case where nobody is watching the
+    // response that used to be the only place these ids appeared.
+    //
+    // Skipped for a cancelled run, which returns above: an operator who stopped
+    // a run is not asking to be asked about the gates it never reached.
+    park_pending_gates(
+        delivery.as_ref(),
+        record,
+        &workflow.id,
+        &run_id,
+        &trigger_input,
+        &outcome.pending_approvals,
+    )
+    .await;
+
     // Route every reached `output` node's report to its configured destination.
     // Deliberately here rather than in the HTTP handler: the orchestrator's
     // `run_workflow` tool and the trigger scheduler drive this same path, and a
@@ -376,6 +400,110 @@ async fn run_workflow_inner(
         deliveries,
         cancelled: false,
     })
+}
+
+/// Parks one approval card per gate the run paused on (issue #395).
+///
+/// # The hole this closes
+///
+/// A node marked `requires_approval` pauses the run, and the engine reports the
+/// gate's node id on `RunOutcome::pending_approvals`. Those ids flowed into
+/// exactly two places — the run route's HTTP response and the
+/// `WorkflowRunFinished` journal line — and **neither is an approval**. The
+/// Approvals page reads the journal's parked [`Effect`](crate::ports::types::Effect)s,
+/// so it was empty by construction: the run paused, the ids were recorded as
+/// trivia, and nothing an operator could act on ever existed. That is why a QA
+/// run with a `requires_approval` node left the page reading "All clear".
+///
+/// # Best-effort, and never fails the run
+///
+/// The engine has already settled by the time this runs; the graph's work is
+/// done and correct whatever happens here. A park that fails is logged loudly —
+/// it is the only trace of a decision the operator will never be asked for —
+/// and the next gate is still attempted. Failing the run instead would discard
+/// a completed run's output over an approvals-queue write.
+///
+/// # Dedupe
+///
+/// A run is re-runnable, and resuming one is itself a re-run, so the same gate
+/// on the same input will be reached again and again. Without a dedupe the
+/// queue fills with identical cards for one decision — which is exactly how an
+/// operator learns to rubber-stamp the queue. Identity is the gate, not the run;
+/// see [`already_parked`](crate::runtime::workflow_resume::already_parked).
+async fn park_pending_gates(
+    delivery: Option<&super::delivery::WorkflowDeliveryDeps>,
+    record: &CompanyRecord,
+    workflow_id: &str,
+    run_id: &str,
+    trigger_input: &Value,
+    pending: &[String],
+) {
+    if pending.is_empty() {
+        return;
+    }
+    let Some(parking) = delivery.and_then(|delivery| delivery.parking.as_ref()) else {
+        // Fails closed and loud, the same stance `deliver_outputs` takes for an
+        // unwired destination: the run genuinely paused, and on this build
+        // nobody can be asked to un-pause it.
+        tracing::error!(
+            company = %record.id,
+            workflow = %workflow_id,
+            %run_id,
+            gates = pending.len(),
+            "workflow: the run paused for approval but this runtime has no approvals queue \
+             wired, so the gates cannot be parked — the run cannot be continued"
+        );
+        return;
+    };
+
+    for node_id in pending {
+        let effect = crate::runtime::workflow_resume::gate_effect(
+            workflow_id,
+            node_id,
+            trigger_input,
+            run_id,
+        );
+        if crate::runtime::workflow_resume::already_parked(&parking.journal, &effect) {
+            tracing::debug!(
+                company = %record.id,
+                workflow = %workflow_id,
+                node = %node_id,
+                "workflow: this gate is already waiting on the operator; not asking twice"
+            );
+            continue;
+        }
+        // A workflow run has no board card behind it and no conversation to
+        // raise the request in — the same two facts the delivery park records
+        // (#333, #379).
+        match parking
+            .park_and_journal(
+                &record.id,
+                effect,
+                crate::runtime::journal::TaskLink::Unlinked,
+                None,
+            )
+            .await
+        {
+            Ok(approval_id) => tracing::info!(
+                company = %record.id,
+                workflow = %workflow_id,
+                node = %node_id,
+                %run_id,
+                %approval_id,
+                "workflow: parked a paused gate for operator approval; approving it starts a \
+                 continuation run"
+            ),
+            Err(err) => tracing::error!(
+                company = %record.id,
+                workflow = %workflow_id,
+                node = %node_id,
+                %run_id,
+                %err,
+                "workflow: a paused gate could NOT be parked for approval; the run cannot be \
+                 continued"
+            ),
+        }
+    }
 }
 
 /// What a run stopped by an operator settles with (issue #383).
@@ -1667,6 +1795,205 @@ to = "done"
             })
             .await;
         assert!(out.is_ok(), "a run below the limit must execute: {out:?}");
+    }
+
+    // --- #395: a paused gate becomes a decidable approval --------------------
+
+    /// The graph T4 uses, with the gate node reachable and an output behind it.
+    const GATED: &str = r#"
+id = "gated"
+name = "Gated"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "gate"
+kind = "tool_call"
+name = "Gate"
+requires_approval = true
+[node.config]
+slug = "csv_export"
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+[[edge]]
+from = "start"
+to = "gate"
+[[edge]]
+from = "gate"
+to = "done"
+"#;
+
+    /// Deps with a real approvals queue — the production gate over a `full`
+    /// policy and a real on-disk journal.
+    ///
+    /// `full` is the mode that matters: it is the tier under which the manifest
+    /// gate's `evaluate` would *allow* most effects. Parking under it proves the
+    /// gate park is the already-decided path rather than a re-evaluation that
+    /// would quietly let the run continue.
+    fn deps_with_parking(
+        dir: &std::path::Path,
+    ) -> (HarnessDeps, Arc<crate::runtime::journal::RuntimeJournal>) {
+        let policy = toml::from_str("mode = \"full\"\n").expect("valid [policy] block");
+        let gate = Arc::new(crate::policy::ManifestApprovalGate::new(policy));
+        let journal = Arc::new(crate::runtime::journal::RuntimeJournal::new(
+            dir.join("journal.jsonl"),
+        ));
+        let mut deps = deps(dir);
+        deps.delivery = Some(super::super::delivery::WorkflowDeliveryDeps {
+            mail: None,
+            inbox: Arc::new(crate::store::FsInboxStore::new(dir)),
+            users: Arc::new(crate::store::FsOps::new(dir)),
+            channels: Vec::new(),
+            parking: Some(super::super::delivery::DeliveryParking {
+                approvals: gate,
+                journal: journal.clone(),
+            }),
+        });
+        (deps, journal)
+    }
+
+    /// The headline regression. A run that pauses on `requires_approval` must
+    /// leave a **parked effect** behind, not just an id on a response body —
+    /// the Approvals page reads the journal, so before #395 it stayed empty
+    /// however many gates a run paused on.
+    #[tokio::test]
+    async fn a_paused_gate_becomes_a_parked_approval() {
+        let dir = tempfile::tempdir().unwrap();
+        let (deps, journal) = deps_with_parking(dir.path());
+        let file = parse_workflow(GATED).expect("parses");
+
+        let run = run_workflow(
+            Arc::new(HarnessPool::new()),
+            deps,
+            &tools_record(),
+            &file,
+            serde_json::json!({ "request": "quarterly numbers" }),
+            &WorkflowRunContext::new(false),
+        )
+        .await
+        .expect("run pauses cleanly");
+        assert!(run.pending_approvals.iter().any(|id| id == "gate"));
+
+        let pending = journal.pending();
+        let card = pending
+            .iter()
+            .find(|p| p.effect.kind == crate::runtime::WORKFLOW_APPROVE_KIND)
+            .expect("the paused gate is waiting on the operator");
+        assert_eq!(card.effect.payload["workflow_id"], "gated");
+        assert_eq!(card.effect.payload["node_id"], "gate");
+        // Self-contained: the trigger input rides the card, which is what makes
+        // approve-after-restart resume without any live state.
+        assert_eq!(card.effect.payload["input"]["request"], "quarterly numbers");
+        // Native — no teammate asked, so approving must not mint a tool grant.
+        assert!(card.effect.agent.is_none());
+        // The run that paused, so the console can tie the card to the history.
+        assert!(card.effect.run_id.is_some());
+    }
+
+    /// Re-running the same graph with the same input must not stack a second
+    /// card for one decision — that is how an approvals queue becomes something
+    /// an operator rubber-stamps.
+    #[tokio::test]
+    async fn re_reaching_the_same_gate_does_not_ask_twice() {
+        let dir = tempfile::tempdir().unwrap();
+        let (deps, journal) = deps_with_parking(dir.path());
+        let file = parse_workflow(GATED).expect("parses");
+        let input = serde_json::json!({ "request": "same" });
+
+        for _ in 0..3 {
+            run_workflow(
+                Arc::new(HarnessPool::new()),
+                deps.clone(),
+                &tools_record(),
+                &file,
+                input.clone(),
+                &WorkflowRunContext::new(false),
+            )
+            .await
+            .expect("run pauses cleanly");
+        }
+
+        let gates = journal
+            .pending()
+            .into_iter()
+            .filter(|p| p.effect.kind == crate::runtime::WORKFLOW_APPROVE_KIND)
+            .count();
+        assert_eq!(gates, 1, "one gate, one decision, one card");
+    }
+
+    /// …but a **different** input at the same gate is a genuinely different
+    /// decision and must be asked about separately.
+    #[tokio::test]
+    async fn the_same_gate_on_a_different_input_is_a_second_decision() {
+        let dir = tempfile::tempdir().unwrap();
+        let (deps, journal) = deps_with_parking(dir.path());
+        let file = parse_workflow(GATED).expect("parses");
+
+        for request in ["first", "second"] {
+            run_workflow(
+                Arc::new(HarnessPool::new()),
+                deps.clone(),
+                &tools_record(),
+                &file,
+                serde_json::json!({ "request": request }),
+                &WorkflowRunContext::new(false),
+            )
+            .await
+            .expect("run pauses cleanly");
+        }
+
+        let gates = journal
+            .pending()
+            .into_iter()
+            .filter(|p| p.effect.kind == crate::runtime::WORKFLOW_APPROVE_KIND)
+            .count();
+        assert_eq!(gates, 2);
+    }
+
+    /// A run an operator stopped parks nothing. They are not asking to be asked
+    /// about gates the run never reached, and `cancelled_run` reports no pending
+    /// approvals for the same reason.
+    #[tokio::test]
+    async fn a_cancelled_run_parks_no_gates() {
+        let dir = tempfile::tempdir().unwrap();
+        let (deps, journal) = deps_with_parking(dir.path());
+        let file = parse_workflow(GATED).expect("parses");
+        let ctx = WorkflowRunContext::new(false);
+        ctx.cancel.cancel();
+
+        let run = run_workflow(
+            Arc::new(HarnessPool::new()),
+            deps,
+            &tools_record(),
+            &file,
+            serde_json::json!({ "request": "x" }),
+            &ctx,
+        )
+        .await
+        .expect("a cancelled run is Ok");
+        assert!(run.cancelled);
+        assert!(journal.pending().is_empty());
+    }
+
+    /// A graph with no gate parks nothing — the addition must be invisible to
+    /// every run that was already working.
+    #[tokio::test]
+    async fn a_run_that_pauses_on_nothing_parks_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let (deps, journal) = deps_with_parking(dir.path());
+        let file = parse_workflow(GREET).expect("parses");
+        let rec = record();
+        let pool = Arc::new(HarnessPool::new());
+        pool.ensure(&rec, &deps).await.expect("roster builds");
+
+        let run = run_workflow(pool, deps, &rec, &file, Value::Null, &WorkflowRunContext::new(false))
+            .await
+            .expect("run completes");
+        assert!(run.pending_approvals.is_empty());
+        assert!(journal.pending().is_empty());
     }
 
     // --- issue #371: the per-node progress trail -----------------------------

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -1989,9 +1989,16 @@ to = "done"
         let pool = Arc::new(HarnessPool::new());
         pool.ensure(&rec, &deps).await.expect("roster builds");
 
-        let run = run_workflow(pool, deps, &rec, &file, Value::Null, &WorkflowRunContext::new(false))
-            .await
-            .expect("run completes");
+        let run = run_workflow(
+            pool,
+            deps,
+            &rec,
+            &file,
+            Value::Null,
+            &WorkflowRunContext::new(false),
+        )
+        .await
+        .expect("run completes");
         assert!(run.pending_approvals.is_empty());
         assert!(journal.pending().is_empty());
     }


### PR DESCRIPTION
## Summary

A workflow run could never park an approval. Whatever its nodes did — a gated
tool call inside an `agent` node, or a node explicitly marked
`requires_approval` — the Approvals page stayed **"All clear"** for the whole
run and after it. Two independent holes, both closed here.

**Hole 1 — a gated tool call in an agent node was queued, then discarded.**
`ApprovalPolicy` is installed pool-wide with the shared `ApprovalRequestQueue`,
so a blocked call inside a workflow agent node *was* recorded. But the only
drain in the codebase lives inside `run_cycle` behind a `CycleHost`, and the
workflow path (`run_agent` → `run_background` → `run_inner`) never touches a
cycle. Nothing drained, and the next chat cycle's `clear()` threw the request
away — whose own doc names exactly this case. The leak was prevented; the
parking was never added.

The node now takes a queue boundary **before** its turn, stamps the run id onto
its own tail, and parks each entry. A new `ApprovalRequestQueue::take_from`
does the claiming: `drain` takes from the front and clears the rest, which
would steal and then wipe a concurrent chat cycle's entries.

**Hole 2 — a paused `requires_approval` node never became a parked effect.**
The engine reports these as node ids on the run outcome, and those ids reached
the HTTP response and the `WorkflowRunFinished` line — neither of which is an
approval. The Approvals page reads parked effects from the journal, so it was
empty by construction. Each pending gate now parks a `workflow.approve` effect
carrying the workflow id, the node id and the trigger input, deduped on that
triple.

**Not the bug:** gating is keyed on the tool being called, never on request
content. There is no topic classifier, so a sensitive-sounding request is not
gated for being sensitive. Working as designed.

## API Or Behavior Changes

**New effect kind `workflow.approve`.** Additive: a native effect (no `agent`),
`EffectGroup::Other`, payload `{workflow_id, node_id, input}`. It appears on
`GET …/approvals` like any other card. A console predating this renders it
through the existing generic projection.

**Approving a paused gate starts a new workflow run.** The engine *settles* a
paused run — nothing holds a task or a connection — so `engine::resume` is not
a resumption primitive either: it unions the gate ids into `input["approvals"]`
and calls `run()` again. The host does exactly that and spawns an ordinary
supervised run. No new engine entry point, no in-memory live-run registry, and
restart-durable for free because the parked card is self-contained.

**Risk, stated plainly: the continuation re-executes upstream nodes.** That is
the engine's own documented semantic, but it is real. Agent nodes re-spend
tokens, and **a reached `output` node re-delivers — a warm-recipient email will
send a second time**, because the established-thread check is state-based, not
run-based. Acceptable for v1 because a gate normally sits *before* the
side-effecting node it guards, which is the entire reason to author one. It is
a real constraint on where a gate belongs in a graph, and it is documented in
`docs/spec/company-brain/approvals.md` rather than left for someone to find.

**What a Hole 1 approval does and does not do.** It takes the existing
single-use-grant path unchanged: the workflow has already finished with the
refusal narrated, so approving executes the tool call **standalone** and does
**not** back-feed downstream nodes. Same semantics as the chat path.

**The shared-queue race is narrowed, not eliminated.** The boundary is taken
before the node's turn and only the tail above it is claimed, so a chat cycle's
existing entries are safe. But a chat turn that pushes *while* the node's turn
runs lands above the boundary and is parked with this run's id stamped on it.
The real fix is a per-run queue, which needs `ApprovalPolicy` installation
re-plumbed out of `build_roster` — out of scope, and documented at the call
site in `src/workflows/caps/mod.rs`.

**No behaviour change for runs that pause on nothing** or park nothing, and the
console run route's spawn is byte-equivalent — it now delegates to the shared
`WorkflowSpawn` rather than owning a second copy of the discipline.

Two console changes that the plan expected to be unnecessary, and were not:
`workflow.approve` had no glossary entry so it rendered as "Do something that
needs your sign-off" under a generic shield; and the approve toast said "the
agent is completing the action" for a card that has no agent.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --lib` — 1487 passed, 0 failed
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 2169 passed, 0 failed
- [x] `cargo check --locked --all-features --all-targets`
- [x] `git diff --stat Cargo.lock` — empty
- [x] `npm ci && npm run typecheck && npm run typecheck:e2e && npm run build`

New coverage, and each of the two headline suites was **verified to fail against
the pre-fix code** rather than assumed to:

- `harness::policy` — `take_from`'s entitlement split, its append-only
  precondition, and the past-the-end boundary.
- `workflows::gated_tool_turn_test` — the real path (graph → `run_workflow` →
  `HarnessAgentRunner` → `HarnessPool` → `ApprovalPolicy` → gate → on-disk
  journal), with only the model's choices stubbed by a scripted
  OpenAI-compatible endpoint on loopback. The load-bearing case is that the
  parked card **survives a subsequent chat cycle's `clear()`** — parking is
  only half the fix otherwise.
- `workflows::runner` — a paused gate parks a self-contained card; a re-run does
  not ask twice; a different input *is* a second decision; a cancelled run parks
  nothing; a graph with no gate parks nothing.
- `runtime::workflow_resume` — unit coverage of the approvals-union merge
  (including the two-gate case, where approving the second must not un-approve
  the first) plus a decide-path suite over a real `CompanyRuntime`, gate and
  journal: approve, deny, double-approve (at-most-once), restart-replay, TTL
  expiry, no-runner, and deleted-graph.

**Manual verification, on a running host, both surfaces.** A scratch company
with two workflows, a scripted model on loopback so a real tool call is really
gated, the console served from `frontend/dist`, signed in through the real
magic-link flow:

*Hole 2* — ran the `requires_approval` workflow: run 1 settled with
`pendingApprovals: ["gate"]` and an **empty node trail** (nothing ran). A
`workflow.approve` card appeared on `GET …/approvals` carrying the graph, node
and input. Approved it **from the console's Approvals page**; the card cleared
and run 2 appeared in the run history with `pending: []`, no error, and a node
trail of `["gate", "done"]` — the gate node *and* the downstream node executed.
The gated tool's real side effect (a CSV) landed in the run's workspace.

*Hole 1* — ran the agent-node workflow: the teammate's `shell` call was gated,
the turn narrated the refusal, and a card appeared naming the asker and the
verbatim command. Then sent an operator chat message — a full chat cycle, the
`clear()` that used to lose it — and the card was **still there**. Approving it
minted the single-use grant, re-dispatched the CEO, and the tool actually ran
("Done — the export ran and printed quarterly-numbers").

*Console* — both card families render correctly and side by side: "Continue a
paused workflow" with `workflow_id` / `node_id` / `input` and no standing-scope
control (correct — no agent to grant to), and "Run a terminal command" with the
command, "Asked by Chief Executive", and the standing-permission control.

## Documentation

- `docs/spec/company-brain/approvals.md` — a new "Approvals inside a workflow
  run" section: both holes, why approving a paused gate is a re-run, and the
  re-execution cost including the email re-send.
- `docs/modules/runtime/README.md` — `workflow_spawn.rs` and
  `workflow_resume.rs`.

Rejected alternatives, recorded in the module docs: a `ResumableRun` held in a
host map (in-memory, dies on restart while the parked approval durably outlives
it, and loses node-progress observation), and `resume_with_checkpointer` (the
right long-term answer, but needs a net-new durable checkpointer and also lacks
the observer + cancel combination this path already has).

Closes #395
