### PR TITLE
fix(runtime): resolve the agent journal inside the data dir, and refuse to start if it cannot persist (#446)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,12 @@ injects its environment. When developing hosted behavior, know the seams:
 - The manager injects `OPENCOMPANY_COMPANY`, `OPENCOMPANY_BIND=0.0.0.0:8080`,
   `OPENCOMPANY_DATA_DIR=/data`, and `OPENCOMPANY_PUBLIC_URL` into every
   tenant container. `OPENCOMPANY_DATA_DIR` is the instance data root for
-  **both** the workspace layout and the company-bundle home; `docker/entrypoint.sh`
+  the workspace layout, the company-bundle home, **and** the embedded OpenHuman
+  runtime's own root: `serve` derives `<data-dir>/openhuman` and exports it as
+  `OPENHUMAN_WORKSPACE`, because the vendored runtime otherwise defaults its
+  durable agent journal into `$HOME` — the read-only root filesystem in a tenant
+  (issue #446). An unwritable journal root aborts boot; see
+  `docs/spec/runtime/storage.md`. `docker/entrypoint.sh`
   additionally forwards it as `--home "$OPENCOMPANY_DATA_DIR"`, which resolves
   identically (the flag outranks the variable). Locally it is the only knob that
   isolates two `serve` processes from each other — see

--- a/docs/spec/runtime/storage.md
+++ b/docs/spec/runtime/storage.md
@@ -56,6 +56,7 @@ locations instead of ad-hoc paths:
   logs/        ← instance logs
   tmp/         ← ephemeral scratch, cleared on startup by default
   harness/     ← agent + workflow sandboxes (see below; minted on demand)
+  openhuman/   ← the embedded OpenHuman runtime's own root (see below)
 ```
 
 Per-company state (each bundle's own `memory/`/`context/`) lives under
@@ -65,6 +66,44 @@ the shared subdirectories and — unless `[workspace].clear_tmp_on_startup` is
 `false` — empties `tmp/` so no stale scratch survives a restart. Because the hosting model runs **one container per tenant** with its
 own `OPENCOMPANY_DATA_DIR`, this root *is* the per-tenant workspace — no separate
 per-tenant path prefix is needed.
+
+### The embedded runtime's root (`<data-dir>/openhuman`, `src/app/journal.rs`)
+
+The vendored OpenHuman runtime resolves its own workspace, and its default is a
+subdirectory of the user's **home directory** — which in a tenant container is
+the read-only root filesystem. Its durable agent journal
+(`{workspace}/tinyagents_store/`) therefore failed to create its store root on
+every append, and the vendored append worker reported that to stderr once per
+event with no dedup or backoff, burying every other line in the container log
+(issue #446).
+
+`serve` closes that gap before any agent exists.
+[`app::journal::prepare`](../../../src/app/journal.rs) resolves the root, proves
+it is writable, and exports it as `OPENHUMAN_WORKSPACE` — the one seam the
+vendored config loader consults ahead of its home-directory default:
+
+```text
+<OPENCOMPANY_DATA_DIR>/openhuman/            ← exported as OPENHUMAN_WORKSPACE
+<OPENCOMPANY_DATA_DIR>/openhuman/workspace/tinyagents_store/   ← the journal
+```
+
+| Precedence | Source | Root |
+|---|---|---|
+| 1 | `OPENHUMAN_WORKSPACE` (non-blank) | its value verbatim — a self-hoster keeps an existing workspace |
+| 2 | `OPENCOMPANY_DATA_DIR` | `<data-dir>/openhuman`, exported so the vendored loader finds it |
+
+`serve` prints the resolved store path at startup (`agent journal: … (root …,
+from …)`) so this class of problem is one line to diagnose rather than a code
+trace. Only the path is printed; no other environment value is read or echoed.
+
+An unwritable root **aborts boot** — the same precedent as a
+selected-but-unavailable storage backend. A tenant that answers but records
+nothing produces confident, unrecoverable work and reports the loss only at
+`debug` level; a tenant that refuses to start is one loud, attributable line.
+Because the check runs after `DataLayout::ensure` has already created the shared
+subdirectories, it can only fail on a genuinely broken mount or an explicitly
+misconfigured `OPENHUMAN_WORKSPACE`, so it cannot turn a healthy tenant into one
+that will not wake.
 
 ### Agent sandboxes (`<home>/harness`)
 

--- a/src/app/journal.rs
+++ b/src/app/journal.rs
@@ -1,0 +1,440 @@
+//! Where the embedded OpenHuman runtime keeps its durable agent journal.
+//!
+//! The vendored runtime writes every agent observation under
+//! `{workspace}/tinyagents_store/`, and it resolves `{workspace}` from *its
+//! own* config — which, absent an override, is a subdirectory of the user's
+//! home directory. In a hosted tenant that home directory sits on the
+//! **read-only root filesystem**: the store's first `create_dir_all` fails with
+//! `EROFS`, and the vendored append worker reports the failure once per queued
+//! event, forever, on stderr. Nothing else in the container's log survives that
+//! (issue #446).
+//!
+//! OpenCompany's writable per-instance root is the data directory
+//! ([`data_dir_from_env`](super::config::data_dir_from_env) — `/data` in a
+//! tenant, where the manager mounts the persistent volume). This module points
+//! the vendored resolver there through the one seam it honours — the
+//! `OPENHUMAN_WORKSPACE` environment variable, which its config loader consults
+//! *before* any home-directory default — and proves the resulting root is
+//! writable while still in `serve`'s startup path.
+//!
+//! Two properties follow from doing the check at startup:
+//!
+//! * **It is loud once, not quiet forever.** A root that cannot be created is a
+//!   misconfiguration the operator must see immediately, so [`prepare`] returns
+//!   an error and `serve` aborts rather than running an agent whose work is
+//!   never recorded.
+//! * **The per-append flood cannot begin.** The vendored append worker has no
+//!   dedup or backoff and reports straight to stderr, so no log filter on this
+//!   side can bound it. Refusing to boot means the loop is never entered — the
+//!   condition it would retry against cannot resolve itself while the process
+//!   lives, because the mount is read-only for the lifetime of the pod.
+//!
+//! Only the resolved *path* is reported at startup. No environment value other
+//! than `OPENHUMAN_WORKSPACE` is read here and none is echoed, so the startup
+//! line cannot carry credential material.
+
+use std::path::{Path, PathBuf};
+
+use crate::Result;
+use crate::error::OpenCompanyError;
+
+/// The vendored runtime's workspace override. Its config loader reads this
+/// before consulting the home-directory default, which makes it the only seam
+/// a host process has for redirecting the journal.
+pub const OPENHUMAN_WORKSPACE_ENV: &str = "OPENHUMAN_WORKSPACE";
+
+/// The data-dir subdirectory handed to the vendored runtime as its root.
+const OPENHUMAN_SUBDIR: &str = "openhuman";
+
+/// The workspace subdirectory the vendored resolver appends to the root.
+const WORKSPACE_SUBDIR: &str = "workspace";
+
+/// The store subtree the journal and kv stores live in, under the workspace.
+const STORE_SUBDIR: &str = "tinyagents_store";
+
+/// Where a resolved journal root came from.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RootSource {
+    /// An operator set `OPENHUMAN_WORKSPACE`; its value is used verbatim.
+    Env,
+    /// Derived from the instance data directory — the normal hosted path.
+    DataDir,
+}
+
+impl RootSource {
+    /// The knob an operator would change to move the root, for the startup line.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Env => OPENHUMAN_WORKSPACE_ENV,
+            Self::DataDir => "OPENCOMPANY_DATA_DIR",
+        }
+    }
+}
+
+/// A resolved (but not yet proven-writable) journal location.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct JournalRoot {
+    root: PathBuf,
+    source: RootSource,
+}
+
+impl JournalRoot {
+    /// The directory handed to the vendored runtime as `OPENHUMAN_WORKSPACE`.
+    /// Everything the journal writes lands beneath it, so this is the path
+    /// whose writability decides whether observations persist.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Which knob put the root where it is.
+    pub fn source(&self) -> RootSource {
+        self.source
+    }
+
+    /// The store subtree the journal is expected to open,
+    /// `<root>/workspace/tinyagents_store`.
+    ///
+    /// This mirrors the vendored resolver's ordinary result. That resolver has
+    /// one legacy branch which, when a sibling `<root>/../.openhuman/config.toml`
+    /// exists, treats `<root>` *itself* as the workspace and would place the
+    /// store at `<root>/tinyagents_store` instead. It requires an
+    /// operator-created directory that a provisioned tenant never has, and both
+    /// outcomes lie inside [`root`](Self::root) — which is why the startup probe
+    /// checks the root rather than this leaf.
+    pub fn store_root(&self) -> PathBuf {
+        self.root.join(WORKSPACE_SUBDIR).join(STORE_SUBDIR)
+    }
+
+    /// The one-line startup report: where observations are being written, and
+    /// which knob decided that.
+    pub fn summary(&self) -> String {
+        format!(
+            "agent journal: {} (root {}, from {})",
+            self.store_root().display(),
+            self.root.display(),
+            self.source.as_str()
+        )
+    }
+}
+
+/// Resolves the journal root from an `OPENHUMAN_WORKSPACE` value and the
+/// instance data directory, without touching the filesystem or the environment.
+///
+/// An operator-set root wins so a self-hoster keeps an existing OpenHuman
+/// workspace. A missing — or blank — value falls back to the data directory,
+/// the one location a tenant container is guaranteed to be able to write.
+pub fn resolve(env_value: Option<&str>, data_dir: &Path) -> JournalRoot {
+    match env_value.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(value) => JournalRoot {
+            root: PathBuf::from(value),
+            source: RootSource::Env,
+        },
+        None => JournalRoot {
+            root: data_dir.join(OPENHUMAN_SUBDIR),
+            source: RootSource::DataDir,
+        },
+    }
+}
+
+/// Resolves the journal root and proves it is writable, without reading or
+/// writing the process environment.
+///
+/// The pure-input half of [`prepare`], so the resolution and the probe can be
+/// exercised without the `set_var` races that make environment mutation
+/// unsuitable for parallel tests.
+pub async fn prepare_with(env_value: Option<&str>, data_dir: &Path) -> Result<JournalRoot> {
+    let resolved = resolve(env_value, data_dir);
+    ensure_writable(resolved.root(), resolved.source()).await?;
+    Ok(resolved)
+}
+
+/// Resolves the journal root, proves it is writable, and — when the root was
+/// derived rather than supplied — exports it as `OPENHUMAN_WORKSPACE` so the
+/// vendored config loader finds it instead of a home-directory default.
+///
+/// Returns the resolved root for the caller to report. An unwritable root is an
+/// error: see the module docs for why that aborts startup instead of degrading.
+///
+/// Call this once, early in `serve`, before any company runtime is built — the
+/// vendored loader reads the variable when the first agent harness is
+/// constructed, and the export must already have happened.
+pub async fn prepare(data_dir: &Path) -> Result<JournalRoot> {
+    let raw = std::env::var(OPENHUMAN_WORKSPACE_ENV).ok();
+    let resolved = prepare_with(raw.as_deref(), data_dir).await?;
+
+    if resolved.source() == RootSource::DataDir {
+        // SAFETY: `serve` calls this once during startup, before any company
+        // runtime, scheduler, mailbox poller or HTTP listener exists, so no
+        // other thread is reading the environment concurrently. The tokio
+        // worker and blocking threads alive at this point are idle and do not
+        // call `getenv`. Setting this later — from a request handler, say —
+        // would race those readers and must not be done.
+        unsafe { std::env::set_var(OPENHUMAN_WORKSPACE_ENV, resolved.root()) };
+    }
+
+    Ok(resolved)
+}
+
+/// Creates `root` and confirms a file can actually be written inside it.
+///
+/// `create_dir_all` alone is not proof: it succeeds silently when the directory
+/// already exists but is not writable by this user, which is exactly the shape
+/// a stale volume or a wrong `fsGroup` produces. The probe file is named per
+/// process so two instances sharing a root cannot collide, and is removed
+/// again — a failure to remove it is not fatal, since the write already proved
+/// the point.
+async fn ensure_writable(root: &Path, source: RootSource) -> Result<()> {
+    let fail = |stage: &str, error: std::io::Error| {
+        OpenCompanyError::Config(format!(
+            "agent journal root {} is not writable ({stage}: {error}); \
+             refusing to start, because agent observations would be silently \
+             discarded on every turn. Point {} at a writable volume — in a \
+             tenant container that is the mounted data volume, not the \
+             read-only root filesystem.",
+            root.display(),
+            source.as_str()
+        ))
+    };
+
+    tokio::fs::create_dir_all(root)
+        .await
+        .map_err(|error| fail("create", error))?;
+
+    let probe = root.join(format!(".opencompany-journal-probe-{}", std::process::id()));
+    tokio::fs::write(&probe, b"")
+        .await
+        .map_err(|error| fail("write", error))?;
+    tokio::fs::remove_file(&probe).await.ok();
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn scratch_root(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("oc-journal-{}-{tag}", std::process::id()))
+    }
+
+    #[test]
+    fn absent_env_roots_the_journal_in_the_data_dir() {
+        let resolved = resolve(None, Path::new("/data"));
+
+        assert_eq!(resolved.root(), Path::new("/data/openhuman"));
+        assert_eq!(resolved.source(), RootSource::DataDir);
+        assert_eq!(
+            resolved.store_root(),
+            Path::new("/data/openhuman/workspace/tinyagents_store"),
+            "the store must land inside the mounted data volume, not $HOME"
+        );
+    }
+
+    #[test]
+    fn an_operator_supplied_root_wins() {
+        let resolved = resolve(Some("/srv/openhuman"), Path::new("/data"));
+
+        assert_eq!(resolved.root(), Path::new("/srv/openhuman"));
+        assert_eq!(resolved.source(), RootSource::Env);
+        assert_eq!(
+            resolved.store_root(),
+            Path::new("/srv/openhuman/workspace/tinyagents_store")
+        );
+    }
+
+    #[test]
+    fn blank_env_values_fall_back_to_the_data_dir() {
+        // The vendored resolver ignores an empty value but would honour a
+        // whitespace-only one as a relative path; treating both as unset keeps
+        // a shell that exports a declared-but-unset variable out of $HOME.
+        for blank in ["", "   ", "\t"] {
+            let resolved = resolve(Some(blank), Path::new("/data"));
+            assert_eq!(
+                resolved.root(),
+                Path::new("/data/openhuman"),
+                "{blank:?} should not be taken as a root"
+            );
+            assert_eq!(resolved.source(), RootSource::DataDir);
+        }
+    }
+
+    #[test]
+    fn the_summary_names_the_store_and_the_knob() {
+        let summary = resolve(None, Path::new("/data")).summary();
+
+        assert!(summary.contains("/data/openhuman/workspace/tinyagents_store"));
+        assert!(summary.contains("OPENCOMPANY_DATA_DIR"));
+
+        let env_summary = resolve(Some("/srv/oh"), Path::new("/data")).summary();
+        assert!(env_summary.contains(OPENHUMAN_WORKSPACE_ENV));
+    }
+
+    #[tokio::test]
+    async fn a_writable_data_dir_prepares_and_leaves_no_probe_behind() {
+        let root = scratch_root("writable");
+        tokio::fs::create_dir_all(&root).await.unwrap();
+
+        let resolved = prepare_with(None, &root).await.unwrap();
+        assert_eq!(resolved.root(), root.join("openhuman"));
+        assert!(resolved.root().is_dir(), "the root is created, not assumed");
+
+        let mut entries = tokio::fs::read_dir(resolved.root()).await.unwrap();
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            let name = entry.file_name();
+            assert!(
+                !name.to_string_lossy().contains("probe"),
+                "the write probe must be cleaned up, found {name:?}"
+            );
+        }
+
+        tokio::fs::remove_dir_all(&root).await.ok();
+    }
+
+    #[tokio::test]
+    async fn preparing_twice_is_idempotent() {
+        let root = scratch_root("idempotent");
+        tokio::fs::create_dir_all(&root).await.unwrap();
+
+        let first = prepare_with(None, &root).await.unwrap();
+        let second = prepare_with(None, &root).await.unwrap();
+        assert_eq!(first, second, "a restart must reuse the same root");
+
+        tokio::fs::remove_dir_all(&root).await.ok();
+    }
+
+    /// The read-only-root condition from issue #446, reproduced with an
+    /// unwritable parent: startup must fail with a message that names the path
+    /// and the knob, rather than letting the runtime discover it per append.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_unwritable_root_fails_loudly_at_startup() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = scratch_root("readonly");
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        let mut perms = tokio::fs::metadata(&root).await.unwrap().permissions();
+        perms.set_mode(0o500);
+        tokio::fs::set_permissions(&root, perms).await.unwrap();
+
+        let outcome = prepare_with(None, &root).await;
+
+        // A root user ignores the mode bits, so the probe would succeed and
+        // there is nothing to assert about. Restore and skip rather than fail.
+        let Err(error) = outcome else {
+            restore_and_remove(&root).await;
+            return;
+        };
+        let message = error.to_string();
+
+        assert!(
+            message.contains("openhuman"),
+            "the failure must name the path: {message}"
+        );
+        assert!(
+            message.contains("OPENCOMPANY_DATA_DIR"),
+            "the failure must name the knob to change: {message}"
+        );
+        assert!(
+            message.contains("refusing to start"),
+            "the failure must say the instance will not run degraded: {message}"
+        );
+
+        restore_and_remove(&root).await;
+    }
+
+    /// A root that exists but cannot be written to is the shape a stale volume
+    /// or a wrong `fsGroup` produces; `create_dir_all` alone reports success.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_existing_but_unwritable_root_is_caught_by_the_write_probe() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let data_dir = scratch_root("existing-ro");
+        let root = data_dir.join("openhuman");
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        let mut perms = tokio::fs::metadata(&root).await.unwrap().permissions();
+        perms.set_mode(0o500);
+        tokio::fs::set_permissions(&root, perms).await.unwrap();
+
+        let outcome = prepare_with(None, &data_dir).await;
+
+        // As above: a root user is not bound by the mode bits.
+        if let Err(error) = outcome {
+            assert!(
+                error.to_string().contains("write"),
+                "create_dir_all succeeds on an existing dir; the probe must be \
+                 what fails: {error}"
+            );
+        }
+
+        restore_and_remove(&root).await;
+        tokio::fs::remove_dir_all(&data_dir).await.ok();
+    }
+
+    /// The seam itself, against the real vendored resolver.
+    ///
+    /// Everything else here tests our side of the contract. This asserts the
+    /// other side: that [`OPENHUMAN_WORKSPACE`](OPENHUMAN_WORKSPACE_ENV) is
+    /// still the name the vendored config loader reads, and that a root of the
+    /// shape [`resolve`] produces still lands its workspace where
+    /// [`JournalRoot::store_root`] says it will. If upstream renames the
+    /// variable or changes its resolution, this fails instead of the journal
+    /// silently reverting to `$HOME` in production.
+    ///
+    /// Serialized and env-mutating, so it is `openhuman`-gated and deliberately
+    /// the only test here that touches the process environment.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn the_vendored_loader_still_honours_the_workspace_variable() {
+        use openhuman_core::openhuman as oh;
+
+        let data_dir = scratch_root("vendored-seam");
+        tokio::fs::create_dir_all(&data_dir).await.unwrap();
+        let resolved = resolve(None, &data_dir);
+
+        let previous = std::env::var_os(OPENHUMAN_WORKSPACE_ENV);
+        // SAFETY: the variable is read by the vendored loader below and by no
+        // other test in this binary; the original value is restored before the
+        // test returns.
+        unsafe { std::env::set_var(OPENHUMAN_WORKSPACE_ENV, resolved.root()) };
+
+        let config = oh::config::Config::load_or_init().await;
+
+        // SAFETY: as above — restoring the environment we captured.
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var(OPENHUMAN_WORKSPACE_ENV, value),
+                None => std::env::remove_var(OPENHUMAN_WORKSPACE_ENV),
+            }
+        }
+
+        let config = config.expect("the vendored config must load from the exported root");
+        assert_eq!(
+            config.workspace_dir,
+            resolved.root().join(WORKSPACE_SUBDIR),
+            "the vendored runtime must place its workspace under the root we \
+             export, not under $HOME"
+        );
+        assert!(
+            config.workspace_dir.starts_with(&data_dir),
+            "the journal must resolve inside the data dir, got {}",
+            config.workspace_dir.display()
+        );
+
+        tokio::fs::remove_dir_all(&data_dir).await.ok();
+    }
+
+    /// Puts an owner-writable mode back on `dir` so the test's own cleanup can
+    /// remove it.
+    #[cfg(unix)]
+    async fn restore_and_remove(dir: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        if let Ok(metadata) = tokio::fs::metadata(dir).await {
+            let mut perms = metadata.permissions();
+            perms.set_mode(0o700);
+            tokio::fs::set_permissions(dir, perms).await.ok();
+        }
+        tokio::fs::remove_dir_all(dir).await.ok();
+    }
+}

--- a/src/app/journal.rs
+++ b/src/app/journal.rs
@@ -231,6 +231,18 @@ mod test {
         std::env::temp_dir().join(format!("oc-journal-{}-{tag}", std::process::id()))
     }
 
+    /// The child test the seam test re-invokes this binary to run.
+    #[cfg(feature = "openhuman")]
+    const SEAM_CHILD_TEST: &str = "app::journal::test::vendored_seam_child";
+
+    /// Which half of the seam the child should assert.
+    #[cfg(feature = "openhuman")]
+    const SEAM_ROLE_ENV: &str = "OC_JOURNAL_SEAM_ROLE";
+
+    /// The data dir the child compares against.
+    #[cfg(feature = "openhuman")]
+    const SEAM_DATA_DIR_ENV: &str = "OC_JOURNAL_SEAM_DATA_DIR";
+
     #[test]
     fn absent_env_roots_the_journal_in_the_data_dir() {
         let resolved = resolve(None, Path::new("/data"));
@@ -411,47 +423,116 @@ mod test {
     /// variable or changes its resolution, this fails instead of the journal
     /// silently reverting to `$HOME` in production.
     ///
-    /// Serialized and env-mutating, so it is `openhuman`-gated and deliberately
-    /// the only test here that touches the process environment.
+    /// Run in a **child process** rather than by mutating this process's
+    /// environment.
+    ///
+    /// `set_var` is process-global, and this library's test binary contains
+    /// unguarded environment readers and writers in several other modules
+    /// (`store::select`, `server::ops::connections`, `harness::composio`,
+    /// `server::ops::mailer`). A lock would only protect this test if every one
+    /// of those took the same lock, and nothing stops the next test from adding
+    /// an unguarded `set_var`. Handing the variable to a child at spawn time
+    /// removes the shared mutable state instead of scheduling around it, and
+    /// exercises the more faithful thing: a process that *starts* with the
+    /// environment a tenant container is given.
+    #[cfg(feature = "openhuman")]
+    #[test]
+    fn the_vendored_loader_still_honours_the_workspace_variable() {
+        let data_dir = scratch_root("vendored-seam");
+        // Deliberately outside the data dir, so "did the workspace land under
+        // the data dir?" cannot be satisfied by the home directory instead.
+        let home = scratch_root("vendored-seam-home");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        std::fs::create_dir_all(&home).unwrap();
+
+        let expected = resolve(None, &data_dir);
+        let run = |role: &str, export_seam: bool| {
+            let mut command = std::process::Command::new(std::env::current_exe().unwrap());
+            command
+                .args([SEAM_CHILD_TEST, "--exact", "--ignored", "--nocapture"])
+                .env(SEAM_ROLE_ENV, role)
+                .env(SEAM_DATA_DIR_ENV, &data_dir)
+                .env("HOME", &home);
+            if export_seam {
+                command.env(OPENHUMAN_WORKSPACE_ENV, expected.root());
+            } else {
+                command.env_remove(OPENHUMAN_WORKSPACE_ENV);
+            }
+            command.output().expect("spawn the seam child process")
+        };
+
+        // A filter that stops matching (a rename, a moved module) makes libtest
+        // run nothing and still exit 0, so success alone would be a vacuous
+        // pass. Require that exactly one test actually ran.
+        let check = |what: &str, out: &std::process::Output| {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let detail = format!(
+                "{what}\n--- child stdout ---\n{stdout}\n--- child stderr ---\n{}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            assert!(out.status.success(), "{detail}");
+            assert!(
+                stdout.contains("1 passed"),
+                "the child must have actually run the assertion, not filtered \
+                 it away — is {SEAM_CHILD_TEST} still the right path?\n{detail}"
+            );
+        };
+
+        // Exporting the variable puts the vendored workspace under the data dir.
+        check("the exported root must be honoured", &run("inside", true));
+
+        // Negative control: without it, the vendored runtime goes to $HOME. If
+        // this ever passes, the check above proves nothing.
+        check(
+            "without the variable the runtime must fall back to $HOME",
+            &run("outside", false),
+        );
+
+        std::fs::remove_dir_all(&data_dir).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// The assertion half of the seam test, executed in the child process the
+    /// test above spawns. Ignored so a normal run never picks it up, and inert
+    /// unless the parent set the role, so a bare `cargo test -- --ignored`
+    /// cannot fail on a missing environment.
     #[cfg(feature = "openhuman")]
     #[tokio::test]
-    async fn the_vendored_loader_still_honours_the_workspace_variable() {
-        use openhuman_core::openhuman as oh;
+    #[ignore = "spawned by the_vendored_loader_still_honours_the_workspace_variable"]
+    async fn vendored_seam_child() {
+        let Ok(role) = std::env::var(SEAM_ROLE_ENV) else {
+            return;
+        };
+        let data_dir = PathBuf::from(std::env::var(SEAM_DATA_DIR_ENV).expect("parent sets this"));
+        let expected = resolve(None, &data_dir);
 
-        let data_dir = scratch_root("vendored-seam");
-        tokio::fs::create_dir_all(&data_dir).await.unwrap();
-        let resolved = resolve(None, &data_dir);
+        let config = openhuman_core::openhuman::config::Config::load_or_init()
+            .await
+            .expect("the vendored config must load");
 
-        let previous = std::env::var_os(OPENHUMAN_WORKSPACE_ENV);
-        // SAFETY: the variable is read by the vendored loader below and by no
-        // other test in this binary; the original value is restored before the
-        // test returns.
-        unsafe { std::env::set_var(OPENHUMAN_WORKSPACE_ENV, resolved.root()) };
-
-        let config = oh::config::Config::load_or_init().await;
-
-        // SAFETY: as above — restoring the environment we captured.
-        unsafe {
-            match previous {
-                Some(value) => std::env::set_var(OPENHUMAN_WORKSPACE_ENV, value),
-                None => std::env::remove_var(OPENHUMAN_WORKSPACE_ENV),
+        match role.as_str() {
+            "inside" => {
+                assert_eq!(
+                    config.workspace_dir,
+                    expected.root().join(WORKSPACE_SUBDIR),
+                    "the vendored runtime must place its workspace under the \
+                     root we export"
+                );
+                assert!(
+                    config.workspace_dir.starts_with(&data_dir),
+                    "the journal must resolve inside the data dir, got {}",
+                    config.workspace_dir.display()
+                );
             }
+            "outside" => assert!(
+                !config.workspace_dir.starts_with(&data_dir),
+                "without {OPENHUMAN_WORKSPACE_ENV} the runtime must not reach \
+                 the data dir on its own — the export is what does the work, \
+                 got {}",
+                config.workspace_dir.display()
+            ),
+            other => panic!("unknown seam role {other:?}"),
         }
-
-        let config = config.expect("the vendored config must load from the exported root");
-        assert_eq!(
-            config.workspace_dir,
-            resolved.root().join(WORKSPACE_SUBDIR),
-            "the vendored runtime must place its workspace under the root we \
-             export, not under $HOME"
-        );
-        assert!(
-            config.workspace_dir.starts_with(&data_dir),
-            "the journal must resolve inside the data dir, got {}",
-            config.workspace_dir.display()
-        );
-
-        tokio::fs::remove_dir_all(&data_dir).await.ok();
     }
 
     /// Puts an owner-writable mode back on `dir` so the test's own cleanup can

--- a/src/app/journal.rs
+++ b/src/app/journal.rs
@@ -52,6 +52,10 @@ const WORKSPACE_SUBDIR: &str = "workspace";
 /// The store subtree the journal and kv stores live in, under the workspace.
 const STORE_SUBDIR: &str = "tinyagents_store";
 
+/// Payload for the startup write probe. Non-empty on purpose — see
+/// [`ensure_writable`].
+const PROBE_BYTES: &[u8] = b"opencompany journal write probe\n";
+
 /// Where a resolved journal root came from.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RootSource {
@@ -188,6 +192,11 @@ pub async fn prepare(data_dir: &Path) -> Result<JournalRoot> {
 /// process so two instances sharing a root cannot collide, and is removed
 /// again — a failure to remove it is not fatal, since the write already proved
 /// the point.
+///
+/// The probe carries real bytes rather than being empty. A zero-length write
+/// allocates no blocks, so it succeeds on a volume that is full or over quota
+/// while every subsequent journal append fails with `ENOSPC` — reintroducing
+/// the per-append failure this module exists to make impossible.
 async fn ensure_writable(root: &Path, source: RootSource) -> Result<()> {
     let fail = |stage: &str, error: std::io::Error| {
         OpenCompanyError::Config(format!(
@@ -206,7 +215,7 @@ async fn ensure_writable(root: &Path, source: RootSource) -> Result<()> {
         .map_err(|error| fail("create", error))?;
 
     let probe = root.join(format!(".opencompany-journal-probe-{}", std::process::id()));
-    tokio::fs::write(&probe, b"")
+    tokio::fs::write(&probe, PROBE_BYTES)
         .await
         .map_err(|error| fail("write", error))?;
     tokio::fs::remove_file(&probe).await.ok();

--- a/src/app/journal.rs
+++ b/src/app/journal.rs
@@ -123,8 +123,13 @@ impl JournalRoot {
 /// An operator-set root wins so a self-hoster keeps an existing OpenHuman
 /// workspace. A missing — or blank — value falls back to the data directory,
 /// the one location a tenant container is guaranteed to be able to write.
+///
+/// Trimming decides only whether a value is blank; a value that survives that
+/// test is used **verbatim**. Leading and trailing spaces are legal in a POSIX
+/// path, so silently stripping them would resolve somewhere the operator did
+/// not configure — the same class of surprise this module exists to remove.
 pub fn resolve(env_value: Option<&str>, data_dir: &Path) -> JournalRoot {
-    match env_value.map(str::trim).filter(|value| !value.is_empty()) {
+    match env_value.filter(|value| !value.trim().is_empty()) {
         Some(value) => JournalRoot {
             root: PathBuf::from(value),
             source: RootSource::Env,
@@ -240,6 +245,22 @@ mod test {
             resolved.store_root(),
             Path::new("/srv/openhuman/workspace/tinyagents_store")
         );
+    }
+
+    #[test]
+    fn a_padded_root_is_used_exactly_as_configured() {
+        // Spaces are legal in a POSIX path, so a value that is not blank must
+        // survive verbatim — trimming it would resolve somewhere the operator
+        // never named.
+        for padded in [" /srv/oh ", "/srv/oh ", " /srv/oh", "/srv/my oh"] {
+            let resolved = resolve(Some(padded), Path::new("/data"));
+            assert_eq!(
+                resolved.root(),
+                Path::new(padded),
+                "{padded:?} must not be rewritten"
+            );
+            assert_eq!(resolved.source(), RootSource::Env);
+        }
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod doctor;
+pub mod journal;
 mod types;
 
 pub use config::{BrainMode, ConfigProvenance, RuntimeConfig, resolve};

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -857,6 +857,19 @@ async fn main() -> Result<()> {
                 .unwrap_or_default();
             let layout = opencompany::store::DataLayout::new(&data_root);
             layout.ensure(workspace_cfg.clear_tmp_on_startup).await?;
+            // Point the embedded OpenHuman runtime's durable agent journal at
+            // the data volume and prove it is writable before a single agent
+            // exists. Left alone the vendored runtime roots it under the user's
+            // home directory, which in a tenant container is the read-only root
+            // filesystem: every observation then fails to persist and the
+            // vendored append worker reports it per event, forever, drowning
+            // the container log (issue #446). An unwritable root aborts boot —
+            // same precedent as a selected-but-unavailable storage backend
+            // below — rather than serving an agent whose work is never
+            // recorded. `println!` for the same reason as the divergence
+            // warning above: the default `EnvFilter` would swallow an `info!`.
+            let journal = opencompany::app::journal::prepare(&data_root).await?;
+            println!("{}", journal.summary());
             // Soft disk-quota alerting. Hard enforcement is the container /
             // StorageClass layer's job (EFS access point, k8s ResourceQuota);
             // here we surface an operator-visible warning when a workspace


### PR DESCRIPTION
## Summary

In a deployed tenant, every agent observation failed to persist and the failure was swallowed on every append. A 200-line log tail from staging contained this line and nothing else:

```
tinyagents: journal-sink durable append failed: validation error: append store mkdir error: Read-only file system (os error 30)
```

The root cause is not in the store that reported it. The embedded runtime resolves its own workspace from **OpenHuman's** config, whose default root is `$HOME/.openhuman` — it has never heard of `OPENCOMPANY_DATA_DIR`. In a tenant pod that home sits on the read-only root while the writable `/data` volume goes unused, so the very first `create_dir_all` fails and every append after it fails the same way.

This resolves the journal root inside the data directory, proves it writable before the harness exists, and refuses to start if it is not.

Closes #446.

## API Or Behavior Changes

**`serve` now refuses to start when agent observations cannot persist.** Previously it started and ran degraded and silent.

This follows precedent already in the same function — a selected-but-unavailable storage backend and an unverifiable signing secret both abort boot rather than degrade. The reasoning is the same: a tenant that answers but records nothing produces confident, unrecoverable work and reports the loss at `debug`. Replay, history and lineage read an empty store. Because tenants scale to zero and wake on request, restarts are the normal path here, not the edge.

The cost is accepted deliberately: a broken mount now means the tenant will not wake and the manager's proxy times out. A wake timeout is attributable in one line; silent data loss surfaced weeks later is not. The check runs *after* `DataLayout::ensure` has already created `memory/ store/ files/ logs/ tmp/` under the same root, so it cannot fire on a healthy tenant — only on a genuinely broken volume or an explicitly misconfigured override.

**`serve` logs its resolved journal root once at startup**, naming which knob supplied it. The issue notes this alone would have settled the diagnosis in seconds.

The seam is an existing vendored knob, `OPENHUMAN_WORKSPACE`, which the resolver checks ahead of the active-user file, the workspace marker and the `$HOME` default. No new variable was introduced, and an operator setting it explicitly is still honoured verbatim.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 2221 passed
- [x] `cargo check --locked --all-features --all-targets`

`Cargo.lock` unchanged. No `vendor/` change.

Nine tests on the new module. One is worth calling out: rather than asserting the variable name by inspection, it calls the **real vendored** `Config::load_or_init()` and asserts `workspace_dir` lands under the exported root. An upstream rename now fails CI instead of silently reverting to `$HOME`.

Verified live against a built binary with `HOME` pointed at a `chmod a-w` directory:

- Healthy start prints the resolved root and its source; the read-only `HOME` is untouched.
- A misconfigured override exits 1 with **exactly one line**, naming the path, the knob and the consequence.
- With `--features openhuman,tinycortex` and a company registered, the log contains zero `read-only file system` / `mkdir error` / `durable append failed`.

**Not verified here:** no agent turn ran, so an observation was never watched landing in the store — that needs inference credentials. The issue's fourth acceptance check, observations surviving a scale-to-zero and wake, therefore needs a staging deploy to confirm.

**Unrelated flake seen while gating:** `workflows::runner::tests::a_cancelled_run_parks_no_gates` failed once in five full-suite runs and once in five isolated runs. It races `ctx.cancel.cancel()` against `run_workflow` completing. `src/workflows/runner.rs` was last touched by this branch's own base commit; this diff adds a module the lib never calls, so it cannot affect that timing. Filed separately.

## Documentation

`docs/spec/runtime/storage.md` gains the layout entry, a precedence table for the root, and the boot-gate rationale. `AGENTS.md`'s hosted-mode seam list now names the journal root.

## Notes for review

The unbounded log repeat is addressed by precondition rather than by bounding the writer. The retry loop is `vendor/tinyagents/.../observability/worker.rs` using `eprintln!` — not `log`/`tracing` — so no subscriber-side filter on this side can reach it. Proving the root writable before the harness exists means the loop is never entered, and the condition it retries against cannot resolve itself while the pod lives.

**Residual, stated plainly:** a volume that flips read-only *mid-life* would still flood. That needs bounded reporting inside the vendored writer.

Related find for the upstream conversation: the vendored tree already contains a five-minute repeat suppressor (`FS_ERROR_COOLDOWN` / `was_recently_reported`). It **is** wired — but only behind the `crash-reporting` feature, and only for the Windows `ERROR_FILE_SYSTEM_LIMITATION` case (os error 665). This build does not enable that feature, so clippy reports it as dead code here. The suppressor is therefore a working precedent to generalise, not an oversight to finish.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `serve` now prepares a writable OpenHuman journal workspace under the instance data directory.
  - Supports configuring the journal location through `OPENHUMAN_WORKSPACE`.
  - Startup diagnostics report the resolved journal location and its source.
- **Bug Fixes**
  - Startup now stops with a clear configuration error when the journal workspace cannot be created or written to.
- **Documentation**
  - Added runtime storage documentation covering workspace layout, location precedence, journal storage, diagnostics, and startup error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->