### PR TITLE
fix(approvals): draw the grant boundary by what a tool reaches, not what it is called (#441, #443, #444)

### DIFF
--- a/docs/modules/mcp.md
+++ b/docs/modules/mcp.md
@@ -69,6 +69,25 @@ tools = ["mcp:notion", "mcp:linear"]   # or "mcp:*"
 `mcp_call_tool` runs under a permissive OpenHuman `SecurityPolicy`; the
 company's own `ApprovalPolicy` tool policy remains the real per-call gate.
 
+## What parks for approval
+
+`mcp_call_tool` parks under the default `supervised` mode and is denied under
+`readonly`: it can perform any effect the remote server advertises, and it can
+never be granted standing for the same reason.
+
+`mcp_list_servers` and `mcp_list_tools` **never** park (issue #443). They read
+local registration state with credentials already redacted and reach nothing.
+This matters more than one saved prompt: the persona brief appended to every
+MCP-granted agent *instructs* it to answer capability questions from a live
+`mcp_list_servers` call rather than from memory, so while these parked, the
+guidance written to stop stale answers could only be followed by interrupting an
+operator. An agent's very first move parked, before it had done anything.
+
+Both verdicts are declared in [`policy::consequence`](../../src/policy/consequence.rs)
+alongside every other tool, and a test builds the live toolbelt and fails if a
+wired tool has no declaration — so a new read-only bridge tool cannot quietly
+start asking for permission.
+
 ## HTTP surface
 
 Both scope forms are registered (`…/companies/{id}/…` and the single-company

--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -141,12 +141,48 @@ operator notice; it is never the enforcement, or "for one hour" would mean
 
 #### What can never be granted broadly
 
-Exactly the tools whose consequence group is the catch-all `Other`. Anything the
-classifier calls **Spend, Send, Sign, Publish, Hire or Identity** stays a
-per-call decision, forever, with nobody having to remember to add it to a list —
-the rule delegates to the taxonomy at the top of this document rather than
-keeping a second hand-written set of "safe" tools, which would be written once
-and then silently accrue every new tool by omission.
+Decided by what a tool can **reach**, not by what it is called.
+
+This used to be "exactly the tools whose consequence group is the catch-all
+`Other`", on the reasoning that delegating to the taxonomy beat keeping a second
+hand-written set of safe tools. The reasoning was right and the measurement was
+wrong. `Other` is where a tool lands when the classifier finds no consequence
+word *in its name*, so the three broadest capabilities in the system —
+running an arbitrary command, reaching an arbitrary address, and overwriting the
+guidance the operator wrote — were all grantable, while a repository read scoped
+to one connected account was not. The bucket also conferred membership by
+omission: adding a tool and not thinking about it handed it the longest
+permission available.
+
+So the two questions are now separate answers from one declaration
+(`src/policy/consequence.rs`), one entry per tool:
+
+- **may it run unattended?** — `readonly` denies anything that mutates or
+  reaches outside; `supervised` parks it. This is what the approval card is for.
+- **may an operator hand it over for a stretch of time?** — refused for anything
+  that can execute arbitrary code (`shell`), reach an arbitrary address
+  (`http_request`, `curl`, `web_fetch`, `git_operations`), act through a
+  third-party server (`mcp_call_tool`), overwrite operator-owned guidance
+  (`workspace_write`), or run a saved workflow; refused for every named
+  consequence — Spend, Send, Sign, Publish, Hire, Identity; and refused for any
+  tool nobody has declared.
+
+What stays grantable is the low-consequence middle the feature exists for:
+writes confined to the agent's own sandboxed workspace (`file_write`, `edit`,
+`apply_patch`, `csv_export`, `memory_store`), and **Composio reads**.
+
+`composio_execute` is the reason arguments are part of the question. Every
+Composio action arrives under that one tool name, so classifying the name
+collapsed "list a repository's pull requests" and "send an email" into one
+verdict, and the cautious answer had to win for both. The action slug in the
+arguments is classified instead, against the provider's own curated catalogue —
+a read is grantable, a send is not, and **anything the catalogue does not name
+is a send**. That last part is not a detail: an action nobody has classified
+might do anything.
+
+Because a standing grant carries no arguments, the policy re-classifies the live
+call before honouring one, so a scope granted on a GitHub read cannot admit an
+outgoing email on the same tool name.
 
 The console hides the control for a card it cannot be used on; that is UX. The
 **enforcement** is host-side at mint time, so a hand-rolled request for a
@@ -157,11 +193,11 @@ this teammate" names neither of the two things it needs.
 A refused scope changes nothing at all — the approval stays parked and no
 verdict is journaled — so the operator can simply approve it once instead.
 
-Known and deliberate: `shell` classifies as `Other` and is therefore grantable.
-Narrowing it belongs in the classifier — giving shell a consequence class — not
-in a second ad-hoc exclusion list, which is the drift this design exists to
-avoid. It is operator opt-in, time-boxed, revocable, and both `never_do` and the
-`readonly` brake outrank it.
+**Not yet as narrow as it should be.** A standing grant records a tool, not a
+toolkit, so "this teammate may read from GitHub for eight hours" is expressed as
+"may make Composio reads for eight hours". Reads only, never sends — but broader
+than the sentence an operator actually consented to. Narrowing it needs a scope
+field on the grant record.
 
 #### Listing and revoking
 
@@ -183,8 +219,8 @@ cannot hand the permission back on boot.
 
 Per-use auditing is tracing-only in v1: mint, revoke and expiry are journaled
 with actor and timestamps, but each admitted call writes no journal record.
-Defensible because a standing grant only ever admits `Other`-group tools and
-never a priced call; a per-use record is additive later.
+Defensible because a standing grant only ever admits tools declared grantable
+and never a priced call; a per-use record is additive later.
 
 ### Precedence at the tool gate
 
@@ -202,7 +238,9 @@ A tool call is decided in this order:
    still *burns*: masking it would leave the operator's one-off approval to
    expire and be announced as "the agent didn't act", about a call that ran.
    This arm refuses a **priced** call (a declared amount, a metered read), so a
-   standing grant can never admit money by placement rather than by promise.
+   standing grant can never admit money by placement rather than by promise —
+   and it re-checks the live arguments, so a grant minted on a Composio read
+   cannot admit a Composio send.
 4. `[policy].always_approve` → park.
 5. mode dispatch (`readonly` / `supervised` / `full`).
 

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -1248,13 +1248,14 @@ impl CompanyRuntime {
                 agent: p.effect.agent.clone(),
                 payload: crate::runtime::approval_display::display_payload(&p.effect),
                 thread: p.thread,
-                // Issue #374. Both halves matter: a native effect has no
-                // teammate and no tool to grant, and a named consequence group
-                // stays a per-call decision. Read off the parked effect, so the
-                // control is offered on exactly the classification the card
-                // itself is showing.
-                broadly_grantable: p.effect.agent.is_some()
-                    && p.effect.group.is_broadly_grantable(),
+                // Issues #374, #444. Both halves matter: a native effect has no
+                // teammate and no tool to grant, and a tool that can reach
+                // further than a standing permission can describe stays a
+                // per-call decision. Read off the parked effect, so the control
+                // is offered on exactly the call the card itself is showing —
+                // which matters for `composio_execute`, where the same tool is
+                // grantable reading a repository and not grantable sending mail.
+                broadly_grantable: p.effect.agent.is_some() && p.effect.may_be_granted_standing(),
             })
             .collect()
     }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -3788,6 +3788,18 @@ budget_usd_daily = 0.0
             // `mcp_list_tools` and `mcp_call_tool` on the belt — the three
             // tools issue #443 is about. Without one the coverage check would
             // pass while never having looked at them.
