### PR TITLE
fix(workflows): a cancelled run always reports itself cancelled (#448)

### DIFF
--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -226,11 +226,12 @@ async fn run_workflow_inner(
             // the end of its scope.
             let mut engine = Box::pin(tinyflows::engine::run(&compiled, input, &capabilities));
             tokio::select! {
-                outcome = &mut engine => outcome.map_err(map_engine_error)?,
+                biased;
                 () = ctx.cancel.cancelled() => {
                     drop(engine);
                     return Ok(cancelled_run());
                 }
+                outcome = &mut engine => outcome.map_err(map_engine_error)?,
             }
         }
         Some(events) => {
@@ -294,8 +295,9 @@ async fn run_workflow_inner(
                 &observer,
             ));
             let outcome = tokio::select! {
-                outcome = &mut engine => Some(outcome),
+                biased;
                 () = ctx.cancel.cancelled() => None,
+                outcome = &mut engine => Some(outcome),
             };
             // **Drop the engine future before the observer, on both arms.** The
             // engine holds observer `Arc` clones inside its per-node handlers;
@@ -1976,6 +1978,52 @@ to = "done"
         .expect("a cancelled run is Ok");
         assert!(run.cancelled);
         assert!(journal.pending().is_empty());
+    }
+
+    /// An already-cancelled run must report `cancelled` **every** time, not most
+    /// of the time.
+    ///
+    /// `tokio::select!` polls its branches in random order and picks among those
+    /// ready. On a token that is already cancelled, the `cancelled()` arm is
+    /// ready on the very first poll — so if the engine future is also ready on
+    /// that poll, which arm wins is a coin flip, and the losing half settles as a
+    /// completed run with `cancelled: false`. An operator's stop was reported as
+    /// a completion.
+    ///
+    /// Both `select!` sites are `biased;` with the cancel arm first, which makes
+    /// an already-signalled cancellation win deterministically.
+    ///
+    /// This runs the path repeatedly on purpose. A single iteration reproduced
+    /// the unbiased defect only about half the time — which is why it read as a
+    /// flaky test for as long as it did, and why anyone who re-ran it in
+    /// isolation concluded it was not real. At this iteration count a revert to
+    /// the unbiased form fails here essentially every time.
+    #[tokio::test]
+    async fn an_already_cancelled_run_always_reports_cancelled() {
+        for iteration in 0..16 {
+            let dir = tempfile::tempdir().unwrap();
+            let (deps, _journal) = deps_with_parking(dir.path());
+            let file = parse_workflow(GATED).expect("parses");
+            let ctx = WorkflowRunContext::new(false);
+            ctx.cancel.cancel();
+
+            let run = run_workflow(
+                Arc::new(HarnessPool::new()),
+                deps,
+                &tools_record(),
+                &file,
+                serde_json::json!({ "request": "x" }),
+                &ctx,
+            )
+            .await
+            .expect("a cancelled run is Ok");
+
+            assert!(
+                run.cancelled,
+                "iteration {iteration}: a run cancelled before it started reported \
+                 itself as not cancelled — the cancel arm lost the select race"
+            );
+        }
     }
 
     /// A graph with no gate parks nothing — the addition must be invisible to


### PR DESCRIPTION
## Summary

A workflow run that was cancelled could come back reporting it was **not** cancelled.

Both `tokio::select!` sites in `run_workflow` were unbiased. `select!` polls its branches in random order and picks among whichever are ready. On a token that is already cancelled, the `cancelled()` arm is ready on the very first poll — so when the engine future is ready on that same poll, which arm wins is a coin flip. When the engine arm won, the run settled as a completed run with `cancelled: false`.

Everything keyed off that flag then took the wrong branch, including the report routing a cancelled run is explicitly not supposed to trigger.

Closes #448.

## API Or Behavior Changes

Both `select!` sites are now `biased;` with the cancel arm first. When the token is not cancelled this changes nothing — the engine arm is the only ready branch. When it is already signalled, cancellation wins deterministically instead of by lottery.

The careful drop-ordering on the cancel arm is unchanged; the comments explaining why the engine future must be dropped before the observer still apply and are still enforced by the borrow checker.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 5 consecutive full-suite runs, 0 failures
- [x] `cargo check --locked --all-features --all-targets`

`Cargo.lock` unchanged.

**Measured in a single clean worktree, baseline and fix in the same tree:**

| | full `--lib` runs | failures |
|---|---|---|
| base `67fe0e9` | 10 | **5** |
| this branch | 10 | **0** |

The failing assertion was always `assert!(run.cancelled)` in `a_cancelled_run_parks_no_gates`, which cancels *before* calling `run_workflow` — so there was no race in the test, only inside the runner.

**The new regression test has a negative control.** Reverting both `select!` sites to the unbiased form makes it fail **3 of 3**. It runs the path 16 times deliberately: a single iteration reproduces the defect only about half the time, so a one-shot test would have gone on being an intermittent red rather than a signal.

## Documentation

The new test carries the explanation inline — why `select!` branch order is load-bearing here, and why isolated runs hide it.

## Notes for review

**This looked like a flaky test for as long as it did because the obvious way to check it is the one way that hides it.** In isolation the test passes 24 out of 24. It only fails as part of the full suite, and it was independently reproduced on four separate occasions by three different people working in three different worktrees — twice after reverting to a pristine base — at rates between 4-in-8 and 5-in-10.

**CI hits it too, just less often — and it did so while this PR was open.** PR #456 went red on exactly this assertion (`assertion failed: run.cancelled`, `runner.rs:1977`) in the `Rust (openhuman, tinycortex)` job, on a branch that touches nothing in `src/workflows/`. So the earlier reading in this description — that CI never sees it — was wrong, and the correction matters: this is not a local-only artefact.

The rate is clearly lower on ubuntu-latest than the ~50% measured locally (this repo merged 23 PRs green in a day), which fits a scheduling-sensitive race where fewer cores make it less likely both branches are ready on the same poll. A lower rate is worse, not better: it is frequent enough to redden an unrelated PR and rare enough that the habit is to hit re-run.

