### PR TITLE
fix(chat): grant a standing scope from the card that interrupted you (#431)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -15,6 +15,7 @@ import {
   ApiError,
   type ApprovalSummary,
   type CompanyStatus,
+  type GrantScope,
   type TurnStep,
   type Verdict,
 } from "@/api/types";
@@ -772,11 +773,18 @@ export function AppShell({
    * called from an event handler, so a `useCallback` here would buy a stale
    * closure and nothing else.
    */
-  const decideApproval = async (approval: ApprovalSummary, verdict: Verdict) => {
+  const decideApproval = async (
+    approval: ApprovalSummary,
+    verdict: Verdict,
+    scope: GrantScope = { kind: "once" },
+  ) => {
     if (decidingApprovals.has(approval.id)) return;
     markDeciding(approval.id, verdict);
     try {
-      await client.resolveApproval(approval.id, verdict, undefined, company, { detach: true });
+      await client.resolveApproval(approval.id, verdict, undefined, company, {
+        detach: true,
+        scope,
+      });
       setDecidedApprovals((prev) => ({ ...prev, [approval.id]: { verdict, approval } }));
       toast.success(
         verdict === "approve"
@@ -918,7 +926,9 @@ export function AppShell({
               approvals={feed.approvals}
               chatChannelByThread={chatChannelByThread}
               now={feed.now}
-              onDecideApproval={(approval, verdict) => void decideApproval(approval, verdict)}
+              onDecideApproval={(approval, verdict, scope) =>
+                void decideApproval(approval, verdict, scope)
+              }
               decidingApprovals={decidingApprovals}
               decidedApprovals={decidedApprovals}
             />

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -14,7 +14,14 @@ import { toast } from "sonner";
 import { listPeople, me as fetchMe, type Person } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
 import { setInboxEnabled } from "@/api/inbox";
-import { ApiError, type ApprovalSummary, type TeamMemberDto, type TurnStep, type Verdict } from "@/api/types";
+import {
+  ApiError,
+  type ApprovalSummary,
+  type GrantScope,
+  type TeamMemberDto,
+  type TurnStep,
+  type Verdict,
+} from "@/api/types";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -114,7 +121,7 @@ interface Props {
    * witnessed verdict survives this view unmounting — the operator can walk to
    * Approvals and back mid-turn.
    */
-  onDecideApproval?: (approval: ApprovalSummary, verdict: Verdict) => void;
+  onDecideApproval?: (approval: ApprovalSummary, verdict: Verdict, scope: GrantScope) => void;
   /** The verdict each card is waiting on, and the ones already witnessed. */
   decidingApprovals?: ReadonlyMap<string, Verdict>;
   decidedApprovals?: Record<string, DecidedApproval>;

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -1,8 +1,10 @@
 // A parked approval, raised inside the conversation that produced it (#379).
 //
 // The same content the Approvals page shows — headline, payload, asker, waiting
-// time, all from `@/components/approval-card` — laid out as a channel row so it
-// reads as part of the thread rather than as a panel bolted beside it.
+// time, and the grant-scope choice (#431), all from `@/components/approval-card`
+// — laid out as a channel row so it reads as part of the thread rather than as a
+// panel bolted beside it. Sharing the scope control rather than restating it is
+// what keeps the two surfaces from offering different things for one approval.
 //
 // The one thing it does differently is how it resolves: **detached** (#391).
 // The default resolve answers with the follow-up turn's replies, and rendering
@@ -12,12 +14,14 @@
 // cannot exist here.
 
 import { Check, Loader2, X } from "lucide-react";
+import { useState } from "react";
 
-import type { ApprovalSummary, Verdict } from "@/api/types";
+import type { ApprovalSummary, GrantScope, Verdict } from "@/api/types";
 import {
   ApprovalHeadline,
   ApprovalMeta,
   ApprovalPayload,
+  ApprovalScopeControl,
 } from "@/components/approval-card";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -47,8 +51,14 @@ export function ApprovalRow({
   deciding: Verdict | null;
   /** A verdict already witnessed — from this console or from the page. */
   decided: Verdict | null;
-  onDecide: (verdict: Verdict) => void;
+  onDecide: (verdict: Verdict, scope: GrantScope) => void;
 }) {
+  // Per-card, exactly as on the page: two approvals can be parked in one
+  // channel and each carries its own decision. Defaults to `once`, so a card
+  // decided without touching the control behaves as it did before #431 — the
+  // scope is opt-in here too.
+  const [scope, setScope] = useState<GrantScope>({ kind: "once" });
+
   return (
     <div className="px-4 py-2">
       <div
@@ -72,7 +82,9 @@ export function ApprovalRow({
                     variant="outline"
                     size="sm"
                     disabled={deciding !== null}
-                    onClick={() => onDecide("deny")}
+                    /* A decline never carries a scope — there is nothing to
+                       grant, and the host refuses the pairing anyway. */
+                    onClick={() => onDecide("deny", { kind: "once" })}
                   >
                     {deciding === "deny" ? (
                       <Loader2 className="size-4 animate-spin" />
@@ -84,7 +96,7 @@ export function ApprovalRow({
                   <Button
                     size="sm"
                     disabled={deciding !== null}
-                    onClick={() => onDecide("approve")}
+                    onClick={() => onDecide("approve", scope)}
                   >
                     {deciding === "approve" ? (
                       <Loader2 className="size-4 animate-spin" />
@@ -99,6 +111,23 @@ export function ApprovalRow({
           />
 
           <ApprovalPayload approval={approval} />
+
+          {/*
+           * The same control the page renders, from the same module — it
+           * self-gates on `broadly_grantable`, so an approval that may not be
+           * granted broadly shows nothing here for exactly the reason it shows
+           * nothing there. A settled card drops it: there is no decision left
+           * to scope.
+           */}
+          {!decided && (
+            <ApprovalScopeControl
+              approval={approval}
+              askerNames={askerNames}
+              scope={scope}
+              onChange={setScope}
+              disabled={deciding !== null}
+            />
+          )}
 
           <ApprovalMeta
             approval={approval}

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 
-import type { ApprovalSummary, TurnStep, Verdict } from "@/api/types";
+import type { ApprovalSummary, GrantScope, TurnStep, Verdict } from "@/api/types";
 import { cn } from "@/lib/utils";
 import { ApprovalRow } from "./ApprovalRow";
 import { Avatar } from "./Avatar";
@@ -35,7 +35,7 @@ interface Props {
   askerNames?: Map<string, string>;
   /** The verdict each inline card is currently waiting on. */
   decidingApprovals?: ReadonlyMap<string, Verdict>;
-  onDecideApproval?: (approval: ApprovalSummary, verdict: Verdict) => void;
+  onDecideApproval?: (approval: ApprovalSummary, verdict: Verdict, scope: GrantScope) => void;
 }
 
 /**
@@ -94,7 +94,7 @@ export function MessageTimeline({
               askerNames={askerNames ?? EMPTY_NAMES}
               deciding={decidingApprovals?.get(item.approval.id) ?? null}
               decided={item.decided}
-              onDecide={(verdict) => onDecideApproval?.(item.approval, verdict)}
+              onDecide={(verdict, scope) => onDecideApproval?.(item.approval, verdict, scope)}
             />
           ),
         )}

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -3584,6 +3584,26 @@ mod test {
         }
     }
 
+    /// A tool call an operator MAY grant a standing permission for (issue
+    /// #431), which `gated_tool_call` deliberately is not: its Composio payload
+    /// names no action slug, so `consequence_of` cannot classify it as a read
+    /// and it stays a per-call decision. `file_write` is declared grantable in
+    /// `src/policy/consequence.rs` and carries an agent, so it satisfies both
+    /// halves of `check_broadly_grantable` — it mutates, but only the agent's
+    /// own sandboxed workspace.
+    fn grantable_tool_call() -> crate::ports::types::Effect {
+        crate::ports::types::Effect {
+            kind: "file_write".into(),
+            group: crate::ports::types::EffectGroup::Other,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::json!({ "path": "notes/a.md", "body": "one" }),
+            agent: Some("ceo".into()),
+            run_id: None,
+        }
+    }
+
     /// The dotted kind the stalled brain parks once its follow-up turn gets
     /// past the barrier. Parking journals durably (`record_parked`), so its
     /// presence in `pending_approvals()` is proof the continuation reached the
@@ -3600,6 +3620,10 @@ mod test {
         entered: Arc<tokio::sync::Notify>,
         /// The test's permission for the turn to finish.
         release: Arc<tokio::sync::Notify>,
+        /// The effect parked for the operator's sign-off. Whether it may be
+        /// granted a standing permission is a property of this effect, so the
+        /// scope tests supply their own rather than sharing one fixture.
+        parked: crate::ports::types::Effect,
     }
 
     #[async_trait::async_trait]
@@ -3612,7 +3636,7 @@ mod test {
             for event in &req.events {
                 match event {
                     CompanyEvent::OperatorMessage { .. } => {
-                        host.park_effect(gated_tool_call()).await?;
+                        host.park_effect(self.parked.clone()).await?;
                     }
                     CompanyEvent::ApprovalResolved { .. } => {
                         self.entered.notify_one();
@@ -3707,6 +3731,15 @@ mod test {
     }
 
     async fn stalled_company(home: &std::path::Path) -> StalledCompany {
+        stalled_company_parking(home, gated_tool_call()).await
+    }
+
+    /// `stalled_company`, with the parked effect chosen by the caller — because
+    /// whether a scope may be granted is decided by the effect, not the route.
+    async fn stalled_company_parking(
+        home: &std::path::Path,
+        parked: crate::ports::types::Effect,
+    ) -> StalledCompany {
         let entered = Arc::new(tokio::sync::Notify::new());
         let release = Arc::new(tokio::sync::Notify::new());
         let state = build_state_with_brain(
@@ -3716,6 +3749,7 @@ mod test {
             Some(Arc::new(StalledContinuationBrain {
                 entered: entered.clone(),
                 release: release.clone(),
+                parked,
             })),
         )
         .await;
@@ -3911,6 +3945,89 @@ mod test {
             "a detached continuation must still land"
         );
         assert_eq!(c.runtime.grants.live_count(), 1);
+    }
+
+    /// **Issue #431.** A *detached* resolve — the verb the inline chat card
+    /// uses — mints a standing grant when one was asked for, and that grant is
+    /// visible on the one list both surfaces read.
+    ///
+    /// This pairing had no coverage before this test, which is why it looked
+    /// covered: its neighbour above sends `detach` with no scope, so the grant
+    /// it asserts is the single-use one, while every standing-grant test
+    /// resolves *without* `detach`. Until #431 the console could not ask for
+    /// this combination at all, so nothing exercised it; now the chat card can,
+    /// it is the console's only way to mint a standing grant.
+    ///
+    /// It holds because `run_resolve` computes the scope and hands it to
+    /// `resolve_approval_spawned` *before* it branches on `detach` — statement
+    /// ordering inside one function, which a refactor could reverse without a
+    /// single existing test going red. Hence asserting it rather than reading it.
+    #[tokio::test]
+    async fn a_detached_resolve_mints_a_standing_grant_and_lists_it() {
+        let home_dir = home();
+        let c = stalled_company_parking(home_dir.path(), grantable_tool_call()).await;
+
+        // The same flag the inline card gates its scope control on: if this is
+        // false the console offers no choice, and the rest of this is moot.
+        assert!(
+            c.runtime.pending_approvals()[0].broadly_grantable,
+            "the fixture must be an approval a standing scope may be asked for"
+        );
+
+        let response = c
+            .app
+            .clone()
+            .oneshot(resolve_request(
+                &c.approval_id,
+                serde_json::json!({
+                    "verdict": "approve",
+                    "detach": true,
+                    "scope": "tool",
+                    "expires_in_millis": 60 * 60 * 1000,
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Minted by the time the detached answer is written, not merely promised
+        // by it — the receipt says `recorded`, so a grant that appeared later
+        // would make that a lie.
+        assert_eq!(
+            c.runtime.grants.standing_count(),
+            1,
+            "a detached resolve carrying a tool scope must mint a standing grant"
+        );
+
+        // And visible on the one list route both surfaces read, described the
+        // same way — this is what "appears in the same list as one granted from
+        // the page" means, there being only one list.
+        let listed = c
+            .app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/company/grants")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(listed.status(), StatusCode::OK);
+        let bytes = to_bytes(listed.into_body(), usize::MAX).await.unwrap();
+        let rows: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(rows.as_array().unwrap().len(), 1);
+        assert_eq!(rows[0]["tool"], "file_write");
+        assert_eq!(rows[0]["agent"], "ceo");
+
+        // The continuation still lands, so the scope did not cost the detach.
+        c.entered.notified().await;
+        c.release.notify_one();
+        assert!(
+            await_continuation(&c.runtime).await,
+            "a detached continuation must still land when a scope was granted"
+        );
     }
 
     /// The default is unchanged: no `detach` key means the response still


### PR DESCRIPTION
## Summary

An approval interrupts an operator **in chat**. The inline card offered only **approve once**, which mints a single-use, argument-exact grant — so the next call with one argument changed asks again, and again.

A real operator hit this on staging today. The agent's own explanation to them:

> *"The `page:2` variant of the Composio call got blocked by the approval policy (the earlier approvals were for specific argument sets, and this new `page:2` combination wasn't pre-approved)."*

The scope control that ends that loop existed — on the Approvals page, which is not where they were.

Closes #431.

## API Or Behavior Changes

**The inline chat approval card now offers the same grant scope as the Approvals page**, and the chosen scope reaches the resolve call.

**This changes no grant semantics.** It makes an existing capability reachable from the surface that interrupts the operator. The property actually complained about — the same tool, called repeatedly with different arguments, stops asking — was already true and is already proven by `a_standing_grant_admits_repeat_calls_with_any_arguments` (`policy.rs`), whose own doc comment reads *"The issue in one test."* That test is the proof of the semantics; this PR claims only the reachability half.

**No new validation path.** `grant_scope()` in `operator.rs` is the single validation point, called from `run_resolve` before the runtime is touched. Both surfaces already POST the same route; chat differs only by `detach: true`. Threading `scope` reuses that identical path.

**Both surfaces render one component.** `ApprovalScopeControl` returns `null` unless the approval is broadly grantable, and that flag is computed server-side at one projection point which routes through `consequence_of(kind, payload)` — so for Composio it is classified from the live action slug. The card asks exactly the question the server will answer. `<fieldset>` appears exactly once in the codebase; the two surfaces cannot drift.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 2290 passed, 0 failed
- [x] `cargo check --locked --all-features --all-targets`
- [x] `npm ci && npm run typecheck && npm run build`

`Cargo.lock` unchanged. No lint script and no component-test script exist in `frontend/`; neither was run and neither is claimed.

**A coverage hole this closes.** The chat path sends `detach: true`; the page path does not. There was **no test** for `detach` + `scope: "tool"` — the exact combination this change makes reachable. The nearest existing test sends `detach` with *no* scope, so it looks like coverage and is not. `a_detached_resolve_mints_a_standing_grant_and_lists_it` now asserts the grant is minted *and* listed by `GET …/grants` by the time the detached receipt is written.

**Shown to bite, by mutation.** `run_resolve` was mutated to pass `GrantScope::Once`: the new test failed, its neighbour still passed. That is the blind spot in one line. Mutation reverted and re-verified.

**Verified live** — real host, real console bundle, real browser, 11 checks, 0 failures:

- The resolve body carried `scope: "tool"` and `expires_in_millis: 28800000` — the option actually selected, not a default — with `detach: true` intact.
- Two approvals in one channel (`file_write` grantable, `shell` per-call): inline, the grantable card shows the control and the per-call card shows none; on the Approvals page exactly one control across the same two cards.
- Four probes POSTed straight at the host, bypassing the console: scope with no duration → 400; deny + scope → 400; a 30-day duration → 400; `once` + a duration → 400.

The approvals *feed* was mocked, same technique and same reason as the existing `chat-inline-approval.spec.ts`; everything downstream of it was real.

**Argued from the type rather than demonstrated:** a grant minted from chat and one from the page land in the same list because there **is** one list — `list_grants(scope: ScopedCompany)` has no surface parameter, and there is one list route and one revoke route. A live walk would show the same rows and prove less.

**Deliberately not driven live:** `check_broadly_grantable()`'s refusal needs a real parked approval, which needs a model making a gated call. No inference credential is available and the harness company runs the offline echo brain. Its coverage is `a_refused_scope_leaves_the_approval_parked_and_unjournaled` (`cycle.rs`). Mocking to a green tick there would prove nothing about the server.

## Documentation

The scope-threading path is documented at the callback seam.

## Notes for review

**Three hunks in `app-shell.tsx`, all in the approvals handler** — the two-line forward plus a type-only import without which they do not compile. A concurrent lane was editing the same file; the nearest hunks are 25 lines apart with an unrelated block between them, and both merge cleanly.

**A third approval surface exists and was deliberately left alone.** The task-detail Approvals tab renders a bare tool name, but it is explicitly non-deciding and its backing type carries no `payload`, `agent` or `broadly_grantable` — it cannot render the shared card without a host projection change. It omits the control by being a different thing, not by drifting. Filed as #468.

**A stale fixture found on the way, filed as #470:** several tests build a `composio_execute` call keyed `tool_slug`, while the tool's schema and the classifier both use `tool`. Those tests exercise the unclassified fallback while reading as Composio tests. Production is unaffected.
