### PR TITLE
fix(spine): one message, one card — a publish files onto the card in scope (#463)

### DIFF
--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -1528,11 +1528,19 @@ impl HarnessBrain {
     ///
     /// A card that has since been deleted falls back to minting, so the
     /// artifact stays reachable rather than being dropped for the sake of the
-    /// rule.
+    /// rule. **The returned id is the card the deliverable actually landed
+    /// on** — the replacement, on that path, not `card_id` — because the caller
+    /// links the operator's reply to it and sending them to an id that no
+    /// longer resolves is the bug this whole change is about.
+    ///
+    /// `chat_id` is carried into that fallback so a minted replacement points
+    /// back at the same conversation the no-card-in-scope path's card does;
+    /// two minting paths must not differ in where their card posts back.
     async fn file_publishes_on_card(
         &self,
         card_id: &str,
         agent: &str,
+        chat_id: Option<&str>,
         published: Vec<publish::PendingPublish>,
     ) -> Result<String> {
         let Some(tasks) = self.deps.tasks.as_ref() else {
@@ -1553,7 +1561,7 @@ impl HarnessBrain {
                  instead of dropping it"
             );
             return self
-                .record_conversation_publishes(agent, None, published)
+                .record_conversation_publishes(agent, chat_id, published)
                 .await;
         };
 
@@ -1992,6 +2000,11 @@ impl Brain for HarnessBrain {
                         // inside a hand-off used to be filed under the
                         // orchestrator that relayed for it — the card named the
                         // wrong person for work it did not do.
+                        //
+                        // The **card** takes one owner, so one agent is picked;
+                        // each artifact keeps its own author further down, in
+                        // `record_published_artifacts`, because a turn can stage
+                        // publishes from more than one agent.
                         let publisher = published
                             .first()
                             .map(|p| p.agent.clone())
@@ -2003,12 +2016,12 @@ impl Brain for HarnessBrain {
                         // card, from each hand-off's card and from the chat
                         // handler's — which is exactly why the reply linked
                         // there while the deliverable sat on a second, orphaned
-                        // card nothing pointed at. Minting is now the
-                        // no-card-in-scope case only, and the reply link stops
-                        // being a choice because only one card exists.
+                        // card nothing pointed at. Minting is the
+                        // no-card-in-scope case, and the fallback inside
+                        // `file_publishes_on_card` for a card deleted mid-turn.
                         let filed = match turn.spawned_task.as_deref() {
                             Some(card_id) => {
-                                self.file_publishes_on_card(card_id, &publisher, published)
+                                self.file_publishes_on_card(card_id, &publisher, chat_id, published)
                                     .await
                             }
                             None => {
@@ -2056,15 +2069,17 @@ impl Brain for HarnessBrain {
                         // minted, which is how the operator gets from "here is
                         // your deliverable" to the thing itself in one click.
                         //
-                        // Since #463 the `or` no longer picks a winner between
-                        // two cards, because there are never two: a publish made
-                        // with a card in scope is filed ONTO `spawned_task`, and
-                        // `published_card` is only ever set when there was no
-                        // card to file onto. The two arms are now the same card
-                        // or a single one, and the operator can no longer be
-                        // sent to an empty card while the deliverable sits on an
-                        // orphan.
-                        task_id: turn.spawned_task.or(published_card),
+                        // **`published_card` wins** (#463). It is `Some` only
+                        // when a publish landed, and it always names the card
+                        // the deliverable landed ON — usually `spawned_task`
+                        // itself, but the freshly minted replacement when that
+                        // card was deleted mid-turn. Preferring `spawned_task`
+                        // there would link the reply to an id that no longer
+                        // resolves while the file sits elsewhere, which is this
+                        // issue's own failure reached through the fallback added
+                        // to prevent it. With no publish this is `None` and the
+                        // turn's own card takes the slot exactly as before.
+                        task_id: published_card.or(turn.spawned_task),
                         channel: "operator".to_string(),
                         text: operator_reply,
                         reply_to: None,
@@ -3015,6 +3030,7 @@ members = ["engineer"]
             .file_publishes_on_card(
                 "t-open",
                 "writer",
+                None,
                 vec![PendingPublish {
                     agent: "writer".to_string(),
                     source: "memo.md".to_string(),
@@ -3071,6 +3087,7 @@ members = ["engineer"]
             .file_publishes_on_card(
                 "t-owned",
                 "writer",
+                None,
                 vec![PendingPublish {
                     agent: "writer".to_string(),
                     source: "memo.md".to_string(),
@@ -3101,6 +3118,7 @@ members = ["engineer"]
             .file_publishes_on_card(
                 "t-gone",
                 "writer",
+                Some("strategy"),
                 vec![PendingPublish {
                     agent: "writer".to_string(),
                     source: "memo.md".to_string(),
@@ -3113,10 +3131,20 @@ members = ["engineer"]
             .await
             .expect("mints a card instead");
 
-        assert_ne!(filed, "t-gone");
         let cards = TaskStore::list(&*ops, &company).await.expect("list");
         assert_eq!(cards.len(), 1, "the deliverable still has a card");
         assert_eq!(cards[0].assignee, "writer");
+        // The returned id must be the REPLACEMENT, not the id that is gone: the
+        // caller links the operator's reply to it (#463 review).
+        assert_eq!(
+            filed, cards[0].id,
+            "the returned id must name the card the deliverable landed on"
+        );
+        assert_ne!(filed, "t-gone");
+        // …and it belongs to the same conversation, like the card the
+        // no-card-in-scope path mints. Two minting paths must not disagree
+        // about where their card posts back.
+        assert_eq!(cards[0].origin_chat_id.as_deref(), Some("strategy"));
     }
 
     /// Each artifact records the agent that published **it** (#463 review).

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -1390,6 +1390,19 @@ impl HarnessBrain {
     /// `run_id` stamps the revision this call writes (#242) so a run row can
     /// point at what it actually produced. An earlier attempt's version keeps
     /// the attempt that wrote *it*.
+    ///
+    /// # Authorship is per file, not per call (issue #463)
+    ///
+    /// Each revision records the agent that published **that file**, read from
+    /// [`PendingPublish::agent`]. `responder` is only the fallback, for a value
+    /// built by hand rather than by the tool.
+    ///
+    /// One drain can hold publishes from more than one agent — the desk lead's
+    /// turn and the orchestrator's own turn both run with the full toolbelt
+    /// under a single `Conversation` claim — so a single author applied to the
+    /// batch stamps one agent's name on another's file. The card above still
+    /// takes one owner, because a card has one; a revision is a different
+    /// question with a different answer.
     async fn record_published_artifacts(
         &self,
         card: &TaskRecord,
@@ -1417,6 +1430,13 @@ impl HarnessBrain {
         let mut written = Vec::with_capacity(published.len());
         for pending in published {
             let at = now_millis();
+            // Issue #463: whoever published THIS file. `responder` is the
+            // fallback for a `PendingPublish` not built by the tool — the tool
+            // always stamps its own agent.
+            let author = match pending.agent.trim() {
+                "" => responder,
+                agent => agent,
+            };
             // Identity, not recency: the record whose `source` is this exact
             // path, or a new one.
             let existing = on_card
@@ -1431,7 +1451,7 @@ impl HarnessBrain {
                     version = found.push_version(
                         &pending.body,
                         ArtifactAuthor::Agent,
-                        responder,
+                        author,
                         at,
                         pending.note.clone(),
                     );
@@ -1450,7 +1470,7 @@ impl HarnessBrain {
                         &pending.title,
                         pending.kind,
                         &pending.body,
-                        responder,
+                        author,
                         at,
                     )
                     .with_source(pending.source.clone());
@@ -3097,6 +3117,96 @@ members = ["engineer"]
         let cards = TaskStore::list(&*ops, &company).await.expect("list");
         assert_eq!(cards.len(), 1, "the deliverable still has a card");
         assert_eq!(cards[0].assignee, "writer");
+    }
+
+    /// Each artifact records the agent that published **it** (#463 review).
+    ///
+    /// One drain can hold publishes from more than one agent — the desk lead's
+    /// turn and the orchestrator's own turn both run with the full toolbelt
+    /// under a single `Conversation` claim. Collapsing the batch to one author
+    /// stamps the writer's name on the orchestrator's file and the reverse.
+    #[tokio::test]
+    async fn each_published_artifact_records_its_own_author() {
+        use crate::harness::publish::PendingPublish;
+        use crate::ports::artifacts::ArtifactStore;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, ops) = brain_with_artifacts(dir.path());
+        let company = CompanyId::new("acme");
+        let publish = |agent: &str, source: &str| PendingPublish {
+            agent: agent.to_string(),
+            source: source.to_string(),
+            title: source.to_string(),
+            kind: crate::ports::artifacts::ArtifactKind::Markdown,
+            note: None,
+            body: format!("# {source}"),
+        };
+
+        brain
+            .record_published_artifacts(
+                &card("t-1", "maya"),
+                // The batch-level fallback, which must NOT win over the
+                // per-item agents below.
+                "maya",
+                vec![publish("writer", "memo.md"), publish("ceo", "notes.md")],
+                None,
+            )
+            .await
+            .expect("records");
+
+        let mut authors: Vec<(String, String)> = ArtifactStore::list(&*ops, &company, Some("t-1"))
+            .await
+            .expect("list")
+            .into_iter()
+            .map(|a| {
+                (
+                    a.source.clone().unwrap_or_default(),
+                    a.versions[0].author_id.clone(),
+                )
+            })
+            .collect();
+        authors.sort();
+        assert_eq!(
+            authors,
+            vec![
+                ("memo.md".to_string(), "writer".to_string()),
+                ("notes.md".to_string(), "ceo".to_string()),
+            ]
+        );
+    }
+
+    /// …and a `PendingPublish` built by hand — not by the tool, which always
+    /// stamps its agent — still falls back to the caller's responder rather
+    /// than recording a blank author.
+    #[tokio::test]
+    async fn a_publish_with_no_agent_falls_back_to_the_responder() {
+        use crate::harness::publish::PendingPublish;
+        use crate::ports::artifacts::ArtifactStore;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, ops) = brain_with_artifacts(dir.path());
+
+        brain
+            .record_published_artifacts(
+                &card("t-1", "maya"),
+                "maya",
+                vec![PendingPublish {
+                    agent: String::new(),
+                    source: "memo.md".to_string(),
+                    title: "Memo".to_string(),
+                    kind: crate::ports::artifacts::ArtifactKind::Markdown,
+                    note: None,
+                    body: "# Memo".to_string(),
+                }],
+                None,
+            )
+            .await
+            .expect("records");
+
+        let listed = ArtifactStore::list(&*ops, &CompanyId::new("acme"), Some("t-1"))
+            .await
+            .expect("list");
+        assert_eq!(listed[0].versions[0].author_id, "maya");
     }
 
     /// The other half: a run that did NOT succeed records nothing either, and

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -1479,6 +1479,87 @@ impl HarnessBrain {
         Ok(written)
     }
 
+    /// Files what a conversation turn published onto the card that turn already
+    /// opened (issue #463). Returns that card's id.
+    ///
+    /// # Why this exists at all
+    ///
+    /// #445 made a chat publish mint a card, which was right for a publish with
+    /// nothing else in scope and wrong the moment #442 started opening a card
+    /// for the work itself: one substantial ask that ended in a published file
+    /// produced two cards, and the reply linked to the one with no artifacts on
+    /// it. Both fixes were correct alone. Together they doubled, and the
+    /// deliverable ended up on the card nothing pointed at.
+    ///
+    /// So a publish files onto the card in scope instead of opening a rival to
+    /// it. The card already carries the request and the answer; this adds the
+    /// artifact and says who delivered it.
+    ///
+    /// # What it changes on the card, and what it leaves alone
+    ///
+    /// The note gains a line naming the published files. The column moves to
+    /// [`COLUMN_IN_REVIEW`] — a deliverable was produced and a person has not
+    /// accepted it yet, the same landing `record_conversation_publishes` gives
+    /// its minted card and the same one a settled run gets. A card with **no
+    /// assignee** — the To-do card the REST chat handler opens, which has never
+    /// belonged to anybody — is assigned to the publisher; a card that already
+    /// has an owner keeps them, because filing a file must not quietly take
+    /// somebody's work away from them.
+    ///
+    /// A card that has since been deleted falls back to minting, so the
+    /// artifact stays reachable rather than being dropped for the sake of the
+    /// rule.
+    async fn file_publishes_on_card(
+        &self,
+        card_id: &str,
+        agent: &str,
+        published: Vec<publish::PendingPublish>,
+    ) -> Result<String> {
+        let Some(tasks) = self.deps.tasks.as_ref() else {
+            return Err(crate::OpenCompanyError::Harness(
+                "a conversation published a file but no task board is wired".to_string(),
+            ));
+        };
+        let Some(mut card) = tasks
+            .list(&self.record.id)
+            .await?
+            .into_iter()
+            .find(|card| card.id == card_id)
+        else {
+            tracing::warn!(
+                task_id = %card_id,
+                agent = %agent,
+                "[publish] the card this turn opened is gone; minting one for the deliverable \
+                 instead of dropping it"
+            );
+            return self
+                .record_conversation_publishes(agent, None, published)
+                .await;
+        };
+
+        let recorded = self
+            .record_published_artifacts(&card, agent, published.clone(), None)
+            .await?;
+        card.note = Some(append_result(
+            card.note.as_deref(),
+            agent,
+            &publish::filed_on_card_note(&published),
+        ));
+        card.column = COLUMN_IN_REVIEW.to_string();
+        if card.assignee.is_empty() {
+            card.assignee = agent.to_string();
+        }
+        card.updated_at_millis = now_millis();
+        tasks.upsert(&self.record.id, &card).await?;
+        tracing::info!(
+            task_id = %card.id,
+            agent = %agent,
+            artifacts = recorded.len(),
+            "[publish] a conversation published files onto the card this message already opened"
+        );
+        Ok(card.id)
+    }
+
     /// Records what a **conversation** turn published, minting the card that
     /// carries it (issue #445). Returns that card's id.
     ///
@@ -1886,10 +1967,36 @@ impl Brain for HarnessBrain {
                     let mut published_card = None;
                     if !published.is_empty() && publish_claim.is_some() {
                         let count = published.len();
-                        match self
-                            .record_conversation_publishes(&responder, chat_id, published)
-                            .await
-                        {
+                        // Issue #463: the agent that actually called the tool,
+                        // not the turn's responder. A desk lead publishing
+                        // inside a hand-off used to be filed under the
+                        // orchestrator that relayed for it — the card named the
+                        // wrong person for work it did not do.
+                        let publisher = published
+                            .first()
+                            .map(|p| p.agent.clone())
+                            .filter(|agent| !agent.is_empty())
+                            .unwrap_or_else(|| responder.clone());
+                        // Issue #463: file onto the card THIS message already
+                        // opened when there is one. `turn.spawned_task` holds it
+                        // by construction — it is seeded from the direct-answer
+                        // card, from each hand-off's card and from the chat
+                        // handler's — which is exactly why the reply linked
+                        // there while the deliverable sat on a second, orphaned
+                        // card nothing pointed at. Minting is now the
+                        // no-card-in-scope case only, and the reply link stops
+                        // being a choice because only one card exists.
+                        let filed = match turn.spawned_task.as_deref() {
+                            Some(card_id) => {
+                                self.file_publishes_on_card(card_id, &publisher, published)
+                                    .await
+                            }
+                            None => {
+                                self.record_conversation_publishes(&publisher, chat_id, published)
+                                    .await
+                            }
+                        };
+                        match filed {
                             Ok(card_id) => published_card = Some(card_id),
                             Err(err) => {
                                 // The agent has already been told the file was
@@ -1928,12 +2035,15 @@ impl Brain for HarnessBrain {
                         // Issue #445 reuses that link for the card a publish
                         // minted, which is how the operator gets from "here is
                         // your deliverable" to the thing itself in one click.
-                        // A `spawn_task` still wins the slot: this field is a
-                        // single id (see `OperatorTurn::spawned_task` on why it
-                        // cannot be widened), so the rule is to never take a
-                        // link away from a turn that already had one. A publish
-                        // card that loses the slot is still on the board, in
-                        // review, carrying a note that explains what it is.
+                        //
+                        // Since #463 the `or` no longer picks a winner between
+                        // two cards, because there are never two: a publish made
+                        // with a card in scope is filed ONTO `spawned_task`, and
+                        // `published_card` is only ever set when there was no
+                        // card to file onto. The two arms are now the same card
+                        // or a single one, and the operator can no longer be
+                        // sent to an empty card while the deliverable sits on an
+                        // orphan.
                         task_id: turn.spawned_task.or(published_card),
                         channel: "operator".to_string(),
                         text: operator_reply,
@@ -2672,6 +2782,7 @@ members = ["engineer"]
         let company = CompanyId::new("acme");
         let c = card("t-1", "maya");
         let publish = |source: &str, body: &str| PendingPublish {
+            agent: "maya".to_string(),
             source: source.to_string(),
             title: source.to_string(),
             kind: crate::ports::artifacts::ArtifactKind::Markdown,
@@ -2781,6 +2892,7 @@ members = ["engineer"]
         let (brain, ops) = brain_with_artifacts(dir.path());
         let c = card("t-1", "maya");
         let publish = |body: &str| PendingPublish {
+            agent: "maya".to_string(),
             source: "spec.md".to_string(),
             title: "spec.md".to_string(),
             kind: crate::ports::artifacts::ArtifactKind::Markdown,
@@ -2842,6 +2954,7 @@ members = ["engineer"]
                 &card("t-1", "maya"),
                 "maya",
                 vec![PendingPublish {
+                    agent: "maya".to_string(),
                     source: "spec.md".to_string(),
                     title: "spec.md".to_string(),
                     kind: crate::ports::artifacts::ArtifactKind::Markdown,
@@ -2853,6 +2966,137 @@ members = ["engineer"]
             .await
             .expect_err("a lost deliverable must not read as a success");
         assert!(err.to_string().contains("the disk is full"), "{err}");
+    }
+
+    /// Issue #463, the headline. A publish made when this message already has a
+    /// card files **onto that card** rather than minting a second one beside it.
+    ///
+    /// #445 minted unconditionally, which was right on its own and wrong beside
+    /// #442's card-by-construction: one substantial ask that ended in a
+    /// published file left two cards, and the reply bubble linked to the empty
+    /// one because that is the card the turn opened.
+    #[tokio::test]
+    async fn a_publish_with_a_card_in_scope_files_onto_it_instead_of_minting() {
+        use crate::harness::publish::PendingPublish;
+        use crate::ports::artifacts::ArtifactStore;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, ops) = brain_with_artifacts(dir.path());
+        let company = CompanyId::new("acme");
+        // The card #442 opens for the work — no owner yet, exactly like the
+        // To-do card the REST chat handler writes.
+        let mut open = card("t-open", "");
+        open.column = COLUMN_TODO.to_string();
+        TaskStore::upsert(&*ops, &company, &open)
+            .await
+            .expect("seed");
+
+        let filed = brain
+            .file_publishes_on_card(
+                "t-open",
+                "writer",
+                vec![PendingPublish {
+                    agent: "writer".to_string(),
+                    source: "memo.md".to_string(),
+                    title: "Q3 board memo".to_string(),
+                    kind: crate::ports::artifacts::ArtifactKind::Markdown,
+                    note: None,
+                    body: "# Memo".to_string(),
+                }],
+            )
+            .await
+            .expect("files onto the card");
+
+        assert_eq!(filed, "t-open", "no second card was minted");
+        let cards = TaskStore::list(&*ops, &company).await.expect("list");
+        assert_eq!(cards.len(), 1, "{cards:?}");
+        assert_eq!(
+            cards[0].column, COLUMN_IN_REVIEW,
+            "a delivered file lands for a person to accept"
+        );
+        assert_eq!(
+            cards[0].assignee, "writer",
+            "an unowned card becomes the publisher's"
+        );
+        assert!(
+            cards[0]
+                .note
+                .as_deref()
+                .unwrap_or_default()
+                .contains("memo.md"),
+            "the note names what landed: {:?}",
+            cards[0].note
+        );
+        let artifacts = ArtifactStore::list(&*ops, &company, Some("t-open"))
+            .await
+            .expect("list artifacts");
+        assert_eq!(artifacts.len(), 1, "the deliverable is ON the card");
+        assert_eq!(artifacts[0].title, "Q3 board memo");
+    }
+
+    /// …but filing a file never takes somebody's card away from them. Only an
+    /// **unowned** card is claimed by the publisher.
+    #[tokio::test]
+    async fn filing_a_publish_leaves_an_owned_card_with_its_owner() {
+        use crate::harness::publish::PendingPublish;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, ops) = brain_with_artifacts(dir.path());
+        let company = CompanyId::new("acme");
+        ops.upsert(&company, &card("t-owned", "maya"))
+            .await
+            .expect("seed");
+
+        brain
+            .file_publishes_on_card(
+                "t-owned",
+                "writer",
+                vec![PendingPublish {
+                    agent: "writer".to_string(),
+                    source: "memo.md".to_string(),
+                    title: "Memo".to_string(),
+                    kind: crate::ports::artifacts::ArtifactKind::Markdown,
+                    note: None,
+                    body: "# Memo".to_string(),
+                }],
+            )
+            .await
+            .expect("files onto the card");
+
+        assert_eq!(only_card(&ops).await.assignee, "maya");
+    }
+
+    /// A card that vanished between the turn and the drain falls back to
+    /// minting. The rule exists to stop a second card, not to lose a
+    /// deliverable — dropping the artifact would be #445 all over again.
+    #[tokio::test]
+    async fn a_publish_onto_a_card_that_vanished_mints_one_rather_than_dropping_it() {
+        use crate::harness::publish::PendingPublish;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, ops) = brain_with_artifacts(dir.path());
+        let company = CompanyId::new("acme");
+
+        let filed = brain
+            .file_publishes_on_card(
+                "t-gone",
+                "writer",
+                vec![PendingPublish {
+                    agent: "writer".to_string(),
+                    source: "memo.md".to_string(),
+                    title: "Memo".to_string(),
+                    kind: crate::ports::artifacts::ArtifactKind::Markdown,
+                    note: None,
+                    body: "# Memo".to_string(),
+                }],
+            )
+            .await
+            .expect("mints a card instead");
+
+        assert_ne!(filed, "t-gone");
+        let cards = TaskStore::list(&*ops, &company).await.expect("list");
+        assert_eq!(cards.len(), 1, "the deliverable still has a card");
+        assert_eq!(cards[0].assignee, "writer");
     }
 
     /// The other half: a run that did NOT succeed records nothing either, and

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -1771,7 +1771,7 @@ impl HarnessBrain {
     ) -> Result<delegation::DelegationOutcome> {
         let run_turn = HarnessRunTurn::new(&self.pool, &self.deps);
         self.delegation_runner(&run_turn)
-            .run_delegation(delegation, chat_id)
+            .run_delegation(delegation, chat_id, false)
             .await
     }
 

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -229,6 +229,7 @@ pub fn build_agent(
     if publishing {
         tools.push(Box::new(crate::harness::publish::PublishArtifactTool::new(
             workspace.clone(),
+            manifest_agent.id.clone(),
             deps.pending_publishes.clone(),
         )));
     } else if wants_files {

--- a/src/harness/publish.rs
+++ b/src/harness/publish.rs
@@ -181,6 +181,19 @@ const MAX_NAMED_FILES: usize = 20;
 /// stored.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PendingPublish {
+    /// The agent that made the call (issue #463).
+    ///
+    /// The queue is shared by every turn a cycle runs, so "who published this"
+    /// is not answerable from the drain site: an operator message can be
+    /// answered by the orchestrator and handed to a desk, and the file comes
+    /// from whichever of them reached for the tool. Recording it at the call —
+    /// the tool is bound to exactly one agent's sandbox — is what stops the
+    /// card and the artifact being filed under the turn's responder when
+    /// somebody else did the work.
+    ///
+    /// Empty only for a value built by hand outside the tool; callers fall back
+    /// to the responder in that case rather than writing a blank author.
+    pub agent: String,
     /// The normalized workspace-relative path — the artifact's identity
     /// alongside its task id.
     pub source: String,
@@ -595,14 +608,23 @@ pub fn capture_body(
 /// shared queue the brain drains.
 pub struct PublishArtifactTool {
     workspace: PathBuf,
+    /// The agent this instance belongs to, stamped onto everything it stages
+    /// (issue #463) — the tool is built per agent, so this is the one place the
+    /// publisher's identity is known for certain.
+    agent: String,
     queue: PendingPublishQueue,
 }
 
 impl PublishArtifactTool {
-    /// Binds the tool to one agent's workspace and the shared queue.
-    pub fn new(workspace: impl Into<PathBuf>, queue: PendingPublishQueue) -> Self {
+    /// Binds the tool to one agent, its workspace, and the shared queue.
+    pub fn new(
+        workspace: impl Into<PathBuf>,
+        agent: impl Into<String>,
+        queue: PendingPublishQueue,
+    ) -> Self {
         Self {
             workspace: workspace.into(),
+            agent: agent.into(),
             queue,
         }
     }
@@ -721,6 +743,7 @@ impl Tool for PublishArtifactTool {
             .map(str::to_string);
 
         self.queue.push(PendingPublish {
+            agent: self.agent.clone(),
             source: source.clone(),
             title: title.clone(),
             kind,
@@ -1067,6 +1090,21 @@ pub fn conversation_card_note(agent: &str, published: &[PendingPublish]) -> Stri
         "Opened to carry what {agent} published during a conversation: {files}. Chat turns run \
          without a card, so this card was created by the act of publishing — it records a \
          delivered file rather than a request somebody made.",
+        files = name_files(&files),
+    )
+}
+
+/// The note line recording a publish filed onto the card the message already
+/// opened (issue #463).
+///
+/// Deliberately not [`conversation_card_note`]'s wording: that one explains why
+/// a card exists that nobody asked for, and this card exists because somebody
+/// asked for it. All this has to say is what landed on it and, through the
+/// attribution the note carries, who put it there.
+pub fn filed_on_card_note(published: &[PendingPublish]) -> String {
+    let files: Vec<String> = published.iter().map(|p| p.source.clone()).collect();
+    format!(
+        "published {files} onto this card — open the Artifacts tab to read the delivered file.",
         files = name_files(&files),
     )
 }

--- a/src/harness/publish/test.rs
+++ b/src/harness/publish/test.rs
@@ -271,7 +271,7 @@ fn the_reference_digest_tracks_the_bytes() {
 async fn publishing_stages_the_file_and_reports_what_was_captured() {
     let dir = workspace(&[("specs/launch.md", b"# Spec\nShip it.")]);
     let (queue, _claim) = claimed(PublishDestination::Task);
-    let tool = PublishArtifactTool::new(dir.path(), queue.clone());
+    let tool = PublishArtifactTool::new(dir.path(), "maya", queue.clone());
 
     let result = run(&tool, json!({ "path": "specs/launch.md" })).await;
     assert!(!result.is_error, "{}", text_of(&result));
@@ -286,11 +286,30 @@ async fn publishing_stages_the_file_and_reports_what_was_captured() {
     assert_eq!(staged[0].note, None);
 }
 
+/// Issue #463: the staged item names **who published it**.
+///
+/// The queue is shared by every turn a cycle runs, so the drain site cannot
+/// answer this — an operator message answered by the orchestrator and handed to
+/// a desk stages a file from whichever of them reached for the tool. Without the
+/// stamp the card and the artifact were filed under the turn's responder, so a
+/// deliverable the writer produced was recorded as the orchestrator's.
+#[tokio::test]
+async fn a_staged_publish_names_the_agent_that_called_the_tool() {
+    let dir = workspace(&[("memo.md", b"# Memo")]);
+    let (queue, _claim) = claimed(PublishDestination::Conversation);
+    let tool = PublishArtifactTool::new(dir.path(), "writer", queue.clone());
+
+    run(&tool, json!({ "path": "memo.md" })).await;
+
+    let staged = queue.drain();
+    assert_eq!(staged[0].agent, "writer");
+}
+
 #[tokio::test]
 async fn an_explicit_title_kind_and_note_are_carried_through() {
     let dir = workspace(&[("out.dat", b"plain text really")]);
     let (queue, _claim) = claimed(PublishDestination::Task);
-    let tool = PublishArtifactTool::new(dir.path(), queue.clone());
+    let tool = PublishArtifactTool::new(dir.path(), "maya", queue.clone());
 
     run(
         &tool,
@@ -322,7 +341,7 @@ async fn an_explicit_title_kind_and_note_are_carried_through() {
 async fn the_body_is_captured_at_publish_time_not_at_drain_time() {
     let dir = workspace(&[("spec.md", b"# The version I published")]);
     let (queue, _claim) = claimed(PublishDestination::Task);
-    let tool = PublishArtifactTool::new(dir.path(), queue.clone());
+    let tool = PublishArtifactTool::new(dir.path(), "maya", queue.clone());
 
     run(&tool, json!({ "path": "spec.md" })).await;
     // The agent's next step scribbles over the file.
@@ -336,7 +355,7 @@ async fn the_body_is_captured_at_publish_time_not_at_drain_time() {
 async fn a_bad_path_is_a_truthful_tool_error_and_stages_nothing() {
     let dir = workspace(&[("spec.md", b"# Spec")]);
     let (queue, _claim) = claimed(PublishDestination::Task);
-    let tool = PublishArtifactTool::new(dir.path(), queue.clone());
+    let tool = PublishArtifactTool::new(dir.path(), "maya", queue.clone());
 
     for path in ["../escape.md", "/etc/hosts", "nope.md", ""] {
         let result = run(&tool, json!({ "path": path })).await;
@@ -351,7 +370,7 @@ async fn a_bad_path_is_a_truthful_tool_error_and_stages_nothing() {
 async fn an_unknown_kind_is_refused_by_name() {
     let dir = workspace(&[("spec.md", b"# Spec")]);
     let (queue, _claim) = claimed(PublishDestination::Task);
-    let tool = PublishArtifactTool::new(dir.path(), queue.clone());
+    let tool = PublishArtifactTool::new(dir.path(), "maya", queue.clone());
 
     let result = run(&tool, json!({ "path": "spec.md", "kind": "spreadsheet" })).await;
     assert!(result.is_error);
@@ -366,6 +385,7 @@ async fn an_unknown_kind_is_refused_by_name() {
 fn the_queue_drains_fifo_and_empties() {
     let queue = PendingPublishQueue::default();
     let publish = |source: &str| PendingPublish {
+        agent: "maya".to_string(),
         source: source.to_string(),
         title: source.to_string(),
         kind: ArtifactKind::Text,
@@ -396,6 +416,7 @@ fn the_queue_drains_fifo_and_empties() {
 fn clear_drops_what_a_prior_turn_staged() {
     let queue = PendingPublishQueue::default();
     queue.push(PendingPublish {
+        agent: "maya".to_string(),
         source: "leftover.md".to_string(),
         title: "leftover".to_string(),
         kind: ArtifactKind::Text,
@@ -418,7 +439,7 @@ fn clear_drops_what_a_prior_turn_staged() {
 async fn a_cloned_handle_sees_the_same_queue() {
     let dir = workspace(&[("spec.md", b"# Spec")]);
     let queue = PendingPublishQueue::default();
-    let tool = PublishArtifactTool::new(dir.path(), queue.clone());
+    let tool = PublishArtifactTool::new(dir.path(), "maya", queue.clone());
 
     let _claim = queue.claim(PublishDestination::Task);
     run(&tool, json!({ "path": "spec.md" })).await;
@@ -655,7 +676,7 @@ fn a_decline_is_recorded_with_both_the_files_and_the_reason() {
 async fn an_unclaimed_queue_refuses_to_publish_and_stages_nothing() {
     let dir = workspace(&[("specs/launch.md", b"# Spec")]);
     let queue = PendingPublishQueue::default();
-    let tool = PublishArtifactTool::new(dir.path(), queue.clone());
+    let tool = PublishArtifactTool::new(dir.path(), "maya", queue.clone());
 
     let result = run(&tool, json!({ "path": "specs/launch.md" })).await;
 
@@ -707,7 +728,7 @@ fn a_fresh_queue_is_unclaimed_by_default() {
 async fn dropping_the_claim_stops_publishing_again() {
     let dir = workspace(&[("spec.md", b"# Spec")]);
     let queue = PendingPublishQueue::default();
-    let tool = PublishArtifactTool::new(dir.path(), queue.clone());
+    let tool = PublishArtifactTool::new(dir.path(), "maya", queue.clone());
 
     let claim = queue.claim(PublishDestination::Task);
     assert!(!run(&tool, json!({ "path": "spec.md" })).await.is_error);
@@ -737,6 +758,7 @@ fn claiming_clears_whatever_a_previous_caller_left_staged() {
     let queue = PendingPublishQueue::default();
     let claim = queue.claim(PublishDestination::Task);
     queue.push(PendingPublish {
+        agent: "maya".to_string(),
         source: "stale.md".to_string(),
         title: "stale".to_string(),
         kind: ArtifactKind::Text,
@@ -758,11 +780,11 @@ async fn the_receipt_names_the_destination_the_caller_actually_has() {
     let dir = workspace(&[("spec.md", b"# Spec")]);
 
     let (task_queue, _task_claim) = claimed(PublishDestination::Task);
-    let task_tool = PublishArtifactTool::new(dir.path(), task_queue);
+    let task_tool = PublishArtifactTool::new(dir.path(), "maya", task_queue);
     let task_receipt = text_of(&run(&task_tool, json!({ "path": "spec.md" })).await);
 
     let (chat_queue, _chat_claim) = claimed(PublishDestination::Conversation);
-    let chat_tool = PublishArtifactTool::new(dir.path(), chat_queue);
+    let chat_tool = PublishArtifactTool::new(dir.path(), "maya", chat_queue);
     let chat_receipt = text_of(&run(&chat_tool, json!({ "path": "spec.md" })).await);
 
     assert!(
@@ -788,6 +810,7 @@ async fn the_receipt_names_the_destination_the_caller_actually_has() {
 #[test]
 fn a_minted_card_is_titled_from_what_was_published() {
     let publish = |title: &str, source: &str| PendingPublish {
+        agent: "maya".to_string(),
         source: source.to_string(),
         title: title.to_string(),
         kind: ArtifactKind::Markdown,
@@ -820,6 +843,7 @@ fn a_minted_card_explains_why_it_exists() {
     let note = conversation_card_note(
         "ceo",
         &[PendingPublish {
+            agent: "maya".to_string(),
             source: "specs/launch.md".to_string(),
             title: "Launch spec".to_string(),
             kind: ArtifactKind::Markdown,

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -295,6 +295,27 @@ impl<'a> DelegationRunner<'a> {
         // responder's turn (metered behind the `RunTurn` impl), then drain
         // whatever it queued.
         self.queue.clear();
+        // Issue #463: did the REST chat handler already card this message?
+        //
+        // Evaluated ONCE, here, and for one reason: this is the only place the
+        // operator's OWN words are still in scope. `run_delegation` receives the
+        // instruction the model wrote, which is a different sentence — a guard
+        // placed there would be asking the detector about the model's prose
+        // rather than about the message the handler classified. #442 put the
+        // stand-down in `open_direct_work_card` only, so a recognised imperative
+        // the orchestrator handed off produced the REST card AND the delegation
+        // card. One message, one card — so every card-opening path below reads
+        // this same answer.
+        let carded_by_handler =
+            crate::company::task_intent::detect_task_intent(operator_words(message)).is_some();
+        // …and *which* card that is, when it is still on the board. Adopting it
+        // is what carries "one message, one card" through the publish drain too:
+        // the caller files a published deliverable onto `spawned_task` rather
+        // than minting a second card beside this one (issue #463).
+        let handler_card = match carded_by_handler {
+            true => self.chat_handler_card(message).await?,
+            false => None,
+        };
         // Issue #442, path one: a desk lead or teammate asked DIRECTLY carries
         // no delegation tools — the card-opening tools are wired only onto the
         // orchestrator — so it has no way to open a card even if it wanted one
@@ -303,7 +324,7 @@ impl<'a> DelegationRunner<'a> {
         // the tracking decision stops depending on which agent answered or which
         // tools it happens to carry.
         let mut direct_card = self
-            .open_direct_work_card(responder, message, chat_id)
+            .open_direct_work_card(responder, message, chat_id, carded_by_handler)
             .await?;
         let outcome = self
             .run_turn
@@ -335,9 +356,17 @@ impl<'a> DelegationRunner<'a> {
         // it the FIRST — a later spawn must not overwrite the id an earlier one
         // already claimed, or the reported card would be whichever the model
         // happened to queue last.
-        let mut spawned_task: Option<String> = direct_card_id;
+        //
+        // The chat handler's card comes first when it opened one: it predates
+        // every card this turn could open, so it IS the first card for this
+        // message (issue #463). Before this it was invisible from here, which is
+        // why the operator bubble linked to nothing on a recognised imperative
+        // even though the board carried a card for it.
+        let mut spawned_task: Option<String> = handler_card.or(direct_card_id);
         for delegation in self.queue.drain(self.max_delegations) {
-            let out = self.run_delegation(delegation, chat_id).await?;
+            let out = self
+                .run_delegation(delegation, chat_id, carded_by_handler)
+                .await?;
             if let Some(id) = out.spawned_task {
                 spawned_task.get_or_insert(id);
             }
@@ -383,7 +412,9 @@ impl<'a> DelegationRunner<'a> {
                     );
                     continue;
                 }
-                let out = self.run_delegation(delegation, chat_id).await?;
+                let out = self
+                    .run_delegation(delegation, chat_id, carded_by_handler)
+                    .await?;
                 if let Some(id) = out.spawned_task {
                     spawned_task.get_or_insert(id);
                 }
@@ -508,7 +539,11 @@ impl<'a> DelegationRunner<'a> {
                 // fact instead of inferring it from an absence. Every other
                 // delegation kind carries no desk and is unaffected.
                 let desk = desk_of(&delegation).map(str::to_string);
-                self.run_delegation(delegation, None).await?;
+                // `false`: a dispatched card's drain has no operator message and
+                // therefore no chat-handler card to defer to. It opens no card
+                // of its own regardless — `for_task` is set, which
+                // `open_work_card` refuses on first.
+                self.run_delegation(delegation, None, false).await?;
                 if let Some(desk) = desk {
                     card.note = Some(append_note(
                         card.note.as_deref(),
@@ -535,7 +570,7 @@ impl<'a> DelegationRunner<'a> {
                 self.hand_card_over(card, delegator, &member, instruction_of(&delegation))
                     .await?;
             }
-            let outcome = self.run_delegation(delegation, None).await?;
+            let outcome = self.run_delegation(delegation, None, false).await?;
             match (owns_card, outcome.desk_reply, outcome.cancelled) {
                 // The delegate answered: they own the card and it settles from
                 // their output.
@@ -583,12 +618,14 @@ impl<'a> DelegationRunner<'a> {
     /// that is about to run somebody's turn goes through here first, so there is
     /// no path on which work starts and the board stays empty.
     ///
-    /// Returns `None` — no card, nothing to settle — in exactly four cases:
+    /// Returns `None` — no card, nothing to settle — in exactly five cases:
     ///
     /// * **no task store wired**, the silent no-op every task path on this seam
     ///   takes;
     /// * **already inside a dispatched card** (`for_task`), which is the card;
     ///   opening a second one would double-count one piece of work;
+    /// * **the chat handler already carded this message** (`carded_by_handler`,
+    ///   issue #463) — see [`handle_operator_message`](Self::handle_operator_message);
     /// * **nothing substantial was asked** — see [`is_trackable_work`]; this is
     ///   the carve-out that keeps a trivial question from minting a card;
     /// * the write failed, which propagates rather than returning `None`.
@@ -602,11 +639,26 @@ impl<'a> DelegationRunner<'a> {
         assignee: &str,
         request: &str,
         chat_id: Option<&str>,
+        carded_by_handler: bool,
     ) -> Result<Option<TaskRecord>> {
         let Some(tasks) = self.tasks else {
             return Ok(None);
         };
         if self.task.is_some() {
+            return Ok(None);
+        }
+        // Issue #463: the REST chat handler read the operator's original words
+        // and already opened a To-do card for them. One message must not become
+        // two cards, whichever of the two card-opening paths below is running —
+        // #442 guarded only the direct path, and a recognised imperative that
+        // was handed off doubled through this one.
+        if carded_by_handler {
+            tracing::debug!(
+                company = %self.company,
+                assignee = %assignee,
+                "[delegation] not opening a card: the chat handler already opened one for this \
+                 message"
+            );
             return Ok(None);
         }
         // What the operator actually asked for, without the open-work briefing
@@ -672,31 +724,65 @@ impl<'a> DelegationRunner<'a> {
     ///
     /// Found live: without this, three consecutive desk messages opened four
     /// cards, one of them a duplicate of the request beside it. The two
-    /// detectors are deliberately not merged here — they answer different
-    /// questions with opposite defaults (that one asks "is this unambiguously an
+    /// detectors are deliberately not merged — they answer different questions
+    /// with opposite defaults (that one asks "is this unambiguously an
     /// instruction?", this one asks "is there any reason NOT to track it?") —
     /// but exactly one of them may open the card.
+    ///
+    /// The stand-down itself now lives in
+    /// [`open_work_card`](Self::open_work_card), reached through
+    /// `carded_by_handler`, because the hand-off path needed the same guard and
+    /// only [`handle_operator_message`](Self::handle_operator_message) can
+    /// answer the question (issue #463).
     async fn open_direct_work_card(
         &self,
         responder: &str,
         message: &str,
         chat_id: Option<&str>,
+        carded_by_handler: bool,
     ) -> Result<Option<TaskRecord>> {
         if responder == self.orchestrator_id() {
             return Ok(None);
         }
-        // The same input the chat handler classified: it saw the operator's text
-        // before the cycle appended its open-work briefing.
-        if crate::company::task_intent::detect_task_intent(operator_words(message)).is_some() {
-            tracing::debug!(
-                company = %self.company,
-                responder = %responder,
-                "[delegation] not opening a card: the chat handler already opened one for this \
-                 message"
-            );
+        self.open_work_card(responder, message, chat_id, carded_by_handler)
+            .await
+    }
+
+    /// The To-do card the REST chat handler opened for this message, when it
+    /// opened one and it is still on the board (issue #463).
+    ///
+    /// Only ever called once [`detect_task_intent`] has already fired, so the
+    /// title it derives is byte-for-byte the one the handler wrote — the handler
+    /// runs the same detector over the same words moments earlier. The match is
+    /// deliberately narrow, and every clause is a property of a card **that
+    /// handler** writes: To-do, no assignee, no origin chat. `list` is
+    /// newest-first, so the first match is the one just written rather than a
+    /// months-old card that happens to share a title.
+    ///
+    /// `None` when no store is wired, or when nothing matches — which is the
+    /// honest answer for a handler write that failed (it is best-effort there)
+    /// and for every non-REST caller of this seam, none of which have a chat
+    /// handler in front of them. Callers must not read `None` as "the handler
+    /// did not fire": the stand-down is keyed on the detector, not on this.
+    async fn chat_handler_card(&self, message: &str) -> Result<Option<String>> {
+        let Some(tasks) = self.tasks else {
             return Ok(None);
-        }
-        self.open_work_card(responder, message, chat_id).await
+        };
+        let Some(title) = crate::company::task_intent::detect_task_intent(operator_words(message))
+        else {
+            return Ok(None);
+        };
+        Ok(tasks
+            .list(self.company)
+            .await?
+            .into_iter()
+            .find(|card| {
+                card.title == title
+                    && card.column == COLUMN_TODO
+                    && card.assignee.is_empty()
+                    && card.origin_chat_id.is_none()
+            })
+            .map(|card| card.id))
     }
 
     /// Settles a card [`open_work_card`](Self::open_work_card) opened, once the
@@ -784,10 +870,18 @@ impl<'a> DelegationRunner<'a> {
     /// unknown desk (no roster-backed lead) or a cancelled run yields nothing to
     /// relay. No sub-agent re-delegation in v1: desk members carry no delegation
     /// tools, so their turns queue nothing.
+    ///
+    /// `carded_by_handler` is [`handle_operator_message`](Self::handle_operator_message)'s
+    /// answer to "did the REST chat handler already card the operator message
+    /// this drain belongs to?" (issue #463). It is threaded in rather than
+    /// recomputed because the only text in scope here is the instruction the
+    /// model wrote, which is not what the handler classified. A dispatched
+    /// card's drain has no operator message and passes `false`.
     pub(crate) async fn run_delegation(
         &self,
         delegation: Delegation,
         chat_id: Option<&str>,
+        carded_by_handler: bool,
     ) -> Result<DelegationOutcome> {
         match delegation {
             Delegation::SpawnTask {
@@ -858,9 +952,13 @@ impl<'a> DelegationRunner<'a> {
                 //
                 // Nothing is opened when the drain is already running inside a
                 // dispatched card (that card *is* the tracking, and #204 hands it
-                // over to this delegate below) or when the instruction is not a
-                // piece of work — see `is_trackable_work`.
-                let mut card = self.open_work_card(&member, &instruction, chat_id).await?;
+                // over to this delegate below), when the REST chat handler
+                // already carded the operator message this hand-off came out of
+                // (issue #463), or when the instruction is not a piece of work —
+                // see `is_trackable_work`.
+                let mut card = self
+                    .open_work_card(&member, &instruction, chat_id, carded_by_handler)
+                    .await?;
                 // Register the delegated turn so an operator can CANCEL it
                 // mid-flight (cancel-only in v1 — pause/redirect are rejected at
                 // the route). RAII guard deregisters on every exit path.
@@ -1750,7 +1848,7 @@ members = ["engineer"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("done")]);
         let outcome = fx
             .runner(&turns)
-            .run_delegation(handoff("draft the launch plan"), None)
+            .run_delegation(handoff("draft the launch plan"), None, false)
             .await
             .expect("delegation runs");
         assert!(outcome.spawned_task.is_some());
@@ -1775,7 +1873,7 @@ members = ["engineer"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::cancelled("half-written")]);
         let outcome = fx
             .runner(&turns)
-            .run_delegation(handoff("write the migration plan"), None)
+            .run_delegation(handoff("write the migration plan"), None, false)
             .await
             .expect("delegation runs");
         assert!(outcome.cancelled);
@@ -1816,7 +1914,7 @@ members = ["engineer"]
         let outcome = fx
             .runner(&turns)
             .for_task("card-1")
-            .run_delegation(handoff("write the migration plan"), None)
+            .run_delegation(handoff("write the migration plan"), None, false)
             .await
             .expect("delegation runs");
         assert!(outcome.spawned_task.is_none());
@@ -1886,6 +1984,87 @@ members = ["engineer"]
             "the chat handler's card is the card; this path opens none"
         );
         assert!(turn.spawned_task.is_none());
+    }
+
+    /// The same stand-down on the **hand-off** path (issue #463). #442 guarded
+    /// only the direct path, so a recognised imperative the orchestrator handed
+    /// off produced the handler's card AND the delegation's — measured on a live
+    /// host as two cards for one message.
+    ///
+    /// The guard cannot live in `run_delegation`: what reaches there is the
+    /// instruction the model wrote, not the operator's words, and the handler
+    /// classified the latter.
+    #[tokio::test]
+    async fn a_hand_off_of_a_message_the_chat_handler_carded_opens_no_second_card() {
+        let imperative = "draft the launch plan for next quarter";
+        let title = crate::company::task_intent::detect_task_intent(imperative)
+            .expect("fixture must be a message the chat handler cards");
+        let fx = Fixture::new();
+        // The card the REST handler wrote moments before the cycle started.
+        fx.tasks
+            .upsert(
+                &fx.record.id,
+                &TaskRecord {
+                    id: "handler-card".to_string(),
+                    title,
+                    note: None,
+                    column: COLUMN_TODO.to_string(),
+                    priority: "medium".to_string(),
+                    assignee: String::new(),
+                    updated_at_millis: now_millis(),
+                    origin_chat_id: None,
+                    parent_task_id: None,
+                    output: None,
+                    plan: None,
+                },
+            )
+            .await
+            .expect("seed the handler's card");
+
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn::queueing("on it", vec![handoff("Draft the launch plan.")]),
+                Turn::reply("drafted"),
+                Turn::reply("the desk drafted it"),
+            ],
+        );
+        let turn = fx
+            .runner(&turns)
+            .handle_operator_message("chief", imperative, None)
+            .await
+            .expect("operator message handled");
+
+        let cards = fx.cards().await;
+        assert_eq!(cards.len(), 1, "one message, one card: {cards:?}");
+        assert_eq!(cards[0].id, "handler-card");
+        // …and the turn ADOPTS it, which is what lets a publish later in the
+        // same message file onto it instead of minting a rival beside it.
+        assert_eq!(turn.spawned_task.as_deref(), Some("handler-card"));
+    }
+
+    /// The stand-down is keyed on the **detector**, not on finding the card:
+    /// the handler's write is best-effort, so a missing card must not be read as
+    /// "the handler did not fire" and re-open one. `spawned_task` is then
+    /// honestly empty — there is no card to point at.
+    #[tokio::test]
+    async fn the_stand_down_holds_even_when_the_handlers_card_cannot_be_found() {
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn::queueing("on it", vec![handoff("Draft the launch plan.")]),
+                Turn::reply("drafted"),
+                Turn::reply("relayed"),
+            ],
+        );
+        let turn = fx
+            .runner(&turns)
+            .handle_operator_message("chief", "draft the launch plan for next quarter", None)
+            .await
+            .expect("operator message handled");
+        assert!(fx.cards().await.is_empty(), "no second card is opened");
+        assert!(turn.spawned_task.is_none(), "and none is claimed");
     }
 
     /// …and the same thread stays quiet for a question, so a desk chat does not

--- a/tests/one_card_per_message.rs
+++ b/tests/one_card_per_message.rs
@@ -1,0 +1,792 @@
+//! One operator message opens **one** card — issue #463.
+//!
+//! Three independent paths can card the same message: the REST chat handler's
+//! `detect_task_intent`, the delegation seam's `open_work_card` (#442), and the
+//! publish drain's minted card (#445). Each was correct alone. Two of them in
+//! one turn produced two cards, and the reply bubble linked to the one with no
+//! artifacts on it, so the operator clicked through to an empty card while the
+//! deliverable sat on an orphan.
+//!
+//! No unit test could see it: the doubling only exists where all three paths are
+//! wired together. So this stands up a real host — real `FsOps` stores, real
+//! platform auth, the production `server::router` on a real TCP socket — and
+//! drives it over HTTP, with a scripted OpenAI-compatible endpoint so a real
+//! model turn can emit `delegate_to_desk` and `publish_artifact`.
+//!
+//! The script is keyed on **which agent is asking and what it has already
+//! seen**, not on call order: the orchestrator turn, the desk turn and the relay
+//! turn interleave, and an order-keyed script answers the wrong one.
+//!
+//! Feature-gated on `openhuman`, which is what wires the harness pool, the
+//! hosted inference provider and `reqwest`.
+#![cfg(feature = "openhuman")]
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use axum::Json;
+use axum::routing::post;
+use serde_json::{Value, json};
+
+use opencompany::app::{AppConfig, AppState};
+use opencompany::company::CompanyManifest;
+use opencompany::company::credentials::Credential;
+use opencompany::company::task_intent::detect_task_intent;
+use opencompany::harness::HarnessPool;
+use opencompany::harness::provider::HostedProviderConfig;
+use opencompany::ports::CompanyId;
+use opencompany::runtime::RuntimeBuilder;
+use opencompany::server::platform_auth::{PlatformAuthConfig, StaticPlatformVerifier};
+
+const TOKEN: &str = "test-platform-token";
+const COMPANY: &str = "acme";
+
+// ---------------------------------------------------------------------------
+// The scripted model
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+enum Turn {
+    /// Emit one tool call.
+    Call { tool: String, args: Value },
+    /// Emit several tool calls in ONE assistant message (for the cap case).
+    Calls(Vec<(String, Value)>),
+    /// Finish with plain assistant text.
+    Say(String),
+}
+
+fn call(tool: &str, args: Value) -> Turn {
+    Turn::Call {
+        tool: tool.into(),
+        args,
+    }
+}
+
+fn say(text: &str) -> Turn {
+    Turn::Say(text.into())
+}
+
+/// A scripted reaction: fires the first time its predicate matches, then is
+/// consumed.
+struct Rule {
+    when: Box<dyn Fn(&Ctx) -> bool + Send>,
+    then: Turn,
+}
+
+/// What the endpoint can see about one request.
+struct Ctx {
+    /// The `role` line of the system prompt, e.g. "Chief Executive".
+    role: String,
+    /// Text of every `tool` message already in the transcript.
+    tool_results: Vec<String>,
+    /// The last user message.
+    user: String,
+}
+
+impl Ctx {
+    fn of(body: &Value) -> Self {
+        let msgs = body["messages"].as_array().cloned().unwrap_or_default();
+        let text = |m: &Value| m["content"].as_str().unwrap_or("").to_string();
+        let role = msgs
+            .iter()
+            .find(|m| m["role"] == "system")
+            .map(text)
+            .unwrap_or_default()
+            .lines()
+            .next()
+            .unwrap_or("")
+            .to_string();
+        Ctx {
+            role,
+            tool_results: msgs
+                .iter()
+                .filter(|m| m["role"] == "tool")
+                .map(text)
+                .collect(),
+            user: msgs
+                .iter()
+                .filter(|m| m["role"] == "user")
+                .map(text)
+                .next_back()
+                .unwrap_or_default(),
+        }
+    }
+
+    /// The agent answering this request.
+    fn is(&self, role: &str) -> bool {
+        self.role.contains(role)
+    }
+
+    /// Its first turn — nothing has come back from a tool yet.
+    fn fresh(&self) -> bool {
+        self.tool_results.is_empty()
+    }
+}
+
+fn rule(when: impl Fn(&Ctx) -> bool + Send + 'static, then: Turn) -> Rule {
+    Rule {
+        when: Box::new(when),
+        then,
+    }
+}
+
+struct Script {
+    rules: Mutex<Vec<Rule>>,
+    /// Every request body the endpoint saw, so a test can assert on what an
+    /// agent was actually shown rather than on what it presumably was.
+    seen: Mutex<Vec<Value>>,
+}
+
+impl Script {
+    /// The last user message each turn by `role` was given.
+    fn prompts_to(&self, role: &str) -> Vec<String> {
+        self.seen
+            .lock()
+            .expect("seen")
+            .iter()
+            .map(Ctx::of)
+            .filter(|ctx| ctx.is(role))
+            .map(|ctx| ctx.user)
+            .collect()
+    }
+}
+
+fn tool_call_message(calls: &[(String, Value)]) -> Value {
+    let tool_calls: Vec<Value> = calls
+        .iter()
+        .enumerate()
+        .map(|(i, (tool, args))| {
+            json!({
+                "id": format!("call_{i}"),
+                "type": "function",
+                "function": { "name": tool, "arguments": args.to_string() }
+            })
+        })
+        .collect();
+    json!({ "role": "assistant", "content": null, "tool_calls": tool_calls })
+}
+
+/// Serves the scripted endpoint on a loopback port. An unmatched request is
+/// answered with plain text, which ends that agent's turn.
+async fn spawn_model(rules: Vec<Rule>) -> (String, Arc<Script>) {
+    let script = Arc::new(Script {
+        rules: Mutex::new(rules),
+        seen: Mutex::new(Vec::new()),
+    });
+    let handle = Arc::clone(&script);
+    let app = axum::Router::new().route(
+        "/chat/completions",
+        post(move |Json(body): Json<Value>| {
+            let script = Arc::clone(&handle);
+            async move {
+                script.seen.lock().expect("seen").push(body.clone());
+                let ctx = Ctx::of(&body);
+                let next = {
+                    let mut rules = script.rules.lock().expect("rules");
+                    rules
+                        .iter()
+                        .position(|r| (r.when)(&ctx))
+                        .map(|i| rules.remove(i).then)
+                };
+                let message = match next.unwrap_or_else(|| say("done")) {
+                    Turn::Say(text) => json!({ "role": "assistant", "content": text }),
+                    Turn::Call { tool, args } => tool_call_message(&[(tool, args)]),
+                    Turn::Calls(calls) => tool_call_message(&calls),
+                };
+                Json(json!({
+                    "id": "chatcmpl-test",
+                    "object": "chat.completion",
+                    "created": 0,
+                    "model": "chat-v1",
+                    "choices": [{ "index": 0, "message": message, "finish_reason": "stop" }],
+                    "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 }
+                }))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind model");
+    let addr: SocketAddr = listener.local_addr().expect("model addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{addr}"), script)
+}
+
+// ---------------------------------------------------------------------------
+// The host
+// ---------------------------------------------------------------------------
+
+const MANIFEST: &str = r#"
+[company]
+name = "Acme"
+output = "Written deliverables"
+human_role = "Steering"
+
+[policy]
+mode = "full"
+
+[tools]
+allow = ["*"]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+description = "Sets direction and delegates the work."
+tier = "orchestrator"
+tools = ["*"]
+
+[[agent]]
+id = "writer"
+role = "Writer"
+description = "Turns rough notes into short, clear written drafts."
+tools = ["*"]
+
+[[agent]]
+id = "analyst"
+role = "Analyst"
+description = "Digs through numbers."
+tools = ["*"]
+
+[[agent]]
+id = "engineer"
+role = "Engineer"
+description = "Builds things."
+tools = ["*"]
+
+[[group_chat]]
+id = "content"
+name = "Content desk"
+description = "Written drafts and copy."
+members = ["writer"]
+
+[[group_chat]]
+id = "research"
+name = "Research desk"
+description = "Numbers and analysis."
+members = ["analyst"]
+
+[[group_chat]]
+id = "engineering"
+name = "Engineering desk"
+description = "How things are built."
+members = ["engineer"]
+"#;
+
+struct Host {
+    base: String,
+    home: PathBuf,
+    _tmp: tempfile::TempDir,
+}
+
+/// Stands up a company on a real router over a real socket, pointed at `model`.
+async fn spawn_host(model: String) -> Host {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path().to_path_buf();
+
+    let company_dir = home.join("manifest");
+    std::fs::create_dir_all(&company_dir).expect("company dir");
+    std::fs::write(company_dir.join("company.toml"), MANIFEST).expect("manifest");
+    let manifest = CompanyManifest::from_path(&company_dir).expect("valid manifest");
+
+    let runtime = RuntimeBuilder::new(home.clone(), manifest)
+        .with_id(CompanyId::new(COMPANY))
+        .with_harness(Arc::new(HarnessPool::new()))
+        .with_harness_inference(
+            HostedProviderConfig {
+                base_url: model,
+                credential: Credential::from_value("scripted"),
+                extra_headers: Vec::new(),
+            },
+            None,
+        )
+        .build()
+        .await
+        .expect("runtime builds");
+
+    let state = AppState::new(AppConfig {
+        bind: "127.0.0.1:0".parse().expect("bind"),
+        ..AppConfig::default()
+    })
+    .with_home(home.clone())
+    .with_platform_auth(PlatformAuthConfig::new(Arc::new(
+        StaticPlatformVerifier::new(TOKEN),
+    )));
+    state
+        .registry()
+        .insert(CompanyId::new(COMPANY), Arc::new(runtime));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind host");
+    let addr: SocketAddr = listener.local_addr().expect("host addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, opencompany::server::router(state)).await;
+    });
+
+    Host {
+        base: format!("http://{addr}"),
+        home,
+        _tmp: tmp,
+    }
+}
+
+impl Host {
+    /// Mirrors `harness::build::agent_workspace(home/harness, company, agent)`.
+    fn agent_sandbox(&self, agent: &str) -> PathBuf {
+        self.home
+            .join("harness")
+            .join(COMPANY)
+            .join(agent)
+            .join("workspace")
+    }
+
+    /// Puts a file in an agent's sandbox so it has something real to publish.
+    fn seed_file(&self, agent: &str, name: &str, body: &str) {
+        let dir = self.agent_sandbox(agent);
+        std::fs::create_dir_all(&dir).expect("sandbox");
+        std::fs::write(dir.join(name), body).expect("seed file");
+    }
+
+    async fn chat(&self, text: &str, desk: Option<&str>) -> Value {
+        let mut body = json!({ "text": text });
+        if let Some(desk) = desk {
+            body["chat"] = json!(desk);
+        }
+        let res = reqwest::Client::new()
+            .post(format!("{}/api/v1/companies/{COMPANY}/chat", self.base))
+            .bearer_auth(TOKEN)
+            .json(&body)
+            .send()
+            .await
+            .expect("chat request");
+        let status = res.status();
+        let text = res.text().await.expect("chat body");
+        assert!(status.is_success(), "chat failed {status}: {text}");
+        serde_json::from_str(&text).expect("chat json")
+    }
+
+    /// The board plus the card the reply linked to — the two facts #463 is about.
+    async fn board(&self, reply: &Value) -> Board {
+        let cards: Vec<Value> = reqwest::Client::new()
+            .get(format!("{}/api/v1/companies/{COMPANY}/tasks", self.base))
+            .bearer_auth(TOKEN)
+            .send()
+            .await
+            .expect("tasks request")
+            .json()
+            .await
+            .expect("tasks json");
+        let linked = reply["responses"]
+            .as_array()
+            .and_then(|r| r.iter().find_map(|m| m["taskId"].as_str()))
+            .map(str::to_string);
+        Board { cards, linked }
+    }
+
+    async fn artifacts(&self, task_id: &str) -> Vec<Value> {
+        reqwest::Client::new()
+            .get(format!(
+                "{}/api/v1/companies/{COMPANY}/tasks/{task_id}/artifacts",
+                self.base
+            ))
+            .bearer_auth(TOKEN)
+            .send()
+            .await
+            .expect("artifacts request")
+            .json()
+            .await
+            .expect("artifacts json")
+    }
+}
+
+struct Board {
+    cards: Vec<Value>,
+    /// The `taskId` the operator's reply bubble points at, if any.
+    linked: Option<String>,
+}
+
+impl Board {
+    /// The single card this message opened. Panics — with the whole board in the
+    /// message — when there is not exactly one, which is the assertion every
+    /// case below is really making.
+    fn only(&self) -> &Value {
+        assert_eq!(
+            self.cards.len(),
+            1,
+            "expected exactly one card for one message, got {}:{}",
+            self.cards.len(),
+            self.describe()
+        );
+        &self.cards[0]
+    }
+
+    fn describe(&self) -> String {
+        self.cards
+            .iter()
+            .map(|c| {
+                format!(
+                    "\n  - id={} column={} assignee={:?} title={:?}",
+                    c["id"].as_str().unwrap_or("?"),
+                    c["column"].as_str().unwrap_or("?"),
+                    c["assignee"].as_str().unwrap_or("?"),
+                    c["title"].as_str().unwrap_or("?"),
+                )
+            })
+            .collect()
+    }
+}
+
+fn id_of(card: &Value) -> &str {
+    card["id"].as_str().expect("card id")
+}
+
+/// Asserts the invariant the issue is about: one card, it holds the delivered
+/// file, the reply links to *it*, and it is filed under the agent that actually
+/// published — not the responder that relayed for them.
+async fn assert_sole_card_carries(host: &Host, board: &Board, publisher: &str, artifact: &str) {
+    let card = board.only();
+    let arts = host.artifacts(id_of(card)).await;
+    let titles: Vec<&str> = arts
+        .iter()
+        .map(|a| a["title"].as_str().unwrap_or("?"))
+        .collect();
+    assert_eq!(
+        titles,
+        [artifact],
+        "the one card must hold the deliverable, not an orphan beside it"
+    );
+    assert_eq!(
+        board.linked.as_deref(),
+        Some(id_of(card)),
+        "the reply must link to the card holding the artifact"
+    );
+    assert_eq!(
+        card["assignee"].as_str(),
+        Some(publisher),
+        "the card belongs to the agent that published, not the turn's responder"
+    );
+}
+
+/// The rules for "orchestrator hands off; the desk drafts and publishes".
+fn delegate_then_publish(
+    desk: &'static str,
+    worker: &'static str,
+    title: &'static str,
+) -> Vec<Rule> {
+    vec![
+        rule(
+            move |c| c.is("Chief Executive") && c.fresh(),
+            call(
+                "delegate_to_desk",
+                json!({ "desk": desk, "instruction": format!("Draft the {title} and publish it.") }),
+            ),
+        ),
+        rule(
+            move |c| c.is(worker) && c.fresh(),
+            call(
+                "publish_artifact",
+                json!({ "path": "memo.md", "title": title }),
+            ),
+        ),
+        rule(move |c| c.is(worker), say("Drafted and published it.")),
+        rule(|c| c.is("Chief Executive"), say("The desk published it.")),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// The cases
+// ---------------------------------------------------------------------------
+
+/// The headline. A substantial ask that ends in a published file used to open
+/// two cards — #442's, which won the reply link and held nothing, and #445's,
+/// which held the deliverable and was reachable from nowhere.
+///
+/// The ask is deliberately *not* a leading imperative, so `detect_task_intent`
+/// stays out of it and what is counted is #442's card against #445's.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_substantial_ask_that_publishes_opens_one_card() {
+    assert!(
+        detect_task_intent("assemble the Q3 board pack").is_none(),
+        "this case must NOT reach the REST detector, or it proves something else"
+    );
+    let (model, _script) =
+        spawn_model(delegate_then_publish("content", "Writer", "Q3 board memo")).await;
+    let host = spawn_host(model).await;
+    host.seed_file("writer", "memo.md", "# Q3 board memo\n");
+
+    let reply = host.chat("assemble the Q3 board pack", None).await;
+    let board = host.board(&reply).await;
+    assert_sole_card_carries(&host, &board, "writer", "Q3 board memo").await;
+}
+
+/// The same shape asked straight of a desk, where #442's *direct* path is what
+/// opens the card rather than the hand-off path.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_substantial_ask_to_a_desk_that_publishes_opens_one_card() {
+    let (model, _script) = spawn_model(vec![
+        rule(
+            |c| c.is("Writer") && c.fresh(),
+            call(
+                "publish_artifact",
+                json!({ "path": "memo.md", "title": "Q3 board memo" }),
+            ),
+        ),
+        rule(|c| c.is("Writer"), say("Drafted and published it.")),
+    ])
+    .await;
+    let host = spawn_host(model).await;
+    host.seed_file("writer", "memo.md", "# Q3 board memo\n");
+
+    let reply = host
+        .chat("assemble the Q3 board pack", Some("content"))
+        .await;
+    let board = host.board(&reply).await;
+    assert_sole_card_carries(&host, &board, "writer", "Q3 board memo").await;
+}
+
+/// A recognised imperative that the orchestrator hands off. The REST handler
+/// carded it before the cycle started; #442's stand-down lived only on the
+/// direct path, so the hand-off opened a second one.
+///
+/// The fixture verb matters more than it looks: `do the quarterly close` never
+/// reaches the REST detector — `do` is not one of its action verbs — so a test
+/// written against it would pass while proving nothing. The assertion below is
+/// the guard against writing that test by accident.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_recognised_imperative_that_is_delegated_opens_one_card() {
+    let imperative = "draft the quarterly close memo";
+    assert!(
+        detect_task_intent(imperative).is_some(),
+        "the fixture must be a message the REST handler cards, or this proves nothing"
+    );
+    assert!(
+        detect_task_intent("do the quarterly close").is_none(),
+        "`do` is not an action verb — a test written against it would prove nothing"
+    );
+    let (model, _script) = spawn_model(vec![
+        rule(
+            |c| c.is("Chief Executive") && c.fresh(),
+            call(
+                "delegate_to_desk",
+                json!({ "desk": "research", "instruction": "Draft the quarterly close memo." }),
+            ),
+        ),
+        rule(|c| c.is("Analyst"), say("Drafted.")),
+        rule(|c| c.is("Chief Executive"), say("Research drafted it.")),
+    ])
+    .await;
+    let host = spawn_host(model).await;
+
+    let reply = host.chat(imperative, None).await;
+    let board = host.board(&reply).await;
+    let card = board.only();
+    // The handler's card is the card — and the reply now points at it, which it
+    // did not before: the operator got a card on the board and a bubble that
+    // mentioned nothing.
+    assert_eq!(board.linked.as_deref(), Some(id_of(card)));
+}
+
+/// All three carding paths in one turn: a recognised imperative, handed off, and
+/// published by the delegate. This is the case that used to produce three cards.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_recognised_imperative_delegated_and_published_opens_one_card() {
+    let imperative = "draft the quarterly close memo";
+    assert!(detect_task_intent(imperative).is_some(), "fixture check");
+    let (model, _script) = spawn_model(delegate_then_publish(
+        "content",
+        "Writer",
+        "Quarterly close memo",
+    ))
+    .await;
+    let host = spawn_host(model).await;
+    host.seed_file("writer", "memo.md", "# Quarterly close\n");
+
+    let reply = host.chat(imperative, None).await;
+    let board = host.board(&reply).await;
+    // The handler's To-do card had no owner; the publish files onto it and it
+    // becomes the writer's, because they are who delivered.
+    assert_sole_card_carries(&host, &board, "writer", "Quarterly close memo").await;
+}
+
+/// A substantial ask with no publish still opens exactly one — the case #442
+/// already got right, kept here so a fix to the publish path cannot regress it.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_substantial_ask_without_a_publish_opens_one_card() {
+    let (model, _script) = spawn_model(vec![
+        rule(
+            |c| c.is("Chief Executive") && c.fresh(),
+            call(
+                "delegate_to_desk",
+                json!({ "desk": "content", "instruction": "Draft the Q3 board memo." }),
+            ),
+        ),
+        rule(|c| c.is("Writer"), say("Here is the draft.")),
+        rule(|c| c.is("Chief Executive"), say("The desk drafted it.")),
+    ])
+    .await;
+    let host = spawn_host(model).await;
+
+    let reply = host.chat("assemble the Q3 board pack", None).await;
+    let board = host.board(&reply).await;
+    let card = board.only();
+    assert_eq!(card["assignee"].as_str(), Some("writer"));
+    assert_eq!(board.linked.as_deref(), Some(id_of(card)));
+}
+
+/// A publish with no card in scope still mints one. This is #445's own case and
+/// the reason the fix is "file onto the card when there is one" rather than
+/// "never mint": a chat deliverable with nothing tracking it would otherwise go
+/// back to being unreachable.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_publish_with_no_card_in_scope_mints_one() {
+    let (model, _script) = spawn_model(vec![
+        rule(
+            |c| c.is("Chief Executive") && c.fresh(),
+            call(
+                "publish_artifact",
+                json!({ "path": "notes.md", "title": "Some notes" }),
+            ),
+        ),
+        rule(|c| c.is("Chief Executive"), say("Published the notes.")),
+    ])
+    .await;
+    let host = spawn_host(model).await;
+    host.seed_file("ceo", "notes.md", "notes\n");
+
+    // "hi" is neither trackable work nor a recognised imperative, so nothing
+    // else in the turn can open a card.
+    let reply = host.chat("hi", None).await;
+    let board = host.board(&reply).await;
+    assert_sole_card_carries(&host, &board, "ceo", "Some notes").await;
+}
+
+/// The constraint that stops the fix becoming its own bug: asking a question is
+/// not commissioning work, on the orchestrator's thread or a desk's.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_trivial_question_opens_no_card() {
+    for desk in [None, Some("engineering")] {
+        let (model, _script) = spawn_model(Vec::new()).await;
+        let host = spawn_host(model).await;
+        let reply = host.chat("what's the status of the build?", desk).await;
+        let board = host.board(&reply).await;
+        assert!(
+            board.cards.is_empty(),
+            "a question is not work ({desk:?}):{}",
+            board.describe()
+        );
+    }
+}
+
+/// A bare pleasantry in a desk thread that already has open work. The open-work
+/// briefing the cycle appends made "thanks!" long enough to score as
+/// substantial, so the card-opening decision has to read the operator's own
+/// words rather than the annotated message.
+///
+/// The seed request is worded to miss the REST detector on purpose — it has to
+/// open a card **assigned to the engineer**, because that is what puts the
+/// briefing on the next message. A seed the handler cards instead leaves an
+/// unassigned To-do card, no briefing, and a regression check that passes
+/// without exercising anything.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_pleasantry_in_a_desk_thread_with_open_work_opens_no_card() {
+    let seed = "the nightly job keeps timing out — work out why and write up what you find";
+    assert!(
+        detect_task_intent(seed).is_none(),
+        "the seed must open the DELEGATION card (assigned to the engineer), not the \
+         handler's unassigned one, or there is no briefing and this proves nothing"
+    );
+    let (model, script) = spawn_model(vec![
+        rule(
+            |c| c.is("Chief Executive") && c.fresh(),
+            call(
+                "delegate_to_desk",
+                json!({ "desk": "engineering", "instruction": "Investigate the flaky nightly job." }),
+            ),
+        ),
+        rule(|c| c.is("Engineer"), say("Looking into it.")),
+        rule(|c| c.is("Chief Executive"), say("Engineering is on it.")),
+        rule(|c| c.is("Engineer"), say("You're welcome!")),
+    ])
+    .await;
+    let host = spawn_host(model).await;
+
+    let seeded = host.chat(seed, None).await;
+    let before = host.board(&seeded).await;
+    assert_eq!(
+        before.only()["assignee"].as_str(),
+        Some("engineer"),
+        "the open work must belong to the engineer for the briefing to mention it"
+    );
+
+    let reply = host.chat("thanks!", Some("engineering")).await;
+    let after = host.board(&reply).await;
+    assert_eq!(
+        after.cards.len(),
+        before.cards.len(),
+        "'thanks!' opened a card:{}",
+        after.describe()
+    );
+
+    // …and the briefing really was on the message, or the check above is
+    // vacuous: the bug needs the annotation present to reproduce.
+    let engineer_saw = script.prompts_to("Engineer");
+    assert!(
+        engineer_saw
+            .iter()
+            .any(|p| p.contains("[Open work already handed to you")),
+        "the open-work briefing was never appended, so nothing was exercised: {engineer_saw:?}"
+    );
+}
+
+/// The per-turn delegation cap still holds: three hand-offs open three cards and
+/// the fourth and fifth are refused in-turn rather than queued.
+#[tokio::test(flavor = "multi_thread")]
+async fn five_delegations_in_one_turn_open_three_cards() {
+    let (model, _script) = spawn_model(vec![
+        rule(
+            |c| c.is("Chief Executive") && c.fresh(),
+            Turn::Calls(vec![
+                (
+                    "delegate_to_desk".into(),
+                    json!({ "desk": "content", "instruction": "Draft the memo." }),
+                ),
+                (
+                    "delegate_to_desk".into(),
+                    json!({ "desk": "research", "instruction": "Pull the numbers." }),
+                ),
+                (
+                    "delegate_to_desk".into(),
+                    json!({ "desk": "engineering", "instruction": "Check the pipeline." }),
+                ),
+                (
+                    "delegate_to_desk".into(),
+                    json!({ "desk": "content", "instruction": "Draft the press note." }),
+                ),
+                (
+                    "delegate_to_desk".into(),
+                    json!({ "desk": "research", "instruction": "Chart the churn." }),
+                ),
+            ]),
+        ),
+        rule(|c| c.is("Chief Executive"), say("Handed out the work.")),
+    ])
+    .await;
+    let host = spawn_host(model).await;
+
+    let reply = host
+        .chat(
+            "hand out these five pieces of work across the desks please",
+            None,
+        )
+        .await;
+    let board = host.board(&reply).await;
+    assert_eq!(
+        board.cards.len(),
+        3,
+        "three delegations open three cards, two are refused:{}",
+        board.describe()
+    );
+}

--- a/tests/one_card_per_message.rs
+++ b/tests/one_card_per_message.rs
@@ -72,6 +72,21 @@ fn say(text: &str) -> Turn {
 struct Rule {
     when: Box<dyn Fn(&Ctx) -> bool + Send>,
     then: Turn,
+    /// Run against the live company *before* answering.
+    effect: Effect,
+}
+
+/// Something a rule does to the running company on its way past.
+///
+/// The scripted endpoint is called from inside the cycle, which makes it the
+/// only place a test can mutate the board **while the turn is still in
+/// flight** — and that is the only way to reach the vanished-card path from
+/// outside the process.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Effect {
+    None,
+    /// Delete every card on the board.
+    ClearBoard,
 }
 
 /// What the endpoint can see about one request.
@@ -122,12 +137,34 @@ impl Ctx {
     fn fresh(&self) -> bool {
         self.tool_results.is_empty()
     }
+
+    /// The CEO-relay hand-back — the extra orchestrator turn that runs *after*
+    /// the desk answered and its card settled.
+    ///
+    /// Matched on the relay prompt's own wording rather than on turn ordering,
+    /// because the orchestrator's first turn continues after `delegate_to_desk`
+    /// returns and that continuation is also a non-fresh orchestrator request.
+    /// A rule keyed only on "the orchestrator, not fresh" lands on the
+    /// continuation, which runs *before* the hand-off has opened its card.
+    fn is_relay(&self) -> bool {
+        self.user
+            .contains("Relay their answer back to the operator")
+    }
 }
 
 fn rule(when: impl Fn(&Ctx) -> bool + Send + 'static, then: Turn) -> Rule {
     Rule {
         when: Box::new(when),
         then,
+        effect: Effect::None,
+    }
+}
+
+/// A rule that wipes the board on its way past — see [`Effect`].
+fn rule_clearing_the_board(when: impl Fn(&Ctx) -> bool + Send + 'static, then: Turn) -> Rule {
+    Rule {
+        effect: Effect::ClearBoard,
+        ..rule(when, then)
     }
 }
 
@@ -136,6 +173,18 @@ struct Script {
     /// Every request body the endpoint saw, so a test can assert on what an
     /// agent was actually shown rather than on what it presumably was.
     seen: Mutex<Vec<Value>>,
+    /// The company's own base URL, registered once the host is up so an
+    /// [`Effect`] can reach back into it mid-turn.
+    host: Mutex<Option<String>>,
+    /// How many cards each fired [`Effect::ClearBoard`] actually deleted.
+    ///
+    /// Recorded rather than asserted in place, because **a panic inside this
+    /// endpoint is invisible to the test**: the agent turn treats a failed
+    /// inference call as a recoverable turn, so the cycle completes and the
+    /// case goes green over a scenario that never happened. Found exactly that
+    /// way — the first draft of the deleted-card test passed while its rule was
+    /// panicking on an empty board. The test asserts on this instead.
+    cleared: Mutex<Vec<usize>>,
 }
 
 impl Script {
@@ -149,6 +198,44 @@ impl Script {
             .filter(|ctx| ctx.is(role))
             .map(|ctx| ctx.user)
             .collect()
+    }
+
+    /// Deletes every card, from inside the turn that is running, and records how
+    /// many went — see [`Script::cleared`] for why it records rather than
+    /// asserts.
+    async fn clear_board(&self) {
+        let Some(base) = self.host.lock().expect("host").clone() else {
+            return;
+        };
+        let client = reqwest::Client::new();
+        let Ok(res) = client
+            .get(format!("{base}/api/v1/companies/{COMPANY}/tasks"))
+            .bearer_auth(TOKEN)
+            .send()
+            .await
+        else {
+            return;
+        };
+        let cards: Vec<Value> = res.json().await.unwrap_or_default();
+        let mut deleted = 0;
+        for card in cards {
+            let Some(id) = card["id"].as_str() else {
+                continue;
+            };
+            let deleted_ok = client
+                .delete(format!("{base}/api/v1/companies/{COMPANY}/tasks/{id}"))
+                .bearer_auth(TOKEN)
+                .send()
+                .await
+                .is_ok_and(|r| r.status().is_success());
+            deleted += usize::from(deleted_ok);
+        }
+        self.cleared.lock().expect("cleared").push(deleted);
+    }
+
+    /// How many cards each fired board-clearing rule deleted, in order.
+    fn cleared(&self) -> Vec<usize> {
+        self.cleared.lock().expect("cleared").clone()
     }
 }
 
@@ -173,6 +260,8 @@ async fn spawn_model(rules: Vec<Rule>) -> (String, Arc<Script>) {
     let script = Arc::new(Script {
         rules: Mutex::new(rules),
         seen: Mutex::new(Vec::new()),
+        host: Mutex::new(None),
+        cleared: Mutex::new(Vec::new()),
     });
     let handle = Arc::clone(&script);
     let app = axum::Router::new().route(
@@ -187,8 +276,16 @@ async fn spawn_model(rules: Vec<Rule>) -> (String, Arc<Script>) {
                     rules
                         .iter()
                         .position(|r| (r.when)(&ctx))
-                        .map(|i| rules.remove(i).then)
+                        .map(|i| rules.remove(i))
+                        .map(|r| (r.then, r.effect))
                 };
+                let (next, effect) = match next {
+                    Some((then, effect)) => (Some(then), effect),
+                    None => (None, Effect::None),
+                };
+                if effect == Effect::ClearBoard {
+                    script.clear_board().await;
+                }
                 let message = match next.unwrap_or_else(|| say("done")) {
                     Turn::Say(text) => json!({ "role": "assistant", "content": text }),
                     Turn::Call { tool, args } => tool_call_message(&[(tool, args)]),
@@ -443,6 +540,27 @@ fn id_of(card: &Value) -> &str {
     card["id"].as_str().expect("card id")
 }
 
+/// `(published path, author of its first version)` for every artifact on a
+/// card, sorted — the per-item attribution the artifact record actually stores.
+async fn authors_on(host: &Host, task_id: &str) -> Vec<(String, String)> {
+    let mut pairs: Vec<(String, String)> = host
+        .artifacts(task_id)
+        .await
+        .iter()
+        .map(|a| {
+            (
+                a["source"].as_str().unwrap_or("?").to_string(),
+                a["versions"][0]["authorId"]
+                    .as_str()
+                    .unwrap_or("?")
+                    .to_string(),
+            )
+        })
+        .collect();
+    pairs.sort();
+    pairs
+}
+
 /// Asserts the invariant the issue is about: one card, it holds the delivered
 /// file, the reply links to *it*, and it is filed under the agent that actually
 /// published — not the responder that relayed for them.
@@ -547,6 +665,61 @@ async fn a_substantial_ask_to_a_desk_that_publishes_opens_one_card() {
     assert_sole_card_carries(&host, &board, "writer", "Q3 board memo").await;
 }
 
+/// The card the turn opened is **deleted mid-turn**, so the publish falls back
+/// to minting a replacement. The reply must link to the card that holds the
+/// deliverable, not to the id of the card that is gone.
+///
+/// This is #463's own failure reachable through the fallback added to prevent
+/// it: `spawned_task` still names the deleted card, `published_card` names the
+/// replacement, and preferring the former sends the operator to a card that no
+/// longer exists — with the deliverable somewhere else.
+///
+/// The delete is fired from the **relay** turn, which is the one window that
+/// works: the hand-off's card is settled by then (an earlier delete would be
+/// undone by that settle) and the publish queue has not yet been drained.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_publish_onto_a_card_deleted_mid_turn_links_the_reply_to_the_replacement() {
+    let (model, script) = spawn_model(vec![
+        rule(
+            |c| c.is("Chief Executive") && c.fresh(),
+            call(
+                "delegate_to_desk",
+                json!({ "desk": "content", "instruction": "Draft the Q3 board memo and publish it." }),
+            ),
+        ),
+        rule(
+            |c| c.is("Writer") && c.fresh(),
+            call(
+                "publish_artifact",
+                json!({ "path": "memo.md", "title": "Q3 board memo" }),
+            ),
+        ),
+        rule(|c| c.is("Writer"), say("Drafted and published it.")),
+        rule_clearing_the_board(
+            |c| c.is("Chief Executive") && c.is_relay(),
+            say("The desk published it — and someone just cleared the board."),
+        ),
+    ])
+    .await;
+    let host = spawn_host(model).await;
+    *script.host.lock().expect("host") = Some(host.base.clone());
+    host.seed_file("writer", "memo.md", "# Q3 board memo\n");
+
+    let reply = host.chat("assemble the Q3 board pack", None).await;
+
+    // Prove the scenario happened before asserting anything about it: exactly
+    // one clearing rule fired and it really deleted the hand-off's card.
+    assert_eq!(
+        script.cleared(),
+        vec![1],
+        "the card was never deleted, so this case proves nothing"
+    );
+    let board = host.board(&reply).await;
+    // The deliverable is never dropped: a replacement card carries it, and the
+    // reply points at THAT card rather than at the id that no longer resolves.
+    assert_sole_card_carries(&host, &board, "writer", "Q3 board memo").await;
+}
+
 /// A recognised imperative that the orchestrator hands off. The REST handler
 /// carded it before the cycle started; #442's stand-down lived only on the
 /// direct path, so the hand-off opened a second one.
@@ -609,6 +782,68 @@ async fn a_recognised_imperative_delegated_and_published_opens_one_card() {
     // The handler's To-do card had no owner; the publish files onto it and it
     // becomes the writer's, because they are who delivered.
     assert_sole_card_carries(&host, &board, "writer", "Quarterly close memo").await;
+}
+
+/// Two different agents publish in one turn, and each artifact records **its
+/// own** author.
+///
+/// The desk lead's turn and the relay turn both run with the full toolbelt
+/// under the same `Conversation` claim, so one drain can hold publishes from
+/// more than one agent. `PendingPublish.agent` carries the truth per item; a
+/// single publisher picked for the whole batch stamps the writer's name on the
+/// orchestrator's file and the reverse.
+///
+/// The **card** still takes one owner — a card has one — so only the artifact
+/// authors are per item.
+#[tokio::test(flavor = "multi_thread")]
+async fn two_agents_publishing_in_one_turn_each_keep_their_own_authorship() {
+    let (model, _script) = spawn_model(vec![
+        rule(
+            |c| c.is("Chief Executive") && c.fresh(),
+            call(
+                "delegate_to_desk",
+                json!({ "desk": "content", "instruction": "Draft the Q3 board memo and publish it." }),
+            ),
+        ),
+        rule(
+            |c| c.is("Writer") && c.fresh(),
+            call(
+                "publish_artifact",
+                json!({ "path": "memo.md", "title": "Q3 board memo" }),
+            ),
+        ),
+        rule(|c| c.is("Writer"), say("Drafted and published it.")),
+        // The relay turn publishes too — the orchestrator's own covering note.
+        rule(
+            |c| c.is("Chief Executive"),
+            call(
+                "publish_artifact",
+                json!({ "path": "notes.md", "title": "Covering note" }),
+            ),
+        ),
+        rule(|c| c.is("Chief Executive"), say("Memo and covering note attached.")),
+    ])
+    .await;
+    let host = spawn_host(model).await;
+    host.seed_file("writer", "memo.md", "# Q3 board memo\n");
+    host.seed_file("ceo", "notes.md", "# Covering note\n");
+
+    let reply = host.chat("assemble the Q3 board pack", None).await;
+    let board = host.board(&reply).await;
+    let card = board.only();
+
+    // `authors_on` sorts by path, so `memo.md` precedes `notes.md`.
+    assert_eq!(
+        authors_on(&host, id_of(card)).await,
+        vec![
+            ("memo.md".to_string(), "writer".to_string()),
+            ("notes.md".to_string(), "ceo".to_string()),
+        ],
+        "each artifact must record the agent that published IT"
+    );
+    // The card keeps a single owner — the first publisher, who is also whose
+    // card it already was.
+    assert_eq!(card["assignee"].as_str(), Some("writer"));
 }
 
 /// A substantial ask with no publish still opens exactly one — the case #442


### PR DESCRIPTION
## Summary

Ask for something substantial that ends in a published file and you got **two cards**, with the reply linking to the one holding **zero artifacts**. The deliverable sat on a second card nothing pointed at. Stack a recognised imperative on top and you got **three**.

This is #442's own defect — *the board does not reflect the work* — reproduced by #442's fix interacting with #445's. Both were correct alone. It is only visible when both are present, which is exactly why per-PR CI could not see it: it was found by a live behavioural walk over the union of the two branches before either merged, and both have since merged, so it is live on `main`.

Closes #463.

## API Or Behavior Changes

**One message, one card.** Three changes hold that invariant:

- **Publish files onto the card already in scope.** `OperatorTurn::spawned_task` is seeded from the direct card and from each delegation's card, so by the time the publish queue drains it already holds the card for this message. Drained publishes now file there. Minting remains for two cases: no card in scope, and a card deleted mid-turn (falling back rather than dropping the deliverable).
- **The reply follows the deliverable.** The bubble links to `published_card.or(turn.spawned_task)` — `published_card` is `Some` only when a publish landed and always names the card it landed **on**, including the replacement minted for a deleted card. An earlier revision of this PR preferred `spawned_task` and claimed the two could never differ; they can, on the deleted-card path, and preferring `spawned_task` there reproduced this issue's own failure through the fallback added to prevent it. Caught in review, fixed in e1e18b89, and now driven by a test.
- **The `task_intent` stand-down is evaluated once, in the right place.** It now runs in `handle_operator_message`, where the **operator's original message** is still in scope — `run_delegation` only ever sees the instruction the model wrote — and both card-opening paths are gated on it.
- **The publisher is carried, not assumed.** The drain site cannot know who published (one queue, many turns), so `PendingPublish` now carries the agent, stamped by the per-agent tool instance. That fixes the card assignee, the note attribution and the artifact author together — previously a publish inside a delegated desk turn was attributed to the operator-turn responder rather than the agent that made the call. **Authorship is per file:** the card takes one owner because a card has one, but each artifact version records the agent that published *that* file, since a single turn can stage publishes from more than one agent.

**One deviation from the brief, and why.** The stand-down alone does not reach the acceptance table: for *recognised imperative, delegated and published*, the delegation card stands down, `spawned_task` is `None`, and the publish mints beside the REST card — two, not one. So `handle_operator_message` also **adopts** the chat handler's card into `spawned_task`. That makes the invariant *one message, one card* rather than *one card per seam*.

The stand-down stays keyed on the **detector**, not on finding the card: the handler's write is best-effort, and a missing card must not be read as "the handler did not fire". #442's own test passes unchanged, and a new test pins that the stand-down holds even when the handler's card cannot be found.

Side effect worth naming: on a recognised imperative the reply bubble now links to the handler's card, where before it linked to nothing.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 2297 passed, 0 failed
- [x] `cargo check --locked --all-features --all-targets`

`Cargo.lock` unchanged.

`tests/one_card_per_message.rs` is new: eleven cases driven against a **real host** — real stores, real platform auth, the production router on a real socket, over HTTP — against a loopback scripted model endpoint keyed on *which agent is asking*, so the orchestrator, desk and relay turns interleave correctly. `--lib` does not run it; `cargo test --features openhuman,tinycortex --test one_card_per_message` → 11 passed, repeated for determinism. Nine lib tests were added alongside so `--lib` covers every defect.

**Proof it catches the regression.** Test copied aside, sources restored to `bd4f6337`, re-run:

```
a_substantial_ask_that_publishes_opens_one_card                 FAILED  got 2
a_substantial_ask_to_a_desk_that_publishes_opens_one_card       FAILED  got 2
a_recognised_imperative_that_is_delegated_opens_one_card        FAILED  got 2
a_recognised_imperative_delegated_and_published_opens_one_card  FAILED  got 3
test result: FAILED. 5 passed; 4 failed
```

Exactly the counts the issue reported.

The two cases added in review were held to the same bar — run against the pre-fix tree first:

```
a_publish_onto_a_card_deleted_mid_turn_links_the_reply_to_the_replacement  FAILED
  the reply must link to the card holding the artifact
  left: Some("…037")   right: Some("…052")

two_agents_publishing_in_one_turn_each_keep_their_own_authorship           FAILED
  left: [("memo.md","ceo"), ("notes.md","ceo")]
  right: [("memo.md","writer"), ("notes.md","ceo")]
```

| Case | Base | Now |
|---|---|---|
| Substantial ask → delegate → publish | 2 | **1**, holds the artifact, reply links to it, assignee correct |
| Same, straight to a desk | 2 | **1** |
| Recognised imperative, delegated | 2 | **1** |
| Recognised imperative, delegated **and** published | 3 | **1** |
| Substantial ask, no publish | 1 | 1 |
| Publish with no card in scope | 1 | 1, carries the artifact |
| Trivial question / pleasantry | 0 | 0 |
| Five delegations in one turn | 3/2 | 3 opened, 2 refused |

## Documentation

The invariant and the adoption rule are documented at the seam in `delegation.rs`.

## Notes for review

**A fourth problem, found in the harness itself and worth carrying forward.** One case's premise went silently vacuous under the fix and would have shipped that way. Its seed message used a verb the REST-layer detector recognises, so with the fix the delegation card is suppressed and only an unassigned To-do card remains — no assigned card means no open-work briefing, which was the entire point of that case. It printed `briefing annotation present: false` while still reporting the count it asserted on, i.e. passing on nothing.

The committed version seeds with language the detector misses, and **asserts** that — plus that the card belongs to the engineer, and that the briefing string actually appeared in what the engineer was shown. So it fails loudly rather than going quiet if that drifts.

The general rule this suggests: any test that depends on a card being opened by the spine must pick language the REST detector misses, and should assert that rather than note it in a comment.

**A fifth, found while writing the review-round tests: a panic inside the scripted model endpoint is invisible.** The agent turn treats a failed inference call as recoverable, so the cycle completes and the case goes green over a scenario that never happened. The first draft of the deleted-card test passed while its rule was panicking on an empty board — it was firing on the orchestrator's turn *continuation* (also a non-fresh orchestrator request) rather than the relay hand-back, before the hand-off had opened any card.

Two things came out of it: the relay turn is now matched on the relay prompt's own wording rather than on turn ordering, and effects **record** what they did so the test asserts the scenario happened (`script.cleared() == vec![1]`) instead of trusting an assertion that cannot fail the test. Any future effect added to this harness should follow the same rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Conversations now keep published files on the card already created for the turn, preventing duplicate cards.
  - Published artifacts include clear attribution to the publishing agent.
  - Filing an artifact adds a card note, moves the card to review, and preserves existing ownership.
  - If the original card was deleted, a replacement card is created automatically.
  - Response links now point consistently to the single relevant card.
- **Bug Fixes**
  - Prevented duplicate cards across direct publishing, delegation, and handoffs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
