### PR TITLE
fix(console): the board hears about a card the moment it is written (#464)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -243,7 +243,13 @@ export function AppShell({
   const [threads, setThreads] = useState(defaultThreads);
   const [activeThreadId, setActiveThreadId] = useState("main");
   // A monotonic nonce bumped on every task-lifecycle SSE event, so the
-  // company-chat in-flight steer strip (issue #111) refetches live.
+  // company-chat in-flight steer strip (issue #111) and the board itself
+  // (issue #464) refetch live.
+  //
+  // A counter rather than the payload, and that is what makes it safe to share:
+  // both consumers re-read their own surface, so two events collapsing into one
+  // React batch still means "re-read" — the frame-loss the workflow canvas had
+  // to fold an event window to avoid cannot happen to a tick.
   const [taskEventTick, setTaskEventTick] = useState(0);
   // Issue #228: bumped on every `workflow_run_finished` so the Workflows view
   // refreshes its run history live. Same shape as `taskEventTick` — a counter,
@@ -943,6 +949,12 @@ export function AppShell({
             <TasksView
               client={client}
               company={company}
+              // Issue #464: the board learns that work appeared. The same
+              // counter the chat's in-flight strip reads — it is bumped by
+              // every task event, now including the host's board-write
+              // announcement — so a card opened from chat lands on the board
+              // without a reload rather than on the fallback poll's schedule.
+              taskEventTick={taskEventTick}
               // Issue #246: the card → chat half of the round trip. A card
               // opened from a conversation remembers which one, so its detail
               // screen can put the operator back in that thread.

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -33,6 +33,41 @@ export type CompanyStreamEvent =
     }
   | { type: "task_dispatched"; seq: number; atMillis: number; taskId: string }
   | { type: "task_steered"; seq: number; atMillis: number; taskId: string; action: string }
+  // A board card was written (issue #464) — the frame the board had no way to
+  // learn about anything from. Emitted by the host's task store, so it fires
+  // for a card opened from chat intake, from a delegation, from the publish
+  // drain and from the REST route alike, rather than for whichever paths
+  // somebody remembered to instrument.
+  //
+  // Deliberately thin, like `approval_parked`: an id, what happened, and where
+  // the card sits. There is **no title and no note** on purpose — the card's
+  // text lives on `GET …/tasks`, and a console reacts to this frame by
+  // re-reading that, so the board's content has exactly one source.
+  | {
+      type: "task_card_changed";
+      seq: number;
+      atMillis: number;
+      taskId: string;
+      /** `opened` | `updated` | `removed`, widened so an unknown word from a
+       *  newer host is not a type error. */
+      change: string;
+      /** Absent on a removed card, which is in no column. */
+      column?: string;
+    }
+  // A dispatched card's run finished (issue #185). The host has projected this
+  // since #185; the console named no type for it, so it fell through to
+  // `default:` and was dropped — the same "the view does not subscribe" half of
+  // #464, one event over. A settle moves the card between columns, so the board
+  // wants it.
+  | {
+      type: "desk_task_completed";
+      seq: number;
+      atMillis: number;
+      taskId: string;
+      desk: string;
+      output: string;
+      column: string;
+    }
   | {
       type: "mcp_call_failed";
       seq: number;
@@ -179,9 +214,18 @@ interface Options {
    */
   onAgentReply?: (event: AgentReplyEvent) => void;
   /**
-   * Called for each task-lifecycle event (`task_dispatched`, `task_steered`) so
-   * a surface showing in-flight runs — the company-chat steer strip (issue #111)
-   * — can refetch live off the existing SSE stream instead of only on a poll.
+   * Called for each task-lifecycle event (`task_dispatched`, `task_steered`,
+   * `task_card_changed`, `desk_task_completed`) so a surface showing board work
+   * — the company-chat steer strip (issue #111) and the board itself (issue
+   * #464) — can refetch live off the existing SSE stream instead of only on a
+   * poll.
+   *
+   * Subscribers here take a **counter**, not the payload: they re-read the
+   * board, and the board's content has one source (`GET …/tasks`). That is also
+   * why they are immune to the frame-loss trap that made
+   * {@link Options.onWorkflowRunEvent}'s consumer fold a *window* of events —
+   * two ticks collapsing inside one React batch still means "re-read", whereas
+   * two payloads collapsing means one is lost.
    */
   onTaskEvent?: (event: CompanyStreamEvent) => void;
   /**
@@ -360,6 +404,20 @@ function handleEvent(
       toast("A task was steered", {
         description: `Your company ${steeredVerb(event.action)} a task.`,
       });
+      onTaskEvent?.(event);
+      break;
+    // Issue #464. Both route to the board's subscriber and **neither toasts**,
+    // which is the deliberate half.
+    //
+    // A card opened from chat is already announced where the operator is
+    // looking — the reply says "Card opened" — so a toast for it would be the
+    // second notification for one action that #379 argues against. And a board
+    // write is not rare: every column move, every settle, every note the run
+    // appends is one. Toasting those would train the operator to dismiss the
+    // toasts that do matter. The card appearing on the board IS the
+    // notification.
+    case "task_card_changed":
+    case "desk_task_completed":
       onTaskEvent?.(event);
       break;
     case "agent_reply":

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -64,7 +64,20 @@ function readTaskDetailId(): string | null {
   }
 }
 
-/** How often to re-poll the board, so a dispatched card's result appears. */
+/**
+ * The board's fallback refresh interval.
+ *
+ * Since issue #464 this is **no longer how the board stays current** — the
+ * company SSE stream is, through `taskEventTick`. It stays as the degradation
+ * path, and only that: a host that does not serve `{scope}/events` (a 404 the
+ * events hook swallows by design) has no push, and without this the board there
+ * would go back to being a snapshot of its own mount. It is the same stance
+ * `use-events.ts` takes toward the 5s status poll.
+ *
+ * Left at its original cadence deliberately. Slowing it down would be paid for
+ * entirely by the hosts that have no push, and speeding it up is the polling
+ * answer #464 exists to replace.
+ */
 const POLL_MS = 4000;
 
 /**
@@ -117,10 +130,31 @@ function columnLabel(id: string): string {
 export function TasksView({
   client,
   company,
+  taskEventTick,
   onOpenThread,
 }: {
   client: OpenCompanyClient;
   company: string | null;
+  /**
+   * A counter the shell bumps on every task event off the company SSE stream
+   * (issue #464) — a card opened, moved, settled, dispatched or steered. The
+   * board re-reads itself whenever it changes, which is what makes *ask for
+   * something in chat, watch it become work on the board* true without a
+   * reload.
+   *
+   * A **counter, not the payload**, and that is the whole design. The board's
+   * cards come from one place (`GET …/tasks`); a frame only ever says
+   * "something moved". So this cannot suffer the frame-loss the workflow canvas
+   * had to fold an event *window* to avoid — two bumps collapsing inside one
+   * React batch still means exactly one thing: re-read. Carrying payloads here
+   * would inherit that problem for no gain, and would give the board's contents
+   * a second source that could disagree with the first.
+   *
+   * Absent when the board is rendered without a shell to subscribe for it, in
+   * which case the fallback poll is the only refresh — the same degradation a
+   * host with no `{scope}/events` gets.
+   */
+  taskEventTick?: number;
   /**
    * Opens the chat thread a card came from (issue #246). Absent when the board
    * is rendered somewhere with no conversation pane to jump to, in which case
@@ -179,6 +213,26 @@ export function TasksView({
       clearInterval(timer);
     };
   }, [refresh]);
+
+  // Issue #464: the push half. Re-read the board the moment the host says
+  // something on it moved, rather than up to a poll interval later.
+  //
+  // Its own effect rather than a dependency of the one above, on purpose:
+  // folding the tick in there would tear down and restart the fallback timer on
+  // every event, so a busy company — one event every few seconds — would keep
+  // resetting the interval and the fallback would effectively stop existing on
+  // exactly the companies that need it most.
+  //
+  // The ref is what keeps this to *changes*. The shell's counter starts at 0
+  // and keeps counting across route changes, so without it every mount — and
+  // every company switch, since `refresh` is a dependency — would fire a second
+  // load on top of the mount fetch above for a card nothing had announced.
+  const seenTick = useRef(taskEventTick);
+  useEffect(() => {
+    if (taskEventTick === undefined || taskEventTick === seenTick.current) return;
+    seenTick.current = taskEventTick;
+    void refresh();
+  }, [taskEventTick, refresh]);
 
   // Follow browser back/forward and manual edits of the `#/tasks/<id>` sub-hash.
   useEffect(() => {

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -161,6 +161,30 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("Dispatched task {task_id}"),
             "task.dispatched",
         ),
+        // Issue #464. Written for completeness, not for a live path — the same
+        // standing as the reaction arm above: this normalizes a cycle's *input*
+        // events, and a board announcement is appended by the task store after
+        // a write it did not start. It drives no cycle, so a brain never sees
+        // one here. Spelled out rather than swept into a wildcard so the next
+        // variant that IS a stimulus cannot inherit a silent default.
+        //
+        // Structural only. The card's title and note stay off this wire for the
+        // same reason they stay off the operator SSE projection: this body is
+        // sent to the inference sidecar, and a board write is not a place to
+        // hand it operator-authored text nobody asked to send.
+        CompanyEvent::TaskCardChanged {
+            task_id,
+            change,
+            column,
+        } => (
+            Role::System,
+            "board".to_string(),
+            match column {
+                Some(column) => format!("Task {task_id} {change} → {column}"),
+                None => format!("Task {task_id} {change}"),
+            },
+            "task.card_changed",
+        ),
         CompanyEvent::McpCallFailed {
             server,
             tool,

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -651,6 +651,19 @@ fn summarize_event(event: &CompanyEvent) -> String {
         CompanyEvent::OperatorMessage { .. } => "operator message".to_string(),
         CompanyEvent::AgentReply { agent_id, .. } => format!("reply from {agent_id}"),
         CompanyEvent::TaskDispatched { task_id, .. } => format!("task dispatched: {task_id}"),
+        // Issue #464. Structural only, like every arm here: the id, the change
+        // word (fixed vocabulary) and the column (one of six). The card's title
+        // is deliberately not named — it is operator- or agent-authored free
+        // text, and this string is a non-sensitive one-liner for the insight
+        // surface, which is exactly where free text does not belong.
+        CompanyEvent::TaskCardChanged {
+            task_id,
+            change,
+            column,
+        } => match column {
+            Some(column) => format!("card {change}: {task_id} → {column}"),
+            None => format!("card {change}: {task_id}"),
+        },
         CompanyEvent::ScheduleFired { cron, .. } => format!("schedule fired: {cron}"),
         CompanyEvent::WebhookReceived { channel, .. } => format!("webhook on {channel}"),
         CompanyEvent::A2aTaskReceived { from, .. } => format!("A2A task from {from}"),

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -616,6 +616,49 @@ pub enum CompanyEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         by: Option<Actor>,
     },
+    /// A board card was written (issue #464) — opened, changed, or removed.
+    ///
+    /// The board's *announcement*, and the thing that was missing: every other
+    /// task event here describes a card that already exists
+    /// ([`TaskDispatched`](Self::TaskDispatched) fires on the `in_progress`
+    /// edge, [`DeskTaskCompleted`](Self::DeskTaskCompleted) on the settle), so
+    /// nothing said a card had come into being. A card opened from chat intake,
+    /// from a delegation, or from the publish drain left no trace on the feed at
+    /// all, and a console watching the board had nothing to react to.
+    ///
+    /// **Emitted from the store, not from the callers.** It is appended by the
+    /// [`BoardAnnouncer`](crate::runtime::BoardAnnouncer) decorator wrapping the
+    /// company's [`TaskStore`](crate::ports::tasks::TaskStore), which is the one
+    /// place every writer already passes through. Emitting it per call site
+    /// would have meant one arm per creation path — and the next path added
+    /// would silently have none, which is the shape of the bug this fixes.
+    ///
+    /// **A record, never a stimulus.** It is appended after the write it
+    /// describes and is never fed into a cycle; the cycle's own trigger
+    /// classification treats it as a pass-through, like every other record.
+    /// Announcing a write must not start work — a card that opened a cycle by
+    /// existing would re-enter this same store and announce again.
+    ///
+    /// Additive: old logs never carry it, and its presence doesn't change how
+    /// any existing variant serializes.
+    TaskCardChanged {
+        /// The written card's id.
+        task_id: String,
+        /// What happened to it, as a stable wire word: `opened` (the write
+        /// brought the card into existence), `updated` (it changed an existing
+        /// one), or `removed` (it was deleted).
+        ///
+        /// A word rather than a `bool`, following
+        /// [`ToolAccessChanged`](Self::ToolAccessChanged)'s `change`: there are
+        /// three outcomes, not two, and a flag would have had to grow a second
+        /// one to say a card is gone.
+        change: String,
+        /// The column the card sits in after the write. `None` on a `removed`
+        /// card, which is no longer in one — omitted rather than an empty
+        /// string, so "gone" cannot be mistaken for a column whose id is blank.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        column: Option<String>,
+    },
     /// A dispatched board task finished its run (issue #185) — the terminal
     /// anchor a per-task timeline ends on and a lineage rollup counts.
     ///

--- a/src/runtime/board_events.rs
+++ b/src/runtime/board_events.rs
@@ -1,0 +1,373 @@
+//! Issue #464: the board announces its own writes.
+//!
+//! A card can come into being on several paths — chat intake's deterministic
+//! `detect_task_intent`, a delegation opening a card for a desk, the publish
+//! drain, the console's `POST …/tasks` — and before this nothing on the company
+//! feed said so. The durable task events all describe a card that *already*
+//! exists ([`TaskDispatched`](CompanyEvent::TaskDispatched) fires on the
+//! `in_progress` edge, [`DeskTaskCompleted`](CompanyEvent::DeskTaskCompleted) on
+//! the settle), so a console watching the board had nothing to react to and no
+//! way to learn a card had appeared.
+//!
+//! ## Why the store, and not the callers
+//!
+//! [`BoardAnnouncer`] is a decorator over the company's
+//! [`TaskStore`](crate::ports::tasks::TaskStore), wrapped in once by
+//! [`RuntimeBuilder`](crate::runtime::RuntimeBuilder). Every writer — REST,
+//! cycle, delegation, the settle mover — already goes through that port, so the
+//! announcement is emitted **once, where cards are actually written**, rather
+//! than once per call site that happens to write one.
+//!
+//! That distinction is the fix, not an implementation detail. The alternative
+//! (an emit at each creation site) is the same shape as the bug: it is correct
+//! only for the paths somebody remembered, and the next path added silently
+//! announces nothing. Here a new writer cannot forget, because it does not get
+//! a say.
+//!
+//! ## What it is not
+//!
+//! * **Not a stimulus.** The event is appended after the write and never fed
+//!   into a cycle. A card that started work merely by existing would re-enter
+//!   this store and announce again.
+//! * **Not the board's truth.** The store is. The frame says *something on the
+//!   board changed*; a console reacts by re-reading the board it already knows
+//!   how to read. That is why a lost frame degrades to "one stale render" and
+//!   never to wrong state.
+//! * **Not a failure path.** Record-keeping never fails the work it records: an
+//!   event log that refuses is logged and swallowed, exactly as the other
+//!   best-effort journalling sites do. A card that was written stays written.
+//!
+//! The same shape fits any other store whose surface is watched and whose
+//! writers are plural — the workspace tree (issue #327) is the obvious next one.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::error::Result;
+use crate::ports::events::EventLog;
+use crate::ports::tasks::{TaskRecord, TaskStore};
+use crate::ports::types::{CompanyEvent, CompanyId};
+
+/// The wire word for a write that brought a card into existence.
+pub const CHANGE_OPENED: &str = "opened";
+/// The wire word for a write that changed a card already on the board.
+pub const CHANGE_UPDATED: &str = "updated";
+/// The wire word for a card that was deleted.
+pub const CHANGE_REMOVED: &str = "removed";
+
+/// A [`TaskStore`] that appends a
+/// [`TaskCardChanged`](CompanyEvent::TaskCardChanged) to the company's event log
+/// after any write that actually changed the board.
+///
+/// Reads pass straight through. See the module docs for why this lives at the
+/// store rather than at the callers.
+pub struct BoardAnnouncer {
+    inner: Arc<dyn TaskStore>,
+    events: Arc<dyn EventLog>,
+}
+
+impl BoardAnnouncer {
+    /// Wraps `inner`, announcing onto `events`.
+    pub fn new(inner: Arc<dyn TaskStore>, events: Arc<dyn EventLog>) -> Self {
+        Self { inner, events }
+    }
+
+    /// Appends one announcement, best-effort.
+    ///
+    /// A refusing event log is warned about and swallowed: the board write it
+    /// describes has already succeeded and must not be undone (or reported as
+    /// failed) because the *record* of it could not be filed.
+    async fn announce(
+        &self,
+        company: &CompanyId,
+        task_id: &str,
+        change: &str,
+        column: Option<String>,
+    ) {
+        let event = CompanyEvent::TaskCardChanged {
+            task_id: task_id.to_string(),
+            change: change.to_string(),
+            column,
+        };
+        if let Err(err) = self.events.append(company, event).await {
+            tracing::warn!(
+                company = %company,
+                task = %task_id,
+                change = %change,
+                error = %err,
+                "could not announce a board write"
+            );
+        }
+    }
+
+    /// The card with `id` as the board holds it now, or `None`.
+    ///
+    /// A read that fails yields `None` rather than propagating: the caller uses
+    /// it only to choose the wire word, and refusing a write because the *prior*
+    /// state could not be read would fail board writes for a diagnostic.
+    async fn current(&self, company: &CompanyId, id: &str) -> Option<TaskRecord> {
+        self.inner
+            .list(company)
+            .await
+            .ok()?
+            .into_iter()
+            .find(|t| t.id == id)
+    }
+}
+
+#[async_trait]
+impl TaskStore for BoardAnnouncer {
+    async fn list(&self, company: &CompanyId) -> Result<Vec<TaskRecord>> {
+        self.inner.list(company).await
+    }
+
+    /// Writes through, then announces — `opened` when the card was not there
+    /// before, `updated` when it was and the write changed it.
+    ///
+    /// **A re-save that changes nothing says nothing.** Idempotent writes are
+    /// ordinary here (a settle that re-persists an unchanged card, a retry), and
+    /// announcing one would put a frame on the feed for a board that did not
+    /// move — noise a console cannot distinguish from a real change.
+    async fn upsert(&self, company: &CompanyId, task: &TaskRecord) -> Result<()> {
+        // Read before the write, so `previous` is genuinely the prior state.
+        // Two concurrent writers can both read "absent" and both announce
+        // `opened`; that costs a duplicate re-read on the console and is
+        // deliberately not locked against, because the board write itself is
+        // where ordering is owned.
+        let previous = self.current(company, &task.id).await;
+        self.inner.upsert(company, task).await?;
+        if previous.as_ref() == Some(task) {
+            return Ok(());
+        }
+        let change = if previous.is_none() {
+            CHANGE_OPENED
+        } else {
+            CHANGE_UPDATED
+        };
+        self.announce(company, &task.id, change, Some(task.column.clone()))
+            .await;
+        Ok(())
+    }
+
+    /// Deletes through, and announces only when a card was actually removed —
+    /// a delete of an id the board never held changed nothing.
+    async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool> {
+        let removed = self.inner.delete(company, id).await?;
+        if removed {
+            self.announce(company, id, CHANGE_REMOVED, None).await;
+        }
+        Ok(removed)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ports::types::{EventSeq, StoredEvent};
+    use futures::stream::BoxStream;
+    use std::sync::Mutex;
+
+    /// An in-memory board, so the decorator is exercised against a real
+    /// `TaskStore` rather than a stub that cannot tell insert from update.
+    #[derive(Default)]
+    struct MemTasks {
+        rows: Mutex<Vec<TaskRecord>>,
+    }
+
+    #[async_trait]
+    impl TaskStore for MemTasks {
+        async fn list(&self, _company: &CompanyId) -> Result<Vec<TaskRecord>> {
+            Ok(self.rows.lock().unwrap().clone())
+        }
+        async fn upsert(&self, _company: &CompanyId, task: &TaskRecord) -> Result<()> {
+            let mut rows = self.rows.lock().unwrap();
+            match rows.iter_mut().find(|t| t.id == task.id) {
+                Some(slot) => *slot = task.clone(),
+                None => rows.push(task.clone()),
+            }
+            Ok(())
+        }
+        async fn delete(&self, _company: &CompanyId, id: &str) -> Result<bool> {
+            let mut rows = self.rows.lock().unwrap();
+            let before = rows.len();
+            rows.retain(|t| t.id != id);
+            Ok(rows.len() != before)
+        }
+    }
+
+    #[derive(Default)]
+    struct MemLog {
+        appended: Mutex<Vec<CompanyEvent>>,
+    }
+
+    #[async_trait]
+    impl EventLog for MemLog {
+        async fn append(&self, _id: &CompanyId, event: CompanyEvent) -> Result<EventSeq> {
+            let mut got = self.appended.lock().unwrap();
+            got.push(event);
+            Ok(EventSeq::new(got.len() as u64))
+        }
+        async fn read_from(
+            &self,
+            _id: &CompanyId,
+            _seq: EventSeq,
+            _limit: usize,
+        ) -> Result<Vec<StoredEvent>> {
+            Ok(Vec::new())
+        }
+        fn subscribe(&self, _id: &CompanyId) -> BoxStream<'static, StoredEvent> {
+            Box::pin(futures::stream::empty())
+        }
+    }
+
+    /// An event log that refuses every append, so the "record-keeping never
+    /// fails the work it records" contract is tested rather than asserted.
+    struct BrokenLog;
+
+    #[async_trait]
+    impl EventLog for BrokenLog {
+        async fn append(&self, _id: &CompanyId, _event: CompanyEvent) -> Result<EventSeq> {
+            Err(crate::error::OpenCompanyError::Store(
+                "log is down".to_string(),
+            ))
+        }
+        async fn read_from(
+            &self,
+            _id: &CompanyId,
+            _seq: EventSeq,
+            _limit: usize,
+        ) -> Result<Vec<StoredEvent>> {
+            Ok(Vec::new())
+        }
+        fn subscribe(&self, _id: &CompanyId) -> BoxStream<'static, StoredEvent> {
+            Box::pin(futures::stream::empty())
+        }
+    }
+
+    fn card(id: &str, column: &str) -> TaskRecord {
+        TaskRecord {
+            id: id.to_string(),
+            title: "Draft the launch note".to_string(),
+            note: None,
+            column: column.to_string(),
+            priority: "medium".to_string(),
+            assignee: String::new(),
+            updated_at_millis: 1,
+            origin_chat_id: None,
+            parent_task_id: None,
+            output: None,
+            plan: None,
+        }
+    }
+
+    fn wired() -> (Arc<BoardAnnouncer>, Arc<MemLog>, CompanyId) {
+        let log = Arc::new(MemLog::default());
+        let store = Arc::new(BoardAnnouncer::new(
+            Arc::new(MemTasks::default()),
+            log.clone(),
+        ));
+        (store, log, CompanyId::new("announcer-co"))
+    }
+
+    /// The headline of #464: a card written by *anything* announces itself, and
+    /// the first write of an id is an `opened` rather than an `updated`.
+    #[tokio::test]
+    async fn a_new_card_announces_that_it_opened() {
+        let (store, log, co) = wired();
+        store.upsert(&co, &card("t-1", "todo")).await.unwrap();
+
+        let got = log.appended.lock().unwrap().clone();
+        assert_eq!(got.len(), 1, "one announcement for one new card: {got:?}");
+        match &got[0] {
+            CompanyEvent::TaskCardChanged {
+                task_id,
+                change,
+                column,
+            } => {
+                assert_eq!(task_id, "t-1");
+                assert_eq!(change, CHANGE_OPENED);
+                assert_eq!(column.as_deref(), Some("todo"));
+            }
+            other => panic!("expected a board announcement, got {other:?}"),
+        }
+    }
+
+    /// A second write of the same id is an update, and carries the column it
+    /// landed in — the frame a second console needs to follow a drag.
+    #[tokio::test]
+    async fn moving_a_card_announces_an_update_with_its_new_column() {
+        let (store, log, co) = wired();
+        store.upsert(&co, &card("t-1", "todo")).await.unwrap();
+        store.upsert(&co, &card("t-1", "in_review")).await.unwrap();
+
+        let got = log.appended.lock().unwrap().clone();
+        assert_eq!(got.len(), 2, "open then move: {got:?}");
+        match &got[1] {
+            CompanyEvent::TaskCardChanged { change, column, .. } => {
+                assert_eq!(change, CHANGE_UPDATED);
+                assert_eq!(column.as_deref(), Some("in_review"));
+            }
+            other => panic!("expected a board announcement, got {other:?}"),
+        }
+    }
+
+    /// Re-saving a card exactly as it already stands announces nothing. A
+    /// settle that re-persists an unchanged card is ordinary, and a frame for a
+    /// board that did not move is noise a console cannot tell from a real
+    /// change.
+    #[tokio::test]
+    async fn an_unchanged_re_save_is_silent() {
+        let (store, log, co) = wired();
+        store.upsert(&co, &card("t-1", "todo")).await.unwrap();
+        store.upsert(&co, &card("t-1", "todo")).await.unwrap();
+
+        assert_eq!(
+            log.appended.lock().unwrap().len(),
+            1,
+            "the identical re-save must not announce"
+        );
+    }
+
+    /// A removed card announces its removal without a column — a card that is
+    /// gone is not in one, and an empty string would read as a column whose id
+    /// is blank.
+    #[tokio::test]
+    async fn a_deleted_card_announces_removal_without_a_column() {
+        let (store, log, co) = wired();
+        store.upsert(&co, &card("t-1", "todo")).await.unwrap();
+        assert!(store.delete(&co, "t-1").await.unwrap());
+
+        let got = log.appended.lock().unwrap().clone();
+        match got.last().expect("a removal announcement") {
+            CompanyEvent::TaskCardChanged { change, column, .. } => {
+                assert_eq!(change, CHANGE_REMOVED);
+                assert!(column.is_none(), "a removed card is in no column");
+            }
+            other => panic!("expected a board announcement, got {other:?}"),
+        }
+    }
+
+    /// Deleting an id the board never held changed nothing, so it announces
+    /// nothing.
+    #[tokio::test]
+    async fn deleting_an_absent_card_is_silent() {
+        let (store, log, co) = wired();
+        assert!(!store.delete(&co, "never-existed").await.unwrap());
+        assert!(log.appended.lock().unwrap().is_empty());
+    }
+
+    /// Record-keeping never fails the work it records: a refusing event log
+    /// leaves the board write successful and the card on the board.
+    #[tokio::test]
+    async fn a_refusing_event_log_does_not_fail_the_board_write() {
+        let store = BoardAnnouncer::new(Arc::new(MemTasks::default()), Arc::new(BrokenLog));
+        let co = CompanyId::new("announcer-broken");
+
+        store
+            .upsert(&co, &card("t-1", "todo"))
+            .await
+            .expect("the board write succeeds even when the announcement cannot be filed");
+        assert_eq!(store.list(&co).await.unwrap().len(), 1);
+    }
+}

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -44,6 +44,7 @@ use crate::ports::{
     FactStore, InboxStore, LoginCodeStore, MemoryStore, RunStore, SecretStore, SessionStore,
     SkillStateStore, TaskStore, ToolProvider, UsageMeter, UserStore, WorkspaceStore,
 };
+use crate::runtime::board_events::BoardAnnouncer;
 use crate::runtime::channel::{OPERATOR_CHANNEL, OperatorChannel};
 use crate::runtime::handover::RuntimeHandover;
 use crate::runtime::journal::RuntimeJournal;
@@ -786,9 +787,19 @@ impl RuntimeBuilder {
         // The WS3 console ports default to a single shared fs backend.
         let fs_ops = Arc::new(FsOps::new(home.clone()));
         let ops = match handover.as_ref() {
+            // A rebuild inherits the ops it was handed, announcer and all — the
+            // wrap below happens once, at first construction. Re-wrapping an
+            // inherited board would announce every write twice.
             Some(h) => h.ops.clone(),
             None => OpsStores {
-                tasks: self.tasks.unwrap_or_else(|| fs_ops.clone()),
+                // Issue #464: the board announces its own writes. Wrapped here,
+                // at the single place the store is chosen, so *every* writer —
+                // REST, the cycle, a delegation, the settle mover — announces
+                // without knowing it does. See [`BoardAnnouncer`].
+                tasks: Arc::new(BoardAnnouncer::new(
+                    self.tasks.unwrap_or_else(|| fs_ops.clone()),
+                    events.clone(),
+                )),
                 workspace: self.workspace.unwrap_or_else(|| fs_ops.clone()),
                 facts: self.facts.unwrap_or_else(|| fs_ops.clone()),
                 artifacts: self.artifacts.unwrap_or_else(|| fs_ops.clone()),

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1273,6 +1273,12 @@ fn cycle_task_id(
             | CompanyEvent::WorkflowNodeFinished { .. }
             | CompanyEvent::TaskSteered { .. }
             | CompanyEvent::TaskDiscussionPosted { .. }
+            // Issue #464: a board write announcing itself. Emphatically a
+            // record — it is appended by the store *after* the write it
+            // describes, so treating it as a trigger would let a card start
+            // work merely by existing, and that work's own card writes would
+            // announce again.
+            | CompanyEvent::TaskCardChanged { .. }
             | CompanyEvent::DeskTaskCompleted { .. } => continue,
         };
         let Some(candidate) = candidate else { continue };
@@ -1377,6 +1383,12 @@ fn cycle_thread_id(
             | CompanyEvent::WorkflowNodeFinished { .. }
             | CompanyEvent::TaskSteered { .. }
             | CompanyEvent::TaskDiscussionPosted { .. }
+            // Issue #464: a board write announcing itself. Emphatically a
+            // record — it is appended by the store *after* the write it
+            // describes, so treating it as a trigger would let a card start
+            // work merely by existing, and that work's own card writes would
+            // announce again.
+            | CompanyEvent::TaskCardChanged { .. }
             | CompanyEvent::DeskTaskCompleted { .. } => continue,
         };
         let Some(candidate) = candidate else { continue };

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -27,6 +27,12 @@ pub mod approval_display;
 /// harness dispatch path and the REST write boundary so the board's assignee
 /// means one thing. See [`assignee`].
 pub mod assignee;
+/// Issue #464: [`BoardAnnouncer`] — the [`TaskStore`](crate::ports::tasks::TaskStore)
+/// decorator that announces a board write on the company event log, so a card
+/// opened by *anything* reaches a watching console without a reload. Emitted at
+/// the store rather than at the callers, which is what stops the next writer
+/// from silently announcing nothing. See [`board_events`].
+pub mod board_events;
 pub mod builder;
 pub mod channel;
 pub mod cron;
@@ -87,6 +93,7 @@ pub mod workflow_scheduler;
 pub mod workflow_spawn;
 
 pub use advance::{SYSTEM_ATTRIBUTION, advance_settled_card, append_result};
+pub use board_events::{BoardAnnouncer, CHANGE_OPENED, CHANGE_REMOVED, CHANGE_UPDATED};
 pub use builder::{RuntimeBuilder, company_id_from_name};
 pub use channel::{OPERATOR_CHANNEL, OperatorChannel};
 pub use cron::{CivilTime, CronExpr};

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -684,6 +684,33 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             o["taskId"] = json!(task_id);
             o
         }
+        // Issue #464: the frame the board was missing. Every other task event
+        // here describes a card that already exists, so a card *opened* — by
+        // chat intake, a delegation, the publish drain, the REST route —
+        // reached the console only on its next reload.
+        //
+        // Three keys, all structural, and every one of them already reachable
+        // by the same operator through `GET {scope}/tasks`. There is
+        // deliberately no title and no note: a card's text is operator- or
+        // agent-authored free text, and this frame's whole job is to say
+        // *something moved*, not to carry the board. The console reacts by
+        // re-reading the board it already knows how to read, which keeps the
+        // card's content on exactly one route instead of two.
+        CompanyEvent::TaskCardChanged {
+            task_id,
+            change,
+            column,
+        } => {
+            let mut o = envelope("task_card_changed");
+            o["taskId"] = json!(task_id);
+            o["change"] = json!(change);
+            // Omitted rather than null on a removal, so "gone" is a presence
+            // check on the console rather than a null check.
+            if let Some(column) = column {
+                o["column"] = json!(column);
+            }
+            o
+        }
         // `message` is scrubbed at the source (`OcMcpCallTool` → `HarnessBrain`
         // drain), so it can never carry a credential, response body, or URL query
         // string — safe to forward verbatim. See `CompanyEvent::McpCallFailed`.
@@ -4330,6 +4357,40 @@ mod test {
         .expect("task_dispatched is an attention signal");
         assert_eq!(v["type"], "task_dispatched");
         assert_eq!(v["taskId"], "t-42");
+    }
+
+    /// Issue #464: an opened card reaches the console as its own frame. This is
+    /// the half a unit test can prove — that the projection exists and carries
+    /// the card; that the *board* redraws off it is a browser fact.
+    #[test]
+    fn projects_task_card_changed() {
+        let v = super::project_event(&stored(CompanyEvent::TaskCardChanged {
+            task_id: "t-77".into(),
+            change: crate::runtime::CHANGE_OPENED.into(),
+            column: Some("todo".into()),
+        }))
+        .expect("a board write is an attention signal");
+        assert_eq!(v["type"], "task_card_changed");
+        assert_eq!(v["taskId"], "t-77");
+        assert_eq!(v["change"], "opened");
+        assert_eq!(v["column"], "todo");
+    }
+
+    /// A removed card is projected without a column — the console's "is it
+    /// gone?" check is a presence check, never a null one.
+    #[test]
+    fn projects_a_removed_card_without_a_column() {
+        let v = super::project_event(&stored(CompanyEvent::TaskCardChanged {
+            task_id: "t-77".into(),
+            change: crate::runtime::CHANGE_REMOVED.into(),
+            column: None,
+        }))
+        .expect("a board write is an attention signal");
+        assert_eq!(v["change"], "removed");
+        assert!(
+            v.get("column").is_none(),
+            "a removed card is in no column: {v}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A card created from chat did not show up on the board. The reply said **Card opened**, the card's own page loaded, the board showed nothing.

Closes #464.

## API Or Behavior Changes

**The host now announces card writes.** `src/runtime/board_events.rs` adds a `BoardAnnouncer` decorator over the `TaskStore` port, wrapped in once in `builder.rs`. It emits `opened` / `updated` / `removed`; an unchanged re-save is silent; a refusing event log is warned and swallowed so a written card stays written.

**Deliberately a decorator, not an emit per call site.** Cards are written from chat intake, delegation, advance, cycle and the tasks ops module — all through `TaskStore::upsert`. Emitting at each creation site is the same shape as the bug being fixed: correct for the paths someone remembered, silent for the next one added. It also meant zero edits to `delegation.rs`, which belongs to another in-flight lane.

**The board subscribes** to those events and to the lifecycle events it previously ignored.

## Correcting the issue's own diagnosis

#464 claimed the board "lists tasks once, on mount". **That is wrong**, and the issue has been corrected. `TasksView` has polled every 4000ms since #27; on a live host the card from chat was measured appearing without a reload in **1608ms**.

The real defect is the one the issue's own "what the fix should do" section names: the board's **only** live path was a fixed-interval poll, and it subscribed to nothing. The reported "nothing until I reloaded" is most plausibly timer throttling in a backgrounded tab — that could not be forced in headless Chromium and **is not claimed as proven**.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 2297 passed, 0 failed
- [x] `cargo check --locked --all-features --all-targets`
- [x] `npm ci && npm run typecheck && npm run build`

`Cargo.lock` unchanged. No lint script and no component-test script exist in `frontend/`; neither was run and neither is claimed.

**Measured in a browser against a live host, watching without touching the page:**

| Check | Before | After |
|---|---|---|
| Card asked for in chat appears on the board | 1608ms (poll) | **151ms** |
| A real drag in tab A moves the card in tab B | — | **162ms** |
| Column change reflected in a second tab | — | **153ms** |
| `GET …/tasks` intervals | flat `[3999, 3999, 4000]` | off-beat `[2482, 1516, 1208, 1158]` |

The drag was a real HTML5 gesture through the board's own handlers, not a synthetic state change. The interval shape is the evidence that **no polling was introduced**: push-driven reads now interleave with the untouched fallback poll rather than replacing it.

**Unit-only:** the six announcer tests and the two projection tests. **Not verified at all:** the harness settle path (`in_progress` → `in_review`) — it needs model credentials. It writes through the same decorator, but that is construction, not evidence, and is stated as such.

## Documentation

`board_events.rs` carries the decorator's rationale, including a note that it is written to be copied for the workspace equivalent.

## Notes for review

**Two sibling issues were deliberately not bundled**, with reasons rather than omissions:

- **#384** (workflow create/update/delete events dropped by the console) is *not* cheap. The host already projects those events; only the console drops them. But `WorkflowsView`'s list effect also owns selection and optimistic local edits, so re-running it on every workflow event risks stamping on an in-progress canvas edit. That needs its own design and its own browser proof, not a bundled arm.
- **#327** (no push channel for workspace files) is the same pattern and needs a `WorkspaceStore` twin of this decorator plus a view subscription. Doubling the surface would have made the browser pass unverifiable in one sitting.

**One thing worth knowing beyond this PR:** clippy under `--features openhuman,tinycortex` caught a fifth exhaustive `CompanyEvent` match in `harness/orchestrator.rs` that the default-feature build does not compile. A default-only gate would have passed a tree that does not build under CI's feature matrix — which is the argument for keeping both clippy lanes mandatory.