+            // A skills source dir is what puts `list_workflows`,
+            // `describe_workflow` and `read_workflow_resource` on the belt.
+            // Leaving it `None` is how those three stayed invisible to this
+            // check while `describe_workflow` parked in production.
+            let company_src = dir.path().join("company-src");
+            std::fs::create_dir_all(company_src.join("skills").join("brief")).expect("skill dir");
+            std::fs::write(
+                company_src.join("skills").join("brief").join("SKILL.md"),
+                "---\nname: brief\ndescription: Write a brief\n---\n\nWrite one.\n",
+            )
+            .expect("skill file");
+            deps.skills_source_dir = Some(company_src);
             deps.mcp_servers = vec![McpServerDecl {
                 name: "notes".to_string(),
                 endpoint: "https://mcp.example.test".to_string(),
@@ -3870,6 +3882,7 @@ budget_usd_daily = 0.0
             "shell",
             "workspace_write",
             "file_read",
+            "describe_workflow",
             #[cfg(feature = "mcp")]
             "mcp_list_servers",
             #[cfg(feature = "mcp")]
@@ -3938,8 +3951,8 @@ budget_usd_daily = 0.0
             checked += 1;
             let verdict = crate::policy::consequence_of(tool.name(), &args);
             assert!(
-                verdict.reach.is_external(),
-                "`{}` declares itself executable but the gate treats it as internal",
+                verdict.reach.denied_under_readonly(),
+                "`{}` declares itself executable but a read-only desk would allow it",
                 tool.name()
             );
             assert!(

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -3759,4 +3759,195 @@ budget_usd_daily = 0.0
             "the cap resets at 00:00Z; yesterday's spend is spent: {reply:?}"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // The approval gate's coverage over the live toolbelt (issue #443)
+    // -----------------------------------------------------------------------
+
+    /// Build one agent and return the tools it actually received.
+    ///
+    /// A local mirror of `build`'s own `built_tool_names` — that one is private
+    /// to its test module, and this file owns `deps_with_plan`, which is the
+    /// expensive half.
+    fn belt(grants: &[&str], is_orchestrator: bool, wire_everything: bool) -> Vec<String> {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut deps = deps_with_plan(dir.path(), Arc::new(MockContext::default()), None, None);
+        if wire_everything {
+            // The three tool families gated on a wired dependency rather than
+            // on a cargo feature. Without these the belt is missing exactly the
+            // tools most likely to be misclassified — the workspace writes and
+            // the priced search.
+            deps.workspace = Some(Arc::new(crate::store::FsOps::new(dir.path())));
+            deps.artifacts = Some(Arc::new(crate::store::FsOps::new(dir.path())));
+            deps.search = Some(crate::harness::search::SearchBackend::new(
+                "https://api.example.test".to_string(),
+                crate::company::credentials::Credential::from_value("managed-platform-token"),
+                crate::company::DEFAULT_SEARCH_DAILY_CALLS,
+            ));
+            // A registered MCP server is what puts `mcp_list_servers`,
+            // `mcp_list_tools` and `mcp_call_tool` on the belt — the three
+            // tools issue #443 is about. Without one the coverage check would
+            // pass while never having looked at them.
+            deps.mcp_servers = vec![McpServerDecl {
+                name: "notes".to_string(),
+                endpoint: "https://mcp.example.test".to_string(),
+                description: None,
+                allowed_tools: Vec::new(),
+                disallowed_tools: Vec::new(),
+                timeout_secs: 30,
+                enabled: true,
+                source: crate::company::mcp::McpSource::Runtime,
+                auth: crate::company::mcp::AuthMaterial::None,
+            }];
+        }
+        let manifest_agent = ManifestAgent {
+            id: "desk".to_string(),
+            role: "Desk Lead".to_string(),
+            description: None,
+            tier: None,
+            tools: Vec::new(),
+            budget_usd_daily: None,
+        };
+        let policy = ApprovalPolicy::new(&Policy::default(), None);
+        let grants: Vec<String> = grants.iter().map(|g| g.to_string()).collect();
+        let agent = build::build_agent(
+            &CompanyId::new("acme"),
+            "Acme",
+            &manifest_agent,
+            policy,
+            &deps,
+            &grants,
+            &[],
+            is_orchestrator,
+        )
+        .expect("agent builds");
+        agent.tools().iter().map(|t| t.name().to_string()).collect()
+    }
+
+    /// **The mechanism issue #443 asks for.** Every tool this crate can put in
+    /// front of an agent must be classified in
+    /// [`crate::policy::consequence`], or this fails.
+    ///
+    /// Three families had needed the same carve-out before it, each added after
+    /// somebody hit it, and what the gate did with the ones nobody hit was
+    /// silent: the tool simply started asking for permission, and whoever
+    /// noticed was an operator wondering why a read needed approving. That is
+    /// how `mcp_list_servers` — which the agent persona *instructs* every agent
+    /// to call — came to cost an approval, and how `file_read`, `glob` and
+    /// `grep` came to park with nobody reporting it.
+    ///
+    /// A tool declaring its own consequence to the gate at call time would be
+    /// better, and is not reachable: openhuman's `ToolPolicy` surface hands the
+    /// bridge a name and arguments, never the tool. So the declaration is
+    /// checked against the live belt here instead — the issue's own stated
+    /// fallback, "exhaustive by construction rather than by memory".
+    ///
+    /// Feature-aware by construction: it enumerates whatever this build wires,
+    /// so a family behind a cargo feature is covered by the lane that enables
+    /// it rather than by a `cfg` branch that has to be kept in step.
+    #[test]
+    fn every_registered_tool_is_declared() {
+        let declared: std::collections::BTreeSet<&str> =
+            crate::policy::consequence::declared_tools().collect();
+        let mut live: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for (grants, orchestrator, everything) in [
+            (&["*"][..], false, false),
+            (&["*"][..], true, false),
+            (&["*"][..], false, true),
+            (&["*"][..], true, true),
+            (
+                &["workspace", "search", "media", "composio"][..],
+                false,
+                true,
+            ),
+        ] {
+            live.extend(belt(grants, orchestrator, everything));
+        }
+        // A vacuity guard with teeth. `!live.is_empty()` would not notice the
+        // belt quietly narrowing to the tools nobody was worried about, and
+        // three of the four names below are the ones the issues are about.
+        for expected in [
+            "shell",
+            "workspace_write",
+            "file_read",
+            #[cfg(feature = "mcp")]
+            "mcp_list_servers",
+            #[cfg(feature = "mcp")]
+            "mcp_call_tool",
+        ] {
+            assert!(
+                live.contains(expected),
+                "the belt builder stopped wiring `{expected}`, so this check has \
+                 narrowed without anyone deciding to narrow it: {live:?}"
+            );
+        }
+        let undeclared: Vec<&String> = live
+            .iter()
+            .filter(|name| !declared.contains(name.as_str()))
+            .collect();
+        assert!(
+            undeclared.is_empty(),
+            "these tools are wired onto a live agent but nobody has said what they can \
+             reach, so the gate is guessing from their names and they cannot be granted \
+             standing: {undeclared:?}. Add them to `crate::policy::consequence::DECLARED`."
+        );
+    }
+
+    /// The one-directional cross-check on the declaration.
+    ///
+    /// A tool's own `permission_level()` is NOT trustworthy as the authority —
+    /// it defaults to `ReadOnly`, and upstream tools that plainly mutate
+    /// (`git_operations`, `memory_store`) never override it, so believing a
+    /// `ReadOnly` claim would wave a write straight through the gate. But the
+    /// claims in the *other* direction are deliberate: nothing declares itself
+    /// `Execute` or `Dangerous` by accident. So those are checked, and a
+    /// `ReadOnly` claim is ignored.
+    #[test]
+    fn nothing_that_declares_itself_executable_is_internal_or_grantable() {
+        use oh::tools::traits::PermissionLevel;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let deps = deps_with_plan(dir.path(), Arc::new(MockContext::default()), None, None);
+        let manifest_agent = ManifestAgent {
+            id: "desk".to_string(),
+            role: "Desk Lead".to_string(),
+            description: None,
+            tier: None,
+            tools: Vec::new(),
+            budget_usd_daily: None,
+        };
+        let agent = build::build_agent(
+            &CompanyId::new("acme"),
+            "Acme",
+            &manifest_agent,
+            ApprovalPolicy::new(&Policy::default(), None),
+            &deps,
+            &["*".to_string()],
+            &[],
+            true,
+        )
+        .expect("agent builds");
+        let args = serde_json::json!({});
+        let mut checked = 0;
+        for tool in agent.tools() {
+            if !matches!(
+                tool.permission_level(),
+                PermissionLevel::Execute | PermissionLevel::Dangerous
+            ) {
+                continue;
+            }
+            checked += 1;
+            let verdict = crate::policy::consequence_of(tool.name(), &args);
+            assert!(
+                verdict.reach.is_external(),
+                "`{}` declares itself executable but the gate treats it as internal",
+                tool.name()
+            );
+            assert!(
+                !verdict.standing.is_grantable(),
+                "`{}` declares itself executable and must not be grantable",
+                tool.name()
+            );
+        }
+        assert!(checked > 0, "no executable tool was on the belt to check");
+    }
 }

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -437,7 +437,7 @@ impl ApprovalPolicy {
     pub fn effect_for(&self, tool_name: &str, args: &serde_json::Value) -> Effect {
         Effect {
             kind: tool_name.to_string(),
-            group: classify_group(tool_name),
+            group: classify_group(tool_name, args),
             amount_usd: Self::amount_usd(args),
             established_thread: false,
             first_time_counterparty: false,
@@ -486,18 +486,38 @@ impl ApprovalPolicy {
     ///   short-circuit [`consume_grant`](Self::consume_grant) takes, so every
     ///   non-harness construction site behaves exactly as it did before.
     /// * **A priced call is refused outright**, even holding a grant. The mint
-    ///   side already refuses to grant anything outside
-    ///   [`EffectGroup::Other`](crate::ports::types::EffectGroup::Other), so a
+    ///   side already refuses to grant anything that is not
+    ///   [`Standing::Grantable`](crate::policy::Standing::Grantable), so a
     ///   `Spend`-group tool can never reach here; this covers the *other* way a
-    ///   call becomes priced, which the tool name cannot predict — an `Other`
+    ///   call becomes priced, which the tool name cannot predict — a grantable
     ///   tool invoked with a declared `amount_usd`. Refusing here means the call
     ///   falls through to the budget and mode arms below and parks, so a
     ///   standing grant cannot admit money **by placement**, not by promise.
+    /// * **The call being made must itself be grantable**, re-checked here
+    ///   rather than trusted from mint time (issue #441). A standing grant
+    ///   matches on `(agent, tool, unexpired)` and admits *any* arguments,
+    ///   which was a fair summary of a tool's consequence while consequence was
+    ///   a property of the tool name. It is not one for `composio_execute`:
+    ///   every Composio action arrives under that name, so a grant minted on a
+    ///   repository read would otherwise admit an outgoing email on the same
+    ///   handle. Re-classifying the live arguments keeps the grant to the shape
+    ///   the operator was shown. It also means a grant replayed from a journal
+    ///   line written before this change cannot admit a send.
     fn standing_grant_allows(&self, tool: &str, args: &serde_json::Value) -> bool {
         let Some(agent) = self.agent.as_deref() else {
             return false;
         };
-        if Self::is_priced_call(tool, Self::amount_usd(args)) {
+        if Self::is_priced_call(tool, args, Self::amount_usd(args)) {
+            return false;
+        }
+        if !crate::policy::consequence_of(tool, args)
+            .standing
+            .is_grantable()
+        {
+            log::debug!(
+                "[approval] tool '{tool}' holds a standing grant for agent '{agent}' but this \
+                 call is not grantable on its own arguments; parking it"
+            );
             return false;
         }
         let Some(grant) =
@@ -533,10 +553,10 @@ impl ApprovalPolicy {
     /// **untouched at cap**. A spend cap caps spend; making a teammate unable to
     /// answer a question because it spent its budget this morning would be a
     /// different feature, and a worse one.
-    fn is_priced_call(tool: &str, declared_amount: Option<f64>) -> bool {
+    fn is_priced_call(tool: &str, args: &serde_json::Value, declared_amount: Option<f64>) -> bool {
         declared_amount.is_some()
-            || is_metered_read(tool)
-            || classify_group(tool) == EffectGroup::Spend
+            || is_metered_read(tool, args)
+            || classify_group(tool, args) == EffectGroup::Spend
     }
 
     /// The per-agent daily spend cap (issue #304): `Some(decision)` when this
@@ -607,7 +627,7 @@ impl ApprovalPolicy {
     ) -> Option<ToolPolicyDecision> {
         let cap = self.budget_usd_daily?;
         let agent = self.agent.as_deref()?;
-        if !Self::is_priced_call(tool, declared_amount) {
+        if !Self::is_priced_call(tool, args, declared_amount) {
             return None;
         }
         let Some(spend) = self.spend.as_ref() else {
@@ -732,7 +752,7 @@ impl ToolPolicy for ApprovalPolicy {
         // The grant is left UNCONSUMED here: this call never ran, so the
         // operator's approval stays redeemable if the brake is released inside
         // the TTL. It expires on its own otherwise.
-        if self.mode == PolicyMode::Readonly && is_external_effect(tool) {
+        if self.mode == PolicyMode::Readonly && is_external_effect(tool, &request.arguments) {
             return ToolPolicyDecision::deny(format!(
                 "'{tool}' mutates or reaches outside; this desk is read-only, \
                  so an earlier approval does not apply"
@@ -774,13 +794,14 @@ impl ToolPolicy for ApprovalPolicy {
         // `readonly` brake denies before either is consulted, leaving the grant
         // intact for when the brake is released.
         //
-        // What keeps this narrow is decided at MINT time, not here:
-        // `broadly_grantable` refuses to grant anything outside
-        // `EffectGroup::Other`, so no Spend / Send / Sign / Publish / Hire /
-        // Identity tool can have a standing grant to match. The one thing the
-        // tool name cannot predict — an `Other` tool carrying a declared amount
-        // — is refused inside `standing_grant_allows`, so this arm can never
-        // admit money.
+        // What keeps this narrow is decided at MINT time and re-checked here.
+        // The mint side refuses to grant anything the declaration does not call
+        // grantable, so no Spend / Send / Sign / Publish / Hire / Identity tool
+        // can have a standing grant to match. Two things the tool NAME cannot
+        // predict are refused inside `standing_grant_allows`: a grantable tool
+        // carrying a declared amount, so this arm can never admit money; and a
+        // `composio_execute` call whose action is a send, so a grant minted on
+        // a repository read cannot admit an outgoing email (issue #441).
         if self.standing_grant_allows(tool, &request.arguments) {
             return ToolPolicyDecision::Allow;
         }
@@ -815,13 +836,13 @@ impl ToolPolicy for ApprovalPolicy {
             return ToolPolicyDecision::Allow;
         }
 
-        let external = is_external_effect(tool);
+        let external = is_external_effect(tool, &request.arguments);
         // A *metered read* (issue #238) is external — it reaches a third party
         // and spends real money — but it changes nothing anywhere, so under
         // `supervised` the consent already given at grant time is enough and
         // the daily call cap is the boundary. Under `readonly` it is still
         // denied: that tier's contract is that nothing is spent.
-        let metered_read = is_metered_read(tool);
+        let metered_read = is_metered_read(tool, &request.arguments);
         match self.mode {
             PolicyMode::Full => ToolPolicyDecision::Allow,
             PolicyMode::Supervised => {
@@ -877,92 +898,31 @@ impl ToolPolicy for ApprovalPolicy {
 ///
 /// An operator who *does* want a per-call gate has one: `[policy].always_approve
 /// = ["web_search"]` wins over every tier, including `full`.
-fn is_metered_read(tool_name: &str) -> bool {
-    tool_name.eq_ignore_ascii_case(crate::harness::search::WEB_SEARCH_TOOL)
+fn is_metered_read(tool_name: &str, args: &serde_json::Value) -> bool {
+    crate::policy::consequence_of(tool_name, args)
+        .reach
+        .is_metered()
 }
 
-/// Heuristic: does this tool mutate state or reach an external counterparty?
+/// Does this tool call mutate state or reach an external counterparty?
 ///
-/// Best-effort classification by name — openhuman's [`ToolPolicy`] surface hands
-/// the bridge only the tool name and arguments, not the tool's own
-/// external-effect flag. Unknown tools are treated as external (fail-safe).
-fn is_external_effect(tool_name: &str) -> bool {
-    // The orchestrator's in-cycle delegation tools (`spawn_task`,
-    // `delegate_to_desk`) enqueue internal work the harness brain drains this
-    // turn — a task card or a hand-off to a desk's lead — never an external
-    // effect. Without this, the default `supervised` policy would park them and
-    // `readonly` would deny them, breaking in-cycle delegation. (Issue #53.)
-    if crate::harness::orchestrator::is_delegation_tool(tool_name) {
-        return false;
-    }
-    // An MCP tool call can perform any effect advertised by a third-party
-    // server. Treat it as external even if future prefix rules become broader.
-    if tool_name.eq_ignore_ascii_case("mcp_registry_tool_call") {
-        return true;
-    }
-    // The media catalog is a read-only GET (issue #109): listing models spends
-    // nothing and must never park for approval, even though its name does not
-    // start with a read-only prefix. The `media_generate_*` tools are NOT listed
-    // here — they spend real money and fall through to the external-effect
-    // default, so they park under supervised / deny under readonly.
-    if tool_name.eq_ignore_ascii_case("media_list_models") {
-        return false;
-    }
-    // The Composio read tools (issue #110) are read-only GETs: listing toolkits,
-    // connections, or action schemas reaches no third party and must never park
-    // for approval, even though the `composio_*` name has no read-only prefix.
-    // `composio_authorize` / `composio_execute` are NOT listed here — they begin
-    // an OAuth handoff / run a real action, so they fall through to the external-
-    // effect default (park under supervised, deny under readonly).
-    if matches!(
-        tool_name.to_ascii_lowercase().as_str(),
-        "composio_list_toolkits" | "composio_list_connections" | "composio_list_tools"
-    ) {
-        return false;
-    }
-    // The company-workspace read tools (issue #237) only read this company's
-    // own note tree — no state changes and no counterparty is reached — but
-    // their names begin with the namespace rather than a read-only prefix, so
-    // without this arm the fail-safe default would park them under the DEFAULT
-    // `supervised` mode and deny them outright under `readonly`. That would
-    // make the workspace unreadable in exactly the mode whose point is that
-    // reads are fine.
-    //
-    // `workspace_write` is deliberately NOT listed: it overwrites
-    // operator-owned guidance, so it falls through to the external-effect
-    // default and parks under supervised / is denied under readonly. That —
-    // not the tool's declared `PermissionLevel::Write` — is what gates the
-    // write; openhuman's `ToolPolicy` surface never sees a permission level.
-    // The tests below pin all three classifications so renaming a tool cannot
-    // silently move it across the gate.
-    if matches!(
-        tool_name.to_ascii_lowercase().as_str(),
-        "workspace_list" | "workspace_read"
-    ) {
-        return false;
-    }
-    // `web_search` (issue #238) is deliberately NOT carved out here. It reaches
-    // a third party and the managed backend charges for it, so it must stay on
-    // the external side and be DENIED under `readonly`. What keeps it from
-    // parking under `supervised` is `is_metered_read`, which is a narrower claim
-    // ("costs money but changes nothing") than the one this function answers.
-    // Note also that it would not have matched a read-only prefix by accident:
-    // the list below starts `search`, but the tool is `web_search`.
-    const READ_ONLY_PREFIXES: &[&str] = &[
-        "read",
-        "list",
-        "get",
-        "search",
-        "recall",
-        "query",
-        "peek",
-        "inspect",
-        "view",
-        "memory_recall",
-        "memory_search",
-    ];
-    let name = tool_name.to_ascii_lowercase();
-    !READ_ONLY_PREFIXES.iter().any(|p| name.starts_with(p))
+/// A thin reader of [`crate::policy::consequence_of`], which is where the
+/// answer is actually declared. It used to be a hand-maintained carve-out list
+/// bolted onto a read-only-*prefix* heuristic, and it drifted the way such
+/// lists do: three separate families needed the same exemption for the same
+/// reason, each added after somebody hit it, and the ones nobody hit stayed
+/// broken. `mcp_list_servers` — which the agent persona *instructs* every agent
+/// to call rather than answer a capability question from memory — parked for
+/// operator approval (issue #443), and so did `file_read`, `glob` and `grep`,
+/// because the prefix rule keys on the start of a name and none of them begins
+/// with a read-only word.
+///
+/// `args` are consulted because one tool name does not always mean one
+/// consequence: every Composio action arrives as `composio_execute`.
+fn is_external_effect(tool_name: &str, args: &serde_json::Value) -> bool {
+    crate::policy::consequence_of(tool_name, args)
+        .reach
+        .is_external()
 }
 
 /// The top-level keys of a tool-argument object, for a mismatch diagnostic.
@@ -974,72 +934,22 @@ fn top_level_keys(args: &serde_json::Value) -> Vec<&str> {
     }
 }
 
-/// Map a tool name onto the supervised [`EffectGroup`] taxonomy.
+/// Map a tool call onto the supervised [`EffectGroup`] taxonomy — the
+/// consequence class the operator's approval card names.
 ///
-/// Since issue #374 this classification decides one more thing: whether a tool
-/// can be given a **standing** grant. The rule is
-/// [`EffectGroup::is_broadly_grantable`] — only the catch-all `Other` — and it
-/// is applied to the group recorded on the *parked effect*, which is the value
-/// this function produced at projection time. So there is one classifier and
-/// one rule, and the operator is checked against the same classification their
-/// card was showing.
+/// A thin reader of [`crate::policy::consequence_of`]. Since issue #444 this
+/// classification decides *only* what the card says: whether the call may be
+/// granted standing is a separate answer from the same declaration
+/// ([`Effect::may_be_granted_standing`](crate::ports::types::Effect::may_be_granted_standing)),
+/// because one enum answering both questions is how the residual `Other` bucket
+/// came to mean "nothing in particular to name" and "safe for a week" at the
+/// same time.
 ///
-/// That also means a tool landing in `Other` by omission now grants more than
-/// it used to. The `deploy` and `filing` arms below exist because of exactly
-/// that; a misclassification *toward* a consequence group is the safe
-/// direction, and the tests pin both.
-fn classify_group(tool_name: &str) -> EffectGroup {
-    let name = tool_name.to_ascii_lowercase();
-    if name == "mcp_registry_tool_call" {
-        EffectGroup::Other
-    } else if name == "composio_authorize" {
-        // Beginning an OAuth handoff establishes an account identity for the
-        // company (issue #110) — an identity effect, parked before it lands.
-        EffectGroup::Identity
-    } else if name == "composio_execute" {
-        // Running a Composio action reaches a third-party account (send an
-        // email, post a message, open a PR) — a send effect. Placed before the
-        // generic `contains` heuristics so the slug can't be misclassified.
-        EffectGroup::Send
-    } else if name == crate::harness::search::WEB_SEARCH_TOOL {
-        // A metered search is billed by the backend per request (issue #238), so
-        // when it *does* park — an operator listing it in `always_approve` — the
-        // Approvals page must say "spend", not the catch-all "other". An
-        // operator approving a paid call deserves to be told it is one.
-        EffectGroup::Spend
-    } else if name.starts_with("media_generate") {
-        // Image/video generation is billed by the backend on submit (issue
-        // #109), so it is a spend effect — parked for approval before money
-        // moves. (`media_list_models` is read-only and never reaches here.)
-        EffectGroup::Spend
-    } else if name.contains("pay") || name.contains("transfer") || name.starts_with("spend") {
-        EffectGroup::Spend
-    } else if name.contains("email") || name.contains("send") || name.contains("message") {
-        EffectGroup::Send
-    } else if name.contains("sign") || name.contains("file") || name.contains("filing") {
-        // `filing` is the second arm issue #374 adds, found the same way as
-        // `deploy` and for the same reason. `approvals.md` lists `filing.submit`
-        // under Sign, but the substring above is `file`, which `filing` does not
-        // contain — so a `filing_submit` tool classified as `Other`, and `Other`
-        // now means "may be granted for a week". No such tool exists today, so
-        // this closes the gap before it can be walked into rather than after.
-        EffectGroup::Sign
-    } else if name.contains("publish") || name.contains("post") || name.contains("deploy") {
-        // `deploy` is new with issue #374 and closes the one consequence class
-        // the heuristics missed. `approvals.md` has always listed website
-        // deploys under Publish, but no arm matched the word, so a `deploy_site`
-        // tool classified as `Other` — which now means something it did not
-        // before: `Other` is exactly the set that can be granted standing. A
-        // deploy is externally visible and not reversible by the company alone,
-        // so it stays a per-call decision.
-        EffectGroup::Publish
-    } else if name.contains("hire") || name.contains("contract") {
-        EffectGroup::Hire
-    } else if name.contains("identity") || name.contains("handle") {
-        EffectGroup::Identity
-    } else {
-        EffectGroup::Other
-    }
+/// `args` matter: `composio_execute` carries every Composio action under one
+/// name, so the group is read from the action rather than from the tool that
+/// delivers it (issue #441).
+fn classify_group(tool_name: &str, args: &serde_json::Value) -> EffectGroup {
+    crate::policy::consequence_of(tool_name, args).group
 }
 
 #[cfg(test)]
@@ -1059,6 +969,15 @@ mod tests {
     fn request(tool: &str, args: serde_json::Value) -> ToolPolicyRequest {
         let ctx = ToolCallContext::session("s", "chat", "ceo", "call-1", 0);
         ToolPolicyRequest::new(tool, args, ctx)
+    }
+
+    /// May this call be granted standing? The rule as the mint path asks it,
+    /// so a test here and the enforcement in the default build cannot answer
+    /// differently.
+    fn grantable(tool: &str, args: &serde_json::Value) -> bool {
+        crate::policy::consequence_of(tool, args)
+            .standing
+            .is_grantable()
     }
 
     #[test]
@@ -2442,6 +2361,15 @@ mod tests {
     // -----------------------------------------------------------------------
     // Standing grants (issue #374)
     // -----------------------------------------------------------------------
+    //
+    // These tests granted a standing scope on `workspace_write` until issue
+    // #444. That tool was never a fair fixture: it is grantable only under the
+    // rule that read grantability off a name's vocabulary, and the parking side
+    // of this same gate has always refused to exempt it because it overwrites
+    // guidance the operator wrote. The two halves of one gate disagreed about
+    // one tool, and the tests pinned the half that was wrong. `file_write` is
+    // the honest stand-in — it mutates, so it still parks the first time, but
+    // what it mutates is the agent's own sandboxed workspace.
 
     fn standing(
         agent: &str,
@@ -2473,7 +2401,7 @@ mod tests {
     #[tokio::test]
     async fn a_standing_grant_admits_repeat_calls_with_any_arguments() {
         let (p, grants) = granting_policy("supervised", &[], "ops");
-        grants.grant_standing(standing("ops", "workspace_write", far_future()));
+        grants.grant_standing(standing("ops", "file_write", far_future()));
 
         for args in [
             serde_json::json!({ "path": "notes/a.md", "body": "one" }),
@@ -2481,7 +2409,7 @@ mod tests {
             serde_json::json!({}),
         ] {
             assert_eq!(
-                p.check(&request("workspace_write", args.clone())).await,
+                p.check(&request("file_write", args.clone())).await,
                 ToolPolicyDecision::Allow,
                 "a standing grant admits any arguments: {args}"
             );
@@ -2503,11 +2431,10 @@ mod tests {
         let (p, grants) = granting_policy("supervised", &[], "ops");
         // Already past — and deliberately left in the set, so this proves the
         // redemption check rather than the sweep.
-        grants.grant_standing(standing("ops", "workspace_write", 1));
+        grants.grant_standing(standing("ops", "file_write", 1));
 
         assert!(matches!(
-            p.check(&request("workspace_write", serde_json::json!({})))
-                .await,
+            p.check(&request("file_write", serde_json::json!({}))).await,
             ToolPolicyDecision::RequireApproval { .. }
         ));
         assert_eq!(grants.standing_count(), 1, "the sweep did not run here");
@@ -2517,15 +2444,14 @@ mod tests {
     async fn a_standing_grant_is_scoped_to_its_agent_and_tool() {
         let (p, grants) = granting_policy("supervised", &[], "marketing");
         // Granted to a different teammate.
-        grants.grant_standing(standing("ops", "workspace_write", far_future()));
+        grants.grant_standing(standing("ops", "file_write", far_future()));
         assert!(matches!(
-            p.check(&request("workspace_write", serde_json::json!({})))
-                .await,
+            p.check(&request("file_write", serde_json::json!({}))).await,
             ToolPolicyDecision::RequireApproval { .. }
         ));
 
         let (p, grants) = granting_policy("supervised", &[], "ops");
-        grants.grant_standing(standing("ops", "workspace_write", far_future()));
+        grants.grant_standing(standing("ops", "file_write", far_future()));
         // A different tool for the right teammate.
         assert!(matches!(
             p.check(&request("send_email", serde_json::json!({}))).await,
@@ -2544,11 +2470,11 @@ mod tests {
     async fn the_single_use_grant_is_consumed_first() {
         let (p, grants) = granting_policy("supervised", &[], "ops");
         let args = serde_json::json!({ "path": "notes/a.md" });
-        grants.grant(granted("ops", "workspace_write", args.clone()));
-        grants.grant_standing(standing("ops", "workspace_write", far_future()));
+        grants.grant(granted("ops", "file_write", args.clone()));
+        grants.grant_standing(standing("ops", "file_write", far_future()));
 
         assert_eq!(
-            p.check(&request("workspace_write", args)).await,
+            p.check(&request("file_write", args)).await,
             ToolPolicyDecision::Allow
         );
         assert_eq!(grants.live_count(), 0, "the single-use grant burned");
@@ -2562,29 +2488,26 @@ mod tests {
 
     /// A standing grant can never admit money — by placement, not by promise.
     ///
-    /// The mint side refuses to grant anything outside `EffectGroup::Other`, so
-    /// no Spend-group tool can have one. This covers the other way a call
-    /// becomes priced, which the tool name cannot predict: an `Other` tool
-    /// invoked with a declared amount. It must fall through to the budget and
-    /// mode arms and park.
+    /// The mint side refuses to grant anything the declaration does not call
+    /// grantable, so no Spend-group tool can have one. This covers the other way
+    /// a call becomes priced, which the tool name cannot predict: a grantable
+    /// tool invoked with a declared amount. It must fall through to the budget
+    /// and mode arms and park.
     #[tokio::test]
     async fn a_standing_grant_refuses_a_priced_call() {
         let (p, grants) = granting_policy("supervised", &[], "ops");
-        grants.grant_standing(standing("ops", "workspace_write", far_future()));
+        grants.grant_standing(standing("ops", "file_write", far_future()));
 
         // Same tool, same grant — the only difference is a declared amount.
         assert_eq!(
-            p.check(&request(
-                "workspace_write",
-                serde_json::json!({ "path": "a" })
-            ))
-            .await,
+            p.check(&request("file_write", serde_json::json!({ "path": "a" })))
+                .await,
             ToolPolicyDecision::Allow
         );
         assert!(
             matches!(
                 p.check(&request(
-                    "workspace_write",
+                    "file_write",
                     serde_json::json!({ "path": "a", "amount_usd": 25.0 })
                 ))
                 .await,
@@ -2622,11 +2545,10 @@ mod tests {
     #[tokio::test]
     async fn readonly_outranks_a_standing_grant_and_leaves_it_intact() {
         let (p, grants) = granting_policy("readonly", &[], "ops");
-        grants.grant_standing(standing("ops", "workspace_write", far_future()));
+        grants.grant_standing(standing("ops", "file_write", far_future()));
 
         assert!(matches!(
-            p.check(&request("workspace_write", serde_json::json!({})))
-                .await,
+            p.check(&request("file_write", serde_json::json!({}))).await,
             ToolPolicyDecision::Deny { .. }
         ));
         assert_eq!(
@@ -2649,31 +2571,31 @@ mod tests {
         ));
     }
 
-    /// What may be granted broadly is exactly `EffectGroup::Other`, derived —
-    /// never listed. A second hand-kept list is the drift the issue forbids.
+    /// What may be granted standing is decided by what a tool can **reach**,
+    /// never by the vocabulary of its name (issue #444).
+    ///
+    /// The list below is the before/after of the boundary. Every tool in the
+    /// first group used to be grantable — `shell` and `web_fetch` and
+    /// `mcp_registry_tool_call` because their names carry no consequence word,
+    /// and `workspace_write` in flat contradiction of the parking side of this
+    /// same gate, which has always refused to exempt it on the grounds that it
+    /// overwrites operator-owned guidance. An operator on staging really did
+    /// get a standing grant on running arbitrary terminal commands while being
+    /// refused one on reading a repository.
     #[test]
-    fn what_may_be_granted_broadly_is_exactly_the_other_group() {
+    fn what_may_be_granted_standing_is_what_a_tool_can_reach() {
+        let args = serde_json::json!({});
         for tool in [
-            "workspace_write",
-            "workspace_read",
+            // Arbitrary code, arbitrary address, operator-owned guidance.
             "shell",
-            "mcp_registry_tool_call",
+            "http_request",
+            "curl",
             "web_fetch",
-        ] {
-            assert!(
-                classify_group(tool).is_broadly_grantable(),
-                "{tool} classifies as Other and is grantable"
-            );
-        }
-        // The classifier is substring heuristics, and it errs toward a
-        // consequence group — `read_file` matches the `file` arm and lands in
-        // `Sign` despite being a pure read. That is the SAFE direction: a
-        // misclassified tool loses the broader scope and keeps asking, rather
-        // than gaining a scope it should not have. Pinned so the asymmetry is
-        // deliberate rather than discovered.
-        assert!(!classify_group("read_file").is_broadly_grantable());
-        for tool in [
-            "composio_execute",
+            "workspace_write",
+            // Anything a remote server chooses to advertise.
+            "mcp_registry_tool_call",
+            "mcp_call_tool",
+            // Named consequences, unchanged.
             "composio_authorize",
             "pay_invoice",
             "transfer_funds",
@@ -2685,24 +2607,204 @@ mod tests {
             "handle_register",
             "filing_submit",
             "deploy_site",
+            // A tool nobody has classified. Landing in the residual bucket no
+            // longer confers the longest permission available.
+            "some_tool_nobody_declared",
         ] {
             assert!(
-                !classify_group(tool).is_broadly_grantable(),
-                "{tool} carries a consequence group and must stay a per-call decision"
+                !grantable(tool, &args),
+                "{tool} can reach further than a standing grant can describe"
+            );
+        }
+        // The feature keeps its point: writes confined to the agent's own
+        // sandbox stay grantable, so a stretch of unattended autonomy is still
+        // worth granting.
+        for tool in ["file_write", "edit", "apply_patch", "memory_store"] {
+            assert!(grantable(tool, &args), "{tool} stays grantable");
+        }
+    }
+
+    /// Issue #441's headline, at the gate rather than at the card: the same
+    /// tool, two verdicts, decided by the action in the arguments.
+    #[test]
+    fn a_composio_read_may_be_granted_standing_and_a_send_may_not() {
+        assert!(grantable(
+            "composio_execute",
+            &serde_json::json!({ "tool": "GITHUB_LIST_PULL_REQUESTS" })
+        ));
+        assert!(!grantable(
+            "composio_execute",
+            &serde_json::json!({ "tool": "GMAIL_SEND_EMAIL" })
+        ));
+        // The cautious fallback: an action the provider catalogue does not name
+        // is a send, so it neither loses its per-call decision nor its `Send`
+        // label on the card.
+        assert!(!grantable(
+            "composio_execute",
+            &serde_json::json!({ "tool": "GITHUB_INVENT_A_NEW_VERB" })
+        ));
+        assert_eq!(
+            classify_group(
+                "composio_execute",
+                &serde_json::json!({ "tool": "GITHUB_INVENT_A_NEW_VERB" })
+            ),
+            EffectGroup::Send
+        );
+    }
+
+    /// The grantability answer and the parking answer are read from one
+    /// declaration, so an effect the policy projects and the effect the mint
+    /// path inspects can never disagree — for every tool, and for both shapes
+    /// of a Composio call.
+    #[test]
+    fn the_projected_effect_and_the_mint_rule_agree_about_every_tool() {
+        let p = policy("supervised", &[], None).with_agent("ops");
+        let cases: Vec<(&str, serde_json::Value)> = crate::policy::consequence::declared_tools()
+            .map(|t| (t, serde_json::json!({})))
+            .chain([
+                (
+                    "composio_execute",
+                    serde_json::json!({ "tool": "GITHUB_LIST_PULL_REQUESTS" }),
+                ),
+                (
+                    "composio_execute",
+                    serde_json::json!({ "tool": "GMAIL_SEND_EMAIL" }),
+                ),
+                ("some_tool_nobody_declared", serde_json::json!({})),
+            ])
+            .collect();
+        for (tool, args) in cases {
+            let effect = p.effect_for(tool, &args);
+            assert_eq!(
+                effect.may_be_granted_standing(),
+                grantable(tool, &args),
+                "the parked effect for `{tool}` disagrees with the declaration it came from"
+            );
+            assert_eq!(
+                effect.group,
+                classify_group(tool, &args),
+                "the parked effect's group for `{tool}` is not the one the classifier gave"
             );
         }
     }
 
-    /// Issue #374 adds the `deploy` arm. `approvals.md` has always listed
-    /// website deploys under Publish, but no arm matched the word, so a deploy
-    /// tool classified as `Other` — which now means something it did not before:
-    /// `Other` is exactly the set that can be granted standing.
+    /// Issue #443: the persona instructs every agent to call these rather than
+    /// answer a capability question from memory, and under the DEFAULT
+    /// supervised mode that instruction used to cost an operator approval to
+    /// follow. Calling *through* a server still parks.
+    #[tokio::test]
+    async fn listing_mcp_servers_and_tools_runs_without_asking() {
+        let p = policy("supervised", &[], None);
+        for tool in [
+            "mcp_list_servers",
+            "mcp_list_tools",
+            "mcp_registry_list_tools",
+        ] {
+            assert_eq!(
+                p.check(&request(tool, serde_json::json!({}))).await,
+                ToolPolicyDecision::Allow,
+                "`{tool}` reads local registration state and reaches nothing"
+            );
+        }
+        for tool in ["mcp_call_tool", "mcp_registry_tool_call"] {
+            assert!(
+                matches!(
+                    p.check(&request(tool, serde_json::json!({}))).await,
+                    ToolPolicyDecision::RequireApproval { .. }
+                ),
+                "`{tool}` can perform any effect the remote server advertises"
+            );
+        }
+    }
+
+    /// The sibling defects the same sweep turned up. Four pure reads of the
+    /// agent's own workspace parked under the default mode, because the
+    /// read-only rule matched a *prefix* and none of these names begins with a
+    /// read-only word. Nobody had reported them; they were found by asking the
+    /// same question of every registered tool.
+    #[tokio::test]
+    async fn a_workspace_read_runs_without_asking_whatever_its_name_begins_with() {
+        let p = policy("supervised", &[], None);
+        for tool in [
+            "file_read",
+            "glob",
+            "grep",
+            "image_info",
+            "list",
+            "read_workspace_state",
+            "memory_recall",
+        ] {
+            assert_eq!(
+                p.check(&request(tool, serde_json::json!({}))).await,
+                ToolPolicyDecision::Allow,
+                "`{tool}` reads the agent's own workspace"
+            );
+        }
+    }
+
+    /// A standing grant admits any arguments, which was a fair summary of a
+    /// tool's consequence while consequence was a property of the tool name.
+    /// It is not one for `composio_execute`, so the grant is re-checked against
+    /// the live call: a scope granted on a repository read must not admit an
+    /// outgoing email on the same handle.
+    #[tokio::test]
+    async fn a_standing_grant_on_a_composio_read_does_not_admit_a_send() {
+        let queue = ApprovalRequestQueue::default();
+        let grants = queue.grants();
+        let p = policy("supervised", &[], None)
+            .with_requests(queue)
+            .with_agent("ops");
+        grants.grant_standing(standing("ops", "composio_execute", far_future()));
+
+        assert_eq!(
+            p.check(&request(
+                "composio_execute",
+                serde_json::json!({ "tool": "GITHUB_LIST_PULL_REQUESTS" })
+            ))
+            .await,
+            ToolPolicyDecision::Allow,
+            "the read the operator granted keeps running"
+        );
+        assert!(
+            matches!(
+                p.check(&request(
+                    "composio_execute",
+                    serde_json::json!({ "tool": "GMAIL_SEND_EMAIL" })
+                ))
+                .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "a send on the same tool name parks despite the grant"
+        );
+    }
+
+    /// Issue #374 added the `deploy` arm. It still applies — to tools with no
+    /// declaration, which is now the only place the name heuristics run.
     #[test]
-    fn a_deploy_classifies_as_publish() {
-        assert_eq!(classify_group("deploy_site"), EffectGroup::Publish);
-        assert_eq!(classify_group("website_deploy"), EffectGroup::Publish);
-        // And the arms it sits beside are unmoved.
-        assert_eq!(classify_group("publish_post"), EffectGroup::Publish);
-        assert_eq!(classify_group("workspace_write"), EffectGroup::Other);
+    fn an_undeclared_deploy_still_classifies_as_publish() {
+        let args = serde_json::json!({});
+        assert_eq!(classify_group("deploy_site", &args), EffectGroup::Publish);
+        assert_eq!(
+            classify_group("website_deploy", &args),
+            EffectGroup::Publish
+        );
+        assert_eq!(classify_group("publish_post", &args), EffectGroup::Publish);
+        // …but it no longer decides grantability, so a deploy tool nobody has
+        // declared is refused a standing scope by the undeclared rule as well
+        // as by its group.
+        assert!(!grantable("deploy_site", &args));
+    }
+
+    /// `workspace_write` keeps its `Other` label on the card — there is no
+    /// consequence word to name — while being refused a standing scope. That
+    /// separation is the point of issue #444: the label and the permission are
+    /// different questions.
+    #[test]
+    fn workspace_write_is_labelled_other_and_is_still_not_grantable() {
+        let args = serde_json::json!({});
+        assert_eq!(classify_group("workspace_write", &args), EffectGroup::Other);
+        assert!(classify_group("workspace_write", &args).is_unclassified());
+        assert!(!grantable("workspace_write", &args));
+        assert!(is_external_effect("workspace_write", &args));
     }
 }

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -543,20 +543,24 @@ impl ApprovalPolicy {
     ///
     /// * the call **declares** an amount (`amount_usd` / `amount`) — the only
     ///   pre-flight signal there is for an x402 payment;
-    /// * it is a [metered read](is_metered_read) — `web_search` changes nothing
-    ///   but the backend charges per request;
-    /// * it projects onto [`EffectGroup::Spend`] — `media_generate_*`,
-    ///   `pay_*`/`transfer_*`, and anything else the group classifier already
-    ///   calls spend.
+    /// * it projects onto [`EffectGroup::Spend`] — `web_search`, whose backend
+    ///   charges per request, plus `media_generate_*`, `pay_*`/`transfer_*`,
+    ///   and anything else the group classifier already calls spend.
+    ///
+    /// A separate "is it a metered read" arm used to sit between those two.
+    /// It was subsumed the moment the declaration named a group and a reach
+    /// together: the only `Reach::Money` tool is `web_search`, and its group is
+    /// `Spend`, so the arm could only ever fire where the one below already
+    /// had. `web_search_is_still_a_priced_call` pins that, so a future
+    /// `Reach::Money` tool that is *not* `Spend` fails a test rather than
+    /// silently escaping the cap.
     ///
     /// Everything else — a read, a send, a publish, a workspace write — is
     /// **untouched at cap**. A spend cap caps spend; making a teammate unable to
     /// answer a question because it spent its budget this morning would be a
     /// different feature, and a worse one.
     fn is_priced_call(tool: &str, args: &serde_json::Value, declared_amount: Option<f64>) -> bool {
-        declared_amount.is_some()
-            || is_metered_read(tool, args)
-            || classify_group(tool, args) == EffectGroup::Spend
+        declared_amount.is_some() || classify_group(tool, args) == EffectGroup::Spend
     }
 
     /// The per-agent daily spend cap (issue #304): `Some(decision)` when this
@@ -836,17 +840,26 @@ impl ToolPolicy for ApprovalPolicy {
             return ToolPolicyDecision::Allow;
         }
 
-        let external = is_external_effect(tool, &request.arguments);
-        // A *metered read* (issue #238) is external — it reaches a third party
-        // and spends real money — but it changes nothing anywhere, so under
-        // `supervised` the consent already given at grant time is enough and
-        // the daily call cap is the boundary. Under `readonly` it is still
-        // denied: that tier's contract is that nothing is spent.
-        let metered_read = is_metered_read(tool, &request.arguments);
+        // One value, two questions. `readonly`'s contract is that nothing
+        // changes and nothing is spent, so it denies anything but `Nothing`.
+        // `supervised` parks only a consequence — which leaves the `Money`
+        // bucket (`web_search`, issue #238) allowed here and denied there,
+        // the split the old boolean could not express.
+        //
+        // Parking a metered read would also be *useless* rather than merely
+        // annoying: openhuman resolves a `RequireApproval` inline and never
+        // re-dispatches the call, so a parked search is a search that never
+        // happens, and an agent with no search invents citations. Consent for
+        // it happens once, at grant time — an explicit `search` grant a `*`
+        // cannot confer — and the per-company daily cap is the boundary. An
+        // operator who does want a per-call gate has
+        // `[policy].always_approve = ["web_search"]`, which wins over every
+        // tier including `full`.
+        let reach = crate::policy::consequence_of(tool, &request.arguments).reach;
         match self.mode {
             PolicyMode::Full => ToolPolicyDecision::Allow,
             PolicyMode::Supervised => {
-                if external && !metered_read {
+                if reach.parks_under_supervision() {
                     self.require_approval(
                         tool,
                         &request.arguments,
@@ -857,7 +870,7 @@ impl ToolPolicy for ApprovalPolicy {
                 }
             }
             PolicyMode::Readonly => {
-                if external {
+                if reach.denied_under_readonly() {
                     ToolPolicyDecision::deny(format!(
                         "'{tool}' mutates or reaches outside; this desk is read-only"
                     ))
@@ -867,41 +880,6 @@ impl ToolPolicy for ApprovalPolicy {
             }
         }
     }
-}
-
-/// Does this tool reach outside and spend money, while changing nothing?
-///
-/// A third bucket the original binary could not express, added for `web_search`
-/// (issue #238). The existing classifier conflates two questions —
-/// *does it change anything / reach a counterparty* and *does it cost money* —
-/// which is fine while every tool answers both the same way. `media_list_models`
-/// is free, so waving it through in every mode is safe.
-/// [`crate::harness::search`]'s `web_search` is not: the backend charges per
-/// request.
-///
-/// The two modes therefore want different answers, and this is what lets them
-/// have them:
-///
-/// * **`supervised`** — allowed. The issue's #188 sign-off is explicit that
-///   individual searches must not park: consent happens once, at grant time (an
-///   explicit `search` grant a `*` cannot confer), and the per-company daily
-///   cap is the boundary. Parking each call would also be *useless* here rather
-///   than merely annoying — openhuman resolves a `RequireApproval` inline and
-///   never re-dispatches the call (see the module docs), so a parked search is
-///   a search that never happens, and an agent with no search does the exact
-///   thing this feature exists to stop: it invents citations.
-/// * **`readonly`** — still denied, via the ordinary external-effect path.
-///   A read-only desk is one that spends nothing, and this spends. That is a
-///   deliberate divergence from the issue text, which would have made a paid
-///   call unstoppable in the one tier whose whole promise is that nothing
-///   moves.
-///
-/// An operator who *does* want a per-call gate has one: `[policy].always_approve
-/// = ["web_search"]` wins over every tier, including `full`.
-fn is_metered_read(tool_name: &str, args: &serde_json::Value) -> bool {
-    crate::policy::consequence_of(tool_name, args)
-        .reach
-        .is_metered()
 }
 
 /// Does this tool call mutate state or reach an external counterparty?
@@ -922,7 +900,7 @@ fn is_metered_read(tool_name: &str, args: &serde_json::Value) -> bool {
 fn is_external_effect(tool_name: &str, args: &serde_json::Value) -> bool {
     crate::policy::consequence_of(tool_name, args)
         .reach
-        .is_external()
+        .denied_under_readonly()
 }
 
 /// The top-level keys of a tool-argument object, for a mismatch diagnostic.
@@ -2685,6 +2663,33 @@ mod tests {
                 classify_group(tool, &args),
                 "the parked effect's group for `{tool}` is not the one the classifier gave"
             );
+        }
+    }
+
+    /// The arm `is_priced_call` dropped, pinned from the other side.
+    ///
+    /// Removing the metered-read arm was safe only because the one
+    /// `Reach::Money` tool is also `EffectGroup::Spend`. If a future tool is
+    /// billed without being classified as spend, it would slip the daily cap
+    /// silently — so this fails instead.
+    #[test]
+    fn web_search_is_still_a_priced_call() {
+        let args = serde_json::json!({});
+        assert!(ApprovalPolicy::is_priced_call(
+            crate::harness::search::WEB_SEARCH_TOOL,
+            &args,
+            None
+        ));
+        for tool in crate::policy::consequence::declared_tools() {
+            let verdict = crate::policy::consequence_of(tool, &args);
+            if verdict.reach.costs_money() {
+                assert_eq!(
+                    verdict.group,
+                    EffectGroup::Spend,
+                    "`{tool}` is billed but is not classified as spend, so the daily \
+                     budget arm would never see it"
+                );
+            }
         }
     }
 

--- a/src/harness/workspace_turn_test.rs
+++ b/src/harness/workspace_turn_test.rs
@@ -199,15 +199,19 @@ fn note(id: &str, name: &str, parent: &str) -> WorkspaceNode {
 
 /// A one-agent company, with `grants` controlling the workspace surface.
 fn manifest(grants: &str) -> CompanyManifest {
+    // `full` so an ordinary turn is not parked; the write tool's own
+    // compare-and-swap token is what guards the write in this mode.
+    manifest_in_mode(grants, "full")
+}
+
+fn manifest_in_mode(grants: &str, mode: &str) -> CompanyManifest {
     toml::from_str(&format!(
         r#"
 [company]
 name = "Acme"
 
 [policy]
-# `full` so an ordinary turn is not parked; the write tool's own
-# compare-and-swap token is what guards the write in this mode.
-mode = "full"
+mode = "{mode}"
 
 [tools]
 allow = [{grants}]
@@ -597,5 +601,182 @@ async fn an_edit_between_turns_changes_what_the_next_turn_reads() {
     assert!(
         after,
         "the second turn did not pick up the operator's edit — the tools are caching: {results:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The approval boundary, driven by a model (issues #443, #444)
+// ---------------------------------------------------------------------------
+
+/// Re-`ensure` the pool against the same deps under a different policy mode.
+///
+/// The fixture above is `full` on purpose — it exists to prove the workspace
+/// tools work, and parking every call would get in the way. The gate is only
+/// observable under `supervised`, which is also the **default** mode a company
+/// gets, so it is the mode these last tests care about.
+async fn supervised(deps: &HarnessDeps, grants: &str) -> (HarnessPool, CompanyRecord) {
+    let mut record = CompanyRecord {
+        id: CompanyId::new("acme"),
+        manifest: manifest_in_mode(grants, "supervised"),
+        ledger: Vec::new(),
+        lifecycle: "running".to_string(),
+        overlay_agents: Vec::new(),
+        overlay_desk_members: Vec::new(),
+        overlay_desk_order: Vec::new(),
+        overlay_desks: Vec::new(),
+        overlay_workflows: Vec::new(),
+        overlay_budgets: Vec::new(),
+        template_provenance: None,
+    };
+    record.manifest.tools.allow = manifest(grants).tools.allow;
+    let pool = HarnessPool::new();
+    pool.ensure(&record, deps).await.expect("pool ensures");
+    (pool, record)
+}
+
+/// End-to-end, through a model: a read of the company workspace runs without
+/// asking, and a write of it parks — **and the parked card does not offer a
+/// standing scope**.
+///
+/// The last clause is issue #444's headline, and nothing shorter than this can
+/// show it. The two halves of the gate live in different modules and disagreed
+/// about this one tool: `is_external_effect` refused to exempt `workspace_write`
+/// because it overwrites guidance the operator wrote, while the standing-grant
+/// rule read its `Other` group — a group it lands in only because the name
+/// carries no consequence word — and offered it for a week. This drives one real
+/// turn and asks both halves about the same call.
+#[tokio::test]
+async fn a_supervised_turn_reads_the_workspace_freely_and_parks_a_write_with_no_scope_offered() {
+    let dir = tempfile::tempdir().unwrap();
+    let (base, script) = spawn_script(vec![
+        Turn::Call {
+            tool: "workspace_read",
+            args: json!({ "path": "Standards/Engineering standards.md" }),
+        },
+        Turn::WriteWithObservedRev {
+            path: "Standards/Engineering standards.md",
+            content: "# Engineering\nRewritten.",
+            delta: 0,
+        },
+        Turn::Say("done"),
+    ])
+    .await;
+    let (_pool, deps, _record, _store) = harness(base, "\"workspace\"", dir.path()).await;
+    let (pool, record) = supervised(&deps, "\"workspace\"").await;
+
+    let queued_before = deps.approval_requests.queued();
+    pool.run(&record.id, "ceo", "tidy the standards", &deps, None)
+        .await
+        .expect("the turn runs");
+    let parked = deps.approval_requests.take_from(queued_before);
+
+    assert_eq!(
+        parked.len(),
+        1,
+        "the read must not park and the write must: {:?}",
+        parked.iter().map(|r| r.tool.clone()).collect::<Vec<_>>()
+    );
+    assert_eq!(parked[0].tool, "workspace_write");
+    // Not vacuous: the read that did not park was really made, and really
+    // returned — so "one parked request" is one write, not one read the belt
+    // silently withheld.
+    assert!(
+        tool_results(&script).len() >= 2,
+        "both the read and the (blocked) write must have fed a result back"
+    );
+    assert!(
+        !parked[0].effect.may_be_granted_standing(),
+        "a card for overwriting operator-owned guidance must not offer a standing scope"
+    );
+}
+
+/// The other side of the same boundary, so the feature is not proved dead:
+/// a write confined to the agent's **own** workspace parks the same way and
+/// *does* offer the scope.
+///
+/// Without this the test above would be satisfied by a gate that simply never
+/// offers a standing grant to anybody.
+#[tokio::test]
+async fn a_parked_write_to_the_agents_own_workspace_does_offer_a_standing_scope() {
+    let dir = tempfile::tempdir().unwrap();
+    let (base, _script) = spawn_script(vec![
+        Turn::Call {
+            tool: "file_write",
+            args: json!({ "path": "notes.md", "content": "draft" }),
+        },
+        Turn::Say("done"),
+    ])
+    .await;
+    let (_pool, deps, _record, _store) =
+        harness(base, "\"files\", \"workspace\"", dir.path()).await;
+    let (pool, record) = supervised(&deps, "\"files\", \"workspace\"").await;
+
+    let queued_before = deps.approval_requests.queued();
+    pool.run(&record.id, "ceo", "jot a note", &deps, None)
+        .await
+        .expect("the turn runs");
+    let parked = deps.approval_requests.take_from(queued_before);
+
+    assert_eq!(parked.len(), 1, "the sandboxed write parks");
+    assert_eq!(parked[0].tool, "file_write");
+    assert!(
+        parked[0].effect.may_be_granted_standing(),
+        "a write confined to the agent's own sandbox is exactly what a standing \
+         grant is for; refusing it would leave the feature with nothing to apply to"
+    );
+}
+
+/// Issue #443, through the turn loop: the reads that used to park.
+///
+/// `file_read` and `grep` are pure reads of the agent's own workspace, and both
+/// parked under the DEFAULT mode — not by anyone's decision, but because the
+/// read-only rule matched a name *prefix* and neither begins with a read-only
+/// word. Nobody had reported them. They were found by asking the same question
+/// of every registered tool, which is the mechanism this lane adds.
+#[tokio::test]
+async fn a_supervised_turn_reads_its_own_workspace_without_asking() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("seed.md"), "hello").ok();
+    let (base, script) = spawn_script(vec![
+        Turn::Call {
+            tool: "grep",
+            args: json!({ "pattern": "hello", "path": "." }),
+        },
+        Turn::Call {
+            tool: "file_read",
+            args: json!({ "path": "seed.md" }),
+        },
+        Turn::Say("done"),
+    ])
+    .await;
+    let (_pool, deps, _record, _store) = harness(base, "\"files\"", dir.path()).await;
+    let (pool, record) = supervised(&deps, "\"files\"").await;
+
+    let queued_before = deps.approval_requests.queued();
+    pool.run(&record.id, "ceo", "what do we have?", &deps, None)
+        .await
+        .expect("the turn runs");
+    let parked = deps.approval_requests.take_from(queued_before);
+
+    assert!(
+        parked.is_empty(),
+        "reading the agent's own workspace must not interrupt an operator: {:?}",
+        parked.iter().map(|r| r.tool.clone()).collect::<Vec<_>>()
+    );
+    // Not vacuous: both reads were genuinely offered to the model and both
+    // came back with a result, so the calls reached the gate and returned.
+    let offered = advertised_tools(&script);
+    for tool in ["grep", "file_read"] {
+        assert!(
+            offered.contains(&tool.to_string()),
+            "`{tool}` was never on the belt, so this proves nothing: {offered:?}"
+        );
+    }
+    // `tool_results` reads every request body the stub saw, and each body
+    // repeats the conversation so far — so this counts cumulatively rather
+    // than once per call. Two distinct calls is the floor.
+    assert!(
+        tool_results(&script).len() >= 2,
+        "both reads must have run and fed a result back"
     );
 }

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -1,0 +1,717 @@
+//! What a tool can **reach** — the one declaration both approval questions read.
+//!
+//! ## Two questions, one declaration (issues #441, #443, #444)
+//!
+//! The approval gate asks two different things about every tool call:
+//!
+//! 1. **May this run unattended?** — answered by [`Reach`]. `readonly` denies
+//!    anything that mutates or reaches outside; `supervised` parks it.
+//! 2. **May an operator hand this over for a stretch of time?** — answered by
+//!    [`Standing`], the standing-grant boundary.
+//!
+//! Until now both were read off one value: the [`EffectGroup`] the tool name
+//! was pattern-matched into. That made the residual `Other` bucket mean two
+//! unrelated things at once — "no particular consequence to name on the card"
+//! *and* "safe to grant for a week" — so the three broadest capabilities in the
+//! system (`shell`, `http_request`, `workspace_write`) were grantable because
+//! their names contain no consequence word, while every Composio action was
+//! ungrantable because they all arrive under one tool name that reads as a send.
+//!
+//! They are separate questions and they now have separate answers, derived from
+//! **one** declaration per tool so they cannot drift apart again.
+//! `is_external_effect` and `classify_group` in
+//! [`crate::harness::policy`] are both thin readers of [`consequence_of`], and
+//! [`Effect::may_be_granted_standing`](crate::ports::types::Effect::may_be_granted_standing)
+//! — the mint-side rule, in the default build where the harness does not compile
+//! — is a third.
+//!
+//! ## Why the table names tools rather than matching their names
+//!
+//! A name's vocabulary is not a property of what a tool can do. `shell` carries
+//! no consequence word and runs arbitrary code; `file_read` carries no
+//! *read-only* prefix and reads a file. Every previous fix here added one more
+//! carve-out to a hand-maintained list, and the failure mode when somebody
+//! forgot was silent — the tool simply started asking for permission, and the
+//! person who noticed was an operator wondering why a read needed approving.
+//!
+//! So the declaration is explicit and the coverage is enforced:
+//! `every_registered_tool_is_declared` in [`crate::harness`] builds every belt
+//! the crate can wire and fails if a live tool is missing from [`DECLARED`].
+//! Adding a tool without classifying it breaks a test rather than an operator's
+//! afternoon.
+//!
+//! ## Unknown means cautious, in both directions
+//!
+//! An undeclared tool keeps the old name heuristics for [`Reach`] — dropping
+//! them would park a `read_*` tool from a build configuration nobody tested —
+//! but it is **never** [`Standing::Grantable`]. A tool nobody has thought about
+//! must not inherit a week-long capability by omission. Likewise an unrecognised
+//! Composio action slug is a **send**, not a read.
+
+use crate::ports::types::EffectGroup;
+
+/// Does a call mutate state or reach outside the company?
+///
+/// The two policy tiers want different cuts of this, which is why it is three
+/// values and not a bool:
+///
+/// * `readonly` denies everything that is not [`Internal`](Self::Internal) —
+///   that tier's contract is that nothing moves and nothing is spent.
+/// * `supervised` parks only [`External`](Self::External).
+///   [`Metered`](Self::Metered) is the third bucket `web_search` needed (issue
+///   #238): it reaches a third party and costs money but changes nothing, and
+///   parking it would be worse than useless — openhuman resolves a
+///   `RequireApproval` inline, so a parked search is a search that never
+///   happens.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Reach {
+    /// Touches only this company's own runtime state, or reads inside the
+    /// agent's own sandboxed workspace. Never parks, never denied.
+    Internal,
+    /// Reaches outside and is billed, but changes nothing anywhere. Allowed
+    /// under `supervised`, denied under `readonly`.
+    Metered,
+    /// Mutates state, reaches a counterparty, executes arbitrary code, reaches
+    /// an arbitrary address, or overwrites operator-owned guidance.
+    External,
+}
+
+impl Reach {
+    /// Does this mutate or reach outside — the `readonly` deny condition.
+    pub fn is_external(self) -> bool {
+        !matches!(self, Self::Internal)
+    }
+
+    /// Does this park under `supervised`?
+    pub fn parks_under_supervision(self) -> bool {
+        matches!(self, Self::External)
+    }
+
+    /// Does this cost money to make, regardless of what it changes?
+    pub fn is_metered(self) -> bool {
+        matches!(self, Self::Metered)
+    }
+}
+
+/// May an operator open this tool up for a stretch of time, or is every call
+/// its own decision (issue #444)?
+///
+/// Decided by what the tool can **reach**, never by what it is called. A tool
+/// that can execute arbitrary code, reach an arbitrary address, or overwrite
+/// operator-owned state is [`PerCall`](Self::PerCall) however innocuous its
+/// name; a read scoped to one connected account is
+/// [`Grantable`](Self::Grantable) however alarming the tool carrying it sounds.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Standing {
+    /// An operator may grant this to a teammate until a deadline.
+    Grantable,
+    /// Every call is its own decision.
+    PerCall,
+}
+
+impl Standing {
+    /// May this be granted standing?
+    pub fn is_grantable(self) -> bool {
+        matches!(self, Self::Grantable)
+    }
+}
+
+/// Everything the approval gate needs to know about one tool call.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Consequence {
+    /// The consequence class the operator's approval card names.
+    pub group: EffectGroup,
+    /// What the call mutates or reaches.
+    pub reach: Reach,
+    /// Whether it can be granted standing.
+    pub standing: Standing,
+}
+
+/// One tool's declaration.
+struct Declared {
+    tool: &'static str,
+    group: EffectGroup,
+    reach: Reach,
+    standing: Standing,
+}
+
+/// The Composio action-running tool. Its consequence is a property of the
+/// *action* in its arguments, not of this name — see
+/// [`composio_execute_consequence`].
+pub const COMPOSIO_EXECUTE: &str = "composio_execute";
+
+/// The argument key `composio_execute` carries the action slug under, on the
+/// wire and in both this crate's tool and openhuman's.
+const COMPOSIO_ACTION_KEY: &str = "tool";
+
+/// Every tool this crate can wire onto an agent, and what it can reach.
+///
+/// Ordered by family for reading, not by any semantic. The **coverage test**
+/// (`every_registered_tool_is_declared`) is what keeps it complete; the
+/// **constant test** below is what keeps the literals here tied to the
+/// `*_TOOL` constants the tools themselves return.
+const DECLARED: &[Declared] = &[
+    // ---- Orchestration: in-cycle work this company hands to itself ---------
+    // These enqueue a task card or a hand-off the harness brain drains in the
+    // same turn. Nothing leaves the company (issue #53). None is grantable:
+    // an internal tool never parks, so its standing answer is unobservable
+    // *unless* an operator puts it in `always_approve` — at which point
+    // `PerCall` is the answer that respects what they asked for.
+    d("query_company", EffectGroup::Other, Reach::Internal),
+    d("spawn_task", EffectGroup::Other, Reach::Internal),
+    d("delegate_to_desk", EffectGroup::Other, Reach::Internal),
+    d("add_agent", EffectGroup::Other, Reach::Internal),
+    d("create_workflow", EffectGroup::Other, Reach::Internal),
+    d("assign_task", EffectGroup::Other, Reach::Internal),
+    d("review_task", EffectGroup::Other, Reach::Internal),
+    // Running a saved workflow performs whatever that workflow performs, which
+    // this layer cannot see. It parks, and it stays a per-call decision.
+    d("run_workflow", EffectGroup::Other, Reach::External),
+    // ---- The agent's own sandboxed workspace: reads ------------------------
+    // All four are pure reads inside the workspace the agent is pinned to.
+    // `file_read`, `glob`, `grep` and `image_info` PARKED before this table
+    // existed — not by anyone's decision, but because the read-only-prefix
+    // heuristic keys on the *start* of the name and none of them begins with
+    // one. `list`, `read_workspace_state` and `memory_recall` happened to.
+    d("file_read", EffectGroup::Other, Reach::Internal),
+    d("glob", EffectGroup::Other, Reach::Internal),
+    d("grep", EffectGroup::Other, Reach::Internal),
+    d("list", EffectGroup::Other, Reach::Internal),
+    d("read_workspace_state", EffectGroup::Other, Reach::Internal),
+    d("memory_recall", EffectGroup::Other, Reach::Internal),
+    d("image_info", EffectGroup::Other, Reach::Internal),
+    // ---- The agent's own sandboxed workspace: writes -----------------------
+    // These mutate, so `readonly` must still deny them and `supervised` must
+    // still park them. But what they mutate is the agent's own scratch space
+    // and this company's own memory — no counterparty, no arbitrary address,
+    // nothing an operator authored. They are the low-consequence tools the
+    // standing grant exists for: without them the feature has almost nothing
+    // left to apply to.
+    d_grantable("file_write", EffectGroup::Other, Reach::External),
+    d_grantable("edit", EffectGroup::Other, Reach::External),
+    d_grantable("apply_patch", EffectGroup::Other, Reach::External),
+    d_grantable("csv_export", EffectGroup::Other, Reach::External),
+    d_grantable("memory_store", EffectGroup::Other, Reach::External),
+    // `git_operations` is deliberately NOT grantable alongside its filesystem
+    // siblings: it can push to a configured remote, so it reaches an address
+    // this layer does not get to see.
+    d("git_operations", EffectGroup::Other, Reach::External),
+    // ---- Arbitrary code, arbitrary addresses -------------------------------
+    // The three shapes issue #444 names, plus the two web tools that share
+    // `http_request`'s shape. A standing grant on any of these is a standing
+    // grant on "anything the sandbox permits", which is not a sentence an
+    // operator can consent to.
+    d("shell", EffectGroup::Other, Reach::External),
+    d("http_request", EffectGroup::Other, Reach::External),
+    d("curl", EffectGroup::Other, Reach::External),
+    d("web_fetch", EffectGroup::Other, Reach::External),
+    // ---- The company workspace: operator-owned guidance --------------------
+    // Reads are free (issue #237). `workspace_write` overwrites guidance the
+    // operator wrote, which is why `is_external_effect` has always refused to
+    // exempt it — and why it is now also refused a standing grant. That
+    // contradiction (park every time / grant for a week) is issue #444's
+    // headline, resolved in the direction the parking side already argued.
+    d("workspace_list", EffectGroup::Other, Reach::Internal),
+    d("workspace_read", EffectGroup::Other, Reach::Internal),
+    d("workspace_write", EffectGroup::Other, Reach::External),
+    // ---- Publishing --------------------------------------------------------
+    // Externally visible and not reversible by the company alone.
+    d("publish_artifact", EffectGroup::Publish, Reach::External),
+    // ---- Priced backend calls ----------------------------------------------
+    // `web_search` is billed per request but changes nothing (issue #238).
+    // Media generation moves real money on submit (issue #109); listing the
+    // catalogue is a free GET.
+    d("web_search", EffectGroup::Spend, Reach::Metered),
+    d("media_generate_image", EffectGroup::Spend, Reach::External),
+    d("media_generate_video", EffectGroup::Spend, Reach::External),
+    d("media_list_models", EffectGroup::Other, Reach::Internal),
+    // ---- MCP ---------------------------------------------------------------
+    // Listing servers and their tools reads local registration state with
+    // credentials redacted and reaches nothing (issue #443). The agent persona
+    // *instructs* every agent to call `mcp_list_servers` rather than answer a
+    // capability question from memory, so parking it made the guidance that
+    // exists to prevent stale answers cost an operator approval to follow.
+    //
+    // Calling *through* a server stays external and per-call: it can perform
+    // any effect the third-party server advertises.
+    d("mcp_list_servers", EffectGroup::Other, Reach::Internal),
+    d("mcp_list_tools", EffectGroup::Other, Reach::Internal),
+    d(
+        "mcp_registry_list_tools",
+        EffectGroup::Other,
+        Reach::Internal,
+    ),
+    d("mcp_call_tool", EffectGroup::Other, Reach::External),
+    d(
+        "mcp_registry_tool_call",
+        EffectGroup::Other,
+        Reach::External,
+    ),
+    // ---- Composio ----------------------------------------------------------
+    // The three list tools are read-only GETs against the tenant's own
+    // Composio surface (issue #110). Authorizing begins an OAuth handoff that
+    // establishes an account identity for the company.
+    //
+    // `composio_execute` is NOT here: one name carries every action, so its
+    // consequence is read from the action slug in its arguments — see
+    // `composio_execute_consequence`.
+    d(
+        "composio_list_toolkits",
+        EffectGroup::Other,
+        Reach::Internal,
+    ),
+    d(
+        "composio_list_connections",
+        EffectGroup::Other,
+        Reach::Internal,
+    ),
+    d("composio_list_tools", EffectGroup::Other, Reach::Internal),
+    d("composio_authorize", EffectGroup::Identity, Reach::External),
+];
+
+/// A per-call declaration — the default. `const fn` so [`DECLARED`] stays a
+/// `const` the compiler can lay out statically.
+const fn d(tool: &'static str, group: EffectGroup, reach: Reach) -> Declared {
+    Declared {
+        tool,
+        group,
+        reach,
+        standing: Standing::PerCall,
+    }
+}
+
+/// A declaration an operator may grant standing on.
+const fn d_grantable(tool: &'static str, group: EffectGroup, reach: Reach) -> Declared {
+    Declared {
+        tool,
+        group,
+        reach,
+        standing: Standing::Grantable,
+    }
+}
+
+/// Every tool name [`DECLARED`] classifies, for the coverage test.
+pub fn declared_tools() -> impl Iterator<Item = &'static str> {
+    DECLARED
+        .iter()
+        .map(|d| d.tool)
+        .chain(std::iter::once(COMPOSIO_EXECUTE))
+}
+
+/// What this tool call can reach, and what an operator may do about it.
+///
+/// `args` are consulted, not decoration: `composio_execute` carries every
+/// Composio action under one name, so classifying it from the name alone
+/// collapsed a repository read and an outgoing email into the same verdict —
+/// and the cautious answer had to win for both (issue #441).
+pub fn consequence_of(tool: &str, args: &serde_json::Value) -> Consequence {
+    let name = tool.to_ascii_lowercase();
+    if name == COMPOSIO_EXECUTE {
+        return composio_execute_consequence(args);
+    }
+    match DECLARED.iter().find(|d| d.tool == name) {
+        Some(found) => Consequence {
+            group: found.group,
+            reach: found.reach,
+            standing: found.standing,
+        },
+        None => undeclared(&name),
+    }
+}
+
+/// The consequence of running one Composio action (issue #441).
+///
+/// ## Why the action and not the tool name
+///
+/// Every Composio action — listing a repository's pull requests, searching a
+/// mailbox, sending an email, opening a PR — arrives as one tool,
+/// `composio_execute`, with the action slug in the arguments. Classifying the
+/// *name* meant the whole surface inherited the send verdict the sends deserve,
+/// so no Composio read could ever hold a standing grant and an operator paid an
+/// approval for every page of every list.
+///
+/// ## Where the read/send answer comes from
+///
+/// The provider's own curated catalogue, vendored with openhuman: ~660
+/// hand-classified actions across ~30 toolkits, each tagged `Read` / `Write` /
+/// `Admin`, already used upstream to enforce a read-only sandbox. It is a
+/// pure, synchronous, in-process table — no network on the approval path — and
+/// it is the same source the provider surfaces the actions from, so it does not
+/// drift the way a list maintained here would the moment a toolkit gains an
+/// action.
+///
+/// ## Anything the catalogue does not name is a send
+///
+/// Deliberately **not** upstream's `classify_unknown`, whose fallback for an
+/// unrecognised slug is `Read`. That is the convenient verdict, and this is the
+/// place where the cautious one has to win: an action nobody has classified
+/// might do anything, so it parks and it cannot be granted standing. Same for a
+/// slug whose toolkit has no catalogue, a missing or non-string `tool`
+/// argument, and — in a build without the harness compiled in — every slug.
+fn composio_execute_consequence(args: &serde_json::Value) -> Consequence {
+    let send = Consequence {
+        group: EffectGroup::Send,
+        reach: Reach::External,
+        standing: Standing::PerCall,
+    };
+    let Some(slug) = args.get(COMPOSIO_ACTION_KEY).and_then(|v| v.as_str()) else {
+        return send;
+    };
+    if composio_action_is_read(slug) {
+        // A read still reaches a third-party account, so `readonly` denies it
+        // and `supervised` parks it the first time. What changes is that the
+        // operator now has something to say other than yes-again: the card
+        // offers a standing scope, and the reads stop asking for its duration.
+        Consequence {
+            group: EffectGroup::Other,
+            reach: Reach::External,
+            standing: Standing::Grantable,
+        }
+    } else {
+        send
+    }
+}
+
+/// Is this Composio action slug a read, according to the provider's own
+/// curated catalogue? Unknown is **not** a read.
+#[cfg(feature = "openhuman")]
+fn composio_action_is_read(slug: &str) -> bool {
+    use openhuman_core::openhuman::memory_sync::composio::providers::{
+        ToolScope, catalog_for_toolkit, find_curated, toolkit_from_slug,
+    };
+    let Some(toolkit) = toolkit_from_slug(slug) else {
+        return false;
+    };
+    let Some(catalog) = catalog_for_toolkit(&toolkit) else {
+        return false;
+    };
+    matches!(
+        find_curated(catalog, slug).map(|entry| entry.scope),
+        Some(ToolScope::Read)
+    )
+}
+
+/// Without the harness feature the curated catalogue is not linked in, and no
+/// `composio_execute` call can be made either — only replayed from a journal
+/// line an openhuman build wrote. Cautious is the only honest answer.
+#[cfg(not(feature = "openhuman"))]
+fn composio_action_is_read(_slug: &str) -> bool {
+    false
+}
+
+/// A tool with no declaration.
+///
+/// **Never grantable** — that is the whole of issue #444's second half. `Other`
+/// used to be the bucket a tool fell into by omission *and* the bucket that
+/// conferred a week-long capability, so adding a tool and forgetting to think
+/// about it handed it the longest permission available.
+///
+/// The name heuristics survive here, and only here, for [`Reach`]. Dropping
+/// them would park every read in a build configuration whose tools nobody
+/// remembered to declare — trading a silent over-grant for a silent
+/// over-prompt. The coverage test is what stops a *registered* tool reaching
+/// this path at all.
+fn undeclared(name: &str) -> Consequence {
+    const READ_ONLY_PREFIXES: &[&str] = &[
+        "read",
+        "list",
+        "get",
+        "search",
+        "recall",
+        "query",
+        "peek",
+        "inspect",
+        "view",
+        "memory_recall",
+        "memory_search",
+    ];
+    let reads = READ_ONLY_PREFIXES.iter().any(|p| name.starts_with(p));
+    Consequence {
+        group: undeclared_group(name),
+        reach: if reads {
+            Reach::Internal
+        } else {
+            Reach::External
+        },
+        standing: Standing::PerCall,
+    }
+}
+
+/// The consequence-word heuristics, kept for undeclared tools so an approval
+/// card for one is still labelled as well as it was before.
+fn undeclared_group(name: &str) -> EffectGroup {
+    if name.contains("pay") || name.contains("transfer") || name.starts_with("spend") {
+        EffectGroup::Spend
+    } else if name.contains("email") || name.contains("send") || name.contains("message") {
+        EffectGroup::Send
+    } else if name.contains("sign") || name.contains("file") || name.contains("filing") {
+        EffectGroup::Sign
+    } else if name.contains("publish") || name.contains("post") || name.contains("deploy") {
+        EffectGroup::Publish
+    } else if name.contains("hire") || name.contains("contract") {
+        EffectGroup::Hire
+    } else if name.contains("identity") || name.contains("handle") {
+        EffectGroup::Identity
+    } else {
+        EffectGroup::Other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn c(tool: &str) -> Consequence {
+        consequence_of(tool, &json!({}))
+    }
+
+    #[test]
+    fn the_table_names_each_tool_once() {
+        let mut seen: Vec<&str> = DECLARED.iter().map(|d| d.tool).collect();
+        let before = seen.len();
+        seen.sort_unstable();
+        seen.dedup();
+        assert_eq!(before, seen.len(), "a tool is declared twice: {seen:?}");
+        for entry in DECLARED {
+            assert_eq!(
+                entry.tool,
+                entry.tool.to_ascii_lowercase(),
+                "declarations are matched lowercased, so `{}` could never be found",
+                entry.tool
+            );
+            assert_ne!(
+                entry.tool, COMPOSIO_EXECUTE,
+                "`composio_execute` is classified from its arguments, not the table"
+            );
+        }
+    }
+
+    /// Issue #444's headline: the three broadest capabilities in the system
+    /// were grantable for up to a week because their names carry no
+    /// consequence word. They are named tools now, and named tools are
+    /// classified by what they reach.
+    #[test]
+    fn arbitrary_code_addresses_and_operator_guidance_are_never_grantable() {
+        for tool in [
+            "shell",
+            "http_request",
+            "curl",
+            "web_fetch",
+            "workspace_write",
+            "git_operations",
+            "run_workflow",
+            "mcp_call_tool",
+            "mcp_registry_tool_call",
+        ] {
+            assert_eq!(
+                c(tool).standing,
+                Standing::PerCall,
+                "`{tool}` can reach further than a standing grant can honestly describe"
+            );
+        }
+    }
+
+    /// The other half of #444: a tool nobody has classified must not inherit
+    /// the longest permission available just by landing in the residual bucket.
+    #[test]
+    fn an_undeclared_tool_is_never_grantable() {
+        assert_eq!(c("some_tool_nobody_declared").standing, Standing::PerCall);
+        // Including one that reads — not grantable is about standing, not about
+        // whether it parks.
+        let read = c("list_something_undeclared");
+        assert_eq!(read.reach, Reach::Internal);
+        assert_eq!(read.standing, Standing::PerCall);
+    }
+
+    /// Issue #441: the consequence of a Composio call is a property of the
+    /// action, not of the one tool name every action arrives under.
+    #[test]
+    fn a_composio_read_is_grantable_and_a_send_is_not() {
+        let read = consequence_of(
+            COMPOSIO_EXECUTE,
+            &json!({ "tool": "GITHUB_LIST_PULL_REQUESTS" }),
+        );
+        assert_eq!(read.group, EffectGroup::Other);
+        assert_eq!(read.standing, Standing::Grantable);
+        // …and it still parks the first time, because it does reach GitHub.
+        assert_eq!(read.reach, Reach::External);
+
+        let send = consequence_of(COMPOSIO_EXECUTE, &json!({ "tool": "GMAIL_SEND_EMAIL" }));
+        assert_eq!(send.group, EffectGroup::Send);
+        assert_eq!(send.standing, Standing::PerCall);
+        assert_eq!(send.reach, Reach::External);
+    }
+
+    /// The cautious direction, four ways. An action the catalogue does not
+    /// name, a toolkit it has never heard of, a missing slug and a slug of the
+    /// wrong type all read as sends.
+    #[test]
+    fn an_unrecognised_composio_action_is_a_send() {
+        for args in [
+            json!({ "tool": "GITHUB_INVENT_A_NEW_VERB" }),
+            json!({ "tool": "NOTAREALTOOLKIT_LIST_THINGS" }),
+            json!({ "tool": "" }),
+            json!({ "tool": 7 }),
+            json!({ "arguments": { "owner": "acme" } }),
+            json!({}),
+        ] {
+            let verdict = consequence_of(COMPOSIO_EXECUTE, &args);
+            assert_eq!(
+                verdict.group,
+                EffectGroup::Send,
+                "an unclassifiable action must read as a send: {args}"
+            );
+            assert_eq!(verdict.standing, Standing::PerCall, "{args}");
+        }
+    }
+
+    /// Deliberately pinned: upstream's own `classify_unknown` would call
+    /// `GITHUB_INVENT_A_NEW_VERB` a read (its fallback arm returns `Read` when
+    /// no write verb matches). We do not use it, and this is the test that says
+    /// so — if somebody swaps the lookup for the heuristic to "cover more
+    /// slugs", the unknown-is-a-send guarantee goes with it.
+    #[test]
+    #[cfg(feature = "openhuman")]
+    fn we_do_not_fall_back_to_the_upstream_read_default() {
+        use openhuman_core::openhuman::memory_sync::composio::providers::{
+            ToolScope, classify_unknown,
+        };
+        assert_eq!(
+            classify_unknown("GITHUB_INVENT_A_NEW_VERB"),
+            ToolScope::Read,
+            "upstream's fallback still defaults to read; if this changes the \
+             comment above is stale, not the behaviour"
+        );
+        assert!(!composio_action_is_read("GITHUB_INVENT_A_NEW_VERB"));
+    }
+
+    /// Issue #443: the agent persona instructs every agent to call these rather
+    /// than answer a capability question from memory. They read local
+    /// registration state and reach nothing.
+    #[test]
+    fn listing_mcp_servers_and_tools_never_parks_but_calling_through_one_does() {
+        for tool in [
+            "mcp_list_servers",
+            "mcp_list_tools",
+            "mcp_registry_list_tools",
+        ] {
+            assert_eq!(c(tool).reach, Reach::Internal, "`{tool}` reads local state");
+        }
+        for tool in ["mcp_call_tool", "mcp_registry_tool_call"] {
+            assert!(
+                c(tool).reach.parks_under_supervision(),
+                "`{tool}` can perform any effect the remote server advertises"
+            );
+        }
+    }
+
+    /// The sibling defects the same sweep turned up: four pure reads of the
+    /// agent's own workspace that parked because the read-only-prefix rule
+    /// keys on the *start* of a name and none of them begins with one.
+    #[test]
+    fn a_workspace_read_never_parks_whatever_its_name_begins_with() {
+        for tool in [
+            "file_read",
+            "glob",
+            "grep",
+            "image_info",
+            "list",
+            "read_workspace_state",
+            "memory_recall",
+            "workspace_list",
+            "workspace_read",
+            "media_list_models",
+            "composio_list_toolkits",
+            "composio_list_connections",
+            "composio_list_tools",
+        ] {
+            assert_eq!(c(tool).reach, Reach::Internal, "`{tool}` is a read");
+        }
+    }
+
+    /// The feature keeps its point: the tools an agent uses to actually do work
+    /// in its own sandbox stay grantable, so an operator handing over a stretch
+    /// of autonomy is still handing over something useful.
+    #[test]
+    fn the_agents_own_workspace_writes_stay_grantable() {
+        for tool in [
+            "file_write",
+            "edit",
+            "apply_patch",
+            "csv_export",
+            "memory_store",
+        ] {
+            let verdict = c(tool);
+            assert_eq!(verdict.standing, Standing::Grantable, "`{tool}`");
+            // They mutate, so `readonly` must still deny and `supervised` must
+            // still park the first call.
+            assert!(verdict.reach.parks_under_supervision(), "`{tool}`");
+        }
+    }
+
+    #[test]
+    fn a_metered_read_is_allowed_under_supervision_and_denied_under_readonly() {
+        let search = c("web_search");
+        assert_eq!(search.reach, Reach::Metered);
+        assert!(!search.reach.parks_under_supervision());
+        assert!(search.reach.is_external());
+        assert!(search.reach.is_metered());
+        assert_eq!(search.group, EffectGroup::Spend);
+        assert_eq!(search.standing, Standing::PerCall);
+    }
+
+    #[test]
+    fn declared_tools_covers_the_table_and_the_argument_classified_tool() {
+        let all: Vec<&str> = declared_tools().collect();
+        assert!(all.contains(&COMPOSIO_EXECUTE));
+        assert!(all.contains(&"shell"));
+        assert_eq!(all.len(), DECLARED.len() + 1);
+    }
+
+    /// The declaration is matched case-insensitively, the way every other arm
+    /// of the gate reads a tool name.
+    #[test]
+    fn lookup_ignores_case() {
+        assert_eq!(c("SHELL").standing, Standing::PerCall);
+        assert_eq!(c("Workspace_Read").reach, Reach::Internal);
+        assert_eq!(
+            consequence_of(
+                "COMPOSIO_EXECUTE",
+                &json!({ "tool": "GITHUB_LIST_BRANCHES" })
+            )
+            .standing,
+            Standing::Grantable
+        );
+    }
+
+    /// The literals above and the constants the tools themselves return are two
+    /// copies of the same string. This is the test that keeps them one.
+    #[test]
+    #[cfg(feature = "openhuman")]
+    fn the_declared_names_are_the_names_the_tools_return() {
+        use crate::harness::{orchestrator, publish, search, workspace_tools};
+        for name in [
+            orchestrator::QUERY_COMPANY_TOOL,
+            orchestrator::SPAWN_TASK_TOOL,
+            orchestrator::DELEGATE_TO_DESK_TOOL,
+            orchestrator::ADD_AGENT_TOOL,
+            orchestrator::CREATE_WORKFLOW_TOOL,
+            orchestrator::ASSIGN_TASK_TOOL,
+            orchestrator::REVIEW_TASK_TOOL,
+            orchestrator::RUN_WORKFLOW_TOOL,
+            publish::PUBLISH_ARTIFACT_TOOL,
+            search::WEB_SEARCH_TOOL,
+            workspace_tools::WORKSPACE_LIST_TOOL,
+            workspace_tools::WORKSPACE_READ_TOOL,
+            workspace_tools::WORKSPACE_WRITE_TOOL,
+            crate::harness::composio_catalog::LIST_TOOLS_TOOL,
+            crate::harness::composio_catalog::LIST_TOOLKITS_TOOL,
+        ] {
+            assert!(
+                DECLARED.iter().any(|d| d.tool == name),
+                "`{name}` is a live tool constant with no declaration"
+            );
+        }
+    }
+}

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -50,46 +50,52 @@
 
 use crate::ports::types::EffectGroup;
 
-/// Does a call mutate state or reach outside the company?
+/// What a call **costs the company** — the axis the two policy tiers cut on.
 ///
-/// The two policy tiers want different cuts of this, which is why it is three
-/// values and not a bool:
+/// Named for consequence rather than for topology, because topology is the
+/// wrong question and asking it is what produced the bug this module exists to
+/// fix. Several tools make a real network request and are nonetheless
+/// [`Nothing`](Self::Nothing): `composio_list_tools`, `media_list_models` and
+/// `mcp_list_tools` all fetch a catalogue over the wire with the tenant's own
+/// credential, change no state anywhere, and are billed for nothing. A tier
+/// that denied them would be denying a company the ability to find out what it
+/// can do.
 ///
-/// * `readonly` denies everything that is not [`Internal`](Self::Internal) —
-///   that tier's contract is that nothing moves and nothing is spent.
-/// * `supervised` parks only [`External`](Self::External).
-///   [`Metered`](Self::Metered) is the third bucket `web_search` needed (issue
-///   #238): it reaches a third party and costs money but changes nothing, and
-///   parking it would be worse than useless — openhuman resolves a
-///   `RequireApproval` inline, so a parked search is a search that never
-///   happens.
+/// * `readonly` denies anything that is not [`Nothing`](Self::Nothing) — that
+///   tier's contract is that nothing changes and nothing is spent.
+/// * `supervised` parks only [`Consequence`](Self::Consequence).
+///   [`Money`](Self::Money) is the third bucket `web_search` needed (issue
+///   #238): it changes nothing but the backend bills per request, and parking
+///   it would be worse than useless — openhuman resolves a `RequireApproval`
+///   inline, so a parked search is a search that never happens.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Reach {
-    /// Touches only this company's own runtime state, or reads inside the
-    /// agent's own sandboxed workspace. Never parks, never denied.
-    Internal,
-    /// Reaches outside and is billed, but changes nothing anywhere. Allowed
-    /// under `supervised`, denied under `readonly`.
-    Metered,
-    /// Mutates state, reaches a counterparty, executes arbitrary code, reaches
-    /// an arbitrary address, or overwrites operator-owned guidance.
-    External,
+    /// Nothing changes and nothing is spent. Runs in every mode, `readonly`
+    /// included. May still read over the network — see the note above.
+    Nothing,
+    /// Nothing changes, but the call is billed. Runs under `supervised`,
+    /// denied under `readonly`.
+    Money,
+    /// State changes, a counterparty is reached, arbitrary code runs, an
+    /// arbitrary address is reached, or operator-owned guidance is overwritten.
+    /// Parks under `supervised`, denied under `readonly`.
+    Consequence,
 }
 
 impl Reach {
-    /// Does this mutate or reach outside — the `readonly` deny condition.
-    pub fn is_external(self) -> bool {
-        !matches!(self, Self::Internal)
+    /// Is this refused outright on a `readonly` desk?
+    pub fn denied_under_readonly(self) -> bool {
+        !matches!(self, Self::Nothing)
     }
 
-    /// Does this park under `supervised`?
+    /// Does this park for an operator under `supervised`?
     pub fn parks_under_supervision(self) -> bool {
-        matches!(self, Self::External)
+        matches!(self, Self::Consequence)
     }
 
-    /// Does this cost money to make, regardless of what it changes?
-    pub fn is_metered(self) -> bool {
-        matches!(self, Self::Metered)
+    /// Does making this call cost money, whatever it changes?
+    pub fn costs_money(self) -> bool {
+        matches!(self, Self::Money)
     }
 }
 
@@ -157,29 +163,29 @@ const DECLARED: &[Declared] = &[
     // an internal tool never parks, so its standing answer is unobservable
     // *unless* an operator puts it in `always_approve` — at which point
     // `PerCall` is the answer that respects what they asked for.
-    d("query_company", EffectGroup::Other, Reach::Internal),
-    d("spawn_task", EffectGroup::Other, Reach::Internal),
-    d("delegate_to_desk", EffectGroup::Other, Reach::Internal),
-    d("add_agent", EffectGroup::Other, Reach::Internal),
-    d("create_workflow", EffectGroup::Other, Reach::Internal),
-    d("assign_task", EffectGroup::Other, Reach::Internal),
-    d("review_task", EffectGroup::Other, Reach::Internal),
+    d("query_company", EffectGroup::Other, Reach::Nothing),
+    d("spawn_task", EffectGroup::Other, Reach::Nothing),
+    d("delegate_to_desk", EffectGroup::Other, Reach::Nothing),
+    d("add_agent", EffectGroup::Other, Reach::Nothing),
+    d("create_workflow", EffectGroup::Other, Reach::Nothing),
+    d("assign_task", EffectGroup::Other, Reach::Nothing),
+    d("review_task", EffectGroup::Other, Reach::Nothing),
     // Running a saved workflow performs whatever that workflow performs, which
     // this layer cannot see. It parks, and it stays a per-call decision.
-    d("run_workflow", EffectGroup::Other, Reach::External),
+    d("run_workflow", EffectGroup::Other, Reach::Consequence),
     // ---- The agent's own sandboxed workspace: reads ------------------------
     // All four are pure reads inside the workspace the agent is pinned to.
     // `file_read`, `glob`, `grep` and `image_info` PARKED before this table
     // existed — not by anyone's decision, but because the read-only-prefix
     // heuristic keys on the *start* of the name and none of them begins with
     // one. `list`, `read_workspace_state` and `memory_recall` happened to.
-    d("file_read", EffectGroup::Other, Reach::Internal),
-    d("glob", EffectGroup::Other, Reach::Internal),
-    d("grep", EffectGroup::Other, Reach::Internal),
-    d("list", EffectGroup::Other, Reach::Internal),
-    d("read_workspace_state", EffectGroup::Other, Reach::Internal),
-    d("memory_recall", EffectGroup::Other, Reach::Internal),
-    d("image_info", EffectGroup::Other, Reach::Internal),
+    d("file_read", EffectGroup::Other, Reach::Nothing),
+    d("glob", EffectGroup::Other, Reach::Nothing),
+    d("grep", EffectGroup::Other, Reach::Nothing),
+    d("list", EffectGroup::Other, Reach::Nothing),
+    d("read_workspace_state", EffectGroup::Other, Reach::Nothing),
+    d("memory_recall", EffectGroup::Other, Reach::Nothing),
+    d("image_info", EffectGroup::Other, Reach::Nothing),
     // ---- The agent's own sandboxed workspace: writes -----------------------
     // These mutate, so `readonly` must still deny them and `supervised` must
     // still park them. But what they mutate is the agent's own scratch space
@@ -187,86 +193,117 @@ const DECLARED: &[Declared] = &[
     // nothing an operator authored. They are the low-consequence tools the
     // standing grant exists for: without them the feature has almost nothing
     // left to apply to.
-    d_grantable("file_write", EffectGroup::Other, Reach::External),
-    d_grantable("edit", EffectGroup::Other, Reach::External),
-    d_grantable("apply_patch", EffectGroup::Other, Reach::External),
-    d_grantable("csv_export", EffectGroup::Other, Reach::External),
-    d_grantable("memory_store", EffectGroup::Other, Reach::External),
+    d_grantable("file_write", EffectGroup::Other, Reach::Consequence),
+    d_grantable("edit", EffectGroup::Other, Reach::Consequence),
+    d_grantable("apply_patch", EffectGroup::Other, Reach::Consequence),
+    d_grantable("csv_export", EffectGroup::Other, Reach::Consequence),
+    d_grantable("memory_store", EffectGroup::Other, Reach::Consequence),
     // `git_operations` is deliberately NOT grantable alongside its filesystem
     // siblings: it can push to a configured remote, so it reaches an address
     // this layer does not get to see.
-    d("git_operations", EffectGroup::Other, Reach::External),
+    d("git_operations", EffectGroup::Other, Reach::Consequence),
     // ---- Arbitrary code, arbitrary addresses -------------------------------
     // The three shapes issue #444 names, plus the two web tools that share
     // `http_request`'s shape. A standing grant on any of these is a standing
     // grant on "anything the sandbox permits", which is not a sentence an
     // operator can consent to.
-    d("shell", EffectGroup::Other, Reach::External),
-    d("http_request", EffectGroup::Other, Reach::External),
-    d("curl", EffectGroup::Other, Reach::External),
-    d("web_fetch", EffectGroup::Other, Reach::External),
+    d("shell", EffectGroup::Other, Reach::Consequence),
+    d("http_request", EffectGroup::Other, Reach::Consequence),
+    d("curl", EffectGroup::Other, Reach::Consequence),
+    d("web_fetch", EffectGroup::Other, Reach::Consequence),
     // ---- The company workspace: operator-owned guidance --------------------
     // Reads are free (issue #237). `workspace_write` overwrites guidance the
     // operator wrote, which is why `is_external_effect` has always refused to
     // exempt it — and why it is now also refused a standing grant. That
     // contradiction (park every time / grant for a week) is issue #444's
     // headline, resolved in the direction the parking side already argued.
-    d("workspace_list", EffectGroup::Other, Reach::Internal),
-    d("workspace_read", EffectGroup::Other, Reach::Internal),
-    d("workspace_write", EffectGroup::Other, Reach::External),
+    d("workspace_list", EffectGroup::Other, Reach::Nothing),
+    d("workspace_read", EffectGroup::Other, Reach::Nothing),
+    d("workspace_write", EffectGroup::Other, Reach::Consequence),
     // ---- Publishing --------------------------------------------------------
     // Externally visible and not reversible by the company alone.
-    d("publish_artifact", EffectGroup::Publish, Reach::External),
+    d("publish_artifact", EffectGroup::Publish, Reach::Consequence),
     // ---- Priced backend calls ----------------------------------------------
     // `web_search` is billed per request but changes nothing (issue #238).
     // Media generation moves real money on submit (issue #109); listing the
-    // catalogue is a free GET.
-    d("web_search", EffectGroup::Spend, Reach::Metered),
-    d("media_generate_image", EffectGroup::Spend, Reach::External),
-    d("media_generate_video", EffectGroup::Spend, Reach::External),
-    d("media_list_models", EffectGroup::Other, Reach::Internal),
-    // ---- MCP ---------------------------------------------------------------
-    // Listing servers and their tools reads local registration state with
-    // credentials redacted and reaches nothing (issue #443). The agent persona
-    // *instructs* every agent to call `mcp_list_servers` rather than answer a
-    // capability question from memory, so parking it made the guidance that
-    // exists to prevent stale answers cost an operator approval to follow.
+    // catalogue is a GET to the same backend that changes nothing and costs
+    // nothing.
+    d("web_search", EffectGroup::Spend, Reach::Money),
+    d(
+        "media_generate_image",
+        EffectGroup::Spend,
+        Reach::Consequence,
+    ),
+    d(
+        "media_generate_video",
+        EffectGroup::Spend,
+        Reach::Consequence,
+    ),
+    d("media_list_models", EffectGroup::Other, Reach::Nothing),
+    // ---- Skills / workflow catalogue ---------------------------------------
+    // The three OpenHuman skill *read* tools, scoped to this agent's own
+    // materialized skill tree under its workspace. All local, all reads.
     //
-    // Calling *through* a server stays external and per-call: it can perform
-    // any effect the third-party server advertises.
-    d("mcp_list_servers", EffectGroup::Other, Reach::Internal),
-    d("mcp_list_tools", EffectGroup::Other, Reach::Internal),
+    // `describe_workflow` PARKED before this table existed, for the same
+    // reason `file_read` did and with nobody reporting either: the read-only
+    // rule matched a name *prefix* and "describe" is not one of the words. The
+    // persona hands an agent all three in one sentence — "use `list_workflows`
+    // to enumerate them, `describe_workflow` to inspect one" — so two ran and
+    // the middle one interrupted an operator.
+    d("list_workflows", EffectGroup::Other, Reach::Nothing),
+    d("describe_workflow", EffectGroup::Other, Reach::Nothing),
+    d("read_workflow_resource", EffectGroup::Other, Reach::Nothing),
+    // ---- MCP ---------------------------------------------------------------
+    // The agent persona *instructs* every agent to call `mcp_list_servers` (and
+    // `mcp_list_tools` for a specific server) rather than answer a capability
+    // question from memory, so parking them made the guidance that exists to
+    // prevent stale answers cost an operator approval to follow (issue #443).
+    //
+    // `mcp_list_servers` and `mcp_registry_list_tools` read process-local
+    // registration state, credentials already redacted. `mcp_list_tools` is
+    // NOT local — it is a `tools/list` round trip to the operator-configured
+    // server. It is `Nothing` all the same: it changes nothing there or here
+    // and is billed for nothing, and a desk that cannot ask a server what it
+    // offers cannot use one. Whether a call *reaches* is the question this
+    // module stopped asking; what it costs is the question it asks instead.
+    //
+    // Calling *through* a server is a consequence and stays per-call: it can
+    // perform any effect the third-party server advertises.
+    d("mcp_list_servers", EffectGroup::Other, Reach::Nothing),
+    d("mcp_list_tools", EffectGroup::Other, Reach::Nothing),
     d(
         "mcp_registry_list_tools",
         EffectGroup::Other,
-        Reach::Internal,
+        Reach::Nothing,
     ),
-    d("mcp_call_tool", EffectGroup::Other, Reach::External),
+    d("mcp_call_tool", EffectGroup::Other, Reach::Consequence),
     d(
         "mcp_registry_tool_call",
         EffectGroup::Other,
-        Reach::External,
+        Reach::Consequence,
     ),
     // ---- Composio ----------------------------------------------------------
-    // The three list tools are read-only GETs against the tenant's own
-    // Composio surface (issue #110). Authorizing begins an OAuth handoff that
-    // establishes an account identity for the company.
+    // The three list tools are authenticated GETs to the managed backend with
+    // the tenant's own bearer (issue #110) — over the wire, but changing
+    // nothing and billed for nothing, so they run in every mode. Authorizing
+    // begins an OAuth handoff that establishes an account identity for the
+    // company, which is a change, so it parks.
     //
     // `composio_execute` is NOT here: one name carries every action, so its
     // consequence is read from the action slug in its arguments — see
     // `composio_execute_consequence`.
-    d(
-        "composio_list_toolkits",
-        EffectGroup::Other,
-        Reach::Internal,
-    ),
+    d("composio_list_toolkits", EffectGroup::Other, Reach::Nothing),
     d(
         "composio_list_connections",
         EffectGroup::Other,
-        Reach::Internal,
+        Reach::Nothing,
     ),
-    d("composio_list_tools", EffectGroup::Other, Reach::Internal),
-    d("composio_authorize", EffectGroup::Identity, Reach::External),
+    d("composio_list_tools", EffectGroup::Other, Reach::Nothing),
+    d(
+        "composio_authorize",
+        EffectGroup::Identity,
+        Reach::Consequence,
+    ),
 ];
 
 /// A per-call declaration — the default. `const fn` so [`DECLARED`] stays a
@@ -351,7 +388,7 @@ pub fn consequence_of(tool: &str, args: &serde_json::Value) -> Consequence {
 fn composio_execute_consequence(args: &serde_json::Value) -> Consequence {
     let send = Consequence {
         group: EffectGroup::Send,
-        reach: Reach::External,
+        reach: Reach::Consequence,
         standing: Standing::PerCall,
     };
     let Some(slug) = args.get(COMPOSIO_ACTION_KEY).and_then(|v| v.as_str()) else {
@@ -364,7 +401,7 @@ fn composio_execute_consequence(args: &serde_json::Value) -> Consequence {
         // offers a standing scope, and the reads stop asking for its duration.
         Consequence {
             group: EffectGroup::Other,
-            reach: Reach::External,
+            reach: Reach::Consequence,
             standing: Standing::Grantable,
         }
     } else {
@@ -429,9 +466,9 @@ fn undeclared(name: &str) -> Consequence {
     Consequence {
         group: undeclared_group(name),
         reach: if reads {
-            Reach::Internal
+            Reach::Nothing
         } else {
-            Reach::External
+            Reach::Consequence
         },
         standing: Standing::PerCall,
     }
@@ -520,7 +557,7 @@ mod tests {
         // Including one that reads — not grantable is about standing, not about
         // whether it parks.
         let read = c("list_something_undeclared");
-        assert_eq!(read.reach, Reach::Internal);
+        assert_eq!(read.reach, Reach::Nothing);
         assert_eq!(read.standing, Standing::PerCall);
     }
 
@@ -541,12 +578,12 @@ mod tests {
         assert_eq!(read.group, EffectGroup::Other);
         assert_eq!(read.standing, Standing::Grantable);
         // …and it still parks the first time, because it does reach GitHub.
-        assert_eq!(read.reach, Reach::External);
+        assert_eq!(read.reach, Reach::Consequence);
 
         let send = consequence_of(COMPOSIO_EXECUTE, &json!({ "tool": "GMAIL_SEND_EMAIL" }));
         assert_eq!(send.group, EffectGroup::Send);
         assert_eq!(send.standing, Standing::PerCall);
-        assert_eq!(send.reach, Reach::External);
+        assert_eq!(send.reach, Reach::Consequence);
     }
 
     /// The cautious direction, four ways. An action the catalogue does not
@@ -619,7 +656,7 @@ mod tests {
             "mcp_list_tools",
             "mcp_registry_list_tools",
         ] {
-            assert_eq!(c(tool).reach, Reach::Internal, "`{tool}` reads local state");
+            assert_eq!(c(tool).reach, Reach::Nothing, "`{tool}` reads local state");
         }
         for tool in ["mcp_call_tool", "mcp_registry_tool_call"] {
             assert!(
@@ -649,7 +686,7 @@ mod tests {
             "composio_list_connections",
             "composio_list_tools",
         ] {
-            assert_eq!(c(tool).reach, Reach::Internal, "`{tool}` is a read");
+            assert_eq!(c(tool).reach, Reach::Nothing, "`{tool}` is a read");
         }
     }
 
@@ -676,10 +713,10 @@ mod tests {
     #[test]
     fn a_metered_read_is_allowed_under_supervision_and_denied_under_readonly() {
         let search = c("web_search");
-        assert_eq!(search.reach, Reach::Metered);
+        assert_eq!(search.reach, Reach::Money);
         assert!(!search.reach.parks_under_supervision());
-        assert!(search.reach.is_external());
-        assert!(search.reach.is_metered());
+        assert!(search.reach.denied_under_readonly());
+        assert!(search.reach.costs_money());
         assert_eq!(search.group, EffectGroup::Spend);
         assert_eq!(search.standing, Standing::PerCall);
     }
@@ -697,7 +734,7 @@ mod tests {
     #[test]
     fn lookup_ignores_case() {
         assert_eq!(c("SHELL").standing, Standing::PerCall);
-        assert_eq!(c("Workspace_Read").reach, Reach::Internal);
+        assert_eq!(c("Workspace_Read").reach, Reach::Nothing);
         // `composio_execute` is matched by the same lowercasing pass, so an
         // upper-cased tool name still reaches the argument classifier rather
         // than falling through to the undeclared heuristics.

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -526,7 +526,13 @@ mod tests {
 
     /// Issue #441: the consequence of a Composio call is a property of the
     /// action, not of the one tool name every action arrives under.
+    ///
+    /// Gated on the harness feature because the read verdict comes from the
+    /// vendored provider catalogue, which is only linked in there — the
+    /// default build's cautious fallback is pinned separately by
+    /// [`without_the_catalogue_every_composio_action_is_a_send`].
     #[test]
+    #[cfg(feature = "openhuman")]
     fn a_composio_read_is_grantable_and_a_send_is_not() {
         let read = consequence_of(
             COMPOSIO_EXECUTE,
@@ -563,6 +569,23 @@ mod tests {
                 "an unclassifiable action must read as a send: {args}"
             );
             assert_eq!(verdict.standing, Standing::PerCall, "{args}");
+        }
+    }
+
+    /// The seam, pinned from the other side. Without the harness feature the
+    /// curated catalogue is not linked in, and the mint path still has to
+    /// answer the grantability question — so it answers it the cautious way,
+    /// for a read as much as for a send. A default build can only ever see a
+    /// `composio_execute` effect replayed from a journal line an openhuman
+    /// build wrote, so refusing the standing scope there costs an operator one
+    /// approve-once and never a wrong grant.
+    #[test]
+    #[cfg(not(feature = "openhuman"))]
+    fn without_the_catalogue_every_composio_action_is_a_send() {
+        for slug in ["GITHUB_LIST_PULL_REQUESTS", "GMAIL_SEND_EMAIL"] {
+            let verdict = consequence_of(COMPOSIO_EXECUTE, &json!({ "tool": slug }));
+            assert_eq!(verdict.group, EffectGroup::Send, "{slug}");
+            assert_eq!(verdict.standing, Standing::PerCall, "{slug}");
         }
     }
 
@@ -675,13 +698,22 @@ mod tests {
     fn lookup_ignores_case() {
         assert_eq!(c("SHELL").standing, Standing::PerCall);
         assert_eq!(c("Workspace_Read").reach, Reach::Internal);
+        // `composio_execute` is matched by the same lowercasing pass, so an
+        // upper-cased tool name still reaches the argument classifier rather
+        // than falling through to the undeclared heuristics.
+        assert_eq!(
+            consequence_of("COMPOSIO_EXECUTE", &json!({ "tool": "GMAIL_SEND_EMAIL" })).group,
+            EffectGroup::Send
+        );
+        #[cfg(feature = "openhuman")]
         assert_eq!(
             consequence_of(
                 "COMPOSIO_EXECUTE",
-                &json!({ "tool": "GITHUB_LIST_BRANCHES" })
+                &json!({ "tool": "github_list_branches" })
             )
             .standing,
-            Standing::Grantable
+            Standing::Grantable,
+            "the curated lookup is case-insensitive on the slug too"
         );
     }
 

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -3,7 +3,16 @@
 //! The [`gate`] module implements the default
 //! [`ApprovalGate`](crate::ports::ApprovalGate) that evaluates emitted effects
 //! against a company's declared policy and holds the in-memory approval queue.
+//!
+//! The [`consequence`] module declares, once, what every tool can reach — the
+//! single source both approval questions read ("may this run unattended?" and
+//! "may an operator grant it standing?"). It is always compiled, because the
+//! standing-grant rule is enforced in the default build (the mint path and the
+//! console card) while the tool policy that parks calls compiles only under the
+//! `openhuman` feature.
 
+pub mod consequence;
 pub mod gate;
 
+pub use consequence::{Consequence, Reach, Standing, consequence_of};
 pub use gate::{DEFAULT_TTL_MILLIS, ManifestApprovalGate};

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -897,24 +897,20 @@ pub enum EffectGroup {
     Other,
 }
 
+/// The residual bucket. Named here rather than inferred, because for a while it
+/// silently meant two things at once — see
+/// [`Effect::may_be_granted_standing`].
 impl EffectGroup {
-    /// May a tool in this group be granted **broadly** — one standing
-    /// permission covering any arguments until a deadline (issue #374)?
+    /// Is this the catch-all bucket, i.e. did the classifier find no particular
+    /// consequence to name on the operator's card?
     ///
-    /// Only [`Other`](Self::Other). Every named group is a consequence the
-    /// operator has to see per call: Spend moves money, Send reaches a
-    /// counterparty, Sign and Publish are externally visible and not reversible
-    /// by the company alone, Hire commits it to someone, Identity changes who it
-    /// is. None of those are things to hand over for a week at a time.
-    ///
-    /// **This is the rule; it lives here so there is one of it.** The tool-name
-    /// → group mapping is `classify_group` in `crate::harness::policy`, which
-    /// compiles only under the `openhuman` feature, while the three places that
-    /// enforce this — the mint path, the approval summary the card reads, and
-    /// the resolve route's 400 — are all in the default build. Expressing the
-    /// rule twice across that seam is exactly the drift the issue forbids, so
-    /// both sides call this.
-    pub fn is_broadly_grantable(&self) -> bool {
+    /// This answers the *labelling* question and nothing else. It used to double
+    /// as the standing-grant rule, which is what let `shell` and
+    /// `workspace_write` be handed over for a week: neither name contains a
+    /// consequence word, so both landed here, so both were grantable. That rule
+    /// now lives on [`Effect::may_be_granted_standing`], where it is decided by
+    /// what the tool can reach.
+    pub fn is_unclassified(&self) -> bool {
         matches!(self, Self::Other)
     }
 }
@@ -1005,6 +1001,44 @@ impl Effect {
     /// Whether the counterparty is new.
     pub fn is_first_time_counterparty(&self) -> bool {
         self.first_time_counterparty
+    }
+
+    /// May an operator turn this parked call into a **standing** permission —
+    /// one grant covering repeat calls until a deadline (issues #374, #444)?
+    ///
+    /// **This is the rule; it lives here so there is one of it.** Three places
+    /// enforce it — the mint path, the approval summary the card reads, and the
+    /// resolve route's 400 — and all three are in the default build, while the
+    /// tool policy that produced the effect compiles only under the `openhuman`
+    /// feature. So the rule cannot live in the policy, and expressing it twice
+    /// across that seam is the drift issue #444 is about.
+    ///
+    /// ## Why it is no longer `group == Other`
+    ///
+    /// `Other` is the bucket a tool falls into when the classifier finds no
+    /// consequence word in its name. Reading that as "safe to hand over for a
+    /// week" put the three broadest capabilities in the system on the grantable
+    /// side — running an arbitrary command, reaching an arbitrary address, and
+    /// overwriting the guidance the operator wrote — while a repository read
+    /// scoped to one connected account stayed off it. Nothing was malfunctioning;
+    /// the rule was measuring a name's vocabulary rather than what the tool can
+    /// do.
+    ///
+    /// It now asks [`consequence_of`](crate::policy::consequence_of), the same
+    /// declaration the parking side reads, using the two things an effect
+    /// already carries: [`kind`](Self::kind) is the tool name and
+    /// [`payload`](Self::payload) is the arguments it was called with. No new
+    /// field, so no journal line changes shape and no replayed effect answers
+    /// this differently from a live one.
+    ///
+    /// Arguments matter here, not just the tool: `composio_execute` carries
+    /// every Composio action under one name, so the same tool is grantable when
+    /// it is listing a repository's pull requests and per-call when it is
+    /// sending mail.
+    pub fn may_be_granted_standing(&self) -> bool {
+        crate::policy::consequence_of(&self.kind, &self.payload)
+            .standing
+            .is_grantable()
     }
 }
 

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -623,15 +623,15 @@ working on):\n{}\n]",
     /// * **native** (`agent: None`) — there is no tool and no agent to grant to.
     ///   The runtime performs these itself; "this tool, for this teammate" names
     ///   neither of the two things it needs.
-    /// * **not broadly grantable** — the effect's group is not
-    ///   [`EffectGroup::Other`](crate::ports::types::EffectGroup::Other), so it
-    ///   is a consequence the operator has to see per call.
+    /// * **not broadly grantable** — the tool can reach further than a standing
+    ///   grant can honestly describe (issue #444), so it is a decision the
+    ///   operator has to take per call.
     ///
-    /// The group is read off the **parked effect** rather than re-derived from
-    /// the tool name, which is both cheaper and more honest: it is the
-    /// classification the card showed the operator, so what they see is what is
-    /// checked. It is also what lets this run in the default build, where the
-    /// harness classifier does not compile.
+    /// The verdict is read off the **parked effect** rather than re-derived from
+    /// a live tool call, which is both cheaper and more honest: the effect
+    /// carries the tool name and the arguments the card showed the operator, so
+    /// what they see is what is checked. It is also what lets this run in the
+    /// default build, where the harness classifier does not compile.
     ///
     /// An unknown or already-resolved id falls through to the ordinary
     /// already-resolved path rather than erroring here — a double-click on the
@@ -647,11 +647,11 @@ working on):\n{}\n]",
                 effect.kind
             )));
         }
-        if !effect.group.is_broadly_grantable() {
+        if !effect.may_be_granted_standing() {
             return Err(OpenCompanyError::InvalidRequest(format!(
-                "'{}' cannot be granted for a period — it is a {:?} action, which stays a \
-                 per-call decision; approve it once instead",
-                effect.kind, effect.group
+                "'{}' cannot be granted for a period — it can reach further than a standing \
+                 permission can describe, so it stays a per-call decision; approve it once instead",
+                effect.kind
             )));
         }
         Ok(())
@@ -4916,12 +4916,22 @@ mod test {
     // Standing grants (issue #374)
     // -----------------------------------------------------------------------
 
-    /// A harness tool call the operator IS allowed to grant broadly: an
-    /// `EffectGroup::Other` effect with no declared amount.
+    /// A harness tool call the operator IS allowed to grant broadly.
     ///
     /// `harness_effect` deliberately uses `Sign` and a real amount, because it
     /// exists to prove the effect was not executed. Both would refuse a broad
     /// scope, so the grantable case needs its own fixture.
+    ///
+    /// **The tool passed in is now load-bearing** (issue #444). These tests
+    /// used to grant a standing scope on `workspace_write` — which was
+    /// grantable only because its name contains no consequence word, while the
+    /// parking side of the same gate refused to exempt it precisely because it
+    /// overwrites guidance the operator wrote. That contradiction is what #444
+    /// is about, and it is resolved in the direction the parking side already
+    /// argued: `workspace_write` stays a per-call decision. `file_write` is the
+    /// honest fixture — it mutates, so it still parks, but what it mutates is
+    /// the agent's own sandboxed workspace, which is exactly the low-consequence
+    /// shape a standing grant is for.
     fn grantable_effect(agent: &str, tool: &str, args: serde_json::Value) -> Effect {
         Effect {
             kind: tool.into(),
@@ -4989,7 +4999,7 @@ mod test {
         let home_dir = tmp_home();
         let (rt, id) = park_one_blocked_tool_call(
             home_dir.path().to_path_buf(),
-            grantable_effect("ops", "workspace_write", serde_json::json!({ "path": "a" })),
+            grantable_effect("ops", "file_write", serde_json::json!({ "path": "a" })),
         )
         .await;
 
@@ -5006,7 +5016,7 @@ mod test {
             "no single-use grant is left behind to expire noisily"
         );
         let listed = rt.standing_grants();
-        assert_eq!(listed[0].tool, "workspace_write");
+        assert_eq!(listed[0].tool, "file_write");
         assert_eq!(listed[0].agent, "ops");
         assert_eq!(listed[0].approval_id, id, "provenance back to the card");
         assert_eq!(
@@ -5082,7 +5092,7 @@ mod test {
     async fn repeated_ordinary_approvals_never_infer_a_standing_grant() {
         let home_dir = tmp_home();
         let home = home_dir.path().to_path_buf();
-        let effect = grantable_effect("ops", "workspace_write", serde_json::json!({ "path": "a" }));
+        let effect = grantable_effect("ops", "file_write", serde_json::json!({ "path": "a" }));
 
         let rt = Arc::new(
             RuntimeBuilder::new(home, manifest("supervised"))
@@ -5124,7 +5134,7 @@ mod test {
         let home = home_dir.path().to_path_buf();
         let (rt, id) = park_one_blocked_tool_call(
             home.clone(),
-            grantable_effect("ops", "workspace_write", serde_json::json!({ "path": "a" })),
+            grantable_effect("ops", "file_write", serde_json::json!({ "path": "a" })),
         )
         .await;
 
@@ -5180,7 +5190,7 @@ mod test {
         let home_dir = tmp_home();
         let (rt, id) = park_one_blocked_tool_call(
             home_dir.path().to_path_buf(),
-            grantable_effect("ops", "workspace_write", serde_json::json!({})),
+            grantable_effect("ops", "file_write", serde_json::json!({})),
         )
         .await;
 
@@ -5204,18 +5214,21 @@ mod test {
     }
 
     /// The summary carries the flag only where the control is actually
-    /// offerable — and the card's own classification is what decides it.
+    /// offerable — and what the tool can reach is what decides it.
     #[tokio::test]
     async fn the_summary_marks_only_broadly_grantable_cards() {
         let home_dir = tmp_home();
         let (rt, _) = park_one_blocked_tool_call(
             home_dir.path().to_path_buf(),
-            grantable_effect("ops", "workspace_write", serde_json::json!({})),
+            grantable_effect("ops", "file_write", serde_json::json!({})),
         )
         .await;
         assert!(rt.pending_approvals()[0].broadly_grantable);
 
-        // A named consequence group is not offerable.
+        // A Composio call with no action slug the classifier recognises reads
+        // as a send, so no scope control is offered (issue #441's cautious
+        // direction — before it, *every* Composio call landed here, including
+        // the reads).
         let home_dir = tmp_home();
         let (rt, _) = park_one(
             home_dir.path().to_path_buf(),
@@ -5223,5 +5236,70 @@ mod test {
         )
         .await;
         assert!(!rt.pending_approvals()[0].broadly_grantable);
+
+        // Issue #444: `workspace_write` used to be marked grantable, because
+        // its name carries no consequence word. It overwrites guidance the
+        // operator wrote, so it stays a per-call decision — the same answer
+        // the parking side of the gate has always given for it.
+        let home_dir = tmp_home();
+        let (rt, _) = park_one_blocked_tool_call(
+            home_dir.path().to_path_buf(),
+            grantable_effect("ops", "workspace_write", serde_json::json!({ "path": "a" })),
+        )
+        .await;
+        assert!(
+            !rt.pending_approvals()[0].broadly_grantable,
+            "overwriting operator-owned guidance is not a week-long permission"
+        );
+
+        // And neither is running an arbitrary command, which is where an
+        // operator on staging *could* get a standing grant before #444.
+        let home_dir = tmp_home();
+        let (rt, _) = park_one_blocked_tool_call(
+            home_dir.path().to_path_buf(),
+            grantable_effect("ops", "shell", serde_json::json!({ "command": "ls" })),
+        )
+        .await;
+        assert!(!rt.pending_approvals()[0].broadly_grantable);
+    }
+
+    /// Issue #441, from the mint side: the same tool, two different answers,
+    /// decided by the action in the arguments rather than the name they share.
+    ///
+    /// This is the whole shape of the bug — an operator could grant a standing
+    /// scope on running arbitrary terminal commands, and could not grant one on
+    /// reading a repository's pull requests.
+    #[tokio::test]
+    #[cfg(feature = "openhuman")]
+    async fn a_composio_read_is_offerable_and_a_composio_send_is_not() {
+        let home_dir = tmp_home();
+        let (rt, _) = park_one_blocked_tool_call(
+            home_dir.path().to_path_buf(),
+            grantable_effect(
+                "ops",
+                "composio_execute",
+                serde_json::json!({ "tool": "GITHUB_LIST_PULL_REQUESTS" }),
+            ),
+        )
+        .await;
+        assert!(
+            rt.pending_approvals()[0].broadly_grantable,
+            "a repository read scoped to a connected account is grantable"
+        );
+
+        let home_dir = tmp_home();
+        let (rt, _) = park_one_blocked_tool_call(
+            home_dir.path().to_path_buf(),
+            grantable_effect(
+                "ops",
+                "composio_execute",
+                serde_json::json!({ "tool": "GMAIL_SEND_EMAIL" }),
+            ),
+        )
+        .await;
+        assert!(
+            !rt.pending_approvals()[0].broadly_grantable,
+            "sending mail stays a per-call decision"
+        );
     }
 }

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -63,10 +63,18 @@
 //!   express "no expiry" cannot regress into it.
 //!
 //! What it never covers is decided elsewhere, once:
-//! [`EffectGroup::is_broadly_grantable`](crate::ports::types::EffectGroup::is_broadly_grantable)
-//! applied to the group already recorded on the parked effect, so only
-//! `EffectGroup::Other` tools can be granted this way — never Spend, Send,
-//! Sign, Publish, Hire or Identity.
+//! [`Effect::may_be_granted_standing`](crate::ports::types::Effect::may_be_granted_standing)
+//! applied to the parked effect, which asks what the tool can **reach** rather
+//! than what its name is called (issue #444). Running an arbitrary command,
+//! reaching an arbitrary address and overwriting operator-owned guidance are
+//! all refused, as is every Spend / Send / Sign / Publish / Hire / Identity
+//! consequence and every tool nobody has classified.
+//!
+//! Because it has no `args` field this type admits any arguments, which is a
+//! fair summary of a tool's consequence only while consequence is a property of
+//! the tool name. It is not one for `composio_execute`, so the policy
+//! re-classifies the live call before honouring a grant — see
+//! [`ApprovalPolicy::standing_grant_allows`](crate::harness::policy::ApprovalPolicy).
 //!
 //! ## Durability
 //!

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -161,11 +161,15 @@ pub struct ApprovalSummary {
     /// Whether the operator may grant this tool **broadly** — one standing
     /// permission covering any arguments until a deadline (issue #374).
     ///
-    /// `true` exactly when the effect came from a harness tool call *and* its
-    /// group is
-    /// [`EffectGroup::Other`](crate::ports::types::EffectGroup::Other). The
-    /// console renders the scope control only then, so the operator is never
-    /// offered a choice the host would refuse.
+    /// `true` exactly when the effect came from a harness tool call *and* the
+    /// tool cannot reach further than a standing permission can honestly
+    /// describe — [`Effect::may_be_granted_standing`](crate::ports::types::Effect::may_be_granted_standing),
+    /// issue #444. The console renders the scope control only then, so the
+    /// operator is never offered a choice the host would refuse.
+    ///
+    /// It is per-*card*, not per-tool: the same `composio_execute` shows the
+    /// control when it is listing a repository's pull requests and not when it
+    /// is sending mail, because the effect carries the action that was called.
     ///
     /// **This flag is UX, not enforcement.** The host re-checks the same rule
     /// when the resolve arrives, and answers 400 — a console that ignored this


### PR DESCRIPTION
## Summary

Three issues, one boundary. Consequence was decided from a tool's **name**, and the name is not the property that matters — so the line fell in close to the opposite of the right place, in both directions at once.

- **#441** — every Composio action arrives as one tool, `composio_execute`, with the action in the arguments. The name was classified as a send, so no Composio read could ever hold a standing grant and an operator paid an approval for every page of every list.
- **#443** — `mcp_list_servers` parked, because it starts with `mcp` rather than `list` and the hand-maintained carve-out list had missed it. The agent persona *instructs every agent to call it* rather than answer from memory, so following the guidance cost an approval.
- **#444** — `shell`, `http_request` and `workspace_write` all classified as `Other`, and `Other` was the residual bucket that `is_broadly_grantable` returned true for. The three broadest capabilities in the system were grantable for a week; the one scoped to a connected account was not. `is_external_effect` and `classify_group` openly contradicted each other about `workspace_write`, in comments, in the same file.

Closes #441. Closes #443. Closes #444.

## API Or Behavior Changes

**One declaration, two questions.** `src/policy/consequence.rs` declares, per tool, what it **reaches** — and the two decisions are now separate types read from that one source, which is #444's open question answered rather than deferred:

- `Reach` — `Nothing` / `Money` / `Consequence`: drives readonly denial, supervised parking, and pricing.
- `Standing` — `Grantable` / `PerCall`: drives whether an operator may open a tool up for a stretch of time.

Both derive from what a tool can reach, never from what it is called. A tool that can execute arbitrary code, reach an arbitrary address, or overwrite operator-owned guidance is `PerCall` however innocuous its name; a read scoped to one connected account is `Grantable` however alarming the tool carrying it sounds. `workspace_write` now has one answer instead of two.

**An undeclared tool is not grantable and parks.** The old residual bucket conferred the longest grant available on anything nobody had thought about. The default is now the cautious direction, so adding a tool cannot silently confer a week-long capability.

**A Composio call is classified from its action, not from `composio_execute`.** The source is the provider's own curated catalogue vendored with openhuman — roughly 660 hand-classified actions across ~30 toolkits, already used upstream to enforce a read-only sandbox. It is a pure, synchronous, in-process table, so no network call enters the approval path, and it does not drift the way a list maintained in this repo would the moment a toolkit gains an action. **#441 explicitly ruled out a hand-maintained slug list, and this is not one.**

Deliberately **not** upstream's `classify_unknown`, whose fallback for an unrecognised slug is `Read`. That is the convenient verdict; this is the place the cautious one has to win. An unrecognised slug, a slug whose toolkit has no catalogue, a missing or non-string action argument, and — in a build without the harness compiled in — every slug, all resolve to send: parks, and cannot be granted standing.

**`mcp_list_servers` and `mcp_list_tools` no longer park; `mcp_call_tool` still does.** Not by adding a fourth carve-out entry — #443 asked for the mechanism rather than the entry, and a test now fails when a wired tool has no declared consequence, so a new read-only tool in a fresh namespace cannot silently start requiring approval.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 2239 passed, 3 consecutive full-suite runs, 0 failures
- [x] `cargo check --locked --all-features --all-targets`

`Cargo.lock` unchanged.

Existing tests that granted standing scopes on `workspace_write` encoded the old boundary and were changed deliberately; each carries a comment explaining why the new expectation is the correct one.

One commit is a test that proves the boundary through a real model-driven turn rather than by calling the classifier directly — the classifier agreeing with itself is not evidence that the gate behaves.

## Documentation

`docs/spec/company-brain/approvals.md` and `docs/modules/mcp.md` are updated to describe the boundary as drawn by reach rather than by name.

## Notes for review

**The two classifications now consult one source and a test enforces that they agree about every tool**, which is what #444 asked for — the previous arrangement had them disagreeing in writing and nobody noticing until standing grants changed what the disagreement cost.

**A grant is narrower but not yet as narrow as #441 asked for.** It covers reads only and never sends, which is the substance of the fix. But *"this teammate may read from GitHub for eight hours"* needs toolkit scoping on `StandingGrant`, and that field's construction site sits in a file owned by concurrent work. Filed as #457 rather than reached across for. So #441's grant-narrowness point is **partially** delivered, and the issue text is worth re-reading against this before it is closed.

**Two more corrections the sweep made to its own work**, worth knowing because they are the kind that pass review: three skill tools were undeclared *and invisible to the coverage test*, because that test's fixture pinned `skills_source_dir: None` — a coverage mechanism that could not see part of what it claimed to cover. And an earlier `Reach::Internal` variant was simply untrue: `mcp_list_tools` performs a `tools/list` round trip, and `composio_list_*` / `media_list_models` are authenticated GETs. It was renamed to describe consequence rather than topology.

**Sibling defects found and fixed here**, all the same root cause: `file_read`, `glob`, `grep`, `image_info`, `describe_workflow` and `mcp_registry_list_tools` were all parking too, because the read-only rule matched a name *prefix*.

**Filed, not fixed** — each needs its own change and two are more serious than the issues this PR closes: **#459** (`read_workspace_state` runs `git` with unsanitised config in an agent-writable directory, which pairs badly with a grantable `file_write`), **#460** (workflow `tool_call` nodes bypass the gate entirely, so `[policy].mode` is inert on that path), **#461** (the two grant matchers disagree on prefix boundaries).

Not addressed here, and deliberately left rather than half-done: the manifest's per-tool standing allowance, and renaming `always_approve` — whose name reads as the opposite of its behaviour, since it means *always park*.

