### PR TITLE
fix(publish): a publish outside a task run records, or refuses (#445)

### DIFF
--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -709,11 +709,16 @@ impl HarnessBrain {
         // spent redirect budget is not a moment to ask an agent about its files.
         let mut declined: Option<String> = None;
         let mut unpublished_before_nudge: Vec<String> = Vec::new();
+        // Issue #420 item 3: whether the scan below saw the whole sandbox. A
+        // partial scan can only under-report, but the nudge must say so rather
+        // than present a DFS prefix as the complete list of what changed.
+        let mut scan_partial = false;
         if run_end == TaskRunEnd::Completed {
             if responder == dispatched_responder {
                 let changed = workspace_at_dispatch.changed_since(&workspace);
+                scan_partial = changed.partial;
                 unpublished_before_nudge =
-                    publish::unpublished(&changed, &self.deps.pending_publishes.sources());
+                    publish::unpublished(&changed.files, &self.deps.pending_publishes.sources());
             } else {
                 // A hand-off reassigned the card, so the snapshot above is of
                 // the delegator's workspace and the work happened in the
@@ -740,6 +745,7 @@ impl HarnessBrain {
                     &base_instruction,
                     &result_text,
                     &unpublished_before_nudge,
+                    scan_partial,
                     &control,
                     sink.clone(),
                 )
@@ -771,6 +777,10 @@ impl HarnessBrain {
                 agent = %responder,
                 files = %publish::name_files(&still_unpublished),
                 declined = declined.is_some(),
+                // Issue #420 item 3: whoever reads this needs to know the file
+                // list is a floor, not an inventory — the agent may have
+                // declined about files this scan never reached.
+                partial_scan = scan_partial,
                 "[publish] the run changed sandbox files and published none of them; no \
                  artifact was recorded"
             );
@@ -1172,10 +1182,11 @@ impl HarnessBrain {
         brief: &str,
         reply: &str,
         unpublished: &[String],
+        scan_partial: bool,
         control: &crate::company::steer::SteerControl,
         sink: Option<Arc<RunTraceSink>>,
     ) -> Option<String> {
-        let instruction = publish::nudge_instruction(brief, reply, unpublished);
+        let instruction = publish::nudge_instruction(brief, reply, unpublished, scan_partial);
         let outcome = run_turn
             .run_steered_background(&self.record.id, responder, &instruction, control, sink)
             .await;

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -61,7 +61,7 @@ use crate::harness::run_trace::RunTraceSink;
 use crate::ports::artifacts::{ArtifactAuthor, ArtifactRecord};
 use crate::ports::brain::{Brain, CycleHost};
 use crate::ports::runs::{RunOutcome, RunStatus};
-use crate::ports::tasks::{TaskOutput, TaskOutputArtifact};
+use crate::ports::tasks::{COLUMN_IN_REVIEW, TaskOutput, TaskOutputArtifact};
 use crate::ports::types::{
     CompanyEvent, CompanyRecord, CompressedTrace, CycleRequest, CycleResult, OutboundMessage,
     TokenUsage, TurnStep, TurnStepKind, TurnStepStatus, Verdict,
@@ -223,6 +223,17 @@ impl HarnessBrain {
         let control = guard.control().clone();
 
         let run_turn = HarnessRunTurn::new(&self.pool, &self.deps);
+        // Issue #445: this is a full agent turn with the whole toolbelt, so it
+        // can publish — and before this nothing drained it, exactly as on the
+        // chat path. It is a conversation continuation (it answers into the
+        // thread the approval was raised in), so it files the same way a chat
+        // turn does.
+        let publish_claim =
+            (self.deps.tasks.is_some() && self.deps.artifacts.is_some()).then(|| {
+                self.deps
+                    .pending_publishes
+                    .claim(publish::PublishDestination::Conversation)
+            });
         // Un-streamed, like a dispatched card: this turn is answered by the
         // bubble returned below, and its transient frames would otherwise
         // misattribute onto whichever chat thread the console is watching.
@@ -230,6 +241,26 @@ impl HarnessBrain {
             .run_steered_background(&self.record.id, &grant.agent, &instruction, &control, None)
             .await;
         drop(guard);
+
+        let published = self.deps.pending_publishes.drain();
+        if !published.is_empty()
+            && publish_claim.is_some()
+            && let Err(err) = self
+                .record_conversation_publishes(
+                    &grant.agent,
+                    grant.origin_thread.as_deref(),
+                    published,
+                )
+                .await
+        {
+            tracing::error!(
+                approval_id = %approval_id,
+                agent = %grant.agent,
+                error = %err,
+                "[publish] the re-issued call published files that could not be recorded"
+            );
+        }
+        drop(publish_claim);
 
         let text = match outcome {
             Ok(outcome) => outcome.reply,
@@ -396,10 +427,23 @@ impl HarnessBrain {
         let dispatched_responder = responder.clone();
         let workspace = agent_workspace(&self.deps.workspace_root, &self.record.id, &responder);
         let workspace_at_dispatch = WorkspaceSnapshot::take(&workspace);
-        // Start from an empty publish queue for the same reason the delegation
-        // queue is cleared per turn: a chat turn earlier in this cycle shares
-        // these deps, and its staged file must never be attributed to this card.
-        self.deps.pending_publishes.clear();
+        // Claim the publish queue for this dispatch (#445). The claim clears on
+        // the way in for the reason the bare `clear()` here always did — a chat
+        // turn earlier in this cycle shares these deps, and its staged file must
+        // never be attributed to this card — and now also tells the tool which
+        // destination to name in its receipt.
+        //
+        // Only when there is an artifact store to record into. Without one the
+        // drain below has nowhere to write and would log a warning while the
+        // agent was told its file was safe, so leaving the queue unclaimed
+        // turns that into an in-turn refusal the agent can actually report.
+        // `build_agent` already declines to wire the tool at all in that case;
+        // this makes the invariant local rather than borrowed from the builder.
+        let _publish_claim = self.deps.artifacts.as_ref().map(|_| {
+            self.deps
+                .pending_publishes
+                .claim(publish::PublishDestination::Task)
+        });
         // Issue #339, same argument for staged workflow references: an operator
         // chat turn earlier in this cycle may have run a workflow through the
         // orchestrator's tool, and that run belongs to the conversation, not to
@@ -727,7 +771,7 @@ impl HarnessBrain {
                 agent = %responder,
                 files = %publish::name_files(&still_unpublished),
                 declined = declined.is_some(),
-                "[publish] the run changed workspace files and published none of them; no \
+                "[publish] the run changed sandbox files and published none of them; no \
                  artifact was recorded"
             );
         }
@@ -1424,6 +1468,98 @@ impl HarnessBrain {
         Ok(written)
     }
 
+    /// Records what a **conversation** turn published, minting the card that
+    /// carries it (issue #445). Returns that card's id.
+    ///
+    /// # Why a card, rather than a company-level artifact
+    ///
+    /// The issue allows either: a chat deliverable becomes an artifact attached
+    /// to no card, or the act of publishing mints the card. This path takes the
+    /// second, and the deciding argument is *reachability* — which is, after
+    /// all, the entire bug.
+    ///
+    /// An [`ArtifactRecord`] carries a non-optional `task_id`, `(task_id,
+    /// source)` **is** its identity, the only route that lists artifacts is
+    /// `GET /tasks/{task_id}/artifacts`, and the only console surface that
+    /// renders one is the per-task Artifacts tab. A card-less artifact would
+    /// therefore need an optional `task_id` (breaking the identity contract), a
+    /// new company-scoped route, and a new console view — and until that last
+    /// piece shipped, the artifact would be recorded and still unreachable,
+    /// which is precisely the failure being fixed, merely moved one layer down.
+    /// Minting the card reuses a path the operator can already open today.
+    ///
+    /// It is also honest about what happened rather than a workaround: an agent
+    /// that produced a deliverable did a unit of work, and a board that shows it
+    /// is more accurate than one that does not. The card lands in
+    /// [`COLUMN_IN_REVIEW`] because that is where the lifecycle already puts
+    /// finished agent work awaiting a person — `COLUMN_DONE` is reached only by
+    /// a human accepting it, and this fix does not get to decide that on their
+    /// behalf.
+    ///
+    /// # What it deliberately does not do
+    ///
+    /// No `output` stamp. That field pins a `run_id` and an attempt ordinal, and
+    /// a chat turn has neither — inventing one would put a fabricated attempt on
+    /// a card to make a field look populated. The artifacts are reachable
+    /// through the tab regardless; an invented run id would not be true.
+    async fn record_conversation_publishes(
+        &self,
+        responder: &str,
+        chat_id: Option<&str>,
+        published: Vec<publish::PendingPublish>,
+    ) -> Result<String> {
+        let Some(tasks) = self.deps.tasks.as_ref() else {
+            // Unreachable while the claim is only taken with both stores wired,
+            // and an error rather than a silent `Ok` so it stays unreachable:
+            // the caller surfaces this to the operator instead of dropping the
+            // deliverable the way #445 did.
+            return Err(crate::OpenCompanyError::Harness(
+                "a conversation published a file but no task board is wired".to_string(),
+            ));
+        };
+
+        let card = TaskRecord {
+            id: generate_id(),
+            title: publish::conversation_card_title(&published),
+            note: Some(publish::conversation_card_note(responder, &published)),
+            // Finished agent work a person has not accepted yet — the same
+            // landing `column_for_settled_run(Succeeded)` gives a dispatched run.
+            column: COLUMN_IN_REVIEW.to_string(),
+            priority: "medium".to_string(),
+            assignee: responder.to_string(),
+            updated_at_millis: now_millis(),
+            // The conversation this came out of, so the card points back at the
+            // thread that produced it (#151 §3.2's field, same meaning).
+            origin_chat_id: chat_id.map(str::to_string),
+            // A chat turn has no card in scope, so this is a lineage root —
+            // the same `None` a `spawn_task` from an ordinary chat turn writes.
+            parent_task_id: None,
+            output: None,
+            plan: None,
+        };
+        // The card is written **first**: an artifact's `task_id` must name a
+        // card that exists. If the artifact writes then fail, the failure
+        // direction is a visible card whose note explains what it was for —
+        // recoverable, and the operator is told below. The reverse order would
+        // leave artifacts pointing at a card that was never created, which is
+        // unreachable by every route and indistinguishable from the original
+        // bug.
+        tasks.upsert(&self.record.id, &card).await?;
+
+        // No run id: there is no attempt row behind a chat turn, and
+        // `stamp_run` is skipped rather than given something invented.
+        let recorded = self
+            .record_published_artifacts(&card, responder, published, None)
+            .await?;
+        tracing::info!(
+            task_id = %card.id,
+            agent = %responder,
+            artifacts = recorded.len(),
+            "[publish] a conversation published files; minted a card to carry them"
+        );
+        Ok(card.id)
+    }
+
     /// Resolves which agent answers an operator message.
     ///
     /// Resolution order, and the order matters:
@@ -1706,6 +1842,19 @@ impl Brain for HarnessBrain {
                     // (the delegation queue is cleared inside the runner, right
                     // before the orchestrator turn).
                     self.deps.mcp_failures.clear();
+                    // Issue #445: claim the publish queue for this conversation,
+                    // so a file published in chat is drained below instead of
+                    // being staged into a queue nothing reaches. Claimed only
+                    // when both stores the drain needs are wired — the claim is
+                    // a promise to record, and one that cannot be kept must not
+                    // be made, or the tool goes back to issuing receipts nothing
+                    // honours.
+                    let publish_claim =
+                        (self.deps.tasks.is_some() && self.deps.artifacts.is_some()).then(|| {
+                            self.deps
+                                .pending_publishes
+                                .claim(publish::PublishDestination::Conversation)
+                        });
                     // Drive the brain-agnostic delegation seam (issue #176): the
                     // orchestrator turn, its queued delegations, and the CEO-relay
                     // hand-back all run behind the `RunTurn` impl. `HarnessDeps` is
@@ -1716,7 +1865,43 @@ impl Brain for HarnessBrain {
                         .handle_operator_message(&responder, text, chat_id)
                         .await?;
                     let mut operator_steps = turn.steps;
-                    let operator_reply = turn.reply;
+                    let mut operator_reply = turn.reply;
+
+                    // Drain what the conversation published (#445). Unconditional
+                    // so nothing survives into the next turn, and only *recorded*
+                    // when the claim was actually taken — an unclaimed queue can
+                    // only be empty here, because the tool refuses without one.
+                    let published = self.deps.pending_publishes.drain();
+                    let mut published_card = None;
+                    if !published.is_empty() && publish_claim.is_some() {
+                        let count = published.len();
+                        match self
+                            .record_conversation_publishes(&responder, chat_id, published)
+                            .await
+                        {
+                            Ok(card_id) => published_card = Some(card_id),
+                            Err(err) => {
+                                // The agent has already been told the file was
+                                // published, and that receipt is now wrong. This
+                                // is the one remaining way that can happen — a
+                                // store write failing under a claim that was
+                                // honestly made — so it is said out loud in the
+                                // conversation rather than left in a log the
+                                // operator will never read. Saying nothing here
+                                // would reproduce #445 exactly: a confident
+                                // delivery claim over nothing recorded.
+                                tracing::error!(
+                                    agent = %responder,
+                                    staged = count,
+                                    error = %err,
+                                    "[publish] a conversation published files but they could not \
+                                     be recorded; telling the operator in the reply"
+                                );
+                                operator_reply.push_str(&publish::recording_failed_notice(count));
+                            }
+                        }
+                    }
+                    drop(publish_claim);
                     // Re-skin any MCP tool-call failures (from the orchestrator
                     // turn, a delegated desk turn, or the relay turn) as error
                     // steps on the operator bubble — one surface, one renderer.
@@ -1728,7 +1913,17 @@ impl Brain for HarnessBrain {
                         // `spawn_task` was invisible in chat — the card landed
                         // on the board and the reply carried nothing tying the
                         // two together.
-                        task_id: turn.spawned_task,
+                        //
+                        // Issue #445 reuses that link for the card a publish
+                        // minted, which is how the operator gets from "here is
+                        // your deliverable" to the thing itself in one click.
+                        // A `spawn_task` still wins the slot: this field is a
+                        // single id (see `OperatorTurn::spawned_task` on why it
+                        // cannot be widened), so the rule is to never take a
+                        // link away from a turn that already had one. A publish
+                        // card that loses the slot is still on the board, in
+                        // review, carrying a note that explains what it is.
+                        task_id: turn.spawned_task.or(published_card),
                         channel: "operator".to_string(),
                         text: operator_reply,
                         reply_to: None,

--- a/src/harness/publish.rs
+++ b/src/harness/publish.rs
@@ -389,8 +389,8 @@ impl PublishPathError {
                  a relative path like \"specs/launch.md\" — absolute paths and `..` are refused."
             ),
             Self::Missing => format!(
-                "There is no file at `{path}` in your sandbox. Check the path with `list_files` \
-                 or `glob`, and write the file before publishing it."
+                "There is no file at `{path}` in your sandbox. Check the path with `list` or \
+                 `glob`, and write the file before publishing it."
             ),
             Self::NotAFile => format!(
                 "`{path}` is not a regular file. Publish one file at a time — a folder cannot be a \

--- a/src/harness/publish.rs
+++ b/src/harness/publish.rs
@@ -850,14 +850,45 @@ impl WorkspaceSnapshot {
     ///
     /// Deletions are deliberately not reported: a file the agent removed is not
     /// a deliverable it forgot to publish.
-    pub fn changed_since(&self, workspace: &Path) -> Vec<String> {
+    ///
+    /// # Why this returns whether it is complete (issue #420 item 3)
+    ///
+    /// Either snapshot may have stopped at [`MAX_SCAN_ENTRIES`], and a diff of
+    /// two partial walks is itself partial. The flag was already set on both
+    /// and [`truncated`](Self::truncated) had **no callers** — so the nudge took
+    /// an arbitrary DFS prefix and presented it to the agent as the complete
+    /// list of what it had changed, which is a quiet completeness claim the scan
+    /// cannot support. Returning the fact alongside the files is what makes it
+    /// impossible to keep ignoring: a caller has to destructure it.
+    pub fn changed_since(&self, workspace: &Path) -> WorkspaceChanges {
         let now = Self::take(workspace);
-        now.entries
+        // Either side truncating makes the *diff* partial: a baseline that
+        // stopped early can make an untouched file look new, and a current walk
+        // that stops early simply misses changes.
+        let partial = self.truncated || now.truncated;
+        let files = now
+            .entries
             .into_iter()
             .filter(|(path, stat)| self.entries.get(path) != Some(stat))
             .map(|(path, _)| path)
-            .collect()
+            .collect();
+        WorkspaceChanges { files, partial }
     }
+}
+
+/// What changed in a sandbox since a snapshot — and whether that list is the
+/// whole story (issue #420 item 3).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WorkspaceChanges {
+    /// Files added or modified, in path order.
+    pub files: Vec<String>,
+    /// The scan hit [`MAX_SCAN_ENTRIES`], so `files` is a subset of what
+    /// actually changed and nothing can say how large a subset.
+    ///
+    /// Only ever *under*-reports: a partial scan can miss a deliverable, never
+    /// invent one. That is the right direction for a heuristic, but it must be
+    /// said out loud rather than left for the agent to assume completeness.
+    pub partial: bool,
 }
 
 /// The changed files that were **not** staged for publication.
@@ -912,7 +943,24 @@ pub fn name_files(files: &[String]) -> String {
 ///
 /// Pure and stringly-typed on purpose, so its content is unit-testable without
 /// a model, a workspace or a turn.
-pub fn nudge_instruction(brief: &str, reply: &str, changed_files: &[String]) -> String {
+/// # Saying when the list is incomplete (issue #420 item 3)
+///
+/// `partial` marks a scan that hit [`MAX_SCAN_ENTRIES`]. The list is then a
+/// subset, so the sentence introducing it must not read as an inventory — an
+/// agent told "you changed these files" reasonably concludes those are the only
+/// ones, and would decline on behalf of a deliverable the scan never reached.
+pub fn nudge_instruction(
+    brief: &str,
+    reply: &str,
+    changed_files: &[String],
+    partial: bool,
+) -> String {
+    let completeness = if partial {
+        "Your sandbox holds more files than this check can read, so this list is incomplete — \
+         there may be other files you changed that are not named here."
+    } else {
+        "That is everything you changed."
+    };
     format!(
         "You have just finished this task and your reply has already been sent. This is a \
          follow-up question about the files, and nothing you say here changes the answer you \
@@ -926,6 +974,7 @@ pub fn nudge_instruction(brief: &str, reply: &str, changed_files: &[String]) -> 
          \n\
          You changed these files in your sandbox and published none of them:\n\
          {files}\n\
+         {completeness}\n\
          \n\
          If any of them is the deliverable this task was asking for, publish it now with \
          `{tool}`. If none of them is — scratch files, notes, intermediate output, work that is \

--- a/src/harness/publish.rs
+++ b/src/harness/publish.rs
@@ -38,6 +38,34 @@
 //! card, the responder and the store. One write site, and "the queue is empty"
 //! doubles as the detection signal the nudge reads.
 //!
+//! # Why staging must be *claimed* (issue #445)
+//!
+//! Staging has one failure mode, and it is the worst kind: a caller for whom
+//! **nothing drains**. The tool returned success and named a destination
+//! regardless, so a publish made during a chat turn was staged, never drained
+//! (no task settles), then cleared by the next turn — a silent no-op reported
+//! as a delivered deliverable. The agent then told the operator the file was
+//! ready, because it had been told exactly that. A tool that cannot fail
+//! launders the failure through the agent into a confident falsehood.
+//!
+//! So the queue carries a [`PublishDestination`] alongside the staged items,
+//! and a drain site **claims** it — [`PendingPublishQueue::claim`] — for the
+//! span in which it promises to drain. The claim is what the receipt is written
+//! from, so the sentence the agent reads describes that caller's actual
+//! destination rather than one case's sentence reused everywhere.
+//!
+//! The default is [`PublishDestination::Unclaimed`], and that direction is the
+//! whole guarantee. A turn run from a path that has not claimed a destination —
+//! including one written later, by someone who never read this module — gets an
+//! honest in-turn refusal instead of a success receipt nothing will honour. The
+//! invariant is enforced by construction rather than by remembering: *no claim,
+//! no publish*. It generalizes [`build_agent`]'s existing fail-closed gate (an
+//! agent with no artifact store is not offered the tool at all) from build time,
+//! where it could only ask "could anything ever drain?", to call time, where it
+//! can ask the question that actually matters — "will anything drain *this*?"
+//!
+//! [`build_agent`]: crate::harness::build::build_agent
+//!
 //! # What is validated, and when
 //!
 //! Everything, at `execute()` time, so the agent gets a truthful in-turn error
@@ -167,21 +195,112 @@ pub struct PendingPublish {
     pub body: String,
 }
 
+/// Where the publishes staged on a queue are going to be recorded — and
+/// therefore what the tool is entitled to tell the agent (issue #445).
+///
+/// Read at `execute()` time, so the receipt describes the caller that made the
+/// call. The variants are the *reachable destinations*, not the call sites: two
+/// paths that file into the same place share one variant, because the agent's
+/// receipt is about where its file lands, not about which function ran it.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PublishDestination {
+    /// Nothing will drain. **The default, and deliberately so.**
+    ///
+    /// Any turn whose caller has not claimed a destination lands here and the
+    /// tool refuses in-turn. That is the fail-safe direction: a new turn-running
+    /// path added later inherits an honest refusal rather than the silent drop
+    /// that made #445 a lie told through the agent.
+    #[default]
+    Unclaimed,
+    /// A dispatched card's settle path drains this, filing each publish on that
+    /// card. The pre-#445 behaviour, unchanged.
+    Task,
+    /// A conversation turn drains this, and publishing **mints the card** that
+    /// carries the artifact — a chat deliverable is real work, so it gets the
+    /// board record the console can already open.
+    Conversation,
+}
+
+impl PublishDestination {
+    /// The sentence appended to a success receipt, or `None` when no publish
+    /// can succeed here at all.
+    ///
+    /// Returning `None` rather than a "sorry" string is what keeps the refusal
+    /// path and the success path from ever being confused: there is no receipt
+    /// to render, so the caller is forced to produce a tool **error** instead.
+    fn receipt_tail(self) -> Option<&'static str> {
+        match self {
+            Self::Unclaimed => None,
+            Self::Task => Some("It appears on this task's Artifacts tab when the run finishes."),
+            Self::Conversation => Some(
+                "Because this is a conversation and not a task, it is filed on a new board card \
+                 for this conversation when your turn finishes — the operator opens it from that \
+                 card's Artifacts tab.",
+            ),
+        }
+    }
+}
+
+/// The agent-facing refusal when nothing is in a position to record a publish.
+///
+/// It has to do two jobs. It must not read as a transient glitch worth
+/// retrying, and it must tell the agent what to say next — because the failure
+/// this replaces was one the agent could not detect, and an agent that thinks it
+/// published will report a delivery that did not happen.
+fn cannot_publish_here(path: &str) -> String {
+    format!(
+        "`{path}` was NOT published: nothing here can record a deliverable, so publishing is \
+         unavailable in this context. Do not retry — it will fail the same way, and do not tell \
+         anyone the file was delivered. The file is still in your sandbox; say plainly that you \
+         could not publish it."
+    )
+}
+
 /// A shared, in-memory queue of staged publishes — the exact
 /// [`McpFailureQueue`](crate::harness::mcp_probe::McpFailureQueue) pattern.
 ///
 /// Cheap to [`Clone`] (a shared handle); the tool built into the agent and the
 /// brain that drains it see the same queue because
 /// [`HarnessDeps`](crate::harness::HarnessDeps) clones share this handle.
+///
+/// The destination (#445) rides the **same handle** rather than sitting beside
+/// it in `HarnessDeps`, which is not a tidiness choice: `build_agent` hands the
+/// tool this one clone and nothing else, so carrying the claim here makes it
+/// impossible to wire a tool that cannot see where its publishes are going.
 #[derive(Clone, Default)]
 pub struct PendingPublishQueue {
     inner: Arc<Mutex<Vec<PendingPublish>>>,
+    destination: Arc<Mutex<PublishDestination>>,
 }
 
 impl PendingPublishQueue {
     /// Stages a publish.
     pub fn push(&self, publish: PendingPublish) {
         self.inner.lock().expect("publish queue").push(publish);
+    }
+
+    /// Where staged publishes are currently headed.
+    pub fn destination(&self) -> PublishDestination {
+        *self.destination.lock().expect("publish destination")
+    }
+
+    /// Claims this queue for a drain site that promises to drain it, for as long
+    /// as the returned [`PublishClaim`] lives.
+    ///
+    /// Clears on the way in for the reason the drain sites already cleared by
+    /// hand — a prior turn's staged file must never be attributed to this
+    /// caller — and, via [`PublishClaim`]'s `Drop`, on the way out too. The exit
+    /// half is the one that is new and load-bearing: an early return, a `?`, or
+    /// a panic mid-run used to leave items staged and the next caller to clear
+    /// them, so correctness depended on every future path remembering. Now the
+    /// claim's scope *is* the window in which publishing works.
+    #[must_use = "the claim releases on drop; dropping it immediately un-claims the queue"]
+    pub fn claim(&self, destination: PublishDestination) -> PublishClaim {
+        self.clear();
+        *self.destination.lock().expect("publish destination") = destination;
+        PublishClaim {
+            queue: self.clone(),
+        }
     }
 
     /// Empties the queue. Called before each turn so nothing a prior turn — an
@@ -216,6 +335,30 @@ impl PendingPublishQueue {
     }
 }
 
+/// The live claim on a [`PendingPublishQueue`] — proof that some drain site is
+/// listening (issue #445).
+///
+/// Held for the span in which a caller promises to drain; on `Drop` the queue
+/// returns to [`PublishDestination::Unclaimed`] and is emptied, so publishing is
+/// off again the moment that promise ends. Mirrors the RAII shape the in-flight
+/// steer guard already uses in the brain, for the same reason: the cleanup has
+/// to happen on **every** exit path, including the ones nobody wrote by hand.
+///
+/// Deliberately not [`Clone`] — two live claims would mean two owners of one
+/// promise, and the second to drop would un-claim the queue underneath the
+/// first.
+pub struct PublishClaim {
+    queue: PendingPublishQueue,
+}
+
+impl Drop for PublishClaim {
+    fn drop(&mut self) {
+        *self.queue.destination.lock().expect("publish destination") =
+            PublishDestination::Unclaimed;
+        self.queue.clear();
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Path resolution
 // ---------------------------------------------------------------------------
@@ -238,15 +381,15 @@ impl PublishPathError {
     /// that only says "no" costs a whole turn to recover from.
     pub fn message(&self, path: &str) -> String {
         match self {
-            Self::Empty => "`path` is required: give the workspace-relative path of the file you \
-                            want to publish, e.g. \"specs/launch.md\"."
+            Self::Empty => "`path` is required: give the path of the file you want to publish, \
+                            relative to your sandbox, e.g. \"specs/launch.md\"."
                 .to_string(),
             Self::Outside => format!(
-                "`{path}` is outside your workspace. Publish only files you wrote inside it, using \
+                "`{path}` is outside your sandbox. Publish only files you wrote inside it, using \
                  a relative path like \"specs/launch.md\" — absolute paths and `..` are refused."
             ),
             Self::Missing => format!(
-                "There is no file at `{path}` in your workspace. Check the path with `list_files` \
+                "There is no file at `{path}` in your sandbox. Check the path with `list_files` \
                  or `glob`, and write the file before publishing it."
             ),
             Self::NotAFile => format!(
@@ -436,7 +579,7 @@ pub fn capture_body(
              bytes: {size}\n\
              sha256: {sha}\n\
              \n\
-             The file lives in the agent's workspace. Wiping the sandbox leaves this record \
+             The file lives in the agent's own sandbox. Wiping the sandbox leaves this record \
              intact and the payload unreachable."
         ),
         forced_kind: Some(forced),
@@ -472,13 +615,13 @@ impl Tool for PublishArtifactTool {
     }
 
     fn description(&self) -> &str {
-        "Publish a file you wrote in your workspace as a deliverable for this task. USE FOR the \
-         finished output somebody asked for — a spec, a draft, a report, an invoice, an exported \
-         dataset. The operator sees published files on the task's Artifacts tab, and republishing \
-         the same path on a later run adds a version rather than a duplicate. NOT for scratch \
-         files, notes to yourself, logs, or build output, and NOT a way to send a message — your \
-         reply already reaches the operator. Publishing nothing is a perfectly good outcome for a \
-         task that produced no file."
+        "Publish a file you wrote in your own sandbox as a deliverable. USE FOR the finished \
+         output somebody asked for — a spec, a draft, a report, an invoice, an exported dataset. \
+         Your sandbox is private to you and the operator cannot see into it, so publishing is the \
+         only thing that hands a file over; republishing the same path later adds a version \
+         rather than a duplicate. NOT for scratch files, notes to yourself, logs, or build \
+         output, and NOT a way to send a message — your reply already reaches the operator. \
+         Publishing nothing is a perfectly good outcome for work that produced no file."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -487,7 +630,7 @@ impl Tool for PublishArtifactTool {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Workspace-relative path of the file to publish, e.g. \"specs/launch.md\". Must be a file you wrote inside your own workspace."
+                    "description": "Path of the file to publish, relative to your own sandbox, e.g. \"specs/launch.md\". Must be a file you wrote inside your sandbox — not a path in the company workspace, which is a different place you reach with the workspace tools."
                 },
                 "title": {
                     "type": "string",
@@ -516,6 +659,21 @@ impl Tool for PublishArtifactTool {
 
     async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
         let raw_path = args.get("path").and_then(Value::as_str).unwrap_or_default();
+
+        // Issue #445: can anything record a publish made from *this* turn?
+        // Asked first, before the path is even resolved, because when the answer
+        // is no it is the only fact that matters — validating a path we are not
+        // going to publish would only produce a more specific way of being
+        // unable to publish.
+        let Some(receipt_tail) = self.queue.destination().receipt_tail() else {
+            tracing::warn!(
+                path = %raw_path.trim(),
+                "[publish] `publish_artifact` was called from a turn with no claimed \
+                 destination; refusing rather than staging into a queue nothing will drain"
+            );
+            return Ok(ToolResult::error(cannot_publish_here(raw_path.trim())));
+        };
+
         let (file, source) = match resolve_in_workspace(&self.workspace, raw_path) {
             Ok(resolved) => resolved,
             Err(err) => return Ok(ToolResult::error(err.message(raw_path.trim()))),
@@ -578,9 +736,12 @@ impl Tool for PublishArtifactTool {
         } else {
             "captured in full"
         };
+        // The tail comes from the claim (#445), so the destination named is the
+        // one this caller actually has. The single hard-coded task sentence is
+        // what told a chat turn its file would appear on a run that was never
+        // going to finish.
         Ok(ToolResult::success(format!(
-            "Published `{source}` as \"{title}\" ({kind}) — {how}. It appears on this task's \
-             Artifacts tab when the run finishes.",
+            "Published `{source}` as \"{title}\" ({kind}) — {how}. {receipt_tail}",
             kind = kind.as_str()
         )))
     }
@@ -763,7 +924,7 @@ pub fn nudge_instruction(brief: &str, reply: &str, changed_files: &[String]) -> 
          Your reply was:\n\
          {reply}\n\
          \n\
-         You changed these files in your workspace and published none of them:\n\
+         You changed these files in your sandbox and published none of them:\n\
          {files}\n\
          \n\
          If any of them is the deliverable this task was asking for, publish it now with \
@@ -789,19 +950,98 @@ pub fn nudge_instruction(brief: &str, reply: &str, changed_files: &[String]) -> 
 /// scratch notes, poisoning the churn signal the artifact port exists to
 /// measure. So this says what a deliverable *is*, says plainly that many tasks
 /// have none, and leaves the judgement where it belongs.
+///
+/// # Two different places called "workspace" (issue #445)
+///
+/// This paragraph and
+/// [`workspace_brief`](crate::harness::workspace_tools::workspace_brief) can sit
+/// in the same system prompt, and before #445 both called their own directory
+/// "your workspace" — the agent's private sandbox here, the operator-owned
+/// company note tree there. So "it's in the workspace" meant one place to the
+/// agent and a different one to the operator reading the console, and an
+/// operator sent to the obvious place correctly found nothing. That collision is
+/// how a lost deliverable stayed lost even once someone went looking, so the
+/// sandbox is named **sandbox** throughout this module and the distinction is
+/// stated outright below rather than left to be inferred.
 pub fn publish_brief() -> String {
     format!(
         "\n\n## Deliverables\n\
-         If this task asks you to produce something — a document, a report, a draft, an export — \
-         write it to a file in your workspace and then publish it with `{PUBLISH_ARTIFACT_TOOL}`. \
-         That is what puts it on the task's Artifacts tab where the operator can read, edit and \
-         version it; a file you merely wrote is invisible to them, and pasting the whole document \
-         into your reply is not the same thing. Republish the same path on a later run to add a \
-         version rather than a duplicate.\n\
+         The files you write live in your **sandbox** — your own private working directory. It is \
+         not the company workspace (the shared note tree you read with the workspace tools), and \
+         the operator cannot see into it. A file you merely wrote is therefore invisible to \
+         everyone but you, however finished it is.\n\
+         So if you are asked to produce something — a document, a report, a draft, an export — \
+         write it to a file in your sandbox and then hand it over with \
+         `{PUBLISH_ARTIFACT_TOOL}`. Publishing is what turns a file into a deliverable the \
+         operator can open, read, edit and version; pasting the whole document into your reply is \
+         not the same thing. Republish the same path later to add a version rather than a \
+         duplicate. The tool tells you where the file landed — say that, and nothing more \
+         confident than that. If it returns an error, the file was NOT delivered and you must not \
+         report it as though it was.\n\
          Publish only the finished thing somebody asked for. Scratch files, notes to yourself, \
-         logs and build output are not deliverables, and plenty of tasks — a question answered, a \
-         check run, a decision made — produce no file at all. Having nothing to publish is a \
+         logs and build output are not deliverables, and plenty of work — a question answered, a \
+         check run, a decision made — produces no file at all. Having nothing to publish is a \
          normal outcome, not a gap to fill."
+    )
+}
+
+/// The title of the board card a conversation's publish mints (issue #445).
+///
+/// Named from what was actually published rather than from the chat text: the
+/// card exists to carry these files, and a title lifted from conversation
+/// ("could you write that up?") would describe the request instead of the
+/// deliverable sitting on it. One file gives its own title; several give the
+/// first plus a count, which stays a fixed-width string no matter how many were
+/// published.
+///
+/// Empty input cannot occur — the card is only minted once there is something to
+/// put on it — but it degrades to a neutral title rather than panicking, because
+/// a card with a dull name is recoverable and a crashed cycle is not.
+pub fn conversation_card_title(published: &[PendingPublish]) -> String {
+    match published {
+        [] => "Deliverable from a conversation".to_string(),
+        [only] => only.title.clone(),
+        [first, rest @ ..] => format!("{} (+{} more)", first.title, rest.len()),
+    }
+}
+
+/// The note explaining why a card exists that nobody asked for (issue #445).
+///
+/// A card appearing on the board with no request behind it is otherwise a small
+/// mystery, so it says outright where it came from: an agent published during a
+/// conversation, and this card is the record that carries the result. Without
+/// this the honest fix for a silent drop would introduce its own small
+/// confusion.
+pub fn conversation_card_note(agent: &str, published: &[PendingPublish]) -> String {
+    let files: Vec<String> = published.iter().map(|p| p.source.clone()).collect();
+    format!(
+        "Opened to carry what {agent} published during a conversation: {files}. Chat turns run \
+         without a card, so this card was created by the act of publishing — it records a \
+         delivered file rather than a request somebody made.",
+        files = name_files(&files),
+    )
+}
+
+/// The line appended to an operator's reply when a publish was accepted in-turn
+/// but could not be recorded (issue #445).
+///
+/// The agent has already said the file is delivered — it was told so — and the
+/// receipt cannot be recalled. The remaining choice is whether the operator
+/// hears about it, and a log line is not hearing about it. So the correction
+/// goes where the false claim went: into the conversation, in the operator's own
+/// words rather than the agent's, immediately after the reply that promised the
+/// file.
+pub fn recording_failed_notice(count: usize) -> String {
+    let subject = if count == 1 {
+        "1 file was".to_string()
+    } else {
+        format!("{count} files were")
+    };
+    format!(
+        "\n\n---\n\n**Note from the system:** {subject} published during this turn but could NOT \
+         be recorded, so there is no card or artifact to open — treat any claim above that the \
+         work was delivered as incorrect. The file is still in the agent's sandbox. Ask for it \
+         again, and if this repeats, the artifact store needs looking at."
     )
 }
 

--- a/src/harness/publish/test.rs
+++ b/src/harness/publish/test.rs
@@ -25,6 +25,18 @@ async fn run(tool: &PublishArtifactTool, args: serde_json::Value) -> ToolResult 
     tool.execute(args).await.expect("the tool never propagates")
 }
 
+/// A queue claimed for `destination`, with the live claim (issue #445).
+///
+/// Both halves must be bound by the caller: the claim releases on drop, so
+/// `let (queue, _) = claimed(..)` would un-claim it immediately and every
+/// publish would then be refused. That is the guard doing its job, but it makes
+/// for a confusing test failure, hence the name `_claim` at each call site.
+fn claimed(destination: PublishDestination) -> (PendingPublishQueue, PublishClaim) {
+    let queue = PendingPublishQueue::default();
+    let claim = queue.claim(destination);
+    (queue, claim)
+}
+
 fn text_of(result: &ToolResult) -> String {
     result
         .content
@@ -258,7 +270,7 @@ fn the_reference_digest_tracks_the_bytes() {
 #[tokio::test]
 async fn publishing_stages_the_file_and_reports_what_was_captured() {
     let dir = workspace(&[("specs/launch.md", b"# Spec\nShip it.")]);
-    let queue = PendingPublishQueue::default();
+    let (queue, _claim) = claimed(PublishDestination::Task);
     let tool = PublishArtifactTool::new(dir.path(), queue.clone());
 
     let result = run(&tool, json!({ "path": "specs/launch.md" })).await;
@@ -277,7 +289,7 @@ async fn publishing_stages_the_file_and_reports_what_was_captured() {
 #[tokio::test]
 async fn an_explicit_title_kind_and_note_are_carried_through() {
     let dir = workspace(&[("out.dat", b"plain text really")]);
-    let queue = PendingPublishQueue::default();
+    let (queue, _claim) = claimed(PublishDestination::Task);
     let tool = PublishArtifactTool::new(dir.path(), queue.clone());
 
     run(
@@ -309,7 +321,7 @@ async fn an_explicit_title_kind_and_note_are_carried_through() {
 #[tokio::test]
 async fn the_body_is_captured_at_publish_time_not_at_drain_time() {
     let dir = workspace(&[("spec.md", b"# The version I published")]);
-    let queue = PendingPublishQueue::default();
+    let (queue, _claim) = claimed(PublishDestination::Task);
     let tool = PublishArtifactTool::new(dir.path(), queue.clone());
 
     run(&tool, json!({ "path": "spec.md" })).await;
@@ -323,7 +335,7 @@ async fn the_body_is_captured_at_publish_time_not_at_drain_time() {
 #[tokio::test]
 async fn a_bad_path_is_a_truthful_tool_error_and_stages_nothing() {
     let dir = workspace(&[("spec.md", b"# Spec")]);
-    let queue = PendingPublishQueue::default();
+    let (queue, _claim) = claimed(PublishDestination::Task);
     let tool = PublishArtifactTool::new(dir.path(), queue.clone());
 
     for path in ["../escape.md", "/etc/hosts", "nope.md", ""] {
@@ -338,7 +350,7 @@ async fn a_bad_path_is_a_truthful_tool_error_and_stages_nothing() {
 #[tokio::test]
 async fn an_unknown_kind_is_refused_by_name() {
     let dir = workspace(&[("spec.md", b"# Spec")]);
-    let queue = PendingPublishQueue::default();
+    let (queue, _claim) = claimed(PublishDestination::Task);
     let tool = PublishArtifactTool::new(dir.path(), queue.clone());
 
     let result = run(&tool, json!({ "path": "spec.md", "kind": "spreadsheet" })).await;
@@ -397,12 +409,20 @@ fn clear_drops_what_a_prior_turn_staged() {
 
 /// The queue handle is shared, not copied — the tool built into the agent and
 /// the brain that drains it must see one queue.
+///
+/// Since #445 that sharing has a second half: the **destination** travels with
+/// the clone too. `build_agent` hands the tool one clone and nothing else, so a
+/// destination that did not survive cloning would leave every built tool
+/// permanently unclaimed and unable to publish at all.
 #[tokio::test]
 async fn a_cloned_handle_sees_the_same_queue() {
     let dir = workspace(&[("spec.md", b"# Spec")]);
     let queue = PendingPublishQueue::default();
     let tool = PublishArtifactTool::new(dir.path(), queue.clone());
+
+    let _claim = queue.claim(PublishDestination::Task);
     run(&tool, json!({ "path": "spec.md" })).await;
+
     assert_eq!(queue.queued(), 1, "the brain's handle sees the tool's push");
 }
 
@@ -618,4 +638,255 @@ fn a_decline_is_recorded_with_both_the_files_and_the_reason() {
         note,
         "unpublished: scratch.txt — agent: Those were intermediate notes, not the deliverable."
     );
+}
+
+// ── Issue #445: no success receipt for a publish nothing will record ───────
+
+/// **The headline test.** With no claimed destination the tool must refuse,
+/// because nothing is listening for what it would stage.
+///
+/// This is the exact shape of #445: the file resolved, it was readable, and
+/// every check the tool used to make passed — so the old tool staged it, said
+/// "published", and the item was cleared unread. A green assertion on the
+/// receipt string would have passed then too, which is why this asserts on the
+/// **queue** as well as on `is_error`.
+#[tokio::test]
+async fn an_unclaimed_queue_refuses_to_publish_and_stages_nothing() {
+    let dir = workspace(&[("specs/launch.md", b"# Spec")]);
+    let queue = PendingPublishQueue::default();
+    let tool = PublishArtifactTool::new(dir.path(), queue.clone());
+
+    let result = run(&tool, json!({ "path": "specs/launch.md" })).await;
+
+    assert!(
+        result.is_error,
+        "a publish nothing will drain must not report success: {}",
+        text_of(&result)
+    );
+    assert_eq!(
+        queue.queued(),
+        0,
+        "a refused publish must not leave anything staged"
+    );
+    let message = text_of(&result);
+    // The agent must be told not to claim delivery — the failure #445 describes
+    // is laundered through the agent into a confident lie to the operator, and
+    // only the tool's own words can stop that.
+    assert!(
+        message.contains("NOT published"),
+        "the refusal must be unambiguous: {message}"
+    );
+    assert!(
+        message.to_lowercase().contains("do not retry"),
+        "an unclaimed queue is not a transient fault: {message}"
+    );
+    assert!(
+        message.contains("sandbox"),
+        "the agent must be told where the file actually still is: {message}"
+    );
+}
+
+/// `Unclaimed` is the [`Default`], which is what makes the guarantee hold for
+/// call sites that do not know this module exists.
+#[test]
+fn a_fresh_queue_is_unclaimed_by_default() {
+    assert_eq!(
+        PendingPublishQueue::default().destination(),
+        PublishDestination::Unclaimed
+    );
+    assert_eq!(PublishDestination::default(), PublishDestination::Unclaimed);
+}
+
+/// The claim is a scope, not a flag: when it ends, publishing is off again.
+///
+/// This is what protects a turn that runs *after* a drain site returns — an
+/// approval re-dispatch, a workflow node, anything reusing the same shared deps
+/// — from inheriting a promise that has already been settled.
+#[tokio::test]
+async fn dropping_the_claim_stops_publishing_again() {
+    let dir = workspace(&[("spec.md", b"# Spec")]);
+    let queue = PendingPublishQueue::default();
+    let tool = PublishArtifactTool::new(dir.path(), queue.clone());
+
+    let claim = queue.claim(PublishDestination::Task);
+    assert!(!run(&tool, json!({ "path": "spec.md" })).await.is_error);
+    drop(claim);
+
+    assert_eq!(
+        queue.destination(),
+        PublishDestination::Unclaimed,
+        "the claim must release on drop"
+    );
+    assert_eq!(
+        queue.queued(),
+        0,
+        "releasing must also clear, so nothing leaks into the next caller"
+    );
+    assert!(
+        run(&tool, json!({ "path": "spec.md" })).await.is_error,
+        "publishing must be refused once the claim has ended"
+    );
+}
+
+/// Claiming clears, so one caller can never be handed the previous caller's
+/// staged file. This is the invariant `run_task`'s hand-written `clear()` used
+/// to carry, now enforced by the claim itself.
+#[test]
+fn claiming_clears_whatever_a_previous_caller_left_staged() {
+    let queue = PendingPublishQueue::default();
+    let claim = queue.claim(PublishDestination::Task);
+    queue.push(PendingPublish {
+        source: "stale.md".to_string(),
+        title: "stale".to_string(),
+        kind: ArtifactKind::Text,
+        note: None,
+        body: "old".to_string(),
+    });
+    drop(claim);
+
+    let _claim = queue.claim(PublishDestination::Conversation);
+    assert_eq!(queue.queued(), 0);
+    assert_eq!(queue.destination(), PublishDestination::Conversation);
+}
+
+/// The receipt must describe **this** caller's destination. One sentence written
+/// for the task case and reused everywhere is what told a chat turn its file
+/// would appear on a run that did not exist.
+#[tokio::test]
+async fn the_receipt_names_the_destination_the_caller_actually_has() {
+    let dir = workspace(&[("spec.md", b"# Spec")]);
+
+    let (task_queue, _task_claim) = claimed(PublishDestination::Task);
+    let task_tool = PublishArtifactTool::new(dir.path(), task_queue);
+    let task_receipt = text_of(&run(&task_tool, json!({ "path": "spec.md" })).await);
+
+    let (chat_queue, _chat_claim) = claimed(PublishDestination::Conversation);
+    let chat_tool = PublishArtifactTool::new(dir.path(), chat_queue);
+    let chat_receipt = text_of(&run(&chat_tool, json!({ "path": "spec.md" })).await);
+
+    assert!(
+        task_receipt.contains("this task's Artifacts tab"),
+        "the task receipt is unchanged by #445: {task_receipt}"
+    );
+    assert!(
+        chat_receipt.contains("card"),
+        "a conversation's file lands on a minted card, and must say so: {chat_receipt}"
+    );
+    assert!(
+        !chat_receipt.contains("this task's"),
+        "a chat turn has no task; the receipt must not name one: {chat_receipt}"
+    );
+    assert_ne!(
+        task_receipt, chat_receipt,
+        "two destinations must not share one sentence"
+    );
+}
+
+// ── Issue #445: the card a conversation's publish mints ───────────────────
+
+#[test]
+fn a_minted_card_is_titled_from_what_was_published() {
+    let publish = |title: &str, source: &str| PendingPublish {
+        source: source.to_string(),
+        title: title.to_string(),
+        kind: ArtifactKind::Markdown,
+        note: None,
+        body: "body".to_string(),
+    };
+
+    assert_eq!(
+        conversation_card_title(&[publish("Launch spec", "specs/launch.md")]),
+        "Launch spec",
+        "one file gives the card its own title"
+    );
+    assert_eq!(
+        conversation_card_title(&[
+            publish("Launch spec", "specs/launch.md"),
+            publish("Pricing", "pricing.md"),
+            publish("FAQ", "faq.md"),
+        ]),
+        "Launch spec (+2 more)",
+        "several files stay one fixed-width title"
+    );
+    // Never panics on the case that cannot happen.
+    assert!(!conversation_card_title(&[]).is_empty());
+}
+
+/// A card nobody asked for has to explain itself, or the honest fix for a
+/// silent drop introduces its own small mystery on the board.
+#[test]
+fn a_minted_card_explains_why_it_exists() {
+    let note = conversation_card_note(
+        "ceo",
+        &[PendingPublish {
+            source: "specs/launch.md".to_string(),
+            title: "Launch spec".to_string(),
+            kind: ArtifactKind::Markdown,
+            note: None,
+            body: "body".to_string(),
+        }],
+    );
+    assert!(note.contains("ceo"), "{note}");
+    assert!(note.contains("specs/launch.md"), "{note}");
+    assert!(note.contains("conversation"), "{note}");
+}
+
+/// If a publish is accepted and then cannot be recorded, the operator hears
+/// about it — in the conversation, where the wrong claim was made.
+#[test]
+fn a_recording_failure_is_stated_in_the_operators_own_reply() {
+    let one = recording_failed_notice(1);
+    assert!(one.contains("1 file was"), "{one}");
+    assert!(
+        one.contains("NOT") && one.to_lowercase().contains("incorrect"),
+        "the operator must be told the delivery claim is wrong: {one}"
+    );
+    let many = recording_failed_notice(3);
+    assert!(many.contains("3 files were"), "{many}");
+}
+
+// ── Issue #445: sandbox is not the company workspace ──────────────────────
+
+/// The naming collision that sent an operator looking in the wrong place.
+///
+/// `publish_brief` and `workspace_brief` can sit in the same system prompt, and
+/// both used to say "your workspace" about different directories. The brief must
+/// now name the sandbox as the sandbox and say outright that it is not the
+/// company workspace.
+#[test]
+fn the_brief_distinguishes_the_sandbox_from_the_company_workspace() {
+    let brief = publish_brief();
+    let lower = brief.to_lowercase();
+
+    assert!(lower.contains("sandbox"), "{brief}");
+    assert!(
+        lower.contains("not the company workspace"),
+        "the two places must be told apart explicitly: {brief}"
+    );
+    assert!(
+        lower.contains("cannot see"),
+        "the agent must know a written file is invisible to the operator: {brief}"
+    );
+    assert!(
+        !lower.contains("in your workspace"),
+        "the sandbox must never be called `your workspace` again: {brief}"
+    );
+    // The non-coercive contract from #244 must survive the rewrite.
+    assert!(
+        lower.contains("normal outcome"),
+        "publishing nothing must stay a fine answer: {brief}"
+    );
+}
+
+/// The agent-facing refusals must not reintroduce the collision either.
+#[test]
+fn path_errors_call_the_sandbox_a_sandbox() {
+    for err in [PublishPathError::Outside, PublishPathError::Missing] {
+        let message = err.message("specs/launch.md");
+        assert!(message.contains("sandbox"), "{err:?}: {message}");
+        assert!(
+            !message.contains("your workspace"),
+            "{err:?} still says `your workspace`: {message}"
+        );
+    }
 }

--- a/src/harness/publish/test.rs
+++ b/src/harness/publish/test.rs
@@ -953,3 +953,15 @@ fn the_nudge_says_when_the_file_list_is_incomplete() {
     // The caveat must not turn the nudge coercive — #244's contract still holds.
     assert!(!partial.to_lowercase().contains("you must"), "{partial}");
 }
+
+/// A refusal that names a tool the agent does not have costs it a turn.
+///
+/// The listing tool is advertised as `list` (openhuman's `ListFilesTool::name`);
+/// the message used to say `list_files`, which is the Rust type name and not
+/// anything the model can call.
+#[test]
+fn the_missing_file_message_names_a_tool_that_exists() {
+    let message = PublishPathError::Missing.message("specs/launch.md");
+    assert!(message.contains("`list`"), "{message}");
+    assert!(!message.contains("list_files"), "{message}");
+}

--- a/src/harness/publish/test.rs
+++ b/src/harness/publish/test.rs
@@ -438,7 +438,7 @@ fn the_scan_sees_new_and_modified_files_but_not_deletions() {
     std::fs::write(dir.path().join("fresh.md"), b"new").unwrap();
     std::fs::remove_file(dir.path().join("gone.md")).unwrap();
 
-    let changed = before.changed_since(dir.path());
+    let changed = before.changed_since(dir.path()).files;
     assert_eq!(
         changed,
         ["fresh.md", "keep.md"],
@@ -460,7 +460,7 @@ fn a_same_instant_rewrite_of_a_different_length_is_still_a_change() {
     file.set_modified(stat.modified().unwrap()).unwrap();
     drop(file);
 
-    assert_eq!(before.changed_since(dir.path()), ["spec.md"]);
+    assert_eq!(before.changed_since(dir.path()).files, ["spec.md"]);
 }
 
 #[test]
@@ -478,7 +478,7 @@ fn the_scan_skips_the_directories_an_exec_sandbox_fills() {
     // …and they are skipped on the diff side too, so a build never nudges.
     let before = WorkspaceSnapshot::take(dir.path());
     std::fs::write(dir.path().join("target/debug/build.log"), b"rebuilt").unwrap();
-    assert!(before.changed_since(dir.path()).is_empty());
+    assert!(before.changed_since(dir.path()).files.is_empty());
 }
 
 /// **The false-positive test that matters most.** The agent's `workspace_dir`
@@ -512,13 +512,13 @@ fn the_scan_ignores_what_the_runtime_itself_writes() {
     }
 
     assert!(
-        before.changed_since(dir.path()).is_empty(),
+        before.changed_since(dir.path()).files.is_empty(),
         "the runtime's own files must never look like unpublished agent work"
     );
 
     // The agent's actual file is still seen, so the exclusions did not blind it.
     std::fs::write(dir.path().join("spec.md"), b"one, revised").unwrap();
-    assert_eq!(before.changed_since(dir.path()), ["spec.md"]);
+    assert_eq!(before.changed_since(dir.path()).files, ["spec.md"]);
 }
 
 /// The entry cap. A truncated scan may only under-report — it feeds a warning,
@@ -540,7 +540,7 @@ fn a_workspace_that_does_not_exist_yet_has_changed_nothing() {
     let never = dir.path().join("no-such-agent/workspace");
     let snapshot = WorkspaceSnapshot::take(&never);
     assert!(snapshot.is_empty());
-    assert!(snapshot.changed_since(&never).is_empty());
+    assert!(snapshot.changed_since(&never).files.is_empty());
 }
 
 #[test]
@@ -576,6 +576,7 @@ fn the_nudge_carries_its_own_context() {
         "Draft the launch spec.",
         "Done — I've written it up.",
         &["specs/launch.md".to_string(), "scratch.txt".to_string()],
+        false,
     );
     assert!(
         instruction.contains("Draft the launch spec."),
@@ -595,7 +596,7 @@ fn the_nudge_carries_its_own_context() {
 /// never claim publishing is required.
 #[test]
 fn the_nudge_offers_the_decline_and_never_demands_a_publish() {
-    let instruction = nudge_instruction("Draft it.", "Done.", &["scratch.txt".to_string()]);
+    let instruction = nudge_instruction("Draft it.", "Done.", &["scratch.txt".to_string()], false);
     let lower = instruction.to_lowercase();
 
     assert!(
@@ -889,4 +890,66 @@ fn path_errors_call_the_sandbox_a_sandbox() {
             "{err:?} still says `your workspace`: {message}"
         );
     }
+}
+
+// ── Issue #420 item 3: a partial scan says it is partial ──────────────────
+
+/// The flag existed and nothing read it, so the nudge presented an arbitrary
+/// DFS prefix as the complete list of what the agent changed.
+#[test]
+fn a_truncated_scan_reports_that_its_diff_is_partial() {
+    let dir = tempfile::tempdir().unwrap();
+    for i in 0..(MAX_SCAN_ENTRIES + 50) {
+        std::fs::write(dir.path().join(format!("f{i}.txt")), b"x").unwrap();
+    }
+    let before = WorkspaceSnapshot::take(dir.path());
+    assert!(before.truncated(), "the fixture must actually truncate");
+
+    let changed = before.changed_since(dir.path());
+    assert!(
+        changed.partial,
+        "a diff of truncated walks must admit it is a subset"
+    );
+}
+
+/// A scan that saw everything must NOT claim to be partial, or the caveat
+/// becomes noise the agent learns to ignore.
+#[test]
+fn a_complete_scan_is_not_reported_as_partial() {
+    let dir = workspace(&[("spec.md", b"one")]);
+    let before = WorkspaceSnapshot::take(dir.path());
+    std::fs::write(dir.path().join("spec.md"), b"one, revised").unwrap();
+
+    let changed = before.changed_since(dir.path());
+    assert_eq!(changed.files, ["spec.md"]);
+    assert!(!changed.partial);
+}
+
+/// The agent has to be told, or it declines on behalf of files the scan never
+/// reached — a completeness claim the scan cannot support.
+#[test]
+fn the_nudge_says_when_the_file_list_is_incomplete() {
+    let files = ["a.md".to_string()];
+
+    let complete = nudge_instruction("brief", "reply", &files, false);
+    assert!(
+        complete.contains("That is everything you changed."),
+        "{complete}"
+    );
+    assert!(
+        !complete.to_lowercase().contains("incomplete"),
+        "{complete}"
+    );
+
+    let partial = nudge_instruction("brief", "reply", &files, true);
+    assert!(
+        partial.to_lowercase().contains("incomplete"),
+        "a partial scan must say so: {partial}"
+    );
+    assert!(
+        !partial.contains("That is everything you changed."),
+        "a partial scan must not claim completeness: {partial}"
+    );
+    // The caveat must not turn the nudge coercive — #244's contract still holds.
+    assert!(!partial.to_lowercase().contains("you must"), "{partial}");
 }

--- a/src/harness/publish_turn_test.rs
+++ b/src/harness/publish_turn_test.rs
@@ -38,7 +38,7 @@ use crate::harness::publish::PUBLISH_ARTIFACT_TOOL;
 use crate::harness::{HarnessBrain, HarnessDeps, HarnessPool};
 use crate::ports::artifacts::{ArtifactRecord, ArtifactStore};
 use crate::ports::brain::{Brain, CycleHost};
-use crate::ports::tasks::{COLUMN_IN_PROGRESS, TaskRecord, TaskStore};
+use crate::ports::tasks::{COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, TaskRecord, TaskStore};
 use crate::ports::types::{
     ApprovalId, CompanyEvent, CompanyId, CompanyRecord, ContextOp, ContextOpResult, CycleRequest,
     Effect, EffectDisposition, ToolCall, ToolResult,
@@ -282,6 +282,23 @@ tier = "orchestrator"
 /// Wire a real brain against the scripted endpoint, with task and artifact
 /// stores on disk.
 fn brain(base_url: String, grants: &str, dir: &std::path::Path) -> (HarnessBrain, Arc<FsOps>) {
+    brain_with(base_url, grants, dir, true)
+}
+
+/// The same brain with **no artifact store** (issue #445).
+///
+/// The fail-closed case: nothing can record a deliverable, so `build_agent`
+/// does not offer the tool and the brain never claims the publish queue.
+fn brain_without_artifacts(base_url: String, dir: &std::path::Path) -> (HarnessBrain, Arc<FsOps>) {
+    brain_with(base_url, "\"*\"", dir, false)
+}
+
+fn brain_with(
+    base_url: String,
+    grants: &str,
+    dir: &std::path::Path,
+    with_artifacts: bool,
+) -> (HarnessBrain, Arc<FsOps>) {
     let ops = Arc::new(FsOps::new(dir));
     let deps = HarnessDeps {
         provider: Arc::new(HostedProvider::new(HostedProviderConfig {
@@ -296,7 +313,7 @@ fn brain(base_url: String, grants: &str, dir: &std::path::Path) -> (HarnessBrain
         workspace_root: dir.to_path_buf(),
         model_override: Some("stub-model".to_string()),
         tasks: Some(ops.clone()),
-        artifacts: Some(ops.clone()),
+        artifacts: with_artifacts.then(|| ops.clone() as Arc<dyn ArtifactStore>),
         skills: None,
         skills_source_dir: None,
         skills_registry: Arc::from([]),
@@ -1133,4 +1150,212 @@ async fn a_dispatch_with_no_attempt_row_stamps_nothing() {
         "the deliverable is still recorded — only the card's link is missing"
     );
     assert_eq!(after.column, crate::ports::tasks::COLUMN_IN_REVIEW);
+}
+
+// ---------------------------------------------------------------------------
+// Issue #445: publishing outside a task run
+// ---------------------------------------------------------------------------
+
+/// An operator message, the shape a chat turn arrives as.
+fn chat(text: &str) -> CycleRequest {
+    CycleRequest {
+        cycle_id: "cycle-1".to_string(),
+        company_id: company(),
+        events: vec![CompanyEvent::OperatorMessage {
+            text: text.to_string(),
+            by: None,
+            chat: None,
+            parent: None,
+        }],
+        event_seqs: Vec::new(),
+        compressed_history: Vec::new(),
+        roster: Vec::new(),
+        context_index: Vec::new(),
+    }
+}
+
+/// Every card on the board, oldest-id first — a chat publish mints one, so the
+/// tests have to find a card they did not create.
+async fn all_cards(ops: &Arc<FsOps>) -> Vec<TaskRecord> {
+    let mut cards = TaskStore::list(&**ops, &company()).await.expect("list");
+    cards.sort_by(|a, b| a.id.cmp(&b.id));
+    cards
+}
+
+/// **The headline for #445.** A model publishes during a *conversation* — no
+/// card, no dispatch, no run — and the file must end up somewhere the operator
+/// can open.
+///
+/// Before this the tool returned success, the queue was never drained, and the
+/// next turn cleared it. Everything was green and the deliverable was gone, so
+/// this asserts on the **stored artifact**, not on the receipt.
+#[tokio::test]
+async fn a_conversation_publish_is_recorded_on_a_card_it_mints() {
+    let (base_url, _script) = spawn_script(vec![
+        write("brief.md", "# Brief\nThe thing you asked for."),
+        publish("brief.md"),
+        Turn::Say("Written up and published."),
+    ])
+    .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (brain, ops) = brain(base_url, "\"*\"", dir.path());
+
+    // No card exists, and none is dispatched — this is purely a chat turn.
+    assert!(all_cards(&ops).await.is_empty());
+
+    brain
+        .run_cycle(chat("Draft me a brief."), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    // A card was minted to carry the deliverable…
+    let cards = all_cards(&ops).await;
+    assert_eq!(
+        cards.len(),
+        1,
+        "publishing in a conversation must mint exactly one card: {cards:?}"
+    );
+    let card = &cards[0];
+    assert_eq!(
+        card.column, COLUMN_IN_REVIEW,
+        "finished agent work awaiting a person"
+    );
+    assert_eq!(card.assignee, AGENT);
+    assert_eq!(card.title, "brief.md", "titled from what was published");
+    assert!(
+        card.note
+            .as_deref()
+            .unwrap_or_default()
+            .contains("conversation"),
+        "the card must explain why it exists: {:?}",
+        card.note
+    );
+    // …and it is reachable by the one route the console actually reads.
+    let artifacts = artifacts_on(&ops, &card.id).await;
+    assert_eq!(artifacts.len(), 1, "the deliverable must be on the card");
+    assert_eq!(artifacts[0].source.as_deref(), Some("brief.md"));
+    assert_eq!(
+        artifacts[0].versions[0].body, "# Brief\nThe thing you asked for.",
+        "the stored body must be the file the agent wrote"
+    );
+}
+
+/// The receipt the *model* was handed must name the destination it actually
+/// got. This reads the wire, so it pins what the agent was told — the sentence
+/// that, when wrong, is laundered into a false claim to the operator.
+#[tokio::test]
+async fn a_conversation_publish_receipt_does_not_promise_a_task_tab() {
+    let (base_url, script) = spawn_script(vec![
+        write("brief.md", "# Brief"),
+        publish("brief.md"),
+        Turn::Say("Published."),
+    ])
+    .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (brain, ops) = brain(base_url, "\"*\"", dir.path());
+    brain
+        .run_cycle(chat("Draft me a brief."), &NoopHost)
+        .await
+        .expect("cycle runs");
+    let _ = &ops;
+
+    // Find the tool result the model was sent back.
+    let receipts: Vec<String> = script
+        .seen
+        .lock()
+        .unwrap()
+        .iter()
+        .flat_map(|body| {
+            body.get("messages")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default()
+        })
+        .filter(|m| m.get("role").and_then(Value::as_str) == Some("tool"))
+        .filter_map(|m| m.get("content").and_then(Value::as_str).map(str::to_string))
+        .filter(|c| c.contains("Published `brief.md`"))
+        .collect();
+
+    assert!(
+        !receipts.is_empty(),
+        "the model was never handed a publish receipt"
+    );
+    for receipt in &receipts {
+        assert!(
+            !receipt.contains("this task's Artifacts tab"),
+            "a chat turn has no task, so the receipt must not name one: {receipt}"
+        );
+        assert!(
+            receipt.contains("card"),
+            "the receipt must name where the file actually went: {receipt}"
+        );
+    }
+}
+
+/// The other half of the floor: with no artifact store there is no claim, so
+/// the tool must **refuse** rather than stage into a queue nothing drains.
+///
+/// `build_agent` already declines to wire the tool without a store, so this
+/// proves the two gates agree — the agent cannot publish, by either route.
+#[tokio::test]
+async fn a_conversation_without_an_artifact_store_cannot_publish() {
+    let (base_url, script) = spawn_script(vec![
+        write("brief.md", "# Brief"),
+        publish("brief.md"),
+        Turn::Say("Tried to publish."),
+    ])
+    .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (brain, ops) = brain_without_artifacts(base_url, dir.path());
+
+    brain
+        .run_cycle(chat("Draft me a brief."), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    assert!(
+        all_cards(&ops).await.is_empty(),
+        "nothing to record means no card is minted"
+    );
+    // The tool is not even advertised — the failure is closed at both ends.
+    let advertised = advertised_tools(&script);
+    assert!(
+        !advertised.contains(&PUBLISH_ARTIFACT_TOOL.to_string()),
+        "publish_artifact must not be offered without a store: {advertised:?}"
+    );
+}
+
+/// A dispatched card must behave **exactly** as it did before #445 — the
+/// artifact lands on the card that was dispatched, and no extra card appears.
+#[tokio::test]
+async fn a_task_run_still_files_onto_its_own_card_and_mints_nothing() {
+    let (base_url, _script) = spawn_script(vec![
+        write("launch.md", "# Launch spec"),
+        publish("launch.md"),
+        Turn::Say("Published."),
+    ])
+    .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (brain, ops) = brain(base_url, "\"*\"", dir.path());
+    TaskStore::upsert(&*ops, &company(), &card("t-1"))
+        .await
+        .unwrap();
+
+    brain
+        .run_cycle(dispatch("t-1"), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    let cards = all_cards(&ops).await;
+    assert_eq!(
+        cards.len(),
+        1,
+        "a task run must not mint a second card: {cards:?}"
+    );
+    assert_eq!(cards[0].id, "t-1");
+    assert_eq!(artifacts_on(&ops, "t-1").await.len(), 1);
 }


### PR DESCRIPTION
## Summary

An agent publishes a file during a conversation. The tool returns **success**. The agent tells the operator the deliverable is ready. Nothing is recorded anywhere the operator can reach, and the file exists only in that agent's sandbox on the server.

Publishing was staged, not written, and the queue was drained in exactly one place: the settle path of a **task** run, and only on success. A chat turn never reaches it, so the staged file was cleared by the next turn. Every piece was individually right — the clears are deliberate, and correctly stop a chat turn's file being attributed to a card that did not produce it. Together they made a publish outside a task run a silent no-op.

The sharpest part was the receipt, which named a destination the caller could not reach: *"It appears on this task's Artifacts tab when the run finishes."* In a chat turn there is no task and no run that will finish. The agent had no way to discover it had been told something false, so the lie was laundered through the agent into a confident, wrong statement to the operator.

Closes #445.

## API Or Behavior Changes

**A publish during a conversation now mints the card that carries it.** The card lands in `in_review`, matching `column_for_settled_run(Succeeded)`; `done` is reached only by a person. No `output` stamp is written — that pins a `run_id` a chat turn does not have.

The destination decision was between *a company artifact attached to no card* and *publishing mints the card*. Reachability decided it, and reachability is the whole bug: `ArtifactRecord.task_id` is non-optional and `(task_id, source)` **is** its identity; the only list route and the only console surface are both task-scoped. A card-less artifact would need an optional `task_id`, a new route and a new console view — and until that last piece shipped it would be recorded and still unreachable, which is this bug moved one layer down.

**A publish from a turn that nothing will drain now refuses, in-turn, and says why.** This is enforced by construction rather than by auditing call sites: the queue carries a destination whose `Default` is `Unclaimed`, and the tool refuses on it before touching the file. A turn-running path added later inherits an honest refusal rather than the silent drop. The claim is taken only when both stores the drain needs are wired, so a promise that cannot be kept is never made.

That default immediately caught a third path for free: the workflow agent node shares the same deps, never claims, and so now refuses honestly — with no edit to that file.

**Receipts describe what actually happened for the caller that made the call**, rather than one sentence written for the task case. **The agent's sandbox and the company workspace are now named distinctly** in the text agents and operators both see, so "it is in the workspace" means one thing.

**Partly addresses #420 (item 3 only — this PR does not close it).** The sandbox scan set `snapshot.truncated` and the accessor had zero callers, so the publish nudge presented an arbitrary DFS prefix as the complete list of changed files. `changed_since` now returns a `partial` flag a caller must destructure. Items 1, 2 and 4 of #420 are untouched.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo check --locked --all-features --all-targets`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 2229 passed, 1 failed

`Cargo.lock` unchanged.

**The one failure is pre-existing and unrelated: `workflows::runner::tests::a_cancelled_run_parks_no_gates` (#448).** Demonstrated rather than asserted — this branch's files were moved aside and the pristine base restored, where it failed **4 of 8**. Nothing in `src/workflows/` touches the publish queue beyond a `default()` construction.

**Verified live** against a real `opencompany serve` host — real HTTP, real harness, real stores, with only the model's choices scripted through a loopback endpoint: an operator chat message → the agent writes and publishes → a card appears on the board in `in_review` → the deliverable is readable at the real `/tasks/{id}/artifacts` route with its actual content. The receipt handed to the model was read back to confirm it now describes the conversation case.

Live testing paid for itself: it caught that the new refusal told agents to call `list_files`, which does not exist — the wire name is `list`. That is the third commit.

**Unit-only:** the approval re-dispatch claim, and the truncation path (needs a sandbox of over 5000 entries).

**Not verified:** the counterfactual on base — that this same live flow records nothing *before* the fix. That rests on code evidence and the new end-to-end test, not a live run of the broken build.

## Documentation

Module docs on `publish.rs` carry the destination rule and the reasoning for the `Unclaimed` default. No spec file needed updating.

## Notes for review

**Interaction found in live testing, worth a reviewer's attention.** `run_chat` already opens a `todo` card for *actionable* asks, so "write me the brief" now yields two cards — the request, and the delivered result carrying the artifact. Attaching to the intake card instead was considered and rejected on evidence: a question-shaped ask created no intake card at all, so that path would have reproduced this bug. Reconciling the two belongs with #442.

Two sibling defects of the same class were found and deliberately **not** fixed here, because their files belong to concurrent work: `review_task` reports *"it is complete and has moved to done"* for work merely staged and undrained on two paths, and `economy::Outbox::publish_card` is drained only under `cfg(test)`. Both are being filed. A third suspect, `workflow_refs`, was checked and is a **false positive** — it stages only a card link and its receipt promises nothing.
